### PR TITLE
VideoPress: Fix mass PHP notices

### DIFF
--- a/projects/packages/videopress/changelog/fix-videopress-mass_notices
+++ b/projects/packages/videopress/changelog/fix-videopress-mass_notices
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Prevent PHP warnings when post is invalid.

--- a/projects/packages/videopress/src/utility-functions.php
+++ b/projects/packages/videopress/src/utility-functions.php
@@ -497,14 +497,15 @@ function video_get_info_by_blogpostid( $blog_id, $post_id ) {
 	$video_info->guid            = null;
 	$video_info->finish_date_gmt = '0000-00-00 00:00:00';
 	$video_info->rating          = null;
-	$video_info->description     = $post->post_content;
-	$video_info->title           = $post->post_title;
-	$video_info->caption         = $post->post_excerpt;
 	$video_info->privacy_setting = VIDEOPRESS_PRIVACY::SITE_DEFAULT;
 
-	if ( is_wp_error( $post ) ) {
+	if ( ! post || is_wp_error( $post ) ) {
 		return $video_info;
 	}
+
+	$video_info->description = $post->post_content;
+	$video_info->title       = $post->post_title;
+	$video_info->caption     = $post->post_excerpt;
 
 	if ( 'video/videopress' !== $post->post_mime_type ) {
 		return $video_info;

--- a/projects/packages/videopress/src/utility-functions.php
+++ b/projects/packages/videopress/src/utility-functions.php
@@ -486,7 +486,7 @@ function videopress_make_resumable_upload_path( $blog_id ) {
  *
  * @param int $blog_id Blog ID.
  * @param int $post_id Post ID.
- * @return bool|stdClass
+ * @return stdClass
  */
 function video_get_info_by_blogpostid( $blog_id, $post_id ) {
 	$post = get_post( $post_id );

--- a/projects/packages/videopress/src/utility-functions.php
+++ b/projects/packages/videopress/src/utility-functions.php
@@ -492,7 +492,10 @@ function video_get_info_by_blogpostid( $blog_id, $post_id ) {
 	$post = get_post( $post_id );
 
 	$video_info                  = new stdClass();
-	$video_info->post_id         = $post_id;
+	$video_info->post_id         = 0;
+	$video_info->description     = '';
+	$video_info->title           = '';
+	$video_info->caption         = '';
 	$video_info->blog_id         = $blog_id;
 	$video_info->guid            = null;
 	$video_info->finish_date_gmt = '0000-00-00 00:00:00';
@@ -503,6 +506,7 @@ function video_get_info_by_blogpostid( $blog_id, $post_id ) {
 		return $video_info;
 	}
 
+	$video_info->post_id     = $post_id;
 	$video_info->description = $post->post_content;
 	$video_info->title       = $post->post_title;
 	$video_info->caption     = $post->post_excerpt;

--- a/projects/packages/videopress/src/utility-functions.php
+++ b/projects/packages/videopress/src/utility-functions.php
@@ -499,7 +499,7 @@ function video_get_info_by_blogpostid( $blog_id, $post_id ) {
 	$video_info->rating          = null;
 	$video_info->privacy_setting = VIDEOPRESS_PRIVACY::SITE_DEFAULT;
 
-	if ( ! post || is_wp_error( $post ) ) {
+	if ( ! $post ) {
 		return $video_info;
 	}
 

--- a/projects/packages/videopress/tests/php/Utility_Functions_Test.php
+++ b/projects/packages/videopress/tests/php/Utility_Functions_Test.php
@@ -29,7 +29,7 @@ class Utility_Functions_Test extends BaseTestCase {
 	 */
 	public function test_video_get_info_by_blogpostid_invalid_post_id() {
 		$blog_id = 1;
-		$post_id = null;
+		$post_id = -1;
 
 		$video_info = video_get_info_by_blogpostid( $blog_id, $post_id );
 

--- a/projects/packages/videopress/tests/php/Utility_Functions_Test.php
+++ b/projects/packages/videopress/tests/php/Utility_Functions_Test.php
@@ -126,6 +126,6 @@ class Utility_Functions_Test extends BaseTestCase {
 		$this->assertSame( 'G', $video_info->rating );
 		$this->assertSame( 1, $video_info->allow_download );
 		$this->assertSame( 1, $video_info->display_embed );
-		$this->assertSame( 1, $video_info->privacy_setting ); // 2 = Private
+		$this->assertSame( 1, $video_info->privacy_setting ); // 1 = Private
 	}
 }

--- a/projects/packages/videopress/tests/php/Utility_Functions_Test.php
+++ b/projects/packages/videopress/tests/php/Utility_Functions_Test.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * Tests for functions defined in utility-functions.php.
+ *
+ * @package automattic/jetpack-videopress
+ */
+
+namespace Automattic\Jetpack;
+
+use PHPUnit\Framework\Attributes\BeforeClass;
+use WorDBless\BaseTestCase;
+use WorDBless\Posts;
+
+class Utility_Functions_Test extends BaseTestCase {
+
+	/**
+	 * Sets up the test environment before the class tests begin.
+	 *
+	 * @beforeClass
+	 */
+	#[BeforeClass]
+	public static function set_up_class() {
+		require_once __DIR__ . '/../../src/utility-functions.php';
+		Posts::init();
+	}
+
+	/**
+	 * Test video_get_info_by_blogpostid when $post_id is invalid.
+	 */
+	public function test_video_get_info_by_blogpostid_invalid_post_id() {
+		$blog_id = 1;
+		$post_id = null;
+
+		$video_info = video_get_info_by_blogpostid( $blog_id, $post_id );
+
+		// Check that the returned object has default values
+		$this->assertInstanceOf( 'stdClass', $video_info );
+		$this->assertSame( 0, $video_info->post_id );
+		$this->assertSame( '', $video_info->description );
+		$this->assertSame( '', $video_info->title );
+		$this->assertSame( '', $video_info->caption );
+		$this->assertSame( $blog_id, $video_info->blog_id );
+		$this->assertNull( $video_info->guid );
+		$this->assertSame( '0000-00-00 00:00:00', $video_info->finish_date_gmt );
+		$this->assertNull( $video_info->rating );
+		$this->assertSame( 2, $video_info->privacy_setting ); // 2 = Site default
+	}
+
+	/**
+	 * Test video_get_info_by_blogpostid with non-VideoPress $post_id.
+	 */
+	public function test_video_get_info_by_blogpostid_non_videopress_post() {
+		$blog_id = 1;
+
+		$post_id = wp_insert_post(
+			array(
+				'post_type'      => 'attachment',
+				'post_mime_type' => 'image/jpeg',
+				'post_title'     => 'Test image',
+				'post_content'   => 'Test content',
+				'post_excerpt'   => 'Test caption',
+			)
+		);
+
+		$video_info = video_get_info_by_blogpostid( $blog_id, $post_id );
+
+		// Check that the returned object has basic post data but no VideoPress specific data
+		$this->assertInstanceOf( 'stdClass', $video_info );
+		$this->assertSame( $post_id, $video_info->post_id );
+		$this->assertSame( $blog_id, $video_info->blog_id );
+		$this->assertSame( 'Test content', $video_info->description );
+		$this->assertSame( 'Test image', $video_info->title );
+		$this->assertSame( 'Test caption', $video_info->caption );
+		$this->assertNull( $video_info->guid );
+		$this->assertSame( '0000-00-00 00:00:00', $video_info->finish_date_gmt );
+		$this->assertNull( $video_info->rating );
+		$this->assertSame( 2, $video_info->privacy_setting ); // 2 = Site default
+	}
+
+	/**
+	 * Test video_get_info_by_blogpostid with VideoPress $post_id.
+	 */
+	public function test_video_get_info_by_blogpostid_videopress_post() {
+		$blog_id = 1;
+		$guid    = 'abc123xyz';
+
+		// Create a VideoPress post
+		$post_id = wp_insert_post(
+			array(
+				'post_type'      => 'attachment',
+				'post_mime_type' => 'video/videopress',
+				'post_title'     => 'Test video',
+				'post_content'   => 'Test description',
+				'post_excerpt'   => 'Test caption',
+			)
+		);
+
+		// Add GUID meta
+		add_post_meta( $post_id, 'videopress_guid', $guid );
+
+		$finish_time = time();
+
+		// Add attachment metadata
+		$metadata = array(
+			'videopress' => array(
+				'rating'          => 'G',
+				'allow_download'  => 1,
+				'display_embed'   => 1,
+				'privacy_setting' => 1, // 1 = Private
+				'finished'        => $finish_time,
+			),
+		);
+		wp_update_attachment_metadata( $post_id, $metadata );
+
+		$video_info = video_get_info_by_blogpostid( $blog_id, $post_id );
+
+		// Check VideoPress data
+		$this->assertInstanceOf( 'stdClass', $video_info );
+		$this->assertSame( $post_id, $video_info->post_id );
+		$this->assertSame( $blog_id, $video_info->blog_id );
+		$this->assertSame( 'Test description', $video_info->description );
+		$this->assertSame( 'Test video', $video_info->title );
+		$this->assertSame( 'Test caption', $video_info->caption );
+		$this->assertSame( $guid, $video_info->guid );
+		$this->assertSame( gmdate( 'Y-m-d H:i:s', $finish_time ), $video_info->finish_date_gmt );
+		$this->assertSame( 'G', $video_info->rating );
+		$this->assertSame( 1, $video_info->allow_download );
+		$this->assertSame( 1, $video_info->display_embed );
+		$this->assertSame( 1, $video_info->privacy_setting ); // 2 = Private
+	}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This area is generating about a million PHP warnings per day. It seems #43233 didn't do the trick, so this PR makes the `video_get_info_by_blogpostid()` function more robust:

* Only use `$post` object properties if $post is valid.
* Return early if `$post` is falsy (before it was doing `is_wp_error`, but `get_post()` returns `null` for invalid posts)
* Adds some basic tests

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

I'm not sure how to best test this outside of mocking, but I've added a few tests.

