### PR TITLE
Forms: Add max-width to Salesforce id input

### DIFF
--- a/projects/packages/forms/changelog/updates-forms-salesforce-id-max-width
+++ b/projects/packages/forms/changelog/updates-forms-salesforce-id-max-width
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Apply max-width on Salesforce ID input.

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/salesforce-card.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/salesforce-card.js
@@ -86,6 +86,7 @@ const SalesforceCard = ( {
 					onChange={ setOrganizationId }
 					__nextHasNoMarginBottom={ true }
 					__next40pxDefaultSize={ true }
+					style={ { maxWidth: '300px' } }
 				/>
 				{ salesforceData.organizationId && organizationIdError && (
 					<HelpMessage isError style={ { marginTop: '8px' } }>


### PR DESCRIPTION
## Proposed changes:

* Applies a 300px max-width to the Salesforce input in the forms integration modal. 

<img width="708" alt="salesforce-input" src="https://github.com/user-attachments/assets/e1d7ab2b-36bd-4157-9102-b9165ab98a4d" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Slack: p1747755037014109/1747753429.822709-slack-C08LJ97DJ6A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No. 

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add a form block to page, click to open the integrations modal, open the Salesforce section, and confirm that the Salesforce ID input is 300px wide (before it was the full width of the modal). 