### PR TITLE
Forms: Fix file upload block insertion 

### DIFF
--- a/projects/packages/forms/changelog/fix-file-upload-insertion
+++ b/projects/packages/forms/changelog/fix-file-upload-insertion
@@ -1,5 +1,5 @@
 Significance: patch
 Type: fixed
-Comment: block still in beta
+Comment: Restrict allowed blocks in file upload field. This fix ensures that only supported blocks can be inserted, improving stability and preventing errors. The file upload block is still in beta.
 
 

--- a/projects/packages/forms/changelog/fix-file-upload-insertion
+++ b/projects/packages/forms/changelog/fix-file-upload-insertion
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: block still in beta
+
+

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-file/index.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-file/index.js
@@ -14,7 +14,6 @@ import { useJetpackFieldStyles } from '../use-jetpack-field-styles';
 import './editor.css';
 
 const ALLOWED_BLOCKS = [
-	'core/audio',
 	'core/columns',
 	'core/group',
 	'core/heading',
@@ -27,7 +26,6 @@ const ALLOWED_BLOCKS = [
 	'core/spacer',
 	'core/stack',
 	'core/subhead',
-	'core/video',
 ];
 
 const BLOCKS_TEMPLATE = [

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-file/index.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-file/index.js
@@ -13,6 +13,23 @@ import { UpsellNudge } from '../upsell-nudge';
 import { useJetpackFieldStyles } from '../use-jetpack-field-styles';
 import './editor.css';
 
+const ALLOWED_BLOCKS = [
+	'core/audio',
+	'core/columns',
+	'core/group',
+	'core/heading',
+	'core/html',
+	'core/image',
+	'core/list',
+	'core/paragraph',
+	'core/row',
+	'core/separator',
+	'core/spacer',
+	'core/stack',
+	'core/subhead',
+	'core/video',
+];
+
 const BLOCKS_TEMPLATE = [
 	[
 		'core/group',
@@ -36,6 +53,7 @@ const BLOCKS_TEMPLATE = [
 					color: 'rgba(125,125,125,0.3)',
 				},
 			},
+			allowedBlocks: ALLOWED_BLOCKS,
 		},
 		[
 			[
@@ -105,7 +123,11 @@ const JetpackFieldFile = props => {
 				<div className="jetpack-form-file-field__dropzone">
 					<div className="jetpack-form-file-field__dropzone-inner">
 						<input type="file" style={ { display: 'none' } } aria-hidden="true" />
-						<InnerBlocks template={ BLOCKS_TEMPLATE } templateLock={ false } />
+						<InnerBlocks
+							allowedBlocks={ ALLOWED_BLOCKS }
+							template={ BLOCKS_TEMPLATE }
+							templateLock={ false }
+						/>
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
This PR fixes the file upload filed by limiting the blocks that you are able to add to it. 
This way we avoid the group block from allowing the
Since you should only be able to set the block to only allow 

Before:

![Screenshot 2025-05-20 at 5 54 36 AM](https://github.com/user-attachments/assets/8a40992f-54f3-459e-baea-d6fbafa936c6)


After:
![Screenshot 2025-05-20 at 10 46 30 AM](https://github.com/user-attachments/assets/8ff03879-28e5-4bbd-95c7-9e5f2c0f3476)


## Proposed changes:
* Limit the group block from a smaller number of core blocks to be added to the file upload field. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
* Have the beta blocks variation. 
* Add the file upload field. 
* Notice that you can only insert a small subset of core blocks into it. 


