### PR TITLE
Retrieve Chrome AI tokens from AI Assistant features

### DIFF
--- a/.phan/stubs/wpcom-stubs.php
+++ b/.phan/stubs/wpcom-stubs.php
@@ -1669,6 +1669,13 @@ namespace WPCOM\Jetpack_AI {
         {
         }
     }
+
+    class Chrome_AI_Tokens
+    {
+        public static function get_tokens(): array
+        {
+        }
+    }
 }
 namespace WPCOM\Jetpack_AI\Usage {
     class Helper

--- a/projects/js-packages/ai-client/changelog/add-chrome-ai-tokens-from-assistant-features
+++ b/projects/js-packages/ai-client/changelog/add-chrome-ai-tokens-from-assistant-features
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+AI Assistant: Retrieve Chrome AI tokens from AI Features response and inject if from the frontend

--- a/projects/js-packages/ai-client/src/hooks/use-ai-feature/index.ts
+++ b/projects/js-packages/ai-client/src/hooks/use-ai-feature/index.ts
@@ -6,7 +6,7 @@ import {
 	usePlanType as getPlanType,
 } from '@automattic/jetpack-shared-extension-utils';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { useMemo } from '@wordpress/element';
+import { useMemo, useEffect } from '@wordpress/element';
 import type { WordPressPlansSelectors } from '@automattic/jetpack-shared-extension-utils/store/wordpress-com';
 
 /**
@@ -33,6 +33,22 @@ export default function useAiFeature() {
 		increaseAiAssistantRequestsCount: increaseRequestsCount,
 		dequeueAiAssistantFeatureAsyncRequest: dequeueAsyncRequest,
 	} = useDispatch( 'wordpress-com/plans' );
+
+	useEffect( () => {
+		if ( ! loading && data ) {
+			// Check if the meta tag already exists
+			const existingMeta = document.querySelector( 'meta[http-equiv="origin-trial"]' );
+			if ( ! existingMeta && data?.chromeAiTokens ) {
+				// iterate through chromeAiTokens and create a meta tag for each one
+				Object.keys( data.chromeAiTokens ).forEach( token => {
+					const otMeta = document.createElement( 'meta' );
+					otMeta.httpEquiv = 'origin-trial';
+					otMeta.content = data.chromeAiTokens[ token ];
+					document.head.appendChild( otMeta );
+				} );
+			}
+		}
+	}, [ loading, data ] );
 
 	return useMemo( () => {
 		const planType = getPlanType( data?.currentTier );

--- a/projects/js-packages/shared-extension-utils/changelog/add-chrome-ai-tokens-from-assistant-features
+++ b/projects/js-packages/shared-extension-utils/changelog/add-chrome-ai-tokens-from-assistant-features
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+AI Assistant: Retrieve Chrome AI tokens from AI Features response and inject if from the frontend

--- a/projects/js-packages/shared-extension-utils/src/store/wordpress-com/actions.ts
+++ b/projects/js-packages/shared-extension-utils/src/store/wordpress-com/actions.ts
@@ -49,6 +49,7 @@ export function mapAiFeatureResponseToAiFeatureProps(
 		tierPlansEnabled: !! response[ 'tier-plans-enabled' ],
 		costs: response.costs,
 		featuresControl: response[ 'features-control' ],
+		chromeAiTokens: response[ 'chrome-ai-tokens' ],
 	};
 }
 

--- a/projects/js-packages/shared-extension-utils/src/store/wordpress-com/types.ts
+++ b/projects/js-packages/shared-extension-utils/src/store/wordpress-com/types.ts
@@ -91,6 +91,10 @@ export type FeatureControl = {
 
 export type FeaturesControl = { [ key: string ]: FeatureControl };
 
+export type ChromeAiTokens = {
+	[ key: string ]: string;
+};
+
 export type AiFeatureProps = {
 	hasFeature: boolean;
 	isOverLimit: boolean;
@@ -114,6 +118,7 @@ export type AiFeatureProps = {
 		};
 	};
 	featuresControl?: FeaturesControl;
+	chromeAiTokens?: ChromeAiTokens;
 };
 
 // Type used in the `wordpress-com/plans` store.
@@ -158,4 +163,5 @@ export type SiteAIAssistantFeatureEndpointResponseProps = {
 		};
 	};
 	'features-control'?: FeaturesControl;
+	'chrome-ai-tokens'?: ChromeAiTokens;
 };

--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-helper.php
@@ -391,6 +391,14 @@ class Jetpack_AI_Helper {
 				}
 			}
 
+			$chrome_ai_tokens = array();
+			if ( ! class_exists( 'WPCOM\Jetpack_AI\Chrome_AI_Tokens' ) ) {
+				if ( is_readable( WP_CONTENT_DIR . '/lib/jetpack-ai/chrome-ai-tokens.php' ) ) {
+					require_once WP_CONTENT_DIR . '/lib/jetpack-ai/chrome-ai-tokens.php';
+					$chrome_ai_tokens = WPCOM\Jetpack_AI\Chrome_AI_Tokens::get_tokens();
+				}
+			}
+
 			// Determine the upgrade type
 			$upgrade_type = wpcom_is_vip( $blog_id ) ? 'vip' : 'default';
 
@@ -409,6 +417,7 @@ class Jetpack_AI_Helper {
 				'tier-plans-enabled'   => WPCOM\Jetpack_AI\Usage\Helper::ai_tier_plans_enabled(),
 				'costs'                => WPCOM\Jetpack_AI\Usage\Helper::get_costs(),
 				'features-control'     => WPCOM\Jetpack_AI\Feature_Control::get_features(),
+				'chrome-ai-tokens'     => $chrome_ai_tokens,
 			);
 		}
 

--- a/projects/plugins/jetpack/changelog/add-chrome-ai-tokens-from-assistant-features
+++ b/projects/plugins/jetpack/changelog/add-chrome-ai-tokens-from-assistant-features
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+AI Assistant: retrieve Chrome AI tokens from the backend

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-assistant.php
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-assistant.php
@@ -10,10 +10,8 @@
 namespace Automattic\Jetpack\Extensions\AIAssistant;
 
 use Automattic\Jetpack\Blocks;
-use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Status\Host;
-use Automattic\Jetpack\Status\Visitor;
 use Jetpack_Gutenberg;
 
 /**
@@ -54,56 +52,6 @@ function load_assets( $attr, $content ) {
 		esc_attr( Blocks::classes( Blocks::get_block_feature( __DIR__ ), $attr ) ),
 		$content
 	);
-}
-
-/**
- * Retrieve the Chrome trial AI token for use with the Chrome AI feature.
- * This ultimately sets an Origin-Trial header with the token.
- */
-function add_chrome_ai_token_headers() {
-	$token_transient_names = array( 'jetpack-ai-chrome-ai-translation-token', 'jetpack-ai-chrome-ai-summarization-token', 'jetpack-ai-chrome-ai-language-detection-token' );
-
-	foreach ( $token_transient_names as $token_transient_name ) {
-		$cached_token = get_transient( $token_transient_name );
-
-		if ( ! $cached_token ) {
-			$blog_id = \Jetpack_Options::get_option( 'id' );
-
-			// get the token from wpcom
-			$wpcom_request = Client::wpcom_json_api_request_as_user(
-				sprintf( '/sites/%d/jetpack-ai/ai-assistant-feature', $blog_id ),
-				'v2',
-				array(
-					'method'  => 'GET',
-					'headers' => array(
-						'X-Forwarded-For' => ( new Visitor() )->get_ip( true ),
-					),
-					'timeout' => 30,
-				),
-				null,
-				'wpcom'
-			);
-
-			$response_code = wp_remote_retrieve_response_code( $wpcom_request );
-			if ( 200 === $response_code ) {
-				$ai_assistant_feature_data = json_decode( wp_remote_retrieve_body( $wpcom_request ), true );
-
-				if ( ! empty( $ai_assistant_feature_data['chrome-ai-tokens'] ) && ! empty( $ai_assistant_feature_data['chrome-ai-tokens'][ $token_transient_name ] ) ) {
-					set_transient(
-						$token_transient_name,
-						$ai_assistant_feature_data['chrome-ai-tokens'][ $token_transient_name ],
-						3600 // cache for an hour, but this can probably be longer
-					);
-
-					$cached_token = $ai_assistant_feature_data['chrome-ai-tokens'][ $token_transient_name ];
-				}
-			}
-		}
-
-		if ( $cached_token ) {
-			echo '<meta http-equiv="origin-trial" content="' . esc_attr( $cached_token ) . '">';
-		}
-	}
 }
 
 /**
@@ -175,7 +123,6 @@ add_action(
 			apply_filters( 'ai_chrome_ai_enabled', false )
 		) {
 			\Jetpack_Gutenberg::set_extension_available( 'ai-use-chrome-ai-sometimes' );
-			add_chrome_ai_token_headers();
 		}
 	}
 );

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-assistant.php
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-assistant.php
@@ -88,14 +88,14 @@ function add_chrome_ai_token_headers() {
 			if ( 200 === $response_code ) {
 				$ai_assistant_feature_data = json_decode( wp_remote_retrieve_body( $wpcom_request ), true );
 
-				if ( ! empty( $ai_assistant_feature_data['chrome-ai-token'] ) ) {
+				if ( ! empty( $ai_assistant_feature_data['chrome-ai-tokens'] ) && ! empty( $ai_assistant_feature_data['chrome-ai-tokens'][ $token_transient_name ] ) ) {
 					set_transient(
 						$token_transient_name,
-						$ai_assistant_feature_data['chrome-ai-token'],
+						$ai_assistant_feature_data['chrome-ai-tokens'][ $token_transient_name ],
 						3600 // cache for an hour, but this can probably be longer
 					);
 
-					$cached_token = $ai_assistant_feature_data['chrome-ai-token'];
+					$cached_token = $ai_assistant_feature_data['chrome-ai-tokens'][ $token_transient_name ];
 				}
 			}
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes AGORA-55

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Added a new section in the AI Assistant features array that contains the Chrome AI tokens retrieved from WPCOM

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* You'll need to test it using the latest Chrome version (136 or later).
* Follow the instructions below from the GitHub Actions bot to apply these changes to your sandbox to test it on Simple sites.
* In your sandbox, edit the file `wp-content/mu-plugins/0-sandbox.php` and add:

```php
define( 'JETPACK_BLOCKS_VARIATION', 'beta' );
add_filter( 'ai_chrome_ai_enabled', '__return_true' );
```

* Then sandbox your simple site.
* Create a new post and add some text.
* Go to the developer console, Application, Frames, top and check that you have three entries in the Origin trials section (LanguageDetectionAPI, TranslationAPI, and AISummarizationAPI).
![Screenshot 2025-05-13 at 20 57 32](https://github.com/user-attachments/assets/ced28340-a806-4fd6-ae85-0f4b8c3739d8)
* Go to the Excerpt section in the post sidebar and click on generate.
* Check in your Network tab that you have a request like this `https://pixel.wp.com/t.gif?feature=jetpack-ai-content-lens&model=gemini-nano&_en=jetpack_ai_assistant_block_generate` with the model parameter set to `gemini-nano`
* Translate a paragraph with the AI Assistant and check that you have another tracking request with the model `gemini-nano`. This is dependent on the translation model you have available with your Chrome browser, so if the language you're trying to translate to is not available, we'll fall back and use our default model.

