### PR TITLE
Tooling: Catch error when providing an invalid project name to jetpack changelogger

### DIFF
--- a/tools/cli/commands/changelog.js
+++ b/tools/cli/commands/changelog.js
@@ -291,7 +291,9 @@ async function getProjectChangeTypes( needChangelog ) {
 	const types = {};
 	for ( const proj of needChangelog ) {
 		const composerJSON = readComposerJson( proj );
-		if (
+		if ( ! composerJSON ) {
+			process.exit( 1 );
+		} else if (
 			composerJSON.extra &&
 			composerJSON.extra.changelogger &&
 			composerJSON.extra.changelogger.types

--- a/tools/cli/helpers/json.js
+++ b/tools/cli/helpers/json.js
@@ -17,7 +17,10 @@ function readJson( project, packageManager, output ) {
 	try {
 		data = fs.readFileSync( `projects/${ project }/${ file }`, 'utf8' );
 	} catch {
-		output && log( chalk.yellow( `This project does not have a ${ file } file.` ) );
+		output &&
+			log(
+				chalk.yellow( `The '${ project }' project has no ${ file } file. Maybe there was a tpyo?` )
+			);
 		return undefined;
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This exits early if unable to read a project's JSON files. Before it would show a message but carry on, resulting in a TypeError shortly after and the actual message was hard to spot.

~I considered catching the error later, but it seemed like if there was no X file, it'd mean something else is probably amiss, so may as well abort.~

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
```
$ jetpack changelogger add asdf
This project does not have a composer.json file.
jetpack changelogger add [project]

Runs a changelogger add command for a project

Positionals:
  cmd      Command for changelog script to run
                       [string] [choices: "add", "validate", "write", "version"]
  project  Project in the form of type/name, e.g. plugins/jetpack       [string]

Options:
      --help                       Show help                           [boolean]
  -v, --verbose                    Enable verbose output
                                                      [boolean] [default: false]
  -f, --file                       Name of changelog file               [string]
  -s, --significance               Significance of changes (patch, minor, major)
                                                                        [string]
  -t, --type                       Type of change                       [string]
  -e, --entry                      Changelog entry                      [string]
  -c, --comment                    Changelog comment                    [string]
      --check-indirect-plugins     Always ask whether affected plugins without d
                                   irect changes should have change entries adde
                                   d.                                  [boolean]
      --no-check-indirect-plugins  Never ask whether affected plugins without di
                                   rect changes should have change entries added
                                   .                                   [boolean]
      --base-ref                   Git ref to compare to.
                                              [string] [default: "origin/trunk"]

TypeError: Cannot read properties of undefined (reading 'extra')
    at getProjectChangeTypes (file:///Users/tmb/GitHub/jetpack/tools/cli/commands/changelog.js:295:17)
    at doAddChangelogs (file:///Users/tmb/GitHub/jetpack/tools/cli/commands/changelog.js:435:35)
    at changelogAdd (file:///Users/tmb/GitHub/jetpack/tools/cli/commands/changelog.js:339:24)
    at Object.handler (file:///Users/tmb/GitHub/jetpack/tools/cli/commands/changelog.js:92:13)
    at file:///Users/tmb/GitHub/jetpack/node_modules/.pnpm/yargs@17.6.2/node_modules/yargs/build/lib/command.js:204:54
    at maybeAsyncResult (file:///Users/tmb/GitHub/jetpack/node_modules/.pnpm/yargs@17.6.2/node_modules/yargs/build/lib/utils/maybe-async-result.js:9:15)
    at CommandInstance.handleValidationAndGetResult (file:///Users/tmb/GitHub/jetpack/node_modules/.pnpm/yargs@17.6.2/node_modules/yargs/build/lib/command.js:203:25)
    at CommandInstance.applyMiddlewareAndGetResult (file:///Users/tmb/GitHub/jetpack/node_modules/.pnpm/yargs@17.6.2/node_modules/yargs/build/lib/command.js:243:20)
    at CommandInstance.runCommand (file:///Users/tmb/GitHub/jetpack/node_modules/.pnpm/yargs@17.6.2/node_modules/yargs/build/lib/command.js:128:20)
    at [runYargsParserAndExecuteCommands] (file:///Users/tmb/GitHub/jetpack/node_modules/.pnpm/yargs@17.6.2/node_modules/yargs/build/lib/yargs-factory.js:1375:105)
```

After:
```
$ jetpack changelogger add asdf
The 'asdf' project has no composer.json file. Maybe there was a tpyo?
```

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* `jetpack changelogger add asdf`
* Does this break other things?