### PR TITLE
Forms: add tracking pixel to form submission emails

### DIFF
--- a/projects/packages/forms/changelog/add-form-submission-tracking-pixel
+++ b/projects/packages/forms/changelog/add-form-submission-tracking-pixel
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: added tracking pixel to form submission emails to know if emails are being open. No user information is being sent, just the tracking event.

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1865,7 +1865,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 		$template       = '';
 		$style          = '';
 		$event          = new Jetpack_Tracks_Event(
-			array(
+			(object) array(
 				'_en' => 'jetpack_forms_email_open',
 				'_ui' => hash_hmac( 'md5', get_option( 'admin_email' ), JETPACK__VERSION ),
 				'_ut' => 'anon',

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -9,6 +9,7 @@ namespace Automattic\Jetpack\Forms\ContactForm;
 
 use Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch;
 use Automattic\Jetpack\Sync\Settings;
+use Jetpack_Tracks_Event;
 use PHPMailer\PHPMailer\PHPMailer;
 use WP_Error;
 
@@ -1861,8 +1862,16 @@ class Contact_Form extends Contact_Form_Shortcode {
 			return $body;
 		}
 
-		$template = '';
-		$style    = '';
+		$template       = '';
+		$style          = '';
+		$event          = new Jetpack_Tracks_Event(
+			array(
+				'_en' => 'jetpack_forms_email_open',
+				'_ui' => hash_hmac( 'md5', get_option( 'admin_email' ), JETPACK__VERSION ),
+				'_ut' => 'anon',
+			)
+		);
+		$tracking_pixel = '<img src="' . $event->build_pixel_url() . '" />';
 
 		/**
 		 * Filter the filename of the template HTML surrounding the response email. The PHP file will return the template in a variable called $template.
@@ -1887,7 +1896,8 @@ class Contact_Form extends Contact_Form_Shortcode {
 			'',
 			'',
 			$footer,
-			$style
+			$style,
+			$tracking_pixel
 		);
 
 		return $html_message;

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1862,16 +1862,20 @@ class Contact_Form extends Contact_Form_Shortcode {
 			return $body;
 		}
 
-		$template       = '';
-		$style          = '';
-		$event          = new Jetpack_Tracks_Event(
+		$template = '';
+		$style    = '';
+
+		// The hash is just used to anonymize the admin email and have a unique identifier for the event.
+		// The secret key used could have been a random string, but it's better to use the version number to make it easier to track.
+		$event = new Jetpack_Tracks_Event(
 			(object) array(
 				'_en' => 'jetpack_forms_email_open',
 				'_ui' => hash_hmac( 'md5', get_option( 'admin_email' ), JETPACK__VERSION ),
 				'_ut' => 'anon',
 			)
 		);
-		$tracking_pixel = '<img src="' . $event->build_pixel_url() . '" />';
+
+		$tracking_pixel = '<img src="' . $event->build_pixel_url() . '" alt="" width="1" height="1" />';
 
 		/**
 		 * Filter the filename of the template HTML surrounding the response email. The PHP file will return the template in a variable called $template.

--- a/projects/packages/forms/src/contact-form/templates/email-response.php
+++ b/projects/packages/forms/src/contact-form/templates/email-response.php
@@ -8,6 +8,7 @@
  * %4$s is a link to the embedded form to allow the site owner to edit it to change their email address.
  * %5$s is the footer HTML.
  * %6$s style HTML tag.
+ * %7$s tracking pixel.
  *
  * @package automattic/jetpack
  */
@@ -65,6 +66,7 @@ $template = '
 			<td class="collapse">&nbsp;</td>
 		</tr>
 	</table>
+	%7$s
 </body>
 </html>
 ';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes FORMS-54

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Added tracking pixel to the form submission emails

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Spin a JN site with this branch.
* Create a simple form and publish it.
* Submit and go to your email inbox to check the form submission email.
* After opening the email, go to Tracks and check that the event `jetpack_forms_email_open` shows up (it might take a few minutes).

