### PR TITLE
Forms:  File upload one file and bug fix

### DIFF
--- a/projects/packages/forms/changelog/update-forms-file-upload-one-file
+++ b/projects/packages/forms/changelog/update-forms-file-upload-one-file
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: remove the ability to upload multiple file at using the same file upload filed. This field is not yet released. 

--- a/projects/packages/forms/changelog/update-forms-file-upload-one-file
+++ b/projects/packages/forms/changelog/update-forms-file-upload-one-file
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Forms: remove the ability to upload multiple file at using the same file upload filed. This field is not yet released. 
+Forms: remove the ability to upload multiple file at using the same file upload field. This field is not yet released. 

--- a/projects/packages/forms/src/blocks/contact-form/child-blocks.js
+++ b/projects/packages/forms/src/blocks/contact-form/child-blocks.js
@@ -609,10 +609,6 @@ export const childBlocks = [
 					type: 'string',
 					default: '',
 				},
-				maxfiles: {
-					type: 'number',
-					default: 1,
-				},
 			},
 			isBeta: true,
 		},

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-file/index.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-file/index.js
@@ -1,6 +1,5 @@
 import { getJetpackExtensionAvailability } from '@automattic/jetpack-shared-extension-utils';
 import { useBlockProps, InnerBlocks } from '@wordpress/block-editor';
-import { __experimentalNumberControl as NumberControl } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
 import { compose } from '@wordpress/compose';
 import { useSelect } from '@wordpress/data';
 import { useMemo } from '@wordpress/element';
@@ -137,32 +136,6 @@ const JetpackFieldFile = props => {
 				setAttributes={ setAttributes }
 				attributes={ attributes }
 				hidePlaceholder={ true }
-				extraFieldSettings={ [
-					{
-						index: 1,
-						element: (
-							<NumberControl
-								key="maxfiles"
-								label={ __( 'Number of files', 'jetpack-forms' ) }
-								value={ attributes.maxfiles }
-								onChange={ value =>
-									setAttributes( {
-										maxfiles: value,
-									} )
-								}
-								max={ 10 }
-								min={ 1 }
-								step={ 1 }
-								__nextHasNoMarginBottom={ true }
-								__next40pxDefaultSize={ true }
-								help={ __(
-									'Maximum number of files that the user is able to upload per form submission. Each file can be up to 20MB.',
-									'jetpack-forms'
-								) }
-							/>
-						),
-					},
-				] }
 			/>
 		</>
 	);

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -913,7 +913,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 				<input
 					type="file" class="jetpack-form-file-field"
 					accept="<?php echo esc_attr( $accept_attribute_value ); ?>"
-					<?php echo ( (int) $max_files > 1 ? 'multiple="multiple"' : '' ); ?>
+					<?php echo ( $max_files > 1 ? 'multiple="multiple"' : '' ); ?>
 					data-wp-on--change="actions.fileAdded"  />
 			</div>
 			<div class="jetpack-form-file-field__preview-wrap" name="file-field-<?php echo esc_attr( $id ); ?>" data-wp-class--is-active="state.hasFiles">

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -913,7 +913,6 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 				<input
 					type="file" class="jetpack-form-file-field"
 					accept="<?php echo esc_attr( $accept_attribute_value ); ?>"
-					<?php echo ( $max_files > 1 ? 'multiple="multiple"' : '' ); ?>
 					data-wp-on--change="actions.fileAdded"  />
 			</div>
 			<div class="jetpack-form-file-field__preview-wrap" name="file-field-<?php echo esc_attr( $id ); ?>" data-wp-class--is-active="state.hasFiles">

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -853,7 +853,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 			$input_attrs['aria-required'] = 'true';
 		}
 
-		$max_files       = 1; // max number of files. - $this->get_attribute( 'maxfiles' )
+		$max_files       = 1; // TODO: Dynamically retrieve the max number of files using $this->get_attribute( 'maxfiles' ) if needed in the future.
 		$max_file_size   = 20 * 1024 * 1024; // 20MB
 		$file_size_units = array(
 			_x( 'B', 'unit symbol', 'jetpack-forms' ),

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -853,7 +853,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 			$input_attrs['aria-required'] = 'true';
 		}
 
-		$max_files       = empty( $this->get_attribute( 'maxfiles' ) ) ? 1 : $this->get_attribute( 'maxfiles' ); // max number of files.
+		$max_files       = 1; // max number of files. - $this->get_attribute( 'maxfiles' )
 		$max_file_size   = 20 * 1024 * 1024; // 20MB
 		$file_size_units = array(
 			_x( 'B', 'unit symbol', 'jetpack-forms' ),

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -1285,7 +1285,11 @@ class Contact_Form_Plugin {
 		foreach ( $md as $key => $value ) {
 			if ( is_array( $value ) ) {
 				if ( Contact_Form::is_file_upload_field( $value ) ) {
-					$value = $value['name'];
+					$file_names = array();
+					foreach ( $value['files'] as $file ) {
+						$file_names[] = $file['name'];
+					}
+					$value = implode( ', ', $file_names );
 				} else {
 					$value = implode( ', ', $value );
 				}

--- a/projects/packages/forms/src/modules/file-field/view.js
+++ b/projects/packages/forms/src/modules/file-field/view.js
@@ -120,9 +120,11 @@ const addFileToContext = file => {
 
 	const clientFileId = performance.now() + '-' + Math.random();
 
-	const fileUrl = [ 'image/gif', 'image/jpg', 'image/png', 'image/jpeg' ].includes( file.type )
-		? 'url(' + URL.createObjectURL( file ) + ')'
-		: null;
+	const fileUrl =
+		[ 'image/gif', 'image/jpg', 'image/png', 'image/jpeg' ].includes( file.type ) &&
+		URL.createObjectURL
+			? 'url(' + URL.createObjectURL( file ) + ')'
+			: null;
 
 	context.files.push( {
 		name: file.name,

--- a/projects/packages/forms/src/modules/file-field/view.js
+++ b/projects/packages/forms/src/modules/file-field/view.js
@@ -92,9 +92,6 @@ const formatBytes = ( size, decimals = 2 ) => {
  * @param {File} file - The file to add.
  */
 const addFileToContext = file => {
-	const reader = new FileReader();
-	reader.readAsDataURL( file );
-
 	const { ref } = getElement();
 	clearInputError( ref, { hasInsetLabel: state.isInlineForm } );
 
@@ -123,12 +120,17 @@ const addFileToContext = file => {
 
 	const clientFileId = performance.now() + '-' + Math.random();
 
+	const fileUrl = [ 'image/gif', 'image/jpg', 'image/png', 'image/jpeg' ].includes( file.type )
+		? 'url(' + URL.createObjectURL( file ) + ')'
+		: null;
+
 	context.files.push( {
 		name: file.name,
 		formattedSize: formatBytes( file.size, 2 ),
 		isUploaded: false,
 		hasError: !! error,
 		id: clientFileId,
+		url: fileUrl,
 		error,
 	} );
 
@@ -136,9 +138,6 @@ const addFileToContext = file => {
 	! error && actions.uploadFile( file, clientFileId );
 
 	// Load the file so we can display it. In case it is an image.
-	reader.onload = withScope( () => {
-		updateFileContext( { url: 'url(' + reader.result + ')' }, clientFileId );
-	} );
 };
 
 // Map to store AbortControllers for each file upload
@@ -360,6 +359,11 @@ const { state, actions } = store( NAMESPACE, {
 			}
 
 			const file = context.files.find( fileObject => fileObject.id === clientFileId );
+			if ( file && file.url ) {
+				// Remove the object URL to free up memory
+				const urlToRemove = file.url.substring( 4, file.url.length - 1 );
+				URL.revokeObjectURL( urlToRemove );
+			}
 
 			if ( file && file.file_id ) {
 				const { endpoint } = getConfig( NAMESPACE );


### PR DESCRIPTION
This removed the multi file upload ability from the file upload field. 

It makes it so that we only allow one file upload filed at a time. 

## Proposed changes:

* Removes the ability for the user to allow multiple file uploads from the file upload field.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
* Add the form block to the page.
* Add the file upload field. Notice that you can't change the number of files any more. 

On the frontend. 
* Fill out the form. Notice that you can't select any more files in the file picker. 
* Dropping more files you will get an error and the form will upload only the first valid file you dropped. 

Submit the form. 

Notice that you can now export not contains the file name. 

