### PR TITLE
Social: Fix admin page images not loading on Simple

### DIFF
--- a/projects/js-packages/publicize-components/changelog/fix-social-admin-page-assets-public-path
+++ b/projects/js-packages/publicize-components/changelog/fix-social-admin-page-assets-public-path
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed webpack publicPath issue for Social admin.

--- a/projects/js-packages/publicize-components/src/components/admin-page/entry-point.tsx
+++ b/projects/js-packages/publicize-components/src/components/admin-page/entry-point.tsx
@@ -1,3 +1,4 @@
+import '../../set-webpack-public-path';
 import { ThemeProvider } from '@automattic/jetpack-components';
 import * as WPElement from '@wordpress/element';
 import React from 'react';

--- a/projects/js-packages/publicize-components/src/set-webpack-public-path.js
+++ b/projects/js-packages/publicize-components/src/set-webpack-public-path.js
@@ -1,0 +1,12 @@
+/* exported __webpack_public_path__ */
+/* global __webpack_public_path__ */
+
+/**
+ * Dynamically set WebPack's publicPath so that split assets can be found.
+ * This ensures that assets (like images) are loaded from the correct path
+ * regardless of the environment (WordPress.com, Simple sites, etc.).
+ */
+if ( typeof window === 'object' && window.JetpackScriptData?.social?.urls?.webpackPublicPath ) {
+	// eslint-disable-next-line no-global-assign
+	__webpack_public_path__ = window.JetpackScriptData.social.urls.webpackPublicPath;
+}

--- a/projects/packages/publicize/changelog/fix-social-admin-page-assets-public-path
+++ b/projects/packages/publicize/changelog/fix-social-admin-page-assets-public-path
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed webpack publicPath issue for Social admin.

--- a/projects/packages/publicize/src/class-publicize-script-data.php
+++ b/projects/packages/publicize/src/class-publicize-script-data.php
@@ -310,6 +310,7 @@ class Publicize_Script_Data {
 
 		$urls = array(
 			'connectionsManagementPage' => self::publicize()->publicize_connections_url(),
+			'webpackPublicPath'         => plugins_url( '/build/', __DIR__ ),
 		);
 
 		// Escape the URLs.

--- a/projects/plugins/jetpack/changelog/fix-social-admin-page-assets-public-path
+++ b/projects/plugins/jetpack/changelog/fix-social-admin-page-assets-public-path
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fixed webpack publicPath issue for Social admin.

--- a/projects/plugins/social/changelog/fix-social-admin-page-assets-public-path
+++ b/projects/plugins/social/changelog/fix-social-admin-page-assets-public-path
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed webpack publicPath issue for Social admin.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes SOCIAL-48

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Added a new file for setting the `publicPath`
* Extended the script-data with the URL

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
SOCIAL-48
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

To test the issue:
* Rsync trunk to your sandbox, and go to your sandboxed simple site. Add `&concat_js=yes` to the URL.
* On the Social Admin page in the Jetpack submenu,  open the SIG settings modal, or the example images in the connection management modal, they won't load.
* Now switch to this branch and rsync it.
* Refresh the page, the images should load up fine, the URL should be `<SITE_URL>/wp-content/mu-plugins/jetpack-plugin/sun/jetpack_vendor/automattic/jetpack-publicize/build/images/...`

