### PR TITLE
Revert "Jetpack: Lower the specificity of the global box-sizing styles applied in the editor context"

### DIFF
--- a/projects/js-packages/components/changelog/fix-turn-off-global-styles-in-the-editor
+++ b/projects/js-packages/components/changelog/fix-turn-off-global-styles-in-the-editor
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-JS Packages: Decrease CSS priority of global styles to prevent them from applying within the editor

--- a/projects/js-packages/components/components/theme-provider/globals.module.scss
+++ b/projects/js-packages/components/components/theme-provider/globals.module.scss
@@ -1,7 +1,7 @@
 /* DO NOT USE THIS TO OVERRIDE STYLES */
 .global {
 
-	:where(&) * {
+	* {
 		box-sizing: border-box;
 	}
 }

--- a/projects/plugins/automattic-for-agencies-client/changelog/fix-turn-off-global-styles-in-the-editor
+++ b/projects/plugins/automattic-for-agencies-client/changelog/fix-turn-off-global-styles-in-the-editor
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-JS Packages: Decrease CSS priority of global styles to prevent them from applying within the editor

--- a/projects/plugins/backup/changelog/fix-turn-off-global-styles-in-the-editor
+++ b/projects/plugins/backup/changelog/fix-turn-off-global-styles-in-the-editor
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-JS Packages: Decrease CSS priority of global styles to prevent them from applying within the editor

--- a/projects/plugins/boost/changelog/fix-turn-off-global-styles-in-the-editor
+++ b/projects/plugins/boost/changelog/fix-turn-off-global-styles-in-the-editor
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-JS Packages: Decrease CSS priority of global styles to prevent them from applying within the editor

--- a/projects/plugins/classic-theme-helper-plugin/changelog/fix-turn-off-global-styles-in-the-editor
+++ b/projects/plugins/classic-theme-helper-plugin/changelog/fix-turn-off-global-styles-in-the-editor
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-JS Packages: Decrease CSS priority of global styles to prevent them from applying within the editor

--- a/projects/plugins/crm/changelog/fix-turn-off-global-styles-in-the-editor
+++ b/projects/plugins/crm/changelog/fix-turn-off-global-styles-in-the-editor
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-JS Packages: Decrease CSS priority of global styles to prevent them from applying within the editor

--- a/projects/plugins/inspect/changelog/fix-turn-off-global-styles-in-the-editor
+++ b/projects/plugins/inspect/changelog/fix-turn-off-global-styles-in-the-editor
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-JS Packages: Decrease CSS priority of global styles to prevent them from applying within the editor

--- a/projects/plugins/jetpack/changelog/fix-turn-off-global-styles-in-the-editor
+++ b/projects/plugins/jetpack/changelog/fix-turn-off-global-styles-in-the-editor
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-JS Packages: Decrease CSS priority of global styles to prevent them from applying within the editor

--- a/projects/plugins/mu-wpcom-plugin/changelog/fix-turn-off-global-styles-in-the-editor
+++ b/projects/plugins/mu-wpcom-plugin/changelog/fix-turn-off-global-styles-in-the-editor
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-JS Packages: Decrease CSS priority of global styles to prevent them from applying within the editor

--- a/projects/plugins/protect/changelog/fix-turn-off-global-styles-in-the-editor
+++ b/projects/plugins/protect/changelog/fix-turn-off-global-styles-in-the-editor
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-JS Packages: Decrease CSS priority of global styles to prevent them from applying within the editor

--- a/projects/plugins/search/changelog/fix-turn-off-global-styles-in-the-editor
+++ b/projects/plugins/search/changelog/fix-turn-off-global-styles-in-the-editor
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-JS Packages: Decrease CSS priority of global styles to prevent them from applying within the editor

--- a/projects/plugins/social/changelog/fix-turn-off-global-styles-in-the-editor
+++ b/projects/plugins/social/changelog/fix-turn-off-global-styles-in-the-editor
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-JS Packages: Decrease CSS priority of global styles to prevent them from applying within the editor

--- a/projects/plugins/starter-plugin/changelog/fix-turn-off-global-styles-in-the-editor
+++ b/projects/plugins/starter-plugin/changelog/fix-turn-off-global-styles-in-the-editor
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-JS Packages: Decrease CSS priority of global styles to prevent them from applying within the editor

--- a/projects/plugins/videopress/changelog/fix-turn-off-global-styles-in-the-editor
+++ b/projects/plugins/videopress/changelog/fix-turn-off-global-styles-in-the-editor
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-JS Packages: Decrease CSS priority of global styles to prevent them from applying within the editor

--- a/projects/plugins/wpcomsh/changelog/fix-turn-off-global-styles-in-the-editor
+++ b/projects/plugins/wpcomsh/changelog/fix-turn-off-global-styles-in-the-editor
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-JS Packages: Decrease CSS priority of global styles to prevent them from applying within the editor


### PR DESCRIPTION
Reverts Automattic/jetpack#43035

Testing revert in case this is causing issues with Forms:

Looks like:
![image](https://github.com/user-attachments/assets/39d4da51-6f04-4cd0-a7bd-f0a88a547e7e)

Should be:
![image](https://github.com/user-attachments/assets/8c413df3-7d4f-4349-bf24-06b5b7a2e447)
