### PR TITLE
Jetpack: Fix redirect_to URL encoding on frontend for upgrade nudge

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/components.php
+++ b/projects/plugins/jetpack/_inc/lib/components.php
@@ -101,11 +101,14 @@ class Jetpack_Components {
 			get_edit_post_link( $post_id )
 		);
 
+		// Decode the URL to avoid double encoding.
+		$redirect_to = html_entity_decode( wp_unslash( $redirect_to ), ENT_QUOTES );
+
 		$upgrade_url =
 			$plan_path_slug
 			? add_query_arg(
 				'redirect_to',
-				$redirect_to,
+				rawurlencode( $redirect_to ),
 				"https://wordpress.com/checkout/{$site_slug}/{$plan_path_slug}"
 			) : '';
 

--- a/projects/plugins/jetpack/_inc/lib/components.php
+++ b/projects/plugins/jetpack/_inc/lib/components.php
@@ -9,6 +9,21 @@ use Automattic\Jetpack\Status;
  */
 class Jetpack_Components {
 	/**
+	 * Get the contents of a component file
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param string $name Component name.
+	 * @return string The component markup
+	 */
+	protected static function get_component_markup( $name ) {
+		ob_start();
+		// `include` fails gracefully and throws a warning, but doesn't halt execution.
+		include JETPACK__PLUGIN_DIR . "_inc/blocks/$name.html";
+		return ob_get_clean();
+	}
+
+	/**
 	 * Load and display a pre-rendered component
 	 *
 	 * @since 7.7.0
@@ -23,10 +38,7 @@ class Jetpack_Components {
 		$rtl = is_rtl() ? '.rtl' : '';
 		wp_enqueue_style( 'jetpack-components', plugins_url( "_inc/blocks/components{$rtl}.css", JETPACK__PLUGIN_FILE ), array( 'wp-components' ), JETPACK__VERSION );
 
-		ob_start();
-		// `include` fails gracefully and throws a warning, but doesn't halt execution.
-		include JETPACK__PLUGIN_DIR . "_inc/blocks/$name.html";
-		$markup = ob_get_clean();
+		$markup = self::get_component_markup( $name );
 
 		foreach ( $props as $key => $value ) {
 			$markup = str_replace(

--- a/projects/plugins/jetpack/changelog/fix-frontend-update-nudge-link
+++ b/projects/plugins/jetpack/changelog/fix-frontend-update-nudge-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Jetpack: Fix redirect_to URL encoding on frontend for upgrade nudge

--- a/projects/plugins/jetpack/tests/php/_inc/lib/Jetpack_Components_Test.php
+++ b/projects/plugins/jetpack/tests/php/_inc/lib/Jetpack_Components_Test.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Components unit tests.
+ *
+ * @package automattic/jetpack
+ */
+
+use PHPUnit\Framework\Attributes\CoversClass;
+
+require_once JETPACK__PLUGIN_DIR . '/_inc/lib/components.php';
+
+/**
+ * Class for testing Jetpack Components functions.
+ *
+ * @covers Jetpack_Components
+ */
+#[CoversClass( Jetpack_Components::class )]
+class Jetpack_Components_Test extends WP_UnitTestCase {
+	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
+
+	/**
+	 * Test that the upgrade URL in render_upgrade_nudge is properly encoded
+	 *
+	 * @since $$next-version$$
+	 */
+	public function test_render_upgrade_nudge_url_encoding() {
+		$edit_url = 'https://example.com/wp-admin/post.php?post=1&action=edit';
+
+		$handles = array();
+
+		// Mock Jetpack_Plans::get_plan to return a valid plan object
+		$handles['get_plan'] = \Patchwork\redefine(
+			'Jetpack_Plans::get_plan',
+			\Patchwork\always(
+				array(
+					'path_slug' => 'jetpack_complete',
+				)
+			)
+		);
+
+		// Mock the get_edit_post_link function to return the test URL
+		$handles['get_edit_post_link'] = \Patchwork\redefine(
+			'get_edit_post_link',
+			\Patchwork\always( $edit_url )
+		);
+
+		// Mock the get_component_markup method, as the file is not available in the test environment
+		$handles['get_component_markup'] = \Patchwork\redefine(
+			'Jetpack_Components::get_component_markup',
+			\Patchwork\always( '<a href="#checkoutUrl#" target="_top" class="components-button is-primary">#buttonText#</a>' )
+		);
+
+		// Call render_upgrade_nudge
+		$output = Jetpack_Components::render_upgrade_nudge(
+			array(
+				'plan' => 'jetpack_complete',
+			)
+		);
+
+		// Verify the output contains properly encoded URL
+		$this->assertStringContainsString(
+			'checkout/example.org/jetpack_complete?redirect_to=',
+			$output,
+			'Output should contain the basic checkout URL structure'
+		);
+
+		// Verify that the redirect_to parameter is properly encoded
+		$this->assertStringContainsString(
+			'redirect_to=https%3A%2F%2Fexample.com%2Fwp-admin%2Fpost.php%3Fpost%3D1%26action%3Dedit%26plan_upgraded%3D1',
+			$output,
+			'The redirect_to parameter should be properly encoded'
+		);
+
+		foreach ( $handles as $handle ) {
+			if ( null !== $handle ) {
+				\Patchwork\restore( $handle );
+			}
+		}
+	}
+}

--- a/projects/plugins/jetpack/tests/php/_inc/lib/Jetpack_Components_Test.php
+++ b/projects/plugins/jetpack/tests/php/_inc/lib/Jetpack_Components_Test.php
@@ -1,6 +1,7 @@
 <?php
 /**
  * Components unit tests.
+ * To run: jetpack docker phpunit jetpack -- --filter=Jetpack_Components_Test
  *
  * @package automattic/jetpack
  */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes JETPACK-483

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Encodes the `redirect_to` param of the checkout URL

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add a block where you can see the upgrade nudge in the frontend if you are the admin. I'm using the file upload block following the instructions on pdtkmj-3Ch-p2
* Publish the post and visit the frontend
* Click on the upgrade nudge and do the checkout
* Check that you are redirected back to the post edit page