### PR TITLE
Forms: update padding for jetpack options in contact form to conform with trunk

### DIFF
--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -528,7 +528,7 @@
 .jetpack-field-multiple__list.jetpack-field-multiple__list {
 	list-style-type: none;
 	margin: 0;
-	padding: var(--jetpack--contact-form--input-padding-left, 16px) 0;
+	padding-left: 0;
 	display: flex;
 	flex-direction: column;
 	align-items: flex-start;

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -891,8 +891,9 @@
 				border-color: transparent !important;
 				border-radius: unset !important;
 				outline: none;
-				padding-left: calc(min(100px, var(--jetpack--contact-form--notch-width)) + 4px);
-				padding-right: var(--jetpack--contact-form--input-padding-left, 16px);
+				padding: var(--jetpack--contact-form--input-padding, 16px);
+				padding-top: calc(var(--jetpack--contact-form--input-padding-top, 16px) + 4px);
+				padding-left: min(100px, var(--jetpack--contact-form--notch-width));
 			}
 		}
 	}
@@ -947,9 +948,14 @@
 				padding-left: var(--jetpack--contact-form--animated-left-offset);
 			}
 
-
-			&.jetpack-field-multiple .animated-label__label {
+			&.is-selected.jetpack-field-multiple .animated-label__label,
+			&.has-placeholder.jetpack-field-multiple .animated-label__label {
 				position: static;
+				margin-bottom: 0.25em;
+
+				.jetpack-field-label__input {
+					font-size: inherit;
+				}
 			}
 
 			&.jetpack-field-textarea .animated-label__label {

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -427,6 +427,7 @@
 	appearance: none;
 	text-overflow: ellipsis;
 	white-space: nowrap;
+	padding: var(--jetpack--contact-form--input-padding);
 }
 
 .contact-form .is-style-outlined,
@@ -789,14 +790,9 @@ on production builds, the attributes are being reordered, causing side-effects
 	margin-left:  var(--jetpack--contact-form--border-left-size, var(--jetpack--contact-form--border-size));
 }
 
-.contact-form :where(.grunion-field-wrap:not(.is-style-button-wrap)) .grunion-checkbox-multiple-options:not(.wp-block-jetpack-options),
-.contact-form :where(.grunion-field-wrap:not(.is-style-button-wrap)) .grunion-radio-options:not(.wp-block-jetpack-options) {
+.contact-form :where(.grunion-field-wrap:not(.is-style-button-wrap)) .grunion-checkbox-multiple-options,
+.contact-form :where(.grunion-field-wrap:not(.is-style-button-wrap)) .grunion-radio-options {
 	padding-top: 8px;
-}
-
-:where(.wp-block-jetpack-options) {
-
-	/* padding: var(--jetpack--contact-form--input-padding-left, 16px) 0; */
 }
 
 :where(.wp-block-jetpack-options.has-background) {
@@ -1052,10 +1048,6 @@ on production builds, the attributes are being reordered, causing side-effects
 .contact-form__checkbox-wrap {
 	display: inline-flex;
 	align-items: baseline;
-
-	:where( .grunion-field-label ) {
-		margin: 0;
-	}
 }
 
 .contact-form :is([type="submit"],button:not([type="reset"])) {

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -90,13 +90,9 @@
 	font-weight: 700;
 }
 
-.grunion-checkbox-multiple-options :where( legend ),
-.grunion-radio-options :where( legend ) {
-	margin-bottom: 0.25em;
+.contact-form :where(legend.grunion-field-label) {
 	padding: 0;
-	font-weight: 700;
 }
-
 
 .contact-form :where(label.consent) {
 	font-size: 13px;
@@ -676,8 +672,7 @@ on production builds, the attributes are being reordered, causing side-effects
 	--field-padding: calc(var(--label-left) - var(--jetpack--contact-form--border-size));
 }
 
-.wp-block-jetpack-contact-form:not(.is-style-outlined) .jetpack-field-multiple__fieldset,
-.wp-block-jetpack-contact-form:not(.is-style-outlined) .jetpack-field-multiple__fieldset legend {
+.wp-block-jetpack-contact-form:not(.is-style-outlined) .jetpack-field-multiple__fieldset {
 	padding: 0;
 	border: 0;
 	margin: 0;
@@ -800,7 +795,8 @@ on production builds, the attributes are being reordered, causing side-effects
 }
 
 :where(.wp-block-jetpack-options) {
-	padding: var(--jetpack--contact-form--input-padding-left, 16px) 0;
+
+	/* padding: var(--jetpack--contact-form--input-padding-left, 16px) 0; */
 }
 
 :where(.wp-block-jetpack-options.has-background) {

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -674,7 +674,7 @@ on production builds, the attributes are being reordered, causing side-effects
 }
 
 .wp-block-jetpack-contact-form:not(.is-style-outlined) .jetpack-field-multiple__fieldset {
-	padding: 0;
+	padding: 8px 0 0 0;
 	border: 0;
 	margin: 0;
 }
@@ -790,8 +790,8 @@ on production builds, the attributes are being reordered, causing side-effects
 	margin-left:  var(--jetpack--contact-form--border-left-size, var(--jetpack--contact-form--border-size));
 }
 
-.contact-form :where(.grunion-field-wrap:not(.is-style-button-wrap)) .grunion-checkbox-multiple-options,
-.contact-form :where(.grunion-field-wrap:not(.is-style-button-wrap)) .grunion-radio-options {
+.contact-form :where(.grunion-field-wrap:not(.is-style-button-wrap)) .grunion-checkbox-multiple-options:not(.wp-block-jetpack-options),
+.contact-form :where(.grunion-field-wrap:not(.is-style-button-wrap)) .grunion-radio-options:not(.wp-block-jetpack-options) {
 	padding-top: 8px;
 }
 

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -673,12 +673,6 @@ on production builds, the attributes are being reordered, causing side-effects
 	--field-padding: calc(var(--label-left) - var(--jetpack--contact-form--border-size));
 }
 
-.wp-block-jetpack-contact-form:not(.is-style-outlined) .jetpack-field-multiple__fieldset {
-	padding: 8px 0 0 0;
-	border: 0;
-	margin: 0;
-}
-
 .contact-form .is-style-animated .grunion-field-wrap input:not([type="checkbox"]):not([type="radio"]) {
 	outline: none;
 }
@@ -790,6 +784,14 @@ on production builds, the attributes are being reordered, causing side-effects
 	margin-left:  var(--jetpack--contact-form--border-left-size, var(--jetpack--contact-form--border-size));
 }
 
+/* fields with multiple options */
+.wp-block-jetpack-contact-form:not(.is-style-outlined) .jetpack-field-multiple__fieldset {
+	padding: 8px 0 0 0;
+	border: 0;
+	margin: 0;
+}
+
+/* fields with multiple options - not .wp-block-jetpack-options because the inner blocks introduce new markup */
 .contact-form :where(.grunion-field-wrap:not(.is-style-button-wrap)) .grunion-checkbox-multiple-options:not(.wp-block-jetpack-options),
 .contact-form :where(.grunion-field-wrap:not(.is-style-button-wrap)) .grunion-radio-options:not(.wp-block-jetpack-options) {
 	padding-top: 8px;


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack-roadmap/issues/2606

JETPACK-498

## Proposed changes:

This PR harmonizes the padding for options blocks between the [feature branch](https://github.com/Automattic/jetpack/pull/42890) and trunk.

Here's a visual diff between the feature branch and trunk. (Trunk is the faded version). See how there's extra padding around the options blocks?

![Screenshot 2025-05-27 at 12 31 05 pm](https://github.com/user-attachments/assets/f3da7cc5-7974-4b14-9ca1-f6f3c20ec451)

This PR tidies that up as best as we can (the violet colors are the differences)

| Frontend | Editor |
|--------|--------|
| <img width="564" alt="Screenshot 2025-05-28 at 1 02 23 pm" src="https://github.com/user-attachments/assets/912ad4de-9253-4a4a-a1de-360efd399c37" /> | <img width="977" alt="Screenshot 2025-05-28 at 12 59 25 pm" src="https://github.com/user-attachments/assets/5296986c-5955-499c-9262-df019e1e4168" /> |









## Testing instructions:

Create a few forms in trunk with multi options (radio and checkbox), along with other fields for good measure. Also create an animated and outlined style form.

Open the forms on the frontend. 

It's a good idea to open the form in two tabs for comparison purposes.

Now load this branch.

Compare the same form in both branches. There should be no weirdness.
