### PR TITLE
WPCOM_JSON_API_Endpoint: Use previous $media_item check to prevent some WP_Error fatals

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-wp-error-Wpcom-json-api-endpoint
+++ b/projects/plugins/jetpack/changelog/fix-wp-error-Wpcom-json-api-endpoint
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: This is a continuation of another PR, and there will be a follow up as well.
+
+

--- a/projects/plugins/jetpack/class.json-api-endpoints.php
+++ b/projects/plugins/jetpack/class.json-api-endpoints.php
@@ -1669,7 +1669,7 @@ abstract class WPCOM_JSON_API_Endpoint {
 			$media_item = get_post( $media_id );
 		}
 
-		if ( ! $media_item || is_wp_error( $media_item ) || ! ( $media_item instanceof WP_Post ) ) {
+		if ( ! $media_item || is_wp_error( $media_item ) ) {
 			return new WP_Error( 'unknown_media', 'Unknown Media', 404 );
 		}
 

--- a/projects/plugins/jetpack/sal/class.json-api-post-base.php
+++ b/projects/plugins/jetpack/sal/class.json-api-post-base.php
@@ -917,6 +917,10 @@ abstract class SAL_Post {
 			return new WP_Error( 'unknown_media', 'Unknown Media', 404 );
 		}
 
+		if ( ! ( $media_item instanceof WP_Post ) ) {
+			return new WP_Error( 'invalid_media', 'Invalid Media Object', 400 );
+		}
+
 		$file      = basename( wp_get_attachment_url( $media_item->ID ) );
 		$file_info = pathinfo( $file );
 		$ext       = isset( $file_info['extension'] ) ? $file_info['extension'] : '';

--- a/projects/plugins/jetpack/sal/class.json-api-post-base.php
+++ b/projects/plugins/jetpack/sal/class.json-api-post-base.php
@@ -917,10 +917,6 @@ abstract class SAL_Post {
 			return new WP_Error( 'unknown_media', 'Unknown Media', 404 );
 		}
 
-		if ( ! ( $media_item instanceof WP_Post ) ) {
-			return new WP_Error( 'invalid_media', 'Invalid Media Object', 400 );
-		}
-
 		$file      = basename( wp_get_attachment_url( $media_item->ID ) );
 		$file_info = pathinfo( $file );
 		$ext       = isset( $file_info['extension'] ) ? $file_info['extension'] : '';


### PR DESCRIPTION

## Proposed changes:

* In https://github.com/Automattic/jetpack/pull/43570 a change was added to prevent several undefined property warnings, which included an added check for `! ( $media_item instanceof WP_Post )`. 
* Soon after deploying the change, a small uptick of fatals began related to ` PHP Fatal error: Uncaught Error: Cannot use object of type WP_Error as array`.
* This PR reverts the change back to how it was, until a better fix can be made to prevent the earlier warnings.


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:

* Ensure the code matches how it was prior to https://github.com/Automattic/jetpack/pull/43570
*

