### PR TITLE
i18n: number-formatters - export CURRENCY_OVERRIDES

### DIFF
--- a/projects/js-packages/number-formatters/changelog/update-i18n-number-formatters-currencies-export
+++ b/projects/js-packages/number-formatters/changelog/update-i18n-number-formatters-currencies-export
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Export the internally used currency-overrides object

--- a/projects/js-packages/number-formatters/package.json
+++ b/projects/js-packages/number-formatters/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/number-formatters",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"description": "Number formatting utilities",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/js-packages/number-formatters/package.json
+++ b/projects/js-packages/number-formatters/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/number-formatters",
-	"version": "1.0.1",
+	"version": "1.0.0",
 	"description": "Number formatting utilities",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/js-packages/number-formatters/src/index.ts
+++ b/projects/js-packages/number-formatters/src/index.ts
@@ -1,4 +1,5 @@
 import createNumberFormatters from './create-number-formatters.ts';
+import { CURRENCY_OVERRIDES } from './number-format-currency/currencies.ts';
 
 const defaultFormatter = createNumberFormatters();
 
@@ -13,7 +14,6 @@ export const {
 
 export { createNumberFormatters };
 
-export type * from './types.ts';
+export { CURRENCY_OVERRIDES };
 
-// We can optionally export the formatters individually if we want to use them in a more granular way.
-// export { numberFormat, numberFormatCompact, numberFormatCurrency, getCurrencyObject };
+export type * from './types.ts';

--- a/projects/js-packages/number-formatters/src/number-format-currency/currencies.ts
+++ b/projects/js-packages/number-formatters/src/number-format-currency/currencies.ts
@@ -1,6 +1,6 @@
 import type { CurrencyOverride } from '../types.ts';
 
-export const defaultCurrencyOverrides: Record< string, CurrencyOverride > = {
+export const CURRENCY_OVERRIDES: Record< string, CurrencyOverride > = {
 	AED: {
 		symbol: 'د.إ.‏',
 	},

--- a/projects/js-packages/number-formatters/src/number-format-currency/index.ts
+++ b/projects/js-packages/number-formatters/src/number-format-currency/index.ts
@@ -1,7 +1,7 @@
 import debugFactory from 'debug';
 import { FALLBACK_CURRENCY } from '../constants.ts';
 import { getCachedFormatter } from '../get-cached-formatter.ts';
-import { defaultCurrencyOverrides } from './currencies.ts';
+import { CURRENCY_OVERRIDES } from './currencies.ts';
 import type { CurrencyOverride, CurrencyObject, NumberFormatCurrencyParams } from '../types.ts';
 
 const debug = debugFactory( 'number-formatters:number-format-currency' );
@@ -20,7 +20,7 @@ function getCurrencyOverride(
 	if ( currency === 'USD' && geoLocation && geoLocation !== '' && geoLocation !== 'US' ) {
 		return { symbol: 'US$' };
 	}
-	return defaultCurrencyOverrides[ currency ];
+	return CURRENCY_OVERRIDES[ currency ];
 }
 
 /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of a PT: pxLjZ-9ME-p2
Partly addresses https://github.com/Automattic/i18n-issues/issues/939 and https://github.com/Automattic/i18n-issues/issues/942

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

The currency formatter uses a record of currency overrides internally (this likely lingered from `@automattic/format-currency` v1 that was developed prior to `Intl.NumberFormat`). 

- Rename `defaultCurrencyOverrides` to `CURRENCY_OVERRIDES`
- Export this constant as it's part of the logic for rendering currencies. Some legacy uses of `@automattic/format-currency` in JP use it.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* No functional changes outside of a rename. Build passing.