### PR TITLE
Docker: add support for multiplugin 'integration' PHP unit tests

### DIFF
--- a/projects/plugins/wpcomsh/changelog/add-multi-plugin-phpunit
+++ b/projects/plugins/wpcomsh/changelog/add-multi-plugin-phpunit
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Added ability to test with other Jetpack monorepo plugins active

--- a/projects/plugins/wpcomsh/tests/WpcomshTest.php
+++ b/projects/plugins/wpcomsh/tests/WpcomshTest.php
@@ -69,7 +69,7 @@ class WpcomshTest extends WP_UnitTestCase {
 	 * @return void
 	 */
 	public function test_is_jetpack_boost_active() {
-		$plugins = getenv( 'INTEGRATION_PLUGINS' );
+		$plugins = getenv( 'JP_MONO_INTEGRATION_PLUGINS' );
 		if ( $plugins && strpos( $plugins, 'boost' ) !== false ) {
 			$this->assertTrue( is_plugin_active( 'boost/jetpack-boost.php' ) );
 			return;

--- a/projects/plugins/wpcomsh/tests/WpcomshTest.php
+++ b/projects/plugins/wpcomsh/tests/WpcomshTest.php
@@ -60,4 +60,20 @@ class WpcomshTest extends WP_UnitTestCase {
 
 		$this->assertEquals( $expected_output, wpcomsh_make_content_clickable( $original_content ) );
 	}
+
+	/**
+	 * Tests if Jetpack Boost plugin is active, to test the integreation setup.
+	 *
+	 * This is for the `jp docker phpunit-integration` command to verify it works.
+	 *
+	 * @return void
+	 */
+	public function test_is_jetpack_boost_active() {
+		$plugins = getenv( 'INTEGRATION_PLUGINS' );
+		if ( $plugins && strpos( $plugins, 'boost' ) !== false ) {
+			$this->assertTrue( is_plugin_active( 'boost/jetpack-boost.php' ) );
+			return;
+		}
+		$this->assertFalse( is_plugin_active( 'boost/jetpack-boost.php' ) );
+	}
 }

--- a/projects/plugins/wpcomsh/tests/bootstrap.php
+++ b/projects/plugins/wpcomsh/tests/bootstrap.php
@@ -69,8 +69,8 @@ tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
  * Add the various plugins to the active options array.
  */
 function _manually_load_other_plugins( $active_plugins ) {
-	// Get the INTEGRATION_PLUGINS env var to include other plugins.
-	$plugins = getenv( 'INTEGRATION_PLUGINS' );
+	// Get the JP_MONO_INTEGRATION_PLUGINS env var to include other plugins.
+	$plugins = getenv( 'JP_MONO_INTEGRATION_PLUGINS' );
 	if ( $plugins ) {
 		$plugins = explode( ',', $plugins );
 		require_once ABSPATH . 'wp-admin/includes/plugin.php';

--- a/projects/plugins/wpcomsh/tests/bootstrap.php
+++ b/projects/plugins/wpcomsh/tests/bootstrap.php
@@ -60,9 +60,39 @@ function _manually_load_plugin() {
 	if ( file_exists( WPMU_PLUGIN_DIR . '/wpcomsh-loader.php' ) ) {
 		return;
 	}
+
 	require_once dirname( __DIR__ ) . '/wpcomsh.php';
 }
 tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
+
+/**
+ * Add the various plugins to the active options array.
+ */
+function _manually_load_other_plugins( $active_plugins ) {
+	// Get the INTEGRATION_PLUGINS env var to include other plugins.
+	$plugins = getenv( 'INTEGRATION_PLUGINS' );
+	if ( $plugins ) {
+		$plugins = explode( ',', $plugins );
+		require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		$all_plugins = get_plugins();
+		foreach ( $plugins as $plugin ) {
+			// Ignore wpcomsh and jetpack for now.
+			if ( 'wpcomsh' === $plugin || 'jetpack' === $plugin ) {
+				continue;
+			}
+			// Find the main plugin file for this plugin directory
+			foreach ( $all_plugins as $plugin_file => $plugin_data ) {
+				if ( strpos( $plugin_file, $plugin . '/' ) === 0 ) {
+					$active_plugins[] = $plugin_file;
+					break;
+				}
+			}
+		}
+	}
+	return $active_plugins;
+}
+
+tests_add_filter( 'option_active_plugins', '_manually_load_other_plugins' );
 
 // Override WP_TESTS_CONFIG_FILE_PATH via environment.
 // Important for monorepo CI, if you don't do this then different test runs might collide!

--- a/tools/cli/commands/docker.js
+++ b/tools/cli/commands/docker.js
@@ -441,6 +441,31 @@ const buildExecCmd = argv => {
 			],
 		};
 		opts = buildPhpUnitTestCmd( argv, opts, unitTestArgs );
+	} else if ( cmd === 'phpunit-integration' ) {
+		// Only run tests for wpcomsh and jetpack, but always set INTEGRATION_PLUGINS to the full list
+		const plugins = argv.plugins || argv._.slice( 2 );
+		const integrationPluginsEnv = plugins.join( ',' );
+		const allCmds = [];
+		// Only run for these plugins
+		const testablePlugins = [ 'wpcomsh', 'jetpack' ];
+		for ( const plugin of testablePlugins ) {
+			if ( ! plugins.includes( plugin ) ) continue;
+			let envVars = [ `INTEGRATION_PLUGINS=${ integrationPluginsEnv }` ];
+			if ( plugin === 'wpcomsh' ) {
+				envVars = envVars.concat( [
+					'WP_TESTS_DIR=/tmp/wordpress-develop/tests/phpunit',
+					'WP_CORE_DIR=/var/www/html',
+					'WP_CONTENT_DIR=/var/www/html/wp-content',
+				] );
+			}
+			const unitTestArgs = {
+				plugin,
+				envVars,
+			};
+			const pluginOpts = buildPhpUnitTestCmd( argv, [ 'exec', 'wordpress' ], unitTestArgs );
+			allCmds.push( buildComposeFiles().concat( pluginOpts ) );
+		}
+		return allCmds;
 	} else if ( cmd === 'wp' ) {
 		const wpArgs = argv._.slice( 2 );
 		// Ugly solution to allow interactive shell work in dev context
@@ -839,6 +864,33 @@ export function dockerDefine( yargs ) {
 					builder: yargCmd => defaultOpts( yargCmd ),
 					handler: async argv => {
 						await generateConfig( argv );
+					},
+				} )
+				.command( {
+					command: 'phpunit-integration <plugins...>',
+					description:
+						'Run PHPUnit for each specified plugin with all specified plugins activated (integration mode)',
+					builder: yargCmd =>
+						defaultOpts( yargCmd ).positional( 'plugins', {
+							describe: 'Plugin slugs to activate and test',
+							type: 'string',
+							array: true,
+						} ),
+					handler: argv => {
+						// Get all the commands to run
+						const allCmds = buildExecCmd( argv );
+						let hasFailure = false;
+						for ( const opts of allCmds ) {
+							try {
+								composeExecutor( argv, opts, buildEnv( argv ) );
+							} catch ( e ) {
+								console.error( chalk.bgRed( `Error: ` ) + e );
+								hasFailure = true;
+							}
+						}
+						if ( hasFailure ) {
+							process.exit( 1 );
+						}
 					},
 				} );
 		},

--- a/tools/cli/commands/docker.js
+++ b/tools/cli/commands/docker.js
@@ -442,7 +442,7 @@ const buildExecCmd = argv => {
 		};
 		opts = buildPhpUnitTestCmd( argv, opts, unitTestArgs );
 	} else if ( cmd === 'phpunit-integration' ) {
-		// Only run tests for wpcomsh and jetpack, but always set INTEGRATION_PLUGINS to the full list
+		// Only run tests for wpcomsh and jetpack, but always set JP_MONO_INTEGRATION_PLUGINS to the full list
 		const plugins = argv.plugins || argv._.slice( 2 );
 		const integrationPluginsEnv = plugins.join( ',' );
 		const allCmds = [];
@@ -450,7 +450,7 @@ const buildExecCmd = argv => {
 		const testablePlugins = [ 'wpcomsh', 'jetpack' ];
 		for ( const plugin of testablePlugins ) {
 			if ( ! plugins.includes( plugin ) ) continue;
-			let envVars = [ `INTEGRATION_PLUGINS=${ integrationPluginsEnv }` ];
+			let envVars = [ `JP_MONO_INTEGRATION_PLUGINS=${ integrationPluginsEnv }` ];
 			if ( plugin === 'wpcomsh' ) {
 				envVars = envVars.concat( [
 					'WP_TESTS_DIR=/tmp/wordpress-develop/tests/phpunit',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

I'm working on a bug that impacts Boost while wpcomsh is running and want to be able to test to confirm the bug and the fix. I don't believe there's a way to run unit tests with multiple plugins running.

This iteration is meant to only run wpcomsh or jetpack unit tests (as they're written to be executed with a full WordPress stack) while including other plugins as active.

It's not the most robust solution and likely incomplete. My thought here is to get something working for being able to test wpcomsh and boost while providing a starting point for more iteration.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add a `jetpack docker phpunit-integration` command.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Ensure docker is running ({jp|jetpack} docker up -d )
* Run {jp|jetpack} docker phpunit-integration wpcomsh boost
* Same command with just wpcomsh
* Both should pass, noting the conditional in the wpcomsh test to check if boost is active or not based on the env vars that are set by the command.
