### PR TITLE
Forms: PoC to add the Forms submenu item on dotcom sites

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-jetpack-forms-wpcom-submenu
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-jetpack-forms-wpcom-submenu
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: Add Jetpack submenu item for forms dashboard

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
@@ -254,6 +254,15 @@ function wpcom_add_jetpack_submenu() {
 		null // @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
 	);
 
+	add_submenu_page(
+		'jetpack',
+		__( 'Jetpack Forms', 'jetpack-mu-wpcom' ),
+		__( 'Forms', 'jetpack-mu-wpcom' ),
+		'edit_pages',
+		'jetpack-forms-admin',
+		null
+	);
+
 	// Re-order menu.
 	global $submenu;
 	if ( ! isset( $submenu['jetpack'] ) ) {
@@ -264,6 +273,7 @@ function wpcom_add_jetpack_submenu() {
 		'my-jetpack',
 		'stats',
 		$activity_log_url,
+		'jetpack-forms-admin',
 		$vaultpress_url,
 		'akismet-key-config',
 		'jetpack-search',


### PR DESCRIPTION
WIP

Fixes #

## Proposed changes:
Add submenu item on mu-wpcom package

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
none yet

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
TBD