### PR TITLE
Boost: Remove beta tag from Auto-resize lazy images

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/features/image-cdn/image-cdn-liar/image-cdn-liar.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/image-cdn/image-cdn-liar/image-cdn-liar.tsx
@@ -3,7 +3,6 @@ import { __ } from '@wordpress/i18n';
 import styles from './image-cdn-liar.module.scss';
 import ModuleSubsection from '$features/ui/module-subsection/module-subsection';
 import { recordBoostEvent } from '$lib/utils/analytics';
-import Pill from '$features/ui/pill/pill';
 import { useMutationNotice } from '$features/ui/mutation-notice/mutation-notice';
 import { useModulesState } from '$features/module/lib/stores';
 
@@ -43,10 +42,7 @@ export default function ImageCdnLiar( { isPremium }: ImageCdnLiarProps ) {
 		<ModuleSubsection>
 			<div className={ styles.wrapper }>
 				<div className={ styles.title }>
-					<h4>
-						{ __( 'Auto-Resize Lazy Images', 'jetpack-boost' ) }
-						<Pill text="Beta" />
-					</h4>
+					<h4>{ __( 'Auto-Resize Lazy Images', 'jetpack-boost' ) }</h4>
 					<ToggleControl
 						className={ styles[ 'toggle-control' ] }
 						checked={ imageCdnLiar }

--- a/projects/plugins/boost/changelog/update-boost-liar-remove-beta-tag
+++ b/projects/plugins/boost/changelog/update-boost-liar-remove-beta-tag
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Auto-resize lazy images: Remove beta tag.


### PR DESCRIPTION
Partially addresses HOG-110

![CleanShot 2025-05-16 at 18 05 47](https://github.com/user-attachments/assets/e578dd39-0d86-48eb-bcee-ccb5f901aab2)

## Proposed changes:

* Remove beta tag from "Auto-resize lazy images".

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

HOG-110

## Does this pull request change what data or activity we track or use?

no

## Testing instructions:

- Make sure the beta tag is removed (this is a premium feature).