### PR TITLE
Forms: tame select arrow positioning

### DIFF
--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -894,7 +894,7 @@
 				border-radius: unset !important;
 				outline: none;
 				padding: var(--jetpack--contact-form--input-padding, 16px);
-				padding-right: calc(var(--jetpack--contact-form--input-padding-top, 16px) + 4px);
+				padding-top: calc(var(--jetpack--contact-form--input-padding-top, 16px) + 4px);
 				padding-left: min(100px, var(--jetpack--contact-form--notch-width));
 			}
 		}

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -697,7 +697,7 @@
 		overflow: visible;
 		margin-right: 4px;
 		// Match the frontend.
-		color: var(--jetpack--contact-form--text-color);
+		color: inherit;
 		font-size: inherit;
 	}
 

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -678,7 +678,6 @@
 	&__toggle {
 		color: var(--jetpack--contact-form--text-color);
 		font-size: var(--jetpack--contact-form--font-size, 16px);
-		line-height: var(--jetpack--contact-form--line-height);
 		padding: var(--jetpack--contact-form--input-padding, 16px);
 		border-color: var(--jetpack--contact-form--border-color);
 		display: flex;
@@ -699,18 +698,21 @@
 		margin-right: 4px;
 		// Match the frontend.
 		color: var(--jetpack--contact-form--text-color);
+		font-size: inherit;
 	}
 
 	&__icon::after {
+		inset-inline-end: 20px;
 		content: "";
 		display: block;
-		box-sizing: border-box;
-		width: 100%;
-		height: 100%;
-		border-bottom: 2px solid;
-		border-right: 2px solid;
-		transform: rotate(45deg);
-		margin-top: -2px;
+		width: calc(1em / 2.5);
+		height: calc(1em / 2.5);
+		border-bottom: calc(1em / 10) solid;
+		border-right: calc(1em / 10) solid;
+		transform: translateY(-12%) rotate(45deg);
+		transform-origin: center center;
+		pointer-events: none;
+		z-index: 1;
 	}
 
 	&__popover {
@@ -892,7 +894,7 @@
 				border-radius: unset !important;
 				outline: none;
 				padding: var(--jetpack--contact-form--input-padding, 16px);
-				padding-top: calc(var(--jetpack--contact-form--input-padding-top, 16px) + 4px);
+				padding-right: calc(var(--jetpack--contact-form--input-padding-top, 16px) + 4px);
 				padding-left: min(100px, var(--jetpack--contact-form--notch-width));
 			}
 		}

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -1347,7 +1347,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 	public function render_select_field( $id, $label, $value, $class, $required, $required_field_text ) {
 		$field  = $this->render_label( 'select', $id, $label, $required, $required_field_text );
 		$class  = preg_replace( "/class=['\"]([^'\"]*)['\"]/", 'class="contact-form__select-wrapper $1"', $class );
-		$field .= "<div ${class} style='" . esc_attr( $this->field_styles ) . "'>";
+		$field .= "<div {$class} style='" . esc_attr( $this->field_styles ) . "'>";
 		$field .= "\t<span class='contact-form__select-element-wrapper'><select name='" . esc_attr( $id ) . "' id='" . esc_attr( $id ) . "' " . ( $required ? "required aria-required='true'" : '' ) . ">\n";
 
 		if ( $this->get_attribute( 'togglelabel' ) ) {

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -1346,11 +1346,9 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 	 */
 	public function render_select_field( $id, $label, $value, $class, $required, $required_field_text ) {
 		$field  = $this->render_label( 'select', $id, $label, $required, $required_field_text );
-		$field .= "<div class='contact-form__select-wrapper'>";
-		if ( ! empty( $this->field_classes ) ) {
-			$class = preg_replace( '/class="([^"]*)"/', 'class="$1 ' . esc_attr( $this->field_classes ) . '"', $class );
-		}
-		$field .= "\t<select name='" . esc_attr( $id ) . "' id='" . esc_attr( $id ) . "' " . $class . ( $required ? "required aria-required='true'" : '' ) . " style='" . esc_attr( $this->field_styles ) . "'>\n";
+		$class  = preg_replace( "/class=['\"]([^'\"]*)['\"]/", 'class="contact-form__select-wrapper $1"', $class );
+		$field .= "<div ${class} style='" . esc_attr( $this->field_styles ) . "'>";
+		$field .= "\t<span class='contact-form__select-element-wrapper'><select name='" . esc_attr( $id ) . "' id='" . esc_attr( $id ) . "' " . ( $required ? "required aria-required='true'" : '' ) . ">\n";
 
 		if ( $this->get_attribute( 'togglelabel' ) ) {
 			$field .= "\t\t<option value=''>" . $this->get_attribute( 'togglelabel' ) . "</option>\n";
@@ -1366,7 +1364,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 								. "</option>\n";
 			}
 		}
-		$field .= "\t</select>\n";
+		$field .= "\t</select><span class='jetpack-field-dropdown__icon'></span></span>\n";
 		$field .= "</div>\n";
 
 		return $field;

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -733,9 +733,8 @@ on production builds, the attributes are being reordered, causing side-effects
 .contact-form .is-style-animated .grunion-field-wrap:not(.no-label) select
 {
 	padding-top: 1.4em;
-
-	/* padding-left: var(--field-padding);
-	padding-right: var(--field-padding); */
+	padding-left: var(--field-padding);
+	padding-right: var(--field-padding);
 }
 
 /* Fix padding for new forms in animated style */

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -44,6 +44,7 @@
 	font: inherit;
 	border: 1px solid #8c8f94;
 	border-radius: 0;
+	z-index: 1;
 }
 
 :where(.contact-form textarea) {
@@ -62,7 +63,6 @@
 }
 
 .contact-form select {
-	padding: 14px 7px;
 	min-width: 150px;
 }
 
@@ -386,27 +386,43 @@
 
 .contact-form .contact-form__select-wrapper {
 	position: relative;
+
+	/*
+	 * Remove padding set on .grunion-field. We want the nested input to have no space around it.
+	 * Instead the padding is added to the `select` element itself.
+	 */
+	 padding: 0;
 }
 
-.contact-form .contact-form__select-wrapper::after {
+.contact-form .contact-form__select-wrapper .jetpack-field-dropdown__icon {
+	position: relative;
+}
+
+.contact-form .contact-form__select-wrapper .jetpack-field-dropdown__icon::after {
 	position: absolute;
-	inset-inline-end: 20px;
-	top: 50%;
+    inset-inline-end: 20px;
+    top: 50%;
+    content: "";
+    display: block;
+    width: calc(1em / 2.5);
+    height: calc(1em / 2.5);
+    border-bottom: calc(1em / 10) solid;
+    border-right: calc(1em / 10) solid;
 	color: var(--jetpack--contact-form--text-color);
-	content: "";
-	display: block;
-	width: 8px;
-	height: 8px;
+	font-size: inherit;
+
+	/*
+	 * The translateY is to center the arrow vertically.
+	 * It's set to -75% to account for the fact that only the bottom-half of the element is visible.
+	 * If we set it to -50%, the element would be centered, but not the visible part of the arrow.
+	 */
+    transform: translateY(-75%) rotate(45deg);
+    transform-origin: center center;
+    pointer-events: none;
 	z-index: 1;
-	border-bottom: 2px solid;
-	border-right: 2px solid;
-	transform: translateY(-50%) rotate(45deg);
-	transform-origin: center center;
-	pointer-events: none;
-	right: calc(var(--jetpack--contact-form--border-right-size, 1px) + 16px);
 }
 
-.contact-form :where( .contact-form__select-wrapper select ) {
+.contact-form :where( .contact-form__select-wrapper ) {
 	background-color: var(--jetpack--contact-form--input-background);
 	border: var(--jetpack--contact-form--border);
 	border-color: var(--jetpack--contact-form--border-color);
@@ -416,9 +432,31 @@
 	color: var(--jetpack--contact-form--text-color);
 	font-family: var(--jetpack--contact-form--font-family);
 	font-size: var(--jetpack--contact-form--font-size);
-	line-height: var(--jetpack--contact-form--line-height);
-	padding-inline-end: calc(var(--jetpack--contact-form--input-padding) * 3);
-	padding: var(--jetpack--contact-form--input-padding);
+}
+
+.contact-form .contact-form__select-element-wrapper {
+	display: flex;
+}
+
+.contact-form :where( .contact-form__select-element-wrapper ),
+.contact-form :where( .contact-form__select-wrapper select ) {
+	background: transparent !important;
+	font-family: inherit;
+	font-size: inherit;
+	color: inherit;
+	font-weight: inherit;
+	line-height: inherit;
+	text-decoration: inherit;
+	text-transform: inherit;
+	letter-spacing: inherit;
+	font-style: inherit;
+	z-index: 1;
+
+	/*
+	 * Remove border width from select element, border should be added by the wrapper.
+	 * Radius is retained to ensure the select element has the same radius as the wrapper.
+	 */
+	border-width: 0 !important;
 }
 
 .contact-form .contact-form__select-wrapper select {
@@ -427,7 +465,7 @@
 	appearance: none;
 	text-overflow: ellipsis;
 	white-space: nowrap;
-	padding: var(--jetpack--contact-form--input-padding);
+	padding: var(--jetpack--contact-form--input-padding-left, 16px);
 }
 
 .contact-form .is-style-outlined,
@@ -467,6 +505,7 @@
 	box-sizing: border-box;
 	text-align: left;
 	pointer-events: none;
+	z-index: 1;
 }
 
 .contact-form .contact-form__select-wrapper + .notched-label {
@@ -632,6 +671,13 @@ on production builds, the attributes are being reordered, causing side-effects
 	transform: translateY(-50%);
 }
 
+/* Form that upgrade to use inner blocks look to the global styles border size accessible via the CSS vars. See Contact_Form_Field::get_form_variation_style_properties() .*/
+.contact-form .is-style-outlined .wp-block-jetpack-input-wrap .notched-label:has(~ .grunion-field:focus) .notched-label__label,
+.contact-form .is-style-outlined .wp-block-jetpack-input-wrap .notched-label:has(~ .grunion-field.has-placeholder) .notched-label__label,
+.contact-form .is-style-outlined .wp-block-jetpack-field-select.wp-block-jetpack-input-wrap .notched-label .notched-label__label {
+	top: calc( var(--jetpack--contact-form--border-top-size, var(--jetpack--contact-form--border-size)) * -1 );
+}
+
 .contact-form .is-style-outlined .grunion-field-wrap .notched-label:has(~ .grunion-field:focus) .grunion-label-text,
 .contact-form .is-style-outlined .grunion-field-wrap .notched-label:has(~ .grunion-field:not(:placeholder-shown)) .grunion-label-text,
 .contact-form .is-style-outlined .grunion-field-wrap .notched-label:has(~ .grunion-field.has-placeholder) .grunion-label-text,
@@ -639,12 +685,6 @@ on production builds, the attributes are being reordered, causing side-effects
 .contact-form .is-style-outlined .grunion-field-wrap .grunion-radio-options .grunion-label-text,
 .contact-form .is-style-outlined .grunion-field-wrap.grunion-field-select-wrap .notched-label .grunion-label-text {
 	font-size: 0.8em;
-}
-
-/* Form that upgrade to use inner blocks look to the global styles border size.*/
-.contact-form .is-style-outlined .wp-block-jetpack-input-wrap .notched-label:has(~ .grunion-field:focus) .notched-label__label,
-.contact-form .is-style-outlined .wp-block-jetpack-field-select.wp-block-jetpack-input-wrap .notched-label .notched-label__label {
-	top: calc( var(--jetpack--contact-form--border-top-size, var(--jetpack--contact-form--border-size)) * -1 );
 }
 
 .contact-form .is-style-outlined .grunion-field-wrap .notched-label:has(~ .grunion-field:focus) .grunion-label-required,
@@ -693,13 +733,14 @@ on production builds, the attributes are being reordered, causing side-effects
 .contact-form .is-style-animated .grunion-field-wrap:not(.no-label) select
 {
 	padding-top: 1.4em;
-	padding-left: var(--field-padding);
-	padding-right: var(--field-padding);
+
+	/* padding-left: var(--field-padding);
+	padding-right: var(--field-padding); */
 }
 
 /* Fix padding for new forms in animated style */
-.contact-form .is-style-animated .grunion-field-wrap:not(.no-label) > .wp-block-jetpack-input,
-.contact-form .is-style-animated .grunion-field-wrap:not(.no-label) .wp-block-jetpack-input,
+.contact-form .is-style-animated .grunion-field-wrap:not(.no-label) > .wp-block-jetpack-input:not(.select),
+.contact-form .is-style-animated .grunion-field-wrap:not(.no-label) .wp-block-jetpack-input:not(.select),
 .contact-form .is-style-animated .wp-block-jetpack-options.jetpack-field-multiple__list--has-border {
 	padding-left: var(--jetpack--contact-form--animated-left-offset);
 	padding-right: var(--jetpack--contact-form--animated-left-offset);
@@ -722,7 +763,7 @@ on production builds, the attributes are being reordered, causing side-effects
 	transform: translateY(-50%);
 	transition: all 150ms cubic-bezier(0.4, 0, 0.2, 1);
 	will-change: transform, top;
-	z-index: 1;
+	z-index: 2;
 }
 
 .contact-form .is-style-animated .grunion-field-wrap .grunion-label-text {

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -440,6 +440,7 @@
 
 .contact-form :where( .contact-form__select-element-wrapper ),
 .contact-form :where( .contact-form__select-wrapper select ) {
+	border: 0 !important;
 	background: transparent !important;
 	font-family: inherit;
 	font-size: inherit;

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -411,10 +411,10 @@
 	font-size: inherit;
 
 	/*
-		* The translateY is to center the arrow vertically.
-		* It's set to -75% to account for the fact that only the bottom-half of the element is visible.
-		* If we set it to -50%, the element would be centered, but not the visible part of the arrow.
-		*/
+	 * The translateY is to center the arrow vertically.
+	 * It's set to -75% to account for the fact that only the bottom-half of the element is visible.
+	 * If we set it to -50%, the element would be centered, but not the visible part of the arrow.
+	 */
 	transform: translateY(-75%) rotate(45deg);
 	transform-origin: center center;
 	pointer-events: none;

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -44,7 +44,6 @@
 	font: inherit;
 	border: 1px solid #8c8f94;
 	border-radius: 0;
-	z-index: 1;
 }
 
 :where(.contact-form textarea) {
@@ -400,25 +399,25 @@
 
 .contact-form .contact-form__select-wrapper .jetpack-field-dropdown__icon::after {
 	position: absolute;
-    inset-inline-end: 20px;
-    top: 50%;
-    content: "";
-    display: block;
-    width: calc(1em / 2.5);
-    height: calc(1em / 2.5);
-    border-bottom: calc(1em / 10) solid;
-    border-right: calc(1em / 10) solid;
-	color: var(--jetpack--contact-form--text-color);
+	inset-inline-end: 20px;
+	top: 50%;
+	content: "";
+	display: block;
+	width: calc(1em / 2.5);
+	height: calc(1em / 2.5);
+	border-bottom: calc(1em / 10) solid;
+	border-right: calc(1em / 10) solid;
+	color: inherit;
 	font-size: inherit;
 
 	/*
-	 * The translateY is to center the arrow vertically.
-	 * It's set to -75% to account for the fact that only the bottom-half of the element is visible.
-	 * If we set it to -50%, the element would be centered, but not the visible part of the arrow.
-	 */
-    transform: translateY(-75%) rotate(45deg);
-    transform-origin: center center;
-    pointer-events: none;
+		* The translateY is to center the arrow vertically.
+		* It's set to -75% to account for the fact that only the bottom-half of the element is visible.
+		* If we set it to -50%, the element would be centered, but not the visible part of the arrow.
+		*/
+	transform: translateY(-75%) rotate(45deg);
+	transform-origin: center center;
+	pointer-events: none;
 	z-index: 1;
 }
 
@@ -739,8 +738,8 @@ on production builds, the attributes are being reordered, causing side-effects
 }
 
 /* Fix padding for new forms in animated style */
-.contact-form .is-style-animated .grunion-field-wrap:not(.no-label) > .wp-block-jetpack-input:not(.select),
-.contact-form .is-style-animated .grunion-field-wrap:not(.no-label) .wp-block-jetpack-input:not(.select),
+.contact-form .is-style-animated .grunion-field-wrap:not(.no-label) > .wp-block-jetpack-input:not(.contact-form__select-wrapper),
+.contact-form .is-style-animated .grunion-field-wrap:not(.no-label) .wp-block-jetpack-input:not(.contact-form__select-wrapper),
 .contact-form .is-style-animated .wp-block-jetpack-options.jetpack-field-multiple__list--has-border {
 	padding-left: var(--jetpack--contact-form--animated-left-offset);
 	padding-right: var(--jetpack--contact-form--animated-left-offset);
@@ -825,6 +824,11 @@ on production builds, the attributes are being reordered, causing side-effects
 	top: 0;
 	left: 0;
 	transform: translateY(0);
+}
+
+.contact-form .is-style-outlined .wp-block-jetpack-input:not(.contact-form__select-wrapper),
+.contact-form .is-style-animated .wp-block-jetpack-input:not(.contact-form__select-wrapper) {
+	z-index: 2;
 }
 
 .contact-form .is-style-below .grunion-field-wrap .below-label__label {

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -1484,9 +1484,10 @@ class Contact_Form_Test extends BaseTestCase {
 				'label for does not equal input name!'
 			);
 
-			$select_wrapper = $wrapper_div->getElementsByTagName( 'div' )->item( 0 );
+			$select_wrapper       = $wrapper_div->getElementsByTagName( 'div' )->item( 0 );
+			$select_wrapper_class = ! empty( $select_wrapper ) ? $select_wrapper->getAttribute( 'class' ) : '';
 
-			$this->assertEquals( 'contact-form__select-wrapper select ' . $attributes['class'] . ' grunion-field', $select_wrapper->getAttribute( 'class' ), ' select class does not match expected' );
+			$this->assertEquals( 'contact-form__select-wrapper select ' . $attributes['class'] . ' grunion-field', $select_wrapper_class, ' select class does not match expected' );
 			// Options.
 			$options = $select->getElementsByTagName( 'option' );
 			$n       = $options->length;

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -1484,8 +1484,9 @@ class Contact_Form_Test extends BaseTestCase {
 				'label for does not equal input name!'
 			);
 
-			$select_wrapper       = $wrapper_div->getElementsByTagName( 'div' )->item( 0 );
-			$select_wrapper_class = ! empty( $select_wrapper ) ? $select_wrapper->getAttribute( 'class' ) : '';
+			$select_wrapper = $wrapper_div->getElementsByTagName( 'div' )->item( 0 );
+			//phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+			$select_wrapper_class = isset( $select_wrapper->className ) ? $select_wrapper->className : '';
 
 			$this->assertEquals( 'contact-form__select-wrapper select ' . $attributes['class'] . ' grunion-field', $select_wrapper_class, ' select class does not match expected' );
 			// Options.

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -1484,8 +1484,9 @@ class Contact_Form_Test extends BaseTestCase {
 				'label for does not equal input name!'
 			);
 
-			$this->assertEquals( $select->getAttribute( 'class' ), 'select ' . $attributes['class'] . ' grunion-field', ' select class does not match expected' );
+			$select_wrapper = $wrapper_div->getElementsByTagName( 'div' )->item( 0 );
 
+			$this->assertEquals( 'contact-form__select-wrapper select ' . $attributes['class'] . ' grunion-field', $select_wrapper->getAttribute( 'class' ), ' select class does not match expected' );
 			// Options.
 			$options = $select->getElementsByTagName( 'option' );
 			$n       = $options->length;

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -1485,8 +1485,8 @@ class Contact_Form_Test extends BaseTestCase {
 			);
 
 			$select_wrapper = $wrapper_div->getElementsByTagName( 'div' )->item( 0 );
-			//phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-			$select_wrapper_class = isset( $select_wrapper->className ) ? $select_wrapper->className : '';
+			// @phan-suppress-next-line PhanUndeclaredMethod
+			$select_wrapper_class = $select_wrapper->getAttribute( 'class' ) ?? '';
 
 			$this->assertEquals( 'contact-form__select-wrapper select ' . $attributes['class'] . ' grunion-field', $select_wrapper_class, ' select class does not match expected' );
 			// Options.


### PR DESCRIPTION

FORMS-36

## Proposed changes:

### TODO

- [x] Update tests

The state of the select arrow in trunk is fairly dire.

In trunk the arrow's appearance in the editor is different to the arrow in the frontend in color, size and position.

| Editor | Frontend |
|--------|--------|
| <img width="712" alt="Screenshot 2025-05-29 at 3 46 52 pm" src="https://github.com/user-attachments/assets/aa7cf2e3-6db6-478e-a1bd-99cf585f1d88" /> | <img width="697" alt="Screenshot 2025-05-29 at 3 46 44 pm" src="https://github.com/user-attachments/assets/520d8327-75fa-476f-ad8f-ce79a069e7e6" /> | 




In this branch we take the state of trunk's frontend as a base, and then harmonize the rest:

| Editor | Frontend |
|--------|--------|
| <img width="691" alt="Screenshot 2025-05-29 at 3 12 35 pm" src="https://github.com/user-attachments/assets/4f644c0b-de2b-4acc-9ff0-b51fc6b7c8cb" /> | <img width="719" alt="Screenshot 2025-05-29 at 3 12 28 pm" src="https://github.com/user-attachments/assets/1c41f355-747b-40bb-8dfa-ff0be74d356b" /> | 



## Testing instructions:

Create a few forms in trunk. Make sure they have select blocks! Style them differently with borders, colors, font styles.

Now load this branch. 

Things should look okay on the frontend.

Go hard on borders and radii on the select box. Make sure the arrow behaves on the frontend.

