### PR TITLE
Fix the stats column width in non-English locales

### DIFF
--- a/projects/packages/stats-admin/changelog/fix-localized-stats-column-width
+++ b/projects/packages/stats-admin/changelog/fix-localized-stats-column-width
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed wrapping on the stats column heading in non-English languages

--- a/projects/packages/stats-admin/src/class-admin-post-list-column.php
+++ b/projects/packages/stats-admin/src/class-admin-post-list-column.php
@@ -66,6 +66,7 @@ class Admin_Post_List_Column {
 		<style type="text/css">
 			.fixed .column-stats {
 				width: 5em;
+				white-space: nowrap;
 			}
 		</style>
 		<?php

--- a/projects/plugins/jetpack/changelog/fix-localized-stats-column-width
+++ b/projects/plugins/jetpack/changelog/fix-localized-stats-column-width
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fixed wrapping on the stats column heading in non-English languages

--- a/projects/plugins/jetpack/modules/comment-likes/admin-style.css
+++ b/projects/plugins/jetpack/modules/comment-likes/admin-style.css
@@ -6,6 +6,7 @@
 
 .fixed .column-stats {
     width: 5em;
+    white-space: nowrap;
 }
 
 .fixed .column-comment_likes .comment-like-count {

--- a/projects/plugins/jetpack/modules/likes.php
+++ b/projects/plugins/jetpack/modules/likes.php
@@ -294,7 +294,7 @@ class Jetpack_Likes {
 			.vers img { display: none; }
 			.metabox-prefs .vers img { display: inline; }
 			.fixed .column-likes { width: 2.5em; padding: 4px 0; text-align: left; }
-			.fixed .column-stats { width: 5em; }
+			.fixed .column-stats { width: 5em; white-space: nowrap; }
 			.fixed .column-likes .post-com-count {
 				-webkit-box-sizing: border-box;
 				-moz-box-sizing: border-box;

--- a/projects/plugins/mu-wpcom-plugin/changelog/fix-localized-stats-column-width
+++ b/projects/plugins/mu-wpcom-plugin/changelog/fix-localized-stats-column-width
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed wrapping on the stats column heading in non-English languages

--- a/projects/plugins/wpcomsh/changelog/fix-localized-stats-column-width
+++ b/projects/plugins/wpcomsh/changelog/fix-localized-stats-column-width
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed wrapping on the stats column heading in non-English languages


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes DOTCOM-13329

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adjust the CSS to prevent the column heading from wrapping.
<img width="339" alt="Screenshot 2025-05-26 at 23 56 45" src="https://github.com/user-attachments/assets/ec2b5a03-3546-4623-954e-69489b17592f" />
<img width="339" alt="Screenshot 2025-05-26 at 23 56 08" src="https://github.com/user-attachments/assets/0425ab89-a16b-470d-8374-948c4e540340" />



### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Use a test site with Jetpack Stats enabled.
* Change your user admin language to Brazilian Portuguese (or Spanish, French, Hebrew, Dutch, Russian, Turkish).
* Go to the list of posts / pages in wp-admin.
* Confirm that the Stats column says `Estatísticas` without wrapping.

