### PR TITLE
Modules: Fix JS string extraction.

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-newsletter-js-string-extraction
+++ b/projects/plugins/jetpack/changelog/fix-newsletter-js-string-extraction
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Subscription Module: Fix Newsletter JS string extraction.

--- a/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/class-jetpack-newsletter-dashboard-widget.php
+++ b/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/class-jetpack-newsletter-dashboard-widget.php
@@ -96,6 +96,7 @@ class Jetpack_Newsletter_Dashboard_Widget {
 				array(
 					'config_variable_name' => 'jetpackNewsletterWidgetConfigData',
 					'config_data'          => static::get_config_data(),
+					'load_minified_js'     => false,
 				)
 			);
 
@@ -142,6 +143,7 @@ class Jetpack_Newsletter_Dashboard_Widget {
 			'config_data'          => array(),
 			'config_variable_name' => 'configData',
 			'enqueue_css'          => true,
+			'load_minified_js'     => true,
 		);
 		$options         = wp_parse_args( $options, $default_options );
 
@@ -158,10 +160,14 @@ class Jetpack_Newsletter_Dashboard_Widget {
 			$version      = $asset['version'];
 		}
 
+		$file_extension = '.min.js';
+		if ( ! $options['load_minified_js'] ) {
+			$file_extension = '.js';
+		}
 		// Register and enqueue the script
 		wp_register_script(
 			$asset_handle,
-			plugins_url( '_inc/build/' . $asset_name . '.min.js', JETPACK__PLUGIN_FILE ),
+			plugins_url( '_inc/build/' . $asset_name . $file_extension, JETPACK__PLUGIN_FILE ),
 			$dependencies,
 			$version,
 			true

--- a/projects/plugins/jetpack/tools/webpack.config.js
+++ b/projects/plugins/jetpack/tools/webpack.config.js
@@ -133,6 +133,17 @@ module.exports = [
 			filename: '[name].min.js', // @todo: Fix this.
 		},
 	},
+	// Build the newsletter widget separately to support translatable strings.
+	{
+		...sharedWebpackConfig,
+		entry: {
+			'newsletter-widget': './modules/subscriptions/newsletter-widget/src/index.tsx',
+		},
+		plugins: [
+			...sharedWebpackConfig.plugins,
+			...jetpackWebpackConfig.DependencyExtractionPlugin(),
+		],
+	},
 	// Build admin page JS.
 	{
 		...sharedWebpackConfig,


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
The Webpack build process for modules generated `.min.js` files. This PR updates the build logic to generate `.js` files (still minified). 

The change is due to the fact that the .org infrastructure ignores `.min.js` files when extracting translatable strings. 

This resulted in some translatable strings not being extracted for the Jetpack plugin. 

Updating the build process to output `.js` files will make sure .org can extract the strings. 

I'll follow up with another PR to handle loading the translations for the scripts. 


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test the Jetpack plugin and confirm the modules work/no JS files are missing.

