### PR TITLE
Forms: fix classic view deprecation notices

### DIFF
--- a/projects/packages/forms/changelog/fix-jetpack-forms-classic-view-deprecation-notices
+++ b/projects/packages/forms/changelog/fix-jetpack-forms-classic-view-deprecation-notices
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix admin notice showing on all screens instead of only forms classic view

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -83,7 +83,7 @@ class Dashboard {
 				if ( Jetpack_Forms::is_legacy_menu_item_retired() ) {
 					$notice = sprintf(
 						/* translators: %s: URL to the Jetpack > Forms menu */
-						__( 'This page has moved to the <a href="%s">Jetpack > Forms</a> menu.', 'jetpack-forms' ),
+						__( 'Forms responses management has moved to the <a href="%s">Jetpack → Forms</a> menu.', 'jetpack-forms' ),
 						$this->switch->get_forms_admin_url()
 					);
 					wp_admin_notice(
@@ -96,7 +96,7 @@ class Dashboard {
 				} elseif ( $this->switch->is_jetpack_forms_admin_page_available() ) {
 					$notice = sprintf(
 						/* translators: %s: URL to the Jetpack > Forms menu */
-						__( 'This page will be moved to the <a href="%s">Jetpack > Forms</a> menu.', 'jetpack-forms' ),
+						__( 'Forms responses management will be moved to the <a href="%s">Jetpack → Forms</a> menu.', 'jetpack-forms' ),
 						$this->switch->get_forms_admin_url()
 					);
 					wp_admin_notice(

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -78,11 +78,33 @@ class Dashboard {
 	 * Load JavaScript for the dashboard.
 	 */
 	public function load_admin_scripts() {
-		if ( ! $this->switch->is_modern_view() && ! $this->switch->is_jetpack_forms_admin_page() ) {
+		if ( ! $this->switch->is_modern_view() && ! $this->switch->is_jetpack_forms_admin_page() && $this->switch->is_classic_view() ) {
 			if ( Jetpack_Forms::is_legacy_menu_item_retired() ) {
-				wp_admin_notice( 'This page has moved to the Jetpack Forms menu.', array( 'type' => 'info' ) );
+				$notice = sprintf(
+					/* translators: %s: URL to the Jetpack > Forms menu */
+					__( 'This page has moved to the <a href="%s">Jetpack > Forms</a> menu.', 'jetpack-forms' ),
+					$this->switch->get_forms_admin_url()
+				);
+				wp_admin_notice(
+					$notice,
+					array(
+						'type'        => 'info',
+						'dismissable' => true,
+					)
+				);
 			} elseif ( $this->switch->is_jetpack_forms_admin_page_available() ) {
-				wp_admin_notice( 'This will be moved to the Jetpack Forms menu.', array( 'type' => 'info' ) );
+				$notice = sprintf(
+					/* translators: %s: URL to the Jetpack > Forms menu */
+					__( 'This page will be moved to the <a href="%s">Jetpack > Forms</a> menu.', 'jetpack-forms' ),
+					$this->switch->get_forms_admin_url()
+				);
+				wp_admin_notice(
+					$notice,
+					array(
+						'type'        => 'info',
+						'dismissable' => true,
+					)
+				);
 			}
 			return;
 		}

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -78,33 +78,35 @@ class Dashboard {
 	 * Load JavaScript for the dashboard.
 	 */
 	public function load_admin_scripts() {
-		if ( ! $this->switch->is_modern_view() && ! $this->switch->is_jetpack_forms_admin_page() && $this->switch->is_classic_view() ) {
-			if ( Jetpack_Forms::is_legacy_menu_item_retired() ) {
-				$notice = sprintf(
-					/* translators: %s: URL to the Jetpack > Forms menu */
-					__( 'This page has moved to the <a href="%s">Jetpack > Forms</a> menu.', 'jetpack-forms' ),
-					$this->switch->get_forms_admin_url()
-				);
-				wp_admin_notice(
-					$notice,
-					array(
-						'type'        => 'info',
-						'dismissable' => true,
-					)
-				);
-			} elseif ( $this->switch->is_jetpack_forms_admin_page_available() ) {
-				$notice = sprintf(
-					/* translators: %s: URL to the Jetpack > Forms menu */
-					__( 'This page will be moved to the <a href="%s">Jetpack > Forms</a> menu.', 'jetpack-forms' ),
-					$this->switch->get_forms_admin_url()
-				);
-				wp_admin_notice(
-					$notice,
-					array(
-						'type'        => 'info',
-						'dismissable' => true,
-					)
-				);
+		if ( ! $this->switch->is_modern_view() && ! $this->switch->is_jetpack_forms_admin_page() ) {
+			if ( $this->switch->is_classic_view() ) {
+				if ( Jetpack_Forms::is_legacy_menu_item_retired() ) {
+					$notice = sprintf(
+						/* translators: %s: URL to the Jetpack > Forms menu */
+						__( 'This page has moved to the <a href="%s">Jetpack > Forms</a> menu.', 'jetpack-forms' ),
+						$this->switch->get_forms_admin_url()
+					);
+					wp_admin_notice(
+						$notice,
+						array(
+							'type'        => 'info',
+							'dismissable' => true,
+						)
+					);
+				} elseif ( $this->switch->is_jetpack_forms_admin_page_available() ) {
+					$notice = sprintf(
+						/* translators: %s: URL to the Jetpack > Forms menu */
+						__( 'This page will be moved to the <a href="%s">Jetpack > Forms</a> menu.', 'jetpack-forms' ),
+						$this->switch->get_forms_admin_url()
+					);
+					wp_admin_notice(
+						$notice,
+						array(
+							'type'        => 'info',
+							'dismissable' => true,
+						)
+					);
+				}
 			}
 			return;
 		}


### PR DESCRIPTION
Related to https://github.com/Automattic/jetpack/pull/43295

## Proposed changes:
On the PR above the notices were introduced as part of the migration plan, but they were not restricted to the forms listing classic view and they would show on all wp-admin pages. This PR addresses the issue.

Before:

<img width="782" alt="image" src="https://github.com/user-attachments/assets/d5f0c779-2983-4992-b387-7995d42b9aaf" />


After:

<img width="791" alt="image" src="https://github.com/user-attachments/assets/2c2c5bad-e319-4077-82cc-0c1e2bf3759a" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion


## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Apply and enable these filters:

```php
add_filter( 'jetpack_forms_use_new_menu_parent', '__return_true' );
add_filter( 'jetpack_forms_retire_view_switch', '__return_true' );
```

Visit wp-admin/edit.php?post_type=feedback to see the notice, navigate anywhere else within wp-admin (Dashboard works) to see the notices do not show there.