### PR TITLE
Full sync: Ensure procesing of start end cancel actions in wpcom

### DIFF
--- a/projects/packages/sync/changelog/update-full-sync-ensure-procesing-of-start-end-cancel-actions-in-wpcom
+++ b/projects/packages/sync/changelog/update-full-sync-ensure-procesing-of-start-end-cancel-actions-in-wpcom
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Full Sync: Ensure procesing of start end and cancelled actions

--- a/projects/packages/sync/src/modules/class-full-sync-immediately.php
+++ b/projects/packages/sync/src/modules/class-full-sync-immediately.php
@@ -486,13 +486,18 @@ class Full_Sync_Immediately extends Module {
 	}
 
 	/**
-	 * Send 'jetpack_full_sync_end' and update 'finished' status.
+	 *  Sends the `jetpack_full_sync_end` action and updates the status when the full sync end action is processed.
 	 *
 	 * @access public
 	 */
 	public function send_full_sync_end() {
 		$range = $this->get_content_range( $this->get_status()['config'] );
 
+		$result = $this->send_action( 'jetpack_full_sync_end', array( '', $range ) );
+
+		if ( is_wp_error( $result ) ) { // Do not set finished status if we get an error.
+			return;
+		}
 		/**
 		 * Fires when a full sync ends. This action is serialized
 		 * and sent to the server.
@@ -505,7 +510,6 @@ class Full_Sync_Immediately extends Module {
 		 * @since-jetpack 7.3.0 Added $range arg.
 		 */
 		do_action( 'jetpack_full_sync_end', '', $range );
-		$this->send_action( 'jetpack_full_sync_end', array( '', $range ) );
 
 		// Setting autoload to true means that it's faster to check whether we should continue enqueuing.
 		$this->update_status( array( 'finished' => time() ) );

--- a/projects/packages/sync/src/modules/class-full-sync-immediately.php
+++ b/projects/packages/sync/src/modules/class-full-sync-immediately.php
@@ -66,15 +66,13 @@ class Full_Sync_Immediately extends Module {
 	 */
 	public function start( $full_sync_config = null, $context = null ) {
 		// There was a full sync in progress.
-		if ( $this->is_started() && ! $this->is_finished() ) {
-			/**
-			 * Fires when a full sync is cancelled.
-			 *
-			 * @since 1.6.3
-			 * @since-jetpack 4.2.0
-			 */
-			do_action( 'jetpack_full_sync_cancelled' );
-			$this->send_action( 'jetpack_full_sync_cancelled' );
+		if ( $this->get_status()['start_action_processed'] && ! $this->is_finished() ) {
+			// Mark that we must send 'cancelled' action.
+			$this->update_status(
+				array(
+					'cancelled_action_processed' => false,
+				)
+			);
 		}
 
 		// Remove all evidence of previous full sync items and status.
@@ -131,12 +129,13 @@ class Full_Sync_Immediately extends Module {
 	 */
 	public function get_status() {
 		$default = array(
-			'start_action_processed' => false,
-			'started'                => false,
-			'finished'               => false,
-			'progress'               => array(),
-			'config'                 => array(),
-			'context'                => null,
+			'start_action_processed'     => false,
+			'cancelled_action_processed' => true, // true by default to avoid sending the action when there is no need,
+			'started'                    => false,
+			'finished'                   => false,
+			'progress'                   => array(),
+			'config'                     => array(),
+			'context'                    => null,
 		);
 
 		return wp_parse_args( \Jetpack_Options::get_raw_option( self::STATUS_OPTION ), $default );
@@ -373,6 +372,10 @@ class Full_Sync_Immediately extends Module {
 	 */
 	public function send() {
 
+		if ( ! $this->maybe_send_cancelled_action() ) {
+			return false;
+		}
+
 		if ( ! $this->maybe_send_full_sync_start() ) {
 			return false;
 		}
@@ -482,6 +485,35 @@ class Full_Sync_Immediately extends Module {
 			)
 		);
 
+		return true;
+	}
+
+	/**
+	 * Sends the `jetpack_full_sync_cancelled` action if it hasn't been processed yet.
+	 *
+	 * @return bool True if the action was successfully sent or already processed, false on failure.
+	 */
+	private function maybe_send_cancelled_action() {
+		$status = $this->get_status();
+
+		if ( true === $status['cancelled_action_processed'] ) {
+			return true;
+		}
+
+		$result = $this->send_action( 'jetpack_full_sync_cancelled' );
+
+		if ( is_wp_error( $result ) ) {
+			return false;
+		}
+
+		/**
+		 * Fires when a full sync is cancelled.
+		 *
+		 * @since 1.6.3
+		 * @since-jetpack 4.2.0
+		 */
+		do_action( 'jetpack_full_sync_cancelled' );
+		$this->update_status( array( 'cancelled_action_processed' => true ) );
 		return true;
 	}
 

--- a/projects/packages/sync/src/modules/class-full-sync-immediately.php
+++ b/projects/packages/sync/src/modules/class-full-sync-immediately.php
@@ -65,18 +65,19 @@ class Full_Sync_Immediately extends Module {
 	 * @return bool Always returns true at success.
 	 */
 	public function start( $full_sync_config = null, $context = null ) {
-		// There was a full sync in progress.
-		if ( $this->get_status()['start_action_processed'] && ! $this->is_finished() ) {
-			// Mark that we must send 'cancelled' action.
+		// Check if there was a full sync in progress already before resetting the data.
+		$should_process_cancelled_action = $this->get_status()['start_action_processed'] && ! $this->is_finished() ? true : false;
+		// Remove all evidence of previous full sync items and status.
+		$this->reset_data();
+
+		// Update status to indicate that a new full sync is starting and need to cancel previous one.
+		if ( $should_process_cancelled_action ) {
 			$this->update_status(
 				array(
 					'cancelled_action_processed' => false,
 				)
 			);
 		}
-
-		// Remove all evidence of previous full sync items and status.
-		$this->reset_data();
 
 		if ( ! is_array( $full_sync_config ) ) {
 			/*

--- a/projects/packages/sync/src/modules/class-full-sync-immediately.php
+++ b/projects/packages/sync/src/modules/class-full-sync-immediately.php
@@ -100,30 +100,13 @@ class Full_Sync_Immediately extends Module {
 			$full_sync_config['users'] = $users_module->get_initial_sync_user_config();
 		}
 
-		$range = $this->get_content_range( $full_sync_config );
-
 		$this->update_status(
 			array(
-				'started'  => time(),
-				'config'   => $full_sync_config,
-				'progress' => $this->get_initial_progress( $full_sync_config, $range ),
+				'started' => time(),
+				'config'  => $full_sync_config,
+				'context' => $context,
 			)
 		);
-		/**
-		 * Fires when a full sync begins. This action is serialized
-		 * and sent to the server so that it knows a full sync is coming.
-		 *
-		 * @param array $full_sync_config Sync configuration for all sync modules.
-		 * @param array $range Range of the sync items, containing min and max IDs for some item types.
-		 * @param mixed $context The context where the full sync was initiated from.
-		 *
-		 * @since 1.6.3
-		 * @since-jetpack 4.2.0
-		 * @since-jetpack 7.3.0 Added $range arg.
-		 * @since 4.4.0 Added $context arg.
-		 */
-		do_action( 'jetpack_full_sync_start', $full_sync_config, $range );
-		$this->send_action( 'jetpack_full_sync_start', array( $full_sync_config, $range, $context ) );
 
 		return true;
 	}
@@ -148,10 +131,12 @@ class Full_Sync_Immediately extends Module {
 	 */
 	public function get_status() {
 		$default = array(
-			'started'  => false,
-			'finished' => false,
-			'progress' => array(),
-			'config'   => array(),
+			'start_action_processed' => false,
+			'started'                => false,
+			'finished'               => false,
+			'progress'               => array(),
+			'config'                 => array(),
+			'context'                => null,
 		);
 
 		return wp_parse_args( \Jetpack_Options::get_raw_option( self::STATUS_OPTION ), $default );
@@ -387,6 +372,10 @@ class Full_Sync_Immediately extends Module {
 	 * @access public
 	 */
 	public function send() {
+
+		if ( ! $this->maybe_send_full_sync_start() ) {
+			return false;
+		}
 		$config = $this->get_status()['config'];
 
 		$max_duration = Settings::get_setting( 'full_sync_send_duration' );
@@ -442,6 +431,58 @@ class Full_Sync_Immediately extends Module {
 			}
 		}
 		return $remaining_modules;
+	}
+
+	/**
+	 * Sends the `jetpack_full_sync_start` action if it hasn't been processed yet.
+	 *
+	 * Prepares the full sync start action, sends it to WordPress.com, fires the local action,
+	 * and updates the sync status to reflect that the start action has been processed.
+	 *
+	 * @return bool True if the action was successfully sent or already processed, false on failure.
+	 */
+	private function maybe_send_full_sync_start() {
+		$status = $this->get_status();
+
+		// If already processed, nothing to do.
+		if ( ! $status['start_action_processed'] ) {
+			return true;
+		}
+
+		$config  = $status['config'];
+		$context = $status['context'];
+		$range   = $this->get_content_range( $config );
+
+		$result = $this->send_action( 'jetpack_full_sync_start', array( $config, $range, $context ) );
+
+		// If the action failed on WordPress.com, return false.
+		if ( is_wp_error( $result ) ) {
+			return false;
+		}
+
+		/**
+		 * Fires when a full sync begins. This action is serialized
+		 * and sent to the server so that it knows a full sync is coming.
+		 *
+		 * @param array $config Sync configuration for all sync modules.
+		 * @param array $range Range of the sync items, containing min and max IDs for some item types.
+		 * @param mixed $context The context where the full sync was initiated from.
+		 *
+		 * @since 1.6.3
+		 * @since-jetpack 4.2.0
+		 * @since-jetpack 7.3.0 Added $range arg.
+		 * @since 4.4.0 Added $context arg.
+		 */
+		do_action( 'jetpack_full_sync_start', $config, $range );
+
+		$this->update_status(
+			array(
+				'start_action_processed' => true,
+				'progress'               => $this->get_initial_progress( $config, $range ),
+			)
+		);
+
+		return true;
 	}
 
 	/**

--- a/projects/packages/sync/src/modules/class-full-sync-immediately.php
+++ b/projects/packages/sync/src/modules/class-full-sync-immediately.php
@@ -445,7 +445,7 @@ class Full_Sync_Immediately extends Module {
 		$status = $this->get_status();
 
 		// If already processed, nothing to do.
-		if ( ! $status['start_action_processed'] ) {
+		if ( true === $status['start_action_processed'] ) {
 			return true;
 		}
 

--- a/projects/plugins/jetpack/changelog/update-full-sync-ensure-procesing-of-start-end-cancel-actions-in-wpcom
+++ b/projects/plugins/jetpack/changelog/update-full-sync-ensure-procesing-of-start-end-cancel-actions-in-wpcom
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Full Sync: updated tests related to changes in the Sync package


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes VULCAN-74

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
- **Full Sync Status Enhancements**:
  - Add three new keys to the full sync status:
    - `start_action_processed`: Tracks whether the `jetpack_full_sync_start` action has been successfully processed.
    - `cancelled_action_processed`: Tracks whether the `jetpack_full_sync_cancelled` action has been successfully processed.
    - `context`: Stores the original context (e.g., initial-sync ) of the full sync request.
- **New Private Methods**:
  - `maybe_send_cancelled_action()`:
    - Tries to send the `jetpack_full_sync_cancelled` action if needed.
    - Updates the status upon successful sending.
    - Retries sending on future runs if the action fails.
  - `maybe_send_full_sync_start()`:
    - Tries to send the `jetpack_full_sync_start` action if needed.
    - Updates the progress and marks the start action as processed upon success.
    - Retries on future runs if sending fails.
- **Update `send()` Flow**:
  - Always call `maybe_send_cancelled_action()` first.
  - Then call `maybe_send_full_sync_start()`.
  - Only proceed with sending regular sync items after both actions have been successfully processed.
  - Fail early if sending either the cancel or start action fails.
- **Update `send_full_sync_end()`**:
  - Ensure `jetpack_full_sync_end` is sent before marking the sync as finished.
  - Skip setting `finished` status if sending `full_sync_end` fails.


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### Run a Full Sync and check nothing major changed

In Debugger, run a Full Sync of Everything and check that all actions are processed as expected.

### Try sabotaging the different actions to see that we retry them until they are processed
Similar to what was done in https://github.com/Automattic/jetpack/pull/43229, we will sabotage the processing of full sync actions in WPCOM by adding something like below snippet inside `process_event` after getting the action name. 
```
if ( 'jetpack_full_sync_start' === $action_name ) {
	error_log('Trying start but not allowed');
	die();
}
```

Also, to speed up things, we could lower [LOCK_TRANSIENT_EXPIRY](https://github.com/Automattic/jetpack/blob/trunk/projects/packages/sync/src/class-lock.php#L32) to something like 10s. We could also lower the 60 seconds to 10 [here](https://github.com/Automattic/jetpack/blob/trunk/projects/packages/sync/src/class-actions.php#L539) since we will be processing WP_Errors and setting the RETRY_AFTER_PREFIX option to not try after 1 minute. 
**Start**
- Sabotage the `jetpack_full_sync_start` action, start a full sync.
- Start a Full Sync
- Check that you get the error in your sandbox.
- Refresh wp_admin after a minute ( or whatever time you need to wait based on LOCK and RETRY) and check that we try again to send a start action by seeing the log again.
- No matter how long you wait, the Full Sync will not send any module. Debugger marks the Full SYnc as started which is correct and is based on the status, but the new `start_action_processed` should be set to false

**Cancelled**
- Remove the sabotaging for a moment and check that Full Sync is in progress in Debugger
- Soon after that (while the Full Sync is in progress), sabotage the full sync but this time for the `jetpack_full_sync_cancelled` action. Change the error message to show `Trying cancelled but not allowed`
- Start a new Full Sync
- Check that you get the new error in your sandbox.
- Refresh wp_admin and check that Full Sync does not proceed. 
- No matter how long you wait, the Full Sync will not proceed.
- Remove the sabotaging.
- By refreshing wp_admin, check that Full Sync actions start to flow again for the new full sync.

**End**
- Sabotage the  `jetpack_full_sync_end` action. Change the error message to show `Trying end but not allowed`
- Check that you get the new error in your sandbox.
- Refresh wp_admin and check that Full Sync never really finishes.
- No matter how long you wait, the Full Sync will never finish.
- Remove the sabotaging.
- Refresh wp_admin and check that Full Sync finishes.