### PR TITLE
Forms: no colon after question mark

### DIFF
--- a/projects/packages/forms/changelog/update-forms-no-colon-after-question-mark
+++ b/projects/packages/forms/changelog/update-forms-no-colon-after-question-mark
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: don't show colon after question mark for form labels

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -2049,7 +2049,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 	 */
 	private static function maybe_add_colon_to_label( $label ) {
 		$formatted_label = $label ? $label : '';
-		$formatted_label = wp_endswith( $formatted_label, '?' ) ? $formatted_label : $formatted_label . ':';
+		$formatted_label = str_ends_with( $formatted_label, '?' ) ? $formatted_label : $formatted_label . ':';
 
 		return $formatted_label;
 	}

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -590,7 +590,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 				}
 
 				$field_index = array_search( $field_ids[ $type ], $field_ids['all'], true );
-				$field_label = $field->get_attribute( 'label' ) ? $field->get_attribute( 'label' ) . ':' : '';
+				$field_label = self::maybe_add_colon_to_label( $field->get_attribute( 'label' ) );
 
 				$compiled_form[ $field_index ] = sprintf(
 					'<div class="field-name">%1$s</div> <div class="field-value">%2$s</div>',
@@ -616,7 +616,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 					$field       = $form->fields[ $field_id ];
 					$field_index = array_search( $field_id, $field_ids['all'], true );
 
-					$label = $field->get_attribute( 'label' ) ? $field->get_attribute( 'label' ) . ':' : '';
+					$label = self::maybe_add_colon_to_label( $field->get_attribute( 'label' ) );
 
 					$compiled_form[ $field_index ] = sprintf(
 						'<div class="field-name">%1$s</div> <div class="field-value">%2$s</div>',
@@ -683,7 +683,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 				}
 
 				$field_index = array_search( $field_ids[ $type ], $field_ids['all'], true );
-				$field_label = $field->get_attribute( 'label' ) ? $field->get_attribute( 'label' ) . ':' : '';
+				$field_label = self::maybe_add_colon_to_label( $field->get_attribute( 'label' ) );
 
 				$compiled_form[ $field_index ] = array(
 					wp_kses( $field_label, array() ),
@@ -709,7 +709,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 					$field       = $form->fields[ $field_id ];
 					$field_index = array_search( $field_id, $field_ids['all'], true );
 
-					$field_label = $field->get_attribute( 'label' ) ? $field->get_attribute( 'label' ) . ':' : '';
+					$field_label = self::maybe_add_colon_to_label( $field->get_attribute( 'label' ) );
 
 					$compiled_form[ $field_index ] = array(
 						wp_kses( $field_label, array() ),
@@ -2039,5 +2039,18 @@ class Contact_Form extends Contact_Form_Shortcode {
 			'field_id' => $field_id,
 			'files'    => $file_data_array,
 		);
+	}
+
+	/**
+	 * Ensures a field label ends with a colon, unless it ends with a question mark.
+	 *
+	 * @param string $label The field label.
+	 * @return string The formatted label.
+	 */
+	private static function maybe_add_colon_to_label( $label ) {
+		$formatted_label = $label ? $label : '';
+		$formatted_label = wp_endswith( $formatted_label, '?' ) ? $formatted_label : $formatted_label . ':';
+
+		return $formatted_label;
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes FORMS-22

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR ensures field labels end with a colon on form submissions and emails, unless they end with a question mark.

Form submission:
Before:
![Screenshot 2025-04-30 at 20 25 59](https://github.com/user-attachments/assets/5c28592b-eeb9-4ecb-8531-dd2d19971801)

After:
![Screenshot 2025-04-30 at 20 31 34](https://github.com/user-attachments/assets/24bd568a-0ee1-4c5c-b6f2-05730b31ca2f)

Email response:
Before:
![Screenshot 2025-04-30 at 20 29 17](https://github.com/user-attachments/assets/a7f8bd2d-5d4f-49a2-870a-0c9396f7d3ad)

After:
![Screenshot 2025-04-30 at 20 29 48](https://github.com/user-attachments/assets/8dbce2c7-2244-48fd-8086-3e9684bfe537)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Spin up a JN site with this branch
* Create a form with at least one label that ends with a question mark, and others without it
* Go to the page/post where you created the form and make a form submission
* Check in the form submission that the label with the question mark doesn't have a colon at the end
* Check in the form submission that the labels without a question mark are followed by a colon
* Check that the same thing as the above is in the email responses