### PR TITLE
Update Open AI proxy endpoint to the new AI API proxy endpoint

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/update-ai-proxy-endpoint
+++ b/projects/github-actions/repo-gardening/changelog/update-ai-proxy-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Updates AI Proxy Endpoint to the new AI API Proxy drop-in replacement

--- a/projects/github-actions/repo-gardening/src/utils/openai/send-request.js
+++ b/projects/github-actions/repo-gardening/src/utils/openai/send-request.js
@@ -19,7 +19,7 @@ async function sendOpenAiRequest( message, responseFormat = 'plain' ) {
 
 	const client = new OpenAI( {
 		apiKey,
-		baseURL: 'https://public-api.wordpress.com/wpcom/v2/openai-proxy/v1',
+		baseURL: 'https://public-api.wordpress.com/wpcom/v2/ai-api-proxy/v1',
 	} );
 
 	debug( 'openai: Sending message to OpenAI.' );


### PR DESCRIPTION
See AI-148
## Proposed changes:

This PR switches the Open AI proxy to the newer generalized AI Proxy endpoint. This endpoint is a drop-in replacement, but is the new intended path.

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:
I'm not sure how to test the repo gardening functionality -- cc @jeherve could you help me here?

