### PR TITLE
Shortcodes: Prefix YouTube shortcode functions

### DIFF
--- a/projects/plugins/jetpack/.phan/baseline.php
+++ b/projects/plugins/jetpack/.phan/baseline.php
@@ -195,7 +195,7 @@ return [
         'extensions/blocks/top-posts/top-posts.php' => ['PhanTypeMismatchReturnProbablyReal'],
         'extensions/blocks/wordads/wordads.php' => ['PhanNonClassMethodCall', 'PhanTypeExpectedObjectPropAccessButGotNull', 'PhanTypeMismatchArgument'],
         'extensions/plugins/sharing/sharing.php' => ['PhanRedundantCondition'],
-        'functions.compat.php' => ['PhanRedefineFunction', 'PhanTypeMismatchReturn'],
+        'functions.compat.php' => ['PhanRedefineFunction'],
         'functions.global.php' => ['PhanRedefineFunction', 'PhanRedundantCondition', 'PhanSuspiciousMagicConstant', 'PhanTypeMismatchArgument'],
         'functions.opengraph.php' => ['PhanTypeArraySuspicious'],
         'json-endpoints/class.wpcom-json-api-add-widget-endpoint.php' => ['PhanNoopNew', 'PhanTypeMismatchReturn'],

--- a/projects/plugins/jetpack/changelog/fix-jetpack-prefix_youtube_id_function
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-prefix_youtube_id_function
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Shortcodes: Prevent redeclared function names with YouTube shortcode.

--- a/projects/plugins/jetpack/functions.compat.php
+++ b/projects/plugins/jetpack/functions.compat.php
@@ -29,7 +29,7 @@ function jetpack_get_youtube_id( $url ) {
 		$url = reset( $url );
 	}
 
-	$url = youtube_sanitize_url( $url );
+	$url = jetpack_youtube_sanitize_url( $url );
 	$url = wp_parse_url( $url );
 	$id  = false;
 
@@ -54,14 +54,14 @@ function jetpack_get_youtube_id( $url ) {
 	return $id;
 }
 
-if ( ! function_exists( 'youtube_sanitize_url' ) ) :
+if ( ! function_exists( 'jetpack_youtube_sanitize_url' ) ) :
 	/**
 	 * Normalizes a YouTube URL to include a v= parameter and a query string free of encoded ampersands.
 	 *
 	 * @param string|array $url YouTube URL.
 	 * @return string|array The normalized URL or false if input is invalid.
 	 */
-	function youtube_sanitize_url( $url ) {
+	function jetpack_youtube_sanitize_url( $url ) {
 		if ( is_array( $url ) && isset( $url['url'] ) ) {
 			$url = $url['url'];
 		}

--- a/projects/plugins/jetpack/functions.compat.php
+++ b/projects/plugins/jetpack/functions.compat.php
@@ -59,7 +59,7 @@ if ( ! function_exists( 'jetpack_youtube_sanitize_url' ) ) :
 	 * Normalizes a YouTube URL to include a v= parameter and a query string free of encoded ampersands.
 	 *
 	 * @param string|array $url YouTube URL.
-	 * @return string|array The normalized URL or false if input is invalid.
+	 * @return string|false The normalized URL or false if input is invalid.
 	 */
 	function jetpack_youtube_sanitize_url( $url ) {
 		if ( is_array( $url ) && isset( $url['url'] ) ) {
@@ -73,7 +73,7 @@ if ( ! function_exists( 'jetpack_youtube_sanitize_url' ) ) :
 		$url = trim( $url );
 		$url = str_replace( array( 'youtu.be/', '/v/', '#!v=', '&amp;', '&#038;', 'playlist' ), array( 'youtu.be/?v=', '/?v=', '?v=', '&', '&', 'videoseries' ), $url );
 
-		// Replace any extra question marks with ampersands - the result of a URL like "https://www.youtube.com/v/9FhMMmqzbD8?fs=1&hl=en_US" being passed in.
+		// Replace any extra question marks with ampersands - the result of a URL like "https://www.youtube.com/v/dQw4w9WgXcQ?fs=1&hl=en_US" being passed in.
 		$query_string_start = strpos( $url, '?' );
 
 		if ( false !== $query_string_start ) {

--- a/projects/plugins/jetpack/modules/shortcodes/youtube.php
+++ b/projects/plugins/jetpack/modules/shortcodes/youtube.php
@@ -681,8 +681,8 @@ function youtube_link( $content ) {
 	return jetpack_youtube_link( $content );
 }
 
-function youtube_link_callback( $content ) {
-	return jetpack_youtube_link_callback( $content );
+function youtube_link_callback( $matches ) {
+	return jetpack_youtube_link_callback( $matches );
 }
 
 function youtube_embed_to_short_code( $content ) {

--- a/projects/plugins/jetpack/modules/shortcodes/youtube.php
+++ b/projects/plugins/jetpack/modules/shortcodes/youtube.php
@@ -116,7 +116,7 @@ add_filter( 'pre_kses', 'youtube_embed_to_short_code' );
  * @return string The content with embeds instead of URLs
  */
 function jetpack_youtube_link( $content ) {
-	return jetpack_preg_replace_callback_outside_tags( '!(?:\n|\A)https?://(?:www\.)?(?:youtube.com/(?:v/|playlist|watch[/\#?])|youtu\.be/)[^\s]+?(?:\n|\Z)!i', 'youtube_link_callback', $content, 'youtube.com/' );
+	return jetpack_preg_replace_callback_outside_tags( '!(?:\n|\A)https?://(?:www\.)?(?:youtube.com/(?:v/|playlist|watch[/\#?])|youtu\.be/)[^\s]+?(?:\n|\Z)!i', 'jetpack_youtube_link_callback', $content, 'youtube.com/' );
 }
 
 /**
@@ -125,7 +125,7 @@ function jetpack_youtube_link( $content ) {
  *
  * @param array $matches An array containing a YouTube URL.
  */
-function youtube_link_callback( $matches ) {
+function jetpack_youtube_link_callback( $matches ) {
 	return "\n" . jetpack_youtube_id( $matches[0] ) . "\n";
 }
 
@@ -679,4 +679,8 @@ function youtube_shortcode( $atts ) {
 
 function youtube_link( $content ) {
 	return jetpack_youtube_link( $content );
+}
+
+function youtube_link_callback( $content ) {
+	return jetpack_youtube_link_callback( $content );
 }

--- a/projects/plugins/jetpack/modules/shortcodes/youtube.php
+++ b/projects/plugins/jetpack/modules/shortcodes/youtube.php
@@ -115,7 +115,7 @@ add_filter( 'pre_kses', 'youtube_embed_to_short_code' );
  *
  * @return string The content with embeds instead of URLs
  */
-function youtube_link( $content ) {
+function jetpack_youtube_link( $content ) {
 	return jetpack_preg_replace_callback_outside_tags( '!(?:\n|\A)https?://(?:www\.)?(?:youtube.com/(?:v/|playlist|watch[/\#?])|youtu\.be/)[^\s]+?(?:\n|\Z)!i', 'youtube_link_callback', $content, 'youtube.com/' );
 }
 
@@ -642,7 +642,7 @@ if (
 	 * so the iframe gets filtered out.
 	 * Higher priority because we need it before auto-link and autop get to it.
 	 */
-	add_filter( 'comment_text', 'youtube_link', 1 );
+	add_filter( 'comment_text', 'jetpack_youtube_link', 1 );
 }
 
 /**
@@ -675,4 +675,8 @@ function youtube_id( $url ) {
 
 function youtube_shortcode( $atts ) {
 	return jetpack_youtube_shortcode( $atts );
+}
+
+function youtube_link( $content ) {
+	return jetpack_youtube_link( $content );
 }

--- a/projects/plugins/jetpack/modules/shortcodes/youtube.php
+++ b/projects/plugins/jetpack/modules/shortcodes/youtube.php
@@ -153,7 +153,7 @@ if ( ! function_exists( 'jetpack_youtube_sanitize_url' ) ) :
 		$url = trim( $url );
 		$url = str_replace( array( 'youtu.be/', '/v/', '#!v=', '&amp;', '&#038;', 'playlist' ), array( 'youtu.be/?v=', '/?v=', '?v=', '&', '&', 'videoseries' ), $url );
 
-		// Replace any extra question marks with ampersands - the result of a URL like "http://www.youtube.com/v/9FhMMmqzbD8?fs=1&hl=en_US" being passed in.
+		// Replace any extra question marks with ampersands - the result of a URL like "https://www.youtube.com/v/dQw4w9WgXcQ?fs=1&hl=en_US" being passed in.
 		$query_string_start = strpos( $url, '?' );
 
 		if ( false !== $query_string_start ) {

--- a/projects/plugins/jetpack/modules/shortcodes/youtube.php
+++ b/projects/plugins/jetpack/modules/shortcodes/youtube.php
@@ -135,13 +135,13 @@ function jetpack_youtube_link_callback( $matches ) {
  * @param string|array $url Youtube URL.
  * @return string|false The normalized URL or false if input is invalid.
  */
-if ( ! function_exists( 'youtube_sanitize_url' ) ) :
+if ( ! function_exists( 'jetpack_youtube_sanitize_url' ) ) :
 	/**
 	 * Clean up Youtube URL to match a single format.
 	 *
 	 * @param string|array $url Youtube URL.
 	 */
-	function youtube_sanitize_url( $url ) {
+	function jetpack_youtube_sanitize_url( $url ) {
 		if ( is_array( $url ) && isset( $url['url'] ) ) {
 			$url = $url['url'];
 		}
@@ -186,7 +186,7 @@ function jetpack_youtube_id( $url ) {
 		return sprintf( '<!--%s-->', esc_html__( 'YouTube Error: bad URL entered', 'jetpack' ) );
 	}
 
-	$url = youtube_sanitize_url( $url );
+	$url = jetpack_youtube_sanitize_url( $url );
 	$url = wp_parse_url( $url );
 
 	$thumbnail = "https://i.ytimg.com/vi/$id/hqdefault.jpg";
@@ -687,4 +687,8 @@ function youtube_link_callback( $content ) {
 
 function youtube_embed_to_short_code( $content ) {
 	return jetpack_youtube_embed_to_short_code( $content );
+}
+
+function youtube_sanitize_url( $url ) {
+	return jetpack_youtube_sanitize_url( $url );
 }

--- a/projects/plugins/jetpack/modules/shortcodes/youtube.php
+++ b/projects/plugins/jetpack/modules/shortcodes/youtube.php
@@ -441,11 +441,11 @@ function jetpack_shortcode_youtube_args( $url ) {
  *
  * @return string The rendered shortcode.
  */
-function youtube_shortcode( $atts ) {
+function jetpack_youtube_shortcode( $atts ) {
 	$url = ( isset( $atts[0] ) ) ? ltrim( $atts[0], '=' ) : shortcode_new_to_old_params( $atts );
 	return jetpack_youtube_id( $url );
 }
-add_shortcode( 'youtube', 'youtube_shortcode' );
+add_shortcode( 'youtube', 'jetpack_youtube_shortcode' );
 
 /**
  * Gets the dimensions of the [youtube] shortcode.
@@ -664,11 +664,15 @@ function jetpack_fix_youtube_shortcode_display_filter( $content ) {
 }
 add_filter( 'the_content', 'jetpack_fix_youtube_shortcode_display_filter', 7 );
 
-// phpcs:disable Squiz.Commenting.FunctionComment
 /**
  * Temporary wrapper functions while purging other codebases of the non-prefixed variants.
  * TODO: Remove these after verifying they're not called elsewhere.
  */
+// phpcs:disable Squiz.Commenting.FunctionComment
 function youtube_id( $url ) {
 	return jetpack_youtube_id( $url );
+}
+
+function youtube_shortcode( $atts ) {
+	return jetpack_youtube_shortcode( $atts );
 }

--- a/projects/plugins/jetpack/modules/shortcodes/youtube.php
+++ b/projects/plugins/jetpack/modules/shortcodes/youtube.php
@@ -33,7 +33,7 @@
  * @param string $content HTML content.
  * @return string The content with YouTube embeds replaced with YouTube shortcodes.
  */
-function youtube_embed_to_short_code( $content ) {
+function jetpack_youtube_embed_to_short_code( $content ) {
 	if ( ! is_string( $content ) || ! str_contains( $content, 'youtube.com' ) ) {
 		return $content;
 	}
@@ -106,7 +106,7 @@ function youtube_embed_to_short_code( $content ) {
 
 	return $content;
 }
-add_filter( 'pre_kses', 'youtube_embed_to_short_code' );
+add_filter( 'pre_kses', 'jetpack_youtube_embed_to_short_code' );
 
 /**
  * Replaces plain-text links to YouTube videos with YouTube embeds.
@@ -683,4 +683,8 @@ function youtube_link( $content ) {
 
 function youtube_link_callback( $content ) {
 	return jetpack_youtube_link_callback( $content );
+}
+
+function youtube_embed_to_short_code( $content ) {
+	return jetpack_youtube_embed_to_short_code( $content );
 }

--- a/projects/plugins/jetpack/modules/shortcodes/youtube.php
+++ b/projects/plugins/jetpack/modules/shortcodes/youtube.php
@@ -126,7 +126,7 @@ function youtube_link( $content ) {
  * @param array $matches An array containing a YouTube URL.
  */
 function youtube_link_callback( $matches ) {
-	return "\n" . youtube_id( $matches[0] ) . "\n";
+	return "\n" . jetpack_youtube_id( $matches[0] ) . "\n";
 }
 
 /**
@@ -179,7 +179,7 @@ endif;
  *
  * @param string $url Youtube URL.
  */
-function youtube_id( $url ) {
+function jetpack_youtube_id( $url ) {
 	$id = jetpack_get_youtube_id( $url );
 
 	if ( ! $id ) {
@@ -443,7 +443,7 @@ function jetpack_shortcode_youtube_args( $url ) {
  */
 function youtube_shortcode( $atts ) {
 	$url = ( isset( $atts[0] ) ) ? ltrim( $atts[0], '=' ) : shortcode_new_to_old_params( $atts );
-	return youtube_id( $url );
+	return jetpack_youtube_id( $url );
 }
 add_shortcode( 'youtube', 'youtube_shortcode' );
 
@@ -532,7 +532,7 @@ function jetpack_shortcode_youtube_dimensions( $query_args ) {
  * @param string $url     Requested URL to be embedded.
  */
 function wpcom_youtube_embed_crazy_url( $matches, $attr, $url ) {
-	return youtube_id( $url );
+	return jetpack_youtube_id( $url );
 }
 
 /**
@@ -581,7 +581,7 @@ function wpcom_youtube_filter_pre_oembed_result( $result, $url, $args ) {
 	}
 
 	// Fallback to the custom handler if the oembed result is not found, especially for the private video.
-	return youtube_id( $url );
+	return jetpack_youtube_id( $url );
 }
 add_filter( 'pre_oembed_result', 'wpcom_youtube_filter_pre_oembed_result', 10, 3 );
 
@@ -663,3 +663,12 @@ function jetpack_fix_youtube_shortcode_display_filter( $content ) {
 	return $content;
 }
 add_filter( 'the_content', 'jetpack_fix_youtube_shortcode_display_filter', 7 );
+
+// phpcs:disable Squiz.Commenting.FunctionComment
+/**
+ * Temporary wrapper functions while purging other codebases of the non-prefixed variants.
+ * TODO: Remove these after verifying they're not called elsewhere.
+ */
+function youtube_id( $url ) {
+	return jetpack_youtube_id( $url );
+}

--- a/projects/plugins/jetpack/tests/php/general/Functions_Compat_Test.php
+++ b/projects/plugins/jetpack/tests/php/general/Functions_Compat_Test.php
@@ -4,10 +4,10 @@ use PHPUnit\Framework\Attributes\CoversFunction;
 
 /**
  * @covers ::jetpack_get_youtube_id
- * @covers ::youtube_sanitize_url
+ * @covers ::jetpack_youtube_sanitize_url
  */
 #[CoversFunction( 'jetpack_get_youtube_id' )]
-#[CoversFunction( 'youtube_sanitize_url' )]
+#[CoversFunction( 'jetpack_youtube_sanitize_url' )]
 class Functions_Compat_Test extends WP_UnitTestCase {
 	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
 
@@ -15,11 +15,11 @@ class Functions_Compat_Test extends WP_UnitTestCase {
 	 * @author enkrates
 	 * @since 3.2
 	 */
-	public function test_youtube_sanitize_url_with_valid_url() {
+	public function test_jetpack_youtube_sanitize_url_with_valid_url() {
 
 		$valid_url = 'https://www.youtube.com/watch?v=snAvGxz7D04';
 
-		$sanitized_url = youtube_sanitize_url( $valid_url );
+		$sanitized_url = jetpack_youtube_sanitize_url( $valid_url );
 
 		$this->assertEquals( $valid_url, $sanitized_url );
 	}
@@ -28,12 +28,12 @@ class Functions_Compat_Test extends WP_UnitTestCase {
 	 * @author enkrates
 	 * @since 3.2
 	 */
-	public function test_youtube_sanitize_url_with_shortened_url() {
+	public function test_jetpack_youtube_sanitize_url_with_shortened_url() {
 
 		$valid_short_url        = 'https://youtu.be/snAvGxz7D04';
 		$expected_sanitized_url = 'https://youtu.be/?v=snAvGxz7D04';
 
-		$sanitized_url = youtube_sanitize_url( $valid_short_url );
+		$sanitized_url = jetpack_youtube_sanitize_url( $valid_short_url );
 
 		$this->assertEquals( $expected_sanitized_url, $sanitized_url );
 	}
@@ -42,12 +42,12 @@ class Functions_Compat_Test extends WP_UnitTestCase {
 	 * @author enkrates
 	 * @since 3.2
 	 */
-	public function test_youtube_sanitize_url_with_slash_v_slash() {
+	public function test_jetpack_youtube_sanitize_url_with_slash_v_slash() {
 
 		$slash_v_slash_url      = 'https://www.youtube.com/v/9FhMMmqzbD8';
 		$expected_sanitized_url = 'https://www.youtube.com/?v=9FhMMmqzbD8';
 
-		$sanitized_url = youtube_sanitize_url( $slash_v_slash_url );
+		$sanitized_url = jetpack_youtube_sanitize_url( $slash_v_slash_url );
 
 		$this->assertEquals( $expected_sanitized_url, $sanitized_url );
 	}
@@ -56,12 +56,12 @@ class Functions_Compat_Test extends WP_UnitTestCase {
 	 * @author enkrates
 	 * @since 3.2
 	 */
-	public function test_youtube_sanitize_url_with_hashbang() {
+	public function test_jetpack_youtube_sanitize_url_with_hashbang() {
 
 		$hashbang_url           = 'https://www.youtube.com/#!v=9FhMMmqzbD8';
 		$expected_sanitized_url = 'https://www.youtube.com/?v=9FhMMmqzbD8';
 
-		$sanitized_url = youtube_sanitize_url( $hashbang_url );
+		$sanitized_url = jetpack_youtube_sanitize_url( $hashbang_url );
 
 		$this->assertEquals( $expected_sanitized_url, $sanitized_url );
 	}
@@ -70,12 +70,12 @@ class Functions_Compat_Test extends WP_UnitTestCase {
 	 * @author enkrates
 	 * @since 3.2
 	 */
-	public function test_youtube_sanitize_url_with_amp_ampersand() {
+	public function test_jetpack_youtube_sanitize_url_with_amp_ampersand() {
 
 		$amp_ampersand_url      = 'https://www.youtube.com/watch?v=snAvGxz7D04&amp;hl=en_US';
 		$expected_sanitized_url = 'https://www.youtube.com/watch?v=snAvGxz7D04&hl=en_US';
 
-		$sanitized_url = youtube_sanitize_url( $amp_ampersand_url );
+		$sanitized_url = jetpack_youtube_sanitize_url( $amp_ampersand_url );
 
 		$this->assertEquals( $expected_sanitized_url, $sanitized_url );
 	}
@@ -84,12 +84,12 @@ class Functions_Compat_Test extends WP_UnitTestCase {
 	 * @author enkrates
 	 * @since 3.2
 	 */
-	public function test_youtube_sanitize_url_with_encoded_ampersand() {
+	public function test_jetpack_youtube_sanitize_url_with_encoded_ampersand() {
 
 		$encoded_ampersand_url  = 'https://www.youtube.com/watch?v=snAvGxz7D04&#038;hl=en_US';
 		$expected_sanitized_url = 'https://www.youtube.com/watch?v=snAvGxz7D04&hl=en_US';
 
-		$sanitized_url = youtube_sanitize_url( $encoded_ampersand_url );
+		$sanitized_url = jetpack_youtube_sanitize_url( $encoded_ampersand_url );
 
 		$this->assertEquals( $expected_sanitized_url, $sanitized_url );
 	}
@@ -98,12 +98,12 @@ class Functions_Compat_Test extends WP_UnitTestCase {
 	 * @author enkrates
 	 * @since 3.2
 	 */
-	public function test_youtube_sanitize_url_with_playlist() {
+	public function test_jetpack_youtube_sanitize_url_with_playlist() {
 
 		$valid_playlist_url     = 'https://www.youtube.com/playlist?list=PL56C3506BBE979C1B';
 		$expected_sanitized_url = 'https://www.youtube.com/videoseries?list=PL56C3506BBE979C1B';
 
-		$sanitized_url = youtube_sanitize_url( $valid_playlist_url );
+		$sanitized_url = jetpack_youtube_sanitize_url( $valid_playlist_url );
 
 		$this->assertEquals( $expected_sanitized_url, $sanitized_url );
 	}
@@ -112,12 +112,12 @@ class Functions_Compat_Test extends WP_UnitTestCase {
 	 * @author enkrates
 	 * @since 3.2
 	 */
-	public function test_youtube_sanitize_url_with_extra_question_mark() {
+	public function test_jetpack_youtube_sanitize_url_with_extra_question_mark() {
 
 		$extra_question_mark_url = 'http://www.youtube.com/v/9FhMMmqzbD8?fs=1&hl=en_US';
 		$expected_sanitized_url  = 'http://www.youtube.com/?v=9FhMMmqzbD8&fs=1&hl=en_US';
 
-		$sanitized_url = youtube_sanitize_url( $extra_question_mark_url );
+		$sanitized_url = jetpack_youtube_sanitize_url( $extra_question_mark_url );
 
 		$this->assertEquals( $expected_sanitized_url, $sanitized_url );
 	}
@@ -126,14 +126,14 @@ class Functions_Compat_Test extends WP_UnitTestCase {
 	 * @author robfelty
 	 * @since 13.2
 	 */
-	public function test_youtube_sanitize_url_as_array() {
+	public function test_jetpack_youtube_sanitize_url_as_array() {
 
 		$url_array              = array(
 			'url' => 'http://www.youtube.com/v/9FhMMmqzbD8?fs=1&hl=en_US',
 		);
 		$expected_sanitized_url = 'http://www.youtube.com/?v=9FhMMmqzbD8&fs=1&hl=en_US';
 
-		$sanitized_url = youtube_sanitize_url( $url_array );
+		$sanitized_url = jetpack_youtube_sanitize_url( $url_array );
 
 		$this->assertEquals( $expected_sanitized_url, $sanitized_url );
 	}
@@ -142,14 +142,14 @@ class Functions_Compat_Test extends WP_UnitTestCase {
 	 * @author robfelty
 	 * @since 13.2
 	 */
-	public function test_youtube_sanitize_url_invalid_input() {
+	public function test_jetpack_youtube_sanitize_url_invalid_input() {
 
 		$invalid_url_array      = array(
 			'vv' => 'http://www.youtube.com/v/9FhMMmqzbD8?fs=1&hl=en_US',
 		);
 		$expected_sanitized_url = false;
 
-		$sanitized_url = youtube_sanitize_url( $invalid_url_array );
+		$sanitized_url = jetpack_youtube_sanitize_url( $invalid_url_array );
 
 		$this->assertEquals( $expected_sanitized_url, $sanitized_url );
 	}

--- a/projects/plugins/jetpack/tests/php/modules/shortcodes/Jetpack_Shortcodes_Youtube_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/shortcodes/Jetpack_Shortcodes_Youtube_Test.php
@@ -10,13 +10,13 @@ require_once __DIR__ . '/trait.http-request-cache.php';
  * @covers ::jetpack_shortcode_youtube_dimensions
  * @covers ::wpcom_youtube_oembed_fetch_url
  * @covers ::jetpack_youtube_id
- * @covers ::youtube_shortcode
+ * @covers ::jetpack_youtube_shortcode
  */
 #[CoversFunction( 'jetpack_shortcode_youtube_args' )]
 #[CoversFunction( 'jetpack_shortcode_youtube_dimensions' )]
 #[CoversFunction( 'wpcom_youtube_oembed_fetch_url' )]
 #[CoversFunction( 'jetpack_youtube_id' )]
-#[CoversFunction( 'youtube_shortcode' )]
+#[CoversFunction( 'jetpack_youtube_shortcode' )]
 class Jetpack_Shortcodes_Youtube_Test extends WP_UnitTestCase {
 	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
 	use Automattic\Jetpack\Tests\HttpRequestCacheTrait;

--- a/projects/plugins/jetpack/tests/php/modules/shortcodes/Jetpack_Shortcodes_Youtube_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/shortcodes/Jetpack_Shortcodes_Youtube_Test.php
@@ -9,13 +9,13 @@ require_once __DIR__ . '/trait.http-request-cache.php';
  * @covers ::jetpack_shortcode_youtube_args
  * @covers ::jetpack_shortcode_youtube_dimensions
  * @covers ::wpcom_youtube_oembed_fetch_url
- * @covers ::youtube_id
+ * @covers ::jetpack_youtube_id
  * @covers ::youtube_shortcode
  */
 #[CoversFunction( 'jetpack_shortcode_youtube_args' )]
 #[CoversFunction( 'jetpack_shortcode_youtube_dimensions' )]
 #[CoversFunction( 'wpcom_youtube_oembed_fetch_url' )]
-#[CoversFunction( 'youtube_id' )]
+#[CoversFunction( 'jetpack_youtube_id' )]
 #[CoversFunction( 'youtube_shortcode' )]
 class Jetpack_Shortcodes_Youtube_Test extends WP_UnitTestCase {
 	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
@@ -84,7 +84,7 @@ class Jetpack_Shortcodes_Youtube_Test extends WP_UnitTestCase {
 	 */
 	#[DataProvider( 'get_youtube_id_options' )]
 	public function test_shortcodes_youtube_id_options( $url, $expected ) {
-		$output = youtube_id( $url );
+		$output = jetpack_youtube_id( $url );
 
 		$this->assertStringContainsString( $expected, $output );
 	}
@@ -187,7 +187,7 @@ class Jetpack_Shortcodes_Youtube_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Gets the test data for youtube_id().
+	 * Gets the test data for jetpack_youtube_id().
 	 *
 	 * @return array[] The test data.
 	 */
@@ -246,7 +246,7 @@ class Jetpack_Shortcodes_Youtube_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test youtube_id.
+	 * Test jetpack_youtube_id().
 	 *
 	 * @dataProvider get_amp_youtube_data
 	 * @param string $url             The shortcode URL.
@@ -261,10 +261,10 @@ class Jetpack_Shortcodes_Youtube_Test extends WP_UnitTestCase {
 		}
 
 		add_filter( 'jetpack_is_amp_request', '__return_true' );
-		$this->assertEquals( $expected_amp, youtube_id( $url ) );
+		$this->assertEquals( $expected_amp, jetpack_youtube_id( $url ) );
 
 		remove_filter( 'jetpack_is_amp_request', '__return_true' );
-		$this->assertEquals( $expected_nonamp, youtube_id( $url ) );
+		$this->assertEquals( $expected_nonamp, jetpack_youtube_id( $url ) );
 	}
 
 	/**
@@ -297,7 +297,7 @@ class Jetpack_Shortcodes_Youtube_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test youtube_id.
+	 * Test jetpack_youtube_id().
 	 *
 	 * @dataProvider get_amp_youtube_shortcode_data
 	 * @param array  $query_args The query args to pass to the function.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This prefixes various function names with `jetpack_` to prevent function name conflicts.

* **Part 1: Rename functions and create wrapper functions with the old names. <-- this PR**
* Part 2: Update other codebases.
* Part 3: Remove wrapper functions.

Atomic logs showed some PHP fatals:

```
PHP Fatal error: Cannot redeclare youtube_id() (previously declared in /srv/htdocs/wp-content/themes/panoptyc-wp/includes/custom-functions.php:69) in /wordpress/plugins/jetpack/14.6-a.9/modules/shortcodes/youtube.php on line 182
```

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Is CI happy? Did I typo anything?