### PR TITLE
Add/blocks get variation method just method

### DIFF
--- a/projects/packages/blocks/changelog/add-blocks-get_variation-method-just-method
+++ b/projects/packages/blocks/changelog/add-blocks-get_variation-method-just-method
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add get variation method to block

--- a/projects/packages/blocks/src/class-blocks.php
+++ b/projects/packages/blocks/src/class-blocks.php
@@ -455,4 +455,95 @@ class Blocks {
 
 		return false === $result ? $block_src_dir : $result;
 	}
+
+	/**
+	 * Determine whether a site should use the default set of blocks, or a custom set.
+	 * Possible variations are currently beta, experimental, and production.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return string $block_varation production|beta|experimental
+	 */
+	public static function get_variation() {
+		// Default to production blocks.
+		$block_varation = 'production';
+
+		/*
+		 * Prefer to use this JETPACK_BLOCKS_VARIATION constant
+		 * or the jetpack_blocks_variation filter
+		 * to set the block variation in your code.
+		 */
+		$default = Constants::get_constant( 'JETPACK_BLOCKS_VARIATION' );
+		if ( ! empty( $default ) && in_array( $default, array( 'beta', 'experimental', 'production' ), true ) ) {
+			$block_varation = $default;
+		}
+
+		/**
+		* Alternative to `JETPACK_BETA_BLOCKS`, set to `true` to load Beta Blocks.
+		*
+		* @since jetpack-6.9.0
+		* @deprecated jetpack-11.8.0 Use jetpack_blocks_variation filter instead.
+		*
+		* @param boolean
+		*/
+		$is_beta = apply_filters_deprecated(
+			'jetpack_load_beta_blocks',
+			array( false ),
+			'jetpack-11.8.0',
+			'jetpack_blocks_variation'
+		);
+
+		/*
+		 * Switch to beta blocks if you use the JETPACK_BETA_BLOCKS constant
+		 * or the deprecated jetpack_load_beta_blocks filter.
+		 * This only applies when not using the newer JETPACK_BLOCKS_VARIATION constant.
+		 */
+		if ( empty( $default )
+				&& (
+					$is_beta
+					|| Constants::is_true( 'JETPACK_BETA_BLOCKS' )
+				)
+			) {
+			$block_varation = 'beta';
+		}
+
+		/**
+		* Alternative to `JETPACK_EXPERIMENTAL_BLOCKS`, set to `true` to load Experimental Blocks.
+		*
+		* @since jetpack-6.9.0
+		* @deprecated jetpack-11.8.0 Use jetpack_blocks_variation filter instead.
+		*
+		* @param boolean
+		*/
+		$is_experimental = apply_filters_deprecated(
+			'jetpack_load_experimental_blocks',
+			array( false ),
+			'jetpack-11.8.0',
+			'jetpack_blocks_variation'
+		);
+
+		/*
+		 * Switch to experimental blocks if you use the JETPACK_EXPERIMENTAL_BLOCKS constant
+		 * or the deprecated jetpack_load_experimental_blocks filter.
+		 * This only applies when not using the newer JETPACK_BLOCKS_VARIATION constant.
+		 */
+		if ( empty( $default )
+			&& (
+				$is_experimental
+				|| Constants::is_true( 'JETPACK_EXPERIMENTAL_BLOCKS' )
+			)
+			) {
+			$block_varation = 'experimental';
+		}
+
+		/**
+		 * Allow customizing the variation of blocks in use on a site.
+		 * Overwrites any previously set values, whether by constant or filter.
+		 *
+		 * @since jetpack-8.1.0
+		 *
+		 * @param string $block_variation Can be beta, experimental, and production. Defaults to production.
+		 */
+		return apply_filters( 'jetpack_blocks_variation', $block_varation );
+	}
 }

--- a/projects/packages/blocks/src/class-blocks.php
+++ b/projects/packages/blocks/src/class-blocks.php
@@ -462,11 +462,11 @@ class Blocks {
 	 *
 	 * @since $$next-version$$
 	 *
-	 * @return string $block_varation production|beta|experimental
+	 * @return string $block_variation production|beta|experimental
 	 */
 	public static function get_variation() {
 		// Default to production blocks.
-		$block_varation = 'production';
+		$block_variation = 'production';
 
 		/*
 		 * Prefer to use this JETPACK_BLOCKS_VARIATION constant
@@ -475,7 +475,7 @@ class Blocks {
 		 */
 		$default = Constants::get_constant( 'JETPACK_BLOCKS_VARIATION' );
 		if ( ! empty( $default ) && in_array( $default, array( 'beta', 'experimental', 'production' ), true ) ) {
-			$block_varation = $default;
+			$block_variation = $default;
 		}
 
 		/**
@@ -504,7 +504,7 @@ class Blocks {
 					|| Constants::is_true( 'JETPACK_BETA_BLOCKS' )
 				)
 			) {
-			$block_varation = 'beta';
+			$block_variation = 'beta';
 		}
 
 		/**
@@ -533,7 +533,7 @@ class Blocks {
 				|| Constants::is_true( 'JETPACK_EXPERIMENTAL_BLOCKS' )
 			)
 			) {
-			$block_varation = 'experimental';
+			$block_variation = 'experimental';
 		}
 
 		/**
@@ -544,6 +544,6 @@ class Blocks {
 		 *
 		 * @param string $block_variation Can be beta, experimental, and production. Defaults to production.
 		 */
-		return apply_filters( 'jetpack_blocks_variation', $block_varation );
+		return apply_filters( 'jetpack_blocks_variation', $block_variation );
 	}
 }


### PR DESCRIPTION
Revert the revert by just adding the new method in this commit. 

Originally implemented in https://github.com/Automattic/jetpack/pull/41589 and reverted in https://github.com/Automattic/jetpack/pull/43250.

This method is originally found in Jetpack_Gutenberg class.

## Proposed changes:
* We are adding a new method here so that we can implement it in the Jetpack forms package. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Do the tests pass? 

