### PR TITLE
Autorelease: Abort if a kill switch tag exists

### DIFF
--- a/.github/files/gh-autorelease/files/autorelease.sh
+++ b/.github/files/gh-autorelease/files/autorelease.sh
@@ -40,10 +40,11 @@ else
 	exit 1
 fi
 
-# Don't auto-release if there's a dummy tag in place.
-dummy_tag=$( git ls-remote --tags origin pause_autorelease_dummy_tag )
-if [[ -n $dummy_tag ]]; then
-	echo 'Dummy tag found ('pause_autorelease_dummy_tag'); aborting auto-release.'
+# Don't auto-release if there's a kill switch tag in place.
+kill_switch_tag_name='autorelease_kill_switch'
+kill_switch_tag=$( git ls-remote --tags origin "$kill_switch_tag_name" )
+if [[ -n "$kill_switch_tag" ]]; then
+	echo "Kill switch tag found ('$kill_switch_tag_name'); aborting auto-release."
 	exit 0
 fi
 

--- a/.github/files/gh-autorelease/files/autorelease.sh
+++ b/.github/files/gh-autorelease/files/autorelease.sh
@@ -44,7 +44,7 @@ fi
 kill_switch_tag_name='autorelease_kill_switch'
 kill_switch_tag=$( git ls-remote --tags origin "$kill_switch_tag_name" )
 if [[ -n "$kill_switch_tag" ]]; then
-	echo "Kill switch tag found ('$kill_switch_tag_name'); aborting auto-release."
+	echo "::notice::Kill switch tag found ('$kill_switch_tag_name'); aborting auto-release."
 	exit 0
 fi
 

--- a/.github/files/gh-autorelease/files/autorelease.sh
+++ b/.github/files/gh-autorelease/files/autorelease.sh
@@ -40,6 +40,13 @@ else
 	exit 1
 fi
 
+# Don't auto-release if there's a dummy release in place.
+dummy_release=$( gh release list --limit 1 --json tagName --jq '.[].tagName | select( contains( "+dummy_release" ) )' )
+if [[ -n $dummy_release ]]; then
+	echo 'Dummy release found; aborting auto-release.'
+	exit 0
+fi
+
 echo "Creating release for $TAG"
 
 ## Determine slug and title format.

--- a/.github/files/gh-autorelease/files/autorelease.sh
+++ b/.github/files/gh-autorelease/files/autorelease.sh
@@ -127,7 +127,7 @@ fi
 if [[ -n "$ROLLING_MODE" ]]; then
 	echo "::group::Deleting stale rolling release"
 
-	for R in $( gh release list --limit 100 --json tagName --jq '.[].tagName | select( contains( "rolling" ) )' ); do
+	for R in $( gh release list --limit 100 --json tagName --jq '.[].tagName | select( contains( "+rolling" ) )' ); do
 		echo "Found $R, deleting"
 		gh release delete "$R" --cleanup-tag --yes
 	done

--- a/.github/files/gh-autorelease/files/autorelease.sh
+++ b/.github/files/gh-autorelease/files/autorelease.sh
@@ -41,9 +41,9 @@ else
 fi
 
 # Don't auto-release if there's a dummy tag in place.
-dummy_tag=$( git ls-remote --tags origin pause_rolling_release_dummy_tag )
+dummy_tag=$( git ls-remote --tags origin pause_autorelease_dummy_tag )
 if [[ -n $dummy_tag ]]; then
-	echo 'Dummy tag found ('pause_rolling_release_dummy_tag'); aborting auto-release.'
+	echo 'Dummy tag found ('pause_autorelease_dummy_tag'); aborting auto-release.'
 	exit 0
 fi
 

--- a/.github/files/gh-autorelease/files/autorelease.sh
+++ b/.github/files/gh-autorelease/files/autorelease.sh
@@ -40,10 +40,10 @@ else
 	exit 1
 fi
 
-# Don't auto-release if there's a dummy release in place.
-dummy_release=$( gh release list --limit 1 --json tagName --jq '.[].tagName | select( contains( "+dummy_release" ) )' )
-if [[ -n $dummy_release ]]; then
-	echo 'Dummy release found; aborting auto-release.'
+# Don't auto-release if there's a dummy tag in place.
+dummy_tag=$( git ls-remote --tags origin pause_rolling_release_dummy_tag )
+if [[ -n $dummy_tag ]]; then
+	echo 'Dummy tag found ('pause_rolling_release_dummy_tag'); aborting auto-release.'
 	exit 0
 fi
 

--- a/.github/files/gh-autorelease/workflows/autorelease.yml
+++ b/.github/files/gh-autorelease/workflows/autorelease.yml
@@ -11,6 +11,7 @@ on:
       - 'v?[0-9]+.[0-9]+.[0-9]+.[0-9]+-*'
     branches:
       - 'trunk'
+  workflow_dispatch:
 
 jobs:
   publish:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

If there is a kill switch tag (i.e. tag name contains `autorelease_kill_switch`), let's abort auto-release.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Originally I was going to abort only for rolling releases, but may as well make this more flexible to allow this to block any auto-releases.

I also enabled manual runs with `workflow_dispatch`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

I'm not sure the best way to test this; one can create a kill switch tag and run the added logic to ensure it picks up?