### PR TITLE
Jetpack Forms: fit dashboard layout height and scrollbars

### DIFF
--- a/projects/packages/forms/changelog/fix-jetpack-forms-dashboard-layout-heights
+++ b/projects/packages/forms/changelog/fix-jetpack-forms-dashboard-layout-heights
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Forms Dashboard: fix containers height to consistently fit on view, single scrollbar on dataviews

--- a/projects/packages/forms/src/dashboard/components/layout/style.scss
+++ b/projects/packages/forms/src/dashboard/components/layout/style.scss
@@ -16,7 +16,7 @@ body.admin_page_jetpack-forms {
 	margin: 0;
 	padding: 0;
 	width: 100%;
-	min-height: 100%;
+	height: 100%;
 
 	.jp-forms__logo-wrapper,
 	.jp-forms__layout-header {
@@ -47,7 +47,9 @@ body.admin_page_jetpack-forms {
 	}
 
 	.jp-forms__dashboard-tabs {
-		min-height: 100%;
+		display: flex;
+		flex-direction: column;
+		flex-grow: 1;
 
 		> .components-tab-panel__tabs {
 			margin: 0;
@@ -78,6 +80,10 @@ body.admin_page_jetpack-forms {
 			@media (max-width: 660px) {
 				padding: 0 24px;
 			}
+		}
+
+		.components-tab-panel__tab-content {
+			height: 100%;
 		}
 	}
 }

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -300,11 +300,13 @@ $action-bar-height: 88px;
 	display: flex;
 	flex-direction: column;
 	height: 100%;
+	max-height: 100%;
 	flex: 1 1 50%;
 
 	.dataviews-wrapper {
 		background: #fff;
-		height: auto;
+		height: 300px;
+		flex-grow: 1;
 		overflow-y: visible;
 		overflow-x: auto;
 
@@ -356,19 +358,17 @@ body[class*="_page_jetpack-forms"] {
 	}
 }
 
-#jp-forms-dashboard,
-.jp-forms__layout.jp-forms__inbox {
+#jp-forms-dashboard {
 	height: 100%;
 	display: flex;
 	flex-direction: column;
 	width: 100%;
-}
 
-.jp-forms__layout.jp-forms__inbox {
-
-	.jp-forms__layout-header {
-		flex: 0 1 auto; /* Flex, but don't grow */
+	// This is the ThemeWrapper div, we need to keep it at 100% for the inner content to be full height.
+	> div:first-child {
+		height: 100%;
 	}
+
 }
 
 .jp-forms__inbox-tabs .components-tab-panel__tab-content {

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -188,7 +188,6 @@ $action-bar-height: 88px;
 	.components-button {
 		background-color: #fff;
 		display: inline-block;
-		float: right;
 		height: 28px;
 		margin-left: auto;
 		padding: 4px 8px;


### PR DESCRIPTION
## Proposed changes:
This PR aims to provide an alternative to consistently fit the dashboard containers so that only a single scrollbar is shown: the dataviews scroller. This way, we can keep all the header controls in view.

**Before:**

https://github.com/user-attachments/assets/96cfe4e4-4193-411e-b2bd-c578b9474d5b


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1746475309202549-slack-C086RGTJT1D

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Visit the Forms Responses dashboard, try to have enough responses so to create scrolling, and then some (on trash) so to see a list without scrolling.

See that now the scrolling is always contained by the dataviews rows scroller.

**After:**

https://github.com/user-attachments/assets/5f353d62-e75b-43fa-87ec-17739b653912

