### PR TITLE
Forms: remove admin notices

### DIFF
--- a/projects/packages/forms/changelog/remove-jetpack-forms-migration-notices
+++ b/projects/packages/forms/changelog/remove-jetpack-forms-migration-notices
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Forms: disable default listing UI for post_type=feedback if the menu item is removed. Remove admin notices about page being moved.

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -215,7 +215,8 @@ class Contact_Form_Plugin {
 					'not_found_in_trash' => __( 'No responses found', 'jetpack-forms' ),
 				),
 				'menu_icon'             => 'dashicons-feedback',
-				'show_ui'               => true,
+				// when the legacy menu item is retired, we don't want to show the default post type listing
+				'show_ui'               => ! Jetpack_Forms::is_legacy_menu_item_retired(),
 				'show_in_menu'          => false,
 				'show_in_admin_bar'     => false,
 				'public'                => false,

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -79,35 +79,6 @@ class Dashboard {
 	 */
 	public function load_admin_scripts() {
 		if ( ! $this->switch->is_modern_view() && ! $this->switch->is_jetpack_forms_admin_page() ) {
-			if ( $this->switch->is_classic_view() ) {
-				if ( Jetpack_Forms::is_legacy_menu_item_retired() ) {
-					$notice = sprintf(
-						/* translators: %s: URL to the Jetpack > Forms menu */
-						__( 'Forms responses management has moved to the <a href="%s">Jetpack → Forms</a> menu.', 'jetpack-forms' ),
-						$this->switch->get_forms_admin_url()
-					);
-					wp_admin_notice(
-						$notice,
-						array(
-							'type'        => 'info',
-							'dismissable' => true,
-						)
-					);
-				} elseif ( $this->switch->is_jetpack_forms_admin_page_available() ) {
-					$notice = sprintf(
-						/* translators: %s: URL to the Jetpack > Forms menu */
-						__( 'Forms responses management will be moved to the <a href="%s">Jetpack → Forms</a> menu.', 'jetpack-forms' ),
-						$this->switch->get_forms_admin_url()
-					);
-					wp_admin_notice(
-						$notice,
-						array(
-							'type'        => 'info',
-							'dismissable' => true,
-						)
-					);
-				}
-			}
 			return;
 		}
 


### PR DESCRIPTION
Related to FORMS-27

## Proposed changes:
This PR

- disables the default listing UI for post type feedback when the legacy menu item is removed
- removes the admin notices previously added. Those were meant to show on the default listing UI for post type feedback. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion


## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Applying this change should get rid of the admin notices, but these are only shown when we're in the process of retiring the legacy menu entry. Without any filters applied, nothing should change.

To test, enable these filters to simulate the first step of the migration process:

```php
add_filter( 'jetpack_forms_use_new_menu_parent', '__return_true' );
add_filter( 'jetpack_forms_retire_view_switch', '__return_true' );
add_filter( 'jetpack_forms_announce_new_menu', '__return_true' );
```

**Before:**
<img width="911" alt="image" src="https://github.com/user-attachments/assets/fc287137-3379-46a9-8ec6-2a969fde37ad" />


**After:**
<img width="913" alt="image" src="https://github.com/user-attachments/assets/861eeba3-4419-43ed-87da-d36cb3adfb38" />


On top of this, if you apply the filter to remove the Feedback > Forms Responses menu entry (to be done further down the line, after a full release cycle/month), the default listing UI should not be accessible anymore:

```php
add_filter( 'jetpack_forms_retire_legacy_menu_item', '__return_true' );
```

<img width="860" alt="image" src="https://github.com/user-attachments/assets/b0562709-122a-41e4-8c9d-488851230870" />
