### PR TITLE
Forms: fix custom class handling in contact form plugin

### DIFF
--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -405,11 +405,12 @@ class Contact_Form_Plugin {
 		$block_style_classes = empty( $matches[0] ) ? '' : implode( ' ', $matches[0] );
 
 		if ( ! empty( $block_style_classes ) ) {
-			$wrap_classes          = ! empty( $matches[0] ) ? ' ' . implode( '-wrap ', $matches[0] ) . '-wrap' : '';
+			$wrap_classes          = ! empty( $matches[0] ) ? ' ' . implode( '-wrap ', array_filter( $matches[0] ) ) . '-wrap' : '';
 			$field_wrapper_classes = " $block_style_classes $wrap_classes";
-			// Remove block style classes from the original classname.
-			$classes_without_block_style = trim( preg_replace( '/is-style-([^\s]+)/i', '', $classname ) );
 		}
+
+		// Remove block style classes from the original classname.
+		$classes_without_block_style = trim( preg_replace( '/is-style-([^\s]+)/i', '', $classname ) );
 
 		return array(
 			'fieldwrapperclasses' => $field_wrapper_classes,

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
@@ -298,7 +298,7 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 	 * @param string $type The type of the field.
 	 */
 	#[DataProvider( 'data_provider_block_attributes_to_shortcode_attributes_with_styles' )]
-	public function test_block_attributes_to_shortcode_attributes_with_styles( $expected, $atts = array(), $inner_blocks, $type = 'text' ) {
+	public function test_block_attributes_to_shortcode_attributes_with_styles( $expected, $atts = array(), $inner_blocks = array(), $type = 'text' ) {
 		$block                = array(
 			'blockName'   => 'jetpack/field-name',
 			'attrs'       => array(

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
@@ -293,11 +293,12 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 	 * @dataProvider data_provider_block_attributes_to_shortcode_attributes_with_styles
 	 *
 	 * @param array  $expected The expected shortcode attributes.
+	 * @param array  $atts The attributes of the shortcode block.
 	 * @param array  $inner_blocks The inner blocks of the block.
 	 * @param string $type The type of the field.
 	 */
 	#[DataProvider( 'data_provider_block_attributes_to_shortcode_attributes_with_styles' )]
-	public function test_block_attributes_to_shortcode_attributes_with_styles( $expected, $inner_blocks, $type = 'text' ) {
+	public function test_block_attributes_to_shortcode_attributes_with_styles( $expected, $atts = array(), $inner_blocks, $type = 'text' ) {
 		$block                = array(
 			'blockName'   => 'jetpack/field-name',
 			'attrs'       => array(
@@ -305,7 +306,7 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 			),
 			'innerBlocks' => $inner_blocks,
 		);
-		$shortcode_attributes = Contact_Form_Plugin::block_attributes_to_shortcode_attributes( array(), $type, new WP_Block( $block ) );
+		$shortcode_attributes = Contact_Form_Plugin::block_attributes_to_shortcode_attributes( $atts, $type, new WP_Block( $block ) );
 
 		// Sorting here so we don't have to care about the order of the attributes in the shortcode/data provider.
 		$expected_keys = array_keys( $expected );
@@ -343,6 +344,7 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 					'stylevariationattributes' => '{"border":{"color":"swamp-blue","width":"1px","style":"dashed"},"color":{"background":"swamp-red"}}',
 					'stylevariationstyles'     => 'background-color:swamp-red; border-color:swamp-blue;border-style:dashed;border-width:1px;',
 				),
+				'atts'         => array(),
 				'inner_blocks' => array(
 					array(
 						'blockName' => 'jetpack/label',
@@ -397,6 +399,7 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 					'type'                => 'radio',
 					'fieldwrapperclasses' => 'wp-block-jetpack-field-radio',
 				),
+				'atts'         => array(),
 				'inner_blocks' => array(
 					array(
 						'blockName' => 'jetpack/option',
@@ -427,6 +430,7 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 			),
 			'label and options' => array(
 				'expected'     => array(
+					'class'                    => 'some-custom-class',
 					'labelclasses'             => 'wp-block-jetpack-label has-text-color has-accent-3-color',
 					'labelstyles'              => 'letter-spacing:0.1em;',
 					'options'                  => 'Option 1,Option 2',
@@ -434,12 +438,15 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 					'label'                    => 'Label multiple options',
 					'type'                     => 'checkbox-multiple',
 					'requiredText'             => 'Do it again',
-					'fieldwrapperclasses'      => 'wp-block-jetpack-field-checkbox-multiple',
+					'fieldwrapperclasses'      => 'wp-block-jetpack-field-checkbox-multiple is-style-button  is-style-button-wrap',
 					'optionsclasses'           => ' has-text-color has-background',
 					'optionsstyles'            => 'color:blue-overture;background-color:green-tonight; border-top-width:2px;border-top-color:terrible-red;border-top-style:solid;',
 					'stylevariationclasses'    => ' has-background',
 					'stylevariationattributes' => '{"border":{"top":{"color":"terrible-red","width":"2px","style":"solid","radius":"10px"}},"color":{"background":"green-tonight"}}',
 					'stylevariationstyles'     => 'background-color:green-tonight; border-top-width:2px;border-top-color:terrible-red;border-top-style:solid;',
+				),
+				'atts'         => array(
+					'className' => 'is-style-button some-custom-class',
 				),
 				'inner_blocks' => array(
 					array(

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -1047,7 +1047,6 @@ class Contact_Form_Test extends BaseTestCase {
 			),
 		);
 		$expected_attributes = array_merge( $attributes, array( 'input_type' => 'checkbox' ) );
-
 		$this->assertValidFieldMultiField( $this->render_field( $attributes ), $expected_attributes );
 	}
 
@@ -1237,7 +1236,9 @@ class Contact_Form_Test extends BaseTestCase {
 		if ( isset( $attributes['class'] ) ) {
 			$wrapper_classes = explode( ' ', $attributes['class'] );
 			foreach ( $wrapper_classes as $wrapper_class ) {
-				$classes_wrap .= " {$wrapper_class}-wrap";
+				if ( $wrapper_class ) {
+					$classes_wrap .= " {$wrapper_class}-wrap";
+				}
 			}
 		}
 
@@ -1245,8 +1246,8 @@ class Contact_Form_Test extends BaseTestCase {
 		$wrapper_div_class = $wrapper_div->getAttribute( 'class' );
 
 		$this->assertEquals(
-			$wrapper_div_class,
 			$css_class,
+			$wrapper_div_class,
 			'div class attribute doesn\'t match'
 		);
 	}
@@ -1294,10 +1295,9 @@ class Contact_Form_Test extends BaseTestCase {
 				$classes_input .= " {$input_class}";
 			}
 		}
-
 		$this->assertEquals(
-			$input->getAttribute( 'class' ),
 			$attributes['type'] . $classes_input . $input_classes_input . $options_classes_input . ' grunion-field',
+			$input->getAttribute( 'class' ),
 			'input class attribute doesn\'t match'
 		);
 	}
@@ -1335,8 +1335,8 @@ class Contact_Form_Test extends BaseTestCase {
 		}
 
 		$this->assertEquals(
-			$label->getAttribute( 'class' ),
 			$classes_prefix . $label_classes_input . $options_classes_input,
+			$label->getAttribute( 'class' ),
 			'input class attribute doesn\'t match'
 		);
 	}


### PR DESCRIPTION

Fixes https://github.com/Automattic/jetpack-roadmap/issues/2600

JETPACK-487

## Proposed changes:

This PR corrects an omission (by me) whereby we're not adding custom classnames to field wrapper where there's no `is-style-*` classname.

If that doesn't make sense to you, don't worry.  The upshot is you should be able to add custom classnames to fields in the editor and that they should appear on the frontend.

## Testing

Fire up this branch. Add some custom classes to a field (not an innerblock).

<img width="1445" alt="Screenshot 2025-05-23 at 4 52 36 pm" src="https://github.com/user-attachments/assets/7f5646d3-27e3-4bed-a35e-8e42abaee46a" />


Check that the custom class appears:

1. On the field wrapper as a `-wrap` class.
2. In the inner control block (input etc) as your class.



<img width="990" alt="Screenshot 2025-05-23 at 4 55 47 pm" src="https://github.com/user-attachments/assets/f83c19af-709d-440a-9df3-bc55794d67fc" />


This is perhaps counter-intuitive. Why wouldn't the custom class appear on the wrapper itself (without the `-wrap` suffix?)

That's how trunk works and we don't want to break stuff for now.



