### PR TITLE
Speed scores: move away from deprecated hook

### DIFF
--- a/projects/packages/boost-speed-score/changelog/fix-deprecated-hook-warning
+++ b/projects/packages/boost-speed-score/changelog/fix-deprecated-hook-warning
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Environment change: update hook name

--- a/projects/packages/boost-speed-score/src/class-speed-score.php
+++ b/projects/packages/boost-speed-score/src/class-speed-score.php
@@ -65,10 +65,11 @@ class Speed_Score {
 		 * Mark the speed score history as stale when the environment changes.
 		 *
 		 * @since 0.3.9 - This hook replaced `handle_environment_change` action.
+		 * @since $$next-version - jetpack_boost_critical_css_environment_changed has been replaced by jetpack_boost_environment_changed.
 		 */
-		add_action( 'jetpack_boost_critical_css_environment_changed', array( Speed_Score_History::class, 'mark_stale' ) );
+		add_action( 'jetpack_boost_environment_changed', array( Speed_Score_History::class, 'mark_stale' ) );
 		/**
-		 * The `handle_environment_change` action is replaced by `jetpack_boost_critical_css_environment_changed` in Jetpack Boost.
+		 * The `handle_environment_change` action is replaced by `jetpack_boost_environment_changed` in Jetpack Boost.
 		 * Keeping the `handle_environment_change` action for backward compatibility.
 		 */
 		add_action( 'handle_environment_change', array( Speed_Score_History::class, 'mark_stale' ) );


### PR DESCRIPTION
Fixes HOG-105

## Proposed changes:

Follow-up to #43151

We deprecated the `jetpack_boost_critical_css_environment_changed` hook, but still use it in one of our packages. Let's update it to avoid deprecation notices like

```
[13-May-2025 13:41:30 UTC] PHP Deprecated:  Hook jetpack_boost_critical_css_environment_changed is <strong>deprecated</strong> since version 3.20.0! Use jetpack_boost_environment_changed instead. in /var/www/html/wp-includes/functions.php on line 6121
```


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* On a site running Jetpack Boost, 
* Add some logging in https://github.com/Automattic/jetpack/blob/b94e1ebf889f4735bc05fe56766587a0c20b9c93/projects/packages/boost-speed-score/src/class-speed-score-history.php#L122
* Switch themes
* Ensure that the theme switch triggers the `mark_stale` method.
