### PR TITLE
Forms: fix feedback submenu items

### DIFF
--- a/projects/packages/forms/changelog/add-jetpack-forms-dev-menu-entry-poc
+++ b/projects/packages/forms/changelog/add-jetpack-forms-dev-menu-entry-poc
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Forms: PoC. add new menu entry and renderer, see what side effects it might have. Test on dotcom

--- a/projects/packages/forms/changelog/add-jetpack-forms-dev-menu-entry-poc
+++ b/projects/packages/forms/changelog/add-jetpack-forms-dev-menu-entry-poc
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: PoC. add new menu entry and renderer, see what side effects it might have. Test on dotcom

--- a/projects/packages/forms/changelog/fix-jetpack-forms-feedback-submenu-items
+++ b/projects/packages/forms/changelog/fix-jetpack-forms-feedback-submenu-items
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: prevent submenu manipulation to mess with Crowdsignal/Polldaddy submenu items

--- a/projects/packages/forms/src/dashboard/class-dashboard-view-switch.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard-view-switch.php
@@ -30,6 +30,18 @@ class Dashboard_View_Switch {
 	const MODERN_VIEW = 'modern';
 
 	/**
+	 * Modern screen IDs.
+	 *
+	 * @var array
+	 */
+	const MODERN_SCREEN_IDS = array(
+		'toplevel_page_jetpack-forms',
+		'admin_page_jetpack-forms',
+		'jetpack_page_jetpack-forms',
+		'feedback_page_jetpack-forms',
+	);
+
+	/**
 	 * Initialize the switch.
 	 */
 	public function init() {
@@ -92,14 +104,20 @@ class Dashboard_View_Switch {
 				margin: 0 0 0 6px;
 			}
 
-			.toplevel_page_jetpack-forms :not(#screen-meta-links) > #jetpack-forms__view-link-wrap {
+			.toplevel_page_jetpack-forms :not(#screen-meta-links) > #jetpack-forms__view-link-wrap,
+			.jetpack_page_jetpack-forms :not(#screen-meta-links) > #jetpack-forms__view-link-wrap,
+			.feedback_page_jetpack-forms :not(#screen-meta-links) > #jetpack-forms__view-link-wrap,
+			.admin_page_jetpack-forms :not(#screen-meta-links) > #jetpack-forms__view-link-wrap {
 				position: absolute;
 				right: 32px;
 				top: 0;
 				z-index: 179;
 			}
 
-			.toplevel_page_jetpack-forms #jetpack-forms__view-link {
+			.toplevel_page_jetpack-forms #jetpack-forms__view-link,
+			.jetpack_page_jetpack-forms #jetpack-forms__view-link,
+			.feedback_page_jetpack-forms #jetpack-forms__view-link,
+			.admin_page_jetpack-forms #jetpack-forms__view-link {
 				background-color: #fff;
 				border: 1px solid #c3c4c7;
 				border-top: none;
@@ -111,7 +129,10 @@ class Dashboard_View_Switch {
 				padding: 3px 6px 3px 16px;
 			}
 
-			.toplevel_page_jetpack-forms #jetpack-forms__view-link::after {
+			.toplevel_page_jetpack-forms #jetpack-forms__view-link::after,
+			.jetpack_page_jetpack-forms #jetpack-forms__view-link::after,
+			.feedback_page_jetpack-forms #jetpack-forms__view-link::after,
+			.admin_page_jetpack-forms #jetpack-forms__view-link::after {
 				right: 0;
 				content: "\\f140";
 				font: normal 20px/1 dashicons;
@@ -296,9 +317,10 @@ CSS
 	public function is_modern_view() {
 		$screen = get_current_screen();
 
-		// When classic view is set as preferred, jetpack-forms is registered under an empty parrent so it doesn't appear in the menu.
-		// Because of this, we need to support these two screens.
-		return $screen && in_array( $screen->id, array( 'admin_page_jetpack-forms', 'toplevel_page_jetpack-forms' ), true );
+		// When classic view is set as preferred, jetpack-forms is registered under different
+		// parents so it doesn't appear in the menu.
+		// Because of this, we need to support these screens.
+		return $screen && in_array( $screen->id, self::MODERN_SCREEN_IDS, true );
 	}
 
 	/**

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -113,7 +113,7 @@ class Dashboard {
 			add_submenu_page(
 				'',
 				__( 'Form Responses', 'jetpack-forms' ),
-				_x( 'Feedback', 'post type name shown in menu', 'jetpack-forms' ),
+				_x( 'Form Responses', 'menu label for form responses', 'jetpack-forms' ),
 				'edit_pages',
 				'jetpack-forms',
 				array( $this, 'render_dashboard' )
@@ -123,17 +123,32 @@ class Dashboard {
 		}
 
 		// MODERN VIEW -- remove the old submenu and add the new one.
-		remove_submenu_page( 'feedback', 'edit.php?post_type=feedback' );
+		// Check if Polldaddy/Crowdsignal plugin is active
+		if ( ! is_plugin_active( 'polldaddy/polldaddy.php' ) ) {
+			remove_menu_page( 'feedback' );
 
-		add_submenu_page(
-			'feedback',
-			__( 'Form Responses', 'jetpack-forms' ),
-			_x( 'Form Responses', 'post type name shown in menu', 'jetpack-forms' ),
-			'edit_pages',
-			'jetpack-forms',
-			array( $this, 'render_dashboard' ),
-			0 // as far top as we can go since responses are the default feedback page.
-		);
+			add_menu_page(
+				__( 'Form Responses', 'jetpack-forms' ),
+				_x( 'Feedback', 'post type name shown in menu', 'jetpack-forms' ),
+				'edit_pages',
+				'jetpack-forms',
+				array( $this, 'render_dashboard' ),
+				'dashicons-feedback',
+				25 // Places 'Feedback' under 'Comments' in the menu
+			);
+		} else {
+			remove_submenu_page( 'feedback', 'edit.php?post_type=feedback' );
+
+			add_submenu_page(
+				'feedback',
+				__( 'Form Responses', 'jetpack-forms' ),
+				_x( 'Form Responses', 'menu label for form responses', 'jetpack-forms' ),
+				'edit_pages',
+				'jetpack-forms',
+				array( $this, 'render_dashboard' ),
+				0 // as far top as we can go since responses are the default feedback page.
+			);
+		}
 	}
 
 	/**

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -68,7 +68,7 @@ class Dashboard {
 	 * @param string $hook The current admin page.
 	 */
 	public function load_admin_scripts( $hook ) {
-		if ( 'toplevel_page_jetpack-forms' !== $hook ) {
+		if ( ! in_array( $hook, Dashboard_View_Switch::MODERN_SCREEN_IDS, true ) ) {
 			return;
 		}
 
@@ -108,6 +108,8 @@ class Dashboard {
 	public function add_admin_submenu() {
 		if ( $this->switch->get_preferred_view() === Dashboard_View_Switch::CLASSIC_VIEW ) {
 			// We still need to register the jetpack forms page so it can be accessed manually.
+			// NOTE: adding submenu this (parent = '') way DOESN'T SHOW ANYWHERE,
+			// it's done just so the page URL doesn't break.
 			add_submenu_page(
 				'',
 				__( 'Form Responses', 'jetpack-forms' ),
@@ -120,16 +122,17 @@ class Dashboard {
 			return;
 		}
 
-		remove_menu_page( 'feedback' );
+		// MODERN VIEW -- remove the old submenu and add the new one.
+		remove_submenu_page( 'feedback', 'edit.php?post_type=feedback' );
 
-		add_menu_page(
+		add_submenu_page(
+			'feedback',
 			__( 'Form Responses', 'jetpack-forms' ),
-			_x( 'Feedback', 'post type name shown in menu', 'jetpack-forms' ),
+			_x( 'Form Responses', 'post type name shown in menu', 'jetpack-forms' ),
 			'edit_pages',
 			'jetpack-forms',
 			array( $this, 'render_dashboard' ),
-			'dashicons-feedback',
-			25 // Places 'Feedback' under 'Comments' in the menu
+			0 // as far top as we can go since responses are the default feedback page.
 		);
 	}
 

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -15,6 +15,7 @@ use Automattic\Jetpack\Forms\Jetpack_Forms;
 use Automattic\Jetpack\Forms\Service\Google_Drive;
 use Automattic\Jetpack\Redirect;
 use Automattic\Jetpack\Status;
+use Automattic\Jetpack\Status\Host;
 use Automattic\Jetpack\Tracking;
 
 /**
@@ -122,7 +123,7 @@ class Dashboard {
 			return;
 		}
 
-		$is_wpcom = defined( 'IS_WPCOM' ) && IS_WPCOM;
+		$is_wpcom = ( new Host() )->is_wpcom_simple();
 
 		// MODERN VIEW -- remove the old submenu and add the new one.
 		// Check if Polldaddy/Crowdsignal plugin is active

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -122,9 +122,11 @@ class Dashboard {
 			return;
 		}
 
+		$is_wpcom = defined( 'IS_WPCOM' ) && IS_WPCOM;
+
 		// MODERN VIEW -- remove the old submenu and add the new one.
 		// Check if Polldaddy/Crowdsignal plugin is active
-		if ( ! is_plugin_active( 'polldaddy/polldaddy.php' ) ) {
+		if ( ! $is_wpcom && ! is_plugin_active( 'polldaddy/polldaddy.php' ) ) {
 			remove_menu_page( 'feedback' );
 
 			add_menu_page(

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -65,11 +65,9 @@ class Dashboard {
 
 	/**
 	 * Load JavaScript for the dashboard.
-	 *
-	 * @param string $hook The current admin page.
 	 */
-	public function load_admin_scripts( $hook ) {
-		if ( ! in_array( $hook, Dashboard_View_Switch::MODERN_SCREEN_IDS, true ) ) {
+	public function load_admin_scripts() {
+		if ( ! ( new Dashboard_View_Switch() )->is_modern_view() ) {
 			return;
 		}
 

--- a/projects/packages/forms/src/dashboard/components/layout/style.scss
+++ b/projects/packages/forms/src/dashboard/components/layout/style.scss
@@ -1,4 +1,7 @@
-body.toplevel_page_jetpack-forms {
+body.toplevel_page_jetpack-forms,
+body.feedback_page_jetpack-forms,
+body.jetpack_page_jetpack-forms,
+body.admin_page_jetpack-forms {
 	background-color: #fff;
 
 	#wpcontent {

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -320,11 +320,17 @@ $action-bar-height: 88px;
 
 
 /* We need to make the available canvas 100% tall. Without this, no flex values will work, they will only use the available space. */
-.toplevel_page_jetpack-forms #wpwrap,
-.toplevel_page_jetpack-forms #wpcontent,
-.toplevel_page_jetpack-forms #wpbody,
-.toplevel_page_jetpack-forms #wpbody-content {
-	height: 100%;
+body.toplevel_page_jetpack-forms,
+body.feedback_page_jetpack-forms,
+body.jetpack_page_jetpack-forms,
+body.admin_page_jetpack-forms {
+
+	#wpwrap,
+	#wpcontent,
+	#wpbody,
+	#wpbody-content {
+		height: 100%;
+	}
 }
 
 #jp-forms-dashboard,

--- a/projects/packages/forms/src/dashboard/style.scss
+++ b/projects/packages/forms/src/dashboard/style.scss
@@ -23,6 +23,8 @@
 }
 
 body.toplevel_page_jetpack-forms,
+body.feedback_page_jetpack-forms,
+body.jetpack_page_jetpack-forms,
 body.admin_page_jetpack-forms {
 
 	#wpbody-content {


### PR DESCRIPTION
## Proposed changes:
This PR changes how we register (and remove) Feedback's submenu items so we don't mess with other submenu items.
This is most noticeable with Crowdsignal (formerly Polldaddy) which uses the same menu page to show its dashboard/listings.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
none

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

## When using classic view for Form Responses, things should be unchanged

| Before | After |
|--------|--------|
| Self-hosted, no other plugins | - |
| <img width="343" alt="image" src="https://github.com/user-attachments/assets/368e071f-88bd-49ef-8926-bec82b60a31f" /> | <img width="363" alt="image" src="https://github.com/user-attachments/assets/5645c3b6-9474-4c1e-8926-cf961eb94f90" /> |
| Self-hosted, Crowdsignal plugin installed | - |
| <img width="360" alt="image" src="https://github.com/user-attachments/assets/8417e4e7-b5e5-4ebd-aed6-a9fecbd35c7a" /> | <img width="345" alt="image" src="https://github.com/user-attachments/assets/8480e6d4-bad8-49d8-a365-6a649217e9d5" /> | 

## When using modern view for Form Responses, things should show as:

| Before | After |
|--------|--------|
| Self-hosted, no other plugins | - |
| <img width="243" alt="image" src="https://github.com/user-attachments/assets/ff05d8ea-5751-402e-9dd7-654173395683" /> | <img width="302" alt="image" src="https://github.com/user-attachments/assets/2f3fde78-d01e-455e-9f33-dd9b8868d3eb" /> |
| Self-hosted, Crowdsignal plugin installed | - |
| <img width="260" alt="image" src="https://github.com/user-attachments/assets/912ef23d-02ca-4174-9f10-f4a06c07e98b" /> | <img width="280" alt="image" src="https://github.com/user-attachments/assets/992a2859-a0b4-4b66-bb6c-d23a19a56c25" /> | 


