### PR TITLE
Bump WC Calypso Bridge to 2.10.3

### DIFF
--- a/projects/plugins/wpcomsh/changelog/wc-woo-calypso-bridge
+++ b/projects/plugins/wpcomsh/changelog/wc-woo-calypso-bridge
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Bump wc-calypso-bridge package
+
+

--- a/projects/plugins/wpcomsh/composer.json
+++ b/projects/plugins/wpcomsh/composer.json
@@ -9,7 +9,7 @@
 		"automattic/custom-fonts": "^3.0",
 		"automattic/custom-fonts-typekit": "^2.0",
 		"automattic/text-media-widget-styles": "^2.0",
-		"automattic/wc-calypso-bridge": "2.10.2",
+		"automattic/wc-calypso-bridge": "2.10.3",
 		"wordpress/classic-editor-plugin": "1.6.7",
 		"automattic/jetpack-composer-plugin": "@dev",
 		"automattic/jetpack-config": "@dev",

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8f95311ab527e301ced3a70f2bcfb8dd",
+    "content-hash": "d45636658dec63882664129cb6181e7b",
     "packages": [
         {
             "name": "automattic/at-pressable-podcasting",
@@ -2049,16 +2049,16 @@
         },
         {
             "name": "automattic/wc-calypso-bridge",
-            "version": "v2.10.2",
+            "version": "v2.10.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/wc-calypso-bridge.git",
-                "reference": "a65ae97a97c53199bb552c4bb79ad54253bfb298"
+                "reference": "e39fbf4447d0d8196955fa1d8c3018e5e9a3b559"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/wc-calypso-bridge/zipball/a65ae97a97c53199bb552c4bb79ad54253bfb298",
-                "reference": "a65ae97a97c53199bb552c4bb79ad54253bfb298",
+                "url": "https://api.github.com/repos/Automattic/wc-calypso-bridge/zipball/e39fbf4447d0d8196955fa1d8c3018e5e9a3b559",
+                "reference": "e39fbf4447d0d8196955fa1d8c3018e5e9a3b559",
                 "shasum": ""
             },
             "require-dev": {
@@ -2097,7 +2097,7 @@
                     "phpcbf -p"
                 ]
             },
-            "time": "2025-05-07T13:52:28+00:00"
+            "time": "2025-05-13T14:23:04+00:00"
         },
         {
             "name": "scssphp/scssphp",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Bump the WC Calypso Bridge package. This new version fixes the duplicate Plugins admin menu item for eCommerce trial sites.

Fixes DOTCOM-10702 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Bump the WC Calypso Bridge package to 2.10.3 - fixing the duplicate Plugins admin menu issue

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to a ecommerce trial site
* In wp-admin notice that there's just one Plugins menu item

