### PR TITLE
Blogging prompt: Fix prompt block not being inserted in the editor

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-writing-prompt
+++ b/projects/plugins/jetpack/changelog/fix-writing-prompt
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Blogging prompt: Fix the prompt block not being inserted based on the URL param.

--- a/projects/plugins/jetpack/extensions/blocks/blogging-prompt/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/blogging-prompt/editor.js
@@ -1,5 +1,6 @@
 import { createBlock } from '@wordpress/blocks';
-import { dispatch } from '@wordpress/data';
+import { dispatch, select } from '@wordpress/data';
+import domReady from '@wordpress/dom-ready';
 import { __ } from '@wordpress/i18n';
 import { registerJetpackBlockFromMetadata } from '../../shared/register-jetpack-block';
 import { waitForEditor } from '../../shared/wait-for-editor';
@@ -45,8 +46,9 @@ async function insertTemplate( promptId ) {
 	insertBlocks( bloggingPromptBlocks, 0, undefined, false );
 }
 
-function initBloggingPrompt() {
+async function initBloggingPrompt() {
 	const url = new URL( document.location.href );
+
 	const isNewPost = url.pathname.endsWith( '/wp-admin/post-new.php' );
 
 	if ( ! isNewPost ) {
@@ -57,8 +59,17 @@ function initBloggingPrompt() {
 	const answerPromptId = parseInt( answerPrompt );
 
 	if ( answerPromptId ) {
-		insertTemplate( answerPromptId );
+		const isEditorReady = select( 'core/editor' ).__unstableIsEditorReady;
+
+		if ( isEditorReady && isEditorReady() === false ) {
+			await waitForEditor();
+		}
+
+		await insertTemplate( answerPromptId );
 	}
 }
 
-initBloggingPrompt();
+// Initialize when the DOM is ready
+domReady( () => {
+	initBloggingPrompt();
+} );

--- a/projects/plugins/jetpack/extensions/blocks/blogging-prompt/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/blogging-prompt/editor.js
@@ -42,6 +42,7 @@ async function insertTemplate( promptId ) {
 		createBlock( 'jetpack/blogging-prompt', { promptFetched: false, promptId, tagsAdded: true } ),
 		createBlock( 'core/paragraph' ),
 	];
+	console.log( 'bloggingPromptBlocks', bloggingPromptBlocks );
 
 	insertBlocks( bloggingPromptBlocks, 0, undefined, false );
 }
@@ -50,6 +51,7 @@ async function initBloggingPrompt() {
 	const url = new URL( document.location.href );
 
 	const isNewPost = url.pathname.endsWith( '/wp-admin/post-new.php' );
+	console.log( 'isNewPost', isNewPost );
 
 	if ( ! isNewPost ) {
 		return;
@@ -57,11 +59,14 @@ async function initBloggingPrompt() {
 
 	const answerPrompt = url.searchParams.get( 'answer_prompt' ) ?? '0';
 	const answerPromptId = parseInt( answerPrompt );
+	console.log( 'answerPromptId', answerPromptId );
 
 	if ( answerPromptId ) {
 		const isEditorReady = select( 'core/editor' ).__unstableIsEditorReady;
+		console.log( 'isEditorReady', isEditorReady );
 
 		if ( isEditorReady && isEditorReady() === false ) {
+			console.log( 'isEditorReady is false, waiting for editor' );
 			await waitForEditor();
 		}
 

--- a/projects/plugins/jetpack/extensions/blocks/blogging-prompt/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/blogging-prompt/editor.js
@@ -38,20 +38,33 @@ async function insertTemplate( promptId ) {
 	await waitForEditor();
 
 	const { insertBlocks } = dispatch( 'core/block-editor' );
+	const { editPost } = dispatch( 'core/editor' );
+
 	const bloggingPromptBlocks = [
 		createBlock( 'jetpack/blogging-prompt', { promptFetched: false, promptId, tagsAdded: true } ),
 		createBlock( 'core/paragraph' ),
 	];
-	console.log( 'bloggingPromptBlocks', bloggingPromptBlocks );
 
+	// Insert blocks and ensure they persist
 	insertBlocks( bloggingPromptBlocks, 0, undefined, false );
+
+	// Force a save to ensure blocks persist
+	editPost( { blocks: select( 'core/block-editor' ).getBlocks() } );
+
+	// Check if blocks were actually inserted
+	const insertedBlocks = select( 'core/block-editor' ).getBlocks();
+
+	// If blocks disappeared, try one more time with a delay
+	if ( ! insertedBlocks.some( block => block.name === 'jetpack/blogging-prompt' ) ) {
+		await new Promise( resolve => setTimeout( resolve, 100 ) );
+		insertBlocks( bloggingPromptBlocks, 0, undefined, false );
+		editPost( { blocks: select( 'core/block-editor' ).getBlocks() } );
+	}
 }
 
 async function initBloggingPrompt() {
 	const url = new URL( document.location.href );
-
 	const isNewPost = url.pathname.endsWith( '/wp-admin/post-new.php' );
-	console.log( 'isNewPost', isNewPost );
 
 	if ( ! isNewPost ) {
 		return;
@@ -59,14 +72,11 @@ async function initBloggingPrompt() {
 
 	const answerPrompt = url.searchParams.get( 'answer_prompt' ) ?? '0';
 	const answerPromptId = parseInt( answerPrompt );
-	console.log( 'answerPromptId', answerPromptId );
 
 	if ( answerPromptId ) {
 		const isEditorReady = select( 'core/editor' ).__unstableIsEditorReady;
-		console.log( 'isEditorReady', isEditorReady );
 
 		if ( isEditorReady && isEditorReady() === false ) {
-			console.log( 'isEditorReady is false, waiting for editor' );
 			await waitForEditor();
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://linear.app/a8c/issue/CML-493/daily-writing-prompt-broken-opens-blank-new-post

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Wait until the editor is ready to insert the blocks.
* Force a save after inserting to persist the blocks. This is needed for Atomic and Simple sites because editor updates are handled differently. Ideally, we would hook into how blocks are persisted in Gutenberg, but that doesn't seem to be working with this programmatic insertion. 

Potential follow up: Add a test for this flow.


https://github.com/user-attachments/assets/dd3d5d1e-f683-42e6-bcd5-75ed65e4499f



### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Simple:
* Run `bin/jetpack-downloader test jetpack fix/writing-prompt` on your sandbox and sandbox the API and a Simple site.
* Go to wordpress.com/home/{site url} for the sandboxed site.
* Click "Post Answer" under the daily writing prompt.
* The editor should load with the prompt block.

Atomic:
* On an Atomic site, check out this branch in Jetpack beta. 
* Go to the wp-admin dashboard.
* Click "Post Answer" under the daily writing prompt.
* The editor should load with the prompt block.

Jetpack:
* On a Jetpack site, check out this branch in Jetpack beta.
* Go to `/wp-admin/post-new.php?answer_prompt=1944`
* The editor should load with the prompt block.

