### PR TITLE
Forms: add section about developer documentation to FAQ

### DIFF
--- a/projects/packages/forms/changelog/update-forms-faq-devdocs
+++ b/projects/packages/forms/changelog/update-forms-faq-devdocs
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: add section about developre documentation to FAQ

--- a/projects/packages/forms/src/dashboard/about/index.tsx
+++ b/projects/packages/forms/src/dashboard/about/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { getRedirectUrl, JetpackIcon } from '@automattic/jetpack-components';
-import { isWpcomPlatformSite } from '@automattic/jetpack-script-data';
+import { isSimpleSite, isWpcomPlatformSite } from '@automattic/jetpack-script-data';
 import { ExternalLink } from '@wordpress/components';
 import { createInterpolateElement, useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -97,6 +97,7 @@ const About = () => {
 	);
 
 	const isWpcomSite = isWpcomPlatformSite();
+	const isSimple = isSimpleSite();
 
 	return (
 		<div className="jp-forms__about">
@@ -199,6 +200,24 @@ const About = () => {
 					<Details summary={ __( 'Is there a form responses limit?', 'jetpack-forms' ) }>
 						{ __( 'No.', 'jetpack-forms' ) }
 					</Details>
+					{ ! isSimple && (
+						<Details
+							summary={ __( 'Can I change Forms functionality via code?', 'jetpack-forms' ) }
+						>
+							{ createInterpolateElement(
+								__(
+									'Yes! You can change several aspects of Forms by using <filtersDocs>WordPress filters</filtersDocs>. Please see our <devDocs>developer documentation</devDocs> for full list of available filters and details.',
+									'jetpack-forms'
+								),
+								{
+									filtersDocs: (
+										<ExternalLink href="https://developer.wordpress.org/plugins/hooks/filters/" />
+									),
+									devDocs: <ExternalLink href={ getRedirectUrl( 'jetpack-contact-support' ) } />,
+								}
+							) }
+						</Details>
+					) }
 					<Details summary={ __( 'What if I would need some help?', 'jetpack-forms' ) }>
 						{ createInterpolateElement(
 							__(
@@ -207,7 +226,7 @@ const About = () => {
 							),
 							{
 								a: isWpcomSite ? (
-									<a href={ getRedirectUrl( 'wpcom-contact-support' ) } />
+									<a href={ getRedirectUrl( 'jetpack-contact-support' ) } />
 								) : (
 									<ExternalLink href={ getRedirectUrl( 'jetpack-contact-support' ) } />
 								),

--- a/projects/packages/forms/src/dashboard/about/index.tsx
+++ b/projects/packages/forms/src/dashboard/about/index.tsx
@@ -213,7 +213,9 @@ const About = () => {
 									filtersDocs: (
 										<ExternalLink href="https://developer.wordpress.org/plugins/hooks/filters/" />
 									),
-									devDocs: <ExternalLink href={ getRedirectUrl( 'jetpack-contact-support' ) } />,
+									devDocs: (
+										<ExternalLink href={ getRedirectUrl( 'jetpack-developer-docs-forms' ) } />
+									),
 								}
 							) }
 						</Details>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


## Proposed changes:
<!--- Explain what functional changes your PR includes -->

Adds a section about developer documentation to About page's FAQ:

<img width="1365" alt="Screenshot 2025-05-28 at 14 08 43" src="https://github.com/user-attachments/assets/13900fcc-934c-4ff8-976a-d9bf4bee7665" />

Links to:
- https://developer.wordpress.org/plugins/hooks/filters/
- https://developer.jetpack.com/module/contact-form/

Section is visible on Jetpack selfhosted and Atomic sites, but not on Simple sites.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Feedback -> About
* See FAQ