### PR TITLE
Sitemaps: Fix video sitemap generation

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-sitemap_notices
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-sitemap_notices
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Sitemap: Prevent PHP notice when generating sitemaps for videos.

--- a/projects/plugins/jetpack/modules/sitemaps/sitemap-buffer-video-xmlwriter.php
+++ b/projects/plugins/jetpack/modules/sitemaps/sitemap-buffer-video-xmlwriter.php
@@ -60,26 +60,28 @@ class Jetpack_Sitemap_Buffer_Video_XMLWriter extends Jetpack_Sitemap_Buffer_XMLW
 	 * @param array $array The URL item to append.
 	 */
 	protected function append_item( $array ) {
-		if ( ! empty( $array['url'] ) ) {
-			$this->writer->startElement( 'url' );
-
-			// Add URL elements
-			foreach ( $array['url'] as $tag => $value ) {
-				if ( $tag !== 'video:video' ) {
-					$this->writer->writeElement( $tag, strval( $value ) );
-				}
-			}
-
-			// Add video:video element and its children.
-			if ( ! empty( $array['url']['video:video'] ) ) {
-				$this->writer->startElement( 'video:video' );
-				foreach ( $array['url']['video:video'] as $tag => $value ) {
-					$this->writer->writeElement( $tag, strval( $value ) );
-				}
-				$this->writer->endElement(); // video:video
-			}
-
-			$this->writer->endElement(); // url
+		// Return early if missing fundamental data.
+		if ( empty( $array['url']['video:video'] ) ) {
+			return;
 		}
+
+		$this->writer->startElement( 'url' );
+
+		// Add URL elements
+		foreach ( $array['url'] as $url_tag => $url_value ) {
+			if ( $url_tag === 'video:video' ) {
+				// Add video:video element and its children.
+				$this->writer->startElement( 'video:video' );
+				foreach ( $array['url']['video:video'] as $video_tag => $video_value ) {
+					$this->writer->writeElement( $video_tag, strval( $video_value ) );
+				}
+				$this->writer->endElement(); // video
+			} else {
+				// Add other eleents.
+				$this->writer->writeElement( $url_tag, strval( $url_value ) );
+			}
+		}
+
+		$this->writer->endElement(); // url
 	}
 }

--- a/projects/plugins/jetpack/modules/sitemaps/sitemap-buffer-video-xmlwriter.php
+++ b/projects/plugins/jetpack/modules/sitemaps/sitemap-buffer-video-xmlwriter.php
@@ -65,20 +65,18 @@ class Jetpack_Sitemap_Buffer_Video_XMLWriter extends Jetpack_Sitemap_Buffer_XMLW
 
 			// Add URL elements
 			foreach ( $array['url'] as $tag => $value ) {
-				if ( $tag !== 'videos' ) {
+				if ( $tag !== 'video:video' ) {
 					$this->writer->writeElement( $tag, strval( $value ) );
 				}
 			}
 
-			// Add video:video elements
-			if ( ! empty( $array['url']['videos'] ) ) {
-				foreach ( $array['url']['videos'] as $video ) {
-					$this->writer->startElement( 'video:video' );
-					foreach ( $video as $tag => $value ) {
-						$this->writer->writeElement( "video:$tag", strval( $value ) );
-					}
-					$this->writer->endElement(); // video:video
+			// Add video:video element and its children.
+			if ( ! empty( $array['url']['video:video'] ) ) {
+				$this->writer->startElement( 'video:video' );
+				foreach ( $array['url']['video:video'] as $tag => $value ) {
+					$this->writer->writeElement( $tag, strval( $value ) );
 				}
+				$this->writer->endElement(); // video:video
 			}
 
 			$this->writer->endElement(); // url

--- a/projects/plugins/jetpack/tests/php/modules/sitemaps/Jetpack_Sitemap_Buffer_XMLWriter_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/sitemaps/Jetpack_Sitemap_Buffer_XMLWriter_Test.php
@@ -152,15 +152,13 @@ class Jetpack_Sitemap_Buffer_XMLWriter_Test extends WP_UnitTestCase {
 
 		$url_data = array(
 			'url' => array(
-				'loc'     => 'https://example.com/test-page',
-				'lastmod' => '2024-03-31 12:00:00',
-				'videos'  => array(
-					array(
-						'title'         => 'Test Video',
-						'description'   => 'A test video description',
-						'thumbnail_loc' => 'https://example.com/thumbnail.jpg',
-						'content_loc'   => 'https://example.com/video.mp4',
-					),
+				'loc'         => 'https://example.com/test-page',
+				'lastmod'     => '2024-03-31 12:00:00',
+				'video:video' => array(
+					'video:title'         => 'Test Video',
+					'video:description'   => 'A test video description',
+					'video:thumbnail_loc' => 'https://example.com/thumbnail.jpg',
+					'video:content_loc'   => 'https://example.com/video.mp4',
 				),
 			),
 		);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Video sitemaps were only generating partial data due to a mismatch between what the passed array looked like and what the array was expected to look like.

It also resulted in lots of these PHP warnings:
```
PHP Warning:  Array to string conversion in /modules/sitemaps/sitemap-buffer-video-xmlwriter.php on line 69
```

Reported in p1745995831728999/1745855658.393169-slack-C01U2KGS2PQ; related to #42767.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

Rather than the needed content being in an array of items in the `videos` key, they were directly in a single array under the `video:video` key. I adjusted the logic to match this and also added an early return to the function.

**I'll note that the schema does allow for multiple `<video:video>` arrays (see example [here](https://developers.google.com/search/docs/crawling-indexing/sitemaps/video-sitemaps#example-video-sitemap)), but I couldn't seem to reproduce any instances where actually pass an array of videos.** There is a filter in `jetpack_sitemap_video_sitemap_item` that could modify this content, but I don't see anywhere we do. I tested with a standalone site as well as WordPress.com Atomic site, and both gave me a single video.

I also updated the test, which had the errant(?) structure.

<details>
<summary>XML generated on a site using the old DOMDocument generator</summary>

```
<?xml version="1.0" encoding="UTF-8"?>
<!--generator='jetpack-14.6-a.9'-->
<!--Jetpack_Sitemap_Buffer_Video-->
<?xml-stylesheet type="text/xsl" href="//example.com/?jetpack-sitemap=video-sitemap.xsl"?>
<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
  <url>
    <loc>https://example.com/?attachment_id=69</loc>
    <lastmod>2025-05-01T15:41:27Z</lastmod>
    <video:video>
      <video:title>some_video</video:title>
      <video:thumbnail_loc>https://s0.wp.com/i/blank.jpg</video:thumbnail_loc>
      <video:description></video:description>
      <video:content_loc>https://example.com/wp-content/uploads/2025/05/example_video.mp4</video:content_loc>
    </video:video>
  </url>
</urlset>
```
</details>

<details>
<summary>XML generated on a site using the new XMLWriter generator (prior to this PR)</summary>

```
<?xml version="1.0" encoding="UTF-8"?>
<!--generator='jetpack-14.6-a.9'-->
<!--Jetpack_Sitemap_Buffer_Video_XMLWriter-->
<?xml-stylesheet type="text/xsl" href="//example.com/?jetpack-sitemap=video-sitemap.xsl"?>
<urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
 <url>
  <loc>https://example.com/?attachment_id=69</loc>
  <lastmod>2025-05-01T15:41:27Z</lastmod>
  <video:video>Array</video:video>
 </url>
</urlset>
```
</details>

<details>
<summary>Array we pass to `Jetpack_Sitemap_Buffer_Video_XMLWriter::append_item()`</summary>

```
array (
  'url' => 
  array (
    'loc' => 'https://example.com/?attachment_id=69',
    'lastmod' => '2025-05-01T15:41:27Z',
    'video:video' => 
    array (
      'video:title' => 'some_video',
      'video:thumbnail_loc' => 'https://s0.wp.com/i/blank.jpg',
      'video:description' => '',
      'video:content_loc' => 'https://example.com/wp-content/uploads/2025/05/example_video.mp4',
    ),
  ),
)
```
</details>

<details>
<summary>Array structure the code was expecting</summary>

```
array (
  'url' => 
  array (
    'loc' => 'https://example.com/?attachment_id=69',
    'lastmod' => '2025-05-01T15:41:27Z',
    'videos' => 
    array (
      array(
        'title' => 'some_video',
        'thumbnail_loc' => 'https://s0.wp.com/i/blank.jpg',
        'description' => '',
        'content_loc' => 'https://example.com/wp-content/uploads/2025/05/example_video.mp4',
      ),
      // ... potentially more items here?
    ),
  ),
)
```
</details>

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Add a video to your site: `/wp-admin/upload.php`
2. Ensure your site is public and allowed to be indexed by search engines: `/wp-admin/options-reading.php`
3. Ensure Sitemaps are enabled: `/wp-admin/admin.php?page=jetpack#/settings?term=sitemaps`
4. Generate a new sitemap with `wp jetpack sitemap rebuild --purge` or by running the `jp_sitemap_cron_hook` cron.
5. Go to the sitemap and verify the Video URL and other fields are filled out: `/video-sitemap-1.xml`