### PR TITLE
Block Delimiter: add package contents

### DIFF
--- a/projects/packages/block-delimiter/README.md
+++ b/projects/packages/block-delimiter/README.md
@@ -6,6 +6,360 @@ Efficiently work with block structure
 
 To use this package in your WordPress plugin, you can require both this package and the [Jetpack Autoloader](https://packagist.org/packages/automattic/jetpack-autoloader) in your project's `composer.json` file.
 
+## Usage
+
+The Block Delimiter package provides an efficient, streaming parser for working with WordPress block structure without the memory overhead of `parse_blocks()`. It's designed for scenarios where you need to inspect, find, or modify specific blocks without parsing the entire block tree.
+
+### Basic Block Scanning
+
+Find and iterate through all block delimiters in a document:
+
+```php
+use Automattic\Block_Delimiter;
+
+$post_content = '<!-- wp:paragraph -->
+<p>Hello world!</p>
+<!-- /wp:paragraph -->
+<!-- wp:image {"id":123} -->
+<figure><img src="example.jpg" /></figure>
+<!-- /wp:image -->';
+
+foreach ( Block_Delimiter::scan_delimiters( $post_content ) as $where => $delimiter ) {
+    // $where is an array: [ byte_offset, byte_length ]
+    // $delimiter is a Block_Delimiter instance
+    
+    echo "Found block: " . $delimiter->allocate_and_return_block_type() . "\n";
+    echo "Type: " . $delimiter->get_delimiter_type() . "\n";
+}
+```
+
+**Output:**
+```
+Found block: core/paragraph
+Type: opener
+Found block: core/paragraph
+Type: closer
+Found block: core/image
+Type: opener
+Found block: core/image
+Type: closer
+```
+
+### Finding Specific Block Types
+
+Efficiently find blocks of a specific type without parsing everything:
+
+```php
+use Automattic\Block_Delimiter;
+
+$post_content = '<!-- wp:paragraph -->
+<p>Welcome to my blog!</p>
+<!-- /wp:paragraph -->
+<!-- wp:image {"id":456} -->
+<figure><img src="photo.jpg" /></figure>
+<!-- /wp:image -->
+<!-- wp:gallery {"ids":[789,101]} -->
+<figure class="wp-block-gallery">...</figure>
+<!-- /wp:gallery -->';
+
+// Find the first image block
+foreach ( Block_Delimiter::scan_delimiters( $post_content ) as $delimiter ) {
+    if ( ! $delimiter->is_block_type( 'image' ) ) {
+        continue;
+    }
+    
+    if ( Block_Delimiter::OPENER === $delimiter->get_delimiter_type() ) {
+        $attributes = $delimiter->allocate_and_return_parsed_attributes();
+        if ( isset( $attributes['id'] ) ) {
+            echo "Found image with ID: " . $attributes['id'];
+            break;
+        }
+    }
+}
+```
+
+**Output:**
+```
+Found image with ID: 456
+```
+
+### Extracting Block Attributes
+
+Parse JSON attributes only when needed:
+
+```php
+use Automattic\Block_Delimiter;
+
+$post_content = '<!-- wp:paragraph {"fontSize":"large"} -->
+<p class="has-large-font-size">This paragraph has a large font size.</p>
+<!-- /wp:paragraph -->
+<!-- wp:paragraph -->
+<p>This paragraph has no custom font size.</p>
+<!-- /wp:paragraph -->
+<!-- wp:paragraph {"fontSize":"small","textColor":"primary"} -->
+<p class="has-primary-color has-small-font-size">This paragraph has a small font size and primary color.</p>
+<!-- /wp:paragraph -->';
+
+foreach ( Block_Delimiter::scan_delimiters( $post_content ) as $delimiter ) {
+    if ( $delimiter->is_block_type( 'core/paragraph' ) && 
+         Block_Delimiter::OPENER === $delimiter->get_delimiter_type() ) {
+        
+        $attributes = $delimiter->allocate_and_return_parsed_attributes();
+        if ( isset( $attributes['fontSize'] ) ) {
+            echo "Paragraph with font size: " . $attributes['fontSize'] . "\n";
+        }
+    }
+}
+```
+
+**Output:**
+```
+Paragraph with font size: large
+Paragraph with font size: small
+```
+
+### Counting Block Types
+
+Get a summary of all block types in a document:
+
+```php
+use Automattic\Block_Delimiter;
+
+$post_content = '<!-- wp:heading {"level":2} -->
+<h2>My Blog Post</h2>
+<!-- /wp:heading -->
+<!-- wp:paragraph -->
+<p>Introduction paragraph.</p>
+<!-- /wp:paragraph -->
+<!-- wp:image {"id":123} -->
+<figure><img src="hero.jpg" /></figure>
+<!-- /wp:image -->
+<!-- wp:paragraph -->
+<p>Another paragraph.</p>
+<!-- /wp:paragraph -->
+<!-- wp:list -->
+<ul><li>Item 1</li><li>Item 2</li></ul>
+<!-- /wp:list -->';
+
+function get_block_types_in( string $html ): array {
+    $block_types = [];
+    
+    foreach ( Block_Delimiter::scan_delimiters( $html ) as $delimiter ) {
+        if ( Block_Delimiter::OPENER === $delimiter->get_delimiter_type() ) {
+            $block_types[ $delimiter->allocate_and_return_block_type() ] = true;
+        }
+    }
+    
+    $block_types = array_keys( $block_types );
+    sort( $block_types );
+    return $block_types;
+}
+
+$block_types = get_block_types_in( $post_content );
+print_r( $block_types );
+```
+
+**Output:**
+```
+Array
+(
+    [0] => core/heading
+    [1] => core/image
+    [2] => core/list
+    [3] => core/paragraph
+)
+```
+
+### Extracting Complete Block Content
+
+Extract an entire block including its delimiters and content:
+
+```php
+use Automattic\Block_Delimiter;
+
+$post_content = '<!-- wp:paragraph -->
+<p>First paragraph.</p>
+<!-- /wp:paragraph -->
+<!-- wp:heading {"level":3} -->
+<h3>Section Title</h3>
+<!-- /wp:heading -->
+<!-- wp:paragraph -->
+<p>Second paragraph with more content.</p>
+<!-- /wp:paragraph -->';
+
+function extract_block( string $block_name, string $html ): ?string {
+    $depth = 0;
+    $starts_at = null;
+    
+    foreach ( Block_Delimiter::scan_delimiters( $html ) as $where => $delimiter ) {
+        if ( ! $delimiter->is_block_type( $block_name ) ) {
+            continue;
+        }
+        
+        switch ( $delimiter->get_delimiter_type() ) {
+            case Block_Delimiter::VOID:
+                return substr( $html, $where[0], $where[1] );
+                
+            case Block_Delimiter::OPENER:
+                $depth++;
+                $starts_at = $starts_at ?? $where[0];
+                break;
+                
+            case Block_Delimiter::CLOSER:
+                if ( --$depth === 0 ) {
+                    return substr( $html, $starts_at, $where[0] + $where[1] - $starts_at );
+                }
+        }
+    }
+    
+    return null;
+}
+
+$heading_block = extract_block( 'heading', $post_content );
+echo $heading_block;
+```
+
+**Output:**
+```
+<!-- wp:heading {"level":3} -->
+<h3>Section Title</h3>
+<!-- /wp:heading -->
+```
+
+### Modifying Block Content
+
+Transform block content efficiently without parsing the entire tree:
+
+```php
+use Automattic\Block_Delimiter;
+
+$post_content = '<!-- wp:paragraph -->
+<p>Some text content.</p>
+<!-- /wp:paragraph -->
+<!-- wp:image {"id":123} -->
+<figure class="wp-block-image"><img src="photo1.jpg" /></figure>
+<!-- /wp:image -->
+<!-- wp:paragraph -->
+<p>More text content.</p>
+<!-- /wp:paragraph -->
+<!-- wp:image {"id":456} -->
+<figure class="wp-block-image"><img src="photo2.jpg" /></figure>
+<!-- /wp:image -->';
+
+function add_css_class_to_images( string $post_content, string $css_class ): string {
+    $output = '';
+    $starts_at = null;
+    $was_at = 0;
+    
+    foreach ( Block_Delimiter::scan_delimiters( $post_content ) as $where => $delimiter ) {
+        if ( ! $delimiter->is_block_type( 'image' ) ) {
+            continue;
+        }
+        
+        list( $at, $length ) = $where;
+        
+        if ( Block_Delimiter::OPENER === $delimiter->get_delimiter_type() ) {
+            $starts_at = $at + $length;
+        } elseif ( Block_Delimiter::CLOSER === $delimiter->get_delimiter_type() ) {
+            // Copy untouched content before this block
+            $output .= substr( $post_content, $was_at, $starts_at - $was_at );
+            
+            // Transform the block content
+            $block_content = substr( $post_content, $starts_at, $at - $starts_at );
+            $output .= add_css_class( $block_content, $css_class );
+            
+            $was_at = $at;
+        }
+    }
+    
+    // Add any remaining content
+    $output .= substr( $post_content, $was_at );
+    return $output;
+}
+
+function add_css_class( string $html, string $css_class ): string {
+    // Simple example - add class to figure elements
+    return str_replace( 'class="wp-block-image"', 'class="wp-block-image ' . $css_class . '"', $html );
+}
+
+$modified_content = add_css_class_to_images( $post_content, 'custom-image-style' );
+echo $modified_content;
+```
+
+**Output:**
+```
+<!-- wp:paragraph -->
+<p>Some text content.</p>
+<!-- /wp:paragraph -->
+<!-- wp:image {"id":123} -->
+<figure class="wp-block-image custom-image-style"><img src="photo1.jpg" /></figure>
+<!-- /wp:image -->
+<!-- wp:paragraph -->
+<p>More text content.</p>
+<!-- /wp:paragraph -->
+<!-- wp:image {"id":456} -->
+<figure class="wp-block-image custom-image-style"><img src="photo2.jpg" /></figure>
+<!-- /wp:image -->
+```
+
+### Error Handling
+
+Check for parsing errors:
+
+```php
+use Automattic\Block_Delimiter;
+
+$post_content = '<!-- wp:paragraph {"invalid": json} -->
+<p>This block has invalid JSON attributes.</p>
+<!-- /wp:paragraph -->
+<!-- wp:image -->
+<figure><img src="valid.jpg" /></figure>
+<!-- /wp:image -->';
+
+foreach ( Block_Delimiter::scan_delimiters( $post_content ) as $delimiter ) {
+    if ( Block_Delimiter::OPENER === $delimiter->get_delimiter_type() ) {
+        $attributes = $delimiter->allocate_and_return_parsed_attributes();
+        if ( null === $attributes && $delimiter->get_last_json_error() !== JSON_ERROR_NONE ) {
+            echo "Invalid JSON in " . $delimiter->allocate_and_return_block_type() . " block\n";
+        } elseif ( is_array( $attributes ) ) {
+            echo "Valid " . $delimiter->allocate_and_return_block_type() . " block\n";
+        } else {
+            echo "No attributes in " . $delimiter->allocate_and_return_block_type() . " block\n";
+        }
+    }
+}
+
+// Check for incomplete input
+$incomplete_content = '<!-- wp:paragraph';
+$delimiter = Block_Delimiter::next_delimiter( $incomplete_content, 0 );
+
+if ( null === $delimiter ) {
+    $error = Block_Delimiter::get_last_error();
+    if ( Block_Delimiter::INCOMPLETE_INPUT === $error ) {
+        echo "Document appears to be truncated\n";
+    }
+}
+```
+
+**Output:**
+```
+Invalid JSON in core/paragraph block
+No attributes in core/image block
+Document appears to be truncated
+```
+
+### Performance Benefits
+
+The Block Delimiter approach offers significant performance advantages:
+
+- **Zero memory overhead**: No block tree construction
+- **Streaming processing**: Process only what you need
+- **Lazy parsing**: JSON attributes parsed only when accessed
+- **String-based operations**: Work directly with the source text
+- **Early termination**: Stop processing when you find what you need
+
+This makes it ideal for operations like finding specific blocks, counting block types, or making targeted modifications without the cost of full block tree parsing.
+
 ## Contribute
 
 You can contribute to this package by submitting a pull request to the [Jetpack repository](https://github.com/Automattic/jetpack/tree/trunk/projects/packages/block-delimiter).

--- a/projects/packages/block-delimiter/changelog/add-block-delimiter-contents
+++ b/projects/packages/block-delimiter/changelog/add-block-delimiter-contents
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add initial functionality.

--- a/projects/packages/block-delimiter/composer.json
+++ b/projects/packages/block-delimiter/composer.json
@@ -47,10 +47,7 @@
 			"link-template": "https://github.com/Automattic/block-delimiter/compare/v${old}...v${new}"
 		},
 		"mirror-repo": "Automattic/block-delimiter",
-		"textdomain": "jetpack-block-delimiter",
-		"version-constants": {
-			"::PACKAGE_VERSION": "src/class-block-delimiter.php"
-		}
+		"textdomain": "jetpack-block-delimiter"
 	},
 	"suggest": {
 		"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."

--- a/projects/packages/block-delimiter/src/class-block-delimiter.php
+++ b/projects/packages/block-delimiter/src/class-block-delimiter.php
@@ -817,6 +817,7 @@ class Block_Delimiter {
 	}
 
 	// Debugging methods not meant for production use.
+	// @codeCoverageIgnoreStart
 
 	/**
 	 * Prints a debugging message showing the structure of the parsed delimiter.
@@ -877,6 +878,8 @@ class Block_Delimiter {
 		echo $w( substr( $this->source_text, $closing_whitespace_at, $closing_whitespace_length ) ); // phpcs:ignore
 		echo "{$c( "\e[0;36m" )}{$void_flag}{$c("\e[90m")}-->\n"; // phpcs:ignore
 	}
+
+	// @codeCoverageIgnoreEnd
 
 	// Constant declarations that would otherwise pollute the top of the class.
 

--- a/projects/packages/block-delimiter/src/class-block-delimiter.php
+++ b/projects/packages/block-delimiter/src/class-block-delimiter.php
@@ -7,6 +7,8 @@
 
 namespace Automattic;
 
+use Exception;
+
 /**
  * Class for efficiently working with block structure.
  *
@@ -21,47 +23,65 @@ class Block_Delimiter {
 	/**
 	 * Indicates if the last operation failed, otherwise
 	 * will be `null` for success.
+	 *
+	 * @var string|null
 	 */
 	private static ?string $last_error = self::UNINITIALIZED;
 
 	/**
 	 * Indicates failures from decoding JSON attributes.
+	 *
+	 * @var int
 	 */
 	private int $last_json_error = JSON_ERROR_NONE;
 
 	/**
 	 * Holds a reference to the original source text from which to
 	 * extract the parsed spans of the delimiter.
+	 *
+	 * @var string
 	 */
 	private string $source_text;
 
 	/**
 	 * Byte offset into source text where entire delimiter begins.
+	 *
+	 * @var int
 	 */
 	private int $delimiter_at;
 
 	/**
 	 * Byte length of full span of delimiter.
+	 *
+	 * @var int
 	 */
 	private int $delimiter_length;
 
 	/**
 	 * Byte offset where namespace span begins.
+	 *
+	 * @var int
 	 */
 	private int $namespace_at;
 
 	/**
 	 * Byte length of namespace span, or `0` if implicitly in the "core" namespace.
+	 *
+	 * @var int
 	 */
 	private int $namespace_length;
 
 	/**
 	 * Byte offset where block name span begins.
+	 *
+	 * @var int
 	 */
 	private int $name_at;
 
 	/**
 	 * Byte length of block name span.
+	 *
+	 * @var int
 	 */
 	private int $name_length;
 
@@ -71,16 +91,22 @@ class Block_Delimiter {
 	 * This may be erroneous if present within a block closer,
 	 * therefore the {@see self::has_void_flag} can be used by
 	 * calling code to perform appropriate error-handling.
+	 *
+	 * @var bool
 	 */
 	private bool $has_void_flag = false;
 
 	/**
 	 * Byte offset where JSON attributes span begins.
+	 *
+	 * @var int
 	 */
 	private int $json_at;
 
 	/**
 	 * Byte length of JSON attributes span, or `0` if none are present.
+	 *
+	 * @var int
 	 */
 	private int $json_length;
 
@@ -97,6 +123,8 @@ class Block_Delimiter {
 	 * flags then it will be interpreted as a void block to match the behavior
 	 * of the official block parser, however, this is a mistake and probably
 	 * the block ought to close an open block of the same name, if one is open.
+	 *
+	 * @var string
 	 */
 	private string $type;
 
@@ -425,7 +453,8 @@ class Block_Delimiter {
 		$match_at     = 0;
 		$match_length = 0;
 
-		while ( null !== ( $delimiter = self::next_delimiter( $text, $at, $match_at, $match_length ) ) ) {
+		$delimiter = self::next_delimiter( $text, $at, $match_at, $match_length );
+		while ( null !== $delimiter ) {
 			// Handle top-level text as freeform blocks
 			if ( 0 === $depth && $match_at > $at && 'visit' === $freeform_blocks ) {
 				list( $text_opener, $text_closer ) = static::freeform_pair( $text, $at, $match_at - $at );
@@ -456,7 +485,8 @@ class Block_Delimiter {
 				--$depth;
 			}
 
-			$at = $match_at + $match_length;
+			$at        = $match_at + $match_length;
+			$delimiter = self::next_delimiter( $text, $at, $match_at, $match_length );
 		}
 
 		$end = strlen( $text );

--- a/projects/packages/block-delimiter/src/class-block-delimiter.php
+++ b/projects/packages/block-delimiter/src/class-block-delimiter.php
@@ -8,9 +8,853 @@
 namespace Automattic;
 
 /**
- * Class description.
+ * Class for efficiently working with block structure.
+ *
+ * This class follows design values of the HTML API:
+ *  - minimize allocations and strive for zero memory overhead
+ *  - make costs explicit; pay only for what you need
+ *  - follow a streaming, re-entrant design for pausing and aborting
+ *
+ * For usage, jump straight to {@see static::next_delimiter}.
  */
 class Block_Delimiter {
+	/**
+	 * Indicates if the last operation failed, otherwise
+	 * will be `null` for success.
+	 */
+	private static ?string $last_error = self::UNINITIALIZED;
 
-	const PACKAGE_VERSION = '0.1.0-alpha';
+	/**
+	 * Indicates failures from decoding JSON attributes.
+	 */
+	private int $last_json_error = JSON_ERROR_NONE;
+
+	/**
+	 * Holds a reference to the original source text from which to
+	 * extract the parsed spans of the delimiter.
+	 */
+	private string $source_text;
+
+	/**
+	 * Byte offset into source text where entire delimiter begins.
+	 */
+	private int $delimiter_at;
+
+	/**
+	 * Byte length of full span of delimiter.
+	 */
+	private int $delimiter_length;
+
+	/**
+	 * Byte offset where namespace span begins.
+	 */
+	private int $namespace_at;
+
+	/**
+	 * Byte length of namespace span, or `0` if implicitly in the "core" namespace.
+	 */
+	private int $namespace_length;
+
+	/**
+	 * Byte offset where block name span begins.
+	 */
+	private int $name_at;
+
+	/**
+	 * Byte length of block name span.
+	 */
+	private int $name_length;
+
+	/**
+	 * Whether the delimiter contains the block self-closing flag.
+	 *
+	 * This may be erroneous if present within a block closer,
+	 * therefore the {@see self::has_void_flag} can be used by
+	 * calling code to perform appropriate error-handling.
+	 */
+	private bool $has_void_flag = false;
+
+	/**
+	 * Byte offset where JSON attributes span begins.
+	 */
+	private int $json_at;
+
+	/**
+	 * Byte length of JSON attributes span, or `0` if none are present.
+	 */
+	private int $json_length;
+
+	/**
+	 * Indicates what kind of block comment delimiter this represents.
+	 *
+	 * One of:
+	 *
+	 *  - `static::OPENER` If the delimiter is opening a block.
+	 *  - `static::CLOSER` If the delimiter is closing an open block.
+	 *  - `static::VOID`   If the delimiter represents a void block with no inner content.
+	 *
+	 * If a parsed comment delimiter contains both the closing and the void
+	 * flags then it will be interpreted as a void block to match the behavior
+	 * of the official block parser, however, this is a mistake and probably
+	 * the block ought to close an open block of the same name, if one is open.
+	 */
+	private string $type;
+
+	/**
+	 * Finds the next block delimiter in a text document and returns a parsed
+	 * block delimiter info record if it parses, otherwise returns `null`.
+	 *
+	 * Block comment delimiters must be valid HTML comments and may contain JSON.
+	 * This search does not determine, however, if the JSON is valid.
+	 *
+	 * Example delimiters:
+	 *
+	 *     `<!-- wp:paragraph {"dropCap": true} -->`
+	 *     `<!-- wp:separator /-->`
+	 *     `<!-- /wp:paragraph -->`
+	 *
+	 * In the case that a block comment delimiter contains both the void indicator and
+	 * also the closing indicator, it will be treated as a void block.
+	 *
+	 * Example:
+	 *
+	 *     // Find all image block opening delimiters.
+	 *     $at     = 0;
+	 *     $end    = strlen( $html );
+	 *     $images = array();
+	 *     while ( $at < $end ) {
+	 *         $delimiter = Block_Delimiter::next_delimiter( $html, $at, $next_at, $next_length );
+	 *         if ( ! isset( $delimiter ) ) {
+	 *             break;
+	 *         }
+	 *
+	 *         if (
+	 *             Block_Delimiter::OPENER === $delimiter->get_delimiter_type() &&
+	 *             $delimiter->is_block_type( 'core/image' )
+	 *         ) {
+	 *             $images[] = $delimiter;
+	 *         }
+	 *
+	 *         $at = $next_at + $next_length;
+	 *     }
+	 *
+	 * @param string   $text                 Input document possibly containing block comment delimiters.
+	 * @param int      $starting_byte_offset Where in the input document to begin searching.
+	 * @param int|null $match_byte_offset    Optional. When provided, will be set to the byte offset in
+	 *                                       the input document where the delimiter was found, if one
+	 *                                       is found, otherwise not set.
+	 * @param int|null $match_byte_length    Optional. When provided, will be set to the byte length of
+	 *                                       the matched delimiter if one is found, otherwise not set.
+	 * @return Block_Delimiter|null Parsed block delimiter info record if found, otherwise `null`.
+	 */
+	public static function next_delimiter( string $text, int $starting_byte_offset, ?int &$match_byte_offset = null, ?int &$match_byte_length = null ): ?Block_Delimiter {
+		$end                = strlen( $text );
+		$at                 = $starting_byte_offset;
+		$delimiter          = null;
+		static::$last_error = null;
+
+		$close_html_comment = function ( $comment_starting_at ) use ( $text, &$at, $end ) {
+			// Find span-of-dashes comments which look like `<!----->`.
+			$span_of_dashes = strspn( $text, '-', $comment_starting_at + 2 );
+			if (
+				$comment_starting_at + 2 + $span_of_dashes < $end &&
+				'>' === $text[ $comment_starting_at + 2 + $span_of_dashes ]
+			) {
+				$at = $comment_starting_at + $span_of_dashes + 1;
+				return;
+			}
+
+			// Otherwise, there are other characters inside the comment, find the first `-->` or `--!>`.
+			$now_at = $comment_starting_at + 4;
+			while ( $now_at < $end ) {
+				$dashes_at = strpos( $text, '--', $now_at );
+				if ( false === $dashes_at ) {
+					static::$last_error = self::INCOMPLETE_INPUT;
+					$at                 = $end;
+					return;
+				}
+
+				$closer_must_be_at = $dashes_at + 2 + strspn( $text, '-', $dashes_at + 2 );
+				if ( $closer_must_be_at < $end && '!' === $text[ $closer_must_be_at ] ) {
+					++$closer_must_be_at;
+				}
+
+				if ( $closer_must_be_at < $end && '>' === $text[ $closer_must_be_at ] ) {
+					$at = $closer_must_be_at + 1;
+					return;
+				}
+
+				++$now_at;
+			}
+		};
+
+		while ( $at < $end ) {
+			/*
+			 * Find the next possible opening.
+			 *
+			 * This follows the behavior in the official block parser, which treats a post
+			 * as a list of blocks with nested HTML. If HTML comment syntax appears within
+			 * an HTML attribute value, SCRIPT or STYLE element, or in other select places,
+			 * which it can do inside of HTML, then the block parsing may break.
+			 *
+			 * For a more robust parse scan through the document with the HTML API. In
+			 * practice, this has not been a problem in the entire history of blocks.
+			 */
+			$comment_opening_at = strpos( $text, '<!--', $at );
+			if ( false === $comment_opening_at ) {
+				return null;
+			}
+
+			$opening_whitespace_at     = $comment_opening_at + 4;
+			$opening_whitespace_length = strspn( $text, " \t\f\r\n", $opening_whitespace_at );
+			if ( 0 === $opening_whitespace_length ) {
+				$close_html_comment( $comment_opening_at );
+				continue;
+			}
+
+			$wp_prefix_at = $opening_whitespace_at + $opening_whitespace_length;
+			if ( $wp_prefix_at >= $end ) {
+				static::$last_error = self::INCOMPLETE_INPUT;
+				return null;
+			}
+
+			$has_closer = false;
+			if ( '/' === $text[ $wp_prefix_at ] ) {
+				$has_closer = true;
+				++$wp_prefix_at;
+			}
+
+			if ( 0 !== substr_compare( $text, 'wp:', $wp_prefix_at, 3 ) ) {
+				$close_html_comment( $comment_opening_at );
+				continue;
+			}
+
+			$namespace_at = $wp_prefix_at + 3;
+			if ( $namespace_at >= $end ) {
+				static::$last_error = self::INCOMPLETE_INPUT;
+				return null;
+			}
+
+			$start_of_namespace = $text[ $namespace_at ];
+
+			// The namespace must start with a-z.
+			if ( 'a' > $start_of_namespace || 'z' < $start_of_namespace ) {
+				$close_html_comment( $comment_opening_at );
+				continue;
+			}
+
+			$namespace_length = 1 + strspn( $text, 'abcdefghijklmnopqrstuvwxyz0123456789-_', $namespace_at + 1 );
+			$separator_at     = $namespace_at + $namespace_length;
+			if ( $separator_at >= $end ) {
+				static::$last_error = self::INCOMPLETE_INPUT;
+				return null;
+			}
+
+			$has_separator = '/' === $text[ $separator_at ];
+			if ( $has_separator ) {
+				$name_at       = $separator_at + 1;
+				$start_of_name = $text[ $name_at ];
+				if ( 'a' > $start_of_name || 'z' < $start_of_name ) {
+					$close_html_comment( $comment_opening_at );
+					continue;
+				}
+
+				$name_length = 1 + strspn( $text, 'abcdefghijklmnopqrstuvwxyz0123456789-_', $name_at + 1 );
+			} else {
+				$name_at          = $namespace_at;
+				$name_length      = $namespace_length;
+				$namespace_length = 0;
+			}
+
+			$after_name_whitespace_at     = $name_at + $name_length;
+			$after_name_whitespace_length = strspn( $text, " \t\f\r\n", $after_name_whitespace_at );
+			if ( 0 === $after_name_whitespace_length ) {
+				$close_html_comment( $comment_opening_at );
+				continue;
+			}
+
+			$json_at = $after_name_whitespace_at + $after_name_whitespace_length;
+			if ( $json_at >= $end ) {
+				static::$last_error = self::INCOMPLETE_INPUT;
+				return null;
+			}
+			$has_json    = '{' === $text[ $json_at ];
+			$json_length = 0;
+
+			/*
+			 * For the final span of the delimiter it's most efficient to find the end
+			 * of the HTML comment and work backwards. This prevents complicated parsing
+			 * inside the JSON span, which cannot contain the HTML comment terminator.
+			 *
+			 * This also matches the behavior in the official block parser, though it
+			 * allows for matching invalid JSON content.
+			 */
+			$comment_closing_at = strpos( $text, '-->', $json_at );
+			if ( false === $comment_closing_at ) {
+				static::$last_error = self::INCOMPLETE_INPUT;
+				return null;
+			}
+
+			/*
+			 * It looks like this logic leaves an error in here, when the position
+			 * overlaps the JSON or block name. However, for neither of those is it
+			 * possible to parse a valid block if that last overlapping character
+			 * is the void flag. This, therefore, will be valid regardless of how
+			 * the rest of the comment delimiter is written.
+			 */
+			if ( '/' === $text[ $comment_closing_at - 1 ] ) {
+				$has_void_flag    = true;
+				$void_flag_length = 1;
+			} else {
+				$has_void_flag    = false;
+				$void_flag_length = 0;
+			}
+
+			/*
+			 * If there's no JSON, then the span of text after the name
+			 * until the comment closing must be completely whitespace.
+			 */
+			if ( ! $has_json ) {
+				$max_whitespace_length = $comment_closing_at - $json_at - $void_flag_length;
+
+				// This shouldn't be possible, but it can't be allowed regardless.
+				if ( $max_whitespace_length < 0 ) {
+					$close_html_comment( $comment_opening_at );
+					continue;
+				}
+
+				$closing_whitespace_length = strspn( $text, " \t\f\r\n", $json_at, $comment_closing_at - $json_at - $void_flag_length );
+				if ( 0 === $after_name_whitespace_length + $closing_whitespace_length ) {
+					$close_html_comment( $comment_opening_at );
+					continue;
+				}
+
+				// This must be a block delimiter!
+				$delimiter = new static();
+				break;
+			}
+
+			// There's no JSON, so attempt to find its boundary.
+			$after_json_whitespace_length = 0;
+			for ( $char_at = $comment_closing_at - $void_flag_length - 1; $char_at > $json_at; $char_at-- ) {
+				$char = $text[ $char_at ];
+
+				switch ( $char ) {
+					case ' ':
+					case "\t":
+					case "\f":
+					case "\r":
+					case "\n":
+						++$after_json_whitespace_length;
+						continue 2;
+
+					case '}':
+						$json_length = $char_at - $json_at + 1;
+						break 2;
+
+					default:
+						++$at;
+						continue 3;
+				}
+			}
+
+			if ( 0 === $json_length || 0 === $after_json_whitespace_length ) {
+				$close_html_comment( $comment_opening_at );
+				continue;
+			}
+
+			// This must be a block delimiter!
+			$delimiter = new static();
+			break;
+		}
+
+		if ( null === $delimiter ) {
+			return null;
+		}
+
+		$delimiter->source_text = $text;
+
+		$delimiter->delimiter_at     = $comment_opening_at;
+		$delimiter->delimiter_length = $comment_closing_at + 3 - $comment_opening_at;
+
+		$delimiter->namespace_at     = $namespace_at;
+		$delimiter->namespace_length = $namespace_length;
+
+		$delimiter->name_at     = $name_at;
+		$delimiter->name_length = $name_length;
+
+		$delimiter->json_at     = $json_at;
+		$delimiter->json_length = $json_length;
+
+		$delimiter->type = $has_closer
+			? static::CLOSER
+			: ( $has_void_flag ? static::VOID : static::OPENER );
+
+		$delimiter->has_void_flag = $has_void_flag;
+
+		$match_byte_offset = $delimiter->delimiter_at;
+		$match_byte_length = $delimiter->delimiter_length;
+
+		return $delimiter;
+	}
+
+	/**
+	 * Generator function to traverse block delimiters in a text and also
+	 * yield the position information for the delimiter as it scans.
+	 *
+	 * Example:
+	 *
+	 *     foreach ( Block_Delimiter::scan_delimiters( $post_content ) as $where => $delimiter ) {
+	 *         echo "Found a {$delimiter->allocate_and_return_block_type()} at {$where[0]} (length is {$where[1]} bytes)\n";
+	 *     }
+	 *
+	 * @param string  $text             Document potentially containing blocks.
+	 * @param ?string $freeform_blocks Optional. 'visit' to visit virtual block delimiters for freeform content.
+	 * @return \Generator Visits each block delimiter and provides [ at, length ] => delimiter.
+	 */
+	public static function scan_delimiters( string $text, ?string $freeform_blocks = 'skip' ): \Generator {
+		$at    = 0;
+		$depth = 0;
+
+		/*
+		 * Although `phpcs` confidently asserts that `$match_at` and `$match_length`
+		 * are undefined, it is not aware enough to realize that they are set by the
+		 * call to `next_delimiter` and so it’s necessary to alter the code so it
+		 * doesn’t get confused and reject valid code.
+		 */
+		$match_at     = 0;
+		$match_length = 0;
+
+		while ( null !== ( $delimiter = self::next_delimiter( $text, $at, $match_at, $match_length ) ) ) {
+			// Handle top-level text as freeform blocks
+			if ( 0 === $depth && $match_at > $at && 'visit' === $freeform_blocks ) {
+				list( $text_opener, $text_closer ) = static::freeform_pair( $text, $at, $match_at - $at );
+
+				++$depth;
+				yield array( $at, 0 ) => $text_opener;
+
+				--$depth;
+				yield array( $match_at, 0 ) => $text_closer;
+			}
+
+			$delimiter_type = $delimiter->get_delimiter_type();
+
+			switch ( $delimiter_type ) {
+				case static::OPENER:
+				case static::VOID:
+					++$depth;
+					break;
+
+				case static::CLOSER:
+					--$depth;
+					break;
+			}
+
+			yield array( $match_at, $match_length ) => $delimiter;
+
+			if ( static::VOID === $delimiter_type ) {
+				--$depth;
+			}
+
+			$at = $match_at + $match_length;
+		}
+
+		$end = strlen( $text );
+		if ( 'visit' === $freeform_blocks && $at < $end ) {
+			list( $text_opener, $text_closer ) = static::freeform_pair( $text, $at, $end - $at );
+
+			++$depth;
+			yield array( $at, 0 ) => $text_opener;
+
+			--$depth;
+			yield array( $end, 0 ) => $text_closer;
+		}
+	}
+
+	/**
+	 * Constructor function.
+	 */
+	private function __construct() {
+		// This is not to be called from the outside.
+	}
+
+	/**
+	 * Creates a pair of delimiters for freeform text content
+	 * since there are no delimiters in a document for them.
+	 *
+	 * @param string $text   Source document.
+	 * @param int    $at     Where the text region starts (byte offset).
+	 * @param int    $length How long the text region spans (byte count).
+	 * @return static[] Opening and closing block delimiters for the text region.
+	 */
+	private static function freeform_pair( string $text, int $at, int $length ): array {
+		$opener                   = new static();
+		$opener->source_text      = $text;
+		$opener->delimiter_at     = $at;
+		$opener->delimiter_length = 0;
+		$opener->namespace_at     = $at;
+		$opener->namespace_length = 0;
+		$opener->name_at          = $at;
+		$opener->name_length      = 0;
+		$opener->json_at          = $at;
+		$opener->json_length      = 0;
+		$opener->type             = static::OPENER;
+		$opener->has_void_flag    = false;
+
+		$closer               = clone $opener;
+		$end_at               = $at + $length;
+		$closer->delimiter_at = $end_at;
+		$closer->namespace_at = $end_at;
+		$closer->name_at      = $end_at;
+		$closer->json_at      = $end_at;
+		$closer->type         = static::CLOSER;
+
+		return array( $opener, $closer );
+	}
+
+	/**
+	 * Indicates if the last attempt to parse a block comment delimiter
+	 * failed, if set, otherwise `null` if the last attempt succeeded.
+	 *
+	 * @return string|null
+	 */
+	public static function get_last_error() {
+		return static::$last_error;
+	}
+
+	/**
+	 * Indicates if the last attempt to parse a block’s JSON attributes failed.
+	 *
+	 * @see JSON_ERROR_NONE, JSON_ERROR_DEPTH, etc…
+	 *
+	 * @return int JSON_ERROR_ code from last attempt to parse block JSON attributes.
+	 */
+	public function get_last_json_error(): int {
+		return $this->last_json_error;
+	}
+
+	/**
+	 * Allocates a substring from the source text containing the delimiter
+	 * and releases the reference to the source text.
+	 *
+	 * Use this function when the delimiter is holding on to the source
+	 * text and preventing it from being freed by PHP. This function incurs
+	 * a string allocation; if the source text will be retained anyway then
+	 * there's no need to detach as that memory cannot be freed.
+	 *
+	 * This is a low-level function available for controlling the performance
+	 * of sensitive hot-paths. You probably don't need this.
+	 *
+	 * Example:
+	 *
+	 *     function first_block( $html ) {
+	 *         return Block_Delimiter::next_delimiter( $really_long_html, 0 );
+	 *     }
+	 *
+	 *     $delimiter = first_block( $really_long_html_document );
+	 *     // `$really_long_html_document` is still retained inside `$delimiter`, which could lead to a memory leak.
+	 *
+	 *     $delimiter->allocate_and_detach_from_source_text();
+	 *     // `$really_long_html_document` is no longer referenced, and its memory may be freed or used for something else.
+	 *
+	 * @return void
+	 */
+	public function allocate_and_detach_from_source_text(): void {
+		$this->source_text = substr( $this->source_text, $this->delimiter_at, $this->delimiter_length );
+
+		$byte_delta = $this->delimiter_at;
+
+		$this->delimiter_at -= $byte_delta;
+		$this->namespace_at -= $byte_delta;
+		$this->name_at      -= $byte_delta;
+		$this->json_at      -= $byte_delta;
+	}
+
+	/**
+	 * Returns the type of the block comment delimiter.
+	 *
+	 * One of:
+	 *
+	 *  - `static::OPENER`
+	 *  - `static::CLOSER`
+	 *  - `static::VOID`
+	 *
+	 * @return string type of the block comment delimiter.
+	 */
+	public function get_delimiter_type(): string {
+		return $this->type;
+	}
+
+	/**
+	 * Returns whether the delimiter contains the void flag.
+	 *
+	 * This should be avoided except in cases of handling errors with
+	 * block closers containing the void flag. For normative use,
+	 * {@see self::get_delimiter_type}.
+	 *
+	 * @return bool
+	 */
+	public function has_void_flag(): bool {
+		return $this->has_void_flag;
+	}
+
+	/**
+	 * Indicates if the block delimiter represents a block of the given type.
+	 *
+	 * Since the "core" namespace may be implicit, it's allowable to pass
+	 * either the fully-qualified block type with namespace and block name
+	 * as well as the shorthand version only containing the block name, if
+	 * the desired block is in the "core" namespace.
+	 *
+	 * Example:
+	 *
+	 *     $is_core_paragraph = $delimiter->is_block_type( 'paragraph' );
+	 *     $is_core_paragraph = $delimiter->is_block_type( 'core/paragraph' );
+	 *     $is_formula        = $delimiter->is_block_type( 'math-block/formula' );
+	 *
+	 * @param string $block_type Block type name for the desired block.
+	 *                           E.g. "paragraph", "core/paragraph", "math-blocks/formula".
+	 * @return bool Whether this delimiter represents a block of the given type.
+	 */
+	public function is_block_type( string $block_type ): bool {
+		// This is a core/freeform text block, it’s special.
+		if ( 0 === $this->name_length ) {
+			return 'core/freeform' === $block_type || 'freeform' === $block_type;
+		}
+
+		$slash_at = strpos( $block_type, '/' );
+		if ( false === $slash_at ) {
+			$namespace  = 'core';
+			$block_name = $block_type;
+		} else {
+			$namespace  = substr( $block_type, 0, $slash_at );
+			$block_name = substr( $block_type, $slash_at + 1 );
+		}
+
+		// Only the 'core' namespace is allowed to be omitted.
+		if ( 0 === $this->namespace_length && 'core' !== $namespace ) {
+			return false;
+		}
+
+		// If given an explicit namespace, they must match.
+		if (
+			0 !== $this->namespace_length && (
+				strlen( $namespace ) !== $this->namespace_length ||
+				0 !== substr_compare( $this->source_text, $namespace, $this->namespace_at, $this->namespace_length )
+			)
+		) {
+			return false;
+		}
+
+		// The block name must match.
+		return (
+			strlen( $block_name ) === $this->name_length &&
+			0 === substr_compare( $this->source_text, $block_name, $this->name_at, $this->name_length )
+		);
+	}
+
+	/**
+	 * Allocates a substring for the block type and returns the
+	 * fully-qualified name, including the namespace.
+	 *
+	 * This function allocates a substring for the given block type. This
+	 * allocation will be small and likely fine in most cases, but it's
+	 * preferable to call {@link static::is_block_type} if only needing
+	 * to know whether the delimiter is for a given block type, as that
+	 * function is more efficient for this purpose and avoids the allocation.
+	 *
+	 * Example:
+	 *
+	 *     'core/paragraph' = $delimiter->allocate_and_return_block_type();
+	 *
+	 * @return string Fully-qualified block namespace and type, e.g. "core/paragraph".
+	 */
+	public function allocate_and_return_block_type(): string {
+		// This is a core/freeform text block, it’s special.
+		if ( 0 === $this->name_length ) {
+			return 'core/freeform';
+		}
+
+		// This is implicitly in the "core" namespace.
+		if ( 0 === $this->namespace_length ) {
+			$block_name = substr( $this->source_text, $this->name_at, $this->name_length );
+			return "core/{$block_name}";
+		}
+
+		return substr( $this->source_text, $this->namespace_at, $this->namespace_length + $this->name_length + 1 );
+	}
+
+	/**
+	 * Returns a lazy wrapper around the block attributes, which can be used
+	 * for efficiently interacting with the JSON attributes.
+	 *
+	 * @throws Exception This function is not yet implemented.
+	 *
+	 * @todo Create a lazy JSON wrapper so specific attributes can be
+	 *       efficiently queried without parsing everything and loading
+	 *       the entire object into memory.
+	 * @todo After realistic benchmarking, see if JsonStreamingParser\Parser
+	 *       could be used — it would need to be fast enough for the reduction
+	 *       in memory use to be worth it, compared to {@see \json_decode}.
+	 *
+	 * @see \JsonStreamingParser\Parser
+	 *
+	 * @return void
+	 */
+	public function get_attributes(): void {
+		throw new Exception( 'Lazy attribute parsing not yet supported' );
+	}
+
+	/**
+	 * Attempts to parse and return the entire JSON attributes from the delimiter,
+	 * allocating memory and processing the JSON span in the process.
+	 *
+	 * This does not return any parsed attributes for a closing block delimiter
+	 * even if there is a span of JSON content; this JSON is a parsing error.
+	 *
+	 * Consider calling {@link static::get_attributes} instead if it's not
+	 * necessary to read all the attributes at the same time, as that provides
+	 * a more efficient mechanism for typical use cases.
+	 *
+	 * Since the JSON span inside the comment delimiter may not be valid JSON,
+	 * this function will return `null` if it cannot parse the span and set the
+	 * {@see static::get_last_json_error} to the appropriate JSON_ERROR_ constant.
+	 *
+	 * If the delimiter contains no JSON span, it will also return `null`,
+	 * but the last error will be set to {@see JSON_ERROR_NONE}.
+	 *
+	 * Example:
+	 *
+	 *     $delimiter = Block_Delimiter::next_delimiter( '<!-- wp:image {"url": "https://wordpress.org/favicon.ico"} -->', 0 );
+	 *     $memory_hungry_and_slow_attributes = $delimiter->allocate_and_return_parsed_attributes();
+	 *     $memory_hungry_and_slow_attributes === array( 'url' => 'https://wordpress.org/favicon.ico' );
+	 *
+	 *     $delimiter      = Block_Delimiter::next_delimiter( '<!-- /wp:image {"url": "https://wordpress.org/favicon.ico"} -->', 0 );
+	 *     null            = $delimiter->allocate_and_return_parsed_attributes();
+	 *     JSON_ERROR_NONE = $delimiter->get_last_json_error();
+	 *
+	 *     $delimiter = Block_Delimiter::next_delimiter( '<!-- wp:separator {} /-->', 0 );
+	 *     array()    === $delimiter->allocate_and_return_parsed_attributes();
+	 *
+	 *     $delimiter = Block_Delimiter::next_delimiter( '<!-- wp:separator /-->', 0 );
+	 *     null       = $delimiter->allocate_and_return_parsed_attributes();
+	 *
+	 *     $delimiter           = Block_Delimiter::next_delimiter( '<!-- wp:image {"url} -->', 0 );
+	 *     null                 = $delimiter->allocate_and_return_parsed_attributes();
+	 *     JSON_ERROR_CTRL_CHAR = $delimiter->get_last_json_error();
+	 *
+	 * @return array|null Parsed JSON attributes, if present and valid, otherwise `null`.
+	 */
+	public function allocate_and_return_parsed_attributes(): ?array {
+		$this->last_json_error = JSON_ERROR_NONE;
+
+		if ( static::CLOSER === $this->type ) {
+			return null;
+		}
+
+		if ( 0 === $this->json_length ) {
+			return null;
+		}
+
+		$json_span = substr( $this->source_text, $this->json_at, $this->json_length );
+		$parsed    = json_decode( $json_span, null, 512, JSON_OBJECT_AS_ARRAY | JSON_INVALID_UTF8_SUBSTITUTE );
+
+		$last_error            = json_last_error();
+		$this->last_json_error = $last_error;
+
+		return ( JSON_ERROR_NONE === $last_error && is_array( $parsed ) )
+			? $parsed
+			: null;
+	}
+
+	// Debugging methods not meant for production use.
+
+	/**
+	 * Prints a debugging message showing the structure of the parsed delimiter.
+	 *
+	 * This is not meant to be used in production!
+	 *
+	 * @access private
+	 */
+	public function debug_print_structure(): void {
+		$c = ( ! defined( 'STDOUT' ) || posix_isatty( STDOUT ) )
+			? function ( $color = null ) { return $color; } // phpcs:ignore
+			: function ( $color ) { return ''; }; // phpcs:ignore
+
+		if ( $this->is_block_type( 'core/freeform' ) ) {
+			$closer = static::CLOSER === $this->get_delimiter_type() ? '/' : '';
+			echo "{$c( "\e[90m" )}<!-- "; // phpcs:ignore
+			echo "{$c( "\e[0;31m" )}{$closer}"; // phpcs:ignore
+			echo "{$c("\e[90m" )}wp:"; // phpcs:ignore
+			echo "{$c( "\e[0;34m" )}freeform"; // phpcs:ignore
+			echo "{$c( "\e[0;36m" )} {$c("\e[90m")}-->\n"; // phpcs:ignore
+			return;
+		}
+
+		$namespace  = substr( $this->source_text, $this->namespace_at, $this->namespace_length );
+		$slash      = 0 === $this->namespace_length ? '' : '/';
+		$block_name = substr( $this->source_text, $this->name_at, $this->name_length );
+		$closer     = static::CLOSER === $this->type ? '/' : '';
+		$json       = substr( $this->source_text, $this->json_at, $this->json_length );
+
+		$opener_whitespace_at     = $this->delimiter_at + 4;
+		$opener_whitespace_length = $this->namespace_at - 3 - $opener_whitespace_at - ( static::CLOSER === $this->type ? 1 : 0 );
+
+		$after_name_whitespace_at     = $this->name_at + $this->name_length;
+		$after_name_whitespace_length = $this->json_at - $after_name_whitespace_at;
+
+		$closing_whitespace_at     = $this->json_at + $this->json_length;
+		$closing_whitespace_length = $this->delimiter_at + $this->delimiter_length - 3 - $closing_whitespace_at;
+
+		if ( '/' === $this->source_text[ $this->delimiter_at + $this->delimiter_length - 4 ] ) {
+			$void_flag = '/';
+			--$closing_whitespace_length;
+		} else {
+			$void_flag = '';
+		}
+
+		$w = function ( $whitespace ) use ( $c ) {
+			return $c( "\e[2;90m" ) . str_replace( array( ' ', "\t", "\f", "\r", "\n" ), array( '␣', '␉', '␌', '␍', '␤' ), $whitespace );
+		};
+
+		echo "{$c( "\e[90m" )}<!--"; // phpcs:ignore
+		echo $w( substr( $this->source_text, $opener_whitespace_at, $opener_whitespace_length ) ); // phpcs:ignore
+		echo "{$c( "\e[0;31m" )}{$closer}"; // phpcs:ignore
+		echo "{$c("\e[90m" )}wp:{$c( "\e[2;34m" )}{$namespace}"; // phpcs:ignore
+		echo "{$c( "\e[2;90m" )}{$slash}"; // phpcs:ignore
+		echo "{$c( "\e[0;34m" )}{$block_name}"; // phpcs:ignore
+		echo $w( substr( $this->source_text, $after_name_whitespace_at, $after_name_whitespace_length ) ); // phpcs:ignore
+		echo "{$c("\e[0;2;32m" )}{$json}"; // phpcs:ignore
+		echo $w( substr( $this->source_text, $closing_whitespace_at, $closing_whitespace_length ) ); // phpcs:ignore
+		echo "{$c( "\e[0;36m" )}{$void_flag}{$c("\e[90m")}-->\n"; // phpcs:ignore
+	}
+
+	// Constant declarations that would otherwise pollute the top of the class.
+
+	/**
+	 * Indicates that the block comment delimiter closes an open block.
+	 */
+	const CLOSER = 'closer';
+
+	/**
+	 * Indicates that the parser started parsing a block comment delimiter, but
+	 * the input document ended before it could finish. The document was likely truncated.
+	 */
+	const INCOMPLETE_INPUT = 'incomplete-input';
+
+	/**
+	 * Indicates that the block comment delimiter opens a block.
+	 */
+	const OPENER = 'opener';
+
+	/**
+	 * Indicates that the parser has not yet attempted to parse a block comment delimiter.
+	 */
+	const UNINITIALIZED = 'uninitialized';
+
+	/**
+	 * Indicates that the block comment delimiter represents a void block
+	 * with no inner content of any kind.
+	 */
+	const VOID = 'void';
 }

--- a/projects/packages/block-delimiter/src/class-block-delimiter.php
+++ b/projects/packages/block-delimiter/src/class-block-delimiter.php
@@ -26,14 +26,14 @@ class Block_Delimiter {
 	 *
 	 * @var string|null
 	 */
-	private static ?string $last_error = self::UNINITIALIZED;
+	private static $last_error = self::UNINITIALIZED;
 
 	/**
 	 * Indicates failures from decoding JSON attributes.
 	 *
 	 * @var int
 	 */
-	private int $last_json_error = JSON_ERROR_NONE;
+	private $last_json_error = JSON_ERROR_NONE;
 
 	/**
 	 * Holds a reference to the original source text from which to
@@ -41,49 +41,49 @@ class Block_Delimiter {
 	 *
 	 * @var string
 	 */
-	private string $source_text;
+	private $source_text;
 
 	/**
 	 * Byte offset into source text where entire delimiter begins.
 	 *
 	 * @var int
 	 */
-	private int $delimiter_at;
+	private $delimiter_at;
 
 	/**
 	 * Byte length of full span of delimiter.
 	 *
 	 * @var int
 	 */
-	private int $delimiter_length;
+	private $delimiter_length;
 
 	/**
 	 * Byte offset where namespace span begins.
 	 *
 	 * @var int
 	 */
-	private int $namespace_at;
+	private $namespace_at;
 
 	/**
 	 * Byte length of namespace span, or `0` if implicitly in the "core" namespace.
 	 *
 	 * @var int
 	 */
-	private int $namespace_length;
+	private $namespace_length;
 
 	/**
 	 * Byte offset where block name span begins.
 	 *
 	 * @var int
 	 */
-	private int $name_at;
+	private $name_at;
 
 	/**
 	 * Byte length of block name span.
 	 *
 	 * @var int
 	 */
-	private int $name_length;
+	private $name_length;
 
 	/**
 	 * Whether the delimiter contains the block self-closing flag.
@@ -94,21 +94,21 @@ class Block_Delimiter {
 	 *
 	 * @var bool
 	 */
-	private bool $has_void_flag = false;
+	private $has_void_flag = false;
 
 	/**
 	 * Byte offset where JSON attributes span begins.
 	 *
 	 * @var int
 	 */
-	private int $json_at;
+	private $json_at;
 
 	/**
 	 * Byte length of JSON attributes span, or `0` if none are present.
 	 *
 	 * @var int
 	 */
-	private int $json_length;
+	private $json_length;
 
 	/**
 	 * Indicates what kind of block comment delimiter this represents.
@@ -126,7 +126,7 @@ class Block_Delimiter {
 	 *
 	 * @var string
 	 */
-	private string $type;
+	private $type;
 
 	/**
 	 * Finds the next block delimiter in a text document and returns a parsed

--- a/projects/packages/block-delimiter/src/class-block-delimiter.php
+++ b/projects/packages/block-delimiter/src/class-block-delimiter.php
@@ -183,6 +183,18 @@ class Block_Delimiter {
 		$delimiter          = null;
 		static::$last_error = null;
 
+		// Initialize all variables that will be used later.
+		$comment_opening_at = 0;
+		$comment_closing_at = 0;
+		$namespace_at       = 0;
+		$namespace_length   = 0;
+		$name_at            = 0;
+		$name_length        = 0;
+		$json_at            = 0;
+		$json_length        = 0;
+		$has_closer         = false;
+		$has_void_flag      = false;
+
 		$close_html_comment = function ( $comment_starting_at ) use ( $text, &$at, $end ) {
 			// Find span-of-dashes comments which look like `<!----->`.
 			$span_of_dashes = strspn( $text, '-', $comment_starting_at + 2 );
@@ -449,8 +461,8 @@ class Block_Delimiter {
 		/*
 		 * Although `phpcs` confidently asserts that `$match_at` and `$match_length`
 		 * are undefined, it is not aware enough to realize that they are set by the
-		 * call to `next_delimiter` and so it’s necessary to alter the code so it
-		 * doesn’t get confused and reject valid code.
+		 * call to `next_delimiter` and so it's necessary to alter the code so it
+		 * doesn't get confused and reject valid code.
 		 */
 		$match_at     = 0;
 		$match_length = 0;
@@ -555,7 +567,7 @@ class Block_Delimiter {
 	}
 
 	/**
-	 * Indicates if the last attempt to parse a block’s JSON attributes failed.
+	 * Indicates if the last attempt to parse a block's JSON attributes failed.
 	 *
 	 * @see JSON_ERROR_NONE, JSON_ERROR_DEPTH, etc…
 	 *
@@ -649,7 +661,7 @@ class Block_Delimiter {
 	 * @return bool Whether this delimiter represents a block of the given type.
 	 */
 	public function is_block_type( string $block_type ): bool {
-		// This is a core/freeform text block, it’s special.
+		// This is a core/freeform text block, it's special.
 		if ( 0 === $this->name_length ) {
 			return 'core/freeform' === $block_type || 'freeform' === $block_type;
 		}
@@ -702,7 +714,7 @@ class Block_Delimiter {
 	 * @return string Fully-qualified block namespace and type, e.g. "core/paragraph".
 	 */
 	public function allocate_and_return_block_type(): string {
-		// This is a core/freeform text block, it’s special.
+		// This is a core/freeform text block, it's special.
 		if ( 0 === $this->name_length ) {
 			return 'core/freeform';
 		}
@@ -731,7 +743,7 @@ class Block_Delimiter {
 	 *
 	 * @see \JsonStreamingParser\Parser
 	 *
-	 * @return void
+	 * @return never
 	 */
 	public function get_attributes(): void {
 		throw new Exception( 'Lazy attribute parsing not yet supported' );
@@ -789,7 +801,12 @@ class Block_Delimiter {
 		}
 
 		$json_span = substr( $this->source_text, $this->json_at, $this->json_length );
-		$parsed    = json_decode( $json_span, null, 512, JSON_OBJECT_AS_ARRAY | JSON_INVALID_UTF8_SUBSTITUTE );
+		$parsed    = json_decode(
+			$json_span,
+			null, // @phan-suppress-current-line PhanTypeMismatchArgumentInternalProbablyReal -- json_decode does accept null.
+			512,
+			JSON_OBJECT_AS_ARRAY | JSON_INVALID_UTF8_SUBSTITUTE
+		);
 
 		$last_error            = json_last_error();
 		$this->last_json_error = $last_error;

--- a/projects/packages/block-delimiter/src/class-block-delimiter.php
+++ b/projects/packages/block-delimiter/src/class-block-delimiter.php
@@ -5,6 +5,8 @@
  * @package automattic/block-delimiter
  */
 
+declare( strict_types = 1 );
+
 namespace Automattic;
 
 use Exception;

--- a/projects/packages/block-delimiter/tests/php/Block_Delimiter_Test.php
+++ b/projects/packages/block-delimiter/tests/php/Block_Delimiter_Test.php
@@ -13,7 +13,6 @@ use PHPUnit\Framework\TestCase;
  */
 #[CoversClass( Block_Delimiter::class )]
 class Block_Delimiter_Test extends TestCase {
-
 	/**
 	 * Test the next_delimiter method with valid block delimiters.
 	 *
@@ -193,37 +192,86 @@ class Block_Delimiter_Test extends TestCase {
 	 */
 	public static function provideBlockTypeChecks(): array {
 		return array(
-			'core paragraph with short name'   => array(
+			'core paragraph with short name'           => array(
 				'<!-- wp:paragraph -->',
 				'paragraph',
 				true,
 			),
-			'core paragraph with full name'    => array(
+			'core paragraph with full name'            => array(
 				'<!-- wp:paragraph -->',
 				'core/paragraph',
 				true,
 			),
-			'wrong block type'                 => array(
+			'wrong block type'                         => array(
 				'<!-- wp:paragraph -->',
 				'heading',
 				false,
 			),
-			'namespaced block correct'         => array(
+			'namespaced block correct'                 => array(
 				'<!-- wp:jetpack/contact-form -->',
 				'jetpack/contact-form',
 				true,
 			),
-			'namespaced block wrong namespace' => array(
+			'namespaced block wrong namespace'         => array(
 				'<!-- wp:jetpack/contact-form -->',
 				'core/contact-form',
 				false,
 			),
-			'namespaced block short name'      => array(
+			'namespaced block short name'              => array(
 				'<!-- wp:jetpack/contact-form -->',
 				'contact-form',
 				false,
 			),
+			'core separator with short name'           => array(
+				'<!-- wp:separator /-->',
+				'separator',
+				true,
+			),
+			'core separator with full name'            => array(
+				'<!-- wp:separator /-->',
+				'core/separator',
+				true,
+			),
+			'core block wrong short name'              => array(
+				'<!-- wp:paragraph -->',
+				'separator',
+				false,
+			),
+			'non-core namespace with short name fails' => array(
+				'<!-- wp:jetpack/contact-form -->',
+				'jetpack',
+				false,
+			),
 		);
+	}
+
+	/**
+	 * Test is_block_type method with freeform blocks.
+	 */
+	public function test_is_block_type_freeform(): void {
+		$content    = 'Some freeform text<!-- wp:paragraph -->block content<!-- /wp:paragraph -->More freeform text';
+		$delimiters = array();
+
+		// Collect freeform delimiters
+		foreach ( Block_Delimiter::scan_delimiters( $content, 'visit' ) as $position => $delimiter ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+			if ( $delimiter->is_block_type( 'core/freeform' ) ) {
+				$delimiters[] = $delimiter;
+			}
+		}
+
+		$this->assertCount( 4, $delimiters ); // 2 freeform sections, each with opener and closer
+
+		// Test the first freeform delimiter
+		$freeform_delimiter = $delimiters[0];
+
+		// Test both short and full freeform block type names
+		$this->assertTrue( $freeform_delimiter->is_block_type( 'core/freeform' ) );
+		$this->assertTrue( $freeform_delimiter->is_block_type( 'freeform' ) );
+
+		// Test that it doesn't match other block types
+		$this->assertFalse( $freeform_delimiter->is_block_type( 'paragraph' ) );
+		$this->assertFalse( $freeform_delimiter->is_block_type( 'core/paragraph' ) );
+		$this->assertFalse( $freeform_delimiter->is_block_type( 'jetpack/freeform' ) );
 	}
 
 	/**

--- a/projects/packages/block-delimiter/tests/php/Block_Delimiter_Test.php
+++ b/projects/packages/block-delimiter/tests/php/Block_Delimiter_Test.php
@@ -2,13 +2,473 @@
 
 namespace Automattic;
 
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 /**
  * Testing the Block Delimiter package.
+ *
+ * @covers \Automattic\Block_Delimiter
  */
+#[CoversClass( Block_Delimiter::class )]
 class Block_Delimiter_Test extends TestCase {
-	public function test_version() {
-		$this->assertIsString( Block_Delimiter::PACKAGE_VERSION );
+
+	/**
+	 * Test the next_delimiter method with valid block delimiters.
+	 *
+	 * @dataProvider provideValidBlockDelimiters
+	 */
+	#[DataProvider( 'provideValidBlockDelimiters' )]
+	public function test_next_delimiter_with_valid_input( string $input, int $start_offset, array $expected ): void {
+		$match_offset = null;
+		$match_length = null;
+
+		$delimiter = Block_Delimiter::next_delimiter( $input, $start_offset, $match_offset, $match_length );
+
+		$this->assertInstanceOf( Block_Delimiter::class, $delimiter );
+		$this->assertEquals( $expected['type'], $delimiter->get_delimiter_type() );
+		$this->assertEquals( $expected['block_type'], $delimiter->allocate_and_return_block_type() );
+		$this->assertEquals( $expected['match_offset'], $match_offset );
+		$this->assertEquals( $expected['match_length'], $match_length );
+		$this->assertNull( Block_Delimiter::get_last_error() );
+	}
+
+	/**
+	 * Data provider for valid block delimiters.
+	 */
+	public static function provideValidBlockDelimiters(): array {
+		return array(
+			'core paragraph opener'            => array(
+				'<!-- wp:paragraph -->',
+				0,
+				array(
+					'type'         => Block_Delimiter::OPENER,
+					'block_type'   => 'core/paragraph',
+					'match_offset' => 0,
+					'match_length' => 21,
+				),
+			),
+			'core paragraph closer'            => array(
+				'<!-- /wp:paragraph -->',
+				0,
+				array(
+					'type'         => Block_Delimiter::CLOSER,
+					'block_type'   => 'core/paragraph',
+					'match_offset' => 0,
+					'match_length' => 22,
+				),
+			),
+			'void block'                       => array(
+				'<!-- wp:separator /-->',
+				0,
+				array(
+					'type'         => Block_Delimiter::VOID,
+					'block_type'   => 'core/separator',
+					'match_offset' => 0,
+					'match_length' => 22,
+				),
+			),
+			'block with namespace'             => array(
+				'<!-- wp:jetpack/contact-form -->',
+				0,
+				array(
+					'type'         => Block_Delimiter::OPENER,
+					'block_type'   => 'jetpack/contact-form',
+					'match_offset' => 0,
+					'match_length' => 32,
+				),
+			),
+			'block with attributes'            => array(
+				'<!-- wp:paragraph {"align":"center"} -->',
+				0,
+				array(
+					'type'         => Block_Delimiter::OPENER,
+					'block_type'   => 'core/paragraph',
+					'match_offset' => 0,
+					'match_length' => 40,
+				),
+			),
+			'block with whitespace variations' => array(
+				'<!--   wp:paragraph   -->',
+				0,
+				array(
+					'type'         => Block_Delimiter::OPENER,
+					'block_type'   => 'core/paragraph',
+					'match_offset' => 0,
+					'match_length' => 25,
+				),
+			),
+		);
+	}
+
+	/**
+	 * Test the next_delimiter method with invalid input.
+	 *
+	 * @dataProvider provideInvalidBlockDelimiters
+	 */
+	#[DataProvider( 'provideInvalidBlockDelimiters' )]
+	public function test_next_delimiter_with_invalid_input( string $input, int $start_offset ): void {
+		$delimiter = Block_Delimiter::next_delimiter( $input, $start_offset );
+
+		$this->assertNull( $delimiter );
+	}
+
+	/**
+	 * Data provider for invalid block delimiters.
+	 */
+	public static function provideInvalidBlockDelimiters(): array {
+		return array(
+			'no block delimiter'                => array( 'Just some regular text', 0 ),
+			'regular HTML comment'              => array( '<!-- This is a regular comment -->', 0 ),
+			'incomplete wp prefix'              => array( '<!-- w:paragraph -->', 0 ),
+			'no whitespace after comment start' => array( '<!--wp:paragraph -->', 0 ),
+			'invalid block name'                => array( '<!-- wp:123invalid -->', 0 ),
+			'empty input'                       => array( '', 0 ),
+		);
+	}
+
+	/**
+	 * Test next_delimiter with incomplete input.
+	 */
+	public function test_next_delimiter_with_incomplete_input(): void {
+		$delimiter = Block_Delimiter::next_delimiter( '<!-- wp:paragraph', 0 );
+
+		$this->assertNull( $delimiter );
+		$this->assertEquals( Block_Delimiter::INCOMPLETE_INPUT, Block_Delimiter::get_last_error() );
+	}
+
+	/**
+	 * Test scanning multiple delimiters.
+	 */
+	public function test_scan_delimiters(): void {
+		$content    = '<!-- wp:paragraph -->Hello<!-- /wp:paragraph --><!-- wp:separator /-->';
+		$delimiters = array();
+
+		foreach ( Block_Delimiter::scan_delimiters( $content ) as $position => $delimiter ) {
+			$delimiters[] = array(
+				'position'   => $position,
+				'type'       => $delimiter->get_delimiter_type(),
+				'block_type' => $delimiter->allocate_and_return_block_type(),
+			);
+		}
+
+		$this->assertCount( 3, $delimiters );
+		$this->assertEquals( Block_Delimiter::OPENER, $delimiters[0]['type'] );
+		$this->assertEquals( 'core/paragraph', $delimiters[0]['block_type'] );
+		$this->assertEquals( Block_Delimiter::CLOSER, $delimiters[1]['type'] );
+		$this->assertEquals( 'core/paragraph', $delimiters[1]['block_type'] );
+		$this->assertEquals( Block_Delimiter::VOID, $delimiters[2]['type'] );
+		$this->assertEquals( 'core/separator', $delimiters[2]['block_type'] );
+	}
+
+	/**
+	 * Test scanning delimiters with freeform content.
+	 */
+	public function test_scan_delimiters_with_freeform(): void {
+		$content    = 'Some text<!-- wp:paragraph -->Hello<!-- /wp:paragraph -->More text';
+		$delimiters = array();
+
+		foreach ( Block_Delimiter::scan_delimiters( $content, 'visit' ) as $position => $delimiter ) {
+			$delimiters[] = array(
+				'position'   => $position,
+				'type'       => $delimiter->get_delimiter_type(),
+				'block_type' => $delimiter->allocate_and_return_block_type(),
+			);
+		}
+
+		$this->assertCount( 6, $delimiters ); // 2 freeform + 2 paragraph + 2 freeform
+		$this->assertEquals( 'core/freeform', $delimiters[0]['block_type'] );
+		$this->assertEquals( 'core/paragraph', $delimiters[2]['block_type'] );
+		$this->assertEquals( 'core/freeform', $delimiters[4]['block_type'] );
+	}
+
+	/**
+	 * Test is_block_type method.
+	 *
+	 * @dataProvider provideBlockTypeChecks
+	 */
+	#[DataProvider( 'provideBlockTypeChecks' )]
+	public function test_is_block_type( string $delimiter_content, string $check_type, bool $expected ): void {
+		$delimiter = Block_Delimiter::next_delimiter( $delimiter_content, 0 );
+
+		$this->assertInstanceOf( Block_Delimiter::class, $delimiter );
+		$this->assertEquals( $expected, $delimiter->is_block_type( $check_type ) );
+	}
+
+	/**
+	 * Data provider for block type checks.
+	 */
+	public static function provideBlockTypeChecks(): array {
+		return array(
+			'core paragraph with short name'   => array(
+				'<!-- wp:paragraph -->',
+				'paragraph',
+				true,
+			),
+			'core paragraph with full name'    => array(
+				'<!-- wp:paragraph -->',
+				'core/paragraph',
+				true,
+			),
+			'wrong block type'                 => array(
+				'<!-- wp:paragraph -->',
+				'heading',
+				false,
+			),
+			'namespaced block correct'         => array(
+				'<!-- wp:jetpack/contact-form -->',
+				'jetpack/contact-form',
+				true,
+			),
+			'namespaced block wrong namespace' => array(
+				'<!-- wp:jetpack/contact-form -->',
+				'core/contact-form',
+				false,
+			),
+			'namespaced block short name'      => array(
+				'<!-- wp:jetpack/contact-form -->',
+				'contact-form',
+				false,
+			),
+		);
+	}
+
+	/**
+	 * Test get_delimiter_type method.
+	 *
+	 * @dataProvider provideDelimiterTypes
+	 */
+	#[DataProvider( 'provideDelimiterTypes' )]
+	public function test_get_delimiter_type( string $delimiter_content, string $expected_type ): void {
+		$delimiter = Block_Delimiter::next_delimiter( $delimiter_content, 0 );
+
+		$this->assertInstanceOf( Block_Delimiter::class, $delimiter );
+		$this->assertEquals( $expected_type, $delimiter->get_delimiter_type() );
+	}
+
+	/**
+	 * Data provider for delimiter types.
+	 */
+	public static function provideDelimiterTypes(): array {
+		return array(
+			'opener' => array( '<!-- wp:paragraph -->', Block_Delimiter::OPENER ),
+			'closer' => array( '<!-- /wp:paragraph -->', Block_Delimiter::CLOSER ),
+			'void'   => array( '<!-- wp:separator /-->', Block_Delimiter::VOID ),
+		);
+	}
+
+	/**
+	 * Test has_void_flag method.
+	 *
+	 * @dataProvider provideVoidFlagTests
+	 */
+	#[DataProvider( 'provideVoidFlagTests' )]
+	public function test_has_void_flag( string $delimiter_content, bool $expected ): void {
+		$delimiter = Block_Delimiter::next_delimiter( $delimiter_content, 0 );
+
+		$this->assertInstanceOf( Block_Delimiter::class, $delimiter );
+		$this->assertEquals( $expected, $delimiter->has_void_flag() );
+	}
+
+	/**
+	 * Data provider for void flag tests.
+	 */
+	public static function provideVoidFlagTests(): array {
+		return array(
+			'opener without void flag'        => array( '<!-- wp:paragraph -->', false ),
+			'closer without void flag'        => array( '<!-- /wp:paragraph -->', false ),
+			'void block with flag'            => array( '<!-- wp:separator /-->', true ),
+			'closer with erroneous void flag' => array( '<!-- /wp:paragraph /-->', true ),
+		);
+	}
+
+	/**
+	 * Test allocate_and_return_block_type method.
+	 *
+	 * @dataProvider provideBlockTypeReturns
+	 */
+	#[DataProvider( 'provideBlockTypeReturns' )]
+	public function test_allocate_and_return_block_type( string $delimiter_content, string $expected ): void {
+		$delimiter = Block_Delimiter::next_delimiter( $delimiter_content, 0 );
+
+		$this->assertInstanceOf( Block_Delimiter::class, $delimiter );
+		$this->assertEquals( $expected, $delimiter->allocate_and_return_block_type() );
+	}
+
+	/**
+	 * Data provider for block type returns.
+	 */
+	public static function provideBlockTypeReturns(): array {
+		return array(
+			'core paragraph'   => array( '<!-- wp:paragraph -->', 'core/paragraph' ),
+			'core separator'   => array( '<!-- wp:separator /-->', 'core/separator' ),
+			'namespaced block' => array( '<!-- wp:jetpack/contact-form -->', 'jetpack/contact-form' ),
+		);
+	}
+
+	/**
+	 * Test allocate_and_return_parsed_attributes method.
+	 *
+	 * @dataProvider provideAttributeTests
+	 */
+	#[DataProvider( 'provideAttributeTests' )]
+	public function test_allocate_and_return_parsed_attributes( string $delimiter_content, ?array $expected, int $expected_json_error ): void {
+		$delimiter = Block_Delimiter::next_delimiter( $delimiter_content, 0 );
+
+		$this->assertInstanceOf( Block_Delimiter::class, $delimiter );
+		$attributes = $delimiter->allocate_and_return_parsed_attributes();
+
+		$this->assertEquals( $expected, $attributes );
+		$this->assertEquals( $expected_json_error, $delimiter->get_last_json_error() );
+	}
+
+	/**
+	 * Data provider for attribute tests.
+	 */
+	public static function provideAttributeTests(): array {
+		return array(
+			'no attributes'                       => array(
+				'<!-- wp:paragraph -->',
+				null,
+				JSON_ERROR_NONE,
+			),
+			'empty attributes'                    => array(
+				'<!-- wp:paragraph {} -->',
+				array(),
+				JSON_ERROR_NONE,
+			),
+			'valid attributes'                    => array(
+				'<!-- wp:paragraph {"align":"center","dropCap":true} -->',
+				array(
+					'align'   => 'center',
+					'dropCap' => true,
+				),
+				JSON_ERROR_NONE,
+			),
+			'invalid JSON'                        => array(
+				'<!-- wp:paragraph {"align":} -->',
+				null,
+				JSON_ERROR_SYNTAX,
+			),
+			'closer with attributes returns null' => array(
+				'<!-- /wp:paragraph {"align":"center"} -->',
+				null,
+				JSON_ERROR_NONE,
+			),
+		);
+	}
+
+	/**
+	 * Test allocate_and_detach_from_source_text method.
+	 */
+	public function test_allocate_and_detach_from_source_text(): void {
+		$long_content = str_repeat( 'A', 1000 ) . '<!-- wp:paragraph -->' . str_repeat( 'B', 1000 );
+		$delimiter    = Block_Delimiter::next_delimiter( $long_content, 1000 );
+
+		$this->assertInstanceOf( Block_Delimiter::class, $delimiter );
+
+		// Before detaching, the delimiter references the full source text
+		$original_type       = $delimiter->get_delimiter_type();
+		$original_block_type = $delimiter->allocate_and_return_block_type();
+
+		// Detach from source text
+		$delimiter->allocate_and_detach_from_source_text();
+
+		// After detaching, functionality should still work
+		$this->assertEquals( $original_type, $delimiter->get_delimiter_type() );
+		$this->assertEquals( $original_block_type, $delimiter->allocate_and_return_block_type() );
+	}
+
+	/**
+	 * Test get_last_error method.
+	 */
+	public function test_get_last_error(): void {
+		// Reset error state by doing a successful parse
+		Block_Delimiter::next_delimiter( '<!-- wp:paragraph -->', 0 );
+		$this->assertNull( Block_Delimiter::get_last_error() );
+
+		// Trigger an incomplete input error
+		Block_Delimiter::next_delimiter( '<!-- wp:paragraph', 0 );
+		$this->assertEquals( Block_Delimiter::INCOMPLETE_INPUT, Block_Delimiter::get_last_error() );
+	}
+
+	/**
+	 * Test get_last_json_error method.
+	 */
+	public function test_get_last_json_error(): void {
+		$delimiter = Block_Delimiter::next_delimiter( '<!-- wp:paragraph {"valid": true} -->', 0 );
+		$this->assertInstanceOf( Block_Delimiter::class, $delimiter );
+
+		$delimiter->allocate_and_return_parsed_attributes();
+		$this->assertEquals( JSON_ERROR_NONE, $delimiter->get_last_json_error() );
+
+		$delimiter = Block_Delimiter::next_delimiter( '<!-- wp:paragraph {"invalid":} -->', 0 );
+		$this->assertInstanceOf( Block_Delimiter::class, $delimiter );
+
+		$delimiter->allocate_and_return_parsed_attributes();
+		$this->assertEquals( JSON_ERROR_SYNTAX, $delimiter->get_last_json_error() );
+	}
+
+	/**
+	 * Test get_attributes method throws exception.
+	 */
+	public function test_get_attributes_throws_exception(): void {
+		$delimiter = Block_Delimiter::next_delimiter( '<!-- wp:paragraph -->', 0 );
+
+		$this->assertInstanceOf( Block_Delimiter::class, $delimiter );
+		$this->expectException( \Exception::class );
+		$this->expectExceptionMessage( 'Lazy attribute parsing not yet supported' );
+
+		$delimiter->get_attributes();
+	}
+
+	/**
+	 * Test debug_print_structure method.
+	 */
+	public function test_debug_print_structure(): void {
+		$delimiter = Block_Delimiter::next_delimiter( '<!-- wp:paragraph {"align":"center"} -->', 0 );
+
+		$this->assertInstanceOf( Block_Delimiter::class, $delimiter );
+
+		// Capture output
+		ob_start();
+		$delimiter->debug_print_structure();
+		$output = ob_get_clean();
+
+		// Should contain the block information
+		$this->assertStringContainsString( 'paragraph', $output );
+		$this->assertStringContainsString( 'wp:', $output );
+	}
+
+	/**
+	 * Test edge cases and error conditions.
+	 */
+	public function test_edge_cases(): void {
+		// Test with starting offset beyond string length
+		$delimiter = Block_Delimiter::next_delimiter( '<!-- wp:paragraph -->', 100 );
+		$this->assertNull( $delimiter );
+
+		// Test with complex nested HTML comments
+		$content   = '<!-- comment --><!-- wp:paragraph -->content<!-- /wp:paragraph -->';
+		$delimiter = Block_Delimiter::next_delimiter( $content, 0 );
+		$this->assertInstanceOf( Block_Delimiter::class, $delimiter );
+		$this->assertEquals( 'core/paragraph', $delimiter->allocate_and_return_block_type() );
+
+		// Test block name with valid characters
+		$delimiter = Block_Delimiter::next_delimiter( '<!-- wp:block-name_123 -->', 0 );
+		$this->assertInstanceOf( Block_Delimiter::class, $delimiter );
+		$this->assertEquals( 'core/block-name_123', $delimiter->allocate_and_return_block_type() );
+	}
+
+	/**
+	 * Test constants are properly defined.
+	 */
+	public function test_constants(): void {
+		$this->assertEquals( 'opener', Block_Delimiter::OPENER );
+		$this->assertEquals( 'closer', Block_Delimiter::CLOSER );
+		$this->assertEquals( 'void', Block_Delimiter::VOID );
+		$this->assertEquals( 'incomplete-input', Block_Delimiter::INCOMPLETE_INPUT );
+		$this->assertEquals( 'uninitialized', Block_Delimiter::UNINITIALIZED );
 	}
 }

--- a/projects/packages/block-delimiter/tests/php/Block_Delimiter_Test.php
+++ b/projects/packages/block-delimiter/tests/php/Block_Delimiter_Test.php
@@ -108,10 +108,11 @@ class Block_Delimiter_Test extends TestCase {
 	 * @dataProvider provideInvalidBlockDelimiters
 	 */
 	#[DataProvider( 'provideInvalidBlockDelimiters' )]
-	public function test_next_delimiter_with_invalid_input( string $input, int $start_offset ): void {
+	public function test_next_delimiter_with_invalid_input( string $input, int $start_offset, ?string $expected_error ): void {
 		$delimiter = Block_Delimiter::next_delimiter( $input, $start_offset );
 
 		$this->assertNull( $delimiter );
+		$this->assertEquals( $expected_error, Block_Delimiter::get_last_error() );
 	}
 
 	/**
@@ -119,23 +120,14 @@ class Block_Delimiter_Test extends TestCase {
 	 */
 	public static function provideInvalidBlockDelimiters(): array {
 		return array(
-			'no block delimiter'                => array( 'Just some regular text', 0 ),
-			'regular HTML comment'              => array( '<!-- This is a regular comment -->', 0 ),
-			'incomplete wp prefix'              => array( '<!-- w:paragraph -->', 0 ),
-			'no whitespace after comment start' => array( '<!--wp:paragraph -->', 0 ),
-			'invalid block name'                => array( '<!-- wp:123invalid -->', 0 ),
-			'empty input'                       => array( '', 0 ),
+			'no block delimiter'                => array( 'Just some regular text', 0, null ),
+			'regular HTML comment'              => array( '<!-- This is a regular comment -->', 0, null ),
+			'incomplete wp prefix'              => array( '<!-- w:paragraph -->', 0, null ),
+			'no whitespace after comment start' => array( '<!--wp:paragraph -->', 0, null ),
+			'invalid block name'                => array( '<!-- wp:123invalid -->', 0, null ),
+			'empty input'                       => array( '', 0, null ),
+			'incomplete input'                  => array( '<!-- wp:paragraph', 0, Block_Delimiter::INCOMPLETE_INPUT ),
 		);
-	}
-
-	/**
-	 * Test next_delimiter with incomplete input.
-	 */
-	public function test_next_delimiter_with_incomplete_input(): void {
-		$delimiter = Block_Delimiter::next_delimiter( '<!-- wp:paragraph', 0 );
-
-		$this->assertNull( $delimiter );
-		$this->assertEquals( Block_Delimiter::INCOMPLETE_INPUT, Block_Delimiter::get_last_error() );
 	}
 
 	/**

--- a/projects/packages/block-delimiter/tests/php/Block_Delimiter_Test.php
+++ b/projects/packages/block-delimiter/tests/php/Block_Delimiter_Test.php
@@ -464,24 +464,6 @@ class Block_Delimiter_Test extends TestCase {
 	}
 
 	/**
-	 * Test debug_print_structure method.
-	 */
-	public function test_debug_print_structure(): void {
-		$delimiter = Block_Delimiter::next_delimiter( '<!-- wp:paragraph {"align":"center"} -->', 0 );
-
-		$this->assertInstanceOf( Block_Delimiter::class, $delimiter );
-
-		// Capture output
-		ob_start();
-		$delimiter->debug_print_structure();
-		$output = ob_get_clean();
-
-		// Should contain the block information
-		$this->assertStringContainsString( 'paragraph', $output );
-		$this->assertStringContainsString( 'wp:', $output );
-	}
-
-	/**
 	 * Test edge cases and error conditions.
 	 */
 	public function test_edge_cases(): void {


### PR DESCRIPTION
## Proposed changes:

Following #43645, this brings the contents of the package from its original class on WordPress.com.

Ref HOG-139

In order to do that, I've also had to make a few changes:

- I fixed some PHPCS warnings. See ca6f2bae43b719d1e50f5155c1b7be9cb3d86c41
- I removed typed properties. This package requires PHP 7.2, and typed properties were introduced in PHP 7.3. See f636bb525fe60ed8f192a09f42e02ac14a6e1b0b

I also added a first set of tests for this new class. See ed7ae1b8e1167b33963af8f9d282860e76fa5815

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* Internal reference: p7H4VZ-5l1-p2

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

Since the package is not yet required by our plugin, we cannot see it in action. For now, tests should be enough.
