### PR TITLE
Support Gutenberg Ad block for Aditude

### DIFF
--- a/docs/automated-testing.md
+++ b/docs/automated-testing.md
@@ -25,7 +25,7 @@ These tests are used to test both plugins and packages code. Depending on develo
 
 Unit tests are used to test individual units of code, such as a function or a class. They are meant to be run in isolation, without any external dependencies. They are fast and easy to write. This is a preferred approach to PHP testing, that leads to decoupled and testable code.
 
-Refer to PHPUnit [documentation](https://phpunit.readthedocs.io/en/9.5/writing-tests-for-phpunit.html) for more details on how to write tests. Also, there are various examples in the repo such as [here](/projects/packages/a8c-mc-stats/tests/php/test_Stats.php).
+Refer to PHPUnit [documentation](https://phpunit.readthedocs.io/en/9.5/writing-tests-for-phpunit.html) for more details on how to write tests. Also, there are various examples in the repo such as [here](/projects/packages/a8c-mc-stats/tests/php/StatsTest.php).
 
 Note: Jetpack monorepo is using a bit different code style to one that used in documentation examples.
 
@@ -43,7 +43,7 @@ Normally, integration tests for packages rely on various mocking solutions avail
 - [brain/monkey](https://packagist.org/packages/brain/monkey) - For mocking and stubbing WordPress functions and classes.
 - [automattic/jetpack-test-environment](../projects/packages/test-environment/README.md) is used to pull in WordPress for testing. It calls in a lightweight version of WordPress (via the [WorDBless](https://packagist.org/packages/automattic/wordbless) package) and provides a way to run tests in a WordPress environment. We use the jetpack-test-environment package within the monorepo to only need one install of WordPress for the entire monorepo.
 
-There are a lot of examples on how to use these tools in the `/projects/packages` folder, such as [here](/projects/packages/connection/tests/php/test_Manager_integration.php).
+There are a lot of examples on how to use these tools in the `/projects/packages` folder, such as [here](/projects/packages/connection/tests/php/ManagerIntegrationTest.php).
 
 ## Javascript tests
 
@@ -51,7 +51,7 @@ Monorepo provides support for `jest` as testing framework, and `@testing-library
 
 ### React components
 
-There are examples scattered through the monorepo such as [connection-status-card](/projects/packages/my-jetpack/_inc/components/connection-status-card/test/component.jsx) card. Refer to [documentation](https://testing-library.com/docs/react-testing-library/intro) for more details.
+There are examples scattered through the monorepo such as [connection-status-card](/projects/packages/my-jetpack/_inc/components/connection-status-card/index.tsx) card. Refer to [documentation](https://testing-library.com/docs/react-testing-library/intro) for more details.
 
 ### Gutenberg blocks
 

--- a/projects/plugins/jetpack/.phan/baseline.php
+++ b/projects/plugins/jetpack/.phan/baseline.php
@@ -33,7 +33,6 @@ return [
     // PhanTypeArraySuspicious : 20+ occurrences
     // PhanTypeMismatchDimFetch : 20+ occurrences
     // PhanSuspiciousMagicConstant : 15+ occurrences
-    // PhanTypeExpectedObjectPropAccessButGotNull : 15+ occurrences
     // PhanTypeMismatchPropertyDefault : 15+ occurrences
     // PhanTypeSuspiciousNonTraversableForeach : 15+ occurrences
     // PhanPluginDuplicateExpressionAssignmentOperation : 10+ occurrences
@@ -56,7 +55,6 @@ return [
     // PhanCommentAbstractOnInheritedMethod : 6 occurrences
     // PhanDeprecatedClass : 5 occurrences
     // PhanImpossibleCondition : 5 occurrences
-    // PhanNonClassMethodCall : 5 occurrences
     // PhanTypeMismatchDimAssignment : 5 occurrences
     // PhanAccessMethodInternal : 4 occurrences
     // PhanTypeInvalidLeftOperandOfAdd : 4 occurrences
@@ -72,6 +70,7 @@ return [
     // PhanTypeObjectUnsetDeclaredProperty : 3 occurrences
     // PhanUndeclaredMethodInCallable : 3 occurrences
     // PhanImpossibleConditionInLoop : 2 occurrences
+    // PhanNonClassMethodCall : 2 occurrences
     // PhanParamTooMany : 2 occurrences
     // PhanParamTooManyCallable : 2 occurrences
     // PhanPluginDuplicateSwitchCaseLooseEquality : 2 occurrences
@@ -192,7 +191,7 @@ return [
         'extensions/blocks/story/story.php' => ['PhanImpossibleCondition', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanPossiblyUndeclaredVariable'],
         'extensions/blocks/subscriptions/subscriptions.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],
         'extensions/blocks/top-posts/top-posts.php' => ['PhanTypeMismatchReturnProbablyReal'],
-        'extensions/blocks/wordads/wordads.php' => ['PhanNonClassMethodCall', 'PhanTypeExpectedObjectPropAccessButGotNull', 'PhanTypeMismatchArgument'],
+        'extensions/blocks/wordads/wordads.php' => ['PhanTypeMismatchArgument'],
         'extensions/plugins/sharing/sharing.php' => ['PhanRedundantCondition'],
         'functions.compat.php' => ['PhanRedefineFunction'],
         'functions.global.php' => ['PhanRedefineFunction', 'PhanRedundantCondition', 'PhanSuspiciousMagicConstant', 'PhanTypeMismatchArgument'],
@@ -446,11 +445,11 @@ return [
         'modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-my-account.php' => ['PhanDeprecatedFunction', 'PhanDeprecatedTrait'],
         'modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-trait.php' => ['PhanDeprecatedFunction', 'PhanTypeSuspiciousNonTraversableForeach', 'PhanUndeclaredMethod'],
         'modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-universal.php' => ['PhanDeprecatedFunction', 'PhanDeprecatedTrait', 'PhanPluginRedundantAssignment'],
-        'modules/wordads/class-wordads.php' => ['PhanNonClassMethodCall', 'PhanPluginRedundantAssignment', 'PhanTypeExpectedObjectPropAccessButGotNull', 'PhanTypeMismatchArgument', 'PhanTypeMismatchPropertyProbablyReal'],
+        'modules/wordads/class-wordads.php' => ['PhanPluginRedundantAssignment', 'PhanTypeMismatchArgument'],
         'modules/wordads/php/class-wordads-admin.php' => ['PhanTypeMismatchArgumentProbablyReal'],
         'modules/wordads/php/class-wordads-api.php' => ['PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal'],
         'modules/wordads/php/class-wordads-params.php' => ['PhanTypeMismatchReturn'],
-        'modules/wordads/php/class-wordads-sidebar-widget.php' => ['PhanTypeExpectedObjectPropAccessButGotNull', 'PhanTypeMismatchArgument'],
+        'modules/wordads/php/class-wordads-sidebar-widget.php' => ['PhanTypeMismatchArgument'],
         'sal/class.json-api-date.php' => ['PhanPluginDuplicateExpressionAssignmentOperation', 'PhanRedundantCondition', 'PhanTypeMismatchArgumentInternalProbablyReal'],
         'sal/class.json-api-links.php' => ['PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal'],
         'sal/class.json-api-post-base.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanRedundantCondition', 'PhanTypeMismatchArgument', 'PhanTypeMismatchReturnNullable', 'PhanTypeMismatchReturnProbablyReal', 'PhanTypePossiblyInvalidDimOffset', 'PhanTypeSuspiciousNonTraversableForeach'],
@@ -525,6 +524,7 @@ return [
         'tests/php/sync/server/class.jetpack-sync-test-object-factory.php' => ['PhanTypeMismatchArgumentProbablyReal'],
         'tests/php/sync/server/class.jetpack-sync-test-replicastore.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeInvalidLeftOperandOfAdd'],
         'tools/build-asset-cdn-json.php' => ['PhanTypeArraySuspiciousNullable', 'PhanTypeMismatchArgument'],
+        'unauth-file-upload.php' => ['PhanParamTooFewInternal'],
         'uninstall.php' => ['PhanTypeMismatchArgumentInternal'],
     ],
     // 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.

--- a/projects/plugins/jetpack/.phan/baseline.php
+++ b/projects/plugins/jetpack/.phan/baseline.php
@@ -79,7 +79,6 @@ return [
     // PhanUndeclaredClassInCallable : 2 occurrences
     // PhanUndeclaredClassMethod : 2 occurrences
     // PhanDeprecatedPartiallySupportedCallable : 1 occurrence
-    // PhanParamTooFewInternal : 1 occurrence
     // PhanPluginDuplicateSwitchCase : 1 occurrence
     // PhanPluginInvalidPregRegex : 1 occurrence
     // PhanPluginUseReturnValueInternalKnown : 1 occurrence
@@ -524,7 +523,6 @@ return [
         'tests/php/sync/server/class.jetpack-sync-test-object-factory.php' => ['PhanTypeMismatchArgumentProbablyReal'],
         'tests/php/sync/server/class.jetpack-sync-test-replicastore.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeInvalidLeftOperandOfAdd'],
         'tools/build-asset-cdn-json.php' => ['PhanTypeArraySuspiciousNullable', 'PhanTypeMismatchArgument'],
-        'unauth-file-upload.php' => ['PhanParamTooFewInternal'],
         'uninstall.php' => ['PhanTypeMismatchArgumentInternal'],
     ],
     // 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.

--- a/projects/plugins/jetpack/changelog/add-aditude-support-for-gutenberg
+++ b/projects/plugins/jetpack/changelog/add-aditude-support-for-gutenberg
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+WordAds: Support Gutenberg Ad block for Aditude

--- a/projects/plugins/jetpack/modules/wordads/class-wordads.php
+++ b/projects/plugins/jetpack/modules/wordads/class-wordads.php
@@ -744,7 +744,7 @@ HTML;
 			$loc_id = esc_js( $loc_id );
 
 			$format = $this->get_wordads_format( (int) $width, (int) $height );
-			if ( $format === null ) {
+			if ( $format === '' ) {
 				return '';
 			}
 

--- a/projects/plugins/jetpack/modules/wordads/class-wordads.php
+++ b/projects/plugins/jetpack/modules/wordads/class-wordads.php
@@ -272,7 +272,7 @@ class WordAds {
 		add_filter( 'wp_resource_hints', array( $this, 'resource_hints' ), 10, 2 );
 
 		// These 'wp_head' actions add the IPONWEB JavaScript snippets to the page.
-		// We need to remove them whenever
+		// We need to remove these calls whenever migration to Aditude is complete.
 		add_action( 'wp_head', array( $this, 'insert_head_meta' ), 20 );
 		add_action( 'wp_head', array( $this, 'insert_head_iponweb' ), 30 );
 

--- a/projects/plugins/jetpack/modules/wordads/class-wordads.php
+++ b/projects/plugins/jetpack/modules/wordads/class-wordads.php
@@ -742,6 +742,12 @@ HTML;
 			}
 
 			$loc_id = esc_js( $loc_id );
+
+			$format = $this->get_wordads_format( (int) $width, (int) $height );
+			if ( $format === null ) {
+				return '';
+			}
+
 			return <<<HTML
 			<div style="padding-bottom:15px;width:{$width}px;height:{$height}px;$css">
 				<div id="atatags-{$ad_number}">
@@ -755,6 +761,15 @@ HTML;
 							height: {$height}
 						});
 					});
+					if ( '{$format}' !== '' ) {
+						window.tudeMappings = window.tudeMappings || [];
+						window.tudeMappings.push( {
+							divId: 'atatags-{$ad_number}',
+							format: '{$format}',
+							width: {$width},
+							height: {$height},
+						} );
+					}
 					</script>
 				</div>
 			</div>
@@ -769,6 +784,34 @@ HTML;
 		}
 
 		return $this->get_dynamic_ad_snippet( $section_id, $form_factor, $location );
+	}
+
+	/**
+	 * Determine the WordAds format based on the ad dimensions.
+	 *
+	 * @param int $width  The width of the ad slot.
+	 * @param int $height The height of the ad slot.
+	 *
+	 * @return string WordAds Format enum.
+	 */
+	private function get_wordads_format( int $width, int $height ): string {
+		if ( $width === 300 && $height === 250 ) {
+			return 'gutenberg_rectangle';
+		}
+
+		if ( $width === 728 && $height === 90 ) {
+			return 'gutenberg_leaderboard';
+		}
+
+		if ( $width === 320 && $height === 50 ) {
+			return 'gutenberg_mobile_leaderboard';
+		}
+
+		if ( $width === 160 && $height === 600 ) {
+			return 'gutenberg_skyscraper';
+		}
+
+		return '';
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/wordads/class-wordads.php
+++ b/projects/plugins/jetpack/modules/wordads/class-wordads.php
@@ -20,6 +20,7 @@ require_once WORDADS_ROOT . '/php/class-wordads-cron.php';
 require_once WORDADS_ROOT . '/php/class-wordads-california-privacy.php';
 require_once WORDADS_ROOT . '/php/class-wordads-ccpa-do-not-sell-link-widget.php';
 require_once WORDADS_ROOT . '/php/class-wordads-consent-management-provider.php';
+require_once WORDADS_ROOT . '/php/class-wordads-formats.php';
 require_once WORDADS_ROOT . '/php/class-wordads-smart.php';
 require_once WORDADS_ROOT . '/php/class-wordads-shortcode.php';
 
@@ -743,7 +744,7 @@ HTML;
 
 			$loc_id = esc_js( $loc_id );
 
-			$format = $this->get_wordads_format( (int) $width, (int) $height );
+			$format = WordAds_Formats::get_format_slug( (int) $width, (int) $height );
 			if ( $format === '' ) {
 				return '';
 			}
@@ -784,34 +785,6 @@ HTML;
 		}
 
 		return $this->get_dynamic_ad_snippet( $section_id, $form_factor, $location );
-	}
-
-	/**
-	 * Determine the WordAds format based on the ad dimensions.
-	 *
-	 * @param int $width  The width of the ad slot.
-	 * @param int $height The height of the ad slot.
-	 *
-	 * @return string WordAds Format enum.
-	 */
-	private function get_wordads_format( int $width, int $height ): string {
-		if ( $width === 300 && $height === 250 ) {
-			return 'gutenberg_rectangle';
-		}
-
-		if ( $width === 728 && $height === 90 ) {
-			return 'gutenberg_leaderboard';
-		}
-
-		if ( $width === 320 && $height === 50 ) {
-			return 'gutenberg_mobile_leaderboard';
-		}
-
-		if ( $width === 160 && $height === 600 ) {
-			return 'gutenberg_skyscraper';
-		}
-
-		return '';
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/wordads/class-wordads.php
+++ b/projects/plugins/jetpack/modules/wordads/class-wordads.php
@@ -274,6 +274,8 @@ class WordAds {
 		// These 'wp_head' actions add the IPONWEB JavaScript snippets to the page.
 		// We need to remove these calls whenever migration to Aditude is complete.
 		add_action( 'wp_head', array( $this, 'insert_head_meta' ), 20 );
+
+		// TODO: Remove this function after June 30th, 2025.
 		add_action( 'wp_head', array( $this, 'insert_head_iponweb' ), 30 );
 
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
@@ -446,14 +448,14 @@ class WordAds {
 
 		// phpcs:disable WordPress.Security.EscapeOutput.HeredocOutputNotEscaped
 		echo <<<HTML
-				<script type="text/javascript">
-					var sas_fallback = sas_fallback || [];
-					sas_fallback.push(
-						{ tag: "$tag_inline", type: 'inline' },
-						{ tag: "$tag_belowpost", type: 'belowpost' },
-						{ tag: "$tag_top", type: 'top' }
-					);
-				</script>
+			<script type="text/javascript">
+				window.sas_fallback = window.sas_fallback || [];
+				window.sas_fallback.push(
+					{ tag: "$tag_inline", type: 'inline' },
+					{ tag: "$tag_belowpost", type: 'belowpost' },
+					{ tag: "$tag_top", type: 'top' }
+				);
+			</script>
 HTML;
 	}
 
@@ -470,10 +472,12 @@ HTML;
 		$data_tags = ( $this->params->cloudflare ) ? ' data-cfasync="false"' : '';
 		?>
 		<script<?php echo esc_attr( $data_tags ); ?> type="text/javascript">
+		function loadIPONWEB() { // TODO: Remove this after June 30th, 2025
 		(function(){var g=Date.now||function(){return+new Date};function h(a,b){a:{for(var c=a.length,d="string"==typeof a?a.split(""):a,e=0;e<c;e++)if(e in d&&b.call(void 0,d[e],e,a)){b=e;break a}b=-1}return 0>b?null:"string"==typeof a?a.charAt(b):a[b]};function k(a,b,c){c=null!=c?"="+encodeURIComponent(String(c)):"";if(b+=c){c=a.indexOf("#");0>c&&(c=a.length);var d=a.indexOf("?");if(0>d||d>c){d=c;var e=""}else e=a.substring(d+1,c);a=[a.substr(0,d),e,a.substr(c)];c=a[1];a[1]=b?c?c+"&"+b:b:c;a=a[0]+(a[1]?"?"+a[1]:"")+a[2]}return a};var l=0;function m(a,b){var c=document.createElement("script");c.src=a;c.onload=function(){b&&b(void 0)};c.onerror=function(){b&&b("error")};a=document.getElementsByTagName("head");var d;a&&0!==a.length?d=a[0]:d=document.documentElement;d.appendChild(c)}function n(a){var b=void 0===b?document.cookie:b;return(b=h(b.split("; "),function(c){return-1!=c.indexOf(a+"=")}))?b.split("=")[1]:""}function p(a){return"string"==typeof a&&0<a.length}
 		function r(a,b,c){b=void 0===b?"":b;c=void 0===c?".":c;var d=[];Object.keys(a).forEach(function(e){var f=a[e],q=typeof f;"object"==q&&null!=f||"function"==q?d.push(r(f,b+e+c)):null!==f&&void 0!==f&&(e=encodeURIComponent(b+e),d.push(e+"="+encodeURIComponent(f)))});return d.filter(p).join("&")}function t(a,b){a||((window.__ATA||{}).config=b.c,m(b.url))}var u=Math.floor(1E13*Math.random()),v=window.__ATA||{};window.__ATA=v;window.__ATA.cmd=v.cmd||[];v.rid=u;v.createdAt=g();var w=window.__ATA||{},x="s.pubmine.com";
 		w&&w.serverDomain&&(x=w.serverDomain);var y="//"+x+"/conf",z=window.top===window,A=window.__ATA_PP&&window.__ATA_PP.gdpr_applies,B="boolean"===typeof A?Number(A):null,C=window.__ATA_PP||null,D=z?document.referrer?document.referrer:null:null,E=z?window.location.href:document.referrer?document.referrer:null,F,G=n("__ATA_tuuid");F=G?G:null;var H=window.innerWidth+"x"+window.innerHeight,I=n("usprivacy"),J=r({gdpr:B,pp:C,rid:u,src:D,ref:E,tuuid:F,vp:H,us_privacy:I?I:null},"",".");
 		(function(a){var b=void 0===b?"cb":b;l++;var c="callback__"+g().toString(36)+"_"+l.toString(36);a=k(a,b,c);window[c]=function(d){t(void 0,d)};m(a,function(d){d&&t(d)})})(y+"?"+J);}).call(this);
+		}
 		</script>
 		<?php
 	}
@@ -756,24 +760,37 @@ HTML;
 			<div style="padding-bottom:15px;width:{$width}px;height:{$height}px;$css">
 				<div id="atatags-{$ad_number}">
 					<script$data_tags type="text/javascript">
-					const __ATA = window.__ATA || {};
-					__ATA.cmd = __ATA.cmd || [];
-					__ATA.cmd.push(function() {
-						__ATA.initSlot('atatags-{$ad_number}',  {
-							collapseEmpty: 'before',
-							sectionId: '{$section_id}',
-							location: {$loc_id},
-							width: {$width},
-							height: {$height}
-						});
-					});
-					window.tudeMappings = window.tudeMappings || [];
-					window.tudeMappings.push( {
-						divId: 'atatags-{$ad_number}',
-						format: '{$format}',
-						width: {$width},
-						height: {$height},
-					} );
+						window.getAdSnippetCallback = function () {
+							if ( true === ( window.isWatlV1 ?? false ) ) {
+								// Use IPONWEB scripts.
+								window.__ATA = window.__ATA || {};
+								window.__ATA.cmd = __ATA.cmd || [];
+								window.__ATA.cmd.push(function() {
+									window.__ATA.initSlot('atatags-{$ad_number}', {
+										collapseEmpty: 'before',
+										sectionId: '{$section_id}',
+										location: {$loc_id},
+										width: {$width},
+										height: {$height}
+									});
+								});
+							} else {
+								// Use Aditude scripts.
+								window.tudeMappings = window.tudeMappings || [];
+								window.tudeMappings.push( {
+									divId: 'atatags-{$ad_number}',
+									format: '{$format}',
+									width: {$width},
+									height: {$height},
+								} );
+							}
+						}
+
+						if ( document.readyState === 'loading' ) {
+							document.addEventListener( 'DOMContentLoaded', window.getAdSnippetCallback );
+						} else {
+							window.getAdSnippetCallback();
+						}
 					</script>
 				</div>
 			</div>
@@ -804,12 +821,9 @@ HTML;
 	 * @since 8.7
 	 */
 	public function get_dynamic_ad_snippet( $section_id, $form_factor = 'square', $location = '', $relocate = '', $id = null ) {
+		$is_location_enabled = in_array( $location, array( 'top', 'belowpost', 'inline' ), true );
 
-		// Allow overriding and printing of the tag parsed by the WATL.
-		// phpcs:disable WordPress.Security.NonceVerification.Recommended
-		$is_location_enabled = isset( $_GET['wordads-logging'] ) && isset( $_GET[ $location ] ) && 'true' === $_GET[ $location ];
-
-		if ( ( 'top' === $location || 'belowpost' === $location ) && $is_location_enabled ) {
+		if ( $is_location_enabled ) {
 			return self::get_watl_ad_html_tag( $location );
 		}
 
@@ -988,7 +1002,32 @@ HTML;
 	 * @since 8.7
 	 */
 	public static function get_watl_ad_html_tag( string $slot_type ): string {
-		return "<div class=\"wordads-tag\" data-slot-type=\"$slot_type\" style=\"display: none;\"></div>";
+		$uid = uniqid( 'atatags-dynamic-' . $slot_type . '-' );
+
+		return <<<HTML
+			<div style="padding-bottom:15px;" class="wordads-tag" data-slot-type="{$slot_type}">
+				<div id="{$uid}">
+					<script type="text/javascript">
+						window.getAdSnippetCallback = function () {
+							if ( false === ( window.isWatlV1 ?? false ) ) {
+								// Use Aditude scripts.
+								window.tudeMappings = window.tudeMappings || [];
+								window.tudeMappings.push( {
+									divId: '{$uid}',
+									format: '{$slot_type}',
+								} );
+							}
+						}
+
+						if ( document.readyState === 'loading' ) {
+							document.addEventListener( 'DOMContentLoaded', window.getAdSnippetCallback );
+						} else {
+							window.getAdSnippetCallback();
+						}
+					</script>
+				</div>
+			</div>
+HTML;
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/wordads/class-wordads.php
+++ b/projects/plugins/jetpack/modules/wordads/class-wordads.php
@@ -269,8 +269,12 @@ class WordAds {
 	 */
 	private function insert_adcode() {
 		add_filter( 'wp_resource_hints', array( $this, 'resource_hints' ), 10, 2 );
+
+		// These 'wp_head' actions add the IPONWEB JavaScript snippets to the page.
+		// We need to remove them whenever
 		add_action( 'wp_head', array( $this, 'insert_head_meta' ), 20 );
 		add_action( 'wp_head', array( $this, 'insert_head_iponweb' ), 30 );
+
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
 		add_filter( 'wordads_ads_txt', array( $this, 'insert_custom_adstxt' ) );
 

--- a/projects/plugins/jetpack/modules/wordads/class-wordads.php
+++ b/projects/plugins/jetpack/modules/wordads/class-wordads.php
@@ -31,7 +31,7 @@ class WordAds {
 	/**
 	 * Ads parameters.
 	 *
-	 * @var null
+	 * @var WordAds_Params
 	 */
 	public $params = null;
 

--- a/projects/plugins/jetpack/modules/wordads/class-wordads.php
+++ b/projects/plugins/jetpack/modules/wordads/class-wordads.php
@@ -756,6 +756,8 @@ HTML;
 			<div style="padding-bottom:15px;width:{$width}px;height:{$height}px;$css">
 				<div id="atatags-{$ad_number}">
 					<script$data_tags type="text/javascript">
+					const __ATA = window.__ATA || {};
+					__ATA.cmd = __ATA.cmd || [];
 					__ATA.cmd.push(function() {
 						__ATA.initSlot('atatags-{$ad_number}',  {
 							collapseEmpty: 'before',

--- a/projects/plugins/jetpack/modules/wordads/class-wordads.php
+++ b/projects/plugins/jetpack/modules/wordads/class-wordads.php
@@ -744,11 +744,14 @@ HTML;
 
 			$loc_id = esc_js( $loc_id );
 
+			// Determine supported Gutenberg format by width and height.
 			$format = WordAds_Formats::get_format_slug( (int) $width, (int) $height );
 			if ( $format === '' ) {
-				return '';
+				return ''; // When format is not supported, ignore placement.
 			}
 
+			// For a while return elements for both IPONWEB (__ATA) and Aditude (tudeMappings).
+			// We will remove using IPONWEB after partnership termination on June 30, 2025.
 			return <<<HTML
 			<div style="padding-bottom:15px;width:{$width}px;height:{$height}px;$css">
 				<div id="atatags-{$ad_number}">
@@ -762,15 +765,13 @@ HTML;
 							height: {$height}
 						});
 					});
-					if ( '{$format}' !== '' ) {
-						window.tudeMappings = window.tudeMappings || [];
-						window.tudeMappings.push( {
-							divId: 'atatags-{$ad_number}',
-							format: '{$format}',
-							width: {$width},
-							height: {$height},
-						} );
-					}
+					window.tudeMappings = window.tudeMappings || [];
+					window.tudeMappings.push( {
+						divId: 'atatags-{$ad_number}',
+						format: '{$format}',
+						width: {$width},
+						height: {$height},
+					} );
 					</script>
 				</div>
 			</div>

--- a/projects/plugins/jetpack/modules/wordads/js/adflow-loader.js
+++ b/projects/plugins/jetpack/modules/wordads/js/adflow-loader.js
@@ -11,11 +11,26 @@ function a8c_adflow_callback( data ) {
 		}
 
 		// Load each adflow script.
+		window.isWatlV1 = window.isWatlV1 ?? false;
 		data.scripts.forEach( function ( scriptUrl ) {
 			let script = document.createElement( 'script' );
 			script.src = scriptUrl;
 			document.head.appendChild( script );
+			if ( scriptUrl.indexOf( 'watl.js' ) !== -1 ) {
+				window.isWatlV1 = true;
+			}
 		} );
+
+		window.loadIPONWEB = window.loadIPONWEB ?? function () {}; // Satisfy linter
+
+		if ( window.isWatlV1 ) {
+			// Then load IPONWEB scripts.
+			if ( document.readyState === 'loading' ) {
+				document.addEventListener( 'DOMContentLoaded', window.loadIPONWEB );
+			} else {
+				window.loadIPONWEB();
+			}
+		}
 	}
 }
 window.a8c_adflow_callback = a8c_adflow_callback;

--- a/projects/plugins/jetpack/modules/wordads/php/class-wordads-formats.php
+++ b/projects/plugins/jetpack/modules/wordads/php/class-wordads-formats.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * WordAds Formats Class file.
+ *
+ * This file contains the definition of the WordAds_Formats class, which handles
+ * determining the appropriate WordAds format slug based on ad slot dimensions.
+ *
+ * @package automattic/jetpack
+ */
+
+declare( strict_types = 1 );
+
+/**
+ * Class WordAds_Formats
+ *
+ * Set of WordAds methods working with formats and Ad dimensions.
+ */
+class WordAds_Formats {
+	/**
+	 * Determine the WordAds format based on the ad dimensions.
+	 *
+	 * @param int $width  The width of the ad slot.
+	 * @param int $height The height of the ad slot.
+	 *
+	 * @return string WordAds Format enum.
+	 */
+	public static function get_format_slug( int $width, int $height ): string {
+		if ( $width === 300 && $height === 250 ) {
+			return 'gutenberg_rectangle';
+		}
+
+		if ( $width === 728 && $height === 90 ) {
+			return 'gutenberg_leaderboard';
+		}
+
+		if ( $width === 320 && $height === 50 ) {
+			return 'gutenberg_mobile_leaderboard';
+		}
+
+		if ( $width === 160 && $height === 600 ) {
+			return 'gutenberg_skyscraper';
+		}
+
+		return '';
+	}
+}

--- a/projects/plugins/jetpack/modules/wordads/php/class-wordads-smart.php
+++ b/projects/plugins/jetpack/modules/wordads/php/class-wordads-smart.php
@@ -150,7 +150,7 @@ class WordAds_Smart {
 
 		wp_enqueue_script(
 			'adflow_config',
-			esc_url( $this->get_config_url() ),
+			$this->get_config_url(), // The URL is not escaped because we need two parameters to pass.
 			array( 'adflow_script_loader' ),
 			JETPACK__VERSION,
 			false
@@ -248,8 +248,9 @@ class WordAds_Smart {
 	 */
 	private function get_config_url(): string {
 		return sprintf(
-			'https://public-api.wordpress.com/wpcom/v2/sites/%1$d/adflow/conf/?_jsonp=a8c_adflow_callback',
-			$this->params->blog_id
+			'https://public-api.wordpress.com/wpcom/v2/sites/%1$d/adflow/conf/?_jsonp=a8c_adflow_callback&is_singular_post=%2$d&',
+			$this->params->blog_id,
+			(int) is_singular( 'post' )
 		);
 	}
 

--- a/projects/plugins/jetpack/phpunit.11.xml.dist
+++ b/projects/plugins/jetpack/phpunit.11.xml.dist
@@ -69,6 +69,9 @@
 		<testsuite name="widget-visibility">
 			<directory suffix="Test.php">tests/php/modules/widget-visibility</directory>
 		</testsuite>
+		<testsuite name="wordads">
+			<directory suffix="Test.php">tests/php/modules/wordads</directory>
+		</testsuite>
 		<testsuite name="sitemaps">
 			<directory suffix="Test.php">tests/php/modules/sitemaps</directory>
 		</testsuite>

--- a/projects/plugins/jetpack/phpunit.9.xml.dist
+++ b/projects/plugins/jetpack/phpunit.9.xml.dist
@@ -60,6 +60,9 @@
 		<testsuite name="widget-visibility">
 			<directory suffix="Test.php">tests/php/modules/widget-visibility</directory>
 		</testsuite>
+		<testsuite name="wordads">
+			<directory suffix="Test.php">tests/php/modules/wordads</directory>
+		</testsuite>
 		<testsuite name="sitemaps">
 			<directory suffix="Test.php">tests/php/modules/sitemaps</directory>
 		</testsuite>

--- a/projects/plugins/jetpack/tests/php/modules/wordads/WordAds_Formats_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/wordads/WordAds_Formats_Test.php
@@ -1,0 +1,67 @@
+<?php
+
+require __DIR__ . '/../../../../modules/wordads/php/class-wordads-formats.php';
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * Test WordAds_Formats.
+ *
+ * @covers \WordAds_Formats
+ */
+#[CoversClass( WordAds_Formats::class )]
+class WordAds_Formats_Test extends WP_UnitTestCase {
+	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
+
+	/**
+	 * Gets the test data for test_get_format_slug().
+	 *
+	 * @return array The test data.
+	 */
+	public static function get_format_data() {
+		return array(
+			'gutenberg_rectangle'          => array(
+				300,
+				250,
+				'gutenberg_rectangle',
+			),
+			'gutenberg_leaderboard'        => array(
+				728,
+				90,
+				'gutenberg_leaderboard',
+			),
+			'gutenberg_mobile_leaderboard' => array(
+				320,
+				50,
+				'gutenberg_mobile_leaderboard',
+			),
+			'gutenberg_skyscraper'         => array(
+				160,
+				600,
+				'gutenberg_skyscraper',
+			),
+			'unknown_format'               => array(
+				400,
+				300,
+				'',
+			),
+		);
+	}
+
+	/**
+	 * Test the widget method that outputs the markup.
+	 *
+	 * @dataProvider get_format_data
+	 * @param int    $width The block's width.
+	 * @param int    $height The block's height.
+	 * @param string $expected The expected format slug.
+	 */
+	#[DataProvider( 'get_format_data' )]
+	public function test_get_format_slug( int $width, int $height, string $expected ): void {
+		$this->assertEquals(
+			$expected,
+			WordAds_Formats::get_format_slug( $width, $height )
+		);
+	}
+}

--- a/projects/plugins/jetpack/unauth-file-upload.php
+++ b/projects/plugins/jetpack/unauth-file-upload.php
@@ -93,7 +93,7 @@ function handle_file_download() {
 
 	// Output file content and exit
 	echo $file['content']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Binary file data
-	exit;
+	exit( 0 );
 }
 
 /**

--- a/projects/plugins/jetpack/unauth-file-upload.php
+++ b/projects/plugins/jetpack/unauth-file-upload.php
@@ -93,7 +93,7 @@ function handle_file_download() {
 
 	// Output file content and exit
 	echo $file['content']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Binary file data
-	exit( 0 );
+	exit;
 }
 
 /**


### PR DESCRIPTION
Related to `184618-ghe-Automattic/wpcom`

## Proposed changes:
- Load IPONWEB scripts conditionally (when Aditude is not used);
- Open locations `top`, `belowpost`, and `inline` to be used for Ad serving;
- Remove escaping for adflow/conf URL because otherwise it loses the second parameter;
- Pass `is_singular( 'post' )` as `is_singular_post` parameter to `adflow/conf` request to let WPCOM know whether it's a post or something else (for some formats we allow to advertise on a posts only).

## Why do we need it?
- As a part of migration to Aditude we need to support Gutenberg Ad blocks. Since those blocks are added dynamically, we need to pass their parameters (ID, format, width, and height) to Aditude wrapper (otherwise they will continue being a white boxes or even be removed)

### Other information:
- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:

Please follow testing instructions from accompanying PR (`184618-ghe-Automattic/wpcom`).

To demo how it works, this's how Aditude works with these changes:

https://github.com/user-attachments/assets/e9fa7abd-00bc-43dc-9aed-096b98f6862b

And that's the proof that IPONWEB is still working as well:

https://github.com/user-attachments/assets/a7161f58-ad2d-4274-af4c-974993cc006d