### PR TITLE
wpcomsh: Add PHPUnit script

### DIFF
--- a/.github/workflows/wpcloud.yml
+++ b/.github/workflows/wpcloud.yml
@@ -128,8 +128,8 @@ jobs:
           ssh jpwpcomsh "wp --skip-plugins --skip-themes dereferenced freshen > /dev/null 2>&1" || CODE=$?
           echo "wp dereferenced freshen has exited with code $CODE"
           ssh jpwpcomsh "rm -rf /tmp/old-* > /dev/null 2>&1"
-          pnpm jetpack rsync wpcomsh jpwpcomsh:~/htdocs/wp-content/mu-plugins
-          scp -r projects/plugins/wpcomsh/bin jpwpcomsh:/srv/htdocs/wp-content/mu-plugins/wpcomsh
+          pnpm jetpack rsync --non-interactive wpcomsh jpwpcomsh:~/htdocs/wp-content/mu-plugins
+          scp -r projects/plugins/wpcomsh/bin jpwpcomsh:/srv/htdocs/wp-content/mu-plugins/wpcomsh/
           scp -r projects/plugins/wpcomsh/tests jpwpcomsh:/srv/htdocs/wp-content/mu-plugins/wpcomsh/
           # The test on wpcloud won't use `phpunit-select-config`, select config manually.
           scp projects/plugins/wpcomsh/phpunit.9.xml.dist jpwpcomsh:/srv/htdocs/wp-content/mu-plugins/wpcomsh/phpunit.xml.dist

--- a/.github/workflows/wpcloud.yml
+++ b/.github/workflows/wpcloud.yml
@@ -137,7 +137,7 @@ jobs:
           echo "::engroup::"
 
           echo "::group::execution"
-          ssh jpwpcomsh "~/htdocs/github-action-handler.sh" || CODE=$?
+          ssh jpwpcomsh "/srv/htdocs/wp-content/mu-plugins/wpcomsh/bin/run-phpunit-tests.sh" || CODE=$?
           echo "::endgroup::"
 
           echo "::group::teardown"

--- a/.github/workflows/wpcloud.yml
+++ b/.github/workflows/wpcloud.yml
@@ -134,7 +134,7 @@ jobs:
           # The test on wpcloud won't use `phpunit-select-config`, select config manually.
           scp projects/plugins/wpcomsh/phpunit.9.xml.dist jpwpcomsh:/srv/htdocs/wp-content/mu-plugins/wpcomsh/phpunit.xml.dist
 
-          echo "::engroup::"
+          echo "::endgroup::"
 
           echo "::group::execution"
           ssh jpwpcomsh "/srv/htdocs/wp-content/mu-plugins/wpcomsh/bin/run-phpunit-tests.sh" || CODE=$?

--- a/.github/workflows/wpcloud.yml
+++ b/.github/workflows/wpcloud.yml
@@ -99,7 +99,7 @@ jobs:
         run: |
           pnpm install
 
-      - name: Configure Github to be able to SSH to the Atomic site
+      - name: Configure Github to be able to SSH to the WP Cloud site
         run: |
           echo "::group::Intializing"
 

--- a/.github/workflows/wpcloud.yml
+++ b/.github/workflows/wpcloud.yml
@@ -1,4 +1,4 @@
-name: WPCloud Unit Testing for WPCOMSH
+name: WP Cloud Unit Testing for WPCOMSH
 
 on:
   pull_request:
@@ -7,7 +7,7 @@ on:
 concurrency:
   group: wpcloud-wpcomsh
   cancel-in-progress: false
-  # Concurrency is set up to make sure we can only run one WPCloud testing job at the same time.
+  # Concurrency is set up to make sure we can only run one WP Cloud testing job at the same time.
 
 jobs:
   build:
@@ -29,7 +29,7 @@ jobs:
       - name: Setup tools
         uses: ./.github/actions/tool-setup
         with:
-          # Match PHP version on wpcloud so the right vendor packages get installed.
+          # Match PHP version on WP Cloud so the right vendor packages get installed.
           php: 8.1
       - name: Monorepo install
         run: |
@@ -75,7 +75,7 @@ jobs:
             !./.github/
           key: ${{ github.sha }}
   deploy:
-    name: Run PHPUnit on the WPCloud test site
+    name: Run PHPUnit on the WP Cloud test site
     runs-on: ubuntu-latest
     needs: build
     if: needs.build.outputs.wpcomsh == 'true'
@@ -131,7 +131,7 @@ jobs:
           pnpm jetpack rsync --non-interactive wpcomsh jpwpcomsh:~/htdocs/wp-content/mu-plugins
           scp -r projects/plugins/wpcomsh/bin jpwpcomsh:/srv/htdocs/wp-content/mu-plugins/wpcomsh/
           scp -r projects/plugins/wpcomsh/tests jpwpcomsh:/srv/htdocs/wp-content/mu-plugins/wpcomsh/
-          # The test on wpcloud won't use `phpunit-select-config`, select config manually.
+          # The test on WP Cloud won't use `phpunit-select-config`, so select config manually.
           scp projects/plugins/wpcomsh/phpunit.9.xml.dist jpwpcomsh:/srv/htdocs/wp-content/mu-plugins/wpcomsh/phpunit.xml.dist
 
           echo "::endgroup::"

--- a/projects/plugins/wpcomsh/bin/run-phpunit-tests.sh
+++ b/projects/plugins/wpcomsh/bin/run-phpunit-tests.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+set -euo pipefail
+
+function ensure_composer() {
+	if [ ! -d "$HOME/.composer" ]; then
+		mkdir "$HOME/.composer"
+	fi
+
+	if [ -f "$HOME/composer" ]; then
+		echo "OK: $HOME/composer"
+	else
+		if wget -O "/tmp/composer-setup.php" https://getcomposer.org/installer; then
+			chmod a+x "/tmp/composer-setup.php"
+		else
+			echo "Failed to download composer"
+			exit 1
+		fi
+
+		echo "export PATH=$HOME/.composer/vendor/bin:$PATH" >> "$HOME/.bashrc"
+		source "$HOME/.bashrc"
+
+		php /tmp/composer-setup.php --install-dir="$HOME" --filename=composer
+
+		echo "Composer set up successfully"
+	fi
+}
+
+function checkout_project() {
+	cd "$HOME/htdocs/wp-content/mu-plugins"
+
+	if [ ! -d wpcomsh ]; then
+		git clone git@github.com:Automattic/wpcomsh.git
+	else
+		cd "$HOME/htdocs/wp-content/mu-plugins/wpcomsh"
+		git checkout .
+		git fetch --all
+		eval "git checkout $GITHUB_REF_NAME"
+		eval "git pull origin $GITHUB_REF_NAME --rebase"
+	fi
+}
+
+function setup_tests() {
+	cd "$HOME/htdocs/wp-content/mu-plugins/wpcomsh"
+	chmod 700 bin/install-wp-tests.sh
+	"$HOME/composer" global require "phpunit/phpunit=^9" --ignore-platform-reqs --dev -W
+	"$HOME/composer" global require "yoast/phpunit-polyfills=^1.0.1" --ignore-platform-reqs --dev
+	# "$HOME/composer" install --no-dev --optimize-autoloader
+
+	bin/install-wp-tests.sh "$DB_NAME" "$DB_USER" "$DB_PASSWORD" "$DB_HOST" latest true
+
+	echo "WordPress tests set up successfully"
+}
+
+function run_tests() {
+	cd "$HOME/htdocs/wp-content/mu-plugins/wpcomsh"
+
+	source "$HOME/.bashrc"
+
+	# Caching causes issues, so move it.
+	[[ -f "$WP_CONTENT_DIR/object-cache.php" ]] && mv -v "$WP_CONTENT_DIR"/object-cache{,_disabled}.php
+
+	$HOME/.composer/vendor/bin/phpunit --testsuite wpcloud
+
+	# Move it back into place
+	[[ -f "$WP_CONTENT_DIR/object-cache_disabled.php" ]] && mv -v "$WP_CONTENT_DIR"/object-cache{_disabled,}.php
+}
+
+export WP_TESTS_PHPUNIT_POLYFILLS_PATH="$HOME/.composer/vendor/yoast/phpunit-polyfills/phpunitpolyfills-autoload.php"
+export COMPOSER_HOME="$HOME/.composer"
+export WP_CORE_DIR="$HOME/htdocs/__wp__"
+export WP_CONTENT_DIR="$HOME/htdocs/wp-content"
+
+ensure_composer
+setup_tests
+run_tests
+

--- a/projects/plugins/wpcomsh/changelog/fix-tooling-prevent_tsconfig_inline_comments
+++ b/projects/plugins/wpcomsh/changelog/fix-tooling-prevent_tsconfig_inline_comments
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Tests: Add script that runs PHPUnit tests.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Previously the script that ran PHPUnit tests on WP Cloud was not in the repo, so when the site went down, this disappeared but for a backup.

This PR:
* Adds the script to the repo and updates the workflow to run it.
* Updates the `jetpack rsync` command to run with `--non-interactive`.
* Fixes an `::engroup::` → `::endgroup::` typo.
* Updates "Atomic" to "WP Cloud".

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Do WPCOMSH tests still run as expected?