### PR TITLE
[WIP] Forms: migrate Outlined form style for inner block based fields

### DIFF
--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -149,7 +149,6 @@ class Contact_Form_Block {
 				'uses_context' => array(
 					'jetpack/field-required',
 					'jetpack/field-dateFormat',
-					'jetpack/field-share-input-type',
 				),
 			)
 		);


### PR DESCRIPTION
## Proposed changes:

Fixes https://github.com/Automattic/jetpack-roadmap/issues/2413

The main thrust of this PR is to ensure that the form style "Outlined" works as expected with inner blocks. See: https://github.com/Automattic/jetpack/pull/42890

The side quest is to fix many of the existing bugs in trunk including, but not exclusive to:

- Multi option fields do not display borders, background styles on the frontend, even though they do in the editor.
- Multi option fields are not synced with other fields when updating styles in the editor
- Global styles do not work at all.
- The select dropdown is styled, but it’s the HTML default in the frontend, and the select arrow icon takes on the input color, but it is always black in the frontend
- Thick borders interfere with the multi option blocks. You cannot add items.

With this branch you can build amazing forms like this!!

<img width="773" alt="Screenshot 2025-05-15 at 3 45 18 pm" src="https://github.com/user-attachments/assets/0182bb0c-37a6-4c40-9dbd-1b6ec3674014" />

This migration PR is the alternative to deprecating the form at https://github.com/Automattic/jetpack/pull/43366

 See JETPACK-273

Prior work:

- https://github.com/Automattic/jetpack/pull/43202
- https://github.com/Automattic/jetpack/pull/43304



## Testing instructions:

There are two objectives to this PR:

- make sure the Outline style copes with innerblocks and global styles
- tweak the styles/functionality so they're better than we left it

Given that, and the many complications and bugs in trunk already, let's not get too picky. The baseline for compatibility is that forms built in trunk shouldn't break when switching to this branch.

Insert a form with lots of fields. Preferably all of them, so let's say at least:

1. Name
2. A drop down
3. A multi checkbox
4. A multi radio
5. Textarea

Apply the "outline" style to the form.

For the `jetpack/input` and `jetpack/options` blocks, play around with border and background color styles in:

- theme.json 
- global styles (via the site editor)
- on individual blocks in the editor

Get funky with large borders and border radii.

In the editor, make sure syncing and sync toggling works (it's a toggle button at the field level)

Check the editor/frontend.

Things should look mostly the same.

https://github.com/user-attachments/assets/8ea5c3e6-6349-456a-b695-130a9af0b405


In the frontend, (not the editor) open up a few pages forms that you built in trunk previously. They shouldn't be terrible.
