### PR TITLE
Forms: Add Integrations tab behind feature flag

### DIFF
--- a/projects/packages/forms/changelog/add-forms-integration-tab-with-flag
+++ b/projects/packages/forms/changelog/add-forms-integration-tab-with-flag
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: Add integration tab with feature flag.

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -161,6 +161,9 @@ class Dashboard {
 		$ai_feature = \Jetpack_AI_Helper::get_ai_assistance_feature();
 		$has_ai     = ! is_wp_error( $ai_feature ) ? $ai_feature['has-feature'] : false;
 
+		// Add feature flag for Integrations tab
+		$enable_integrations_tab = apply_filters( 'jetpack_forms_enable_integrations_tab', false );
+
 		$config = array(
 			'blogId'                  => get_current_blog_id(),
 			'exportNonce'             => wp_create_nonce( 'feedback_export' ),
@@ -171,6 +174,7 @@ class Dashboard {
 			'siteURL'                 => ( new Status() )->get_site_suffix(),
 			'hasFeedback'             => $this->has_feedback(),
 			'hasAI'                   => $has_ai,
+			'enableIntegrationsTab'   => $enable_integrations_tab,
 		);
 		?>
 		<div id="jp-forms-dashboard" data-config="<?php echo esc_attr( wp_json_encode( $config, JSON_FORCE_OBJECT ) ); ?>"></div>

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -36,6 +36,13 @@ class Dashboard {
 	const MENU_PRIORITY = 999;
 
 	/**
+	 * Whether the integrations tab is enabled.
+	 *
+	 * @var bool
+	 */
+	public static $show_integrations = false;
+
+	/**
 	 * Dashboard_View_Switch instance
 	 *
 	 * @var Dashboard_View_Switch
@@ -49,6 +56,9 @@ class Dashboard {
 	 */
 	public function __construct( Dashboard_View_Switch $switch ) {
 		$this->switch = $switch;
+
+		// Set the integrations tab feature flag
+		self::$show_integrations = apply_filters( 'jetpack_forms_enable_integrations_tab', false );
 	}
 
 	/**
@@ -161,9 +171,6 @@ class Dashboard {
 		$ai_feature = \Jetpack_AI_Helper::get_ai_assistance_feature();
 		$has_ai     = ! is_wp_error( $ai_feature ) ? $ai_feature['has-feature'] : false;
 
-		// Add feature flag for Integrations tab
-		$enable_integrations_tab = apply_filters( 'jetpack_forms_enable_integrations_tab', false );
-
 		$config = array(
 			'blogId'                  => get_current_blog_id(),
 			'exportNonce'             => wp_create_nonce( 'feedback_export' ),
@@ -174,7 +181,7 @@ class Dashboard {
 			'siteURL'                 => ( new Status() )->get_site_suffix(),
 			'hasFeedback'             => $this->has_feedback(),
 			'hasAI'                   => $has_ai,
-			'enableIntegrationsTab'   => $enable_integrations_tab,
+			'enableIntegrationsTab'   => self::$show_integrations,
 		);
 		?>
 		<div id="jp-forms-dashboard" data-config="<?php echo esc_attr( wp_json_encode( $config, JSON_FORCE_OBJECT ) ); ?>"></div>

--- a/projects/packages/forms/src/dashboard/components/layout/index.js
+++ b/projects/packages/forms/src/dashboard/components/layout/index.js
@@ -15,11 +15,16 @@ const Layout = ( { className, showFooter } ) => {
 	const location = useLocation();
 	const navigate = useNavigate();
 
+	const enableIntegrationsTab = config( 'enableIntegrationsTab' );
+
 	const tabs = [
 		{
 			name: 'responses',
 			title: __( 'Responses', 'jetpack-forms' ),
 		},
+		...( enableIntegrationsTab
+			? [ { name: 'integrations', title: __( 'Integrations', 'jetpack-forms' ) } ]
+			: [] ),
 		{
 			name: 'about',
 			title: __( 'About', 'jetpack-forms' ),

--- a/projects/packages/forms/src/dashboard/index.js
+++ b/projects/packages/forms/src/dashboard/index.js
@@ -11,6 +11,7 @@ import { createHashRouter, Navigate, RouterProvider } from 'react-router-dom';
 import About from './about';
 import Layout from './components/layout';
 import Inbox from './inbox';
+import Integrations from './integrations';
 import DashboardNotices from './notices-list';
 import './style.scss';
 
@@ -36,6 +37,10 @@ window.addEventListener( 'load', () => {
 				{
 					path: 'responses',
 					element: <Inbox />,
+				},
+				{
+					path: 'integrations',
+					element: <Integrations />,
 				},
 				{
 					path: 'about',

--- a/projects/packages/forms/src/dashboard/index.js
+++ b/projects/packages/forms/src/dashboard/index.js
@@ -38,10 +38,14 @@ window.addEventListener( 'load', () => {
 					path: 'responses',
 					element: <Inbox />,
 				},
-				{
-					path: 'integrations',
-					element: <Integrations />,
-				},
+				...( config( 'enableIntegrationsTab' )
+					? [
+							{
+								path: 'integrations',
+								element: <Integrations />,
+							},
+					  ]
+					: [] ),
 				{
 					path: 'about',
 					element: <About />,

--- a/projects/packages/forms/src/dashboard/integrations/index.tsx
+++ b/projects/packages/forms/src/dashboard/integrations/index.tsx
@@ -1,0 +1,12 @@
+import { __ } from '@wordpress/i18n';
+import './style.scss';
+
+const Integrations = () => (
+	<div className="jp-forms__integrations">
+		<div className="section-main">
+			<h3>{ __( 'Third party integrations coming soon…', 'jetpack-forms' ) }</h3>
+		</div>
+	</div>
+);
+
+export default Integrations;

--- a/projects/packages/forms/src/dashboard/integrations/style.scss
+++ b/projects/packages/forms/src/dashboard/integrations/style.scss
@@ -1,0 +1,3 @@
+.jp-forms__integrations {
+	padding: 20px 48px;
+} 

--- a/projects/packages/forms/src/dashboard/integrations/style.scss
+++ b/projects/packages/forms/src/dashboard/integrations/style.scss
@@ -1,3 +1,3 @@
 .jp-forms__integrations {
 	padding: 20px 48px;
-} 
+}


### PR DESCRIPTION
## Proposed changes:

Adds Integrations tab (with placeholder content) to forms dashboard, behind a feature flag. To enable the feature flag, add this: 

`add_filter( 'jetpack_forms_enable_integrations_tab', '__return_true' );`

When enabled, you'll see a new tab with placeholder content. Screenhot:

<img width="1494" alt="feature-flag-integrations" src="https://github.com/user-attachments/assets/e4e6ce08-0526-4489-926d-1b2ed76259d0" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
P2: p1HpG7-wzu-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No. 

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add `add_filter( 'jetpack_forms_enable_integrations_tab', '__return_true' );`
* Go to the Feedback tab and confirm that the Integration tab shows like screenshot above. 
* Comment out the feature flag and confirm that the integration tab goes away and that the other tabs and dashboard functionality continue to behave as before. 