### PR TITLE
Boost: Add the rest of the global variables for WP CLI

### DIFF
--- a/projects/plugins/super-cache/changelog/fix-super-cache-wp-cli-global-variables
+++ b/projects/plugins/super-cache/changelog/fix-super-cache-wp-cli-global-variables
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+General: improve WP CLI support by making variables global

--- a/projects/plugins/super-cache/wp-cache.php
+++ b/projects/plugins/super-cache/wp-cache.php
@@ -125,6 +125,17 @@ global $wp_cache_preload_email_me, $wp_cache_preload_email_volume;
 global $wp_cache_mobile, $wp_cache_mobile_enabled, $wp_cache_mobile_browsers, $wp_cache_mobile_prefixes;
 global $wp_cache_config_file, $wp_cache_config_file_sample;
 
+// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+global $wpsc_advanced_cache_filename, $wpsc_advanced_cache_dist_filename;
+global $wp_cache_phase1_loaded, $blog_cache_dir, $wp_supercache_304, $wp_cache_mfunc_enabled;
+global $wp_cache_front_page_checks, $wpsc_save_headers, $is_nginx, $wpsc_promo_links;
+global $wp_cache_disable_utf8, $wp_cache_not_logged_in, $wp_cache_make_known_anon;
+global $wpsc_tracking_parameters, $wpsc_rejected_cookies, $cache_rejected_uri;
+global $cache_acceptable_files, $wp_super_cache_comments;
+global $wp_super_cache_front_page_check, $wp_super_cache_front_page_clear;
+global $wp_super_cache_front_page_text, $wp_super_cache_front_page_notification;
+global $wpsc_plugins, $wpsc_cookies, $wpsc_version, $wp_cache_clear_on_post_edit;
+// phpcs:enable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 // Check is cache config already loaded.
 if ( ! isset( $cache_enabled, $super_cache_enabled, $wp_cache_mod_rewrite, $cache_path ) &&
 	empty( $wp_cache_phase1_loaded ) &&


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

WP CLI loads WordPress through a function and the global variables used by WP Super Cache have to be declared global. We did this with most variables, but it [was reported](https://wordpress.org/support/topic/not-working-properly-when-processed-with-wp-cli-cron/) one was missing.
I added many more in this PR.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add global variables to wp-cache.php

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply PR
* Test WP CLI code that interact with the cache.

