### PR TITLE
Jetpack Backup: Fix PHP Fatal on some WP_Error responses

### DIFF
--- a/projects/packages/backup/changelog/fix-jpb-wp-errors
+++ b/projects/packages/backup/changelog/fix-jpb-wp-errors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix for PHP Fatals on WP_Error in Backup package

--- a/projects/packages/backup/src/class-jetpack-backup.php
+++ b/projects/packages/backup/src/class-jetpack-backup.php
@@ -503,11 +503,7 @@ class Jetpack_Backup {
 			'wpcom'
 		);
 
-		if ( is_wp_error( $response ) ) {
-			return null;
-		}
-
-		if ( 200 !== $response['response']['code'] ) {
+		if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
 			return null;
 		}
 

--- a/projects/packages/backup/src/class-jetpack-backup.php
+++ b/projects/packages/backup/src/class-jetpack-backup.php
@@ -437,7 +437,7 @@ class Jetpack_Backup {
 			'wpcom'
 		);
 
-		if ( 200 !== $response['response']['code'] ) {
+		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
 			return null;
 		}
 
@@ -462,7 +462,7 @@ class Jetpack_Backup {
 
 		$response = Client::wpcom_json_api_request_as_blog( sprintf( '/sites/%d/rewind', $site_id ) . '?force=wpcom', '2', array( 'timeout' => 2 ), null, 'wpcom' );
 
-		if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
+		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
 			return new WP_Error( 'rewind_state_fetch_failed' );
 		}
 
@@ -534,7 +534,7 @@ class Jetpack_Backup {
 			'wpcom'
 		);
 
-		if ( 200 !== $response['response']['code'] ) {
+		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
 			return null;
 		}
 

--- a/projects/packages/backup/src/class-jetpack-backup.php
+++ b/projects/packages/backup/src/class-jetpack-backup.php
@@ -437,7 +437,7 @@ class Jetpack_Backup {
 			'wpcom'
 		);
 
-		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
+		if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
 			return null;
 		}
 
@@ -462,7 +462,7 @@ class Jetpack_Backup {
 
 		$response = Client::wpcom_json_api_request_as_blog( sprintf( '/sites/%d/rewind', $site_id ) . '?force=wpcom', '2', array( 'timeout' => 2 ), null, 'wpcom' );
 
-		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
+		if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
 			return new WP_Error( 'rewind_state_fetch_failed' );
 		}
 
@@ -534,7 +534,7 @@ class Jetpack_Backup {
 			'wpcom'
 		);
 
-		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
+		if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
 			return null;
 		}
 

--- a/projects/packages/backup/tests/php/Jetpack_Backup_Test.php
+++ b/projects/packages/backup/tests/php/Jetpack_Backup_Test.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Unit tests for the Jetpack_Backup class.
+ *
+ * @package automattic/jetpack-backup
+ */
+
+namespace Automattic\Jetpack\Backup\V0005;
+
+use PHPUnit\Framework\TestCase;
+use WP_Error;
+
+class Jetpack_Backup_Test extends TestCase {
+
+	public function test_get_backup_capabilities_handles_wp_error() {
+		add_filter( 'pre_http_request', array( $this, 'mock_request_as_wp_error' ) );
+
+		$result = Jetpack_Backup::get_backup_capabilities();
+
+		$this->assertNull( $result );
+
+		remove_filter( 'pre_http_request', array( $this, 'mock_request_as_wp_error' ) );
+	}
+
+	public function test_get_recent_backups_handles_wp_error() {
+		add_filter( 'pre_http_request', array( $this, 'mock_request_as_wp_error' ) );
+
+		$result = Jetpack_Backup::get_recent_backups();
+
+		$this->assertNull( $result );
+
+		remove_filter( 'pre_http_request', array( $this, 'mock_request_as_wp_error' ) );
+	}
+
+	public function test_get_recent_restores_handles_wp_error() {
+		add_filter( 'pre_http_request', array( $this, 'mock_request_as_wp_error' ) );
+
+		$result = Jetpack_Backup::get_recent_restores();
+
+		$this->assertNull( $result );
+
+		remove_filter( 'pre_http_request', array( $this, 'mock_request_as_wp_error' ) );
+	}
+
+	/**
+	 * Mock the HTTP request to return a WP_Error.
+	 *
+	 * @return WP_Error
+	 */
+	public function mock_request_as_wp_error() {
+		return new WP_Error( 'http_request_failed', 'The request failed.' );
+	}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes [BACKUP-168][1].

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
```
PHP Fatal error: Uncaught Error: Cannot use object of type WP_Error as array in /wordpress/plugins/jetpack/14.6/jetpack_vendor/automattic/jetpack-backup/src/class-jetpack-backup.php:440
```

Checks for WP_Error and accesses the response in a more WP friendly way.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Run the unit tests:

```
$ cd projects/packages/backup
$ composer test-php tests/php/Jetpack_Backup_Test.php
> phpunit-select-config phpunit.#.xml.dist --colors=always 'tests/php/Jetpack_Backup_Test.php'
PHPUnit 11.5.24 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.2.28
Configuration: /home/myhro/Documents/github.com/Automattic/jetpack/projects/packages/backup/phpunit.11.xml.dist

...                                                                 3 / 3 (100%)

Time: 00:00.003, Memory: 44.50 MB

OK (3 tests, 3 assertions)
```

[1]: https://linear.app/a8c/issue/BACKUP-168/