### PR TITLE
Donations block: Update to utilise formatCurrency from @automattic/number-formatters

### DIFF
--- a/projects/plugins/jetpack/changelog/udpate-i18n-number-formatters-donations-block
+++ b/projects/plugins/jetpack/changelog/udpate-i18n-number-formatters-donations-block
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Update donations block to utilise formatCurrency from @automattic/number-formatters

--- a/projects/plugins/jetpack/extensions/blocks/donations/amount.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/amount.js
@@ -1,4 +1,4 @@
-import formatCurrency, { CURRENCIES } from '@automattic/format-currency';
+import { formatCurrency } from '@automattic/number-formatters';
 import { RichText } from '@wordpress/block-editor';
 import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
 import clsx from 'clsx';
@@ -14,7 +14,7 @@ const Amount = ( {
 	value = '',
 } ) => {
 	const [ editedValue, setEditedValue ] = useState(
-		formatCurrency( value, currency, { symbol: '' } )
+		value ? formatCurrency( Number( value ), currency ) : null
 	);
 	const [ isFocused, setIsFocused ] = useState( false );
 	const [ isInvalid, setIsInvalid ] = useState( false );
@@ -62,7 +62,7 @@ const Amount = ( {
 		const onBlur = () => {
 			setIsFocused( false );
 			if ( ! editedValue ) {
-				setAmount( formatCurrency( defaultValue, currency, { symbol: '' } ) );
+				setAmount( defaultValue ? formatCurrency( Number( defaultValue ), currency ) : null );
 			}
 		};
 
@@ -78,11 +78,11 @@ const Amount = ( {
 		if ( isFocused || isInvalid ) {
 			return;
 		}
-		setEditedValue( formatCurrency( value, currency, { symbol: '' } ) );
+		setEditedValue( value ? formatCurrency( Number( value ), currency ) : null );
 	}, [ currency, isFocused, isInvalid, value ] );
 
 	useEffect( () => {
-		setAmount( formatCurrency( value, currency, { symbol: '' } ) );
+		setAmount( value ? formatCurrency( Number( value ), currency ) : null );
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ currency, value ] );
 
@@ -97,17 +97,16 @@ const Amount = ( {
 			onClick={ setFocus }
 			onKeyDown={ setFocus }
 		>
-			{ CURRENCIES[ currency ].symbol }
 			{ disabled ? (
 				<div className="donations__amount-value">
-					{ formatCurrency( value ? value : defaultValue, currency, { symbol: '' } ) }
+					{ formatCurrency( value ? Number( value ) : Number( defaultValue ), currency ) }
 				</div>
 			) : (
 				<RichText
 					allowedFormats={ [] }
 					aria-label={ label }
 					onChange={ amount => setAmount( amount, true ) }
-					placeholder={ formatCurrency( defaultValue, currency, { symbol: '' } ) }
+					placeholder={ defaultValue ? formatCurrency( Number( defaultValue ), currency ) : null }
 					ref={ richTextRef }
 					value={ editedValue }
 					withoutInteractiveFormatting

--- a/projects/plugins/jetpack/extensions/blocks/donations/deprecated/v1/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/deprecated/v1/index.js
@@ -1,4 +1,4 @@
-import formatCurrency, { CURRENCIES } from '@automattic/format-currency';
+import { formatCurrency } from '@automattic/number-formatters';
 import { RichText } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 import { minimumTransactionAmountForCurrency } from '../../../../shared/currencies';
@@ -148,14 +148,12 @@ export default {
 								<>
 									<RichText.Content tagName="p" value={ customAmountText } />
 									<div className="donations__amount donations__custom-amount">
-										{ CURRENCIES[ currency ].symbol }
 										<div
 											className="donations__amount-value"
 											data-currency={ currency }
 											data-empty-text={ formatCurrency(
 												minimumTransactionAmountForCurrency( currency ) * 100,
-												currency,
-												{ symbol: '' }
+												currency
 											) }
 										/>
 									</div>

--- a/projects/plugins/jetpack/extensions/blocks/donations/view.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/view.js
@@ -1,4 +1,4 @@
-import formatCurrency from '@automattic/format-currency';
+import { formatCurrency } from '@automattic/number-formatters';
 import domReady from '@wordpress/dom-ready';
 import { addQueryArgs, removeQueryArgs } from '@wordpress/url';
 import { minimumTransactionAmountForCurrency, parseAmount } from '../../shared/currencies';
@@ -181,9 +181,7 @@ class JetpackDonations {
 			}
 
 			// Formats the entered amount.
-			input.innerHTML = formatCurrency( this.amount, input.dataset.currency, {
-				symbol: '',
-			} );
+			input.innerHTML = formatCurrency( Number( this.amount ), input.dataset.currency );
 		} );
 
 		input.addEventListener( 'input', () => this.updateAmountFromCustomAmountInput() );

--- a/projects/plugins/jetpack/tools/check-block-assets.php
+++ b/projects/plugins/jetpack/tools/check-block-assets.php
@@ -66,6 +66,9 @@ $allowed = array(
 		'wp-compose',
 		'wp-element',
 	),
+	'donations'      => array(
+		'wp-date',
+	),
 	'podcast-player' => array(
 		'lodash',
 		'react',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/Automattic/jetpack/pull/43405 and https://github.com/Automattic/jetpack/pull/42796
Post-fix addressing https://github.com/Automattic/jetpack/issues/43401

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

The donations block is a fairly old and untyped implementation that also consumes an older version of `@automattic/format-currency` (`1.0.0`, never updated to the latest `2.0.0`). The implementation between the two versions differs, also, the older version doesn't readily migrate to `@automattic/number-formatters`, which is now the only preferred way of formatting numbers and currencies (`@automattic/format-currency` is being fully deprecated in https://github.com/Automattic/wp-calypso/pull/100559) - for example, certain options are no longer supported (like `symbol` that renders a currency without a symbol if falsy - something that Donations block uses).

This PR aims to re-attempt a migration to `@automattic/number-formatters` and should (along with https://github.com/Automattic/jetpack/pull/42457) complete the migration to the new package in Jetpack.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Need to test the donations block thoroughly
* See https://github.com/Automattic/jetpack/issues/43401 for instructions. 
* Ensure that the issues outlined in https://github.com/Automattic/jetpack/issues/43401 do not resurface 

