### PR TITLE
Forms: Fix responses toggle background

### DIFF
--- a/projects/packages/forms/changelog/fix-form-toggle-bg
+++ b/projects/packages/forms/changelog/fix-form-toggle-bg
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Fix responses toggle background.

--- a/projects/packages/forms/src/dashboard/components/InboxStatusToggle/index.js
+++ b/projects/packages/forms/src/dashboard/components/InboxStatusToggle/index.js
@@ -66,6 +66,7 @@ export default function InboxStatusToggle( { currentQuery } ) {
 
 	return (
 		<ToggleGroupControl
+			key={ `${ totalItemsInbox ?? 0 }-${ totalItemsSpam ?? 0 }-${ totalItemsTrash ?? 0 }` }
 			className="jp-forms__inbox-status-toggle"
 			value={ status }
 			onChange={ handleChange }


### PR DESCRIPTION
## Proposed changes:

We recently updated the responses page to use the experimental ToggleControlGroup component to load Inbox / Spam / Trash tabs. On the tabs we also load the quantities for each, but those are delayed because they require an API call. When the update, the size of the tabs update, but the background on the active tab does not. The component sets the background using an absolutely positioned/sized :before pseudo element. 

To ensure that the background element is positioned and sized correctly, this PR sets a key on the ToggleControlGroup using the quantities. When the quantities update, the key updates and the component rerenders and the component sets the correct size and position on the background. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Slack: p1746475309202549-slack-C086RGTJT1D

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Ensure that you have at least 10 items in your form submission inbox. 
* Go to the feedback page and watch the Inbox / Spam / Trash toggle. Initially they will show zero until the responses load. Once they load, the numbers will update on the toggles. Confirm that when they do, the black background is correctly positioned.