### PR TITLE
Forms: Show exports only on responses tab

### DIFF
--- a/projects/packages/forms/changelog/update-forms-exports-responses-only
+++ b/projects/packages/forms/changelog/update-forms-exports-responses-only
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Show export button only on responses tab.

--- a/projects/packages/forms/src/dashboard/components/layout/index.js
+++ b/projects/packages/forms/src/dashboard/components/layout/index.js
@@ -54,7 +54,7 @@ const Layout = ( { className, showFooter } ) => {
 				<div className="jp-forms__logo-wrapper">
 					<JetpackFormsLogo />
 				</div>
-				<ExportResponsesButton />
+				{ getCurrentTab() === 'responses' && <ExportResponsesButton /> }
 			</div>
 			<TabPanel
 				className="jp-forms__dashboard-tabs"


### PR DESCRIPTION
## Proposed changes:

A recent PR updated tabs on the forms responses page, and as a part of that moved the Export button for responses to the header. This PR ensures that Export button should only show on the response tab, not the About tab.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None. 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Go to form responses page and confirm that the Export button in the header does not show if you click the About tab. 