### PR TITLE
Block Delimiter: add package skeleton

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2160,6 +2160,8 @@ importers:
         specifier: 6.0.1
         version: 6.0.1(webpack@5.94.0)
 
+  projects/packages/block-delimiter: {}
+
   projects/packages/boost-core: {}
 
   projects/packages/calypsoify:

--- a/projects/packages/block-delimiter/.gitattributes
+++ b/projects/packages/block-delimiter/.gitattributes
@@ -1,0 +1,16 @@
+# Files not needed to be distributed in the package.
+.gitattributes    export-ignore
+.github/          export-ignore
+package.json      export-ignore
+
+# Files to include in the mirror repo, but excluded via gitignore
+# Remember to end all directories with `/**` to properly tag every file.
+# /src/js/example.min.js  production-include
+
+# Files to exclude from the mirror repo, but included in the monorepo.
+# Remember to end all directories with `/**` to properly tag every file.
+.gitignore        production-exclude
+changelog/**      production-exclude
+.phpcs.dir.xml    production-exclude
+tests/**          production-exclude
+.phpcsignore      production-exclude

--- a/projects/packages/block-delimiter/.gitignore
+++ b/projects/packages/block-delimiter/.gitignore
@@ -1,0 +1,2 @@
+vendor/
+node_modules/

--- a/projects/packages/block-delimiter/.phan/baseline.php
+++ b/projects/packages/block-delimiter/.phan/baseline.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * This is an automatically generated baseline for Phan issues.
+ *
+ * Use `jetpack phan --update-baseline` to update this file.
+ */
+return [
+    // Currently, file_suppressions and directory_suppressions are the only supported suppressions
+    'file_suppressions' => [],
+    // 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.
+    // (directory_suppressions will currently be ignored by subsequent calls to --save-baseline, but may be preserved in future Phan releases)
+];

--- a/projects/packages/block-delimiter/.phan/baseline.php
+++ b/projects/packages/block-delimiter/.phan/baseline.php
@@ -1,12 +1,17 @@
 <?php
 /**
  * This is an automatically generated baseline for Phan issues.
+ * When Phan is invoked with --load-baseline=path/to/baseline.php,
+ * The pre-existing issues listed in this file won't be emitted.
  *
- * Use `jetpack phan --update-baseline` to update this file.
+ * This file can be updated by invoking Phan with --save-baseline=path/to/baseline.php
+ * (can be combined with --load-baseline)
  */
 return [
+    // This baseline has no suppressions
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
-    'file_suppressions' => [],
+    'file_suppressions' => [
+    ],
     // 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.
     // (directory_suppressions will currently be ignored by subsequent calls to --save-baseline, but may be preserved in future Phan releases)
 ];

--- a/projects/packages/block-delimiter/.phan/config.php
+++ b/projects/packages/block-delimiter/.phan/config.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * This configuration will be read and overlaid on top of the
+ * default configuration. Command-line arguments will be applied
+ * after this file is read.
+ *
+ * @package automattic/jetpack-block-delimiter
+ */
+
+// Require base config.
+require __DIR__ . '/../../../../.phan/config.base.php';
+
+return make_phan_config( dirname( __DIR__ ) );

--- a/projects/packages/block-delimiter/.phpcs.dir.xml
+++ b/projects/packages/block-delimiter/.phpcs.dir.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<ruleset>
+
+	<rule ref="WordPress.WP.I18n">
+		<properties>
+			<property name="text_domain" type="array">
+				<element value="jetpack-block-delimiter" />
+			</property>
+		</properties>
+	</rule>
+	<rule ref="Jetpack.Functions.I18n">
+		<properties>
+			<property name="text_domain" value="jetpack-block-delimiter" />
+		</properties>
+	</rule>
+
+	<rule ref="WordPress.Utils.I18nTextDomainFixer">
+		<properties>
+			<property name="old_text_domain" type="array" />
+			<property name="new_text_domain" value="jetpack-block-delimiter" />
+		</properties>
+	</rule>
+
+</ruleset>

--- a/projects/packages/block-delimiter/CHANGELOG.md
+++ b/projects/packages/block-delimiter/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+

--- a/projects/packages/block-delimiter/README.md
+++ b/projects/packages/block-delimiter/README.md
@@ -1,0 +1,23 @@
+# Block Delimiter
+
+Efficiently work with block structure
+
+## How to install block-delimiter
+
+To use this package in your WordPress plugin, you can require both this package and the [Jetpack Autoloader](https://packagist.org/packages/automattic/jetpack-autoloader) in your project's `composer.json` file.
+
+## Contribute
+
+You can contribute to this package by submitting a pull request to the [Jetpack repository](https://github.com/Automattic/jetpack/tree/trunk/projects/packages/block-delimiter).
+
+## Using this package in your WordPress plugin
+
+If you plan on using this package in your WordPress plugin, we would recommend that you use [Jetpack Autoloader](https://packagist.org/packages/automattic/jetpack-autoloader) as your autoloader. This will allow for maximum interoperability with other plugins that use this package as well.
+
+## Security
+
+Need to report a security vulnerability? Go to [https://automattic.com/security/](https://automattic.com/security/) or directly to our security bug bounty site [https://hackerone.com/automattic](https://hackerone.com/automattic).
+
+## License
+
+Block Delimiter is licensed under [GNU General Public License v2 (or later)](./LICENSE.txt)

--- a/projects/packages/block-delimiter/changelog/initial-version
+++ b/projects/packages/block-delimiter/changelog/initial-version
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Initial version.

--- a/projects/packages/block-delimiter/composer.json
+++ b/projects/packages/block-delimiter/composer.json
@@ -8,7 +8,8 @@
 	},
 	"require-dev": {
 		"yoast/phpunit-polyfills": "^4.0.0",
-		"automattic/jetpack-changelogger": "@dev"
+		"automattic/jetpack-changelogger": "@dev",
+		"automattic/phpunit-select-config": "@dev"
 	},
 	"autoload": {
 		"classmap": [

--- a/projects/packages/block-delimiter/composer.json
+++ b/projects/packages/block-delimiter/composer.json
@@ -1,0 +1,57 @@
+{
+	"name": "automattic/block-delimiter",
+	"description": "Efficiently work with block structure",
+	"type": "jetpack-library",
+	"license": "GPL-2.0-or-later",
+	"require": {
+		"php": ">=7.2"
+	},
+	"require-dev": {
+		"yoast/phpunit-polyfills": "^4.0.0",
+		"automattic/jetpack-changelogger": "@dev"
+	},
+	"autoload": {
+		"classmap": [
+			"src/"
+		]
+	},
+	"scripts": {
+		"phpunit": [
+			"phpunit-select-config phpunit.#.xml.dist --colors=always"
+		],
+		"test-coverage": [
+			"php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+		],
+		"test-php": [
+			"@composer phpunit"
+		]
+	},
+	"repositories": [
+		{
+			"type": "path",
+			"url": "../../packages/*",
+			"options": {
+				"monorepo": true
+			}
+		}
+	],
+	"minimum-stability": "dev",
+	"prefer-stable": true,
+	"extra": {
+		"autotagger": true,
+		"branch-alias": {
+			"dev-trunk": "0.1.x-dev"
+		},
+		"changelogger": {
+			"link-template": "https://github.com/Automattic/block-delimiter/compare/v${old}...v${new}"
+		},
+		"mirror-repo": "Automattic/block-delimiter",
+		"textdomain": "jetpack-block-delimiter",
+		"version-constants": {
+			"::PACKAGE_VERSION": "src/class-block-delimiter.php"
+		}
+	},
+	"suggest": {
+		"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+	}
+}

--- a/projects/packages/block-delimiter/package.json
+++ b/projects/packages/block-delimiter/package.json
@@ -1,0 +1,25 @@
+{
+	"private": true,
+	"name": "@automattic/block-delimiter",
+	"version": "0.1.0-alpha",
+	"description": "Efficiently work with block structure",
+	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/block-delimiter/#readme",
+	"bugs": {
+		"url": "https://github.com/Automattic/jetpack/labels/[Package] Block Delimiter"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/Automattic/jetpack.git",
+		"directory": "projects/packages/block-delimiter"
+	},
+	"license": "GPL-2.0-or-later",
+	"author": "Automattic",
+	"scripts": {
+		"build": "echo 'Not implemented.'",
+		"build-js": "echo 'Not implemented.'",
+		"build-production": "echo 'Not implemented.'",
+		"build-production-js": "echo 'Not implemented.'",
+		"clean": "true"
+	},
+	"devDependencies": {}
+}

--- a/projects/packages/block-delimiter/phpunit.11.xml.dist
+++ b/projects/packages/block-delimiter/phpunit.11.xml.dist
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+	bootstrap="tests/php/bootstrap.php"
+	cacheDirectory=".phpunit.cache"
+	colors="true"
+	executionOrder="depends"
+	beStrictAboutOutputDuringTests="true"
+	displayDetailsOnPhpunitDeprecations="true"
+	displayDetailsOnTestsThatTriggerDeprecations="true"
+	displayDetailsOnTestsThatTriggerErrors="true"
+	displayDetailsOnTestsThatTriggerNotices="true"
+	displayDetailsOnTestsThatTriggerWarnings="true"
+	failOnDeprecation="true"
+	failOnEmptyTestSuite="true"
+	failOnPhpunitDeprecation="true"
+	failOnNotice="true"
+	failOnRisky="true"
+	failOnWarning="true"
+>
+	<testsuites>
+		<testsuite name="main">
+			<directory suffix="Test.php">tests/php</directory>
+		</testsuite>
+	</testsuites>
+
+	<source>
+		<include>
+			<!-- Better to only include "src" than to add "." and then exclude "tests", "vendor", and so on, as PHPUnit still scans the excluded directories. -->
+			<!-- Add additional lines for any files or directories outside of src/ that need coverage. -->
+			<directory suffix=".php">src</directory>
+		</include>
+	</source>
+	<coverage ignoreDeprecatedCodeUnits="true">
+	</coverage>
+</phpunit>

--- a/projects/packages/block-delimiter/phpunit.12.xml.dist
+++ b/projects/packages/block-delimiter/phpunit.12.xml.dist
@@ -1,0 +1,1 @@
+phpunit.11.xml.dist

--- a/projects/packages/block-delimiter/phpunit.8.xml.dist
+++ b/projects/packages/block-delimiter/phpunit.8.xml.dist
@@ -1,0 +1,1 @@
+phpunit.9.xml.dist

--- a/projects/packages/block-delimiter/phpunit.9.xml.dist
+++ b/projects/packages/block-delimiter/phpunit.9.xml.dist
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd"
+	bootstrap="tests/php/bootstrap.php"
+	cacheResultFile=".phpunit.cache/test-results"
+	colors="true"
+	executionOrder="depends"
+	beStrictAboutOutputDuringTests="true"
+	failOnRisky="true"
+	failOnWarning="true"
+>
+	<testsuites>
+		<testsuite name="main">
+			<directory suffix="Test.php">tests/php</directory>
+		</testsuite>
+	</testsuites>
+</phpunit>

--- a/projects/packages/block-delimiter/src/class-block-delimiter.php
+++ b/projects/packages/block-delimiter/src/class-block-delimiter.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Efficiently working with block structure.
+ *
+ * @package automattic/block-delimiter
+ */
+
+namespace Automattic;
+
+/**
+ * Class description.
+ */
+class Block_Delimiter {
+
+	const PACKAGE_VERSION = '0.1.0-alpha';
+}

--- a/projects/packages/block-delimiter/tests/.phpcs.dir.xml
+++ b/projects/packages/block-delimiter/tests/.phpcs.dir.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<ruleset>
+	<rule ref="Jetpack-Tests" />
+</ruleset>

--- a/projects/packages/block-delimiter/tests/php/Block_Delimiter_Test.php
+++ b/projects/packages/block-delimiter/tests/php/Block_Delimiter_Test.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Automattic;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Testing the Block Delimiter package.
+ */
+class Block_Delimiter_Test extends TestCase {
+	public function test_version() {
+		$this->assertIsString( Block_Delimiter::PACKAGE_VERSION );
+	}
+}

--- a/projects/packages/block-delimiter/tests/php/bootstrap.php
+++ b/projects/packages/block-delimiter/tests/php/bootstrap.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Bootstrap.
+ *
+ * @package automattic/block-delimiter
+ */
+
+/**
+ * Include the composer autoloader.
+ */
+require_once __DIR__ . '/../../vendor/autoload.php';


### PR DESCRIPTION
## Proposed changes:

This PR adds the package's skeleton to the monorepo.

Ref HOG-139.

Once merged, the package will be available by requiring `automattic/block-delimiter` in your projects.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* See p7H4VZ-5l1-p2

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

Not much to test yet. Check that CI is happy.
