### PR TITLE
Stats: avoid trying to access formatter for unavailable locale

### DIFF
--- a/projects/packages/stats-admin/changelog/fix-php84-locale-error-stats
+++ b/projects/packages/stats-admin/changelog/fix-php84-locale-error-stats
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Stats column: avoid PHP fatal when a locale is not available

--- a/projects/packages/stats-admin/src/class-admin-post-list-column.php
+++ b/projects/packages/stats-admin/src/class-admin-post-list-column.php
@@ -113,7 +113,7 @@ class Admin_Post_List_Column {
 
 				$views = $post_views[ $post_id ] ?? null;
 
-				$current_locale = get_bloginfo( 'language' );
+				$current_locale = get_locale();
 
 				if ( null !== $views ) {
 					$formatted_views = class_exists( '\NumberFormatter' )

--- a/projects/packages/stats-admin/src/class-admin-post-list-column.php
+++ b/projects/packages/stats-admin/src/class-admin-post-list-column.php
@@ -230,6 +230,14 @@ class Admin_Post_List_Column {
 			return $this->formatter[ $locale ];
 		}
 
+		/*
+		 * Check if the locale is valid and available.
+		 * If not, fallback to en_US.
+		 */
+		if ( ! in_array( $locale, \IntlCalendar::getAvailableLocales(), true ) ) {
+			$locale = 'en_US';
+		}
+
 		/**
 		 * PHP's NumberFormatter is just a wrapper over the ICU C library. The library does support decimal compact short formatter, but PHP doesn't have a stub for it (=< PHP 8.4).
 		 *

--- a/projects/packages/stats-admin/src/class-admin-post-list-column.php
+++ b/projects/packages/stats-admin/src/class-admin-post-list-column.php
@@ -36,6 +36,13 @@ class Admin_Post_List_Column {
 	private $formatter;
 
 	/**
+	 * The current locale.
+	 *
+	 * @var string
+	 */
+	private $locale;
+
+	/**
 	 * The constructor.
 	 */
 	public function __construct() {
@@ -219,6 +226,30 @@ class Admin_Post_List_Column {
 	}
 
 	/**
+	 * Get and validate the locale.
+	 *
+	 * @param string $locale The locale to validate.
+	 *
+	 * @return string The validated locale.
+	 */
+	protected function get_validated_locale( string $locale ): string {
+		if ( isset( $this->locale ) ) {
+			return $this->locale;
+		}
+
+		/*
+		 * Check if the locale is valid and available.
+		 * If not, fallback to en_US.
+		 */
+		if ( ! in_array( $locale, \IntlCalendar::getAvailableLocales(), true ) ) {
+			$locale = 'en_US';
+		}
+
+		$this->locale = $locale;
+		return $locale;
+	}
+
+	/**
 	 * Get the NumberFormatter instance.
 	 *
 	 * @param string $locale The current locale.
@@ -230,13 +261,7 @@ class Admin_Post_List_Column {
 			return $this->formatter[ $locale ];
 		}
 
-		/*
-		 * Check if the locale is valid and available.
-		 * If not, fallback to en_US.
-		 */
-		if ( ! in_array( $locale, \IntlCalendar::getAvailableLocales(), true ) ) {
-			$locale = 'en_US';
-		}
+		$locale = $this->get_validated_locale( $locale );
 
 		/**
 		 * PHP's NumberFormatter is just a wrapper over the ICU C library. The library does support decimal compact short formatter, but PHP doesn't have a stub for it (=< PHP 8.4).

--- a/projects/packages/stats-admin/src/class-admin-post-list-column.php
+++ b/projects/packages/stats-admin/src/class-admin-post-list-column.php
@@ -232,7 +232,7 @@ class Admin_Post_List_Column {
 	 *
 	 * @return string The validated locale.
 	 */
-	protected function get_validated_locale( string $locale ): string {
+	public function get_validated_locale( string $locale ): string {
 		if ( isset( $this->locale ) ) {
 			return $this->locale;
 		}

--- a/projects/packages/stats-admin/tests/php/Admin_Post_List_Test.php
+++ b/projects/packages/stats-admin/tests/php/Admin_Post_List_Test.php
@@ -267,6 +267,7 @@ class Admin_Post_List_Test extends BaseTestCase {
 		$this->assertEquals( $output, $instance->get_validated_locale( $input ) );
 
 		// Test caching behavior
+		// @phan-suppress-next-line PhanPluginDuplicateAdjacentStatement -- This is done on purpose to ensure the second call will return the cached value.
 		$this->assertEquals( $output, $instance->get_validated_locale( $input ) );
 	}
 

--- a/projects/packages/stats-admin/tests/php/Admin_Post_List_Test.php
+++ b/projects/packages/stats-admin/tests/php/Admin_Post_List_Test.php
@@ -1,6 +1,7 @@
 <?php
 use Automattic\Jetpack\Stats_Admin\Admin_Post_List_Column;
 use Automattic\Jetpack\Stats_Admin\TestCase as BaseTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class Admin_Post_List_Test extends BaseTestCase {
 	public function test_register_creates_instance() {
@@ -246,5 +247,52 @@ class Admin_Post_List_Test extends BaseTestCase {
 		$this->assertEquals( '1K', $instance->get_fallback_format_to_compact_version( 1000 ) );
 		$this->assertEquals( '1.2K', $instance->get_fallback_format_to_compact_version( 1200 ) );
 		$this->assertSame( '999', $instance->get_fallback_format_to_compact_version( 999 ) );
+	}
+
+	/**
+	 * Test the locale validation and caching.
+	 *
+	 * @dataProvider locale_provider
+	 *
+	 * @param string $input  The input locale.
+	 * @param string $output The expected output locale.
+	 *
+	 * @return void
+	 */
+	#[DataProvider( 'locale_provider' )]
+	public function test_get_validated_locale( $input, $output ) {
+		$instance = new Admin_Post_List_Column();
+
+		// Test first call
+		$this->assertEquals( $output, $instance->get_validated_locale( $input ) );
+
+		// Test caching behavior
+		$this->assertEquals( $output, $instance->get_validated_locale( $input ) );
+	}
+
+	/**
+	 * Data provider for test_get_validated_locale.
+	 *
+	 * @return array
+	 */
+	public static function locale_provider() {
+		return array(
+			'valid locale en_US'            => array(
+				'input'  => 'en_US',
+				'output' => 'en_US',
+			),
+			'invalid locale skr'            => array(
+				'input'  => 'skr',
+				'output' => 'en_US',
+			),
+			'invalid locale invalid_locale' => array(
+				'input'  => 'invalid_locale',
+				'output' => 'en_US',
+			),
+			'valid locale fr_FR'            => array(
+				'input'  => 'fr_FR',
+				'output' => 'fr_FR',
+			),
+		);
 	}
 }


### PR DESCRIPTION
## Proposed changes:

This should avoid errors like:

```
Fatal error: Uncaught ValueError: NumberFormatter::__construct(): Argument #1 ($locale) "skr" is invalid
```

Some of the locale codes we pass to NumberFormatter are not always available. `skr` is a good example. I've detailed this problem in this issue: https://github.com/php/php-src/issues/18515

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

Internal reference: p1746629628168729-slack-CDLH4C1UZ

## Does this pull request change what data or activity we track or use?
* No

## Testing instructions:

* Switch your interface language to Saraiki.
* Go to Posts > All Posts
* Notice that posts in the Stats column are still displayed properly.

<img width="610" alt="Image" src="https://github.com/user-attachments/assets/065b7bcb-4533-437e-9fb9-6f5cffd06938" />
