### PR TITLE
Repo Gardening: disable AI labeling by default

### DIFF
--- a/projects/github-actions/repo-gardening/README.md
+++ b/projects/github-actions/repo-gardening/README.md
@@ -85,8 +85,8 @@ The action relies on the following parameters.
 - (Optional) `triage_projects_token` is a [personal access token](https://github.com/settings/tokens/new) with `repo` and `project` scopes. The token should be stored in a secret. This is required if you want to use the `triageIssues` task.
 - (Optional) `project_board_url` is the URL of a GitHub Project Board. We'll automate some of the work on that board in the `triageIssues` task.
 - (Optional) `labels_team_assignments` is a list of features you can provide, with matching team names, as specified in the "Team" field of your GitHub Project Board used for the `triageIssues` task, and lists of labels in use in your repository.
+- (Optional) `ai_labeling_enabled` is a boolean value that allows you to enable or disable the AI labeling of issues. The default value is `false`.
 - (Optional) `openai_api_key` is the API key for OpenAI. This is required if you want to use the `triageIssues` task to automatically add labels to your issues. **Note**: this option is only available for Automattic-hosted repositories.
-
 #### How to create a Slack bot and get your SLACK_TOKEN
 
 To create a bot and get your `SLACK_TOKEN`, follow [the general instructions here](https://slack.com/intl/en-hu/help/articles/115005265703-Create-a-bot-for-your-workspace):

--- a/projects/github-actions/repo-gardening/README.md
+++ b/projects/github-actions/repo-gardening/README.md
@@ -87,6 +87,7 @@ The action relies on the following parameters.
 - (Optional) `labels_team_assignments` is a list of features you can provide, with matching team names, as specified in the "Team" field of your GitHub Project Board used for the `triageIssues` task, and lists of labels in use in your repository.
 - (Optional) `ai_labeling_enabled` is a boolean value that allows you to enable or disable the AI labeling of issues. The default value is `false`.
 - (Optional) `openai_api_key` is the API key for OpenAI. This is required if you want to use the `triageIssues` task to automatically add labels to your issues. **Note**: this option is only available for Automattic-hosted repositories.
+
 #### How to create a Slack bot and get your SLACK_TOKEN
 
 To create a bot and get your `SLACK_TOKEN`, follow [the general instructions here](https://slack.com/intl/en-hu/help/articles/115005265703-Create-a-bot-for-your-workspace):

--- a/projects/github-actions/repo-gardening/action.yml
+++ b/projects/github-actions/repo-gardening/action.yml
@@ -56,6 +56,10 @@ inputs:
     description: "Mapping of team assignments for labels"
     required: false
     default: ""
+  ai_labeling_enabled:
+    description: "Enable AI labeling of issues"
+    required: false
+    default: "false"
   openai_api_key:
     description: "OpenAI API key"
     required: false

--- a/projects/github-actions/repo-gardening/changelog/update-ai-labeling-conditions-toggle
+++ b/projects/github-actions/repo-gardening/changelog/update-ai-labeling-conditions-toggle
@@ -1,0 +1,4 @@
+Significance: major
+Type: changed
+
+AI Labeling: AI labeling now requires a specific workflow input to be enabled: ai_labeling_enabled

--- a/projects/github-actions/repo-gardening/src/tasks/triage-issues/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/triage-issues/index.js
@@ -148,17 +148,19 @@ async function triageIssues( payload, octokit ) {
 			}
 		}
 
-		// Use OpenAI to automatically add labels to issues.
-		const issueLabels = await aiLabeling( payload, octokit );
+		// If AI Labeling is enabled, use OpenAI to automatically add labels to issues.
+		if ( getInput( 'ai_labeling_enabled' ) ) {
+			const issueLabels = await aiLabeling( payload, octokit );
 
-		// At this point, if we still miss a [Type] label, a [Feature] label, or a [Pri] label, ask the author to add it.
-		const requiredLabelTypes = [ /^\[Type\]/, /^\[Pri/, /^\[[^\]]*Feature/ ];
-		const missingLabelTypes = requiredLabelTypes.filter(
-			requiredLabelType => ! issueLabels.some( label => requiredLabelType.test( label ) )
-		);
+			// At this point, if we still miss a [Type] label, a [Feature] label, or a [Pri] label, ask the author to add it.
+			const requiredLabelTypes = [ /^\[Type\]/, /^\[Pri/, /^\[[^\]]*Feature/ ];
+			const missingLabelTypes = requiredLabelTypes.filter(
+				requiredLabelType => ! issueLabels.some( label => requiredLabelType.test( label ) )
+			);
 
-		if ( missingLabelTypes.length > 0 ) {
-			await addCommentAskLabels( octokit, ownerLogin, authorLogin, name, number );
+			if ( missingLabelTypes.length > 0 ) {
+				await addCommentAskLabels( octokit, ownerLogin, authorLogin, name, number );
+			}
 		}
 	}
 

--- a/projects/github-actions/repo-gardening/src/tasks/triage-issues/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/triage-issues/index.js
@@ -149,7 +149,7 @@ async function triageIssues( payload, octokit ) {
 		}
 
 		// If AI Labeling is enabled, use OpenAI to automatically add labels to issues.
-		if ( getInput( 'ai_labeling_enabled' ) ) {
+		if ( getInput( 'ai_labeling_enabled' ) === 'true' ) {
 			const issueLabels = await aiLabeling( payload, octokit );
 
 			// At this point, if we still miss a [Type] label, a [Feature] label, or a [Pri] label, ask the author to add it.


### PR DESCRIPTION
Fixes ARC-144

## Proposed changes:

Now that we won't have "Type", "Feature", or "Feature Group" labels anymore, we cannot ask OpenAI to add such labels, or post comments asking folks to add such labels.

The feature remains available in the action, but it now disabled by default.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

Nothing should change in the current behavior until this PR is merged. When it will be merged, you can create a new issue, not add any labels to it, and no comment should be posted by OpenAI.
e.g.  https://github.com/jeherve/jetpack/issues/205
