### PR TITLE
Forms: Fix CSS specificity for compatibility with global styles on the frontend

### DIFF
--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -819,11 +819,11 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 					}
 					$used_html_ids[ $radio_id ] = true;
 
-					$default_classes = 'wp-block-jetpack-option grunion-radio-label radio';
+					$default_classes = 'grunion-radio-label radio';
 					$option_styles   = empty( $option['style'] ) ? '' : "style='" . $option['style'] . "'";
 					$option_classes  = empty( $option['class'] ) ? $default_classes : $default_classes . ' ' . $option['class'];
 
-					$field .= "<p class='contact-form-field'>";
+					$field .= "<p class='contact-form-field wp-block-jetpack-option'>";
 					$field .= "<input
 									id='" . esc_attr( $radio_id ) . "'
 									type='radio'
@@ -1175,11 +1175,11 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 					}
 					$used_html_ids[ $checkbox_id ] = true;
 
-					$default_classes = 'wp-block-jetpack-option grunion-checkbox-multiple-label checkbox-multiple';
+					$default_classes = 'grunion-checkbox-multiple-label checkbox-multiple';
 					$option_styles   = empty( $option['style'] ) ? '' : "style='" . $option['style'] . "'";
 					$option_classes  = empty( $option['class'] ) ? $default_classes : $default_classes . ' ' . $option['class'];
 
-					$field .= "<p class='contact-form-field'>";
+					$field .= "<p class='contact-form-field wp-block-jetpack-option'>";
 					$field .= "<input
 								id='" . esc_attr( $checkbox_id ) . "'
 								type='checkbox'

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -823,7 +823,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 					$option_styles   = empty( $option['style'] ) ? '' : "style='" . $option['style'] . "'";
 					$option_classes  = empty( $option['class'] ) ? $default_classes : $default_classes . ' ' . $option['class'];
 
-					$field .= "<p class='{$option_classes}'>";
+					$field .= "<p {$option_styles} class='{$option_classes}'>";
 					$field .= "<input
 									id='" . esc_attr( $radio_id ) . "'
 									type='radio'
@@ -833,7 +833,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 									. checked( $option_label, $value, false ) . ' '
 									. ( $required ? "required aria-required='true'" : '' )
 									. '/> ';
-					$field .= "<label for='" . esc_attr( $radio_id ) . "' {$option_styles} class='grunion-radio-label radio" . ( $this->is_error() ? ' form-error' : '' ) . "'>";
+					$field .= "<label for='" . esc_attr( $radio_id ) . "' class='grunion-radio-label radio" . ( $this->is_error() ? ' form-error' : '' ) . "'>";
 					$field .= "<span class='grunion-field-text'>" . esc_html( $option_label ) . '</span>';
 					$field .= '</label>';
 					$field .= '</p>';
@@ -1179,7 +1179,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 					$option_styles   = empty( $option['style'] ) ? '' : "style='" . $option['style'] . "'";
 					$option_classes  = empty( $option['class'] ) ? $default_classes : $default_classes . ' ' . $option['class'];
 
-					$field .= "<p class='{$option_classes}'>";
+					$field .= "<p {$option_styles} class='{$option_classes}'>";
 					$field .= "<input
 								id='" . esc_attr( $checkbox_id ) . "'
 								type='checkbox'
@@ -1188,7 +1188,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 								. $class
 								. checked( in_array( $option_label, (array) $value, true ), true, false )
 								. ' /> ';
-					$field .= "<label for='" . esc_attr( $checkbox_id ) . "' {$option_styles} class='grunion-checkbox-multiple-label checkbox-multiple" . ( $this->is_error() ? ' form-error' : '' ) . "'>";
+					$field .= "<label for='" . esc_attr( $checkbox_id ) . "' class='grunion-checkbox-multiple-label checkbox-multiple" . ( $this->is_error() ? ' form-error' : '' ) . "'>";
 					$field .= "<span class='grunion-field-text'>" . esc_html( $option_label ) . '</span>';
 					$field .= '</label>';
 					$field .= '</p>';

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -819,11 +819,11 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 					}
 					$used_html_ids[ $radio_id ] = true;
 
-					$default_classes = 'grunion-radio-label radio';
+					$default_classes = 'contact-form-field wp-block-jetpack-option';
 					$option_styles   = empty( $option['style'] ) ? '' : "style='" . $option['style'] . "'";
 					$option_classes  = empty( $option['class'] ) ? $default_classes : $default_classes . ' ' . $option['class'];
 
-					$field .= "<p class='contact-form-field wp-block-jetpack-option'>";
+					$field .= "<p class='{$option_classes}'>";
 					$field .= "<input
 									id='" . esc_attr( $radio_id ) . "'
 									type='radio'
@@ -833,7 +833,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 									. checked( $option_label, $value, false ) . ' '
 									. ( $required ? "required aria-required='true'" : '' )
 									. '/> ';
-					$field .= "<label for='" . esc_attr( $radio_id ) . "' {$option_styles} class='" . $option_classes . ( $this->is_error() ? ' form-error' : '' ) . "'>";
+					$field .= "<label for='" . esc_attr( $radio_id ) . "' {$option_styles} class='grunion-radio-label radio" . ( $this->is_error() ? ' form-error' : '' ) . "'>";
 					$field .= "<span class='grunion-field-text'>" . esc_html( $option_label ) . '</span>';
 					$field .= '</label>';
 					$field .= '</p>';
@@ -1175,11 +1175,11 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 					}
 					$used_html_ids[ $checkbox_id ] = true;
 
-					$default_classes = 'grunion-checkbox-multiple-label checkbox-multiple';
+					$default_classes = 'contact-form-field wp-block-jetpack-option';
 					$option_styles   = empty( $option['style'] ) ? '' : "style='" . $option['style'] . "'";
 					$option_classes  = empty( $option['class'] ) ? $default_classes : $default_classes . ' ' . $option['class'];
 
-					$field .= "<p class='contact-form-field wp-block-jetpack-option'>";
+					$field .= "<p class='{$option_classes}'>";
 					$field .= "<input
 								id='" . esc_attr( $checkbox_id ) . "'
 								type='checkbox'
@@ -1188,7 +1188,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 								. $class
 								. checked( in_array( $option_label, (array) $value, true ), true, false )
 								. ' /> ';
-					$field .= "<label for='" . esc_attr( $checkbox_id ) . "' {$option_styles} class='" . $option_classes . ( $this->is_error() ? ' form-error' : '' ) . "'>";
+					$field .= "<label for='" . esc_attr( $checkbox_id ) . "' {$option_styles} class='grunion-checkbox-multiple-label checkbox-multiple" . ( $this->is_error() ? ' form-error' : '' ) . "'>";
 					$field .= "<span class='grunion-field-text'>" . esc_html( $option_label ) . '</span>';
 					$field .= '</label>';
 					$field .= '</p>';

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -107,7 +107,9 @@
 .contact-form :where(label.checkbox-multiple),
 .contact-form :where(label.radio),
 .contact-form :where(label.checkbox) {
-	font-weight: 400;
+
+	/* Inherit the font weight from the parent 'option' block wrapper */
+	font-weight: inherit;
 }
 
 .contact-form label.checkbox-multiple,
@@ -644,6 +646,12 @@ on production builds, the attributes are being reordered, causing side-effects
 .contact-form :where(.grunion-field-wrap:not(.is-style-button-wrap)) .grunion-checkbox-multiple-options,
 .contact-form :where(.grunion-field-wrap:not(.is-style-button-wrap)) .grunion-radio-options {
 	padding-top: 8px;
+}
+
+.contact-form :where(.grunion-checkbox-multiple-options .contact-form-field),
+.contact-form :where(.grunion-radio-options .contact-form-field),
+.contact-form :where(.grunion-checkbox .contact-form-field) {
+	font-weight: 400;
 }
 
 .contact-form :where(.grunion-checkbox-multiple-options .contact-form-field),

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -646,13 +646,24 @@ on production builds, the attributes are being reordered, causing side-effects
 	padding-top: 8px;
 }
 
+.contact-form :where(.grunion-checkbox-multiple-options .contact-form-field),
+.contact-form :where(.grunion-radio-options .contact-form-field) {
+
+	/* Back compat for the old css vars used in the old radio and checkbox styles */
+	font-size: var(--jetpack--contact-form--font-size);
+}
+
 .contact-form .grunion-field-wrap input.checkbox-multiple,
 .contact-form .grunion-field-wrap input.radio {
 	position: relative;
 
 	box-sizing: border-box;
-	width: var(--jetpack--contact-form--font-size);
-	height: var(--jetpack--contact-form--font-size);
+
+	/* Inherit the font size from the parent element. This allows the input to scale with the font size
+	   set from global styles or from block styles */
+	font-size: inherit;
+	width: 1em;
+	height: 1em;
 	margin-inline-end: calc(var(--jetpack--contact-form--font-size) / 2);
 	padding: 0;
 
@@ -670,14 +681,16 @@ on production builds, the attributes are being reordered, causing side-effects
 
 .contact-form .grunion-field-wrap input.checkbox-multiple:checked::before {
 	content: "\2713";
-
 	position: absolute;
-	top: calc(var(--jetpack--contact-form--font-size) / 2);
-	left: calc(var(--jetpack--contact-form--font-size) / 2);
+
+	/* Inherit the font size from the parent element. This allows the input to scale with the font size
+	   set from global styles or from block styles */
+	font-size: inherit;
+	top: calc(1em / 2);
+	left: calc(1em / 2);
 
 	display: block;
 
-	font-size: var(--jetpack--contact-form--font-size);
 	line-height: 1;
 
   transform: translate(-50%, -50%);
@@ -687,12 +700,16 @@ on production builds, the attributes are being reordered, causing side-effects
 	background: currentColor;
 	border-radius: 50%;
 	content: '';
-	height: calc(var(--jetpack--contact-form--font-size) / 2);
+
+	/* Inherit the font size from the parent element. This allows the input to scale with the font size
+	   set from global styles or from block styles */
+	font-size: inherit;
+	height: calc(1em / 2);
+	width: calc(1em / 2);
 	margin-left: 50%;
 	margin-top: 50%;
 	position: absolute;
 	transform: translate(-50%, -50%);
-	width: calc(var(--jetpack--contact-form--font-size) / 2);
 }
 
 .contact-form .grunion-field-wrap.grunion-field-checkbox-multiple-wrap.is-style-button-wrap .contact-form-field,

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -104,14 +104,15 @@
 	display: none;
 }
 
-.contact-form label.checkbox {
+.contact-form :where(label.checkbox-multiple),
+.contact-form :where(label.radio),
+.contact-form :where(label.checkbox) {
 	font-weight: 400;
 }
 
 .contact-form label.checkbox-multiple,
 .contact-form label.radio {
 	margin-bottom: 0;
-	font-weight: 400;
 	flex: 1;
 }
 

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -713,18 +713,17 @@ on production builds, the attributes are being reordered, causing side-effects
 }
 
 .contact-form .grunion-field-wrap.grunion-field-checkbox-multiple-wrap.is-style-button-wrap .contact-form-field,
-.contact-form .grunion-field-wrap.is-style-button-wrap .grunion-radio-label {
+.contact-form .grunion-field-wrap.grunion-field-radio-wrap.is-style-button-wrap .contact-form-field {
 	display: inline-flex;
 	align-items: center;
 	padding: var(--jetpack--contact-form--button-outline--padding);
 }
 
 .contact-form :where(.grunion-field-wrap.grunion-field-checkbox-multiple-wrap.is-style-button-wrap .contact-form-field),
-.contact-form :where(.grunion-field-wrap.is-style-button-wrap .grunion-radio-label) {
+.contact-form :where(.grunion-field-wrap.grunion-field-radio-wrap.is-style-button-wrap .contact-form-field) {
 	background: var(--jetpack--contact-form--button-outline--background-color);
 	border: var(--jetpack--contact-form--button-outline--border);
 	border-radius: var(--jetpack--contact-form--button-outline--border-radius);
-	color: var(--jetpack--contact-form--button-outline--text-color);
 	line-height: var(--jetpack--contact-form--button-outline--line-height);
 }
 

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -165,8 +165,8 @@
 	margin: 0;
 }
 
-.contact-form label span.required,
-.grunion-label-required {
+.contact-form :where(label span.required),
+.contact-form :where(.grunion-label-required) {
 	font-size: 85%;
 	margin-left: 0.25em;
 	font-weight: 400;
@@ -379,13 +379,13 @@
 	inset-inline-end: 20px;
 	top: 50%;
 
-  content: "";
-  display: block;
+	content: "";
+	display: block;
 	width: 8px;
 	height: 8px;
 
 	border-bottom: 2px solid;
-  border-right: 2px solid;
+	border-right: 2px solid;
 
 	transform: translateY(-50%) rotate(45deg);
 	transform-origin: center center;

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -89,10 +89,13 @@
 	font-weight: 700;
 }
 
-.contact-form label.consent {
+.contact-form :where(label.consent) {
 	font-size: 13px;
 	font-weight: 400;
 	text-transform: uppercase;
+}
+
+.contact-form label.consent {
 	display: flex;
 	align-items: center;
 }

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -724,6 +724,7 @@ on production builds, the attributes are being reordered, causing side-effects
 	background: var(--jetpack--contact-form--button-outline--background-color);
 	border: var(--jetpack--contact-form--button-outline--border);
 	border-radius: var(--jetpack--contact-form--button-outline--border-radius);
+	color: var(--jetpack--contact-form--button-outline--text-color);
 	line-height: var(--jetpack--contact-form--button-outline--line-height);
 }
 

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -149,8 +149,6 @@
 }
 
 .contact-form .is-style-outlined .grunion-checkbox-multiple-options legend,
-
-.contact-form .is-style-outlined .grunion-checkbox-multiple-options legend,
 .contact-form .is-style-outlined .grunion-radio-options legend {
 	margin: 0 0 -0.75em;
 	padding: 0 0.25em;

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -728,12 +728,12 @@ on production builds, the attributes are being reordered, causing side-effects
 
 	/* visually-hidden */
 	clip: rect(0 0 0 0);
-  clip-path: inset(50%);
-  height: 1px;
-  overflow: hidden;
-  position: absolute;
-  white-space: nowrap;
-  width: 1px;
+	clip-path: inset(50%);
+	height: 1px;
+	overflow: hidden;
+	position: absolute;
+	white-space: nowrap;
+	width: 1px;
 }
 
 .contact-form .grunion-field-wrap.is-style-button-wrap .grunion-field.radio:checked + .grunion-radio-label {

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -717,6 +717,10 @@ on production builds, the attributes are being reordered, causing side-effects
 	display: inline-flex;
 	align-items: center;
 	padding: var(--jetpack--contact-form--button-outline--padding);
+}
+
+.contact-form :where(.grunion-field-wrap.grunion-field-checkbox-multiple-wrap.is-style-button-wrap .contact-form-field),
+.contact-form :where(.grunion-field-wrap.is-style-button-wrap .grunion-radio-label) {
 	background: var(--jetpack--contact-form--button-outline--background-color);
 	border: var(--jetpack--contact-form--button-outline--border);
 	border-radius: var(--jetpack--contact-form--button-outline--border-radius);
@@ -751,10 +755,9 @@ on production builds, the attributes are being reordered, causing side-effects
 	outline-offset: 2px;
 }
 
-.contact-form .grunion-field-wrap.is-style-button-wrap .grunion-field.checkbox-multiple {
+.contact-form :where(.grunion-field-wrap.is-style-button-wrap .grunion-field.checkbox-multiple) {
 	border-radius: var(--jetpack--contact-form--button-outline--border-radius);
 	color: var(--jetpack--contact-form--button-outline--text-color);
-
 	font-family: var(--wp--preset--font-family--body);
 }
 
@@ -762,7 +765,8 @@ on production builds, the attributes are being reordered, causing side-effects
 	outline-width: 0; /* focus style defined on parent */
 }
 
-.contact-form .is-style-button-wrap input.grunion-field + .grunion-field-text::before {
+/* TODO - is this style used anywhere? if not, remove it */
+.contact-form :where(.is-style-button-wrap input.grunion-field + .grunion-field-text::before) {
 	background: var(--jetpack--contact-form--button-outline--background-color);
 	border: var(--jetpack--contact-form--button-outline--border);
 	border-color: currentColor;
@@ -778,16 +782,16 @@ on production builds, the attributes are being reordered, causing side-effects
 	z-index: -1;
 }
 
-.contact-form .is-style-button-wrap input.grunion-field {
+.contact-form :where(.is-style-button-wrap input.grunion-field) {
 	color: var(--jetpack--contact-form--button-outline--color);
 }
 
-.contact-form .is-style-button-wrap input.grunion-field:checked,
-.contact-form .is-style-button-wrap input.grunion-field:checked + .grunion-field-text {
+.contact-form :where(.is-style-button-wrap input.grunion-field:checked),
+.contact-form :where(.is-style-button-wrap input.grunion-field:checked + .grunion-field-text) {
 	color: var(--jetpack--contact-form--button-outline--background-color-fallback);
 }
 
-.contact-form .is-style-button-wrap input.grunion-field:checked + .grunion-field-text::before {
+.contact-form :where(.is-style-button-wrap input.grunion-field:checked + .grunion-field-text::before) {
 	background: var(--jetpack--contact-form--button-outline--text-color);
 	border-color: var(--jetpack--contact-form--button-outline--text-color);
 }

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -1393,8 +1393,10 @@ class Contact_Form_Test extends BaseTestCase {
 					}
 					// @phan-suppress-next-line PhanUndeclaredMethod
 					if ( ! empty( $item_label->getAttribute( 'class' ) ) ) {
+						// Classes are applied to the option wrapper, not the label.
+						$option = $item_label->parentNode;  //phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 						// @phan-suppress-next-line PhanUndeclaredMethod
-						$this->assertContains( $label_style->class, explode( ' ', $item_label->getAttribute( 'class' ) ), 'Class doesn\'t match' );
+						$this->assertContains( $label_style->class, explode( ' ', $option->getAttribute( 'class' ) ), 'Class doesn\'t match' );
 					}
 				}
 			}

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -1379,24 +1379,25 @@ class Contact_Form_Test extends BaseTestCase {
 				}
 
 				if ( ! empty( $attributes['optionsdata'] ) ) {
-					$filtered    = array_filter(
+					$filtered = array_filter(
 						json_decode( $attributes['optionsdata'] ),
 						function ( $option ) use ( $input ) {
 							return $option->label === $input->getAttribute( 'value' );
 						}
 					);
-					$label_style = array_values( $filtered )[0] ?? null;
+					// Block styles and classes are applied to the option wrapper.
+					$option = $item_label->parentNode;  //phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+
+					$option_data = array_values( $filtered )[0] ?? null;
 					// @phan-suppress-next-line PhanUndeclaredMethod - Phan doesn't know that getAttribute is available. But it is.
 					if ( ! empty( $item_label->getAttribute( 'style' ) ) ) {
 						// @phan-suppress-next-line PhanUndeclaredMethod
-						$this->assertEquals( $item_label->getAttribute( 'style' ), $label_style->style, 'Style doesn\'t match' );
+						$this->assertEquals( $option->getAttribute( 'style' ), $option_data->style, 'Style doesn\'t match' );
 					}
 					// @phan-suppress-next-line PhanUndeclaredMethod
 					if ( ! empty( $item_label->getAttribute( 'class' ) ) ) {
-						// Classes are applied to the option wrapper, not the label.
-						$option = $item_label->parentNode;  //phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 						// @phan-suppress-next-line PhanUndeclaredMethod
-						$this->assertContains( $label_style->class, explode( ' ', $option->getAttribute( 'class' ) ), 'Class doesn\'t match' );
+						$this->assertContains( $option_data->class, explode( ' ', $option->getAttribute( 'class' ) ), 'Class doesn\'t match' );
 					}
 				}
 			}


### PR DESCRIPTION
Note - this PR merges into https://github.com/Automattic/jetpack/pull/42890 rather than trunk.
Part of JETPACK-277
Follow on from #43125 (which updated the editor styles)

## Proposed changes:
Updates the frontend (grunion.css) styles for form fields lowering specificity to 0-1-0 where needed so that global styles can override the CSS.

Note: this doesn't cover the animated or outlined form style variations, only the default styles.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
The first thing is to check that this PR doesn't modify the default styles of blocks when compared to trunk.

Next, update the theme.json file for your active theme to add styles for option, label, and input blocks. Here's a little code snippet to get you started, but you should try every possible style property (colors and typography for the label and option. Colors, typography and border for inputs). Add this to the `styles.blocks` property in the theme.json and then tinker, refresh your editor to check that the styles apply consistenty to all fields:
<details><summary>Click here to view snippet</summary>

```json
"jetpack/label": {
	"color": {
		"text": "var(--wp--preset--color--accent)"
	},
	"typography": {
		"fontFamily": "var(--wp--preset--font-family--body)",
		"fontSize": "3rem",
		"fontStyle": "italic",
		"fontWeight": "1000"
	}
},
"jetpack/input": {
	"border": {
		"width": "5px",
		"radius": "var(--wp--preset--spacing--20)"
	},
	"color": {
		"text": "var(--wp--preset--color--accent)"
	}
},
"jetpack/option": {
	"border": {
		"width": "5px",
		"radius": "var(--wp--preset--spacing--20)"
	},
	"color": {
		"text": "var(--wp--preset--color--accent)"
	}
},
```

</details> 

Next, using the site editor, modify the global styles for these blocks and check that the changes apply consistently to every field.

Finally modify the styles on the block instances themselves and check that the styles apply consistently.
