### PR TITLE
Sharing service: Prevent various undefined array key warnings

### DIFF
--- a/projects/plugins/jetpack/changelog/update-sharing-service-undefined-array-key
+++ b/projects/plugins/jetpack/changelog/update-sharing-service-undefined-array-key
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Sharing service: Prevent warnings in error logs when certain keys are not set."

--- a/projects/plugins/jetpack/modules/sharedaddy/sharing-service.php
+++ b/projects/plugins/jetpack/modules/sharedaddy/sharing-service.php
@@ -689,7 +689,7 @@ class Sharing_Service_Total {
 		$this->service = $services->get_service( $id );
 		$this->total   = (int) $total;
 
-		if ( is_object( $this->service ) ) {
+		if ( $this->service instanceof Sharing_Source ) {
 			$this->name = $this->service->get_name();
 		}
 	}

--- a/projects/plugins/jetpack/modules/sharedaddy/sharing-service.php
+++ b/projects/plugins/jetpack/modules/sharedaddy/sharing-service.php
@@ -120,8 +120,10 @@ class Sharing_Service {
 		if ( $include_custom ) {
 			// Add any custom services in
 			$options = $this->get_global_options();
-			foreach ( (array) $options['custom'] as $custom_id ) {
-				$services[ $custom_id ] = 'Share_Custom';
+			if ( isset( $options['custom'] ) ) {
+				foreach ( $options['custom'] as $custom_id ) {
+					$services[ $custom_id ] = 'Share_Custom';
+				}
 			}
 		}
 
@@ -313,13 +315,13 @@ class Sharing_Service {
 		}
 
 		// Cleanup after any filters that may have produced duplicate services
-		if ( is_array( $enabled['visible'] ) ) {
+		if ( isset( $enabled['visible'] ) && is_array( $enabled['visible'] ) ) {
 			$enabled['visible'] = array_unique( $enabled['visible'] );
 		} else {
 			$enabled['visible'] = array();
 		}
 
-		if ( is_array( $enabled['hidden'] ) ) {
+		if ( isset( $enabled['hidden'] ) && is_array( $enabled['hidden'] ) ) {
 			$enabled['hidden'] = array_unique( $enabled['hidden'] );
 		} else {
 			$enabled['hidden'] = array();
@@ -499,7 +501,7 @@ class Sharing_Service {
 			}
 		}
 
-		if ( false === $this->global['sharing_label'] || $this->global['sharing_label'] === 'Share this:' ) {
+		if ( ! isset( $this->global['sharing_label'] ) || false === $this->global['sharing_label'] || $this->global['sharing_label'] === 'Share this:' ) {
 			$this->global['sharing_label'] = $this->default_sharing_label;
 		}
 
@@ -687,7 +689,9 @@ class Sharing_Service_Total {
 		$this->service = $services->get_service( $id );
 		$this->total   = (int) $total;
 
-		$this->name = $this->service->get_name();
+		if ( $this->service && is_object( $this->service ) ) {
+			$this->name = $this->service->get_name();
+		}
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/sharedaddy/sharing-service.php
+++ b/projects/plugins/jetpack/modules/sharedaddy/sharing-service.php
@@ -689,7 +689,7 @@ class Sharing_Service_Total {
 		$this->service = $services->get_service( $id );
 		$this->total   = (int) $total;
 
-		if ( $this->service && is_object( $this->service ) ) {
+		if ( is_object( $this->service ) ) {
 			$this->name = $this->service->get_name();
 		}
 	}


### PR DESCRIPTION
Fixes VULCAN-137

## Proposed changes:

* This PR prevents a few undefined array key warnings: `Warning: Undefined array key "sharing_label"`, `Undefined array key "custom"`, `Undefined array key "hidden"`, `Undefined array key "visible"`, as well as a rarer fatal - `Uncaught Error: Call to a member function get_name() on false`
* The approach to fix these is just to check if they are set
* In the case of the fatal, we check to see if `$this->service` an instance of `Sharing_Source`, as it can be an bool.
* Logs: c9a04af81a4f4f4eec9167d272bcbe2f-logstash

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

pdWQjU-1g0-p2

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

I've been unable to replicate the warnings in practice, but it would seem they are likely happening when options are corrupted or not fully initialized. In most cases the warnings can be replicated by modifiying the relevant options values. So, a good way to test this is with a sandboxed Jurassic Ninja site. I recommend using a JN site because we're modifying options (so if you are using the JN site for anything else you may want to note the options when retrieveing them, and reset them back to original values afterwards):
* Create a Jurassic Ninja site using the `?specialops=true` options - make sure to select 'Enable Sandbox access' (you don't need the Jetpack Beta tester plugin).
* Visit Settings > Jetpack Constants, and add your sandbox domain
* Connect Jetpack
* Retrieve your new blog ID from the Jetpack debugger
* Open up your sandbox, and in `wpsh` run the following:
```
switch_to_blog(YOUR_BLOG_ID);
return get_option('sharing-options');
$options['global'] = array()
update_option('sharing-options', $options);
```
* Then visit the Jetpack Stats page (Jetpack > Stats).
* Make sure you are tailing errors - `tail -f /tmp/php-errors` - and you should see undefined array key warnings related to the `custom` and `sharing_label` keys.
* Then, run the following:
```
return get_option('sharing-services');
$services = array();
update_option('sharing-services', $services);
```
* Then visit the Jetpack Stats page again (Jetpack > Stats).
* You should see undefined array key warnings related to the `visible` and `hidden` keys now.

The only other change is the check to see if `$this->service` is an instance of Sharing_Source - this has only occurred twice over the last month, and proof-reading the change should be sufficient. 
* That said the warning can be replicated (`Uncaught Error: Call to a member function get_name() on false`) by directly setting `$this->service` to false [here](https://github.com/Automattic/jetpack/blob/3b228f7d271d03962b442ddc5523aec97f90445a/projects/plugins/jetpack/modules/sharedaddy/sharing-service.php#L689), before we set `$this->name`. 
* You'd be best making the change via moon or sun in your sandbox (whichever is active for testing). 
* Then sandbox a Simple test site and visit the following page: `/wp-admin/admin.php?page=stats`. You should see the warning on trunk
* With the PR applied using the command in the generated comment below, and with `$this->service` still set to false, the warning should not exist.