### PR TITLE
Forms: Refactor to Use JWT for Form Reconstruction

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-submit-in-templates
+++ b/projects/packages/forms/changelog/fix-forms-submit-in-templates
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Not significant to the end user
+
+

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -1196,174 +1196,28 @@ class Contact_Form_Plugin {
 		add_filter( 'contact_form_subject', array( $this, 'replace_tokens_with_input' ), 10, 2 );
 
 		// phpcs:disable WordPress.Security.NonceVerification.Missing -- Checked below for logged-in users only, see https://plugins.trac.wordpress.org/ticket/1859
-		$id   = isset( $_POST['contact-form-id'] ) ? sanitize_text_field( wp_unslash( $_POST['contact-form-id'] ) ) : null;
-		$hash = isset( $_POST['contact-form-hash'] ) ? sanitize_text_field( wp_unslash( $_POST['contact-form-hash'] ) ) : null;
-		$hash = is_string( $hash ) ? preg_replace( '/[^\da-f]/i', '', $hash ) : $hash;
+		$id = isset( $_POST['contact-form-id'] ) ? sanitize_text_field( wp_unslash( $_POST['contact-form-id'] ) ) : null;
+
 		// phpcs:enable
 
-		if ( ! is_string( $id ) || ! is_string( $hash ) ) {
+		if ( ! is_string( $id ) ) {
 			return false;
 		}
 
 		if ( is_user_logged_in() ) {
 			check_admin_referer( "contact-form_{$id}" );
 		}
-
-		$is_widget              = str_starts_with( $id, 'widget-' );
-		$is_block_template      = str_starts_with( $id, 'block-template-' );
-		$is_block_template_part = str_starts_with( $id, 'block-template-part-' );
-
-		$form = false;
-
-		if ( $is_widget ) {
-			// It's a form embedded in a text widget
-			$this->current_widget_id = substr( $id, 7 ); // remove "widget-"
-			$widget_type             = implode( '-', array_slice( explode( '-', $this->current_widget_id ), 0, -1 ) ); // Remove trailing -#
-
-			// Is the widget active?
-			$sidebar = is_active_widget( false, $this->current_widget_id, $widget_type );
-
-			// This is lame - no core API for getting a widget by ID
-			$widget = isset( $GLOBALS['wp_registered_widgets'][ $this->current_widget_id ] ) ? $GLOBALS['wp_registered_widgets'][ $this->current_widget_id ] : false;
-
-			if ( $sidebar && $widget && isset( $widget['callback'] ) ) {
-				// prevent PHP notices by populating widget args
-				$widget_args = array(
-					'before_widget' => '',
-					'after_widget'  => '',
-					'before_title'  => '',
-					'after_title'   => '',
-				);
-				// This is lamer - no API for outputting a given widget by ID
-				ob_start();
-				// Process the widget to populate Contact_Form::$last
-				call_user_func( $widget['callback'], $widget_args, $widget['params'][0] );
-				ob_end_clean();
-			}
-		} elseif ( $is_block_template ) {
-			/*
-			 * Recreate the logic in wp-includes/template-loader.php
-			 * that happens *after* 'template_redirect'.
-			 *
-			 * This logic populates the $_wp_current_template_content
-			 * global, which we need in order to render the contact
-			 * form for this block template.
-			 */
-			// start of copy-pasta from wp-includes/template-loader.php.
-			$tag_templates = array(
-				'is_embed'             => 'get_embed_template',
-				'is_404'               => 'get_404_template',
-				'is_search'            => 'get_search_template',
-				'is_front_page'        => 'get_front_page_template',
-				'is_home'              => 'get_home_template',
-				'is_privacy_policy'    => 'get_privacy_policy_template',
-				'is_post_type_archive' => 'get_post_type_archive_template',
-				'is_tax'               => 'get_taxonomy_template',
-				'is_attachment'        => 'get_attachment_template',
-				'is_single'            => 'get_single_template',
-				'is_page'              => 'get_page_template',
-				'is_singular'          => 'get_singular_template',
-				'is_category'          => 'get_category_template',
-				'is_tag'               => 'get_tag_template',
-				'is_author'            => 'get_author_template',
-				'is_date'              => 'get_date_template',
-				'is_archive'           => 'get_archive_template',
-			);
-			$template      = false;
-			// Loop through each of the template conditionals, and find the appropriate template file.
-			// This is what calls locate_block_template() to hydrate $_wp_current_template_content.
-			foreach ( $tag_templates as $tag => $template_getter ) {
-				if ( call_user_func( $tag ) ) {
-					$template = call_user_func( $template_getter );
-				}
-				if ( $template ) {
-					if ( 'is_attachment' === $tag ) {
-						remove_filter( 'the_content', 'prepend_attachment' );
-					}
-					break;
-				}
-			}
-			if ( ! $template ) {
-				$template = get_index_template();
-			}
-			// end of copy-pasta from wp-includes/template-loader.php.
-
-			// Ensure 'block_template' attribute is added to any shortcodes in the template.
-			$template = Util::grunion_contact_form_set_block_template_attribute( $template );
-
-			// Process the block template to populate Contact_Form::$last
-			get_the_block_template_html();
-		} elseif ( $is_block_template_part ) {
-			$block_template_part_id   = str_replace( 'block-template-part-', '', $id );
-			$bits                     = explode( '//', $block_template_part_id );
-			$block_template_part_slug = array_pop( $bits );
-			// Process the block part template to populate Contact_Form::$last
-			$attributes = array(
-				'theme'   => wp_get_theme()->get_stylesheet(),
-				'slug'    => $block_template_part_slug,
-				'tagName' => 'div',
-			);
-			do_blocks( '<!-- wp:template-part ' . wp_json_encode( $attributes ) . ' /-->' );
-		} else {
-			// It's a form embedded in a post
-
-			if ( ! is_post_publicly_viewable( $id ) && ! current_user_can( 'read_post', $id ) ) {
-				// The user can't see the post.
-				return false;
-			}
-
-			if ( post_password_required( $id ) ) {
-				// The post is password-protected and the password is not provided.
-				return false;
-			}
-
-			$post = get_post( $id );
-
-			// Process the content to populate Contact_Form::$last
-			if ( $post ) {
-				if ( str_contains( $post->post_content, '<!--nextpage-->' ) ) {
-					$postdata = generate_postdata( $post );
-					$page     = isset( $_POST['page'] ) ? absint( wp_unslash( $_POST['page'] ) ) : null; // phpcs:Ignore WordPress.Security.NonceVerification.Missing
-					$paged    = isset( $page ) ? $page : 1;
-					$content  = isset( $postdata['pages'][ $paged - 1 ] ) ? $postdata['pages'][ $paged - 1 ] : $post->post_content;
-				} else {
-					$content = $post->post_content;
-				}
-				/** This filter is already documented in core. wp-includes/post-template.php */
-				apply_filters( 'the_content', $content );
-			}
+		$jwt = isset( $_POST['jetpack_contact_form_jwt'] ) ? sanitize_text_field( wp_unslash( $_POST['jetpack_contact_form_jwt'] ) ) : null;
+		if ( ! $jwt ) {
+			// If the JWT is not provided, return an error.
+			return new WP_Error( 'jwt_not_found', __( 'The form you are trying to submit does not exist.', 'jetpack-forms' ) );
 		}
-
-		$form = isset( Contact_Form::$forms[ $hash ] ) ? Contact_Form::$forms[ $hash ] : null;
-
-		// No form may mean user is using do_shortcode, grab the form using the stored post meta
-		if ( ! $form && is_numeric( $id ) && $hash ) {
-
-			// Get shortcode from post meta
-			$shortcode = get_post_meta( $id, "_g_feedback_shortcode_{$hash}", true );
-
-			// Format it
-			if ( $shortcode !== '' && $shortcode !== false ) {
-
-				// Get attributes from post meta.
-				$parameters = '';
-				$attributes = get_post_meta( $id, "_g_feedback_shortcode_atts_{$hash}", true );
-				if ( ! empty( $attributes ) && is_array( $attributes ) ) {
-					foreach ( array_filter( $attributes ) as $param => $value ) {
-						$parameters .= " $param=\"$value\"";
-					}
-				}
-
-				$shortcode = '[contact-form' . $parameters . ']' . $shortcode . '[/contact-form]';
-				do_shortcode( $shortcode );
-
-				// Recreate form
-				$form = Contact_Form::$last;
-			}
-		}
+		// Get the contact form instance from the JWT.
+		$form = Contact_Form::get_instance_from_jwt( $jwt );
 
 		if ( ! $form ) {
-			return false;
+			// If the form is not found, return an error.
+			return new WP_Error( 'form_not_found', __( 'The form you are trying to submit does not exist.', 'jetpack-forms' ) );
 		}
 
 		if ( is_wp_error( $form->errors ) && $form->errors->get_error_codes() ) {

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1613,7 +1613,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 
 		$comment_ip_text = $comment_author_ip ? "IP: {$comment_author_ip}\n" : null;
 
-		$post_id = wp_insert_post(
+		$feedback_post_id = wp_insert_post(
 			array(
 				'post_date'    => addslashes( $feedback_time ),
 				'post_type'    => 'feedback',
@@ -1629,7 +1629,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 		// once insert has finished we don't need this filter any more
 		remove_filter( 'wp_insert_post_data', array( $plugin, 'insert_feedback_filter' ), 10 );
 
-		update_post_meta( $post_id, '_feedback_extra_fields', $this->addslashes_deep( $extra_values ) );
+		update_post_meta( $feedback_post_id, '_feedback_extra_fields', $this->addslashes_deep( $extra_values ) );
 
 		if ( 'publish' === $feedback_status ) {
 			// Increase count of unread feedback.
@@ -1638,7 +1638,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 		}
 
 		if ( defined( 'AKISMET_VERSION' ) ) {
-			update_post_meta( $post_id, '_feedback_akismet_values', $this->addslashes_deep( $akismet_values ) );
+			update_post_meta( $feedback_post_id, '_feedback_akismet_values', $this->addslashes_deep( $akismet_values ) );
 		}
 
 		/**
@@ -1653,7 +1653,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 		 * @param boolean $is_spam Whether the form submission has been identified as spam.
 		 * @param array   $entry_values The feedback entry values.
 		 */
-		do_action( 'grunion_after_feedback_post_inserted', $post_id, $this->fields, $is_spam, $entry_values );
+		do_action( 'grunion_after_feedback_post_inserted', $feedback_post_id, $this->fields, $is_spam, $entry_values );
 
 		/**
 		 * Filter the title used in the response email.
@@ -1665,7 +1665,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 		 * @param string the title of the email
 		 */
 		$title   = (string) apply_filters( 'jetpack_forms_response_email_title', '' );
-		$message = self::get_compiled_form_for_email( $post_id, $this );
+		$message = self::get_compiled_form_for_email( $feedback_post_id, $this );
 
 		if ( is_user_logged_in() ) {
 			$sent_by_text = sprintf(
@@ -1771,7 +1771,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 		// This is called after `contact_form_message`, in order to preserve back-compat
 		$message = self::wrap_message_in_html_tags( $title, $message, $footer, $actions );
 
-		update_post_meta( $post_id, '_feedback_email', $this->addslashes_deep( compact( 'to', 'message' ) ) );
+		update_post_meta( $feedback_post_id, '_feedback_email', $this->addslashes_deep( compact( 'to', 'message' ) ) );
 
 		/**
 		 * Fires right before the contact form message is sent via email to
@@ -1785,7 +1785,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 		 * @param array $all_values Contact form fields
 		 * @param array $extra_values Contact form fields not included in $all_values
 		 */
-		do_action( 'grunion_pre_message_sent', $post_id, $all_values, $extra_values );
+		do_action( 'grunion_pre_message_sent', $feedback_post_id, $all_values, $extra_values );
 
 		// schedule deletes of old spam feedbacks
 		if ( ! wp_next_scheduled( 'grunion_scheduled_delete' ) ) {
@@ -1804,7 +1804,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 			 * @param bool true Should an email be sent after a form submission. Default to true.
 			 * @param int $post_id Post ID.
 			 */
-			true === apply_filters( 'grunion_should_send_email', true, $post_id )
+			true === apply_filters( 'grunion_should_send_email', true, $feedback_post_id )
 		) {
 			self::wp_mail( $to, "{$spam}{$subject}", $message, $headers );
 		} elseif (
@@ -1838,7 +1838,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 		 * @param array $all_values Contact form fields.
 		 * @param array $extra_values Contact form fields not included in $all_values
 		 */
-		do_action( 'grunion_after_message_sent', $post_id, $to, $subject, $message, $headers, $all_values, $extra_values );
+		do_action( 'grunion_after_message_sent', $feedback_post_id, $to, $subject, $message, $headers, $all_values, $extra_values );
 
 		// If the request accepts JSON, return a JSON response instead of redirecting
 		$is_ajax_submission_enabled = apply_filters( 'jetpack_forms_enable_ajax_submission', false );
@@ -1859,7 +1859,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 		}
 
 		if ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
-			return self::success_message( $post_id, $this );
+			return self::success_message( $feedback_post_id, $this );
 		}
 
 		$redirect        = '';
@@ -1886,8 +1886,8 @@ class Contact_Form extends Contact_Form_Shortcode {
 				urlencode_deep(
 					array(
 						'contact-form-id'   => $rendered_form_id,
-						'contact-form-sent' => $post_id,
-						'_wpnonce'          => wp_create_nonce( "contact-form-sent-{$post_id}" ), // wp_nonce_url HTMLencodes :( .
+						'contact-form-sent' => $feedback_post_id,
+						'_wpnonce'          => wp_create_nonce( "contact-form-sent-{$feedback_post_id}" ), // wp_nonce_url HTMLencodes :( .
 					)
 				),
 				$redirect
@@ -1905,7 +1905,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 		 * @param int $id Contact Form ID.
 		 * @param int $post_id Post ID.
 		 */
-		$redirect = apply_filters( 'grunion_contact_form_redirect_url', $redirect, $rendered_form_id, $post_id );
+		$redirect = apply_filters( 'grunion_contact_form_redirect_url', $redirect, $rendered_form_id, $feedback_post_id );
 		// phpcs:ignore WordPress.Security.SafeRedirect.wp_redirect_wp_redirect -- We intentially allow external redirects here.
 		wp_redirect( $redirect );
 		exit( 0 );

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -89,10 +89,10 @@ class Contact_Form extends Contact_Form_Shortcode {
 	 * @param string $content - the content.
 	 */
 	public function __construct( $attributes, $content = null ) {
-		global $post, $page;
+		global $post;
 
 		// Set up the default subject and recipient for this form.
-		$default_to      = '';
+		$default_to      = get_option( 'admin_email' );
 		$default_subject = '[' . get_option( 'blogname' ) . ']';
 
 		if ( ! isset( $attributes ) || ! is_array( $attributes ) ) {
@@ -108,45 +108,14 @@ class Contact_Form extends Contact_Form_Shortcode {
 			);
 		}
 
-		if ( ! empty( $attributes['widget'] ) && $attributes['widget'] ) {
-			$default_to      .= get_option( 'admin_email' );
-			$attributes['id'] = 'widget-' . $attributes['widget'];
-			// translators: the blog name (and post name, if applicable).
-			$default_subject = sprintf( _x( '%1$s Sidebar', '%1$s = blog name', 'jetpack-forms' ), $default_subject );
-		} elseif ( ! empty( $attributes['block_template'] ) && $attributes['block_template'] ) {
-			$default_to      .= get_option( 'admin_email' );
-			$attributes['id'] = 'block-template-' . $attributes['block_template'];
-		} elseif ( ! empty( $attributes['block_template_part'] ) && $attributes['block_template_part'] ) {
-			$default_to      .= get_option( 'admin_email' );
-			$attributes['id'] = 'block-template-part-' . $attributes['block_template_part'];
-		} elseif ( $post ) {
-			$attributes['id'] = $post->ID;
-			$post_author      = get_userdata( $post->post_author );
+		if ( $post ) {
+			$post_author = get_userdata( $post->post_author );
 			if ( is_a( $post_author, '\WP_User' ) ) {
-				$default_to .= $post_author->user_email;
-			} else {
-				$default_to .= get_option( 'admin_email' );
+				$default_to = $post_author->user_email;
 			}
 		}
-
-		if ( ! empty( self::$forms ) ) {
-			// Ensure 'id' exists in $attributes before trying to modify it
-			if ( ! isset( $attributes['id'] ) ) {
-				$attributes['id'] = '';
-			}
-
-			// When submitting the page number is not always set, so we need to handle that: TODO: This is a hack, we need to find a better way to handle form identification
-			$page_num = max( 1, intval( $page ) );
-
-			$attributes['id'] = $attributes['id'] . '-' . ( count( self::$forms ) + 1 ) . '-' . $page_num;
-		}
-
-		$hashable_attributes = $attributes;
-		unset( $hashable_attributes['id'] ); // Remove the ID from the attributes to be hashed, as it is not part of the form's content.
-		$this->hash = sha1( wp_json_encode( array( $content, $hashable_attributes ) ) );
-		if ( ! isset( self::$forms[ $this->hash ] ) ) {
-			// If no ID is set, generate a unique one.
-			self::$forms[ $this->hash ] = $this;
+		if ( ! isset( $attributes['id'] ) || isset( self::$forms[ $attributes['id'] ] ) ) {
+			$attributes['id'] = ! ( empty( self::$forms ) ) ? count( self::$forms ) + 1 : 1;
 		}
 
 		// Keep reference to $this for parsing form fields.
@@ -198,16 +167,11 @@ class Contact_Form extends Contact_Form_Shortcode {
 				[contact-field label="' . __( 'Message', 'jetpack-forms' ) . '" type="textarea" /]';
 
 			$this->parse_content( $default_form );
-
-			// Store the shortcode.
-			$this->store_shortcode( $default_form, $attributes, $this->hash );
-		} else {
-			// Store the shortcode.
-			$this->store_shortcode( $content, $attributes, $this->hash );
 		}
 
 		// $this->body and $this->fields have been setup.  We no longer need the contact-field shortcode.
 		Contact_Form_Plugin::$using_contact_form_field = false;
+		self::$forms[ $this->get_attribute( 'id' ) ]   = $this;
 	}
 
 	/**
@@ -216,7 +180,13 @@ class Contact_Form extends Contact_Form_Shortcode {
 	 * @return Contact_Form|null
 	 */
 	public function get_jwt() {
-		return JWT::encode( array( $this->attributes, $this->content ), ( new Tokens() )->get_access_token()->secret );
+		return JWT::encode(
+			array(
+				'attributes' => $this->attributes,
+				'content'    => $this->content,
+			),
+			( new Tokens() )->get_access_token()->secret
+		);
 	}
 
 	/**
@@ -228,43 +198,15 @@ class Contact_Form extends Contact_Form_Shortcode {
 	 */
 	public static function get_instance_from_jwt( $jwt ) {
 		try {
-			// Decode the JWT to get the attributes and content.
 			$data = JWT::decode( $jwt, ( new Tokens() )->get_access_token()->secret, array( 'HS256' ) );
 		} catch ( \Exception $e ) {
-			// If decoding fails, return an empty instance.
 			return null;
 		}
+		$attributes = (array) $data->attributes;
 		return new self(
-			$data[0], // attributes
-			$data[1]  // content
+			$attributes,
+			$data->content
 		);
-	}
-
-	/**
-	 * Store shortcode content for recall later
-	 *  - used to receate shortcode when user uses do_shortcode
-	 *
-	 * @param string $content - the content.
-	 * @param array  $attributes - the attributes.
-	 * @param string $hash - the hash.
-	 */
-	public static function store_shortcode( $content = null, $attributes = null, $hash = null ) {
-
-		if ( $content && isset( $attributes['id'] ) ) {
-
-			if ( empty( $hash ) ) {
-				$hash = sha1( wp_json_encode( $attributes ) . $content );
-			}
-
-			$shortcode_meta = (string) get_post_meta( $attributes['id'], "_g_feedback_shortcode_{$hash}", true );
-
-			if ( $shortcode_meta !== '' || $shortcode_meta !== $content ) {
-				update_post_meta( $attributes['id'], "_g_feedback_shortcode_{$hash}", $content );
-
-				// Save attributes to post_meta for later use. They're not available later in do_shortcode situations.
-				update_post_meta( $attributes['id'], "_g_feedback_shortcode_atts_{$hash}", $attributes );
-			}
-		}
 	}
 
 	/**

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -177,7 +177,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 	/**
 	 * Get the JWT for this contact form instance.
 	 *
-	 * @return Contact_Form|null
+	 * @return string
 	 */
 	public function get_jwt() {
 		return JWT::encode(
@@ -1701,7 +1701,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 		$status = $is_spam ? 'spam' : 'inbox';
 
 		// Build the dashboard URL with the status and the feedback's post id
-		$dashboard_url = ( new Dashboard_View_Switch() )->get_forms_admin_url( $status, true ) . '&r=' . $post_id;
+		$dashboard_url = ( new Dashboard_View_Switch() )->get_forms_admin_url( $status, true ) . '&r=' . $feedback_post_id;
 
 		$mark_as_spam_url = $dashboard_url . '&mark_as_spam';
 
@@ -1851,7 +1851,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 				array(
 					'success' => true,
 					'message' => __( 'Your message has been sent', 'jetpack-forms' ),
-					'data'    => self::get_json_data( $post_id, $this ),
+					'data'    => self::get_json_data( $feedback_post_id, $this ),
 				)
 			);
 

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -7,12 +7,16 @@
 
 namespace Automattic\Jetpack\Forms\ContactForm;
 
+use Automattic\Jetpack\Connection\Tokens;
 use Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch;
+use Automattic\Jetpack\JWT;
 use Automattic\Jetpack\Sync\Settings;
 use Jetpack_Tracks_Event;
 use PHPMailer\PHPMailer\PHPMailer;
 use WP_Block;
 use WP_Error;
+
+require_once __DIR__ . '/class-jwt.php';
 
 /**
  * Class for the contact-form shortcode.
@@ -137,8 +141,13 @@ class Contact_Form extends Contact_Form_Shortcode {
 			$attributes['id'] = $attributes['id'] . '-' . ( count( self::$forms ) + 1 ) . '-' . $page_num;
 		}
 
-		$this->hash                 = sha1( wp_json_encode( $attributes ) );
-		self::$forms[ $this->hash ] = $this;
+		$hashable_attributes = $attributes;
+		unset( $hashable_attributes['id'] ); // Remove the ID from the attributes to be hashed, as it is not part of the form's content.
+		$this->hash = sha1( wp_json_encode( array( $content, $hashable_attributes ) ) );
+		if ( ! isset( self::$forms[ $this->hash ] ) ) {
+			// If no ID is set, generate a unique one.
+			self::$forms[ $this->hash ] = $this;
+		}
 
 		// Keep reference to $this for parsing form fields.
 		self::$current_form = $this;
@@ -199,6 +208,36 @@ class Contact_Form extends Contact_Form_Shortcode {
 
 		// $this->body and $this->fields have been setup.  We no longer need the contact-field shortcode.
 		Contact_Form_Plugin::$using_contact_form_field = false;
+	}
+
+	/**
+	 * Get the JWT for this contact form instance.
+	 *
+	 * @return Contact_Form|null
+	 */
+	public function get_jwt() {
+		return JWT::encode( array( $this->attributes, $this->content ), ( new Tokens() )->get_access_token()->secret );
+	}
+
+	/**
+	 * Get an instance of Contact_Form from a JWT.
+	 *
+	 * @param string $jwt - the JWT to decode.
+	 *
+	 * @return Contact_Form|null
+	 */
+	public static function get_instance_from_jwt( $jwt ) {
+		try {
+			// Decode the JWT to get the attributes and content.
+			$data = JWT::decode( $jwt, ( new Tokens() )->get_access_token()->secret, array( 'HS256' ) );
+		} catch ( \Exception $e ) {
+			// If decoding fails, return an empty instance.
+			return null;
+		}
+		return new self(
+			$data[0], // attributes
+			$data[1]  // content
+		);
 	}
 
 	/**
@@ -341,10 +380,8 @@ class Contact_Form extends Contact_Form_Shortcode {
 		}
 
 		if ( isset( $_GET['contact-form-id'] )
-			&& (int) $_GET['contact-form-id'] === (int) self::$last->get_attribute( 'id' )
-			&& isset( $_GET['contact-form-sent'] ) && isset( $_GET['contact-form-hash'] )
-			&& is_string( $_GET['contact-form-hash'] )
-			&& hash_equals( $form->hash, wp_unslash( $_GET['contact-form-hash'] ) ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			&& isset( $_GET['contact-form-sent'] )
+			&& $_GET['contact-form-id'] === $id ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			// The contact form was submitted.  Show the success message/results.
 			$feedback_id = (int) $_GET['contact-form-sent'];
 
@@ -467,6 +504,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 				$r .= '<input type="submit" style="display: none;" />';
 			}
 
+			$r .= "<input type='hidden' name='jetpack_contact_form_jwt' value='" . esc_attr( $form->get_jwt() ) . "' />\n";
 			$r .= $form->body;
 
 			if ( $is_multistep ) {
@@ -532,7 +570,6 @@ class Contact_Form extends Contact_Form_Shortcode {
 			}
 			$r .= "\t\t<input type='hidden' name='contact-form-id' value='$id' />\n";
 			$r .= "\t\t<input type='hidden' name='action' value='grunion-contact-form' />\n";
-			$r .= "\t\t<input type='hidden' name='contact-form-hash' value='" . esc_attr( $form->hash ) . "' />\n";
 
 			if ( $page && $page > 1 ) {
 				$r .= "\t\t<input type='hidden' name='page' value='$page' />\n";
@@ -1046,8 +1083,6 @@ class Contact_Form extends Contact_Form_Shortcode {
 			isset( $_POST['action'] ) && 'grunion-contact-form' === $_POST['action']
 			&&
 			isset( $_POST['contact-form-id'] ) && (string) $form->get_attribute( 'id' ) === $_POST['contact-form-id']
-			&&
-			isset( $_POST['contact-form-hash'] ) && is_string( $_POST['contact-form-hash'] ) && hash_equals( $form->hash, wp_unslash( $_POST['contact-form-hash'] ) )
 		) { // phpcs:enable
 			// If we're processing a POST submission for this contact form, validate the field value so we can show errors as necessary.
 			$field->validate();
@@ -1242,7 +1277,6 @@ class Contact_Form extends Contact_Form_Shortcode {
 
 		$plugin = Contact_Form_Plugin::init();
 
-		$id                  = $this->get_attribute( 'id' );
 		$to                  = $this->get_attribute( 'to' );
 		$widget              = $this->get_attribute( 'widget' );
 		$block_template      = $this->get_attribute( 'block_template' );
@@ -1278,23 +1312,6 @@ class Contact_Form extends Contact_Form_Shortcode {
 		// Last ditch effort to set a recipient if somehow none have been set.
 		if ( empty( $to ) ) {
 			$to = get_option( 'admin_email' );
-		}
-
-		// Make sure we're processing the form we think we're processing... probably a redundant check.
-		if ( $widget ) {
-			if ( isset( $_POST['contact-form-id'] ) && 'widget-' . $widget !== $_POST['contact-form-id'] ) { // phpcs:Ignore WordPress.Security.NonceVerification.Missing -- check done by caller process_form_submission()
-				return false;
-			}
-		} elseif ( $block_template ) {
-			if ( isset( $_POST['contact-form-id'] ) && 'block-template-' . $block_template !== $_POST['contact-form-id'] ) { // phpcs:Ignore WordPress.Security.NonceVerification.Missing -- check done by caller process_form_submission()
-				return false;
-			}
-		} elseif ( $block_template_part ) {
-			if ( isset( $_POST['contact-form-id'] ) && 'block-template-part-' . $block_template_part !== $_POST['contact-form-id'] ) { // phpcs:Ignore WordPress.Security.NonceVerification.Missing -- check done by caller process_form_submission()
-				return false;
-			}
-		} elseif ( isset( $_POST['contact-form-id'] ) && ( empty( $post ) || $post->ID !== (int) $_POST['contact-form-id'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing -- check done by caller process_form_submission()
-			return false;
 		}
 
 		$field_ids = $this->get_field_ids();
@@ -1920,13 +1937,14 @@ class Contact_Form extends Contact_Form_Shortcode {
 			$redirect        = isset( $_SERVER['REQUEST_URI'] ) ? esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
 		}
 
+		$rendered_form_id = isset( $_POST['contact-form-id'] ) ? sanitize_text_field( wp_unslash( $_POST['contact-form-id'] ) ) : 0; // phpcs:ignore WordPress.Security.NonceVerification.Missing
+
 		if ( ! $custom_redirect ) {
 			$redirect = add_query_arg(
 				urlencode_deep(
 					array(
-						'contact-form-id'   => $id,
+						'contact-form-id'   => $rendered_form_id,
 						'contact-form-sent' => $post_id,
-						'contact-form-hash' => $this->hash,
 						'_wpnonce'          => wp_create_nonce( "contact-form-sent-{$post_id}" ), // wp_nonce_url HTMLencodes :( .
 					)
 				),
@@ -1945,8 +1963,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 		 * @param int $id Contact Form ID.
 		 * @param int $post_id Post ID.
 		 */
-		$redirect = apply_filters( 'grunion_contact_form_redirect_url', $redirect, $id, $post_id );
-
+		$redirect = apply_filters( 'grunion_contact_form_redirect_url', $redirect, $rendered_form_id, $post_id );
 		// phpcs:ignore WordPress.Security.SafeRedirect.wp_redirect_wp_redirect -- We intentially allow external redirects here.
 		wp_redirect( $redirect );
 		exit( 0 );

--- a/projects/packages/forms/src/contact-form/class-jwt.php
+++ b/projects/packages/forms/src/contact-form/class-jwt.php
@@ -1,0 +1,426 @@
+<?php
+/**
+ * JSON Web Token implementation, based on this spec:
+ * https://tools.ietf.org/html/rfc7519
+ *
+ * @package Automattic\Jetpack\
+ */
+
+namespace Automattic\Jetpack;
+
+use DateTime;
+use DomainException;
+use InvalidArgumentException;
+use UnexpectedValueException;
+
+/**
+ * JSON Web Token implementation, based on this spec:
+ * https://tools.ietf.org/html/rfc7519
+ *
+ * PHP version 5
+ *
+ * @category Authentication
+ * @package  Authentication_JWT
+ * @author   Neuman Vong <neuman@twilio.com>
+ * @author   Anant Narayanan <anant@php.net>
+ * @license  http://opensource.org/licenses/BSD-3-Clause 3-clause BSD
+ * @link     https://github.com/firebase/php-jwt
+ */
+class JWT {
+	/**
+	 * When checking nbf, iat or expiration times,
+	 * we want to provide some extra leeway time to
+	 * account for clock skew.
+	 *
+	 * @var int $leeway The leeway value.
+	 */
+	public static $leeway = 0;
+
+	/**
+	 * Allow the current timestamp to be specified.
+	 * Useful for fixing a value within unit testing.
+	 *
+	 * Will default to PHP time() value if null.
+	 *
+	 * @var string $timestamp The timestamp.
+	 */
+	public static $timestamp = null;
+
+	/**
+	 * Supported algorithms.
+	 *
+	 * @var array $supported_algs Supported algorithms.
+	 */
+	public static $supported_algs = array(
+		'HS256' => array( 'hash_hmac', 'SHA256' ),
+		'HS512' => array( 'hash_hmac', 'SHA512' ),
+		'HS384' => array( 'hash_hmac', 'SHA384' ),
+		'RS256' => array( 'openssl', 'SHA256' ),
+		'RS384' => array( 'openssl', 'SHA384' ),
+		'RS512' => array( 'openssl', 'SHA512' ),
+	);
+
+	/**
+	 * Decodes a JWT string into a PHP object.
+	 *
+	 * @param string       $jwt            The JWT.
+	 * @param string|array $key            The key, or map of keys.
+	 *                                     If the algorithm used is asymmetric, this is the public key.
+	 * @param array        $allowed_algs   List of supported verification algorithms.
+	 *                                     Supported algorithms are 'HS256', 'HS384', 'HS512' and 'RS256'.
+	 *
+	 * @return object The JWT's payload as a PHP object
+	 *
+	 * @throws UnexpectedValueException     Provided JWT was invalid.
+	 * @throws SignatureInvalidException    Provided JWT was invalid because the signature verification failed.
+	 * @throws InvalidArgumentException     Provided JWT is trying to be used before it's eligible as defined by 'nbf'.
+	 * @throws BeforeValidException         Provided JWT is trying to be used before it's been created as defined by 'iat'.
+	 * @throws ExpiredException             Provided JWT has since expired, as defined by the 'exp' claim.
+	 *
+	 * @uses json_decode
+	 * @uses urlsafe_b64_decode
+	 */
+	public static function decode( $jwt, $key, array $allowed_algs = array() ) {
+		$timestamp = static::$timestamp === null ? time() : static::$timestamp;
+
+		if ( empty( $key ) ) {
+			throw new InvalidArgumentException( 'Key may not be empty' );
+		}
+
+		$tks = explode( '.', $jwt );
+		if ( count( $tks ) !== 3 ) {
+			throw new UnexpectedValueException( 'Wrong number of segments' );
+		}
+
+		list( $headb64, $bodyb64, $cryptob64 ) = $tks;
+
+		$header = static::json_decode( static::urlsafe_b64_decode( $headb64 ) );
+		if ( null === $header ) {
+			throw new UnexpectedValueException( 'Invalid header encoding' );
+		}
+
+		$payload = static::json_decode( static::urlsafe_b64_decode( $bodyb64 ) );
+		if ( null === $payload ) {
+			throw new UnexpectedValueException( 'Invalid claims encoding' );
+		}
+
+		$sig = static::urlsafe_b64_decode( $cryptob64 );
+		if ( false === $sig ) {
+			throw new UnexpectedValueException( 'Invalid signature encoding' );
+		}
+
+		if ( empty( $header->alg ) ) {
+			throw new UnexpectedValueException( 'Empty algorithm' );
+		}
+
+		if ( empty( static::$supported_algs[ $header->alg ] ) ) {
+			throw new UnexpectedValueException( 'Algorithm not supported' );
+		}
+
+		if ( ! in_array( $header->alg, $allowed_algs, true ) ) {
+			throw new UnexpectedValueException( 'Algorithm not allowed' );
+		}
+
+		if ( is_array( $key ) || $key instanceof \ArrayAccess ) {
+			if ( isset( $header->kid ) ) {
+				if ( ! isset( $key[ $header->kid ] ) ) {
+					throw new UnexpectedValueException( '"kid" invalid, unable to lookup correct key' );
+				}
+				$key = $key[ $header->kid ];
+			} else {
+				throw new UnexpectedValueException( '"kid" empty, unable to lookup correct key' );
+			}
+		}
+
+		// Check the signature.
+		if ( ! static::verify( "$headb64.$bodyb64", $sig, $key, $header->alg ) ) {
+			throw new SignatureInvalidException( 'Signature verification failed' );
+		}
+
+		// Check if the nbf if it is defined. This is the time that the
+		// token can actually be used. If it's not yet that time, abort.
+		if ( isset( $payload->nbf ) && $payload->nbf > ( $timestamp + static::$leeway ) ) {
+			throw new BeforeValidException(
+				'Cannot handle token prior to ' . gmdate( DateTime::ISO8601, $payload->nbf )
+			);
+		}
+
+		// Check that this token has been created before 'now'. This prevents
+		// using tokens that have been created for later use (and haven't
+		// correctly used the nbf claim).
+		if ( isset( $payload->iat ) && $payload->iat > ( $timestamp + static::$leeway ) ) {
+			throw new BeforeValidException(
+				'Cannot handle token prior to ' . gmdate( DateTime::ISO8601, $payload->iat )
+			);
+		}
+
+		// Check if this token has expired.
+		if ( isset( $payload->exp ) && ( $timestamp - static::$leeway ) >= $payload->exp ) {
+			throw new ExpiredException( 'Expired token' );
+		}
+
+		return $payload;
+	}
+
+	/**
+	 * Converts and signs a PHP object or array into a JWT string.
+	 *
+	 * @param object|array $payload    PHP object or array.
+	 * @param string       $key        The secret key.
+	 *                                 If the algorithm used is asymmetric, this is the private key.
+	 * @param string       $alg        The signing algorithm.
+	 *                                 Supported algorithms are 'HS256', 'HS384', 'HS512' and 'RS256'.
+	 * @param mixed        $key_id     The key ID.
+	 * @param array        $head       An array with header elements to attach.
+	 *
+	 * @return string A signed JWT
+	 *
+	 * @uses json_encode
+	 * @uses urlsafe_b64_decode
+	 */
+	public static function encode( $payload, $key, $alg = 'HS256', $key_id = null, $head = null ) {
+		$header = array(
+			'typ' => 'JWT',
+			'alg' => $alg,
+		);
+
+		if ( null !== $key_id ) {
+			$header['kid'] = $key_id;
+		}
+
+		if ( isset( $head ) && is_array( $head ) ) {
+			$header = array_merge( $head, $header );
+		}
+
+		$segments      = array();
+		$segments[]    = static::urlsafe_b64_encode( static::json_encode( $header ) );
+		$segments[]    = static::urlsafe_b64_encode( static::json_encode( $payload ) );
+		$signing_input = implode( '.', $segments );
+
+		$signature  = static::sign( $signing_input, $key, $alg );
+		$segments[] = static::urlsafe_b64_encode( $signature );
+
+		return implode( '.', $segments );
+	}
+
+	/**
+	 * Sign a string with a given key and algorithm.
+	 *
+	 * @param string          $msg    The message to sign.
+	 * @param string|resource $key    The secret key.
+	 * @param string          $alg    The signing algorithm.
+	 *                                Supported algorithms are 'HS256', 'HS384', 'HS512' and 'RS256'.
+	 *
+	 * @return string An encrypted message
+	 *
+	 * @throws DomainException Unsupported algorithm was specified.
+	 */
+	public static function sign( $msg, $key, $alg = 'HS256' ) {
+		if ( empty( static::$supported_algs[ $alg ] ) ) {
+			throw new DomainException( 'Algorithm not supported' );
+		}
+		list($function, $algorithm) = static::$supported_algs[ $alg ];
+		switch ( $function ) {
+			case 'hash_hmac':
+				return hash_hmac( $algorithm, $msg, $key, true );
+			case 'openssl':
+				$signature = '';
+				$success   = openssl_sign( $msg, $signature, $key, $algorithm );
+				if ( ! $success ) {
+					throw new DomainException( 'OpenSSL unable to sign data' );
+				} else {
+					return $signature;
+				}
+		}
+	}
+
+	/**
+	 * Verify a signature with the message, key and method. Not all methods
+	 * are symmetric, so we must have a separate verify and sign method.
+	 *
+	 * @param string          $msg        The original message (header and body).
+	 * @param string          $signature  The original signature.
+	 * @param string|resource $key        For HS*, a string key works. for RS*, must be a resource of an openssl public key.
+	 * @param string          $alg        The algorithm.
+	 *
+	 * @return bool
+	 *
+	 * @throws DomainException Invalid Algorithm or OpenSSL failure.
+	 */
+	private static function verify( $msg, $signature, $key, $alg ) {
+		if ( empty( static::$supported_algs[ $alg ] ) ) {
+			throw new DomainException( 'Algorithm not supported' );
+		}
+
+		list($function, $algorithm) = static::$supported_algs[ $alg ];
+		switch ( $function ) {
+			case 'openssl':
+				$success = openssl_verify( $msg, $signature, $key, $algorithm );
+
+				if ( 1 === $success ) {
+					return true;
+				} elseif ( 0 === $success ) {
+					return false;
+				}
+
+				// returns 1 on success, 0 on failure, -1 on error.
+				throw new DomainException(
+					'OpenSSL error: ' . openssl_error_string()
+				);
+			case 'hash_hmac':
+			default:
+				$hash = hash_hmac( $algorithm, $msg, $key, true );
+
+				if ( function_exists( 'hash_equals' ) ) {
+					return hash_equals( $signature, $hash );
+				}
+
+				$len = min( static::safe_strlen( $signature ), static::safe_strlen( $hash ) );
+
+				$status = 0;
+
+				for ( $i = 0; $i < $len; $i++ ) {
+					$status |= ( ord( $signature[ $i ] ) ^ ord( $hash[ $i ] ) );
+				}
+
+				$status |= ( static::safe_strlen( $signature ) ^ static::safe_strlen( $hash ) );
+
+				return ( 0 === $status );
+		}
+	}
+
+	/**
+	 * Decode a JSON string into a PHP object.
+	 *
+	 * @param string $input JSON string.
+	 *
+	 * @return object Object representation of JSON string
+	 *
+	 * @throws DomainException Provided string was invalid JSON.
+	 */
+	public static function json_decode( $input ) {
+		$obj   = json_decode( $input, false, 512, JSON_BIGINT_AS_STRING );
+		$errno = json_last_error();
+
+		if ( $errno ) {
+			static::handle_json_error( $errno );
+		} elseif ( null === $obj && 'null' !== $input ) {
+			throw new DomainException( 'Null result with non-null input' );
+		}
+		return $obj;
+	}
+
+	/**
+	 * Encode a PHP object into a JSON string.
+	 *
+	 * @param object|array $input A PHP object or array.
+	 *
+	 * @return string JSON representation of the PHP object or array.
+	 *
+	 * @throws DomainException Provided object could not be encoded to valid JSON.
+	 */
+	public static function json_encode( $input ) {
+		$json  = wp_json_encode( $input );
+		$errno = json_last_error();
+
+		if ( $errno ) {
+			static::handle_json_error( $errno );
+		} elseif ( 'null' === $json && null !== $input ) {
+			throw new DomainException( 'Null result with non-null input' );
+		}
+		return $json;
+	}
+
+	/**
+	 * Decode a string with URL-safe Base64.
+	 *
+	 * @param string $input A Base64 encoded string.
+	 *
+	 * @return string A decoded string
+	 */
+	public static function urlsafe_b64_decode( $input ) {
+		$remainder = strlen( $input ) % 4;
+		if ( $remainder ) {
+			$padlen = 4 - $remainder;
+			$input .= str_repeat( '=', $padlen );
+		}
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
+		return base64_decode( strtr( $input, '-_', '+/' ) );
+	}
+
+	/**
+	 * Encode a string with URL-safe Base64.
+	 *
+	 * @param string $input The string you want encoded.
+	 *
+	 * @return string The base64 encode of what you passed in
+	 */
+	public static function urlsafe_b64_encode( $input ) {
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
+		return str_replace( '=', '', strtr( base64_encode( $input ), '+/', '-_' ) );
+	}
+
+	/**
+	 * Helper method to create a JSON error.
+	 *
+	 * @param int $errno An error number from json_last_error().
+	 * @throws DomainException .
+	 *
+	 * @return never
+	 */
+	private static function handle_json_error( $errno ) {
+		$messages = array(
+			JSON_ERROR_DEPTH          => 'Maximum stack depth exceeded',
+			JSON_ERROR_STATE_MISMATCH => 'Invalid or malformed JSON',
+			JSON_ERROR_CTRL_CHAR      => 'Unexpected control character found',
+			JSON_ERROR_SYNTAX         => 'Syntax error, malformed JSON',
+			JSON_ERROR_UTF8           => 'Malformed UTF-8 characters',
+		);
+		throw new DomainException(
+			isset( $messages[ $errno ] )
+			? $messages[ $errno ]
+			: 'Unknown JSON error: ' . $errno
+		);
+	}
+
+	/**
+	 * Get the number of bytes in cryptographic strings.
+	 *
+	 * @param string $str .
+	 *
+	 * @return int
+	 */
+	private static function safe_strlen( $str ) {
+		if ( function_exists( 'mb_strlen' ) ) {
+			return mb_strlen( $str, '8bit' );
+		}
+		return strlen( $str );
+	}
+}
+
+// phpcs:disable
+if ( ! class_exists( 'SignatureInvalidException' ) ) {
+	/**
+	 * SignatureInvalidException
+	 *
+	 * @package Automattic\Jetpack\Extensions\Premium_Content
+	 */
+	class SignatureInvalidException extends \UnexpectedValueException { }
+}
+if ( ! class_exists( 'ExpiredException' ) ) {
+	/**
+	 * ExpiredException
+	 *
+	 * @package Automattic\Jetpack\Extensions\Premium_Content
+	 */
+	class ExpiredException extends \UnexpectedValueException { }
+}
+if ( ! class_exists( 'BeforeValidException' ) ) {
+	/**
+	 * BeforeValidException
+	 *
+	 * @package Automattic\Jetpack\Extensions\Premium_Content
+	 */
+	class BeforeValidException extends \UnexpectedValueException { }
+}
+// phpcs:enable

--- a/projects/plugins/jetpack/changelog/fix-forms-submit-in-templates
+++ b/projects/plugins/jetpack/changelog/fix-forms-submit-in-templates
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Form: Improve form processing


### PR DESCRIPTION
This PR fixes the an issue where forms that are placed inside form different templates and don't get processed as expected.

Fixes [FORMS-109](https://linear.app/a8c/issue/FORMS-109)

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Refactors the contact form submission handler to always reconstruct the form instance from the JWT (`jetpack_contact_form_jwt`) provided in the POST data.
* Removes legacy logic for reconstructing forms based on widget, block template, or block template part context, as well as the use of form hashes.
* Simplifies the code by eliminating the need to parse the page context or retrieve shortcodes/attributes from post meta.
* Improves error handling: returns a clear error if the JWT is missing or invalid.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No, this PR does not change what data or activity we track or use. It only changes the internal mechanism for reconstructing the form on submission.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to a page or post  with a contact form (including forms in widgets, block templates, or template parts).
* Submit the form with various field values.
* Verify that the form submission is processed correctly and that the success message is displayed as expected.
* Check that feedback is stored and visible in the admin as before.
* Try submitting forms in different contexts (widget, block, template part) to ensure all are processed correctly.
* Try submitting a form with a missing or tampered JWT and verify that a clear error is shown.

