### PR TITLE
Reader: Improve Jetpack paywall styling for both Reader and emails

### DIFF
--- a/projects/plugins/jetpack/changelog/improve-reader-paywall-styling
+++ b/projects/plugins/jetpack/changelog/improve-reader-paywall-styling
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Reader: Fix paywall styling on Reader and improve few other styles

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -1285,15 +1285,18 @@ function get_paywall_blocks_subscribe_pending() {
  * @return string
  */
 function get_paywall_simple() {
-	$access_heading = esc_html__( "You're currently a free subscriber. Upgrade your subscription to get access to the rest of this post and other paid-subscriber only content.", 'jetpack' );
-
-	$subscribe_text = esc_html__( 'Upgrade subscription', 'jetpack' );
+	$paywall_heading     = esc_html__( 'Subscribe to keep reading', 'jetpack' );
+	$paywall_description = esc_html__( "You're currently a free subscriber. Upgrade your subscription to get access to the rest of this post and other paid-subscriber only content.", 'jetpack' );
+	$paywall_action_btn  = esc_html__( 'Upgrade subscription', 'jetpack' );
 
 	return '
 <!-- wp:columns -->
 <div class="wp-block-columns jetpack-paywall-simple" style="display: inline-block; width: 90%">
     <!-- wp:column -->
     <div class="wp-block-column" style="background-color: #F6F7F7; padding: 32px; 24px;">
+        <!-- wp:heading -->
+        <h2 class="has-text-align-center" style="margin: 0 0 12px; font-weight: 600;">' . $paywall_heading . '</h2>
+        <!-- /wp:heading -->
         <!-- wp:paragraph -->
         <p class="has-text-align-center"
            style="text-align: center;
@@ -1302,7 +1305,7 @@ function get_paywall_simple() {
                   font-size: 16px;
                   font-family: \'SF Pro Text\', sans-serif;
                   line-height: 28.8px;">
-        ' . $access_heading . '
+        ' . $paywall_description . '
         </p>
         <!-- /wp:paragraph -->
         <!-- wp:buttons -->
@@ -1320,7 +1323,7 @@ function get_paywall_simple() {
                           font-family: \'SF Pro Display\', sans-serif;
                           font-weight: 500;
                           font-size: 16px;
-                          text-align: center;">' . $subscribe_text . '</a>
+                          text-align: center;">' . $paywall_action_btn . '</a>
             </div>
             <!-- /wp:button -->
         </div>

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -1291,7 +1291,7 @@ function get_paywall_simple() {
 
 	return '
 <!-- wp:columns -->
-<div class="wp-block-columns" style="display: inline-block; width: 90%">
+<div class="wp-block-columns jetpack-paywall-simple" style="display: inline-block; width: 90%">
     <!-- wp:column -->
     <div class="wp-block-column" style="background-color: #F6F7F7; padding: 32px; 24px;">
         <!-- wp:paragraph -->
@@ -1308,12 +1308,12 @@ function get_paywall_simple() {
         <!-- wp:buttons -->
         <div class="wp-block-buttons" style="text-align: center;">
             <!-- wp:button -->
-            <div class="wp-block-button" style="display: inline-block; margin: 10px 0;">
+            <div class="wp-block-button" style="display: inline-block; margin: 10px 0; border-style: none; padding: 0;">
                 <a href="' . esc_url( get_post_permalink() ) . '" class="wp-block-button__link wp-element-button"
                    data-wpcom-track data-tracks-link-desc="paywall-email-click"
                    style="display: inline-block;
-                          padding: 15px 20px;
-                          background-color: #0675C4;
+                          padding: 12px 15px;
+                          background-color: #3858e9;
                           color: #FFFFFF;
                           text-decoration: none;
                           border-radius: 5px;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to [CML-522](https://linear.app/a8c/issue/CML-522/reader-improve-layout-of-paywall-placeholder)

## Proposed changes:

- Added `jetpack-paywall-simple` class on paywall content so that we can ignore stripping of style attributes in Calypso.
- Updated few other styles to improve the UI.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

Kindly refer to mentioned issue.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Download the branch to your sandbox by following the instructions given in comment.
2. Follow instructions available on this calypso PR (https://github.com/Automattic/wp-calypso/pull/103743) to test both changes simultaneously.

