### PR TITLE
Carousel: fix comment form element detection

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-carousel-comments-closed
+++ b/projects/plugins/jetpack/changelog/fix-carousel-comments-closed
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Carousel: do not display comment form when comments are closed for a specific media attachment.

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -1124,7 +1124,7 @@
 		}
 
 		function testCommentsOpened( opened ) {
-			var commentForm = carousel.container.querySelector( '.jp-carousel-comment-form-container' );
+			var commentForm = carousel.info.querySelector( '#jp-carousel-comment-form-container' );
 			var isOpened = parseInt( opened, 10 ) === 1;
 
 			if ( isOpened ) {


### PR DESCRIPTION
Fixes JETPACK-428

## Proposed changes:

Ensure that we detect the comment form using the correct selector, and in the correct wrapper.

This will in turn ensure that when we want to hide the comment form from the Carousel modal, we can do so.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Go to Jetpack > Settings > Writing and enable the carousel feature.
    * Ensure that the comment sub-setting is also toggled on.
* Go to Media > Library
* Pick one of your recently uploaded images, click on it.
* Click on the link to edit the media attachment.
* In the attachment edit page that loads, check the screen options tab at the top
* Ensure the "Discussion" setting is toggled on.
* Disable comments for that image.
* Save your changes.
* In a new post, add a gallery block.
* Upload a few images.
* Add in the image where you changed the dicussion settings and closed comments.
* View your post on the frontend.
* Click on an image to open the carousel modal.
* Click on the comment icon.
* No comment form should be visible for the image where comments are closed.


