### PR TITLE
Returns site slug in the REST /sites/%s endpoint

### DIFF
--- a/projects/plugins/jetpack/changelog/get-site-slug
+++ b/projects/plugins/jetpack/changelog/get-site-slug
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Returns site slug in the REST /sites/%s endpoint

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -42,6 +42,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 	 */
 	public static $site_format = array(
 		'ID'                          => '(int) Site ID',
+		'slug'                        => '(string) Slug of site',
 		'name'                        => '(string) Title of site',
 		'description'                 => '(string) Tagline or description of site',
 		'URL'                         => '(string) Full URL to the site',
@@ -229,6 +230,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 	 * @var array $jetpack_response_field_additions
 	 */
 	protected static $jetpack_response_field_additions = array(
+		'slug',
 		'subscribers_count',
 		'site_migration',
 		'site_owner',
@@ -463,6 +465,9 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		switch ( $key ) {
 			case 'ID':
 				$response[ $key ] = $this->site->blog_id;
+				break;
+			case 'slug':
+				$response[ $key ] = $this->site->get_slug();
 				break;
 			case 'name':
 				$response[ $key ] = $this->site->get_name();

--- a/projects/plugins/jetpack/sal/class.json-api-site-base.php
+++ b/projects/plugins/jetpack/sal/class.json-api-site-base.php
@@ -61,6 +61,15 @@ abstract class SAL_Site {
 	}
 
 	/**
+	 * Returns the site slug.
+	 *
+	 * @return string
+	 */
+	public function get_slug() {
+		return ( new Status() )->get_site_suffix();
+	}
+
+	/**
 	 * Returns the site name.
 	 *
 	 * @return string


### PR DESCRIPTION
Related to DOTCOM-12936

## Proposed changes:

This PR allows `slug` to be returned as the response of the following REST endpoints:

- `/rest/v1.2/me/sites`
- `rest/v1.1/sites/%s`

This is to prevent logic duplication between wpcom and Calypso:

- wpcom: https://github.com/Automattic/jetpack/blob/cb4e65d685d55f00f9649d5158b67c62f9447e32/projects/packages/status/src/class-status.php#L411-L438
- Calypso: https://github.com/Automattic/wp-calypso/blob/13b5bb7a5322b99d1ae1bf45ea298c30da0bf8dc/client/data/sites/use-site-excerpts-query.ts#L85-L99

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

See testing instructions on https://github.com/Automattic/wp-calypso/pull/103015.

