### PR TITLE
WooCommerce Analytics: Catch errant null param from third-party code

### DIFF
--- a/projects/packages/woocommerce-analytics/changelog/fix-woocommerc-analytics-catch_null_param
+++ b/projects/packages/woocommerce-analytics/changelog/fix-woocommerc-analytics-catch_null_param
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Catch PHP error if null param is errantly passed by third-party code.

--- a/projects/packages/woocommerce-analytics/src/class-universal.php
+++ b/projects/packages/woocommerce-analytics/src/class-universal.php
@@ -499,11 +499,7 @@ class Universal {
 	 * @return array|null
 	 */
 	public function save_checkout_post_data( ?array $data ) {
-		if (
-			is_object( WC()->session )
-			&& is_array( $data )
-			&& ! empty( $data['createaccount'] )
-		) {
+		if ( is_object( WC()->session ) && ! empty( $data['createaccount'] ) ) {
 			WC()->session->set( 'wc_checkout_createaccount_used', true );
 			WC()->session->save_data();
 		}

--- a/projects/packages/woocommerce-analytics/src/class-universal.php
+++ b/projects/packages/woocommerce-analytics/src/class-universal.php
@@ -494,17 +494,18 @@ class Universal {
 	/**
 	 * Save createaccount post data to be used in $this->order_process.
 	 *
-	 * @param array|null $data post data from the checkout page.
+	 * @param array|null $data Post data from the checkout page.
 	 *
 	 * @return array|null
 	 */
 	public function save_checkout_post_data( ?array $data ) {
-		$session = WC()->session;
-		if ( is_object( $session ) && is_array( $data ) ) {
-			if ( isset( $data['createaccount'] ) && ! empty( $data['createaccount'] ) ) {
-				$session->set( 'wc_checkout_createaccount_used', true );
-				$session->save_data();
-			}
+		if (
+			is_object( WC()->session )
+			&& is_array( $data )
+			&& ! empty( $data['createaccount'] )
+		) {
+			WC()->session->set( 'wc_checkout_createaccount_used', true );
+			WC()->session->save_data();
 		}
 		return $data;
 	}

--- a/projects/packages/woocommerce-analytics/src/class-universal.php
+++ b/projects/packages/woocommerce-analytics/src/class-universal.php
@@ -494,13 +494,13 @@ class Universal {
 	/**
 	 * Save createaccount post data to be used in $this->order_process.
 	 *
-	 * @param array $data post data from the checkout page.
+	 * @param array|null $data post data from the checkout page.
 	 *
-	 * @return array
+	 * @return array|null
 	 */
-	public function save_checkout_post_data( array $data ) {
+	public function save_checkout_post_data( ?array $data ) {
 		$session = WC()->session;
-		if ( is_object( $session ) ) {
+		if ( is_object( $session ) && is_array( $data ) ) {
 			if ( isset( $data['createaccount'] ) && ! empty( $data['createaccount'] ) ) {
 				$session->set( 'wc_checkout_createaccount_used', true );
 				$session->save_data();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This updates `Automattic\Woocommerce_Analytics\Universal::save_checkout_post_data()` to handle a `null` param gracefully.

I also combined some conditions.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

This showed up several hundred times in Atomic PHP logs:

```
PHP Fatal error: Uncaught TypeError: Automattic\Woocommerce_Analytics\Universal::save_checkout_post_data(): Argument #1 ($data) must be of type array, null given, called in /wordpress/core/6.8.1/wp-includes/class-wp-hook.php on line 324 and defined in /wordpress/plugins/jetpack/14.6-a.9/jetpack_vendor/automattic/woocommerce-analytics/src/class-universal.php:501
```

The function is triggered by the `woocommerce_checkout_posted_data` filter and receives an `array`:
https://github.com/woocommerce/woocommerce/blob/e6694edd5620e7646a559319f809002948ec68b5/plugins/woocommerce/includes/class-wc-checkout.php#L827

However, it seems some plugin must be either changing the data or failing to properly return it.

I note there's similar code in this deprecated file, but I didn't change it there as I don't think it's used anymore and it wasn't showing in logs:
https://github.com/Automattic/jetpack/blob/fd4c202e3445bc9b59ec07bd83271ae554aec3a7/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-universal.php#L524

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

