### PR TITLE
Boost Page Cache: make module off when Endurance Page Cache is on

### DIFF
--- a/projects/plugins/boost/app/admin/class-config.php
+++ b/projects/plugins/boost/app/admin/class-config.php
@@ -4,6 +4,8 @@ namespace Automattic\Jetpack_Boost\Admin;
 
 use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Status\Host;
+use Automattic\Jetpack_Boost\Lib\Cache_Compatibility;
+
 /**
  * Handle the configuration constants.
  *
@@ -26,10 +28,11 @@ class Config {
 			'assetPath'           => plugins_url( $internal_path, JETPACK_BOOST_PATH ),
 			'canResizeImages'     => wp_image_editor_supports( array( 'methods' => array( 'resize' ) ) ),
 			'site'                => array(
-				'url'    => get_home_url(),
-				'domain' => ( new Status() )->get_site_suffix(),
-				'online' => ! ( new Status() )->is_offline_mode() && ! ( new Status() )->is_private_site(),
-				'host'   => $this->get_hosting_provider(),
+				'url'      => get_home_url(),
+				'domain'   => ( new Status() )->get_site_suffix(),
+				'online'   => ! ( new Status() )->is_offline_mode() && ! ( new Status() )->is_private_site(),
+				'host'     => $this->get_hosting_provider(),
+				'hasCache' => Cache_Compatibility::has_cache(),
 			),
 			'api'                 => array(
 				'namespace' => JETPACK_BOOST_REST_NAMESPACE,

--- a/projects/plugins/boost/app/assets/src/js/features/page-cache/page-cache.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/page-cache/page-cache.tsx
@@ -10,6 +10,7 @@ import { __ } from '@wordpress/i18n';
 import { useSingleModuleState } from '$features/module/lib/stores';
 import styles from './page-cache.module.scss';
 import { isWpCloudClient, isWoaHosting } from '$lib/utils/hosting';
+import { hasConflictingCache } from '$lib/utils/caching';
 
 const DismissableNotice = ( { title, children }: { title: string; children: ReactNode } ) => {
 	const [ dismissed, setDismissed ] = useState( false );
@@ -37,7 +38,7 @@ const PageCache = () => {
 		pageCacheSetup.isSuccess && !! moduleState?.active
 	);
 	const showCacheFromHostingNotice =
-		! moduleState?.available && ( isWoaHosting() || isWpCloudClient() );
+		! moduleState?.available && ( isWoaHosting() || isWpCloudClient() || hasConflictingCache() );
 
 	const [ removePageCacheNotice ] = useMutationNotice(
 		'page-cache-setup',

--- a/projects/plugins/boost/app/assets/src/js/global.d.ts
+++ b/projects/plugins/boost/app/assets/src/js/global.d.ts
@@ -27,6 +27,7 @@ declare global {
 			url: string;
 			online: boolean;
 			host: string;
+			hasCache: boolean;
 		};
 		assetPath: string;
 		pluginDirUrl: string;

--- a/projects/plugins/boost/app/assets/src/js/lib/utils/caching.ts
+++ b/projects/plugins/boost/app/assets/src/js/lib/utils/caching.ts
@@ -1,0 +1,8 @@
+/**
+ * Determine if the site has a caching plugin that conflicts with Boost's Page Cache.
+ *
+ * @return {boolean} True if the site has a caching plugin that conflicts with Boost's Page Cache, false otherwise.
+ */
+export const hasConflictingCache = (): boolean => {
+	return Jetpack_Boost.site.hasCache;
+};

--- a/projects/plugins/boost/app/lib/class-cache-compatibility.php
+++ b/projects/plugins/boost/app/lib/class-cache-compatibility.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Compatibility class for caching plugins.
+ */
+
+namespace Automattic\Jetpack_Boost\Lib;
+
+/**
+ * Compatibility class for caching plugins.
+ */
+class Cache_Compatibility {
+	/**
+	 * Checks if the site has a caching plugin.
+	 *
+	 * Supports:
+	 * - Endurance Page Cache
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return bool True if the site has a caching plugin, false otherwise.
+	 */
+	public static function has_cache() {
+		/**
+		 * Filters whether the site has a caching plugin.
+		 * Useful for testing.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param bool $has_cache True if the site has a caching plugin, false otherwise.
+		 */
+		$has_cache = apply_filters( 'jetpack_boost_compatibility_has_cache', false );
+		if ( $has_cache ) {
+			return true;
+		}
+
+		/*
+		 * Disable Page Cache on sites that run Newfold's caching service.
+		 * Their cache is considered enabled when the endurance_cache_level option is set to 2 or 3.
+		 *
+		 * @link https://github.com/bluehost/endurance-page-cache/blob/59fe9993d2cb8a03d1df6da8325f73ad0851ba0a/endurance-page-cache.php#L343
+		 */
+		if (
+			class_exists( '\\Endurance_Page_Cache' )
+			&& 2 <= (int) get_option( 'endurance_cache_level' )
+		) {
+			return true;
+		}
+
+		return false;
+	}
+}

--- a/projects/plugins/boost/app/modules/optimizations/page-cache/class-page-cache.php
+++ b/projects/plugins/boost/app/modules/optimizations/page-cache/class-page-cache.php
@@ -112,6 +112,19 @@ class Page_Cache implements Feature, Has_Deactivate, Has_Data_Sync, Optimization
 			return false;
 		}
 
+		/*
+		 * Disable Page Cache on sites that run Newfold's caching service.
+		 * Their cache is considered enabled when the endurance_cache_level option is set to 2 or 3.
+		 *
+		 * @link https://github.com/bluehost/endurance-page-cache/blob/59fe9993d2cb8a03d1df6da8325f73ad0851ba0a/endurance-page-cache.php#L343
+		 */
+		if (
+			class_exists( 'Endurance_Page_Cache' )
+			&& 2 <= (int) get_option( 'endurance_cache_level' )
+		) {
+			return false;
+		}
+
 		return true;
 	}
 

--- a/projects/plugins/boost/app/modules/optimizations/page-cache/class-page-cache.php
+++ b/projects/plugins/boost/app/modules/optimizations/page-cache/class-page-cache.php
@@ -10,6 +10,7 @@ use Automattic\Jetpack_Boost\Contracts\Has_Data_Sync;
 use Automattic\Jetpack_Boost\Contracts\Has_Deactivate;
 use Automattic\Jetpack_Boost\Contracts\Needs_To_Be_Ready;
 use Automattic\Jetpack_Boost\Contracts\Optimization;
+use Automattic\Jetpack_Boost\Lib\Cache_Compatibility;
 use Automattic\Jetpack_Boost\Modules\Optimizations\Page_Cache\Data_Sync\Page_Cache_Entry;
 use Automattic\Jetpack_Boost\Modules\Optimizations\Page_Cache\Data_Sync_Actions\Clear_Page_Cache;
 use Automattic\Jetpack_Boost\Modules\Optimizations\Page_Cache\Data_Sync_Actions\Deactivate_WPSC;
@@ -112,16 +113,8 @@ class Page_Cache implements Feature, Has_Deactivate, Has_Data_Sync, Optimization
 			return false;
 		}
 
-		/*
-		 * Disable Page Cache on sites that run Newfold's caching service.
-		 * Their cache is considered enabled when the endurance_cache_level option is set to 2 or 3.
-		 *
-		 * @link https://github.com/bluehost/endurance-page-cache/blob/59fe9993d2cb8a03d1df6da8325f73ad0851ba0a/endurance-page-cache.php#L343
-		 */
-		if (
-			class_exists( '\\Endurance_Page_Cache' )
-			&& 2 <= (int) get_option( 'endurance_cache_level' )
-		) {
+		// Disable Page Cache on sites that have their own caching service.
+		if ( Cache_Compatibility::has_cache() ) {
 			return false;
 		}
 

--- a/projects/plugins/boost/app/modules/optimizations/page-cache/class-page-cache.php
+++ b/projects/plugins/boost/app/modules/optimizations/page-cache/class-page-cache.php
@@ -119,7 +119,7 @@ class Page_Cache implements Feature, Has_Deactivate, Has_Data_Sync, Optimization
 		 * @link https://github.com/bluehost/endurance-page-cache/blob/59fe9993d2cb8a03d1df6da8325f73ad0851ba0a/endurance-page-cache.php#L343
 		 */
 		if (
-			class_exists( 'Endurance_Page_Cache' )
+			class_exists( '\\Endurance_Page_Cache' )
 			&& 2 <= (int) get_option( 'endurance_cache_level' )
 		) {
 			return false;

--- a/projects/plugins/boost/changelog/update-boost-cache-endurance
+++ b/projects/plugins/boost/changelog/update-boost-cache-endurance
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Page Cache: improve compatibility with sites using Endurance Page Cache.

--- a/projects/plugins/boost/tests/php/lib/Cache_Compatibility_Test.php
+++ b/projects/plugins/boost/tests/php/lib/Cache_Compatibility_Test.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Tests for the Cache_Compatibility class.
+ */
+
+namespace Automattic\Jetpack_Boost\Tests\Lib;
+
+use Automattic\Jetpack_Boost\Lib\Cache_Compatibility;
+use Automattic\Jetpack_Boost\Tests\Base_TestCase;
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+/**
+ * Class Cache_Compatibility_Test
+ *
+ * @covers \Automattic\Jetpack_Boost\Lib\Cache_Compatibility
+ */
+#[CoversClass( Cache_Compatibility::class )]
+class Cache_Compatibility_Test extends Base_TestCase {
+	/**
+	 * Set up the test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		// Set up Brain Monkey
+		Monkey\setUp();
+	}
+
+	/**
+	 * Tear down the test.
+	 */
+	public function tearDown(): void {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	/**
+	 * Test that the has_cache method returns true when the filter is used to override.
+	 */
+	public function test_has_cache_with_filter() {
+		Functions\expect( 'apply_filters' )
+			->once()
+			->with( 'jetpack_boost_compatibility_has_cache', false )
+			->andReturn( true );
+
+		$this->assertTrue( Cache_Compatibility::has_cache() );
+	}
+}


### PR DESCRIPTION
Fixes HOG-96

## Proposed changes:

When a site already uses the Endurance Page Cache service, and that service is active on the site, we should not offer the option to turn on Boost's page cache.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* p1746778589553919-slack-C016BBAFHHS

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

> [!NOTE]
> Test this on a site using Endurance page cache. See HOG-96.
> Alternatively, you can set `add_filter( 'jetpack_boost_compatibility_has_cache', '__return_true' );` in your testing environment to mock things.

* Go to Settings > General
* Scroll down to the bottom of the page
* Change settings to activate or deactivate page cache
* Go to Jetpack > Boost
* The Page Cache module availability should be updated accordingly. A notice should be displayed

<img width="895" alt="Screenshot 2025-05-09 at 12 03 52" src="https://github.com/user-attachments/assets/58e4ae66-8aff-427c-9f45-c200c5fa48d6" />

