### PR TITLE
Boost: Do not run an LCP analysis for cornerstone update if module is off

### DIFF
--- a/projects/plugins/boost/app/modules/optimizations/lcp/class-optimize-lcp-endpoint.php
+++ b/projects/plugins/boost/app/modules/optimizations/lcp/class-optimize-lcp-endpoint.php
@@ -3,6 +3,7 @@
 namespace Automattic\Jetpack_Boost\Modules\Optimizations\Lcp;
 
 use Automattic\Jetpack\WP_JS_Data_Sync\Contracts\Data_Sync_Action;
+use Automattic\Jetpack_Boost\Modules\Modules_Setup;
 
 class Optimize_LCP_Endpoint implements Data_Sync_Action {
 
@@ -13,6 +14,15 @@ class Optimize_LCP_Endpoint implements Data_Sync_Action {
 	 * @param \WP_REST_Request $_request The request object.
 	 */
 	public function handle( $_data, $_request ) {
+		// Check if the module is enabled first.
+		$states = ( new Modules_Setup() )->get_status();
+		if ( ! $states['lcp'] ) {
+			return array(
+				'success' => false,
+				'state'   => array(),
+			);
+		}
+
 		$analyzer = new LCP_Analyzer();
 		$state    = $analyzer->get_state();
 		if ( $state->is_pending() ) {

--- a/projects/plugins/boost/changelog/fix-no-lcp-when-off
+++ b/projects/plugins/boost/changelog/fix-no-lcp-when-off
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix for an unreleased feature
+
+


### PR DESCRIPTION
## Proposed changes:
* Check if the LCP module is on before requesting a new analysis.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
* Turn of the LCP module
* Update cornerstone pages list
* Make sure no request goes to the cloud to re-analyze the LCP

