### PR TITLE
Jetpack CRM: Improve Woo Sync's Tax Importing process

### DIFF
--- a/projects/plugins/crm/changelog/improve-woosync
+++ b/projects/plugins/crm/changelog/improve-woosync
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+fixed a bug where tax names appended From WooCommerce

--- a/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-background-sync-job.php
+++ b/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-background-sync-job.php
@@ -1258,8 +1258,8 @@ class Woo_Sync_Background_Sync_Job {
 
 	        		if ( 
 	        			
-	        			// name
-	        			sprintf( __( '%s (From WooCommerce)', 'zero-bs-crm' ), $tax_label ) == $tax_rate_detail['name']
+						// name
+						$tax_label === $tax_rate_detail['name']
 	        			&&
 	        			// rate
 	        			$tax_rate == $tax_rate_detail['rate']
@@ -1282,7 +1282,7 @@ class Woo_Sync_Background_Sync_Job {
 
 							//'id'   => -1,
 							'data' => array(
-								'name' => sprintf( __( '%s (From WooCommerce)', 'zero-bs-crm' ), $tax_label ),
+								'name' => $tax_label,
 								'rate' => (float)$tax_rate,
 							),
 						)
@@ -1612,8 +1612,7 @@ class Woo_Sync_Background_Sync_Job {
 					$tax_label = $tax_items_labels[ $rate_id ];
 
 					foreach ( $tax_rates_table as $tax_rate_id => $tax_rate_detail ) {
-						// Translators: %s = tax rate name
-						if ( sprintf( __( '%s (From WooCommerce)', 'zero-bs-crm' ), $tax_label ) === $tax_rate_detail['name'] ) {
+						if ( $tax_label === $tax_rate_detail['name'] ) {
 							$shipping_tax_id = $tax_rate_id;
 							break;
 						}
@@ -1661,7 +1660,7 @@ class Woo_Sync_Background_Sync_Job {
 			        	// match tax label to tax in our crm tax table (should have been added by the logic above here, even if new)
 			        	foreach ( $tax_rates_table as $tax_rate_id => $tax_rate_detail ){
 
-			        		if ( sprintf( __( '%s (From WooCommerce)', 'zero-bs-crm' ), $tax_label ) == $tax_rate_detail['name'] ){
+							if ( $tax_label === $tax_rate_detail['name'] ) {
 
 			        			// this tax is applied to this line item
 			        			$item_tax_rate_ids[] = $tax_rate_id;


### PR DESCRIPTION
Fixes part of the issues reported [here](https://github.com/Automattic/zero-bs-crm/issues/3552) I'll put more PRs in for other tweaks. 

## Proposed changes:
* Stops tax rates importing as "(From WooCommerce)"

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
Discussed here: p1743898356211569/1743574639.732139-slack-CL5UJ9ASE

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
- Have a Woo Store with tax rates, name one VAT at 20% (doesn't matter the rate)
- Create an order, with a value and VAT applied
- This will be added to the CRM invoice as "VAT (From WooCommerce)" which makes no sense when on an invoice
