### PR TITLE
Tooling: Fix some `jetpack generate` quirks

### DIFF
--- a/projects/plugins/automattic-for-agencies-client/changelog/update-tooling-add_wp_slug_via_generate_command
+++ b/projects/plugins/automattic-for-agencies-client/changelog/update-tooling-add_wp_slug_via_generate_command
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Clean up some Starter Plugin leakage.
+
+

--- a/projects/plugins/automattic-for-agencies-client/tests/e2e/specs/start.test.js
+++ b/projects/plugins/automattic-for-agencies-client/tests/e2e/specs/start.test.js
@@ -3,7 +3,7 @@ import { prerequisitesBuilder } from '_jetpack-e2e-commons/env/prerequisites.js'
 import { Sidebar, DashboardPage } from '_jetpack-e2e-commons/pages/wp-admin/index.js';
 import playwrightConfig from '../playwright.config.mjs';
 
-test.describe( 'Starter plugin!', () => {
+test.describe( 'Automattic for Agencies plugin!', () => {
 	test.beforeEach( async ( { browser } ) => {
 		const page = await browser.newPage( playwrightConfig.use );
 		await prerequisitesBuilder( page ).withCleanEnv().withLoggedIn( true ).build();

--- a/projects/plugins/classic-theme-helper-plugin/changelog/update-tooling-add_wp_slug_via_generate_command
+++ b/projects/plugins/classic-theme-helper-plugin/changelog/update-tooling-add_wp_slug_via_generate_command
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Clean up some Starter Plugin leakage.
+
+

--- a/projects/plugins/classic-theme-helper-plugin/tests/e2e/specs/start.test.js
+++ b/projects/plugins/classic-theme-helper-plugin/tests/e2e/specs/start.test.js
@@ -3,7 +3,7 @@ import { prerequisitesBuilder } from '_jetpack-e2e-commons/env/prerequisites.js'
 import { Sidebar, DashboardPage } from '_jetpack-e2e-commons/pages/wp-admin/index.js';
 import playwrightConfig from '../playwright.config.mjs';
 
-test.describe( 'Starter plugin!', () => {
+test.describe( 'Classic Theme Helper plugin!', () => {
 	test.beforeEach( async ( { browser } ) => {
 		const page = await browser.newPage( playwrightConfig.use );
 		await prerequisitesBuilder( page ).withCleanEnv().withLoggedIn( true ).build();

--- a/projects/plugins/starter-plugin/changelog/update-tooling-add_wp_slug_via_generate_command
+++ b/projects/plugins/starter-plugin/changelog/update-tooling-add_wp_slug_via_generate_command
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Clean up some Starter Plugin leakage.
+
+

--- a/projects/plugins/starter-plugin/composer.json
+++ b/projects/plugins/starter-plugin/composer.json
@@ -61,8 +61,7 @@
 	"extra": {
 		"mirror-repo": "Automattic/jetpack-starter-plugin",
 		"release-branch-prefix": "starter-plugin",
-		"beta-plugin-slug": "jetpack-starter-plugin",
-		"wp-plugin-slug": "jetpack-starter-plugin"
+		"beta-plugin-slug": "jetpack-starter-plugin"
 	},
 	"config": {
 		"allow-plugins": {

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "682976550e53f0e359e11f5d439d560b",
+    "content-hash": "85723ba4bb858bcfcd6330adc83db808",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",

--- a/projects/plugins/starter-plugin/jetpack-starter-plugin.php
+++ b/projects/plugins/starter-plugin/jetpack-starter-plugin.php
@@ -61,7 +61,7 @@ if ( is_readable( $jetpack_autoloader ) ) {
 		function ( $slugs ) {
 			$slugs['jetpack-starter-plugin-bad-installation'] = array(
 				'data' => array(
-					'plugin' => 'Jetpack Starter',
+					'plugin' => 'Jetpack Starter Plugin',
 				),
 			);
 
@@ -79,7 +79,7 @@ if ( is_readable( $jetpack_autoloader ) ) {
 			$message = sprintf(
 				wp_kses(
 					/* translators: Placeholder is a link to a support document. */
-					__( 'Your installation of Jetpack Starter is incomplete. If you installed Jetpack Starter Plugin from GitHub, please refer to <a href="%1$s" target="_blank" rel="noopener noreferrer">this document</a> to set up your development environment. Jetpack Starter Plugin must have Composer dependencies installed and built via the build command.', 'jetpack-starter-plugin' ),
+					__( 'Your installation of Jetpack Starter Plugin is incomplete. If you installed Jetpack Starter Plugin from GitHub, please refer to <a href="%1$s" target="_blank" rel="noopener noreferrer">this document</a> to set up your development environment. Jetpack Starter Plugin must have Composer dependencies installed and built via the build command.', 'jetpack-starter-plugin' ),
 					array(
 						'a' => array(
 							'href'   => array(),

--- a/projects/plugins/starter-plugin/src/class-jetpack-starter-plugin.php
+++ b/projects/plugins/starter-plugin/src/class-jetpack-starter-plugin.php
@@ -2,7 +2,7 @@
 /**
  * Primary class file for the Jetpack Starter Plugin plugin.
  *
- * @package automattic/jetpack-starter-plugin-plugin
+ * @package automattic/jetpack-starter-plugin
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/projects/plugins/starter-plugin/tests/e2e/specs/start.test.js
+++ b/projects/plugins/starter-plugin/tests/e2e/specs/start.test.js
@@ -3,7 +3,7 @@ import { prerequisitesBuilder } from '_jetpack-e2e-commons/env/prerequisites.js'
 import { Sidebar, DashboardPage } from '_jetpack-e2e-commons/pages/wp-admin/index.js';
 import playwrightConfig from '../playwright.config.mjs';
 
-test.describe( 'Starter plugin!', () => {
+test.describe( 'Starter Plugin!', () => {
 	test.beforeEach( async ( { browser } ) => {
 		const page = await browser.newPage( playwrightConfig.use );
 		await prerequisitesBuilder( page ).withCleanEnv().withLoggedIn( true ).build();

--- a/projects/plugins/starter-plugin/tests/php/Jetpack_Starter_Plugin_Test.php
+++ b/projects/plugins/starter-plugin/tests/php/Jetpack_Starter_Plugin_Test.php
@@ -2,7 +2,7 @@
 /**
  * Main plugin file testing.
  *
- * @package automattic/jetpack-social-plugin
+ * @package automattic/jetpack-starter-plugin
  */
 
 use WorDBless\BaseTestCase;

--- a/projects/plugins/starter-plugin/tests/php/Jetpack_Starter_Plugin_Test.php
+++ b/projects/plugins/starter-plugin/tests/php/Jetpack_Starter_Plugin_Test.php
@@ -22,17 +22,17 @@ class Jetpack_Starter_Plugin_Test extends BaseTestCase {
 	private static $user_id;
 
 	/**
-	 * The starter plugin object.
+	 * The Starter Plugin object.
 	 *
 	 * @var \Jetpack_Starter_Plugin
 	 */
-	public $starter;
+	public $starter_plugin;
 
 	/**
 	 * Initialize tests
 	 */
 	public function set_up() {
-		$this->starter = new Jetpack_Starter_Plugin();
+		$this->starter_plugin = new Jetpack_Starter_Plugin();
 	}
 
 	/**

--- a/projects/plugins/starter-plugin/tests/php/bootstrap.php
+++ b/projects/plugins/starter-plugin/tests/php/bootstrap.php
@@ -2,7 +2,7 @@
 /**
  * Bootstrap.
  *
- * @package automattic/
+ * @package automattic/jetpack-starter-plugin
  */
 
 /**

--- a/projects/plugins/videopress/changelog/update-tooling-add_wp_slug_via_generate_command
+++ b/projects/plugins/videopress/changelog/update-tooling-add_wp_slug_via_generate_command
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Clean up some Starter Plugin leakage.
+
+

--- a/projects/plugins/videopress/tests/e2e/specs/start.test.js
+++ b/projects/plugins/videopress/tests/e2e/specs/start.test.js
@@ -3,7 +3,7 @@ import { prerequisitesBuilder } from '_jetpack-e2e-commons/env/prerequisites.js'
 import { Sidebar, DashboardPage } from '_jetpack-e2e-commons/pages/wp-admin/index.js';
 import playwrightConfig from '../playwright.config.mjs';
 
-test.describe( 'Starter plugin!', () => {
+test.describe( 'VideoPress plugin!', () => {
 	test.beforeEach( async ( { browser } ) => {
 		const page = await browser.newPage( playwrightConfig.use );
 		await prerequisitesBuilder( page ).withCleanEnv().withLoggedIn( true ).build();

--- a/tools/cli/commands/generate.js
+++ b/tools/cli/commands/generate.js
@@ -378,7 +378,19 @@ async function generatePluginFromStarter( projDir, answers ) {
 	files = files.split( '\n' ).map( str => str.replace( 'projects/plugins/starter-plugin', '' ) );
 	files.forEach( file => {
 		if ( file && ! file.startsWith( 'changelog/' ) ) {
-			copyFile( path.join( projDir, file ), path.join( starterDir, file ) );
+			if ( file === 'tests/php/Jetpack_Starter_Plugin_Test.php' ) {
+				copyFile(
+					path.join(
+						projDir,
+						'tests/php/' + transformToPhpClassName( answers.name, false ) + '_Test.php'
+					),
+					path.join( starterDir, file )
+				);
+			} else if ( file === 'CHANGELOG.md' ) {
+				copyFile( path.join( projDir, file ), 'tools/cli/skeletons/common/CHANGELOG.md' );
+			} else {
+				copyFile( path.join( projDir, file ), path.join( starterDir, file ) );
+			}
 		}
 	} );
 

--- a/tools/cli/commands/generate.js
+++ b/tools/cli/commands/generate.js
@@ -440,6 +440,10 @@ async function generatePluginFromStarter( projDir, answers ) {
 	composerJson.extra ||= {};
 	composerJson.extra.changelogger ||= {};
 	composerJson.extra.changelogger.versioning = answers.versioningMethod;
+	// Add proposed WP.org slug if we've indicated this is a public plugin.
+	if ( answers.mirrorrepo ) {
+		composerJson.extra[ 'wp-plugin-slug' ] = normalizeSlug( answers.name );
+	}
 	writeComposerJson( answers.project, composerJson, answers.projDir );
 }
 

--- a/tools/cli/commands/generate.js
+++ b/tools/cli/commands/generate.js
@@ -452,9 +452,10 @@ async function generatePluginFromStarter( projDir, answers ) {
 	composerJson.extra ||= {};
 	composerJson.extra.changelogger ||= {};
 	composerJson.extra.changelogger.versioning = answers.versioningMethod;
-	// Add proposed WP.org slug if we've indicated this is a public plugin.
+	// Add proposed WP.org slug and remove alternative beta slug if we've indicated this is a public plugin.
 	if ( answers.mirrorrepo ) {
 		composerJson.extra[ 'wp-plugin-slug' ] = normalizeSlug( answers.name );
+		delete composerJson.extra[ 'beta-plugin-slug' ];
 	}
 	writeComposerJson( answers.project, composerJson, answers.projDir );
 }

--- a/tools/cli/commands/generate.js
+++ b/tools/cli/commands/generate.js
@@ -14,7 +14,7 @@ import {
 	writePackageJson,
 	writeComposerJson,
 } from '../helpers/json.js';
-import mergeDirs, { copyFile } from '../helpers/mergeDirs.js';
+import mergeDirs, { copyFile, copySymlink } from '../helpers/mergeDirs.js';
 import { normalizeGenerateArgv } from '../helpers/normalizeArgv.js';
 import { projectTypes, checkNameValid } from '../helpers/projectHelpers.js';
 import {
@@ -388,6 +388,8 @@ async function generatePluginFromStarter( projDir, answers ) {
 				);
 			} else if ( file === 'CHANGELOG.md' ) {
 				copyFile( path.join( projDir, file ), 'tools/cli/skeletons/common/CHANGELOG.md' );
+			} else if ( fs.lstatSync( path.join( starterDir, file ) ).isSymbolicLink() ) {
+				copySymlink( path.join( projDir, file ), path.join( starterDir, file ) );
 			} else {
 				copyFile( path.join( projDir, file ), path.join( starterDir, file ) );
 			}

--- a/tools/cli/commands/generate.js
+++ b/tools/cli/commands/generate.js
@@ -382,7 +382,7 @@ async function generatePluginFromStarter( projDir, answers ) {
 				copyFile(
 					path.join(
 						projDir,
-						'tests/php/' + transformToPhpClassName( answers.name, false ) + '_Test.php'
+						'tests/php/' + transformToPhpClassName( answers.name ) + '_Test.php'
 					),
 					path.join( starterDir, file )
 				);

--- a/tools/cli/commands/generate.js
+++ b/tools/cli/commands/generate.js
@@ -266,15 +266,15 @@ export function getQuestions( type ) {
 		{
 			type: 'select',
 			name: 'pluginTemplate',
-			message: 'Create a blank plugin or use the Starter plugin?',
+			message: 'Use the Starter plugin or a blank plugin as a template?',
 			choices: [
-				{
-					message: 'Blank plugin',
-					value: 'blank',
-				},
 				{
 					message: 'Use Jetpack Starter plugin',
 					value: 'starter',
+				},
+				{
+					message: 'Blank plugin',
+					value: 'blank',
 				},
 			],
 		},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This applies a few small changes to `jetpack generate`:

* `wp-plugin-slug` is added on the fly only if one states it's a public plugin (i.e. needs a mirror repo)
* The Starter Plugin is now default instead of the blank plugin skeleton.
* `CHANGELOG.md` is now copied from the blank plugin skeleton instead of the Starter Plugin.
* The PHPUnit test file is now renamed when copying from the Starter Plugin.

I also addressed a few places where the Starter Plugin name leaked into the generated plugin and fixed a few small typos.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Verify `jetpack generate` works for generating a plugin, and results in no "starter" leakage.
2. Verify tests run on the generated plugin: `jetpack test php plugins/some_plugin`

