### PR TITLE
Generate command add phpunit-select-config to the base config

### DIFF
--- a/tools/cli/skeletons/common/composer.json
+++ b/tools/cli/skeletons/common/composer.json
@@ -6,7 +6,8 @@
 	"require": {},
 	"require-dev": {
 		"yoast/phpunit-polyfills": "^4.0.0",
-		"automattic/jetpack-changelogger": "@dev"
+		"automattic/jetpack-changelogger": "@dev",
+		"automattic/phpunit-select-config": "@dev"
 	},
 	"autoload": {
 		"classmap": [


### PR DESCRIPTION
Follow-up to #42266

## Proposed changes:

Since we rely on `automattic/phpunit-select-config` for testing, let's require the package by default.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Run `jetpack generate`
* Ensure the package gets added as dependency when creating a package.
