### PR TITLE
My Jetpack: Onboarding i3 | Split the overview tab

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
@@ -189,7 +189,6 @@ export default function MyJetpackScreen() {
 			useInternalLinks={ shouldUseInternalLinks() }
 		>
 			<h1 className="screen-reader-text">{ __( 'My Jetpack', 'jetpack-my-jetpack' ) }</h1>
-			<hr className={ styles.separator } />
 
 			<IDCModal />
 			<GlobalNotices />

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/styles.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/styles.module.scss
@@ -148,8 +148,3 @@
 		}
 	}
 }
-
-.separator {
-	margin: 0;
-	border-bottom: none;
-}

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/overview-content.tsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/overview-content.tsx
@@ -1,5 +1,4 @@
 import ProductCardsSection from '../product-cards-section';
-import styles from './styles.module.scss';
 
 /**
  * The Overview content component.
@@ -8,7 +7,7 @@ import styles from './styles.module.scss';
  */
 export function OverviewContent() {
 	return (
-		<div className={ styles[ 'overview-content' ] }>
+		<div>
 			<ProductCardsSection />
 		</div>
 	);

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/overview-content.tsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/overview-content.tsx
@@ -1,3 +1,6 @@
+import ProductCardsSection from '../product-cards-section';
+import styles from './styles.module.scss';
+
 /**
  * The Overview content component.
  *
@@ -5,8 +8,8 @@
  */
 export function OverviewContent() {
 	return (
-		<div>
-			<h2>Overview Tab</h2>
+		<div className={ styles[ 'overview-content' ] }>
+			<ProductCardsSection />
 		</div>
 	);
 }

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/styles.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/styles.module.scss
@@ -1,26 +1,27 @@
 @import '@automattic/jetpack-base-styles/gutenberg-base-styles';
 
 .tab-panel {
-	margin-inline-start: 2rem;
 
-	@media ( max-width: $break-medium ) {
-		margin-inline-start: 1rem;
+	:global(.components-tab-panel__tabs) {
+		padding-inline-start: 2rem;
+		margin-block-end: -1px;
+
+		@media (max-width: $break-medium ) {
+			padding-inline-start: 1rem;
+		}
+	}
+
+	:global(.components-tab-panel__tab-content) {
+		border-top: 1px solid var(--jp-gray);
+
 	}
 }
 
 .tab-content-wrapper {
-	padding-inline-start: 1rem;
-	
-	@media ( max-width: $break-medium ) {
-		padding-inline-start: 0;
-	}
-}
+	padding-block-start: 2.5rem;
+	padding-inline: 3rem;
 
-.overview-content {
-	padding-block-start: 2.5rem;	
-	padding-inline-end: 3rem;
-
-	@media ( max-width: $break-medium ) {
-		padding-inline-end: 1rem;
+	@media (max-width: $break-medium ) {
+		padding-inline: 1rem;
 	}
 }

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/styles.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/styles.module.scss
@@ -10,4 +10,17 @@
 
 .tab-content-wrapper {
 	padding-inline-start: 1rem;
+	
+	@media ( max-width: $break-medium ) {
+		padding-inline-start: 0;
+	}
+}
+
+.overview-content {
+	padding-block-start: 2.5rem;	
+	padding-inline-end: 3rem;
+
+	@media ( max-width: $break-medium ) {
+		padding-inline-end: 1rem;
+	}
 }

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/index.tsx
@@ -1,11 +1,9 @@
-import { Container, Col, Text, AdminSectionHero } from '@automattic/jetpack-components';
-import { __ } from '@wordpress/i18n';
-import { useMemo, useCallback, useState, useEffect } from 'react';
+import { Col, Container } from '@automattic/jetpack-components';
+import { useCallback, useEffect, useState } from 'react';
 import { PRODUCT_SLUGS } from '../../data/constants';
 import useProductsByOwnership from '../../data/products/use-products-by-ownership';
 import { getMyJetpackWindowInitialState } from '../../data/utils/get-my-jetpack-window-state';
 import LoadingBlock from '../loading-block';
-import ProductsTableView from '../products-table-view';
 import StatsSection from '../stats-section';
 import AiCard from './ai-card';
 import AntiSpamCard from './anti-spam-card';
@@ -105,12 +103,12 @@ const DisplayItems: FC< DisplayItemsProps > = ( { slugs, isLoading } ) => {
 };
 
 interface ProductCardsSectionProps {
-	noticeMessage: ReactNode;
+	noticeMessage?: ReactNode;
 }
 
 const ProductCardsSection: FC< ProductCardsSectionProps > = ( { noticeMessage } ) => {
 	const {
-		data: { ownedProducts, unownedProducts },
+		data: { ownedProducts },
 		isLoading,
 	} = useProductsByOwnership();
 
@@ -128,13 +126,7 @@ const ProductCardsSection: FC< ProductCardsSectionProps > = ( { noticeMessage } 
 		requestAnimationFrame( () => setIsLoadingProducts( false ) );
 	} );
 
-	const { canUserViewStats, userIsAdmin } = getMyJetpackWindowInitialState();
-
-	const unownedSectionTitle = useMemo( () => {
-		return ownedProducts.length > 0
-			? __( 'Discover more', 'jetpack-my-jetpack' )
-			: __( 'Discover all Jetpack Products', 'jetpack-my-jetpack' );
-	}, [ ownedProducts.length ] );
+	const { canUserViewStats } = getMyJetpackWindowInitialState();
 
 	const filterProducts = useCallback(
 		( products: JetpackModule[] ) => {
@@ -165,31 +157,17 @@ const ProductCardsSection: FC< ProductCardsSectionProps > = ( { noticeMessage } 
 	);
 
 	const filteredOwnedProducts = filterProducts( ownedProducts );
-	const filteredUnownedProducts = filterProducts( unownedProducts );
 
 	return (
 		<>
 			{ ( isLoadingProducts || filteredOwnedProducts.length > 0 ) && (
-				<AdminSectionHero>
-					<Container horizontalSpacing={ 6 } horizontalGap={ noticeMessage ? 3 : 6 }>
-						<Col>
-							<Col sm={ 4 } md={ 8 } lg={ 12 } className={ styles.cardListTitle }>
-								<Text variant="headline-small">{ __( 'My products', 'jetpack-my-jetpack' ) }</Text>
-							</Col>
-
-							<DisplayItems isLoading={ isLoadingProducts } slugs={ filteredOwnedProducts } />
-						</Col>
-					</Container>
-				</AdminSectionHero>
-			) }
-
-			{ userIsAdmin && filteredUnownedProducts.length > 0 && (
-				<Container horizontalSpacing={ 6 } horizontalGap={ noticeMessage ? 3 : 6 }>
+				<Container
+					horizontalSpacing={ 0 }
+					horizontalGap={ noticeMessage ? 3 : 6 }
+					className={ styles[ 'products-container' ] }
+				>
 					<Col>
-						<Col sm={ 4 } md={ 8 } lg={ 12 } className={ styles.cardListTitle }>
-							<Text variant="headline-small">{ unownedSectionTitle }</Text>
-						</Col>
-						<ProductsTableView products={ filteredUnownedProducts } />
+						<DisplayItems isLoading={ isLoadingProducts } slugs={ filteredOwnedProducts } />
 					</Col>
 				</Container>
 			) }

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/style.module.scss
@@ -47,7 +47,6 @@
 	}
 }
 
-.cardListTitle,
 .fullStatsCard {
 	margin-bottom: 1.5rem;
 }
@@ -90,4 +89,8 @@
 			grid-column-end: auto;
 		}
 	}	
+}
+
+.products-container {
+	padding-inline: 0;
 }

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-split-overview-tab
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-split-overview-tab
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Onboarding: Update the overview tab based on i3 design.


### PR DESCRIPTION
This PR updates the Overview tab to reflect the updated designs.

Completes MYJP-130

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Update the Overview tab with the product cards from the existing My Jetpack screen

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to My Jetpack
* Go to the Overview tab
* Confirm that you see the overview as given in the designs - ofX26tWPDKuUh5v1qzgKog-fi-4497_76952
* Confirm that the UI looks fine on different viewpoints

Here are the screenshots at different viewpoints

<img width="1025" alt="Screenshot 2025-05-27 at 10 46 23 AM" src="https://github.com/user-attachments/assets/9013344d-3d6e-4156-842a-df044d7d032a" />
<img width="638" alt="Screenshot 2025-05-27 at 10 48 00 AM" src="https://github.com/user-attachments/assets/fca252a1-a8c1-454a-a232-a4f0d771eab5" />
<img width="825" alt="Screenshot 2025-05-27 at 10 47 47 AM" src="https://github.com/user-attachments/assets/b770b013-5015-4559-9e69-b5393b3ad9d2" />
<img width="832" alt="Screenshot 2025-05-27 at 10 47 39 AM" src="https://github.com/user-attachments/assets/6dcbb053-f6a2-4f4a-8708-69b78894c6dc" />
<img width="1001" alt="Screenshot 2025-05-27 at 10 47 16 AM" src="https://github.com/user-attachments/assets/025542bb-0324-4637-95fb-4cc9a86fe329" />
