### PR TITLE
Add endpoint for LCP analysis payload

### DIFF
--- a/projects/plugins/boost/app/class-jetpack-boost.php
+++ b/projects/plugins/boost/app/class-jetpack-boost.php
@@ -39,6 +39,7 @@ use Automattic\Jetpack_Boost\Modules\Optimizations\Page_Cache\Page_Cache;
 use Automattic\Jetpack_Boost\Modules\Optimizations\Page_Cache\Page_Cache_Setup;
 use Automattic\Jetpack_Boost\Modules\Optimizations\Page_Cache\Pre_WordPress\Boost_Cache_Settings;
 use Automattic\Jetpack_Boost\REST_API\Endpoints\List_Cornerstone_Pages;
+use Automattic\Jetpack_Boost\REST_API\Endpoints\List_LCP_Analysis;
 use Automattic\Jetpack_Boost\REST_API\Endpoints\List_Site_Urls;
 use Automattic\Jetpack_Boost\REST_API\Endpoints\List_Source_Providers;
 use Automattic\Jetpack_Boost\REST_API\REST_API;
@@ -265,6 +266,7 @@ class Jetpack_Boost {
 		REST_API::register( List_Site_Urls::class );
 		REST_API::register( List_Source_Providers::class );
 		REST_API::register( List_Cornerstone_Pages::class );
+		REST_API::register( List_LCP_Analysis::class );
 
 		$this->connection->ensure_connection();
 		( new Admin() )->init( $modules_setup );

--- a/projects/plugins/boost/app/modules/optimizations/lcp/class-lcp-utils.php
+++ b/projects/plugins/boost/app/modules/optimizations/lcp/class-lcp-utils.php
@@ -14,7 +14,7 @@ class LCP_Utils {
 	 *
 	 * @return array Array of LCP analysis data keyed by page URL.
 	 */
-	public static function get_list() {
+	public static function get_analysis_data() {
 		$cornerstone_pages = Cornerstone_Utils::get_list();
 		$storage           = new LCP_Storage();
 		$analysis_data     = array();

--- a/projects/plugins/boost/app/modules/optimizations/lcp/class-lcp-utils.php
+++ b/projects/plugins/boost/app/modules/optimizations/lcp/class-lcp-utils.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Automattic\Jetpack_Boost\Modules\Optimizations\Lcp;
+
+use Automattic\Jetpack_Boost\Lib\Cornerstone\Cornerstone_Utils;
+
+/**
+ * Utility class for LCP functionality.
+ */
+class LCP_Utils {
+
+	/**
+	 * Get LCP analysis data for all cornerstone pages.
+	 *
+	 * @return array Array of LCP analysis data keyed by page URL.
+	 */
+	public static function get_list() {
+		$cornerstone_pages = Cornerstone_Utils::get_list();
+		$storage           = new LCP_Storage();
+		$analysis_data     = array();
+
+		foreach ( $cornerstone_pages as $page_url ) {
+			$key      = Cornerstone_Utils::get_provider_key( $page_url );
+			$lcp_data = $storage->get_lcp( $key );
+			if ( ! empty( $lcp_data ) ) {
+				$analysis_data[ $page_url ] = $lcp_data;
+			}
+		}
+
+		return $analysis_data;
+	}
+}

--- a/projects/plugins/boost/app/rest-api/endpoints/class-list-lcp-analysis.php
+++ b/projects/plugins/boost/app/rest-api/endpoints/class-list-lcp-analysis.php
@@ -18,7 +18,7 @@ class List_LCP_Analysis implements Endpoint {
 	}
 
 	public function response( $_request ) {
-		return rest_ensure_response( LCP_Utils::get_list() );
+		return rest_ensure_response( LCP_Utils::get_analysis_data() );
 	}
 
 	public function permissions() {

--- a/projects/plugins/boost/app/rest-api/endpoints/class-list-lcp-analysis.php
+++ b/projects/plugins/boost/app/rest-api/endpoints/class-list-lcp-analysis.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Create a new request for LCP analysis data.
+ *
+ * Handler for GET '/list-lcp-analysis'.
+ */
+
+namespace Automattic\Jetpack_Boost\REST_API\Endpoints;
+
+use Automattic\Jetpack_Boost\Modules\Optimizations\Lcp\LCP_Utils;
+use Automattic\Jetpack_Boost\REST_API\Contracts\Endpoint;
+use Automattic\Jetpack_Boost\REST_API\Permissions\Signed_With_Blog_Token;
+
+class List_LCP_Analysis implements Endpoint {
+
+	public function request_methods() {
+		return \WP_REST_Server::READABLE;
+	}
+
+	public function response( $_request ) {
+		return rest_ensure_response( LCP_Utils::get_list() );
+	}
+
+	public function permissions() {
+		return array(
+			new Signed_With_Blog_Token(),
+		);
+	}
+
+	public function name() {
+		return '/list-lcp-analysis';
+	}
+}

--- a/projects/plugins/boost/changelog/add-boost-endpoint-lcp-payload
+++ b/projects/plugins/boost/changelog/add-boost-endpoint-lcp-payload
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: LCP: Add endpoint for payload. Useful for debugging.
+
+


### PR DESCRIPTION
Fixes HOG-104

This data is used for debugging when a user reaches out to us.

## Proposed changes:

* Add a simple endpoint that lists LCP analysis data;
* Add a utils class for LCP related functionality.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

n/a

## Does this pull request change what data or activity we track or use?

no

## Testing instructions:

- Make sure you're running this branch and the trunk version of Boost Developer;
- Run an analysis and wait for it to finish;
- Make sure you see the analysis data on the endpoint - http://jetpack-boost.test/wp-json/jetpack-boost/v1/list-lcp-analysis