### PR TITLE
Jetpack Forms: Add icons for input, label, option, and options blocks

### DIFF
--- a/projects/packages/forms/src/blocks/input/index.js
+++ b/projects/packages/forms/src/blocks/input/index.js
@@ -1,4 +1,6 @@
+import { Path } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import renderMaterialIcon from '../contact-form/util/render-material-icon';
 import edit from './edit';
 import save from './save';
 
@@ -8,6 +10,11 @@ const settings = {
 	title: __( 'Input', 'jetpack-forms' ),
 	description: __( 'An input for a form field', 'jetpack-forms' ),
 	category: 'contact-form',
+	icon: {
+		src: renderMaterialIcon(
+			<Path d="M19 6.5C19.5304 6.5 20.039 6.71086 20.4141 7.08594C20.7891 7.46101 21 7.96957 21 8.5V15C21 15.5304 20.7891 16.039 20.4141 16.4141C20.039 16.7891 19.5304 17 19 17H5C4.46957 17 3.96101 16.7891 3.58594 16.4141C3.21086 16.039 3 15.5304 3 15V8.5C3 7.96957 3.21086 7.46101 3.58594 7.08594C3.96101 6.71086 4.46957 6.5 5 6.5H19ZM5 8C4.86739 8 4.74025 8.05272 4.64648 8.14648C4.55272 8.24025 4.5 8.36739 4.5 8.5V15C4.5 15.1326 4.55272 15.2597 4.64648 15.3535C4.74025 15.4473 4.86739 15.5 5 15.5H19C19.1326 15.5 19.2597 15.4473 19.3535 15.3535C19.4473 15.2597 19.5 15.1326 19.5 15V8.5C19.5 8.36739 19.4473 8.24025 19.3535 8.14648C19.2597 8.05272 19.1326 8 19 8H5Z" />
+		),
+	},
 	parent: [
 		'jetpack/field-date',
 		'jetpack/field-email',

--- a/projects/packages/forms/src/blocks/label/index.js
+++ b/projects/packages/forms/src/blocks/label/index.js
@@ -1,4 +1,6 @@
+import { Path } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import renderMaterialIcon from '../contact-form/util/render-material-icon';
 import edit from './edit';
 import save from './save';
 
@@ -8,6 +10,11 @@ const settings = {
 	title: __( 'Label', 'jetpack-forms' ),
 	description: __( 'A label for a form field', 'jetpack-forms' ),
 	category: 'contact-form',
+	icon: {
+		src: renderMaterialIcon(
+			<Path d="M12.9 6H10.9L6.90002 17H8.80002L9.90002 14H14.1L15.2 17H17.1L12.9 6ZM10.4 12.5L11.9 7.6L13.6 12.5H10.4Z" />
+		),
+	},
 	parent: [
 		'jetpack/field-date',
 		'jetpack/field-email',

--- a/projects/packages/forms/src/blocks/option/index.js
+++ b/projects/packages/forms/src/blocks/option/index.js
@@ -1,4 +1,6 @@
+import { Path } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import renderMaterialIcon from '../contact-form/util/render-material-icon';
 import edit from './edit';
 import save from './save';
 
@@ -8,6 +10,9 @@ const settings = {
 	title: __( 'Option', 'jetpack-forms' ),
 	description: __( 'An option for a form choice field', 'jetpack-forms' ),
 	category: 'contact-form',
+	icon: {
+		src: renderMaterialIcon( <Path d="M5 11.25H19V12.75H5V11.25Z" /> ),
+	},
 	parent: [ 'jetpack/field-checkbox', 'jetpack/field-consent', 'jetpack/options' ],
 	supports: {
 		reusable: false,

--- a/projects/packages/forms/src/blocks/options/index.js
+++ b/projects/packages/forms/src/blocks/options/index.js
@@ -1,4 +1,6 @@
+import { Path } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import renderMaterialIcon from '../contact-form/util/render-material-icon';
 import edit from './edit';
 import save from './save';
 
@@ -8,6 +10,11 @@ const settings = {
 	title: __( 'Options', 'jetpack-forms' ),
 	description: __( 'A wrapper for a group of options', 'jetpack-forms' ),
 	category: 'contact-form',
+	icon: {
+		src: renderMaterialIcon(
+			<Path d="M11.1 15.8H20V14.3H11.1V15.8ZM11.1 7.2V8.7H20V7.2H11.1ZM6 13C4.9 13 4 13.9 4 15C4 16.1 4.9 17 6 17C7.1 17 8 16.1 8 15C8 13.9 7.1 13 6 13ZM6 6C4.9 6 4 6.9 4 8C4 9.1 4.9 10 6 10C7.1 10 8 9.1 8 8C8 6.9 7.1 6 6 6Z" />
+		),
+	},
 	parent: [ 'jetpack/field-multiple-choice', 'jetpack/field-single-choice' ],
 	attributes: {
 		type: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of JETPACK-276

Note, this PR is branched from #42890, so will merge into that larger PR, rather than trunk. This is to ensure tasks like this one remain granular and self-contained.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add SVG icons for input, label, option, and options blocks
* Do not use the "green" color for these blocks
* NOTE: there's also the proposal to remove the green color from the other form block icons. To keep things granular, I've left that change out of this PR. Happy to work on it in another PR, though!
* Also, I've left out a changelogger entry since that'll be covered by the main PR

### Screenshot

<img width="349" alt="image" src="https://github.com/user-attachments/assets/53f0ed8f-f435-4a1f-9c81-149a5aad69cc" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add a Jetpack Form to a post or page
* Ensure the form contains enough fields so that you can see the input, label, option, and options blocks in the list view. See the screenshot above as an example.
* Double-check that the block icons look okay while selected as well (they should invert correctly to white)

