### PR TITLE
Forms: address integrations designs

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2446,6 +2446,9 @@ importers:
       '@automattic/jetpack-shared-extension-utils':
         specifier: workspace:*
         version: link:../../js-packages/shared-extension-utils
+      '@wordpress/base-styles':
+        specifier: 5.22.0
+        version: 5.22.0
       '@wordpress/block-editor':
         specifier: 14.19.0
         version: 14.19.0(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)

--- a/projects/packages/forms/changelog/change-jetpack-forms-integrations-styles
+++ b/projects/packages/forms/changelog/change-jetpack-forms-integrations-styles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Forms: address styles design on integrations tabs and modal

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -44,6 +44,7 @@
 		"@wordpress/compose": "7.24.0",
 		"@wordpress/core-data": "7.24.0",
 		"@wordpress/data": "10.24.0",
+		"@wordpress/base-styles": "5.22.0",
 		"@wordpress/dataviews": "4.17.0",
 		"@wordpress/dependency-extraction-webpack-plugin": "6.24.0",
 		"@wordpress/element": "6.24.0",

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/akismet-card.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/akismet-card.js
@@ -68,7 +68,9 @@ const AkismetCard = ( { isExpanded, onToggle, data, refreshStatus } ) => {
 				</div>
 			) : (
 				<div>
-					<p>{ __( 'Your forms are automatically protected with Akismet.', 'jetpack-forms' ) }</p>
+					<p className="integration-card__description">
+						{ __( 'Your forms are automatically protected with Akismet.', 'jetpack-forms' ) }
+					</p>
 					<div className="integration-card__links">
 						<Button
 							variant="link"

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/creative-mail-card.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/creative-mail-card.js
@@ -60,7 +60,7 @@ const CreativeMailCard = ( { isExpanded, onToggle, data, refreshStatus, borderBo
 			borderBottom={ borderBottom }
 		>
 			<div>
-				<p>
+				<p className="integration-card__description">
 					{ __(
 						"You're all setup for email marketing with Creative Mail. Please manage your marketing from Creative Mail panel.",
 						'jetpack-forms'

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/google-sheets-card.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/google-sheets-card.js
@@ -81,7 +81,7 @@ const GoogleSheetsCard = ( { isExpanded, onToggle, data, refreshStatus } ) => {
 				</div>
 			) : (
 				<div>
-					<p>
+					<p className="integration-card__description">
 						{ __(
 							'Google Sheets is connected. You can export your form responses from the form responses page.',
 							'jetpack-forms'

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/style.scss
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/style.scss
@@ -116,7 +116,8 @@
 	}
 
 	.components-card__body {
-		padding-bottom: 30px;
+		padding-top: 8px;
+		padding-bottom: 24px;
 		padding-left: 0;
 		padding-right: 0;
 	}

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/style.scss
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/style.scss
@@ -97,6 +97,7 @@
 		color: var(--jp-gray-50);
 		font-size: 13px;
 		line-height: 1.5;
+		margin-top: 0;
 
 		@media (max-width: 782px) {
 			text-wrap: balance;

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/style.scss
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/style.scss
@@ -119,8 +119,12 @@
 	.components-card__body {
 		padding-top: 8px;
 		padding-bottom: 24px;
-		padding-left: 0;
+		padding-left: 60px; // this is to align with the row above's icon + gap (44 + 16)
 		padding-right: 0;
+
+		:last-child {
+			margin-bottom: 0;
+		}
 	}
 
 	.components-card-header {

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/jetpack-crm-card.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/jetpack-crm-card.js
@@ -52,7 +52,7 @@ const JetpackCRMCard = ( {
 		if ( ! isRecentVersion ) {
 			return (
 				<div>
-					<p>
+					<p className="integration-card__description">
 						{ __(
 							'Please update to the latest version of the Jetpack CRM plugin to integrate your contact form with your CRM.',
 							'jetpack-forms'
@@ -75,7 +75,7 @@ const JetpackCRMCard = ( {
 		if ( ! hasExtension ) {
 			return (
 				<div>
-					<p>
+					<p className="integration-card__description">
 						{ createInterpolateElement(
 							__(
 								"You can integrate this contact form with Jetpack CRM by enabling Jetpack CRM's <a>Jetpack Forms extension</a>.",

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/salesforce-card.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/salesforce-card.js
@@ -67,7 +67,7 @@ const SalesforceCard = ( {
 		>
 			<BaseControl __nextHasNoMarginBottom={ true }>
 				{ ! isValidSalesforceOrgId( salesforceData.organizationId ) && (
-					<p style={ { marginBottom: '20px' } }>
+					<p className="integration-card__description" style={ { marginBottom: '20px' } }>
 						{ __(
 							'Enter the Salesforce organization ID where you want to send leads.',
 							'jetpack-forms'

--- a/projects/packages/forms/src/dashboard/integrations/akismet-card.tsx
+++ b/projects/packages/forms/src/dashboard/integrations/akismet-card.tsx
@@ -72,7 +72,9 @@ const AkismetDashboardCard = ( {
 				</div>
 			) : (
 				<div>
-					<p>{ __( 'Your forms are automatically protected with Akismet.', 'jetpack-forms' ) }</p>
+					<p className="integration-card__description">
+						{ __( 'Your forms are automatically protected with Akismet.', 'jetpack-forms' ) }
+					</p>
 					<div className="integration-card__links">
 						<Button
 							variant="link"

--- a/projects/packages/forms/src/dashboard/integrations/creative-mail-card.tsx
+++ b/projects/packages/forms/src/dashboard/integrations/creative-mail-card.tsx
@@ -41,7 +41,9 @@ const CreativeMailDashboardCard = ( {
 			borderBottom={ borderBottom }
 		>
 			<div>
-				<p>{ __( "You're all setup for email marketing with Creative Mail.", 'jetpack-forms' ) }</p>
+				<p className="integration-card__description">
+					{ __( "You're all setup for email marketing with Creative Mail.", 'jetpack-forms' ) }
+				</p>
 				<Button
 					variant="link"
 					href={ settingsUrl }

--- a/projects/packages/forms/src/dashboard/integrations/google-sheets-card.tsx
+++ b/projects/packages/forms/src/dashboard/integrations/google-sheets-card.tsx
@@ -69,7 +69,7 @@ const GoogleSheetsDashboardCard = ( {
 				</div>
 			) : (
 				<div>
-					<p>
+					<p className="integration-card__description">
 						{ __(
 							'Google Sheets is connected. You can export your form responses from the form responses page.',
 							'jetpack-forms'

--- a/projects/packages/forms/src/dashboard/integrations/index.tsx
+++ b/projects/packages/forms/src/dashboard/integrations/index.tsx
@@ -46,7 +46,7 @@ const Integrations = () => {
 			<div className="jp-forms__integrations-wrapper">
 				<div className="jp-forms__integrations-header">
 					<h2 className="jp-forms__integrations-header-heading">
-						{ __( 'Third party integrations', 'jetpack-forms' ) }
+						{ __( 'Streamline your forms', 'jetpack-forms' ) }
 					</h2>
 					<div className="jp-forms__integrations-header-description">
 						{ __(

--- a/projects/packages/forms/src/dashboard/integrations/index.tsx
+++ b/projects/packages/forms/src/dashboard/integrations/index.tsx
@@ -43,39 +43,51 @@ const Integrations = () => {
 
 	return (
 		<div className="jp-forms__integrations">
-			<div className="section-main">
-				<h2>{ __( 'Third party integrations', 'jetpack-forms' ) }</h2>
-				<AkismetDashboardCard
-					isExpanded={ expandedCards.akismet }
-					onToggle={ handleToggleAkismet }
-					data={ findIntegrationById( 'akismet' ) }
-					refreshStatus={ refreshIntegrations }
-				/>
-				<GoogleSheetsDashboardCard
-					isExpanded={ expandedCards.googleSheets }
-					onToggle={ handleToggleGoogleSheets }
-					data={ findIntegrationById( 'google-drive' ) }
-					refreshStatus={ refreshIntegrations }
-				/>
-				<JetpackCRMDashboardCard
-					isExpanded={ expandedCards.crm }
-					onToggle={ handleToggleCRM }
-					data={ findIntegrationById( 'zero-bs-crm' ) }
-					refreshStatus={ refreshIntegrations }
-				/>
-				<SalesforceDashboardCard
-					isExpanded={ expandedCards.salesforce }
-					onToggle={ handleToggleSalesforce }
-					data={ findIntegrationById( 'salesforce' ) }
-					refreshStatus={ refreshIntegrations }
-				/>
-				<CreativeMailDashboardCard
-					isExpanded={ expandedCards.creativemail }
-					onToggle={ handleToggleCreativeMail }
-					data={ findIntegrationById( 'creative-mail-by-constant-contact' ) }
-					refreshStatus={ refreshIntegrations }
-					borderBottom={ false }
-				/>
+			<div className="jp-forms__integrations-wrapper">
+				<div className="jp-forms__integrations-header">
+					<h2 className="jp-forms__integrations-header-heading">
+						{ __( 'Third party integrations', 'jetpack-forms' ) }
+					</h2>
+					<div className="jp-forms__integrations-header-description">
+						{ __(
+							'Manage integrations for all forms on your site. You can turn them on or off per form in the editor.',
+							'jetpack-forms'
+						) }
+					</div>
+				</div>
+				<div className="jp-forms__integrations-body">
+					<AkismetDashboardCard
+						isExpanded={ expandedCards.akismet }
+						onToggle={ handleToggleAkismet }
+						data={ findIntegrationById( 'akismet' ) }
+						refreshStatus={ refreshIntegrations }
+					/>
+					<GoogleSheetsDashboardCard
+						isExpanded={ expandedCards.googleSheets }
+						onToggle={ handleToggleGoogleSheets }
+						data={ findIntegrationById( 'google-drive' ) }
+						refreshStatus={ refreshIntegrations }
+					/>
+					<JetpackCRMDashboardCard
+						isExpanded={ expandedCards.crm }
+						onToggle={ handleToggleCRM }
+						data={ findIntegrationById( 'zero-bs-crm' ) }
+						refreshStatus={ refreshIntegrations }
+					/>
+					<SalesforceDashboardCard
+						isExpanded={ expandedCards.salesforce }
+						onToggle={ handleToggleSalesforce }
+						data={ findIntegrationById( 'salesforce' ) }
+						refreshStatus={ refreshIntegrations }
+					/>
+					<CreativeMailDashboardCard
+						isExpanded={ expandedCards.creativemail }
+						onToggle={ handleToggleCreativeMail }
+						data={ findIntegrationById( 'creative-mail-by-constant-contact' ) }
+						refreshStatus={ refreshIntegrations }
+						borderBottom={ false }
+					/>
+				</div>
 			</div>
 		</div>
 	);

--- a/projects/packages/forms/src/dashboard/integrations/jetpack-crm-card.tsx
+++ b/projects/packages/forms/src/dashboard/integrations/jetpack-crm-card.tsx
@@ -42,7 +42,7 @@ const JetpackCRMDashboardCard = ( {
 		if ( ! isRecentVersion ) {
 			return (
 				<div>
-					<p>
+					<p className="integration-card__description">
 						{ __(
 							'Please update to the latest version of the Jetpack CRM plugin to integrate your contact form with your CRM.',
 							'jetpack-forms'
@@ -65,7 +65,7 @@ const JetpackCRMDashboardCard = ( {
 		if ( ! hasExtension ) {
 			return (
 				<div>
-					<p>
+					<p className="integration-card__description">
 						{ createInterpolateElement(
 							__(
 								"You can integrate Jetpack CRM by enabling Jetpack CRM's <a>Jetpack Forms extension</a>.",
@@ -84,7 +84,7 @@ const JetpackCRMDashboardCard = ( {
 						) }
 					</p>
 					{ ! canActivateExtension && (
-						<p>
+						<p className="integration-card__description">
 							{ __(
 								'A site administrator must enable the CRM Jetpack Forms extension.',
 								'jetpack-forms'

--- a/projects/packages/forms/src/dashboard/integrations/jetpack-crm-card.tsx
+++ b/projects/packages/forms/src/dashboard/integrations/jetpack-crm-card.tsx
@@ -84,7 +84,7 @@ const JetpackCRMDashboardCard = ( {
 						) }
 					</p>
 					{ ! canActivateExtension && (
-						<p className="integration-card__description">
+						<p>
 							{ __(
 								'A site administrator must enable the CRM Jetpack Forms extension.',
 								'jetpack-forms'

--- a/projects/packages/forms/src/dashboard/integrations/salesforce-card.tsx
+++ b/projects/packages/forms/src/dashboard/integrations/salesforce-card.tsx
@@ -27,7 +27,7 @@ const SalesforceDashboardCard = ( {
 			cardData={ cardData }
 		>
 			<div>
-				<p>
+				<p className="integration-card__description">
 					{ __(
 						'Salesforce connections are managed for each form individually in the block editor.',
 						'jetpack-forms'

--- a/projects/packages/forms/src/dashboard/integrations/style.scss
+++ b/projects/packages/forms/src/dashboard/integrations/style.scss
@@ -3,6 +3,10 @@
 .jp-forms__integrations {
 	padding: 32px 16.6%;
 
+	@media ( max-width: 782px ) {
+		padding: 32px 8px;
+	}
+
 	.jp-forms__integrations-header {
 		display: flex;
 		flex-direction: column;
@@ -26,5 +30,9 @@
 		border: 1px solid $gray-200;
 		border-radius: 8px;
 		padding: 12px 24px;
+
+		@media ( max-width: 782px ) {
+			padding: 12px 8px;
+		}
 	}
 }

--- a/projects/packages/forms/src/dashboard/integrations/style.scss
+++ b/projects/packages/forms/src/dashboard/integrations/style.scss
@@ -1,3 +1,30 @@
+@import "@wordpress/base-styles/variables";
+
 .jp-forms__integrations {
-	padding: 20px 48px;
+	padding: 32px 16.6%;
+
+	.jp-forms__integrations-header {
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+		margin-bottom: 24px;
+
+		.jp-forms__integrations-header-heading {
+			color: $gray-900;
+			font-size: $font-size-2x-large;
+			line-height: $font-line-height-2x-large;
+			margin-block: 0;
+		}
+
+		.jp-forms__integrations-header-description {
+			color: $gray-700;
+			max-width: 75ch; /* stylelint-disable-line unit-allowed-list */
+		}
+	}
+
+	.jp-forms__integrations-body {
+		border: 1px solid $gray-200;
+		border-radius: 8px;
+		padding: 12px 24px;
+	}
 }

--- a/projects/plugins/jetpack/changelog/change-jetpack-forms-integrations-styles
+++ b/projects/plugins/jetpack/changelog/change-jetpack-forms-integrations-styles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Add wordpress/base-styles dependency


### PR DESCRIPTION
Related to DSGJP-63
Fixes FORMS-94

## Proposed changes:
Address design for integrations tab and modal.

Before:
<img width="934" alt="image" src="https://github.com/user-attachments/assets/701d1b0d-aa3e-4c60-8b65-2416eb9c2b9b" />


After:
<img width="928" alt="image" src="https://github.com/user-attachments/assets/4c8e598c-8cb5-4a35-a167-86630404ece0" />
<img width="709" alt="image" src="https://github.com/user-attachments/assets/20d1e1df-bbd8-4bad-a0e6-1bde31d756d7" />



### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1747846143256819/1747711615.235999-slack-C052XEUUBL4

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Add the feature filter to enable the integrations tab:

```php
add_filter( 'jetpack_forms_enable_integrations_tab', '__return_true' );
```

Apply and visit wp-admin/admin.php?page=jetpack-forms#/integrations, verify the designs.
Go to editor, add a form and open integrations from the sidebar, verify the modal also reflects the design changes