### PR TITLE
WPCOM_JSON_API_Update_Post_Endpoint: Ensure key and meta_key properties are not undefined.

### DIFF
--- a/projects/plugins/jetpack/changelog/update-json-api-post-endpoint-undefined-property
+++ b/projects/plugins/jetpack/changelog/update-json-api-post-endpoint-undefined-property
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Endpoints: Preventing warnings in error logs when using the update post endpoint without keys.

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-post-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-post-endpoint.php
@@ -750,7 +750,7 @@ class WPCOM_JSON_API_Update_Post_Endpoint extends WPCOM_JSON_API_Post_Endpoint {
 				$meta = (object) $meta;
 
 				if (
-					in_array( $meta->key, Jetpack_SEO_Posts::POST_META_KEYS_ARRAY, true ) &&
+					in_array( isset( $meta->key ) ? $meta->key : null, Jetpack_SEO_Posts::POST_META_KEYS_ARRAY, true ) &&
 					! Jetpack_SEO_Utils::is_enabled_jetpack_seo()
 				) {
 					return new WP_Error( 'unauthorized', __( 'SEO tools are not enabled for this site.', 'jetpack' ), 403 );
@@ -780,10 +780,10 @@ class WPCOM_JSON_API_Update_Post_Endpoint extends WPCOM_JSON_API_Post_Endpoint {
 					}
 				}
 
-				$unslashed_meta_key           = wp_unslash( $meta->key ); // should match what the final key will be.
-				$meta->key                    = wp_slash( $meta->key );
-				$unslashed_existing_meta_key  = wp_unslash( $existing_meta_item->meta_key );
-				$existing_meta_item->meta_key = wp_slash( $existing_meta_item->meta_key );
+				$unslashed_meta_key           = wp_unslash( isset( $meta->key ) ? $meta->key : null ); // should match what the final key will be.
+				$meta->key                    = wp_slash( isset( $meta->key ) ? $meta->key : null );
+				$unslashed_existing_meta_key  = wp_unslash( isset( $existing_meta_item->meta_key ) ? $existing_meta_item->meta_key : null );
+				$existing_meta_item->meta_key = wp_slash( isset( $existing_meta_item->meta_key ) ? $existing_meta_item->meta_key : null );
 
 				// make sure that the meta id passed matches the existing meta key.
 				if ( ! empty( $meta->id ) && ! empty( $meta->key ) ) {

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-post-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-post-endpoint.php
@@ -780,10 +780,10 @@ class WPCOM_JSON_API_Update_Post_Endpoint extends WPCOM_JSON_API_Post_Endpoint {
 					}
 				}
 
-				$unslashed_meta_key           = wp_unslash( isset( $meta->key ) ? $meta->key : null ); // should match what the final key will be.
-				$meta->key                    = wp_slash( isset( $meta->key ) ? $meta->key : null );
-				$unslashed_existing_meta_key  = wp_unslash( isset( $existing_meta_item->meta_key ) ? $existing_meta_item->meta_key : null );
-				$existing_meta_item->meta_key = wp_slash( isset( $existing_meta_item->meta_key ) ? $existing_meta_item->meta_key : null );
+				$unslashed_meta_key           = isset( $meta->key ) ? wp_unslash( $meta->key ) : null; // should match what the final key will be.
+				$meta->key                    = isset( $meta->key ) ? wp_slash( $meta->key ) : null;
+				$unslashed_existing_meta_key  = isset( $existing_meta_item->meta_key ) ? wp_unslash( $existing_meta_item->meta_key ) : null;
+				$existing_meta_item->meta_key = isset( $existing_meta_item->meta_key ) ? wp_slash( $existing_meta_item->meta_key ) : null;
 
 				// make sure that the meta id passed matches the existing meta key.
 				if ( ! empty( $meta->id ) && ! empty( $meta->key ) ) {


### PR DESCRIPTION
Part of `VULCAN-100`

## Proposed changes:

* This PR ensures that key and meta_key properties are not checked for within `WPCOM_JSON_API_Update_Post_Endpoint` if they do not exist - set to null otherwise.
* This prevents warnings from filling up PHP error logs (though all searchable records are currently only coming from one site).
* Logs: 761cfa7c58fa9782e3868ae76965b196-logstash

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

n/a

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* To test the endpoint out, sandbox the WPcom public api, then visit the developer console at `https://developer.wordpress.com/docs/api/console/`.
* Test creating a new post by using the WPCOM API, v1, POST. begin typing so that you see the suggested endpoints, and select `/sites/[site]/posts/new`. Fill in the site placeholder with your Simple site blog id. Then fill in some fields - title and content is fine, and run the command A new post should have been created.

To replicate the issue: 

* Depending on which is live on WPcom - sun or moon - you'll want to make some changes to the endpoint file to be able to replicate the warning (as it's unclear to me how to naturally replicate this). First though, to confirm you can add a new metadata item. Just above the [check for $metadata here](https://github.com/Automattic/jetpack/blob/d162cbcc28ca5ed80f0865dd82f69f301fcc5790/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-post-endpoint.php#L747), create a demo array of objects such as:
```
		$metadata = array(
				(object) array(
					'key' => '_test_key',
					'value' => '123',
					'post_id' => $post_id,
					'meta_key' => '_test_key',
					'operation' => 'add',
				),
			);
```
* Then add the object from within the array (but named  `$existing_meta_item` ) to [replace the current `$existing_meta_item`](https://github.com/Automattic/jetpack/blob/d162cbcc28ca5ed80f0865dd82f69f301fcc5790/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-post-endpoint.php#L759) (eg. `$existing_meta_item = (object) array( 'key =>...`)
* Test creating a new post using the developer console, and you should now see the new metadata in the results. 
* To replicate the issue, comment out the key value in both.
* Test creating a new post again - notice no additional metadata item is created, and you should see warnings related to `$key` being undefined.
* If you comment out the `$meta_key` as well, you'll also see warnings related to those. Comment out only `$meta_key` and a meta value will be created, but you will see warnings related to that key.

To test the fix:

* You'll then want to apply the changes in this PR by running the command in the generated comment below. 
* Depending on which has the changes - sun or moon - you'll want to make the same file additions. In the instance where the key exists, the metadata should be created. In the instance where it doesn't, no additional metadata should be created but there should also be no warnings.


