### PR TITLE
WPCOM: Add tracks in the post list for Quick links and stats icon

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-post-list-tracking
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-post-list-tracking
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Add tracks for WPCOM Simple and Atomic
+
+

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -281,6 +281,7 @@ class Jetpack_Mu_Wpcom {
 		require_once __DIR__ . '/features/wpcom-hotfixes/wpcom-hotfixes.php';
 		require_once __DIR__ . '/features/wpcom-logout/wpcom-logout.php';
 		require_once __DIR__ . '/features/wpcom-themes/wpcom-theme-fixes.php';
+		require_once __DIR__ . '/features/wpcom-post-list/wpcom-post-types-tracking.php';
 		require_once __DIR__ . '/features/wpcom-widgets/wpcom-widgets.php';
 		require_once __DIR__ . '/features/wpcom-wpadmin-page-view/wpcom-wpadmin-page-view.php';
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-post-list/js/wpcom-post-list-tracks.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-post-list/js/wpcom-post-list-tracks.ts
@@ -10,7 +10,7 @@ declare const wpcomPostListData: {
 function wpcomPostListTracks() {
 	document.getElementById( 'the-list' )?.addEventListener( 'click', function ( event ) {
 		const target = event.target as HTMLElement;
-		if ( target.tagName === 'A' ) {
+		if ( target.tagName === 'A' || target.className === 'button-link editinline' ) {
 			wpcomTrackQuickLinksClicks( target );
 			return;
 		}
@@ -37,8 +37,14 @@ function wpcomTrackQuickLinksClicks( target: HTMLElement ) {
 		return;
 	}
 
+	let linkName = span.className;
+
+	if ( linkName === 'inline hide-if-no-js' ) {
+		linkName = 'quick-edit';
+	}
+
 	wpcomTrackEvent( 'wpcom_post_list_quick_link_clicked', {
-		link_name: span.className,
+		link_name: linkName,
 		post_type: wpcomPostListData.postType,
 	} );
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-post-list/js/wpcom-post-list-tracks.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-post-list/js/wpcom-post-list-tracks.ts
@@ -1,0 +1,63 @@
+import { wpcomTrackEvent } from '../../../common/tracks';
+
+declare const wpcomPostListData: {
+	postType: string;
+};
+
+/**
+ * Tracks clicks on the post list table.
+ */
+function wpcomPostListTracks() {
+	document.getElementById( 'the-list' )?.addEventListener( 'click', function ( event ) {
+		const target = event.target as HTMLElement;
+		if ( target.tagName === 'A' ) {
+			wpcomTrackQuickLinksClicks( target );
+			return;
+		}
+
+		if ( target.tagName === 'SPAN' ) {
+			wpcomTrackStatsIconClicks( target );
+		}
+	} );
+}
+
+/**
+ * Tracks clicks on the quick links in the post list table.
+ *
+ * @param target - The element that was clicked.
+ */
+function wpcomTrackQuickLinksClicks( target: HTMLElement ) {
+	const isPartOfRowActions = !! target.closest( '.row-actions' );
+	if ( ! isPartOfRowActions ) {
+		return;
+	}
+
+	const span = target.parentElement;
+	if ( ! span ) {
+		return;
+	}
+
+	wpcomTrackEvent( 'wpcom_post_list_quick_link_click', {
+		link_name: span.className,
+		post_type: wpcomPostListData.postType,
+	} );
+}
+
+/**
+ * Tracks clicks on the stats icon in the post list table.
+ *
+ * @param target - The element that was clicked.
+ */
+function wpcomTrackStatsIconClicks( target: HTMLElement ) {
+	const parentElement = target.parentElement?.parentElement;
+
+	if ( parentElement?.className !== 'stats column-stats' ) {
+		return;
+	}
+
+	wpcomTrackEvent( 'wpcom_post_list_stats_icon_click', {
+		post_type: wpcomPostListData.postType,
+	} );
+}
+
+document.addEventListener( 'DOMContentLoaded', wpcomPostListTracks );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-post-list/js/wpcom-post-list-tracks.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-post-list/js/wpcom-post-list-tracks.ts
@@ -10,7 +10,7 @@ declare const wpcomPostListData: {
 function wpcomPostListTracks() {
 	document.getElementById( 'the-list' )?.addEventListener( 'click', function ( event ) {
 		const target = event.target as HTMLElement;
-		if ( target.tagName === 'A' || target.className === 'button-link editinline' ) {
+		if ( target.tagName === 'A' || target.matches( '.button-link.editinline' ) ) {
 			wpcomTrackQuickLinksClicks( target );
 			return;
 		}
@@ -39,7 +39,7 @@ function wpcomTrackQuickLinksClicks( target: HTMLElement ) {
 
 	let linkName = span.className;
 
-	if ( linkName === 'inline hide-if-no-js' ) {
+	if ( span.matches( '.inline.hide-if-no-js' ) ) {
 		linkName = 'quick-edit';
 	}
 
@@ -57,7 +57,7 @@ function wpcomTrackQuickLinksClicks( target: HTMLElement ) {
 function wpcomTrackStatsIconClicks( target: HTMLElement ) {
 	const parentElement = target.parentElement?.parentElement;
 
-	if ( parentElement?.className !== 'stats column-stats' ) {
+	if ( ! parentElement?.matches( '.stats.column-stats' ) ) {
 		return;
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-post-list/js/wpcom-post-list-tracks.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-post-list/js/wpcom-post-list-tracks.ts
@@ -37,7 +37,7 @@ function wpcomTrackQuickLinksClicks( target: HTMLElement ) {
 		return;
 	}
 
-	wpcomTrackEvent( 'wpcom_post_list_quick_link_click', {
+	wpcomTrackEvent( 'wpcom_post_list_quick_link_clicked', {
 		link_name: span.className,
 		post_type: wpcomPostListData.postType,
 	} );
@@ -55,7 +55,7 @@ function wpcomTrackStatsIconClicks( target: HTMLElement ) {
 		return;
 	}
 
-	wpcomTrackEvent( 'wpcom_post_list_stats_icon_click', {
+	wpcomTrackEvent( 'wpcom_post_list_stats_icon_clicked', {
 		post_type: wpcomPostListData.postType,
 	} );
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-post-list/wpcom-post-types-tracking.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-post-list/wpcom-post-types-tracking.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Add tracks events for Quick links and the Stats icon.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+declare(strict_types=1);
+
+/**
+ * Add tracks for the post list.
+ *
+ * @return void
+ */
+function wpcom_post_list_add_stats_tracking() {
+	global $post_type;
+
+	$handle = jetpack_mu_wpcom_enqueue_assets( 'wpcom-post-list-tracks', array( 'js' ) );
+
+	wp_localize_script( $handle, 'wpcomPostListData', array( 'postType' => $post_type ) );
+}
+
+add_action( 'admin_print_scripts-edit.php', 'wpcom_post_list_add_stats_tracking' );

--- a/projects/packages/jetpack-mu-wpcom/webpack.config.js
+++ b/projects/packages/jetpack-mu-wpcom/webpack.config.js
@@ -54,6 +54,7 @@ module.exports = [
 				'./src/features/wpcom-options-general/options-general.ts',
 				'./src/features/wpcom-options-general/options-general.scss',
 			],
+			'wpcom-post-list-tracks': './src/features/wpcom-post-list/js/wpcom-post-list-tracks.ts',
 			'wpcom-plugins-banner': './src/features/wpcom-plugins/js/banner.js',
 			'wpcom-plugins-banner-style': './src/features/wpcom-plugins/css/banner.css',
 			'wpcom-profile-settings-link-to-wpcom':


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes DOTCOM-12958

This PR is a second take on https://github.com/Automattic/jetpack/pull/40935. This PR uses a slightly different approach for the event.

Also, about the stats icon, I've decided to add it here because:
- This only affects WPCOM Simple and Atomic (not Jetpack sites)
- The generic wpcomTrackEvent function comes bundled with the JS asset I've created (since it's imported). If I were to add it in Jetpack, the function would be bundled in two places (not a huge problem)

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add tracks events for quick links and the stats icon in the post list

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this PR on Simple and Atomic
* Go to wp-admin/edit.php
* Click on the Quick links for each post
* Notice that we trigger an event: wpcom_post_list_quick_link_clicked
* Click on the stats icon
* Notice that we trigger an event: wpcom_post_list_stats_icon_clicked

