### PR TITLE
Image Compare block: Make sure nav block submenu items are not hidden by the block

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-image-compare-block-overlapping-nav-submenu
+++ b/projects/plugins/jetpack/changelog/fix-image-compare-block-overlapping-nav-submenu
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Image Compare block: Ensure block does not overlap navigation submenu items.

--- a/projects/plugins/jetpack/extensions/blocks/image-compare/view.scss
+++ b/projects/plugins/jetpack/extensions/blocks/image-compare/view.scss
@@ -22,6 +22,7 @@ div.jx-slider {
 	overflow: hidden;
 	cursor: pointer;
 	color: #f3f3f3;
+	z-index: 1;
 }
 
 div.jx-handle {


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/39952
Fixes VULCAN-85

## Proposed changes:

* This PR changes the z-index of the `jx-slider` class, which encloses the Image Compare block contents. This helps make sure that when there is a navigation block with nav items that have submenu items, those menu items won't be hidden beneath the block.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

n/a

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

On a self-hosted test site applying this PR locally, or using the Jetpack Beta plugin on a WoA or Jurassic Ninja site, or applying the command in the generated comment below for a sandboxed Simple site:
* Install and activate the Twenty Twenty Five theme on a site. For WoA and Simple, I found I had to use the theme in the original issue report (AlleyOop) to replicate the original issue so you may need to as well.
* Open up the site editor, and in the single posts template for the Twenty Twenty Five theme, find the header block
* From here you should be able to add sub-menu items to a navigation item directly - make sure you have enough to be able to overlap post content.
* You'll likely also want to edit the template to remove any extra 'noise' - I removed cover images (leaving the header just with the navigation block), and any content for the post itself that is not post content (eg featured image, post date / author details).
* You can choose a header with a dark background from the header block sidebar so that the issue will be easier to replicate, though it shouldn't matter much here.
* Then add a new post and add an Image Compare block with two images.
* Preview the post on the front-end - you may need to narrow down the width of your browser tab to ensure the menu item sites above the block. Then open up the submenu and notice that it sits above the block. 

To replicate the issue itself on trunk, follow the same steps as above without the PR applied.

