### PR TITLE
Update endpoint Boost calls on WP.com for LCP requests

### DIFF
--- a/projects/plugins/boost/app/modules/optimizations/lcp/class-lcp-analyzer.php
+++ b/projects/plugins/boost/app/modules/optimizations/lcp/class-lcp-analyzer.php
@@ -99,7 +99,7 @@ class LCP_Analyzer {
 			'pages'     => $pages,
 			'requestId' => md5( wp_json_encode( $pages ) . time() ),
 		);
-		return Boost_API::post( 'analyze-lcp', $payload );
+		return Boost_API::post( 'lcp', $payload );
 	}
 
 	/**

--- a/projects/plugins/boost/changelog/fix-boost-lcp-wpcom-endpoint
+++ b/projects/plugins/boost/changelog/fix-boost-lcp-wpcom-endpoint
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: LCP: Fix sending LCP requests to wrong wp.com endpoint.
+
+


### PR DESCRIPTION
Fix making requests to the incorrect endpoint. An upcoming patch will introduce the `lcp` endpoint. Boost was incorrectly using `analyze-lcp`.

## Proposed changes:

* Fix using wrong endpoint path.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

n/a

## Does this pull request change what data or activity we track or use?

no

## Testing instructions:

- Nothing to test. Endpoint was updated.