### PR TITLE
Site: Add hosting_features to the WPCOM_JSON_API_GET_Site_Endpoint endpoint

### DIFF
--- a/projects/plugins/jetpack/changelog/feat-add-wpcom-features-to-site-endpoint
+++ b/projects/plugins/jetpack/changelog/feat-add-wpcom-features-to-site-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Site: Add hosting_features to the WPCOM_JSON_API_GET_Site_Endpoint endpoint

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -89,6 +89,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'is_deleted'                  => '(bool) If the site flagged as deleted.',
 		'is_a4a_client'               => '(bool) If the site is an A4A client site.',
 		'is_a4a_dev_site'             => '(bool) If the site is an A4A dev site.',
+		'hosting_features'            => '(array) Details of the hosting features for the current user on this site.',
 	);
 
 	/**
@@ -252,6 +253,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'plan',
 		'products',
 		'zendesk_site_meta',
+		'hosting_features',
 	);
 
 	/**
@@ -625,6 +627,9 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 				break;
 			case 'is_a4a_dev_site':
 				$response[ $key ] = $this->site->is_a4a_dev_site();
+				break;
+			case 'hosting_features':
+				$response[ $key ] = $this->site->get_hosting_features();
 				break;
 		}
 
@@ -1002,6 +1007,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 			unset( $response->plan );
 			unset( $response->products );
 			unset( $response->zendesk_site_meta );
+			unset( $response->hosting_features );
 		}
 
 		// render additional options.

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-v1-2-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-v1-2-endpoint.php
@@ -82,6 +82,7 @@ class WPCOM_JSON_API_GET_Site_V1_2_Endpoint extends WPCOM_JSON_API_GET_Site_Endp
 		'is_deleted'                  => '(bool) If the site flagged as deleted.',
 		'is_a4a_client'               => '(bool) If the site is an A4A client site.',
 		'is_a4a_dev_site'             => '(bool) If the site is an A4A dev site.',
+		'hosting_features'            => '(array) Details of the hosting features for the current user on this site.',
 	);
 
 	/**

--- a/projects/plugins/jetpack/sal/class.json-api-site-base.php
+++ b/projects/plugins/jetpack/sal/class.json-api-site-base.php
@@ -1684,4 +1684,11 @@ abstract class SAL_Site {
 	 * @return bool
 	 */
 	abstract public function is_pending_plan();
+
+	/**
+	 * Defaults to false instead of returning the hosting features for the current user on this site.
+	 *
+	 * @see class.json-api-site-jetpack-shadow.php on WordPress.com for implementation. Only applicable on WordPress.com.
+	 */
+	abstract public function get_hosting_features();
 }

--- a/projects/plugins/jetpack/sal/class.json-api-site-jetpack.php
+++ b/projects/plugins/jetpack/sal/class.json-api-site-jetpack.php
@@ -731,4 +731,15 @@ class Jetpack_Site extends Abstract_Jetpack_Site {
 	public function is_pending_plan() {
 		return false;
 	}
+
+	/**
+	 * Defaults to false instead of returning the hosting features for the current user on this site.
+	 *
+	 * @see class.json-api-site-jetpack-shadow.php on WordPress.com for implementation. Only applicable on WordPress.com.
+	 *
+	 * @return bool
+	 */
+	public function get_hosting_features() {
+		return false;
+	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of DOTCOM-13234, 183534-ghe-Automattic/wpcom

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add `hosting_features` to the `WPCOM_JSON_API_GET_Site_Endpoint` endpoint. We'll continue to implement the details on wpcom. With this change, we can reduce duplication and improve maintainability on Calypso

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply changes to your site
* Call `/sites/:site` endpoint
* Ensure you can see the `hosting_features` on the response