### PR TITLE
Boost: Ensure LCP Image comparison ignores HTML encoding

### DIFF
--- a/projects/plugins/boost/app/modules/optimizations/lcp/class-lcp-optimize-img-tag.php
+++ b/projects/plugins/boost/app/modules/optimizations/lcp/class-lcp-optimize-img-tag.php
@@ -48,8 +48,14 @@ class LCP_Optimize_Img_Tag {
 		 * By removing the last character from the LCP HTML, we can quickly check if the tag is in the buffer.
 		 *
 		 * `substr( '<img src="...">', 0, -1 )` -> `<img src="..."`
+		 *
+		 * We need to normalize HTML entities since the buffer may have &#038; while LCP data may have &amp;
 		 */
-		if ( ! str_contains( $buffer, substr( $this->lcp_data['html'], 0, -1 ) ) ) {
+		$search_string     = substr( $this->lcp_data['html'], 0, -1 );
+		$normalized_buffer = html_entity_decode( $buffer, ENT_QUOTES | ENT_HTML5, 'UTF-8' );
+		$normalized_search = html_entity_decode( $search_string, ENT_QUOTES | ENT_HTML5, 'UTF-8' );
+
+		if ( ! str_contains( $normalized_buffer, $normalized_search ) ) {
 			return $buffer;
 		}
 		// Create the optimized tag with required attributes.

--- a/projects/plugins/boost/changelog/fix-boost-lcp-image-string-comparison
+++ b/projects/plugins/boost/changelog/fix-boost-lcp-image-string-comparison
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: LCP: Changes to an unreleased feature.
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes [HOG-124: Make LCP optimization and Image CDN play nice with each other](https://linear.app/a8c/issue/HOG-124/make-lcp-optimization-and-image-cdn-play-nice-with-each-other)

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Ensures that the image HTML from the $buffer and the HTML from the Cloud are compared with the same appropriate characters.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
**Prerequisites:**

* Ensure https://github.com/Automattic/boost-cloud/pull/688 is checked out within Boost Cloud
* Latest Jetpack Boost Developer plugin installed and activated.
* Your local Boost Cloud is connected to your local WP instance.
* At least one Cornerstone Page set.
* Boost Feature Flag enabled within the install (`JETPACK_BOOST_ALPHA_FEATURES`)
* LCP Optimization feature enabled.
* Image CDN is enabled.

**Instructions**
1. Optimize the LCP, and wait for it to be completed.
2. Visit the optimized page
3. Check that the LCP image receives the LCP optimization attributes, such as:
	* fetchpriority="high"
	* loading="eager"
4. Inspect the network tab to ensure Image CDN URLs are applied
5. Before this fix: LCP images with HTML entity differences would not be matched and optimized.
6. After this fix: LCP images are properly matched and optimized regardless of HTML entity encoding variations.
