### PR TITLE
Forms Fix animated label centered positioning

### DIFF
--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -927,7 +927,7 @@
 			.animated-label__label {
 				position: absolute;
 				z-index: 1;
-				top: var(--jetpack--contact-form--animated-top-offset);
+				top: calc(50% + (var(--jetpack--contact-form--border-top-size, 0px) * 0.5) - (var(--jetpack--contact-form--border-bottom-size, 0px) * 0.5));
 				left: calc(var(--jetpack--contact-form--border-left-size, 1px) + var(--jetpack--contact-form--animated-left-offset));
 				width: auto;
 				max-width: 100%;

--- a/projects/packages/forms/src/blocks/shared/hooks/use-variation-style-properties.js
+++ b/projects/packages/forms/src/blocks/shared/hooks/use-variation-style-properties.js
@@ -196,14 +196,9 @@ export default function useVariationStyleProperties( {
 			};
 		}
 		if ( formStyle === FORM_STYLE.ANIMATED ) {
-			const hasTopBorder =
-				!! borderWidths?.borderTopWidth && parseInt( borderWidths?.borderTopWidth ) > 0;
 			styleSpecificCssVars = {
 				// For the animated labels.
 				'--jetpack--contact-form--animated-left-offset': '16px', // Probably can be removed or we use `--jetpack--contact-form--input-padding`
-				'--jetpack--contact-form--animated-top-offset': hasTopBorder
-					? 'calc(var(--jetpack--contact-form--border-top-size) + var(--jetpack--contact-form--animated-left-offset))'
-					: '50%',
 			};
 		}
 

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -1583,8 +1583,6 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 			$css_vars .= '--jetpack--contact-form--notch-width: max(var(--jetpack--contact-form--input-padding-left, 16px), var(--jetpack--contact-form--border-radius));';
 		} elseif ( 'animated' === $form_style ) {
 			$css_vars .= '--jetpack--contact-form--animated-left-offset: 16px;';
-			$css_vars .= '--jetpack--contact-form--animated-top-offset:' . $border_top_size ? 'calc(var(--jetpack--contact-form--border-top-size) + var(--jetpack--contact-form--animated-left-offset));'
-				: '50%;';
 		}
 
 		return array(

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -710,7 +710,7 @@ on production builds, the attributes are being reordered, causing side-effects
 	justify-content: flex-start;
 	align-items: baseline;
 	position: absolute;
-	top: 50%;
+	top: calc(50% + (var(--jetpack--contact-form--border-top-size, 0px) * 0.5) - (var(--jetpack--contact-form--border-bottom-size, 0px) * 0.5));
 	left: calc(var(--jetpack--contact-form--border-left-size, 0px) + var(--jetpack--contact-form--animated-left-offset, var(--label-left)));
 	width: 100%;
 	max-width: 100%;


### PR DESCRIPTION
Fixes the issue mentioned here - https://github.com/Automattic/jetpack/pull/43615/files/1d5cdf72b65932cb1970242c3f895966af9d1130#diff-b032342e36da30ca1c7a18a770aac75a9d52bdec892fe09e3e047c3a8ca73b69

Fixes JETPACK-497

Alternative to #43633

Note - this merges into https://github.com/Automattic/jetpack/pull/42890 rather than trunk.

## Proposed changes:
As spotted by @ramonjd, when using the animated form style, labels weren't centered correctly if the user is using uneven top/bottom borders.

In trunk, the css uses `top: 50%`, which always works because the user can only set equal top/bottom borders.

With #42890 the user can set different top/bottom border values, so we need a slightly different calculation. It's not too tricky, we just need to do 50% + ( half-of-top-border - half-of-bottom-border ), and thankfully there already top/bottom border css vars being injected.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
1. Add a contact form
2. Switch it to the Animated style variation
3. Click an input and give it a large top border value
4. Deselect the input and check that the label is correctly centered in the field
5. Save and check the frontend looks the same.
6. Back in the editor, give the input bottom border to match the top border
7. Repeat steps 4-5
8. In the editor again, remove the top border of the input
9. Repeat steps 4-5 again

### Screenshot of expected results:

#### Uneven bottom border

<img width="643" alt="Screenshot 2025-05-27 at 2 06 02 pm" src="https://github.com/user-attachments/assets/9636df96-97eb-4bd0-b11d-958b7dd27aaf" />

#### Uneven top border

<img width="631" alt="Screenshot 2025-05-27 at 2 06 51 pm" src="https://github.com/user-attachments/assets/9d9e389b-e7da-4935-a14f-a9d23318afdc" />

#### Equal borders

<img width="628" alt="Screenshot 2025-05-27 at 2 07 31 pm" src="https://github.com/user-attachments/assets/bb57a136-306b-4149-8d81-ebd37981de31" />

