### PR TITLE
Forms: Preserve responses query parameters

### DIFF
--- a/projects/packages/forms/changelog/fix-form-responses-parameters
+++ b/projects/packages/forms/changelog/fix-form-responses-parameters
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Preserve responses query parameters.

--- a/projects/packages/forms/src/dashboard/components/layout/index.js
+++ b/projects/packages/forms/src/dashboard/components/layout/index.js
@@ -39,9 +39,13 @@ const Layout = ( { className, showFooter } ) => {
 			if ( ! tabName ) {
 				tabName = config( 'hasFeedback' ) ? 'responses' : 'about';
 			}
-			navigate( `/${ tabName }` );
+			// Preserve query params when navigating
+			navigate( {
+				pathname: `/${ tabName }`,
+				search: location.search,
+			} );
 		},
-		[ navigate ]
+		[ navigate, location.search ]
 	);
 
 	return (

--- a/projects/packages/forms/src/dashboard/components/layout/index.js
+++ b/projects/packages/forms/src/dashboard/components/layout/index.js
@@ -39,10 +39,9 @@ const Layout = ( { className, showFooter } ) => {
 			if ( ! tabName ) {
 				tabName = config( 'hasFeedback' ) ? 'responses' : 'about';
 			}
-			// Preserve query params when navigating
 			navigate( {
 				pathname: `/${ tabName }`,
-				search: location.search,
+				search: tabName === 'responses' ? location.search : '',
 			} );
 		},
 		[ navigate, location.search ]

--- a/projects/plugins/jetpack/changelog/fix-form-responses-parameters
+++ b/projects/plugins/jetpack/changelog/fix-form-responses-parameters
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: Preserve responses query parameters.


### PR DESCRIPTION
## Proposed changes:

This PR ensures that we always preserve status routing for the forms inbox. 

In #43280, we add path-based routing for dashboard tabs. This works fine, and once you are on the responses pages, the trash/spam tabs also work fine. But if you navigate directly to `wp-admin/admin.php?page=jetpack-forms#/responses?status=trash` we would route to 'responses' without keeping the query parameter. The change ensures we keep query parameters. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
On slack: p1746430706382069-slack-C086RGTJT1D

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No. 

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Navigate directly to `wp-admin/admin.php?page=jetpack-forms#/responses?status=trash` and `wp-admin/admin.php?page=jetpack-forms#/responses?status=spam`, and confirm that the form responses list is filters to show only trash and spam. 
* Also then just try navigating between various tabs to ensure no other regressions. 