### PR TITLE
Appearance menu: Add Additional CSS menu for classic themes

### DIFF
--- a/projects/packages/masterbar/changelog/fix-add-additional-css-on-atomic
+++ b/projects/packages/masterbar/changelog/fix-add-additional-css-on-atomic
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Add the Additional CSS in the Appearance menu for Atomic sites

--- a/projects/packages/masterbar/src/admin-menu/class-atomic-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-atomic-admin-menu.php
@@ -110,6 +110,26 @@ class Atomic_Admin_Menu extends Admin_Menu {
 	}
 
 	/**
+	 * Add the appearance menu.
+	 *
+	 * @return string
+	 */
+	public function add_appearance_menu() {
+		$customize_url                 = parent::add_appearance_menu();
+		$should_display_additional_css = current_user_can( 'customize' ) && ! wp_is_block_theme();
+
+		if ( ! $should_display_additional_css ) {
+			return $customize_url;
+		}
+
+		$customize_custom_css_url = add_query_arg( array( 'autofocus' => array( 'section' => 'custom_css' ) ), $customize_url );
+		// @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
+		add_submenu_page( 'themes.php', esc_attr__( 'Additional CSS', 'jetpack-masterbar' ), __( 'Additional CSS', 'jetpack-masterbar' ), 'customize', esc_url( $customize_custom_css_url ), null, 20 );
+
+		return $customize_url;
+	}
+
+	/**
 	 * Adds Users menu.
 	 */
 	public function add_users_menu() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR re-adds the Additional CSS submenu item that was removed from Jetpack. The menu is visible only for Atomic sites that are using a classic theme.

Fixes linear DOTCOM-10681

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Bring back Additional CSS in Appearance menu for Atomic sites

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Use Jetpack beta and install this branch on your AT Dev Site
* Notice that the Additional CSS submenu is now visible in Appearance
* Click on it
* Notice that you are redirected to the Additional CSS page
* Click X (close)
* Notice you are redirected back to the correct page on your site

