### PR TITLE
wpcomsh: Colors_Manager_Common: Remove long-disabled caching code

### DIFF
--- a/projects/plugins/wpcomsh/changelog/wpcomsh-remove-unused-color-caching
+++ b/projects/plugins/wpcomsh/changelog/wpcomsh-remove-unused-color-caching
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: Colors_Manager_Common: Remove long-disabled caching code
+
+

--- a/projects/plugins/wpcomsh/custom-colors/colors.php
+++ b/projects/plugins/wpcomsh/custom-colors/colors.php
@@ -13,8 +13,6 @@
 // phpcs:disable Universal.Files.SeparateFunctionsFromOO.Mixed
 // phpcs:disable Generic.Files.OneObjectStructurePerFile.MultipleFound
 
-define( 'WPCOM_USE_CACHED_COLORS', false );
-
 /**
  * The common color manager class.
  */
@@ -1351,9 +1349,6 @@ class Colors_Manager_Common {
 	 * @return array
 	 */
 	public static function sanitize_colors_on_save( $set_colors ) {
-		// since this function only gets called if the colors changed,
-		// we can safely invalidate without further checks
-		add_action( 'shutdown', array( __CLASS__, 'delete_cached_css_on_shutdown_because_reasons' ) );
 		return self::sanitize_colors( $set_colors );
 	}
 
@@ -1385,23 +1380,6 @@ class Colors_Manager_Common {
 			}
 		}
 		return $colors_wanted;
-	}
-
-	/**
-	 * Goodbye, cache!
-	 */
-	private static function delete_cached_css() {
-		$colors_manager           = (array) get_theme_mod( 'colors_manager' );
-		$colors_manager['cached'] = false;
-		set_theme_mod( 'colors_manager', $colors_manager );
-	}
-
-	/**
-	 * Goodbye, cache. Because reasons.
-	 */
-	public static function delete_cached_css_on_shutdown_because_reasons() {
-		remove_all_filters( 'theme_mod_colors_manager' );
-		self::delete_cached_css();
 	}
 
 	/**
@@ -1479,19 +1457,12 @@ class Colors_Manager_Common {
 	 * Return theme CSS.
 	 */
 	public static function get_theme_css() {
-		$opts       = get_theme_mod(
+		$opts   = get_theme_mod(
 			'colors_manager',
 			array(
 				'colors' => false,
-				'cached' => false,
 			)
 		);
-		$has_cached = isset( $opts['cached'] ) && $opts['cached'];
-
-		if ( $has_cached && WPCOM_USE_CACHED_COLORS ) {
-			return $opts['cached'];
-		}
-
 		$colors = $opts['colors'];
 
 		// extra colors/CSS: always on
@@ -1512,9 +1483,6 @@ class Colors_Manager_Common {
 		// Minify & cache for future use.
 		$minifier = new tubalmartin\CssMin\Minifier();
 		$css      = $minifier->run( $css );
-
-		$opts['cached'] = $css;
-		set_theme_mod( 'colors_manager', $opts );
 
 		return $css;
 	}


### PR DESCRIPTION
## Proposed changes:

`WPCOM_USE_CACHED_COLORS` has been set to false for several years, so none of the caching code has been doing anything. Remove it.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?

## Testing instructions:

* Switch to 2016 theme
* Visit /wp-admin/customize.php and make sure customizing colors still saves (and then is displayed properly on the front-end)
