### PR TITLE
Revert "Forms: Fix responses management compatibility with 6.6"

### DIFF
--- a/projects/packages/forms/changelog/revert-42883-fix-forms-dataviews-with-6-6
+++ b/projects/packages/forms/changelog/revert-42883-fix-forms-dataviews-with-6-6
@@ -1,0 +1,4 @@
+Significance: major
+Type: deprecated
+
+Forms: drop WP 6.6 support in Inbox by using new format for useResizeObserver

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
@@ -79,9 +79,15 @@ function getStatusFilter( urlStatus ) {
 export default function InboxView() {
 	const [ view, setView ] = useView();
 	const [ searchParams, setSearchParams ] = useSearchParams();
+	const [ containerWidth, setContainerWidth ] = useState( 0 );
 	const [ queryArgs, setQueryArgs ] = useState( EMPTY_OBJECT );
 	const dateSettings = getDateSettings();
-	const [ resizeListener, { width: containerWidth } ] = useResizeObserver();
+	const containerRef = useResizeObserver(
+		resizeObserverEntries => {
+			setContainerWidth( resizeObserverEntries[ 0 ].borderBoxSize[ 0 ].inlineSize );
+		},
+		{ box: 'border-box' }
+	);
 	const isMobile = containerWidth <= MOBILE_BREAKPOINT;
 	const { setCurrentQuery, setSelectedResponses } = useDispatch( dashboardStore );
 	const selectedResponses = searchParams.get( 'r' );
@@ -288,9 +294,9 @@ export default function InboxView() {
 			spacing={ 5 }
 			alignment="top"
 			justify="flex-start"
+			ref={ containerRef }
 			className="jp-forms__inbox__dataviews__container"
 		>
-			{ resizeListener }
 			<div className="jp-forms__inbox__dataviews">
 				<DataViews
 					paginationInfo={ paginationInfo }

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/views.js
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/views.js
@@ -1,7 +1,8 @@
 /**
  * WordPress dependencies
  */
-import { useEffect, useState, useCallback, useRef } from '@wordpress/element';
+import { useEvent } from '@wordpress/compose';
+import { useEffect, useState } from '@wordpress/element';
 import { useSearchParams } from 'react-router-dom';
 
 const LAYOUT_TABLE = 'table';
@@ -30,37 +31,30 @@ export const defaultLayouts = {
 export function useView() {
 	const [ searchParams, setSearchParams ] = useSearchParams();
 	const urlSearch = searchParams.get( 'search' );
-	const urlSearchRef = useRef();
-	useEffect( () => {
-		urlSearchRef.current = urlSearch;
-	}, [ urlSearch ] );
 	const [ view, setView ] = useState( () => ( {
 		...defaultView,
 		search: urlSearch ?? '',
 	} ) );
 	// When view changes, update the URL params if needed.
-	const setViewWithUrlUpdate = useCallback(
-		newView => {
-			setView( newView );
-			if ( newView.search !== urlSearchRef?.current ) {
-				setSearchParams( previousSearchParams => {
-					const _searchParams = new URLSearchParams( previousSearchParams );
-					if ( newView.search ) {
-						_searchParams.set( 'search', newView.search );
-					} else {
-						_searchParams.delete( 'search' );
-					}
-					return _searchParams;
-				} );
-			}
-		},
-		[ setSearchParams ]
-	);
+	const setViewWithUrlUpdate = useEvent( newView => {
+		setView( newView );
+		if ( newView.search !== urlSearch ) {
+			setSearchParams( previousSearchParams => {
+				const _searchParams = new URLSearchParams( previousSearchParams );
+				if ( newView.search ) {
+					_searchParams.set( 'search', newView.search );
+				} else {
+					_searchParams.delete( 'search' );
+				}
+				return _searchParams;
+			} );
+		}
+	} );
 	// When search URL param changes, update the view's search filter
 	// without affecting any other config.
-	const onUrlSearchChange = useCallback( () => {
+	const onUrlSearchChange = useEvent( () => {
 		setView( previousView => {
-			const newValue = urlSearchRef?.current ?? '';
+			const newValue = urlSearch ?? '';
 			if ( newValue === previousView.search ) {
 				return previousView;
 			}
@@ -69,7 +63,7 @@ export function useView() {
 				search: newValue,
 			};
 		} );
-	}, [] );
+	} );
 	useEffect( () => {
 		onUrlSearchChange();
 	}, [ onUrlSearchChange, urlSearch ] );


### PR DESCRIPTION
Now that we support WP 6.7 as our minimum version, we can use `useResizeObserver` hook in a new way that wasn't supported by WP 6.6.

Reverts:
- https://github.com/Automattic/jetpack/pull/42883

See:
- https://github.com/Automattic/jetpack/issues/39922

To test:
- Go to "Feedback" from sidebar
- If not in modern Inbox view, pick "Inbox" from "View" menu
- DataViews should continue work just fine in WP6.7—6.8, but 6.6 doesn't work anymore