### PR TITLE
Forms: address integrations modal and tab designs

### DIFF
--- a/projects/packages/forms/changelog/fix-jetpack-forms-integrations-labels
+++ b/projects/packages/forms/changelog/fix-jetpack-forms-integrations-labels
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: styles, labels and copy edits for integrations modal and tab

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/integration-card-header.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/integration-card-header.js
@@ -41,6 +41,9 @@ const IntegrationCardHeader = ( {
 			{ __( 'Needs connection', 'jetpack-forms' ) }
 		</span>
 	);
+	const installPluginActionLabel = __( 'Plugin needs install', 'jetpack-forms' );
+	const activatePluginActionLabel = __( 'Plugin needs activation', 'jetpack-forms' );
+
 	const getTooltipText = checked => {
 		if ( toggleTooltip ) {
 			return toggleTooltip;
@@ -85,13 +88,14 @@ const IntegrationCardHeader = ( {
 							<h3 className="integration-card__title">{ title }</h3>
 							{ showPluginAction && (
 								<span className="integration-card__plugin-badge">
-									{ __( 'Plugin', 'jetpack-forms' ) }
+									{ ! isInstalled && installPluginActionLabel }
+									{ isInstalled && ! isActive && activatePluginActionLabel }
 								</span>
 							) }
 							{ showConnectedBadge && (
 								<span className="integration-card__connected-badge">
-									<Icon icon="yes-alt" size={ 16 } />
-									{ __( 'Connected', 'jetpack-forms' ) }
+									<Icon icon="yes-alt" size={ 12 } />
+									{ __( 'Enabled', 'jetpack-forms' ) }
 								</span>
 							) }
 							{ showPendingBadge && <>{ pendingBadge }</> }

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/integration-card-header.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/integration-card-header.js
@@ -28,12 +28,19 @@ const IntegrationCardHeader = ( {
 		isHeaderToggleEnabled,
 		onHeaderToggleChange,
 		toggleDisabledTooltip,
+		setupBadge,
 	} = cardData;
 	const showPluginAction = type === 'plugin' && ( ! isInstalled || ! isActive );
 	const showConnectedBadge = isActive && isConnected;
 	const disableFormText = __( 'Disable for this form', 'jetpack-forms' );
 	const enableFormText = __( 'Enable for this form', 'jetpack-forms' );
 
+	const showPendingBadge = ! showPluginAction && ! isConnected;
+	const pendingBadge = setupBadge || (
+		<span className="integration-card__plugin-badge">
+			{ __( 'Needs connection', 'jetpack-forms' ) }
+		</span>
+	);
 	const getTooltipText = checked => {
 		if ( toggleTooltip ) {
 			return toggleTooltip;
@@ -87,6 +94,7 @@ const IntegrationCardHeader = ( {
 									{ __( 'Connected', 'jetpack-forms' ) }
 								</span>
 							) }
+							{ showPendingBadge && <>{ pendingBadge }</> }
 						</div>
 						{ description && (
 							<span className="integration-card__description">{ description }</span>

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/style.scss
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/style.scss
@@ -68,7 +68,8 @@
 	}
 
 	&__plugin-badge,
-	&__connected-badge {
+	&__connected-badge,
+	&__setup-badge {
 		font-size: 12px;
 		padding: 4px 8px;
 		border-radius: 3px;
@@ -91,6 +92,20 @@
 		.components-icon {
 			color: #93c692;
 		}
+	}
+
+	&__setup-badge {
+		// copy of how Badge (private api yet) is styled
+		background: color( sRGB 0.921961 0.93451 0.991373 );
+		color: color( sRGB 0.109804 0.172549 0.456863 );
+		display: flex;
+		align-items: center;
+		gap: 4px;
+
+		.components-icon {
+			color: #93c692;
+		}
+
 	}
 
 	&__description {

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/salesforce-card.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/salesforce-card.js
@@ -1,4 +1,4 @@
-import { TextControl, BaseControl, ExternalLink } from '@wordpress/components';
+import { TextControl, BaseControl, ExternalLink, Icon } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import SalesforceIcon from '../../../../icons/salesforce';
@@ -54,6 +54,12 @@ const SalesforceCard = ( {
 		toggleDisabledTooltip: ! isValidSalesforceOrgId( salesforceData.organizationId )
 			? __( 'Enter a Salesforce Organization ID to enable.', 'jetpack-forms' )
 			: undefined,
+		setupBadge: (
+			<span className="integration-card__setup-badge">
+				<Icon icon="info-outline" size={ 12 } />
+				{ __( 'Enter organization ID', 'jetpack-forms' ) }
+			</span>
+		),
 	};
 
 	return (

--- a/projects/packages/forms/src/dashboard/integrations/salesforce-card.tsx
+++ b/projects/packages/forms/src/dashboard/integrations/salesforce-card.tsx
@@ -1,3 +1,4 @@
+import { Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import IntegrationCard from '../../blocks/contact-form/components/jetpack-integrations-modal/integration-card';
 import SalesforceIcon from '../../icons/salesforce';
@@ -14,6 +15,12 @@ const SalesforceDashboardCard = ( {
 		showHeaderToggle: false, // Always off for dashboard
 		isLoading: ! data || typeof data.isInstalled === 'undefined',
 		refreshStatus,
+		setupBadge: (
+			<span className="integration-card__setup-badge">
+				<Icon icon="info-outline" size={ 12 } />
+				{ __( 'Enter organization ID', 'jetpack-forms' ) }
+			</span>
+		),
 	};
 
 	return (


### PR DESCRIPTION

Related to DSGJP-64

## Proposed changes:
This PR addresses some copy edits on labels and badges and styles according to designs.

<img width="645" alt="image" src="https://github.com/user-attachments/assets/89f153fb-0010-413c-8cd7-475396a1bffc" />

<img width="722" alt="image" src="https://github.com/user-attachments/assets/b754c14d-18bb-4d17-a521-e33c3284d4ff" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
DSGJP-64

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Insert a form in the editor, open the integrations modal from the sidebar. Verify the labels and styles change