### PR TITLE
Jetpack Forms: fix forms dashboard not loading on different languages

### DIFF
--- a/projects/packages/forms/changelog/fix-jetpack-forms-menu-page-translated-bug
+++ b/projects/packages/forms/changelog/fix-jetpack-forms-menu-page-translated-bug
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Jetpack Forms: fix a bug preventing responses dashboard to load (blank screen)

--- a/projects/packages/forms/src/dashboard/class-dashboard-view-switch.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard-view-switch.php
@@ -30,18 +30,6 @@ class Dashboard_View_Switch {
 	const MODERN_VIEW = 'modern';
 
 	/**
-	 * Modern screen IDs.
-	 *
-	 * @var array
-	 */
-	const MODERN_SCREEN_IDS = array(
-		'toplevel_page_jetpack-forms',
-		'admin_page_jetpack-forms',
-		'jetpack_page_jetpack-forms',
-		'feedback_page_jetpack-forms',
-	);
-
-	/**
 	 * Initialize the switch.
 	 */
 	public function init() {
@@ -315,12 +303,15 @@ CSS
 	 * @return boolean
 	 */
 	public function is_modern_view() {
-		$screen = get_current_screen();
+		// The menu slug might vary depending on language, but modern view is always a jetpack-forms page.
+		// See: https://a8c.slack.com/archives/C03TY6J1A/p1747148941583849
+		$page_hook_suffix = '_page_jetpack-forms';
+		$screen           = get_current_screen();
 
 		// When classic view is set as preferred, jetpack-forms is registered under different
 		// parents so it doesn't appear in the menu.
 		// Because of this, we need to support these screens.
-		return $screen && in_array( $screen->id, self::MODERN_SCREEN_IDS, true );
+		return $screen && str_ends_with( $screen->id, $page_hook_suffix );
 	}
 
 	/**

--- a/projects/packages/forms/src/dashboard/class-dashboard-view-switch.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard-view-switch.php
@@ -92,20 +92,14 @@ class Dashboard_View_Switch {
 				margin: 0 0 0 6px;
 			}
 
-			.toplevel_page_jetpack-forms :not(#screen-meta-links) > #jetpack-forms__view-link-wrap,
-			.jetpack_page_jetpack-forms :not(#screen-meta-links) > #jetpack-forms__view-link-wrap,
-			.feedback_page_jetpack-forms :not(#screen-meta-links) > #jetpack-forms__view-link-wrap,
-			.admin_page_jetpack-forms :not(#screen-meta-links) > #jetpack-forms__view-link-wrap {
+			body[class*="_page_jetpack-forms"] :not(#screen-meta-links) > #jetpack-forms__view-link-wrap {
 				position: absolute;
 				right: 32px;
 				top: 0;
 				z-index: 179;
 			}
 
-			.toplevel_page_jetpack-forms #jetpack-forms__view-link,
-			.jetpack_page_jetpack-forms #jetpack-forms__view-link,
-			.feedback_page_jetpack-forms #jetpack-forms__view-link,
-			.admin_page_jetpack-forms #jetpack-forms__view-link {
+			body[class*="_page_jetpack-forms"] #jetpack-forms__view-link {
 				background-color: #fff;
 				border: 1px solid #c3c4c7;
 				border-top: none;
@@ -117,10 +111,7 @@ class Dashboard_View_Switch {
 				padding: 3px 6px 3px 16px;
 			}
 
-			.toplevel_page_jetpack-forms #jetpack-forms__view-link::after,
-			.jetpack_page_jetpack-forms #jetpack-forms__view-link::after,
-			.feedback_page_jetpack-forms #jetpack-forms__view-link::after,
-			.admin_page_jetpack-forms #jetpack-forms__view-link::after {
+			body[class*="_page_jetpack-forms"] #jetpack-forms__view-link::after {
 				right: 0;
 				content: "\\f140";
 				font: normal 20px/1 dashicons;

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -339,10 +339,6 @@ $action-bar-height: 88px;
 
 
 /* We need to make the available canvas 100% tall. Without this, no flex values will work, they will only use the available space. */
-// body.toplevel_page_jetpack-forms,
-// body.feedback_page_jetpack-forms,
-// body.jetpack_page_jetpack-forms,
-// body.admin_page_jetpack-forms,
 body[class*="_page_jetpack-forms"] {
 
 	#wpwrap,

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -339,10 +339,11 @@ $action-bar-height: 88px;
 
 
 /* We need to make the available canvas 100% tall. Without this, no flex values will work, they will only use the available space. */
-body.toplevel_page_jetpack-forms,
-body.feedback_page_jetpack-forms,
-body.jetpack_page_jetpack-forms,
-body.admin_page_jetpack-forms {
+// body.toplevel_page_jetpack-forms,
+// body.feedback_page_jetpack-forms,
+// body.jetpack_page_jetpack-forms,
+// body.admin_page_jetpack-forms,
+body[class*="_page_jetpack-forms"] {
 
 	#wpwrap,
 	#wpcontent,


### PR DESCRIPTION
Fixes FORMS-68

## Proposed changes:
This PR uses a suffix to check for page hook and css classes as our page hooks are reacting to translations.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1747148941583849-slack-C03TY6J1A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Visit Feedback > Form responses, verify that it continues to work as usual both in Classic and Inbox view (use top right View selector). The View selector working is part of the test.

Change your account settings (likely from https://wordpress.com/me/account) and switch to another language (Spanish shows this issue).

Visit the forms dashboard (Simple sites show menu as "Formularios", Atomic shows it as "Mensajes"). See that the page loads fine both on Classic and Inbox views.

If testing locally, also go to site settings and change the site language.

Test locally, on Simple sites and AT