### PR TITLE
Boost: Fix upgrade CTA on critical CSS tooltip.

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/features/premium-tooltip/premium-tooltip.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/premium-tooltip/premium-tooltip.tsx
@@ -1,7 +1,7 @@
 import { IconTooltip } from '@automattic/jetpack-components';
 import { __ } from '@wordpress/i18n';
 import styles from './premium-tooltip.module.scss';
-import UpgradeCTA from '$features/upgrade-cta/upgrade-cta';
+import InterstitialModalCTA from '$features/upgrade-cta/interstitial-modal-cta';
 
 const PremiumTooltip = () => {
 	return (
@@ -42,10 +42,9 @@ const PremiumTooltip = () => {
 			</ul>
 
 			<div className={ styles[ 'upgrade-cta' ] }>
-				<UpgradeCTA
+				<InterstitialModalCTA
 					identifier="critical-css-tooltip"
 					description={ __( 'Automatic Critical CSS regeneration', 'jetpack-boost' ) }
-					eventName="upsell_cta_from_settings_page_tooltip_in_plugin"
 				/>
 			</div>
 		</IconTooltip>

--- a/projects/plugins/boost/changelog/fix-tooltip-cta
+++ b/projects/plugins/boost/changelog/fix-tooltip-cta
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fixed an issue with an upgrade CTA.
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes HOG-76

## Proposed changes:
* Make the upgrade CTA on critical CSS tooltip functional.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
* Start with a site running Boost free.
* Go to Jetpack > Boost.
* Click on the "info" icon after You should regenerate your Critical CSS whenever you make changes to the HTML or CSS structure of your site.
* Click the CTA.
* It should show the upgrade interstitial.

