### PR TITLE
My Jetpack: Fix onboarding E2E tests for site connection

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-onboarding-e2e-tests
+++ b/projects/plugins/jetpack/changelog/fix-onboarding-e2e-tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Fix My Jetpack onbaording E2E tests

--- a/projects/plugins/jetpack/tests/e2e/specs/onboarding/site-connection.test.ts
+++ b/projects/plugins/jetpack/tests/e2e/specs/onboarding/site-connection.test.ts
@@ -12,7 +12,10 @@ test( 'Site only connection', async ( { page, admin } ) => {
 	const onboarding = new Onboarding( page );
 
 	await test.step( 'Connect site', async () => {
-		await Promise.all( [ onboarding.start(), onboarding.waitForSiteConnection() ] );
+		const siteConnectionPromise = onboarding.waitForSiteConnection();
+		await onboarding.start();
+		await siteConnectionPromise;
+		await onboarding.waitForRedirectToWpcom();
 	} );
 
 	await test.step( 'Verify site connection', async () => {


### PR DESCRIPTION
Currently, when running E2E tests for site connection, we simply abandon the existing request and the associated redirects it might cause once the site is registered. So, what happens is that the site is registered and we try to go to My Jetpack page but the UI redirects to WPCOM and it causes the tests to fail.

The fix is to wait for the wpcom redirect before going to My Jetpack to avoid race conditions.


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Ensure to wait for WPCOM redirect for site connection before making assertions.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* CI should be happy
