### PR TITLE
Boost: skip flaky e2e tests pending proper fix

### DIFF
--- a/projects/plugins/boost/changelog/fix-boost-module-e2e-tests
+++ b/projects/plugins/boost/changelog/fix-boost-module-e2e-tests
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Only updating e2e tests
+
+

--- a/projects/plugins/boost/tests/e2e/specs/modules/modules-common.test.js
+++ b/projects/plugins/boost/tests/e2e/specs/modules/modules-common.test.js
@@ -25,6 +25,7 @@ test.describe.serial( 'Modules', () => {
 
 	modules.forEach( ( [ moduleSlug, moduleState ] = module ) => {
 		test( `The ${ moduleSlug } module should be ${ moduleState } by default`, async () => {
+			test.skip( true, 'Skipping this test as it is flaky and we are working on it' );
 			expect(
 				await jetpackBoostPage.isModuleEnabled( moduleSlug ),
 				`${ moduleSlug } should be enabled`

--- a/projects/plugins/boost/tests/e2e/specs/modules/speed-score.test.js
+++ b/projects/plugins/boost/tests/e2e/specs/modules/speed-score.test.js
@@ -31,6 +31,7 @@ test.describe( 'Speed Score feature', () => {
 	} );
 
 	test( 'The Speed Scores should be able to refresh', async () => {
+		test.skip( true, 'Skipping this test as it is flaky and we are working on it' );
 		await jetpackBoostPage.waitForScoreLoadingToFinish();
 		await jetpackBoostPage.clickRefreshSpeedScore();
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

See HOG-106

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Skips flaky tests pending better fix

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
..

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check e2e tests in CI, any more flaky tests?

