### PR TITLE
Forms: Fix label position when input has border and options does not

### DIFF
--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -1546,6 +1546,11 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		$css_vars        = '';
 		$outline_styles  = $this->get_attribute( 'outlinestyledata' );
 		$outline_classes = $this->get_attribute( 'outlinestyleclasses' );
+		$block_name      = 'jetpack/input';
+
+		if ( $this->maybe_override_type() === 'radio' || $this->maybe_override_type() === 'checkbox-multiple' ) {
+			$block_name = 'jetpack/options';
+		}
 
 		if ( ! empty( $outline_styles ) ) {
 			$outline_styles = json_decode( html_entity_decode( $outline_styles, ENT_COMPAT ), true );
@@ -1558,7 +1563,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 			$global_styles = wp_get_global_styles(
 				array( 'border' ),
 				array(
-					'block_name' => 'jetpack/input',
+					'block_name' => $block_name,
 					'transforms' => array( 'resolve-variables' ),
 				)
 			);


### PR DESCRIPTION
Follow up to https://github.com/Automattic/jetpack/pull/43327
Fixes an issue mentioned here - https://github.com/Automattic/jetpack/pull/43327#issuecomment-2885377415
Merges into the branch from #42890 and not trunk

## Proposed changes:
In global styles, if you set the input block to have a wider border (but leave the options block as it was originally), the options field's label is adjusted as though it had the wider border.

This seems to be a side effect of hard-coding the input block's name in the `get_outline_styles` function.

To fix, this PR proposes deriving the inner block name from the field type, defaulting to `jetpack/input`, but using `jetpack/options` if the field type is `radio` or `checkbox-multiple`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1747367710269879-slack-C02A76B714Z

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
1. Add a form and ensure that form has Single Choice, Multiple Choice and Name/Email fields.
2. In Global Styles, set a large border width for the Input block and save
3. View your form on the frontend

**Before this PR** - the Single/Multiple choice fields label is positioned incorrectly
<img width="609" alt="Screenshot 2025-05-16 at 3 30 39 pm" src="https://github.com/user-attachments/assets/d627c35f-3180-42da-882a-9aeffd0ef8af" />


**After this PR** - the Single/Multiple choice fields label is positioned correctly
<img width="612" alt="Screenshot 2025-05-16 at 3 30 26 pm" src="https://github.com/user-attachments/assets/b7bf6fcd-68e3-44a2-b90e-d44f0dc5d6fd" />
