### PR TITLE
Forms: Add useIntegrationStatus hook for Google Drive

### DIFF
--- a/projects/packages/forms/changelog/update-forms-new-google-endpoint
+++ b/projects/packages/forms/changelog/update-forms-new-google-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: Get Google status with new useIntegrationStatus hook.

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/hooks/useIntegrationStatus.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/hooks/useIntegrationStatus.js
@@ -1,0 +1,57 @@
+import apiFetch from '@wordpress/api-fetch';
+import { useState, useEffect, useCallback } from '@wordpress/element';
+
+/**
+ * Custom hook to fetch and manage a single integration's status.
+ *
+ * @param {string} slug - The integration slug (e.g., 'google-drive')
+ * @return {object} Object containing integration data and loading state
+ */
+export const useIntegrationStatus = slug => {
+	const [ status, setStatus ] = useState( {
+		isLoading: true,
+		integration: null,
+		error: null,
+	} );
+
+	const fetchIntegration = useCallback( async () => {
+		if ( ! slug ) {
+			setStatus( {
+				isLoading: false,
+				integration: null,
+				error: new Error( 'No integration slug provided.' ),
+			} );
+			return;
+		}
+		try {
+			const response = await apiFetch( {
+				path: `/wp/v2/feedback/integrations/${ slug }`,
+			} );
+			setStatus( {
+				isLoading: false,
+				integration: response,
+				error: null,
+			} );
+		} catch ( error ) {
+			setStatus( {
+				isLoading: false,
+				integration: null,
+				error,
+			} );
+		}
+	}, [ slug ] );
+
+	useEffect( () => {
+		fetchIntegration();
+	}, [ fetchIntegration ] );
+
+	const refreshStatus = useCallback( async () => {
+		setStatus( current => ( {
+			...current,
+			isLoading: true,
+		} ) );
+		await fetchIntegration();
+	}, [ fetchIntegration ] );
+
+	return { ...status, refreshStatus };
+};

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -692,7 +692,7 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 				$jetpack_connected       = ( new Host() )->is_wpcom_simple() || ( new Connection_Manager( 'jetpack-forms' ) )->is_user_connected( $user_id );
 				$is_connected            = $jetpack_connected && Google_Drive::has_valid_connection( $user_id );
 				$response['isConnected'] = $is_connected;
-				$response['settingsUrl'] = esc_url( Redirect::get_url( 'jetpack-form-responses-connect' ) );
+				$response['settingsUrl'] = esc_url( Redirect::get_url( 'jetpack-forms-responses-connect' ) );
 				break;
 			case 'salesforce':
 				// No overrides needed for now; keep defaults.

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -692,7 +692,7 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 				$jetpack_connected       = ( new Host() )->is_wpcom_simple() || ( new Connection_Manager( 'jetpack-forms' ) )->is_user_connected( $user_id );
 				$is_connected            = $jetpack_connected && Google_Drive::has_valid_connection( $user_id );
 				$response['isConnected'] = $is_connected;
-				$response['settingsUrl'] = esc_url( Redirect::get_url( 'jetpack-forms-responses-connect' ) );
+				$response['settingsUrl'] = Redirect::get_url( 'jetpack-forms-responses-connect' );
 				break;
 			case 'salesforce':
 				// No overrides needed for now; keep defaults.

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -692,6 +692,7 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 				$jetpack_connected       = ( new Host() )->is_wpcom_simple() || ( new Connection_Manager( 'jetpack-forms' ) )->is_user_connected( $user_id );
 				$is_connected            = $jetpack_connected && Google_Drive::has_valid_connection( $user_id );
 				$response['isConnected'] = $is_connected;
+				$response['settingsUrl'] = esc_url( Redirect::get_url( 'jetpack-form-responses-connect' ) );
 				break;
 			case 'salesforce':
 				// No overrides needed for now; keep defaults.

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -165,7 +165,6 @@ class Dashboard {
 			'blogId'                  => get_current_blog_id(),
 			'exportNonce'             => wp_create_nonce( 'feedback_export' ),
 			'newFormNonce'            => wp_create_nonce( 'create_new_form' ),
-			'gdriveConnectURL'        => esc_url( Redirect::get_url( 'jetpack-forms-responses-connect' ) ),
 			'gdriveConnectSupportURL' => esc_url( Redirect::get_url( 'jetpack-support-contact-form-export' ) ),
 			'checkForSpamNonce'       => wp_create_nonce( 'grunion_recheck_queue' ),
 			'pluginAssetsURL'         => Jetpack_Forms::assets_url(),

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -9,10 +9,8 @@ namespace Automattic\Jetpack\Forms\Dashboard;
 
 use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Connection\Initial_State as Connection_Initial_State;
-use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin;
 use Automattic\Jetpack\Forms\Jetpack_Forms;
-use Automattic\Jetpack\Forms\Service\Google_Drive;
 use Automattic\Jetpack\Redirect;
 use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Status\Host;
@@ -163,14 +161,10 @@ class Dashboard {
 		$ai_feature = \Jetpack_AI_Helper::get_ai_assistance_feature();
 		$has_ai     = ! is_wp_error( $ai_feature ) ? $ai_feature['has-feature'] : false;
 
-		$jetpack_connected = ( defined( 'IS_WPCOM' ) && IS_WPCOM ) || ( new Connection_Manager( 'jetpack-forms' ) )->is_user_connected( get_current_user_id() );
-		$user_id           = (int) get_current_user_id();
-
 		$config = array(
 			'blogId'                  => get_current_blog_id(),
 			'exportNonce'             => wp_create_nonce( 'feedback_export' ),
 			'newFormNonce'            => wp_create_nonce( 'create_new_form' ),
-			'gdriveConnection'        => $jetpack_connected && Google_Drive::has_valid_connection( $user_id ),
 			'gdriveConnectURL'        => esc_url( Redirect::get_url( 'jetpack-forms-responses-connect' ) ),
 			'gdriveConnectSupportURL' => esc_url( Redirect::get_url( 'jetpack-support-contact-form-export' ) ),
 			'checkForSpamNonce'       => wp_create_nonce( 'grunion_recheck_queue' ),

--- a/projects/packages/forms/src/dashboard/inbox/export-responses/google-drive.js
+++ b/projects/packages/forms/src/dashboard/inbox/export-responses/google-drive.js
@@ -15,7 +15,7 @@ import { useIntegrationStatus } from '../../../blocks/contact-form/components/je
 import { PARTIAL_RESPONSES_PATH, PREFERRED_VIEW } from '../../../util/get-preferred-responses-view';
 
 const GoogleDriveExport = ( { onExport, autoConnect = false } ) => {
-	const { integration, isLoading, refreshStatus } = useIntegrationStatus( 'google-drive' );
+	const { integration, refreshStatus } = useIntegrationStatus( 'google-drive' );
 	const isConnectedToGoogleDrive = !! integration?.isConnected;
 	const { tracks } = useAnalytics();
 	const autoConnectOpened = useRef( false );
@@ -104,7 +104,7 @@ const GoogleDriveExport = ( { onExport, autoConnect = false } ) => {
 					</div>
 				</div>
 				<div className="jp-forms__export-modal-card-body-cta">
-					{ isLoading && ! isConnectedToGoogleDrive ? (
+					{ ! integration ? (
 						<Spinner />
 					) : (
 						<>

--- a/projects/packages/forms/src/dashboard/inbox/export-responses/google-drive.js
+++ b/projects/packages/forms/src/dashboard/inbox/export-responses/google-drive.js
@@ -133,7 +133,7 @@ const GoogleDriveExport = ( { onExport, autoConnect = false } ) => {
 
 							{ ! isConnectedToGoogleDrive && isUserConnected && (
 								<Button
-									href={ config( 'gdriveConnectURL' ) }
+									href={ integration?.settingsUrl }
 									className={ buttonClasses }
 									variant="primary"
 									rel="noopener noreferrer"

--- a/projects/packages/forms/src/dashboard/inbox/export-responses/google-drive.js
+++ b/projects/packages/forms/src/dashboard/inbox/export-responses/google-drive.js
@@ -7,11 +7,11 @@ import { Button, Spinner } from '@wordpress/components';
 import { useCallback, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
-import { config } from '../..';
-import { useIntegrationStatus } from '../../../blocks/contact-form/components/jetpack-integrations-modal/hooks/useIntegrationStatus';
 /**
  * Internal dependencies
  */
+import { config } from '../..';
+import { useIntegrationStatus } from '../../../blocks/contact-form/components/jetpack-integrations-modal/hooks/useIntegrationStatus';
 import { PARTIAL_RESPONSES_PATH, PREFERRED_VIEW } from '../../../util/get-preferred-responses-view';
 
 const GoogleDriveExport = ( { onExport, autoConnect = false } ) => {

--- a/projects/packages/forms/src/dashboard/inbox/export-responses/google-drive.js
+++ b/projects/packages/forms/src/dashboard/inbox/export-responses/google-drive.js
@@ -133,7 +133,7 @@ const GoogleDriveExport = ( { onExport, autoConnect = false } ) => {
 
 							{ ! isConnectedToGoogleDrive && isUserConnected && (
 								<Button
-									href={ integration?.settingsUrl }
+									href={ config( 'gdriveConnectURL' ) }
 									className={ buttonClasses }
 									variant="primary"
 									rel="noopener noreferrer"

--- a/projects/packages/forms/src/dashboard/inbox/export-responses/google-drive.js
+++ b/projects/packages/forms/src/dashboard/inbox/export-responses/google-drive.js
@@ -3,21 +3,20 @@
  */
 import { useConnection } from '@automattic/jetpack-connection';
 import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
-import { Button } from '@wordpress/components';
-import { useCallback, useState, useRef } from '@wordpress/element';
+import { Button, Spinner } from '@wordpress/components';
+import { useCallback, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
-import { tap } from 'lodash';
+import { config } from '../..';
+import { useIntegrationStatus } from '../../../blocks/contact-form/components/jetpack-integrations-modal/hooks/useIntegrationStatus';
 /**
  * Internal dependencies
  */
-import { config } from '../..';
 import { PARTIAL_RESPONSES_PATH, PREFERRED_VIEW } from '../../../util/get-preferred-responses-view';
 
 const GoogleDriveExport = ( { onExport, autoConnect = false } ) => {
-	const [ isConnectedToGoogleDrive, setIsConnectedToGoogleDrive ] = useState(
-		config( 'gdriveConnection' )
-	);
+	const { integration, isLoading, refreshStatus } = useIntegrationStatus( 'google-drive' );
+	const isConnectedToGoogleDrive = !! integration?.isConnected;
 	const { tracks } = useAnalytics();
 	const autoConnectOpened = useRef( false );
 
@@ -32,28 +31,13 @@ const GoogleDriveExport = ( { onExport, autoConnect = false } ) => {
 				clearInterval( interval );
 				return;
 			}
-
 			try {
-				const response = await fetch( window.ajaxurl, {
-					method: 'POST',
-					body: tap( new FormData(), data => {
-						data.append( 'action', 'grunion_gdrive_connection' );
-						data.append( 'feedback_export_nonce_gdrive', config( 'exportNonce' ) );
-					} ),
-				} );
-				const data = await response.json();
-
-				if ( data.connection !== true ) {
-					return;
-				}
-
-				clearInterval( interval );
-				setIsConnectedToGoogleDrive( true );
+				await refreshStatus();
 			} catch {
 				clearInterval( interval );
 			}
 		}, 5000 );
-	}, [ isConnectedToGoogleDrive ] );
+	}, [ isConnectedToGoogleDrive, refreshStatus ] );
 
 	const exportToGoogleDrive = useCallback( () => {
 		tracks.recordEvent( 'jetpack_forms_export_click', {
@@ -120,42 +104,52 @@ const GoogleDriveExport = ( { onExport, autoConnect = false } ) => {
 					</div>
 				</div>
 				<div className="jp-forms__export-modal-card-body-cta">
-					{ isConnectedToGoogleDrive && (
-						<Button className={ buttonClasses } variant="primary" onClick={ exportToGoogleDrive }>
-							{ __( 'Export', 'jetpack-forms' ) }
-						</Button>
-					) }
+					{ isLoading && ! isConnectedToGoogleDrive ? (
+						<Spinner />
+					) : (
+						<>
+							{ isConnectedToGoogleDrive && (
+								<Button
+									className={ buttonClasses }
+									variant="primary"
+									onClick={ exportToGoogleDrive }
+								>
+									{ __( 'Export', 'jetpack-forms' ) }
+								</Button>
+							) }
 
-					{ ! isConnectedToGoogleDrive && ! isUserConnected && (
-						<Button
-							className={ buttonClasses }
-							variant="primary"
-							rel="noopener noreferrer"
-							target="_blank"
-							onClick={ handleConnectUser }
-							isBusy={ userIsConnecting }
-						>
-							{ __( 'Connect Jetpack user account', 'jetpack-forms' ) }
-						</Button>
-					) }
+							{ ! isConnectedToGoogleDrive && ! isUserConnected && (
+								<Button
+									className={ buttonClasses }
+									variant="primary"
+									rel="noopener noreferrer"
+									target="_blank"
+									onClick={ handleConnectUser }
+									isBusy={ userIsConnecting }
+								>
+									{ __( 'Connect Jetpack user account', 'jetpack-forms' ) }
+								</Button>
+							) }
 
-					{ ! isConnectedToGoogleDrive && isUserConnected && (
-						<Button
-							href={ config( 'gdriveConnectURL' ) }
-							className={ buttonClasses }
-							variant="primary"
-							rel="noopener noreferrer"
-							target="_blank"
-							onClick={ handleConnectClick }
-							ref={ el => {
-								if ( autoConnect && ! autoConnectOpened.current ) {
-									el?.click();
-									autoConnectOpened.current = true;
-								}
-							} }
-						>
-							{ __( 'Connect to Google Drive', 'jetpack-forms' ) }
-						</Button>
+							{ ! isConnectedToGoogleDrive && isUserConnected && (
+								<Button
+									href={ config( 'gdriveConnectURL' ) }
+									className={ buttonClasses }
+									variant="primary"
+									rel="noopener noreferrer"
+									target="_blank"
+									onClick={ handleConnectClick }
+									ref={ el => {
+										if ( autoConnect && ! autoConnectOpened.current ) {
+											el?.click();
+											autoConnectOpened.current = true;
+										}
+									} }
+								>
+									{ __( 'Connect to Google Drive', 'jetpack-forms' ) }
+								</Button>
+							) }
+						</>
 					) }
 				</div>
 			</div>


### PR DESCRIPTION
## Proposed changes:

A [recent PR](https://github.com/Automattic/jetpack/pull/43453) updated our integrations endpoint to (a) include Google Drive and (b) improve the endpoint for fetching single integrations vs multiple. This PR: 
 - Creates a new custom hook for fetching the status of a single integration (will be usable for many other cases beyond the one in this PR)
 - Updates our modern forms inbox to use use this hook to fetch Google status
 - Removes code in php that was getting google drive status and passing that to React
 
The polling method that's updated in this was using an old ajax endpoint/callback. We can't delete that yet because the classic inbox view is still using it. A time is coming soon when we'll remove the classic inbox view, at which point we can remove that method. The goal is to get to a point where we're using the same endpoint for all integration status checks.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None. 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

TIP: You'll get a slightly cleaner diff for this if you adjust the setting at the top of the diff page to hide whitespace. 

* This is a refactor. The code should work the same before and after. 
* Go to the feedback page, and confirm that the Google drive state shows and updates correctly. 
  - Upon modal opening, while fetching data for the GDrive connection, a spinner was added:

<img width="796" alt="image" src="https://github.com/user-attachments/assets/bc49845d-8b65-4656-ba1f-cbc7095e677a" />

  - Unconnected: If you have not connected google drive for you should see a Connect button. 
  - Connected: If you have connected google drive, you should see an export button. 
  - Connection process: Starting from unconnected, click the connect button which will take you to WordPress.com. You may need to select the site. But you'll end up on the marking page. Find the google drive button and click connect. Come back to the tab with the export modal and confirm the buttons updates from 'Connect' to 'Export' automatically. 

