### PR TITLE
Forms: add submenu item on dotcom

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-jetpack-forms-wpcom-submenu
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-jetpack-forms-wpcom-submenu
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: Add Jetpack submenu item for forms dashboard

--- a/projects/packages/jetpack-mu-wpcom/composer.json
+++ b/projects/packages/jetpack-mu-wpcom/composer.json
@@ -10,6 +10,7 @@
 		"automattic/jetpack-calypsoify": "@dev",
 		"automattic/jetpack-classic-theme-helper": "@dev",
 		"automattic/jetpack-connection": "@dev",
+		"automattic/jetpack-forms": "@dev",
 		"automattic/jetpack-masterbar": "@dev",
 		"automattic/jetpack-redirect": "@dev",
 		"automattic/jetpack-stats-admin": "@dev",

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
@@ -479,11 +479,14 @@ add_action( 'admin_menu', 'wpcom_add_plugins_menu' );
  */
 function add_submenu_jetpack_forms() {
 	$has_switch_class = class_exists( 'Dashboard_View_Switch' );
-	$has_method       = method_exists( 'Dashboard_View_Switch', 'is_jetpack_forms_admin_page_available' );
+	// @phan-suppress-next-line PhanUndeclaredClassReference
+	$has_method = method_exists( 'Dashboard_View_Switch', 'is_jetpack_forms_admin_page_available' );
+	// @phan-suppress-next-line PhanUndeclaredStaticMethod
 	if ( ! $has_switch_class || ! $has_method || ! Dashboard_View_Switch::is_jetpack_forms_admin_page_available() ) {
 		return;
 	}
 
+	// @phan-suppress-next-line PhanRedundantCondition
 	$handler = $has_switch_class
 		? ( new Dashboard_View_Switch() )->get_forms_admin_url()
 		: 'edit.php?post_type=feedback';

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
@@ -480,7 +480,6 @@ add_action( 'admin_menu', 'wpcom_add_plugins_menu' );
 function add_submenu_jetpack_forms() {
 	$has_switch_class = class_exists( 'Dashboard_View_Switch' );
 
-	// @phan-suppress-next-line PhanUndeclaredStaticMethod
 	if ( ! $has_switch_class || ! Dashboard_View_Switch::is_jetpack_forms_admin_page_available() ) {
 		return;
 	}

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
@@ -479,10 +479,9 @@ add_action( 'admin_menu', 'wpcom_add_plugins_menu' );
  */
 function add_submenu_jetpack_forms() {
 	$has_switch_class = class_exists( 'Dashboard_View_Switch' );
-	// @phan-suppress-next-line PhanUndeclaredClassReference
-	$has_method = method_exists( 'Dashboard_View_Switch', 'is_jetpack_forms_admin_page_available' );
 
-	if ( ! $has_switch_class || ! $has_method || ! Dashboard_View_Switch::is_jetpack_forms_admin_page_available() ) {
+	// @phan-suppress-next-line PhanUndeclaredStaticMethod
+	if ( ! $has_switch_class || ! Dashboard_View_Switch::is_jetpack_forms_admin_page_available() ) {
 		return;
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
@@ -481,7 +481,7 @@ function add_submenu_jetpack_forms() {
 	$has_switch_class = class_exists( 'Dashboard_View_Switch' );
 	// @phan-suppress-next-line PhanUndeclaredClassReference
 	$has_method = method_exists( 'Dashboard_View_Switch', 'is_jetpack_forms_admin_page_available' );
-	// @phan-suppress-next-line PhanUndeclaredStaticMethod
+
 	if ( ! $has_switch_class || ! $has_method || ! Dashboard_View_Switch::is_jetpack_forms_admin_page_available() ) {
 		return;
 	}

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
@@ -485,10 +485,8 @@ function add_submenu_jetpack_forms() {
 		return;
 	}
 
-	// @phan-suppress-next-line PhanRedundantCondition
-	$handler = $has_switch_class
-		? ( new Dashboard_View_Switch() )->get_forms_admin_url()
-		: 'edit.php?post_type=feedback';
+	// This is so we don't just hardcode get_admin_url() . 'admin.php?page=jetpack-forms-admin', should we?
+	$handler = ( new Dashboard_View_Switch() )->get_forms_admin_url();
 
 	add_submenu_page(
 		'jetpack',

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
@@ -7,8 +7,9 @@
  * @package automattic/jetpack-mu-wpcom
  */
 
+use Automattic\Jetpack\Admin_UI\Admin_Menu;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
-use Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch;
+use Automattic\Jetpack\Forms\Dashboard;
 use Automattic\Jetpack\Redirect;
 use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Subscribers_Dashboard\Dashboard as Subscribers_Dashboard;
@@ -478,21 +479,20 @@ add_action( 'admin_menu', 'wpcom_add_plugins_menu' );
  * Adds a submenu item for Jetpack Forms.
  */
 function add_submenu_jetpack_forms() {
-	$has_switch_class = class_exists( 'Dashboard_View_Switch' );
+	$has_switch_class = class_exists( 'Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch' );
 
-	if ( ! $has_switch_class || ! Dashboard_View_Switch::is_jetpack_forms_admin_page_available() ) {
+	if ( ! $has_switch_class || ! Dashboard\Dashboard_View_Switch::is_jetpack_forms_admin_page_available() ) {
 		return;
 	}
 
-	// This is so we don't just hardcode get_admin_url() . 'admin.php?page=jetpack-forms-admin', should we?
-	$handler = ( new Dashboard_View_Switch() )->get_forms_admin_url();
+	$forms_dashboard = new Dashboard\Dashboard();
 
-	add_submenu_page(
-		'jetpack',
+	Admin_Menu::add_menu(
 		__( 'Jetpack Forms', 'jetpack-mu-wpcom' ),
 		__( 'Forms', 'jetpack-mu-wpcom' ),
 		'edit_pages',
-		$handler
+		'jetpack-forms-admin',
+		array( $forms_dashboard, 'render_new_dashboard' )
 	);
 }
 add_action( 'admin_menu', 'add_submenu_jetpack_forms' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
@@ -8,6 +8,7 @@
  */
 
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
+use Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch;
 use Automattic\Jetpack\Redirect;
 use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Subscribers_Dashboard\Dashboard as Subscribers_Dashboard;
@@ -477,13 +478,14 @@ add_action( 'admin_menu', 'wpcom_add_plugins_menu' );
  * Adds a submenu item for Jetpack Forms.
  */
 function add_submenu_jetpack_forms() {
-	$has_switch_class = class_exists( 'Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch' );
-	if ( ! $has_switch_class || ! Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch::is_jetpack_forms_admin_page_available() ) {
+	$has_switch_class = class_exists( 'Dashboard_View_Switch' );
+	$has_method       = method_exists( 'Dashboard_View_Switch', 'is_jetpack_forms_admin_page_available' );
+	if ( ! $has_switch_class || ! $has_method || ! Dashboard_View_Switch::is_jetpack_forms_admin_page_available() ) {
 		return;
 	}
 
 	$handler = $has_switch_class
-		? ( new Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch() )->get_forms_admin_url()
+		? ( new Dashboard_View_Switch() )->get_forms_admin_url()
 		: 'edit.php?post_type=feedback';
 
 	add_submenu_page(

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
@@ -472,3 +472,26 @@ function wpcom_add_plugins_menu() {
 	}
 }
 add_action( 'admin_menu', 'wpcom_add_plugins_menu' );
+
+/**
+ * Adds a submenu item for Jetpack Forms.
+ */
+function add_submenu_jetpack_forms() {
+	$has_switch_class = class_exists( 'Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch' );
+	if ( ! $has_switch_class || ! Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch::is_jetpack_forms_admin_page_available() ) {
+		return;
+	}
+
+	$handler = $has_switch_class
+		? ( new Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch() )->get_forms_admin_url()
+		: 'edit.php?post_type=feedback';
+
+	add_submenu_page(
+		'jetpack',
+		__( 'Jetpack Forms', 'jetpack-mu-wpcom' ),
+		__( 'Forms', 'jetpack-mu-wpcom' ),
+		'edit_pages',
+		$handler
+	);
+}
+add_action( 'admin_menu', 'add_submenu_jetpack_forms' );

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-jetpack-forms-dotcom-submenu
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-jetpack-forms-dotcom-submenu
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add jetpack-forms package dependency

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -750,6 +750,86 @@
             }
         },
         {
+            "name": "automattic/jetpack-forms",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/forms",
+                "reference": "08f17c79ceca2c91d89cb5538a0eacdfacc1118e"
+            },
+            "require": {
+                "automattic/jetpack-assets": "@dev",
+                "automattic/jetpack-blocks": "@dev",
+                "automattic/jetpack-connection": "@dev",
+                "automattic/jetpack-logo": "@dev",
+                "automattic/jetpack-plans": "@dev",
+                "automattic/jetpack-status": "@dev",
+                "automattic/jetpack-sync": "@dev",
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
+                "automattic/jetpack-connection": "@dev",
+                "automattic/jetpack-test-environment": "@dev",
+                "automattic/phpunit-select-config": "@dev",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-forms",
+                "changelogger": {
+                    "link-template": "https://github.com/automattic/jetpack-forms/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "0.54.x-dev"
+                },
+                "textdomain": "jetpack-forms",
+                "version-constants": {
+                    "::PACKAGE_VERSION": "src/class-jetpack-forms.php"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-coverage": [
+                    "pnpm concurrently --names php,js 'php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\"' 'pnpm:test-coverage'"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "test-js": [
+                    "pnpm run test:contact-form"
+                ],
+                "build-production": [
+                    "pnpm run build-production"
+                ],
+                "build-development": [
+                    "pnpm run build"
+                ],
+                "watch": [
+                    "Composer\\Config::disableProcessTimeout",
+                    "pnpm run watch"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Jetpack Forms",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
             "name": "automattic/jetpack-google-analytics",
             "version": "dev-trunk",
             "dist": {
@@ -1093,7 +1173,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "095df0be4fcbc25febd3cc8a73f1d118acb374d3"
+                "reference": "9f4712f3acb9dc19a5805c6c6435db34f7ab5aa0"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -1102,6 +1182,7 @@
                 "automattic/jetpack-classic-theme-helper": "@dev",
                 "automattic/jetpack-compat": "@dev",
                 "automattic/jetpack-connection": "@dev",
+                "automattic/jetpack-forms": "@dev",
                 "automattic/jetpack-google-analytics": "@dev",
                 "automattic/jetpack-masterbar": "@dev",
                 "automattic/jetpack-redirect": "@dev",

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -755,9 +755,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/forms",
-                "reference": "08f17c79ceca2c91d89cb5538a0eacdfacc1118e"
+                "reference": "ac0e0b7b8e1ba05b3e5062a898b1277cc3e35a19"
             },
             "require": {
+                "automattic/jetpack-admin-ui": "@dev",
                 "automattic/jetpack-assets": "@dev",
                 "automattic/jetpack-blocks": "@dev",
                 "automattic/jetpack-connection": "@dev",

--- a/projects/plugins/wpcomsh/changelog/add-jetpack-forms-dotcom-submenu
+++ b/projects/plugins/wpcomsh/changelog/add-jetpack-forms-dotcom-submenu
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add jetpack-forms package dependency

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -897,9 +897,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/forms",
-                "reference": "08f17c79ceca2c91d89cb5538a0eacdfacc1118e"
+                "reference": "ac0e0b7b8e1ba05b3e5062a898b1277cc3e35a19"
             },
             "require": {
+                "automattic/jetpack-admin-ui": "@dev",
                 "automattic/jetpack-assets": "@dev",
                 "automattic/jetpack-blocks": "@dev",
                 "automattic/jetpack-connection": "@dev",

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -892,6 +892,86 @@
             }
         },
         {
+            "name": "automattic/jetpack-forms",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/forms",
+                "reference": "08f17c79ceca2c91d89cb5538a0eacdfacc1118e"
+            },
+            "require": {
+                "automattic/jetpack-assets": "@dev",
+                "automattic/jetpack-blocks": "@dev",
+                "automattic/jetpack-connection": "@dev",
+                "automattic/jetpack-logo": "@dev",
+                "automattic/jetpack-plans": "@dev",
+                "automattic/jetpack-status": "@dev",
+                "automattic/jetpack-sync": "@dev",
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
+                "automattic/jetpack-connection": "@dev",
+                "automattic/jetpack-test-environment": "@dev",
+                "automattic/phpunit-select-config": "@dev",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-forms",
+                "changelogger": {
+                    "link-template": "https://github.com/automattic/jetpack-forms/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "0.54.x-dev"
+                },
+                "textdomain": "jetpack-forms",
+                "version-constants": {
+                    "::PACKAGE_VERSION": "src/class-jetpack-forms.php"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-coverage": [
+                    "pnpm concurrently --names php,js 'php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\"' 'pnpm:test-coverage'"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "test-js": [
+                    "pnpm run test:contact-form"
+                ],
+                "build-production": [
+                    "pnpm run build-production"
+                ],
+                "build-development": [
+                    "pnpm run build"
+                ],
+                "watch": [
+                    "Composer\\Config::disableProcessTimeout",
+                    "pnpm run watch"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Jetpack Forms",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
             "name": "automattic/jetpack-google-analytics",
             "version": "dev-trunk",
             "dist": {
@@ -1235,7 +1315,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "095df0be4fcbc25febd3cc8a73f1d118acb374d3"
+                "reference": "9f4712f3acb9dc19a5805c6c6435db34f7ab5aa0"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -1244,6 +1324,7 @@
                 "automattic/jetpack-classic-theme-helper": "@dev",
                 "automattic/jetpack-compat": "@dev",
                 "automattic/jetpack-connection": "@dev",
+                "automattic/jetpack-forms": "@dev",
                 "automattic/jetpack-google-analytics": "@dev",
                 "automattic/jetpack-masterbar": "@dev",
                 "automattic/jetpack-redirect": "@dev",


### PR DESCRIPTION


Depends on #43295 

Fixes FORMS-27

## Proposed changes:
This PR is the counterpart of the mentioned above and will be in charge of adding the Jetpack > Forms submenu when the conditions given by the feature filters are met.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
none yet

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

Enable these filters one by one, see they reflect the described behavior at:
peKye1-1xB-p2

```php
add_filter( 'jetpack_forms_use_new_menu_parent', '__return_true' );
add_filter( 'jetpack_forms_retire_view_switch', '__return_true' );
add_filter( 'jetpack_forms_announce_new_menu', '__return_true' );
add_filter( 'jetpack_forms_retire_legacy_menu_item', '__return_true' );
```