### PR TITLE
cli: Update `jetpack docker phpunit` command

### DIFF
--- a/docs/development-environment.md
+++ b/docs/development-environment.md
@@ -259,31 +259,44 @@ To get started, there are several ways to run the unit tests, depending on how y
 
 ## PHP unit tests
 
-⚠️ This section is in need of update! Changes to how WordPress sets up its tests mean that a global version of phpunit is no longer provided.
-
 * ### Docker
 
 	To run the PHP unit tests for Jetpack if you're running Docker, you can run the following:
 
 	```sh
-	jetpack docker phpunit
+	jetpack docker phpunit jetpack
 	```
 
 	This will run unit tests for Jetpack. You can pass arguments to phpunit like so:
 
 	```sh
-	jetpack docker phpunit -- --filter=Protect
+	jetpack docker phpunit jetpack -- --filter=Protect
 	```
 
 	This command runs the tests as a multi site install
 
 	```sh
-	jetpack docker phpunit-jp-multisite -- --filter=Protect
+	jetpack docker phpunit jp-multisite -- --filter=Protect
 	```
 
-	To run tests for specific packages, you can run the tests locally, from within the package's directory:
+	To run tests for specific packages, you can run the tests locally. The most straightforward way is to use `jetpack test`, for example
+	```sh
+	jetpack test -v php packages/assets
+	```
+	or you can usually run them manually like
 	```sh
 	cd projects/packages/assets
+	composer phpunit
+	```
+
+	If you want to run a package's tests inside the Docker environment, you can get a shell inside the Docker environment with `jetpack docker sh` and then
+	```sh
+	cd /usr/local/src/jetpack-monorepo/
+	pnpm jetpack test -v php packages/assets
+	```
+	or
+	```sh
+	cd /usr/local/src/jetpack-monorepo/projects/packages/assets
 	composer phpunit
 	```
 

--- a/projects/plugins/jetpack/changelog/update-cli-docker-phpunit-command
+++ b/projects/plugins/jetpack/changelog/update-cli-docker-phpunit-command
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Update docs relating to `jetpack docker phpunit` command.
+
+

--- a/projects/plugins/jetpack/extensions/shared/test/block-fixtures.md
+++ b/projects/plugins/jetpack/extensions/shared/test/block-fixtures.md
@@ -126,7 +126,7 @@ The provided `generate_server_side_rendering_based_on_serialized_fixtures` metho
 To run (or generate) server-rendered fixture tests:
 
 ```sh
-jetpack docker phpunit -- --testsuite=extensions
+jetpack docker phpunit jetpack -- --testsuite=extensions
 ```
 
 To regenerate server-rendered fixtures, delete the fixtures with the `.server-rendered.html` extension and re-run the above command. The tests will fail, and report that the fixtures have been generated. Re-run the command again, and the tests should pass. Be sure to commit any updated or generated fixtures.

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Send_Email_Preview_Test.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Send_Email_Preview_Test.php
@@ -2,7 +2,7 @@
 /**
  * Tests for WPCOM_REST_API_V2_Endpoint_Send_Email_Preview.
  * To run this test by itself use the following command:
- * jetpack docker phpunit -- --filter=WPCOM_REST_API_V2_Endpoint_Send_Email_Preview_Test
+ * jetpack docker phpunit jetpack -- --filter=WPCOM_REST_API_V2_Endpoint_Send_Email_Preview_Test
  */
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/projects/plugins/jetpack/tests/php/json-api/Jetpack_Base_Json_Api_Endpoints_Test.php
+++ b/projects/plugins/jetpack/tests/php/json-api/Jetpack_Base_Json_Api_Endpoints_Test.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Jetpack_JSON_API_Endpoint class unit tests.
- * Run this test with command: jetpack docker phpunit -- --filter=Jetpack_Base_Json_Api_Endpoints_Test
+ * Run this test with command: jetpack docker phpunit jetpack -- --filter=Jetpack_Base_Json_Api_Endpoints_Test
  *
  * @package automattic/jetpack
  *

--- a/projects/plugins/jetpack/tests/php/json-api/WPCOM_JSON_API_Site_Settings_V1_4_Endpoint_Test.php
+++ b/projects/plugins/jetpack/tests/php/json-api/WPCOM_JSON_API_Site_Settings_V1_4_Endpoint_Test.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Jetpack `sites/%s/settings` endpoint unit tests.
- * Run this test with command: jetpack docker phpunit -- --filter=WPCOM_JSON_API_Site_Settings_V1_4_Endpoint_Test
+ * Run this test with command: jetpack docker phpunit jetpack -- --filter=WPCOM_JSON_API_Site_Settings_V1_4_Endpoint_Test
  *
  * @package automattic/jetpack
  */

--- a/projects/plugins/jetpack/tests/php/modules/videopress/VideoPress_Player_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/videopress/VideoPress_Player_Test.php
@@ -14,7 +14,7 @@ require_once JETPACK__PLUGIN_DIR . 'modules/videopress/class.videopress-video.ph
 /**
  * Tests Jetpack VideoPress Player
  *
- * To run: jetpack docker phpunit -- --filter=videopress_player
+ * To run: jetpack docker phpunit jetpack -- --filter=VideoPress_Player_Test
  *
  * @covers \VideoPress_Player
  */

--- a/projects/plugins/jetpack/tests/php/modules/widget-visibility/Jetpack_Widget_Conditions_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/widget-visibility/Jetpack_Widget_Conditions_Test.php
@@ -7,7 +7,7 @@ require_once JETPACK__PLUGIN_DIR . 'modules/widget-visibility/widget-conditions.
 /**
  * Test class for Jetpack_Widget_Conditions (widget visibility)
  *
- * To run: jetpack docker phpunit -- --filter=widget
+ * To run: jetpack docker phpunit jetpack -- --filter=Jetpack_Widget_Conditions_Test
  *
  * @covers Jetpack_Widget_Conditions
  */

--- a/tools/cli/commands/docker.js
+++ b/tools/cli/commands/docker.js
@@ -384,63 +384,46 @@ const buildExecCmd = argv => {
 	} else if ( cmd === 'db' ) {
 		opts.push( 'mysql', '--defaults-group-suffix=docker' );
 	} else if ( cmd === 'phpunit' ) {
-		// @todo: Make this scale.
-		console.warn( chalk.yellow( 'This currently only run tests for the Jetpack plugin.' ) );
-		console.warn(
-			chalk.yellow(
-				'Other projects do not require a working database, so you can run them locally or directly within jetpack docker sh'
+		const unitTestArgs = {};
+		switch ( argv.target ) {
+			case 'jetpack':
+				unitTestArgs.plugin = 'jetpack';
+				break;
+			case 'jp-multisite':
+				unitTestArgs.plugin = 'jetpack';
+				unitTestArgs.configFile = 'tests/php.multisite.#.xml';
+				break;
+			case 'jp-wpcomsh':
+				unitTestArgs.plugin = 'jetpack';
+				unitTestArgs.envVars = [ 'JETPACK_TEST_WPCOMSH=1' ];
+				break;
+			case 'crm':
+				unitTestArgs.plugin = 'crm';
+				break;
+			case 'wpcomsh':
+				unitTestArgs.plugin = 'wpcomsh';
+				unitTestArgs.envVars = [
+					'WP_TESTS_DIR=/tmp/wordpress-develop/tests/phpunit',
+					'WP_CORE_DIR=/var/www/html',
+					'WP_CONTENT_DIR=/var/www/html/wp-content',
+				];
+				break;
+		}
+		opts = buildPhpUnitTestCmd( argv, opts, unitTestArgs );
+	} else if (
+		cmd === 'phpunit-jp-multisite' ||
+		cmd === 'phpunit-jp-wpcomsh' ||
+		cmd === 'phpunit-crm' ||
+		cmd === 'phpunit-wpcomsh'
+	) {
+		console.error(
+			chalk.red(
+				`This command is deprecated. Please use \`jetpack docker phpunit ${ cmd.substring(
+					8
+				) }\` instead.`
 			)
 		);
-		const unitTestArgs = {
-			plugin: 'jetpack',
-		};
-		opts = buildPhpUnitTestCmd( argv, opts, unitTestArgs );
-	} else if ( cmd === 'phpunit-jp-multisite' ) {
-		// @todo: Make this scale.
-		console.warn( chalk.yellow( 'This currently only run tests for the Jetpack plugin.' ) );
-		console.warn(
-			chalk.yellow(
-				'Other projects do not require a working database, so you can run them locally or directly within jetpack docker sh'
-			)
-		);
-
-		const unitTestArgs = {
-			plugin: 'jetpack',
-			configFile: 'tests/php.multisite.#.xml',
-		};
-		opts = buildPhpUnitTestCmd( argv, opts, unitTestArgs );
-	} else if ( cmd === 'phpunit-jp-wpcomsh' ) {
-		console.warn( chalk.yellow( 'This currently only run tests for the Jetpack plugin.' ) );
-		console.warn(
-			chalk.yellow(
-				'Other projects do not require a working database, so you can run them locally or directly within jetpack docker sh'
-			)
-		);
-		const unitTestArgs = {
-			plugin: 'jetpack',
-			envVars: [ 'JETPACK_TEST_WPCOMSH=1' ],
-		};
-		opts = buildPhpUnitTestCmd( argv, opts, unitTestArgs );
-	} else if ( cmd === 'phpunit-crm' ) {
-		console.warn( chalk.yellow( 'This currently only run tests for the Jetpack CRM plugin.' ) );
-		const unitTestArgs = {
-			plugin: 'crm',
-		};
-		opts = buildPhpUnitTestCmd( argv, opts, unitTestArgs );
-	} else if ( cmd === 'phpunit-wpcomsh' ) {
-		console.warn( chalk.yellow( 'This currently only run tests for the wpcomsh plugin.' ) );
-		console.warn(
-			chalk.bold.yellow( 'Use `phpunit-jp-wpcomsh` to run tests for Jetpack with wpcomsh enabled.' )
-		);
-		const unitTestArgs = {
-			plugin: 'wpcomsh',
-			envVars: [
-				'WP_TESTS_DIR=/tmp/wordpress-develop/tests/phpunit',
-				'WP_CORE_DIR=/var/www/html',
-				'WP_CONTENT_DIR=/var/www/html/wp-content',
-			],
-		};
-		opts = buildPhpUnitTestCmd( argv, opts, unitTestArgs );
+		process.exit( 1 );
 	} else if ( cmd === 'phpunit-integration' ) {
 		// Only run tests for wpcomsh and jetpack, but always set JP_MONO_INTEGRATION_PLUGINS to the full list
 		const plugins = argv.plugins || argv._.slice( 2 );
@@ -724,13 +707,20 @@ export function dockerDefine( yargs ) {
 					handler: argv => execDockerCmdHandler( argv ),
 				} )
 				.command( {
-					command: 'phpunit',
-					description: 'Run PHPUnit tests inside container',
+					command: 'phpunit <target>',
+					description:
+						'Run PHPUnit tests inside container, for plugins that require a WordPress install.\n\nMost projects do not need a WordPress install, and can be tested on the host by using the `jetpack test` command. If you really want to run them inside the container anyway, see docs in docs/development-environment.md.',
 					builder: yargCmd =>
-						defaultOpts( yargCmd ).option( 'php', {
-							describe: 'Use the specified version of PHP.',
-							type: 'string',
-						} ),
+						defaultOpts( yargCmd )
+							.option( 'php', {
+								describe: 'Use the specified version of PHP.',
+								type: 'string',
+							} )
+							.positional( 'target', {
+								describe:
+									'Which PHPUnit tests to run:\n- jetpack: Jetpack plugin tests\n- jp-multisite: Jetpack plugin multisite tests.\n- jp-wpcomsh: Jetpack plugin tests with wpcomsh installed.\n- crm: Jetpack CRM plugin tests.\n- wpcomsh: Wpcomsh plugin tests.',
+								type: 'string',
+							} ),
 					handler: argv => execDockerCmdHandler( argv ),
 				} )
 				.command( {
@@ -753,46 +743,22 @@ export function dockerDefine( yargs ) {
 				} )
 				.command( {
 					command: 'phpunit-jp-multisite',
-					alias: 'phpunit:jp:multisite',
-					description: 'Run multisite Jetpack PHPUnit tests inside container',
-					builder: yargCmd =>
-						defaultOpts( yargCmd ).option( 'php', {
-							describe: 'Use the specified version of PHP.',
-							type: 'string',
-						} ),
+					deprecated: true,
 					handler: argv => execDockerCmdHandler( argv ),
 				} )
 				.command( {
 					command: 'phpunit-jp-wpcomsh',
-					alias: 'phpunit:jp:wpcomsh',
-					description: 'Run Jetpack PHPUnit tests with wpcomsh inside container',
-					builder: yargCmd =>
-						defaultOpts( yargCmd ).option( 'php', {
-							describe: 'Use the specified version of PHP.',
-							type: 'string',
-						} ),
+					deprecated: true,
 					handler: argv => execDockerCmdHandler( argv ),
 				} )
 				.command( {
 					command: 'phpunit-crm',
-					alias: 'phpunit:crm',
-					description: 'Run Jetpack CRM PHPUnit inside container',
-					builder: yargCmd =>
-						defaultOpts( yargCmd ).option( 'php', {
-							describe: 'Use the specified version of PHP.',
-							type: 'string',
-						} ),
+					deprecated: true,
 					handler: argv => execDockerCmdHandler( argv ),
 				} )
 				.command( {
 					command: 'phpunit-wpcomsh',
-					alias: 'phpunit:wpcomsh',
-					description: 'Run WPCOMSH PHPUnit inside container',
-					builder: yargCmd =>
-						defaultOpts( yargCmd ).option( 'php', {
-							describe: 'Use the specified version of PHP.',
-							type: 'string',
-						} ),
+					deprecated: true,
 					handler: argv => execDockerCmdHandler( argv ),
 				} )
 				.command( {

--- a/tools/cli/commands/docker.js
+++ b/tools/cli/commands/docker.js
@@ -709,7 +709,7 @@ export function dockerDefine( yargs ) {
 				.command( {
 					command: 'phpunit <target>',
 					description:
-						'Run PHPUnit tests inside container, for plugins that require a WordPress install.\n\nMost projects do not need a WordPress install, and can be tested on the host by using the `jetpack test` command. If you really want to run them inside the container anyway, see docs in docs/development-environment.md.',
+						'Run PHPUnit tests inside container for plugins that require a WordPress install.\n\nMost projects do not need a WordPress install, and can be tested on the host by using the `jetpack test` command. If you really want to run them inside the container anyway, see docs in docs/development-environment.md.',
 					builder: yargCmd =>
 						defaultOpts( yargCmd )
 							.option( 'php', {

--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -151,7 +151,7 @@ Will stop all of the containers created by this Docker compose configuration and
 These commands require the WordPress container to be running.
 
 ```sh
-jetpack docker phpunit
+jetpack docker phpunit jetpack
 ```
 
 This will run unit tests for Jetpack. You can pass arguments to `phpunit` like so:
@@ -162,10 +162,14 @@ jetpack docker phpunit -- --filter=Protect
 
 This command runs the tests as a multi site install
 ```sh
-jetpack docker phpunit-jp-multisite -- --filter=Protect
+jetpack docker phpunit jp-multisite -- --filter=Protect
 ```
 
-To run tests for specific packages, you can run the tests locally, from within the package's directory:
+To run tests for specific packages, you can run the tests locally. The most straightforward way is to use `jetpack test`, for example
+```sh
+jetpack test -v php packages/assets
+```
+or you can usually run them manually like
 ```sh
 cd projects/packages/assets
 composer phpunit


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
The command now takes a "target" argument specifying which tests to run. The separate commands "phpunit-jp-multisite", "phpunit-crm", and so on are deprecated.

This also updates the docs and messages from the CLI to note that `jetpack test` should be used to run tests for anything not supported by `jetpack docker phpunit`, with instructions added in `docs/development-environment.md` for how to use `jetpack docker sh` to run them inside the container if you really want to.

Unfortunately the help output from yargs (at least the version we currently use) is fairly lacking. But that can be looked at in a separate PR.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1746656515250989/1746628203.330399-slack-CDLH4C1UZ

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Try it out.
* Proofread the changed docs too.