### PR TITLE
My Jetpack: Fix license activation button hover styles

### DIFF
--- a/projects/js-packages/licensing/changelog/fix-my-jetpack-license-activation-button-hover-styles
+++ b/projects/js-packages/licensing/changelog/fix-my-jetpack-license-activation-button-hover-styles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed readability of license activation button on hover.

--- a/projects/js-packages/licensing/components/activation-screen-controls/style.scss
+++ b/projects/js-packages/licensing/components/activation-screen-controls/style.scss
@@ -102,7 +102,7 @@
 			width: auto;
 		}
 
-		&:hover {
+		&.components-button:hover {
 			background-color: var( --jp-black-80 );
 			color: var( --jp-white );
 		}

--- a/projects/plugins/backup/changelog/fix-my-jetpack-license-activation-button-hover-styles
+++ b/projects/plugins/backup/changelog/fix-my-jetpack-license-activation-button-hover-styles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: Fix readability of license activation button on hover.

--- a/projects/plugins/boost/changelog/fix-my-jetpack-license-activation-button-hover-styles
+++ b/projects/plugins/boost/changelog/fix-my-jetpack-license-activation-button-hover-styles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: Fix readability of license activation button on hover.

--- a/projects/plugins/jetpack/changelog/fix-my-jetpack-license-activation-button-hover-styles
+++ b/projects/plugins/jetpack/changelog/fix-my-jetpack-license-activation-button-hover-styles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+My Jetpack: Fix readability of license activation button on hover.

--- a/projects/plugins/mu-wpcom-plugin/changelog/fix-my-jetpack-license-activation-button-hover-styles
+++ b/projects/plugins/mu-wpcom-plugin/changelog/fix-my-jetpack-license-activation-button-hover-styles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: Fix readability of license activation button on hover.

--- a/projects/plugins/protect/changelog/fix-my-jetpack-license-activation-button-hover-styles
+++ b/projects/plugins/protect/changelog/fix-my-jetpack-license-activation-button-hover-styles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: Fix readability of license activation button on hover.

--- a/projects/plugins/search/changelog/fix-my-jetpack-license-activation-button-hover-styles
+++ b/projects/plugins/search/changelog/fix-my-jetpack-license-activation-button-hover-styles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: Fix readability of license activation button on hover.

--- a/projects/plugins/social/changelog/fix-my-jetpack-license-activation-button-hover-styles
+++ b/projects/plugins/social/changelog/fix-my-jetpack-license-activation-button-hover-styles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: Fix readability of license activation button on hover.

--- a/projects/plugins/starter-plugin/changelog/fix-my-jetpack-license-activation-button-hover-styles
+++ b/projects/plugins/starter-plugin/changelog/fix-my-jetpack-license-activation-button-hover-styles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: Fix readability of license activation button on hover.

--- a/projects/plugins/videopress/changelog/fix-my-jetpack-license-activation-button-hover-styles
+++ b/projects/plugins/videopress/changelog/fix-my-jetpack-license-activation-button-hover-styles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: Fix readability of license activation button on hover.

--- a/projects/plugins/wpcomsh/changelog/fix-my-jetpack-license-activation-button-hover-styles
+++ b/projects/plugins/wpcomsh/changelog/fix-my-jetpack-license-activation-button-hover-styles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: Fix readability of license activation button on hover.


### PR DESCRIPTION
The hover state in the "Activate" button in the license activation screen is unreadable.

Fixes MYJP-115

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fix the license activation button color on hover by adding more specificity to the CSS selector

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to `/wp-admin/admin.php?page=my-jetpack#/add-license`
* Enter anything in the license input
* Hover over "Activate" button
* Confirm that he color of the button is white instead of black

| BEFORE | BEFORE |
|--------|--------|
| <img width="601" alt="Screenshot 2025-05-21 at 3 49 28 PM" src="https://github.com/user-attachments/assets/a69ca89c-fabf-4926-9ac6-ee34903dae7d" /> | <img width="597" alt="Screenshot 2025-05-21 at 3 49 06 PM" src="https://github.com/user-attachments/assets/8a86efc0-996e-4655-98d6-d46f137d1544" /> | 

