### PR TITLE
Forms: add menu entry feature flags and code

### DIFF
--- a/projects/packages/forms/changelog/add-jetpack-forms-dev-menu-entry-poc
+++ b/projects/packages/forms/changelog/add-jetpack-forms-dev-menu-entry-poc
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: add feature filter flags and code for moving submenu item from Feedback > Forms responses to Jetpack > Forms

--- a/projects/packages/forms/composer.json
+++ b/projects/packages/forms/composer.json
@@ -11,7 +11,8 @@
 		"automattic/jetpack-logo": "@dev",
 		"automattic/jetpack-plans": "@dev",
 		"automattic/jetpack-status": "@dev",
-		"automattic/jetpack-sync": "@dev"
+		"automattic/jetpack-sync": "@dev",
+		"automattic/jetpack-admin-ui": "@dev"
 	},
 	"require-dev": {
 		"yoast/phpunit-polyfills": "^4.0.0",

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -9,7 +9,6 @@ namespace Automattic\Jetpack\Forms;
 
 use Automattic\Jetpack\Forms\ContactForm\Util;
 use Automattic\Jetpack\Forms\Dashboard\Dashboard;
-use Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch;
 /**
  * Understands the Jetpack Forms package.
  */
@@ -24,9 +23,7 @@ class Jetpack_Forms {
 		Util::init();
 
 		if ( is_admin() && self::is_feedback_dashboard_enabled() ) {
-			$view_switch = new Dashboard_View_Switch();
-
-			$dashboard = new Dashboard( $view_switch );
+			$dashboard = new Dashboard();
 			$dashboard->init();
 		}
 

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -67,4 +67,13 @@ class Jetpack_Forms {
 		 */
 		return apply_filters( 'jetpack_forms_dashboard_enable', true );
 	}
+
+	/**
+	 * Returns true if the legacy menu item is retired.
+	 *
+	 * @return boolean
+	 */
+	public static function is_legacy_menu_item_retired() {
+		return apply_filters( 'jetpack_forms_retire_legacy_menu_item', false );
+	}
 }

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -13,6 +13,7 @@ use Automattic\Jetpack\Extensions\Contact_Form\Contact_Form_Block;
 use Automattic\Jetpack\Forms\Jetpack_Forms;
 use Automattic\Jetpack\Forms\Service\Post_To_Url;
 use Automattic\Jetpack\Status;
+use Automattic\Jetpack\Status\Host;
 use Automattic\Jetpack\Terms_Of_Service;
 use Automattic\Jetpack\Tracking;
 use Jetpack_Options;
@@ -560,17 +561,20 @@ class Contact_Form_Plugin {
 	 * Add the 'Form Responses' menu item as a submenu of Feedback.
 	 */
 	public function admin_menu() {
-		$slug = 'feedback';
+		$slug     = 'feedback';
+		$is_wpcom = ( new Host() )->is_wpcom_simple();
 
-		add_menu_page(
-			__( 'Feedback', 'jetpack-forms' ),
-			__( 'Feedback', 'jetpack-forms' ),
-			'edit_pages',
-			$slug,
-			null,
-			'dashicons-feedback',
-			45
-		);
+		if ( $is_wpcom || is_plugin_active( 'polldaddy/polldaddy.php' ) || ! Jetpack_Forms::is_legacy_menu_item_retired() ) {
+			add_menu_page(
+				__( 'Feedback', 'jetpack-forms' ),
+				__( 'Feedback', 'jetpack-forms' ),
+				'edit_pages',
+				$slug,
+				null,
+				'dashicons-feedback',
+				45
+			);
+		}
 
 		add_submenu_page(
 			$slug,
@@ -586,6 +590,13 @@ class Contact_Form_Plugin {
 			$slug,
 			$slug
 		);
+
+		if ( Jetpack_Forms::is_legacy_menu_item_retired() ) {
+			remove_submenu_page(
+				$slug,
+				'edit.php?post_type=feedback'
+			);
+		}
 	}
 
 	/**

--- a/projects/packages/forms/src/dashboard/admin-migrate-page/index.tsx
+++ b/projects/packages/forms/src/dashboard/admin-migrate-page/index.tsx
@@ -1,0 +1,9 @@
+import About from '../about';
+
+// TODO: This is a temporary page to migrate the admin page to the new menu
+// and this is a mockup of the new page until the new page is implemented.
+const AdminMigratePage = () => {
+	return <About />;
+};
+
+export default AdminMigratePage;

--- a/projects/packages/forms/src/dashboard/class-dashboard-view-switch.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard-view-switch.php
@@ -328,4 +328,40 @@ CSS
 
 		return $url;
 	}
+
+	/**
+	 * Returns true if the new Jetpack Forms admin page is available.
+	 *
+	 * @return boolean
+	 */
+	public static function is_jetpack_forms_admin_page_available() {
+		return apply_filters( 'jetpack_forms_use_new_menu_parent', false );
+	}
+
+	/**
+	 * Returns true if the view switch is available.
+	 *
+	 * @return boolean
+	 */
+	public static function is_jetpack_forms_view_switch_available() {
+		return ! apply_filters( 'jetpack_forms_retire_view_switch', false );
+	}
+
+	/**
+	 * Returns true if the new Jetpack Forms admin page is announcing the new menu.
+	 *
+	 * @return boolean
+	 */
+	public static function is_jetpack_forms_announcing_new_menu() {
+		return apply_filters( 'jetpack_forms_announce_new_menu', false );
+	}
+
+	/**
+	 * Returns true if the classic view is available.
+	 *
+	 * @return boolean
+	 */
+	public static function is_classic_view_available() {
+		return ! Jetpack_Forms::is_legacy_menu_item_retired();
+	}
 }

--- a/projects/packages/forms/src/dashboard/class-dashboard-view-switch.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard-view-switch.php
@@ -306,6 +306,16 @@ CSS
 	}
 
 	/**
+	 * Returns true if the current screen is the Jetpack Forms admin page.
+	 *
+	 * @return boolean
+	 */
+	public function is_jetpack_forms_admin_page() {
+		$screen = get_current_screen();
+		return $screen && $screen->id === 'jetpack_page_jetpack-forms-admin';
+	}
+
+	/**
 	 * Returns url of forms admin page.
 	 *
 	 * @param string|null $tab Tab to open in the forms admin page.
@@ -313,11 +323,15 @@ CSS
 	 * @return string
 	 */
 	public function get_forms_admin_url( $tab = null ) {
-		$is_classic = $this->get_preferred_view() === self::CLASSIC_VIEW;
+		$is_classic          = $this->get_preferred_view() === self::CLASSIC_VIEW;
+
+		$admin_dashboard_url = $this->is_jetpack_forms_admin_page_available()
+			? 'admin.php?page=jetpack-forms-admin'
+			: 'admin.php?page=jetpack-forms';
 
 		$url = $is_classic
 			? get_admin_url() . 'edit.php?post_type=feedback'
-			: get_admin_url() . 'admin.php?page=jetpack-forms';
+			: get_admin_url() . $admin_dashboard_url;
 
 		// Return url directly to spam tab.
 		if ( $tab === 'spam' ) {

--- a/projects/packages/forms/src/dashboard/class-dashboard-view-switch.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard-view-switch.php
@@ -236,9 +236,9 @@ CSS
 	 */
 	public function handle_preferred_view() {
 		// For simplicity, we only treat this as a valid operation
-		// if it occurs on one of the screens with the switch active.
+		// if it occurs on one of our screens.
 		// phpcs:disable WordPress.Security.NonceVerification
-		if ( ! $this->is_visible() || ! isset( $_GET['dashboard-preferred-view'] ) ) {
+		if ( ( ! $this->is_modern_view() && ! $this->is_classic_view() ) || ! isset( $_GET['dashboard-preferred-view'] ) ) {
 			return;
 		}
 
@@ -271,9 +271,10 @@ CSS
 	 * @return boolean
 	 */
 	public function is_visible() {
-		return Jetpack_Forms::is_feedback_dashboard_enabled() && (
+		return Jetpack_Forms::is_feedback_dashboard_enabled() && $this->is_classic_view_available() &&
+		(
 			$this->is_classic_view() ||
-			$this->is_modern_view()
+			( $this->is_modern_view() && $this->is_jetpack_forms_view_switch_available() )
 		);
 	}
 
@@ -324,18 +325,19 @@ CSS
 	 */
 	public function get_forms_admin_url( $tab = null ) {
 		$is_classic          = $this->get_preferred_view() === self::CLASSIC_VIEW;
+		$switch_is_available = $this->is_jetpack_forms_view_switch_available();
 
 		$admin_dashboard_url = $this->is_jetpack_forms_admin_page_available()
 			? 'admin.php?page=jetpack-forms-admin'
 			: 'admin.php?page=jetpack-forms';
 
-		$url = $is_classic
+		$url = $is_classic && $switch_is_available
 			? get_admin_url() . 'edit.php?post_type=feedback'
 			: get_admin_url() . $admin_dashboard_url;
 
 		// Return url directly to spam tab.
 		if ( $tab === 'spam' ) {
-			$url = $is_classic
+			$url = $is_classic && $switch_is_available
 				? add_query_arg( 'post_status', 'spam', $url )
 				: $url . '#/responses?status=spam';
 		}

--- a/projects/packages/forms/src/dashboard/class-dashboard-view-switch.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard-view-switch.php
@@ -250,8 +250,10 @@ CSS
 		}
 
 		update_user_option( get_current_user_id(), 'jetpack_forms_admin_preferred_view', $view );
-		wp_safe_redirect( remove_query_arg( 'dashboard-preferred-view' ) );
-		exit( 0 );
+		if ( ! Jetpack_Forms::is_legacy_menu_item_retired() ) {
+			wp_safe_redirect( remove_query_arg( 'dashboard-preferred-view' ) );
+			exit( 0 );
+		}
 	}
 
 	/**

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -116,6 +116,10 @@ class Dashboard {
 	 * Register the dashboard admin submenu.
 	 */
 	public function add_admin_submenu() {
+		if ( Jetpack_Forms::is_legacy_menu_item_retired() ) {
+			return;
+		}
+
 		if ( $this->switch->get_preferred_view() === Dashboard_View_Switch::CLASSIC_VIEW ) {
 			// We still need to register the jetpack forms page so it can be accessed manually.
 			// NOTE: adding submenu this (parent = '') way DOESN'T SHOW ANYWHERE,

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -79,6 +79,11 @@ class Dashboard {
 	 */
 	public function load_admin_scripts() {
 		if ( ! $this->switch->is_modern_view() && ! $this->switch->is_jetpack_forms_admin_page() ) {
+			if ( Jetpack_Forms::is_legacy_menu_item_retired() ) {
+				wp_admin_notice( 'This page has moved to the Jetpack Forms menu.', array( 'type' => 'info' ) );
+			} elseif ( $this->switch->is_jetpack_forms_admin_page_available() ) {
+				wp_admin_notice( 'This will be moved to the Jetpack Forms menu.', array( 'type' => 'info' ) );
+			}
 			return;
 		}
 

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -7,6 +7,7 @@
 
 namespace Automattic\Jetpack\Forms\Dashboard;
 
+use Automattic\Jetpack\Admin_UI\Admin_Menu;
 use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Connection\Initial_State as Connection_Initial_State;
 use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin;
@@ -66,6 +67,8 @@ class Dashboard {
 	 */
 	public function init() {
 		add_action( 'admin_menu', array( $this, 'add_admin_submenu' ), self::MENU_PRIORITY );
+		add_action( 'admin_menu', array( $this, 'add_new_admin_submenu' ), self::MENU_PRIORITY );
+
 		add_action( 'admin_enqueue_scripts', array( $this, 'load_admin_scripts' ) );
 
 		$this->switch->init();
@@ -75,7 +78,7 @@ class Dashboard {
 	 * Load JavaScript for the dashboard.
 	 */
 	public function load_admin_scripts() {
-		if ( ! ( new Dashboard_View_Switch() )->is_modern_view() ) {
+		if ( ! $this->switch->is_modern_view() && ! $this->switch->is_jetpack_forms_admin_page() ) {
 			return;
 		}
 
@@ -161,9 +164,40 @@ class Dashboard {
 	}
 
 	/**
-	 * Render the dashboard.
+	 * Register the NEW dashboard admin submenu Forms under Jetpack menu.
 	 */
-	public function render_dashboard() {
+	public function add_new_admin_submenu() {
+		if ( ! $this->switch->is_jetpack_forms_admin_page_available() ) {
+			return;
+		}
+
+		// When on WPCOM, we don't need to add the submenu page, it is handled by jetpack-mu-wpcom
+		if ( ( new Host() )->is_wpcom_simple() ) {
+			return;
+		}
+
+		Admin_Menu::add_menu(
+			__( 'Jetpack Forms', 'jetpack-forms' ),
+			_x( 'Forms', 'submenu title for Jetpack Forms', 'jetpack-forms' ),
+			'edit_pages',
+			'jetpack-forms-admin',
+			array( $this, 'render_new_dashboard' )
+		);
+	}
+
+	/**
+	 * Render the new dashboard.
+	 */
+	public function render_new_dashboard() {
+		$this->render_dashboard( array( 'renderMigrationPage' => false ) );
+	}
+
+	/**
+	 * Render the dashboard.
+	 *
+	 * @param array $extra_config Extra configuration to pass to the dashboard.
+	 */
+	public function render_dashboard( $extra_config = array() ) {
 		if ( ! class_exists( 'Jetpack_AI_Helper' ) ) {
 			require_once JETPACK__PLUGIN_DIR . '_inc/lib/class-jetpack-ai-helper.php';
 		}
@@ -183,6 +217,9 @@ class Dashboard {
 			'hasAI'                   => $has_ai,
 			'enableIntegrationsTab'   => self::$show_integrations,
 		);
+		if ( ! empty( $extra_config ) ) {
+			$config = array_merge( $config, $extra_config );
+		}
 		?>
 		<div id="jp-forms-dashboard" data-config="<?php echo esc_attr( wp_json_encode( $config, JSON_FORCE_OBJECT ) ); ?>"></div>
 		<?php

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -55,7 +55,7 @@ class Dashboard {
 	 *
 	 * @param Dashboard_View_Switch $switch Dashboard_View_Switch instance to use.
 	 */
-	public function __construct( Dashboard_View_Switch $switch ) {
+	public function __construct( Dashboard_View_Switch $switch = null ) {
 		$this->switch = $switch ?? new Dashboard_View_Switch();
 
 		// Set the integrations tab feature flag

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -55,7 +55,7 @@ class Dashboard {
 	 * @param Dashboard_View_Switch $switch Dashboard_View_Switch instance to use.
 	 */
 	public function __construct( Dashboard_View_Switch $switch ) {
-		$this->switch = $switch;
+		$this->switch = $switch ?? new Dashboard_View_Switch();
 
 		// Set the integrations tab feature flag
 		self::$show_integrations = apply_filters( 'jetpack_forms_enable_integrations_tab', false );

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -53,9 +53,9 @@ class Dashboard {
 	/**
 	 * Creates a new Dashboard instance.
 	 *
-	 * @param Dashboard_View_Switch $switch Dashboard_View_Switch instance to use.
+	 * @param Dashboard_View_Switch|null $switch Dashboard_View_Switch instance to use.
 	 */
-	public function __construct( Dashboard_View_Switch $switch = null ) {
+	public function __construct( ?Dashboard_View_Switch $switch = null ) {
 		$this->switch = $switch ?? new Dashboard_View_Switch();
 
 		// Set the integrations tab feature flag

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -225,6 +225,7 @@ class Dashboard {
 			'hasFeedback'             => $this->has_feedback(),
 			'hasAI'                   => $has_ai,
 			'enableIntegrationsTab'   => self::$show_integrations,
+			'renderMigrationPage'     => $this->switch->is_jetpack_forms_announcing_new_menu(),
 		);
 		if ( ! empty( $extra_config ) ) {
 			$config = array_merge( $config, $extra_config );

--- a/projects/packages/forms/src/dashboard/components/layout/style.scss
+++ b/projects/packages/forms/src/dashboard/components/layout/style.scss
@@ -8,7 +8,8 @@
 body.toplevel_page_jetpack-forms,
 body.feedback_page_jetpack-forms,
 body.jetpack_page_jetpack-forms,
-body.admin_page_jetpack-forms {
+body.admin_page_jetpack-forms,
+body.jetpack_page_jetpack-forms-admin {
 	background-color: #fff;
 
 	#wpcontent {

--- a/projects/packages/forms/src/dashboard/components/layout/style.scss
+++ b/projects/packages/forms/src/dashboard/components/layout/style.scss
@@ -5,10 +5,7 @@
 	}
 }
 
-body.toplevel_page_jetpack-forms,
-body.feedback_page_jetpack-forms,
-body.jetpack_page_jetpack-forms,
-body.admin_page_jetpack-forms,
+body[class*="_page_jetpack-forms"],
 body.jetpack_page_jetpack-forms-admin {
 	background-color: #fff;
 

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -348,7 +348,8 @@ $action-bar-height: 88px;
 
 
 /* We need to make the available canvas 100% tall. Without this, no flex values will work, they will only use the available space. */
-body[class*="_page_jetpack-forms"] {
+body[class*="_page_jetpack-forms"],
+body.jetpack_page_jetpack-forms-admin {
 
 	#wpwrap,
 	#wpcontent,

--- a/projects/packages/forms/src/dashboard/index.tsx
+++ b/projects/packages/forms/src/dashboard/index.tsx
@@ -9,6 +9,7 @@ import { createHashRouter, Navigate, RouterProvider } from 'react-router-dom';
  * Internal dependencies
  */
 import About from './about';
+import AdminMigratePage from './admin-migrate-page';
 import Layout from './components/layout';
 import Inbox from './inbox';
 import Integrations from './integrations';
@@ -24,6 +25,16 @@ window.addEventListener( 'load', () => {
 
 	settings = JSON.parse( decodeURIComponent( container.dataset.config ) );
 	delete container.dataset.config;
+
+	if ( config( 'renderMigrationPage' ) ) {
+		const root = createRoot( container );
+		root.render(
+			<ThemeProvider>
+				<AdminMigratePage />
+			</ThemeProvider>
+		);
+		return;
+	}
 
 	const router = createHashRouter( [
 		{

--- a/projects/packages/forms/src/dashboard/style.scss
+++ b/projects/packages/forms/src/dashboard/style.scss
@@ -22,10 +22,7 @@
 	--wp-admin-theme-color-darker-20--rgb: 44, 51, 56;
 }
 
-body.toplevel_page_jetpack-forms,
-body.feedback_page_jetpack-forms,
-body.jetpack_page_jetpack-forms,
-body.admin_page_jetpack-forms,
+body[class*="_page_jetpack-forms"],
 body.jetpack_page_jetpack-forms-admin {
 
 	#wpbody-content {

--- a/projects/packages/forms/src/dashboard/style.scss
+++ b/projects/packages/forms/src/dashboard/style.scss
@@ -25,7 +25,8 @@
 body.toplevel_page_jetpack-forms,
 body.feedback_page_jetpack-forms,
 body.jetpack_page_jetpack-forms,
-body.admin_page_jetpack-forms {
+body.admin_page_jetpack-forms,
+body.jetpack_page_jetpack-forms-admin {
 
 	#wpbody-content {
 		padding-bottom: 0;

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-jetpack-forms-wpcom-submenu
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-jetpack-forms-wpcom-submenu
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: Add Jetpack submenu item for forms dashboard

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-jetpack-forms-wpcom-submenu
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-jetpack-forms-wpcom-submenu
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Forms: Add Jetpack submenu item for forms dashboard

--- a/projects/plugins/jetpack/changelog/add-jetpack-forms-dev-menu-entry-poc
+++ b/projects/plugins/jetpack/changelog/add-jetpack-forms-dev-menu-entry-poc
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Forms: update dependency on packages/admin_ui, composer.lock update

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -1360,7 +1360,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/forms",
-				"reference": "08f17c79ceca2c91d89cb5538a0eacdfacc1118e"
+				"reference": "ac0e0b7b8e1ba05b3e5062a898b1277cc3e35a19"
 			},
 			"require": {
 				"automattic/jetpack-admin-ui": "@dev",

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -1363,6 +1363,7 @@
 				"reference": "08f17c79ceca2c91d89cb5538a0eacdfacc1118e"
 			},
 			"require": {
+				"automattic/jetpack-admin-ui": "@dev",
 				"automattic/jetpack-assets": "@dev",
 				"automattic/jetpack-blocks": "@dev",
 				"automattic/jetpack-connection": "@dev",


### PR DESCRIPTION
Fixes FORMS-27

## Proposed changes:
This PR adds the feature filter flags and code to move submenu item from Feedback > Form Responses to Jetpack > Forms. 

The change involves synchronizing all our envs functionality, so the feature flags are there for both an incremental change and a safe approach.

- `jetpack_forms_use_new_menu_parent`
- `jetpack_forms_retire_view_switch`
- `jetpack_forms_announce_new_menu`
- `jetpack_forms_retire_legacy_menu_item`


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1745869498096489-slack-C052XEUUBL4
peKye1-1w9-p2

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
The main intention of the feature filter flags is to put the code in place without any effect unless the filters return `true`. Basic testing should be verifying everything is still working as usual.

Testing on each feature filter and steps is being developed alongside a P2 post.

JN/Self-hosted:
<img width="594" alt="image" src="https://github.com/user-attachments/assets/829152da-41bc-4255-8b5f-c10ca7fd846b" />

