### PR TITLE
Forms: options block layout tweaks

### DIFF
--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -441,11 +441,15 @@
 	.wp-block-jetpack-field-option-checkbox,
 	.wp-block-jetpack-field-option-radio {
 		display: flex;
-		align-items: center;
+		align-items: baseline; /* Align input with first label line */
 		flex-wrap: nowrap;
 
 		.jetpack-option__type::before {
 			display: block; /* display: flex causes baselines to not align */
+		}
+
+		.rich-text {
+			transform: translateY(-0.15rem);
 		}
 	}
 }

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -419,7 +419,7 @@
 
 		&[type="radio"]::before {
 			border-radius: 50%;
-			transform: translateY(0.15rem);
+			transform: translateY(0.15em);
 		}
 	}
 
@@ -447,12 +447,8 @@
 
 		.jetpack-option__type::before {
 			display: block; /* display: flex causes baselines to not align */
-			transform: translateY(0.15rem);
+			transform: translateY(0.15em);
 		}
-	}
-
-	.rich-text {
-		transform: translateY(-0.1rem);
 	}
 }
 

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -419,7 +419,7 @@
 
 		&[type="radio"]::before {
 			border-radius: 50%;
-			transform: translateY(15%);
+			transform: translateY(0.15rem);
 		}
 	}
 
@@ -447,15 +447,12 @@
 
 		.jetpack-option__type::before {
 			display: block; /* display: flex causes baselines to not align */
+			transform: translateY(0.15rem);
 		}
 	}
 
-	.jetpack-field-option.field-option-radio,
-	.wp-block-jetpack-field-option-radio {
-
-		.jetpack-option__type {
-			transform: translateY(5%); /* Small offset to compensate the slightly odd perceived alignment that's due to the circular shape */
-		}
+	.rich-text {
+		transform: translateY(-0.1rem);
 	}
 }
 

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -374,33 +374,32 @@
 
 	.jetpack-option__type.jetpack-option__type {
 		align-items: center;
-		appearance: none;
 		display: flex;
 		justify-content: center;
 		margin: 0 10px 0 0;
-		outline: none;
 		position: relative;
 		pointer-events: none;
-		border: none;
+
+		/* Force opinionated styles for the input. */
+		width: 1em !important;
+		height: 1em !important;
+		box-shadow: none !important;
+		border: none !important;
+		appearance: none !important;
+		outline: none !important;
 
 		/* Some classic themes set the min-widths, which gives an elliptical shape to the input. */
 		min-width: auto;
-		width: 1em;
-		height: 1em;
-		box-shadow: none;
 	}
 
 	:where(.jetpack-option__type) {
 		all: initial;
 		color: var(--jetpack--contact-form--text-color);
-		border: none;
 		// Inherit the font size from the parent element, this needs
 		// to override the `all: initial` above.
 		// Set the height and width to 1em, so that the input scales
 		// with the font size.
 		font-size: inherit;
-		height: 1em;
-		width: 1em;
 
 		&::after, &::before {
 			all: initial;
@@ -567,10 +566,6 @@
 	display: flex;
 	align-items: center;
 	margin: 0;
-}
-
-.jetpack-option__type.jetpack-option__type {
-	margin-top: 0;
 }
 
 // TODO - This looks like dead code, along with the `JetpackOption` component.

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -381,6 +381,13 @@
 		outline: none;
 		position: relative;
 		pointer-events: none;
+		border: none;
+
+		/* Some classic themes set the min-widths, which gives an elliptical shape to the input. */
+		min-width: auto;
+		width: 1em;
+		height: 1em;
+		box-shadow: none;
 	}
 
 	:where(.jetpack-option__type) {
@@ -419,7 +426,6 @@
 
 		&[type="radio"]::before {
 			border-radius: 50%;
-			transform: translateY(0.15em);
 		}
 	}
 

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -419,6 +419,7 @@
 
 		&[type="radio"]::before {
 			border-radius: 50%;
+			transform: translateY(15%);
 		}
 	}
 

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -419,7 +419,6 @@
 
 		&[type="radio"]::before {
 			border-radius: 50%;
-			transform: translateY(15%);
 		}
 	}
 
@@ -442,19 +441,11 @@
 	.wp-block-jetpack-field-option-checkbox,
 	.wp-block-jetpack-field-option-radio {
 		display: flex;
-		align-items: baseline; /* Align input with first label line */
+		align-items: center;
 		flex-wrap: nowrap;
 
 		.jetpack-option__type::before {
 			display: block; /* display: flex causes baselines to not align */
-		}
-	}
-
-	.jetpack-field-option.field-option-radio,
-	.wp-block-jetpack-field-option-radio {
-
-		.jetpack-option__type {
-			transform: translateY(5%); /* Small offset to compensate the slightly odd perceived alignment that's due to the circular shape */
 		}
 	}
 }

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -447,9 +447,13 @@
 		.jetpack-option__type::before {
 			display: block; /* display: flex causes baselines to not align */
 		}
+	}
 
-		.rich-text {
-			transform: translateY(-0.15rem);
+	.jetpack-field-option.field-option-radio,
+	.wp-block-jetpack-field-option-radio {
+
+		.jetpack-option__type {
+			transform: translateY(5%); /* Small offset to compensate the slightly odd perceived alignment that's due to the circular shape */
 		}
 	}
 }

--- a/projects/packages/forms/src/blocks/options/index.js
+++ b/projects/packages/forms/src/blocks/options/index.js
@@ -8,7 +8,7 @@ const name = 'options';
 const settings = {
 	apiVersion: 3,
 	title: __( 'Options', 'jetpack-forms' ),
-	description: __( 'A wrapper for a group of options', 'jetpack-forms' ),
+	description: __( 'A collection of option blocks', 'jetpack-forms' ),
 	category: 'contact-form',
 	icon: {
 		src: renderMaterialIcon(

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -886,7 +886,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 					}
 					$used_html_ids[ $radio_id ] = true;
 
-					$default_classes = 'contact-form-field wp-block-jetpack-option';
+					$default_classes = 'contact-form-field';
 					$option_styles   = empty( $option['style'] ) ? '' : "style='" . esc_attr( $option['style'] ) . "'";
 					$option_classes  = empty( $option['class'] ) ? $default_classes : $default_classes . ' ' . esc_attr( $option['class'] );
 
@@ -962,7 +962,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 	public function render_checkbox_field( $id, $label, $value, $class, $required, $required_field_text ) {
 		// TODO: Make this backward compatible. Previously, this would use label styles not option styles.
 		// TODO: Is it better to apply the option classes and styles to the wrapper or the label?
-		$label_class  = 'wp-block-jetpack-option grunion-field-label checkbox';
+		$label_class  = 'grunion-field-label checkbox';
 		$label_class .= $this->is_error() ? ' form-error' : '';
 		$label_class .= $this->label_classes ? ' ' . $this->label_classes : '';
 		$label_class .= $this->option_classes ? ' ' . $this->option_classes : '';
@@ -988,7 +988,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		$consent_message = 'explicit' === $consent_type ? $this->get_attribute( 'explicitconsentmessage' ) : $this->get_attribute( 'implicitconsentmessage' );
 
 		// TODO: Confirm legacy consent blocks with custom label styles still display correctly without having been migrated.
-		$label_class  = 'wp-block-jetpack-option grunion-field-label consent consent-' . esc_attr( $consent_type );
+		$label_class  = 'grunion-field-label consent consent-' . esc_attr( $consent_type );
 		$label_class .= $this->option_classes ? ' ' . $this->option_classes : '';
 
 		$field = "<label class='" . esc_attr( $label_class ) . "' style='" . esc_attr( $this->label_styles ) . esc_attr( $this->option_styles ) . "'>";
@@ -1292,7 +1292,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 					}
 					$used_html_ids[ $checkbox_id ] = true;
 
-					$default_classes = 'contact-form-field wp-block-jetpack-option';
+					$default_classes = 'contact-form-field';
 					$option_styles   = empty( $option['style'] ) ? '' : "style='" . esc_attr( $option['style'] ) . "'";
 					$option_classes  = empty( $option['class'] ) ? $default_classes : $default_classes . ' ' . esc_attr( $option['class'] );
 

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -858,7 +858,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 			/*
 			 * For the "outlined" style, the styles and classes are applied to the fieldset element.
 			 */
-			$field = "<fieldset {$fieldset_id} class='wp-block-jetpack-options grunion-radio-options " . esc_attr( $options_classes ) . "' style='" . esc_attr( $options_styles ) . "'>";
+			$field = "<fieldset {$fieldset_id} class='grunion-radio-options " . esc_attr( $options_classes ) . "' style='" . esc_attr( $options_styles ) . "'>";
 		} else {
 			$field = "<fieldset {$fieldset_id} class='jetpack-field-multiple__fieldset'>";
 		}
@@ -866,7 +866,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		$field .= $this->render_legend_as_label( '', $id, $label, $required, $required_field_text );
 
 		if ( ! $is_outlined_style ) {
-			$field .= "<div class='wp-block-jetpack-options grunion-radio-options" . esc_attr( $options_classes ) . "' style='" . esc_attr( $options_styles ) . "'>";
+			$field .= "<div class='grunion-radio-options " . esc_attr( $options_classes ) . "' style='" . esc_attr( $options_styles ) . "'>";
 		}
 
 		$options_data  = $this->get_attribute( 'optionsdata' );
@@ -1226,11 +1226,12 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		$form_style        = $this->get_form_style();
 		$is_outlined_style = 'outlined' === $form_style;
 
-		// The `data-required` attribute is used in `accessible-form.js` to ensure at least one
-		// checkbox is checked. Unlike radio buttons, for which the required attribute is satisfied if
-		// any of the radio buttons in the group is selected, adding a required attribute directly to
-		// a checkbox means that this specific checkbox must be checked.
-
+		/*
+		 * The `data-required` attribute is used in `accessible-form.js` to ensure at least one
+		 * checkbox is checked. Unlike radio buttons, for which the required attribute is satisfied if
+		 * any of the radio buttons in the group is selected, adding a required attribute directly to
+		 * a checkbox means that this specific checkbox must be checked.
+		 */
 		$fieldset_id = "id='" . esc_attr( "$id-label" ) . "'";
 
 		if ( $is_outlined_style ) {
@@ -1240,10 +1241,12 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 				$style_variation_attributes = json_decode( html_entity_decode( $style_variation_attributes, ENT_COMPAT ), true );
 			}
 
-			// When there's an outlined style, and border radius is set, the existing inline border radius is overridden to apply
-			// a limit of `100px` to the radius on the x axis. This achieves the same look and feel as other fields
-			// that use the notch html (`notched-label__leading` has a max-width of `100px` to prevent it from getting too wide).
-			// It prevents large border radius values from disrupting the look and feel of the fields.
+			/*
+			 * When there's an outlined style, and border radius is set, the existing inline border radius is overridden to apply
+			 * a limit of `100px` to the radius on the x axis. This achieves the same look and feel as other fields
+			 * that use the notch html (`notched-label__leading` has a max-width of `100px` to prevent it from getting too wide).
+			 * It prevents large border radius values from disrupting the look and feel of the fields.
+			 */
 			if ( isset( $style_variation_attributes['border']['radius'] ) ) {
 				$options_styles          = $options_styles ?? '';
 				$radius                  = $style_variation_attributes['border']['radius'];
@@ -1261,7 +1264,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 			/*
 			 * For the "outlined" style, the styles and classes are applied to the fieldset element.
 			 */
-			$field = "<fieldset {$fieldset_id} class='wp-block-jetpack-options grunion-checkbox-multiple-options" . $options_classes . "' style='" . $options_styles . "' " . ( $required ? 'data-required' : '' ) . '>';
+			$field = "<fieldset {$fieldset_id} class='grunion-checkbox-multiple-options " . $options_classes . "' style='" . $options_styles . "' " . ( $required ? 'data-required' : '' ) . '>';
 		} else {
 			$field = "<fieldset {$fieldset_id} class='jetpack-field-multiple__fieldset'>";
 		}
@@ -1269,7 +1272,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		$field .= $this->render_legend_as_label( '', $id, $label, $required, $required_field_text );
 
 		if ( ! $is_outlined_style ) {
-			$field .= "<div class='wp-block-jetpack-options grunion-checkbox-multiple-options" . $options_classes . "' style='" . $options_styles . "' " . ( $required ? 'data-required' : '' ) . '>';
+			$field .= "<div class='grunion-checkbox-multiple-options " . $options_classes . "' style='" . $options_styles . "' " . ( $required ? 'data-required' : '' ) . '>';
 		}
 
 		$options_data  = $this->get_attribute( 'optionsdata' );
@@ -1535,27 +1538,31 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		 * For newer forms that use global styles or the block supports styles, this value will be empty and is ignored.
 		 */
 		$border_width_attribute = $this->get_attribute( 'borderwidth' );
-		$legacy_border_size     = ! empty( $border_width_attribute ) || $border_width_attribute === '0' ? $border_width_attribute . 'px' : $variation_attributes['border']['width'] ?? null;
-		$legacy_border_size     = is_numeric( $legacy_border_size ) ? $legacy_border_size . 'px' : $legacy_border_size;
-		$legacy_border_radius   = $variation_attributes['border']['radius'] ?? null;
-		$legacy_border_radius   = is_numeric( $legacy_border_radius ) ? $legacy_border_radius . 'px' : $legacy_border_radius;
+		$legacy_border_size     = ! empty( $border_width_attribute ) || $border_width_attribute === '0' ? $border_width_attribute . 'px' : null;
+
+		$border_radius_attribute = $this->get_attribute( 'borderradius' );
+		$legacy_border_radius    = ! empty( $border_radius_attribute ) || $border_radius_attribute === '0' ? $border_radius_attribute . 'px' : $variation_attributes['border']['radius'] ?? null;
 
 		$border_top_size = $legacy_border_size ??
+			$variation_attributes['border']['width'] ??
 			$variation_attributes['border']['top']['width'] ??
 			$global_styles['width'] ??
 			$global_styles['top']['width'] ?? null;
 
 		$border_right_size = $legacy_border_size ??
+
 			$variation_attributes['border']['right']['width'] ??
 			$global_styles['width'] ??
 			$global_styles['right']['width'] ?? null;
 
 		$border_bottom_size = $legacy_border_size ??
+			$variation_attributes['border']['width'] ??
 			$variation_attributes['border']['bottom']['width'] ??
 			$global_styles['width'] ??
 			$global_styles['bottom']['width'] ?? null;
 
 		$border_left_size = $legacy_border_size ??
+			$variation_attributes['border']['width'] ??
 			$variation_attributes['border']['left']['width'] ??
 			$global_styles['width'] ??
 			$global_styles['left']['width'] ?? null;
@@ -1563,7 +1570,10 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		$border_radius = $legacy_border_radius ??
 			$global_styles['radius'] ?? null;
 
-		$css_vars  = $border_top_size ? '--jetpack--contact-form--border-size: ' . $border_top_size . ';' : '';
+		// Border size to accommodate legacy border width attribute.
+		$css_vars = $legacy_border_size ? '--jetpack--contact-form--border-size: ' . $legacy_border_size . ';' : '';
+
+		// Border side sizes to accommodate global styles split values.
 		$css_vars .= $border_top_size ? '--jetpack--contact-form--border-top-size: ' . $border_top_size . ';' : '';
 		$css_vars .= $border_right_size ? '--jetpack--contact-form--border-right-size: ' . $border_right_size . ';' : '';
 		$css_vars .= $border_bottom_size ? '--jetpack--contact-form--border-bottom-size: ' . $border_bottom_size . ';' : '';

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -520,8 +520,11 @@ class Contact_Form_Plugin {
 							$option_data  = array( 'label' => $option_label );
 
 							if ( isset( $option_attrs['class'] ) ) {
-								$option_data['class'] = $option_attrs['class'];
+								$option_data['class'] = $option_attrs['class'] . ' wp-block-jetpack-option';
+							} else {
+								$option_data['class'] = 'wp-block-jetpack-option';
 							}
+
 							if ( isset( $option_attrs['style'] ) ) {
 								$option_data['style'] = $option_attrs['style'];
 							}

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -489,12 +489,23 @@ class Contact_Form_Plugin {
 
 				// The following handles choice fields such as; Single Choice Field (radio) or Multiple Choice Field (checkbox).
 				if ( 'jetpack/options' === $block_name ) {
-					$option_blocks          = $inner_block['innerBlocks'] ?? array();
-					$options                = array();
-					$options_data           = array();
-					$options_attrs          = self::get_block_support_classes_and_styles( $block_name, $inner_block['attrs'] );
-					$atts['optionsclasses'] = isset( $options_attrs['class'] ) ? ' ' . $options_attrs['class'] : '';
-					if ( isset( $inner_block['attrs']['style']['border']['width'] ) || isset( $inner_block['attrs']['style']['border']['left']['width'] ) ) {
+					$option_blocks           = $inner_block['innerBlocks'] ?? array();
+					$options                 = array();
+					$options_data            = array();
+					$atts['optionsclasses']  = 'wp-block-jetpack-options';
+					$options_attrs           = self::get_block_support_classes_and_styles( $block_name, $inner_block['attrs'] );
+					$atts['optionsclasses'] .= isset( $options_attrs['class'] ) ? ' ' . $options_attrs['class'] : '';
+
+					// Check if the block has left border, then apply a class for indentation.
+					$global_styles = wp_get_global_styles(
+						array( 'border' ),
+						array(
+							'block_name' => $block_name,
+							'transforms' => array( 'resolve-variables' ),
+						)
+					);
+
+					if ( isset( $inner_block['attrs']['style']['border']['width'] ) || isset( $inner_block['attrs']['style']['border']['left']['width'] ) || isset( $global_styles['width'] ) || isset( $global_styles['left']['width'] ) ) {
 						$atts['optionsclasses'] .= ' jetpack-field-multiple__list--has-border';
 					}
 
@@ -568,6 +579,10 @@ class Contact_Form_Plugin {
 		// to the custom label HTML, so we pick those attributes and ignore the rest.
 		if ( isset( $attrs['backgroundColor'] ) ) {
 			$picked_attributes['backgroundColor'] = $attrs['backgroundColor'];
+		}
+
+		if ( isset( $attrs['borderColor'] ) ) {
+			$picked_attributes['borderColor'] = $attrs['borderColor'];
 		}
 
 		if ( isset( $attrs['style']['border'] ) ) {

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -482,7 +482,8 @@ class Contact_Form_Plugin {
 				if ( 'jetpack/option' === $block_name ) {
 					$atts['label']                            = $inner_block['attrs']['label'] ?? $inner_block['attrs']['defaultLabel'] ?? '';
 					$option_attrs                             = self::get_block_support_classes_and_styles( $block_name, $inner_block['attrs'] );
-					$atts['optionclasses']                    = isset( $option_attrs['class'] ) ? ' ' . $option_attrs['class'] : '';
+					$atts['optionclasses']                    = 'wp-block-jetpack-option';
+					$atts['optionclasses']                   .= isset( $option_attrs['class'] ) ? ' ' . $option_attrs['class'] : '';
 					$atts['optionstyles']                     = $option_attrs['style'] ?? null;
 					$add_block_style_classes_to_field_wrapper = true;
 				}

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -2061,10 +2061,36 @@ class Contact_Form extends Contact_Form_Shortcode {
 			$data['settings']['blocks'] = array();
 		}
 
-		$data['settings']['blocks']['jetpack/input'] = array(
+		$input_settings = array(
 			'color'      => array(
 				'text'       => true,
 				'background' => true,
+			),
+			'border'     => array(
+				'color'  => true,
+				'radius' => true,
+				'style'  => true,
+				'width'  => true,
+			),
+			'typography' => array(
+				'fontFamily'     => true,
+				'fontSize'       => true,
+				'fontStyle'      => true,
+				'fontWeight'     => true,
+				'letterSpacing'  => true,
+				'lineHeight'     => true,
+				'textDecoration' => true,
+				'textTransform'  => true,
+			),
+		);
+
+		$data['settings']['blocks']['jetpack/input']   = $input_settings;
+		$data['settings']['blocks']['jetpack/options'] = $input_settings;
+
+		$data['settings']['blocks']['jetpack/input'] = array(
+			'color'      => array(
+				'text'       => true,
+				'background' => false,
 			),
 			'border'     => array(
 				'color'  => true,

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -2061,32 +2061,6 @@ class Contact_Form extends Contact_Form_Shortcode {
 			$data['settings']['blocks'] = array();
 		}
 
-		$input_settings = array(
-			'color'      => array(
-				'text'       => true,
-				'background' => true,
-			),
-			'border'     => array(
-				'color'  => true,
-				'radius' => true,
-				'style'  => true,
-				'width'  => true,
-			),
-			'typography' => array(
-				'fontFamily'     => true,
-				'fontSize'       => true,
-				'fontStyle'      => true,
-				'fontWeight'     => true,
-				'letterSpacing'  => true,
-				'lineHeight'     => true,
-				'textDecoration' => true,
-				'textTransform'  => true,
-			),
-		);
-
-		$data['settings']['blocks']['jetpack/input']   = $input_settings;
-		$data['settings']['blocks']['jetpack/options'] = $input_settings;
-
 		$data['settings']['blocks']['jetpack/input'] = array(
 			'color'      => array(
 				'text'       => true,
@@ -2107,6 +2081,19 @@ class Contact_Form extends Contact_Form_Shortcode {
 				'lineHeight'     => true,
 				'textDecoration' => true,
 				'textTransform'  => true,
+			),
+		);
+
+		$data['settings']['blocks']['jetpack/options'] = array(
+			'color'  => array(
+				'text'       => true,
+				'background' => true,
+			),
+			'border' => array(
+				'color'  => true,
+				'radius' => true,
+				'style'  => true,
+				'width'  => true,
 			),
 		);
 

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -178,11 +178,6 @@
 	margin: 0;
 }
 
-.contact-form .grunion-radio-options .contact-form-field .grunion-radio-label,
-.contact-form .grunion-checkbox-multiple-options .contact-form-field .grunion-checkbox-multiple-label {
-	transform: translateY(-0.1rem);
-}
-
 .contact-form :where(label span.required),
 .contact-form :where(.grunion-label-required) {
 	font-size: 85%;
@@ -850,7 +845,7 @@ on production builds, the attributes are being reordered, causing side-effects
 	border: solid 1px currentColor;
     color: currentColor;
 	outline-offset: 4px;
-	transform: translateY(0.15rem);
+	transform: translateY(0.15em);
 }
 
 .contact-form .grunion-field-wrap input.radio {

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -174,8 +174,13 @@
 .contact-form .grunion-checkbox-multiple-options .contact-form-field,
 .contact-form .grunion-radio-options .contact-form-field {
 	display: flex;
-	align-items: center;
+	align-items: baseline; /* Align input with first label line */
 	margin: 0;
+}
+
+.contact-form .grunion-radio-options .contact-form-field .grunion-radio-label,
+.contact-form .grunion-checkbox-multiple-options .contact-form-field .grunion-checkbox-multiple-label {
+	transform: translateY(-0.15rem);
 }
 
 .contact-form :where(label span.required),

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -174,7 +174,7 @@
 .contact-form .grunion-checkbox-multiple-options .contact-form-field,
 .contact-form .grunion-radio-options .contact-form-field {
 	display: flex;
-	align-items: baseline;
+	align-items: center;
 	margin: 0;
 }
 
@@ -625,7 +625,7 @@ on production builds, the attributes are being reordered, causing side-effects
 .contact-form .is-style-outlined .grunion-field-wrap .notched-label:has(~ .grunion-field.has-placeholder) .notched-label__label,
 .contact-form .is-style-outlined .grunion-field-wrap.grunion-field-select-wrap .notched-label .notched-label__label
 {
-	top: calc( var(--jetpack--contact-form--border-top-size, var(--jetpack--contact-form--border-size)) * -1 );
+	top: calc(var(--jetpack--contact-form--border-size) * -1);
 	transform: translateY(-50%);
 }
 
@@ -636,6 +636,12 @@ on production builds, the attributes are being reordered, causing side-effects
 .contact-form .is-style-outlined .grunion-field-wrap .grunion-radio-options .grunion-label-text,
 .contact-form .is-style-outlined .grunion-field-wrap.grunion-field-select-wrap .notched-label .grunion-label-text {
 	font-size: 0.8em;
+}
+
+/* Form that upgrade to use inner blocks look to the global styles border size.*/
+.contact-form .is-style-outlined .wp-block-jetpack-input-wrap .notched-label:has(~ .grunion-field:focus) .notched-label__label,
+.contact-form .is-style-outlined .wp-block-jetpack-field-select.wp-block-jetpack-input-wrap .notched-label .notched-label__label {
+	top: calc( var(--jetpack--contact-form--border-top-size, var(--jetpack--contact-form--border-size)) * -1 );
 }
 
 .contact-form .is-style-outlined .grunion-field-wrap .notched-label:has(~ .grunion-field:focus) .grunion-label-required,
@@ -843,8 +849,6 @@ on production builds, the attributes are being reordered, causing side-effects
 
 .contact-form .grunion-field-wrap input.radio {
 	border-radius: 50%;
-
-	transform: translateY(15%); /* Small offset to compensate the slightly odd perceived alignment that's due to the circular shape */
 }
 
 .contact-form .grunion-field-wrap input.checkbox-multiple:checked::before {

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -174,8 +174,13 @@
 .contact-form .grunion-checkbox-multiple-options .contact-form-field,
 .contact-form .grunion-radio-options .contact-form-field {
 	display: flex;
-	align-items: baseline;
+	align-items: baseline; /* Align input with first label line */
 	margin: 0;
+}
+
+.contact-form .grunion-radio-options .contact-form-field .grunion-radio-label,
+.contact-form .grunion-checkbox-multiple-options .contact-form-field .grunion-checkbox-multiple-label {
+	transform: translateY(-0.1rem);
 }
 
 .contact-form :where(label span.required),
@@ -845,12 +850,11 @@ on production builds, the attributes are being reordered, causing side-effects
 	border: solid 1px currentColor;
     color: currentColor;
 	outline-offset: 4px;
+	transform: translateY(0.15rem);
 }
 
 .contact-form .grunion-field-wrap input.radio {
 	border-radius: 50%;
-
-	transform: translateY(15%); /* Small offset to compensate the slightly odd perceived alignment that's due to the circular shape */
 }
 
 .contact-form .grunion-field-wrap input.checkbox-multiple:checked::before {

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -174,13 +174,8 @@
 .contact-form .grunion-checkbox-multiple-options .contact-form-field,
 .contact-form .grunion-radio-options .contact-form-field {
 	display: flex;
-	align-items: baseline; /* Align input with first label line */
+	align-items: baseline;
 	margin: 0;
-}
-
-.contact-form .grunion-radio-options .contact-form-field .grunion-radio-label,
-.contact-form .grunion-checkbox-multiple-options .contact-form-field .grunion-checkbox-multiple-label {
-	transform: translateY(-0.15rem);
 }
 
 .contact-form :where(label span.required),
@@ -854,6 +849,8 @@ on production builds, the attributes are being reordered, causing side-effects
 
 .contact-form .grunion-field-wrap input.radio {
 	border-radius: 50%;
+
+	transform: translateY(15%); /* Small offset to compensate the slightly odd perceived alignment that's due to the circular shape */
 }
 
 .contact-form .grunion-field-wrap input.checkbox-multiple:checked::before {

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
@@ -125,7 +125,7 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 
 		// Render the shortcode.
 		$shortcode = Contact_Form_Plugin::gutenblock_render_field_checkbox_multiple( array(), '', new WP_Block( $block ) );
-		$expected  = '[contact-field type="checkbox-multiple" label="Choose several options" labelclasses="wp-block-jetpack-label has-text-color has-swamp-green-color" optionsclasses="" options="truth,dare" optionsdata="&#091;{&quot;label&quot;:&quot;truth&quot;&#044;&quot;class&quot;:&quot;has-text-color&quot;&#044;&quot;style&quot;:&quot;color:caramel; font-size:24px;&quot;}&#044;{&quot;label&quot;:&quot;dare&quot;&#044;&quot;class&quot;:&quot;has-text-color&quot;&#044;&quot;style&quot;:&quot;color:gummy; font-size:24px;&quot;}&#093;" stylevariationattributes="" stylevariationclasses="" stylevariationstyles="" fieldwrapperclasses="wp-block-jetpack-field-checkbox-multiple"/]';
+		$expected  = '[contact-field type="checkbox-multiple" label="Choose several options" labelclasses="wp-block-jetpack-label has-text-color has-swamp-green-color" optionsclasses="wp-block-jetpack-options" options="truth,dare" optionsdata="&#091;{&quot;label&quot;:&quot;truth&quot;&#044;&quot;class&quot;:&quot;has-text-color&quot;&#044;&quot;style&quot;:&quot;color:caramel; font-size:24px;&quot;}&#044;{&quot;label&quot;:&quot;dare&quot;&#044;&quot;class&quot;:&quot;has-text-color&quot;&#044;&quot;style&quot;:&quot;color:gummy; font-size:24px;&quot;}&#093;" stylevariationattributes="" stylevariationclasses="" stylevariationstyles="" fieldwrapperclasses="wp-block-jetpack-field-checkbox-multiple"/]';
 
 		$this->assertEquals( $expected, $shortcode, 'Shortcode is not as expected' );
 	}
@@ -282,7 +282,7 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 
 		// Render the shortcode.
 		$shortcode = Contact_Form_Plugin::gutenblock_render_field_radio( array(), '', new WP_Block( $block ) );
-		$expected  = '[contact-field type="radio" label="Radio gaga" labelclasses="wp-block-jetpack-label has-text-color has-turmoil-purple-color" optionsclasses="" options="freddy,brian" optionsdata="&#091;{&quot;label&quot;:&quot;freddy&quot;&#044;&quot;class&quot;:&quot;has-text-color&quot;&#044;&quot;style&quot;:&quot;color:reddo; font-size:24px;&quot;}&#044;{&quot;label&quot;:&quot;brian&quot;&#044;&quot;class&quot;:&quot;has-text-color&quot;&#044;&quot;style&quot;:&quot;color:blueo; font-size:100rem;&quot;}&#093;" stylevariationattributes="" stylevariationclasses="" stylevariationstyles="" fieldwrapperclasses="wp-block-jetpack-field-radio"/]';
+		$expected  = '[contact-field type="radio" label="Radio gaga" labelclasses="wp-block-jetpack-label has-text-color has-turmoil-purple-color" optionsclasses="wp-block-jetpack-options" options="freddy,brian" optionsdata="&#091;{&quot;label&quot;:&quot;freddy&quot;&#044;&quot;class&quot;:&quot;has-text-color&quot;&#044;&quot;style&quot;:&quot;color:reddo; font-size:24px;&quot;}&#044;{&quot;label&quot;:&quot;brian&quot;&#044;&quot;class&quot;:&quot;has-text-color&quot;&#044;&quot;style&quot;:&quot;color:blueo; font-size:100rem;&quot;}&#093;" stylevariationattributes="" stylevariationclasses="" stylevariationstyles="" fieldwrapperclasses="wp-block-jetpack-field-radio"/]';
 
 		$this->assertEquals( $expected, $shortcode, 'Shortcode is not as expected' );
 	}
@@ -439,7 +439,7 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 					'type'                     => 'checkbox-multiple',
 					'requiredText'             => 'Do it again',
 					'fieldwrapperclasses'      => 'wp-block-jetpack-field-checkbox-multiple is-style-button  is-style-button-wrap',
-					'optionsclasses'           => ' has-background',
+					'optionsclasses'           => 'wp-block-jetpack-options has-background',
 					'optionsstyles'            => 'background-color:green-tonight; border-top-width:2px;border-top-color:terrible-red;border-top-style:solid;',
 					'stylevariationclasses'    => ' has-background',
 					'stylevariationattributes' => '{"border":{"top":{"color":"terrible-red","width":"2px","style":"solid","radius":"10px"}},"color":{"background":"green-tonight"}}',

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
@@ -125,7 +125,7 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 
 		// Render the shortcode.
 		$shortcode = Contact_Form_Plugin::gutenblock_render_field_checkbox_multiple( array(), '', new WP_Block( $block ) );
-		$expected  = '[contact-field type="checkbox-multiple" label="Choose several options" labelclasses="wp-block-jetpack-label has-text-color has-swamp-green-color" optionsclasses="wp-block-jetpack-options" options="truth,dare" optionsdata="&#091;{&quot;label&quot;:&quot;truth&quot;&#044;&quot;class&quot;:&quot;has-text-color&quot;&#044;&quot;style&quot;:&quot;color:caramel; font-size:24px;&quot;}&#044;{&quot;label&quot;:&quot;dare&quot;&#044;&quot;class&quot;:&quot;has-text-color&quot;&#044;&quot;style&quot;:&quot;color:gummy; font-size:24px;&quot;}&#093;" stylevariationattributes="" stylevariationclasses="" stylevariationstyles="" fieldwrapperclasses="wp-block-jetpack-field-checkbox-multiple"/]';
+		$expected  = '[contact-field type="checkbox-multiple" label="Choose several options" labelclasses="wp-block-jetpack-label has-text-color has-swamp-green-color" optionsclasses="wp-block-jetpack-options" options="truth,dare" optionsdata="&#091;{&quot;label&quot;:&quot;truth&quot;&#044;&quot;class&quot;:&quot;has-text-color wp-block-jetpack-option&quot;&#044;&quot;style&quot;:&quot;color:caramel; font-size:24px;&quot;}&#044;{&quot;label&quot;:&quot;dare&quot;&#044;&quot;class&quot;:&quot;has-text-color wp-block-jetpack-option&quot;&#044;&quot;style&quot;:&quot;color:gummy; font-size:24px;&quot;}&#093;" stylevariationattributes="" stylevariationclasses="" stylevariationstyles="" fieldwrapperclasses="wp-block-jetpack-field-checkbox-multiple"/]';
 
 		$this->assertEquals( $expected, $shortcode, 'Shortcode is not as expected' );
 	}
@@ -282,7 +282,7 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 
 		// Render the shortcode.
 		$shortcode = Contact_Form_Plugin::gutenblock_render_field_radio( array(), '', new WP_Block( $block ) );
-		$expected  = '[contact-field type="radio" label="Radio gaga" labelclasses="wp-block-jetpack-label has-text-color has-turmoil-purple-color" optionsclasses="wp-block-jetpack-options" options="freddy,brian" optionsdata="&#091;{&quot;label&quot;:&quot;freddy&quot;&#044;&quot;class&quot;:&quot;has-text-color&quot;&#044;&quot;style&quot;:&quot;color:reddo; font-size:24px;&quot;}&#044;{&quot;label&quot;:&quot;brian&quot;&#044;&quot;class&quot;:&quot;has-text-color&quot;&#044;&quot;style&quot;:&quot;color:blueo; font-size:100rem;&quot;}&#093;" stylevariationattributes="" stylevariationclasses="" stylevariationstyles="" fieldwrapperclasses="wp-block-jetpack-field-radio"/]';
+		$expected  = '[contact-field type="radio" label="Radio gaga" labelclasses="wp-block-jetpack-label has-text-color has-turmoil-purple-color" optionsclasses="wp-block-jetpack-options" options="freddy,brian" optionsdata="&#091;{&quot;label&quot;:&quot;freddy&quot;&#044;&quot;class&quot;:&quot;has-text-color wp-block-jetpack-option&quot;&#044;&quot;style&quot;:&quot;color:reddo; font-size:24px;&quot;}&#044;{&quot;label&quot;:&quot;brian&quot;&#044;&quot;class&quot;:&quot;has-text-color wp-block-jetpack-option&quot;&#044;&quot;style&quot;:&quot;color:blueo; font-size:100rem;&quot;}&#093;" stylevariationattributes="" stylevariationclasses="" stylevariationstyles="" fieldwrapperclasses="wp-block-jetpack-field-radio"/]';
 
 		$this->assertEquals( $expected, $shortcode, 'Shortcode is not as expected' );
 	}
@@ -434,7 +434,7 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 					'labelclasses'             => 'wp-block-jetpack-label has-text-color has-accent-3-color',
 					'labelstyles'              => 'letter-spacing:0.1em;',
 					'options'                  => 'Option 1,Option 2',
-					'optionsdata'              => '[{"label":"Option 1","class":"has-text-color has-sweet-potato-option-1-color","style":"font-size:24px;font-weight:bold;line-height:1.5;letter-spacing:0.1em;"},{"label":"Option 2","class":"has-text-color has-sweet-potato-option-2-color","style":"font-size:22px;font-weight:normal;"}]',
+					'optionsdata'              => '[{"label":"Option 1","class":"has-text-color has-sweet-potato-option-1-color wp-block-jetpack-option","style":"font-size:24px;font-weight:bold;line-height:1.5;letter-spacing:0.1em;"},{"label":"Option 2","class":"has-text-color has-sweet-potato-option-2-color wp-block-jetpack-option","style":"font-size:22px;font-weight:normal;"}]',
 					'label'                    => 'Label multiple options',
 					'type'                     => 'checkbox-multiple',
 					'requiredText'             => 'Do it again',

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
@@ -159,7 +159,7 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 			),
 		);
 		$shortcode = Contact_Form_Plugin::gutenblock_render_field_checkbox( array(), '', new WP_Block( $block ) );
-		$expected  = '[contact-field type="checkbox" label="single" optionclasses=" has-text-color" optionstyles="color:caramel; font-size:24px;" fieldwrapperclasses="wp-block-jetpack-field-checkbox"/]';
+		$expected  = '[contact-field type="checkbox" label="single" optionclasses="wp-block-jetpack-option has-text-color" optionstyles="color:caramel; font-size:24px;" fieldwrapperclasses="wp-block-jetpack-field-checkbox"/]';
 
 		$this->assertEquals( $expected, $shortcode );
 	}
@@ -393,7 +393,7 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 			),
 			'option'            => array(
 				'expected'     => array(
-					'optionclasses'       => ' has-text-color has-swamp-cheese-color',
+					'optionclasses'       => 'wp-block-jetpack-option has-text-color has-swamp-cheese-color',
 					'optionstyles'        => 'font-size:24px;font-style:italic;font-weight:bold;line-height:1.5;letter-spacing:0.1em;',
 					'label'               => 'Option',
 					'type'                => 'radio',

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -1440,7 +1440,7 @@ class Contact_Form_Test extends BaseTestCase {
 		$this->assertInstanceOf( DOMElement::class, $label );
 		$this->assertInstanceOf( DOMElement::class, $input );
 
-		$this->assertLabelClasses( $label, $attributes, 'wp-block-jetpack-option grunion-field-label ' . $attributes['type'] );
+		$this->assertLabelClasses( $label, $attributes, 'grunion-field-label ' . $attributes['type'] );
 
 		$this->assertEquals( $input->getAttribute( 'name' ), $attributes['id'], 'Input name doesn\'t match' );
 		$this->assertEquals( 'Yes', $input->getAttribute( 'value' ), 'Input value doesn\'t match' );


### PR DESCRIPTION
## Proposed changes:

> [!IMPORTANT]
> This PR's base is https://github.com/Automattic/jetpack/pull/42890

Fixes: https://github.com/Automattic/jetpack-roadmap/issues/2501

This PR:

- Updates CSS for radio and checkbox options to use consistent alignment (JETPACK-373)
- Applies legacy border width to `--jetpack--contact-form--border-size` now that we have `--jetpack--contact-form--border-*-size` to handle global styles. This ensures legacy forms use their original values.
- Applies padding to options blocks where they have a border, including checking for global styles
- Only applies `wp-block-jetpack-options` where the inner block exists. This makes the implementation consistent with `wp-block-jetpack-input`

## TODO

- [x] Update tests


## Testing instructions:


### For the checkbox layout
Create a default form with some multi fields (checkbox and radio). Play around with the option text length and font size.
Ensure that the option input aligns with the text at the top of the parent container. There will be a pixel off here and there depending on the font size, but it should be an improvement on trunk.


### For the CSS var

Create a few forms in trunk, all with options blocks (checkbox and radio fields). No need to style them.
Now switch to this branch.
Add some border color, width and radius styles to the `jetpack/options` block in global styles.
Check that your forms built in trunk are unaffected on the frontend

### For the default padding
Create a default form with some multi fields (checkbox and radio). With your global styles for the `jetpack/options` block still active, visit the frontend. The multi fields should have left padding via the `jetpack-field-multiple__list--has-border` class.


