### PR TITLE
Forms: Add google to form integrations endpoint

### DIFF
--- a/projects/packages/forms/changelog/add-google-to-form-integrations-endpoint
+++ b/projects/packages/forms/changelog/add-google-to-form-integrations-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: Add Google to form integrations endpoint.

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -9,6 +9,7 @@ namespace Automattic\Jetpack\Forms\ContactForm;
 
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Forms\Service\Google_Drive;
+use Automattic\Jetpack\Redirect;
 use Automattic\Jetpack\Status\Host;
 use WP_Error;
 use WP_REST_Request;
@@ -625,7 +626,7 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 	 * REST callback for /integrations/{slug}
 	 *
 	 * @param WP_REST_Request $request Request object.
-	 * @return WP_REST_Response Response object.
+	 * @return WP_REST_Response|WP_Error Response object or error.
 	 */
 	public function get_single_integration_status( $request ) {
 		$slug         = $request->get_param( 'slug' );
@@ -672,7 +673,7 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 			'type'        => $config['type'],
 			'slug'        => $slug,
 			'isConnected' => false,
-			'settingsUrl' => isset( $config['settings_url'] ) ? $config['settings_url'] : null,
+			'settingsUrl' => $config['settings_url'] ?? null,
 			'pluginFile'  => null,
 			'isInstalled' => false,
 			'isActive'    => false,

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -7,6 +7,9 @@
 
 namespace Automattic\Jetpack\Forms\ContactForm;
 
+use Automattic\Jetpack\Connection\Manager as Connection_Manager;
+use Automattic\Jetpack\Forms\Service\Google_Drive;
+use Automattic\Jetpack\Status\Host;
 use WP_Error;
 use WP_REST_Request;
 use WP_REST_Response;
@@ -40,7 +43,12 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 			'settings_url' => 'admin.php?page=zerobscrm-plugin-settings',
 		),
 		'salesforce'                        => array(
-			'type'         => 'internal',
+			'type'         => 'service',
+			'file'         => null,
+			'settings_url' => null,
+		),
+		'google-drive'                      => array(
+			'type'         => 'service',
 			'file'         => null,
 			'settings_url' => null,
 		),
@@ -599,7 +607,37 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 	}
 
 	/**
-	 * Get status for all supported integrations.
+	 * Core logic for a single integration
+	 *
+	 * @param string $slug Integration slug.
+	 * @return array Integration status data.
+	 */
+	private function get_integration( $slug ) {
+		$config       = $this->get_supported_integrations()[ $slug ];
+		$status       = $config['type'] === 'plugin'
+			? $this->get_plugin_status( $slug )
+			: $this->get_service_status( $slug );
+		$status['id'] = $slug;
+		return $status;
+	}
+
+	/**
+	 * REST callback for /integrations/{slug}
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response Response object.
+	 */
+	public function get_single_integration_status( $request ) {
+		$slug         = $request->get_param( 'slug' );
+		$integrations = $this->get_supported_integrations();
+		if ( ! isset( $integrations[ $slug ] ) ) {
+			return new \WP_Error( 'rest_integration_not_found', __( 'Integration not found.', 'jetpack-forms' ), array( 'status' => 404 ) );
+		}
+		return rest_ensure_response( $this->get_integration( $slug ) );
+	}
+
+	/**
+	 * REST callback for /integrations
 	 *
 	 * @param WP_REST_Request $request Request object.
 	 * @return WP_REST_Response Response object.
@@ -609,14 +647,11 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 		$integrations = array();
 
 		foreach ( $this->get_supported_integrations() as $slug => $config ) {
-			$integration_status = ( isset( $config['type'] ) && $config['type'] === 'plugin' )
-				? $this->get_plugin_status( $slug )
-				: $this->get_service_status( $slug );
-
+			$status = $this->get_integration( $slug );
 			if ( 1 === $version ) {
-				$integrations[ $slug ] = $integration_status;
+				$integrations[ $slug ] = $status;
 			} else {
-				$integrations[] = array_merge( array( 'id' => $slug ), $integration_status );
+				$integrations[] = $status;
 			}
 		}
 
@@ -630,46 +665,40 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 	 * @return array Service status data.
 	 */
 	private function get_service_status( $slug ) {
-		switch ( $slug ) {
-			case 'salesforce':
-				return array(
-					'type'        => 'service',
-					'slug'        => 'salesforce',
-					'pluginFile'  => null,
-					'isInstalled' => false,
-					'isActive'    => false,
-					'isConnected' => false,
-					'version'     => null,
-					'settingsUrl' => null,
-					'details'     => array(),
-				);
-			default:
-				return array(
-					'type'        => 'service',
-					'slug'        => $slug,
-					'pluginFile'  => null,
-					'isInstalled' => false,
-					'isActive'    => false,
-					'isConnected' => false,
-					'version'     => null,
-					'settingsUrl' => null,
-					'details'     => array(),
-				);
-		}
-	}
+		$config = $this->get_supported_integrations()[ $slug ];
 
-	/**
-	 * REST endpoint handler for single integration status.
-	 *
-	 * @param WP_REST_Request $request Request object.
-	 * @return WP_REST_Response Response object.
-	 */
-	public function get_single_integration_status( $request ) {
-		// Slug validation is handled in endpoint registration.
-		$slug = $request->get_param( 'slug' );
-		// For now, we only have plugin integrations.
-		// When needed, handle other integration types here.
-		return rest_ensure_response( $this->get_plugin_status( $slug ) );
+		// Default response for all integrations
+		$response = array(
+			'type'        => $config['type'],
+			'slug'        => $slug,
+			'isConnected' => false,
+			'settingsUrl' => isset( $config['settings_url'] ) ? $config['settings_url'] : null,
+			'pluginFile'  => null,
+			'isInstalled' => false,
+			'isActive'    => false,
+			'version'     => null,
+			'details'     => array(),
+		);
+
+		// Process settingsUrl to return a full URL if present (for services only)
+		if ( $response['settingsUrl'] ) {
+			$response['settingsUrl'] = esc_url( Redirect::get_url( $response['settingsUrl'] ) );
+		}
+
+		switch ( $slug ) {
+			case 'google-drive':
+				$user_id                 = get_current_user_id();
+				$jetpack_connected       = ( new Host() )->is_wpcom_simple() || ( new Connection_Manager( 'jetpack-forms' ) )->is_user_connected( $user_id );
+				$is_connected            = $jetpack_connected && Google_Drive::has_valid_connection( $user_id );
+				$response['isConnected'] = $is_connected;
+				break;
+			case 'salesforce':
+				// No overrides needed for now; keep defaults.
+				break;
+			// Add other service cases as needed.
+		}
+
+		return $response;
 	}
 
 	/**

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Endpoint_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Endpoint_Test.php
@@ -139,12 +139,19 @@ class Contact_Form_Endpoint_Test extends TestCase {
 		$this->assertArrayHasKey( 'akismet', $data );
 		$this->assertArrayHasKey( 'creative-mail-by-constant-contact', $data );
 		$this->assertArrayHasKey( 'zero-bs-crm', $data );
+		$this->assertArrayHasKey( 'google-drive', $data );
 
 		// Verify structure of one integration
 		$this->assertArrayHasKey( 'type', $data['akismet'] );
 		$this->assertArrayHasKey( 'isInstalled', $data['akismet'] );
 		$this->assertArrayHasKey( 'isActive', $data['akismet'] );
 		$this->assertArrayHasKey( 'isConnected', $data['akismet'] );
+
+		// Verify structure of google-drive
+		$this->assertArrayHasKey( 'type', $data['google-drive'] );
+		$this->assertArrayHasKey( 'isInstalled', $data['google-drive'] );
+		$this->assertArrayHasKey( 'isActive', $data['google-drive'] );
+		$this->assertArrayHasKey( 'isConnected', $data['google-drive'] );
 	}
 
 	/**
@@ -169,6 +176,7 @@ class Contact_Form_Endpoint_Test extends TestCase {
 		$this->assertContains( 'akismet', $integration_ids );
 		$this->assertContains( 'creative-mail-by-constant-contact', $integration_ids );
 		$this->assertContains( 'zero-bs-crm', $integration_ids );
+		$this->assertContains( 'google-drive', $integration_ids );
 
 		// Verify structure of each integration
 		foreach ( $data as $integration ) {
@@ -193,6 +201,39 @@ class Contact_Form_Endpoint_Test extends TestCase {
 	public function test_get_integrations_returns_401() {
 		wp_set_current_user( 0 );
 		$request  = new WP_REST_Request( 'GET', '/wp/v2/feedback/integrations' );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 401, $response->get_status() );
+	}
+
+	/**
+	 * Test GET feedback/integrations/{slug} with a valid integration
+	 */
+	public function test_get_single_integration_returns_200_and_structure() {
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/feedback/integrations/google-drive' );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+		$data = $response->get_data();
+		$this->assertArrayHasKey( 'type', $data );
+		$this->assertArrayHasKey( 'isInstalled', $data );
+		$this->assertArrayHasKey( 'isActive', $data );
+		$this->assertArrayHasKey( 'isConnected', $data );
+	}
+
+	/**
+	 * Test GET feedback/integrations/{slug} with an invalid integration
+	 */
+	public function test_get_single_integration_returns_400_for_invalid_slug() {
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/feedback/integrations/not-a-real-integration' );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 400, $response->get_status() );
+	}
+
+	/**
+	 * Test GET feedback/integrations/{slug} unauthorized access
+	 */
+	public function test_get_single_integration_returns_401_for_unauthorized() {
+		wp_set_current_user( 0 );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/feedback/integrations/google-drive' );
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 401, $response->get_status() );
 	}

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Endpoint_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Endpoint_Test.php
@@ -182,16 +182,26 @@ class Contact_Form_Endpoint_Test extends TestCase {
 		foreach ( $data as $integration ) {
 			$this->assertArrayHasKey( 'id', $integration );
 			$this->assertArrayHasKey( 'type', $integration );
+			$this->assertArrayHasKey( 'slug', $integration );
 			$this->assertArrayHasKey( 'isInstalled', $integration );
 			$this->assertArrayHasKey( 'isActive', $integration );
 			$this->assertArrayHasKey( 'isConnected', $integration );
+			$this->assertArrayHasKey( 'settingsUrl', $integration );
+			$this->assertArrayHasKey( 'pluginFile', $integration );
+			$this->assertArrayHasKey( 'version', $integration );
+			$this->assertArrayHasKey( 'details', $integration );
 
 			// Verify expected data types
 			$this->assertIsString( $integration['id'] );
 			$this->assertIsString( $integration['type'] );
+			$this->assertIsString( $integration['slug'] );
 			$this->assertIsBool( $integration['isInstalled'] );
 			$this->assertIsBool( $integration['isActive'] );
 			$this->assertIsBool( $integration['isConnected'] );
+			$this->assertTrue( $integration['settingsUrl'] === null || is_string( $integration['settingsUrl'] ) );
+			$this->assertTrue( $integration['pluginFile'] === null || is_string( $integration['pluginFile'] ) );
+			$this->assertTrue( $integration['version'] === null || is_string( $integration['version'] ) );
+			$this->assertIsArray( $integration['details'] );
 		}
 	}
 
@@ -214,9 +224,14 @@ class Contact_Form_Endpoint_Test extends TestCase {
 		$this->assertEquals( 200, $response->get_status() );
 		$data = $response->get_data();
 		$this->assertArrayHasKey( 'type', $data );
+		$this->assertArrayHasKey( 'slug', $data );
 		$this->assertArrayHasKey( 'isInstalled', $data );
 		$this->assertArrayHasKey( 'isActive', $data );
 		$this->assertArrayHasKey( 'isConnected', $data );
+		$this->assertArrayHasKey( 'settingsUrl', $data );
+		$this->assertArrayHasKey( 'pluginFile', $data );
+		$this->assertArrayHasKey( 'version', $data );
+		$this->assertArrayHasKey( 'details', $data );
 	}
 
 	/**

--- a/projects/plugins/jetpack/changelog/add-google-to-form-integrations-endpoint
+++ b/projects/plugins/jetpack/changelog/add-google-to-form-integrations-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: Add Google to form integrations endpoint.


### PR DESCRIPTION
## Proposed changes:

Updates forms integrations endpoint with the following changes:
- Return data for Google drive. Mostly what we need here is connected status. Fetching for this is patterned off code here and here (eventually those other endpoints will be removed). 
- Update /integrations (all integrations) and /integrations/[slug] (single integration) endpoints to rely on the same get_integration() method for consistency. 
- A bit of other clean up to ensure we do not duplicate anything and return consistent data. 
- Added tests for single integration endpoint, and updated tests for all integrations endpoint to cover Google.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None. 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No. 

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

First, confirm that these changes did not break our existing endpoint behavior for other integrations.
- Add a form block to a page
- Click to open the Integrations modal
- Confirm correct state and behavior for Akismet, Jetpack CRM, Creative Mail, and Salesforce cards. 

Second, confirm tests for this endpoint pass. 
- Navigate to projects/packages/forms
- Run `composer install`
- Run `composer test-php tests/php/contact-form/Contact_Form_Endpoint_Test.php`

Third, check that we return correct data for Google Drive. 
- Refresh this page
- One page is loaded, open network tab in browser, and clear history
- Select your form block, which will cause the request to the integrations endpoint to fire
- In your network tab, check that the expected data is returned for the Google endpoint along with the data for the other integrations. The data should look like this. Most of these will be fixed, and the only thing that should vary is isConnected, which will show true if your site has connected Google drive, or else false. 

``` 
{
        "type": "service",
        "slug": "google-drive",
        "isConnected": false, // will depend on if its conen
        "settingsUrl": null,
        "pluginFile": null,
        "isInstalled": false,
        "isActive": false,
        "version": null,
        "details": [],
        "id": "google-drive"
  }
 ```