### PR TITLE
functions-wpcom-features.php: Sync changes from wpcom

### DIFF
--- a/projects/plugins/wpcomsh/changelog/update-functions-wpcom-features
+++ b/projects/plugins/wpcomsh/changelog/update-functions-wpcom-features
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: functions-wpcom-features: Syncing changes from wpcom, that are not run on jetpack.
+
+

--- a/projects/plugins/wpcomsh/wpcom-features/functions-wpcom-features.php
+++ b/projects/plugins/wpcomsh/wpcom-features/functions-wpcom-features.php
@@ -180,6 +180,53 @@ function _wpcom_features_get_simple_site_purchases( $blog_id ) {
 		return (array) $purchases;
 	}
 
+	$lock_key   = "{$wp_cache_key}_building";
+	$lock_found = false;
+	$lock       = wp_cache_get( $lock_key, $wp_cache_group, false, $lock_found );
+	if ( $lock_found ) {
+		// Another request is already rebuilding the purchases cache.
+		// Let's try 2 short sleeps of 200ms to see if that finishes, and if not,
+		// return an empty set of purchases. The DB must be backed up and we don't
+		// want to contribute to the problem.
+		$attempts = 2;
+		while ( $attempts > 0 ) {
+			$lock = wp_cache_get( $lock_key, $wp_cache_group, true /* force remote recheck */, $lock_found );
+			if ( ! $lock_found ) {
+				// The lock is no longer in cache, so we can break out of the loop.
+				break;
+			}
+			// Sleep 200ms
+			usleep( 200000 );
+			--$attempts;
+		}
+
+		// Has the first request has populated the cache?
+		$purchases = wp_cache_get( $wp_cache_key, $wp_cache_group, true /* force remote recheck */, $wp_cache_found );
+		if ( false !== $wp_cache_found ) {
+			return (array) $purchases;
+		}
+
+		// It's still not there, return [] as a fallback;
+		// Also let future checks for this blog for the life of this request fail
+		$target_blog_id = $blog_id;
+		add_filter(
+			'wpcom_simple_skip_purchase_lookup',
+			function ( $skip, $checked_blog_id ) use ( $target_blog_id ) {
+				if ( $checked_blog_id === $target_blog_id ) {
+					return true; // Skip purchases lookup
+				}
+				return $skip;
+			},
+			10,
+			2
+		);
+		return array();
+	}
+
+	// Let other requests know that we are rebuilding purchases, to stop multiples of the same
+	// request from stacking up.
+	wp_cache_set( $lock_key, true, $wp_cache_group, 30 ); // (30 second TTL)
+
 	// Get $purchases with a direct SQL query.
 	// We are intentionally NOT using the Purchases API as this code needs to be runnable
 	// in some contexts where the billing code-base is not available.
@@ -244,11 +291,12 @@ function _wpcom_features_get_simple_site_purchases( $blog_id ) {
 	}
 
 	/*
-	* Cache the $purchases for 3 hours. Otherwise, the cache is invalidated when a purchase is made, using:
+	* Cache the $purchases for 6-8 hours. Otherwise, the cache is invalidated when a purchase is made, using:
 	* add_action( 'subscription_changed', 'clear_wp_cache_site_purchases', 10, 1 );
 	* Found in ./wp-content/mu-plugins/wpcom-features.php
 	*/
-	wp_cache_set( $wp_cache_key, $purchases, $wp_cache_group, 3 * HOUR_IN_SECONDS );
+	wp_cache_set( $wp_cache_key, $purchases, $wp_cache_group, ( 6 * HOUR_IN_SECONDS ) + mt_rand( 1, 2 * 60 * MINUTE_IN_SECONDS ) );
+	wp_cache_delete( $lock_key, $wp_cache_group ); // Release the lock telling other requests we are building purchases.
 
 	return $purchases;
 }

--- a/projects/plugins/wpcomsh/wpcom-features/functions-wpcom-features.php
+++ b/projects/plugins/wpcomsh/wpcom-features/functions-wpcom-features.php
@@ -182,7 +182,8 @@ function _wpcom_features_get_simple_site_purchases( $blog_id ) {
 
 	$lock_key   = "{$wp_cache_key}_building";
 	$lock_found = false;
-	$lock       = wp_cache_get( $lock_key, $wp_cache_group, false, $lock_found );
+	// phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+	$lock = wp_cache_get( $lock_key, $wp_cache_group, false, $lock_found );
 	if ( $lock_found ) {
 		// Another request is already rebuilding the purchases cache.
 		// Let's try 2 short sleeps of 200ms to see if that finishes, and if not,
@@ -190,6 +191,7 @@ function _wpcom_features_get_simple_site_purchases( $blog_id ) {
 		// want to contribute to the problem.
 		$attempts = 2;
 		while ( $attempts > 0 ) {
+			// phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 			$lock = wp_cache_get( $lock_key, $wp_cache_group, true /* force remote recheck */, $lock_found );
 			if ( ! $lock_found ) {
 				// The lock is no longer in cache, so we can break out of the loop.
@@ -295,6 +297,7 @@ function _wpcom_features_get_simple_site_purchases( $blog_id ) {
 	* add_action( 'subscription_changed', 'clear_wp_cache_site_purchases', 10, 1 );
 	* Found in ./wp-content/mu-plugins/wpcom-features.php
 	*/
+	// phpcs:ignore WordPress.WP.AlternativeFunctions.rand_mt_rand
 	wp_cache_set( $wp_cache_key, $purchases, $wp_cache_group, ( 6 * HOUR_IN_SECONDS ) + mt_rand( 1, 2 * 60 * MINUTE_IN_SECONDS ) );
 	wp_cache_delete( $lock_key, $wp_cache_group ); // Release the lock telling other requests we are building purchases.
 


### PR DESCRIPTION
Syncing changes from WPCOM to keep the two files in sync. These changes aren't run on Jetpack sites or Atomic sites because they will fall into a different path.

## Proposed changes:
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?

## Testing instructions:

* Make an atomic dev site, put this branch of wpcomsh on it and double check it doesn't blow up


