### PR TITLE
Forms: support 1/3 (33%) width in fields

### DIFF
--- a/projects/packages/forms/changelog/update-forms-1-3-input
+++ b/projects/packages/forms/changelog/update-forms-1-3-input
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: add 33% width option to fields and button

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-width.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-width.js
@@ -5,7 +5,7 @@ import {
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
-const PERCENTAGE_WIDTHS = [ 25, 50, 75, 100 ];
+const PERCENTAGE_WIDTHS = [ 25, 33, 50, 75, 100 ];
 
 export default function JetpackFieldWidth( { setAttributes, width } ) {
 	return (

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -65,6 +65,7 @@
 			}
 
 			&.jetpack-field__width-25,
+			&.jetpack-field__width-33,
 			&.jetpack-field__width-50,
 			&.jetpack-field__width-75 {
 				box-sizing: border-box;
@@ -77,6 +78,11 @@
 				.jetpack-option__input.jetpack-option__input.jetpack-option__input {
 					width: 70px;
 				}
+			}
+
+			&.jetpack-field__width-33 {
+				flex: 1 1 calc( 33.33% - calc(var(--wp--style--block-gap, 1.5rem) * 1) );
+				max-width: 33.33%;
 			}
 
 			&.jetpack-field__width-50 {

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -296,6 +296,11 @@
 	max-width: 25%;
 }
 
+.wp-block-jetpack-contact-form .grunion-field-width-33-wrap {
+	flex: 1 1 calc( 33.33% - calc(var(--wp--style--block-gap, 1.5rem) * 1) );
+	max-width: 33.33%;
+}
+
 .wp-block-jetpack-contact-form .grunion-field-width-50-wrap {
 	flex: 1 1 calc( 50% - calc(var(--wp--style--block-gap, 1.5rem) * 1) );
 	max-width: 50%;

--- a/projects/plugins/jetpack/changelog/update-forms-1-3-input
+++ b/projects/plugins/jetpack/changelog/update-forms-1-3-input
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: adds 33% width option to fields and buttons

--- a/projects/plugins/jetpack/extensions/shared/width-panel.js
+++ b/projects/plugins/jetpack/extensions/shared/width-panel.js
@@ -21,7 +21,7 @@ const alignedWidthUnits = [
 	{ value: 'em', label: 'em', default: 10 },
 ];
 
-const predefinedWidths = [ '25%', '33%', '50%', '75%', '100%' ];
+const predefinedWidths = [ '25%', '50%', '75%', '100%' ];
 
 export function WidthPanel( props ) {
 	return (

--- a/projects/plugins/jetpack/extensions/shared/width-panel.js
+++ b/projects/plugins/jetpack/extensions/shared/width-panel.js
@@ -21,7 +21,7 @@ const alignedWidthUnits = [
 	{ value: 'em', label: 'em', default: 10 },
 ];
 
-const predefinedWidths = [ '25%', '50%', '75%', '100%' ];
+const predefinedWidths = [ '25%', '33%', '50%', '75%', '100%' ];
 
 export function WidthPanel( props ) {
 	return (
@@ -69,7 +69,7 @@ export function WidthControl( { align, width, onChange, showLabel = true } ) {
 					<ToggleGroupControl
 						__next40pxDefaultSize
 						__nextHasNoMarginBottom
-						aria-label={ __( 'Percentage Width', 'jetpack' ) }
+						aria-label={ __( 'Percentage width', 'jetpack' ) }
 						isBlock
 						value={ width }
 						onChange={ handleChange }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Adds 1/3 (33%) width option to Jetpack Form fields.

Based on customer feedback in peKye1-1x8-p2

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

**Layouts on the site:**
Desktop
<img width="822" alt="Screenshot 2025-05-09 at 12 43 31" src="https://github.com/user-attachments/assets/3f9cd5fc-7c0d-4d2a-8d0c-99803a00e72d" />
Moble
<img width="412" alt="Screenshot 2025-05-09 at 12 43 39" src="https://github.com/user-attachments/assets/48024e50-332a-46dd-ad80-ebb673a6af4e" />

**Layout example in editor, including button:**
<img width="716" alt="Screenshot 2025-05-09 at 12 57 13" src="https://github.com/user-attachments/assets/91dc47af-edf3-40ec-9e06-5b625e175776" />

**Controls:**
<img width="272" alt="Screenshot 2025-05-09 at 12 57 20" src="https://github.com/user-attachments/assets/71ca1908-0700-4978-b9bf-615f95853f54" />

Button control already supports custom % widths, so I didn't add extra preset as that would make the control too crowded:

<img width="291" alt="Screenshot 2025-05-09 at 12 55 33" src="https://github.com/user-attachments/assets/bf3c5364-7cda-465c-9216-6645749b7f9e" />
<img width="293" alt="Screenshot 2025-05-09 at 12 56 55" src="https://github.com/user-attachments/assets/8c351a72-6102-46a0-b00d-dd299bdb03a2" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add forms
* Add fields and set their width to 33%
* Test mobile/desktop
* Try button width too