### PR TITLE
Forms: Refactor logic for Success and Email Messages

### DIFF
--- a/projects/packages/forms/changelog/update-forms-success-message
+++ b/projects/packages/forms/changelog/update-forms-success-message
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Improve Success and Email messages

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -531,6 +531,12 @@ class Contact_Form extends Contact_Form_Shortcode {
 
 		foreach ( $compiled_form as $field_index => $data ) {
 			$safe_display_value = self::escape_and_sanitize_field_value( $data['value'] );
+
+			if ( '' === $safe_display_value ) {
+				unset( $compiled_form[ $field_index ] );
+				continue;
+			}
+
 			if ( ! empty( $data['label'] ) ) {
 				$safe_display_label            = self::escape_and_sanitize_field_label( $data['label'] );
 				$compiled_form[ $field_index ] = sprintf(

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -544,6 +544,32 @@ class Contact_Form extends Contact_Form_Shortcode {
 	 * @return array $lines
 	 */
 	public static function get_compiled_form( $feedback_id, $form ) {
+		$raw_compiled_form = self::get_raw_compiled_form_data( $feedback_id, $form );
+		$compiled_form     = array();
+
+		foreach ( $raw_compiled_form as $field_index => $data ) {
+			$compiled_form[ $field_index ] = sprintf(
+				'<div class="field-name">%1$s</div> <div class="field-value">%2$s</div>',
+				wp_kses( $data['label'], array() ),
+				self::escape_and_sanitize_field_value( $data['value'] )
+			);
+		}
+
+		// Sorting lines by the field index
+		ksort( $compiled_form );
+
+		return $compiled_form;
+	}
+
+	/**
+	 * Retrieves raw compiled form data.
+	 *
+	 * @param int          $feedback_id - the feedback ID.
+	 * @param Contact_Form $form - the form.
+	 *
+	 * @return array $raw_data Associative array where keys are field_index and values are arrays with 'label' and 'value'.
+	 */
+	private static function get_raw_compiled_form_data( $feedback_id, $form ) {
 		$feedback       = get_post( $feedback_id );
 		$field_ids      = $form->get_field_ids();
 		$content_fields = Contact_Form_Plugin::parse_fields_from_content( $feedback_id );
@@ -557,12 +583,13 @@ class Contact_Form extends Contact_Form_Shortcode {
 			'textarea' => false, // not a post_meta key.  This is stored in post_content
 		);
 
-		$compiled_form = array();
+		$raw_data = array();
 
 		// "Standard" field allowed list.
 		foreach ( $field_value_map as $type => $meta_key ) {
 			if ( isset( $field_ids[ $type ] ) ) {
 				$field = $form->fields[ $field_ids[ $type ] ];
+				$value = null;
 
 				if ( $meta_key ) {
 					if ( isset( $content_fields[ "_feedback_{$meta_key}" ] ) ) {
@@ -578,10 +605,10 @@ class Contact_Form extends Contact_Form_Shortcode {
 					}
 				} else {
 					// The feedback content is stored as the first "half" of post_content
-					$value         = ( is_object( $feedback ) && is_a( $feedback, '\WP_Post' ) ) ?
+					$current_value         = ( is_object( $feedback ) && is_a( $feedback, '\WP_Post' ) ) ?
 									$feedback->post_content : '';
-					list( $value ) = explode( '<!--more-->', $value );
-					$value         = trim( $value );
+					list( $current_value ) = explode( '<!--more-->', $current_value );
+					$value                 = trim( $current_value );
 				}
 
 				// If we still do not have any value, bail.
@@ -592,10 +619,9 @@ class Contact_Form extends Contact_Form_Shortcode {
 				$field_index = array_search( $field_ids[ $type ], $field_ids['all'], true );
 				$field_label = self::maybe_add_colon_to_label( $field->get_attribute( 'label' ) );
 
-				$compiled_form[ $field_index ] = sprintf(
-					'<div class="field-name">%1$s</div> <div class="field-value">%2$s</div>',
-					wp_kses( $field_label, array() ),
-					self::escape_and_sanitize_field_value( $value )
+				$raw_data[ $field_index ] = array(
+					'label' => $field_label,
+					'value' => $value,
 				);
 			}
 		}
@@ -615,24 +641,17 @@ class Contact_Form extends Contact_Form_Shortcode {
 				foreach ( $field_ids['extra'] as $field_id ) {
 					$field       = $form->fields[ $field_id ];
 					$field_index = array_search( $field_id, $field_ids['all'], true );
+					$field_label = self::maybe_add_colon_to_label( $field->get_attribute( 'label' ) );
 
-					$label = self::maybe_add_colon_to_label( $field->get_attribute( 'label' ) );
-
-					$compiled_form[ $field_index ] = sprintf(
-						'<div class="field-name">%1$s</div> <div class="field-value">%2$s</div>',
-						wp_kses( $label, array() ),
-						self::escape_and_sanitize_field_value( $extra_fields[ $extra_field_keys[ $i ] ] )
+					$raw_data[ $field_index ] = array(
+						'label' => $field_label,
+						'value' => $extra_fields[ $extra_field_keys[ $i ] ],
 					);
-
 					++$i;
 				}
 			}
 		}
-
-		// Sorting lines by the field index
-		ksort( $compiled_form );
-
-		return $compiled_form;
+		return $raw_data;
 	}
 
 	/**
@@ -645,80 +664,14 @@ class Contact_Form extends Contact_Form_Shortcode {
 	 * @return array $lines
 	 */
 	public static function get_compiled_form_for_email( $feedback_id, $form ) {
-		$feedback       = get_post( $feedback_id );
-		$field_ids      = $form->get_field_ids();
-		$content_fields = Contact_Form_Plugin::parse_fields_from_content( $feedback_id );
+		$raw_compiled_data = self::_get_raw_compiled_form_data( $feedback_id, $form );
+		$compiled_form     = array();
 
-		// Maps field_ids to post_meta keys
-		$field_value_map = array(
-			'name'     => 'author',
-			'email'    => 'author_email',
-			'url'      => 'author_url',
-			'subject'  => 'subject',
-			'textarea' => false, // not a post_meta key.  This is stored in post_content
-		);
-
-		$compiled_form = array();
-
-		// "Standard" field allowed list.
-		foreach ( $field_value_map as $type => $meta_key ) {
-			if ( isset( $field_ids[ $type ] ) ) {
-				$field = $form->fields[ $field_ids[ $type ] ];
-
-				if ( $meta_key ) {
-					if ( isset( $content_fields[ "_feedback_{$meta_key}" ] ) ) {
-						$value = $content_fields[ "_feedback_{$meta_key}" ];
-					}
-				} else {
-					// The feedback content is stored as the first "half" of post_content
-					$value         = ( is_object( $feedback ) && is_a( $feedback, '\WP_Post' ) ) ?
-									$feedback->post_content : '';
-					list( $value ) = explode( '<!--more-->', $value );
-					$value         = trim( $value );
-				}
-
-				// If we still do not have any value, bail.
-				if ( empty( $value ) ) {
-					continue;
-				}
-
-				$field_index = array_search( $field_ids[ $type ], $field_ids['all'], true );
-				$field_label = self::maybe_add_colon_to_label( $field->get_attribute( 'label' ) );
-
-				$compiled_form[ $field_index ] = array(
-					wp_kses( $field_label, array() ),
-					self::escape_and_sanitize_field_value( $value ),
-				);
-			}
-		}
-
-		// "Non-standard" fields
-		if ( $field_ids['extra'] ) {
-			// array indexed by field label (not field id)
-			$extra_fields = get_post_meta( $feedback_id, '_feedback_extra_fields', true );
-
-			/**
-			 * Only get data for the compiled form if `$extra_fields` is a valid and non-empty array.
-			 */
-			if ( is_array( $extra_fields ) && ! empty( $extra_fields ) ) {
-
-				$extra_field_keys = array_keys( $extra_fields );
-
-				$i = 0;
-				foreach ( $field_ids['extra'] as $field_id ) {
-					$field       = $form->fields[ $field_id ];
-					$field_index = array_search( $field_id, $field_ids['all'], true );
-
-					$field_label = self::maybe_add_colon_to_label( $field->get_attribute( 'label' ) );
-
-					$compiled_form[ $field_index ] = array(
-						wp_kses( $field_label, array() ),
-						self::escape_and_sanitize_field_value( $extra_fields[ $extra_field_keys[ $i ] ] ),
-					);
-
-					++$i;
-				}
-			}
+		foreach ( $raw_compiled_data as $field_index => $data ) {
+			$compiled_form[ $field_index ] = array(
+				wp_kses( $data['label'], array() ),
+				self::escape_and_sanitize_field_value( $data['value'] ),
+			);
 		}
 
 		/**
@@ -2050,7 +2003,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 	 */
 	private static function maybe_add_colon_to_label( $label ) {
 		$formatted_label = $label ? $label : '';
-		$formatted_label = str_ends_with( $formatted_label, '?' ) ? $formatted_label : $formatted_label . ':';
+		$formatted_label = str_ends_with( $formatted_label, '?' ) ? $formatted_label : rtrim( $formatted_label, ':' ) . ':';
 
 		return $formatted_label;
 	}

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -675,8 +675,8 @@ class Contact_Form extends Contact_Form_Shortcode {
 		} else {
 			// add styling to the array
 			foreach ( $compiled_form as $key => $value ) {
-				$safe_display_label = self::escape_and_sanitize_field_label( $value[0] );
-				$safe_display_value = self::escape_and_sanitize_field_value( $value[1] );
+				$safe_display_label = self::escape_and_sanitize_field_label( $value['label'] );
+				$safe_display_value = self::escape_and_sanitize_field_value( $value['value'] );
 
 				if ( ! empty( $safe_display_label ) ) {
 					$compiled_form[ $key ] = sprintf(

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -527,17 +527,15 @@ class Contact_Form extends Contact_Form_Shortcode {
 	 * @return array $lines
 	 */
 	public static function get_compiled_form( $feedback_id, $form ) {
-		$raw_compiled_form = self::get_raw_compiled_form_data( $feedback_id, $form );
-		$compiled_form     = array();
+		$compiled_form = self::get_raw_compiled_form_data( $feedback_id, $form );
 
-		foreach ( $raw_compiled_form as $field_index => $data ) {
-			$safe_display_label = self::get_formatted_display_label( $data['label'] );
+		foreach ( $compiled_form as $field_index => $data ) {
 			$safe_display_value = self::escape_and_sanitize_field_value( $data['value'] );
-
-			if ( ! empty( $safe_display_label ) ) {
+			if ( ! empty( $data['label'] ) ) {
+				$safe_display_label            = self::escape_and_sanitize_field_label( $data['label'] );
 				$compiled_form[ $field_index ] = sprintf(
 					'<div class="field-name">%1$s</div> <div class="field-value">%2$s</div>',
-					$safe_display_label,
+					self::maybe_add_colon_to_label( $safe_display_label ),
 					$safe_display_value
 				);
 			} else {
@@ -611,7 +609,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 				}
 
 				$field_index = array_search( $field_ids[ $type ], $field_ids['all'], true );
-				$field_label = self::maybe_add_colon_to_label( $field->get_attribute( 'label' ) );
+				$field_label = $field->get_attribute( 'label' );
 
 				$raw_data[ $field_index ] = array(
 					'label' => $field_label,
@@ -635,7 +633,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 				foreach ( $field_ids['extra'] as $field_id ) {
 					$field       = $form->fields[ $field_id ];
 					$field_index = array_search( $field_id, $field_ids['all'], true );
-					$field_label = self::maybe_add_colon_to_label( $field->get_attribute( 'label' ) );
+					$field_label = $field->get_attribute( 'label' );
 
 					$raw_data[ $field_index ] = array(
 						'label' => $field_label,
@@ -677,13 +675,13 @@ class Contact_Form extends Contact_Form_Shortcode {
 		} else {
 			// add styling to the array
 			foreach ( $compiled_form as $key => $value ) {
-				$safe_display_label = self::get_formatted_display_label( $value[0] );
+				$safe_display_label = self::escape_and_sanitize_field_label( $value[0] );
 				$safe_display_value = self::escape_and_sanitize_field_value( $value[1] );
 
 				if ( ! empty( $safe_display_label ) ) {
 					$compiled_form[ $key ] = sprintf(
 						'<p><strong>%1$s</strong><br /><span>%2$s</span></p>',
-						$safe_display_label,
+						self::maybe_add_colon_to_label( $safe_display_label ),
 						$safe_display_value
 					);
 				} else {
@@ -2010,12 +2008,10 @@ class Contact_Form extends Contact_Form_Shortcode {
 	 * @param string|null $raw_label The raw label input.
 	 * @return string The formatted and kses'd label string, or an empty string if raw_label is empty.
 	 */
-	private static function get_formatted_display_label( $raw_label ) {
+	private static function escape_and_sanitize_field_label( $raw_label ) {
 		if ( empty( $raw_label ) ) {
 			return ''; // kses the empty string
 		}
-		$display_label   = (string) $raw_label;
-		$formatted_label = str_ends_with( $display_label, '?' ) ? $display_label : rtrim( $display_label, ':' ) . ':';
-		return wp_kses( $formatted_label, array() );
+		return wp_kses( (string) $raw_label, array() );
 	}
 }

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1040,9 +1040,15 @@ class Contact_Form extends Contact_Form_Shortcode {
 		$field_ids['email_marketing_consent'] = null;
 
 		foreach ( $this->fields as $id => $field ) {
+			$type = $field->get_attribute( 'type' );
+
+			// If the field is not renderable, skip it.
+			if ( ! $field->is_field_renderable( $type ) ) {
+				continue;
+			}
+
 			$field_ids['all'][] = $id;
 
-			$type = $field->get_attribute( 'type' );
 			if ( isset( $field_ids[ $type ] ) ) {
 				// This type of field is already present in our allowed list of "standard" fields for this form
 				// Put it in extra

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -533,8 +533,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 			$safe_display_value = self::escape_and_sanitize_field_value( $data['value'] );
 
 			if ( '' === $safe_display_value ) {
-				unset( $compiled_form[ $field_index ] );
-				continue;
+				$safe_display_value = '-';
 			}
 
 			if ( ! empty( $data['label'] ) ) {
@@ -607,11 +606,6 @@ class Contact_Form extends Contact_Form_Shortcode {
 									$feedback->post_content : '';
 					list( $current_value ) = explode( '<!--more-->', $current_value );
 					$value                 = trim( $current_value );
-				}
-
-				// If we still do not have any value, bail.
-				if ( empty( $value ) ) {
-					continue;
 				}
 
 				$field_index = array_search( $field_ids[ $type ], $field_ids['all'], true );

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -631,13 +631,13 @@ class Contact_Form extends Contact_Form_Shortcode {
 
 				$i = 0;
 				foreach ( $field_ids['extra'] as $field_id ) {
-					$field       = $form->fields[ $field_id ];
-					$field_index = array_search( $field_id, $field_ids['all'], true );
-					$field_label = $field->get_attribute( 'label' );
-
+					$field                    = $form->fields[ $field_id ];
+					$field_index              = array_search( $field_id, $field_ids['all'], true );
+					$field_label              = $field->get_attribute( 'label' );
+					$value                    = isset( $extra_field_keys[ $i ] ) && isset( $extra_fields[ $extra_field_keys[ $i ] ] ) ? $extra_fields[ $extra_field_keys[ $i ] ] : '';
 					$raw_data[ $field_index ] = array(
 						'label' => $field_label,
-						'value' => $extra_fields[ $extra_field_keys[ $i ] ],
+						'value' => $value,
 					);
 					++$i;
 				}

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -514,24 +514,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 			$message       = '<p>' . implode( '</p><p>', $compiled_form ) . '</p>';
 		}
 
-		// Add more allowed HTML elements for file download links
-		$allowed_html = array(
-			'br'         => array(),
-			'blockquote' => array( 'class' => array() ),
-			'p'          => array(),
-			'div'        => array(
-				'class' => array(),
-				'style' => array(),
-			),
-			'span'       => array(
-				'class' => array(),
-				'style' => array(),
-			),
-		);
-
-		$filtered_message = wp_kses( $message, $allowed_html );
-
-		return $filtered_message;
+		return $message;
 	}
 
 	/**
@@ -548,11 +531,22 @@ class Contact_Form extends Contact_Form_Shortcode {
 		$compiled_form     = array();
 
 		foreach ( $raw_compiled_form as $field_index => $data ) {
-			$compiled_form[ $field_index ] = sprintf(
-				'<div class="field-name">%1$s</div> <div class="field-value">%2$s</div>',
-				wp_kses( $data['label'], array() ),
-				self::escape_and_sanitize_field_value( $data['value'] )
-			);
+			$safe_display_label = self::get_formatted_display_label( $data['label'] );
+			$safe_display_value = self::escape_and_sanitize_field_value( $data['value'] );
+
+			if ( ! empty( $safe_display_label ) ) {
+				$compiled_form[ $field_index ] = sprintf(
+					'<div class="field-name">%1$s</div> <div class="field-value">%2$s</div>',
+					$safe_display_label,
+					$safe_display_value
+				);
+			} else {
+				// If there is no label, only output the field value, wrapped in its div.
+				$compiled_form[ $field_index ] = sprintf(
+					'<div class="field-value">%s</div>',
+					$safe_display_value
+				);
+			}
 		}
 
 		// Sorting lines by the field index
@@ -664,15 +658,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 	 * @return array $lines
 	 */
 	public static function get_compiled_form_for_email( $feedback_id, $form ) {
-		$raw_compiled_data = self::_get_raw_compiled_form_data( $feedback_id, $form );
-		$compiled_form     = array();
-
-		foreach ( $raw_compiled_data as $field_index => $data ) {
-			$compiled_form[ $field_index ] = array(
-				wp_kses( $data['label'], array() ),
-				self::escape_and_sanitize_field_value( $data['value'] ),
-			);
-		}
+		$compiled_form = self::get_raw_compiled_form_data( $feedback_id, $form );
 
 		/**
 		 * This filter allows a site owner to customize the response to be emailed, by adding their own HTML around it for example.
@@ -691,11 +677,21 @@ class Contact_Form extends Contact_Form_Shortcode {
 		} else {
 			// add styling to the array
 			foreach ( $compiled_form as $key => $value ) {
-				$compiled_form[ $key ] = sprintf(
-					'<p><strong>%1$s</strong><br /><span>%2$s</span></p>',
-					$value[0],
-					$value[1]
-				);
+				$safe_display_label = self::get_formatted_display_label( $value[0] );
+				$safe_display_value = self::escape_and_sanitize_field_value( $value[1] );
+
+				if ( ! empty( $safe_display_label ) ) {
+					$compiled_form[ $key ] = sprintf(
+						'<p><strong>%1$s</strong><br /><span>%2$s</span></p>',
+						$safe_display_label,
+						$safe_display_value
+					);
+				} else {
+					$compiled_form[ $key ] = sprintf(
+						'<p><span>%s</span></p>',
+						$safe_display_value
+					);
+				}
 			}
 		}
 
@@ -2006,5 +2002,20 @@ class Contact_Form extends Contact_Form_Shortcode {
 		$formatted_label = str_ends_with( $formatted_label, '?' ) ? $formatted_label : rtrim( $formatted_label, ':' ) . ':';
 
 		return $formatted_label;
+	}
+
+	/**
+	 * Helper method to format a raw label string for display, including kses sanitization.
+	 *
+	 * @param string|null $raw_label The raw label input.
+	 * @return string The formatted and kses'd label string, or an empty string if raw_label is empty.
+	 */
+	private static function get_formatted_display_label( $raw_label ) {
+		if ( empty( $raw_label ) ) {
+			return ''; // kses the empty string
+		}
+		$display_label   = (string) $raw_label;
+		$formatted_label = str_ends_with( $display_label, '?' ) ? $display_label : rtrim( $display_label, ':' ) . ':';
+		return wp_kses( $formatted_label, array() );
 	}
 }

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -508,7 +508,22 @@ class Contact_Form extends Contact_Form_Shortcode {
 	public static function success_message( $feedback_id, $form ) {
 
 		if ( 'message' === $form->get_attribute( 'customThankyou' ) ) {
-			$message = wpautop( $form->get_attribute( 'customThankyouMessage' ) );
+			$raw_message = wpautop( $form->get_attribute( 'customThankyouMessage' ) );
+			// Add more allowed HTML elements for file download links
+			$allowed_html = array(
+				'br'         => array(),
+				'blockquote' => array( 'class' => array() ),
+				'p'          => array(),
+				'div'        => array(
+					'class' => array(),
+					'style' => array(),
+				),
+				'span'       => array(
+					'class' => array(),
+					'style' => array(),
+				),
+			);
+			$message      = wp_kses( $raw_message, $allowed_html );
 		} else {
 			$compiled_form = self::get_compiled_form( $feedback_id, $form );
 			$message       = '<p>' . implode( '</p><p>', $compiled_form ) . '</p>';

--- a/projects/plugins/jetpack/changelog/update-forms-success-message
+++ b/projects/plugins/jetpack/changelog/update-forms-success-message
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Forms: Improve Success and Email messages


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Forms: Improve Success and Email Messages

<!-- Would you like this feature to be tested by Beta testers?

Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes # <!-- Please link to the issue number here -->

## Proposed changes:

<!--- Explain what functional changes your PR includes -->

*   Refactors the way success messages and email notifications are generated for Jetpack Forms.
*   Introduces a new private method `get_raw_compiled_form_data` to centralize the fetching and initial processing of form submission data. This method is now used by both `get_compiled_form` (for on-page success messages) and `get_compiled_form_for_email`.
*   Ensures consistent HTML sanitization for field labels by introducing a new helper method `escape_and_sanitize_field_label`.
*   Improves the `maybe_add_colon_to_label` method to prevent double colons by trimming existing colons before appending a new one.
*   Removes a direct `wp_kses` call in the `success_message` method, as sanitization is handled more granularly in `escape_and_sanitize_field_value` and the new `escape_and_sanitize_field_label`.
*   Ensures that "standard" fields (like Name, Email, URL, Subject, Textarea) are always included in the displayed form submission, showing a hyphen ('-') if their value was empty. This was achieved by removing a condition in `get_raw_compiled_form_data` that previously skipped empty standard fields.
*   Modifies `get_compiled_form` to display a hyphen ('-') for any field that has an empty value, ensuring consistent display of empty fields.

#### Before:

<img width="730" alt="Screenshot 2025-05-06 at 12 23 02 PM" src="https://github.com/user-attachments/assets/3a2c7e03-d527-4331-87d2-89ac103e394f" />

#### After:

<img width="762" alt="Screenshot 2025-05-06 at 1 42 29 PM" src="https://github.com/user-attachments/assets/dd21edcc-d679-4f2c-bd2d-6b0b73fb412e" />


#### The Form:

<img width="713" alt="Screenshot 2025-05-06 at 12 22 05 PM" src="https://github.com/user-attachments/assets/7b3e6f56-faa1-4b1f-b6f0-92d413e8f325" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?

<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
No, this pull request does not change what data or activity is tracked or used. It primarily refactors existing functionality for message generation.
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:

<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1.  **Set up a Test Form:**
    *   Create a post or page.
    *   Add a Jetpack Contact Form block.
    *   Include a variety of fields: Name, Email, Website, Textarea (Message), and some custom fields (e.g., a text field, a dropdown, a checkbox).
    *   For one of the field labels, end it with a question mark (e.g., "Your favorite color?").
    *   For another field label, end it with a colon (e.g., "Special Instructions:").
2.  **Submit the Form (Test 1 - All fields filled):**
    *   View the page on the frontend.
    *   Fill out all the fields in the form.
    *   Submit the form.
3.  **Verify On-Page Success Message (Test 1):**
    *   Observe the success message displayed on the page after submission.
    *   **Check:** All fields submitted (including those with special characters in labels) are displayed correctly.
    *   **Check:** Labels are formatted correctly (e.g., "Your favorite color?" should remain as is, "Special Instructions:" should have only one colon).
    *   **Check:** Values are displayed next to their respective labels.
4.  **Verify Email (Test 1):**
    *   Check the email notification sent to the configured address.
    *   **Check:** The email subject and sender details are correct.
    *   **Check:** All submitted field data is present in the email body.
    *   **Check:** Labels and their corresponding values are clearly presented and correctly formatted (similar to the on-page success message checks regarding colons and question marks).
    *   **Check:** The HTML structure of the email looks good in an email client.
5.  **Submit the Form (Test 2 - Some fields empty):**
    *   View the page on the frontend again (or refresh).
    *   Fill out some fields, but leave a few intentionally blank (e.g., leave "Website" empty, and one of your custom fields empty).
    *   Submit the form.
6.  **Verify On-Page Success Message (Test 2 - Empty Fields):**
    *   **Check:** Fields that were filled have their values displayed.
    *   **Check:** Fields that were left empty are now displayed with a hyphen ('-') as their value.
7.  **Verify Email (Test 2 - Empty Fields):**
    *   Check the email notification for this second submission.
    *   **Check:** Fields that were filled have their values displayed.
    *   **Check:** Fields that were left empty are now displayed with a hyphen ('-') as their value.
8.  **Test Edge Cases (Optional but Recommended):**
    *   Submit the form with special characters in the input values. Verify they are displayed correctly (sanitized but readable) in both the success message and email.

* Go to '..'
* <!-- Add further specific steps if needed -->