### PR TITLE
Sitemaps: reduce total items per individual sitemap

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-reduce-sitemap-items
+++ b/projects/plugins/jetpack/changelog/fix-reduce-sitemap-items
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Sitemaps: reduce default limit of items per sitemap to 1000, previously 2000.

--- a/projects/plugins/jetpack/modules/sitemaps/sitemap-constants.php
+++ b/projects/plugins/jetpack/modules/sitemaps/sitemap-constants.php
@@ -42,7 +42,7 @@ if ( ! defined( 'JP_SITEMAP_MAX_BYTES' ) ) {
  * @since 4.8.0
  */
 if ( ! defined( 'JP_SITEMAP_MAX_ITEMS' ) ) {
-	define( 'JP_SITEMAP_MAX_ITEMS', 2000 );
+	define( 'JP_SITEMAP_MAX_ITEMS', 1000 );
 }
 
 /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Sets the default limit to number of URLs in an individual sitemap file to 1000.

This is aimed to reduce the memory needed for the base64 encoding, which is OOMing on some systems.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1745861115727469-slack-C016BBAFHHS

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* None really. This is just changing the pagination criteria to a different number, not changing any logic.