### PR TITLE
CI: Force a fresh apt-get pull allowing releaseinfo change

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -213,6 +213,8 @@ jobs:
           PROJECT_NAME: ${{ matrix.project }}
           HOST_CWD: ${{ github.workspace }}
         run: |
+          # The apt-get is due to a change in label in a PPA used by playwright. Can probably be removed in a week or two. 2025-04-27 -- kraftbj
+          sudo apt-get update --allow-releaseinfo-change
           echo "::group::Decrypt config"
           pnpm run config:decrypt
           echo "::endgroup::"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -143,7 +143,9 @@ jobs:
         env:
           FORCE_PACKAGE_TESTS: ${{ matrix.force-package-tests && 'true' || 'false' }}
           CHANGED: ${{ steps.changed.outputs.projects }}
+        # The apt-get is due to a change in label in a PPA used by playwright. Can probably be removed in a week or two. 2025-04-27 -- kraftbj
         run: |
+          sudo apt-get update --allow-releaseinfo-change
           EXIT=0
           declare -A PIDS
           PIDS=()
@@ -369,8 +371,10 @@ jobs:
 
       - name: Install playwright
         if: steps.changed.outputs.any == 'true'
+        # The apt-get is due to a change in label in a PPA used by playwright. Can probably be removed in a week or two. 2025-04-27 -- kraftbj
         run: |
           cd projects/js-packages/storybook
+          sudo apt-get update --allow-releaseinfo-change
           pnpm exec playwright install --with-deps chromium
 
       - name: Test storybook


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

The GH Action golden VM has some info for the PPA that has changed, so it's failing. This will update the apt-get stuff to keep the tests moving.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Refresh packages before playwright installs.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
no

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Does the Storybook test passes?

