### PR TITLE
Boost: Remove experimental tag from Cornerstone Pages

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/features/cornerstone-pages/cornerstone-pages.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/cornerstone-pages/cornerstone-pages.tsx
@@ -6,7 +6,6 @@ import styles from './cornerstone-pages.module.scss';
 import { usePremiumFeatures } from '$lib/stores/premium-features';
 import { recordBoostEvent } from '$lib/utils/analytics';
 import { useCornerstonePages } from './lib/stores/cornerstone-pages';
-import Pill from '$features/ui/pill/pill';
 import Prerender from './prerender/prerender';
 import { useSingleModuleState } from '$features/module/lib/stores';
 
@@ -25,7 +24,6 @@ const CornerstonePages = () => {
 						<div>
 							<h3>
 								{ __( 'Cornerstone Pages', 'jetpack-boost' ) }
-								<Pill text={ __( 'Experimental', 'jetpack-boost' ) } />
 								{ isPremium && <Upgraded /> }
 							</h3>
 							<CornerstoneTitleSummary />

--- a/projects/plugins/boost/changelog/remove-boost-cornerstone-pages-experimental-tag
+++ b/projects/plugins/boost/changelog/remove-boost-cornerstone-pages-experimental-tag
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Cornerstone Pages: Remove "Experimental" tag from UI.


### PR DESCRIPTION
Partially addresses HOG-110.

We're adding a feature that depends on it so it no longer makes sense to have it tagged as an experiment.

![CleanShot 2025-05-16 at 13 24 12](https://github.com/user-attachments/assets/c3c21658-1e98-447e-81aa-7c66d4ee86b9)


## Proposed changes:

* Remove "Experimental" tag from Cornerstone Pages in Boost settings page.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

n/a

## Does this pull request change what data or activity we track or use?

no

## Testing instructions:

- Make sure the tag is removed from the Cornerstone Pages.