### PR TITLE
Forms: Fix typography input styles applying to labels when outline style is active (on frontend)

### DIFF
--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -103,52 +103,53 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 	public function __construct( $attributes, $content = null, $form = null ) {
 		$attributes = shortcode_atts(
 			array(
-				'label'                  => null,
-				'togglelabel'            => null,
-				'type'                   => 'text',
-				'required'               => false,
-				'requiredtext'           => null,
-				'options'                => array(),
-				'optionsdata'            => array(),
-				'id'                     => null,
-				'style'                  => null,
-				'fieldbackgroundcolor'   => null,
-				'buttonbackgroundcolor'  => null,
-				'buttonborderradius'     => null,
-				'buttonborderwidth'      => null,
-				'textcolor'              => null,
-				'default'                => null,
-				'values'                 => null,
-				'placeholder'            => null,
-				'class'                  => null,
-				'width'                  => null,
-				'consenttype'            => null,
-				'dateformat'             => null,
-				'implicitconsentmessage' => null,
-				'explicitconsentmessage' => null,
-				'borderradius'           => null,
-				'borderwidth'            => null,
-				'lineheight'             => null,
-				'labellineheight'        => null,
-				'bordercolor'            => null,
-				'inputcolor'             => null,
-				'labelcolor'             => null,
-				'labelfontsize'          => null,
-				'fieldfontsize'          => null,
-				'labelclasses'           => null,
-				'labelstyles'            => null,
-				'inputclasses'           => null,
-				'inputstyles'            => null,
-				'optionclasses'          => null,
-				'optionstyles'           => null,
-				'min'                    => null,
-				'max'                    => null,
-				'maxfiles'               => null,
-				'fieldwrapperclasses'    => null,
-				'outlinestyledata'       => array(),
-				'outlinestyleclasses'    => null,
-				'optionsclasses'         => null,
-				'optionsstyles'          => null,
+				'label'                    => null,
+				'togglelabel'              => null,
+				'type'                     => 'text',
+				'required'                 => false,
+				'requiredtext'             => null,
+				'options'                  => array(),
+				'optionsdata'              => array(),
+				'id'                       => null,
+				'style'                    => null,
+				'fieldbackgroundcolor'     => null,
+				'buttonbackgroundcolor'    => null,
+				'buttonborderradius'       => null,
+				'buttonborderwidth'        => null,
+				'textcolor'                => null,
+				'default'                  => null,
+				'values'                   => null,
+				'placeholder'              => null,
+				'class'                    => null,
+				'width'                    => null,
+				'consenttype'              => null,
+				'dateformat'               => null,
+				'implicitconsentmessage'   => null,
+				'explicitconsentmessage'   => null,
+				'borderradius'             => null,
+				'borderwidth'              => null,
+				'lineheight'               => null,
+				'labellineheight'          => null,
+				'bordercolor'              => null,
+				'inputcolor'               => null,
+				'labelcolor'               => null,
+				'labelfontsize'            => null,
+				'fieldfontsize'            => null,
+				'labelclasses'             => null,
+				'labelstyles'              => null,
+				'inputclasses'             => null,
+				'inputstyles'              => null,
+				'optionclasses'            => null,
+				'optionstyles'             => null,
+				'min'                      => null,
+				'max'                      => null,
+				'maxfiles'                 => null,
+				'fieldwrapperclasses'      => null,
+				'stylevariationattributes' => array(),
+				'stylevariationclasses'    => null,
+				'stylevariationstyles'     => null,
+				'optionsclasses'           => null,
+				'optionsstyles'            => null,
 			),
 			$attributes,
 			'contact-field'
@@ -830,19 +831,19 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		$fieldset_id       = "id='" . esc_attr( "$id-label" ) . "'";
 
 		if ( $is_outlined_style ) {
-			$outline_styles = $this->get_attribute( 'outlinestyledata' );
+			$style_variation_attributes = $this->get_attribute( 'stylevariationattributes' );
 
-			if ( ! empty( $outline_styles ) ) {
-				$outline_styles = json_decode( html_entity_decode( $outline_styles, ENT_COMPAT ), true );
+			if ( ! empty( $style_variation_attributes ) ) {
+				$style_variation_attributes = json_decode( html_entity_decode( $style_variation_attributes, ENT_COMPAT ), true );
 			}
 
 			// When there's an outlined style, and border radius is set, the existing inline border radius is overridden to apply
 			// a limit of `100px` to the radius on the x axis. This achieves the same look and feel as other fields
 			// that use the notch html (`notched-label__leading` has a max-width of `100px` to prevent it from getting too wide).
 			// It prevents large border radius values from disrupting the look and feel of the fields.
-			if ( isset( $outline_styles['border']['radius'] ) ) {
+			if ( isset( $style_variation_attributes['border']['radius'] ) ) {
 				$options_styles          = $options_styles ?? '';
-				$radius                  = $outline_styles['border']['radius'];
+				$radius                  = $style_variation_attributes['border']['radius'];
 				$has_split_radius_values = is_array( $radius );
 				$top_left_radius         = $has_split_radius_values ? $radius['topLeft'] : $radius;
 				$top_right_radius        = $has_split_radius_values ? $radius['topRight'] : $radius;
@@ -1233,19 +1234,19 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		$fieldset_id = "id='" . esc_attr( "$id-label" ) . "'";
 
 		if ( $is_outlined_style ) {
-			$outline_styles = $this->get_attribute( 'outlinestyledata' );
+			$style_variation_attributes = $this->get_attribute( 'stylevariationattributes' );
 
-			if ( ! empty( $outline_styles ) ) {
-				$outline_styles = json_decode( html_entity_decode( $outline_styles, ENT_COMPAT ), true );
+			if ( ! empty( $style_variation_attributes ) ) {
+				$style_variation_attributes = json_decode( html_entity_decode( $style_variation_attributes, ENT_COMPAT ), true );
 			}
 
 			// When there's an outlined style, and border radius is set, the existing inline border radius is overridden to apply
 			// a limit of `100px` to the radius on the x axis. This achieves the same look and feel as other fields
 			// that use the notch html (`notched-label__leading` has a max-width of `100px` to prevent it from getting too wide).
 			// It prevents large border radius values from disrupting the look and feel of the fields.
-			if ( isset( $outline_styles['border']['radius'] ) ) {
+			if ( isset( $style_variation_attributes['border']['radius'] ) ) {
 				$options_styles          = $options_styles ?? '';
-				$radius                  = $outline_styles['border']['radius'];
+				$radius                  = $style_variation_attributes['border']['radius'];
 				$has_split_radius_values = is_array( $radius );
 				$top_left_radius         = $has_split_radius_values ? $radius['topLeft'] : $radius;
 				$top_right_radius        = $has_split_radius_values ? $radius['topRight'] : $radius;
@@ -1543,21 +1544,15 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 	 * }
 	 */
 	private function get_form_variation_style_properties( $form_style = 'outlined' ) {
-		$style_attrs     = '';
-		$css_vars        = '';
-		$outline_styles  = $this->get_attribute( 'outlinestyledata' );
-		$outline_classes = $this->get_attribute( 'outlinestyleclasses' );
-		$block_name      = 'jetpack/input';
+		$css_vars             = '';
+		$variation_attributes = $this->get_attribute( 'stylevariationattributes' );
+		$variation_attributes = ! empty( $variation_attributes ) ? json_decode( html_entity_decode( $variation_attributes, ENT_COMPAT ), true ) : array();
+		$variation_classes    = $this->get_attribute( 'stylevariationclasses' );
+		$variation_style      = $this->get_attribute( 'stylevariationstyles' );
+		$block_name           = 'jetpack/input';
 
 		if ( $this->maybe_override_type() === 'radio' || $this->maybe_override_type() === 'checkbox-multiple' ) {
 			$block_name = 'jetpack/options';
-		}
-
-		$outline_styles = ! empty( $outline_styles ) ? json_decode( html_entity_decode( $outline_styles, ENT_COMPAT ), true ) : array();
-		$input_styles   = $this->get_attribute( 'inputstyles' );
-
-		if ( ! empty( $input_styles ) ) {
-			$style_attrs = $input_styles;
 		}
 
 		$global_styles = wp_get_global_styles(
@@ -1575,28 +1570,28 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		 * For newer forms that use global styles or the block supports styles, this value will be empty and is ignored.
 		 */
 		$border_width_attribute = $this->get_attribute( 'borderwidth' );
-		$legacy_border_size     = ! empty( $border_width_attribute ) || $border_width_attribute === '0' ? $border_width_attribute . 'px' : $outline_styles['border']['width'] ?? null;
+		$legacy_border_size     = ! empty( $border_width_attribute ) || $border_width_attribute === '0' ? $border_width_attribute . 'px' : $variation_attributes['border']['width'] ?? null;
 		$legacy_border_size     = is_numeric( $legacy_border_size ) ? $legacy_border_size . 'px' : $legacy_border_size;
-		$legacy_border_radius   = $outline_styles['border']['radius'] ?? null;
+		$legacy_border_radius   = $variation_attributes['border']['radius'] ?? null;
 		$legacy_border_radius   = is_numeric( $legacy_border_radius ) ? $legacy_border_radius . 'px' : $legacy_border_radius;
 
 		$border_top_size = $legacy_border_size ??
-			$outline_styles['border']['top']['width'] ??
+			$variation_attributes['border']['top']['width'] ??
 			$global_styles['width'] ??
 			$global_styles['top']['width'] ?? null;
 
 		$border_right_size = $legacy_border_size ??
-			$outline_styles['border']['right']['width'] ??
+			$variation_attributes['border']['right']['width'] ??
 			$global_styles['width'] ??
 			$global_styles['right']['width'] ?? null;
 
 		$border_bottom_size = $legacy_border_size ??
-			$outline_styles['border']['bottom']['width'] ??
+			$variation_attributes['border']['bottom']['width'] ??
 			$global_styles['width'] ??
 			$global_styles['bottom']['width'] ?? null;
 
 		$border_left_size = $legacy_border_size ??
-			$outline_styles['border']['left']['width'] ??
+			$variation_attributes['border']['left']['width'] ??
 			$global_styles['width'] ??
 			$global_styles['left']['width'] ?? null;
 
@@ -1628,9 +1623,9 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		}
 
 		return array(
-			'style'      => $style_attrs,
+			'style'      => $variation_style,
 			'css_vars'   => $css_vars,
-			'class_name' => $outline_classes,
+			'class_name' => $variation_classes,
 		);
 	}
 

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -470,9 +470,8 @@ class Contact_Form_Plugin {
 					/*
 						Borders for the outlined notched HTML.
 					*/
-					$outlined_style_data                      = self::get_outlined_style_attributes( $block_name, $inner_block['attrs'] );
-					$atts['outlinestyledata']                 = $outlined_style_data['outlinestyledata'] ?? null;
-					$atts['outlinestyleclasses']              = $outlined_style_data['outlinestyleclasses'] ?? null;
+					$style_variation_data                     = self::get_style_variation_shortcode_attributes( $block_name, $inner_block['attrs'] );
+					$atts                                     = array_merge( $atts, $style_variation_data );
 					$add_block_style_classes_to_field_wrapper = true;
 				}
 
@@ -523,9 +522,8 @@ class Contact_Form_Plugin {
 					/*
 						Borders for the outlined notched HTML.
 					*/
-					$outlined_style_data                      = self::get_outlined_style_attributes( $block_name, $inner_block['attrs'] );
-					$atts['outlinestyledata']                 = $outlined_style_data['outlinestyledata'];
-					$atts['outlinestyleclasses']              = $outlined_style_data['outlinestyleclasses'];
+					$style_variation_atts                     = self::get_style_variation_shortcode_attributes( $block_name, $inner_block['attrs'] );
+					$atts                                     = array_merge( $atts, $style_variation_atts );
 					$add_block_style_classes_to_field_wrapper = true;
 				}
 			}
@@ -552,7 +550,7 @@ class Contact_Form_Plugin {
 
 	/**
 	 * Returns the form "Outlined" style classes and styles.
-	 * Important: The "Outlined" style is somewhat different as it uses custom HTML to create a border around the field.
+	 * Important: The "Outlined" style is somewhat different as it uses custom HTML to create a border around the field's label.
 	 * When applying styles to the control, background and border styles are applied to the custom HTML, not the input itself.
 	 *
 	 * @param string $block_name - the block name.
@@ -560,16 +558,17 @@ class Contact_Form_Plugin {
 	 *
 	 * @return array
 	 */
-	protected static function get_outlined_style_attributes( $block_name, $attrs ) {
-		$outlined_style_data           = array();
-		$attributes_for_outlined_style = array();
+	protected static function get_style_variation_shortcode_attributes( $block_name, $attrs ) {
+		$picked_attributes = array();
 
+		// For style variations like the outlined style, we only care about porting specific attributes like background color and border
+		// to the custom label HTML, so we pick those attributes and ignore the rest.
 		if ( isset( $attrs['backgroundColor'] ) ) {
-			$attributes_for_outlined_style['backgroundColor'] = $attrs['backgroundColor'];
+			$picked_attributes['backgroundColor'] = $attrs['backgroundColor'];
 		}
 
 		if ( isset( $attrs['style']['border'] ) ) {
-			$attributes_for_outlined_style['style']['border'] = $attrs['style']['border'];
+			$picked_attributes['style']['border'] = $attrs['style']['border'];
 		}
 
 		if ( isset( $attrs['borderColor'] ) ) {
@@ -577,13 +576,15 @@ class Contact_Form_Plugin {
 		}
 
 		if ( isset( $attrs['style']['color']['background'] ) ) {
-			$attributes_for_outlined_style['style']['color']['background'] = $attrs['style']['color']['background'];
+			$picked_attributes['style']['color']['background'] = $attrs['style']['color']['background'];
 		}
 
-		$outlined_attrs                             = self::get_block_support_classes_and_styles( $block_name, $attributes_for_outlined_style );
-		$outlined_style_data['outlinestyledata']    = isset( $attributes_for_outlined_style['style'] ) ? \wp_json_encode( $attributes_for_outlined_style['style'] ) : '';
-		$outlined_style_data['outlinestyleclasses'] = isset( $outlined_attrs['class'] ) ? ' ' . $outlined_attrs['class'] : '';
-		return $outlined_style_data;
+		$block_support_styles = self::get_block_support_classes_and_styles( $block_name, $picked_attributes );
+		return array(
+			'stylevariationattributes' => isset( $picked_attributes['style'] ) ? \wp_json_encode( $picked_attributes['style'] ) : '',
+			'stylevariationclasses'    => isset( $block_support_styles['class'] ) ? ' ' . $block_support_styles['class'] : '',
+			'stylevariationstyles'     => isset( $block_support_styles['style'] ) ? $block_support_styles['style'] : '',
+		);
 	}
 
 	/**

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -572,7 +572,7 @@ class Contact_Form_Plugin {
 		}
 
 		if ( isset( $attrs['borderColor'] ) ) {
-			$attributes_for_outlined_style['borderColor'] = $attrs['borderColor'];
+			$picked_attributes['borderColor'] = $attrs['borderColor'];
 		}
 
 		if ( isset( $attrs['style']['color']['background'] ) ) {

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
@@ -125,7 +125,7 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 
 		// Render the shortcode.
 		$shortcode = Contact_Form_Plugin::gutenblock_render_field_checkbox_multiple( array(), '', new WP_Block( $block ) );
-		$expected  = '[contact-field type="checkbox-multiple" label="Choose several options" labelclasses="wp-block-jetpack-label has-text-color has-swamp-green-color" optionsclasses="" options="truth,dare" optionsdata="&#091;{&quot;label&quot;:&quot;truth&quot;&#044;&quot;class&quot;:&quot;has-text-color&quot;&#044;&quot;style&quot;:&quot;color:caramel; font-size:24px;&quot;}&#044;{&quot;label&quot;:&quot;dare&quot;&#044;&quot;class&quot;:&quot;has-text-color&quot;&#044;&quot;style&quot;:&quot;color:gummy; font-size:24px;&quot;}&#093;" stylevariationattributes="" stylevariationclasses="" fieldwrapperclasses="wp-block-jetpack-field-checkbox-multiple"/]';
+		$expected  = '[contact-field type="checkbox-multiple" label="Choose several options" labelclasses="wp-block-jetpack-label has-text-color has-swamp-green-color" optionsclasses="" options="truth,dare" optionsdata="&#091;{&quot;label&quot;:&quot;truth&quot;&#044;&quot;class&quot;:&quot;has-text-color&quot;&#044;&quot;style&quot;:&quot;color:caramel; font-size:24px;&quot;}&#044;{&quot;label&quot;:&quot;dare&quot;&#044;&quot;class&quot;:&quot;has-text-color&quot;&#044;&quot;style&quot;:&quot;color:gummy; font-size:24px;&quot;}&#093;" stylevariationattributes="" stylevariationclasses="" stylevariationstyles="" fieldwrapperclasses="wp-block-jetpack-field-checkbox-multiple"/]';
 
 		$this->assertEquals( $expected, $shortcode, 'Shortcode is not as expected' );
 	}
@@ -209,7 +209,7 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 			),
 		);
 		$shortcode = Contact_Form_Plugin::gutenblock_render_field_text( array(), '', new WP_Block( $block ) );
-		$expected  = '[contact-field type="text" label="Label" requiredText="Do it" labelclasses="wp-block-jetpack-label has-text-color" labelstyles="color:caramel; font-size:24px;" placeholder="hi!" min="1" max="10" inputclasses="wp-block-jetpack-input has-text-color has-border-color" inputstyles="color:toot; font-size:33rem; border-color:toot;border-width:1px;" stylevariationattributes="{&quot;border&quot;:{&quot;color&quot;:&quot;toot&quot;&#044;&quot;width&quot;:&quot;1px&quot;}}" stylevariationclasses=" has-border-color" fieldwrapperclasses="wp-block-jetpack-field-text"/]';
+		$expected  = '[contact-field type="text" label="Label" requiredText="Do it" labelclasses="wp-block-jetpack-label has-text-color" labelstyles="color:caramel; font-size:24px;" placeholder="hi!" min="1" max="10" inputclasses="wp-block-jetpack-input has-text-color has-border-color" inputstyles="color:toot; font-size:33rem; border-color:toot;border-width:1px;" stylevariationattributes="{&quot;border&quot;:{&quot;color&quot;:&quot;toot&quot;&#044;&quot;width&quot;:&quot;1px&quot;}}" stylevariationclasses=" has-border-color" stylevariationstyles="border-color:toot;border-width:1px;" fieldwrapperclasses="wp-block-jetpack-field-text"/]';
 
 		$this->assertEquals( $expected, $shortcode );
 	}
@@ -282,7 +282,7 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 
 		// Render the shortcode.
 		$shortcode = Contact_Form_Plugin::gutenblock_render_field_radio( array(), '', new WP_Block( $block ) );
-		$expected  = '[contact-field type="radio" label="Radio gaga" labelclasses="wp-block-jetpack-label has-text-color has-turmoil-purple-color" optionsclasses="" options="freddy,brian" optionsdata="&#091;{&quot;label&quot;:&quot;freddy&quot;&#044;&quot;class&quot;:&quot;has-text-color&quot;&#044;&quot;style&quot;:&quot;color:reddo; font-size:24px;&quot;}&#044;{&quot;label&quot;:&quot;brian&quot;&#044;&quot;class&quot;:&quot;has-text-color&quot;&#044;&quot;style&quot;:&quot;color:blueo; font-size:100rem;&quot;}&#093;" stylevariationattributes="" stylevariationclasses="" fieldwrapperclasses="wp-block-jetpack-field-radio"/]';
+		$expected  = '[contact-field type="radio" label="Radio gaga" labelclasses="wp-block-jetpack-label has-text-color has-turmoil-purple-color" optionsclasses="" options="freddy,brian" optionsdata="&#091;{&quot;label&quot;:&quot;freddy&quot;&#044;&quot;class&quot;:&quot;has-text-color&quot;&#044;&quot;style&quot;:&quot;color:reddo; font-size:24px;&quot;}&#044;{&quot;label&quot;:&quot;brian&quot;&#044;&quot;class&quot;:&quot;has-text-color&quot;&#044;&quot;style&quot;:&quot;color:blueo; font-size:100rem;&quot;}&#093;" stylevariationattributes="" stylevariationclasses="" stylevariationstyles="" fieldwrapperclasses="wp-block-jetpack-field-radio"/]';
 
 		$this->assertEquals( $expected, $shortcode, 'Shortcode is not as expected' );
 	}
@@ -341,6 +341,7 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 					'fieldwrapperclasses'      => 'wp-block-jetpack-field-text',
 					'stylevariationclasses'    => ' has-background has-border-color',
 					'stylevariationattributes' => '{"border":{"color":"swamp-blue","width":"1px","style":"dashed"},"color":{"background":"swamp-red"}}',
+					'stylevariationstyles'     => 'background-color:swamp-red; border-color:swamp-blue;border-style:dashed;border-width:1px;',
 				),
 				'inner_blocks' => array(
 					array(
@@ -438,6 +439,7 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 					'optionsstyles'            => 'color:blue-overture;background-color:green-tonight; border-top-width:2px;border-top-color:terrible-red;border-top-style:solid;',
 					'stylevariationclasses'    => ' has-background',
 					'stylevariationattributes' => '{"border":{"top":{"color":"terrible-red","width":"2px","style":"solid","radius":"10px"}},"color":{"background":"green-tonight"}}',
+					'stylevariationstyles'     => 'background-color:green-tonight; border-top-width:2px;border-top-color:terrible-red;border-top-style:solid;',
 				),
 				'inner_blocks' => array(
 					array(

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
@@ -125,7 +125,7 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 
 		// Render the shortcode.
 		$shortcode = Contact_Form_Plugin::gutenblock_render_field_checkbox_multiple( array(), '', new WP_Block( $block ) );
-		$expected  = '[contact-field type="checkbox-multiple" label="Choose several options" labelclasses="wp-block-jetpack-label has-text-color has-swamp-green-color" optionsclasses="" options="truth,dare" optionsdata="&#091;{&quot;label&quot;:&quot;truth&quot;&#044;&quot;class&quot;:&quot;has-text-color&quot;&#044;&quot;style&quot;:&quot;color:caramel; font-size:24px;&quot;}&#044;{&quot;label&quot;:&quot;dare&quot;&#044;&quot;class&quot;:&quot;has-text-color&quot;&#044;&quot;style&quot;:&quot;color:gummy; font-size:24px;&quot;}&#093;" outlinestyledata="" outlinestyleclasses="" fieldwrapperclasses="wp-block-jetpack-field-checkbox-multiple"/]';
+		$expected  = '[contact-field type="checkbox-multiple" label="Choose several options" labelclasses="wp-block-jetpack-label has-text-color has-swamp-green-color" optionsclasses="" options="truth,dare" optionsdata="&#091;{&quot;label&quot;:&quot;truth&quot;&#044;&quot;class&quot;:&quot;has-text-color&quot;&#044;&quot;style&quot;:&quot;color:caramel; font-size:24px;&quot;}&#044;{&quot;label&quot;:&quot;dare&quot;&#044;&quot;class&quot;:&quot;has-text-color&quot;&#044;&quot;style&quot;:&quot;color:gummy; font-size:24px;&quot;}&#093;" stylevariationattributes="" stylevariationclasses="" fieldwrapperclasses="wp-block-jetpack-field-checkbox-multiple"/]';
 
 		$this->assertEquals( $expected, $shortcode, 'Shortcode is not as expected' );
 	}
@@ -209,7 +209,7 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 			),
 		);
 		$shortcode = Contact_Form_Plugin::gutenblock_render_field_text( array(), '', new WP_Block( $block ) );
-		$expected  = '[contact-field type="text" label="Label" requiredText="Do it" labelclasses="wp-block-jetpack-label has-text-color" labelstyles="color:caramel; font-size:24px;" placeholder="hi!" min="1" max="10" inputclasses="wp-block-jetpack-input has-text-color has-border-color" inputstyles="color:toot; font-size:33rem; border-color:toot;border-width:1px;" outlinestyledata="{&quot;border&quot;:{&quot;color&quot;:&quot;toot&quot;&#044;&quot;width&quot;:&quot;1px&quot;}}" outlinestyleclasses=" has-border-color" fieldwrapperclasses="wp-block-jetpack-field-text"/]';
+		$expected  = '[contact-field type="text" label="Label" requiredText="Do it" labelclasses="wp-block-jetpack-label has-text-color" labelstyles="color:caramel; font-size:24px;" placeholder="hi!" min="1" max="10" inputclasses="wp-block-jetpack-input has-text-color has-border-color" inputstyles="color:toot; font-size:33rem; border-color:toot;border-width:1px;" stylevariationattributes="{&quot;border&quot;:{&quot;color&quot;:&quot;toot&quot;&#044;&quot;width&quot;:&quot;1px&quot;}}" stylevariationclasses=" has-border-color" fieldwrapperclasses="wp-block-jetpack-field-text"/]';
 
 		$this->assertEquals( $expected, $shortcode );
 	}
@@ -282,7 +282,7 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 
 		// Render the shortcode.
 		$shortcode = Contact_Form_Plugin::gutenblock_render_field_radio( array(), '', new WP_Block( $block ) );
-		$expected  = '[contact-field type="radio" label="Radio gaga" labelclasses="wp-block-jetpack-label has-text-color has-turmoil-purple-color" optionsclasses="" options="freddy,brian" optionsdata="&#091;{&quot;label&quot;:&quot;freddy&quot;&#044;&quot;class&quot;:&quot;has-text-color&quot;&#044;&quot;style&quot;:&quot;color:reddo; font-size:24px;&quot;}&#044;{&quot;label&quot;:&quot;brian&quot;&#044;&quot;class&quot;:&quot;has-text-color&quot;&#044;&quot;style&quot;:&quot;color:blueo; font-size:100rem;&quot;}&#093;" outlinestyledata="" outlinestyleclasses="" fieldwrapperclasses="wp-block-jetpack-field-radio"/]';
+		$expected  = '[contact-field type="radio" label="Radio gaga" labelclasses="wp-block-jetpack-label has-text-color has-turmoil-purple-color" optionsclasses="" options="freddy,brian" optionsdata="&#091;{&quot;label&quot;:&quot;freddy&quot;&#044;&quot;class&quot;:&quot;has-text-color&quot;&#044;&quot;style&quot;:&quot;color:reddo; font-size:24px;&quot;}&#044;{&quot;label&quot;:&quot;brian&quot;&#044;&quot;class&quot;:&quot;has-text-color&quot;&#044;&quot;style&quot;:&quot;color:blueo; font-size:100rem;&quot;}&#093;" stylevariationattributes="" stylevariationclasses="" fieldwrapperclasses="wp-block-jetpack-field-radio"/]';
 
 		$this->assertEquals( $expected, $shortcode, 'Shortcode is not as expected' );
 	}
@@ -328,19 +328,19 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 		return array(
 			'label and input'   => array(
 				'expected'     => array(
-					'labelclasses'        => 'wp-block-jetpack-label has-text-color has-accent-3-color',
-					'labelstyles'         => 'font-size:32px;',
-					'inputclasses'        => 'wp-block-jetpack-input has-text-color has-background has-border-color',
-					'inputstyles'         => 'color:swamp-green;background-color:swamp-red; font-size:24px;font-style:italic;font-weight:bold;line-height:1.5;letter-spacing:0.1em; border-color:swamp-blue;border-style:dashed;border-width:1px;',
-					'label'               => 'Label and Input',
-					'requiredText'        => 'Do it',
-					'placeholder'         => 'Yo',
-					'min'                 => '1',
-					'max'                 => '10',
-					'type'                => 'text',
-					'fieldwrapperclasses' => 'wp-block-jetpack-field-text',
-					'outlinestyleclasses' => ' has-background has-border-color',
-					'outlinestyledata'    => '{"border":{"color":"swamp-blue","width":"1px","style":"dashed"},"color":{"background":"swamp-red"}}',
+					'labelclasses'             => 'wp-block-jetpack-label has-text-color has-accent-3-color',
+					'labelstyles'              => 'font-size:32px;',
+					'inputclasses'             => 'wp-block-jetpack-input has-text-color has-background has-border-color',
+					'inputstyles'              => 'color:swamp-green;background-color:swamp-red; font-size:24px;font-style:italic;font-weight:bold;line-height:1.5;letter-spacing:0.1em; border-color:swamp-blue;border-style:dashed;border-width:1px;',
+					'label'                    => 'Label and Input',
+					'requiredText'             => 'Do it',
+					'placeholder'              => 'Yo',
+					'min'                      => '1',
+					'max'                      => '10',
+					'type'                     => 'text',
+					'fieldwrapperclasses'      => 'wp-block-jetpack-field-text',
+					'stylevariationclasses'    => ' has-background has-border-color',
+					'stylevariationattributes' => '{"border":{"color":"swamp-blue","width":"1px","style":"dashed"},"color":{"background":"swamp-red"}}',
 				),
 				'inner_blocks' => array(
 					array(
@@ -426,18 +426,18 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 			),
 			'label and options' => array(
 				'expected'     => array(
-					'labelclasses'        => 'wp-block-jetpack-label has-text-color has-accent-3-color',
-					'labelstyles'         => 'letter-spacing:0.1em;',
-					'options'             => 'Option 1,Option 2',
-					'optionsdata'         => '[{"label":"Option 1","class":"has-text-color has-sweet-potato-option-1-color","style":"font-size:24px;font-weight:bold;line-height:1.5;letter-spacing:0.1em;"},{"label":"Option 2","class":"has-text-color has-sweet-potato-option-2-color","style":"font-size:22px;font-weight:normal;"}]',
-					'label'               => 'Label multiple options',
-					'type'                => 'checkbox-multiple',
-					'requiredText'        => 'Do it again',
-					'fieldwrapperclasses' => 'wp-block-jetpack-field-checkbox-multiple',
-					'optionsclasses'      => ' has-text-color has-background',
-					'optionsstyles'       => 'color:blue-overture;background-color:green-tonight; border-top-width:2px;border-top-color:terrible-red;border-top-style:solid;',
-					'outlinestyleclasses' => ' has-background',
-					'outlinestyledata'    => '{"border":{"top":{"color":"terrible-red","width":"2px","style":"solid","radius":"10px"}},"color":{"background":"green-tonight"}}',
+					'labelclasses'             => 'wp-block-jetpack-label has-text-color has-accent-3-color',
+					'labelstyles'              => 'letter-spacing:0.1em;',
+					'options'                  => 'Option 1,Option 2',
+					'optionsdata'              => '[{"label":"Option 1","class":"has-text-color has-sweet-potato-option-1-color","style":"font-size:24px;font-weight:bold;line-height:1.5;letter-spacing:0.1em;"},{"label":"Option 2","class":"has-text-color has-sweet-potato-option-2-color","style":"font-size:22px;font-weight:normal;"}]',
+					'label'                    => 'Label multiple options',
+					'type'                     => 'checkbox-multiple',
+					'requiredText'             => 'Do it again',
+					'fieldwrapperclasses'      => 'wp-block-jetpack-field-checkbox-multiple',
+					'optionsclasses'           => ' has-text-color has-background',
+					'optionsstyles'            => 'color:blue-overture;background-color:green-tonight; border-top-width:2px;border-top-color:terrible-red;border-top-style:solid;',
+					'stylevariationclasses'    => ' has-background',
+					'stylevariationattributes' => '{"border":{"top":{"color":"terrible-red","width":"2px","style":"solid","radius":"10px"}},"color":{"background":"green-tonight"}}',
 				),
 				'inner_blocks' => array(
 					array(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Best reviewed with white space turned off because of draconian WordPress coding standards

This PR merges into https://github.com/Automattic/jetpack/pull/42890 not trunk
Related [JETPACK-277](https://linear.app/a8c/issue/JETPACK-277)

## Proposed changes:
Fixes an issue where with the outlined form style active, when you apply some typography styles to an input they're also applied to the label.

The actual bug is that in `get_form_variation_style_properties`, we're using the `inputstyles` attribute for the label, and it contains all input inline styles (so things like typography).

What we need to do instead is generate the inline styles for only the border and background styles, which at the moment probably is best done during the shortcode rendering, but perhaps that part could be reconsidered.

I went quite far with this PR and ended up renaming a lot of stuff, because I felt the names would have been confusing otherwise.

We had two shortcode properties called 'outlinestyledata' and 'outlinestyleclasses', and I needed to add a third one which would've been called 'outlinestylestyle' with the previous naming convention.

It's also misleading that the property is called `outlinestyle` because it's used for the animated style.

I've renamed it to `stylevariationattributes` / `stylevariationclasses` / `stylevariationstyles`, but the previous naming is used in a lot of places, so it required quite a bit of updating.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
1. Add a form
2. Select an input and apply some typography styles (text decoration and font weight are good ones to try).
3. Save and view the frontend

Before this PR - typography styles applied to an input would also apply to the label
After this PR - typography styles applied to an input only affect the input.