### PR TITLE
Forms: Remove options text color support

### DIFF
--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -163,7 +163,7 @@ class Contact_Form_Block {
 						'width'  => true,
 					),
 					'color'                => array(
-						'text'       => true,
+						'text'       => false,
 						'background' => true,
 					),
 					'spacing'              => array(

--- a/projects/packages/forms/src/blocks/options/index.js
+++ b/projects/packages/forms/src/blocks/options/index.js
@@ -32,7 +32,7 @@ const settings = {
 			blockGap: false,
 		},
 		color: {
-			text: true,
+			text: false,
 			background: true,
 		},
 		__experimentalBorder: {

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Block_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Block_Test.php
@@ -73,7 +73,7 @@ class Contact_Form_Block_Test extends BaseTestCase {
 						'width'  => true,
 					),
 					'color'                => array(
-						'text'       => false,
+						'text'       => true,
 						'background' => true,
 						'gradients'  => false,
 					),
@@ -119,7 +119,7 @@ class Contact_Form_Block_Test extends BaseTestCase {
 						'width'  => true,
 					),
 					'color'                => array(
-						'text'       => true,
+						'text'       => false,
 						'background' => true,
 					),
 					'spacing'              => array(

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Block_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Block_Test.php
@@ -73,7 +73,7 @@ class Contact_Form_Block_Test extends BaseTestCase {
 						'width'  => true,
 					),
 					'color'                => array(
-						'text'       => true,
+						'text'       => false,
 						'background' => true,
 						'gradients'  => false,
 					),

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
@@ -439,7 +439,7 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 					'type'                     => 'checkbox-multiple',
 					'requiredText'             => 'Do it again',
 					'fieldwrapperclasses'      => 'wp-block-jetpack-field-checkbox-multiple is-style-button  is-style-button-wrap',
-					'optionsclasses'           => ' has-text-color has-background',
+					'optionsclasses'           => ' has-background',
 					'optionsstyles'            => 'color:blue-overture;background-color:green-tonight; border-top-width:2px;border-top-color:terrible-red;border-top-style:solid;',
 					'stylevariationclasses'    => ' has-background',
 					'stylevariationattributes' => '{"border":{"top":{"color":"terrible-red","width":"2px","style":"solid","radius":"10px"}},"color":{"background":"green-tonight"}}',

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
@@ -440,7 +440,7 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 					'requiredText'             => 'Do it again',
 					'fieldwrapperclasses'      => 'wp-block-jetpack-field-checkbox-multiple is-style-button  is-style-button-wrap',
 					'optionsclasses'           => ' has-background',
-					'optionsstyles'            => 'color:blue-overture;background-color:green-tonight; border-top-width:2px;border-top-color:terrible-red;border-top-style:solid;',
+					'optionsstyles'            => 'background-color:green-tonight; border-top-width:2px;border-top-color:terrible-red;border-top-style:solid;',
 					'stylevariationclasses'    => ' has-background',
 					'stylevariationattributes' => '{"border":{"top":{"color":"terrible-red","width":"2px","style":"solid","radius":"10px"}},"color":{"background":"green-tonight"}}',
 					'stylevariationstyles'     => 'background-color:green-tonight; border-top-width:2px;border-top-color:terrible-red;border-top-style:solid;',
@@ -480,7 +480,6 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 								),
 								'color'  => array(
 									'background' => 'green-tonight',
-									'text'       => 'blue-overture',
 								),
 							),
 						),


### PR DESCRIPTION
Note - this merges into https://github.com/Automattic/jetpack/pull/42890 rather than trunk.

## Proposed changes:
Removes text color support from the Options block. This was added as part of the changes in #42890.

The discussion in p1747888061449759-slack-C02A76B714Z has more information around why we're doing this.

The TLDR is that the Multiple and Single choice fields have different markup on the backend and frontend. When setting text color in the editor, only child option blocks inherit color, but on the frontend both the label/legend and option items are children of the options blocks and receive the color.

The pragmatic options seems to be to remove support for text color. Users can already set a text color on an individual option, and that color will be synced to every option in the form, so the text color on Options is a little duplicative.

A low priority follow up task to #42890 could investigate removing the disparity in markup and re-introducing the Text color on options.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1747888061449759-slack-C02A76B714Z

## Does this pull request change what data or activity we track or use?
No
## Testing instructions:
1. Add a form
2. Add a single or multiple choice field
3. Select the options block
4. Notice you can't set Text color any more.