### PR TITLE
Fix/forms emails double subject

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-emails-double-subject
+++ b/projects/packages/forms/changelog/fix-forms-emails-double-subject
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Fixes the double subject in the response emails

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1606,7 +1606,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 		 *
 		 * @param string the title of the email
 		 */
-		$title   = (string) apply_filters( 'jetpack_forms_response_email_title', $subject );
+		$title   = (string) apply_filters( 'jetpack_forms_response_email_title', '' );
 		$message = self::get_compiled_form_for_email( $post_id, $this );
 
 		if ( is_user_logged_in() ) {

--- a/projects/plugins/jetpack/changelog/fix-forms-emails-double-subject
+++ b/projects/plugins/jetpack/changelog/fix-forms-emails-double-subject
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: fixes the double subject in the response emails


### PR DESCRIPTION
Fixes issue where the Response subject now appears in the response email twice. The issue was introduced in https://github.com/Automattic/jetpack/pull/43093 

Before:

![Screenshot 2025-04-16 at 5 12 09 PM](https://github.com/user-attachments/assets/9d23f12d-4862-454e-be2d-db8f74a089f2)

After: 

![Screenshot 2025-04-30 at 12 46 31 PM](https://github.com/user-attachments/assets/87251d81-63a3-4081-9c98-ce074c84f66f)


## Proposed changes:
* Revert the subject line to be blank so that it doesn't show for users in iOS Mail App twice. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion


## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Fill out the form.
How does the new email template look like?
Does it work nicely in different email clients?
