### PR TITLE
Forms: Fix Single Choice (radio) block missing checkmark for selected option on frontend

### DIFF
--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -717,17 +717,17 @@ on production builds, the attributes are being reordered, causing side-effects
   width: 1px;
 }
 
-.contact-form .grunion-field-wrap.is-style-button-wrap .grunion-field.radio.is-style-button:checked + .grunion-radio-label {
+.contact-form .grunion-field-wrap.is-style-button-wrap .grunion-field.radio:checked + .grunion-radio-label {
 	display: inline-flex;
 	gap: 0.5em;
 }
 
-.contact-form .grunion-field-wrap.is-style-button-wrap .grunion-field.radio.is-style-button:checked + .grunion-radio-label::before {
+.contact-form .grunion-field-wrap.is-style-button-wrap .grunion-field.radio:checked + .grunion-radio-label::before {
 	content: "\2713";
 }
 
 .contact-form .grunion-field-wrap.grunion-field-checkbox-multiple-wrap.is-style-button-wrap .contact-form-field:focus-within,
-.contact-form .grunion-field-wrap.is-style-button-wrap .grunion-field.radio.is-style-button:focus + .grunion-radio-label {
+.contact-form .grunion-field-wrap.is-style-button-wrap .grunion-field.radio:focus + .grunion-radio-label {
 	outline: var(--jetpack--contact-form--button-outline--border);
 	outline-offset: 2px;
 }
@@ -739,11 +739,11 @@ on production builds, the attributes are being reordered, causing side-effects
 	font-family: var(--wp--preset--font-family--body);
 }
 
-.contact-form .grunion-field-wrap.is-style-button-wrap .grunion-field.checkbox-multiple.is-style-button:focus {
+.contact-form .grunion-field-wrap.is-style-button-wrap .grunion-field.checkbox-multiple:focus {
 	outline-width: 0; /* focus style defined on parent */
 }
 
-.contact-form .is-style-button input.grunion-field + .grunion-field-text::before {
+.contact-form .is-style-button-wrap input.grunion-field + .grunion-field-text::before {
 	background: var(--jetpack--contact-form--button-outline--background-color);
 	border: var(--jetpack--contact-form--button-outline--border);
 	border-color: currentColor;
@@ -759,16 +759,16 @@ on production builds, the attributes are being reordered, causing side-effects
 	z-index: -1;
 }
 
-.contact-form .is-style-button input.grunion-field {
+.contact-form .is-style-button-wrap input.grunion-field {
 	color: var(--jetpack--contact-form--button-outline--color);
 }
 
-.contact-form input.grunion-field.is-style-button:checked,
-.contact-form input.grunion-field.is-style-button:checked + .grunion-field-text {
+.contact-form .is-style-button-wrap input.grunion-field:checked,
+.contact-form .is-style-button-wrap input.grunion-field:checked + .grunion-field-text {
 	color: var(--jetpack--contact-form--button-outline--background-color-fallback);
 }
 
-.contact-form input.grunion-field.is-style-button:checked + .grunion-field-text::before {
+.contact-form .is-style-button-wrap input.grunion-field:checked + .grunion-field-text::before {
 	background: var(--jetpack--contact-form--button-outline--text-color);
 	border-color: var(--jetpack--contact-form--button-outline--text-color);
 }


### PR DESCRIPTION
Fixes JETPACK-367

Note - this PR merges into https://github.com/Automattic/jetpack/pull/42890 rather than trunk.

## Proposed changes:
Fixes missing checkmarks on Single Choice (Radio) option fields on the frontend.

I did some digging and it looks like after #43184 the `is-style-button` classname moved from being added to the inner `input` element to the parent `div.wp-block-jetpack-field-radio` element. The CSS that renders the check depended on the classname being on the input.

There's a lot of duplication with the classnames, most of the css selectors are using the `.is-style-button-wrap` selector instead of `.is-style-button`, so I've updated the broken selectors to use `.is-style-button-wrap`. My understanding is that this classname hasn't changed at all from trunk, so it should work regardless of whether a form is new or old.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
1. Add a contact form
2. Add a 'Single Choice (Radio)' block to the form
3. Switch to the 'Button' style for the newly added block
4. Add a couple of options to the single choice block
5. Save and view the frontend
6. Select one of the options

**In this PR**: A small check mark appears next to the selected option

<img src="https://uploads.linear.app/f629fcde-6f9b-48e8-8af3-60eed8823bff/14fc92ff-fcf1-4671-b3d5-1af94ceccc90/38b403f5-d101-4213-b494-31713fd2c6fa?signature=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXRoIjoiL2Y2MjlmY2RlLTZmOWItNDhlOC04YWYzLTYwZWVkODgyM2JmZi8xNGZjOTJmZi1mY2YxLTQ2NzEtYjNkNS0xYWY5NGNlY2NjOTAvMzhiNDAzZjUtZDEwMS00MjEzLWI0OTQtMzE3MTNmZDJjNmZhIiwiaWF0IjoxNzQ1OTE3MTc5LCJleHAiOjMzMzE2NDc3MTc5fQ.mg3OAzWieAjt4S0CYU-ttbJuNC48zqH8Cjo5VL7Qi88 " alt="Screenshot 2025-04-29 at 4.59.07 pm.png" width="161" data-linear-height="137" />

**Before this PR**: No check appears and the user is unable to tell which option is selected

<img src="https://uploads.linear.app/f629fcde-6f9b-48e8-8af3-60eed8823bff/0c7927b2-76f7-4aaf-8522-5fb9cedbf43c/1bfccf87-4d23-4da5-a90c-8038f7ae97f0?signature=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXRoIjoiL2Y2MjlmY2RlLTZmOWItNDhlOC04YWYzLTYwZWVkODgyM2JmZi8wYzc5MjdiMi03NmY3LTRhYWYtODUyMi01ZmI5Y2VkYmY0M2MvMWJmY2NmODctNGQyMy00ZGE1LWE5MGMtODAzOGY3YWU5N2YwIiwiaWF0IjoxNzQ1OTE3MjM2LCJleHAiOjMzMzE2NDc3MjM2fQ.xClTxo6cyAl3iDfKtgP_xoSwRywj99cmahUoI5ahfj8 " alt="Screenshot 2025-04-29 at 5.00.04 pm.png" width="171" data-linear-height="133" />
