### PR TITLE
WPCOM_JSON_API_GET_Site_Endpoint: Stop fetching site_goals twice

### DIFF
--- a/projects/plugins/jetpack/changelog/remove-site-goals-duplicate
+++ b/projects/plugins/jetpack/changelog/remove-site-goals-duplicate
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: WPCOM_JSON_API_GET_Site_Endpoint: Stop fetching site_goals twice
+
+

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -207,7 +207,6 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'is_difm_lite_in_progress',
 		'site_intent',
 		'site_partner_bundle',
-		'site_goals',
 		'onboarding_segment',
 		'site_vertical_id',
 		'blogging_prompts_settings',


### PR DESCRIPTION
## Proposed changes:

* There's no need to fetch site_goals once, then do it again and overwrite it. Once will do.

Before my diff, it shows up twice in the list:

<img width="404" alt="Screenshot 2025-04-28 at 5 20 44 PM" src="https://github.com/user-attachments/assets/cca433e0-e038-47d5-9f24-991169d8011e" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?

## Testing instructions:

* Go to '..'
*

