### PR TITLE
Forms: Fix Akismet spam URL

### DIFF
--- a/projects/packages/forms/changelog/update-forms-akismet-links
+++ b/projects/packages/forms/changelog/update-forms-akismet-links
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Fix Akismet spam URL.

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -295,21 +295,19 @@ class Contact_Form_Block {
 		$contact_form            = new Contact_Form( array() );
 		$defaults                = $contact_form->defaults;
 		$form_responses_url      = $dashboard_view_switch->get_forms_admin_url();
-		$form_responses_spam_url = $dashboard_view_switch->get_forms_admin_url( 'spam' );
 		$akismet_active_with_key = Jetpack::is_akismet_active();
 		$akismet_key_url         = admin_url( 'admin.php?page=akismet-key-config' );
 		$preferred_view          = $dashboard_view_switch->get_preferred_view();
 
 		$data = array(
 			'defaults' => array(
-				'to'                    => $defaults['to'],
-				'subject'               => $defaults['subject'],
-				'formsResponsesUrl'     => $form_responses_url,
-				'formsResponsesSpamUrl' => $form_responses_spam_url,
-				'akismetActiveWithKey'  => $akismet_active_with_key,
-				'akismetUrl'            => $akismet_key_url,
-				'assetsUrl'             => Jetpack_Forms::assets_url(),
-				'preferredView'         => $preferred_view,
+				'to'                   => $defaults['to'],
+				'subject'              => $defaults['subject'],
+				'formsResponsesUrl'    => $form_responses_url,
+				'akismetActiveWithKey' => $akismet_active_with_key,
+				'akismetUrl'           => $akismet_key_url,
+				'assetsUrl'            => Jetpack_Forms::assets_url(),
+				'preferredView'        => $preferred_view,
 			),
 		);
 

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/akismet-card.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/akismet-card.js
@@ -6,7 +6,7 @@ import AkismetIcon from '../../../../icons/akismet';
 import IntegrationCard from './integration-card';
 
 const AkismetCard = ( { isExpanded, onToggle, data, refreshStatus } ) => {
-	const formSubmissionsUrl = window?.jpFormsBlocks?.defaults?.formsResponsesSpamUrl || '';
+	const formSubmissionsUrl = data?.details?.formSubmissionsSpamUrl || '';
 
 	const { isConnected: akismetActiveWithKey = false, settingsUrl = '' } = data || {};
 
@@ -80,7 +80,7 @@ const AkismetCard = ( { isExpanded, onToggle, data, refreshStatus } ) => {
 						</Button>
 						<span>|</span>
 						<Button variant="link" href={ settingsUrl } target="_blank" rel="noopener noreferrer">
-							{ __( 'View stats', 'jetpack-forms' ) }
+							{ __( 'View stats and settings', 'jetpack-forms' ) }
 						</Button>
 						<span>|</span>
 						<ExternalLink href={ getRedirectUrl( 'akismet-jetpack-forms-docs' ) }>

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -8,6 +8,7 @@
 namespace Automattic\Jetpack\Forms\ContactForm;
 
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
+use Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch;
 use Automattic\Jetpack\Forms\Service\Google_Drive;
 use Automattic\Jetpack\Redirect;
 use Automattic\Jetpack\Status\Host;
@@ -735,7 +736,9 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 
 		// Plugin-specific customizations
 		if ( 'akismet' === $plugin_slug ) {
-			$response['isConnected'] = class_exists( 'Jetpack' ) && \Jetpack::is_akismet_active();
+			$dashboard_view_switch                         = new Dashboard_View_Switch();
+			$response['isConnected']                       = class_exists( 'Jetpack' ) && \Jetpack::is_akismet_active();
+			$response['details']['formSubmissionsSpamUrl'] = $dashboard_view_switch->get_forms_admin_url( 'spam' );
 		} elseif ( 'zero-bs-crm' === $plugin_slug && $is_active ) {
 			$has_extension       = function_exists( 'zeroBSCRM_isExtensionInstalled' ) && zeroBSCRM_isExtensionInstalled( 'jetpackforms' ); // @phan-suppress-current-line PhanUndeclaredFunction -- We're checking the function exists first
 			$response['details'] = array(

--- a/projects/packages/forms/src/dashboard/integrations/akismet-card.tsx
+++ b/projects/packages/forms/src/dashboard/integrations/akismet-card.tsx
@@ -4,7 +4,7 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import IntegrationCard from '../../blocks/contact-form/components/jetpack-integrations-modal/integration-card';
 import AkismetIcon from '../../icons/akismet';
-import type { IntegrationCardProps, JPFormsBlocksWindow } from './types';
+import type { IntegrationCardProps } from './types';
 
 const AkismetDashboardCard = ( {
 	isExpanded,
@@ -12,9 +12,7 @@ const AkismetDashboardCard = ( {
 	data,
 	refreshStatus,
 }: IntegrationCardProps ) => {
-	const formSubmissionsUrl =
-		( window as JPFormsBlocksWindow ).jpFormsBlocks?.defaults?.formsResponsesSpamUrl || '';
-
+	const formSubmissionsUrl = data?.details?.formSubmissionsSpamUrl || '';
 	const { isConnected: akismetActiveWithKey = false, settingsUrl = '' } = data || {};
 
 	const cardData = {
@@ -86,7 +84,7 @@ const AkismetDashboardCard = ( {
 						</Button>
 						<span>|</span>
 						<Button variant="link" href={ settingsUrl } target="_blank" rel="noopener noreferrer">
-							{ __( 'View stats', 'jetpack-forms' ) }
+							{ __( 'View stats and settings', 'jetpack-forms' ) }
 						</Button>
 						<span>|</span>
 						<ExternalLink href={ getRedirectUrl( 'akismet-jetpack-forms-docs' ) }>

--- a/projects/plugins/jetpack/changelog/update-forms-akismet-links
+++ b/projects/plugins/jetpack/changelog/update-forms-akismet-links
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: Fix Akismet spam URL.


### PR DESCRIPTION
## Proposed changes:

* Updates integrations endpoint to return the url to see spam for Akismet
* Updates the integrations modal > Akismet card to use this over global JS variable
* Updates the forms dashboard > integrations tab to use this value (before this was broken because we only load the global JS variable in the block editor)
* Updates 'View Stats' link to 'View Stats and Settings' since both are on the same page.

*Screenshots: modal*
<img width="716" alt="integrations-modal-3" src="https://github.com/user-attachments/assets/4635e89f-5abe-41d7-b20f-5a93c6f870bf" />

*Screenshot: dashboard integrations tab*
<img width="1323" alt="form-integrations-tab-2" src="https://github.com/user-attachments/assets/af755721-1fba-46bd-b429-52d71b40eef9" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Slack: p1747755037014109/1747753429.822709-slack-C08LJ97DJ6A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No. 

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add contact form block to page, click to open integrations modal, and check that Akismet 'View Spam' links takes you to form responses page with 'spam' filter pre-applied.
* To see the Integrations tab, you'll need to add: `add_filter( 'jetpack_forms_enable_integrations_tab', '__return_true' );`
* Go to dashboard > Feedback > Integrations, and check that Akismet 'View Spam' links takes you to form responses page with 'spam' filter pre-applied.