### PR TITLE
Forms: Ensure block modal handles services

### DIFF
--- a/projects/packages/forms/changelog/update-forms-modal-for-services
+++ b/projects/packages/forms/changelog/update-forms-modal-for-services
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Ensure forms modal handles services.

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/integration-card-body.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/integration-card-body.js
@@ -5,18 +5,32 @@ const IntegrationCardBody = ( { isExpanded, children, cardData = {} } ) => {
 		return null;
 	}
 
-	const { notInstalledMessage, notActivatedMessage, isInstalled, isActive, isLoading } = cardData;
+	const { notInstalledMessage, notActivatedMessage, isInstalled, isActive, isLoading, type } =
+		cardData;
+
+	const isPlugin = type === 'plugin';
+	const isService = type === 'service';
+	const showPluginInstallMessage = isPlugin && ! isInstalled;
+	const showPluginActivateMessage = isPlugin && isInstalled && ! isActive;
+	const showContent = ( isPlugin && isInstalled && isActive ) || isService;
+
+	if ( isLoading ) {
+		return (
+			<CardBody>
+				<Spinner />
+			</CardBody>
+		);
+	}
 
 	return (
 		<CardBody>
-			{ isLoading && <Spinner /> }
-			{ ! isLoading && ! isInstalled && (
+			{ showPluginInstallMessage && (
 				<p className="integration-card__description">{ notInstalledMessage }</p>
 			) }
-			{ ! isLoading && isInstalled && ! isActive && (
+			{ showPluginActivateMessage && (
 				<p className="integration-card__description">{ notActivatedMessage }</p>
 			) }
-			{ ! isLoading && isInstalled && isActive && children }
+			{ showContent && children }
 		</CardBody>
 	);
 };

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/integration-card-header.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/integration-card-header.js
@@ -96,13 +96,13 @@ const IntegrationCardHeader = ( {
 							trackEventName={ cardData.trackEventName }
 						/>
 					) }
-					{ ( isActive || isConnected ) && showHeaderToggle && (
+					{ ! showPluginAction && showHeaderToggle && (
 						<Tooltip text={ getTooltipText( headerToggleValue ) }>
 							<span className="integration-card__toggle-tooltip-wrapper">
 								<ToggleControl
-									checked={ headerToggleValue }
+									checked={ headerToggleValue && ( isActive || isConnected ) }
 									onChange={ handleToggleChange }
-									disabled={ ! isHeaderToggleEnabled }
+									disabled={ ! isHeaderToggleEnabled || ! ( isActive || isConnected ) }
 									__nextHasNoMarginBottom={ true }
 								/>
 							</span>


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Right now, our only form integrations are plugins. The code in the form modal, particularly the IntegrationCardHeader and IntegrationCardBody, was assuming plugin status. This updates the modal to render header/body content correctly for non-plugin services in advance of a separate PR to [adding the Salesforce card](https://github.com/Automattic/jetpack/pull/43297). 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None. 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

This is a refactor. The forms modal should behave the same before and after. 

Add a form block open the integrations modal, and confirm it behaves before. Test with deactivating / uninstalling Akismet or Jetpack CRM or Creative mail, and confirm that the plugin install/activate button, and the enable toggle show (or not) as expected.

