### PR TITLE
My Jetpack: Update small screen styles for button in notice

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/styles.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/styles.module.scss
@@ -81,6 +81,10 @@
 			> div:has(svg) {
 				position: initial;
 			}
+
+			:global(.components-button) {
+				white-space: normal;
+			}
 		}
 	}
 

--- a/projects/packages/my-jetpack/changelog/update-notice-button-breaking-styles
+++ b/projects/packages/my-jetpack/changelog/update-notice-button-breaking-styles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jtepack: Fixed styles for notice in small screens.

--- a/projects/packages/my-jetpack/changelog/update-notice-button-breaking-styles
+++ b/projects/packages/my-jetpack/changelog/update-notice-button-breaking-styles
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-My Jtepack: Fixed styles for notice in small screens.
+My Jetpack: Fixed styles for notice in small screens.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes VULCAN-10

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Changed styles for the buttons in notices to use `white-space: normal;` when in smaller screens

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Test on a new site with Jetpack Complete and CRM not installed
- Use the Browser's dev tools to see how this works at smaller screen sizes or test with an actual mobile device.

