### PR TITLE
Jetpack Sync: Fix checksum support for 'woocommerce_order_itemeta' table

### DIFF
--- a/projects/packages/sync/changelog/fix-sync-checksum-woo-meta
+++ b/projects/packages/sync/changelog/fix-sync-checksum-woo-meta
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Jetpack Sync: Fix checksum support for 'woocommerce_order_itemeta' table

--- a/projects/packages/sync/src/replicastore/class-table-checksum.php
+++ b/projects/packages/sync/src/replicastore/class-table-checksum.php
@@ -306,7 +306,9 @@ class Table_Checksum {
 				'parent_table'              => 'woocommerce_order_items',
 				'parent_join_field'         => 'order_item_id',
 				'table_join_field'          => 'order_item_id',
-				'is_table_enabled_callback' => 'Automattic\Jetpack\Sync\Replicastore\Table_Checksum::enable_woocommerce_tables',
+				'is_table_enabled_callback' => function () {
+					return false !== Sync\Modules::get_module( 'meta' ) && self::enable_woocommerce_tables();
+				},
 			),
 			'wc_orders'                  => array(
 				'table'                     => "{$wpdb->prefix}wc_orders",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes VULCAN-81

There is a logic error when it comes to [checking Sync Checksum support](https://github.com/Automattic/jetpack/blob/trunk/projects/packages/sync/src/replicastore/class-table-checksum.php#L309) for `woocommerce_order_itemmeta` in the Sync package logic.

We treat it the same way we do for the rest WooCommerce modules by only checking if the Sync WooCommerce module is enabled, however `woocommerce_order_itemmeta` also relies on the Sync Meta module.

**The bug is only reproducible when Sync is configured by its consumers to NOT activate the Meta module.** Such a consumer is the [WooCommerce Analytics plugin](https://github.com/woocommerce/woocommerce-analytics/blob/develop/src/Internal/Jetpack/Sync/Configuration.php#L60).

What happens in this case is that while we can successfully calculate the checksum for `woocommerce_order_itemmeta` table on both ends (remote site and Cache site), when we later attempt to actually fix the discrepancies via a Fix Checksum all requests to fetch the remote sync objects fail with an `invalid_module` [error](https://github.com/Automattic/jetpack/blob/trunk/projects/packages/sync/src/class-rest-endpoints.php#L559).  

In order to fix the bug we need to confirm the Meta module is enabled [here](https://github.com/Automattic/jetpack/blob/trunk/projects/packages/sync/src/replicastore/class-table-checksum.php#L309)

If the module is not enabled we don't want to take it into account during simple, detailed or fix checksums, since there's no use in calculating the checksums but not being able to fix the discrepancies.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* `Table_Checksum::get_default_tables`: Update `is_table_enabled_callback` for `woocommerce_order_itemmeta` to ensure we also check that the Sync Meta module is active.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* See VULCAN-81

