### PR TITLE
Donations Block: ensure links in modal use ExternalLink component

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-donation-modal-external
+++ b/projects/plugins/jetpack/changelog/fix-donation-modal-external
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Donations Block: ensure links in modal use the External Link indicator

--- a/projects/plugins/jetpack/extensions/blocks/donations/first-time-modal.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/first-time-modal.js
@@ -1,6 +1,6 @@
 import { getRedirectUrl } from '@automattic/jetpack-components';
 import { isAtomicSite, isSimpleSite } from '@automattic/jetpack-shared-extension-utils';
-import { Modal, Button } from '@wordpress/components';
+import { Modal, Button, ExternalLink } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
@@ -24,13 +24,7 @@ const FirstTimeModal = ( { onClose } ) => {
 							'jetpack'
 						),
 						{
-							docLink: (
-								<a
-									href={ getRedirectUrl( supportLinkSource ) }
-									target="_blank"
-									rel="noopener noreferrer"
-								/>
-							),
+							docLink: <ExternalLink href={ getRedirectUrl( supportLinkSource ) } />,
 						}
 					) }
 				</p>
@@ -53,10 +47,8 @@ const FirstTimeModal = ( { onClose } ) => {
 						),
 						{
 							requirementsLink: (
-								<a
+								<ExternalLink
 									href={ getRedirectUrl( 'jetpack-support-donation-block-stripe-reqs' ) }
-									target="_blank"
-									rel="noopener noreferrer"
 								/>
 							),
 						}


### PR DESCRIPTION
## Proposed changes:

External links should be indicated as such in wp-admin. 

**before**

<img width="843" alt="Screenshot 2025-05-08 at 10 00 57" src="https://github.com/user-attachments/assets/4e7d07f6-817a-4bf1-af93-c04d2058a9bd" />

**after**

<img width="864" alt="Screenshot 2025-05-08 at 10 04 15" src="https://github.com/user-attachments/assets/a2b40c70-1fa1-424d-a943-2ce2b1ee8a9b" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Go to Posts > Add New
* Insert a Donations block
* Notice the links in the modal that appears.

