### PR TITLE
e2e tests: attempt to more explicitely start tunnel

### DIFF
--- a/.github/workflows/block-performance.yml
+++ b/.github/workflows/block-performance.yml
@@ -59,6 +59,7 @@ jobs:
           mkdir results
           pnpm config:decrypt
           pnpm env:start
+          pnpm tunnel:on
 
           # The twentytwentyone theme is required for the post-editor test suite.
           pnpm jetpack docker --type e2e --name t1 wp theme install twentytwentyone

--- a/.github/workflows/block-performance.yml
+++ b/.github/workflows/block-performance.yml
@@ -6,6 +6,11 @@ on:
   workflow_dispatch:
   pull_request:
 
+env:
+  # Prevent wp-scripts from downloading extra Playwright browsers,
+  # since Chromium will be installed in its dedicated step already.
+  PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: true
+
 jobs:
   block-performance:
     name: "Performance tests"

--- a/.github/workflows/block-performance.yml
+++ b/.github/workflows/block-performance.yml
@@ -4,6 +4,7 @@ on:
   schedule:
     - cron:  '0 */12 * * *'
   workflow_dispatch:
+  pull_request:
 
 jobs:
   block-performance:

--- a/tools/e2e-commons/config/global-setup.mjs
+++ b/tools/e2e-commons/config/global-setup.mjs
@@ -1,5 +1,6 @@
 import { request } from '@playwright/test';
 import { RequestUtils } from '@wordpress/e2e-test-utils-playwright';
+import { getSiteCredentials } from '../helpers/utils-helper.js';
 
 /**
  * Global setup for Playwright tests.
@@ -16,8 +17,10 @@ async function globalSetup( config ) {
 		baseURL,
 	} );
 
+	const user = getSiteCredentials();
 	const requestUtils = new RequestUtils( requestContext, {
 		storageStatePath,
+		user,
 	} );
 
 	// Authenticate and save the storageState to disk.

--- a/tools/e2e-commons/helpers/utils-helper.js
+++ b/tools/e2e-commons/helpers/utils-helper.js
@@ -212,10 +212,14 @@ export function getSiteCredentials() {
  */
 export function setWpEnvVars() {
 	const site = getConfigTestSite();
+	const storage = config.get( 'temp.storage' );
 
 	process.env.WP_BASE_URL = resolveSiteUrl();
 	process.env.WP_USERNAME = site.username;
 	process.env.WP_PASSWORD = site.password;
+	if ( storage ) {
+		process.env.STORAGE_STATE_PATH = storage;
+	}
 }
 
 /**


### PR DESCRIPTION
Fixes #43260

## Proposed changes:

Let's try to be more explicit in starting the tunnel for the test. 

I'm not quite sure why `tunnel.js on` isn't enough ; let's try to fix that.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* N/A

## Testing instructions:

* Is CI happy? https://github.com/Automattic/jetpack/actions/runs/14694210582/job/41233658493?pr=43261
