### PR TITLE
Newspack Blocks: Fix Warnings in Newspack_Blocks::get_term_classes

### DIFF
--- a/projects/packages/classic-theme-helper/changelog/fix-newspack-blocks-warnings
+++ b/projects/packages/classic-theme-helper/changelog/fix-newspack-blocks-warnings
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Newspack Blocks: Fix Warnings in Newspack_Blocks::get_term_classes
+
+

--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-newspack-blocks-warnings
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-newspack-blocks-warnings
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Newspack Blocks: Fix Warnings in Newspack_Blocks::get_term_classes
+
+

--- a/projects/packages/jetpack-mu-wpcom/src/features/newspack-blocks/synced-newspack-blocks/class-newspack-blocks.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/newspack-blocks/synced-newspack-blocks/class-newspack-blocks.php
@@ -809,7 +809,9 @@ class Newspack_Blocks {
 		$categories = get_the_terms( $post_id, 'category' );
 		if ( ! empty( $categories ) ) {
 			foreach ( $categories as $cat ) {
-				$classes[] = 'category-' . $cat->slug;
+				if ( ! empty( $cat->slug ) ) {
+					$classes[] = 'category-' . $cat->slug;
+				}
 			}
 		}
 
@@ -817,7 +819,9 @@ class Newspack_Blocks {
 			$terms = get_the_terms( $post_id, $tax['slug'] );
 			if ( ! empty( $terms ) ) {
 				foreach ( $terms as $term ) {
-					$classes[] = $term->taxonomy . '-' . $term->slug;
+					if ( ! empty( $term->taxonomy ) && ! empty( $term->slug ) ) {
+						$classes[] = $term->taxonomy . '-' . $term->slug;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes the following Warnings: `Attempt to read property "slug" on null` in `class-newspack-blocks.php` line `812`.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* `Newspack_Blocks::get_term_classes`: Ensure `cat->slug` is non empty before using it. Same for `term->slug` and `term->taxonomy` a few lines after.
* Logs: p1745798781632459-slack-C034JEXD1RD

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Code Review