### PR TITLE
sass: Fix remaining `@import`s in js-packages

### DIFF
--- a/projects/js-packages/base-styles/README.md
+++ b/projects/js-packages/base-styles/README.md
@@ -17,19 +17,13 @@ npm install @automattic/jetpack-base-styles --save-dev
 In your application's SCSS file, include styles like so:
 
 ```scss
-@import '@automattic/jetpack-base-styles/style';
+@use '@automattic/jetpack-base-styles/style';
 ```
 
-If you use [Webpack](https://webpack.js.org/) for your SCSS pipeline, you can omit `node_modules/`:
-
-```scss
-@import '@automattic/jetpack-base-styles/style';
-```
-
-To make that work with [`sass`](https://www.npmjs.com/package/sass) or [`node-sass`](https://www.npmjs.com/package/node-sass) NPM modules without Webpack, you'd have to use [includePaths option](https://sass-lang.com/documentation/js-api#includepaths):
+To make that work with [`sass`](https://www.npmjs.com/package/sass) NPM modules without Webpack, you'd have to use [loadPaths](https://sass-lang.com/documentation/js-api/interfaces/options/#loadPaths) or [includePaths](https://sass-lang.com/documentation/js-api/interfaces/legacyfileoptions/#includePaths):
 
 ```json
 {
-	"includePaths": [ "node_modules" ]
+	"loadPaths": [ "node_modules" ]
 }
 ```

--- a/projects/js-packages/base-styles/changelog/fix-scss-import-in-js-packages
+++ b/projects/js-packages/base-styles/changelog/fix-scss-import-in-js-packages
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update README for Sass modules.

--- a/projects/js-packages/components/changelog/fix-scss-import-in-js-packages
+++ b/projects/js-packages/components/changelog/fix-scss-import-in-js-packages
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: sass: Replace remaining `@import`s with `@use`.
+
+

--- a/projects/js-packages/components/components/layout/col/style.module.scss
+++ b/projects/js-packages/components/components/layout/col/style.module.scss
@@ -1,9 +1,9 @@
 @use "sass:map";
-@import "../breakpoints.module";
+@use "../breakpoints.module" as breakpoints;
 
 @mixin cols($size) {
 
-	@include media($size) using ($columns) {
+	@include breakpoints.media($size) using ($columns) {
 
 		@for $i from 1 through $columns {
 			.col-#{$size}-#{$i} {
@@ -24,7 +24,7 @@
 @include cols("lg");
 
 :export {
-	smCols: map.get($cols-sizes, "sm");
-	mdCols: map.get($cols-sizes, "md");
-	lgCols: map.get($cols-sizes, "lg");
+	smCols: map.get(breakpoints.$cols-sizes, "sm");
+	mdCols: map.get(breakpoints.$cols-sizes, "md");
+	lgCols: map.get(breakpoints.$cols-sizes, "lg");
 }

--- a/projects/js-packages/components/components/layout/container/style.module.scss
+++ b/projects/js-packages/components/components/layout/container/style.module.scss
@@ -1,11 +1,11 @@
 @use "sass:map";
-@import "../breakpoints.module";
+@use "../breakpoints.module" as breakpoints;
 
 @mixin container($size) {
 	$paddings: ("sm": "16px", "md": "18px", "lg": "24px");
 	$padding: map.get($paddings, #{$size});
 
-	@include media(#{$size}) using ($columns) {
+	@include breakpoints.media(#{$size}) using ($columns) {
 		padding: 0 #{$padding};
 		grid-template-columns: repeat( #{$columns}, minmax(0, 1fr) );
 	}

--- a/projects/js-packages/publicize-components/changelog/fix-scss-import-in-js-packages
+++ b/projects/js-packages/publicize-components/changelog/fix-scss-import-in-js-packages
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: sass: Replace remaining `@import`s with `@use`.
+
+

--- a/projects/js-packages/publicize-components/src/components/share-status/styles.module.scss
+++ b/projects/js-packages/publicize-components/src/components/share-status/styles.module.scss
@@ -78,8 +78,7 @@
 	 */
 	// Use :global scope to avoid CSS encapsulation
 	:global {
-		// Use import without ".css" extension to avoid it being rendered as URL
-		/* stylelint-disable-next-line no-invalid-position-at-import-rule -- this import is intentionally scoped */
+
 		@include meta.load-css( '@wordpress/dataviews/build-style/style' );
 	}
 

--- a/projects/js-packages/publicize-components/src/components/share-status/styles.module.scss
+++ b/projects/js-packages/publicize-components/src/components/share-status/styles.module.scss
@@ -1,3 +1,5 @@
+@use 'sass:meta';
+
 .trigger-wrapper {
 	padding-block: 1rem;
 
@@ -78,7 +80,7 @@
 	:global {
 		// Use import without ".css" extension to avoid it being rendered as URL
 		/* stylelint-disable-next-line no-invalid-position-at-import-rule -- this import is intentionally scoped */
-		@import '@wordpress/dataviews/build-style/style';
+		@include meta.load-css( '@wordpress/dataviews/build-style/style' );
 	}
 
 	// Hide the table actions

--- a/projects/js-packages/storybook/changelog/fix-scss-import-in-js-packages
+++ b/projects/js-packages/storybook/changelog/fix-scss-import-in-js-packages
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: sass: Replace remaining `@import`s with `@use`.
+
+

--- a/projects/js-packages/storybook/changelog/fix-scss-import-in-js-packages#2
+++ b/projects/js-packages/storybook/changelog/fix-scss-import-in-js-packages#2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Import built CSS for `@wordpress/*` packages instead of rebuilding from Sass sources.

--- a/projects/js-packages/storybook/storybook/stories/playground/style.scss
+++ b/projects/js-packages/storybook/storybook/stories/playground/style.scss
@@ -1,8 +1,8 @@
 @use "@wordpress/base-styles/colors";
 @use "@wordpress/base-styles/variables";
 @use "@wordpress/base-styles/mixins";
-@import "./reset";
-@import "./editor-styles";
+@use "./reset";
+@use "./editor-styles";
 
 .playground {
 	padding-top: 20px;

--- a/projects/js-packages/storybook/storybook/style.scss
+++ b/projects/js-packages/storybook/storybook/style.scss
@@ -1,23 +1,10 @@
-@use "sass:math";
-
-// Loading @wordpress/base-styles as they have mixins and other dependencies
-// used within @wordpress/*/src/*.scss
-// @todo Remove once @wordpress/*/src/*.scss has been updated to use `@use`.
-@import "@wordpress/base-styles/animations";
-@import "@wordpress/base-styles/breakpoints";
-@import "@wordpress/base-styles/colors";
-@import "@wordpress/base-styles/mixins";
-@import "@wordpress/base-styles/variables";
-@import "@wordpress/base-styles/z-index";
-@import "@wordpress/base-styles/default-custom-properties";
+// Root variables from js-packages base styles
+@use "../../base-styles/root-variables";
 
 // @wordpress package styles
-@import "@wordpress/components/src/style";
-@import "@wordpress/block-editor/src/style";
-@import "@wordpress/block-library/src/style";
-@import "@wordpress/block-library/src/theme";
-@import "@wordpress/block-library/src/editor";
-@import "@wordpress/format-library/src/style";
-
-// Root variables from js-packages base styles
-@import "../../base-styles/root-variables";
+@import "@wordpress/components/build-style/style.css";
+@import "@wordpress/block-editor/build-style/style.css";
+@import "@wordpress/block-library/build-style/style.css";
+@import "@wordpress/block-library/build-style/theme.css";
+@import "@wordpress/block-library/build-style/editor.css";
+@import "@wordpress/format-library/build-style/style.css";


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Mostly this is pretty straightforward. The few `@import`s that remain are CSS imports rather than Sass imports (you can identify them by the fact that they import a path ending in ".css").

For js-packages/storybook, we switch to doing a CSS import of built files from various `@wordpress/*` packages, rather than rebuilding them from the sass sources.

We also update the js-packages/base-styles README.md to correct and update the usage information.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* No changes in built CSS artifacts, except for Storybook.
* Storybook should render correctly.
