### PR TITLE
Forms: Update border radius and width handling in deprecateFieldStyles function

### DIFF
--- a/projects/packages/forms/src/blocks/shared/util/deprecate-field-styles.js
+++ b/projects/packages/forms/src/blocks/shared/util/deprecate-field-styles.js
@@ -20,7 +20,7 @@ const deprecateFieldStyles = attributes => {
 		color: { text: labelColor },
 		typography: {
 			fontSize: labelFontSize,
-			lineHeight: labelLineHeight,
+			lineHeight: labelLineHeight ? `${ labelLineHeight }` : undefined,
 		},
 	} );
 
@@ -37,7 +37,7 @@ const deprecateFieldStyles = attributes => {
 		},
 		typography: {
 			fontSize: fieldFontSize,
-			lineHeight: lineHeight,
+			lineHeight: lineHeight ? `${ lineHeight }` : undefined,
 		},
 	} );
 
@@ -49,7 +49,7 @@ const deprecateFieldStyles = attributes => {
 		},
 		typography: {
 			fontSize: fieldFontSize,
-			lineHeight: lineHeight,
+			lineHeight: lineHeight ? `${ lineHeight }` : undefined,
 		},
 	} );
 

--- a/projects/packages/forms/src/blocks/shared/util/deprecate-field-styles.js
+++ b/projects/packages/forms/src/blocks/shared/util/deprecate-field-styles.js
@@ -27,9 +27,9 @@ const deprecateFieldStyles = attributes => {
 	const inputStyles = cleanEmptyObject( {
 		border: {
 			color: borderColor,
-			radius: borderRadius ? `${ borderRadius }px` : undefined,
+			radius: !! borderRadius || borderRadius === 0 ? `${ borderRadius }px` : undefined,
 			style: 'solid',
-			width: borderWidth,
+			width: !! borderWidth || borderWidth === 0 ? `${ borderWidth }px` : undefined,
 		},
 		color: {
 			text: inputColor,

--- a/projects/packages/forms/src/blocks/shared/util/test/deprecate-field-styles.test.js
+++ b/projects/packages/forms/src/blocks/shared/util/test/deprecate-field-styles.test.js
@@ -1,0 +1,95 @@
+import deprecateFieldStyles from '../deprecate-field-styles';
+
+describe( 'deprecateFieldStyles', () => {
+	it( 'should deprecate input styles', () => {
+		const attributes = {
+			borderColor: '#000000',
+			borderRadius: 5,
+			borderWidth: 2,
+			fieldBackgroundColor: '#ffffff',
+			fieldFontSize: '16px',
+			inputColor: '#333333',
+			lineHeight: 1.5,
+		};
+
+		const result = deprecateFieldStyles( attributes );
+
+		expect( result.inputStyles ).toEqual( {
+			border: {
+				color: '#000000',
+				radius: '5px',
+				style: 'solid',
+				width: '2px',
+			},
+			color: {
+				text: '#333333',
+				background: '#ffffff',
+			},
+			typography: {
+				fontSize: '16px',
+				lineHeight: 1.5,
+			},
+		} );
+	} );
+
+	it( 'should deprecate label styles', () => {
+		const attributes = {
+			labelColor: '#666666',
+			labelFontSize: '14px',
+			labelLineHeight: 1.2,
+		};
+
+		const result = deprecateFieldStyles( attributes );
+
+		expect( result.labelStyles ).toEqual( {
+			color: {
+				text: '#666666',
+			},
+			typography: {
+				fontSize: '14px',
+				lineHeight: 1.2,
+			},
+		} );
+	} );
+
+	it( 'should deprecate option styles', () => {
+		const attributes = {
+			inputColor: '#333333',
+			fieldFontSize: '16px',
+			lineHeight: 1.5,
+		};
+
+		const result = deprecateFieldStyles( attributes );
+
+		expect( result.optionStyles ).toEqual( {
+			color: {
+				text: '#333333',
+			},
+			typography: {
+				fontSize: '16px',
+				lineHeight: 1.5,
+			},
+		} );
+	} );
+
+	it( 'should handle empty or undefined values', () => {
+		const attributes = {
+			borderRadius: 0,
+			borderWidth: 0,
+			placeholder: 'Enter text',
+		};
+
+		const result = deprecateFieldStyles( attributes );
+
+		expect( result.inputStyles ).toEqual( {
+			border: {
+				radius: '0px',
+				style: 'solid',
+				width: '0px',
+			},
+		} );
+		expect( result.labelStyles ).toBeUndefined();
+		expect( result.optionStyles ).toBeUndefined();
+		expect( result.restAttributes ).toEqual( {} );
+	} );
+} );

--- a/projects/packages/forms/src/blocks/shared/util/test/deprecate-field-styles.test.js
+++ b/projects/packages/forms/src/blocks/shared/util/test/deprecate-field-styles.test.js
@@ -27,7 +27,7 @@ describe( 'deprecateFieldStyles', () => {
 			},
 			typography: {
 				fontSize: '16px',
-				lineHeight: 1.5,
+				lineHeight: '1.5',
 			},
 		} );
 	} );
@@ -47,7 +47,7 @@ describe( 'deprecateFieldStyles', () => {
 			},
 			typography: {
 				fontSize: '14px',
-				lineHeight: 1.2,
+				lineHeight: '1.2',
 			},
 		} );
 	} );
@@ -67,7 +67,7 @@ describe( 'deprecateFieldStyles', () => {
 			},
 			typography: {
 				fontSize: '16px',
-				lineHeight: 1.5,
+				lineHeight: '1.5',
 			},
 		} );
 	} );

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -17,8 +17,8 @@ use Automattic\Jetpack\Status\Host;
 use Automattic\Jetpack\Terms_Of_Service;
 use Automattic\Jetpack\Tracking;
 use Jetpack_Options;
-use WP_Block_Patterns_Registry;
 use WP_Block;
+use WP_Block_Patterns_Registry;
 use WP_Block_Type_Registry;
 use WP_Error;
 

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -17,8 +17,8 @@ use Automattic\Jetpack\Status\Host;
 use Automattic\Jetpack\Terms_Of_Service;
 use Automattic\Jetpack\Tracking;
 use Jetpack_Options;
-use WP_Block;
 use WP_Block_Patterns_Registry;
+use WP_Block;
 use WP_Block_Type_Registry;
 use WP_Error;
 


### PR DESCRIPTION

JETPACK-500

## Proposed changes:

Ensure border radius and width are correctly set to 'undefined' only when they are not provided or are null, allowing for proper handling of zero values.


## Why are these changes being made?

In trunk, the border controls deal with numbers. The `px` unit is attached manually when rendering styles.

In short, to display the borders correctly using block styles, units are required.

Without this change the individual border values are saved as numbers. The frontend doesn't add the `px` to the and we get styles such as `border-bottom-width:9`.

## Testing instructions:

Create a form in trunk. Give your controls some borders and a bit of border radius.

Now switch to this branch.

Open your form in the editor.

Edit a single side, e.g., top, of the borders' widths and radius.

Save and view the frontend. 

Your borders should look fine. 

