### PR TITLE
Forms: use WP.com specific copy and URLs at about page

### DIFF
--- a/projects/packages/forms/changelog/update-forms-about-links
+++ b/projects/packages/forms/changelog/update-forms-about-links
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Forms: use WP.com specific URLs at about page

--- a/projects/packages/forms/src/dashboard/landing/index.js
+++ b/projects/packages/forms/src/dashboard/landing/index.js
@@ -238,15 +238,10 @@ const LandingPage = () => {
 				<div className="jp-forms__landing-content">
 					<h1 className="mb-6">{ __( 'Frequently Asked Questions', 'jetpack-forms' ) }</h1>
 					<Details summary={ __( 'What do I need to use Jetpack Forms?', 'jetpack-forms' ) }>
-						{ isJetpackSite
-							? __(
-									'Jetpack Forms is activated by default, so it\'s already fully functional. To get started, simply open the WordPress editor and search for the "Form" block in the block library. You can then add the form block and its corresponding child blocks, such as the text input field or multiple choice block, to your website. You can easily manage incoming form responses within the WP-Admin area.',
-									'jetpack-forms'
-							  )
-							: __(
-									'To get started, simply open the WordPress editor and search for the "Form" block in the block library. You can then add the form block and its corresponding child blocks, such as the text input field or multiple choice block, to your website. You can easily manage incoming form responses within the WP-Admin area.',
-									'jetpack-forms'
-							  ) }
+						{ __(
+							'To get started, simply open the WordPress editor and search for the "Form" block in the block library. You can then add the form block and its corresponding child blocks, such as the text input field or multiple choice block, to your website. You can easily manage incoming form responses within the WP-Admin area.',
+							'jetpack-forms'
+						) }
 					</Details>
 					{ isJetpackSite && (
 						<Details summary={ __( 'How much does Jetpack Forms cost?', 'jetpack-forms' ) }>

--- a/projects/packages/forms/src/dashboard/landing/index.js
+++ b/projects/packages/forms/src/dashboard/landing/index.js
@@ -3,7 +3,7 @@
  */
 import jetpackAnalytics from '@automattic/jetpack-analytics';
 import { getRedirectUrl } from '@automattic/jetpack-components';
-import { isJetpackSelfHostedSite } from '@automattic/jetpack-script-data';
+import { isWpcomPlatformSite } from '@automattic/jetpack-script-data';
 import { ExternalLink } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -28,7 +28,7 @@ import './style.scss';
 
 const LandingPage = () => {
 	const navigate = useNavigate();
-	const isJetpackSite = isJetpackSelfHostedSite();
+	const isWpcomSite = isWpcomPlatformSite();
 
 	// If a user has responses, redirect them to the inbox.
 	useEffect( () => {
@@ -243,7 +243,7 @@ const LandingPage = () => {
 							'jetpack-forms'
 						) }
 					</Details>
-					{ isJetpackSite && (
+					{ ! isWpcomSite && (
 						<Details summary={ __( 'How much does Jetpack Forms cost?', 'jetpack-forms' ) }>
 							{ __(
 								'Jetpack Forms is currently free and comes by default with your Jetpack plugin.',
@@ -272,10 +272,10 @@ const LandingPage = () => {
 								'jetpack-forms'
 							),
 							{
-								a: isJetpackSite ? (
-									<ExternalLink href={ getRedirectUrl( 'jetpack-contact-support' ) } />
-								) : (
+								a: isWpcomSite ? (
 									<a href={ getRedirectUrl( 'wpcom-contact-support' ) } />
+								) : (
+									<ExternalLink href={ getRedirectUrl( 'jetpack-contact-support' ) } />
 								),
 							}
 						) }

--- a/projects/packages/forms/src/dashboard/landing/index.js
+++ b/projects/packages/forms/src/dashboard/landing/index.js
@@ -3,6 +3,8 @@
  */
 import jetpackAnalytics from '@automattic/jetpack-analytics';
 import { getRedirectUrl } from '@automattic/jetpack-components';
+import { isJetpackSelfHostedSite } from '@automattic/jetpack-script-data';
+import { ExternalLink } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useEffect } from 'react';
@@ -26,6 +28,7 @@ import './style.scss';
 
 const LandingPage = () => {
 	const navigate = useNavigate();
+	const isJetpackSite = isJetpackSelfHostedSite();
 
 	// If a user has responses, redirect them to the inbox.
 	useEffect( () => {
@@ -235,17 +238,24 @@ const LandingPage = () => {
 				<div className="jp-forms__landing-content">
 					<h1 className="mb-6">{ __( 'Frequently Asked Questions', 'jetpack-forms' ) }</h1>
 					<Details summary={ __( 'What do I need to use Jetpack Forms?', 'jetpack-forms' ) }>
-						{ __(
-							'Jetpack Forms is activated by default, so it\'s already fully functional. To get started, simply open the WordPress editor and search for the "Form" block in the block library. You can then add the form block and its corresponding child blocks, such as the text input field or multiple choice block, to your website. You can easily manage incoming form responses within the WP-Admin area.',
-							'jetpack-forms'
-						) }
+						{ isJetpackSite
+							? __(
+									'Jetpack Forms is activated by default, so it\'s already fully functional. To get started, simply open the WordPress editor and search for the "Form" block in the block library. You can then add the form block and its corresponding child blocks, such as the text input field or multiple choice block, to your website. You can easily manage incoming form responses within the WP-Admin area.',
+									'jetpack-forms'
+							  )
+							: __(
+									'To get started, simply open the WordPress editor and search for the "Form" block in the block library. You can then add the form block and its corresponding child blocks, such as the text input field or multiple choice block, to your website. You can easily manage incoming form responses within the WP-Admin area.',
+									'jetpack-forms'
+							  ) }
 					</Details>
-					<Details summary={ __( 'How much does Jetpack Forms cost?', 'jetpack-forms' ) }>
-						{ __(
-							'Jetpack Forms is currently free and comes by default with your Jetpack plugin.',
-							'jetpack-forms'
-						) }
-					</Details>
+					{ isJetpackSite && (
+						<Details summary={ __( 'How much does Jetpack Forms cost?', 'jetpack-forms' ) }>
+							{ __(
+								'Jetpack Forms is currently free and comes by default with your Jetpack plugin.',
+								'jetpack-forms'
+							) }
+						</Details>
+					) }
 					<Details summary={ __( 'Is Jetpack Forms GDPR compliant?', 'jetpack-forms' ) }>
 						{ createInterpolateElement(
 							__(
@@ -253,13 +263,7 @@ const LandingPage = () => {
 								'jetpack-forms'
 							),
 							{
-								a: (
-									<a
-										href="https://automattic.com/privacy/"
-										rel="noreferrer noopener"
-										target="_blank"
-									/>
-								),
+								a: <ExternalLink href={ getRedirectUrl( 'wpcom-tos' ) } />,
 							}
 						) }
 					</Details>
@@ -274,10 +278,12 @@ const LandingPage = () => {
 							),
 							{
 								a: (
-									<a
-										href="https://jetpack.com/contact-support/"
-										rel="noreferrer noopener"
-										target="_blank"
+									<ExternalLink
+										href={
+											isJetpackSite
+												? getRedirectUrl( 'jetpack-contact-support' )
+												: getRedirectUrl( 'wpcom-contact-support' )
+										}
 									/>
 								),
 							}

--- a/projects/packages/forms/src/dashboard/landing/index.js
+++ b/projects/packages/forms/src/dashboard/landing/index.js
@@ -277,14 +277,10 @@ const LandingPage = () => {
 								'jetpack-forms'
 							),
 							{
-								a: (
-									<ExternalLink
-										href={
-											isJetpackSite
-												? getRedirectUrl( 'jetpack-contact-support' )
-												: getRedirectUrl( 'wpcom-contact-support' )
-										}
-									/>
+								a: isJetpackSite ? (
+									<ExternalLink href={ getRedirectUrl( 'jetpack-contact-support' ) } />
+								) : (
+									<a href={ getRedirectUrl( 'wpcom-contact-support' ) } />
 								),
 							}
 						) }

--- a/projects/packages/forms/src/dashboard/landing/index.js
+++ b/projects/packages/forms/src/dashboard/landing/index.js
@@ -258,7 +258,7 @@ const LandingPage = () => {
 								'jetpack-forms'
 							),
 							{
-								a: <ExternalLink href={ getRedirectUrl( 'wpcom-tos' ) } />,
+								a: <ExternalLink href={ getRedirectUrl( 'a8c-privacy' ) } />,
 							}
 						) }
 					</Details>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

As a follow-up to:
- https://github.com/Automattic/jetpack/issues/43280

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Use WP.com specific support link at Forms about page for WP.com sites
* Fetch TOS link via JPs redirect tool
* Hide "Jetpack Forms is activated by default..." copy for WP.com sites as the language isn't so familiar with those customers who didn't install the plugin. We likely need to revisit this later more.
* Hide "How much does Jetpack Forms cost?" for WP.com sites; again just risking confusing customers.

<img width="1379" alt="Screenshot 2025-05-02 at 12 02 43" src="https://github.com/user-attachments/assets/4c09abc7-928f-456f-91f4-45301547f4cb" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to "Feedback"
* If not at modern inbox, pick Inbox from "View" menu
* Go to "About" tab

