### PR TITLE
Forms: remove color gradients block supports

### DIFF
--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -106,7 +106,7 @@ class Contact_Form_Block {
 					'color'                => array(
 						'text'       => true,
 						'background' => true,
-						'gradient'   => true,
+						'gradients'  => false,
 					),
 					'typography'           => array(
 						'fontSize'                     => true,
@@ -129,7 +129,7 @@ class Contact_Form_Block {
 					'color'      => array(
 						'text'       => true,
 						'background' => false,
-						'gradient'   => false,
+						'gradients'  => false,
 					),
 					'typography' => array(
 						'fontSize'                     => true,
@@ -168,7 +168,7 @@ class Contact_Form_Block {
 					'color'      => array(
 						'text'       => true,
 						'background' => false,
-						'gradient'   => false,
+						'gradients'  => false,
 					),
 					'typography' => array(
 						'fontSize'                     => true,

--- a/projects/packages/forms/src/blocks/input/index.js
+++ b/projects/packages/forms/src/blocks/input/index.js
@@ -32,7 +32,7 @@ const settings = {
 		color: {
 			text: true,
 			background: true,
-			gradient: true,
+			gradients: false,
 		},
 		__experimentalBorder: {
 			color: true,

--- a/projects/packages/forms/src/blocks/label/index.js
+++ b/projects/packages/forms/src/blocks/label/index.js
@@ -33,7 +33,7 @@ const settings = {
 		color: {
 			text: true,
 			background: false,
-			gradient: false,
+			gradients: false,
 		},
 		typography: {
 			fontSize: true,

--- a/projects/packages/forms/src/blocks/option/index.js
+++ b/projects/packages/forms/src/blocks/option/index.js
@@ -21,7 +21,7 @@ const settings = {
 		color: {
 			text: true,
 			background: false,
-			gradient: false,
+			gradients: false,
 		},
 		typography: {
 			fontSize: true,

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Block_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Block_Test.php
@@ -75,7 +75,7 @@ class Contact_Form_Block_Test extends BaseTestCase {
 					'color'                => array(
 						'text'       => true,
 						'background' => true,
-						'gradient'   => true,
+						'gradients'  => false,
 					),
 					'typography'           => array(
 						'fontSize'                     => true,
@@ -95,7 +95,7 @@ class Contact_Form_Block_Test extends BaseTestCase {
 					'color'      => array(
 						'text'       => true,
 						'background' => false,
-						'gradient'   => false,
+						'gradients'  => false,
 					),
 					'typography' => array(
 						'fontSize'                     => true,
@@ -123,7 +123,7 @@ class Contact_Form_Block_Test extends BaseTestCase {
 					'color'      => array(
 						'text'       => true,
 						'background' => false,
-						'gradient'   => false,
+						'gradients'  => false,
 					),
 					'typography' => array(
 						'fontSize'                     => true,


### PR DESCRIPTION

## Proposed changes:
Removes `color.gradients` block supports from inner blocks by explicitly setting it to `false`.

Jetpack forms in trunk does not use gradients yet.

Here's a screenshot from trunk

<img width="275" alt="Screenshot 2025-05-12 at 12 16 08 pm" src="https://github.com/user-attachments/assets/71ffc1a7-37cf-4863-a025-680b9f2c37b4" />


Gradient introduce a complexity factor in relation to supporting the form styles. Let's deal with it later.



https://github.com/user-attachments/assets/82ef966d-f158-4a73-9c09-519548df2aad



