### PR TITLE
charts: Fix tests on hosts with a negative UTC offset

### DIFF
--- a/projects/js-packages/charts/changelog/fix-charts-test-on-utc-negative-timezone-hosts
+++ b/projects/js-packages/charts/changelog/fix-charts-test-on-utc-negative-timezone-hosts
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix tests on hosts configured with a negative offset from UTC by setting the `TZ` environment variable.
+
+

--- a/projects/js-packages/charts/package.json
+++ b/projects/js-packages/charts/package.json
@@ -15,7 +15,7 @@
 	"author": "Automattic",
 	"scripts": {
 		"clean": "rm -rf dist",
-		"test": "jest --config=tests/jest.config.cjs",
+		"test": "TZ=UTC jest --config=tests/jest.config.cjs",
 		"test-coverage": "pnpm run test --coverage",
 		"storybook": "cd ../storybook && pnpm run storybook:dev",
 		"compile-ts": "tsc --pretty",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
`new Date( '2024-01-03' )` creates an object for 2024-01-03T00:00:00Z. If the host is configured with a timezone that is a negative offset from UTC, later processing of this object interprets this as a date in the evening of January 2 rather than the morning of January 3, causing two tests to fail.

We can set the `TZ` environment variable to UTC to force the "local" timezone for the tests as UTC to avoid this problem.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Set your timezone to a negative UTC offset, e.g. with `export TZ=EST+5`. Confirm that `node -e 'const dt = new Date( "2024-01-03" ); console.log( dt.toDateString(), dt.toTimeString() );'` outputs something like "Tue Jan 02 2024 19:00:00 GMT-0500 (GMT-05:00)".
* Run tests (e.g. `jetpack test js js-packages/charts`) without and with this PR.
