### PR TITLE
Jetpack Post Images: Prevent undefined variable and key warnings

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-post-images-fixup-warnings
+++ b/projects/plugins/jetpack/changelog/update-jetpack-post-images-fixup-warnings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Post Images: Prevent undefined variable and key warnings

--- a/projects/plugins/jetpack/class.jetpack-post-images.php
+++ b/projects/plugins/jetpack/class.jetpack-post-images.php
@@ -283,16 +283,16 @@ class Jetpack_PostImages {
 
 		foreach ( $html_images as $html_image ) {
 			$src = wp_parse_url( $html_image['src'] );
-			if ( ! $src ) {
+			if ( ! $src || empty( $src['path'] ) ) {
 				continue;
 			}
 
 			// strip off any query strings from src.
-			if ( ! empty( $src['scheme'] ) && ! empty( $src['host'] ) && ! empty( $src['path'] ) ) {
+			if ( ! empty( $src['scheme'] ) && ! empty( $src['host'] ) ) {
 				$inserted_images[] = $src['scheme'] . '://' . $src['host'] . $src['path'];
-			} elseif ( ! empty( $src['host'] ) && ! empty( $src['path'] ) ) {
+			} elseif ( ! empty( $src['host'] ) ) {
 				$inserted_images[] = set_url_scheme( 'http://' . $src['host'] . $src['path'] );
-			} elseif ( ! empty( $src['path'] ) ) {
+			} else {
 				$inserted_images[] = site_url( '/' ) . $src['path'];
 			}
 		}

--- a/projects/plugins/jetpack/class.jetpack-post-images.php
+++ b/projects/plugins/jetpack/class.jetpack-post-images.php
@@ -288,12 +288,12 @@ class Jetpack_PostImages {
 			}
 
 			// strip off any query strings from src.
-			if ( ! empty( $src['scheme'] ) && ! empty( $src['host'] ) ) {
-				$inserted_images[] = $src['scheme'] . '://' . $src['host'] . ( isset( $src['path'] ) ? $src['path'] : '' );
-			} elseif ( ! empty( $src['host'] ) ) {
-				$inserted_images[] = set_url_scheme( 'http://' . $src['host'] . ( isset( $src['path'] ) ? $src['path'] : '' ) );
-			} else {
-				$inserted_images[] = site_url( '/' ) . ( isset( $src['path'] ) ? $src['path'] : '' );
+			if ( ! empty( $src['scheme'] ) && ! empty( $src['host'] ) && ! empty( $src['path'] ) ) {
+				$inserted_images[] = $src['scheme'] . '://' . $src['host'] . $src['path'];
+			} elseif ( ! empty( $src['host'] ) && ! empty( $src['path'] ) ) {
+				$inserted_images[] = set_url_scheme( 'http://' . $src['host'] . $src['path'] );
+			} elseif ( ! empty( $src['path'] ) ) {
+				$inserted_images[] = site_url( '/' ) . $src['path'];
 			}
 		}
 		foreach ( $images as $i => $image ) {

--- a/projects/plugins/jetpack/class.jetpack-post-images.php
+++ b/projects/plugins/jetpack/class.jetpack-post-images.php
@@ -46,7 +46,7 @@ class Jetpack_PostImages {
 		$permalink = get_permalink( $post->ID );
 
 		// Mechanic: Somebody set us up the bomb.
-		$old_post                  = $GLOBALS['post'];
+		$old_post                  = $GLOBALS['post'] ?? null;
 		$GLOBALS['post']           = $post; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		$old_shortcodes            = $GLOBALS['shortcode_tags'];
 		$GLOBALS['shortcode_tags'] = array( 'slideshow' => $old_shortcodes['slideshow'] ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
@@ -289,11 +289,11 @@ class Jetpack_PostImages {
 
 			// strip off any query strings from src.
 			if ( ! empty( $src['scheme'] ) && ! empty( $src['host'] ) ) {
-				$inserted_images[] = $src['scheme'] . '://' . $src['host'] . $src['path'];
+				$inserted_images[] = $src['scheme'] . '://' . $src['host'] . ( isset( $src['path'] ) ? $src['path'] : '' );
 			} elseif ( ! empty( $src['host'] ) ) {
-				$inserted_images[] = set_url_scheme( 'http://' . $src['host'] . $src['path'] );
+				$inserted_images[] = set_url_scheme( 'http://' . $src['host'] . ( isset( $src['path'] ) ? $src['path'] : '' ) );
 			} else {
-				$inserted_images[] = site_url( '/' ) . $src['path'];
+				$inserted_images[] = site_url( '/' ) . ( isset( $src['path'] ) ? $src['path'] : '' );
 			}
 		}
 		foreach ( $images as $i => $image ) {


### PR DESCRIPTION
Fixes VULCAN-126

## Proposed changes:

* This PR ensures that we don't attempt to use the 'path' array key if it is not defined, and also that we don't attempt to utilize an undefined global variable - `$post`.
* Logs: e94492b989f1a188a5ed8862ea1e094b-logstash

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

pdWQjU-1g0-p2

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

To replicate the `Undefined array key "path"` warning:

* Sandbox and visit one of the WPcom sites reporting the error. See a5a0e4295de1bc23f6e07fb4e07b2511-logstash to find a WPcom URL (or view the linked Linear issue)
* You should be able to see the path warnings in your error log (and on the site).

To replicate the `Undefined global variable $post` warning:
* Sandbox and visit one of the WPcom sites reporting the error. See ed20fa79485364fa7d02ee9cc846dabe-logstash to find a WPcom URL (or view the linked Linear issue)
* You should be able to see the path warnings in your error log.

To test the fix:
* Apply this PR by using the command in the generated comment below. Then follow the same steps as above. There should be no warnings.