### PR TITLE
Launchpad - first post published task - ignore import process

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-launchpad-first-post-published-counting-imports
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-launchpad-first-post-published-counting-imports
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+prevent import processes from marking the first post published tasks complete in launchpad

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -1632,6 +1632,10 @@ function wpcom_launchpad_track_publish_first_post_task() {
 	if ( defined( 'HEADSTART' ) && HEADSTART ) {
 		return;
 	}
+	// Ensure that Imports don't mark this as complete.
+	if ( defined( 'WP_IMPORTING' ) && WP_IMPORTING ) {
+		return;
+	}
 	// Since we share the same callback for generic first post and newsletter-specific, we mark both.
 	wpcom_launchpad_mark_launchpad_task_complete_if_active( 'first_post_published' );
 	wpcom_launchpad_mark_launchpad_task_complete_if_active( 'first_post_published_newsletter' );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes # github.com/Automattic/loop#672

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

Fixes a bug where the 'first_post_published' launchpad tasks were being marked as complete during the import process. In some flows (like newsletter) we have post publish (start writing) tasks after import tasks, and they are being bypassed / falsly marked as complete as a result.
* Checks the 'WP_IMPORTING' constant when determining whether to mark these tasks as complete on `publish_post` action.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Patch this build onto your sandbox (command in comment below: `bin/jetpack-downloader test jetpack-mu-wpcom-plugin fix/launchpad-first-post-published-counting-imports`)
* Sandbox the public-api
* Follow steps on the FG for testing async jobs on sandbox - PCYsg-3Ri-p2
    * Use the second 0-sandbox.php example with the larger list of items.
    * Run the watcher on your sandbox
* start a WordPress.com/newsletter and create a site in the import newsletter flow.
* once getting to the launchpad, go to the import/migrate content step.
* Migrate content with posts to your site (this could be WP, substack, etc.)
* Once migration is complete, click "my home"
* Verify you are loaded back to the launchpad with "Start Writing" as the CTA. Previously this launchpad was dismissed as start writing was marked as complete due to the imports. 
* Now, follow the start writing task and go publish a post. The task should be complete / launchpad dismissed and my-home should show the follow up task list.