### PR TITLE
Forms: Fix custom classnames support in inner blocks migration

### DIFF
--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -385,7 +385,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 			$form_style = $this->get_form_style();
 			if ( 'outlined' === $form_style || 'animated' === $form_style ) {
 				$output_data         = $this->get_form_variation_style_properties( $form_style );
-				$this->block_styles .= $output_data['css_vars'];
+				$this->block_styles .= esc_attr( $output_data['css_vars'] );
 			}
 		} else {
 			if ( is_numeric( $this->get_attribute( 'borderradius' ) ) ) {
@@ -887,8 +887,8 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 					$used_html_ids[ $radio_id ] = true;
 
 					$default_classes = 'contact-form-field wp-block-jetpack-option';
-					$option_styles   = empty( $option['style'] ) ? '' : "style='" . $option['style'] . "'";
-					$option_classes  = empty( $option['class'] ) ? $default_classes : $default_classes . ' ' . $option['class'];
+					$option_styles   = empty( $option['style'] ) ? '' : "style='" . esc_attr( $option['style'] ) . "'";
+					$option_classes  = empty( $option['class'] ) ? $default_classes : $default_classes . ' ' . esc_attr( $option['class'] );
 
 					$field .= "<p {$option_styles} class='{$option_classes}'>";
 					$field .= "<input
@@ -1290,8 +1290,8 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 					$used_html_ids[ $checkbox_id ] = true;
 
 					$default_classes = 'contact-form-field wp-block-jetpack-option';
-					$option_styles   = empty( $option['style'] ) ? '' : "style='" . $option['style'] . "'";
-					$option_classes  = empty( $option['class'] ) ? $default_classes : $default_classes . ' ' . $option['class'];
+					$option_styles   = empty( $option['style'] ) ? '' : "style='" . esc_attr( $option['style'] ) . "'";
+					$option_classes  = empty( $option['class'] ) ? $default_classes : $default_classes . ' ' . esc_attr( $option['class'] );
 
 					$field .= "<p {$option_styles} class='{$option_classes}'>";
 					$field .= "<input
@@ -1516,7 +1516,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 					<label
 						for="' . esc_attr( $id ) . '"
 						class=" ' . $classes . '"
-						style="' . $this->label_styles . $output_data['css_vars'] . '"
+						style="' . $this->label_styles . esc_attr( $output_data['css_vars'] ) . '"
 					>'
 			. esc_html( $label )
 			. ( $required ? '<span class="grunion-label-required" aria-hidden="true">' . $required_field_text . '</span>' : '' ) .

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -344,6 +344,7 @@ class Contact_Form_Plugin {
 		$color_styles      = \wp_apply_colors_support( $block_type, $attrs );
 		$typography_styles = \wp_apply_typography_support( $block_type, $attrs );
 		$border_styles     = \wp_apply_border_support( $block_type, $attrs );
+		$custom_classname  = \wp_apply_custom_classname_support( $block_type, $attrs );
 
 		// Merge all the block support classes and styles.
 		$classes = array_filter(
@@ -351,6 +352,7 @@ class Contact_Form_Plugin {
 				$color_styles['class'] ?? '',
 				$typography_styles['class'] ?? '',
 				$border_styles['class'] ?? '',
+				$custom_classname['class'] ?? '',
 			),
 			'strlen'
 		);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR is proposed to merge into the inner blocks refactor over in #42890

Allow custom classname support to work correctly, particularly on Option blocks where it wasn't working previously (either in the inner blocks migration PR, or on trunk).

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add a call to the block support for custom classnames
* Add some `esc_attr` calls where it looked like we might have needed them

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add a Form block
* Add a multiple choice or single choice block and add some individual option blocks
* In an individual option block, under Advanced give it a custom class name
* On the site frontend, the custom classname should be output

## Screenshot

<img width="811" alt="image" src="https://github.com/user-attachments/assets/bd5c09e8-f5ce-4b66-8bbd-65c63054aef5" />

