### PR TITLE
Subscriptions: Load script translations for newsletter.

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-newsletter-localization
+++ b/projects/plugins/jetpack/changelog/fix-newsletter-localization
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Subscriptions: load newsletter JS translations

--- a/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/class-jetpack-newsletter-dashboard-widget.php
+++ b/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/class-jetpack-newsletter-dashboard-widget.php
@@ -173,6 +173,9 @@ class Jetpack_Newsletter_Dashboard_Widget {
 			true
 		);
 		wp_enqueue_script( $asset_handle );
+		if ( in_array( 'wp-i18n', $dependencies, true ) ) {
+			wp_set_script_translations( $asset_handle, 'jetpack' );
+		}
 
 		// Enqueue the CSS if enabled
 		if ( $options['enqueue_css'] ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Follow-up to #43403

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* The previous PR enabled string extraction; this PR enables loading translations for the newsletter widget.

With both these changes, the newsletter widget is now ready to be localized.
### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Code review.

