### PR TITLE
Prevent PHP fatal when `option_site_logo` filter receives WP_Error as param

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-site_logo_fatal
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-site_logo_fatal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Site Logo: Prevent PHP fatal when third-party code passes unexpected content to `option_site_logo` filter.

--- a/projects/plugins/jetpack/modules/theme-tools/site-logo.php
+++ b/projects/plugins/jetpack/modules/theme-tools/site-logo.php
@@ -71,11 +71,11 @@ add_action( 'after_switch_theme', 'jetpack_update_custom_logo_from_site_logo', 1
  *
  * @since 9.9.0
  *
- * @param int|array $site_logo Option.
- * @return int
+ * @param int|array|WP_Error $site_logo Option.
+ * @return int|WP_Error
  */
 function jetpack_site_logo_block_compat( $site_logo ) {
-	if ( isset( $site_logo['id'] ) ) {
+	if ( is_array( $site_logo ) && isset( $site_logo['id'] ) ) {
 		remove_filter( 'option_site_logo', 'jetpack_site_logo_block_compat', 1 );
 		update_option( 'site_logo', $site_logo['id'] );
 		return $site_logo['id'];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

The one site in question is using an `electra` theme, though that might be irrelevant. Ultimately it seems for some reason that `get_option()` is returning a `WP_Error`, which is being passed to the `option_site_logo` filter.

In any case, it's generating about 1200 fatals per day.

```
PHP Fatal error: Uncaught Error: Cannot use object of type WP_Error as array in /wordpress/plugins/jetpack/14.6/modules/theme-tools/site-logo.php:78
```

Stack trace:
```
Stack trace:
#0 /wordpress/core/6.8.1/wp-includes/class-wp-hook.php(326): jetpack_site_logo_block_compat(Object(WP_Error))
#1 /wordpress/core/6.8.1/wp-includes/plugin.php(205): WP_Hook->apply_filters(Object(WP_Error), Array)
#2 /wordpress/core/6.8.1/wp-includes/option.php(256): apply_filters('option_site_log...', Object(WP_Error), 'site_logo')
#3 /wordpress/core/6.8.1/wp-includes/blocks/site-logo.php(131): get_option('site_logo')
#4 /wordpress/core/6.8.1/wp-includes/class-wp-hook.php(324): _override_custom_logo_theme_mod('')
#5 /wordpress/core/6.8.1/wp-includes/plugin.php(205): WP_Hook->apply_filters('', Array)
#6 /wordpress/core/6.8.1/wp-includes/theme.php(1082): apply_filters('theme_mod_custo...', '')
#7 /srv/htdocs/wp-content/themes/electra/header.php(12): get_theme_mod('custom_logo', '')
#8 /wordpress/core/6.8.1/wp-includes/template.php(810): require_once('/srv/htdocs/wp-...')
#9 /wordpress/core/6.8.1/wp-includes/template.php(745): load_template('/srv/htdocs/wp-...', true, Array)
#10 /wordpress/core/6.8.1/wp-includes/general-template.php(48): locate_template(Array, true, true, Array)
#11 /srv/htdocs/wp-content/themes/electra/page.php(10): get_header()
#12 /wordpress/core/6.8.1/wp-includes/template-loader.php(106): include('/srv/htdocs/wp-...')
#13 /wordpress/core/6.8.1/wp-blog-header.php(19): require_once('/wordpress/core...')
#14 /wordpress/core/6.8.1/index.php(17): require('/wordpress/core...')
#15 {main}
  thrown in /wordpress/plugins/jetpack/14.6/modules/theme-tools/site-logo.php on line 78
```

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

🤷 
