### PR TITLE
Blogging Prompt: Handle URL parameter + block registration

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-blogging-prompt-from-param-1
+++ b/projects/plugins/jetpack/changelog/fix-blogging-prompt-from-param-1
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Blogging prompt: Make sure the block is registered before inserting.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://linear.app/a8c/issue/CML-493/daily-writing-prompt-broken-opens-blank-new-post

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fix for https://github.com/Automattic/jetpack/pull/43580, which I reverted because manual block insertion wasn't working. This PR allows for both types (via URL parameter or manual).

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

See Linear issue.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

N/A

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Atomic:
* On an Atomic site, check out this branch in Jetpack beta. 
* Go to the wp-admin dashboard.
* Click "Post Answer" under the daily writing prompt.
* The editor should load with the prompt block.
* Create a new post and make sure you can still add the "Writing prompt" block.

Jetpack:
* On a Jetpack site, check out this branch in Jetpack beta.
* Go to `/wp-admin/post-new.php?answer_prompt=1944`
* The editor should load with the prompt block.
* Create a new post and make sure you can still add the "Writing prompt" block.

Simple: note that this isn't expected to change the behavior for Simple.
* Run `bin/jetpack-downloader test jetpack fix/blogging-prompt-from-param-1` on your sandbox and sandbox the API and a Simple site.
* Turn on write access.
* Create a new post and make sure you can still add the "Writing prompt" block.
