### PR TITLE
Testing adding CSS vars to field for block level styles

### DIFF
--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -869,6 +869,13 @@
 				padding-top: calc(var(--jetpack--contact-form--input-padding, 16px) + 4px);
 				border-top: none;
 
+				.wp-block-jetpack-options {
+					border-radius: unset !important;
+					border: none !important;
+					border-color: transparent !important;
+					border-style: none !important;
+				}
+
 				.notched-label {
 					height: unset;
 

--- a/projects/packages/forms/src/blocks/field-email/edit.js
+++ b/projects/packages/forms/src/blocks/field-email/edit.js
@@ -20,6 +20,7 @@ export default function EmailFieldEdit( props ) {
 			width={ props.attributes.width }
 			attributes={ props.attributes }
 			insertBlocksAfter={ props.insertBlocksAfter }
+			context={ props.context }
 		/>
 	);
 }

--- a/projects/packages/forms/src/blocks/field-email/index.js
+++ b/projects/packages/forms/src/blocks/field-email/index.js
@@ -36,6 +36,7 @@ const settings = {
 			},
 		],
 	},
+	usesContext: [ 'jetpack/form-className' ],
 };
 
 export default {

--- a/projects/packages/forms/src/blocks/field-multiple-choice/edit.js
+++ b/projects/packages/forms/src/blocks/field-multiple-choice/edit.js
@@ -6,14 +6,19 @@ import {
 import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
+import { isNumber } from 'lodash';
 import JetpackFieldControls from '../shared/components/jetpack-field-controls';
 import useFormWrapper from '../shared/hooks/use-form-wrapper';
+import useJetpackFieldStyles from '../shared/hooks/use-jetpack-field-styles';
+import { FORM_STYLE } from '../shared/util/constants';
+import getBlockStyle from '../shared/util/get-block-style.js';
 
 export default function MultipleChoiceFieldEdit( props ) {
-	const { className, clientId, setAttributes, isSelected, attributes } = props;
+	const { className, clientId, setAttributes, isSelected, attributes, context } = props;
 	const { required, id, width } = attributes;
 
 	useFormWrapper( props );
+	const { blockStyle } = useJetpackFieldStyles( attributes );
 
 	const innerBlocks = useSelect(
 		select => select( blockEditorStore ).getBlock( clientId ).innerBlocks,
@@ -27,8 +32,11 @@ export default function MultipleChoiceFieldEdit( props ) {
 
 	const blockProps = useBlockProps( {
 		className: classes,
+		style: {
+			...blockStyle,
+		},
 	} );
-
+	console.log( 'MultipleChoiceFieldEdit', attributes, blockStyle );
 	const innerBlockProps = useInnerBlocksProps( blockProps, {
 		template: [
 			[

--- a/projects/packages/forms/src/blocks/field-multiple-choice/edit.js
+++ b/projects/packages/forms/src/blocks/field-multiple-choice/edit.js
@@ -20,6 +20,35 @@ export default function MultipleChoiceFieldEdit( props ) {
 	useFormWrapper( props );
 	const { blockStyle } = useJetpackFieldStyles( attributes );
 
+	const firstInputBlock = useSelect(
+		select => {
+			const { getBlock } = select( blockEditorStore );
+
+			// Get the current (parent) block
+			const parentBlock = getBlock( clientId );
+			if ( ! parentBlock ) return null;
+
+			// Find first input block within the innerBlocks
+			return parentBlock.innerBlocks.find( block => block.name === 'jetpack/options' );
+		},
+		[ clientId ]
+	);
+
+	// Access the input block's attributes
+	const inputBorderStyles = firstInputBlock?.attributes?.style?.border;
+	const isOutlined = getBlockStyle( context?.[ 'jetpack/form-className' ] ) === FORM_STYLE.OUTLINED;
+	let outlinedBorderStyles = {};
+	if ( isOutlined && !! inputBorderStyles ) {
+		outlinedBorderStyles = {
+			'--jetpack--contact-form--border-size': isNumber( inputBorderStyles?.width )
+				? `${ inputBorderStyles?.width }px`
+				: inputBorderStyles?.width,
+			'--jetpack--contact-form--border-color': inputBorderStyles?.color,
+			'--jetpack--contact-form--border-radius': inputBorderStyles?.radius,
+			'--jetpack--contact-form--border-style': inputBorderStyles?.style,
+		};
+	}
+
 	const innerBlocks = useSelect(
 		select => select( blockEditorStore ).getBlock( clientId ).innerBlocks,
 		[ clientId ]
@@ -34,9 +63,10 @@ export default function MultipleChoiceFieldEdit( props ) {
 		className: classes,
 		style: {
 			...blockStyle,
+			...outlinedBorderStyles,
 		},
 	} );
-	console.log( 'MultipleChoiceFieldEdit', attributes, blockStyle );
+	console.log( 'MultipleChoiceFieldEdit', attributes, blockStyle, outlinedBorderStyles );
 	const innerBlockProps = useInnerBlocksProps( blockProps, {
 		template: [
 			[

--- a/projects/packages/forms/src/blocks/field-multiple-choice/index.js
+++ b/projects/packages/forms/src/blocks/field-multiple-choice/index.js
@@ -66,6 +66,7 @@ const settings = {
 		{ name: 'list', label: __( 'List', 'jetpack-forms' ), isDefault: true },
 		{ name: 'button', label: __( 'Button', 'jetpack-forms' ) },
 	],
+	usesContext: [ 'jetpack/form-className' ],
 };
 
 export default {

--- a/projects/packages/forms/src/blocks/field-name/edit.js
+++ b/projects/packages/forms/src/blocks/field-name/edit.js
@@ -20,6 +20,7 @@ export default function NameFieldEdit( props ) {
 			width={ props.attributes.width }
 			attributes={ props.attributes }
 			insertBlocksAfter={ props.insertBlocksAfter }
+			context={ props.context }
 		/>
 	);
 }

--- a/projects/packages/forms/src/blocks/field-name/index.js
+++ b/projects/packages/forms/src/blocks/field-name/index.js
@@ -37,6 +37,7 @@ const settings = {
 			},
 		],
 	},
+	usesContext: [ 'jetpack/form-className' ],
 };
 
 export default {

--- a/projects/packages/forms/src/blocks/field-number/edit.js
+++ b/projects/packages/forms/src/blocks/field-number/edit.js
@@ -20,6 +20,7 @@ export default function NumberFieldEdit( props ) {
 			width={ props.attributes.width }
 			attributes={ props.attributes }
 			insertBlocksAfter={ props.insertBlocksAfter }
+			context={ props.context }
 		/>
 	);
 }

--- a/projects/packages/forms/src/blocks/field-select/edit.js
+++ b/projects/packages/forms/src/blocks/field-select/edit.js
@@ -10,17 +10,19 @@ import { useSelect } from '@wordpress/data';
 import { useMemo, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
+import { isNumber } from 'lodash';
 import JetpackFieldControls from '../shared/components/jetpack-field-controls';
 import useFormWrapper from '../shared/hooks/use-form-wrapper';
 import useJetpackFieldStyles from '../shared/hooks/use-jetpack-field-styles';
 import { getCaretPosition } from '../shared/util/caret';
-import { ALLOWED_INNER_BLOCKS } from '../shared/util/constants';
+import { ALLOWED_INNER_BLOCKS, FORM_STYLE } from '../shared/util/constants';
+import getBlockStyle from '../shared/util/get-block-style.js';
 import setFocus from '../shared/util/set-focus';
 
 const noop = () => undefined;
 
 export default function DropdownFieldEdit( props ) {
-	const { attributes, clientId, isSelected, name, setAttributes } = props;
+	const { attributes, clientId, isSelected, name, setAttributes, context } = props;
 	const { id, options, required, width } = attributes;
 	const { blockStyle } = useJetpackFieldStyles( attributes );
 	const { isInnerBlockSelected, inputBlockAttributes } = useSelect(
@@ -34,12 +36,44 @@ export default function DropdownFieldEdit( props ) {
 		[ clientId ]
 	);
 
+	const firstInputBlock = useSelect(
+		select => {
+			const { getBlock } = select( blockEditorStore );
+
+			// Get the current (parent) block
+			const parentBlock = getBlock( clientId );
+			if ( ! parentBlock ) return null;
+
+			// Find first input block within the innerBlocks
+			return parentBlock.innerBlocks.find( block => block.name === 'jetpack/input' );
+		},
+		[ clientId ]
+	);
+
+	// Access the input block's attributes
+	const inputBorderStyles = firstInputBlock?.attributes?.style?.border;
+	const isOutlined = getBlockStyle( context?.[ 'jetpack/form-className' ] ) === FORM_STYLE.OUTLINED;
+	let outlinedBorderStyles = {};
+	if ( isOutlined && !! inputBorderStyles ) {
+		outlinedBorderStyles = {
+			'--jetpack--contact-form--border-size': isNumber( inputBorderStyles?.width )
+				? `${ inputBorderStyles?.width }px`
+				: null,
+			'--jetpack--contact-form--border-color': inputBorderStyles?.color,
+			'--jetpack--contact-form--border-radius': inputBorderStyles?.radius,
+			'--jetpack--contact-form--border-style': inputBorderStyles?.style,
+		};
+	}
+
 	const blockProps = useBlockProps( {
 		className: clsx( 'jetpack-field jetpack-field-dropdown', {
 			'is-selected': isSelected || isInnerBlockSelected,
 			'has-placeholder': !! inputBlockAttributes?.placeholder,
 		} ),
-		style: blockStyle,
+		style: {
+			...blockStyle,
+			...outlinedBorderStyles,
+		},
 	} );
 
 	const optionsWrapper = useRef( undefined );

--- a/projects/packages/forms/src/blocks/field-select/edit.js
+++ b/projects/packages/forms/src/blocks/field-select/edit.js
@@ -58,7 +58,7 @@ export default function DropdownFieldEdit( props ) {
 		outlinedBorderStyles = {
 			'--jetpack--contact-form--border-size': isNumber( inputBorderStyles?.width )
 				? `${ inputBorderStyles?.width }px`
-				: null,
+				: inputBorderStyles?.width,
 			'--jetpack--contact-form--border-color': inputBorderStyles?.color,
 			'--jetpack--contact-form--border-radius': inputBorderStyles?.radius,
 			'--jetpack--contact-form--border-style': inputBorderStyles?.style,

--- a/projects/packages/forms/src/blocks/field-select/index.js
+++ b/projects/packages/forms/src/blocks/field-select/index.js
@@ -61,6 +61,7 @@ const settings = {
 			},
 		],
 	},
+	usesContext: [ 'jetpack/form-className' ],
 };
 
 export default {

--- a/projects/packages/forms/src/blocks/field-single-choice/edit.js
+++ b/projects/packages/forms/src/blocks/field-single-choice/edit.js
@@ -6,13 +6,20 @@ import {
 import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
+import { isNumber } from 'lodash';
 import JetpackFieldControls from '../shared/components/jetpack-field-controls';
 import useFormWrapper from '../shared/hooks/use-form-wrapper';
+import { useSyncedAttributes } from '../shared/hooks/use-synced-attributes';
+import { FORM_STYLE } from '../shared/util/constants';
+import getBlockStyle from '../shared/util/get-block-style.js';
+
+const SYNCED_ATTRIBUTE_KEYS = [ 'borderColor', 'borderRadius', 'borderWidth', 'style' ];
 
 export default function SingleChoiceFieldEdit( props ) {
-	const { className, clientId, setAttributes, isSelected, attributes } = props;
+	const { name, className, clientId, setAttributes, isSelected, attributes, context } = props;
 	const { required, id, width } = attributes;
-
+	const { 'jetpack/field-share-attributes': isSynced } = context;
+	useSyncedAttributes( name, isSynced, SYNCED_ATTRIBUTE_KEYS, attributes, setAttributes );
 	useFormWrapper( props );
 
 	const innerBlocks = useSelect(
@@ -25,10 +32,43 @@ export default function SingleChoiceFieldEdit( props ) {
 		'has-placeholder': !! options?.length,
 	} );
 
+	const firstInputBlock = useSelect(
+		select => {
+			const { getBlock } = select( blockEditorStore );
+
+			// Get the current (parent) block
+			const parentBlock = getBlock( clientId );
+			if ( ! parentBlock ) return null;
+
+			// Find first input block within the innerBlocks
+			return parentBlock.innerBlocks.find( block => block.name === 'jetpack/options' );
+		},
+		[ clientId ]
+	);
+
+	// Access the input block's attributes
+	const inputBorderStyles = firstInputBlock?.attributes?.style?.border;
+	const isOutlined = getBlockStyle( context?.[ 'jetpack/form-className' ] ) === FORM_STYLE.OUTLINED;
+	let outlinedBorderStyles = {};
+	if ( isOutlined && !! inputBorderStyles ) {
+		outlinedBorderStyles = {
+			'--jetpack--contact-form--border-size': isNumber( inputBorderStyles?.width )
+				? `${ inputBorderStyles?.width }px`
+				: inputBorderStyles?.width,
+			'--jetpack--contact-form--border-color': inputBorderStyles?.color,
+			'--jetpack--contact-form--border-radius': inputBorderStyles?.radius,
+			'--jetpack--contact-form--border-style': inputBorderStyles?.style,
+		};
+	}
+
 	const blockProps = useBlockProps( {
 		className: classes,
+		style: {
+			...outlinedBorderStyles,
+		},
 	} );
 
+	console.log( 'SingleChoiceFieldEdit', { attributes, blockProps } );
 	const innerBlockProps = useInnerBlocksProps( blockProps, {
 		template: [
 			[

--- a/projects/packages/forms/src/blocks/field-single-choice/index.js
+++ b/projects/packages/forms/src/blocks/field-single-choice/index.js
@@ -64,6 +64,7 @@ const settings = {
 			},
 		],
 	},
+	usesContext: [ 'jetpack/form-className' ],
 };
 
 export default {

--- a/projects/packages/forms/src/blocks/field-telephone/edit.js
+++ b/projects/packages/forms/src/blocks/field-telephone/edit.js
@@ -20,6 +20,7 @@ export default function TelephoneFieldEdit( props ) {
 			width={ props.attributes.width }
 			attributes={ props.attributes }
 			insertBlocksAfter={ props.insertBlocksAfter }
+			context={ props.context }
 		/>
 	);
 }

--- a/projects/packages/forms/src/blocks/field-telephone/index.js
+++ b/projects/packages/forms/src/blocks/field-telephone/index.js
@@ -40,6 +40,7 @@ const settings = {
 			},
 		],
 	},
+	usesContext: [ 'jetpack/form-className' ],
 };
 
 export default {

--- a/projects/packages/forms/src/blocks/field-text/edit.js
+++ b/projects/packages/forms/src/blocks/field-text/edit.js
@@ -20,6 +20,7 @@ export default function TextFieldEdit( props ) {
 			width={ props.attributes.width }
 			attributes={ props.attributes }
 			insertBlocksAfter={ props.insertBlocksAfter }
+			context={ props.context }
 		/>
 	);
 }

--- a/projects/packages/forms/src/blocks/field-text/index.js
+++ b/projects/packages/forms/src/blocks/field-text/index.js
@@ -37,6 +37,7 @@ const settings = {
 			},
 		],
 	},
+	usesContext: [ 'jetpack/form-className' ],
 };
 
 export default {

--- a/projects/packages/forms/src/blocks/field-textarea/edit.js
+++ b/projects/packages/forms/src/blocks/field-textarea/edit.js
@@ -45,7 +45,7 @@ export default function TextareaFieldEdit( props ) {
 		outlinedBorderStyles = {
 			'--jetpack--contact-form--border-size': isNumber( inputBorderStyles?.width )
 				? `${ inputBorderStyles?.width }px`
-				: null,
+				: inputBorderStyles?.width,
 			'--jetpack--contact-form--border-color': inputBorderStyles?.color,
 			'--jetpack--contact-form--border-radius': inputBorderStyles?.radius,
 			'--jetpack--contact-form--border-style': inputBorderStyles?.style,

--- a/projects/packages/forms/src/blocks/field-textarea/edit.js
+++ b/projects/packages/forms/src/blocks/field-textarea/edit.js
@@ -1,26 +1,65 @@
-import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
+import {
+	useBlockProps,
+	useInnerBlocksProps,
+	store as blockEditorStore,
+} from '@wordpress/block-editor';
+import { useSelect } from '@wordpress/data';
 import { useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
+import { isNumber } from 'lodash';
 import JetpackFieldControls from '../shared/components/jetpack-field-controls';
 import useFieldSelected from '../shared/hooks/use-field-selected';
 import useFormWrapper from '../shared/hooks/use-form-wrapper';
 import useJetpackFieldStyles from '../shared/hooks/use-jetpack-field-styles';
-import { ALLOWED_INNER_BLOCKS } from '../shared/util/constants';
+import { ALLOWED_INNER_BLOCKS, FORM_STYLE } from '../shared/util/constants';
+import getBlockStyle from '../shared/util/get-block-style.js';
 
 export default function TextareaFieldEdit( props ) {
-	const { attributes, clientId, id, isSelected, label, requiredText, setAttributes } = props;
+	const { attributes, clientId, id, isSelected, label, requiredText, setAttributes, context } =
+		props;
 	const { required, width } = attributes;
 
 	useFormWrapper( props );
 	const { blockStyle } = useJetpackFieldStyles( attributes );
 	const { isInnerBlockSelected, hasPlaceholder } = useFieldSelected( clientId );
+	const firstInputBlock = useSelect(
+		select => {
+			const { getBlock } = select( blockEditorStore );
+
+			// Get the current (parent) block
+			const parentBlock = getBlock( clientId );
+			if ( ! parentBlock ) return null;
+
+			// Find first input block within the innerBlocks
+			return parentBlock.innerBlocks.find( block => block.name === 'jetpack/input' );
+		},
+		[ clientId ]
+	);
+
+	// Access the input block's attributes
+	const inputBorderStyles = firstInputBlock?.attributes?.style?.border;
+	const isOutlined = getBlockStyle( context?.[ 'jetpack/form-className' ] ) === FORM_STYLE.OUTLINED;
+	let outlinedBorderStyles = {};
+	if ( isOutlined && !! inputBorderStyles ) {
+		outlinedBorderStyles = {
+			'--jetpack--contact-form--border-size': isNumber( inputBorderStyles?.width )
+				? `${ inputBorderStyles?.width }px`
+				: null,
+			'--jetpack--contact-form--border-color': inputBorderStyles?.color,
+			'--jetpack--contact-form--border-radius': inputBorderStyles?.radius,
+			'--jetpack--contact-form--border-style': inputBorderStyles?.style,
+		};
+	}
 	const blockProps = useBlockProps( {
 		className: clsx( 'jetpack-field jetpack-field-textarea', {
 			'is-selected': isSelected || isInnerBlockSelected,
 			'has-placeholder': hasPlaceholder,
 		} ),
-		style: blockStyle,
+		style: {
+			...blockStyle,
+			...outlinedBorderStyles,
+		},
 	} );
 
 	const defaultLabel = __( 'Message', 'jetpack-forms' );

--- a/projects/packages/forms/src/blocks/field-textarea/index.js
+++ b/projects/packages/forms/src/blocks/field-textarea/index.js
@@ -42,6 +42,7 @@ const settings = {
 			},
 		],
 	},
+	usesContext: [ 'jetpack/form-className' ],
 };
 
 export default {

--- a/projects/packages/forms/src/blocks/field-url/edit.js
+++ b/projects/packages/forms/src/blocks/field-url/edit.js
@@ -20,6 +20,7 @@ export default function UrlFieldEdit( props ) {
 			width={ props.attributes.width }
 			attributes={ props.attributes }
 			insertBlocksAfter={ props.insertBlocksAfter }
+			context={ props.context }
 		/>
 	);
 }

--- a/projects/packages/forms/src/blocks/field-url/index.js
+++ b/projects/packages/forms/src/blocks/field-url/index.js
@@ -41,6 +41,7 @@ const settings = {
 			},
 		],
 	},
+	usesContext: [ 'jetpack/form-className' ],
 };
 
 export default {

--- a/projects/packages/forms/src/blocks/input/edit.js
+++ b/projects/packages/forms/src/blocks/input/edit.js
@@ -45,7 +45,7 @@ const InputEdit = ( { attributes, clientId, isSelected, name, setAttributes, con
 		},
 		[ setAttributes ]
 	);
-
+	console.log( 'InputEdit attributes', attributes );
 	if ( type === 'dropdown' ) {
 		return (
 			<div { ...blockProps }>

--- a/projects/packages/forms/src/blocks/options/edit.js
+++ b/projects/packages/forms/src/blocks/options/edit.js
@@ -1,6 +1,17 @@
 import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
+import { useSyncedAttributes } from '../shared/hooks/use-synced-attributes';
 
-const OptionsEdit = () => {
+const SYNCED_ATTRIBUTE_KEYS = [ 'borderColor', 'style' ];
+
+const OptionsEdit = ( { attributes, name, setAttributes, context } ) => {
+	useSyncedAttributes(
+		'jetpack/input',
+		context?.[ 'jetpack/field-share-attributes' ],
+		SYNCED_ATTRIBUTE_KEYS,
+		attributes,
+		setAttributes
+	);
+	console.log( 'OptionsEdit', { attributes, context } );
 	const blockProps = useBlockProps( { className: 'jetpack-field-multiple__list' } );
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		allowedBlocks: [ `jetpack/option` ],

--- a/projects/packages/forms/src/blocks/options/index.js
+++ b/projects/packages/forms/src/blocks/options/index.js
@@ -23,12 +23,25 @@ const settings = {
 		},
 	},
 	allowedBlocks: [ 'jetpack/field-options' ],
+	usesContext: [ 'jetpack/field-share-attributes' ],
 	providesContext: {
 		'jetpack/field-options-type': 'type',
 	},
 	supports: {
 		spacing: {
 			blockGap: false,
+		},
+		__experimentalBorder: {
+			color: true,
+			radius: true,
+			style: true,
+			width: true,
+			__experimentalDefaultControls: {
+				color: true,
+				radius: true,
+				style: true,
+				width: true,
+			},
 		},
 	},
 	edit,

--- a/projects/packages/forms/src/blocks/shared/components/jetpack-field.js
+++ b/projects/packages/forms/src/blocks/shared/components/jetpack-field.js
@@ -2,6 +2,7 @@ import {
 	useBlockProps,
 	store as blockEditorStore,
 	useInnerBlocksProps,
+	__experimentalGetBorderClassesAndStyles as getBorderClassesAndStyles, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 } from '@wordpress/block-editor';
 import { getBlockType } from '@wordpress/blocks';
 import { createHigherOrderComponent } from '@wordpress/compose';
@@ -47,17 +48,18 @@ const JetpackField = props => {
 	);
 
 	// Access the input block's attributes
-	const inputBorderStyles = firstInputBlock?.attributes?.style?.border;
+	const inputBorderStyles = getBorderClassesAndStyles( firstInputBlock?.attributes ?? {} );
 	const isOutlined = getBlockStyle( context?.[ 'jetpack/form-className' ] ) === FORM_STYLE.OUTLINED;
+	console.log( 'JetpackField inputBorderStyles', inputBorderStyles );
 	let outlinedBorderStyles = {};
-	if ( isOutlined && !! inputBorderStyles ) {
+	if ( isOutlined && !! inputBorderStyles?.style ) {
 		outlinedBorderStyles = {
-			'--jetpack--contact-form--border-size': isNumber( inputBorderStyles?.width )
-				? `${ inputBorderStyles?.width }px`
-				: null,
-			'--jetpack--contact-form--border-color': inputBorderStyles?.color,
-			'--jetpack--contact-form--border-radius': inputBorderStyles?.radius,
-			'--jetpack--contact-form--border-style': inputBorderStyles?.style,
+			'--jetpack--contact-form--border-size': isNumber( inputBorderStyles?.style?.borderWidth )
+				? `${ inputBorderStyles?.style?.borderWidth }px`
+				: inputBorderStyles?.style?.borderWidth,
+			'--jetpack--contact-form--border-color': inputBorderStyles?.style?.borderColor,
+			'--jetpack--contact-form--border-radius': inputBorderStyles?.style?.borderRadius,
+			'--jetpack--contact-form--border-style': inputBorderStyles?.style?.borderStyle,
 		};
 	}
 
@@ -65,6 +67,7 @@ const JetpackField = props => {
 		className: clsx( 'jetpack-field', {
 			'is-selected': isSelected || isInnerBlockSelected,
 			'has-placeholder': hasPlaceholder,
+			[ inputBorderStyles?.className ]: !! inputBorderStyles?.className,
 		} ),
 		style: {
 			...blockStyle,

--- a/projects/packages/forms/src/blocks/shared/components/jetpack-field.js
+++ b/projects/packages/forms/src/blocks/shared/components/jetpack-field.js
@@ -1,12 +1,19 @@
-import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
+import {
+	useBlockProps,
+	store as blockEditorStore,
+	useInnerBlocksProps,
+} from '@wordpress/block-editor';
 import { getBlockType } from '@wordpress/blocks';
 import { createHigherOrderComponent } from '@wordpress/compose';
+import { useSelect } from '@wordpress/data';
 import { useMemo } from '@wordpress/element';
 import { addFilter } from '@wordpress/hooks';
 import clsx from 'clsx';
+import { isNumber } from 'lodash';
 import useFieldSelected from '../hooks/use-field-selected';
 import useJetpackFieldStyles from '../hooks/use-jetpack-field-styles';
-import { ALLOWED_INNER_BLOCKS } from '../util/constants';
+import { ALLOWED_INNER_BLOCKS, FORM_STYLE } from '../util/constants';
+import getBlockStyle from '../util/get-block-style.js';
 import JetpackFieldControls from './jetpack-field-controls';
 
 const JetpackField = props => {
@@ -21,15 +28,48 @@ const JetpackField = props => {
 		setAttributes,
 		type,
 		width,
+		context,
 	} = props;
 	const { isInnerBlockSelected, hasPlaceholder } = useFieldSelected( clientId );
 	const { blockStyle } = useJetpackFieldStyles( attributes );
+	const firstInputBlock = useSelect(
+		select => {
+			const { getBlock } = select( blockEditorStore );
+
+			// Get the current (parent) block
+			const parentBlock = getBlock( clientId );
+			if ( ! parentBlock ) return null;
+
+			// Find first input block within the innerBlocks
+			return parentBlock.innerBlocks.find( block => block.name === 'jetpack/input' );
+		},
+		[ clientId ]
+	);
+
+	// Access the input block's attributes
+	const inputBorderStyles = firstInputBlock?.attributes?.style?.border;
+	const isOutlined = getBlockStyle( context?.[ 'jetpack/form-className' ] ) === FORM_STYLE.OUTLINED;
+	let outlinedBorderStyles = {};
+	if ( isOutlined && !! inputBorderStyles ) {
+		outlinedBorderStyles = {
+			'--jetpack--contact-form--border-size': isNumber( inputBorderStyles?.width )
+				? `${ inputBorderStyles?.width }px`
+				: null,
+			'--jetpack--contact-form--border-color': inputBorderStyles?.color,
+			'--jetpack--contact-form--border-radius': inputBorderStyles?.radius,
+			'--jetpack--contact-form--border-style': inputBorderStyles?.style,
+		};
+	}
+
 	const blockProps = useBlockProps( {
 		className: clsx( 'jetpack-field', {
 			'is-selected': isSelected || isInnerBlockSelected,
 			'has-placeholder': hasPlaceholder,
 		} ),
-		style: blockStyle,
+		style: {
+			...blockStyle,
+			...outlinedBorderStyles,
+		},
 	} );
 
 	const labelBlockType = getBlockType( 'jetpack/label' );

--- a/projects/packages/forms/src/blocks/shared/hooks/use-synced-attributes.js
+++ b/projects/packages/forms/src/blocks/shared/hooks/use-synced-attributes.js
@@ -47,6 +47,8 @@ export function SyncedAttributeProvider( { children } ) {
 function useSyncedAttributesForBlock( name, contextValue ) {
 	const [ syncedAttributes, setSyncedAttributes ] = contextValue;
 
+	console.log( 'useSyncedAttributesForBlock', { name, syncedAttributes } );
+
 	return useMemo( () => {
 		return [ syncedAttributes[ name ], attributes => setSyncedAttributes( { name, attributes } ) ];
 	}, [ name, setSyncedAttributes, syncedAttributes ] );
@@ -124,6 +126,14 @@ export function useSyncedAttributes(
 		name,
 		contextValue
 	);
+
+	console.log( 'useSyncedAttributes', {
+		name,
+		isSynced,
+		syncedAttributeKeys,
+		attributes,
+		setOwnAttributes,
+	} );
 
 	// The own attributes belong to the current block that this hook operates on.
 	// If these change and the block is synced, the synced attributes will be updated on the parent form using


### PR DESCRIPTION
Similar to https://github.com/Automattic/jetpack/pull/43202 but starting out on unmigrated forms and building upwards.


Update: this approach is invalid. It's trying to use the existing system of CSS vars which are incompatible with the block editor styles system.

The style is pretty borked in general. There's a path to semi-support but it's convoluted, like a regular block isn't.

### Known constraints:

Input border styles should apply to the notched labels, but we have to use the style object and override the CSS vars

The current state of the outline style for forms is that the borders only apply to input fields. Checkbox/radio fields get the borders in the editor, but not in the frontend







JETPACK-273

https://github.com/user-attachments/assets/9ea5b241-f3fc-40ec-8d08-f1a7d9f75961



<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

