### PR TITLE
Forms: fix inconsistent weights in outline style and terms labels

### DIFF
--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -609,10 +609,11 @@
 .jetpack-field-checkbox,
 .jetpack-field-consent {
 	display: flex;
+}
 
-	.jetpack-field-label .jetpack-field-label__input {
-		font-weight: 400;
-	}
+.jetpack-field-consent,
+.jetpack-field-checkbox .jetpack-field-label .jetpack-field-label__input {
+	font-weight: 400;
 }
 
 .jetpack-field-checkbox {

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -614,11 +614,6 @@
 	display: flex;
 }
 
-.jetpack-field-consent,
-.jetpack-field-checkbox .jetpack-field-label .jetpack-field-label__input {
-	font-weight: 400;
-}
-
 .jetpack-field-checkbox {
 	align-items: baseline;
 
@@ -628,6 +623,7 @@
 }
 
 .jetpack-field-consent {
+	font-weight: 400;
 
 	:where(.wp-block-jetpack-option) {
 		font-size: 13px;
@@ -1066,7 +1062,7 @@
 	font-weight: 700;
 }
 
-:where(.is-style-outlined .wp-block-jetpack-label) {
+.is-style-outlined :where(.wp-block-jetpack-label) {
 	font-weight: 300;
 }
 

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -418,7 +418,7 @@
 
 		&[type="radio"]::before {
 			border-radius: 50%;
-			transform: translateY(15%);
+			transform: translateY(0.15rem);
 		}
 	}
 
@@ -446,15 +446,12 @@
 
 		.jetpack-option__type::before {
 			display: block; /* display: flex causes baselines to not align */
+			transform: translateY(0.15rem);
 		}
 	}
 
-	.jetpack-field-option.field-option-radio,
-	.wp-block-jetpack-field-option-radio {
-
-		.jetpack-option__type {
-			transform: translateY(5%); /* Small offset to compensate the slightly odd perceived alignment that's due to the circular shape */
-		}
+	.rich-text {
+		transform: translateY(-0.1rem);
 	}
 }
 
@@ -813,7 +810,7 @@
 				transition: all 150ms cubic-bezier(0.4, 0, 0.2, 1);
 				margin: 0;
 
-				:where( label, .jetpack-field-label__suffix ) {
+				.jetpack-field-label__suffix {
 					font-weight: 300;
 				}
 			}
@@ -1063,6 +1060,10 @@
 
 :where(.wp-block-jetpack-label) {
 	font-weight: 700;
+}
+
+:where(.is-style-outlined .wp-block-jetpack-label) {
+	font-weight: 300;
 }
 
 .jetpack-field-dropdown__toggle .rich-text {

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -418,7 +418,7 @@
 
 		&[type="radio"]::before {
 			border-radius: 50%;
-			transform: translateY(0.15rem);
+			transform: translateY(15%);
 		}
 	}
 
@@ -446,12 +446,15 @@
 
 		.jetpack-option__type::before {
 			display: block; /* display: flex causes baselines to not align */
-			transform: translateY(0.15rem);
 		}
 	}
 
-	.rich-text {
-		transform: translateY(-0.1rem);
+	.jetpack-field-option.field-option-radio,
+	.wp-block-jetpack-field-option-radio {
+
+		.jetpack-option__type {
+			transform: translateY(5%); /* Small offset to compensate the slightly odd perceived alignment that's due to the circular shape */
+		}
 	}
 }
 

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -98,7 +98,7 @@
 }
 
 
-.contact-form :where(label.consent) {
+:where(.contact-form label.consent) {
 	font-size: 13px;
 	font-weight: 400;
 	text-transform: uppercase;

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -84,11 +84,19 @@
 	display: block;
 }
 
-.contact-form :where(legend.grunion-field-label),
-.contact-form :where(label) {
+:where(.contact-form legend.grunion-field-label),
+:where(.contact-form label) {
 	margin-bottom: 0.25em;
 	font-weight: 700;
 }
+
+:where( .grunion-checkbox-multiple-options legend ),
+:where( .grunion-radio-options legend ) {
+	margin-bottom: 0.25em;
+	padding: 0;
+	font-weight: 700;
+}
+
 
 .contact-form :where(label.consent) {
 	font-size: 13px;
@@ -142,16 +150,6 @@
 :where( .contact-form .is-style-outlined .grunion-checkbox-multiple-options ),
 :where( .contact-form .is-style-outlined .grunion-radio-options )  {
 	border: solid 1px var( --jetpack--contact-form--border-color );
-}
-
-.grunion-checkbox-multiple-options,
-.grunion-radio-options {
-
-	:where( legend ) {
-		margin-bottom: 0.25em;
-		padding: 0;
-		font-weight: 700;
-	}
 }
 
 .contact-form .is-style-animated .grunion-checkbox-multiple-options legend,
@@ -574,10 +572,10 @@ on production builds, the attributes are being reordered, causing side-effects
 	will-change: transform;
 	transition: all 150ms cubic-bezier(0.4, 0, 0.2, 1);
 	margin: 0;
-	font-weight: 300;
 }
 
-.contact-form .is-style-outlined .grunion-field-wrap legend.grunion-field-label {
+:where(.contact-form .is-style-outlined .grunion-field-wrap .notched-label .notched-label__label),
+:where(.contact-form .is-style-outlined .grunion-field-wrap legend.grunion-field-label) {
 	font-weight: 300;
 }
 

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -84,8 +84,8 @@
 	display: block;
 }
 
-:where(.contact-form legend.grunion-field-label),
-:where(.contact-form label) {
+.contact-form :where(legend.grunion-field-label),
+.contact-form :where(label) {
 	margin-bottom: 0.25em;
 	font-weight: 700;
 }

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -98,7 +98,7 @@
 }
 
 
-:where(.contact-form label.consent) {
+.contact-form :where(label.consent) {
 	font-size: 13px;
 	font-weight: 400;
 	text-transform: uppercase;

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -90,8 +90,8 @@
 	font-weight: 700;
 }
 
-:where( .grunion-checkbox-multiple-options legend ),
-:where( .grunion-radio-options legend ) {
+.grunion-checkbox-multiple-options :where( legend ),
+.grunion-radio-options :where( legend ) {
 	margin-bottom: 0.25em;
 	padding: 0;
 	font-weight: 700;
@@ -574,8 +574,8 @@ on production builds, the attributes are being reordered, causing side-effects
 	margin: 0;
 }
 
-:where(.contact-form .is-style-outlined .grunion-field-wrap .notched-label .notched-label__label),
-:where(.contact-form .is-style-outlined .grunion-field-wrap legend.grunion-field-label) {
+.contact-form :where(.is-style-outlined .grunion-field-wrap .notched-label .notched-label__label),
+.contact-form :where(.is-style-outlined .grunion-field-wrap legend.grunion-field-label) {
 	font-weight: 300;
 }
 


### PR DESCRIPTION

Fixes FORMS-41

## Proposed changes:

1. Ensure that existing font-weight CSS does not override block and global label styles by adjusting specificity of default font-weight rules. This ensures consistency in frontend and editor.
2. Ensure the terms and condition label is consistent in frontend and editor, and is overridable by global styles (`jetpack/option`)


## Testing instructions:

Create an outlined form block with:

- inputs
- multi options
- select
- terms
- text area

In global styles, update the typography appearance for the `jetpack/label` block to **bold and italic** or some other conspicuous combo.

<img width="274" alt="Screenshot 2025-05-21 at 3 12 52 pm" src="https://github.com/user-attachments/assets/097131da-f4dd-4ebf-b848-711b31c7cd23" />

Save that. Check that the frontend and editor are consistent.

### Before (editor wasn't displaying the global font weight)

<img width="400" alt="Screenshot 2025-05-21 at 2 53 58 pm" src="https://github.com/user-attachments/assets/ce64a64b-4b88-4b3e-9afa-db9e4064cc43" />

### After (it now does)

<img width="400" alt="Screenshot 2025-05-21 at 3 12 43 pm" src="https://github.com/user-attachments/assets/3dbc56a8-95a6-42a2-a0ea-9ebb95349e89" />


--------

Now reset your global styles for the label block. 

Head to the post editor and apply a typography appearance to the label.

Check that the frontend and editor are consistent.

### Before

| Editor | Frontend |
|--------|--------|
| <img width="400" alt="Screenshot 2025-05-21 at 3 05 09 pm" src="https://github.com/user-attachments/assets/01353cce-78c1-4c7e-ae9e-e1ed8b352b44" /> | <img width="400" alt="Screenshot 2025-05-21 at 3 05 14 pm" src="https://github.com/user-attachments/assets/c6981600-6484-4fde-88aa-4c9183ccfc2e" /> | 



### After

| Editor | Frontend |
|--------|--------|
| <img width="400" alt="Screenshot 2025-05-21 at 3 14 49 pm" src="https://github.com/user-attachments/assets/93ea4e70-7f58-4375-b9a0-9ae7ee5442ad" /> | <img width="400" alt="Screenshot 2025-05-21 at 3 14 45 pm" src="https://github.com/user-attachments/assets/51c6c5a1-7dbf-45e2-bf25-2cc0babcb50a" /> | 


--------


Also check that the terms and conditions label has a weight of `400` in both the frontend and editor. The frontend has always been 400.


### Before

<img width="400" alt="Screenshot 2025-05-21 at 3 16 16 pm" src="https://github.com/user-attachments/assets/2cf6deb4-babc-41ef-8f48-b1e0004faba3" />


### After

<img width="400" alt="Screenshot 2025-05-21 at 3 16 25 pm" src="https://github.com/user-attachments/assets/ad6a7882-b557-46e3-9bfc-e213fae91b9a" />


