### PR TITLE
phpcs-filter: Fix code coverage run with phpcs 3.13

### DIFF
--- a/projects/packages/phpcs-filter/changelog/fix-phpcs-filter-phpunit-coverage
+++ b/projects/packages/phpcs-filter/changelog/fix-phpcs-filter-phpunit-coverage
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix Code coverage run when testing with PHPCS 3.13.
+
+

--- a/projects/packages/phpcs-filter/tests/php/bootstrap.php
+++ b/projects/packages/phpcs-filter/tests/php/bootstrap.php
@@ -8,5 +8,15 @@
 // Include the Composer autoloader.
 require_once __DIR__ . '/../../vendor/autoload.php';
 
+// PHPCS 3.13.0 starts defining these PHP 8.4 constants, but defines them as strings. Meanwhile nikic/php-parser complains if they're not ints.
+// But the problem only occurs with the combination of the require below and PHPUnit generating coverage.
+// Anyway, we can preemptively define the constants before the require to avoid the problem.
+// @todo Drop this once we run coverage with PHP 8.4, or when phpcs fixes it themself.
+if ( ! defined( 'T_PUBLIC_SET' ) ) {
+	define( 'T_PUBLIC_SET', 8675309 );
+	define( 'T_PROTECTED_SET', 8675310 );
+	define( 'T_PRIVATE_SET', 8675311 );
+}
+
 // Phpcs needs some bootstrapping of its own for tests to work.
 require_once __DIR__ . '/../../vendor/squizlabs/php_codesniffer/tests/bootstrap.php';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
PHPCS 3.13.0 starts defining some PHP 8.4 token constants if they don't exist, but defines them as strings. Meanwhile nikic/php-parser complains if they're not ints.

The problem only occurs for this package with the coverage run, because it depends on phpcs loading its replacement constants (which only happens here because of the weird way we set things up to be able to test the filter) and on PHPUnit generating code coverage.

We can preemptively define the constants before the require to avoid the problem, so let's do that for now.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1747410329232199/1747410196.700419-slack-C034JEXD1RD

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* CI coverage job happy?