### PR TITLE
e2e tests: fix typo preventing helper import causing 100% performance bin failures

### DIFF
--- a/tools/e2e-commons/config/playwright.config.default.mjs
+++ b/tools/e2e-commons/config/playwright.config.default.mjs
@@ -2,7 +2,7 @@ import fs from 'fs';
 import { fileURLToPath } from 'url';
 import { defineConfig, devices } from '@playwright/test';
 import config from 'config';
-import { resolveSiteUrl, setWpEnvVars } from '../helpers/utils-helper';
+import { resolveSiteUrl, setWpEnvVars } from '../helpers/utils-helper.js';
 
 const reporter = [
 	[ 'list' ],

--- a/tools/e2e-commons/reporters/flaky-tests-reporter.ts
+++ b/tools/e2e-commons/reporters/flaky-tests-reporter.ts
@@ -9,7 +9,7 @@
  * - If it fail all 3 times, then it's a **failed** test.
  */
 import fs from 'fs';
-import { fileNameFormatter } from '../helpers/utils-helper';
+import { fileNameFormatter } from '../helpers/utils-helper.js';
 import type { Reporter, TestCase, TestResult } from '@playwright/test/reporter';
 
 type FormattedTestResult = Omit< TestResult, 'steps' >;


### PR DESCRIPTION
Noticed today in a failed test run what looks like an incorrect import file URL.

Run failure:
https://github.com/Automattic/jetpack/actions/runs/14681039283/job/41203731699

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/home/runner/work/jetpack/jetpack/tools/e2e-commons/helpers/utils-helper' imported from /home/runner/work/jetpack/jetpack/tools/e2e-commons/config/playwright.config.default.mjs
    at finalizeResolution (node:internal/modules/esm/resolve:275:11)
    at moduleResolve (node:internal/modules/esm/resolve:860:10)
    at defaultResolve (node:internal/modules/esm/resolve:984:11)
    at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:685:12)
    at #cachedDefaultResolve (node:internal/modules/esm/loader:634:25)
    at ModuleLoader.resolve (node:internal/modules/esm/loader:6[17](https://github.com/Automattic/jetpack/actions/runs/14681039283/job/41203731699#step:10:18):38)
    at ModuleLoader.getModuleJobForImport (node:internal/modules/esm/loader:273:38)
    at ModuleJob._link (node:internal/modules/esm/module_job:135:49) {
  code: 'ERR_MODULE_NOT_FOUND',
  url: 'file:///home/runner/work/jetpack/jetpack/tools/e2e-commons/helpers/utils-helper'
}
```

While this might see TOO obvious... I recommend fixing the import file path.

## Testing instructions

Jetpack is complex these days! I imagine the steps would be:

- Build locally
- Run e2e locally to verify

(I'd love help on this, CC @jeherve — maybe a quick tutorial or pairing session?)

## Does this pull request change what data or activity we track or use?

No.