### PR TITLE
Forms: Fix: Ensure File Upload field auto-wraps in Form

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-file-upload-insert
+++ b/projects/packages/forms/changelog/fix-forms-file-upload-insert
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: feature not released yet
+
+

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-file/index.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-file/index.js
@@ -96,11 +96,11 @@ const BLOCKS_TEMPLATE = [
 ];
 
 const JetpackFieldFile = props => {
-	const { attributes, clientId, isSelected, setAttributes } = props;
+	const { attributes, clientId, isSelected, setAttributes, name } = props;
 	const { id, label, required, requiredText, width } = attributes;
 	const fieldFileAvailability = getJetpackExtensionAvailability( 'field-file' );
 
-	useFormWrapper( { attributes, clientId } );
+	useFormWrapper( { attributes, clientId, name } );
 	const { blockStyle } = useJetpackFieldStyles( attributes );
 
 	const blockProps = useBlockProps( {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes FORMS-45

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Ensures the `jetpack/field-file` (File Upload Field) block correctly auto-wraps in a `jetpack/contact-form` block when inserted outside of an existing form. This is achieved by passing the block `name` prop to the `useFormWrapper` hook within the `JetpackFieldFile` component. Previously, the missing `name` prop prevented the `useFormWrapper` hook from correctly recreating the file field block within the new form.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No changes to data or activity tracking.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1.  Navigate to the WordPress block editor (e.g., create a new post or page).
2.  Attempt to insert a "File Upload" field block (`jetpack/field-file`) directly onto the page (i.e., not within an existing Contact Form block).
3.  **Before this change:** Insert would error.
4.  **After this change:** The File Upload field should now be automatically wrapped within a "Contact Form" (`jetpack/contact-form`) block. A "Submit" button should also appear as part of this newly created form.
5.  Verify that the File Upload field is functional within this new form structure (though full upload functionality testing might be out of scope for this specific UI fix).
6.  Verify that other form fields (e.g., Text, Email) still correctly auto-create a form when inserted independently.