### PR TITLE
Forms: Fix block instance border color not overriding global styles border color with outlined style active (on the frontend)

### DIFF
--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -1510,8 +1510,8 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 
 		return '
 			<div class="notched-label">
-				<div class="notched-label__leading ' . esc_attr( $output_data['class_name'] ) . '" style="' . esc_attr( $output_data['style'] ) . '"></div>
-				<div class="notched-label__notch ' . esc_attr( $output_data['class_name'] ) . '" style="' . esc_attr( $output_data['style'] ) . '">
+				<div class="notched-label__leading' . esc_attr( $output_data['class_name'] ) . '" style="' . esc_attr( $output_data['style'] ) . '"></div>
+				<div class="notched-label__notch' . esc_attr( $output_data['class_name'] ) . '" style="' . esc_attr( $output_data['style'] ) . '">
 					<label
 						for="' . esc_attr( $id ) . '"
 						class=" ' . $classes . '"
@@ -1521,8 +1521,8 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 			. ( $required ? '<span class="grunion-label-required" aria-hidden="true">' . $required_field_text . '</span>' : '' ) .
 			'</label>
 				</div>
-				<div class="notched-label__filler ' . esc_attr( $output_data['class_name'] ) . '" style="' . esc_attr( $output_data['style'] ) . '"></div>
-				<div class="notched-label__trailing ' . esc_attr( $output_data['class_name'] ) . '" style="' . esc_attr( $output_data['style'] ) . '"></div>
+				<div class="notched-label__filler' . esc_attr( $output_data['class_name'] ) . '" style="' . esc_attr( $output_data['style'] ) . '"></div>
+				<div class="notched-label__trailing' . esc_attr( $output_data['class_name'] ) . '" style="' . esc_attr( $output_data['style'] ) . '"></div>
 			</div>';
 	}
 

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -572,6 +572,10 @@ class Contact_Form_Plugin {
 			$attributes_for_outlined_style['style']['border'] = $attrs['style']['border'];
 		}
 
+		if ( isset( $attrs['borderColor'] ) ) {
+			$attributes_for_outlined_style['borderColor'] = $attrs['borderColor'];
+		}
+
 		if ( isset( $attrs['style']['color']['background'] ) ) {
 			$attributes_for_outlined_style['style']['color']['background'] = $attrs['style']['color']['background'];
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR merges into #42890 not trunk
Related JETPACK-277

## Proposed changes:
While working on form specificity fixes (JETPACK-277) I noticed that with the outlined form style active, block instance border color doesn't override global styles border color for any fields that use an Input block.

The reason seems to be that `get_outlined_style_attributes` doesn't include the `borderColor` property in its special collection of attributes for the outlined styles. That results in the notched html elements not receiving a `has-border-color` class.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
1. In global styles, change the Input block's styles. Set a border width and color. From what I can tell it doesn't matter what color, but it's worth testing using a preset color from the swatch and a custom color.
2. Inset a form
3. Select one of the inputs and change the border color to a preset color from the swatch (here it does matter that you use a preset color. Custom colors are added as inline styles and this does work correctly, while preset colors are added using a classname and that's where the bug is).
4. In the editor observe that the color changes correctly
5. Save everything and view the form on the frontend

Before this PR - the block instance border color isn't shown, only the global styles border color
After this PR - the block instance border color correctly overrides the global styles border color.
