### PR TITLE
Forms: change copy of upsell banner for file upload block

### DIFF
--- a/projects/packages/forms/changelog/update-forms-file-upload-upsell-copy
+++ b/projects/packages/forms/changelog/update-forms-file-upload-upsell-copy
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: change copy of upsell banner for file upload block

--- a/projects/packages/forms/src/blocks/contact-form/components/upsell-nudge/index.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/upsell-nudge/index.js
@@ -1,8 +1,6 @@
 import { useUpgradeFlow } from '@automattic/jetpack-shared-extension-utils';
 import { Nudge } from '@automattic/jetpack-shared-extension-utils/components';
 import { __ } from '@wordpress/i18n';
-// TODO: decide if we want to "dress like calypso" or just default nudge
-// import './style.scss';
 
 export const UpsellNudge = ( { requiredPlan } ) => {
 	const [ checkoutUrl, goToCheckoutPage, isRedirecting ] = useUpgradeFlow( requiredPlan );
@@ -10,7 +8,7 @@ export const UpsellNudge = ( { requiredPlan } ) => {
 		<div className="jetpack-forms-upsell-nudge">
 			<Nudge
 				className=""
-				title={ __( 'Upgrade to a paid plan to use this feature.', 'jetpack-forms' ) }
+				title={ __( 'Upgrade to a paid plan to use file uploads.', 'jetpack-forms' ) }
 				buttonText={ __( 'Upgrade', 'jetpack-forms' ) }
 				checkoutUrl={ checkoutUrl }
 				isRedirecting={ isRedirecting }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Change banner copy in the editor from:
   > Upgrade to a paid plan to use this feature. 

To:
   > Upgrade to a paid plan to use file uploads.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Site without a paid plan
* Add file upload block
* See banner copy in editor
* Doesn't change the banner copy on the frontend of the site (that's quite a bit more complicated to change)

