### PR TITLE
MU WPCOM: Fix Incorrectly Namespaced Tracks Events

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/dotcom-12946-investigate-settings-upsells-not-firing-tracks-event
+++ b/projects/packages/jetpack-mu-wpcom/changelog/dotcom-12946-investigate-settings-upsells-not-firing-tracks-event
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Update incorrect Tracks events names.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-fiverr/wpcom-fiverr.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-fiverr/wpcom-fiverr.ts
@@ -13,7 +13,7 @@ document.addEventListener( 'DOMContentLoaded', () => {
 		fiverCta.addEventListener( 'click', e => {
 			e.preventDefault();
 
-			wpcomTrackEvent( 'wp_admin_site_icon_fiverr_logo_maker_cta_click', {
+			wpcomTrackEvent( 'wpcom_admin_site_icon_fiverr_logo_maker_cta_click', {
 				cta_name: 'wp_admin_site_icon_fiverr_logo_maker',
 			} );
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.ts
@@ -21,7 +21,7 @@ function wpcomInitializeFiverrCta() {
 		fiverCta.addEventListener( 'click', e => {
 			e.preventDefault();
 
-			wpcomTrackEvent( 'wp_admin_site_icon_fiverr_logo_maker_cta_click', {
+			wpcomTrackEvent( 'wpcom_admin_site_icon_fiverr_logo_maker_cta_click', {
 				cta_name: 'wp_admin_site_icon_fiverr_logo_maker',
 			} );
 
@@ -54,7 +54,7 @@ function _wpcomBuildAddCustomAddressButton( fragment: DocumentFragment ) {
 			return;
 		}
 
-		wpcomTrackEvent( 'wp_admin_upgrade_nudge_cta_click', {
+		wpcomTrackEvent( 'wpcom_admin_upgrade_nudge_cta_click', {
 			cta_name: 'settings_site_address',
 		} );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes DOTCOM-12946

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Replace disallowed Tracks events namespaces (`wp_admin_*`) with an allowed one (`wpcom_*`), keeping the rest of the names consistent with similar events.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

Linear DOTCOM-12946

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* (For Automatticians) Test on a Simple site using the Downloader provided [below](https://github.com/Automattic/jetpack/pull/43329#issuecomment-2844902666).
* Sandbox a test site, and navigate to Settings -> General.
* Click on the "Try Fiverr Logo Maker" button.
* Ensure an event named `wpcom_admin_site_icon_fiverr_logo_maker_cta_click` is fired.
* Click on the "Add custom address" button.
* Ensure an event named `wpcom_admin_upgrade_nudge_cta_click` is fired.