### PR TITLE
Image Guide: remove rollup-plugin-svelte-svg dependency

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1015,9 +1015,6 @@ importers:
       rollup-plugin-svelte:
         specifier: 7.2.2
         version: 7.2.2(rollup@3.29.5)(svelte@4.2.19)
-      rollup-plugin-svelte-svg:
-        specifier: 1.0.0-beta.6
-        version: 1.0.0-beta.6(svelte@4.2.19)
       sass:
         specifier: 1.87.0
         version: 1.87.0
@@ -14353,12 +14350,6 @@ packages:
     engines: {node: '>=10'}
     peerDependencies:
       postcss: 8.x
-
-  rollup-plugin-svelte-svg@1.0.0-beta.6:
-    resolution: {integrity: sha512-6uJb9kuaqK6p+DvkgphhGN18wvUzdT6h7MQC2B8P1omi9omC9lQC54pwaot21h6z9ibhGPLG9a1XFLeDQth/kg==}
-    deprecated: 'Svelte supports this usecase natively now. This package is redundant. See: https://svelte.dev/playground/86553af5c35449ab88e34f1e50eb298f?version=5.30.1'
-    peerDependencies:
-      svelte: '*'
 
   rollup-plugin-svelte@7.2.2:
     resolution: {integrity: sha512-hgnIblTRewaBEVQD6N0Q43o+y6q1TmDRhBjaEzQCi50bs8TXqjc+d1zFZyE8tsfgcfNHZQzclh4RxlFUB85H8Q==}
@@ -28921,12 +28912,6 @@ snapshots:
       style-inject: 0.3.0
     transitivePeerDependencies:
       - ts-node
-
-  rollup-plugin-svelte-svg@1.0.0-beta.6(svelte@4.2.19):
-    dependencies:
-      rollup-pluginutils: 2.8.2
-      svelte: 4.2.19
-      svgo: 3.3.2
 
   rollup-plugin-svelte@7.2.2(rollup@3.29.5)(svelte@4.2.19):
     dependencies:

--- a/projects/js-packages/image-guide/changelog/update-svelte
+++ b/projects/js-packages/image-guide/changelog/update-svelte
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: Removed unneeded dependency (rollup-plugin-svelte-svg)
+
+

--- a/projects/js-packages/image-guide/package.json
+++ b/projects/js-packages/image-guide/package.json
@@ -47,7 +47,6 @@
 		"rollup": "3.29.5",
 		"rollup-plugin-postcss": "4.0.2",
 		"rollup-plugin-svelte": "7.2.2",
-		"rollup-plugin-svelte-svg": "1.0.0-beta.6",
 		"sass": "1.87.0",
 		"svelte": "4.2.19",
 		"svelte-preprocess": "6.0.2",

--- a/projects/js-packages/image-guide/rollup.config.js
+++ b/projects/js-packages/image-guide/rollup.config.js
@@ -8,7 +8,6 @@ import terser from '@rollup/plugin-terser';
 import typescript from '@rollup/plugin-typescript';
 import postcss from 'rollup-plugin-postcss';
 import svelte from 'rollup-plugin-svelte';
-import { svelteSVG } from 'rollup-plugin-svelte-svg';
 import sveltePreprocess from 'svelte-preprocess';
 
 const production = process.env.NODE_ENV === 'production';
@@ -65,7 +64,6 @@ export default {
 			minimize: production,
 		} ),
 
-		svelteSVG(),
 		svelte( {
 			preprocess: sveltePreprocess( {
 				sourceMap: ! production,


### PR DESCRIPTION
Fixes HOG-117

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

`rollup-plugin-svelte-svg` seems to not be needed at all. Svelte seems to have had SVG support for awhile now.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Remove unused dependency.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1747856388314489-slack-CDLH4C1UZ

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Does it build?
* With Boost, enable the image guide and visit the front page when there's a blog post with an image. Confirm the icons that are overlayed are visible.