### PR TITLE
Classes and methods checks before initializing submenu

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-jetpack-forms-dotcom-submenu-method-check
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-jetpack-forms-dotcom-submenu-method-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Check for classes and methods before call

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
@@ -479,9 +479,16 @@ add_action( 'admin_menu', 'wpcom_add_plugins_menu' );
  * Adds a submenu item for Jetpack Forms.
  */
 function add_submenu_jetpack_forms() {
-	$has_switch_class = class_exists( 'Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch' );
+	$has_switch_class    = class_exists( 'Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch' );
+	$has_dashboard_class = class_exists( 'Automattic\Jetpack\Forms\Dashboard\Dashboard' );
+	if ( ! $has_switch_class || ! $has_dashboard_class ) {
+		return;
+	}
 
-	if ( ! $has_switch_class || ! Dashboard\Dashboard_View_Switch::is_jetpack_forms_admin_page_available() ) {
+	$has_switch_method = method_exists( Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch::class, 'is_jetpack_forms_admin_page_available' );
+	$has_render_method = method_exists( Automattic\Jetpack\Forms\Dashboard\Dashboard::class, 'render_new_dashboard' );
+
+	if ( ! $has_switch_method || ! $has_render_method || ! Dashboard\Dashboard_View_Switch::is_jetpack_forms_admin_page_available() ) {
 		return;
 	}
 

--- a/projects/plugins/mu-wpcom-plugin/changelog/fix-jetpack-forms-dotcom-submenu-method-check
+++ b/projects/plugins/mu-wpcom-plugin/changelog/fix-jetpack-forms-dotcom-submenu-method-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Check for classes and methods before call

--- a/projects/plugins/wpcomsh/changelog/fix-jetpack-forms-dotcom-submenu-method-check
+++ b/projects/plugins/wpcomsh/changelog/fix-jetpack-forms-dotcom-submenu-method-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Check for classes and methods before call


### PR DESCRIPTION
Related to FORMS-27

## Proposed changes:
This is a safety check on a previously merged commit, which triggered fatals.
Original PR/change: https://github.com/Automattic/jetpack/pull/43295

Refs:
p1748029896984859-slack-C7YPW6K40
83a3574ff8efa100ae82b1950b52ba71-logstash


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1748029896984859-slack-C7YPW6K40

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
TBD