### PR TITLE
Inline Search: Mitigate P2 bug

### DIFF
--- a/projects/packages/search/changelog/fix-highlighter-title-param
+++ b/projects/packages/search/changelog/fix-highlighter-title-param
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Mitigate bug with certain P2 theme

--- a/projects/packages/search/src/inline-search/class-inline-search-highlighter.php
+++ b/projects/packages/search/src/inline-search/class-inline-search-highlighter.php
@@ -45,7 +45,8 @@ class Inline_Search_Highlighter {
 	 * Set up the WordPress filters for highlighting.
 	 */
 	public function setup(): void {
-		add_filter( 'the_title', array( $this, 'filter_highlighted_title' ), 10, 2 );
+		// phpcs:ignore Squiz.PHP.CommentedOutCode.Found -- Temporarily disabled due to incompatibility with P2 theme
+		// add_filter( 'the_title', array( $this, 'filter_highlighted_title' ), 10, 2 );
 		add_filter( 'the_excerpt', array( $this, 'filter_highlighted_excerpt' ) );
 		add_filter( 'render_block_core/post-excerpt', array( $this, 'filter_render_highlighted_block' ), 10, 3 );
 	}
@@ -71,24 +72,12 @@ class Inline_Search_Highlighter {
 	/**
 	 * Filter the post title to show highlighted version.
 	 *
-	 * @param string   $title   The post title.
-	 * @param int|null $post_id Optional. The post ID. If not provided, attempts to get from current post.
-	 *                          Made optional to handle cases where filters don't pass the second parameter,
-	 *                          though ideally all callers should pass both parameters as per WordPress standards.
+	 * @param string $title The post title.
+	 * @param int    $post_id The post ID.
 	 *
 	 * @return string The filtered title.
 	 */
-	public function filter_highlighted_title( string $title, ?int $post_id = null ): string {
-		// If post_id is not provided, try to get it from the current post
-		if ( $post_id === null ) {
-			$post_id = get_the_ID();
-
-			// If we still don't have a post ID, return the original title
-			if ( ! $post_id ) {
-				return $title;
-			}
-		}
-
+	public function filter_highlighted_title( string $title, int $post_id ): string {
 		if ( ! $this->is_search_result( $post_id ) ) {
 			return $title;
 		}

--- a/projects/packages/search/src/inline-search/class-inline-search-highlighter.php
+++ b/projects/packages/search/src/inline-search/class-inline-search-highlighter.php
@@ -71,12 +71,24 @@ class Inline_Search_Highlighter {
 	/**
 	 * Filter the post title to show highlighted version.
 	 *
-	 * @param string $title The post title.
-	 * @param int    $post_id The post ID.
+	 * @param string   $title   The post title.
+	 * @param int|null $post_id Optional. The post ID. If not provided, attempts to get from current post.
+	 *                          Made optional to handle cases where filters don't pass the second parameter,
+	 *                          though ideally all callers should pass both parameters as per WordPress standards.
 	 *
 	 * @return string The filtered title.
 	 */
-	public function filter_highlighted_title( string $title, int $post_id ): string {
+	public function filter_highlighted_title( string $title, ?int $post_id = null ): string {
+		// If post_id is not provided, try to get it from the current post
+		if ( $post_id === null ) {
+			$post_id = get_the_ID();
+
+			// If we still don't have a post ID, return the original title
+			if ( ! $post_id ) {
+				return $title;
+			}
+		}
+
 		if ( ! $this->is_search_result( $post_id ) ) {
 			return $title;
 		}

--- a/projects/plugins/jetpack/changelog/fix-highlighter-title-param
+++ b/projects/plugins/jetpack/changelog/fix-highlighter-title-param
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Mitigate bug with certain P2 theme

--- a/projects/plugins/search/changelog/fix-highlighter-title-param
+++ b/projects/plugins/search/changelog/fix-highlighter-title-param
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Mitigate bug with certain p2 theme


### PR DESCRIPTION
Mitigate behaviour reported in p1747423124187819-slack-C02FMH4G8

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A

## Does this pull request change what data or activity we track or use?

N/A

## Testing instructions:

- Either set `add_filter( 'jetpack_search_replace_classic', '__return_true', 20 );` somewhere (e.g. using `Code Snippets` plugin) or add an early `return true` to `should_replace_classic_search()`
- Run a new search. You should expect to see the search term highlighted in the returned results, per above.
- Run searches for other words and ensure word boundaries are respected.

