### PR TITLE
Forms: tame animated style labels for individual borders

### DIFF
--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -927,7 +927,7 @@
 			.animated-label__label {
 				position: absolute;
 				z-index: 1;
-				top: var(--jetpack--contact-form--animated-top-offset);
+				top: var(--jetpack--contact-form--animated-top-offset, 50%);
 				left: calc(var(--jetpack--contact-form--border-left-size, 1px) + var(--jetpack--contact-form--animated-left-offset));
 				width: auto;
 				max-width: 100%;

--- a/projects/packages/forms/src/blocks/shared/hooks/use-variation-style-properties.js
+++ b/projects/packages/forms/src/blocks/shared/hooks/use-variation-style-properties.js
@@ -196,14 +196,21 @@ export default function useVariationStyleProperties( {
 			};
 		}
 		if ( formStyle === FORM_STYLE.ANIMATED ) {
+			const hasEqualVerticalBorderSizes =
+				borderWidths?.borderTopWidth === borderWidths?.borderBottomWidth;
 			const hasTopBorder =
 				!! borderWidths?.borderTopWidth && parseInt( borderWidths?.borderTopWidth ) > 0;
 			styleSpecificCssVars = {
 				// For the animated labels.
 				'--jetpack--contact-form--animated-left-offset': '16px', // Probably can be removed or we use `--jetpack--contact-form--input-padding`
-				'--jetpack--contact-form--animated-top-offset': hasTopBorder
-					? 'calc(var(--jetpack--contact-form--border-top-size) + var(--jetpack--contact-form--animated-left-offset))'
-					: '50%',
+				/*
+				 * If the top and bottom borders are not equal, we can't float the animated label in the vertical center.
+				 * So just make sure it sits under the top border. Add 1rem to offset huge font sizes.
+				 */
+				'--jetpack--contact-form--animated-top-offset':
+					hasTopBorder && ! hasEqualVerticalBorderSizes
+						? `calc(var(--jetpack--contact-form--border-top-size) + var(--jetpack--contact-form--animated-left-offset) + 1rem)`
+						: '50%',
 			};
 		}
 

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -1613,13 +1613,18 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		} elseif ( isset( $border_radius ) ) {
 			$css_vars .= $border_radius ? '--jetpack--contact-form--border-radius: ' . $border_radius . ';' : '';
 		}
-
 		if ( 'outlined' === $form_style ) {
 			$css_vars .= '--jetpack--contact-form--notch-width: max(var(--jetpack--contact-form--input-padding-left, 16px), var(--jetpack--contact-form--border-radius));';
 		} elseif ( 'animated' === $form_style ) {
-			$css_vars .= '--jetpack--contact-form--animated-left-offset: 16px;';
-			$css_vars .= '--jetpack--contact-form--animated-top-offset:' . $border_top_size ? 'calc(var(--jetpack--contact-form--border-top-size) + var(--jetpack--contact-form--animated-left-offset));'
-				: '50%;';
+			$has_equal_vertical_border_sizes = $border_top_size === $border_bottom_size;
+
+			/*
+			 * If the top and bottom borders are not equal, we can't float the animated label in the vertical center.
+			 * So just make sure it sits under the top border. Add 1rem to offset huge font sizes.
+			 */
+			$animated_top_offset = $border_top_size && ! $has_equal_vertical_border_sizes ? 'calc(var(--jetpack--contact-form--border-top-size) + var(--jetpack--contact-form--animated-left-offset) + 1rem);' : '50%;';
+			$css_vars           .= '--jetpack--contact-form--animated-left-offset: 16px;';
+			$css_vars           .= '--jetpack--contact-form--animated-top-offset:' . $animated_top_offset;
 		}
 
 		return array(

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -705,7 +705,7 @@ on production builds, the attributes are being reordered, causing side-effects
 
 .contact-form .is-style-animated .grunion-field-wrap .animated-label__label {
 	position: absolute;
-	top: 50%;
+	top: var(--jetpack--contact-form--animated-top-offset);
 	left: calc(var(--jetpack--contact-form--border-left-size, 0px) + var(--jetpack--contact-form--animated-left-offset, var(--label-left)));
 	width: 100%;
 	max-width: 100%;

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -705,7 +705,7 @@ on production builds, the attributes are being reordered, causing side-effects
 
 .contact-form .is-style-animated .grunion-field-wrap .animated-label__label {
 	position: absolute;
-	top: var(--jetpack--contact-form--animated-top-offset);
+	top: var(--jetpack--contact-form--animated-top-offset, 50%);
 	left: calc(var(--jetpack--contact-form--border-left-size, 0px) + var(--jetpack--contact-form--animated-left-offset, var(--label-left)));
 	width: 100%;
 	max-width: 100%;


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack-roadmap/issues/2605

JETPACK-497

Base branch: https://github.com/Automattic/jetpack/pull/42890

## Proposed changes:

This PR fixes label positioning for the animated style, ensuring defaults for legacy forms.

Main changes:

- ensures that unfocussed input labels float at the vertical centre where the top and bottom borders are equal
- otherwise, make them float underneath the top border.

Why?

Because the label is absolutely positioned, we can't reliably calculate where the label should sit given varying individual border sizes. 

Normally, the label hovers in the centre of the input. However, if the top border is, for example `100px` and the bottom `20em`, we can't calculate where the input sits and therefore where its centre point it. Throw in variable font sizes for the input and it's just not worth it.

This PR makes the label behave at least under such conditions.


## Testing instructions:

Add an animated form with all the fields.

Experiment with different border widths for input fields.

Check that label behaves mostly okay.

For equal vertical border sizes, and for forms built in trunk, the label should float in the middle.


Look at these cool example videos!

https://github.com/user-attachments/assets/0a3eb1d6-b1ab-4353-a8c0-3f709dfe6c88




https://github.com/user-attachments/assets/7c6d9cff-435a-4c00-a4fa-f2947f344b3b


https://github.com/user-attachments/assets/dc700801-10d9-4dca-9c26-a9c5ea26d98a


https://github.com/user-attachments/assets/f9d5f49b-8307-426d-ba03-a92bc450b4e3

