### PR TITLE
Forms: Fix double scrollbars for responses

### DIFF
--- a/projects/packages/forms/changelog/update-form-responses-styles
+++ b/projects/packages/forms/changelog/update-form-responses-styles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Fix double scrollbars for responses.

--- a/projects/packages/forms/src/dashboard/components/layout/style.scss
+++ b/projects/packages/forms/src/dashboard/components/layout/style.scss
@@ -52,7 +52,7 @@ body.admin_page_jetpack-forms {
 		> .components-tab-panel__tabs {
 			margin: 0;
 			padding: 0 48px;
-			border-bottom: 1px solid #dcdcde;
+			border-bottom: 1px solid var(--jp-gray-5);
 
 			.components-tab-panel__tabs-item {
 				border-bottom: 2px solid transparent;

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -89,8 +89,8 @@ $action-bar-height: 88px;
 	flex-direction: column;
 	min-height: 300px;
 	overflow: hidden;
-	width: 100%;
 	background-color: #fff;
+	margin: 20px 20px 20px 0;
 	position: relative;
 
 	&::before {
@@ -303,7 +303,9 @@ $action-bar-height: 88px;
 
 	.dataviews-wrapper {
 		background: #fff;
-		border-radius: 8px;
+		height: auto;
+		overflow: visible;
+		border-right: 1px solid var(--jp-gray-5);
 
 		.dataviews__view-actions {
 			align-items: center;

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -90,7 +90,6 @@ $action-bar-height: 88px;
 	min-height: 300px;
 	overflow: hidden;
 	background-color: #fff;
-	margin: 20px 20px 20px 0;
 	position: relative;
 
 	&::before {
@@ -131,6 +130,10 @@ $action-bar-height: 88px;
 				z-index: 1;
 			}
 		}
+	}
+
+	@media (min-width: 816px) {
+		margin: 20px 20px 20px 0;
 	}
 }
 
@@ -298,14 +301,17 @@ $action-bar-height: 88px;
 	display: flex;
 	flex-direction: column;
 	height: 100%;
-	max-height: 100vh;
 	flex: 1 1 50%;
 
 	.dataviews-wrapper {
 		background: #fff;
 		height: auto;
-		overflow: visible;
-		border-right: 1px solid var(--jp-gray-5);
+		overflow-y: visible;
+		overflow-x: auto;
+
+		@media (min-width: 782px) {
+			border-right: 1px solid var(--jp-gray-5);
+		}
 
 		.dataviews__view-actions {
 			align-items: center;

--- a/projects/plugins/jetpack/changelog/update-form-responses-styles
+++ b/projects/plugins/jetpack/changelog/update-form-responses-styles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: Fix double scrollbars for responses.


### PR DESCRIPTION
## Proposed changes:

Fixes double scrollbars for forms lists, and padding around single forms responses. Note: we need to keep horizontal scrollbars on the dataviews table or else decide to hide a lot of columns on mobile or smaller screens. 

**Before**
<img width="1354" alt="form-scrollbars-before" src="https://github.com/user-attachments/assets/1dd53cc4-993a-4da7-a5f5-301d09ac90fc" />

**After**
<img width="1350" alt="forms-scrollbars-after" src="https://github.com/user-attachments/assets/b616f529-bea4-47d4-82c4-8ff1ea9ea808" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Slacke: p1747229919224019-slack-C052XEUUBL4

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the Feedback screen. You'll need site with many form submission.
* Confirm you can never trigger double scrollbars on the page and dataviews table. 
* Click a single response and confirm there is reasonable padding on the top and right.
* It's tricky to get this all just right across screensizes, so check mobile too. We still need horizontal scrolling on the dataviews table on mobile, and the single response screen pops up in a modal. 