### PR TITLE
Forms: Add remove icon to dropdown items

### DIFF
--- a/projects/packages/forms/changelog/add-forms-delete-dropdown-items
+++ b/projects/packages/forms/changelog/add-forms-delete-dropdown-items
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: add remove button for dropdown options and prevent dropdowns with no options

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -1115,3 +1115,11 @@
 	flex-grow: 1;
 }
 
+.jetpack-field-dropdown__option-remove {
+	display: none;
+	margin-right: 5px;
+}
+
+.jetpack-field-dropdown__option:hover .jetpack-field-dropdown__option-remove {
+	display: inline-flex;
+}

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -1116,10 +1116,11 @@
 }
 
 .jetpack-field-dropdown__option-remove {
-	display: none;
+	display: inline-flex;
+	visibility: hidden;
 	margin-right: 5px;
 }
 
 .jetpack-field-dropdown__option:hover .jetpack-field-dropdown__option-remove {
-	display: inline-flex;
+	visibility: visible;
 }

--- a/projects/packages/forms/src/blocks/field-select/edit.js
+++ b/projects/packages/forms/src/blocks/field-select/edit.js
@@ -4,9 +4,11 @@ import {
 	useBlockProps,
 	useInnerBlocksProps,
 } from '@wordpress/block-editor';
+import { Icon, Button, Flex, FlexItem } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { useMemo, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { close } from '@wordpress/icons';
 import clsx from 'clsx';
 import JetpackFieldControls from '../shared/components/jetpack-field-controls';
 import useFormWrapper from '../shared/hooks/use-form-wrapper';
@@ -139,6 +141,9 @@ export default function DropdownFieldEdit( props ) {
 
 		const _options = [ ...attributes.options ];
 		_options.splice( index, 1 );
+		if ( _options.length === 0 || _options.filter( option => option ).length === 0 ) {
+			return;
+		}
 		setAttributes( { options: _options } );
 		changeFocus( Math.max( index - 1, 0 ), true );
 	};
@@ -149,16 +154,30 @@ export default function DropdownFieldEdit( props ) {
 			{ ( isSelected || isInnerBlockSelected ) && (
 				<div ref={ optionsWrapper } { ...optionWrapperStyles }>
 					{ options.map( ( option, index ) => (
-						<RichText
-							key={ index }
-							value={ option }
-							onChange={ handleChangeOption( index ) }
-							onKeyDown={ handleKeyDown( index ) }
-							onRemove={ handleDeleteOption( index ) }
-							onReplace={ noop }
-							placeholder={ __( 'Add option…', 'jetpack-forms' ) }
-							__unstableDisableFormats
-						/>
+						<Flex key={ index } className="jetpack-field-dropdown__option">
+							<FlexItem isBlock>
+								<RichText
+									value={ option }
+									onChange={ handleChangeOption( index ) }
+									onKeyDown={ handleKeyDown( index ) }
+									onRemove={ handleDeleteOption( index ) }
+									onReplace={ noop }
+									placeholder={ __( 'Add option…', 'jetpack-forms' ) }
+									__unstableDisableFormats
+								/>
+							</FlexItem>
+							<FlexItem>
+								{ ( options.filter( opt => opt ).length > 1 || option === '' ) && (
+									<Button
+										className="jetpack-field-dropdown__option-remove"
+										label={ __( 'Remove', 'jetpack-forms' ) }
+										onClick={ handleDeleteOption( index ) }
+									>
+										<Icon icon={ close } />
+									</Button>
+								) }
+							</FlexItem>
+						</Flex>
 					) ) }
 				</div>
 			) }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR has been created from `update/migrate-form-fields-to-inner-blocks` branch and shouldn't be merged to trunk. When reviewing the code, filter the view to only show the commit `f1f5cec`.

![Screenshot 2025-05-26 at 15 34 43](https://github.com/user-attachments/assets/93f7c23c-82eb-414a-8908-9059c2891844)


Fixes 12 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* I've added a remove button that shows on hover only when there is more than one dropdown option
* For mobile form factors, the button appears when the dropdown option is tapped

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a JN site with this branch or check it out on your local environment
* Create a form and add a dropdown field
* Hover on the first option and check that no remove button appears next to it (we can't have dropdown fields with no options)
* Add more options, and then hover over them and check if the remove icon appears on the right-hand side of the option
* Click on the remove icon and confirm that the option is removed
* Check that it also works on a mobile form-factor. The remove button should appear when you tap on one of the options.

