### PR TITLE
Concatenate JS: avoid issues with WooCommerce Bookings

### DIFF
--- a/projects/plugins/boost/changelog/fix-boost-concat-js-woocommerce-bookings
+++ b/projects/plugins/boost/changelog/fix-boost-concat-js-woocommerce-bookings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Concatenate JS: ensure compatibility with the WooCommerce Bookings plugin.

--- a/projects/plugins/boost/compatibility/js-concatenate.php
+++ b/projects/plugins/boost/compatibility/js-concatenate.php
@@ -14,6 +14,8 @@ function maybe_do_not_concat( $do_concat, $handle ) {
 		'woocommerce-shipping-checkout-address-validation',
 		// Plugin: `depay-payments-for-woocommerce`
 		'DEPAY_WC_WIDGETS',
+		// Plugin: `woocommerce-bookings`
+		'wc-bookings-booking-form',
 	);
 
 	if ( in_array( $handle, $excluded_handles, true ) ) {


### PR DESCRIPTION
Fixes #43428

## Proposed changes:

The conflict seems to come from a dependency of the plugin, so let's avoid concatenating the problematic file altogether.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Start with a site running the WooCommerce Bookings plugin.
* Go to Bookings > Add Product
* Publish a simple booking product using one of the templates, e.g. "mentoring"
* Visit the product's page and notice the calendar.
* Go to Jetpack > Boost
* Enable JS concatenation.
* Go back to the product's page 
    * The calendar should still be displayed.
