### PR TITLE
Forms: Fix animated style label font scaling

### DIFF
--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -942,6 +942,11 @@
 					transition: font-size 150ms cubic-bezier(0.4, 0, 0.2, 1);
 					will-change: font-size;
 				}
+
+				.required {
+					transition: font-size 150ms cubic-bezier(0.4, 0, 0.2, 1);
+					will-change: font-size;
+				}
 			}
 
 			.jetpack-field-multiple__list.jetpack-field-multiple__list--has-border {

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -935,9 +935,12 @@
 				margin: 0;
 				transform: translateY(-50%);
 				transition: all 150ms cubic-bezier(0.4, 0, 0.2, 1);
+				will-change: transform, top;
 
 				.jetpack-field-label__input {
 					margin: 0;
+					transition: font-size 150ms cubic-bezier(0.4, 0, 0.2, 1);
+					will-change: font-size;
 				}
 			}
 
@@ -958,9 +961,19 @@
 			&.is-selected, &.has-placeholder {
 
 				.animated-label__label {
-					font-size: 0.75em;
 					transform: translateY(0);
 					top: calc(2px + var(--jetpack--contact-form--border-top-size, 1px));
+
+					.jetpack-field-label__input {
+						font-size: 0.75em;
+					}
+
+					.required {
+						// The required text is usually 85% of the label font size.
+						// The label is being reduced to 0.75em in a separate rule which doesn't apply to the required text font size.
+						// Thus we take into account here - 0.85 * 0.75 = 0.6375em.
+						font-size: 0.6375em;
+					}
 				}
 			}
 		}

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -963,22 +963,20 @@
 				top: calc(2px + var(--jetpack--contact-form--border-top-size, 1px));
 			}
 
-			&.is-selected, &.has-placeholder {
+			&.is-selected .animated-label__label:not(.is-selected),
+			&.has-placeholder .animated-label__label {
+				transform: translateY(0);
+				top: calc(2px + var(--jetpack--contact-form--border-top-size, 1px));
 
-				.animated-label__label {
-					transform: translateY(0);
-					top: calc(2px + var(--jetpack--contact-form--border-top-size, 1px));
+				.jetpack-field-label__input {
+					font-size: 0.75em;
+				}
 
-					.jetpack-field-label__input {
-						font-size: 0.75em;
-					}
-
-					.required {
-						// The required text is usually 85% of the label font size.
-						// The label is being reduced to 0.75em in a separate rule which doesn't apply to the required text font size.
-						// Thus we take into account here - 0.85 * 0.75 = 0.6375em.
-						font-size: 0.6375em;
-					}
+				.required {
+					// The required text is usually 85% of the label font size.
+					// The label is being reduced to 0.75em in a separate rule which doesn't apply to the required text font size.
+					// Thus we take into account here - 0.85 * 0.75 = 0.6375em.
+					font-size: 0.6375em;
 				}
 			}
 		}

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -1493,41 +1493,6 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 	}
 
 	/**
-	 * Return the HTML for the outlined label.
-	 *
-	 * @param int    $id - the ID.
-	 * @param string $label - the label.
-	 * @param bool   $required - if the field is marked as required.
-	 * @param string $required_field_text - the text in the required text field.
-	 *
-	 * @return string HTML
-	 */
-	public function render_outline_label( $id, $label, $required, $required_field_text ) {
-		$classes  = 'notched-label__label';
-		$classes .= $this->is_error() ? ' form-error' : '';
-		$classes .= $this->label_classes ? ' ' . $this->label_classes : '';
-
-		$output_data = $this->get_form_variation_style_properties();
-
-		return '
-			<div class="notched-label">
-				<div class="notched-label__leading' . esc_attr( $output_data['class_name'] ) . '" style="' . esc_attr( $output_data['style'] ) . '"></div>
-				<div class="notched-label__notch' . esc_attr( $output_data['class_name'] ) . '" style="' . esc_attr( $output_data['style'] ) . '">
-					<label
-						for="' . esc_attr( $id ) . '"
-						class=" ' . $classes . '"
-						style="' . $this->label_styles . esc_attr( $output_data['css_vars'] ) . '"
-					>
-					<span class="grunion-label-text">' . esc_html( $label ) . '</span>'
-					. ( $required ? '<span class="grunion-label-required" aria-hidden="true">' . $required_field_text . '</span>' : '' ) .
-			'</label>
-				</div>
-				<div class="notched-label__filler' . esc_attr( $output_data['class_name'] ) . '" style="' . esc_attr( $output_data['style'] ) . '"></div>
-				<div class="notched-label__trailing' . esc_attr( $output_data['class_name'] ) . '" style="' . esc_attr( $output_data['style'] ) . '"></div>
-			</div>';
-	}
-
-	/**
 	 * Returns the styles, classes and CSS vars necessary to render fields in the "Outlined" style.
 	 * The "Animated" style variation shares the CSS vars, which require similar calculations for the left offset and label left position.
 	 * At the block level, the styles are extracted and added to the shortcode attributes in
@@ -1630,6 +1595,41 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 	}
 
 	/**
+	 * Return the HTML for the outlined label.
+	 *
+	 * @param int    $id - the ID.
+	 * @param string $label - the label.
+	 * @param bool   $required - if the field is marked as required.
+	 * @param string $required_field_text - the text in the required text field.
+	 *
+	 * @return string HTML
+	 */
+	public function render_outline_label( $id, $label, $required, $required_field_text ) {
+		$classes  = 'notched-label__label';
+		$classes .= $this->is_error() ? ' form-error' : '';
+		$classes .= $this->label_classes ? ' ' . $this->label_classes : '';
+
+		$output_data = $this->get_form_variation_style_properties();
+
+		return '
+			<div class="notched-label">
+				<div class="notched-label__leading' . esc_attr( $output_data['class_name'] ) . '" style="' . esc_attr( $output_data['style'] ) . '"></div>
+				<div class="notched-label__notch' . esc_attr( $output_data['class_name'] ) . '" style="' . esc_attr( $output_data['style'] ) . '">
+					<label
+						for="' . esc_attr( $id ) . '"
+						class=" ' . $classes . '"
+						style="' . $this->label_styles . esc_attr( $output_data['css_vars'] ) . '"
+					>
+					<span class="grunion-label-text">' . esc_html( $label ) . '</span>'
+					. ( $required ? '<span class="grunion-label-required" aria-hidden="true">' . $required_field_text . '</span>' : '' ) .
+			'</label>
+				</div>
+				<div class="notched-label__filler' . esc_attr( $output_data['class_name'] ) . '" style="' . esc_attr( $output_data['style'] ) . '"></div>
+				<div class="notched-label__trailing' . esc_attr( $output_data['class_name'] ) . '" style="' . esc_attr( $output_data['style'] ) . '"></div>
+			</div>';
+	}
+
+	/**
 	 * Return the HTML for the animated label.
 	 *
 	 * @param int    $id - the ID.
@@ -1649,9 +1649,9 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 				for="' . esc_attr( $id ) . '"
 				class="' . $classes . '"
 				style="' . $this->label_styles . '"
-			>'
-			. esc_html( $label )
-			. ( $required ? '<span class="grunion-label-required" aria-hidden="true">' . $required_field_text . '</span>' : '' ) .
+			>
+				<span class="grunion-label-text">' . esc_html( $label ) . '</span>'
+				. ( $required ? '<span class="grunion-label-required" aria-hidden="true">' . $required_field_text . '</span>' : '' ) .
 			'</label>';
 	}
 

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -728,6 +728,11 @@ on production builds, the attributes are being reordered, causing side-effects
 	will-change: font-size;
 }
 
+.contact-form .is-style-animated .grunion-field-wrap .grunion-label-required {
+	transition: font-size 150ms cubic-bezier(0.4, 0, 0.2, 1);
+	will-change: font-size;
+}
+
 .contact-form .is-style-animated .grunion-field-textarea-wrap .animated-label__label {
 	transform: unset;
 	top: calc(2px + var(--jetpack--contact-form--border-top-size, var( --jetpack--contact-form--border-size, 1px )));
@@ -748,6 +753,20 @@ on production builds, the attributes are being reordered, causing side-effects
 .contact-form .is-style-animated .grunion-field-wrap.grunion-field-select-wrap .animated-label__label .grunion-label-text
 {
 	font-size: 0.75em;
+}
+
+.contact-form .is-style-animated .grunion-field-wrap .animated-label__label:has(~ .grunion-field:focus) .grunion-label-required,
+.contact-form .is-style-animated .grunion-field-wrap .animated-label__label:has(~ .grunion-field:not(:placeholder-shown)) .grunion-label-required,
+.contact-form .is-style-animated .grunion-field-wrap .animated-label__label:has(~ .grunion-field.has-placeholder) .grunion-label-required,
+.contact-form .is-style-animated .grunion-field-wrap.grunion-field-select-wrap .animated-label__label .grunion-label-required
+{
+
+	/*
+	 * The required text is always 85% of the label font size.
+	 * The label font size is reduced to 0.75em in a separate rule, so that needs to be accounted for.
+	 * 0.85 * 0.75 = 0.6375em.
+	 */
+	font-size: 0.6375em;
 }
 
 /* The following is scoped by the presence of the custom font size CSS var to avoid needing conditional fallback within the var() */

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -704,6 +704,11 @@ on production builds, the attributes are being reordered, causing side-effects
 }
 
 .contact-form .is-style-animated .grunion-field-wrap .animated-label__label {
+	display: flex;
+	flex-direction: row;
+	flex-wrap: wrap;
+	justify-content: flex-start;
+	align-items: baseline;
 	position: absolute;
 	top: 50%;
 	left: calc(var(--jetpack--contact-form--border-left-size, 0px) + var(--jetpack--contact-form--animated-left-offset, var(--label-left)));
@@ -714,7 +719,13 @@ on production builds, the attributes are being reordered, causing side-effects
 	margin: 0;
 	transform: translateY(-50%);
 	transition: all 150ms cubic-bezier(0.4, 0, 0.2, 1);
+	will-change: transform, top;
 	z-index: 1;
+}
+
+.contact-form .is-style-animated .grunion-field-wrap .grunion-label-text {
+	transition: font-size 150ms cubic-bezier(0.4, 0, 0.2, 1);
+	will-change: font-size;
 }
 
 .contact-form .is-style-animated .grunion-field-textarea-wrap .animated-label__label {
@@ -727,9 +738,16 @@ on production builds, the attributes are being reordered, causing side-effects
 .contact-form .is-style-animated .grunion-field-wrap .animated-label__label:has(~ .grunion-field.has-placeholder),
 .contact-form .is-style-animated .grunion-field-wrap.grunion-field-select-wrap .animated-label__label
 {
-	font-size: 0.75em;
 	transform: translateY(0);
 	top: calc(2px + var(--jetpack--contact-form--border-top-size, var( --jetpack--contact-form--border-size, 1px )));
+}
+
+.contact-form .is-style-animated .grunion-field-wrap .animated-label__label:has(~ .grunion-field:focus) .grunion-label-text,
+.contact-form .is-style-animated .grunion-field-wrap .animated-label__label:has(~ .grunion-field:not(:placeholder-shown)) .grunion-label-text,
+.contact-form .is-style-animated .grunion-field-wrap .animated-label__label:has(~ .grunion-field.has-placeholder) .grunion-label-text,
+.contact-form .is-style-animated .grunion-field-wrap.grunion-field-select-wrap .animated-label__label .grunion-label-text
+{
+	font-size: 0.75em;
 }
 
 /* The following is scoped by the presence of the custom font size CSS var to avoid needing conditional fallback within the var() */


### PR DESCRIPTION
Note - this merges into https://github.com/Automattic/jetpack/pull/42890 rather than trunk.

## Proposed changes:
In #43590, an issue with the font scaling for the Outlined form style was fixed.

This PR fixes the same issue, but for the Animated form style.

When using the animated style, if the user sets a large font size in global styles, this should be respected by the label whether the input is unfocused, focused, or has a placeholder.

When focused or the field has a placeholder, the label size should be reduced slightly by 25% (0.75em). Prior to this PR, this wasn't happening, a `font-size: 0.75em` rule was overriding the user's desired font size. To fix this, I've moved the `font-size: 0.75em` rule to a child element of the label so that it can modify the user specified font size (which is inherited).

Some small adjustments were also needed for the required text to ensure that stayed smaller than the rest of the label text. On the frontend, the label was missing the `flex` style that labels have in the editor. This will cause the labels to appear slightly different to trunk, but IMO it's an improvement and a fix.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1748245066960179-slack-C02A76B714Z

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
1. Open the site editor
2. Go to Styles > Blocks > Labels and set an XL/XXL font size
3. Add a contact form to a page or template
4. Select the 'Animated' block style variation for the form
5. Click into one of the inputs and notice that the XXL font size is now respected.
6. Set some placeholder text for the input
7. Save and view the frontend
8. Observe that the font-size is also respected there and the appearance matches the editor.

#### Before
<img width="631" alt="Screenshot 2025-05-26 at 5 02 59 pm" src="https://github.com/user-attachments/assets/1f295eff-1d7e-409b-ab95-0215d6042639" />

#### After
<img width="634" alt="Screenshot 2025-05-26 at 4 59 47 pm" src="https://github.com/user-attachments/assets/ed15eff2-dd85-40b9-8d6c-388ad81f1bf2" />

