### PR TITLE
Forms: remove default left/right padding from forms

### DIFF
--- a/projects/packages/forms/changelog/update-form-variations-remove-default-spacing
+++ b/projects/packages/forms/changelog/update-form-variations-remove-default-spacing
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: remove default spacing from variations

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-salesforce-lead-form/jetpack-salesforce-lead-form-settings.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-salesforce-lead-form/jetpack-salesforce-lead-form-settings.js
@@ -82,14 +82,6 @@ export const salesforceLeadFormVariation = {
 			organizationId: '',
 			sendToSalesforce: true,
 		},
-		style: {
-			spacing: {
-				padding: {
-					top: '16px',
-					bottom: '16px',
-				},
-			},
-		},
 	},
 	example: {
 		innerBlocks: [

--- a/projects/packages/forms/src/blocks/contact-form/variations.js
+++ b/projects/packages/forms/src/blocks/contact-form/variations.js
@@ -7,17 +7,6 @@ import { salesforceLeadFormVariation } from './components/jetpack-salesforce-lea
 import { getIconColor } from './util/block-icons';
 import renderMaterialIcon from './util/render-material-icon';
 
-const defaultBlockStyling = {
-	style: {
-		spacing: {
-			padding: {
-				top: '16px',
-				bottom: '16px',
-			},
-		},
-	},
-};
-
 const variations = compact( [
 	{
 		name: 'contact-form',
@@ -53,9 +42,7 @@ const variations = compact( [
 				},
 			],
 		],
-		attributes: {
-			...defaultBlockStyling,
-		},
+		attributes: {},
 	},
 	{
 		name: 'rsvp-form',
@@ -100,7 +87,6 @@ const variations = compact( [
 			],
 		],
 		attributes: {
-			...defaultBlockStyling,
 			subject: __( 'A new RSVP from your website', 'jetpack-forms' ),
 		},
 		example: {
@@ -186,7 +172,6 @@ const variations = compact( [
 			],
 		],
 		attributes: {
-			...defaultBlockStyling,
 			subject: __( 'A new registration from your website', 'jetpack-forms' ),
 		},
 		example: {
@@ -279,7 +264,6 @@ const variations = compact( [
 			],
 		],
 		attributes: {
-			...defaultBlockStyling,
 			subject: __( 'A new appointment booked from your website', 'jetpack-forms' ),
 		},
 		example: {
@@ -383,7 +367,6 @@ const variations = compact( [
 			],
 		],
 		attributes: {
-			...defaultBlockStyling,
 			subject: __( 'New feedback received from your website', 'jetpack-forms' ),
 		},
 		example: {
@@ -451,9 +434,7 @@ const variations = compact( [
 				},
 			],
 		],
-		attributes: {
-			...defaultBlockStyling,
-		},
+		attributes: {},
 		example: {
 			innerBlocks: [
 				{


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Follow up to:
- https://github.com/Automattic/jetpack/pull/42340
- https://github.com/Automattic/jetpack/pull/43124

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

Removes default top/bottom padding — previously we removed left/right padding with a note:

> This remove the left/right padding so forms stay aligned. I kept the top/bottom padding to keep spacing between the form block and other content on the page.

<img width="288" alt="Screenshot 2025-05-02 at 12 36 46" src="https://github.com/user-attachments/assets/fe9aa4ee-7ccf-484f-9b34-b303cfae54be" />
<img width="708" alt="Screenshot 2025-05-02 at 12 36 20" src="https://github.com/user-attachments/assets/30773bfb-a600-4447-b798-dbb524108155" />



The spacing remains problematic for newly inserted blocks as themes have "default spacing between blocks" (theme dependant). Consider for example image, heading and form block:

Before the change
<img width="1031" alt="Screenshot 2025-05-02 at 12 37 45" src="https://github.com/user-attachments/assets/ee39d59a-77ca-4436-a77d-d84e1e7eacfe" />

After the change
<img width="910" alt="Screenshot 2025-05-02 at 12 38 27" src="https://github.com/user-attachments/assets/e4e60daa-b308-4be5-97b7-732d8725631b" />



### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add different form block variations to the page
* Add surrounding blocks before/after forms
* Test different themes on editor and frontend

