### PR TITLE
Connection: protected owner class

### DIFF
--- a/projects/plugins/wpcomsh/changelog/add-protected_owner_error_wpcomsh
+++ b/projects/plugins/wpcomsh/changelog/add-protected_owner_error_wpcomsh
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Adding support for protected connection owner.

--- a/projects/plugins/wpcomsh/connection/class-protected-owner-error-handler.php
+++ b/projects/plugins/wpcomsh/connection/class-protected-owner-error-handler.php
@@ -209,28 +209,8 @@ class Protected_Owner_Error_Handler {
 
 		// Output hidden field and JavaScript to prepopulate the form
 		?>
-		<tr class="form-field form-required">
-			<th scope="row">
-				<label for="jetpack_protected_owner_notice">
-					<?php esc_html_e( 'WordPress.com Plan Owner', 'wpcomsh' ); ?>
-				</label>
-			</th>
-			<td>
-				<div class="notice notice-info inline">
-					<p>
-						<?php
-						printf(
-							/* translators: %s is the email address */
-							esc_html__( 'Creating account for WordPress.com plan owner: %s', 'wpcomsh' ),
-							'<strong>' . esc_html( $email ) . '</strong>'
-						);
-						?>
-					</p>
-				</div>
-				<input type="hidden" id="jetpack_prepopulate_email" value="<?php echo esc_attr( $email ); ?>" />
-				<input type="hidden" name="jetpack_create_missing_account" value="1" />
-			</td>
-		</tr>
+		<input type="hidden" id="jetpack_prepopulate_email" value="<?php echo esc_attr( $email ); ?>" />
+		<input type="hidden" name="jetpack_create_missing_account" value="1" />
 		
 		<script type="text/javascript">
 		(function($) {

--- a/projects/plugins/wpcomsh/connection/class-protected-owner-error-handler.php
+++ b/projects/plugins/wpcomsh/connection/class-protected-owner-error-handler.php
@@ -281,7 +281,7 @@ class Protected_Owner_Error_Handler {
 		if ( isset( $_GET['jetpack_protected_owner_email'] ) &&
 			isset( $_GET['jetpack_create_missing_account'] ) ) {
 			$email = sanitize_email( wp_unslash( $_GET['jetpack_protected_owner_email'] ) );
-			if ( is_email( $email ) ) { // phpcs:ignore WordPress.PHP.StrictInArray.Missing -- This is a valid use of is_email
+			if ( is_email( $email ) ) {
 				return $email;
 			}
 		}

--- a/projects/plugins/wpcomsh/connection/class-protected-owner-error-handler.php
+++ b/projects/plugins/wpcomsh/connection/class-protected-owner-error-handler.php
@@ -366,11 +366,12 @@ class Protected_Owner_Error_Handler {
 								type="checkbox"
 								id="invite_user_wpcom"
 								value="1"
+								disabled
 								>
 							<?php esc_html_e( 'Invite user to WordPress.com', 'wpcomsh' ); ?>
 						</label>
 						<p class="description">
-							<?php esc_html_e( 'Note: This user is being created to resolve a problem with your WordPress.com plan. They will be automatically connected to WordPress.com.', 'wpcomsh' ); ?>
+							<?php esc_html_e( 'Note: This user is being created to resolve a problem with your WordPress.com plan. Invitation is not needed.', 'wpcomsh' ); ?>
 						</p>
 					</fieldset>
 				</td>

--- a/projects/plugins/wpcomsh/connection/class-protected-owner-error-handler.php
+++ b/projects/plugins/wpcomsh/connection/class-protected-owner-error-handler.php
@@ -370,7 +370,7 @@ class Protected_Owner_Error_Handler {
 							<?php esc_html_e( 'Invite user to WordPress.com', 'wpcomsh' ); ?>
 						</label>
 						<p class="description">
-							<?php esc_html_e( 'Note: This user is being created to resolve a Jetpack connection issue. You may choose whether to invite them to WordPress.com.', 'wpcomsh' ); ?>
+							<?php esc_html_e( 'Note: This user is being created to resolve a problem with your WordPress.com plan. They will be automatically connected to WordPress.com.', 'wpcomsh' ); ?>
 						</p>
 					</fieldset>
 				</td>

--- a/projects/plugins/wpcomsh/connection/class-protected-owner-error-handler.php
+++ b/projects/plugins/wpcomsh/connection/class-protected-owner-error-handler.php
@@ -212,7 +212,7 @@ class Protected_Owner_Error_Handler {
 		<tr class="form-field form-required">
 			<th scope="row">
 				<label for="jetpack_protected_owner_notice">
-					<?php esc_html_e( 'Jetpack Connection Owner', 'wpcomsh' ); ?>
+					<?php esc_html_e( 'WordPress.com Plan Owner', 'wpcomsh' ); ?>
 				</label>
 			</th>
 			<td>
@@ -221,7 +221,7 @@ class Protected_Owner_Error_Handler {
 						<?php
 						printf(
 							/* translators: %s is the email address */
-							esc_html__( 'Creating account for Jetpack connection owner: %s', 'wpcomsh' ),
+							esc_html__( 'Creating account for WordPress.com plan owner: %s', 'wpcomsh' ),
 							'<strong>' . esc_html( $email ) . '</strong>'
 						);
 						?>
@@ -235,10 +235,11 @@ class Protected_Owner_Error_Handler {
 		<script type="text/javascript">
 		(function($) {
 			$(document).ready(function() {
-				// Prepopulate the email field only
+				// Prepopulate the email field and role
 				var email = $('#jetpack_prepopulate_email').val();
 				if (email) {
 					$('#email').val(email);
+					$('#role').val('administrator');
 					
 					// Ensure invite checkbox is unchecked for protected owner creation
 					$('#invite_user_wpcom').prop('checked', false);

--- a/projects/plugins/wpcomsh/connection/class-protected-owner-error-handler.php
+++ b/projects/plugins/wpcomsh/connection/class-protected-owner-error-handler.php
@@ -288,12 +288,7 @@ class Protected_Owner_Error_Handler {
 		}
 		// phpcs:enable WordPress.Security.NonceVerification.Recommended
 
-		// Check stored error data as fallback
-		$raw_error = $this->get_active_error();
-		if ( $raw_error && isset( $raw_error['email'] ) && is_email( $raw_error['email'] ) ) {
-			return $raw_error['email'];
-		}
-
+		// Only prepopulate when explicitly triggered from dashboard
 		return false;
 	}
 

--- a/projects/plugins/wpcomsh/connection/class-protected-owner-error-handler.php
+++ b/projects/plugins/wpcomsh/connection/class-protected-owner-error-handler.php
@@ -15,6 +15,13 @@ namespace Automattic\WPComSH\Connection;
  *
  * The class automatically clears errors when the required local account is created,
  * allowing external healing code to establish the proper Jetpack connection.
+ *
+ * Additionally, this class provides email prepopulation functionality for the WordPress
+ * user creation form when creating missing protected owner accounts. It overrides the
+ * default User_Admin class behavior to ensure the WP.com invitation checkbox is not
+ * pre-checked when creating protected owner accounts.
+ *
+ * @since $$next-version$$
  */
 class Protected_Owner_Error_Handler {
 
@@ -42,6 +49,11 @@ class Protected_Owner_Error_Handler {
 		// Clear errors when the missing user is created or updated (allows external healing code to work)
 		add_action( 'user_register', array( $this, 'check_and_clear_error_for_user' ) );
 		add_action( 'profile_update', array( $this, 'check_and_clear_error_for_user' ) );
+
+		// Add form prepopulation functionality - run before User_Admin class (priority 0)
+		add_action( 'user_new_form', array( $this, 'override_wpcom_invite_checkbox' ), 0 );
+		add_action( 'user_new_form', array( $this, 'prepopulate_user_form' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_form_scripts' ) );
 	}
 
 	/**
@@ -183,5 +195,211 @@ class Protected_Owner_Error_Handler {
 			// Clear the error so external healing code can establish the connection
 			$this->delete_error();
 		}
+	}
+
+	/**
+	 * Add form prepopulation functionality
+	 */
+	public function prepopulate_user_form() {
+		$email = $this->get_prepopulation_email();
+
+		if ( ! $email ) {
+			return;
+		}
+
+		// Output hidden field and JavaScript to prepopulate the form
+		?>
+		<tr class="form-field form-required">
+			<th scope="row">
+				<label for="jetpack_protected_owner_notice">
+					<?php esc_html_e( 'Jetpack Connection Owner', 'wpcomsh' ); ?>
+				</label>
+			</th>
+			<td>
+				<div class="notice notice-info inline">
+					<p>
+						<?php
+						printf(
+							/* translators: %s is the email address */
+							esc_html__( 'Creating account for Jetpack connection owner: %s', 'wpcomsh' ),
+							'<strong>' . esc_html( $email ) . '</strong>'
+						);
+						?>
+					</p>
+				</div>
+				<input type="hidden" id="jetpack_prepopulate_email" value="<?php echo esc_attr( $email ); ?>" />
+				<input type="hidden" name="jetpack_create_missing_account" value="1" />
+			</td>
+		</tr>
+		
+		<script type="text/javascript">
+		(function($) {
+			$(document).ready(function() {
+				// Prepopulate the email field only
+				var email = $('#jetpack_prepopulate_email').val();
+				if (email) {
+					$('#email').val(email);
+					
+					// Ensure invite checkbox is unchecked for protected owner creation
+					$('#invite_user_wpcom').prop('checked', false);
+				}
+			});
+		})(jQuery);
+		</script>
+		<?php
+	}
+
+	/**
+	 * Enqueue form scripts
+	 *
+	 * @param string $hook The current admin page hook.
+	 */
+	public function enqueue_form_scripts( $hook ) {
+		// Only load on user-new.php page
+		if ( 'user-new.php' !== $hook ) {
+			return;
+		}
+
+		// Only enqueue if we have an email to prepopulate
+		$email = $this->get_prepopulation_email();
+		if ( ! $email ) {
+			return;
+		}
+
+		// Enqueue jQuery (should already be available in admin)
+		wp_enqueue_script( 'jquery' );
+	}
+
+	/**
+	 * Get the email address for prepopulation from various sources
+	 *
+	 * @return string|false Email address if available, false otherwise
+	 */
+	private function get_prepopulation_email() {
+		// Check URL parameters first (from React component)
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended -- URL parameters are read-only for prepopulation, no sensitive actions performed
+		if ( isset( $_GET['jetpack_protected_owner_email'] ) &&
+			isset( $_GET['jetpack_create_missing_account'] ) ) {
+			$email = sanitize_email( wp_unslash( $_GET['jetpack_protected_owner_email'] ) );
+			if ( is_email( $email ) ) { // phpcs:ignore WordPress.PHP.StrictInArray.Missing -- This is a valid use of is_email
+				return $email;
+			}
+		}
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
+
+		// Check stored error data as fallback
+		$raw_error = $this->get_active_error();
+		if ( $raw_error && isset( $raw_error['email'] ) && is_email( $raw_error['email'] ) ) {
+			return $raw_error['email'];
+		}
+
+		return false;
+	}
+
+	/**
+	 * Override the WP.com invite checkbox behavior when creating a missing protected user
+	 *
+	 * This method runs before the User_Admin class hook (priority 0) to override
+	 * the default checkbox behavior when we're creating a missing protected owner account.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param string $type The type of new user form the hook follows.
+	 */
+	public function override_wpcom_invite_checkbox( $type ) {
+		// Only override for add-new-user form type
+		if ( 'add-new-user' !== $type ) {
+			return;
+		}
+
+		// Check if we're in a protected owner creation context
+		$email = $this->get_prepopulation_email();
+		if ( ! $email ) {
+			return; // Not a protected owner creation, let the default behavior proceed
+		}
+
+		// Remove the User_Admin hook that would pre-check the invitation checkbox
+		$this->remove_user_admin_invite_checkbox_hook();
+
+		// Add our own version that ensures the checkbox is unchecked
+		add_action( 'user_new_form', array( $this, 'render_unchecked_wpcom_invite_checkbox' ), 1 );
+	}
+
+	/**
+	 * Remove the User_Admin class hook that renders the invite checkbox
+	 *
+	 * This is necessary to prevent the default pre-checked behavior for protected owner creation.
+	 *
+	 * @since $$next-version$$
+	 */
+	private function remove_user_admin_invite_checkbox_hook() {
+		// Get all hooked functions for the user_new_form action
+		global $wp_filter;
+
+		if ( ! isset( $wp_filter['user_new_form'] ) ) {
+			return;
+		}
+
+		// Look for the User_Admin class hook at priority 1
+		if ( isset( $wp_filter['user_new_form']->callbacks[1] ) ) {
+			foreach ( $wp_filter['user_new_form']->callbacks[1] as $callback ) {
+				// Check if this is the User_Admin render_wpcom_invite_checkbox method
+				if (
+					is_array( $callback['function'] ) &&
+					is_object( $callback['function'][0] ) &&
+					get_class( $callback['function'][0] ) === 'Automattic\Jetpack\Connection\SSO\User_Admin' &&
+					$callback['function'][1] === 'render_wpcom_invite_checkbox'
+				) {
+					// Remove the hook
+					remove_action( 'user_new_form', $callback['function'], 1 );
+					break;
+				}
+			}
+		}
+	}
+
+	/**
+	 * Render the WP.com invite checkbox in an unchecked state for protected owner creation
+	 *
+	 * This replaces the User_Admin method to ensure the checkbox is not pre-checked
+	 * when creating a missing protected owner account.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param string $type The type of new user form the hook follows.
+	 */
+	public function render_unchecked_wpcom_invite_checkbox( $type ) {
+		if ( 'add-new-user' !== $type ) {
+			return;
+		}
+
+		?>
+		<table class="form-table">
+			<tr class="form-field">
+				<th scope="row">
+					<label for="invite_user_wpcom"><?php esc_html_e( 'Invite user', 'wpcomsh' ); ?></label>
+				</th>
+				<td>
+					<fieldset>
+						<legend class="screen-reader-text">
+							<span><?php esc_html_e( 'Invite user', 'wpcomsh' ); ?></span>
+						</legend>
+						<label for="invite_user_wpcom">
+							<input
+								name="invite_user_wpcom"
+								type="checkbox"
+								id="invite_user_wpcom"
+								value="1"
+								>
+							<?php esc_html_e( 'Invite user to WordPress.com', 'wpcomsh' ); ?>
+						</label>
+						<p class="description">
+							<?php esc_html_e( 'Note: This user is being created to resolve a Jetpack connection issue. You may choose whether to invite them to WordPress.com.', 'wpcomsh' ); ?>
+						</p>
+					</fieldset>
+				</td>
+			</tr>
+		</table>
+		<?php
 	}
 }

--- a/projects/plugins/wpcomsh/connection/class-protected-owner-error-handler.php
+++ b/projects/plugins/wpcomsh/connection/class-protected-owner-error-handler.php
@@ -50,10 +50,12 @@ class Protected_Owner_Error_Handler {
 		add_action( 'user_register', array( $this, 'check_and_clear_error_for_user' ) );
 		add_action( 'profile_update', array( $this, 'check_and_clear_error_for_user' ) );
 
-		// Add form prepopulation functionality - run before User_Admin class (priority 0)
-		add_action( 'user_new_form', array( $this, 'override_wpcom_invite_checkbox' ), 0 );
+		// Add form prepopulation functionality
 		add_action( 'user_new_form', array( $this, 'prepopulate_user_form' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_form_scripts' ) );
+
+		// Disable WordPress.com invitations when creating protected owner accounts
+		add_filter( 'jetpack_sso_invite_new_users_wpcom', array( $this, 'disable_wpcom_invite_for_protected_owner' ) );
 	}
 
 	/**
@@ -220,9 +222,6 @@ class Protected_Owner_Error_Handler {
 				if (email) {
 					$('#email').val(email);
 					$('#role').val('administrator');
-					
-					// Ensure invite checkbox is unchecked for protected owner creation
-					$('#invite_user_wpcom').prop('checked', false);
 				}
 			});
 		})(jQuery);
@@ -273,110 +272,19 @@ class Protected_Owner_Error_Handler {
 	}
 
 	/**
-	 * Override the WP.com invite checkbox behavior when creating a missing protected user
+	 * Disable WordPress.com invitations when creating protected owner accounts
 	 *
-	 * This method runs before the User_Admin class hook (priority 0) to override
-	 * the default checkbox behavior when we're creating a missing protected owner account.
-	 *
-	 * @since $$next-version$$
-	 *
-	 * @param string $type The type of new user form the hook follows.
+	 * @param bool $invite_new_users_wpcom Whether to invite new users to WordPress.com.
+	 * @return bool Updated value indicating whether to invite new users to WordPress.com.
 	 */
-	public function override_wpcom_invite_checkbox( $type ) {
-		// Only override for add-new-user form type
-		if ( 'add-new-user' !== $type ) {
-			return;
-		}
-
+	public function disable_wpcom_invite_for_protected_owner( $invite_new_users_wpcom ) {
 		// Check if we're in a protected owner creation context
 		$email = $this->get_prepopulation_email();
 		if ( ! $email ) {
-			return; // Not a protected owner creation, let the default behavior proceed
+			return $invite_new_users_wpcom; // Not a protected owner creation, let the default behavior proceed
 		}
 
-		// Remove the User_Admin hook that would pre-check the invitation checkbox
-		$this->remove_user_admin_invite_checkbox_hook();
-
-		// Add our own version that ensures the checkbox is unchecked
-		add_action( 'user_new_form', array( $this, 'render_unchecked_wpcom_invite_checkbox' ), 1 );
-	}
-
-	/**
-	 * Remove the User_Admin class hook that renders the invite checkbox
-	 *
-	 * This is necessary to prevent the default pre-checked behavior for protected owner creation.
-	 *
-	 * @since $$next-version$$
-	 */
-	private function remove_user_admin_invite_checkbox_hook() {
-		// Get all hooked functions for the user_new_form action
-		global $wp_filter;
-
-		if ( ! isset( $wp_filter['user_new_form'] ) ) {
-			return;
-		}
-
-		// Look for the User_Admin class hook at priority 1
-		if ( isset( $wp_filter['user_new_form']->callbacks[1] ) ) {
-			foreach ( $wp_filter['user_new_form']->callbacks[1] as $callback ) {
-				// Check if this is the User_Admin render_wpcom_invite_checkbox method
-				if (
-					is_array( $callback['function'] ) &&
-					is_object( $callback['function'][0] ) &&
-					get_class( $callback['function'][0] ) === 'Automattic\Jetpack\Connection\SSO\User_Admin' &&
-					$callback['function'][1] === 'render_wpcom_invite_checkbox'
-				) {
-					// Remove the hook
-					remove_action( 'user_new_form', $callback['function'], 1 );
-					break;
-				}
-			}
-		}
-	}
-
-	/**
-	 * Render the WP.com invite checkbox in an unchecked state for protected owner creation
-	 *
-	 * This replaces the User_Admin method to ensure the checkbox is not pre-checked
-	 * when creating a missing protected owner account.
-	 *
-	 * @since $$next-version$$
-	 *
-	 * @param string $type The type of new user form the hook follows.
-	 */
-	public function render_unchecked_wpcom_invite_checkbox( $type ) {
-		if ( 'add-new-user' !== $type ) {
-			return;
-		}
-
-		?>
-		<table class="form-table">
-			<tr class="form-field">
-				<th scope="row">
-					<label for="invite_user_wpcom"><?php esc_html_e( 'Invite user', 'wpcomsh' ); ?></label>
-				</th>
-				<td>
-					<fieldset>
-						<legend class="screen-reader-text">
-							<span><?php esc_html_e( 'Invite user', 'wpcomsh' ); ?></span>
-						</legend>
-						<label for="invite_user_wpcom">
-							<input
-								name="invite_user_wpcom"
-								type="checkbox"
-								id="invite_user_wpcom"
-								value="1"
-								disabled
-								>
-							<?php esc_html_e( 'Invite user to WordPress.com', 'wpcomsh' ); ?>
-						</label>
-						<p class="description">
-							<?php esc_html_e( 'Note: This user is being created to resolve a problem with your WordPress.com plan. Invitation is not needed.', 'wpcomsh' ); ?>
-						</p>
-					</fieldset>
-				</td>
-			</tr>
-		</table>
-		<?php
+		// Disable invitations for protected owner creation
+		return false;
 	}
 }

--- a/projects/plugins/wpcomsh/connection/class-protected-owner-error-handler.php
+++ b/projects/plugins/wpcomsh/connection/class-protected-owner-error-handler.php
@@ -52,7 +52,6 @@ class Protected_Owner_Error_Handler {
 
 		// Add form prepopulation functionality
 		add_action( 'user_new_form', array( $this, 'prepopulate_user_form' ) );
-		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_form_scripts' ) );
 
 		// Disable WordPress.com invitations when creating protected owner accounts
 		add_filter( 'jetpack_sso_invite_new_users_wpcom', array( $this, 'disable_wpcom_invite_for_protected_owner' ) );
@@ -215,39 +214,25 @@ class Protected_Owner_Error_Handler {
 		<input type="hidden" name="jetpack_create_missing_account" value="1" />
 		
 		<script type="text/javascript">
-		(function($) {
-			$(document).ready(function() {
+		(function() {
+			document.addEventListener('DOMContentLoaded', function() {
 				// Prepopulate the email field and role
-				var email = $('#jetpack_prepopulate_email').val();
-				if (email) {
-					$('#email').val(email);
-					$('#role').val('administrator');
+				var emailInput = document.getElementById('jetpack_prepopulate_email');
+				if (emailInput && emailInput.value) {
+					var emailField = document.getElementById('email');
+					var roleField = document.getElementById('role');
+					
+					if (emailField) {
+						emailField.value = emailInput.value;
+					}
+					if (roleField) {
+						roleField.value = 'administrator';
+					}
 				}
 			});
-		})(jQuery);
+		})();
 		</script>
 		<?php
-	}
-
-	/**
-	 * Enqueue form scripts
-	 *
-	 * @param string $hook The current admin page hook.
-	 */
-	public function enqueue_form_scripts( $hook ) {
-		// Only load on user-new.php page
-		if ( 'user-new.php' !== $hook ) {
-			return;
-		}
-
-		// Only enqueue if we have an email to prepopulate
-		$email = $this->get_prepopulation_email();
-		if ( ! $email ) {
-			return;
-		}
-
-		// Enqueue jQuery (should already be available in admin)
-		wp_enqueue_script( 'jquery' );
 	}
 
 	/**

--- a/projects/plugins/wpcomsh/connection/class-protected-owner-error-handler.php
+++ b/projects/plugins/wpcomsh/connection/class-protected-owner-error-handler.php
@@ -36,6 +36,12 @@ class Protected_Owner_Error_Handler {
 	 * Initialize instance and register hooks
 	 */
 	private function __construct() {
+		// Inject protected owner errors into the connection error system
+		add_filter( 'jetpack_connection_get_verified_errors', array( $this, 'handle_error' ) );
+
+		// Add React dashboard integration for protected owner errors
+		add_filter( 'react_connection_errors_initial_state', array( $this, 'add_to_react_dashboard' ) );
+
 		// Clear errors on reconnection or token updates
 		add_action( 'jetpack_site_registered', array( $this, 'delete_error' ) );
 		add_filter( 'jetpack_connection_disconnect_site_wpcom', array( $this, 'delete_error_and_return_unfiltered_value' ) );
@@ -44,11 +50,8 @@ class Protected_Owner_Error_Handler {
 		add_action( 'jetpack_updated_user_token', array( $this, 'delete_error' ) );
 
 		// Clear errors when the missing user is created or updated (allows external healing code to work)
-		add_action( 'user_register', array( $this, 'check_and_clear_error_on_user_creation' ) );
-		add_action( 'profile_update', array( $this, 'check_and_clear_error_on_user_update' ) );
-
-		// Handle context-specific error integration
-		add_action( 'admin_enqueue_scripts', array( $this, 'setup_context_specific_error_handling' ) );
+		add_action( 'user_register', array( $this, 'check_and_clear_error_for_user' ) );
+		add_action( 'profile_update', array( $this, 'check_and_clear_error_for_user' ) );
 	}
 
 	/**
@@ -64,12 +67,12 @@ class Protected_Owner_Error_Handler {
 	}
 
 	/**
-	 * Get the stored error from the database and process it for My Jetpack (verified errors format)
+	 * Check if there's an active protected owner error
 	 *
-	 * @return array|false The verified errors array or false if no error is stored or valid.
+	 * @return array|false Raw error data if there's an active error, false otherwise.
 	 */
-	public function get_error() {
-		// Get the raw error data from the option
+	private function get_active_error() {
+		// Check if option is populated
 		$raw_error = get_option( self::STORED_ERRORS_OPTION, false );
 
 		// Return early if no error is stored
@@ -82,27 +85,43 @@ class Protected_Owner_Error_Handler {
 			return false;
 		}
 
-		// Get the master user (connection owner) ID
-		$master_user_id = \Jetpack_Options::get_option( 'master_user' );
-		$master_user    = $master_user_id ? get_user_by( 'id', $master_user_id ) : false;
-
-		// Determine the error code based on error_type and current connection state
-		$error_code = $this->determine_error_code( $raw_error, $master_user );
-
-		// If error_code is false, no valid error condition exists
-		if ( ! $error_code ) {
+		// Check if user exists with the required email
+		$user = get_user_by( 'email', $raw_error['email'] );
+		if ( $user ) {
+			// User exists, delete the option and return false (no active error)
 			$this->delete_error();
 			return false;
 		}
 
-		// Prepare error data for My Jetpack (verified errors format)
+		// User doesn't exist, we have an active error
+		return $raw_error;
+	}
+
+	/**
+	 * Handle protected owner errors in the connection error system
+	 *
+	 * @param array $verified_errors Current verified errors.
+	 * @return array Updated verified errors including protected owner errors.
+	 */
+	public function handle_error( $verified_errors ) {
+		$raw_error = $this->get_active_error();
+
+		// Return early if no active error
+		if ( ! $raw_error ) {
+			return $verified_errors;
+		}
+
+		// Use a consistent error code for all protected owner errors
+		$error_code = 'protected_owner_missing';
+
+		// Prepare error data for the connection error system
 		$user_id   = $raw_error['protected_owner_local_id'] ?? '0';
 		$timestamp = $raw_error['timestamp'] ?? time();
 
 		$error_details = array(
 			'error_code'    => $error_code,
 			'user_id'       => $user_id,
-			'error_message' => $this->get_error_message( $error_code, $raw_error['email'] ),
+			'error_message' => $this->get_error_message( $raw_error['email'] ),
 			'error_data'    => array(
 				'email'      => $raw_error['email'],
 				'error_type' => $raw_error['error_type'],
@@ -112,7 +131,8 @@ class Protected_Owner_Error_Handler {
 			'error_type'    => 'protected_owner',
 		);
 
-		// Return in verified errors format for My Jetpack
+		// Return only the protected owner error - it takes priority over other connection errors
+		// since it's typically the root cause and other errors may be symptoms
 		return array(
 			$error_code => array(
 				$user_id => $error_details,
@@ -121,64 +141,57 @@ class Protected_Owner_Error_Handler {
 	}
 
 	/**
-	 * Determine the error code based on the raw error data and current connection state
+	 * Get a user-friendly error message for protected owner errors
 	 *
-	 * @param array         $raw_error      The raw error data.
-	 * @param \WP_User|bool $master_user The master user object or false if not exists.
-	 * @return string|false The determined error code or false if no valid error.
-	 */
-	private function determine_error_code( $raw_error, $master_user ) {
-		$error_type = $raw_error['error_type'];
-
-		// Handle missing_owner error type
-		if ( 'missing_owner' === $error_type ) {
-			if ( $master_user ) {
-				// Master user exists, so the protected owner is missing but someone is connected
-				return 'wrong_owner_protected_owner_missing';
-			} else {
-				// No master user, completely missing connection owner
-				return 'no_user_connection_protected_owner_missing';
-			}
-		}
-
-		// Unrecognized error type
-		return false;
-	}
-
-	/**
-	 * Get a user-friendly error message based on the error type
-	 *
-	 * @param string $error_type The type of error.
 	 * @param string $email The WordPress.com email address of the protected owner.
 	 * @return string The error message.
 	 */
-	protected function get_error_message( $error_type, $email ) {
-		// Use plain text for the email - frontend will handle styling
-		$email_text = esc_html( $email );
+	private function get_error_message( $email ) {
+		return sprintf(
+			// translators: %s is the WordPress.com email address
+			__( 'This site needs to be connected to WordPress.com by the plan owner account with email %s. Please create the missing account to resolve this issue.', 'wpcomsh' ),
+			esc_html( $email )
+		);
+	}
 
-		// Fix explanation for manual account creation only
-		$fix_explanation = ' ' . __( 'Please create the missing account to resolve this issue.', 'wpcomsh' );
+	/**
+	 * Add protected owner error to React dashboard
+	 *
+	 * @param array $errors Current errors for React dashboard.
+	 * @return array Updated errors including protected owner error.
+	 */
+	public function add_to_react_dashboard( $errors ) {
+		$raw_error = $this->get_active_error();
 
-		switch ( $error_type ) {
-			case 'wrong_owner_protected_owner_missing':
-				return sprintf(
-					// translators: %s is the WordPress.com email address
-					__( 'This site is connected, but the WordPress.com plan owner with email %s is missing.', 'wpcomsh' ),
-					$email_text
-				) . $fix_explanation;
-			case 'no_user_connection_protected_owner_missing':
-				return sprintf(
-					// translators: %s is the WordPress.com email address
-					__( 'This site needs to be connected to WordPress.com by the plan owner account with email %s.', 'wpcomsh' ),
-					$email_text
-				) . $fix_explanation;
-			default:
-				return sprintf(
-					// translators: %s is the WordPress.com email address
-					__( 'There is an issue with the connection owner for this site. The WordPress.com plan owner email is %s.', 'wpcomsh' ),
-					$email_text
-				) . $fix_explanation;
+		// Return early if no active error
+		if ( ! $raw_error ) {
+			return $errors;
 		}
+
+		// Ensure errors is an array
+		$errors = is_array( $errors ) ? $errors : array();
+
+		// Add the protected owner error
+		$errors[] = array(
+			'code'         => 'protected_owner_missing',
+			'message'      => $this->get_error_message( $raw_error['email'] ),
+			'action'       => 'protected_owner_action',
+			'action_links' => array(
+				array(
+					'title'     => __( 'Create missing account', 'wpcomsh' ),
+					'action'    => 'create_missing_account',
+					'errorCode' => 'protected_owner_missing',
+					'errorData' => array(
+						'email'      => $raw_error['email'],
+						'error_type' => $raw_error['error_type'],
+					),
+					'variant'   => 'primary',
+				),
+			),
+			'can_be_fixed' => true,
+		);
+
+		return $errors;
 	}
 
 	/**
@@ -186,6 +199,32 @@ class Protected_Owner_Error_Handler {
 	 */
 	public function delete_error() {
 		delete_option( self::STORED_ERRORS_OPTION );
+
+		// Also clear our error from Jetpack's verified errors since we injected it there
+		$this->clear_from_verified_errors();
+	}
+
+	/**
+	 * Clear protected owner errors from Jetpack's verified errors
+	 */
+	private function clear_from_verified_errors() {
+		$verified_errors = get_option( 'jetpack_connection_xmlrpc_verified_errors', array() );
+
+		if ( ! is_array( $verified_errors ) ) {
+			return;
+		}
+
+		// Remove our error code from verified errors
+		if ( isset( $verified_errors['protected_owner_missing'] ) ) {
+			unset( $verified_errors['protected_owner_missing'] );
+
+			// Update the option with our error removed
+			if ( empty( $verified_errors ) ) {
+				delete_option( 'jetpack_connection_xmlrpc_verified_errors' );
+			} else {
+				update_option( 'jetpack_connection_xmlrpc_verified_errors', $verified_errors );
+			}
+		}
 	}
 
 	/**
@@ -201,131 +240,12 @@ class Protected_Owner_Error_Handler {
 	}
 
 	/**
-	 * Handle context-specific error integration
-	 */
-	public function setup_context_specific_error_handling() {
-		// Only proceed if we have an error to display
-		if ( ! $this->get_error() ) {
-			return;
-		}
-
-		// Detect the current admin page context
-		$current_screen = get_current_screen();
-
-		// Handle My Jetpack context
-		if ( 'jetpack_page_my-jetpack' === $current_screen->id ) {
-			$this->setup_my_jetpack_error_handling();
-		} elseif ( in_array( $current_screen->id, array( 'admin_page_jetpack', 'toplevel_page_jetpack' ), true ) ) {
-			// Handle main Jetpack Dashboard context
-			$this->setup_jetpack_dashboard_error_handling();
-		}
-	}
-
-	/**
-	 * Setup error handling for My Jetpack context
-	 */
-	private function setup_my_jetpack_error_handling() {
-		// For My Jetpack, inject errors directly into Error_Handler's verified errors
-		add_filter( 'jetpack_connection_get_verified_errors', array( $this, 'add_to_verified_errors' ) );
-	}
-
-	/**
-	 * Setup error handling for Jetpack Dashboard context
-	 */
-	private function setup_jetpack_dashboard_error_handling() {
-		// For Jetpack Dashboard, use the existing react_connection_errors_initial_state filter
-		add_filter( 'react_connection_errors_initial_state', array( $this, 'add_to_react_connection_errors' ) );
-	}
-
-	/**
-	 * Add protected owner error to Error_Handler's verified errors
-	 *
-	 * @param array $verified_errors Current verified errors.
-	 * @return array Updated verified errors including protected owner errors.
-	 */
-	public function add_to_verified_errors( $verified_errors ) {
-		$protected_owner_error = $this->get_error();
-
-		// Return early if no error
-		if ( ! $protected_owner_error ) {
-			return $verified_errors;
-		}
-
-		// Return only the protected owner error - it takes priority over other connection errors
-		// since it's typically the root cause and other errors may be symptoms
-		return $protected_owner_error;
-	}
-
-	/**
-	 * Add protected owner errors to the react connection errors initial state
-	 *
-	 * @param array $errors Current errors.
-	 * @return array Updated errors including protected owner errors.
-	 */
-	public function add_to_react_connection_errors( $errors ) {
-		$verified_errors = $this->get_error();
-
-		// Return early if no error
-		if ( ! $verified_errors ) {
-			return $errors;
-		}
-
-		// Ensure errors is an array
-		$errors = is_array( $errors ) ? $errors : array();
-
-		// Extract the first error from verified errors format
-		$error_code    = key( $verified_errors );
-		$user_errors   = reset( $verified_errors );
-		$error_details = reset( $user_errors );
-
-		$error_data = $error_details['error_data'];
-
-		// Add error with only the "Create missing account" action
-		$errors[] = array(
-			'code'         => 'protected_owner_' . $error_code,
-			'message'      => $error_details['error_message'],
-			'action'       => 'protected_owner_action',
-			'action_links' => array(
-				array(
-					'title'     => __( 'Create missing account', 'wpcomsh' ),
-					'action'    => 'create_missing_account',
-					'errorCode' => $error_code,
-					'errorData' => $error_data,
-					'variant'   => 'primary',
-				),
-			),
-			'raw_error'    => $error_details,
-			'can_be_fixed' => true,
-		);
-
-		return $errors;
-	}
-
-	/**
-	 * Clear the error when a user with the required email address is created
-	 *
-	 * @param int $user_id The ID of the newly created user.
-	 */
-	public function check_and_clear_error_on_user_creation( $user_id ) {
-		$this->check_and_clear_error_for_user( $user_id );
-	}
-
-	/**
-	 * Clear the error when a user with the required email address is updated
-	 *
-	 * @param int $user_id The ID of the updated user.
-	 */
-	public function check_and_clear_error_on_user_update( $user_id ) {
-		$this->check_and_clear_error_for_user( $user_id );
-	}
-
-	/**
 	 * Check if the user matches the protected owner error and clear it if so
 	 * This allows external healing code to automatically establish the connection
 	 *
 	 * @param int $user_id The ID of the user to check.
 	 */
-	private function check_and_clear_error_for_user( $user_id ) {
+	public function check_and_clear_error_for_user( $user_id ) {
 		// Get the raw error data to check the email
 		$raw_error = get_option( self::STORED_ERRORS_OPTION, false );
 

--- a/projects/plugins/wpcomsh/connection/class-protected-owner-error-handler.php
+++ b/projects/plugins/wpcomsh/connection/class-protected-owner-error-handler.php
@@ -163,7 +163,7 @@ class Protected_Owner_Error_Handler {
 			case 'wrong_owner_protected_owner_missing':
 				return sprintf(
 					// translators: %s is the WordPress.com email address
-					__( 'This site is connected to WordPress.com, but the WordPress.com plan owner with email %s is missing.', 'wpcomsh' ),
+					__( 'This site is connected, but the WordPress.com plan owner with email %s is missing.', 'wpcomsh' ),
 					$email_text
 				) . $fix_explanation;
 			case 'no_user_connection_protected_owner_missing':

--- a/projects/plugins/wpcomsh/connection/class-protected-owner-error-handler.php
+++ b/projects/plugins/wpcomsh/connection/class-protected-owner-error-handler.php
@@ -78,7 +78,7 @@ class Protected_Owner_Error_Handler {
 		}
 
 		// Validate the minimal required fields
-		if ( ! isset( $raw_error['error_type'] ) || ! isset( $raw_error['wpcom_email'] ) ) {
+		if ( ! isset( $raw_error['error_type'] ) || ! isset( $raw_error['email'] ) ) {
 			return false;
 		}
 
@@ -96,16 +96,16 @@ class Protected_Owner_Error_Handler {
 		}
 
 		// Prepare error data for My Jetpack (verified errors format)
-		$user_id   = isset( $raw_error['protected_owner_local_id'] ) ? $raw_error['protected_owner_local_id'] : '0';
-		$timestamp = isset( $raw_error['timestamp'] ) ? $raw_error['timestamp'] : time();
+		$user_id   = $raw_error['protected_owner_local_id'] ?? '0';
+		$timestamp = $raw_error['timestamp'] ?? time();
 
 		$error_details = array(
 			'error_code'    => $error_code,
 			'user_id'       => $user_id,
-			'error_message' => $this->get_error_message( $error_code, $raw_error['wpcom_email'] ),
+			'error_message' => $this->get_error_message( $error_code, $raw_error['email'] ),
 			'error_data'    => array(
-				'wpcom_email' => $raw_error['wpcom_email'],
-				'error_type'  => $raw_error['error_type'],
+				'email'      => $raw_error['email'],
+				'error_type' => $raw_error['error_type'],
 			),
 			'timestamp'     => $timestamp,
 			'nonce'         => wp_generate_password( 10, false ),
@@ -123,8 +123,8 @@ class Protected_Owner_Error_Handler {
 	/**
 	 * Determine the error code based on the raw error data and current connection state
 	 *
-	 * @param array        $raw_error      The raw error data.
-	 * @param WP_User|bool $master_user The master user object or false if not exists.
+	 * @param array         $raw_error      The raw error data.
+	 * @param \WP_User|bool $master_user The master user object or false if not exists.
 	 * @return string|false The determined error code or false if no valid error.
 	 */
 	private function determine_error_code( $raw_error, $master_user ) {
@@ -149,12 +149,12 @@ class Protected_Owner_Error_Handler {
 	 * Get a user-friendly error message based on the error type
 	 *
 	 * @param string $error_type The type of error.
-	 * @param string $wpcom_email The WordPress.com email address of the protected owner.
+	 * @param string $email The WordPress.com email address of the protected owner.
 	 * @return string The error message.
 	 */
-	protected function get_error_message( $error_type, $wpcom_email ) {
+	protected function get_error_message( $error_type, $email ) {
 		// Use plain text for the email - frontend will handle styling
-		$email_text = esc_html( $wpcom_email );
+		$email_text = esc_html( $email );
 
 		// Fix explanation for manual account creation only
 		$fix_explanation = ' ' . __( 'Please create the missing account to resolve this issue.', 'wpcomsh' );
@@ -326,11 +326,11 @@ class Protected_Owner_Error_Handler {
 	 * @param int $user_id The ID of the user to check.
 	 */
 	private function check_and_clear_error_for_user( $user_id ) {
-		// Get the raw error data to check the wpcom_email
+		// Get the raw error data to check the email
 		$raw_error = get_option( self::STORED_ERRORS_OPTION, false );
 
 		// Return early if no error is stored
-		if ( ! $raw_error || ! is_array( $raw_error ) || ! isset( $raw_error['wpcom_email'] ) ) {
+		if ( ! $raw_error || ! is_array( $raw_error ) || ! isset( $raw_error['email'] ) ) {
 			return;
 		}
 
@@ -340,8 +340,8 @@ class Protected_Owner_Error_Handler {
 			return;
 		}
 
-		// Check if the user's email matches the required wpcom_email
-		if ( strtolower( $user->user_email ) === strtolower( $raw_error['wpcom_email'] ) ) {
+		// Check if the user's email matches the required email
+		if ( strtolower( $user->user_email ) === strtolower( $raw_error['email'] ) ) {
 			// The user with the required email has been created/updated
 			// Clear the error so external healing code can establish the connection
 			$this->delete_error();

--- a/projects/plugins/wpcomsh/connection/class-protected-owner-error-handler.php
+++ b/projects/plugins/wpcomsh/connection/class-protected-owner-error-handler.php
@@ -39,16 +39,6 @@ class Protected_Owner_Error_Handler {
 		// Inject protected owner errors into the connection error system
 		add_filter( 'jetpack_connection_get_verified_errors', array( $this, 'handle_error' ) );
 
-		// Add React dashboard integration for protected owner errors
-		add_filter( 'react_connection_errors_initial_state', array( $this, 'add_to_react_dashboard' ) );
-
-		// Clear errors on reconnection or token updates
-		add_action( 'jetpack_site_registered', array( $this, 'delete_error' ) );
-		add_filter( 'jetpack_connection_disconnect_site_wpcom', array( $this, 'delete_error_and_return_unfiltered_value' ) );
-		add_filter( 'jetpack_connection_delete_all_tokens', array( $this, 'delete_error_and_return_unfiltered_value' ) );
-		add_action( 'jetpack_unlinked_user', array( $this, 'delete_error' ) );
-		add_action( 'jetpack_updated_user_token', array( $this, 'delete_error' ) );
-
 		// Clear errors when the missing user is created or updated (allows external healing code to work)
 		add_action( 'user_register', array( $this, 'check_and_clear_error_for_user' ) );
 		add_action( 'profile_update', array( $this, 'check_and_clear_error_for_user' ) );
@@ -123,8 +113,10 @@ class Protected_Owner_Error_Handler {
 			'user_id'       => $user_id,
 			'error_message' => $this->get_error_message( $raw_error['email'] ),
 			'error_data'    => array(
-				'email'      => $raw_error['email'],
-				'error_type' => $raw_error['error_type'],
+				'email'       => $raw_error['email'],
+				'error_type'  => $raw_error['error_type'],
+				'action'      => 'create_missing_account',
+				'support_url' => admin_url( 'user-new.php' ),
 			),
 			'timestamp'     => $timestamp,
 			'nonce'         => wp_generate_password( 10, false ),
@@ -148,50 +140,10 @@ class Protected_Owner_Error_Handler {
 	 */
 	private function get_error_message( $email ) {
 		return sprintf(
-			// translators: %s is the WordPress.com email address
-			__( 'This site needs to be connected to WordPress.com by the plan owner account with email %s. Please create the missing account to resolve this issue.', 'wpcomsh' ),
+			/* translators: %s is the WordPress.com email address */
+			__( 'This site needs to be connected to WordPress.com by the plan owner account with email %s. Please create a local user account with this email address to resolve this issue.', 'wpcomsh' ),
 			esc_html( $email )
 		);
-	}
-
-	/**
-	 * Add protected owner error to React dashboard
-	 *
-	 * @param array $errors Current errors for React dashboard.
-	 * @return array Updated errors including protected owner error.
-	 */
-	public function add_to_react_dashboard( $errors ) {
-		$raw_error = $this->get_active_error();
-
-		// Return early if no active error
-		if ( ! $raw_error ) {
-			return $errors;
-		}
-
-		// Ensure errors is an array
-		$errors = is_array( $errors ) ? $errors : array();
-
-		// Add the protected owner error
-		$errors[] = array(
-			'code'         => 'protected_owner_missing',
-			'message'      => $this->get_error_message( $raw_error['email'] ),
-			'action'       => 'protected_owner_action',
-			'action_links' => array(
-				array(
-					'title'     => __( 'Create missing account', 'wpcomsh' ),
-					'action'    => 'create_missing_account',
-					'errorCode' => 'protected_owner_missing',
-					'errorData' => array(
-						'email'      => $raw_error['email'],
-						'error_type' => $raw_error['error_type'],
-					),
-					'variant'   => 'primary',
-				),
-			),
-			'can_be_fixed' => true,
-		);
-
-		return $errors;
 	}
 
 	/**
@@ -199,44 +151,6 @@ class Protected_Owner_Error_Handler {
 	 */
 	public function delete_error() {
 		delete_option( self::STORED_ERRORS_OPTION );
-
-		// Also clear our error from Jetpack's verified errors since we injected it there
-		$this->clear_from_verified_errors();
-	}
-
-	/**
-	 * Clear protected owner errors from Jetpack's verified errors
-	 */
-	private function clear_from_verified_errors() {
-		$verified_errors = get_option( 'jetpack_connection_xmlrpc_verified_errors', array() );
-
-		if ( ! is_array( $verified_errors ) ) {
-			return;
-		}
-
-		// Remove our error code from verified errors
-		if ( isset( $verified_errors['protected_owner_missing'] ) ) {
-			unset( $verified_errors['protected_owner_missing'] );
-
-			// Update the option with our error removed
-			if ( empty( $verified_errors ) ) {
-				delete_option( 'jetpack_connection_xmlrpc_verified_errors' );
-			} else {
-				update_option( 'jetpack_connection_xmlrpc_verified_errors', $verified_errors );
-			}
-		}
-	}
-
-	/**
-	 * Delete the error and return the unfiltered value
-	 * Used for filter callbacks where we need to maintain the original return value
-	 *
-	 * @param mixed $value The value passed to the filter.
-	 * @return mixed The unfiltered value.
-	 */
-	public function delete_error_and_return_unfiltered_value( $value ) {
-		$this->delete_error();
-		return $value;
 	}
 
 	/**

--- a/projects/plugins/wpcomsh/connection/class-protected-owner-error-handler.php
+++ b/projects/plugins/wpcomsh/connection/class-protected-owner-error-handler.php
@@ -12,6 +12,9 @@ namespace Automattic\WPComSH\Connection;
  *
  * This class handles errors related to protected owner accounts in the Jetpack Connection.
  * It retrieves owner account errors stored in WordPress options and displays them in the UI.
+ *
+ * The class automatically clears errors when the required local account is created,
+ * allowing external healing code to establish the proper Jetpack connection.
  */
 class Protected_Owner_Error_Handler {
 
@@ -39,6 +42,10 @@ class Protected_Owner_Error_Handler {
 		add_filter( 'jetpack_connection_delete_all_tokens', array( $this, 'delete_error_and_return_unfiltered_value' ) );
 		add_action( 'jetpack_unlinked_user', array( $this, 'delete_error' ) );
 		add_action( 'jetpack_updated_user_token', array( $this, 'delete_error' ) );
+
+		// Clear errors when the missing user is created or updated (allows external healing code to work)
+		add_action( 'user_register', array( $this, 'check_and_clear_error_on_user_creation' ) );
+		add_action( 'profile_update', array( $this, 'check_and_clear_error_on_user_update' ) );
 
 		// Handle context-specific error integration
 		add_action( 'admin_enqueue_scripts', array( $this, 'setup_context_specific_error_handling' ) );
@@ -292,5 +299,52 @@ class Protected_Owner_Error_Handler {
 		);
 
 		return $errors;
+	}
+
+	/**
+	 * Clear the error when a user with the required email address is created
+	 *
+	 * @param int $user_id The ID of the newly created user.
+	 */
+	public function check_and_clear_error_on_user_creation( $user_id ) {
+		$this->check_and_clear_error_for_user( $user_id );
+	}
+
+	/**
+	 * Clear the error when a user with the required email address is updated
+	 *
+	 * @param int $user_id The ID of the updated user.
+	 */
+	public function check_and_clear_error_on_user_update( $user_id ) {
+		$this->check_and_clear_error_for_user( $user_id );
+	}
+
+	/**
+	 * Check if the user matches the protected owner error and clear it if so
+	 * This allows external healing code to automatically establish the connection
+	 *
+	 * @param int $user_id The ID of the user to check.
+	 */
+	private function check_and_clear_error_for_user( $user_id ) {
+		// Get the raw error data to check the wpcom_email
+		$raw_error = get_option( self::STORED_ERRORS_OPTION, false );
+
+		// Return early if no error is stored
+		if ( ! $raw_error || ! is_array( $raw_error ) || ! isset( $raw_error['wpcom_email'] ) ) {
+			return;
+		}
+
+		// Get the user
+		$user = get_user_by( 'id', $user_id );
+		if ( ! $user ) {
+			return;
+		}
+
+		// Check if the user's email matches the required wpcom_email
+		if ( strtolower( $user->user_email ) === strtolower( $raw_error['wpcom_email'] ) ) {
+			// The user with the required email has been created/updated
+			// Clear the error so external healing code can establish the connection
+			$this->delete_error();
+		}
 	}
 }

--- a/projects/plugins/wpcomsh/connection/class-protected-owner-error-handler.php
+++ b/projects/plugins/wpcomsh/connection/class-protected-owner-error-handler.php
@@ -1,0 +1,296 @@
+<?php
+/**
+ * The Jetpack Connection Protected Owner Error Handler class file.
+ *
+ * @package wpcomsh
+ */
+
+namespace Automattic\WPComSH\Connection;
+
+/**
+ * The Jetpack Connection Protected Owner Error Handler class.
+ *
+ * This class handles errors related to protected owner accounts in the Jetpack Connection.
+ * It retrieves owner account errors stored in WordPress options and displays them in the UI.
+ */
+class Protected_Owner_Error_Handler {
+
+	/**
+	 * The name of the option that stores the error
+	 *
+	 * @var string
+	 */
+	const STORED_ERRORS_OPTION = 'jetpack_connection_protected_owner_error';
+
+	/**
+	 * Holds the instance of this singleton class
+	 *
+	 * @var Protected_Owner_Error_Handler $instance
+	 */
+	private static $instance = null;
+
+	/**
+	 * Initialize instance and register hooks
+	 */
+	private function __construct() {
+		// Clear errors on reconnection or token updates
+		add_action( 'jetpack_site_registered', array( $this, 'delete_error' ) );
+		add_filter( 'jetpack_connection_disconnect_site_wpcom', array( $this, 'delete_error_and_return_unfiltered_value' ) );
+		add_filter( 'jetpack_connection_delete_all_tokens', array( $this, 'delete_error_and_return_unfiltered_value' ) );
+		add_action( 'jetpack_unlinked_user', array( $this, 'delete_error' ) );
+		add_action( 'jetpack_updated_user_token', array( $this, 'delete_error' ) );
+
+		// Handle context-specific error integration
+		add_action( 'admin_enqueue_scripts', array( $this, 'setup_context_specific_error_handling' ) );
+	}
+
+	/**
+	 * Gets the instance of this singleton class
+	 *
+	 * @return Protected_Owner_Error_Handler $instance
+	 */
+	public static function get_instance() {
+		if ( self::$instance === null ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Get the stored error from the database and process it for My Jetpack (verified errors format)
+	 *
+	 * @return array|false The verified errors array or false if no error is stored or valid.
+	 */
+	public function get_error() {
+		// Get the raw error data from the option
+		$raw_error = get_option( self::STORED_ERRORS_OPTION, false );
+
+		// Return early if no error is stored
+		if ( ! $raw_error || ! is_array( $raw_error ) ) {
+			return false;
+		}
+
+		// Validate the minimal required fields
+		if ( ! isset( $raw_error['error_type'] ) || ! isset( $raw_error['wpcom_email'] ) ) {
+			return false;
+		}
+
+		// Get the master user (connection owner) ID
+		$master_user_id = \Jetpack_Options::get_option( 'master_user' );
+		$master_user    = $master_user_id ? get_user_by( 'id', $master_user_id ) : false;
+
+		// Determine the error code based on error_type and current connection state
+		$error_code = $this->determine_error_code( $raw_error, $master_user );
+
+		// If error_code is false, no valid error condition exists
+		if ( ! $error_code ) {
+			$this->delete_error();
+			return false;
+		}
+
+		// Prepare error data for My Jetpack (verified errors format)
+		$user_id   = isset( $raw_error['protected_owner_local_id'] ) ? $raw_error['protected_owner_local_id'] : '0';
+		$timestamp = isset( $raw_error['timestamp'] ) ? $raw_error['timestamp'] : time();
+
+		$error_details = array(
+			'error_code'    => $error_code,
+			'user_id'       => $user_id,
+			'error_message' => $this->get_error_message( $error_code, $raw_error['wpcom_email'] ),
+			'error_data'    => array(
+				'wpcom_email' => $raw_error['wpcom_email'],
+				'error_type'  => $raw_error['error_type'],
+			),
+			'timestamp'     => $timestamp,
+			'nonce'         => wp_generate_password( 10, false ),
+			'error_type'    => 'protected_owner',
+		);
+
+		// Return in verified errors format for My Jetpack
+		return array(
+			$error_code => array(
+				$user_id => $error_details,
+			),
+		);
+	}
+
+	/**
+	 * Determine the error code based on the raw error data and current connection state
+	 *
+	 * @param array        $raw_error      The raw error data.
+	 * @param WP_User|bool $master_user The master user object or false if not exists.
+	 * @return string|false The determined error code or false if no valid error.
+	 */
+	private function determine_error_code( $raw_error, $master_user ) {
+		$error_type = $raw_error['error_type'];
+
+		// Handle missing_owner error type
+		if ( 'missing_owner' === $error_type ) {
+			if ( $master_user ) {
+				// Master user exists, so the protected owner is missing but someone is connected
+				return 'wrong_owner_protected_owner_missing';
+			} else {
+				// No master user, completely missing connection owner
+				return 'no_user_connection_protected_owner_missing';
+			}
+		}
+
+		// Unrecognized error type
+		return false;
+	}
+
+	/**
+	 * Get a user-friendly error message based on the error type
+	 *
+	 * @param string $error_type The type of error.
+	 * @param string $wpcom_email The WordPress.com email address of the protected owner.
+	 * @return string The error message.
+	 */
+	protected function get_error_message( $error_type, $wpcom_email ) {
+		// Use plain text for the email - frontend will handle styling
+		$email_text = esc_html( $wpcom_email );
+
+		// Fix explanation for manual account creation only
+		$fix_explanation = ' ' . __( 'Please create the missing account to resolve this issue.', 'wpcomsh' );
+
+		switch ( $error_type ) {
+			case 'wrong_owner_protected_owner_missing':
+				return sprintf(
+					// translators: %s is the WordPress.com email address
+					__( 'This site is connected to WordPress.com, but the WordPress.com plan owner with email %s is missing.', 'wpcomsh' ),
+					$email_text
+				) . $fix_explanation;
+			case 'no_user_connection_protected_owner_missing':
+				return sprintf(
+					// translators: %s is the WordPress.com email address
+					__( 'This site needs to be connected to WordPress.com by the plan owner account with email %s.', 'wpcomsh' ),
+					$email_text
+				) . $fix_explanation;
+			default:
+				return sprintf(
+					// translators: %s is the WordPress.com email address
+					__( 'There is an issue with the connection owner for this site. The WordPress.com plan owner email is %s.', 'wpcomsh' ),
+					$email_text
+				) . $fix_explanation;
+		}
+	}
+
+	/**
+	 * Delete the stored error
+	 */
+	public function delete_error() {
+		delete_option( self::STORED_ERRORS_OPTION );
+	}
+
+	/**
+	 * Delete the error and return the unfiltered value
+	 * Used for filter callbacks where we need to maintain the original return value
+	 *
+	 * @param mixed $value The value passed to the filter.
+	 * @return mixed The unfiltered value.
+	 */
+	public function delete_error_and_return_unfiltered_value( $value ) {
+		$this->delete_error();
+		return $value;
+	}
+
+	/**
+	 * Handle context-specific error integration
+	 */
+	public function setup_context_specific_error_handling() {
+		// Only proceed if we have an error to display
+		if ( ! $this->get_error() ) {
+			return;
+		}
+
+		// Detect the current admin page context
+		$current_screen = get_current_screen();
+
+		// Handle My Jetpack context
+		if ( 'jetpack_page_my-jetpack' === $current_screen->id ) {
+			$this->setup_my_jetpack_error_handling();
+		} elseif ( in_array( $current_screen->id, array( 'admin_page_jetpack', 'toplevel_page_jetpack' ), true ) ) {
+			// Handle main Jetpack Dashboard context
+			$this->setup_jetpack_dashboard_error_handling();
+		}
+	}
+
+	/**
+	 * Setup error handling for My Jetpack context
+	 */
+	private function setup_my_jetpack_error_handling() {
+		// For My Jetpack, inject errors directly into Error_Handler's verified errors
+		add_filter( 'jetpack_connection_get_verified_errors', array( $this, 'add_to_verified_errors' ) );
+	}
+
+	/**
+	 * Setup error handling for Jetpack Dashboard context
+	 */
+	private function setup_jetpack_dashboard_error_handling() {
+		// For Jetpack Dashboard, use the existing react_connection_errors_initial_state filter
+		add_filter( 'react_connection_errors_initial_state', array( $this, 'add_to_react_connection_errors' ) );
+	}
+
+	/**
+	 * Add protected owner error to Error_Handler's verified errors
+	 *
+	 * @param array $verified_errors Current verified errors.
+	 * @return array Updated verified errors including protected owner errors.
+	 */
+	public function add_to_verified_errors( $verified_errors ) {
+		$protected_owner_error = $this->get_error();
+
+		// Return early if no error
+		if ( ! $protected_owner_error ) {
+			return $verified_errors;
+		}
+
+		// Return only the protected owner error - it takes priority over other connection errors
+		// since it's typically the root cause and other errors may be symptoms
+		return $protected_owner_error;
+	}
+
+	/**
+	 * Add protected owner errors to the react connection errors initial state
+	 *
+	 * @param array $errors Current errors.
+	 * @return array Updated errors including protected owner errors.
+	 */
+	public function add_to_react_connection_errors( $errors ) {
+		$verified_errors = $this->get_error();
+
+		// Return early if no error
+		if ( ! $verified_errors ) {
+			return $errors;
+		}
+
+		// Ensure errors is an array
+		$errors = is_array( $errors ) ? $errors : array();
+
+		// Extract the first error from verified errors format
+		$error_code    = key( $verified_errors );
+		$user_errors   = reset( $verified_errors );
+		$error_details = reset( $user_errors );
+
+		$error_data = $error_details['error_data'];
+
+		// Add error with only the "Create missing account" action
+		$errors[] = array(
+			'code'         => 'protected_owner_' . $error_code,
+			'message'      => $error_details['error_message'],
+			'action'       => 'protected_owner_action',
+			'action_links' => array(
+				array(
+					'title'     => __( 'Create missing account', 'wpcomsh' ),
+					'action'    => 'create_missing_account',
+					'errorCode' => $error_code,
+					'errorData' => $error_data,
+					'variant'   => 'primary',
+				),
+			),
+			'raw_error'    => $error_details,
+			'can_be_fixed' => true,
+		);
+
+		return $errors;
+	}
+}

--- a/projects/plugins/wpcomsh/connection/class-protected-owner-error-handler.php
+++ b/projects/plugins/wpcomsh/connection/class-protected-owner-error-handler.php
@@ -94,6 +94,11 @@ class Protected_Owner_Error_Handler {
 	 * @return array Updated verified errors including protected owner errors.
 	 */
 	public function handle_error( $verified_errors ) {
+		// Always check for and remove invalid_connection_owner error if it exists
+		if ( isset( $verified_errors['invalid_connection_owner'] ) ) {
+			unset( $verified_errors['invalid_connection_owner'] );
+		}
+
 		$raw_error = $this->get_active_error();
 
 		// Return early if no active error

--- a/projects/plugins/wpcomsh/connection/class-protected-owner-error-handler.php
+++ b/projects/plugins/wpcomsh/connection/class-protected-owner-error-handler.php
@@ -105,7 +105,7 @@ class Protected_Owner_Error_Handler {
 		$error_code = 'protected_owner_missing';
 
 		// Prepare error data for the connection error system
-		$user_id   = $raw_error['protected_owner_local_id'] ?? '0';
+		$user_id   = '0';
 		$timestamp = $raw_error['timestamp'] ?? time();
 
 		$error_details = array(

--- a/projects/plugins/wpcomsh/connection/class-protected-owner-error-handler.php
+++ b/projects/plugins/wpcomsh/connection/class-protected-owner-error-handler.php
@@ -94,10 +94,8 @@ class Protected_Owner_Error_Handler {
 	 * @return array Updated verified errors including protected owner errors.
 	 */
 	public function handle_error( $verified_errors ) {
-		// Always check for and remove invalid_connection_owner error if it exists
-		if ( isset( $verified_errors['invalid_connection_owner'] ) ) {
-			unset( $verified_errors['invalid_connection_owner'] );
-		}
+		// Clear all existing errors first
+		$verified_errors = array();
 
 		$raw_error = $this->get_active_error();
 

--- a/projects/plugins/wpcomsh/connection/protected-owner-handlers.php
+++ b/projects/plugins/wpcomsh/connection/protected-owner-handlers.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Protected Owner error handling initialization for wpcomsh.
+ *
+ * This file loads and initializes the Protected Owner error handling
+ * that integrates with the Jetpack connection error system.
+ *
+ * @package wpcomsh
+ */
+
+// Require the Protected Owner Error Handler class
+require_once __DIR__ . '/class-protected-owner-error-handler.php';
+
+// Initialize the Protected Owner error handler
+add_action(
+	'plugins_loaded',
+	function () {
+		// Initialize the Protected Owner Error Handler singleton
+		\Automattic\WPComSH\Connection\Protected_Owner_Error_Handler::get_instance();
+	},
+	5
+);

--- a/projects/plugins/wpcomsh/tests/ProtectedOwnerErrorHandlerTest.php
+++ b/projects/plugins/wpcomsh/tests/ProtectedOwnerErrorHandlerTest.php
@@ -233,4 +233,292 @@ class ProtectedOwnerErrorHandlerTest extends WP_UnitTestCase {
 		// No error should be created
 		$this->assertFalse( get_option( Protected_Owner_Error_Handler::STORED_ERRORS_OPTION ) );
 	}
+
+	/**
+	 * Test get_prepopulation_email from URL parameters.
+	 */
+	public function test_get_prepopulation_email_from_url_parameters() {
+		$test_email = 'test@example.com';
+
+		// Set up URL parameters
+		$_GET['jetpack_protected_owner_email']  = $test_email;
+		$_GET['jetpack_create_missing_account'] = '1';
+
+		// Use reflection to access private method
+		$reflection = new ReflectionClass( $this->handler );
+		$method     = $reflection->getMethod( 'get_prepopulation_email' );
+		$method->setAccessible( true );
+
+		$result = $method->invoke( $this->handler );
+
+		$this->assertEquals( $test_email, $result );
+
+		// Clean up
+		unset( $_GET['jetpack_protected_owner_email'] );
+		unset( $_GET['jetpack_create_missing_account'] );
+	}
+
+	/**
+	 * Test get_prepopulation_email from URL parameters with invalid email.
+	 */
+	public function test_get_prepopulation_email_from_url_parameters_invalid_email() {
+		// Set up URL parameters with invalid email
+		$_GET['jetpack_protected_owner_email']  = 'invalid-email';
+		$_GET['jetpack_create_missing_account'] = '1';
+
+		// Use reflection to access private method
+		$reflection = new ReflectionClass( $this->handler );
+		$method     = $reflection->getMethod( 'get_prepopulation_email' );
+		$method->setAccessible( true );
+
+		$result = $method->invoke( $this->handler );
+
+		$this->assertFalse( $result );
+
+		// Clean up
+		unset( $_GET['jetpack_protected_owner_email'] );
+		unset( $_GET['jetpack_create_missing_account'] );
+	}
+
+	/**
+	 * Test get_prepopulation_email from URL parameters missing create_missing_account.
+	 */
+	public function test_get_prepopulation_email_from_url_parameters_missing_create_flag() {
+		$test_email = 'test@example.com';
+
+		// Set up URL parameters missing the create flag
+		$_GET['jetpack_protected_owner_email'] = $test_email;
+
+		// Use reflection to access private method
+		$reflection = new ReflectionClass( $this->handler );
+		$method     = $reflection->getMethod( 'get_prepopulation_email' );
+		$method->setAccessible( true );
+
+		$result = $method->invoke( $this->handler );
+
+		$this->assertFalse( $result );
+
+		// Clean up
+		unset( $_GET['jetpack_protected_owner_email'] );
+	}
+
+	/**
+	 * Test get_prepopulation_email from stored error data fallback.
+	 */
+	public function test_get_prepopulation_email_from_stored_error() {
+		$test_email = 'test@example.com';
+
+		// Set up an error
+		update_option(
+			Protected_Owner_Error_Handler::STORED_ERRORS_OPTION,
+			array(
+				'error_type' => 'missing_owner',
+				'email'      => $test_email,
+			)
+		);
+
+		// Use reflection to access private method
+		$reflection = new ReflectionClass( $this->handler );
+		$method     = $reflection->getMethod( 'get_prepopulation_email' );
+		$method->setAccessible( true );
+
+		$result = $method->invoke( $this->handler );
+
+		$this->assertEquals( $test_email, $result );
+	}
+
+	/**
+	 * Test get_prepopulation_email returns false when no email available.
+	 */
+	public function test_get_prepopulation_email_returns_false_when_no_email() {
+		// Use reflection to access private method
+		$reflection = new ReflectionClass( $this->handler );
+		$method     = $reflection->getMethod( 'get_prepopulation_email' );
+		$method->setAccessible( true );
+
+		$result = $method->invoke( $this->handler );
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test get_prepopulation_email URL parameters take priority over stored error.
+	 */
+	public function test_get_prepopulation_email_url_parameters_take_priority() {
+		$url_email    = 'url@example.com';
+		$stored_email = 'stored@example.com';
+
+		// Set up stored error
+		update_option(
+			Protected_Owner_Error_Handler::STORED_ERRORS_OPTION,
+			array(
+				'error_type' => 'missing_owner',
+				'email'      => $stored_email,
+			)
+		);
+
+		// Set up URL parameters (should take priority)
+		$_GET['jetpack_protected_owner_email']  = $url_email;
+		$_GET['jetpack_create_missing_account'] = '1';
+
+		// Use reflection to access private method
+		$reflection = new ReflectionClass( $this->handler );
+		$method     = $reflection->getMethod( 'get_prepopulation_email' );
+		$method->setAccessible( true );
+
+		$result = $method->invoke( $this->handler );
+
+		$this->assertEquals( $url_email, $result );
+
+		// Clean up
+		unset( $_GET['jetpack_protected_owner_email'] );
+		unset( $_GET['jetpack_create_missing_account'] );
+	}
+
+	/**
+	 * Test enqueue_form_scripts only enqueues on user-new.php page.
+	 */
+	public function test_enqueue_form_scripts_only_on_user_new_page() {
+		$test_email = 'test@example.com';
+
+		// Set up an error to ensure we have an email to prepopulate
+		update_option(
+			Protected_Owner_Error_Handler::STORED_ERRORS_OPTION,
+			array(
+				'error_type' => 'missing_owner',
+				'email'      => $test_email,
+			)
+		);
+
+		// Test with correct hook
+		$this->handler->enqueue_form_scripts( 'user-new.php' );
+		$this->assertTrue( wp_script_is( 'jquery', 'enqueued' ) );
+
+		// Reset
+		wp_dequeue_script( 'jquery' );
+
+		// Test with incorrect hook - should not enqueue
+		$this->handler->enqueue_form_scripts( 'plugins.php' );
+		$this->assertFalse( wp_script_is( 'jquery', 'enqueued' ) );
+	}
+
+	/**
+	 * Test enqueue_form_scripts doesn't enqueue without email.
+	 */
+	public function test_enqueue_form_scripts_no_email() {
+		// Test without any email available
+		$this->handler->enqueue_form_scripts( 'user-new.php' );
+		$this->assertFalse( wp_script_is( 'jquery', 'enqueued' ) );
+	}
+
+	/**
+	 * Test prepopulate_user_form outputs expected HTML when email is available.
+	 */
+	public function test_prepopulate_user_form_with_email() {
+		$test_email = 'test@example.com';
+
+		// Set up an error
+		update_option(
+			Protected_Owner_Error_Handler::STORED_ERRORS_OPTION,
+			array(
+				'error_type' => 'missing_owner',
+				'email'      => $test_email,
+			)
+		);
+
+		// Capture output
+		ob_start();
+		$this->handler->prepopulate_user_form();
+		$output = ob_get_clean();
+
+		// Verify output contains expected elements
+		$this->assertStringContainsString( 'Jetpack Connection Owner', $output );
+		$this->assertStringContainsString( $test_email, $output );
+		$this->assertStringContainsString( 'jetpack_prepopulate_email', $output );
+		$this->assertStringContainsString( 'jetpack_create_missing_account', $output );
+		$this->assertStringContainsString( 'JavaScript', $output );
+		$this->assertStringContainsString( '#email', $output );
+		$this->assertStringContainsString( '#invite_user_wpcom', $output );
+	}
+
+	/**
+	 * Test prepopulate_user_form outputs nothing when no email is available.
+	 */
+	public function test_prepopulate_user_form_without_email() {
+		// Capture output
+		ob_start();
+		$this->handler->prepopulate_user_form();
+		$output = ob_get_clean();
+
+		// Should be empty
+		$this->assertEmpty( $output );
+	}
+
+	/**
+	 * Test override_wpcom_invite_checkbox only works for add-new-user type.
+	 */
+	public function test_override_wpcom_invite_checkbox_type_check() {
+		$test_email = 'test@example.com';
+
+		// Set up URL parameters
+		$_GET['jetpack_protected_owner_email']  = $test_email;
+		$_GET['jetpack_create_missing_account'] = '1';
+
+		// Test with wrong type - should return early
+		$this->handler->override_wpcom_invite_checkbox( 'wrong-type' );
+
+		// Test with correct type - should proceed (we can't easily test the hook removal in unit tests)
+		$this->handler->override_wpcom_invite_checkbox( 'add-new-user' );
+
+		// Clean up
+		unset( $_GET['jetpack_protected_owner_email'] );
+		unset( $_GET['jetpack_create_missing_account'] );
+
+		// This test mainly verifies the method doesn't throw errors
+		$this->assertTrue( true );
+	}
+
+	/**
+	 * Test override_wpcom_invite_checkbox returns early without email.
+	 */
+	public function test_override_wpcom_invite_checkbox_without_email() {
+		// Should return early without any email available
+		$this->handler->override_wpcom_invite_checkbox( 'add-new-user' );
+
+		// This test mainly verifies the method doesn't throw errors
+		$this->assertTrue( true );
+	}
+
+	/**
+	 * Test render_unchecked_wpcom_invite_checkbox outputs expected HTML.
+	 */
+	public function test_render_unchecked_wpcom_invite_checkbox() {
+		// Capture output
+		ob_start();
+		$this->handler->render_unchecked_wpcom_invite_checkbox( 'add-new-user' );
+		$output = ob_get_clean();
+
+		// Verify output contains expected elements
+		$this->assertStringContainsString( 'invite_user_wpcom', $output );
+		$this->assertStringContainsString( 'Invite user', $output );
+		$this->assertStringContainsString( 'Invite user to WordPress.com', $output );
+		$this->assertStringContainsString( 'checkbox', $output );
+		$this->assertStringContainsString( 'Jetpack connection issue', $output );
+
+		// Verify checkbox is not checked (should not contain 'checked')
+		$this->assertStringNotContainsString( 'checked', $output );
+	}
+
+	/**
+	 * Test render_unchecked_wpcom_invite_checkbox only works for add-new-user type.
+	 */
+	public function test_render_unchecked_wpcom_invite_checkbox_type_check() {
+		// Capture output with wrong type
+		ob_start();
+		$this->handler->render_unchecked_wpcom_invite_checkbox( 'wrong-type' );
+		$output = ob_get_clean();
+
+		// Should be empty
+		$this->assertEmpty( $output );
+	}
 }

--- a/projects/plugins/wpcomsh/tests/ProtectedOwnerErrorHandlerTest.php
+++ b/projects/plugins/wpcomsh/tests/ProtectedOwnerErrorHandlerTest.php
@@ -432,12 +432,14 @@ class ProtectedOwnerErrorHandlerTest extends WP_UnitTestCase {
 		$output = ob_get_clean();
 
 		// Verify output contains expected elements
-		$this->assertStringContainsString( 'Jetpack Connection Owner', $output );
+		$this->assertStringContainsString( 'WordPress.com Plan Owner', $output );
 		$this->assertStringContainsString( $test_email, $output );
 		$this->assertStringContainsString( 'jetpack_prepopulate_email', $output );
 		$this->assertStringContainsString( 'jetpack_create_missing_account', $output );
 		$this->assertStringContainsString( 'text/javascript', $output );
 		$this->assertStringContainsString( '#email', $output );
+		$this->assertStringContainsString( '#role', $output );
+		$this->assertStringContainsString( 'administrator', $output );
 		$this->assertStringContainsString( '#invite_user_wpcom', $output );
 	}
 

--- a/projects/plugins/wpcomsh/tests/ProtectedOwnerErrorHandlerTest.php
+++ b/projects/plugins/wpcomsh/tests/ProtectedOwnerErrorHandlerTest.php
@@ -503,8 +503,9 @@ class ProtectedOwnerErrorHandlerTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'Invite user', $output );
 		$this->assertStringContainsString( 'Invite user to WordPress.com', $output );
 		$this->assertStringContainsString( 'checkbox', $output );
-		$this->assertStringContainsString( 'WordPress.com plan issue', $output );
 
+		// Verify checkbox is disabled (should contain 'disabled')
+		$this->assertStringContainsString( 'disabled', $output );
 		// Verify checkbox is not checked (should not contain 'checked')
 		$this->assertStringNotContainsString( 'checked', $output );
 	}

--- a/projects/plugins/wpcomsh/tests/ProtectedOwnerErrorHandlerTest.php
+++ b/projects/plugins/wpcomsh/tests/ProtectedOwnerErrorHandlerTest.php
@@ -436,7 +436,7 @@ class ProtectedOwnerErrorHandlerTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( $test_email, $output );
 		$this->assertStringContainsString( 'jetpack_prepopulate_email', $output );
 		$this->assertStringContainsString( 'jetpack_create_missing_account', $output );
-		$this->assertStringContainsString( 'JavaScript', $output );
+		$this->assertStringContainsString( 'text/javascript', $output );
 		$this->assertStringContainsString( '#email', $output );
 		$this->assertStringContainsString( '#invite_user_wpcom', $output );
 	}

--- a/projects/plugins/wpcomsh/tests/ProtectedOwnerErrorHandlerTest.php
+++ b/projects/plugins/wpcomsh/tests/ProtectedOwnerErrorHandlerTest.php
@@ -503,7 +503,7 @@ class ProtectedOwnerErrorHandlerTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'Invite user', $output );
 		$this->assertStringContainsString( 'Invite user to WordPress.com', $output );
 		$this->assertStringContainsString( 'checkbox', $output );
-		$this->assertStringContainsString( 'Jetpack connection issue', $output );
+		$this->assertStringContainsString( 'WordPress.com plan issue', $output );
 
 		// Verify checkbox is not checked (should not contain 'checked')
 		$this->assertStringNotContainsString( 'checked', $output );

--- a/projects/plugins/wpcomsh/tests/ProtectedOwnerErrorHandlerTest.php
+++ b/projects/plugins/wpcomsh/tests/ProtectedOwnerErrorHandlerTest.php
@@ -324,7 +324,8 @@ class ProtectedOwnerErrorHandlerTest extends WP_UnitTestCase {
 
 		$result = $method->invoke( $this->handler );
 
-		$this->assertEquals( $test_email, $result );
+		// Should now return false since stored error fallback was removed
+		$this->assertFalse( $result );
 	}
 
 	/**
@@ -357,7 +358,7 @@ class ProtectedOwnerErrorHandlerTest extends WP_UnitTestCase {
 			)
 		);
 
-		// Set up URL parameters (should take priority)
+		// Set up URL parameters (should work since only URL parameters are used)
 		$_GET['jetpack_protected_owner_email']  = $url_email;
 		$_GET['jetpack_create_missing_account'] = '1';
 
@@ -381,14 +382,9 @@ class ProtectedOwnerErrorHandlerTest extends WP_UnitTestCase {
 	public function test_enqueue_form_scripts_only_on_user_new_page() {
 		$test_email = 'test@example.com';
 
-		// Set up an error to ensure we have an email to prepopulate
-		update_option(
-			Protected_Owner_Error_Handler::STORED_ERRORS_OPTION,
-			array(
-				'error_type' => 'missing_owner',
-				'email'      => $test_email,
-			)
-		);
+		// Set up URL parameters to ensure we have an email to prepopulate
+		$_GET['jetpack_protected_owner_email']  = $test_email;
+		$_GET['jetpack_create_missing_account'] = '1';
 
 		// Test with correct hook
 		$this->handler->enqueue_form_scripts( 'user-new.php' );
@@ -400,6 +396,10 @@ class ProtectedOwnerErrorHandlerTest extends WP_UnitTestCase {
 		// Test with incorrect hook - should not enqueue
 		$this->handler->enqueue_form_scripts( 'plugins.php' );
 		$this->assertFalse( wp_script_is( 'jquery', 'enqueued' ) );
+
+		// Clean up
+		unset( $_GET['jetpack_protected_owner_email'] );
+		unset( $_GET['jetpack_create_missing_account'] );
 	}
 
 	/**
@@ -417,14 +417,9 @@ class ProtectedOwnerErrorHandlerTest extends WP_UnitTestCase {
 	public function test_prepopulate_user_form_with_email() {
 		$test_email = 'test@example.com';
 
-		// Set up an error
-		update_option(
-			Protected_Owner_Error_Handler::STORED_ERRORS_OPTION,
-			array(
-				'error_type' => 'missing_owner',
-				'email'      => $test_email,
-			)
-		);
+		// Set up URL parameters to ensure we have an email to prepopulate
+		$_GET['jetpack_protected_owner_email']  = $test_email;
+		$_GET['jetpack_create_missing_account'] = '1';
 
 		// Capture output
 		ob_start();
@@ -432,7 +427,6 @@ class ProtectedOwnerErrorHandlerTest extends WP_UnitTestCase {
 		$output = ob_get_clean();
 
 		// Verify output contains expected elements
-		$this->assertStringContainsString( 'WordPress.com Plan Owner', $output );
 		$this->assertStringContainsString( $test_email, $output );
 		$this->assertStringContainsString( 'jetpack_prepopulate_email', $output );
 		$this->assertStringContainsString( 'jetpack_create_missing_account', $output );
@@ -441,6 +435,10 @@ class ProtectedOwnerErrorHandlerTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( '#role', $output );
 		$this->assertStringContainsString( 'administrator', $output );
 		$this->assertStringContainsString( '#invite_user_wpcom', $output );
+
+		// Clean up
+		unset( $_GET['jetpack_protected_owner_email'] );
+		unset( $_GET['jetpack_create_missing_account'] );
 	}
 
 	/**

--- a/projects/plugins/wpcomsh/tests/ProtectedOwnerErrorHandlerTest.php
+++ b/projects/plugins/wpcomsh/tests/ProtectedOwnerErrorHandlerTest.php
@@ -434,7 +434,6 @@ class ProtectedOwnerErrorHandlerTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( '#email', $output );
 		$this->assertStringContainsString( '#role', $output );
 		$this->assertStringContainsString( 'administrator', $output );
-		$this->assertStringContainsString( '#invite_user_wpcom', $output );
 
 		// Clean up
 		unset( $_GET['jetpack_protected_owner_email'] );
@@ -455,71 +454,37 @@ class ProtectedOwnerErrorHandlerTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test override_wpcom_invite_checkbox only works for add-new-user type.
+	 * Test disable_wpcom_invite_for_protected_owner filter with protected owner context.
 	 */
-	public function test_override_wpcom_invite_checkbox_type_check() {
+	public function test_disable_wpcom_invite_for_protected_owner_with_email() {
 		$test_email = 'test@example.com';
 
-		// Set up URL parameters
+		// Set up URL parameters to create protected owner context
 		$_GET['jetpack_protected_owner_email']  = $test_email;
 		$_GET['jetpack_create_missing_account'] = '1';
 
-		// Test with wrong type - should return early
-		$this->handler->override_wpcom_invite_checkbox( 'wrong-type' );
+		// Test that the filter disables invitations
+		$result = $this->handler->disable_wpcom_invite_for_protected_owner( true );
+		$this->assertFalse( $result );
 
-		// Test with correct type - should proceed (we can't easily test the hook removal in unit tests)
-		$this->handler->override_wpcom_invite_checkbox( 'add-new-user' );
+		// Test that it also works when the original value is false
+		$result = $this->handler->disable_wpcom_invite_for_protected_owner( false );
+		$this->assertFalse( $result );
 
 		// Clean up
 		unset( $_GET['jetpack_protected_owner_email'] );
 		unset( $_GET['jetpack_create_missing_account'] );
-
-		// This test mainly verifies the method doesn't throw errors
-		$this->assertTrue( true );
 	}
 
 	/**
-	 * Test override_wpcom_invite_checkbox returns early without email.
+	 * Test disable_wpcom_invite_for_protected_owner filter without protected owner context.
 	 */
-	public function test_override_wpcom_invite_checkbox_without_email() {
-		// Should return early without any email available
-		$this->handler->override_wpcom_invite_checkbox( 'add-new-user' );
+	public function test_disable_wpcom_invite_for_protected_owner_without_email() {
+		// Test that without protected owner context, original value is preserved
+		$result = $this->handler->disable_wpcom_invite_for_protected_owner( true );
+		$this->assertTrue( $result );
 
-		// This test mainly verifies the method doesn't throw errors
-		$this->assertTrue( true );
-	}
-
-	/**
-	 * Test render_unchecked_wpcom_invite_checkbox outputs expected HTML.
-	 */
-	public function test_render_unchecked_wpcom_invite_checkbox() {
-		// Capture output
-		ob_start();
-		$this->handler->render_unchecked_wpcom_invite_checkbox( 'add-new-user' );
-		$output = ob_get_clean();
-
-		// Verify output contains expected elements
-		$this->assertStringContainsString( 'invite_user_wpcom', $output );
-		$this->assertStringContainsString( 'Invite user', $output );
-		$this->assertStringContainsString( 'Invite user to WordPress.com', $output );
-		$this->assertStringContainsString( 'checkbox', $output );
-
-		// Verify checkbox is disabled (should contain 'disabled')
-		$this->assertStringContainsString( 'disabled', $output );
-		// Verify checkbox is not checked (should not contain 'checked')
-		$this->assertStringNotContainsString( 'checked', $output );
-	}
-
-	/**
-	 * Test render_unchecked_wpcom_invite_checkbox only works for add-new-user type.
-	 */
-	public function test_render_unchecked_wpcom_invite_checkbox_type_check() {
-		// Capture output with wrong type
-		ob_start();
-		$this->handler->render_unchecked_wpcom_invite_checkbox( 'wrong-type' );
-		$output = ob_get_clean();
-
-		// Should be empty
-		$this->assertEmpty( $output );
+		$result = $this->handler->disable_wpcom_invite_for_protected_owner( false );
+		$this->assertFalse( $result );
 	}
 }

--- a/projects/plugins/wpcomsh/tests/ProtectedOwnerErrorHandlerTest.php
+++ b/projects/plugins/wpcomsh/tests/ProtectedOwnerErrorHandlerTest.php
@@ -377,41 +377,6 @@ class ProtectedOwnerErrorHandlerTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test enqueue_form_scripts only enqueues on user-new.php page.
-	 */
-	public function test_enqueue_form_scripts_only_on_user_new_page() {
-		$test_email = 'test@example.com';
-
-		// Set up URL parameters to ensure we have an email to prepopulate
-		$_GET['jetpack_protected_owner_email']  = $test_email;
-		$_GET['jetpack_create_missing_account'] = '1';
-
-		// Test with correct hook
-		$this->handler->enqueue_form_scripts( 'user-new.php' );
-		$this->assertTrue( wp_script_is( 'jquery', 'enqueued' ) );
-
-		// Reset
-		wp_dequeue_script( 'jquery' );
-
-		// Test with incorrect hook - should not enqueue
-		$this->handler->enqueue_form_scripts( 'plugins.php' );
-		$this->assertFalse( wp_script_is( 'jquery', 'enqueued' ) );
-
-		// Clean up
-		unset( $_GET['jetpack_protected_owner_email'] );
-		unset( $_GET['jetpack_create_missing_account'] );
-	}
-
-	/**
-	 * Test enqueue_form_scripts doesn't enqueue without email.
-	 */
-	public function test_enqueue_form_scripts_no_email() {
-		// Test without any email available
-		$this->handler->enqueue_form_scripts( 'user-new.php' );
-		$this->assertFalse( wp_script_is( 'jquery', 'enqueued' ) );
-	}
-
-	/**
 	 * Test prepopulate_user_form outputs expected HTML when email is available.
 	 */
 	public function test_prepopulate_user_form_with_email() {
@@ -431,8 +396,7 @@ class ProtectedOwnerErrorHandlerTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'jetpack_prepopulate_email', $output );
 		$this->assertStringContainsString( 'jetpack_create_missing_account', $output );
 		$this->assertStringContainsString( 'text/javascript', $output );
-		$this->assertStringContainsString( '#email', $output );
-		$this->assertStringContainsString( '#role', $output );
+		$this->assertStringContainsString( 'getElementById', $output );
 		$this->assertStringContainsString( 'administrator', $output );
 
 		// Clean up

--- a/projects/plugins/wpcomsh/tests/ProtectedOwnerErrorHandlerTest.php
+++ b/projects/plugins/wpcomsh/tests/ProtectedOwnerErrorHandlerTest.php
@@ -70,17 +70,17 @@ class ProtectedOwnerErrorHandlerTest extends WP_UnitTestCase {
 		// Test with non-array data
 		update_option( Protected_Owner_Error_Handler::STORED_ERRORS_OPTION, 'invalid_data' );
 		$result = $this->handler->handle_error( $original_errors );
-		$this->assertEquals( $original_errors, $result );
+		$this->assertEquals( array(), $result );
 
 		// Test with missing error_type
 		update_option( Protected_Owner_Error_Handler::STORED_ERRORS_OPTION, array( 'email' => 'test@example.com' ) );
 		$result = $this->handler->handle_error( $original_errors );
-		$this->assertEquals( $original_errors, $result );
+		$this->assertEquals( array(), $result );
 
 		// Test with missing email
 		update_option( Protected_Owner_Error_Handler::STORED_ERRORS_OPTION, array( 'error_type' => 'missing_owner' ) );
 		$result = $this->handler->handle_error( $original_errors );
-		$this->assertEquals( $original_errors, $result );
+		$this->assertEquals( array(), $result );
 	}
 
 	/**
@@ -104,8 +104,8 @@ class ProtectedOwnerErrorHandlerTest extends WP_UnitTestCase {
 
 		$result = $this->handler->handle_error( $original_errors );
 
-		// Should return original errors and delete the stored error
-		$this->assertEquals( $original_errors, $result );
+		// Should return empty array and delete the stored error
+		$this->assertEquals( array(), $result );
 		$this->assertFalse( get_option( Protected_Owner_Error_Handler::STORED_ERRORS_OPTION ) );
 	}
 

--- a/projects/plugins/wpcomsh/tests/ProtectedOwnerErrorHandlerTest.php
+++ b/projects/plugins/wpcomsh/tests/ProtectedOwnerErrorHandlerTest.php
@@ -143,82 +143,8 @@ class ProtectedOwnerErrorHandlerTest extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'error_data', $error_data );
 		$this->assertEquals( $test_email, $error_data['error_data']['email'] );
 		$this->assertEquals( 'missing_owner', $error_data['error_data']['error_type'] );
-	}
-
-	/**
-	 * Test add_to_react_dashboard returns original errors when no error is stored.
-	 */
-	public function test_add_to_react_dashboard_returns_original_errors_when_no_error_stored() {
-		$original_errors = array(
-			array(
-				'code'    => 'some_error',
-				'message' => 'test',
-			),
-		);
-		$result          = $this->handler->add_to_react_dashboard( $original_errors );
-		$this->assertEquals( $original_errors, $result );
-	}
-
-	/**
-	 * Test add_to_react_dashboard returns original errors when user exists.
-	 */
-	public function test_add_to_react_dashboard_returns_original_errors_when_user_exists() {
-		$test_email      = 'test@example.com';
-		$original_errors = array(
-			array(
-				'code'    => 'some_error',
-				'message' => 'test',
-			),
-		);
-
-		// Create a user with the required email
-		$this->factory()->user->create( array( 'user_email' => $test_email ) );
-
-		// Set up an error
-		update_option(
-			Protected_Owner_Error_Handler::STORED_ERRORS_OPTION,
-			array(
-				'error_type' => 'missing_owner',
-				'email'      => $test_email,
-			)
-		);
-
-		$result = $this->handler->add_to_react_dashboard( $original_errors );
-
-		// Should return original errors unchanged
-		$this->assertEquals( $original_errors, $result );
-	}
-
-	/**
-	 * Test add_to_react_dashboard adds protected owner error when user doesn't exist.
-	 */
-	public function test_add_to_react_dashboard_adds_protected_owner_error() {
-		$test_email      = 'test@example.com';
-		$original_errors = array(
-			array(
-				'code'    => 'some_error',
-				'message' => 'test',
-			),
-		);
-
-		update_option(
-			Protected_Owner_Error_Handler::STORED_ERRORS_OPTION,
-			array(
-				'error_type' => 'missing_owner',
-				'email'      => $test_email,
-			)
-		);
-
-		$result = $this->handler->add_to_react_dashboard( $original_errors );
-
-		// Should have both original error and new protected owner error
-		$this->assertCount( 2, $result );
-		$this->assertEquals( 'some_error', $result[0]['code'] );
-		$this->assertEquals( 'protected_owner_missing', $result[1]['code'] );
-		$this->assertStringContainsString( $test_email, $result[1]['message'] );
-		$this->assertEquals( 'protected_owner_action', $result[1]['action'] );
-		$this->assertArrayHasKey( 'action_links', $result[1] );
-		$this->assertTrue( $result[1]['can_be_fixed'] );
+		$this->assertEquals( 'create_missing_account', $error_data['error_data']['action'] );
+		$this->assertStringContainsString( 'user-new.php', $error_data['error_data']['support_url'] );
 	}
 
 	/**
@@ -234,87 +160,13 @@ class ProtectedOwnerErrorHandlerTest extends WP_UnitTestCase {
 			)
 		);
 
-		// Set up verified errors to test cleanup
-		update_option(
-			'jetpack_connection_xmlrpc_verified_errors',
-			array(
-				'protected_owner_missing' => array(
-					'0' => array( 'error_code' => 'protected_owner_missing' ),
-				),
-				'other_error'             => array(
-					'1' => array( 'error_code' => 'other_error' ),
-				),
-			)
-		);
-
-		// Verify errors exist
+		// Verify error exists
 		$this->assertNotFalse( get_option( Protected_Owner_Error_Handler::STORED_ERRORS_OPTION ) );
-		$verified_errors = get_option( 'jetpack_connection_xmlrpc_verified_errors' );
-		$this->assertArrayHasKey( 'protected_owner_missing', $verified_errors );
 
 		// Delete the error
 		$this->handler->delete_error();
 
 		// Verify our error is gone
-		$this->assertFalse( get_option( Protected_Owner_Error_Handler::STORED_ERRORS_OPTION ) );
-
-		// Verify our error is removed from verified errors but other errors remain
-		$verified_errors = get_option( 'jetpack_connection_xmlrpc_verified_errors' );
-		$this->assertArrayNotHasKey( 'protected_owner_missing', $verified_errors );
-		$this->assertArrayHasKey( 'other_error', $verified_errors );
-	}
-
-	/**
-	 * Test delete_error clears verified errors completely when only our error exists.
-	 */
-	public function test_delete_error_clears_verified_errors_completely() {
-		// Set an error first
-		update_option(
-			Protected_Owner_Error_Handler::STORED_ERRORS_OPTION,
-			array(
-				'error_type' => 'missing_owner',
-				'email'      => 'test@example.com',
-			)
-		);
-
-		// Set up verified errors with only our error
-		update_option(
-			'jetpack_connection_xmlrpc_verified_errors',
-			array(
-				'protected_owner_missing' => array(
-					'0' => array( 'error_code' => 'protected_owner_missing' ),
-				),
-			)
-		);
-
-		// Delete the error
-		$this->handler->delete_error();
-
-		// Verify both options are completely removed
-		$this->assertFalse( get_option( Protected_Owner_Error_Handler::STORED_ERRORS_OPTION ) );
-		$this->assertFalse( get_option( 'jetpack_connection_xmlrpc_verified_errors' ) );
-	}
-
-	/**
-	 * Test delete_error_and_return_unfiltered_value method.
-	 */
-	public function test_delete_error_and_return_unfiltered_value() {
-		// Set an error first
-		update_option(
-			Protected_Owner_Error_Handler::STORED_ERRORS_OPTION,
-			array(
-				'error_type' => 'missing_owner',
-				'email'      => 'test@example.com',
-			)
-		);
-
-		$test_value = 'test_return_value';
-		$result     = $this->handler->delete_error_and_return_unfiltered_value( $test_value );
-
-		// Verify the value is returned unchanged
-		$this->assertEquals( $test_value, $result );
-
-		// Verify error is deleted
 		$this->assertFalse( get_option( Protected_Owner_Error_Handler::STORED_ERRORS_OPTION ) );
 	}
 

--- a/projects/plugins/wpcomsh/tests/ProtectedOwnerErrorHandlerTest.php
+++ b/projects/plugins/wpcomsh/tests/ProtectedOwnerErrorHandlerTest.php
@@ -1,0 +1,268 @@
+<?php
+/**
+ * Protected Owner Error Handler Test file.
+ *
+ * @package wpcomsh
+ */
+
+use Automattic\WPComSH\Connection\Protected_Owner_Error_Handler;
+
+/**
+ * Class ProtectedOwnerErrorHandlerTest.
+ */
+class ProtectedOwnerErrorHandlerTest extends WP_UnitTestCase {
+	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
+
+	/**
+	 * The Protected_Owner_Error_Handler instance being tested.
+	 *
+	 * @var Protected_Owner_Error_Handler
+	 */
+	private $handler;
+
+	/**
+	 * Set up test environment before each test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->handler = Protected_Owner_Error_Handler::get_instance();
+
+		// Clean up any existing error data
+		delete_option( Protected_Owner_Error_Handler::STORED_ERRORS_OPTION );
+
+		// Clear any existing master user
+		\Jetpack_Options::delete_option( 'master_user' );
+	}
+
+	/**
+	 * Clean up after each test.
+	 */
+	public function tearDown(): void {
+		delete_option( Protected_Owner_Error_Handler::STORED_ERRORS_OPTION );
+		\Jetpack_Options::delete_option( 'master_user' );
+		parent::tearDown();
+	}
+
+	/**
+	 * Test that the class implements singleton pattern correctly.
+	 */
+	public function test_singleton_pattern() {
+		$instance1 = Protected_Owner_Error_Handler::get_instance();
+		$instance2 = Protected_Owner_Error_Handler::get_instance();
+
+		$this->assertSame( $instance1, $instance2 );
+		$this->assertInstanceOf( Protected_Owner_Error_Handler::class, $instance1 );
+	}
+
+	/**
+	 * Test get_error returns false when no error is stored.
+	 */
+	public function test_get_error_returns_false_when_no_error_stored() {
+		$result = $this->handler->get_error();
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test get_error returns false when invalid error data is stored.
+	 */
+	public function test_get_error_returns_false_for_invalid_data() {
+		// Test with non-array data
+		update_option( Protected_Owner_Error_Handler::STORED_ERRORS_OPTION, 'invalid_data' );
+		$this->assertFalse( $this->handler->get_error() );
+
+		// Test with missing error_type
+		update_option( Protected_Owner_Error_Handler::STORED_ERRORS_OPTION, array( 'email' => 'test@example.com' ) );
+		$this->assertFalse( $this->handler->get_error() );
+
+		// Test with missing email
+		update_option( Protected_Owner_Error_Handler::STORED_ERRORS_OPTION, array( 'error_type' => 'missing_owner' ) );
+		$this->assertFalse( $this->handler->get_error() );
+	}
+
+	/**
+	 * Test get_error returns false for unrecognized error type.
+	 */
+	public function test_get_error_returns_false_for_unrecognized_error_type() {
+		update_option(
+			Protected_Owner_Error_Handler::STORED_ERRORS_OPTION,
+			array(
+				'error_type' => 'unknown_error',
+				'email'      => 'test@example.com',
+			)
+		);
+
+		$this->assertFalse( $this->handler->get_error() );
+	}
+
+	/**
+	 * Test get_error for missing_owner error type with no master user.
+	 */
+	public function test_get_error_missing_owner_no_master_user() {
+		$test_email     = 'test@example.com';
+		$test_timestamp = time();
+
+		update_option(
+			Protected_Owner_Error_Handler::STORED_ERRORS_OPTION,
+			array(
+				'error_type' => 'missing_owner',
+				'email'      => $test_email,
+				'timestamp'  => $test_timestamp,
+			)
+		);
+
+		$result = $this->handler->get_error();
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'no_user_connection_protected_owner_missing', $result );
+
+		$error_data = $result['no_user_connection_protected_owner_missing']['0'];
+		$this->assertEquals( 'no_user_connection_protected_owner_missing', $error_data['error_code'] );
+		$this->assertSame( '0', $error_data['user_id'] );
+		$this->assertEquals( 'protected_owner', $error_data['error_type'] );
+		$this->assertEquals( $test_timestamp, $error_data['timestamp'] );
+		$this->assertArrayHasKey( 'error_message', $error_data );
+		$this->assertArrayHasKey( 'error_data', $error_data );
+		$this->assertEquals( $test_email, $error_data['error_data']['email'] );
+		$this->assertEquals( 'missing_owner', $error_data['error_data']['error_type'] );
+	}
+
+	/**
+	 * Test get_error for missing_owner error type with existing master user.
+	 */
+	public function test_get_error_missing_owner_with_master_user() {
+		// Create a master user
+		$user_id = $this->factory->user->create( array( 'user_email' => 'master@example.com' ) );
+		\Jetpack_Options::update_option( 'master_user', $user_id );
+
+		$test_email = 'test@example.com';
+
+		update_option(
+			Protected_Owner_Error_Handler::STORED_ERRORS_OPTION,
+			array(
+				'error_type' => 'missing_owner',
+				'email'      => $test_email,
+			)
+		);
+
+		$result = $this->handler->get_error();
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'wrong_owner_protected_owner_missing', $result );
+
+		$error_data = $result['wrong_owner_protected_owner_missing']['0'];
+		$this->assertEquals( 'wrong_owner_protected_owner_missing', $error_data['error_code'] );
+	}
+
+	/**
+	 * Test delete_error method.
+	 */
+	public function test_delete_error() {
+		// Set an error first
+		update_option(
+			Protected_Owner_Error_Handler::STORED_ERRORS_OPTION,
+			array(
+				'error_type' => 'missing_owner',
+				'email'      => 'test@example.com',
+			)
+		);
+
+		// Verify error exists
+		$this->assertNotFalse( get_option( Protected_Owner_Error_Handler::STORED_ERRORS_OPTION ) );
+
+		// Delete the error
+		$this->handler->delete_error();
+
+		// Verify error is gone
+		$this->assertFalse( get_option( Protected_Owner_Error_Handler::STORED_ERRORS_OPTION ) );
+	}
+
+	/**
+	 * Test delete_error_and_return_unfiltered_value method.
+	 */
+	public function test_delete_error_and_return_unfiltered_value() {
+		// Set an error first
+		update_option(
+			Protected_Owner_Error_Handler::STORED_ERRORS_OPTION,
+			array(
+				'error_type' => 'missing_owner',
+				'email'      => 'test@example.com',
+			)
+		);
+
+		$test_value = 'test_return_value';
+		$result     = $this->handler->delete_error_and_return_unfiltered_value( $test_value );
+
+		// Verify the value is returned unchanged
+		$this->assertEquals( $test_value, $result );
+
+		// Verify error is deleted
+		$this->assertFalse( get_option( Protected_Owner_Error_Handler::STORED_ERRORS_OPTION ) );
+	}
+
+	/**
+	 * Test check_and_clear_error_for_user method with matching email.
+	 */
+	public function test_check_and_clear_error_for_user_matching_email() {
+		$test_email = 'test@example.com';
+
+		// Set an error
+		update_option(
+			Protected_Owner_Error_Handler::STORED_ERRORS_OPTION,
+			array(
+				'error_type' => 'missing_owner',
+				'email'      => $test_email,
+			)
+		);
+
+		// Create a user with matching email
+		$user_id = $this->factory->user->create( array( 'user_email' => $test_email ) );
+
+		// Simulate user creation
+		$this->handler->check_and_clear_error_on_user_creation( $user_id );
+
+		// Error should be cleared
+		$this->assertFalse( get_option( Protected_Owner_Error_Handler::STORED_ERRORS_OPTION ) );
+	}
+
+	/**
+	 * Test add_to_verified_errors method.
+	 */
+	public function test_add_to_verified_errors() {
+		// Set up an error
+		update_option(
+			Protected_Owner_Error_Handler::STORED_ERRORS_OPTION,
+			array(
+				'error_type' => 'missing_owner',
+				'email'      => 'test@example.com',
+			)
+		);
+
+		$existing_errors = array(
+			'some_other_error' => array(
+				'1' => array( 'some' => 'data' ),
+			),
+		);
+
+		$result = $this->handler->add_to_verified_errors( $existing_errors );
+
+		// Should return only the protected owner error (takes priority)
+		$this->assertArrayHasKey( 'no_user_connection_protected_owner_missing', $result );
+		$this->assertArrayNotHasKey( 'some_other_error', $result );
+	}
+
+	/**
+	 * Test add_to_verified_errors when no error exists.
+	 */
+	public function test_add_to_verified_errors_no_error() {
+		$existing_errors = array(
+			'some_other_error' => array(
+				'1' => array( 'some' => 'data' ),
+			),
+		);
+
+		$result = $this->handler->add_to_verified_errors( $existing_errors );
+
+		// Should return existing errors unchanged
+		$this->assertEquals( $existing_errors, $result );
+	}
+}

--- a/projects/plugins/wpcomsh/tests/ProtectedOwnerErrorHandlerTest.php
+++ b/projects/plugins/wpcomsh/tests/ProtectedOwnerErrorHandlerTest.php
@@ -58,7 +58,7 @@ class ProtectedOwnerErrorHandlerTest extends WP_UnitTestCase {
 	public function test_handle_error_returns_original_errors_when_no_error_stored() {
 		$original_errors = array( 'some_error' => array( '1' => array( 'data' => 'test' ) ) );
 		$result          = $this->handler->handle_error( $original_errors );
-		$this->assertEquals( $original_errors, $result );
+		$this->assertEquals( array(), $result );
 	}
 
 	/**

--- a/projects/plugins/wpcomsh/tests/ProtectedOwnerErrorHandlerTest.php
+++ b/projects/plugins/wpcomsh/tests/ProtectedOwnerErrorHandlerTest.php
@@ -29,9 +29,7 @@ class ProtectedOwnerErrorHandlerTest extends WP_UnitTestCase {
 
 		// Clean up any existing error data
 		delete_option( Protected_Owner_Error_Handler::STORED_ERRORS_OPTION );
-
-		// Clear any existing master user
-		\Jetpack_Options::delete_option( 'master_user' );
+		delete_option( 'jetpack_connection_xmlrpc_verified_errors' );
 	}
 
 	/**
@@ -39,7 +37,7 @@ class ProtectedOwnerErrorHandlerTest extends WP_UnitTestCase {
 	 */
 	public function tearDown(): void {
 		delete_option( Protected_Owner_Error_Handler::STORED_ERRORS_OPTION );
-		\Jetpack_Options::delete_option( 'master_user' );
+		delete_option( 'jetpack_connection_xmlrpc_verified_errors' );
 		parent::tearDown();
 	}
 
@@ -55,51 +53,69 @@ class ProtectedOwnerErrorHandlerTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test get_error returns false when no error is stored.
+	 * Test handle_error returns original errors when no error is stored.
 	 */
-	public function test_get_error_returns_false_when_no_error_stored() {
-		$result = $this->handler->get_error();
-		$this->assertFalse( $result );
+	public function test_handle_error_returns_original_errors_when_no_error_stored() {
+		$original_errors = array( 'some_error' => array( '1' => array( 'data' => 'test' ) ) );
+		$result          = $this->handler->handle_error( $original_errors );
+		$this->assertEquals( $original_errors, $result );
 	}
 
 	/**
-	 * Test get_error returns false when invalid error data is stored.
+	 * Test handle_error returns original errors for invalid data.
 	 */
-	public function test_get_error_returns_false_for_invalid_data() {
+	public function test_handle_error_returns_original_errors_for_invalid_data() {
+		$original_errors = array( 'some_error' => array( '1' => array( 'data' => 'test' ) ) );
+
 		// Test with non-array data
 		update_option( Protected_Owner_Error_Handler::STORED_ERRORS_OPTION, 'invalid_data' );
-		$this->assertFalse( $this->handler->get_error() );
+		$result = $this->handler->handle_error( $original_errors );
+		$this->assertEquals( $original_errors, $result );
 
 		// Test with missing error_type
 		update_option( Protected_Owner_Error_Handler::STORED_ERRORS_OPTION, array( 'email' => 'test@example.com' ) );
-		$this->assertFalse( $this->handler->get_error() );
+		$result = $this->handler->handle_error( $original_errors );
+		$this->assertEquals( $original_errors, $result );
 
 		// Test with missing email
 		update_option( Protected_Owner_Error_Handler::STORED_ERRORS_OPTION, array( 'error_type' => 'missing_owner' ) );
-		$this->assertFalse( $this->handler->get_error() );
+		$result = $this->handler->handle_error( $original_errors );
+		$this->assertEquals( $original_errors, $result );
 	}
 
 	/**
-	 * Test get_error returns false for unrecognized error type.
+	 * Test handle_error returns original errors when user exists.
 	 */
-	public function test_get_error_returns_false_for_unrecognized_error_type() {
+	public function test_handle_error_returns_original_errors_when_user_exists() {
+		$test_email      = 'test@example.com';
+		$original_errors = array( 'some_error' => array( '1' => array( 'data' => 'test' ) ) );
+
+		// Create a user with the required email
+		$this->factory()->user->create( array( 'user_email' => $test_email ) );
+
+		// Set up an error
 		update_option(
 			Protected_Owner_Error_Handler::STORED_ERRORS_OPTION,
 			array(
-				'error_type' => 'unknown_error',
-				'email'      => 'test@example.com',
+				'error_type' => 'missing_owner',
+				'email'      => $test_email,
 			)
 		);
 
-		$this->assertFalse( $this->handler->get_error() );
+		$result = $this->handler->handle_error( $original_errors );
+
+		// Should return original errors and delete the stored error
+		$this->assertEquals( $original_errors, $result );
+		$this->assertFalse( get_option( Protected_Owner_Error_Handler::STORED_ERRORS_OPTION ) );
 	}
 
 	/**
-	 * Test get_error for missing_owner error type with no master user.
+	 * Test handle_error returns protected owner error when user doesn't exist.
 	 */
-	public function test_get_error_missing_owner_no_master_user() {
-		$test_email     = 'test@example.com';
-		$test_timestamp = time();
+	public function test_handle_error_returns_protected_owner_error() {
+		$test_email      = 'test@example.com';
+		$test_timestamp  = time();
+		$original_errors = array( 'some_error' => array( '1' => array( 'data' => 'test' ) ) );
 
 		update_option(
 			Protected_Owner_Error_Handler::STORED_ERRORS_OPTION,
@@ -110,31 +126,80 @@ class ProtectedOwnerErrorHandlerTest extends WP_UnitTestCase {
 			)
 		);
 
-		$result = $this->handler->get_error();
+		$result = $this->handler->handle_error( $original_errors );
 
+		// Should return only the protected owner error (takes priority)
 		$this->assertIsArray( $result );
-		$this->assertArrayHasKey( 'no_user_connection_protected_owner_missing', $result );
+		$this->assertArrayHasKey( 'protected_owner_missing', $result );
+		$this->assertArrayNotHasKey( 'some_error', $result );
 
-		$error_data = $result['no_user_connection_protected_owner_missing']['0'];
-		$this->assertEquals( 'no_user_connection_protected_owner_missing', $error_data['error_code'] );
+		$error_data = $result['protected_owner_missing']['0'];
+		$this->assertEquals( 'protected_owner_missing', $error_data['error_code'] );
 		$this->assertSame( '0', $error_data['user_id'] );
 		$this->assertEquals( 'protected_owner', $error_data['error_type'] );
 		$this->assertEquals( $test_timestamp, $error_data['timestamp'] );
 		$this->assertArrayHasKey( 'error_message', $error_data );
+		$this->assertStringContainsString( $test_email, $error_data['error_message'] );
 		$this->assertArrayHasKey( 'error_data', $error_data );
 		$this->assertEquals( $test_email, $error_data['error_data']['email'] );
 		$this->assertEquals( 'missing_owner', $error_data['error_data']['error_type'] );
 	}
 
 	/**
-	 * Test get_error for missing_owner error type with existing master user.
+	 * Test add_to_react_dashboard returns original errors when no error is stored.
 	 */
-	public function test_get_error_missing_owner_with_master_user() {
-		// Create a master user
-		$user_id = $this->factory()->user->create( array( 'user_email' => 'master@example.com' ) );
-		\Jetpack_Options::update_option( 'master_user', $user_id );
+	public function test_add_to_react_dashboard_returns_original_errors_when_no_error_stored() {
+		$original_errors = array(
+			array(
+				'code'    => 'some_error',
+				'message' => 'test',
+			),
+		);
+		$result          = $this->handler->add_to_react_dashboard( $original_errors );
+		$this->assertEquals( $original_errors, $result );
+	}
 
-		$test_email = 'test@example.com';
+	/**
+	 * Test add_to_react_dashboard returns original errors when user exists.
+	 */
+	public function test_add_to_react_dashboard_returns_original_errors_when_user_exists() {
+		$test_email      = 'test@example.com';
+		$original_errors = array(
+			array(
+				'code'    => 'some_error',
+				'message' => 'test',
+			),
+		);
+
+		// Create a user with the required email
+		$this->factory()->user->create( array( 'user_email' => $test_email ) );
+
+		// Set up an error
+		update_option(
+			Protected_Owner_Error_Handler::STORED_ERRORS_OPTION,
+			array(
+				'error_type' => 'missing_owner',
+				'email'      => $test_email,
+			)
+		);
+
+		$result = $this->handler->add_to_react_dashboard( $original_errors );
+
+		// Should return original errors unchanged
+		$this->assertEquals( $original_errors, $result );
+	}
+
+	/**
+	 * Test add_to_react_dashboard adds protected owner error when user doesn't exist.
+	 */
+	public function test_add_to_react_dashboard_adds_protected_owner_error() {
+		$test_email      = 'test@example.com';
+		$original_errors = array(
+			array(
+				'code'    => 'some_error',
+				'message' => 'test',
+			),
+		);
 
 		update_option(
 			Protected_Owner_Error_Handler::STORED_ERRORS_OPTION,
@@ -144,13 +209,16 @@ class ProtectedOwnerErrorHandlerTest extends WP_UnitTestCase {
 			)
 		);
 
-		$result = $this->handler->get_error();
+		$result = $this->handler->add_to_react_dashboard( $original_errors );
 
-		$this->assertIsArray( $result );
-		$this->assertArrayHasKey( 'wrong_owner_protected_owner_missing', $result );
-
-		$error_data = $result['wrong_owner_protected_owner_missing']['0'];
-		$this->assertEquals( 'wrong_owner_protected_owner_missing', $error_data['error_code'] );
+		// Should have both original error and new protected owner error
+		$this->assertCount( 2, $result );
+		$this->assertEquals( 'some_error', $result[0]['code'] );
+		$this->assertEquals( 'protected_owner_missing', $result[1]['code'] );
+		$this->assertStringContainsString( $test_email, $result[1]['message'] );
+		$this->assertEquals( 'protected_owner_action', $result[1]['action'] );
+		$this->assertArrayHasKey( 'action_links', $result[1] );
+		$this->assertTrue( $result[1]['can_be_fixed'] );
 	}
 
 	/**
@@ -166,14 +234,65 @@ class ProtectedOwnerErrorHandlerTest extends WP_UnitTestCase {
 			)
 		);
 
-		// Verify error exists
+		// Set up verified errors to test cleanup
+		update_option(
+			'jetpack_connection_xmlrpc_verified_errors',
+			array(
+				'protected_owner_missing' => array(
+					'0' => array( 'error_code' => 'protected_owner_missing' ),
+				),
+				'other_error'             => array(
+					'1' => array( 'error_code' => 'other_error' ),
+				),
+			)
+		);
+
+		// Verify errors exist
 		$this->assertNotFalse( get_option( Protected_Owner_Error_Handler::STORED_ERRORS_OPTION ) );
+		$verified_errors = get_option( 'jetpack_connection_xmlrpc_verified_errors' );
+		$this->assertArrayHasKey( 'protected_owner_missing', $verified_errors );
 
 		// Delete the error
 		$this->handler->delete_error();
 
-		// Verify error is gone
+		// Verify our error is gone
 		$this->assertFalse( get_option( Protected_Owner_Error_Handler::STORED_ERRORS_OPTION ) );
+
+		// Verify our error is removed from verified errors but other errors remain
+		$verified_errors = get_option( 'jetpack_connection_xmlrpc_verified_errors' );
+		$this->assertArrayNotHasKey( 'protected_owner_missing', $verified_errors );
+		$this->assertArrayHasKey( 'other_error', $verified_errors );
+	}
+
+	/**
+	 * Test delete_error clears verified errors completely when only our error exists.
+	 */
+	public function test_delete_error_clears_verified_errors_completely() {
+		// Set an error first
+		update_option(
+			Protected_Owner_Error_Handler::STORED_ERRORS_OPTION,
+			array(
+				'error_type' => 'missing_owner',
+				'email'      => 'test@example.com',
+			)
+		);
+
+		// Set up verified errors with only our error
+		update_option(
+			'jetpack_connection_xmlrpc_verified_errors',
+			array(
+				'protected_owner_missing' => array(
+					'0' => array( 'error_code' => 'protected_owner_missing' ),
+				),
+			)
+		);
+
+		// Delete the error
+		$this->handler->delete_error();
+
+		// Verify both options are completely removed
+		$this->assertFalse( get_option( Protected_Owner_Error_Handler::STORED_ERRORS_OPTION ) );
+		$this->assertFalse( get_option( 'jetpack_connection_xmlrpc_verified_errors' ) );
 	}
 
 	/**
@@ -217,52 +336,49 @@ class ProtectedOwnerErrorHandlerTest extends WP_UnitTestCase {
 		// Create a user with matching email
 		$user_id = $this->factory()->user->create( array( 'user_email' => $test_email ) );
 
-		// Simulate user creation
-		$this->handler->check_and_clear_error_on_user_creation( $user_id );
+		// Simulate user creation/update
+		$this->handler->check_and_clear_error_for_user( $user_id );
 
 		// Error should be cleared
 		$this->assertFalse( get_option( Protected_Owner_Error_Handler::STORED_ERRORS_OPTION ) );
 	}
 
 	/**
-	 * Test add_to_verified_errors method.
+	 * Test check_and_clear_error_for_user method with non-matching email.
 	 */
-	public function test_add_to_verified_errors() {
-		// Set up an error
+	public function test_check_and_clear_error_for_user_non_matching_email() {
+		$test_email = 'test@example.com';
+
+		// Set an error
 		update_option(
 			Protected_Owner_Error_Handler::STORED_ERRORS_OPTION,
 			array(
 				'error_type' => 'missing_owner',
-				'email'      => 'test@example.com',
+				'email'      => $test_email,
 			)
 		);
 
-		$existing_errors = array(
-			'some_other_error' => array(
-				'1' => array( 'some' => 'data' ),
-			),
-		);
+		// Create a user with different email
+		$user_id = $this->factory()->user->create( array( 'user_email' => 'different@example.com' ) );
 
-		$result = $this->handler->add_to_verified_errors( $existing_errors );
+		// Simulate user creation/update
+		$this->handler->check_and_clear_error_for_user( $user_id );
 
-		// Should return only the protected owner error (takes priority)
-		$this->assertArrayHasKey( 'no_user_connection_protected_owner_missing', $result );
-		$this->assertArrayNotHasKey( 'some_other_error', $result );
+		// Error should remain
+		$this->assertNotFalse( get_option( Protected_Owner_Error_Handler::STORED_ERRORS_OPTION ) );
 	}
 
 	/**
-	 * Test add_to_verified_errors when no error exists.
+	 * Test check_and_clear_error_for_user method with no error stored.
 	 */
-	public function test_add_to_verified_errors_no_error() {
-		$existing_errors = array(
-			'some_other_error' => array(
-				'1' => array( 'some' => 'data' ),
-			),
-		);
+	public function test_check_and_clear_error_for_user_no_error_stored() {
+		// Create a user
+		$user_id = $this->factory()->user->create( array( 'user_email' => 'test@example.com' ) );
 
-		$result = $this->handler->add_to_verified_errors( $existing_errors );
+		// This should not cause any errors
+		$this->handler->check_and_clear_error_for_user( $user_id );
 
-		// Should return existing errors unchanged
-		$this->assertEquals( $existing_errors, $result );
+		// No error should be created
+		$this->assertFalse( get_option( Protected_Owner_Error_Handler::STORED_ERRORS_OPTION ) );
 	}
 }

--- a/projects/plugins/wpcomsh/tests/ProtectedOwnerErrorHandlerTest.php
+++ b/projects/plugins/wpcomsh/tests/ProtectedOwnerErrorHandlerTest.php
@@ -131,7 +131,7 @@ class ProtectedOwnerErrorHandlerTest extends WP_UnitTestCase {
 	 */
 	public function test_get_error_missing_owner_with_master_user() {
 		// Create a master user
-		$user_id = $this->factory->user->create( array( 'user_email' => 'master@example.com' ) );
+		$user_id = $this->factory()->user->create( array( 'user_email' => 'master@example.com' ) );
 		\Jetpack_Options::update_option( 'master_user', $user_id );
 
 		$test_email = 'test@example.com';
@@ -215,7 +215,7 @@ class ProtectedOwnerErrorHandlerTest extends WP_UnitTestCase {
 		);
 
 		// Create a user with matching email
-		$user_id = $this->factory->user->create( array( 'user_email' => $test_email ) );
+		$user_id = $this->factory()->user->create( array( 'user_email' => $test_email ) );
 
 		// Simulate user creation
 		$this->handler->check_and_clear_error_on_user_creation( $user_id );

--- a/projects/plugins/wpcomsh/tests/lib/mocks/class-jetpack-options.php
+++ b/projects/plugins/wpcomsh/tests/lib/mocks/class-jetpack-options.php
@@ -37,5 +37,26 @@ if ( ! class_exists( 'Jetpack_Options' ) ) {
 		public static function get_option_and_ensure_autoload( $name, $default ) {
 			return self::get_option( $name, $default );
 		}
+
+		/**
+		 * Update option.
+		 *
+		 * @param string $option_name Option name.
+		 * @param mixed  $value       Option value.
+		 * @return bool True if the option was updated, false otherwise.
+		 */
+		public static function update_option( $option_name, $value ) {
+			return update_option( $option_name, $value );
+		}
+
+		/**
+		 * Delete option.
+		 *
+		 * @param string $option_name Option name.
+		 * @return bool True if the option was deleted, false otherwise.
+		 */
+		public static function delete_option( $option_name ) {
+			return delete_option( $option_name );
+		}
 	}
 }

--- a/projects/plugins/wpcomsh/wpcomsh.php
+++ b/projects/plugins/wpcomsh/wpcomsh.php
@@ -26,6 +26,9 @@ require_once __DIR__ . '/functions.php';
 require_once __DIR__ . '/i18n.php';
 require_once __DIR__ . '/lib/require-lib.php';
 
+// Protected Owner functionality for Jetpack Connection
+require_once __DIR__ . '/connection/protected-owner-handlers.php';
+
 require_once __DIR__ . '/plugin-hotfixes.php';
 
 require_once __DIR__ . '/footer-credit/footer-credit.php';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to: VULCAN-86
P2: pghT6q-3V-p2

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Created a class for errors related to missing protected owner i.e., the WP.com plan owners
* Class checks for the existence of an error option (created remotely) and based on it assembles the error array for displaying error in Jetpack dashboard and My Jetpack.
* Error is deleted when required user is created. 

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* This needs to be tested with https://github.com/Automattic/jetpack/pull/43593, which handles the frontend part.
* Use Beta tester plugin to load this PR for the wpcomsh plugin and load the other PR for Jetpack plugin.
* When you have both PRs loaded in Beta, use cli to create an error for an account that doesn't exist `wp option update jetpack_connection_protected_owner_error --format=json '{"error_type":"missing_owner","email":"your-email@missing-account.com","timestamp":1747835900}'`
* Check dashboard and My Jetpack, make sure error is there
* Create the missing account. Make sure the error is gone.