### PR TITLE
AI Assistant: Track model used in toolbar extension and AI excerpt features

### DIFF
--- a/projects/js-packages/ai-client/changelog/ai-model-used
+++ b/projects/js-packages/ai-client/changelog/ai-model-used
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+AI Assistant: propagate the AI model used in the AI requests

--- a/projects/js-packages/ai-client/src/chrome-ai/factory.ts
+++ b/projects/js-packages/ai-client/src/chrome-ai/factory.ts
@@ -124,14 +124,39 @@ export default async function ChromeAIFactory( promptArg: PromptProp ) {
 		return chromeAI;
 	}
 
-	// TODO: consider also using ChromeAI for ai-assistant-summarize
 	if ( promptType.startsWith( 'ai-content-lens' ) ) {
+		if ( ! ( 'ai' in self ) || ! ( 'summarizer' in self.ai ) ) {
+			return false;
+		}
+
+		if ( context.language ) {
+			if ( context.language !== 'en (English)' ) {
+				return false;
+			}
+		}
+
+		if ( 'ai' in self && self.ai.languageDetector ) {
+			// Detect if the content is in English and fallback if it's not otherwise the model will respond with mixed language
+			const detector = await self.ai.languageDetector.create();
+			const confidences = await detector.detect( context.content );
+
+			for ( const confidence of confidences ) {
+				// 75% confidence is just a value that was picked. Generally
+				// 80% of higher is pretty safe, but the source language is
+				// required for the translator to work at all, which is also
+				// why en is the default language.
+				if ( confidence.confidence > 0.75 && confidence.detectedLanguage !== 'en' ) {
+					return false;
+				}
+			}
+		}
+
+		// if we can't detect the language, we'll assume it's English
 		const summaryOpts = {
 			tone: tone,
 			wordCount: wordCount,
 		};
 
-		// TODO: detect if the content is in English and fallback if it's not
 		return new ChromeAISuggestionsEventSource( {
 			content: context.content,
 			promptType: PROMPT_TYPE_SUMMARIZE,

--- a/projects/js-packages/ai-client/src/chrome-ai/factory.ts
+++ b/projects/js-packages/ai-client/src/chrome-ai/factory.ts
@@ -79,9 +79,10 @@ export default async function ChromeAIFactory( promptArg: PromptProp ) {
 		const [ language ] = context.language.split( ' ' );
 
 		if (
-			! ( 'translation' in self ) ||
-			! self.translation.createTranslator ||
-			! self.translation.canTranslate
+			! ( 'ai' in self ) ||
+			! ( 'translator' in self.ai ) ||
+			! self.ai.translator.create ||
+			! self.ai.translator.availability
 		) {
 			return false;
 		}
@@ -108,9 +109,9 @@ export default async function ChromeAIFactory( promptArg: PromptProp ) {
 			}
 		}
 
-		const canTranslate = await self.translation.canTranslate( languageOpts );
+		const translationAvailability = await self.ai.translator.availability( languageOpts );
 
-		if ( canTranslate === 'no' ) {
+		if ( translationAvailability === 'unavailable' ) {
 			return false;
 		}
 

--- a/projects/js-packages/ai-client/src/chrome-ai/factory.ts
+++ b/projects/js-packages/ai-client/src/chrome-ai/factory.ts
@@ -86,20 +86,19 @@ export default async function ChromeAIFactory( promptArg: PromptProp ) {
 	// If the languageDetector is not available, we can't use the translation or summary features—it's safer to fall back
 	// to the default AI model than to risk an unexpected error.
 	if (
-		! ( 'ai' in self ) ||
-		! ( 'languageDetector' in self.ai ) ||
-		! self.ai.languageDetector.create ||
-		! self.ai.languageDetector.availability
+		! ( 'LanguageDetector' in self ) ||
+		! self.LanguageDetector.create ||
+		! self.LanguageDetector.availability
 	) {
 		return false;
 	}
 
-	const languageDetectorAvailability = await self.ai.languageDetector.availability();
+	const languageDetectorAvailability = await self.LanguageDetector.availability();
 	if ( languageDetectorAvailability === 'unavailable' ) {
 		return false;
 	}
 
-	const detector = await self.ai.languageDetector.create();
+	const detector = await self.LanguageDetector.create();
 	if ( languageDetectorAvailability !== 'available' ) {
 		await detector.ready;
 	}
@@ -108,10 +107,9 @@ export default async function ChromeAIFactory( promptArg: PromptProp ) {
 		const [ language ] = context.language.split( ' ' );
 
 		if (
-			! ( 'ai' in self ) ||
-			! ( 'translator' in self.ai ) ||
-			! self.ai.translator.create ||
-			! self.ai.translator.availability
+			! ( 'Translator' in self ) ||
+			! self.Translator.create ||
+			! self.Translator.availability
 		) {
 			return false;
 		}
@@ -134,7 +132,7 @@ export default async function ChromeAIFactory( promptArg: PromptProp ) {
 			}
 		}
 
-		const translationAvailability = await self.ai.translator.availability( languageOpts );
+		const translationAvailability = await self.Translator.availability( languageOpts );
 
 		if ( translationAvailability === 'unavailable' ) {
 			return false;
@@ -150,11 +148,11 @@ export default async function ChromeAIFactory( promptArg: PromptProp ) {
 	}
 
 	if ( promptType.startsWith( 'ai-content-lens' ) ) {
-		if ( ! ( 'ai' in self ) || ! ( 'summarizer' in self.ai ) ) {
+		if ( ! ( 'Summarizer' in self ) ) {
 			return false;
 		}
 
-		if ( context.language !== 'en (English)' ) {
+		if ( context.language && context.language !== 'en (English)' ) {
 			return false;
 		}
 

--- a/projects/js-packages/ai-client/src/chrome-ai/factory.ts
+++ b/projects/js-packages/ai-client/src/chrome-ai/factory.ts
@@ -75,6 +75,34 @@ export default async function ChromeAIFactory( promptArg: PromptProp ) {
 		}
 	}
 
+	// Early return if the prompt type is not supported.
+	if (
+		! promptType.startsWith( 'ai-assistant-change-language' ) &&
+		! promptType.startsWith( 'ai-content-lens' )
+	) {
+		return false;
+	}
+
+	// If the languageDetector is not available, we can't use the translation or summary features—it's safer to fall back
+	// to the default AI model than to risk an unexpected error.
+	if (
+		! ( 'languageDetector' in self.ai ) ||
+		! self.ai.languageDetector.create ||
+		! self.ai.languageDetector.availability
+	) {
+		return false;
+	}
+
+	const languageDetectorAvailability = await self.ai.languageDetector.availability();
+	if ( languageDetectorAvailability === 'unavailable' ) {
+		return false;
+	}
+
+	const detector = await self.ai.languageDetector.create();
+	if ( languageDetectorAvailability !== 'available' ) {
+		await detector.ready;
+	}
+
 	if ( promptType.startsWith( 'ai-assistant-change-language' ) ) {
 		const [ language ] = context.language.split( ' ' );
 
@@ -92,20 +120,16 @@ export default async function ChromeAIFactory( promptArg: PromptProp ) {
 			targetLanguage: language,
 		};
 
-		// see if we can detect the source language
-		if ( 'ai' in self && self.ai.languageDetector ) {
-			const detector = await self.ai.languageDetector.create();
-			const confidences = await detector.detect( context.content );
+		const confidences = await detector.detect( context.content );
 
-			for ( const confidence of confidences ) {
-				// 75% confidence is just a value that was picked. Generally
-				// 80% of higher is pretty safe, but the source language is
-				// required for the translator to work at all, which is also
-				// why en is the default language.
-				if ( confidence.confidence > 0.75 ) {
-					languageOpts.sourceLanguage = confidence.detectedLanguage;
-					break;
-				}
+		for ( const confidence of confidences ) {
+			// 75% confidence is just a value that was picked. Generally
+			// 80% of higher is pretty safe, but the source language is
+			// required for the translator to work at all, which is also
+			// why en is the default language.
+			if ( confidence.confidence > 0.75 ) {
+				languageOpts.sourceLanguage = confidence.detectedLanguage;
+				break;
 			}
 		}
 
@@ -133,23 +157,19 @@ export default async function ChromeAIFactory( promptArg: PromptProp ) {
 			return false;
 		}
 
-		if ( 'ai' in self && self.ai.languageDetector ) {
-			// Detect if the content is in English and fallback if it's not otherwise the model will respond with mixed language
-			const detector = await self.ai.languageDetector.create();
-			const confidences = await detector.detect( context.content );
+		const confidences = await detector.detect( context.content );
 
-			for ( const confidence of confidences ) {
-				// 75% confidence is just a value that was picked. Generally
-				// 80% of higher is pretty safe, but the source language is
-				// required for the translator to work at all, which is also
-				// why en is the default language.
-				if ( confidence.confidence > 0.75 && confidence.detectedLanguage !== 'en' ) {
-					return false;
-				}
+		// if it doesn't look like the content is in English, we can't use the summary feature
+		for ( const confidence of confidences ) {
+			// 75% confidence is just a value that was picked. Generally
+			// 80% of higher is pretty safe, but the source language is
+			// required for the translator to work at all, which is also
+			// why en is the default language.
+			if ( confidence.confidence > 0.75 && confidence.detectedLanguage !== 'en' ) {
+				return false;
 			}
 		}
 
-		// if we can't detect the language, we'll assume it's English
 		const summaryOpts = {
 			tone: tone,
 			wordCount: wordCount,

--- a/projects/js-packages/ai-client/src/chrome-ai/factory.ts
+++ b/projects/js-packages/ai-client/src/chrome-ai/factory.ts
@@ -86,6 +86,7 @@ export default async function ChromeAIFactory( promptArg: PromptProp ) {
 	// If the languageDetector is not available, we can't use the translation or summary features—it's safer to fall back
 	// to the default AI model than to risk an unexpected error.
 	if (
+		! ( 'ai' in self ) ||
 		! ( 'languageDetector' in self.ai ) ||
 		! self.ai.languageDetector.create ||
 		! self.ai.languageDetector.availability

--- a/projects/js-packages/ai-client/src/chrome-ai/factory.ts
+++ b/projects/js-packages/ai-client/src/chrome-ai/factory.ts
@@ -129,10 +129,8 @@ export default async function ChromeAIFactory( promptArg: PromptProp ) {
 			return false;
 		}
 
-		if ( context.language ) {
-			if ( context.language !== 'en (English)' ) {
-				return false;
-			}
+		if ( context.language !== 'en (English)' ) {
+			return false;
 		}
 
 		if ( 'ai' in self && self.ai.languageDetector ) {

--- a/projects/js-packages/ai-client/src/chrome-ai/suggestions.ts
+++ b/projects/js-packages/ai-client/src/chrome-ai/suggestions.ts
@@ -172,12 +172,11 @@ export default class ChromeAISuggestionsEventSource extends EventTarget {
 
 		const summarizerOptions = this.getSummarizerOptions( tone, wordCount );
 
-		let summarizer;
-		summarizer = await self.ai.summarizer.create( summarizerOptions );
+		const summarizer = await self.ai.summarizer.create( summarizerOptions );
 
 		if ( available !== 'available' ) {
 			await summarizer.ready;
-		} 
+		}
 
 		try {
 			const context = `Write with a ${ tone } tone.`;

--- a/projects/js-packages/ai-client/src/chrome-ai/suggestions.ts
+++ b/projects/js-packages/ai-client/src/chrome-ai/suggestions.ts
@@ -173,12 +173,11 @@ export default class ChromeAISuggestionsEventSource extends EventTarget {
 		const summarizerOptions = this.getSummarizerOptions( tone, wordCount );
 
 		let summarizer;
-		if ( available === 'available' ) {
-			summarizer = await self.ai.summarizer.create( summarizerOptions );
-		} else {
-			summarizer = await self.ai.summarizer.create( summarizerOptions );
+		summarizer = await self.ai.summarizer.create( summarizerOptions );
+
+		if ( available !== 'available' ) {
 			await summarizer.ready;
-		}
+		} 
 
 		try {
 			const context = `Write with a ${ tone } tone.`;

--- a/projects/js-packages/ai-client/src/chrome-ai/suggestions.ts
+++ b/projects/js-packages/ai-client/src/chrome-ai/suggestions.ts
@@ -110,11 +110,11 @@ export default class ChromeAISuggestionsEventSource extends EventTarget {
 
 	// use the Chrome AI translator
 	async translate( text: string, target: string, source: string = '' ) {
-		if ( ! ( 'ai' in self ) || ! ( 'translator' in self.ai ) ) {
+		if ( ! ( 'Translator' in self ) ) {
 			return;
 		}
 
-		const translator = await self.ai.translator.create( {
+		const translator = await self.Translator.create( {
 			sourceLanguage: source,
 			targetLanguage: target,
 		} );
@@ -161,20 +161,22 @@ export default class ChromeAISuggestionsEventSource extends EventTarget {
 
 	// use the Chrome AI summarizer
 	async summarize( text: string, tone?: string, wordCount?: number ) {
-		if ( ! ( 'ai' in self ) || ! ( 'summarizer' in self.ai ) ) {
+		if ( ! ( 'Summarizer' in self ) ) {
 			return;
 		}
-		const available = ( await self.ai.summarizer.capabilities() ).available;
+		// eslint-disable-next-line no-console
+		console.log( 'Summarizer is available' );
+		const availability = await self.Summarizer.availability();
 
-		if ( available === 'unavailable' ) {
+		if ( availability === 'unavailable' ) {
 			return;
 		}
 
 		const summarizerOptions = this.getSummarizerOptions( tone, wordCount );
 
-		const summarizer = await self.ai.summarizer.create( summarizerOptions );
+		const summarizer = await self.Summarizer.create( summarizerOptions );
 
-		if ( available !== 'available' ) {
+		if ( availability !== 'available' ) {
 			await summarizer.ready;
 		}
 

--- a/projects/js-packages/ai-client/src/chrome-ai/suggestions.ts
+++ b/projects/js-packages/ai-client/src/chrome-ai/suggestions.ts
@@ -166,15 +166,17 @@ export default class ChromeAISuggestionsEventSource extends EventTarget {
 		}
 		const available = ( await self.ai.summarizer.capabilities() ).available;
 
-		if ( available === 'no' ) {
+		if ( available === 'unavailable' ) {
 			return;
 		}
 
 		const summarizerOptions = this.getSummarizerOptions( tone, wordCount );
 
-		const summarizer = await self.ai.summarizer.create( summarizerOptions );
-
-		if ( available === 'after-download' ) {
+		let summarizer;
+		if ( available === 'available' ) {
+			summarizer = await self.ai.summarizer.create( summarizerOptions );
+		} else {
+			summarizer = await self.ai.summarizer.create( summarizerOptions );
 			await summarizer.ready;
 		}
 

--- a/projects/js-packages/ai-client/src/chrome-ai/suggestions.ts
+++ b/projects/js-packages/ai-client/src/chrome-ai/suggestions.ts
@@ -110,11 +110,11 @@ export default class ChromeAISuggestionsEventSource extends EventTarget {
 
 	// use the Chrome AI translator
 	async translate( text: string, target: string, source: string = '' ) {
-		if ( ! ( 'translation' in self ) ) {
+		if ( ! ( 'ai' in self ) || ! ( 'translator' in self.ai ) ) {
 			return;
 		}
 
-		const translator = await self.translation.createTranslator( {
+		const translator = await self.ai.translator.create( {
 			sourceLanguage: source,
 			targetLanguage: target,
 		} );
@@ -125,6 +125,7 @@ export default class ChromeAISuggestionsEventSource extends EventTarget {
 
 		try {
 			const translation = await translator.translate( renderHTMLFromMarkdown( { content: text } ) );
+
 			this.processEvent( {
 				id: '',
 				event: 'translation',
@@ -169,9 +170,9 @@ export default class ChromeAISuggestionsEventSource extends EventTarget {
 			return;
 		}
 
-		const options = this.getSummarizerOptions( tone, wordCount );
+		const summarizerOptions = this.getSummarizerOptions( tone, wordCount );
 
-		const summarizer = await self.ai.summarizer.create( options );
+		const summarizer = await self.ai.summarizer.create( summarizerOptions );
 
 		if ( available === 'after-download' ) {
 			await summarizer.ready;

--- a/projects/js-packages/ai-client/src/types.ts
+++ b/projects/js-packages/ai-client/src/types.ts
@@ -141,20 +141,8 @@ export interface BlockEditorStore {
 
 declare global {
 	interface Window {
-		translation?: {
-			canTranslate: ( options: {
-				sourceLanguage: string;
-				targetLanguage: string;
-			} ) => Promise< 'no' | 'yes' | string >;
-			createTranslator: ( options: {
-				sourceLanguage: string;
-				targetLanguage: string;
-			} ) => Promise< {
-				translate: ( text: string ) => Promise< string >;
-			} >;
-		};
 		ai?: {
-			languageDetector: {
+			languageDetector?: {
 				create: () => Promise< {
 					detect: ( text: string ) => Promise<
 						{
@@ -163,6 +151,19 @@ declare global {
 						}[]
 					>;
 				} >;
+				availability: () => Promise<
+					'unavailable' | 'available' | 'downloadable' | 'downloading' | string
+				>;
+			};
+			translator?: {
+				create: ( options: {
+					sourceLanguage: string;
+					targetLanguage: string;
+				} ) => Promise< { translate: ( text: string ) => Promise< string > } >;
+				availability: ( options: {
+					sourceLanguage: string;
+					targetLanguage: string;
+				} ) => Promise< 'unavailable' | 'available' | 'downloadable' | 'downloading' | string >;
 			};
 			summarizer?: {
 				capabilities: () => Promise< {

--- a/projects/js-packages/ai-client/src/types.ts
+++ b/projects/js-packages/ai-client/src/types.ts
@@ -150,6 +150,7 @@ declare global {
 							confidence: number;
 						}[]
 					>;
+					ready: Promise< void >;
 				} >;
 				availability: () => Promise<
 					'unavailable' | 'available' | 'downloadable' | 'downloading' | string

--- a/projects/js-packages/ai-client/src/types.ts
+++ b/projects/js-packages/ai-client/src/types.ts
@@ -141,45 +141,43 @@ export interface BlockEditorStore {
 
 declare global {
 	interface Window {
-		ai?: {
-			languageDetector?: {
-				create: () => Promise< {
-					detect: ( text: string ) => Promise<
-						{
-							detectedLanguage: string;
-							confidence: number;
-						}[]
-					>;
-					ready: Promise< void >;
-				} >;
-				availability: () => Promise<
-					'unavailable' | 'available' | 'downloadable' | 'downloading' | string
+		LanguageDetector?: {
+			create: () => Promise< {
+				detect: ( text: string ) => Promise<
+					{
+						detectedLanguage: string;
+						confidence: number;
+					}[]
 				>;
-			};
-			translator?: {
-				create: ( options: {
-					sourceLanguage: string;
-					targetLanguage: string;
-				} ) => Promise< { translate: ( text: string ) => Promise< string > } >;
-				availability: ( options: {
-					sourceLanguage: string;
-					targetLanguage: string;
-				} ) => Promise< 'unavailable' | 'available' | 'downloadable' | 'downloading' | string >;
-			};
-			summarizer?: {
-				capabilities: () => Promise< {
-					available: 'unavailable' | 'available' | 'downloadable' | 'downloading' | string;
-				} >;
-				create: ( options: {
-					sharedContext?: string;
-					type?: string;
-					format?: string;
-					length?: string;
-				} ) => Promise< {
-					ready: Promise< void >;
-					summarize: ( text: string, summarizeOptions?: { context?: string } ) => Promise< string >;
-				} >;
-			};
+				ready: Promise< void >;
+			} >;
+			availability: () => Promise<
+				'unavailable' | 'available' | 'downloadable' | 'downloading' | string
+			>;
+		};
+		Translator?: {
+			create: ( options: {
+				sourceLanguage: string;
+				targetLanguage: string;
+			} ) => Promise< { translate: ( text: string ) => Promise< string > } >;
+			availability: ( options: {
+				sourceLanguage: string;
+				targetLanguage: string;
+			} ) => Promise< 'unavailable' | 'available' | 'downloadable' | 'downloading' | string >;
+		};
+		Summarizer?: {
+			availability: () => Promise<
+				'unavailable' | 'available' | 'downloadable' | 'downloading' | string
+			>;
+			create: ( options: {
+				sharedContext?: string;
+				type?: string;
+				format?: string;
+				length?: string;
+			} ) => Promise< {
+				ready: Promise< void >;
+				summarize: ( text: string, summarizeOptions?: { context?: string } ) => Promise< string >;
+			} >;
 		};
 	}
 }

--- a/projects/js-packages/ai-client/src/types.ts
+++ b/projects/js-packages/ai-client/src/types.ts
@@ -93,8 +93,14 @@ export type RequestingStateProp = ( typeof REQUESTING_STATES )[ number ];
  */
 export const AI_MODEL_GPT_3_5_Turbo_16K = 'gpt-3.5-turbo-16k' as const;
 export const AI_MODEL_GPT_4 = 'gpt-4' as const;
+export const AI_MODEL_DEFAULT = 'default' as const;
+export const AI_MODEL_GEMINI_NANO = 'gemini-nano' as const;
 
-export type AiModelTypeProp = typeof AI_MODEL_GPT_3_5_Turbo_16K | typeof AI_MODEL_GPT_4;
+export type AiModelTypeProp =
+	| typeof AI_MODEL_GPT_3_5_Turbo_16K
+	| typeof AI_MODEL_GPT_4
+	| typeof AI_MODEL_GEMINI_NANO
+	| typeof AI_MODEL_DEFAULT;
 
 /*
  * Media recording types

--- a/projects/js-packages/ai-client/src/types.ts
+++ b/projects/js-packages/ai-client/src/types.ts
@@ -167,7 +167,7 @@ declare global {
 			};
 			summarizer?: {
 				capabilities: () => Promise< {
-					available: 'no' | 'yes' | 'after-download';
+					available: 'unavailable' | 'available' | 'downloadable' | 'downloading' | string;
 				} >;
 				create: ( options: {
 					sharedContext?: string;

--- a/projects/plugins/jetpack/changelog/add-chrome-ai-event-properties
+++ b/projects/plugins/jetpack/changelog/add-chrome-ai-event-properties
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+AI Assistant: Added tracking events to know when we're using built-in AI models in some requests and adapted to Chrome AI API changes

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-assistant.php
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-assistant.php
@@ -61,7 +61,7 @@ function load_assets( $attr, $content ) {
  * This ultimately sets an Origin-Trial header with the token.
  */
 function add_chrome_ai_token_headers() {
-	$token_transient_names = array( 'jetpack-ai-chrome-ai-translation-token', 'jetpack-ai-chrome-ai-summarization-token' );
+	$token_transient_names = array( 'jetpack-ai-chrome-ai-translation-token', 'jetpack-ai-chrome-ai-summarization-token', 'jetpack-ai-chrome-ai-language-detection-token' );
 
 	foreach ( $token_transient_names as $token_transient_name ) {
 		$cached_token = get_transient( $token_transient_name );

--- a/projects/plugins/jetpack/extensions/plugins/ai-content-lens/components/ai-excerpt-control/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-content-lens/components/ai-excerpt-control/index.tsx
@@ -15,7 +15,6 @@ import { ToneDropdownMenu } from '../../../../blocks/ai-assistant/components/ton
  */
 import type { LanguageProp } from '../../../../blocks/ai-assistant/components/i18n-dropdown-control';
 import type { ToneProp } from '../../../../blocks/ai-assistant/components/tone-dropdown-control';
-import type { AiModelTypeProp } from '@automattic/jetpack-ai-client';
 
 export type AiExcerptControlProps = {
 	/*
@@ -48,9 +47,6 @@ export type AiExcerptControlProps = {
 
 	tone?: ToneProp;
 	onToneChange?: ( tone: ToneProp ) => void;
-
-	model?: AiModelTypeProp;
-	onModelChange?: ( model: AiModelTypeProp ) => void;
 };
 
 import './style.scss';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->
We need to track when we're using our default AI model and when we're using Chrome's AI built-in model. We also need to update the code to adapt to Chrome AI API changes.

Fixes JETPACK-326

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*  Added two new events to track toolbar extension generate and undo actions (similar to events that we already have but these will have the model used)
* Added a model property in the AI excerpt tracking events
* Modified the code to adapt to Chrome AI API changes in the languageDetector and Translator API.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Prerequisites:
* You'll need to test it using Chrome version 133 or higher.
* First you'll need a token to use the Chrome AI API. Check the comments on the issue JETPACK-326 for the tokens you need to use in the following snippet.
* Check out this branch, add the following snippet to enable beta features, the feature flag, and add your token in place of [ your trial token goes here ]:
```php
define( 'JETPACK_BLOCKS_VARIATION', 'beta' );
add_filter( 'ai_chrome_ai_enabled', '__return_true' );

$token_transient_name = 'jetpack-ai-chrome-ai-summarization-token';

set_transient(
    $token_transient_name,
    "[ your translation trial token goes here ]",
    3600
);


$token_transient_name = 'jetpack-ai-chrome-ai-translation-token';
set_transient(
    $token_transient_name,
    "[ your translation trial token goes here ]",
    3600
);

$token_transient_name = 'jetpack-ai-chrome-ai-language-detection-token';
set_transient(
    $token_transient_name,
    "[ your translation trial token goes here ]",
    3600
);
```
* Once this is set up, you should be able to create an excerpt using Chrome's AI API.
* Open the javascript console and enable debug mode.
* Create a new post and add some text.
* Go to the Excerpt section in the post sidebar and click on generate.
* The first time you click on it, the browser needs to download the model, which can take several seconds (close to a minute for me). There are no UI progress indicators for this, so you'll just have to be patient the first time. The following requests are almost instantaneous.
* Tone, word count, and language settings should work.
* The summarization API only returns summaries in English, check that if the content is in a different language, we fallback to using our default AI model.
* For the excerpt feature check that the following events have the `model` property and is `gemini-nano` or `default` for the fallback case:
  * jetpack_ai_assistant_block_generate
  * jetpack_ai_assistant_block_accept
  * jetpack_ai_assistant_block_discard
* Follow the instructions on https://github.com/Automattic/jetpack/pull/41724 to test the translation feature, but ignore the token setup part.
* For the translation feature check for these events: 
  * jetpack_ai_assistant_toolbar_extension_generate
  * jetpack_ai_assistant_toolbar_extension_undo