### PR TITLE
JP CLI: add support for git command passthrough

### DIFF
--- a/projects/js-packages/jetpack-cli/bin/jp.js
+++ b/projects/js-packages/jetpack-cli/bin/jp.js
@@ -306,6 +306,24 @@ const main = async () => {
 			}
 		}
 
+		// Handle git passthrough: run git commands inside the container for pre-commit hooks, etc.
+		if ( args[ 0 ] === 'git' ) {
+			// This allows: jp git commit -m "msg" (runs inside container, so hooks/tools are consistent)
+			// Always disable GPG signing in the container to avoid missing key errors.
+			const result = spawnSync(
+				resolve( monorepoRoot, 'tools/docker/bin/monorepo' ),
+				[ 'git', '-c', 'commit.gpgSign=false', ...args.slice( 1 ) ],
+				{
+					stdio: 'inherit',
+					cwd: monorepoRoot,
+				}
+			);
+			if ( result.status !== 0 ) {
+				throw new Error( `Git command failed with status ${ result.status }` );
+			}
+			return;
+		}
+
 		// Run the monorepo script with the original arguments
 		const result = spawnSync(
 			resolve( monorepoRoot, 'tools/docker/bin/monorepo' ),

--- a/projects/js-packages/jetpack-cli/changelog/add-jp-git-passthrough
+++ b/projects/js-packages/jetpack-cli/changelog/add-jp-git-passthrough
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add support for git command passthrough

--- a/tools/docker/bin/monorepo
+++ b/tools/docker/bin/monorepo
@@ -36,6 +36,13 @@ if ! docker image inspect jetpack-monorepo:latest >/dev/null 2>&1; then
     fi
 fi
 
+# If the user's .gitconfig exists, mount it into the container for git passthrough commands (jp git ...)
+if [ -f "$HOME/.gitconfig" ]; then
+    GITCONFIG_MOUNT="-v $HOME/.gitconfig:/root/.gitconfig:ro"
+else
+    GITCONFIG_MOUNT=""
+fi
+
 # Run the command in the container
 docker run --rm -it \
     -v "$MONOREPO_ROOT:/workspace" \
@@ -51,5 +58,6 @@ docker run --rm -it \
     -e NPM_CONFIG_CACHE=/root/.npm \
     -e PNPM_HOME=/root/.local/share/pnpm \
     -e PNPM_STORE_DIR=/root/.pnpm-store \
+    $GITCONFIG_MOUNT \
     jetpack-monorepo:latest \
     "$@"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

I realize this may not be the ideal approach. :)

The problem: The `jp` command uses a docker container for running development commands to avoid needing your machine to have the right versions of everything.

This works fairly well for all commands in the `jetpack` CLI; however, we expect precommit and prepush hooks to run, which currently are on the local machine. So, we still need things setup right on the local machine.

The solution: This adds a `jp git` command that passes through to git on the developer container, where node, etc are all set.

Nuance: my gitconfig file has me sign everything by default, but for this iteration, I didn't want to handle some type of key forwarding (which doesn't natively exist like ssh -A). In this initial iteration, just ensure we don't try to sign things.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Pass `jp git` commands to `git` on the dev container.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* `./projects/js-packages/jetpack-cli/bin/jp.js --help` [ensure the default behavior works, passing to `jetpack`
* `./projects/js-packages/jetpack-cli/bin/jp.js git status` [ensures git works]
* `./projects/js-packages/jetpack-cli/bin/jp.js install -r` [install monorepo root, just in case it hasn't been done]
* `./projects/js-packages/jetpack-cli/bin/jp.js git commit -a -m "test test test"` [after making some local changes, namely to php and js files to let phpcbf, prettier, etc run on precommit]

The following will not yet work and will need a follow-up PR.
* `./projects/js-packages/jetpack-cli/bin/jp.js git push` [need to get key support working]
* `./projects/js-packages/jetpack-cli/bin/jp.js git commit -a` [where it needs to prompt you for the commit messages. to get a quoted string to work, I disabled shell, but that breaks the editor prompt. Will aim to figure this out in a follow-up.
