### PR TITLE
Forms: restore not spam action

### DIFF
--- a/projects/packages/forms/changelog/fix-jetpack-forms-restore-not-spam-action
+++ b/projects/packages/forms/changelog/fix-jetpack-forms-restore-not-spam-action
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Forms: reinstate sending submission email when user moves response from spam to inbox

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -386,7 +386,7 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 	 * Overrides the parent method to resend the email when the item is updated from spam to publish.
 	 *
 	 * @param WP_REST_Request $request Request object.
-	 * @return WP_REST_Response Response object.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
 	 */
 	public function update_item( $request ) {
 		$valid_check = parent::get_post( $request['id'] );

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -389,9 +389,15 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 	 * @return WP_REST_Response Response object.
 	 */
 	public function update_item( $request ) {
+		$valid_check = parent::get_post( $request['id'] );
+		if ( is_wp_error( $valid_check ) ) {
+			return $valid_check;
+		}
+
 		$post_id         = $request['id'];
 		$previous_status = get_post_status( $post_id );
 		$updated_item    = parent::update_item( $request );
+
 		if ( ! is_wp_error( $updated_item ) && ! empty( $updated_item->data && ! empty( $updated_item->data['status'] ) ) ) {
 			if ( $previous_status === 'spam' && $updated_item->data['status'] === 'publish' ) {
 				// updated item is going from spam to inbox

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -382,6 +382,93 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 	}
 
 	/**
+	 * Updates the item.
+	 * Overrides the parent method to resend the email when the item is updated from spam to publish.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response Response object.
+	 */
+	public function update_item( $request ) {
+		$post_id         = $request['id'];
+		$previous_status = get_post_status( $post_id );
+		$updated_item    = parent::update_item( $request );
+		if ( ! is_wp_error( $updated_item ) && ! empty( $updated_item->data && ! empty( $updated_item->data['status'] ) ) ) {
+			if ( $previous_status === 'spam' && $updated_item->data['status'] === 'publish' ) {
+				// updated item is going from spam to inbox
+				$akismet_values = get_post_meta( $post_id, '_feedback_akismet_values', true );
+				/** This action is documented in \Automattic\Jetpack\Forms\ContactForm\Admin */
+				do_action( 'contact_form_akismet', 'ham', $akismet_values );
+				$this->resend_email( $post_id );
+			}
+		}
+		return $updated_item;
+	}
+
+	/**
+	 * Resends the email for a given post ID.
+	 *
+	 * @param int $post_id The ID of the post to resend the email for.
+	 */
+	public function resend_email( $post_id ) {
+		$comment_author_email = false;
+		$reply_to_addr        = false;
+		$message              = false;
+		$to                   = false;
+		$headers              = false;
+		$blog_url             = wp_parse_url( site_url() );
+
+		// resend the original email
+		$email          = get_post_meta( $post_id, '_feedback_email', true );
+		$content_fields = Contact_Form_Plugin::parse_fields_from_content( $post_id );
+
+		if ( ! empty( $email ) && ! empty( $content_fields ) ) {
+			if ( isset( $content_fields['_feedback_author_email'] ) ) {
+				$comment_author_email = $content_fields['_feedback_author_email'];
+			}
+
+			if ( isset( $email['to'] ) ) {
+				$to = $email['to'];
+			}
+
+			if ( isset( $email['message'] ) ) {
+				$message = $email['message'];
+			}
+
+			if ( isset( $email['headers'] ) ) {
+				$headers = $email['headers'];
+			} else {
+				$headers = 'From: "' . $content_fields['_feedback_author'] . '" <wordpress@' . $blog_url['host'] . ">\r\n";
+
+				if ( ! empty( $comment_author_email ) ) {
+					$reply_to_addr = $comment_author_email;
+				} elseif ( is_array( $to ) ) {
+					$reply_to_addr = $to[0];
+				}
+
+				if ( $reply_to_addr ) {
+					$headers .= 'Reply-To: "' . $content_fields['_feedback_author'] . '" <' . $reply_to_addr . ">\r\n";
+				}
+
+				$headers .= 'Content-Type: text/plain; charset="' . get_option( 'blog_charset' ) . '"';
+			}
+
+			/**
+			 * Filters the subject of the email sent after a contact form submission.
+			 *
+			 * @module contact-form
+			 *
+			 * @since 3.0.0
+			 *
+			 * @param string $content_fields['_feedback_subject'] Feedback's subject line.
+			 * @param array $content_fields['_feedback_all_fields'] Feedback's data from old fields.
+			 */
+			$subject = apply_filters( 'contact_form_subject', $content_fields['_feedback_subject'], $content_fields['_feedback_all_fields'] );
+
+			Contact_Form::wp_mail( $to, $subject, $message, $headers );
+		}
+	}
+
+	/**
 	 * Prepares the item for the REST response.
 	 *
 	 * @param object          $item    WP Cron event.

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -412,7 +412,7 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 	public function resend_email( $post_id ) {
 		$comment_author_email = false;
 		$reply_to_addr        = false;
-		$message              = false;
+		$message              = '';
 		$to                   = false;
 		$headers              = false;
 		$blog_url             = wp_parse_url( site_url() );


### PR DESCRIPTION
Related to FORMS-89

## Proposed changes:
This PR adds the old Admin ajax process to send the submission email when the user moves a response from spam to inbox.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1747734409666879-slack-C086RGTJT1D

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Test this on your sandbox, local envs usually don't send emails. Unsure about JN sites.

Move a response from Spam to Inbox, you should receive a submission email on the associated email address as with a regular submission.