### PR TITLE
Sharing buttons: Ensure we don't retrieve the post title or id from the object if it does not exist

### DIFF
--- a/projects/plugins/jetpack/changelog/update-class-sharing-source-block-undefined-properties
+++ b/projects/plugins/jetpack/changelog/update-class-sharing-source-block-undefined-properties
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Sharing buttons: Prevent PHP warnings in some scenarios, ensuring we only check the post tle and id if posts exist.

--- a/projects/plugins/jetpack/extensions/blocks/sharing-button/class-sharing-source-block.php
+++ b/projects/plugins/jetpack/extensions/blocks/sharing-button/class-sharing-source-block.php
@@ -541,7 +541,7 @@ class Share_Facebook_Block extends Sharing_Source_Block {
 	 * @return void
 	 */
 	public function process_request( $post, array $post_data ) {
-		$post_id = $post ? $post->ID : 0;
+		$post_id = $post instanceof WP_Post ? $post->ID : 0;
 		$fb_url  = $this->http() . '://www.facebook.com/sharer.php?u=' . rawurlencode( $this->get_share_url( $post_id ) ) . '&t=' . rawurlencode( $this->get_share_title( $post_id ) );
 
 		// Record stats

--- a/projects/plugins/jetpack/extensions/blocks/sharing-button/class-sharing-source-block.php
+++ b/projects/plugins/jetpack/extensions/blocks/sharing-button/class-sharing-source-block.php
@@ -114,8 +114,7 @@ abstract class Sharing_Source_Block {
 		 * @param int $post_id Post ID.
 		 * @param int $this->id Sharing ID.
 		 */
-		$title = apply_filters( 'sharing_title', $post->post_title, $post_id, $this->id );
-
+		$title = $post ? apply_filters( 'sharing_title', $post->post_title, $post_id, $this->id ) : '';
 		return html_entity_decode( wp_kses( $title, '' ), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 );
 	}
 
@@ -542,7 +541,8 @@ class Share_Facebook_Block extends Sharing_Source_Block {
 	 * @return void
 	 */
 	public function process_request( $post, array $post_data ) {
-		$fb_url = $this->http() . '://www.facebook.com/sharer.php?u=' . rawurlencode( $this->get_share_url( $post->ID ) ) . '&t=' . rawurlencode( $this->get_share_title( $post->ID ) );
+		$post_id = $post ? $post->ID : 0;
+		$fb_url  = $this->http() . '://www.facebook.com/sharer.php?u=' . rawurlencode( $this->get_share_url( $post_id ) ) . '&t=' . rawurlencode( $this->get_share_title( $post_id ) );
 
 		// Record stats
 		parent::process_request( $post, $post_data );

--- a/projects/plugins/jetpack/extensions/blocks/sharing-button/class-sharing-source-block.php
+++ b/projects/plugins/jetpack/extensions/blocks/sharing-button/class-sharing-source-block.php
@@ -114,7 +114,7 @@ abstract class Sharing_Source_Block {
 		 * @param int $post_id Post ID.
 		 * @param int $this->id Sharing ID.
 		 */
-		$title = $post ? apply_filters( 'sharing_title', $post->post_title, $post_id, $this->id ) : '';
+		$title = $post instanceof WP_Post ? apply_filters( 'sharing_title', $post->post_title, $post_id, $this->id ) : '';
 		return html_entity_decode( wp_kses( $title, '' ), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 );
 	}
 


### PR DESCRIPTION
Fixes VULCAN-123

## Proposed changes:

* This PR prevents two undefined property warnings: `Warning: Attempt to read property "post_title" on null`, and `Warning: Attempt to read property "ID" on null`
* For the first (most numerous) warning, we are ensuring that we are only applying the `sharing_filter` filter if a pos actually exists, otherwise we'll return an empty string for the post title.
* For the second, if the post doesn't exist we'll set the ID to 0, so we can continue to create a sharing URL (for Facebook), though not passing any data in that is useful to the specific post (as the post won't exist).
* The testing scenarios outline cases where each of these issues can happen.
* Logs: 85bae41249850811839892386f2072c2-logstash

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

pdWQjU-1g0-p2

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

To replicate the undefined `post_title` property warning:
* On a test site using Jetpack trunk, add a block theme that allows you to add a footer to all pages, or preferably a 404 page (eg. Twenty Twenty Five) where you can add to any part of the template.
* In that template (or footer of another template such as pages or single posts) add a Sharing Buttons block and add an email share button.
* On the site, attempt to open up a non-existent post or page, so that you see the 404 page. 
* You should see the warning - `Warning:  Attempt to read property "post_title" on null` - in your error logs.

To replicate the `ID` property warning: 
* On the same test site, attempt to visit a page with a similar URL as the ones generating these errors - the URL visible under 'phperrors-by-request' via this log: bff7a69b383ed5bc9444a99b705d1f99-logstash (noting there has only been a few from the one site just yesterday, nothing in the past month, so once the logs pass their expiry there may be nothing visible here). As an example: `https://mytestsite.com/2025/05/19/test-post//file=https://mytestsite.com/feed/?share=facebook&share=facebook`

You can test the fix by applying this PR locally or using the Jetpack Beta Tester (self-hosted, you can try WoA though I wasn't able to replicate the issue there). The same testing steps should not result in warnings.

On Simple: Follow the same testing steps as above. When testing the fix, use the command in the generated comment below, for a sandboxed Simple site.