### PR TITLE
wpcomsh_footer_rum_js: Add wptheme, wptheme_is_block, logged_in custom properties

### DIFF
--- a/projects/plugins/wpcomsh/changelog/update-wpcomsh-bilmur
+++ b/projects/plugins/wpcomsh/changelog/update-wpcomsh-bilmur
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+wpcomsh: bilmur: Now includes theme name

--- a/projects/plugins/wpcomsh/wpcomsh.php
+++ b/projects/plugins/wpcomsh/wpcomsh.php
@@ -599,6 +599,10 @@ function wpcomsh_footer_rum_js() {
 
 	$rum_kv = array();
 	$rum_kv = wpcomsh_get_woo_rum_data( $rum_kv );
+	// Add user login and theme info.
+	$rum_kv['logged_in']        = is_user_logged_in() ? '1' : '0';
+	$rum_kv['wptheme']          = get_stylesheet();
+	$rum_kv['wptheme_is_block'] = wp_is_block_theme() ? '1' : '0';
 
 	if ( count( $rum_kv ) > 0 ) {
 		$rum_kv = wp_json_encode( $rum_kv, JSON_FORCE_OBJECT );


### PR DESCRIPTION
Fixes #

## Proposed changes:

* In the custom properties of rum data on atomic sites, include wptheme (string), wptheme_is_block (bool), logged_in (bool) attributes

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?

## Testing instructions:


* Visit the frontend of a WoA site and check the `<meta id="bilmur"` tag for additional custom properties

