### PR TITLE
Forms: standardize animated variation style paddings

### DIFF
--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -525,14 +525,6 @@
 	}
 }
 
-:where(:not(.contact-form)) > .jetpack-field {
-
-	.jetpack-field__input, .jetpack-field__textarea {
-		padding-left: max(var(--jetpack--contact-form--input-padding-left, 16px), var(--jetpack--contact-form--border-radius));
-		padding-right: max(var(--jetpack--contact-form--input-padding-left, 16px), var(--jetpack--contact-form--border-radius));
-	}
-}
-
 // Duplicated to elevate specificity in order to overwrite core styles
 .jetpack-field-multiple__list.jetpack-field-multiple__list {
 	list-style-type: none;
@@ -919,15 +911,15 @@
 			.jetpack-field-dropdown__toggle
 			{
 				padding-top: 1.4em;
-				padding-left: var(--jetpack--contact-form--field-padding);
+				padding-left: var(--jetpack--contact-form--animated-left-offset);
 			}
 
 			.animated-label__label {
 				position: absolute;
 				z-index: 1;
 				top: 50%;
-				left: var(--jetpack--contact-form--label-left);
-				width: calc( 100% - var(--jetpack--contact-form--label-left));
+				left: calc(var(--jetpack--contact-form--border-size, 0px) + var(--jetpack--contact-form--animated-left-offset));
+				width: auto;
 				max-width: 100%;
 				box-sizing: border-box;
 				margin: 0;
@@ -939,17 +931,22 @@
 				}
 			}
 
+			.jetpack-field-multiple__list.jetpack-field-multiple__list--has-border {
+				padding-left: var(--jetpack--contact-form--animated-left-offset);
+			}
 
-			&.jetpack-field-multiple {
 
-				.animated-label__label {
-					position: static;
-				}
+			&.jetpack-field-multiple .animated-label__label {
+				position: static;
 			}
 
 			&.jetpack-field-textarea .animated-label__label {
 				transform: unset;
-				top: var(--jetpack--contact-form--input-padding-top, 16px);
+				top: var(--jetpack--contact-form--animated-left-offset);
+			}
+
+			&.jetpack-field-textarea .animated-label__label {
+				top: var(--jetpack--contact-form--border-size);
 			}
 
 			&.is-selected, &.has-placeholder {

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -357,7 +357,7 @@
 		border: var(--jetpack--contact-form--border, 1px solid #8c8f94);
 		border-color: var(--jetpack--contact-form--border-color, #8c8f94);
 		border-style: var(--jetpack--contact-form--border-style, solid);
-		border-width: var(--jetpack--contact-form--border-size, 1px);
+		border-width: var(--jetpack--contact-form--border-left-size, 1px);
 	}
 
 	.components-base-control__field {
@@ -849,7 +849,7 @@
 				}
 
 				.notched-label__label {
-					top: calc(var(--jetpack--contact-form--border-size) * -1);
+					top: calc(var(--jetpack--contact-form--border-top-size) * -1);
 					transform: translateY(-50%);
 					font-size: 0.8em;
 				}
@@ -917,8 +917,8 @@
 			.animated-label__label {
 				position: absolute;
 				z-index: 1;
-				top: 50%;
-				left: calc(var(--jetpack--contact-form--border-size, 0px) + var(--jetpack--contact-form--animated-left-offset));
+				top: var(--jetpack--contact-form--animated-top-offset);
+				left: calc(var(--jetpack--contact-form--border-left-size, 1px) + var(--jetpack--contact-form--animated-left-offset));
 				width: auto;
 				max-width: 100%;
 				box-sizing: border-box;
@@ -946,7 +946,8 @@
 			}
 
 			&.jetpack-field-textarea .animated-label__label {
-				top: var(--jetpack--contact-form--border-size);
+				top: calc(2px + var(--jetpack--contact-form--border-top-size, 1px));
+
 			}
 
 			&.is-selected, &.has-placeholder {
@@ -954,7 +955,7 @@
 				.animated-label__label {
 					font-size: 0.75em;
 					transform: translateY(0);
-					top: calc(2px + var(--jetpack--contact-form--border-size));
+					top: calc(2px + var(--jetpack--contact-form--border-top-size, 1px));
 				}
 			}
 		}

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -942,12 +942,7 @@
 
 			&.jetpack-field-textarea .animated-label__label {
 				transform: unset;
-				top: var(--jetpack--contact-form--animated-left-offset);
-			}
-
-			&.jetpack-field-textarea .animated-label__label {
 				top: calc(2px + var(--jetpack--contact-form--border-top-size, 1px));
-
 			}
 
 			&.is-selected, &.has-placeholder {

--- a/projects/packages/forms/src/blocks/shared/hooks/use-variation-style-properties.js
+++ b/projects/packages/forms/src/blocks/shared/hooks/use-variation-style-properties.js
@@ -46,10 +46,8 @@ function getBorderRadiusCssVar( style ) {
 /**
  * Returns the border widths for the input block.
  *
- * @param {object} blockAttributes    - The attributes of the input block.
- * @param {object} globalStyles       - The global styles.
- * @param          blockBorderStyles
- * @param          globalBorderStyles
+ * @param {object} blockBorderStyles  - The attributes of the input block.
+ * @param {object} globalBorderStyles - The global styles.
  * @return {object} The border widths.
  */
 function getBorderWidths( blockBorderStyles, globalBorderStyles ) {

--- a/projects/packages/forms/src/blocks/shared/hooks/use-variation-style-properties.js
+++ b/projects/packages/forms/src/blocks/shared/hooks/use-variation-style-properties.js
@@ -144,6 +144,9 @@ export default function useVariationStyleProperties( {
 			.join( ' ' );
 
 		let styleSpecificCssVars = {};
+		const borderRadius =
+			getBorderRadius( blockBorderClassesAndStyles.style ) ||
+			getBorderRadius( globalBorderClassesAndStyles.style );
 
 		if ( formStyle === FORM_STYLE.OUTLINED ) {
 			styleSpecificCssVars = {
@@ -152,17 +155,8 @@ export default function useVariationStyleProperties( {
 			};
 		}
 		if ( formStyle === FORM_STYLE.ANIMATED ) {
-			const borderLeftSize =
-				getIntAsPxValue( blockBorderClassesAndStyles?.style?.borderWidth ) ||
-				blockBorderClassesAndStyles?.style?.borderLeftWidth ||
-				globalBorderClassesAndStyles?.style?.borderWidth ||
-				globalBorderClassesAndStyles?.style?.borderLeftWidth ||
-				'1px';
 			styleSpecificCssVars = {
-				'--jetpack--contact-form--left-offset': `calc(var(--jetpack--contact-form--input-padding-left, 16px) + ${ borderLeftSize })`,
-				'--jetpack--contact-form--label-left':
-					'max(var(--jetpack--contact-form--left-offset), var(--jetpack--contact-form--border-radius))',
-				'--jetpack--contact-form--field-padding': `calc(var(--jetpack--contact-form--label-left) - ${ borderLeftSize })`,
+				'--jetpack--contact-form--animated-left-offset': borderRadius ? '32px' : '16px',
 			};
 		}
 

--- a/projects/packages/forms/src/blocks/shared/hooks/use-variation-style-properties.js
+++ b/projects/packages/forms/src/blocks/shared/hooks/use-variation-style-properties.js
@@ -144,9 +144,8 @@ export default function useVariationStyleProperties( {
 			.join( ' ' );
 
 		let styleSpecificCssVars = {};
-		const borderRadius =
-			getBorderRadiusCssVar( blockBorderClassesAndStyles.style ) ||
-			getBorderRadiusCssVar( globalBorderClassesAndStyles.style );
+		const hasBorderRadius =
+			!! inputBlockAttributes?.style?.border?.radius || !! mergedGlobalBlockStyles?.border?.radius;
 
 		if ( formStyle === FORM_STYLE.OUTLINED ) {
 			styleSpecificCssVars = {
@@ -156,7 +155,7 @@ export default function useVariationStyleProperties( {
 		}
 		if ( formStyle === FORM_STYLE.ANIMATED ) {
 			styleSpecificCssVars = {
-				'--jetpack--contact-form--animated-left-offset': borderRadius ? '32px' : '16px',
+				'--jetpack--contact-form--animated-left-offset': hasBorderRadius ? '32px' : '16px',
 			};
 		}
 

--- a/projects/packages/forms/src/blocks/shared/hooks/use-variation-style-properties.js
+++ b/projects/packages/forms/src/blocks/shared/hooks/use-variation-style-properties.js
@@ -145,8 +145,8 @@ export default function useVariationStyleProperties( {
 
 		let styleSpecificCssVars = {};
 		const borderRadius =
-			getBorderRadius( blockBorderClassesAndStyles.style ) ||
-			getBorderRadius( globalBorderClassesAndStyles.style );
+			getBorderRadiusCssVar( blockBorderClassesAndStyles.style ) ||
+			getBorderRadiusCssVar( globalBorderClassesAndStyles.style );
 
 		if ( formStyle === FORM_STYLE.OUTLINED ) {
 			styleSpecificCssVars = {

--- a/projects/packages/forms/src/blocks/shared/hooks/use-variation-style-properties.js
+++ b/projects/packages/forms/src/blocks/shared/hooks/use-variation-style-properties.js
@@ -44,6 +44,47 @@ function getBorderRadiusCssVar( style ) {
 }
 
 /**
+ * Returns the border widths for the input block.
+ *
+ * @param {object} blockAttributes    - The attributes of the input block.
+ * @param {object} globalStyles       - The global styles.
+ * @param          blockBorderStyles
+ * @param          globalBorderStyles
+ * @return {object} The border widths.
+ */
+function getBorderWidths( blockBorderStyles, globalBorderStyles ) {
+	/*
+	 * Use `getIntAsPxValue` on the borderWidth as legacy form blocks might not have a value unit.
+	 * Sides (top, right, bottom, left) are available post-upgrade.
+	 */
+	const borderWidth =
+		getIntAsPxValue( blockBorderStyles?.borderWidth ) || globalBorderStyles?.borderWidth;
+
+	if ( borderWidth ) {
+		return {
+			borderTopWidth: borderWidth,
+			borderRightWidth: borderWidth,
+			borderBottomWidth: borderWidth,
+			borderLeftWidth: borderWidth,
+		};
+	}
+
+	const borderTopWidth = blockBorderStyles?.borderTopWidth || globalBorderStyles?.borderTopWidth;
+	const borderRightWidth =
+		blockBorderStyles?.borderRightWidth || globalBorderStyles?.borderRightWidth;
+	const borderBottomWidth =
+		blockBorderStyles?.borderBottomWidth || globalBorderStyles?.borderBottomWidth;
+	const borderLeftWidth = blockBorderStyles?.borderLeftWidth || globalBorderStyles?.borderLeftWidth;
+
+	return {
+		borderTopWidth,
+		borderRightWidth,
+		borderBottomWidth,
+		borderLeftWidth,
+	};
+}
+
+/**
  * Returns properties that help achieve the outlined and animated form styles.
  *
  * The outlined style in particular requires taking specific style properties (especially border and background)
@@ -95,29 +136,31 @@ export default function useVariationStyleProperties( {
 		[ inputBaseGlobalStyles, inputUserGlobalStyles ]
 	);
 
-	// Add a class to apply padding to option groups that have a border.
-	const customBorderClasses = useMemo( () => {
+	return useMemo( () => {
+		// Access the input block's attributes.
+		const blockBorderClassesAndStyles = getBorderClassesAndStyles( inputBlockAttributes ?? {} );
+		const globalBorderClassesAndStyles = getBorderClassesAndStyles( {
+			style: mergedGlobalBlockStyles,
+		} );
+		const borderWidths = getBorderWidths(
+			blockBorderClassesAndStyles?.style,
+			globalBorderClassesAndStyles?.style
+		);
+
+		// Add a class to apply padding to option groups that have a border.
 		const hasBorder =
 			inputBlockName === 'jetpack/options' &&
-			( !! inputBlockAttributes?.style?.border?.width ||
-				!! inputBlockAttributes?.style?.border?.left?.width ||
-				!! mergedGlobalBlockStyles?.border?.width ||
-				!! mergedGlobalBlockStyles?.border?.left?.width );
-		return hasBorder ? 'jetpack-field-multiple__list--has-border' : '';
-	}, [ inputBlockName, inputBlockAttributes, mergedGlobalBlockStyles ] );
+			!! borderWidths?.borderLeftWidth &&
+			parseInt( borderWidths?.borderLeftWidth ) > 0;
 
-	return useMemo( () => {
+		const customBorderClasses = hasBorder ? 'jetpack-field-multiple__list--has-border' : '';
+
 		// Only return styles for outlined and animated forms.
 		if ( formStyle !== FORM_STYLE.OUTLINED && formStyle !== FORM_STYLE.ANIMATED ) {
 			return {
 				className: customBorderClasses,
 			};
 		}
-		// Access the input block's attributes.
-		const blockBorderClassesAndStyles = getBorderClassesAndStyles( inputBlockAttributes ?? {} );
-		const globalBorderClassesAndStyles = getBorderClassesAndStyles( {
-			style: mergedGlobalBlockStyles,
-		} );
 
 		// Notched HTML only needs the background color and associated classes.
 		const attributesWithBackgroundColor = inputBlockAttributes
@@ -144,8 +187,6 @@ export default function useVariationStyleProperties( {
 			.join( ' ' );
 
 		let styleSpecificCssVars = {};
-		const hasBorderRadius =
-			!! inputBlockAttributes?.style?.border?.radius || !! mergedGlobalBlockStyles?.border?.radius;
 
 		if ( formStyle === FORM_STYLE.OUTLINED ) {
 			styleSpecificCssVars = {
@@ -154,8 +195,14 @@ export default function useVariationStyleProperties( {
 			};
 		}
 		if ( formStyle === FORM_STYLE.ANIMATED ) {
+			const hasTopBorder =
+				!! borderWidths?.borderTopWidth && parseInt( borderWidths?.borderTopWidth ) > 0;
 			styleSpecificCssVars = {
-				'--jetpack--contact-form--animated-left-offset': hasBorderRadius ? '32px' : '16px',
+				// For the animated labels.
+				'--jetpack--contact-form--animated-left-offset': '16px', // Probably can be removed or we use `--jetpack--contact-form--input-padding`
+				'--jetpack--contact-form--animated-top-offset': hasTopBorder
+					? 'calc(var(--jetpack--contact-form--border-top-size) + var(--jetpack--contact-form--animated-left-offset))'
+					: '50%',
 			};
 		}
 
@@ -167,18 +214,16 @@ export default function useVariationStyleProperties( {
 				backgroundColor: blockColorClassesAndStyles?.style?.backgroundColor,
 			},
 			cssVars: {
-				// Sets the value of top: calc(var(--jetpack--contact-form--border-size) * -1) for .notched-label__label.
-				'--jetpack--contact-form--border-size':
-					getIntAsPxValue( blockBorderClassesAndStyles?.style?.borderWidth ) ||
-					blockBorderClassesAndStyles?.style?.borderTopWidth ||
-					globalBorderClassesAndStyles?.style?.borderWidth ||
-					globalBorderClassesAndStyles?.style?.borderTopWidth,
 				// Sets the value of --notch-width: max(var(--jetpack--contact-form--input-padding-left, 16px), var(--jetpack--contact-form--border-radius)); for .notched-label.
 				'--jetpack--contact-form--border-radius':
 					getBorderRadiusCssVar( blockBorderClassesAndStyles.style ) ||
 					getBorderRadiusCssVar( globalBorderClassesAndStyles.style ),
+				'--jetpack--contact-form--border-left-size': borderWidths?.borderLeftWidth,
+				'--jetpack--contact-form--border-right-size': borderWidths?.borderRightWidth,
+				'--jetpack--contact-form--border-top-size': borderWidths?.borderTopWidth,
+				'--jetpack--contact-form--border-bottom-size': borderWidths?.borderBottomWidth,
 				...styleSpecificCssVars,
 			},
 		};
-	}, [ inputBlockAttributes, mergedGlobalBlockStyles, formStyle, customBorderClasses ] );
+	}, [ inputBlockAttributes, mergedGlobalBlockStyles, formStyle, inputBlockName ] );
 }

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -1583,23 +1583,29 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 			$global_styles['width'] ??
 			$global_styles['top']['width'] ?? null;
 
-		$border_left_size = $legacy_border_size ??
-			$outline_styles['border']['left']['width'] ??
-			$global_styles['width'] ??
-			$global_styles['left']['width'] ?? null;
-
 		$border_right_size = $legacy_border_size ??
 			$outline_styles['border']['right']['width'] ??
 			$global_styles['width'] ??
 			$global_styles['right']['width'] ?? null;
+
+		$border_bottom_size = $legacy_border_size ??
+			$outline_styles['border']['bottom']['width'] ??
+			$global_styles['width'] ??
+			$global_styles['bottom']['width'] ?? null;
+
+		$border_left_size = $legacy_border_size ??
+			$outline_styles['border']['left']['width'] ??
+			$global_styles['width'] ??
+			$global_styles['left']['width'] ?? null;
 
 		$border_radius = $legacy_border_radius ??
 			$global_styles['radius'] ?? null;
 
 		$css_vars  = $border_top_size ? '--jetpack--contact-form--border-size: ' . $border_top_size . ';' : '';
 		$css_vars .= $border_top_size ? '--jetpack--contact-form--border-top-size: ' . $border_top_size . ';' : '';
-		$css_vars .= $border_left_size ? '--jetpack--contact-form--border-left-size: ' . $border_left_size . ';' : '';
 		$css_vars .= $border_right_size ? '--jetpack--contact-form--border-right-size: ' . $border_right_size . ';' : '';
+		$css_vars .= $border_bottom_size ? '--jetpack--contact-form--border-bottom-size: ' . $border_bottom_size . ';' : '';
+		$css_vars .= $border_left_size ? '--jetpack--contact-form--border-left-size: ' . $border_left_size . ';' : '';
 
 		// Check if border radius is split or a single value.
 		if ( is_array( $border_radius ) ) {

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -1590,17 +1590,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 			if ( 'outlined' === $form_style ) {
 				$css_vars .= '--jetpack--contact-form--notch-width: max(var(--jetpack--contact-form--input-padding-left, 16px), var(--jetpack--contact-form--border-radius));';
 			} elseif ( 'animated' === $form_style ) {
-				$legacy_border_left_size = $outline_styles['border']['width'] ?? null;
-				$legacy_border_left_size = is_numeric( $legacy_border_left_size ) ? $legacy_border_left_size . 'px' : $legacy_border_left_size;
-
-				$border_left_size = $legacy_border_left_size ??
-				$outline_styles['border']['left']['width'] ??
-				$global_styles['width'] ??
-				$global_styles['left']['width'];
-
-				$css_vars .= "--jetpack--contact-form--left-offset: calc(var(--jetpack--contact-form--input-padding-left, 16px) + {$border_left_size});";
-				$css_vars .= '--jetpack--contact-form--label-left: max(var(--jetpack--contact-form--left-offset), var(--jetpack--contact-form--border-radius));';
-				$css_vars .= "--jetpack--contact-form--field-padding: calc(var(--jetpack--contact-form--label-left) - {$border_left_size});";
+				$css_vars .= '--jetpack--contact-form--animated-left-offset: ' . ( ! empty( $border_radius ) ? '32px' : '16px' ) . ';';
 			}
 		}
 

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -1568,13 +1568,14 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 			)
 		);
 
-		// The `borderwidth` attribute contains the border value that forms used before the migration to global styles.
-		// Any old forms saved in a post will still use this attribute, so it needs to be factored into the css vars for border
-		// to properly support backwards compatibility. Use `isset` to check instead of `empty` as `'0'` is a valid width value
-		// that should override global styles.
-		// For newer forms that use global styles or the block supports styles, this value will be empty and is ignored.
+		/*
+		 * The `borderwidth` attribute contains the border value that forms used before the migration to global styles.
+		 * Any old forms saved in a post will still use this attribute, so it needs to be factored into the css vars for border
+		 * to properly support backwards compatibility. So we check if the attribute is set and if it's not empty or '0', which is a valid width value.
+		 * For newer forms that use global styles or the block supports styles, this value will be empty and is ignored.
+		 */
 		$border_width_attribute = $this->get_attribute( 'borderwidth' );
-		$legacy_border_size     = isset( $border_width_attribute ) ? $border_width_attribute . 'px' : $outline_styles['border']['width'] ?? null;
+		$legacy_border_size     = ! empty( $border_width_attribute ) || $border_width_attribute === '0' ? $border_width_attribute . 'px' : $outline_styles['border']['width'] ?? null;
 		$legacy_border_size     = is_numeric( $legacy_border_size ) ? $legacy_border_size . 'px' : $legacy_border_size;
 		$legacy_border_radius   = $outline_styles['border']['radius'] ?? null;
 		$legacy_border_radius   = is_numeric( $legacy_border_radius ) ? $legacy_border_radius . 'px' : $legacy_border_radius;

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -1576,20 +1576,20 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		$border_top_size = $legacy_border_size ??
 			$outline_styles['border']['top']['width'] ??
 			$global_styles['width'] ??
-			$global_styles['top']['width'];
+			$global_styles['top']['width'] ?? null;
 
 		$border_left_size = $legacy_border_size ??
 			$outline_styles['border']['left']['width'] ??
 			$global_styles['width'] ??
-			$global_styles['left']['width'];
+			$global_styles['left']['width'] ?? null;
 
 		$border_right_size = $legacy_border_size ??
 			$outline_styles['border']['right']['width'] ??
 			$global_styles['width'] ??
-			$global_styles['right']['width'];
+			$global_styles['right']['width'] ?? null;
 
 		$border_radius = $legacy_border_radius ??
-			$global_styles['radius'];
+			$global_styles['radius'] ?? null;
 
 		$css_vars  = $border_top_size ? '--jetpack--contact-form--border-size: ' . $border_top_size . ';' : '';
 		$css_vars .= $border_top_size ? '--jetpack--contact-form--border-top-size: ' . $border_top_size . ';' : '';

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -1548,51 +1548,65 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		$outline_styles  = $this->get_attribute( 'outlinestyledata' );
 		$outline_classes = $this->get_attribute( 'outlinestyleclasses' );
 
-		if ( ! empty( $outline_styles ) ) {
-			$outline_styles = json_decode( html_entity_decode( $outline_styles, ENT_COMPAT ), true );
-			$input_styles   = $this->get_attribute( 'inputstyles' );
+		$outline_styles = ! empty( $outline_styles ) ? json_decode( html_entity_decode( $outline_styles, ENT_COMPAT ), true ) : array();
+		$input_styles   = $this->get_attribute( 'inputstyles' );
 
-			if ( ! empty( $input_styles ) ) {
-				$style_attrs = $input_styles;
-			}
+		if ( ! empty( $input_styles ) ) {
+			$style_attrs = $input_styles;
+		}
 
-			$global_styles = wp_get_global_styles(
-				array( 'border' ),
-				array(
-					'block_name' => 'jetpack/input',
-					'transforms' => array( 'resolve-variables' ),
-				)
-			);
+		$global_styles = wp_get_global_styles(
+			array( 'border' ),
+			array(
+				'block_name' => 'jetpack/input',
+				'transforms' => array( 'resolve-variables' ),
+			)
+		);
 
-			$legacy_border_size   = $outline_styles['border']['width'] ?? null;
-			$legacy_border_size   = is_numeric( $legacy_border_size ) ? $legacy_border_size . 'px' : $legacy_border_size;
-			$legacy_border_radius = $outline_styles['border']['radius'] ?? null;
-			$legacy_border_radius = is_numeric( $legacy_border_radius ) ? $legacy_border_radius . 'px' : $legacy_border_radius;
+		$legacy_border_size   = $outline_styles['border']['width'] ?? null;
+		$legacy_border_size   = is_numeric( $legacy_border_size ) ? $legacy_border_size . 'px' : $legacy_border_size;
+		$legacy_border_radius = $outline_styles['border']['radius'] ?? null;
+		$legacy_border_radius = is_numeric( $legacy_border_radius ) ? $legacy_border_radius . 'px' : $legacy_border_radius;
 
-			$border_size = $legacy_border_size ??
-				$outline_styles['border']['top']['width'] ??
-				$global_styles['width'] ??
-				$global_styles['top']['width'];
+		$border_top_size = $legacy_border_size ??
+			$outline_styles['border']['top']['width'] ??
+			$global_styles['width'] ??
+			$global_styles['top']['width'];
 
-			$border_radius = $legacy_border_radius ??
-				$global_styles['radius'];
+		$border_left_size = $legacy_border_size ??
+			$outline_styles['border']['left']['width'] ??
+			$global_styles['width'] ??
+			$global_styles['left']['width'];
 
-			$css_vars = $border_size ? '--jetpack--contact-form--border-size: ' . $border_size . ';' : '';
-			// Check if border radius is split or a single value.
-			if ( is_array( $border_radius ) ) {
-				// If corner radii are set on the top-left or bottom-left of the block, take the maximum of the two.
-				// We check the left side due to writing direction—this variable is used to offset text.
-				// TODO: this should factor in RTL languages.
-				$css_vars .= $border_radius ? '--jetpack--contact-form--border-radius: max(' . $border_radius['topLeft'] . ',' . $border_radius['bottomLeft'] . ');' : '';
-			} elseif ( isset( $border_radius ) ) {
-				$css_vars .= $border_radius ? '--jetpack--contact-form--border-radius: ' . $border_radius . ';' : '';
-			}
+		$border_right_size = $legacy_border_size ??
+			$outline_styles['border']['right']['width'] ??
+			$global_styles['width'] ??
+			$global_styles['right']['width'];
 
-			if ( 'outlined' === $form_style ) {
-				$css_vars .= '--jetpack--contact-form--notch-width: max(var(--jetpack--contact-form--input-padding-left, 16px), var(--jetpack--contact-form--border-radius));';
-			} elseif ( 'animated' === $form_style ) {
-				$css_vars .= '--jetpack--contact-form--animated-left-offset: ' . ( ! empty( $border_radius ) ? '32px' : '16px' ) . ';';
-			}
+		$border_radius = $legacy_border_radius ??
+			$global_styles['radius'];
+
+		$css_vars  = $border_top_size ? '--jetpack--contact-form--border-size: ' . $border_top_size . ';' : '';
+		$css_vars .= $border_top_size ? '--jetpack--contact-form--border-top-size: ' . $border_top_size . ';' : '';
+		$css_vars .= $border_left_size ? '--jetpack--contact-form--border-left-size: ' . $border_left_size . ';' : '';
+		$css_vars .= $border_right_size ? '--jetpack--contact-form--border-right-size: ' . $border_right_size . ';' : '';
+
+		// Check if border radius is split or a single value.
+		if ( is_array( $border_radius ) ) {
+			// If corner radii are set on the top-left or bottom-left of the block, take the maximum of the two.
+			// We check the left side due to writing direction—this variable is used to offset text.
+			// TODO: this should factor in RTL languages.
+			$css_vars .= $border_radius ? '--jetpack--contact-form--border-radius: max(' . $border_radius['topLeft'] . ',' . $border_radius['bottomLeft'] . ');' : '';
+		} elseif ( isset( $border_radius ) ) {
+			$css_vars .= $border_radius ? '--jetpack--contact-form--border-radius: ' . $border_radius . ';' : '';
+		}
+
+		if ( 'outlined' === $form_style ) {
+			$css_vars .= '--jetpack--contact-form--notch-width: max(var(--jetpack--contact-form--input-padding-left, 16px), var(--jetpack--contact-form--border-radius));';
+		} elseif ( 'animated' === $form_style ) {
+			$css_vars .= '--jetpack--contact-form--animated-left-offset: 16px;';
+			$css_vars .= '--jetpack--contact-form--animated-top-offset:' . $border_top_size ? 'calc(var(--jetpack--contact-form--border-top-size) + var(--jetpack--contact-form--animated-left-offset));'
+				: '50%;';
 		}
 
 		return array(

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -1573,7 +1573,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		// to properly support backwards compatibility.
 		// For newer forms that use global styles or the block supports styles, this value will be empty and is ignored.
 		$border_width_attribute = $this->get_attribute( 'borderwidth' );
-		$legacy_border_size     = ! empty( $border_width_attribute ) ? $this->get_attribute( 'borderwidth' ) . 'px' : $outline_styles['border']['width'] ?? null;
+		$legacy_border_size     = ! empty( $border_width_attribute ) ? $border_width_attribute . 'px' : $outline_styles['border']['width'] ?? null;
 		$legacy_border_size     = is_numeric( $legacy_border_size ) ? $legacy_border_size . 'px' : $legacy_border_size;
 		$legacy_border_radius   = $outline_styles['border']['radius'] ?? null;
 		$legacy_border_radius   = is_numeric( $legacy_border_radius ) ? $legacy_border_radius . 'px' : $legacy_border_radius;

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -1570,10 +1570,11 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 
 		// The `borderwidth` attribute contains the border value that forms used before the migration to global styles.
 		// Any old forms saved in a post will still use this attribute, so it needs to be factored into the css vars for border
-		// to properly support backwards compatibility.
+		// to properly support backwards compatibility. Use `isset` to check instead of `empty` as `'0'` is a valid width value
+		// that should override global styles.
 		// For newer forms that use global styles or the block supports styles, this value will be empty and is ignored.
 		$border_width_attribute = $this->get_attribute( 'borderwidth' );
-		$legacy_border_size     = ! empty( $border_width_attribute ) ? $border_width_attribute . 'px' : $outline_styles['border']['width'] ?? null;
+		$legacy_border_size     = isset( $border_width_attribute ) ? $border_width_attribute . 'px' : $outline_styles['border']['width'] ?? null;
 		$legacy_border_size     = is_numeric( $legacy_border_size ) ? $legacy_border_size . 'px' : $legacy_border_size;
 		$legacy_border_radius   = $outline_styles['border']['radius'] ?? null;
 		$legacy_border_radius   = is_numeric( $legacy_border_radius ) ? $legacy_border_radius . 'px' : $legacy_border_radius;

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -383,7 +383,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 			// For Outline style support.
 			$form_style = $this->get_form_style();
 			if ( 'outlined' === $form_style || 'animated' === $form_style ) {
-				$output_data         = $this->get_outline_styles( $form_style );
+				$output_data         = $this->get_form_variation_style_properties( $form_style );
 				$this->block_styles .= $output_data['css_vars'];
 			}
 		} else {
@@ -1506,7 +1506,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		$classes .= $this->is_error() ? ' form-error' : '';
 		$classes .= $this->label_classes ? ' ' . $this->label_classes : '';
 
-		$output_data = $this->get_outline_styles();
+		$output_data = $this->get_form_variation_style_properties();
 
 		return '
 			<div class="notched-label">
@@ -1528,6 +1528,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 
 	/**
 	 * Returns the styles, classes and CSS vars necessary to render fields in the "Outlined" style.
+	 * The "Animated" style variation shares the CSS vars, which require similar calculations for the left offset and label left position.
 	 * At the block level, the styles are extracted and added to the shortcode attributes in
 	 * Contact_Form_Plugin::get_outlined_style_attributes().
 	 * This function extracts those styles and applies them to the field,
@@ -1541,7 +1542,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 	 *     @type string $class_name The class name.
 	 * }
 	 */
-	private function get_outline_styles( $form_style = 'outlined' ) {
+	private function get_form_variation_style_properties( $form_style = 'outlined' ) {
 		$style_attrs     = '';
 		$css_vars        = '';
 		$outline_styles  = $this->get_attribute( 'outlinestyledata' );

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -1568,10 +1568,11 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 			)
 		);
 
-		$legacy_border_size   = $outline_styles['border']['width'] ?? null;
-		$legacy_border_size   = is_numeric( $legacy_border_size ) ? $legacy_border_size . 'px' : $legacy_border_size;
-		$legacy_border_radius = $outline_styles['border']['radius'] ?? null;
-		$legacy_border_radius = is_numeric( $legacy_border_radius ) ? $legacy_border_radius . 'px' : $legacy_border_radius;
+		$border_width_attribute = $this->get_attribute( 'borderwidth' );
+		$legacy_border_size     = ! empty( $border_width_attribute ) ? $this->get_attribute( 'borderwidth' ) . 'px' : $outline_styles['border']['width'] ?? null;
+		$legacy_border_size     = is_numeric( $legacy_border_size ) ? $legacy_border_size . 'px' : $legacy_border_size;
+		$legacy_border_radius   = $outline_styles['border']['radius'] ?? null;
+		$legacy_border_radius   = is_numeric( $legacy_border_radius ) ? $legacy_border_radius . 'px' : $legacy_border_radius;
 
 		$border_top_size = $legacy_border_size ??
 			$outline_styles['border']['top']['width'] ??

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -1568,6 +1568,10 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 			)
 		);
 
+		// The `borderwidth` attribute contains the border value that forms used before the migration to global styles.
+		// Any old forms saved in a post will still use this attribute, so it needs to be factored into the css vars for border
+		// to properly support backwards compatibility.
+		// For newer forms that use global styles or the block supports styles, this value will be empty and is ignored.
 		$border_width_attribute = $this->get_attribute( 'borderwidth' );
 		$legacy_border_size     = ! empty( $border_width_attribute ) ? $this->get_attribute( 'borderwidth' ) . 'px' : $outline_styles['border']['width'] ?? null;
 		$legacy_border_size     = is_numeric( $legacy_border_size ) ? $legacy_border_size . 'px' : $legacy_border_size;

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -168,7 +168,7 @@
 	font-size: 0.8em;
 	padding: 0 0.25em;
 	position: relative;
-	top: calc(var(--jetpack--contact-form--border-size, 1px) / 2 * -1);
+	top: calc(var(--jetpack--contact-form--border-top-size, 1px) / 2 * -1);
 
 }
 
@@ -408,7 +408,7 @@
 	transform: translateY(-50%) rotate(45deg);
 	transform-origin: center center;
 	pointer-events: none;
-	right: calc(var(--jetpack--contact-form--border-size) + 16px);
+	right: calc(var(--jetpack--contact-form--border-right-size, 1px) + 16px);
 }
 
 .contact-form :where( .contact-form__select-wrapper select ) {
@@ -417,7 +417,7 @@
 	border-color: var(--jetpack--contact-form--border-color);
 	border-radius: var(--jetpack--contact-form--border-radius);
 	border-style: var(--jetpack--contact-form--border-style);
-	border-width: var(--jetpack--contact-form--border-size);
+	border-width:  var(--jetpack--contact-form--border-left-size, var(--jetpack--contact-form--border-size));
 	color: var(--jetpack--contact-form--text-color);
 	font-family: var(--jetpack--contact-form--font-family);
 	font-size: var(--jetpack--contact-form--font-size);
@@ -495,7 +495,7 @@
 :where( .wp-block-jetpack-contact-form.is-style-outlined ) .notched-label__leading {
 	border-color: var(--jetpack--contact-form--border-color);
 	border-style: var(--jetpack--contact-form--border-style);
-	border-width: var(--jetpack--contact-form--border-size);
+	border-width:  var(--jetpack--contact-form--border-left-size, var(--jetpack--contact-form--border-size));
 	border-radius: var(--jetpack--contact-form--border-radius);
 	width: var(--jetpack--contact-form--notch-width);
 	max-width: 100px;
@@ -508,7 +508,7 @@
 :where( .wp-block-jetpack-contact-form.is-style-outlined ) .notched-label__notch {
 	border-color: var(--jetpack--contact-form--border-color);
 	border-style: var(--jetpack--contact-form--border-style);
-	border-width: var(--jetpack--contact-form--border-size);
+	border-width:  var(--jetpack--contact-form--border-left-size, var(--jetpack--contact-form--border-size));
 	border-radius: unset !important;
 	padding: 0 4px;
 	transition: border 150ms linear;
@@ -520,7 +520,7 @@
 :where( .wp-block-jetpack-contact-form.is-style-outlined ) .notched-label__filler {
 	border-color: var(--jetpack--contact-form--border-color);
 	border-style: var(--jetpack--contact-form--border-style);
-	border-width: var(--jetpack--contact-form--border-size);
+	border-width: var(--jetpack--contact-form--border-left-size, var(--jetpack--contact-form--border-size));
 	flex-grow: 1;
 	border-left: none !important;
 	border-right: none !important;
@@ -531,7 +531,7 @@
 :where( .wp-block-jetpack-contact-form.is-style-outlined ) .notched-label__trailing {
 	border-color: var(--jetpack--contact-form--border-color);
 	border-style: var(--jetpack--contact-form--border-style);
-	border-width: var(--jetpack--contact-form--border-size);
+	border-width: var(--jetpack--contact-form--border-left-size, var(--jetpack--contact-form--border-size));
 	border-radius: var(--jetpack--contact-form--border-radius);
 	flex-grow: 1;
 	max-width: 100px;
@@ -612,7 +612,7 @@ on production builds, the attributes are being reordered, causing side-effects
 .contact-form .is-style-outlined .grunion-field-wrap .notched-label:has(~ .grunion-radio-options) .notched-label__label,
 .contact-form .is-style-outlined .grunion-field-wrap.grunion-field-select-wrap .notched-label .notched-label__label
 {
-	top: calc(var(--jetpack--contact-form--border-size) * -1 );
+	top: calc( var(--jetpack--contact-form--border-top-size, var(--jetpack--contact-form--border-size)) * -1 );
 	transform: translateY(-50%);
 	font-size: 0.8em;
 }
@@ -639,11 +639,11 @@ on production builds, the attributes are being reordered, causing side-effects
 	position: relative;
 }
 
-.contact-form .is-style-animated .grunion-field-wrap {
+/* .contact-form .is-style-animated .grunion-field-wrap {
 	--left-offset: calc(var(--jetpack--contact-form--input-padding-left, 16px) + var(--jetpack--contact-form--border-size));
 	--label-left: max(var(--left-offset), var(--jetpack--contact-form--border-radius));
 	--field-padding: calc(var(--label-left) - var(--jetpack--contact-form--border-size));
-}
+} */
 
 .wp-block-jetpack-contact-form:not(.is-style-outlined) .jetpack-field-multiple__fieldset,
 .wp-block-jetpack-contact-form:not(.is-style-outlined) .jetpack-field-multiple__fieldset legend {
@@ -681,7 +681,7 @@ on production builds, the attributes are being reordered, causing side-effects
 .contact-form .is-style-animated .grunion-field-wrap .animated-label__label {
 	position: absolute;
 	top: 50%;
-	left: calc(var(--jetpack--contact-form--border-size, 0px) + var(--jetpack--contact-form--animated-left-offset));
+	left: calc(var(--jetpack--contact-form--border-left-size, 0px) + var(--jetpack--contact-form--animated-left-offset));
 	width: 100%;
 	max-width: 100%;
 	box-sizing: border-box;
@@ -704,7 +704,7 @@ on production builds, the attributes are being reordered, causing side-effects
 {
 	font-size: 0.75em;
 	transform: translateY(0);
-	top: calc(2px + var(--jetpack--contact-form--border-size));
+	top: calc(2px + var(--jetpack--contact-form--border-top-size, 1px));
 }
 
 /* The following is scoped by the presence of the custom font size CSS var to avoid needing conditional fallback within the var() */
@@ -723,7 +723,7 @@ on production builds, the attributes are being reordered, causing side-effects
 }
 
 .contact-form .is-style-below .grunion-field-wrap .below-label__label {
-	margin-left: var(--jetpack--contact-form--border-size);
+	margin-left:  var(--jetpack--contact-form--border-left-size, var(--jetpack--contact-form--border-size));
 }
 
 .contact-form :where(.grunion-field-wrap:not(.is-style-button-wrap)) .grunion-checkbox-multiple-options:not(.wp-block-jetpack-options),

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -694,7 +694,7 @@ on production builds, the attributes are being reordered, causing side-effects
 
 .contact-form .is-style-animated .grunion-field-textarea-wrap .animated-label__label {
 	transform: unset;
-	top: var(--jetpack--contact-form--animated-left-offset);
+	top: calc(2px + var(--jetpack--contact-form--border-top-size, 1px));
 }
 
 .contact-form .is-style-animated .grunion-field-wrap .animated-label__label:has(~ .grunion-field:focus),

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -495,7 +495,10 @@
 :where( .wp-block-jetpack-contact-form.is-style-outlined ) .notched-label__leading {
 	border-color: var(--jetpack--contact-form--border-color);
 	border-style: var(--jetpack--contact-form--border-style);
-	border-width:  var(--jetpack--contact-form--border-left-size, var(--jetpack--contact-form--border-size));
+	border-top-width: var(--jetpack--contact-form--border-top-size, var(--jetpack--contact-form--border-size));
+	border-right-width: var(--jetpack--contact-form--border-right-size, var(--jetpack--contact-form--border-size));
+	border-bottom-width: var(--jetpack--contact-form--border-bottom-size, var(--jetpack--contact-form--border-size));
+	border-left-width: var(--jetpack--contact-form--border-left-size, var(--jetpack--contact-form--border-size));
 	border-radius: var(--jetpack--contact-form--border-radius);
 	width: var(--jetpack--contact-form--notch-width);
 	max-width: 100px;
@@ -508,7 +511,10 @@
 :where( .wp-block-jetpack-contact-form.is-style-outlined ) .notched-label__notch {
 	border-color: var(--jetpack--contact-form--border-color);
 	border-style: var(--jetpack--contact-form--border-style);
-	border-width:  var(--jetpack--contact-form--border-left-size, var(--jetpack--contact-form--border-size));
+	border-top-width: var(--jetpack--contact-form--border-top-size, var(--jetpack--contact-form--border-size));
+	border-right-width: var(--jetpack--contact-form--border-right-size, var(--jetpack--contact-form--border-size));
+	border-bottom-width: var(--jetpack--contact-form--border-bottom-size, var(--jetpack--contact-form--border-size));
+	border-left-width: var(--jetpack--contact-form--border-left-size, var(--jetpack--contact-form--border-size));
 	border-radius: unset !important;
 	padding: 0 4px;
 	transition: border 150ms linear;
@@ -520,7 +526,10 @@
 :where( .wp-block-jetpack-contact-form.is-style-outlined ) .notched-label__filler {
 	border-color: var(--jetpack--contact-form--border-color);
 	border-style: var(--jetpack--contact-form--border-style);
-	border-width: var(--jetpack--contact-form--border-left-size, var(--jetpack--contact-form--border-size));
+	border-top-width: var(--jetpack--contact-form--border-top-size, var(--jetpack--contact-form--border-size));
+	border-right-width: var(--jetpack--contact-form--border-right-size, var(--jetpack--contact-form--border-size));
+	border-bottom-width: var(--jetpack--contact-form--border-bottom-size, var(--jetpack--contact-form--border-size));
+	border-left-width: var(--jetpack--contact-form--border-left-size, var(--jetpack--contact-form--border-size));
 	flex-grow: 1;
 	border-left: none !important;
 	border-right: none !important;
@@ -531,7 +540,10 @@
 :where( .wp-block-jetpack-contact-form.is-style-outlined ) .notched-label__trailing {
 	border-color: var(--jetpack--contact-form--border-color);
 	border-style: var(--jetpack--contact-form--border-style);
-	border-width: var(--jetpack--contact-form--border-left-size, var(--jetpack--contact-form--border-size));
+	border-top-width: var(--jetpack--contact-form--border-top-size, var(--jetpack--contact-form--border-size));
+	border-right-width: var(--jetpack--contact-form--border-right-size, var(--jetpack--contact-form--border-size));
+	border-bottom-width: var(--jetpack--contact-form--border-bottom-size, var(--jetpack--contact-form--border-size));
+	border-left-width: var(--jetpack--contact-form--border-left-size, var(--jetpack--contact-form--border-size));
 	border-radius: var(--jetpack--contact-form--border-radius);
 	flex-grow: 1;
 	max-width: 100px;

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -639,11 +639,11 @@ on production builds, the attributes are being reordered, causing side-effects
 	position: relative;
 }
 
-/* .contact-form .is-style-animated .grunion-field-wrap {
+.contact-form .is-style-animated .grunion-field-wrap {
 	--left-offset: calc(var(--jetpack--contact-form--input-padding-left, 16px) + var(--jetpack--contact-form--border-size));
 	--label-left: max(var(--left-offset), var(--jetpack--contact-form--border-radius));
 	--field-padding: calc(var(--label-left) - var(--jetpack--contact-form--border-size));
-} */
+}
 
 .wp-block-jetpack-contact-form:not(.is-style-outlined) .jetpack-field-multiple__fieldset,
 .wp-block-jetpack-contact-form:not(.is-style-outlined) .jetpack-field-multiple__fieldset legend {
@@ -681,7 +681,7 @@ on production builds, the attributes are being reordered, causing side-effects
 .contact-form .is-style-animated .grunion-field-wrap .animated-label__label {
 	position: absolute;
 	top: 50%;
-	left: calc(var(--jetpack--contact-form--border-left-size, 0px) + var(--jetpack--contact-form--animated-left-offset));
+	left: calc(var(--jetpack--contact-form--border-left-size, 0px) + var(--jetpack--contact-form--animated-left-offset, var(--label-left)));
 	width: 100%;
 	max-width: 100%;
 	box-sizing: border-box;

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -496,7 +496,6 @@
 	border-color: var(--jetpack--contact-form--border-color);
 	border-style: var(--jetpack--contact-form--border-style);
 	border-top-width: var(--jetpack--contact-form--border-top-size, var(--jetpack--contact-form--border-size));
-	border-right-width: var(--jetpack--contact-form--border-right-size, var(--jetpack--contact-form--border-size));
 	border-bottom-width: var(--jetpack--contact-form--border-bottom-size, var(--jetpack--contact-form--border-size));
 	border-left-width: var(--jetpack--contact-form--border-left-size, var(--jetpack--contact-form--border-size));
 	border-radius: var(--jetpack--contact-form--border-radius);
@@ -512,9 +511,7 @@
 	border-color: var(--jetpack--contact-form--border-color);
 	border-style: var(--jetpack--contact-form--border-style);
 	border-top-width: var(--jetpack--contact-form--border-top-size, var(--jetpack--contact-form--border-size));
-	border-right-width: var(--jetpack--contact-form--border-right-size, var(--jetpack--contact-form--border-size));
 	border-bottom-width: var(--jetpack--contact-form--border-bottom-size, var(--jetpack--contact-form--border-size));
-	border-left-width: var(--jetpack--contact-form--border-left-size, var(--jetpack--contact-form--border-size));
 	border-radius: unset !important;
 	padding: 0 4px;
 	transition: border 150ms linear;
@@ -527,9 +524,7 @@
 	border-color: var(--jetpack--contact-form--border-color);
 	border-style: var(--jetpack--contact-form--border-style);
 	border-top-width: var(--jetpack--contact-form--border-top-size, var(--jetpack--contact-form--border-size));
-	border-right-width: var(--jetpack--contact-form--border-right-size, var(--jetpack--contact-form--border-size));
 	border-bottom-width: var(--jetpack--contact-form--border-bottom-size, var(--jetpack--contact-form--border-size));
-	border-left-width: var(--jetpack--contact-form--border-left-size, var(--jetpack--contact-form--border-size));
 	flex-grow: 1;
 	border-left: none !important;
 	border-right: none !important;
@@ -543,7 +538,6 @@
 	border-top-width: var(--jetpack--contact-form--border-top-size, var(--jetpack--contact-form--border-size));
 	border-right-width: var(--jetpack--contact-form--border-right-size, var(--jetpack--contact-form--border-size));
 	border-bottom-width: var(--jetpack--contact-form--border-bottom-size, var(--jetpack--contact-form--border-size));
-	border-left-width: var(--jetpack--contact-form--border-left-size, var(--jetpack--contact-form--border-size));
 	border-radius: var(--jetpack--contact-form--border-radius);
 	flex-grow: 1;
 	max-width: 100px;

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -694,7 +694,7 @@ on production builds, the attributes are being reordered, causing side-effects
 
 .contact-form .is-style-animated .grunion-field-textarea-wrap .animated-label__label {
 	transform: unset;
-	top: calc(2px + var(--jetpack--contact-form--border-top-size, 1px));
+	top: calc(2px + var(--jetpack--contact-form--border-top-size, var( --jetpack--contact-form--border-size, 1px )));
 }
 
 .contact-form .is-style-animated .grunion-field-wrap .animated-label__label:has(~ .grunion-field:focus),
@@ -704,7 +704,7 @@ on production builds, the attributes are being reordered, causing side-effects
 {
 	font-size: 0.75em;
 	transform: translateY(0);
-	top: calc(2px + var(--jetpack--contact-form--border-top-size, 1px));
+	top: calc(2px + var(--jetpack--contact-form--border-top-size, var( --jetpack--contact-form--border-size, 1px )));
 }
 
 /* The following is scoped by the presence of the custom font size CSS var to avoid needing conditional fallback within the var() */

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -670,10 +670,18 @@ on production builds, the attributes are being reordered, causing side-effects
 	padding-right: var(--field-padding);
 }
 
+/* Fix padding for new forms in animated style */
+.contact-form .is-style-animated .grunion-field-wrap:not(.no-label) > .wp-block-jetpack-input,
+.contact-form .is-style-animated .grunion-field-wrap:not(.no-label) .wp-block-jetpack-input,
+.contact-form .is-style-animated .wp-block-jetpack-options.jetpack-field-multiple__list--has-border {
+	padding-left: var(--jetpack--contact-form--animated-left-offset);
+	padding-right: var(--jetpack--contact-form--animated-left-offset);
+}
+
 .contact-form .is-style-animated .grunion-field-wrap .animated-label__label {
 	position: absolute;
 	top: 50%;
-	left: var(--label-left);
+	left: calc(var(--jetpack--contact-form--border-size, 0px) + var(--jetpack--contact-form--animated-left-offset));
 	width: 100%;
 	max-width: 100%;
 	box-sizing: border-box;
@@ -686,7 +694,7 @@ on production builds, the attributes are being reordered, causing side-effects
 
 .contact-form .is-style-animated .grunion-field-textarea-wrap .animated-label__label {
 	transform: unset;
-	top: var(--jetpack--contact-form--input-padding-top, 16px);
+	top: var(--jetpack--contact-form--animated-left-offset);
 }
 
 .contact-form .is-style-animated .grunion-field-wrap .animated-label__label:has(~ .grunion-field:focus),


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack-roadmap/issues/2574

## Proposed changes:

Follow up to https://github.com/Automattic/jetpack/pull/43327

Standardizes padding behaviour in animated variation and brings the behaviour closer to trunk.

### The issue

With the animated style applied to a form, inputing large values for border width and border radius affects the indentation of the label and input elements.

https://github.com/user-attachments/assets/800788b1-8038-4ada-8af6-c79a45aaa73d

In trunk, we don't see this on the frontend.

https://github.com/user-attachments/assets/e4ab7088-08a8-44dd-9d79-d416c123d0a4

Furthermore, where individual border widths are added, we want the label and input to adjust their positions to sit inside the border. Not this:

<img width="702" alt="Screenshot 2025-05-16 at 3 52 33 pm" src="https://github.com/user-attachments/assets/093db0f5-05c3-4617-a1cb-31c1eb728871" />

### The solution

Instead of tracking a single border width with CSS vars, track individual border widths so we can position the elements accordingly.

https://github.com/user-attachments/assets/272a126c-c025-4a6d-9ed3-d7d64d26bcba




## Testing instructions:

1. Create a new form in this branch (text fields, multi option fields and a select dropdown)
2. Edit global styles for `jetpack/input` and `jetpack/options` blocks to give them largish individual border widths.
3. Check that things look as expected in the editor and frontend
4. Now, edit the block styles in the editor. Ensure the input and label paddings are consistent.

Here's a general guide of how things should look:

| Editor | Frontend |
|--------|--------|
| <img width="638" alt="Screenshot 2025-05-19 at 12 03 21 pm" src="https://github.com/user-attachments/assets/5490dd7b-a0cd-4531-9d54-7d462e0216ab" /> | <img width="624" alt="Screenshot 2025-05-19 at 12 03 42 pm" src="https://github.com/user-attachments/assets/438e7f22-fc70-4cf4-970f-b757d4b28bcd" /> | 




