### PR TITLE
HC: Add odie conversation endpoint

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-odie-conversation-endpoint
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-odie-conversation-endpoint
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes DOTCOM-13194
| Before  | After |
| ------------- | ------------- |
|  <img width="396" alt="Screenshot 2025-05-21 at 11 51 18" src="https://github.com/user-attachments/assets/bf1b379a-d071-46f8-8c46-f821c71bce39" /> | <img width="568" alt="Screenshot 2025-05-21 at 11 50 20" src="https://github.com/user-attachments/assets/9cad9da9-3cb2-473a-bab7-14db97882954" />  |


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* The `odie/conversations` endpoint was not available for atomic sites
* This PR adds it, to that the functionality is available

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Sync this PR to atomic site
* Open the help center
* Ensure that there are no 404 errors when the endpoint `*/odie/conversations/wpcom-support-chat*` is called

