### PR TITLE
Forms: Fix outline style label font size

### DIFF
--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -278,6 +278,7 @@
 .jetpack-field-label {
 	display: flex;
 	flex-direction: row;
+	flex-wrap: wrap;
 	justify-content: flex-start;
 	align-items: baseline;
 
@@ -833,7 +834,10 @@
 				max-width: 100px;
 			}
 
-			.jetpack-field-label .jetpack-field-label__input {
+			.jetpack-field-label .jetpack-field-label__input,
+			.jetpack-field-label .required {
+				will-change: font-size;
+				transition: font-size 150ms cubic-bezier(0.4, 0, 0.2, 1);
 				margin-bottom: 0;
 			}
 
@@ -851,6 +855,16 @@
 				.notched-label__label {
 					top: calc(var(--jetpack--contact-form--border-top-size) * -1);
 					transform: translateY(-50%);
+				}
+
+				.jetpack-field-label .required {
+					// The required text is always 85% of the label font size.
+					// The label font size is reduced to 0.8em in a separate rule, so that needs to be accounted for.
+					// 0.85 * 0.8 = 0.68em.
+					font-size: 0.68em;
+				}
+
+				.jetpack-field-label__input {
 					font-size: 0.8em;
 				}
 

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -810,7 +810,6 @@
 				position: relative;
 				top: 50%;
 				transform: translateY(-50%);
-				will-change: transform;
 				transition: all 150ms cubic-bezier(0.4, 0, 0.2, 1);
 				margin: 0;
 
@@ -853,7 +852,7 @@
 				}
 
 				.notched-label__label {
-					top: calc(var(--jetpack--contact-form--border-top-size) * -1);
+					top: calc(var(--jetpack--contact-form--border-top-size, 1px) * -1);
 					transform: translateY(-50%);
 				}
 

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -1517,9 +1517,9 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 						for="' . esc_attr( $id ) . '"
 						class=" ' . $classes . '"
 						style="' . $this->label_styles . esc_attr( $output_data['css_vars'] ) . '"
-					>'
-			. esc_html( $label )
-			. ( $required ? '<span class="grunion-label-required" aria-hidden="true">' . $required_field_text . '</span>' : '' ) .
+					>
+					<span class="grunion-label-text">' . esc_html( $label ) . '</span>'
+					. ( $required ? '<span class="grunion-label-required" aria-hidden="true">' . $required_field_text . '</span>' : '' ) .
 			'</label>
 				</div>
 				<div class="notched-label__filler' . esc_attr( $output_data['class_name'] ) . '" style="' . esc_attr( $output_data['style'] ) . '"></div>

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -666,7 +666,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		return '<legend '
 				. $extra_attrs_string
 				. '>'
-				. esc_html( $legend )
+				. '<span class="grunion-label-text">' . esc_html( $legend ) . '</span>'
 				. ( $required ? '<span class="grunion-label-required">' . $required_field_text . '</span>' : '' )
 				. "</legend>\n";
 	}

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -575,7 +575,6 @@ on production builds, the attributes are being reordered, causing side-effects
 	top: 50%;
 	transform: translateY(-50%);
 	pointer-events: none;
-	will-change: transform;
 	transition: all 150ms cubic-bezier(0.4, 0, 0.2, 1);
 	margin: 0;
 	font-weight: 300;

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -165,11 +165,15 @@
 }
 
 .wp-block-jetpack-contact-form.is-style-outlined .wp-block-jetpack-options legend {
-	font-size: 0.8em;
+	display: flex;
+	align-items: baseline;
 	padding: 0 0.25em;
 	position: relative;
 	top: calc(var(--jetpack--contact-form--border-top-size, 1px) / 2 * -1);
+}
 
+.wp-block-jetpack-contact-form.is-style-outlined .wp-block-jetpack-options .grunion-label-text {
+	font-size: 0.8em;
 }
 
 .contact-form .grunion-checkbox-multiple-options .contact-form-field,

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -657,16 +657,6 @@ on production builds, the attributes are being reordered, causing side-effects
 	font-size: 0.68em;
 }
 
-/* The following is scoped by the presence of the custom font size CSS var to avoid needing conditional fallback within the var() */
-.contact-form .is-style-outlined .grunion-field-wrap .notched-label:has(~ .grunion-field:focus) .notched-label__label[style*="--jetpack--contact-form--label--font-size"],
-.contact-form .is-style-outlined .grunion-field-wrap .notched-label:has(~ .grunion-field:not(:placeholder-shown)) .notched-label__label[style*="--jetpack--contact-form--label--font-size"],
-.contact-form .is-style-outlined .grunion-field-wrap .notched-label:has(~ .grunion-field.has-placeholder) .notched-label__label[style*="--jetpack--contact-form--label--font-size"],
-.contact-form .is-style-outlined .grunion-field-wrap .notched-label:has(~ .grunion-checkbox-multiple-options) .notched-label__label[style*="--jetpack--contact-form--label--font-size"],
-.contact-form .is-style-outlined .grunion-field-wrap .notched-label:has(~ .grunion-radio-options) .notched-label__label[style*="--jetpack--contact-form--label--font-size"],
-.contact-form .is-style-outlined .grunion-field-wrap.grunion-field-select-wrap .notched-label .notched-label__label[style*="--jetpack--contact-form--label--font-size"] {
-	font-size: calc(var(--jetpack--contact-form--label--font-size) * 0.8);
-}
-
 .contact-form .is-style-outlined .grunion-field-wrap > input,
 .contact-form .is-style-outlined .grunion-field-wrap > textarea,
 .contact-form .is-style-outlined .grunion-field-wrap select {

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -568,6 +568,8 @@ on production builds, the attributes are being reordered, causing side-effects
 
 .contact-form .is-style-outlined .grunion-field-wrap .notched-label .notched-label__label {
 	position: relative;
+	display: flex;
+	align-items: baseline;
 	top: 50%;
 	transform: translateY(-50%);
 	pointer-events: none;
@@ -575,6 +577,16 @@ on production builds, the attributes are being reordered, causing side-effects
 	transition: all 150ms cubic-bezier(0.4, 0, 0.2, 1);
 	margin: 0;
 	font-weight: 300;
+}
+
+.contact-form .is-style-outlined .grunion-field-wrap .notched-label .grunion-label-text {
+	will-change: font-size;
+	transition: font-size 150ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.contact-form .is-style-outlined .grunion-field-wrap .notched-label .grunion-label-required {
+	will-change: font-size;
+	transition: font-size 150ms cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 .contact-form .is-style-outlined .grunion-field-wrap legend.grunion-field-label {
@@ -620,7 +632,29 @@ on production builds, the attributes are being reordered, causing side-effects
 {
 	top: calc( var(--jetpack--contact-form--border-top-size, var(--jetpack--contact-form--border-size)) * -1 );
 	transform: translateY(-50%);
+}
+
+.contact-form .is-style-outlined .grunion-field-wrap .notched-label:has(~ .grunion-field:focus) .grunion-label-text,
+.contact-form .is-style-outlined .grunion-field-wrap .notched-label:has(~ .grunion-field:not(:placeholder-shown)) .grunion-label-text,
+.contact-form .is-style-outlined .grunion-field-wrap .notched-label:has(~ .grunion-field.has-placeholder) .grunion-label-text,
+.contact-form .is-style-outlined .grunion-field-wrap .notched-label:has(~ .grunion-checkbox-multiple-options) .grunion-label-text,
+.contact-form .is-style-outlined .grunion-field-wrap .notched-label:has(~ .grunion-radio-options) .grunion-label-text,
+.contact-form .is-style-outlined .grunion-field-wrap.grunion-field-select-wrap .notched-label .grunion-label-text {
 	font-size: 0.8em;
+}
+
+.contact-form .is-style-outlined .grunion-field-wrap .notched-label:has(~ .grunion-field:focus) .grunion-label-required,
+.contact-form .is-style-outlined .grunion-field-wrap .notched-label:has(~ .grunion-field:not(:placeholder-shown)) .grunion-label-required,
+.contact-form .is-style-outlined .grunion-field-wrap .notched-label:has(~ .grunion-field.has-placeholder) .grunion-label-required,
+.contact-form .is-style-outlined .grunion-field-wrap .notched-label:has(~ .grunion-checkbox-multiple-options) .grunion-label-required,
+.contact-form .is-style-outlined .grunion-field-wrap .notched-label:has(~ .grunion-radio-options) .grunion-label-required,
+.contact-form .is-style-outlined .grunion-field-wrap.grunion-field-select-wrap .notched-label .grunion-label-required {
+
+	/*
+	 * The font size should be 85% of the label font size, which is reduced separately to 0.8em for this focused style.
+	 * 0.85 * 0.8 = 0.68em.
+	 */
+	font-size: 0.68em;
 }
 
 /* The following is scoped by the presence of the custom font size CSS var to avoid needing conditional fallback within the var() */

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -167,6 +167,7 @@
 .wp-block-jetpack-contact-form.is-style-outlined .wp-block-jetpack-options legend {
 	display: flex;
 	align-items: baseline;
+	flex-wrap: wrap;
 	padding: 0 0.25em;
 	position: relative;
 	top: calc(var(--jetpack--contact-form--border-top-size, 1px) / 2 * -1);
@@ -570,6 +571,7 @@ on production builds, the attributes are being reordered, causing side-effects
 	position: relative;
 	display: flex;
 	align-items: baseline;
+	flex-wrap: wrap;
 	top: 50%;
 	transform: translateY(-50%);
 	pointer-events: none;

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -172,10 +172,6 @@
 	top: calc(var(--jetpack--contact-form--border-top-size, 1px) / 2 * -1);
 }
 
-.wp-block-jetpack-contact-form.is-style-outlined .wp-block-jetpack-options .grunion-label-text {
-	font-size: 0.8em;
-}
-
 .contact-form .grunion-checkbox-multiple-options .contact-form-field,
 .contact-form .grunion-radio-options .contact-form-field {
 	display: flex;
@@ -620,8 +616,6 @@ on production builds, the attributes are being reordered, causing side-effects
 .contact-form .is-style-outlined .grunion-field-wrap .notched-label:has(~ .grunion-field:focus) .notched-label__notch,
 .contact-form .is-style-outlined .grunion-field-wrap .notched-label:has(~ .grunion-field:not(:placeholder-shown)) .notched-label__notch,
 .contact-form .is-style-outlined .grunion-field-wrap .notched-label:has(~ .grunion-field.has-placeholder) .notched-label__notch,
-.contact-form .is-style-outlined .grunion-field-wrap .notched-label:has(~ .grunion-checkbox-multiple-options) .notched-label__notch,
-.contact-form .is-style-outlined .grunion-field-wrap .notched-label:has(~ .grunion-radio-options) .notched-label__notch,
 .contact-form .is-style-outlined .grunion-field-wrap.grunion-field-select-wrap .notched-label .notched-label__notch
 {
 	border-top-color: transparent !important;
@@ -630,8 +624,6 @@ on production builds, the attributes are being reordered, causing side-effects
 .contact-form .is-style-outlined .grunion-field-wrap .notched-label:has(~ .grunion-field:focus) .notched-label__label,
 .contact-form .is-style-outlined .grunion-field-wrap .notched-label:has(~ .grunion-field:not(:placeholder-shown)) .notched-label__label,
 .contact-form .is-style-outlined .grunion-field-wrap .notched-label:has(~ .grunion-field.has-placeholder) .notched-label__label,
-.contact-form .is-style-outlined .grunion-field-wrap .notched-label:has(~ .grunion-checkbox-multiple-options) .notched-label__label,
-.contact-form .is-style-outlined .grunion-field-wrap .notched-label:has(~ .grunion-radio-options) .notched-label__label,
 .contact-form .is-style-outlined .grunion-field-wrap.grunion-field-select-wrap .notched-label .notched-label__label
 {
 	top: calc( var(--jetpack--contact-form--border-top-size, var(--jetpack--contact-form--border-size)) * -1 );
@@ -641,8 +633,8 @@ on production builds, the attributes are being reordered, causing side-effects
 .contact-form .is-style-outlined .grunion-field-wrap .notched-label:has(~ .grunion-field:focus) .grunion-label-text,
 .contact-form .is-style-outlined .grunion-field-wrap .notched-label:has(~ .grunion-field:not(:placeholder-shown)) .grunion-label-text,
 .contact-form .is-style-outlined .grunion-field-wrap .notched-label:has(~ .grunion-field.has-placeholder) .grunion-label-text,
-.contact-form .is-style-outlined .grunion-field-wrap .notched-label:has(~ .grunion-checkbox-multiple-options) .grunion-label-text,
-.contact-form .is-style-outlined .grunion-field-wrap .notched-label:has(~ .grunion-radio-options) .grunion-label-text,
+.contact-form .is-style-outlined .grunion-field-wrap .grunion-checkbox-multiple-options .grunion-label-text,
+.contact-form .is-style-outlined .grunion-field-wrap .grunion-radio-options .grunion-label-text,
 .contact-form .is-style-outlined .grunion-field-wrap.grunion-field-select-wrap .notched-label .grunion-label-text {
 	font-size: 0.8em;
 }
@@ -650,8 +642,8 @@ on production builds, the attributes are being reordered, causing side-effects
 .contact-form .is-style-outlined .grunion-field-wrap .notched-label:has(~ .grunion-field:focus) .grunion-label-required,
 .contact-form .is-style-outlined .grunion-field-wrap .notched-label:has(~ .grunion-field:not(:placeholder-shown)) .grunion-label-required,
 .contact-form .is-style-outlined .grunion-field-wrap .notched-label:has(~ .grunion-field.has-placeholder) .grunion-label-required,
-.contact-form .is-style-outlined .grunion-field-wrap .notched-label:has(~ .grunion-checkbox-multiple-options) .grunion-label-required,
-.contact-form .is-style-outlined .grunion-field-wrap .notched-label:has(~ .grunion-radio-options) .grunion-label-required,
+.contact-form .is-style-outlined .grunion-field-wrap .grunion-checkbox-multiple-options .grunion-label-required,
+.contact-form .is-style-outlined .grunion-field-wrap .grunion-radio-options .grunion-label-required,
 .contact-form .is-style-outlined .grunion-field-wrap.grunion-field-select-wrap .notched-label .grunion-label-required {
 
 	/*


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes and issue I noticed while working on JETPACK-277

Note - this merges into #42890 rather than trunk.

## Proposed changes:
If a user creates a form and uses the Outlined form style variation, they can no longer adjust the global styles font size of labels for any inputs that are focused, have a placeholder, or if the field is a Single/Multi choice field. This only happens in #42890, in trunk it works fine.

The issue is that we're attempting to use a `font-size: 0.8em` to scale the font to a smaller size when a field is focused, but this rule completely overrides the `font-size` applied by global styles. Block styles can also override the `0.8em`, so have the opposite effect.

The fix I've taken is to move the `font-size: 0.8em` rule to a child element, so it correctly scales the inherited font size from any global/block styles that are set on the parent. In the editor there's already a child element that can serve this purpose. On the frontend, there is no element, so a new `span` has been added. This might be a good idea anyway, as it makes the markup more like the editor, although it's not an exact match.

As part of this, the PR also updates the scaling of the required text, which is usually 85% of the size of the label so that it works consistently.

With the font size moved to a different element, a new `transition` also has to be implemented for the font-size scaling, otherwise it looks jarring when clicking into or out of a field.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1747968046579529-slack-C02A76B714Z

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
1. Add a contact form
2. With the form selected, change to the 'Outlined' style variation in the block inspector
3. Select one of the inputs and type some placeholder text in
4. Go to Global Styles > Blocks > Label and change the font size to something noticabely different (e.g. XL or XXL)

Expected: The font size should visible change:
<img width="634" alt="Screenshot 2025-05-23 at 3 53 44 pm" src="https://github.com/user-attachments/assets/7efff0d2-02dd-4abf-9358-8f4c7ce4177e" />

Before: The font size stayed the same:
<img width="648" alt="Screenshot 2025-05-23 at 4 06 24 pm" src="https://github.com/user-attachments/assets/86c01d5f-1a48-49ca-9dd4-5a8302c00367" />