### PR TITLE
Theme Compatibility: Catch Twenty Twenty PHP warning

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-twentytwenty_compat_warning
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-twentytwenty_compat_warning
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Theme Compatibility: Prevent warning when custom color value isn't set.

--- a/projects/plugins/jetpack/modules/theme-tools/compat/twentytwenty.php
+++ b/projects/plugins/jetpack/modules/theme-tools/compat/twentytwenty.php
@@ -100,15 +100,16 @@ add_action( 'wp_enqueue_scripts', 'twentytwenty_enqueue_jetpack_style' );
  * Add inline custom CSS with custom accent color if there is any set.
  */
 function twentytwenty_infinity_accent_color_css() {
+	$color_info = get_theme_mod( 'accent_accessible_colors' );
+
 	// Bail early if no custom color was set.
 	if (
-	'custom' !== get_theme_mod( 'accent_hue_active' )
-	|| empty( get_theme_mod( 'accent_accessible_colors' ) )
+		'custom' !== get_theme_mod( 'accent_hue_active' )
+		|| empty( $color_info )
 	) {
 		return;
 	}
 
-	$color_info = get_theme_mod( 'accent_accessible_colors' );
 	$custom_css = sprintf(
 		'
 	.infinite-scroll #site-content #infinite-handle span button,

--- a/projects/plugins/jetpack/modules/theme-tools/compat/twentytwenty.php
+++ b/projects/plugins/jetpack/modules/theme-tools/compat/twentytwenty.php
@@ -124,7 +124,7 @@ function twentytwenty_infinity_accent_color_css() {
 	}
 	',
 		$color_info['content']['accent'],
-		$color_info['content']['background'],
+		$color_info['content']['background'] ?? '#f5efe0',
 		$color_info['content']['secondary']
 	);
 

--- a/projects/plugins/jetpack/modules/theme-tools/compat/twentytwenty.php
+++ b/projects/plugins/jetpack/modules/theme-tools/compat/twentytwenty.php
@@ -125,7 +125,7 @@ function twentytwenty_infinity_accent_color_css() {
 	}
 	',
 		$color_info['content']['accent'],
-		$color_info['content']['background'] ?? '#f5efe0',
+		$color_info['content']['background'] ?? '#fff',
 		$color_info['content']['secondary']
 	);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

We get over 10K of these notices every day on WP Cloud (about 10% of the total warning/error count):
```
PHP Warning: Undefined array key "background" in /wordpress/plugins/jetpack/14.7-a.3/modules/theme-tools/compat/twentytwenty.php on line 127
```

It seems Twenty Twenty doesn't set this property by default:
https://github.com/wordpress/twentytwenty/blob/master/classes/class-twentytwenty-customize.php#L152

However, if some colors are set but the main background color is not, one gets the PHP notice.

Note that the current output CSS defaults to an empty value. I originally was going to set the fallback to `#f5efe0`, which is what clicking "default" in the Customizer uses, but instead I decided to match what the current behaviour (inheriting `#fff`) to avoid annoying users with a potential unexpected color change.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Set up a new site with the Twenty Twenty theme (you can reset the necessary settings by deleting the `theme_mods_twentytwenty` option).
2. Ensure you have more than one page of posts. You can adjust posts per page here: `/wp-admin/options-reading.php`
3. Enable "Infinite Scroll with a button": `/wp-admin/admin.php?page=jetpack#/settings?term=infinite`
4. Go to Customizer → Colors: `/wp-admin/customize.php`
5. Do NOT touch the main "Background Color" setting.
6. Change the main "Header & Footer Background Color" setting.
7. Set the "Primary Color" setting to a custom color.
8. Save.
9. Load the posts page.

In `trunk` one gets a warning each time the page is loaded.

In the `fix/jetpack/twentytwenty_compat_warning` branch, the warning is avoided.