### PR TITLE
Boost: Check LCP data status before applying optimization

### DIFF
--- a/projects/plugins/boost/app/modules/optimizations/lcp/class-lcp-optimizer.php
+++ b/projects/plugins/boost/app/modules/optimizations/lcp/class-lcp-optimizer.php
@@ -235,6 +235,13 @@ class LCP_Optimizer {
 		return $tag;
 	}
 
+	/**
+	 * Check if the LCP data is valid and can be optimized.
+	 *
+	 * @return bool True if the LCP data is valid and can be optimized, false otherwise.
+	 *
+	 * @since $$next-version$$
+	 */
 	private function can_optimize() {
 		if ( empty( $this->lcp_data ) || ! is_array( $this->lcp_data ) ) {
 			return false;

--- a/projects/plugins/boost/app/modules/optimizations/lcp/class-lcp-optimizer.php
+++ b/projects/plugins/boost/app/modules/optimizations/lcp/class-lcp-optimizer.php
@@ -104,7 +104,11 @@ class LCP_Optimizer {
 	 * @since $$next-version$$
 	 */
 	public function optimize_buffer( $buffer ) {
-		if ( empty( $this->lcp_data ) || ! isset( $this->lcp_data['success'] ) || ! $this->lcp_data['success'] || empty( $this->lcp_data['html'] ) ) {
+		if ( empty( $this->lcp_data ) || ! is_array( $this->lcp_data ) ) {
+			return $buffer;
+		}
+
+		if ( ! isset( $this->lcp_data['success'] ) || ! $this->lcp_data['success'] ) {
 			return $buffer;
 		}
 
@@ -137,11 +141,23 @@ class LCP_Optimizer {
 	}
 
 	public function get_image_to_preload() {
-		if ( empty( $this->lcp_data ) || ! isset( $this->lcp_data['success'] ) || ! $this->lcp_data['success'] || LCP::TYPE_BACKGROUND_IMAGE !== $this->lcp_data['type'] ) {
+		if ( empty( $this->lcp_data ) || ! is_array( $this->lcp_data ) ) {
 			return null;
 		}
 
-		if ( empty( $this->lcp_data['elementData'] ) || empty( $this->lcp_data['elementData']['url'] ) ) {
+		if ( ! isset( $this->lcp_data['success'] ) || ! $this->lcp_data['success'] ) {
+			return null;
+		}
+
+		if ( LCP::TYPE_BACKGROUND_IMAGE !== $this->lcp_data['type'] ) {
+			return null;
+		}
+
+		if ( empty( $this->lcp_data['elementData'] ) || ! is_array( $this->lcp_data['elementData'] ) ) {
+			return null;
+		}
+
+		if ( empty( $this->lcp_data['elementData']['url'] ) ) {
 			return null;
 		}
 

--- a/projects/plugins/boost/app/modules/optimizations/lcp/class-lcp-optimizer.php
+++ b/projects/plugins/boost/app/modules/optimizations/lcp/class-lcp-optimizer.php
@@ -104,11 +104,7 @@ class LCP_Optimizer {
 	 * @since $$next-version$$
 	 */
 	public function optimize_buffer( $buffer ) {
-		if ( empty( $this->lcp_data ) || ! is_array( $this->lcp_data ) ) {
-			return $buffer;
-		}
-
-		if ( ! isset( $this->lcp_data['success'] ) || ! $this->lcp_data['success'] ) {
+		if ( ! $this->can_optimize() ) {
 			return $buffer;
 		}
 
@@ -141,11 +137,7 @@ class LCP_Optimizer {
 	}
 
 	public function get_image_to_preload() {
-		if ( empty( $this->lcp_data ) || ! is_array( $this->lcp_data ) ) {
-			return null;
-		}
-
-		if ( ! isset( $this->lcp_data['success'] ) || ! $this->lcp_data['success'] ) {
+		if ( ! $this->can_optimize() ) {
 			return null;
 		}
 
@@ -241,5 +233,17 @@ class LCP_Optimizer {
 		$tag = preg_replace( '/<img\s/i', '<img sizes="' . esc_attr( $sizes_string ) . '" ', $tag );
 
 		return $tag;
+	}
+
+	private function can_optimize() {
+		if ( empty( $this->lcp_data ) || ! is_array( $this->lcp_data ) ) {
+			return false;
+		}
+
+		if ( ! isset( $this->lcp_data['success'] ) || ! $this->lcp_data['success'] ) {
+			return false;
+		}
+
+		return true;
 	}
 }

--- a/projects/plugins/boost/app/modules/optimizations/lcp/class-lcp-optimizer.php
+++ b/projects/plugins/boost/app/modules/optimizations/lcp/class-lcp-optimizer.php
@@ -104,7 +104,7 @@ class LCP_Optimizer {
 	 * @since $$next-version$$
 	 */
 	public function optimize_buffer( $buffer ) {
-		if ( empty( $this->lcp_data ) || empty( $this->lcp_data['html'] ) ) {
+		if ( empty( $this->lcp_data ) || ! isset( $this->lcp_data['success'] ) || ! $this->lcp_data['success'] || empty( $this->lcp_data['html'] ) ) {
 			return $buffer;
 		}
 
@@ -137,7 +137,7 @@ class LCP_Optimizer {
 	}
 
 	public function get_image_to_preload() {
-		if ( empty( $this->lcp_data ) || LCP::TYPE_BACKGROUND_IMAGE !== $this->lcp_data['type'] ) {
+		if ( empty( $this->lcp_data ) || ! isset( $this->lcp_data['success'] ) || ! $this->lcp_data['success'] || LCP::TYPE_BACKGROUND_IMAGE !== $this->lcp_data['type'] ) {
 			return null;
 		}
 

--- a/projects/plugins/boost/changelog/fix-boost-lcp-apply-only-when-successful
+++ b/projects/plugins/boost/changelog/fix-boost-lcp-apply-only-when-successful
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: LCP: Only attempt to apply LCP optimization if data is valid.
+
+


### PR DESCRIPTION
This is necessary, because an upcoming update in the cloud (https://github.com/Automattic/boost-cloud/pull/684) will allow `success` to be `false` for a device in the LCP analysis. Boost didn't check this and returning a response like this:

```
Array
(
    [mobile] => Array
        (
            [success] => 
            [message] => Unable to load page: http://jetpack-boost.test/?jb-disable-modules=all
        )

    [desktop] => Array
        (
            [success] => 
            [message] => Unable to load page: http://jetpack-boost.test/?jb-disable-modules=all
        )

)
```

resulted in PHP notices:

```
Warning: Undefined array key "type" in /usr/local/src/jetpack-monorepo/projects/plugins/boost/app/modules/optimizations/lcp/class-lcp-optimizer.php on line 140
```

## Proposed changes:

* Check LCP status before applying optimization.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

n/a

## Does this pull request change what data or activity we track or use?

no

## Testing instructions:

- Apply https://github.com/Automattic/boost-cloud/pull/684 on your local cloud;
- Make sure Boost is running this PR;
- Configure Boost Developer:
  - `Connect to local Shield` should be enabled;
  - `LCP Test Element` should be set to `Image Tag`;
  - `Force Critical CSS generation Error` should be set to `Showstopper`. This will force front-end pages on your website to return an error 500 when the cloud tries to analyze the LCP;
- Request an LCP analysis and wait for the process to complete;
- Visit one of the cornerstone pages and there should be no PHP notices on the page. The LCP optimization shouldn't be applied as well, since the page couldn't be analyzed by the cloud;
- You can try the same with Boost running off of trunk to see the PHP notice.