### PR TITLE
Reader: Improve paywall messages for restricted content

### DIFF
--- a/projects/plugins/jetpack/changelog/improve-paywall-messages-for-restricted-content
+++ b/projects/plugins/jetpack/changelog/improve-paywall-messages-for-restricted-content
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Reader: Update paywall messages for the restricted content.

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -1326,15 +1326,15 @@ function get_paywall_simple(): string {
 
 	if ( $is_subscribers_post && ! $is_subscriber ) {
 		$paywall_description = esc_html__( "It's a subscribers only post. Subscribe to get access to the rest of this post and other subscriber-only content.", 'jetpack' );
-		$paywall_action_btn = esc_html__( 'Subscribe', 'jetpack' );
+		$paywall_action_btn  = esc_html__( 'Subscribe', 'jetpack' );
 	} elseif ( $is_paid_post && $is_subscriber ) {
 		$paywall_description = esc_html__( "You're currently a free subscriber. Upgrade your subscription to get access to the rest of this post and other paid-subscriber only content.", 'jetpack' );
-		$paywall_action_btn = esc_html__( 'Upgrade subscription', 'jetpack' );
+		$paywall_action_btn  = esc_html__( 'Upgrade subscription', 'jetpack' );
 	} else {
 		// - For paid post when the user is not a subscriber.
 		// - Default for all other cases.
 		$paywall_description = esc_html__( 'Become a paid subscriber to get access to the rest of this post and other exclusive content.', 'jetpack' );
-		$paywall_action_btn = esc_html__( 'Subscribe', 'jetpack' );
+		$paywall_action_btn  = esc_html__( 'Subscribe', 'jetpack' );
 	}
 
 	return '

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -19,7 +19,6 @@ use Jetpack_Subscriptions_Widget;
 require_once __DIR__ . '/class-jetpack-subscription-site.php';
 require_once __DIR__ . '/constants.php';
 require_once JETPACK__PLUGIN_DIR . 'extensions/blocks/premium-content/_inc/subscription-service/include.php';
-require_once JETPACK__PLUGIN_DIR . '/modules/memberships/class-jetpack-memberships.php';
 
 /**
  * These block defaults should match ./constants.js
@@ -51,6 +50,8 @@ function register_block() {
 	if ( ! ( new Modules() )->is_active( 'subscriptions' ) ) {
 		return;
 	}
+
+	require_once JETPACK__PLUGIN_DIR . '/modules/memberships/class-jetpack-memberships.php';
 
 	if ( \Jetpack_Memberships::should_enable_monetize_blocks_in_editor() ) {
 		Blocks::jetpack_register_block(
@@ -951,6 +952,8 @@ function jetpack_filter_excerpt_for_newsletter( $excerpt, $post = null ) {
  * @return string
  */
 function add_paywall( $the_content ) {
+	require_once JETPACK__PLUGIN_DIR . 'modules/memberships/class-jetpack-memberships.php';
+
 	$post_access_level = Jetpack_Memberships::get_post_access_level();
 
 	if ( Jetpack_Memberships::user_can_view_post() ) {
@@ -994,6 +997,7 @@ function maybe_close_comments( $default_comments_open, $post_id ) {
 		return $default_comments_open;
 	}
 
+	require_once JETPACK__PLUGIN_DIR . 'modules/memberships/class-jetpack-memberships.php';
 	return Jetpack_Memberships::user_can_view_post();
 }
 
@@ -1009,6 +1013,7 @@ function maybe_gate_existing_comments( $comment ) {
 		return $comment;
 	}
 
+	require_once JETPACK__PLUGIN_DIR . 'modules/memberships/class-jetpack-memberships.php';
 	if ( Jetpack_Memberships::user_can_view_post() ) {
 		return $comment;
 	}
@@ -1149,6 +1154,7 @@ function get_paywall_blocks() {
 		return get_paywall_simple();
 	}
 
+	require_once JETPACK__PLUGIN_DIR . 'modules/memberships/class-jetpack-memberships.php';
 	$is_paid_post       = is_paid_post();
 	$is_paid_subscriber = Jetpack_Memberships::user_is_paid_subscriber();
 
@@ -1243,6 +1249,8 @@ function is_user_auth(): bool {
  * Returns `true` if the post is a paid post.
  */
 function is_paid_post(): bool {
+	require_once JETPACK__PLUGIN_DIR . 'modules/memberships/class-jetpack-memberships.php';
+
 	// Make sure Stripe is connected and the post is marked for paid subscribers.
 	if ( Jetpack_Memberships::has_connected_account() && is_jetpack_token_subscription_service_loaded() ) {
 		return Jetpack_Memberships::get_post_access_level() === Jetpack_Token_Subscription_Service::POST_ACCESS_LEVEL_PAID_SUBSCRIBERS;
@@ -1255,6 +1263,8 @@ function is_paid_post(): bool {
  * Returns true if the post is a subscribers post.
  */
 function is_subscribers_post(): bool {
+	require_once JETPACK__PLUGIN_DIR . 'modules/memberships/class-jetpack-memberships.php';
+
 	// Make sure Stripe is connected and the post is marked for paid subscribers.
 	if ( Jetpack_Memberships::has_connected_account() && is_jetpack_token_subscription_service_loaded() ) {
 		return Jetpack_Memberships::get_post_access_level() === Jetpack_Token_Subscription_Service::POST_ACCESS_LEVEL_SUBSCRIBERS;

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -965,7 +965,7 @@ function add_paywall( $the_content ) {
 		return $the_content;
 	}
 
-	$paywalled_content = get_paywall_content( $post_access_level ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+	$paywalled_content = get_paywall_content();
 
 	if ( has_block( \Automattic\Jetpack\Extensions\Paywall\BLOCK_NAME ) ) {
 		if ( strpos( $the_content, \Automattic\Jetpack\Extensions\Paywall\BLOCK_HTML ) ) {
@@ -1044,17 +1044,16 @@ function maybe_prevent_super_cache_caching() {
 /**
  * Returns paywall content blocks
  *
- * @param string $post_access_level The newsletter access level.
  * @return string
  */
-function get_paywall_content( $post_access_level ) {
+function get_paywall_content() {
 	if ( Jetpack_Memberships::user_is_pending_subscriber() ) {
 		return get_paywall_blocks_subscribe_pending();
 	}
 	if ( doing_filter( 'get_the_excerpt' ) ) {
 		return '';
 	}
-	return get_paywall_blocks( $post_access_level );
+	return get_paywall_blocks();
 }
 
 /**
@@ -1138,20 +1137,19 @@ function sanitize_submit_text( $text ) {
 /**
  * Returns paywall content blocks if user is not authenticated
  *
- * @param string $newsletter_access_level The newsletter access level.
  * @return string
  */
-function get_paywall_blocks( $newsletter_access_level ) {
+function get_paywall_blocks() {
 	$custom_paywall = apply_filters( 'jetpack_custom_paywall_blocks', false );
 	if ( ! empty( $custom_paywall ) ) {
 		return $custom_paywall;
 	}
 
 	if ( ! jetpack_is_frontend() ) { // emails
-		return get_paywall_simple( $newsletter_access_level );
+		return get_paywall_simple();
 	}
 
-	$is_paid_post       = is_paid_post( $newsletter_access_level );
+	$is_paid_post       = is_paid_post();
 	$is_paid_subscriber = Jetpack_Memberships::user_is_paid_subscriber();
 
 	$access_heading = $is_paid_subscriber
@@ -1247,7 +1245,7 @@ function is_user_auth(): bool {
 function is_paid_post(): bool {
 	// Make sure Stripe is connected and the post is marked for paid subscribers.
 	if ( Jetpack_Memberships::has_connected_account() && is_jetpack_token_subscription_service_loaded() ) {
-		return get_post_access_level_for_current_post() === Jetpack_Token_Subscription_Service::POST_ACCESS_LEVEL_PAID_SUBSCRIBERS;
+		return Jetpack_Memberships::get_post_access_level() === Jetpack_Token_Subscription_Service::POST_ACCESS_LEVEL_PAID_SUBSCRIBERS;
 	}
 
 	return false;
@@ -1259,7 +1257,7 @@ function is_paid_post(): bool {
 function is_subscribers_post(): bool {
 	// Make sure Stripe is connected and the post is marked for paid subscribers.
 	if ( Jetpack_Memberships::has_connected_account() && is_jetpack_token_subscription_service_loaded() ) {
-		return get_post_access_level_for_current_post() === Jetpack_Token_Subscription_Service::POST_ACCESS_LEVEL_SUBSCRIBERS;
+		return Jetpack_Memberships::get_post_access_level() === Jetpack_Token_Subscription_Service::POST_ACCESS_LEVEL_SUBSCRIBERS;
 	}
 
 	return false;
@@ -1309,13 +1307,11 @@ function get_paywall_blocks_subscribe_pending() {
 
 /**
  * Return content for non frontend views like Reader, emails.
- *
- * @param string $newsletter_access_level The newsletter access level. We use this to show custom messages based on the access level.
  */
-function get_paywall_simple( string $newsletter_access_level ): string {
-	$is_paid_post        = is_paid_post( $newsletter_access_level );
-	$is_subscribers_post = is_subscribers_post( $newsletter_access_level );
-	$is_subscriber       = is_jetpack_memberships_loaded() && Jetpack_Memberships::user_is_subscriber();
+function get_paywall_simple(): string {
+	$is_paid_post        = is_paid_post();
+	$is_subscribers_post = is_subscribers_post();
+	$is_subscriber       = is_jetpack_memberships_loaded() && Jetpack_Memberships::is_current_user_subscribed();
 	$paywall_heading     = esc_html__( 'Subscribe to keep reading', 'jetpack' );
 
 	if ( $is_subscribers_post && ! $is_subscriber ) {

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -19,6 +19,7 @@ use Jetpack_Subscriptions_Widget;
 require_once __DIR__ . '/class-jetpack-subscription-site.php';
 require_once __DIR__ . '/constants.php';
 require_once JETPACK__PLUGIN_DIR . 'extensions/blocks/premium-content/_inc/subscription-service/include.php';
+require_once JETPACK__PLUGIN_DIR . '/modules/memberships/class-jetpack-memberships.php';
 
 /**
  * These block defaults should match ./constants.js
@@ -50,8 +51,6 @@ function register_block() {
 	if ( ! ( new Modules() )->is_active( 'subscriptions' ) ) {
 		return;
 	}
-
-	require_once JETPACK__PLUGIN_DIR . '/modules/memberships/class-jetpack-memberships.php';
 
 	if ( \Jetpack_Memberships::should_enable_monetize_blocks_in_editor() ) {
 		Blocks::jetpack_register_block(
@@ -618,6 +617,13 @@ function get_color_from_slug( $slug ) {
 }
 
 /**
+ * Is the Jetpack_Memberships class loaded.
+ */
+function is_jetpack_memberships_loaded(): bool {
+	return class_exists( '\Jetpack_Memberships' );
+}
+
+/**
  * Subscriptions block render callback.
  *
  * @param array $attributes Array containing the block attributes.
@@ -630,7 +636,7 @@ function render_block( $attributes ) {
 		return '';
 	}
 
-	if ( class_exists( '\Jetpack_Memberships' ) ) {
+	if ( is_jetpack_memberships_loaded() ) {
 		// We only want the sites that have newsletter feature enabled to be graced by this JavaScript.
 		Jetpack_Gutenberg::load_assets_as_required( __DIR__ );
 	} else {
@@ -945,8 +951,6 @@ function jetpack_filter_excerpt_for_newsletter( $excerpt, $post = null ) {
  * @return string
  */
 function add_paywall( $the_content ) {
-	require_once JETPACK__PLUGIN_DIR . 'modules/memberships/class-jetpack-memberships.php';
-
 	$post_access_level = Jetpack_Memberships::get_post_access_level();
 
 	if ( Jetpack_Memberships::user_can_view_post() ) {
@@ -990,7 +994,6 @@ function maybe_close_comments( $default_comments_open, $post_id ) {
 		return $default_comments_open;
 	}
 
-	require_once JETPACK__PLUGIN_DIR . 'modules/memberships/class-jetpack-memberships.php';
 	return Jetpack_Memberships::user_can_view_post();
 }
 
@@ -1006,7 +1009,6 @@ function maybe_gate_existing_comments( $comment ) {
 		return $comment;
 	}
 
-	require_once JETPACK__PLUGIN_DIR . 'modules/memberships/class-jetpack-memberships.php';
 	if ( Jetpack_Memberships::user_can_view_post() ) {
 		return $comment;
 	}
@@ -1144,12 +1146,12 @@ function get_paywall_blocks( $newsletter_access_level ) {
 	if ( ! empty( $custom_paywall ) ) {
 		return $custom_paywall;
 	}
+
 	if ( ! jetpack_is_frontend() ) { // emails
-		return get_paywall_simple();
+		return get_paywall_simple( $newsletter_access_level );
 	}
-	require_once JETPACK__PLUGIN_DIR . 'modules/memberships/class-jetpack-memberships.php';
-	// Only display paid texts when Stripe is connected and the post is marked for paid subscribers
-	$is_paid_post       = $newsletter_access_level === 'paid_subscribers' && Jetpack_Memberships::has_connected_account();
+
+	$is_paid_post       = is_paid_post( $newsletter_access_level );
 	$is_paid_subscriber = Jetpack_Memberships::user_is_paid_subscriber();
 
 	$access_heading = $is_paid_subscriber
@@ -1158,9 +1160,11 @@ function get_paywall_blocks( $newsletter_access_level ) {
 
 	$subscribe_text = $is_paid_post
 		// translators: %s is the name of the site.
-		? $is_paid_subscriber
-		? esc_html__( 'Upgrade to get access to the rest of this post and other exclusive content.', 'jetpack' )
-		: esc_html__( 'Become a paid subscriber to get access to the rest of this post and other exclusive content.', 'jetpack' )
+		? (
+			$is_paid_subscriber
+				? esc_html__( 'Upgrade to get access to the rest of this post and other exclusive content.', 'jetpack' )
+				: esc_html__( 'Become a paid subscriber to get access to the rest of this post and other exclusive content.', 'jetpack' )
+		)
 		// translators: %s is the name of the site.
 		: esc_html__( 'Subscribe to get access to the rest of this post and other subscriber-only content.', 'jetpack' );
 
@@ -1238,6 +1242,30 @@ function is_user_auth(): bool {
 }
 
 /**
+ * Returns `true` if the post is a paid post.
+ */
+function is_paid_post(): bool {
+	// Make sure Stripe is connected and the post is marked for paid subscribers.
+	if ( Jetpack_Memberships::has_connected_account() && is_jetpack_token_subscription_service_loaded() ) {
+		return get_post_access_level_for_current_post() === Jetpack_Token_Subscription_Service::POST_ACCESS_LEVEL_PAID_SUBSCRIBERS;
+	}
+
+	return false;
+}
+
+/**
+ * Returns true if the post is a subscribers post.
+ */
+function is_subscribers_post(): bool {
+	// Make sure Stripe is connected and the post is marked for paid subscribers.
+	if ( Jetpack_Memberships::has_connected_account() && is_jetpack_token_subscription_service_loaded() ) {
+		return get_post_access_level_for_current_post() === Jetpack_Token_Subscription_Service::POST_ACCESS_LEVEL_SUBSCRIBERS;
+	}
+
+	return false;
+}
+
+/**
  * Returns paywall content blocks when email confirmation is pending
  *
  * @return string
@@ -1280,14 +1308,28 @@ function get_paywall_blocks_subscribe_pending() {
 }
 
 /**
- * Return content for non frontend views like emails.
+ * Return content for non frontend views like Reader, emails.
  *
- * @return string
+ * @param string $newsletter_access_level The newsletter access level. We use this to show custom messages based on the access level.
  */
-function get_paywall_simple() {
+function get_paywall_simple( string $newsletter_access_level ): string {
+	$is_paid_post        = is_paid_post( $newsletter_access_level );
+	$is_subscribers_post = is_subscribers_post( $newsletter_access_level );
+	$is_subscriber       = is_jetpack_memberships_loaded() && Jetpack_Memberships::user_is_subscriber();
 	$paywall_heading     = esc_html__( 'Subscribe to keep reading', 'jetpack' );
-	$paywall_description = esc_html__( "You're currently a free subscriber. Upgrade your subscription to get access to the rest of this post and other paid-subscriber only content.", 'jetpack' );
-	$paywall_action_btn  = esc_html__( 'Upgrade subscription', 'jetpack' );
+
+	if ( $is_subscribers_post && ! $is_subscriber ) {
+		$paywall_description = esc_html__( "It's a subscribers only post. Subscribe to get access to the rest of this post and other subscriber-only content.", 'jetpack' );
+		$paywall_action_btn = esc_html__( 'Subscribe', 'jetpack' );
+	} elseif ( $is_paid_post && $is_subscriber ) {
+		$paywall_description = esc_html__( "You're currently a free subscriber. Upgrade your subscription to get access to the rest of this post and other paid-subscriber only content.", 'jetpack' );
+		$paywall_action_btn = esc_html__( 'Upgrade subscription', 'jetpack' );
+	} else {
+		// - For paid post when the user is not a subscriber.
+		// - Default for all other cases.
+		$paywall_description = esc_html__( 'Become a paid subscriber to get access to the rest of this post and other exclusive content.', 'jetpack' );
+		$paywall_action_btn = esc_html__( 'Subscribe', 'jetpack' );
+	}
 
 	return '
 <!-- wp:columns -->

--- a/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
+++ b/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
@@ -728,6 +728,17 @@ class Jetpack_Memberships {
 	}
 
 	/**
+	 * Determines whether the current user is a subscriber.
+	 *
+	 * @return bool Whether the user is a subscriber
+	 */
+	public static function user_is_subscriber() {
+		require_once JETPACK__PLUGIN_DIR . 'extensions/blocks/premium-content/_inc/subscription-service/include.php';
+		$subscription_service = \Automattic\Jetpack\Extensions\Premium_Content\subscription_service();
+		return $subscription_service->is_current_user_subscribed();
+	}
+
+	/**
 	 * Determines whether the current user is a paid subscriber and caches the result.
 	 *
 	 * @param array    $valid_plan_ids An array of valid plan ids that the user could be subscribed to which would make the user able to view this content. Defaults to an empty array which will be filled with all newsletter plan IDs.

--- a/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
+++ b/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
@@ -728,17 +728,6 @@ class Jetpack_Memberships {
 	}
 
 	/**
-	 * Determines whether the current user is a subscriber.
-	 *
-	 * @return bool Whether the user is a subscriber
-	 */
-	public static function user_is_subscriber() {
-		require_once JETPACK__PLUGIN_DIR . 'extensions/blocks/premium-content/_inc/subscription-service/include.php';
-		$subscription_service = \Automattic\Jetpack\Extensions\Premium_Content\subscription_service();
-		return $subscription_service->is_current_user_subscribed();
-	}
-
-	/**
 	 * Determines whether the current user is a paid subscriber and caches the result.
 	 *
 	 * @param array    $valid_plan_ids An array of valid plan ids that the user could be subscribed to which would make the user able to view this content. Defaults to an empty array which will be filled with all newsletter plan IDs.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes [CML-521](https://linear.app/a8c/issue/CML-521/reader-paywall-message-while-restricting-content-is-not-always-correct)

## Proposed changes:

Currently while showing paywall we show same message for all cases and this is confusing for users which are not subscribed to the site.

| Scenario | Before | After |
| ---------| -------| ------| 
| Unsubscribed user viewing the subscribers only post |  ![image](https://github.com/user-attachments/assets/9b92db68-70af-4211-a198-fb3290bbd836) | ![image](https://github.com/user-attachments/assets/faee0bbd-8697-4c26-8921-5893b966f1bb) |
| Unsubscribed user viewing the paid post | ![image](https://github.com/user-attachments/assets/565f043a-43b6-4358-9249-effdd9457eaf) |  ![image](https://github.com/user-attachments/assets/0d83908e-e012-461c-b91e-949db2aef129) | 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

Refer to the attached issue.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Checkout related wpcom change (183791-ghe-Automattic/wpcom) if not merged.
- Download the branch to your sandbox by following the instructions given in comment.
- Verify paywall messaging for all cases using instructions available on 183791-ghe-Automattic/wpcom.