### PR TITLE
Classic Theme Helper: Catch PHP warning in featured content feature

### DIFF
--- a/projects/packages/classic-theme-helper/.phan/baseline.php
+++ b/projects/packages/classic-theme-helper/.phan/baseline.php
@@ -17,14 +17,13 @@ return [
     // PhanUndeclaredClassReference : 4 occurrences
     // PhanTypeInvalidDimOffset : 2 occurrences
     // PhanTypeMismatchArgument : 2 occurrences
-    // PhanTypeComparisonToArray : 1 occurrence
     // PhanTypeMismatchProperty : 1 occurrence
     // PhanUndeclaredTypeProperty : 1 occurrence
 
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
         '_inc/lib/tonesque.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchArgumentProbablyReal'],
-        'src/class-featured-content.php' => ['PhanTypeComparisonToArray', 'PhanTypeInvalidDimOffset', 'PhanTypeMismatchArgument', 'PhanTypeMismatchProperty', 'PhanTypePossiblyInvalidDimOffset'],
+        'src/class-featured-content.php' => ['PhanTypeInvalidDimOffset', 'PhanTypeMismatchArgument', 'PhanTypeMismatchProperty', 'PhanTypePossiblyInvalidDimOffset'],
         'src/class-social-links.php' => ['PhanUndeclaredClassMethod', 'PhanUndeclaredClassReference', 'PhanUndeclaredTypeProperty'],
         'src/content-options/featured-images-fallback.php' => ['PhanTypePossiblyInvalidDimOffset'],
         'src/custom-content-types.php' => ['PhanUndeclaredClassMethod'],

--- a/projects/packages/classic-theme-helper/changelog/fix-class-theme-helper-php_warning_on_featured_content
+++ b/projects/packages/classic-theme-helper/changelog/fix-class-theme-helper-php_warning_on_featured_content
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Featured Content: Prevent error if invalid taxonomy data is provided.

--- a/projects/packages/classic-theme-helper/src/class-featured-content.php
+++ b/projects/packages/classic-theme-helper/src/class-featured-content.php
@@ -464,15 +464,20 @@ if ( ! class_exists( __NAMESPACE__ . '\Featured_Content' ) ) {
 		 *
 		 * @uses Featured_Content::get_setting()
 		 *
-		 * @param array  $terms A list of term objects. This is the return value of get_the_terms().
-		 * @param int    $id The ID field for the post object that terms are associated with.
-		 * @param string $taxonomy The slug of the taxonomy.
+		 * @param \WP_Term[]|\WP_Error $terms A list of term objects. This is the return value of get_the_terms().
+		 * @param int                  $id The ID field for the post object that terms are associated with.
+		 * @param string               $taxonomy The slug of the taxonomy.
 		 * @return array $terms
 		 */
 		public static function hide_the_featured_term( $terms, $id, $taxonomy ) {
 
 			// This filter is only appropriate on the front-end.
 			if ( is_admin() || ( defined( 'REST_REQUEST' ) && REST_REQUEST ) || ( defined( 'XMLRPC_REQUEST' ) && XMLRPC_REQUEST ) ) {
+				return $terms;
+			}
+
+			// This could be a WP_Error or something invalid from another hook function.
+			if ( ! is_array( $terms ) ) {
 				return $terms;
 			}
 

--- a/projects/packages/classic-theme-helper/src/class-featured-content.php
+++ b/projects/packages/classic-theme-helper/src/class-featured-content.php
@@ -464,9 +464,9 @@ if ( ! class_exists( __NAMESPACE__ . '\Featured_Content' ) ) {
 		 *
 		 * @uses Featured_Content::get_setting()
 		 *
-		 * @param array $terms A list of term objects. This is the return value of get_the_terms().
-		 * @param int   $id The ID field for the post object that terms are associated with.
-		 * @param array $taxonomy An array of taxonomy slugs.
+		 * @param array  $terms A list of term objects. This is the return value of get_the_terms().
+		 * @param int    $id The ID field for the post object that terms are associated with.
+		 * @param string $taxonomy The slug of the taxonomy.
 		 * @return array $terms
 		 */
 		public static function hide_the_featured_term( $terms, $id, $taxonomy ) {
@@ -491,6 +491,9 @@ if ( ! class_exists( __NAMESPACE__ . '\Featured_Content' ) ) {
 
 			if ( false !== $tag ) {
 				foreach ( $terms as $order => $term ) {
+					if ( ! $term ) {
+						continue;
+					}
 					if ( $settings['tag-id'] === $term->term_id || $settings['tag-name'] === $term->name ) {
 						unset( $terms[ $order ] );
 					}

--- a/projects/packages/classic-theme-helper/src/class-featured-content.php
+++ b/projects/packages/classic-theme-helper/src/class-featured-content.php
@@ -467,7 +467,7 @@ if ( ! class_exists( __NAMESPACE__ . '\Featured_Content' ) ) {
 		 * @param \WP_Term[]|\WP_Error $terms A list of term objects. This is the return value of get_the_terms().
 		 * @param int                  $id The ID field for the post object that terms are associated with.
 		 * @param string               $taxonomy The slug of the taxonomy.
-		 * @return array $terms
+		 * @return \WP_Term[]|\WP_Error $terms
 		 */
 		public static function hide_the_featured_term( $terms, $id, $taxonomy ) {
 

--- a/projects/plugins/jetpack/changelog/fix-class-theme-helper-php_warning_on_featured_content
+++ b/projects/plugins/jetpack/changelog/fix-class-theme-helper-php_warning_on_featured_content
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Featured Content: Prevent error if invalid taxonomy data is provided.

--- a/projects/plugins/jetpack/modules/theme-tools/featured-content.php
+++ b/projects/plugins/jetpack/modules/theme-tools/featured-content.php
@@ -239,10 +239,10 @@ if ( ! class_exists( 'Featured_Content' ) && isset( $GLOBALS['pagenow'] ) && 'pl
 		 * @deprecated 13.6 Moved to Classic Theme Helper package.
 		 * @uses Featured_Content::get_setting()
 		 *
-		 * @param array $terms A list of term objects. This is the return value of get_the_terms().
-		 * @param int   $id The ID field for the post object that terms are associated with.
-		 * @param array $taxonomy An array of taxonomy slugs.
-		 * @return array $terms
+		 * @param \WP_Term[]|\WP_Error $terms A list of term objects. This is the return value of get_the_terms().
+		 * @param int                  $id The ID field for the post object that terms are associated with.
+		 * @param string               $taxonomy The slug of the taxonomy.
+		 * @return \WP_Term[]|\WP_Error $terms
 		 */
 		public static function hide_the_featured_term( $terms, $id, $taxonomy ) {
 			_deprecated_function( __METHOD__, 'jetpack-13.6', 'Automattic\\Jetpack\\Classic_Theme_Helper\\Featured_Content\\hide_the_featured_term' );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This handles the following PHP warnings, at a rate of about 9000 per day in WP Cloud:

```
PHP Warning: Attempt to read property "term_id" on null in /wordpress/plugins/jetpack/14.7-a.5/jetpack_vendor/automattic/jetpack-classic-theme-helper/src/class-featured-content.php on line 494
PHP Warning: Attempt to read property "name" on null in /wordpress/plugins/jetpack/14.7-a.5/jetpack_vendor/automattic/jetpack-classic-theme-helper/src/class-featured-content.php on line 494
```

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

The few sites I checked had little commonality: stock plugins, a few random third-party plugins (not the same ones), plus a theme (e.g. Dara) that supported featured content. I wasn't able to reproduce a scenario where `$terms` gives an array with `null` elements, which doesn't match documentation, so all I can guess is some custom code is modifying the hook content prior to it reaching this code.

The proposed fix adds a `continue` if the `$term` is falsy (e.g. `null`).

I also updated an errant type on a param annotation; `$taxonomy` is a string:
https://developer.wordpress.org/reference/hooks/get_the_terms/

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

🤷 