### PR TITLE
Help Center APIs: Add support for an array of statuses

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-hc-apu
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-hc-apu
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+Help Center: Update support for multiple statuses in endpoint.

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-wp-rest-help-center-support-interactions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-wp-rest-help-center-support-interactions.php
@@ -33,20 +33,20 @@ class WP_REST_Help_Center_Support_Interactions extends \WP_REST_Controller {
 				'callback'            => array( $this, 'get_support_interactions' ),
 				'permission_callback' => 'is_user_logged_in',
 				'args'                => array(
-					'status'   => [
+					'status'   => array(
 						'type'     => 'array',
 						'required' => false,
-						'items'    => [
+						'items'    => array(
 							'type' => 'string',
-							'enum' => [
+							'enum' => array(
 								'open',
 								'resolved',
 								'solved',
 								'closed',
-							],
-						],
-						'default'  => [],
-					],
+							),
+						),
+						'default'  => array(),
+					),
 					'page'     => array(
 						'type'     => 'integer',
 						'required' => false,

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-wp-rest-help-center-support-interactions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-wp-rest-help-center-support-interactions.php
@@ -33,15 +33,20 @@ class WP_REST_Help_Center_Support_Interactions extends \WP_REST_Controller {
 				'callback'            => array( $this, 'get_support_interactions' ),
 				'permission_callback' => 'is_user_logged_in',
 				'args'                => array(
-					'status'   => array(
-						'type'     => 'string',
+					'status'   => [
+						'type'     => 'array',
 						'required' => false,
-						'enum'     => array(
-							'open',
-							'resolved',
-							'closed',
-						),
-					),
+						'items'    => [
+							'type' => 'string',
+							'enum' => [
+								'open',
+								'resolved',
+								'solved',
+								'closed',
+							],
+						],
+						'default'  => [],
+					],
 					'page'     => array(
 						'type'     => 'integer',
 						'required' => false,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->



## Proposed changes:
<!--- Explain what functional changes your PR includes -->

Atomic sites rely on Jetpack for the API calls to work.
Recently we updated calls to get support interactions to allow to pass multiple statuses as parameter. 
This PR updates the Jetpack APIs called by Atomic websites.

## Testing instructions:

1. Use Jetpack Beta to sync this to WordPress.com Features
2. Open devtools and check that, when opening Help Center, you do not have errors on calls to /support-interactions

## Does this pull request change what data or activity we track or use?

No change.