### PR TITLE
sass: Fix "slash as division" deprecation warning

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-sass-slash-div
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-sass-slash-div
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: sass: Fix "slash as division" deprecation warning.
+
+

--- a/projects/packages/jetpack-mu-wpcom/src/features/holiday-snow/holiday-snow.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/holiday-snow/holiday-snow.scss
@@ -6,6 +6,7 @@
  */
 
 @use 'sass:list';
+@use 'sass:math';
 
 $grid_width: 600;
 $snow_density: 10;
@@ -54,7 +55,7 @@ html {
 	}
 
 	#{$snow_selector}:after {
-		margin-left: -$grid_width / 3 + px;
+		margin-left: math.div( -$grid_width, 3 ) + px;
 		opacity: .4;
 		animation-duration: $snow_speed * 2;
 		animation-direction: reverse;
@@ -64,7 +65,7 @@ html {
 	#{$snow_selector}:before {
 		animation-duration: $snow_speed * 3;
 		animation-direction: reverse;
-		margin-left: -$grid_width / 2 + px;
+		margin-left: math.div( -$grid_width, 2 ) + px;
 		opacity: .65;
 		filter: blur(1.5px);
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
CSS uses `/` as a separator in some contexts. Sass treats it as division when it's not a separator, but it can be confusing which is the case, so sass v2 is removing slash-as-division in favor of the `math.div()` function.

https://sass-lang.com/documentation/breaking-changes/slash-div/

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* There should be no changes to the built CSS artifacts.
