### PR TITLE
AI Chat / Donations blocks: fix inline script loading

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-order-chat-donations-blocks
+++ b/projects/plugins/jetpack/changelog/fix-order-chat-donations-blocks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+AI Chat & Donations blocks: ensure all metadata is properly attached to the blocks in the block editor.

--- a/projects/plugins/jetpack/extensions/blocks/ai-chat/ai-chat.php
+++ b/projects/plugins/jetpack/extensions/blocks/ai-chat/ai-chat.php
@@ -94,4 +94,4 @@ function add_ai_chat_block_data() {
 		'before'
 	);
 }
-add_action( 'enqueue_block_assets', __NAMESPACE__ . '\add_ai_chat_block_data' );
+add_action( 'enqueue_block_assets', __NAMESPACE__ . '\add_ai_chat_block_data', 11 );

--- a/projects/plugins/jetpack/extensions/blocks/donations/donations.php
+++ b/projects/plugins/jetpack/extensions/blocks/donations/donations.php
@@ -269,7 +269,7 @@ function load_editor_scripts() {
 		'before'
 	);
 }
-add_action( 'enqueue_block_assets', __NAMESPACE__ . '\load_editor_scripts' );
+add_action( 'enqueue_block_assets', __NAMESPACE__ . '\load_editor_scripts', 11 );
 
 /**
  * Determine if AMP should be disabled on posts having Donations blocks.


### PR DESCRIPTION
Fixes DLINK-5

## Proposed changes:

Follow-up to #39734

Since we've changed the loading strategy for the main Jetpack blocks bundle, we also need to change how additional inline scripts are hooked before that big bundle.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Start with a site that's connected to WordPress.com, running `trunk`.
* Go to Jetpack > Search, and enable Search and Instant Search
* Go to Posts > Add New
* Insert a Jetpack AI Chat block, as well as a Donations block
* Save your post as a draft.
* Open your browser's JavaScript console.
* Look for the value of the `Jetpack_DonationsBlock` and `Jetpack_AIChatBlock` objects
    * They're both undefined.
* Now switch to this branch.
* Refresh the post editor.
* Check the JS console again.
* The 2 objects now return the expected values.
