### PR TITLE
My Jetpack: Fix onboarding slider shift on window resize

### DIFF
--- a/projects/js-packages/components/changelog/fix-my-jetpack-slider-shift-on-window-resize
+++ b/projects/js-packages/components/changelog/fix-my-jetpack-slider-shift-on-window-resize
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed Swipeable width being stale on window resize

--- a/projects/js-packages/components/components/swipeable/index.tsx
+++ b/projects/js-packages/components/components/swipeable/index.tsx
@@ -366,6 +366,8 @@ export const Swipeable = ( {
 				className="swipeable__container"
 				ref={ pagesRef }
 				{ ...otherProps }
+				// Ensure that state is reset when the window is resized
+				key={ containerWidth?.toString() }
 			>
 				<div
 					className={ clsx( 'swipeable__pages', containerClassName ) }


### PR DESCRIPTION
Fixes MYJP-111

<details>
<summary>@keoshi noticed that the My Jetpack onboarding carousel slides shift slightly when the browser window is resized.</summary>

https://github.com/user-attachments/assets/ab55fe56-2a6c-4bda-9ef5-60e345743940
</details>

The reason for the issue is that the container width in `Swipeable` component is stale for a moment when the window is resized and is not immediately applied to the slide, which is used by the [`DotPager`](https://github.com/Automattic/jetpack/blob/96bde59fcc757cc7c4de23df3053840410caa093/projects/js-packages/components/components/dot-pager/index.tsx#L76) component.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Reset the `Swipeable` component local state when the window is resized by using an underrated feature of React - [Resetting state with a key](https://react.dev/learn/preserving-and-resetting-state#option-2-resetting-state-with-a-key)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Disconnect your site - `jetpack docker wp jetpack disconnect blog`
* Go to My Jetpack
* Resize the browser window
* Confirm that the carousel slides do not shift


<table>
    <tbody>
        <tr>
            <th>BEFORE</th>
            <th>AFTER</th>
        </tr>
        <tr>
            <td>

https://github.com/user-attachments/assets/cf162227-cb64-44fa-bf25-b3e43b59e689

</td>
            <td>

https://github.com/user-attachments/assets/ff38e868-3018-4fc2-bb59-d31d4516eb3b

</td>
        </tr>
    </tbody>
</table>