### PR TITLE
Boost: Update LCP to note that it's in beta

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/features/lcp/lcp.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/lcp/lcp.tsx
@@ -6,6 +6,7 @@ import Module from '$features/module/module';
 import { useLcpState, useOptimizeLcpAction } from './lib/stores/lcp-state';
 import TimeAgo from '$features/critical-css/time-ago/time-ago';
 import { recordBoostEvent } from '$lib/utils/analytics';
+import Pill from '$features/ui/pill/pill';
 
 const Status = () => {
 	const [ query ] = useLcpState();
@@ -76,7 +77,12 @@ const Lcp = () => {
 	return (
 		<Module
 			slug="lcp"
-			title={ __( 'Optimize LCP', 'jetpack-boost' ) }
+			title={
+				<>
+					{ __( 'Optimize LCP', 'jetpack-boost' ) }
+					<Pill text={ __( 'Beta', 'jetpack-boost' ) } />
+				</>
+			}
 			description={
 				<p>
 					{ __(

--- a/projects/plugins/boost/changelog/update-boost-lcp-add-beta-pill
+++ b/projects/plugins/boost/changelog/update-boost-lcp-add-beta-pill
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: LCP: Tag as beta in UI.
+
+


### PR DESCRIPTION
Partially addresses HOG-110.

![CleanShot 2025-05-16 at 13 16 41](https://github.com/user-attachments/assets/6a0b0f58-64fa-47bd-8b06-43d5e95155c8)

## Proposed changes:

* Add Beta tag to LCP in Boost settings page.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

n/a

## Does this pull request change what data or activity we track or use?

no

## Testing instructions:

- Make sure the beta tag is showing.
