### PR TITLE
Enforce comment blocks allowlist on inner blocks

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/improve_verbum_filtering
+++ b/projects/packages/jetpack-mu-wpcom/changelog/improve_verbum_filtering
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Prevent disallowed blocks from being used inside inner comments

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/assets/class-verbum-block-utils.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/assets/class-verbum-block-utils.php
@@ -20,19 +20,60 @@ class Verbum_Block_Utils {
 			return $content;
 		}
 
-		$allowed_blocks = self::get_allowed_blocks();
 		// The block attributes come slashed and `parse_blocks` won't be able to parse them.
 		$content = wp_unslash( $content );
-		$blocks  = parse_blocks( $content );
-		$output  = '';
+
+		// Parse blocks first
+		$blocks = parse_blocks( $content );
+
+		// Filter blocks recursively
+		$filtered_blocks = self::filter_blocks_recursive( $blocks );
+
+		// Convert the filtered blocks back to HTML
+		return serialize_blocks( $filtered_blocks );
+	}
+
+	/**
+	 * Recursively filter blocks and their inner blocks
+	 *
+	 * @param array $blocks Array of blocks to filter.
+	 * @return array Filtered blocks.
+	 */
+	private static function filter_blocks_recursive( $blocks ) {
+		$allowed_blocks = self::get_allowed_blocks();
+		$filtered       = array();
 
 		foreach ( $blocks as $block ) {
-			if ( in_array( $block['blockName'], $allowed_blocks, true ) ) {
-				$output .= serialize_block( $block );
+			if ( ! in_array( $block['blockName'], $allowed_blocks, true ) ) {
+				continue;
 			}
+
+			if ( ! empty( $block['innerBlocks'] ) ) {
+				$block['innerBlocks'] = self::filter_blocks_recursive( $block['innerBlocks'] );
+
+				// Reconstruct innerContent to match filtered innerBlocks
+				$inner_content = array();
+				$block_index   = 0;
+				foreach ( $block['innerContent'] as $chunk ) {
+					if ( is_string( $chunk ) ) {
+						$inner_content[] = $chunk;
+					} elseif ( isset( $block['innerBlocks'][ $block_index ] ) ) {
+						$inner_content[] = null;
+						++$block_index;
+					}
+				}
+				$block['innerContent'] = $inner_content;
+			}
+
+			$block['innerHTML'] = $block['innerHTML'] ?? '';
+			if ( empty( $block['innerContent'] ) ) {
+				$block['innerContent'] = array( $block['innerHTML'] );
+			}
+
+			$filtered[] = $block;
 		}
 
-		return ltrim( $output );
+		return array_values( $filtered );
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/assets/class-verbum-block-utils.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/assets/class-verbum-block-utils.php
@@ -22,14 +22,11 @@ class Verbum_Block_Utils {
 
 		// The block attributes come slashed and `parse_blocks` won't be able to parse them.
 		$content = wp_unslash( $content );
+		$blocks  = parse_blocks( $content );
 
-		// Parse blocks first
-		$blocks = parse_blocks( $content );
-
-		// Filter blocks recursively
 		$filtered_blocks = self::filter_blocks_recursive( $blocks );
 
-		// Convert the filtered blocks back to HTML
+		// Convert the filtered blocks back to string
 		return serialize_blocks( $filtered_blocks );
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/assets/class-verbum-block-utils.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/assets/class-verbum-block-utils.php
@@ -62,7 +62,7 @@ class Verbum_Block_Utils {
 				$block['innerContent'] = $inner_content;
 			}
 
-			$block['innerHTML'] = $block['innerHTML'] ?? '';
+			$block['innerHTML'] ??= '';
 			if ( empty( $block['innerContent'] ) ) {
 				$block['innerContent'] = array( $block['innerHTML'] );
 			}

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/assets/class-verbum-block-utils.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/assets/class-verbum-block-utils.php
@@ -70,7 +70,7 @@ class Verbum_Block_Utils {
 			$filtered[] = $block;
 		}
 
-		return array_values( $filtered );
+		return $filtered;
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/verbum-comments/Verbum_Block_Utils_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/verbum-comments/Verbum_Block_Utils_Test.php
@@ -76,22 +76,29 @@ class Verbum_Block_Utils_Test extends \WorDBless\BaseTestCase {
 	 * Ensure innerBlocks are removed if not allowed
 	 */
 	public function test_pre_comment_content_inner_blocks() {
-		$comment_content  = '<!-- wp:quote -->
+		$comment_content = <<<HTML
+<!-- wp:quote -->
 <blockquote class="wp-block-quote">
 	<p>Allowed outer quote block</p>
 	<!-- wp:button {"text":"I am a disallowed button!","url":"#"} -->
 	<a class="wp-block-button__link" href="#">I am a disallowed button!</a>
 	<!-- /wp:button -->
 </blockquote>
-<!-- /wp:quote -->';
-		$filtered_content = Verbum_Block_Utils::remove_blocks( $comment_content );
-		$this->assertSame(
-			'<!-- wp:quote -->
+<!-- /wp:quote -->
+HTML;
+
+		$expected_content = <<<HTML
+<!-- wp:quote -->
 <blockquote class="wp-block-quote">
 	<p>Allowed outer quote block</p>
 </blockquote>
-<!-- /wp:quote -->',
-			$filtered_content
-		);
+<!-- /wp:quote -->
+HTML;
+
+		$filtered_content = Verbum_Block_Utils::remove_blocks( $comment_content );
+		// Normalize whitespace before comparison
+		$filtered_content = preg_replace( '/\s+/', ' ', $filtered_content );
+		$expected_content = preg_replace( '/\s+/', ' ', $expected_content );
+		$this->assertSame( $expected_content, $filtered_content );
 	}
 }

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/verbum-comments/Verbum_Block_Utils_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/verbum-comments/Verbum_Block_Utils_Test.php
@@ -71,4 +71,27 @@ class Verbum_Block_Utils_Test extends \WorDBless\BaseTestCase {
 		$filtered_content = Verbum_Block_Utils::remove_blocks( $comment_content );
 		$this->assertEquals( '<!-- wp:paragraph -->Testing<!-- /wp:paragraph -->', $filtered_content );
 	}
+
+	/**
+	 * Ensure innerBlocks are removed if not allowed
+	 */
+	public function test_pre_comment_content_inner_blocks() {
+		$comment_content  = '<!-- wp:quote -->
+<blockquote class="wp-block-quote">
+	<p>Allowed outer quote block</p>
+	<!-- wp:button {"text":"I am a disallowed button!","url":"#"} -->
+	<a class="wp-block-button__link" href="#">I am a disallowed button!</a>
+	<!-- /wp:button -->
+</blockquote>
+<!-- /wp:quote -->';
+		$filtered_content = Verbum_Block_Utils::remove_blocks( $comment_content );
+		$this->assertSame(
+			'<!-- wp:quote -->
+<blockquote class="wp-block-quote">
+	<p>Allowed outer quote block</p>
+</blockquote>
+<!-- /wp:quote -->',
+			$filtered_content
+		);
+	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://linear.app/a8c/issue/DOTCOM-13240/

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Fixes an issue where disallowed blocks could be added as inner blocks

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

The unit test I added failed before and passes now.

From a user pov:

 1. Create a blog post with comments enabled
 2. Click in the comments box and enter a string like 'test'
 3. Fill in the email/name if necessary
 4. Open the browser tools and delete `.verbum-editor-wrapper`
 5. Edit the `#comment` textarea to add thestring from the linear issue as the textarea's value
 6. Press Comment to submit the form.
 7. The issue has been reproduced

Now sandbox the site, apply this change and try again, you shouldn't be able to reproduce the issue with a new comment (you may have to vary the string slightly to evade duplicate detection) - the inner content will have been removed.

