### PR TITLE
docker: fix Xdebug on Linux hosts

### DIFF
--- a/tools/docker/docker-compose.yml
+++ b/tools/docker/docker-compose.yml
@@ -49,3 +49,5 @@ services:
     environment:
       - HOST_PORT=${PORT_WORDPRESS:-80}
       - COMPOSE_PROJECT_NAME=$COMPOSE_PROJECT_NAME
+    extra_hosts:
+      - 'host.docker.internal:host-gateway'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes Xdebug when the host is a Linux machine.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

The [guide on debugging with Xdebug on Docker][1] wasn't working for me. While reviewing `/var/log/php/xdebug_remote.log`, I noticed the following errors:

```
[34] [Step Debug] INFO: Connecting to configured address/port: host.docker.internal:9003.
[34] [Step Debug] WARN: Creating socket for 'host.docker.internal:9003', getaddrinfo: No such file or directory.
[34] [Step Debug] ERR: Could not connect to debugging client. Tried: host.docker.internal:9003 (through xdebug.client_host/xdebug.client_port).
```

I confirmed that `host.docker.internal` was not present in `/etc/hosts`:

```
root@b4654185c15c:/var/www/html# grep host.docker.internal /etc/hosts
```

This makes sense, as `host.docker.internal` appears to be a Docker Desktop feature [available on macOS and Windows, but not on Linux][2].

Explicitly [adding it to Docker Compose][3] resolves the issue:

```
[34] [Step Debug] INFO: Connecting to configured address/port: host.docker.internal:9003.
[34] [Step Debug] INFO: Connected to debugging client: host.docker.internal:9003 (through xdebug.client_host/xdebug.client_port).
[34] [Step Debug] -> <init xmlns="urn:debugger_protocol_v1" xmlns:xdebug="https://xdebug.org/dbgp/xdebug" fileuri="file:///var/www/html/index.php" language="PHP" xdebug:language_version="8.2.27" protocol_version="1.0" appid="34" idekey="VSCODE"><engine version="3.4.1"><![CDATA[Xdebug]]></engine><author><![CDATA[Derick Rethans]]></author><url><![CDATA[https://xdebug.org]]></url><copyright><![CDATA[Copyright (c) 2002-2025 by Derick Rethans]]></copyright></init>
```

```
root@b4d5c89af4c7:/var/www/html# grep host.docker.internal /etc/hosts
172.17.0.1      host.docker.internal
```

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Try accessing any Jetpack local development page with Xdebug enabled in the browser.
* Check `/var/log/php/xdebug_remote.log` and confirm that there are no errors.

[1]: https://github.com/Automattic/jetpack/blob/59ea1b80bf0251adad53cdb558a168cf1a583591/tools/docker/README.md#debugging-php-with-xdebug
[2]: https://www.reddit.com/r/docker/comments/idu7e0/comment/g2berah/
[3]: https://stackoverflow.com/a/67158212