### PR TITLE
Launchpad checklist: mark migrate_content task complete on imports.

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-launchpad-migrate-content-task-completion
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-launchpad-migrate-content-task-completion
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-mark migrate subscribers task complete when importing content
+launchpad checklists: mark migrate content task complete when importing content

--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-launchpad-migrate-content-task-completion
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-launchpad-migrate-content-task-completion
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+mark migrate subscribers task complete when importing content

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -1650,10 +1650,17 @@ function wpcom_launchpad_track_publish_first_post_task() {
  * @return void
  */
 function wpcom_launchpad_track_migrate_content_task() {
+	// Ensure that Headstart posts don't mark this as complete.
+	// Headstart also enables WP_IMPORTING, so it is necessary to check both.
+	if ( defined( 'HEADSTART' ) && HEADSTART ) {
+		return;
+	}
 	// Only mark this complete when importing content.
 	if ( ! defined( 'WP_IMPORTING' ) || ! WP_IMPORTING ) {
 		return;
 	}
+	// Check the option to prevent firing this repeatedly during imports, spamming tracks and extra
+	// unnecessary logic.
 	if ( wpcom_launchpad_is_task_option_completed( array( 'id' => 'migrate_content' ) ) ) {
 		return;
 	}

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -1654,12 +1654,10 @@ function wpcom_launchpad_track_migrate_content_task() {
 	if ( ! defined( 'WP_IMPORTING' ) || ! WP_IMPORTING ) {
 		return;
 	}
-	// Prevent firing this repeatedly during imports by tracking the transient.
-	if ( get_transient( 'wpcom_launchpad_migrated_content_task_marked' ) ) {
+	if ( wpcom_launchpad_is_task_option_completed( array( 'id' => 'migrate_content' ) ) ) {
 		return;
 	}
 	wpcom_launchpad_mark_launchpad_task_complete_if_active( 'migrate_content' );
-	set_transient( 'wpcom_launchpad_migrated_content_task_marked', true, 10 * MINUTE_IN_SECONDS );
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -249,12 +249,15 @@ function wpcom_launchpad_get_task_definitions() {
 			},
 		),
 		'migrate_content'                 => array(
-			'get_title'            => function () {
+			'get_title'             => function () {
 				return __( 'Import content', 'jetpack-mu-wpcom' );
 			},
-			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
-			'is_visible_callback'  => 'wpcom_launchpad_has_goal_import_subscribers',
-			'get_calypso_path'     => function ( $task, $default, $data ) {
+			'is_complete_callback'  => 'wpcom_launchpad_is_task_option_completed',
+			'is_visible_callback'   => 'wpcom_launchpad_has_goal_import_subscribers',
+			'add_listener_callback' => function () {
+				add_action( 'save_post', 'wpcom_launchpad_track_migrate_content_task' );
+			},
+			'get_calypso_path'      => function ( $task, $default, $data ) {
 				if ( wpcom_launchpad_should_use_wp_admin_link() ) {
 					return admin_url( 'import.php' );
 				}
@@ -1639,6 +1642,24 @@ function wpcom_launchpad_track_publish_first_post_task() {
 	// Since we share the same callback for generic first post and newsletter-specific, we mark both.
 	wpcom_launchpad_mark_launchpad_task_complete_if_active( 'first_post_published' );
 	wpcom_launchpad_mark_launchpad_task_complete_if_active( 'first_post_published_newsletter' );
+}
+
+/**
+ * Callback for completing migrate content task.
+ *
+ * @return void
+ */
+function wpcom_launchpad_track_migrate_content_task() {
+	// Only mark this complete when importing content.
+	if ( ! defined( 'WP_IMPORTING' ) || ! WP_IMPORTING ) {
+		return;
+	}
+	// Prevent firing this repeatedly during imports by tracking the transient.
+	if ( get_transient( 'wpcom_launchpad_migrated_content_task_marked' ) ) {
+		return;
+	}
+	wpcom_launchpad_mark_launchpad_task_complete_if_active( 'migrate_content' );
+	set_transient( 'wpcom_launchpad_migrated_content_task_marked', true, 10 * MINUTE_IN_SECONDS );
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -1659,8 +1659,8 @@ function wpcom_launchpad_track_migrate_content_task() {
 	if ( ! defined( 'WP_IMPORTING' ) || ! WP_IMPORTING ) {
 		return;
 	}
-	// Check the option to prevent firing this repeatedly during imports, spamming tracks and extra
-	// unnecessary logic.
+	// Check the option to prevent setting this repeatedly during imports, which could spam tracks
+	// and run extra unnecessary logic.
 	if ( wpcom_launchpad_is_task_option_completed( array( 'id' => 'migrate_content' ) ) ) {
 		return;
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes # Automattic/loop#676 / https://linear.app/a8c/issue/CML-445/newsletter-launchpad-import-content-task-not-being-marked-off
 
## Proposed changes:
<!--- Explain what functional changes your PR includes -->

Marks the migrate_content task complete when migrating content.
* Adds a listener callback to the task, on the save_post hook.
    * Use save post instead of publish post since not all imported posts may be published (drafts, etc.).
    * Ignores headstart, and ignores if we are not in an import process. So whenever a post is saved in the import process that is not headstart, and the task is not yet completed, it becomes marked as complete.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this branch to your sandbox (command in comment below), sanbox the public api.
* Enable async jobs to run on your sandbox via a hook in 0-sandbox.php.
* Run the watcher for async jobs on your sandbox.
* Create a new newsletter site from WordPress.com/newsletter, and select the "import" flow.
* Once getting to the launchpad, click the "Import content" task.
* Select an import flow and start importing content.
* Verify the task is now marked as complete.

