### PR TITLE
Boost + wpcomsh: ensure API endpoints are registered

### DIFF
--- a/projects/plugins/wpcomsh/changelog/fix-hog-87
+++ b/projects/plugins/wpcomsh/changelog/fix-hog-87
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Ensure wpcomsh users are able to purchase the Boost paid offering

--- a/projects/plugins/wpcomsh/class-jetpack-plugin-compatibility.php
+++ b/projects/plugins/wpcomsh/class-jetpack-plugin-compatibility.php
@@ -205,7 +205,12 @@ class Jetpack_Plugin_Compatibility {
 		add_filter(
 			'jetpack_my_jetpack_should_initialize',
 			function () {
-				return get_option( 'wpcom_admin_interface' ) === 'wp-admin';
+				$should_init = get_option( 'wpcom_admin_interface' ) === 'wp-admin';
+				if ( ! $should_init ) {
+					// My Jetpack REST API endpoints are used for more than just My Jetpack UI.
+					add_action( 'rest_api_init', array( '\Automattic\Jetpack\My_Jetpack\Initializer', 'register_rest_endpoints' ) );
+				}
+				return $should_init;
 			}
 		);
 	}

--- a/projects/plugins/wpcomsh/class-jetpack-plugin-compatibility.php
+++ b/projects/plugins/wpcomsh/class-jetpack-plugin-compatibility.php
@@ -206,9 +206,9 @@ class Jetpack_Plugin_Compatibility {
 			'jetpack_my_jetpack_should_initialize',
 			function () {
 				$should_init = get_option( 'wpcom_admin_interface' ) === 'wp-admin';
-				if ( ! $should_init ) {
+				if ( ! $should_init && class_exists( '\Automattic\Jetpack\My_Jetpack\Initializer' ) ) {
 					// My Jetpack REST API endpoints are used for more than just My Jetpack UI.
-					add_action( 'rest_api_init', array( '\Automattic\Jetpack\My_Jetpack\Initializer', 'register_rest_endpoints' ) );
+					add_action( 'rest_api_init', array( '\Automattic\Jetpack\My_Jetpack\Initializer', 'register_rest_endpoints' ) ); // @phan-suppress-current-line PhanUndeclaredClassInCallable
 				}
 				return $should_init;
 			}

--- a/projects/plugins/wpcomsh/tests/JetpackCompatibilityTest.php
+++ b/projects/plugins/wpcomsh/tests/JetpackCompatibilityTest.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Jetpack Compatibility Test file.
+ *
+ * @package wpcomsh
+ */
+
+/**
+ * Test Jetpack_Compatibility functionality.
+ */
+class JetpackCompatibilityTest extends WP_UnitTestCase {
+	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
+
+	/**
+	 * Test_wpcomsh_get_plugin_updated_submenus.
+	 */
+	public function test_wpcomsh_my_jetpack_rest_apis_available() {
+		// Check if the REST API routes are registered if Boost is included.
+		$plugins = getenv( 'INTEGRATION_PLUGINS' );
+		if ( ! $plugins || strpos( $plugins, 'boost' ) === false ) {
+			$this->markTestSkipped( 'Jetpack Boost plugin is not included in INTEGRATION_PLUGINS.' );
+		}
+
+		$routes = rest_get_server()->get_routes();
+
+		$this->assertArrayHasKey( '/my-jetpack/v1/site/products', $routes, 'Products endpoint is not registered' );
+	}
+}

--- a/projects/plugins/wpcomsh/tests/JetpackCompatibilityTest.php
+++ b/projects/plugins/wpcomsh/tests/JetpackCompatibilityTest.php
@@ -16,9 +16,9 @@ class JetpackCompatibilityTest extends WP_UnitTestCase {
 	 */
 	public function test_wpcomsh_my_jetpack_rest_apis_available() {
 		// Check if the REST API routes are registered if Boost is included.
-		$plugins = getenv( 'INTEGRATION_PLUGINS' );
+		$plugins = getenv( 'JP_MONO_INTEGRATION_PLUGINS' );
 		if ( ! $plugins || strpos( $plugins, 'boost' ) === false ) {
-			$this->markTestSkipped( 'Jetpack Boost plugin is not included in INTEGRATION_PLUGINS.' );
+			$this->markTestSkipped( 'Jetpack Boost plugin is not included in JP_MONO_INTEGRATION_PLUGINS.' );
 		}
 
 		$routes = rest_get_server()->get_routes();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes HOG-87

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* With wpcomsh running, My Jetpack is forced off unless the site owner has chosen the wp-admin interface.
* If a site has chosen Calypso or not chosen at all, My Jetpack does not init, which means the REST API endpoints are not registered.
* With Jetpack Boost, the CTA for upgrading relies on the My Jetpack products endpoint to provide information.
* With the API not available, the link to purchase the upgrade is malformed and not able to be purchased.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On a site with wpcomsh + Boost, before the patch, visit the Jetpack->Boost page and click the CTA to upgrade.
* Clicking on the CTA in the modal will take you to the WordPress.com checkout with an error.
* Try again with the patch.
* Purchase Boost!

