### PR TITLE
Fixing button label for E2E tests for onboarding

### DIFF
--- a/tools/e2e-commons/flows/onboarding.ts
+++ b/tools/e2e-commons/flows/onboarding.ts
@@ -60,7 +60,7 @@ export class Onboarding {
 	}
 
 	/**
-	 * Approves the user connection by clicking on the "Approve" button.
+	 * Approves the user connection by clicking on the "Connect my site" button.
 	 * It assumes that
 	 * - the user is already logged in to wp.com.
 	 * - we are on the wp.com connect page.
@@ -81,9 +81,9 @@ export class Onboarding {
 			{ timeout: DEFAULT_TIMEOUT }
 		);
 
-		logger.info( 'Click on "Approve" button and wait for redirect to My Jetpack' );
+		logger.info( 'Click on "Connect my site" button and wait for redirect to My Jetpack' );
 
-		const approveButton = this.page.getByRole( 'button', { name: 'Approve', exact: true } );
+		const approveButton = this.page.getByRole( 'button', { name: 'Connect my site', exact: true } );
 
 		return Promise.all( [ waitForMyJetpackPage, approveButton.click() ] );
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes JETPACK-431

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* fixing E2E tests after button change from "Approve" to "Connect my site" (https://github.com/Automattic/wp-calypso/pull/103145)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Verify that the PR tests pass

