### PR TITLE
Social: Fix images in connections management not loading when concatenating JS

### DIFF
--- a/projects/js-packages/publicize-components/changelog/fix-publicize-webpack-public-path-for-wpcom
+++ b/projects/js-packages/publicize-components/changelog/fix-publicize-webpack-public-path-for-wpcom
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Social: Fix images in connections management not loading when concatenating JS.

--- a/projects/js-packages/publicize-components/src/components/admin-page/entry-point.tsx
+++ b/projects/js-packages/publicize-components/src/components/admin-page/entry-point.tsx
@@ -1,3 +1,4 @@
+import '../../utils/public-path.js';
 import { ThemeProvider } from '@automattic/jetpack-components';
 import * as WPElement from '@wordpress/element';
 import React from 'react';

--- a/projects/js-packages/publicize-components/src/components/block-editor/jetpack-sidebar.tsx
+++ b/projects/js-packages/publicize-components/src/components/block-editor/jetpack-sidebar.tsx
@@ -1,3 +1,4 @@
+import '../../utils/public-path.js';
 import { handleJetpackEditorAction } from '@automattic/jetpack-shared-extension-utils';
 import { Fill } from '@wordpress/components';
 import { registerPlugin } from '@wordpress/plugins';

--- a/projects/js-packages/publicize-components/src/components/block-editor/social-sidebar.tsx
+++ b/projects/js-packages/publicize-components/src/components/block-editor/social-sidebar.tsx
@@ -1,3 +1,4 @@
+import '../../utils/public-path.js';
 import { SocialIcon } from '@automattic/jetpack-components';
 import { handleJetpackEditorAction } from '@automattic/jetpack-shared-extension-utils';
 import { PluginSidebar } from '@wordpress/editor';

--- a/projects/js-packages/publicize-components/src/types.ts
+++ b/projects/js-packages/publicize-components/src/types.ts
@@ -50,6 +50,7 @@ export type PluginInfo = Record< 'social' | 'jetpack', { version: string | null 
 
 export interface SocialScriptData {
 	api_paths: ApiPaths;
+	assets_url: string;
 	feature_flags: FeatureFlags;
 	is_publicize_enabled: boolean;
 	plugin_info: PluginInfo;

--- a/projects/js-packages/publicize-components/src/utils/public-path.js
+++ b/projects/js-packages/publicize-components/src/utils/public-path.js
@@ -1,0 +1,12 @@
+/* exported __webpack_public_path__ */
+/* global __webpack_public_path__ */
+
+/**
+ * Dynamically set WebPack's publicPath so that split assets can be found.
+ * Unfortunately we can't set `publicPath: 'auto'` because WordPress.com Simple's JS concatenation breaks it (and other plugins that do JS concatenation probably would too).
+ * @see https://webpack.js.org/guides/public-path/#on-the-fly
+ */
+if ( typeof window === 'object' && window.JetpackScriptData?.social?.assets_url ) {
+	// eslint-disable-next-line no-global-assign
+	__webpack_public_path__ = window.JetpackScriptData.social.assets_url;
+}

--- a/projects/packages/publicize/changelog/fix-publicize-webpack-public-path-for-wpcom
+++ b/projects/packages/publicize/changelog/fix-publicize-webpack-public-path-for-wpcom
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Social: Fix images in connections management not loading when concatenating JS.

--- a/projects/packages/publicize/src/class-publicize-script-data.php
+++ b/projects/packages/publicize/src/class-publicize-script-data.php
@@ -116,6 +116,7 @@ class Publicize_Script_Data {
 
 		$basic_data = array(
 			'api_paths'            => self::get_api_paths(),
+			'assets_url'           => plugins_url( '/build/', __DIR__ ),
 			'is_publicize_enabled' => Utils::is_publicize_active(),
 			'feature_flags'        => self::get_feature_flags(),
 			'supported_services'   => array(),

--- a/projects/plugins/jetpack/changelog/fix-publicize-webpack-public-path-for-wpcom
+++ b/projects/plugins/jetpack/changelog/fix-publicize-webpack-public-path-for-wpcom
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Social: Fix images in connections management not loading when concatenating JS.

--- a/projects/plugins/social/changelog/fix-publicize-webpack-public-path-for-wpcom
+++ b/projects/plugins/social/changelog/fix-publicize-webpack-public-path-for-wpcom
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed images in connections management not loading when concatenating JS.


### PR DESCRIPTION
WordPress.com uses concatenation for JS assets, which results in public paths being broken for images imported in JS modules.

Fixes SOCIAL-48

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Set the `__webpack_public_path__` for publicize bundles to set the correct path for assets.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this PR to your sandbox
* Point the public API and your Simple site to your sandbox
* Go to the Social admin page or the editor on the Simple site
* Add `&concat_js=yes` to the URL to force concatenation
* Open connections management modal
* Expand Facebook or Instagram when there are no connections for those networks
* Confirm that the example image loads fine
* Confirm the same for a Jetpack site

<table>
    <tbody>
        <tr>
            <th>BEFORE</th>
            <th>AFTER</th>
        </tr>
        <tr>
            <td>
<img width="1047" alt="Screenshot 2025-05-28 at 4 47 36 PM" src="https://github.com/user-attachments/assets/e5cf02be-85ae-41f9-ba57-8aaf26b12f7d" />
</td>
            <td>
<img width="1044" alt="Screenshot 2025-05-28 at 4 46 18 PM" src="https://github.com/user-attachments/assets/27e5d03f-5f4a-4b8b-b1fc-bf4a0e4286cc" />
</td>
        </tr>
    </tbody>
</table>