### PR TITLE
Sitemap: make XMLWriter optional, off by default

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-sitemap-oom
+++ b/projects/plugins/jetpack/changelog/fix-sitemap-oom
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Sitemaps: disable XMLWriter by default unless enabled by a filter pending memory usage investigation.

--- a/projects/plugins/jetpack/modules/sitemaps/sitemap-buffer-factory.php
+++ b/projects/plugins/jetpack/modules/sitemaps/sitemap-buffer-factory.php
@@ -26,8 +26,21 @@ class Jetpack_Sitemap_Buffer_Factory {
 	 * @return Jetpack_Sitemap_Buffer|null The created buffer or null if type is invalid.
 	 */
 	public static function create( $type, $item_limit, $byte_limit, $time = '1970-01-01 00:00:00' ) {
+
+		/**
+		 * Hook to allow for XMLWriter usage.
+		 *
+		 * Temporary filter to disallow XMLWriter usage.
+		 *
+		 * @since $$next-version$$
+		 * @module sitemaps
+		 *
+		 * @param bool $use_xmlwriter Whether to use XMLWriter. Current default is false.
+		 */
+		$use_xmlwriter = apply_filters( 'jetpack_sitemap_use_xmlwriter', false );
+
 		// First try XMLWriter if available
-		if ( class_exists( 'XMLWriter' ) ) {
+		if ( $use_xmlwriter && class_exists( 'XMLWriter' ) ) {
 			$class_name = 'Jetpack_Sitemap_Buffer_' . ucfirst( $type ) . '_XMLWriter';
 			if ( class_exists( $class_name ) ) {
 				return new $class_name( $item_limit, $byte_limit, $time );

--- a/projects/plugins/jetpack/modules/sitemaps/sitemap-logger.php
+++ b/projects/plugins/jetpack/modules/sitemaps/sitemap-logger.php
@@ -68,6 +68,10 @@ class Jetpack_Sitemap_Logger {
 		if ( ! $is_error && ! ( defined( 'JETPACK_DEV_DEBUG' ) && JETPACK_DEV_DEBUG ) ) {
 			return;
 		}
+		// Append memory usage in MB (human readable)
+		$usage    = memory_get_usage( true );
+		$usage_mb = round( $usage / MB_IN_BYTES, 2 );
+		$message .= ' [Memory usage: ' . $usage_mb . ' MB]';
 		error_log( $message ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 	}
 

--- a/projects/plugins/jetpack/tests/php/modules/sitemaps/Jetpack_Sitemap_Buffer_Factory_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/sitemaps/Jetpack_Sitemap_Buffer_Factory_Test.php
@@ -16,6 +16,17 @@ require_once JETPACK__PLUGIN_DIR . 'modules/sitemaps/sitemap-buffer-factory.php'
 class Jetpack_Sitemap_Buffer_Factory_Test extends WP_UnitTestCase {
 	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
 
+	/** Test Setup */
+	public function set_up() {
+		parent::set_up();
+		add_filter( 'jetpack_sitemap_use_xmlwriter', '__return_true' );
+	}
+
+	public function tear_down() {
+		parent::tear_down();
+		remove_filter( 'jetpack_sitemap_use_xmlwriter', '__return_true' );
+	}
+
 	/**
 	 * Test creating a page buffer with XMLWriter.
 	 *

--- a/projects/plugins/jetpack/tests/php/modules/sitemaps/Jetpack_Sitemap_Builder_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/sitemaps/Jetpack_Sitemap_Builder_Test.php
@@ -99,6 +99,7 @@ class Jetpack_Sitemap_Builder_Test extends WP_UnitTestCase {
 	public function test_master_sitemap_generation() {
 		$this->markTestSkipped( 'Skipping master sitemap generation test since it assumed XMLWriter usage.' );
 		// Create content of different types
+		// @phan-suppress-next-line PhanPluginUnreachableCode -- Disabling until OOM issues are better understood/corrected.
 		self::factory()->post->create_many(
 			5,
 			array(

--- a/projects/plugins/jetpack/tests/php/modules/sitemaps/Jetpack_Sitemap_Builder_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/sitemaps/Jetpack_Sitemap_Builder_Test.php
@@ -97,6 +97,7 @@ class Jetpack_Sitemap_Builder_Test extends WP_UnitTestCase {
 	 * Test master sitemap generation
 	 */
 	public function test_master_sitemap_generation() {
+		$this->markTestSkipped( 'Skipping master sitemap generation test since it assumed XMLWriter usage.' );
 		// Create content of different types
 		self::factory()->post->create_many(
 			5,


### PR DESCRIPTION
- **Sitemaps: track memory usage when JETPACK_DEV_DEBUG is enabled**
- **Sitemaps: add filter to disable xmlwriter**

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

We're seeing more out of memory errors than I would expect or am comfortable with. Instead of a full revert, adding a filter to disable by default XMLWriter pending further investigation.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds a `jetpack_sitemap_use_xmlwriter` to enable using XMLWriter.
* Default filter to false, so DOMDocument returns as the primary method of sitemap generation (pre-14.6 behavior)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
..

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* `wp jetpack sitemap rebuild --purge` -- confirm it rebuilds the sitemap.

