### PR TITLE
CI: Increase trunk build artifact retention from 1 to 7 days

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -145,7 +145,7 @@ jobs:
           name: jetpack-build
           path: build.tar.xz
           # Only need to retain for a day since the beta builder slurps it up to distribute.
-          retention-days: 1
+          retention-days: 7
           # Already compressed.
           compression-level: 0
 
@@ -156,7 +156,7 @@ jobs:
           name: plugins.tsv
           path: ${{ env.BUILD_BASE }}/plugins.tsv
           # We don't really care about this artifact, its presence is a flag to the post-build job.
-          retention-days: 1
+          retention-days: 7
 
       - name: Update reminder with testing instructions
         id: update-reminder-comment
@@ -254,7 +254,7 @@ jobs:
           name: plugins
           path: zips
           # Only need to retain for a day since the beta builder slurps it up to distribute.
-          retention-days: 1
+          retention-days: 7
           # Already compressed.
           compression-level: 0
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -144,7 +144,7 @@ jobs:
         with:
           name: jetpack-build
           path: build.tar.xz
-          # Only need to retain for a day since the beta builder slurps it up to distribute.
+          # Retain trunk builds for 7 days so we can manually download for branch comparisons. Branch builds only need one day so the beta builder can slurp it up to distribute.
           retention-days: ${{ github.ref == 'refs/heads/trunk' && 7 || 1 }}
           # Already compressed.
           compression-level: 0
@@ -156,7 +156,7 @@ jobs:
           name: plugins.tsv
           path: ${{ env.BUILD_BASE }}/plugins.tsv
           # We don't really care about this artifact, its presence is a flag to the post-build job.
-          retention-days: ${{ github.ref == 'refs/heads/trunk' && 7 || 1 }}
+          retention-days: 1
 
       - name: Update reminder with testing instructions
         id: update-reminder-comment
@@ -254,7 +254,7 @@ jobs:
           name: plugins
           path: zips
           # Only need to retain for a day since the beta builder slurps it up to distribute.
-          retention-days: ${{ github.ref == 'refs/heads/trunk' && 7 || 1 }}
+          retention-days: 1
           # Already compressed.
           compression-level: 0
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -145,7 +145,7 @@ jobs:
           name: jetpack-build
           path: build.tar.xz
           # Only need to retain for a day since the beta builder slurps it up to distribute.
-          retention-days: 7
+          retention-days: ${{ github.ref == 'refs/heads/trunk' && 7 || 1 }}
           # Already compressed.
           compression-level: 0
 
@@ -156,7 +156,7 @@ jobs:
           name: plugins.tsv
           path: ${{ env.BUILD_BASE }}/plugins.tsv
           # We don't really care about this artifact, its presence is a flag to the post-build job.
-          retention-days: 7
+          retention-days: ${{ github.ref == 'refs/heads/trunk' && 7 || 1 }}
 
       - name: Update reminder with testing instructions
         id: update-reminder-comment
@@ -254,7 +254,7 @@ jobs:
           name: plugins
           path: zips
           # Only need to retain for a day since the beta builder slurps it up to distribute.
-          retention-days: 7
+          retention-days: ${{ github.ref == 'refs/heads/trunk' && 7 || 1 }}
           # Already compressed.
           compression-level: 0
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Sometimes we need to compare build artifacts between different branches. It's nice when those artifacts are available to download, but currently they expire after one day. This PR increases retention to seven days for trunk builds.

See conversation here: p1747669245685409-slack-C01U2KGS2PQ

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Merge this.
2. Check the build artifacts on this PR every day for 7 days.
3. After the 7th day, they should no longer be available.