### PR TITLE
locked-mode: Check option before checking feature

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-locked-mode
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-locked-mode
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: wpcom: locked-mode: Check option before checking feature
+
+

--- a/projects/packages/jetpack-mu-wpcom/src/features/100-year-plan/locked-mode.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/100-year-plan/locked-mode.php
@@ -15,7 +15,7 @@ function wpcom_lm_maybe_add_map_meta_cap_filter() {
 		return;
 	}
 
-	if ( wpcom_site_has_feature( WPCOM_Features::LOCKED_MODE ) && get_option( 'wpcom_locked_mode' ) ) {
+	if ( get_option( 'wpcom_locked_mode' ) && wpcom_site_has_feature( WPCOM_Features::LOCKED_MODE ) ) {
 		add_filter( 'map_meta_cap', 'wpcom_lm_remove_post_capabilities', 10, 2 );
 	} else {
 		remove_filter( 'map_meta_cap', 'wpcom_lm_remove_post_capabilities' );
@@ -199,7 +199,7 @@ function wpcom_lm_remove_post_capabilities( $caps, $cap ) {
  * @param bool $comments_open Whether the current post is open for comments.
  */
 function wpcom_lm_disable_comments( $comments_open ) {
-	if ( wpcom_site_has_feature( WPCOM_Features::LOCKED_MODE ) && get_option( 'wpcom_locked_mode' ) ) {
+	if ( get_option( 'wpcom_locked_mode' ) && wpcom_site_has_feature( WPCOM_Features::LOCKED_MODE ) ) {
 		return false;
 	}
 


### PR DESCRIPTION
## Proposed changes:

* In order to reduce the # of feature checks on the front-end, only check for the locked-mode feature after we've seen the locked mode option.

Most sites will have neither, and it's better to check the site's options.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?

## Testing instructions:

* Test on WPCOM Simple and verify the filter runs without crashing.

