### PR TITLE
Forms: Fix HTML tags rendering in form labels

### DIFF
--- a/projects/packages/forms/changelog/fix-legend-html-escaping
+++ b/projects/packages/forms/changelog/fix-legend-html-escaping
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Contact Form: Use wp_kses_post instead of esc_html for legend rendering to allow safe HTML in fieldset legends. 

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -537,7 +537,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 				class='grunion-field-label{$type_class}" . ( $this->is_error() ? ' form-error' : '' ) . "'"
 				. $extra_attrs_string
 				. '>'
-				. esc_html( $legend )
+				. wp_kses_post( $legend )
 				. ( $required ? '<span class="grunion-label-required">' . $required_field_text . '</span>' : '' )
 				. "</legend>\n";
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes FORMS-106

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Updates the Contact Form fieldset legend rendering to use `wp_kses_post()` instead of `esc_html()`. This allows safe HTML to be included in fieldset legends, improving flexibility for form creators while maintaining security.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to a page or post with a Jetpack Contact Form that uses a fieldset legend.
* Edit the legend to include some safe HTML (e.g., `<strong>Important</strong> legend text`).
* View the form on the frontend.
* Confirm that the HTML in the legend is rendered as expected (e.g., the text is bold), and that no unsafe HTML is allowed.
* Verify that other form functionality is unaffected.
