### PR TITLE
Blogging prompt: Make sure block is registered before inserting

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-blogging-prompt-from-param
+++ b/projects/plugins/jetpack/changelog/fix-blogging-prompt-from-param
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Blogging prompt: Make sure the block is registered before inserting.

--- a/projects/plugins/jetpack/extensions/blocks/blogging-prompt/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/blogging-prompt/editor.js
@@ -1,4 +1,4 @@
-import { createBlock } from '@wordpress/blocks';
+import { createBlock, getBlockType } from '@wordpress/blocks';
 import { dispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { registerJetpackBlockFromMetadata } from '../../shared/register-jetpack-block';
@@ -13,36 +13,53 @@ import save from './save';
 import './editor.scss';
 import './style.scss';
 
-registerJetpackBlockFromMetadata( metadata, {
-	edit,
-	save,
-	example: {
-		attributes: {
-			answersLink: 'https://wordpress.com/tag/dailyprompt',
-			answersLinkText: __( 'View all responses', 'jetpack' ),
-			gravatars: [ { url: avatar1 }, { url: avatar2 }, { url: avatar3 } ],
-			promptLabel: __( 'Daily writing prompt', 'jetpack' ),
-			promptText: __( "What's your favorite place to visit?", 'jetpack' ),
-			promptFetched: true,
-			promptId: 1234,
-			showResponses: true,
-			showLabel: true,
-			tagsAdded: true,
-			isBloganuary: false,
-		},
-	},
-} );
+// Register the block and return a promise that resolves when registration is complete
+const registerBlock = () =>
+	new Promise( resolve => {
+		registerJetpackBlockFromMetadata( metadata, {
+			edit,
+			save,
+			example: {
+				attributes: {
+					answersLink: 'https://wordpress.com/tag/dailyprompt',
+					answersLinkText: __( 'View all responses', 'jetpack' ),
+					gravatars: [ { url: avatar1 }, { url: avatar2 }, { url: avatar3 } ],
+					promptLabel: __( 'Daily writing prompt', 'jetpack' ),
+					promptText: __( "What's your favorite place to visit?", 'jetpack' ),
+					promptFetched: true,
+					promptId: 1234,
+					showResponses: true,
+					showLabel: true,
+					tagsAdded: true,
+					isBloganuary: false,
+				},
+			},
+		} );
+
+		// Wait for next tick to ensure registration is complete
+		setTimeout( resolve, 0 );
+	} );
 
 async function insertTemplate( promptId ) {
 	await waitForEditor();
 
-	const { insertBlocks } = dispatch( 'core/block-editor' );
-	const bloggingPromptBlocks = [
-		createBlock( 'jetpack/blogging-prompt', { promptFetched: false, promptId, tagsAdded: true } ),
-		createBlock( 'core/paragraph' ),
-	];
+	// Ensure block is registered before insertion
+	const blockType = getBlockType( 'jetpack/blogging-prompt' );
+	if ( ! blockType ) {
+		await registerBlock();
+	}
 
-	insertBlocks( bloggingPromptBlocks, 0, undefined, false );
+	const { insertBlocks } = dispatch( 'core/block-editor' );
+
+	const bloggingPromptBlock = createBlock( 'jetpack/blogging-prompt', {
+		promptFetched: false,
+		promptId,
+		tagsAdded: true,
+	} );
+
+	const paragraphBlock = createBlock( 'core/paragraph' );
+
+	insertBlocks( [ bloggingPromptBlock, paragraphBlock ], 0, undefined, false );
 }
 
 function initBloggingPrompt() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://linear.app/a8c/issue/CML-493/daily-writing-prompt-broken-opens-blank-new-post

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Wrap `registerJetpackBlockFromMetadata` with a promise we wait for before attempting to insert the block.


https://github.com/user-attachments/assets/f2f91665-6df6-4d1b-a16d-efc0663a3e30



### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

https://linear.app/a8c/issue/CML-493/daily-writing-prompt-broken-opens-blank-new-post

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

N/A

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Atomic:
* On an Atomic site, check out this branch in Jetpack beta. 
* Go to the wp-admin dashboard.
* Click "Post Answer" under the daily writing prompt.
* The editor should load with the prompt block.

Jetpack:
* On a Jetpack site, check out this branch in Jetpack beta.
* Go to `/wp-admin/post-new.php?answer_prompt=1944`
* The editor should load with the prompt block.

Simple: note that this isn't expected to change the behavior for Simple.
* Go to wordpress.com/home/{site url} for a Simple site.
* Click "Post Answer" under the daily writing prompt.
* Check if the editor loads with the prompt block.
* Run `bin/jetpack-downloader test jetpack fix/blogging-prompt-from-param` on your sandbox and sandbox the API and a Simple site.
* Turn on write access.
* Go to wordpress.com/home/{site url} for the sandboxed site.
* Click "Post Answer" under the daily writing prompt.
* The editor should load with the same behavior as before.
