### PR TITLE
Forms: Adjust form responses styles

### DIFF
--- a/projects/packages/forms/changelog/fix-form-export-button-mobile
+++ b/projects/packages/forms/changelog/fix-form-export-button-mobile
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Adjust export button mobile styles.

--- a/projects/packages/forms/src/dashboard/components/InboxStatusToggle/index.js
+++ b/projects/packages/forms/src/dashboard/components/InboxStatusToggle/index.js
@@ -70,6 +70,7 @@ export default function InboxStatusToggle( { currentQuery } ) {
 			className="jp-forms__inbox-status-toggle"
 			value={ status }
 			onChange={ handleChange }
+			isAdaptiveWidth={ true }
 		>
 			{ statusTabs.map( option => (
 				<ToggleGroupControlOption

--- a/projects/packages/forms/src/dashboard/components/InboxStatusToggle/style.scss
+++ b/projects/packages/forms/src/dashboard/components/InboxStatusToggle/style.scss
@@ -4,8 +4,4 @@
 	&::before {
 		left: 0;
 	}
-	
-	> div {
-		flex: initial;
-	}
 } 

--- a/projects/packages/forms/src/dashboard/components/InboxStatusToggle/style.scss
+++ b/projects/packages/forms/src/dashboard/components/InboxStatusToggle/style.scss
@@ -1,3 +1,11 @@
-.jp-forms__inbox-status-toggle.components-toggle-group-control > div {
-  flex: initial;
+.jp-forms__inbox-status-toggle.components-toggle-group-control {
+	border-color: var(--wp-components-color-gray-700, #757575);
+
+	&::before {
+		left: 0;
+	}
+	
+	> div {
+		flex: initial;
+	}
 } 

--- a/projects/packages/forms/src/dashboard/components/layout/style.scss
+++ b/projects/packages/forms/src/dashboard/components/layout/style.scss
@@ -38,7 +38,7 @@ body.toplevel_page_jetpack-forms {
 		justify-content: space-between;
 		padding: 20px 150px 0 0;
 
-		@media (max-width: 660px) {
+		@media (max-width: 782px) {
 			padding: 40px 20px 0 0;
 		}
 	}

--- a/projects/packages/forms/src/dashboard/components/layout/style.scss
+++ b/projects/packages/forms/src/dashboard/components/layout/style.scss
@@ -36,7 +36,7 @@ body.toplevel_page_jetpack-forms {
 		display: flex;
 		align-items: center;
 		justify-content: space-between;
-		padding: 20px 150px 0 0;
+		padding: 30px 30px 0 0;
 
 		@media (max-width: 782px) {
 			padding: 40px 20px 0 0;

--- a/projects/packages/forms/src/dashboard/components/layout/style.scss
+++ b/projects/packages/forms/src/dashboard/components/layout/style.scss
@@ -37,6 +37,10 @@ body.toplevel_page_jetpack-forms {
 		align-items: center;
 		justify-content: space-between;
 		padding: 20px 150px 0 0;
+
+		@media (max-width: 660px) {
+			padding-top: 30px;
+		}
 	}
 
 	.jp-forms__dashboard-tabs {

--- a/projects/packages/forms/src/dashboard/components/layout/style.scss
+++ b/projects/packages/forms/src/dashboard/components/layout/style.scss
@@ -39,7 +39,7 @@ body.toplevel_page_jetpack-forms {
 		padding: 20px 150px 0 0;
 
 		@media (max-width: 660px) {
-			padding-top: 30px;
+			padding: 40px 20px 0 0;
 		}
 	}
 

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
@@ -75,7 +75,7 @@ function getStatusFilter( urlStatus ) {
 /**
  * The DataViews implementation.
  *
- * @return {JSX.Element} The DataViews component.
+ * @return {React.JSX.Element} The DataViews component.
  */
 export default function InboxView() {
 	const [ view, setView ] = useView();

--- a/projects/packages/forms/src/dashboard/inbox/export-responses/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/export-responses/style.scss
@@ -65,4 +65,5 @@
 	color: var(--jp-green-50);
 	border-color: var(--jp-green-50);
 	box-shadow: inset 0 0 0 1px var(--jp-green-50), 0 0 0 currentColor;
+	min-width: auto;
 }

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -307,6 +307,10 @@ $action-bar-height: 88px;
 
 		.dataviews__view-actions {
 			align-items: center;
+
+			@media (max-width: 660px) {
+				flex-direction: column;
+			}
 		}
 	}
 }

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -311,6 +311,14 @@ $action-bar-height: 88px;
 			@media (max-width: 782px) {
 				flex-direction: column;
 			}
+
+			> div {
+
+				@media (max-width: 782px) {
+					width: 100%;
+					justify-content: space-between;
+				}
+			}
 		}
 	}
 }

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -308,7 +308,7 @@ $action-bar-height: 88px;
 		.dataviews__view-actions {
 			align-items: center;
 
-			@media (max-width: 660px) {
+			@media (max-width: 782px) {
 				flex-direction: column;
 			}
 		}

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -309,7 +309,7 @@ $action-bar-height: 88px;
 			align-items: center;
 
 			@media (max-width: 782px) {
-				flex-direction: column;
+				flex-direction: column-reverse;
 			}
 
 			> div {
@@ -317,6 +317,13 @@ $action-bar-height: 88px;
 				@media (max-width: 782px) {
 					width: 100%;
 					justify-content: space-between;
+				}
+
+				&:nth-of-type(2) {
+
+					@media (max-width: 782px) {
+						justify-content: flex-end;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
## Proposed changes:

This addresses some follow up items from [this PR ](https://github.com/Automattic/jetpack/pull/43358)to update the tab structure on the forms page.

Changes:
* Export button
  - Adjusts top and left padding for header and thus button
  - Fixes odd issue with button border collapsing on mobile
* Search box & Inbox/Spam/Trash tabs for dataviews:
   - On mobile use column-reverse to move search/filter box to next line. 
   - Make these full width
   - Search / filter bar is justify-content: space-between, while tabs are flex-end
   - Make hover border around tabs always present and tweak left padding to be even with top/bottom
* Updated jsdoc return type for Inboxview (small follow up from [here](https://github.com/Automattic/jetpack/pull/43358#discussion_r2075732444))

**Before**
<img width="375" alt="form-response-mobile-before" src="https://github.com/user-attachments/assets/ba515173-3dcd-4f50-a327-cb90f7dea958" />

**After**
<img width="518" alt="Monosnap Form Responses ‹ JetpackDev — WordPress 2025-05-06 11-40-20" src="https://github.com/user-attachments/assets/632730d3-ce5b-4a91-9c83-02fc63c31c1b" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Slack: p1746475309202549-slack-C086RGTJT1D

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Load the form responses page, test on normal and small screen, and confirm the export button, tabs, and search bar always render nicely. On mobile, they should look like screenshot above. 