### PR TITLE
Forms: only apply `wp-` and `is-style-` classes to fields of new inner block types

### DIFF
--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -1492,13 +1492,13 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 
 		// Shell wrapper classes. Add -wrap to each class.
 		$wrap_classes          = empty( $class ) ? '' : implode( '-wrap ', array_filter( explode( ' ', $class ) ) ) . '-wrap';
-		$field_wrapper_classes = $this->get_attribute( 'fieldwrapperclasses' ) ?? '';
+		$field_wrapper_classes = $this->get_attribute( 'fieldwrapperclasses' ) ? $this->get_attribute( 'fieldwrapperclasses' ) . ' ' : '';
 
 		if ( empty( $label ) ) {
 			$wrap_classes .= ' no-label';
 		}
 
-		$shell_field_class = "class='" . $field_wrapper_classes . ' grunion-field-' . $trimmed_type . '-wrap ' . esc_attr( $wrap_classes ) . "' ";
+		$shell_field_class = "class='" . $field_wrapper_classes . 'grunion-field-' . $trimmed_type . '-wrap ' . esc_attr( $wrap_classes ) . "' ";
 
 		/**
 		 * Filter the Contact Form required field text

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -377,38 +377,41 @@ class Contact_Form_Plugin {
 	}
 
 	/**
-	 * Returns an array containing the block style classes, the remaining classes without block style classes, and the wrap classes.
+	 * Returns an array containing the field classes (including -wrap classes), the remaining classes without block style classes.
 	 * The wrap classes are used for the wrapper div around the field.
 	 *
 	 * @param string $classname The class name.
 	 *
 	 * @return array {
-	 *     @type string $block_style_classes         The block style classes (is-style-* classes).
-	 *     @type string $classes_without_block_style The remaining classes without block style classes.
-	 *     @type string $wrap_classes                The wrap classes.
+	 *     @type string $fieldwrapperclasses         Classes that should be added to the field wrapper.
+	 *     @type string $classes_without_block_style The remaining classes without block style classes, intended for internal field controls.
 	 * }
 	 */
 	private static function get_block_style_classes( $classname = '' ) {
 		if ( ! $classname ) {
 			return array(
-				'block_style_classes' => '',
+				'fieldwrapperclasses' => '',
 				'classes'             => '',
-				'wrap_classes'        => '',
 			);
 		}
+
+		$field_wrapper_classes       = '';
+		$classes_without_block_style = '';
 
 		preg_match_all( '/is-style-([^\s]+)/i', $classname, $matches );
 
 		$block_style_classes = empty( $matches[0] ) ? '' : implode( ' ', $matches[0] );
-		$wrap_classes        = ! empty( $matches[0] ) ? implode( '-wrap ', $matches[0] ) . '-wrap' : '';
 
-		// Remove block style classes from the original classname
-		$classes_without_block_style = trim( preg_replace( '/is-style-([^\s]+)/i', '', $classname ) );
+		if ( ! empty( $block_style_classes ) ) {
+			$wrap_classes          = ! empty( $matches[0] ) ? ' ' . implode( '-wrap ', $matches[0] ) . '-wrap' : '';
+			$field_wrapper_classes = ' ' . $block_style_classes . $wrap_classes;
+			// Remove block style classes from the original classname.
+			$classes_without_block_style = trim( preg_replace( '/is-style-([^\s]+)/i', '', $classname ) );
+		}
 
 		return array(
-			'block_style_classes' => $block_style_classes,
+			'fieldwrapperclasses' => $field_wrapper_classes,
 			'classes'             => $classes_without_block_style,
-			'wrap_classes'        => $wrap_classes,
 		);
 	}
 
@@ -516,10 +519,9 @@ class Contact_Form_Plugin {
 				$atts['fieldwrapperclasses'] = 'wp-block-jetpack-field-' . $type;
 				if ( ! empty( $atts['class'] ) ) {
 					$block_style_classes          = self::get_block_style_classes( $atts['class'] );
-					$spacer                       = ! empty( $block_style_classes['block_style_classes'] ) ? ' ' : '';
-					$atts['fieldwrapperclasses'] .= $spacer . $block_style_classes['block_style_classes'] . $spacer . $block_style_classes['wrap_classes'];
+					$atts['fieldwrapperclasses'] .= $block_style_classes['fieldwrapperclasses'];
 					// Return the rest of the classes without the block style classes.
-					$atts['class'] = ! empty( $block_style_classes['classes'] ) ? $block_style_classes['classes'] : '';
+					$atts['class'] = $block_style_classes['classes'];
 				}
 			}
 		}

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -512,13 +512,15 @@ class Contact_Form_Plugin {
 			 * This ensures any updates to field block styles in theme.json or global styles are
 			 * correctly applied.
 			 */
-			if ( ! empty( $atts['class'] ) && $add_block_style_classes_to_field_wrapper ) {
-				$atts['fieldwrapperclasses']  = 'wp-block-jetpack-field-' . $type;
-				$block_style_classes          = self::get_block_style_classes( $atts['class'] );
-				$spacer                       = ! empty( $block_style_classes['block_style_classes'] ) ? ' ' : '';
-				$atts['fieldwrapperclasses'] .= $spacer . $block_style_classes['block_style_classes'] . $spacer . $block_style_classes['wrap_classes'];
-				// Return the rest of the classes without the block style classes.
-				$atts['class'] = ! empty( $block_style_classes['classes'] ) ? $block_style_classes['classes'] : '';
+			if ( $add_block_style_classes_to_field_wrapper ) {
+				$atts['fieldwrapperclasses'] = 'wp-block-jetpack-field-' . $type;
+				if ( ! empty( $atts['class'] ) ) {
+					$block_style_classes          = self::get_block_style_classes( $atts['class'] );
+					$spacer                       = ! empty( $block_style_classes['block_style_classes'] ) ? ' ' : '';
+					$atts['fieldwrapperclasses'] .= $spacer . $block_style_classes['block_style_classes'] . $spacer . $block_style_classes['wrap_classes'];
+					// Return the rest of the classes without the block style classes.
+					$atts['class'] = ! empty( $block_style_classes['classes'] ) ? $block_style_classes['classes'] : '';
+				}
 			}
 		}
 

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -435,30 +435,20 @@ class Contact_Form_Plugin {
 
 		// Process inner blocks to shortcode attributes.
 		if ( $block && ! empty( $block->parsed_block['innerBlocks'] ) ) {
-			/*
-			 * Add the `wp-block-jetpack-field-*` and `is-style-*` classes to the field wrapper div
-			 * This ensures any updates to field block styles in theme.json or global styles are
-			 * correctly applied.
-			 */
-			$atts['fieldwrapperclasses'] = 'wp-block-jetpack-field-' . $type;
-			if ( ! empty( $atts['class'] ) ) {
-				$block_style_classes          = self::get_block_style_classes( $atts['class'] );
-				$spacer                       = ! empty( $block_style_classes['block_style_classes'] ) ? ' ' : '';
-				$atts['fieldwrapperclasses'] .= $spacer . $block_style_classes['block_style_classes'] . $spacer . $block_style_classes['wrap_classes'];
-				// Return the rest of the classes without the block style classes.
-				$atts['class'] = ! empty( $block_style_classes['classes'] ) ? $block_style_classes['classes'] : '';
-			}
+			// Only apply the block style classes to the field wrapper if the field is one of the new inner block types.
+			$add_block_style_classes_to_field_wrapper = false;
 
 			foreach ( $block->parsed_block['innerBlocks'] as $inner_block ) {
 				$block_name = $inner_block['blockName'] ?? '';
 
 				if ( 'jetpack/label' === $block_name ) {
-					$atts['label']         = $inner_block['attrs']['label'] ?? $inner_block['attrs']['defaultLabel'] ?? '';
-					$atts['requiredText']  = $inner_block['attrs']['requiredText'] ?? null;
-					$label_attrs           = self::get_block_support_classes_and_styles( $block_name, $inner_block['attrs'] );
-					$atts['labelclasses']  = 'wp-block-jetpack-label';
-					$atts['labelclasses'] .= isset( $label_attrs['class'] ) ? ' ' . $label_attrs['class'] : '';
-					$atts['labelstyles']   = $label_attrs['style'] ?? null;
+					$atts['label']                            = $inner_block['attrs']['label'] ?? $inner_block['attrs']['defaultLabel'] ?? '';
+					$atts['requiredText']                     = $inner_block['attrs']['requiredText'] ?? null;
+					$label_attrs                              = self::get_block_support_classes_and_styles( $block_name, $inner_block['attrs'] );
+					$atts['labelclasses']                     = 'wp-block-jetpack-label';
+					$atts['labelclasses']                    .= isset( $label_attrs['class'] ) ? ' ' . $label_attrs['class'] : '';
+					$atts['labelstyles']                      = $label_attrs['style'] ?? null;
+					$add_block_style_classes_to_field_wrapper = true;
 				}
 
 				if ( 'jetpack/input' === $block_name ) {
@@ -473,14 +463,16 @@ class Contact_Form_Plugin {
 					if ( 'jetpack/field-select' === $block->name ) {
 						$atts['togglelabel'] = $inner_block['attrs']['placeholder'];
 					}
+					$add_block_style_classes_to_field_wrapper = true;
 				}
 
 				// The following handles when option blocks are a direct inner block for a field e.g. singular checkbox field.
 				if ( 'jetpack/option' === $block_name ) {
-					$atts['label']         = $inner_block['attrs']['label'] ?? $inner_block['attrs']['defaultLabel'] ?? '';
-					$option_attrs          = self::get_block_support_classes_and_styles( $block_name, $inner_block['attrs'] );
-					$atts['optionclasses'] = isset( $option_attrs['class'] ) ? ' ' . $option_attrs['class'] : '';
-					$atts['optionstyles']  = $option_attrs['style'] ?? null;
+					$atts['label']                            = $inner_block['attrs']['label'] ?? $inner_block['attrs']['defaultLabel'] ?? '';
+					$option_attrs                             = self::get_block_support_classes_and_styles( $block_name, $inner_block['attrs'] );
+					$atts['optionclasses']                    = isset( $option_attrs['class'] ) ? ' ' . $option_attrs['class'] : '';
+					$atts['optionstyles']                     = $option_attrs['style'] ?? null;
+					$add_block_style_classes_to_field_wrapper = true;
 				}
 
 				// The following handles choice fields such as; Single Choice Field (radio) or Multiple Choice Field (checkbox).
@@ -508,9 +500,25 @@ class Contact_Form_Plugin {
 						}
 					}
 
-					$atts['options']     = implode( ',', $options );
-					$atts['optionsdata'] = \wp_json_encode( $options_data );
+					$atts['options']                          = implode( ',', $options );
+					$atts['optionsdata']                      = \wp_json_encode( $options_data );
+					$add_block_style_classes_to_field_wrapper = true;
 				}
+			}
+
+			/*
+			 * Add the `wp-block-jetpack-field-*` and `is-style-*` classes to the field wrapper div
+			 * for fields that are one of the new inner block types.
+			 * This ensures any updates to field block styles in theme.json or global styles are
+			 * correctly applied.
+			 */
+			if ( ! empty( $atts['class'] ) && $add_block_style_classes_to_field_wrapper ) {
+				$atts['fieldwrapperclasses']  = 'wp-block-jetpack-field-' . $type;
+				$block_style_classes          = self::get_block_style_classes( $atts['class'] );
+				$spacer                       = ! empty( $block_style_classes['block_style_classes'] ) ? ' ' : '';
+				$atts['fieldwrapperclasses'] .= $spacer . $block_style_classes['block_style_classes'] . $spacer . $block_style_classes['wrap_classes'];
+				// Return the rest of the classes without the block style classes.
+				$atts['class'] = ! empty( $block_style_classes['classes'] ) ? $block_style_classes['classes'] : '';
 			}
 		}
 

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -404,7 +404,7 @@ class Contact_Form_Plugin {
 
 		if ( ! empty( $block_style_classes ) ) {
 			$wrap_classes          = ! empty( $matches[0] ) ? ' ' . implode( '-wrap ', $matches[0] ) . '-wrap' : '';
-			$field_wrapper_classes = ' ' . $block_style_classes . $wrap_classes;
+			$field_wrapper_classes = " $block_style_classes $wrap_classes";
 			// Remove block style classes from the original classname.
 			$classes_without_block_style = trim( preg_replace( '/is-style-([^\s]+)/i', '', $classname ) );
 		}

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
@@ -125,7 +125,7 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 
 		// Render the shortcode.
 		$shortcode = Contact_Form_Plugin::gutenblock_render_field_checkbox_multiple( array(), '', new WP_Block( $block ) );
-		$expected  = '[contact-field type="checkbox-multiple" fieldwrapperclasses="wp-block-jetpack-field-checkbox-multiple" label="Choose several options" labelclasses="wp-block-jetpack-label has-text-color has-swamp-green-color" options="truth,dare" optionsdata="&#091;{&quot;label&quot;:&quot;truth&quot;&#044;&quot;class&quot;:&quot;has-text-color&quot;&#044;&quot;style&quot;:&quot;color:caramel; font-size:24px;&quot;}&#044;{&quot;label&quot;:&quot;dare&quot;&#044;&quot;class&quot;:&quot;has-text-color&quot;&#044;&quot;style&quot;:&quot;color:gummy; font-size:24px;&quot;}&#093;"/]';
+		$expected  = '[contact-field type="checkbox-multiple" label="Choose several options" labelclasses="wp-block-jetpack-label has-text-color has-swamp-green-color" options="truth,dare" optionsdata="&#091;{&quot;label&quot;:&quot;truth&quot;&#044;&quot;class&quot;:&quot;has-text-color&quot;&#044;&quot;style&quot;:&quot;color:caramel; font-size:24px;&quot;}&#044;{&quot;label&quot;:&quot;dare&quot;&#044;&quot;class&quot;:&quot;has-text-color&quot;&#044;&quot;style&quot;:&quot;color:gummy; font-size:24px;&quot;}&#093;" fieldwrapperclasses="wp-block-jetpack-field-checkbox-multiple"/]';
 
 		$this->assertEquals( $expected, $shortcode, 'Shortcode is not as expected' );
 	}
@@ -159,7 +159,7 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 			),
 		);
 		$shortcode = Contact_Form_Plugin::gutenblock_render_field_checkbox( array(), '', new WP_Block( $block ) );
-		$expected  = '[contact-field type="checkbox" fieldwrapperclasses="wp-block-jetpack-field-checkbox" label="single" optionclasses=" has-text-color" optionstyles="color:caramel; font-size:24px;"/]';
+		$expected  = '[contact-field type="checkbox" label="single" optionclasses=" has-text-color" optionstyles="color:caramel; font-size:24px;" fieldwrapperclasses="wp-block-jetpack-field-checkbox"/]';
 
 		$this->assertEquals( $expected, $shortcode );
 	}
@@ -209,7 +209,7 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 			),
 		);
 		$shortcode = Contact_Form_Plugin::gutenblock_render_field_text( array(), '', new WP_Block( $block ) );
-		$expected  = '[contact-field type="text" fieldwrapperclasses="wp-block-jetpack-field-text" label="Label" requiredText="Do it" labelclasses="wp-block-jetpack-label has-text-color" labelstyles="color:caramel; font-size:24px;" placeholder="hi!" min="1" max="10" inputclasses="wp-block-jetpack-input has-text-color has-border-color" inputstyles="color:toot; font-size:33rem; border-color:toot;border-width:1px;"/]';
+		$expected  = '[contact-field type="text" label="Label" requiredText="Do it" labelclasses="wp-block-jetpack-label has-text-color" labelstyles="color:caramel; font-size:24px;" placeholder="hi!" min="1" max="10" inputclasses="wp-block-jetpack-input has-text-color has-border-color" inputstyles="color:toot; font-size:33rem; border-color:toot;border-width:1px;" fieldwrapperclasses="wp-block-jetpack-field-text"/]';
 
 		$this->assertEquals( $expected, $shortcode );
 	}
@@ -282,7 +282,7 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 
 		// Render the shortcode.
 		$shortcode = Contact_Form_Plugin::gutenblock_render_field_radio( array(), '', new WP_Block( $block ) );
-		$expected  = '[contact-field type="radio" fieldwrapperclasses="wp-block-jetpack-field-radio" label="Radio gaga" labelclasses="wp-block-jetpack-label has-text-color has-turmoil-purple-color" options="freddy,brian" optionsdata="&#091;{&quot;label&quot;:&quot;freddy&quot;&#044;&quot;class&quot;:&quot;has-text-color&quot;&#044;&quot;style&quot;:&quot;color:reddo; font-size:24px;&quot;}&#044;{&quot;label&quot;:&quot;brian&quot;&#044;&quot;class&quot;:&quot;has-text-color&quot;&#044;&quot;style&quot;:&quot;color:blueo; font-size:100rem;&quot;}&#093;"/]';
+		$expected  = '[contact-field type="radio" label="Radio gaga" labelclasses="wp-block-jetpack-label has-text-color has-turmoil-purple-color" options="freddy,brian" optionsdata="&#091;{&quot;label&quot;:&quot;freddy&quot;&#044;&quot;class&quot;:&quot;has-text-color&quot;&#044;&quot;style&quot;:&quot;color:reddo; font-size:24px;&quot;}&#044;{&quot;label&quot;:&quot;brian&quot;&#044;&quot;class&quot;:&quot;has-text-color&quot;&#044;&quot;style&quot;:&quot;color:blueo; font-size:100rem;&quot;}&#093;" fieldwrapperclasses="wp-block-jetpack-field-radio"/]';
 
 		$this->assertEquals( $expected, $shortcode, 'Shortcode is not as expected' );
 	}


### PR DESCRIPTION
## Proposed changes:

Fixes https://github.com/Automattic/jetpack-roadmap/issues/2490

Follow up to https://github.com/Automattic/jetpack/pull/43184

Only apply the block style classes to the field wrapper if the field is one of the new inner block types. See: https://github.com/Automattic/jetpack/pull/43184#discussion_r2057604422

Why? The general approach has been to preserve existing forms on the frontend so that there's not style shock when https://github.com/Automattic/jetpack/pull/42890 is eventually merged.

This PR ensures that we only modify forms that have the new inner blocks introduced in https://github.com/Automattic/jetpack/pull/42890.

Thank you.

- [x] Update test cases




## Testing instructions

Create a form in trunk. Include a multi-option checkbox for example.

Save that form. Let's call it "Your form".

Now checkout this branch, and visit "Your form" on the frontend. 

Using the browser's inspector tool, check the wrapping div of the fields. They should have their regular classnames, e.g., `grunion-field-checkbox-multiple-wrap`, BUT they shouldn't have any WordPress block classes, e.g., `wp-block-jetpack-field-checkbox-multiple`. 

Edit the page with "Your form" and save.

Return to the frontend and refresh.

Now, the fields should have their regular classnames, e.g., `grunion-field-checkbox-multiple-wrap`, AND they the correct WordPress block classes, e.g., `wp-block-jetpack-field-checkbox-multiple`. 

Run the tests!

```
jetpack test php packages/forms --verbose --debug
```