### PR TITLE
Forms: Update feedback email template

### DIFF
--- a/projects/packages/forms/changelog/update-feedback-emails-take-2
+++ b/projects/packages/forms/changelog/update-feedback-emails-take-2
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: update the email template for feedback responses

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1653,15 +1653,12 @@ class Contact_Form extends Contact_Form_Shortcode {
 			apply_filters(
 				'jetpack_forms_response_email_footer',
 				array(
-					'<br />',
-					'<hr />',
 					'<span style="font-size: 12px">',
 					$footer_time . '<br />',
 					$footer_ip ? $footer_ip . '<br />' : null,
 					$footer_url . '<br />',
 					$sent_by_text,
 					'</span>',
-					'<hr />',
 				)
 			)
 		);
@@ -1897,6 +1894,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 		}
 
 		$template = '';
+		$style    = '';
 
 		/**
 		 * Filter the filename of the template HTML surrounding the response email. The PHP file will return the template in a variable called $template.
@@ -1920,7 +1918,8 @@ class Contact_Form extends Contact_Form_Shortcode {
 			$body,
 			'',
 			'',
-			$footer
+			$footer,
+			$style
 		);
 
 		return $html_message;

--- a/projects/packages/forms/src/contact-form/templates/email-response.php
+++ b/projects/packages/forms/src/contact-form/templates/email-response.php
@@ -7,24 +7,215 @@
  * %3$s is a link to the response page in wp-admin
  * %4$s is a link to the embedded form to allow the site owner to edit it to change their email address.
  * %5$s is the footer HTML.
+ * %6$s style HTML tag.
  *
  * @package automattic/jetpack
  */
 
 // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- used in class-contact-form.php
 $template = '
-<!doctype html>
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	%6$s
+</head>
 <body>
-<!-- title -->
-%1$s
+	<table role="presentation" border="0" cellpadding="0" cellspacing="0" class="body">
+		<tr>
+			<td class="collapse">&nbsp;</td>
+			<td class="container">
+				<div class="content">
+					<span class="preheader">%1$s</span>
+					<table role="presentation" border="0" cellpadding="0" cellspacing="0" class="main">
+						<tr>
+						<td class="wrapper">
+							<!-- response -->
+							<p>%2$s</p>
+							%3$s
+							%4$s
+						</td>
+						</tr>
+					</table>
 
-<!-- response -->
-<p>%2$s</p>
-%3$s
-%4$s
-<!-- footer -->
-<p>%5$s</p>
+					<!-- START FOOTER -->
+					<div class="footer">
+						<table role="presentation" border="0" cellpadding="0" cellspacing="0">
+						<tr>
+							<td class="content-block wrapper">
+								<!-- footer -->
+								<p>%5$s</p>
+							</td>
+						</tr>
+						<tr>
+							<td class="content-block powered-by">
+								' .
+								sprintf(
+									// translators: %1$s is a link to the Jetpack Forms page.
+									__( 'Powered by %1$s', 'jetpack-forms' ),
+									'<a href="https://jetpack.com/forms/?utm_source=jetpack-forms&utm_medium=email&utm_campaign=form-submissions">Jetpack Forms</a>'
+								) . '
+							</td>
+						</tr>
+						</table>
+					</div>
+				</div>
+			</td>
+			<td class="collapse">&nbsp;</td>
+		</tr>
+	</table>
 </body>
 </html>
 ';
+
+// phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- used in class-contact-form.php
+$style = '<style media="all" type="text/css">
+	body {
+		font-family: sans-serif;
+		-webkit-font-smoothing: antialiased;
+		font-size: 16px;
+		line-height: 1.3;
+		-ms-text-size-adjust: 100%;
+		-webkit-text-size-adjust: 100%;
+	}
+
+	table {
+		border-collapse: separate;
+		mso-table-lspace: 0pt;
+		mso-table-rspace: 0pt;
+		width: 100%;
+	}
+
+	table td {
+		font-family: Helvetica, sans-serif;
+		font-size: 16px;
+		vertical-align: top;
+	}
+
+	body {
+		background-color: #f6f7f7;
+		margin: 0;
+		padding: 0;
+	}
+
+	.body {
+		background-color: #f6f7f7;
+		width: 100%;
+	}
+
+	.container {
+		margin: 0 auto !important;
+		max-width: 640px;
+		padding: 0;
+		padding-top: 24px;
+		width: 640px;
+	}
+
+	.content {
+		box-sizing: border-box;
+		display: block;
+		margin: 0 auto;
+		max-width: 640px;
+		padding: 0;
+	}
+
+	.main {
+		background: #fff;
+		width: 100%;
+	}
+
+	.wrapper {
+		box-sizing: border-box;
+		padding: 24px;
+	}
+	.content-block {
+		box-sizing: border-box;
+		padding: 0 24px 24px;
+	}
+
+	.footer {
+		clear: both;
+		padding: 24px 0;
+		width: 100%;
+	}
+	.footer td,
+	.footer p,
+	.footer span,
+	.footer a {
+		color: #101517;
+		font-size: 12px;
+	}
+	h1 {
+		font-size: 20px;
+	}
+	p {
+		font-family: sans-serif;
+		font-size: 16px;
+		font-weight: normal;
+		margin: 0;
+		margin-bottom: 16px;
+	}
+
+	.powered-by a {
+		text-decoration: none;
+	}
+	@media only screen and (max-width: 640px) {
+		.main p,
+		.main td,
+		.main span {
+			font-size: 16px !important;
+		}
+		.wrapper {
+			padding: 8px 16px !important;
+		}
+		.powered-by {
+			padding: 0 16px 16px!important;
+		}
+		.content {
+			padding: 0 !important;
+		}
+		.container {
+			padding: 0 !important;
+			padding-top: 8px !important;
+			width: 100% !important;
+		}
+		.main {
+			border-left-width: 0 !important;
+			border-radius: 0 !important;
+			border-right-width: 0 !important;
+		}
+		.collapse { display: none; }
+		h1 { padding:0 16px; }
+	}
+
+	@media all {
+		.ExternalClass {
+			width: 100%;
+		}
+		.ExternalClass,
+		.ExternalClass p,
+		.ExternalClass span,
+		.ExternalClass font,
+		.ExternalClass td,
+		.ExternalClass div {
+			line-height: 100%;
+		}
+		.apple-link a {
+			color: inherit !important;
+			font-family: inherit !important;
+			font-size: inherit !important;
+			font-weight: inherit !important;
+			line-height: inherit !important;
+			text-decoration: none !important;
+		}
+		#MessageViewBody a {
+			color: inherit;
+			text-decoration: none;
+			font-size: inherit;
+			font-family: inherit;
+			font-weight: inherit;
+			line-height: inherit;
+		}
+	}
+</style>';

--- a/projects/plugins/jetpack/changelog/update-feedback-emails-take-2
+++ b/projects/plugins/jetpack/changelog/update-feedback-emails-take-2
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: update the email template for feedback responses


### PR DESCRIPTION
Resolves FORMS-40

This PR updates the email template that is send to admins when someone submits the form. 

We are doing this so that the email that goes out look a more modern. The current email template does not apply any styles so the emails. So fonts and such look dated. 

This PR is a revert or a revert ( + bug fixes )
This version of the email template doesn't include the subject line in the email copy so that it doesn't show up twice in some email clients.

Before:
![Screenshot 2025-05-01 at 10 39 38 AM](https://github.com/user-attachments/assets/f95ab88b-88f9-4f32-98c7-ff9b896cf201)

After:
![Screenshot 2025-05-01 at 10 41 08 AM](https://github.com/user-attachments/assets/66bad05f-2c6d-466a-8a19-6b72bedd1c09)

## Proposed changes:
* Update the design to look more modern. 
* Add a footer linking to jetpack forms. 

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion


## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
On a jurassic.ninja site or a hosted jetpack site. Apply this branch.
* Create a form. Insert it into a page or post.
* Fill out the form. 
* Check the email that get sent to the admin across different email client. Mobile and desktop. 
* Notice that it looks good across them. 

