### PR TITLE
Jetpack CRM: WooCommerce - Import the short description from the Product to the invoice description (and not just title(ID))

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-woo-import-short-description-as-invoice-description
+++ b/projects/plugins/crm/changelog/fix-crm-woo-import-short-description-as-invoice-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Invoice line items now import the product short descritpion if set. If not set just the item name.

--- a/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-background-sync-job.php
+++ b/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-background-sync-job.php
@@ -1673,19 +1673,6 @@ class Woo_Sync_Background_Sync_Job {
 
 			    }
 
-				// attributes not yet translatable but originally referenced: `variation_id|tax_class|subtotal_tax`
-				$new_line_item = array(
-					'order'    => $order_post_id, // passed as parameter to this function
-					'currency' => $order_currency,
-					'quantity' => $item_data['quantity'],
-					'price'    => $price,
-					'total'    => $item_data['total'],
-					'title'    => $item_data['name'],
-					'desc'     => '', // Placeholder, will be set below.
-					'tax'      => $item_data['total_tax'],
-					'shipping' => 0,
-				);
-
 				// Get product short description for line item description.
 				$product_id_to_fetch = $item_data['product_id'];
 				if ( isset( $item_data['variation_id'] ) && $item_data['variation_id'] > 0 ) {
@@ -1697,12 +1684,25 @@ class Woo_Sync_Background_Sync_Job {
 				if ( empty( $line_item_description ) ) {
 					$line_item_description = $item_data['name'];
 				}
-				$new_line_item['desc'] = $line_item_description;
+
+				// attributes not yet translatable but originally referenced: `variation_id|tax_class|subtotal_tax`
+				$new_line_item = array(
+					'order'    => $order_post_id, // passed as parameter to this function
+					'currency' => $order_currency,
+					'quantity' => $item_data['quantity'],
+					'price'    => $price,
+					'total'    => $item_data['total'],
+					'title'    => $item_data['name'],
+					'desc'     => $line_item_description,
+					'tax'      => $item_data['total_tax'],
+					'shipping' => 0,
+				);
 
 				// add taxes, where present
 				if ( is_array( $item_tax_rate_ids ) && count( $item_tax_rate_ids ) > 0 ) {
 					$new_line_item['taxes'] = implode( ',', $item_tax_rate_ids );
 				}
+
 				// Add order item line
 				$data['lineitems'][] = $new_line_item;
 

--- a/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-background-sync-job.php
+++ b/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-background-sync-job.php
@@ -1681,10 +1681,23 @@ class Woo_Sync_Background_Sync_Job {
 					'price'    => $price,
 					'total'    => $item_data['total'],
 					'title'    => $item_data['name'],
-					'desc'     => $item_data['name'] . ' (#' . $item_data['product_id'] . ')',
+					'desc'     => '', // Placeholder, will be set below.
 					'tax'      => $item_data['total_tax'],
 					'shipping' => 0,
 				);
+
+				// Get product short description for line item description.
+				$product_id_to_fetch = $item_data['product_id'];
+				if ( isset( $item_data['variation_id'] ) && $item_data['variation_id'] > 0 ) {
+					$product_id_to_fetch = $item_data['variation_id'];
+				}
+				$product               = wc_get_product( $product_id_to_fetch );
+				$line_item_description = $product ? $product->get_short_description() : '';
+				// If short description is empty or product not found, fall back to the product name.
+				if ( empty( $line_item_description ) ) {
+					$line_item_description = $item_data['name'];
+				}
+				$new_line_item['desc'] = $line_item_description;
 
 				// add taxes, where present
 				if ( is_array( $item_tax_rate_ids ) && count( $item_tax_rate_ids ) > 0 ) {


### PR DESCRIPTION
Fixes part of the issues reported https://github.com/Automattic/zero-bs-crm/issues/3552 I'll put more PRs in for other tweaks.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Improves the data imported into WooCommerce invoices. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
Discussed here: p1743898356211569/1743574639.732139-slack-CL5UJ9ASE

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
- Have WooCommerce and Jetpack CRM active and Woo Sync module enabled 
- Have a WooCommerce Product with a Title - e.g. "Jetpack CRM" this might have ID = 456
- Add a short description to the product - e.g. "The best way to make money online is with Jetpack CRM"
- Create a WooCommerce Order, Completed and save it

Previously
- An invoice would be created, with title "Jetpack CRM" and description "Jetpack CRM (456)" 

Now
- An invoice is created with title "Jetpack CRM" and description "The best way to make money online is with Jetpack CRM"