### PR TITLE
WPCOM_JSON_API_Update_Post_v1_1_Endpoint: Ensure properties and keys are not undefined

### DIFF
--- a/projects/plugins/jetpack/changelog/update-json-api-post-endpoint-v1-1-undefined-values
+++ b/projects/plugins/jetpack/changelog/update-json-api-post-endpoint-v1-1-undefined-values
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Endpoints: Adding checks within the v1.1 post update endpoint to ensure values are defined.

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-post-v1-1-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-post-v1-1-endpoint.php
@@ -928,7 +928,8 @@ class WPCOM_JSON_API_Update_Post_v1_1_Endpoint extends WPCOM_JSON_API_Post_v1_1_
 			$return['media_errors'] = $media_results['errors'];
 		}
 
-		if ( 'publish' !== $post->post_status ) {
+		// Generate suggestions for new posts or non-published posts
+		if ( $new || ( isset( $return['status'] ) && 'publish' !== $return['status'] ) ) {
 			$sal_site             = $this->get_sal_post_by( 'ID', $post_id, $args['context'] );
 			$return['other_URLs'] = (object) $sal_site->get_permalink_suggestions( $input['title'] );
 		}

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-post-v1-1-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-post-v1-1-endpoint.php
@@ -522,7 +522,8 @@ class WPCOM_JSON_API_Update_Post_v1_1_Endpoint extends WPCOM_JSON_API_Post_v1_1_
 					$discussion[ $discussion_status ] = $is_open ? 'open' : 'closed';
 				}
 
-				if ( in_array( $discussion[ $discussion_status ], array( 'open', 'closed' ), true ) ) {
+				if ( isset( $discussion[ $discussion_status ] ) &&
+					in_array( $discussion[ $discussion_status ], array( 'open', 'closed' ), true ) ) {
 					$insert[ $discussion_status ] = $discussion[ $discussion_status ];
 				}
 			}

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-post-v1-1-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-post-v1-1-endpoint.php
@@ -829,7 +829,7 @@ class WPCOM_JSON_API_Update_Post_v1_1_Endpoint extends WPCOM_JSON_API_Post_v1_1_
 				$meta = (object) $meta;
 
 				if (
-					in_array( $meta->key, Jetpack_SEO_Posts::POST_META_KEYS_ARRAY, true ) &&
+					in_array( isset( $meta->key ) ? $meta->key : null, Jetpack_SEO_Posts::POST_META_KEYS_ARRAY, true ) &&
 					! Jetpack_SEO_Utils::is_enabled_jetpack_seo()
 				) {
 					return new WP_Error( 'unauthorized', __( 'SEO tools are not enabled for this site.', 'jetpack' ), 403 );
@@ -859,10 +859,10 @@ class WPCOM_JSON_API_Update_Post_v1_1_Endpoint extends WPCOM_JSON_API_Post_v1_1_
 					}
 				}
 
-				$unslashed_meta_key           = wp_unslash( $meta->key ); // should match what the final key will be.
-				$meta->key                    = wp_slash( $meta->key );
-				$unslashed_existing_meta_key  = wp_unslash( $existing_meta_item->meta_key );
-				$existing_meta_item->meta_key = wp_slash( $existing_meta_item->meta_key );
+				$unslashed_meta_key           = isset( $meta->key ) ? wp_unslash( $meta->key ) : null; // should match what the final key will be.
+				$meta->key                    = isset( $meta->key ) ? wp_slash( $meta->key ) : null;
+				$unslashed_existing_meta_key  = isset( $existing_meta_item->meta_key ) ? wp_unslash( $existing_meta_item->meta_key ) : null;
+				$existing_meta_item->meta_key = isset( $existing_meta_item->meta_key ) ? wp_slash( $existing_meta_item->meta_key ) : null;
 
 				// make sure that the meta id passed matches the existing meta key.
 				if ( ! empty( $meta->id ) && ! empty( $meta->key ) ) {

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-post-v1-1-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-post-v1-1-endpoint.php
@@ -932,7 +932,8 @@ class WPCOM_JSON_API_Update_Post_v1_1_Endpoint extends WPCOM_JSON_API_Post_v1_1_
 		// Generate suggestions for new posts or non-published posts
 		if ( $new || ( isset( $return['status'] ) && 'publish' !== $return['status'] ) ) {
 			$sal_site             = $this->get_sal_post_by( 'ID', $post_id, $args['context'] );
-			$return['other_URLs'] = (object) $sal_site->get_permalink_suggestions( $input['title'] );
+			$title                = isset( $input['title'] ) ? $input['title'] : '';
+			$return['other_URLs'] = (object) $sal_site->get_permalink_suggestions( $title );
 		}
 
 		/** This action is documented in json-endpoints/class.wpcom-json-api-site-settings-endpoint.php */
@@ -1109,7 +1110,8 @@ class WPCOM_JSON_API_Update_Post_v1_1_Endpoint extends WPCOM_JSON_API_Post_v1_1_
 		wp_untrash_post( $post->ID );
 		$untrashed_post = get_post( $post->ID );
 		// Lets make sure that we use the reverted the slug.
-		if ( isset( $untrashed_post->post_name ) && $untrashed_post->post_name . '__trashed' === $input['slug'] ) {
+		if ( isset( $input['slug'] ) && isset( $untrashed_post->post_name ) &&
+			$untrashed_post->post_name . '__trashed' === $input['slug'] ) {
 			unset( $input['slug'] );
 		}
 		return $input;


### PR DESCRIPTION
Fixes VULCAN-119

## Proposed changes:

* This PR ensures that various properties and array keys are not checked for within `WPCOM_JSON_API_Update_Post_v1_1_Endpoint` if they do not exist.
* This prevents warnings from filling up PHP error logs. These warnings are:
  * Attempt to read property "post_status" on null  (line 931)
  * Undefined property: stdClass::$meta_key (line 864 and 865)
  * Undefined array key "comment_status" and "ping_status" on line 525
  * Undefined property: stdClass::$key on lines 832, 862 and 863
  * Undefined array key "title" on line 933.
* In terms of changes, most are straight forward, but the replacement for `'publish' !== $post->post_status` to prevent the `post_status` warning now essentially does the same but without checking the `$post value` as well (`$return` is created [after all the updates are complete](https://github.com/Automattic/jetpack/blob/96bde59fcc757cc7c4de23df3053840410caa093/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-post-v1-1-endpoint.php#L913), whereas `$post` was [only being defined on post update](https://github.com/Automattic/jetpack/blob/96bde59fcc757cc7c4de23df3053840410caa093/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-post-v1-1-endpoint.php#L335), not for new posts)
* Logs: 6a0cfb7d9b77eee03683612eb4be21a1-logstash
* Also Atomic logs: c25c15873906e0233e07311099e2e2a8-logstash

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

pdWQjU-1g0-p2

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

The best way to replicate the warnings and test the fixes is to use the Postman API platform. The below testing instructions are based on using that.

* Open the developer console - `https://developer.wordpress.com/docs/api/console/` - do a post request for the WPCOM API, v1.1, `/sites/{your simple site ID}/posts/new`. Use the dropdown to select the API request, and add a title and some content:

<img width="1619" alt="Screenshot 2025-05-19 at 16 54 15" src="https://github.com/user-attachments/assets/5c207e77-923d-4bce-b6d9-e363fe3c1d5b" />


Then:
* Make sure your Simple site is sandboxed. 
* Open up the browser console, network tab.
* Submit the request, and notice the request in the console.
* Right click and select 'Copy', then 'Copy as cURL'
* Paste this straight into the URL field for a new request in Postman (click '+', then paste the info in directly).
* Click on 'Send', and you should notice a new post being created on your Simple test site.

To test the `Attempt to read property "post_status" on null` warning:
* This should be replicable with the testing instructions above.

To test the `Undefined property: stdClass::$meta_key` and `Undefined property: stdClass::$key` warnings:
* Add the following to the Postman post body:
```
"metadata": [
    {
      "key": "custom_key_1",
      "value": "custom_value_1",
      "operation": "add"
    },
    {
      "value": "custom_value_2",
      "previous_value": "old_value",
      "operation": "update"
    }
  ]
```
This should look similar to this: 
<img width="849" alt="Screenshot 2025-05-19 at 16 44 00" src="https://github.com/user-attachments/assets/7cf9d54e-a488-4207-9e6d-067ea87035be" />

* Clicking on send in Postman, you should see the `$meta_key` and `$key` warnings.

To test the `Undefined array key "comment_status"` ( and `"ping_status"` ) warnings:

* Add the following object to the body object: 
```
"discussion": {
        "comments_open": true,
        "pings_open": true
    }
```
* Comment out `comments_open`, and then separately `pings_open`, and test each time. You should get a warning regarding an undefined array key for the commented out key.

To test `Undefined array key "title"`:
* Remove the title property and value (no empty string for the value, both must be removed) from the body object, and re-test.

---

To test the fix, apply this PR by using the command in the generated comment below on your sandbox. Run through the same testing steps, and the warnings should not be visible. 
* An additional warning was also fixed - `Undefined array key "slug"` though testing proved tricky. However this is now just including a check to see if the `slug` key is set first, so a proof-read should suffice.