### PR TITLE
Forms: Fix not working on Homepage template when more than one form is added

### DIFF
--- a/projects/packages/forms/changelog/fix-multiple-forms-hash-collision
+++ b/projects/packages/forms/changelog/fix-multiple-forms-hash-collision
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix: Ensure each contact form instance on a page has a unique and stable id, preventing hash collisions and submission issues when multiple forms are present. The form id is now deterministic and not based on the order of rendering, resolving issues with the second form not submitting. 

--- a/projects/packages/forms/src/blocks/contact-form/attributes.js
+++ b/projects/packages/forms/src/blocks/contact-form/attributes.js
@@ -40,4 +40,8 @@ export default {
 			sendToSalesforce: false,
 		},
 	},
+	id: {
+		type: 'string',
+		default: '',
+	},
 };

--- a/projects/packages/forms/src/blocks/contact-form/deprecated.js
+++ b/projects/packages/forms/src/blocks/contact-form/deprecated.js
@@ -16,6 +16,29 @@ const deprecatedAttributes = [
 	'hasFormSettingsSet',
 ];
 
+const v3 = {
+	attributes: {
+		...defaultAttributes,
+	},
+	supports: {
+		html: false,
+	},
+	migrate: ( attributes, innerBlocks ) => {
+		if ( ! attributes.id ) {
+			return [
+				{
+					...attributes,
+					id: `contact-form-migrated-${ Date.now() }-${ Math.floor( Math.random() * 10000 ) }`,
+				},
+				innerBlocks,
+			];
+		}
+		return [ attributes, innerBlocks ];
+	},
+	isEligible: attr => ! attr.id,
+	save: () => <InnerBlocks.Content />,
+};
+
 const v2 = {
 	attributes: {
 		...defaultAttributes,
@@ -90,4 +113,4 @@ const v1 = {
 	save: () => <InnerBlocks.Content />,
 };
 
-export default [ v2, v1 ];
+export default [ v3, v2, v1 ];

--- a/projects/packages/forms/src/blocks/contact-form/edit.js
+++ b/projects/packages/forms/src/blocks/contact-form/edit.js
@@ -19,7 +19,7 @@ import { useInstanceId } from '@wordpress/compose';
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
-import { useRef } from '@wordpress/element';
+import { useRef, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import { filter, isArray, map } from 'lodash';
@@ -61,6 +61,12 @@ const ALLOWED_BLOCKS = [
 const PRIORITIZED_INSERTER_BLOCKS = [ ...map( validFields, block => `jetpack/${ block.name }` ) ];
 
 function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, className } ) {
+	useEffect( () => {
+		if ( ! attributes.id ) {
+			setAttributes( { id: `contact-form-${ clientId }` } );
+		}
+	}, [ attributes.id, clientId, setAttributes ] );
+
 	const {
 		to,
 		subject,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes FORMS-109

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fixes an issue where only the first contact form on a page could be submitted. Now, each contact form instance is assigned a unique and stable id, preventing hash collisions and ensuring all forms on a page can be submitted independently.
* The form id is now deterministic and not based on the order of rendering.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On a WordPress.com website using a Block Theme such as Fixmate:
  1. Navigate to the Site Editor to edit the Home template.
  2. If the template already has a Contact form, check that it works as expected.
  3. Return to the template editor, and add another form; test the form that is further to the bottom.
  4. Notice how, before this fix, the page reloads and nothing happens when submitting the second form.
  5. With this PR, both forms should submit successfully and display the success message. 

* Additional steps:
  - Go to a page or post and add two or more Forms.
  - Publish or update the page.
  - Try submitting each form independently.
  - Each form should submit successfully and display the success message.
  - Test on a multipage post to ensure the correct page is preserved after submission.