### PR TITLE
My Jetpack: Tab fitering for admin role

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/utils.ts
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/utils.ts
@@ -1,5 +1,6 @@
 import { TabPanelProps } from '@wordpress/components/build-types/tab-panel/types';
 import { __ } from '@wordpress/i18n';
+import { getMyJetpackWindowInitialState } from '../../data/utils/get-my-jetpack-window-state';
 import {
 	MY_JETPACK_SECTION_HELP,
 	MY_JETPACK_SECTION_OVERVIEW,
@@ -12,7 +13,9 @@ import {
  * @return The sections for the My Jetpack tab panel.
  */
 export function getMyJetpackSections(): TabPanelProps[ 'tabs' ] {
-	return [
+	const { userIsAdmin } = getMyJetpackWindowInitialState();
+
+	const tabs = [
 		{
 			name: MY_JETPACK_SECTION_OVERVIEW,
 			title: __( 'Overview', 'jetpack-my-jetpack' ),
@@ -20,12 +23,15 @@ export function getMyJetpackSections(): TabPanelProps[ 'tabs' ] {
 		{
 			name: MY_JETPACK_SECTION_PRODUCTS,
 			title: __( 'Products', 'jetpack-my-jetpack' ),
+			isAdminOnly: true,
 		},
 		{
 			name: MY_JETPACK_SECTION_HELP,
 			title: __( 'Help', 'jetpack-my-jetpack' ),
 		},
 	];
+
+	return tabs.filter( tab => ! ( tab.isAdminOnly && ! userIsAdmin ) );
 }
 
 /**

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/utils.ts
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/utils.ts
@@ -1,6 +1,6 @@
+import { currentUserCan } from '@automattic/jetpack-script-data';
 import { TabPanelProps } from '@wordpress/components/build-types/tab-panel/types';
 import { __ } from '@wordpress/i18n';
-import { getMyJetpackWindowInitialState } from '../../data/utils/get-my-jetpack-window-state';
 import {
 	MY_JETPACK_SECTION_HELP,
 	MY_JETPACK_SECTION_OVERVIEW,
@@ -13,7 +13,7 @@ import {
  * @return The sections for the My Jetpack tab panel.
  */
 export function getMyJetpackSections(): TabPanelProps[ 'tabs' ] {
-	const { userIsAdmin } = getMyJetpackWindowInitialState();
+	const showAdminTab = currentUserCan( 'manage_options' );
 
 	const tabs = [
 		{
@@ -31,7 +31,7 @@ export function getMyJetpackSections(): TabPanelProps[ 'tabs' ] {
 		},
 	];
 
-	return tabs.filter( tab => ! ( tab.isAdminOnly && ! userIsAdmin ) );
+	return tabs.filter( tab => ! ( tab.isAdminOnly && ! showAdminTab ) );
 }
 
 /**

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-tab-access
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-tab-access
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+My Jetpack: Onboarding - Updated Products tab access to admin only.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes MYJP-140

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* hiding Products tab for users that are not admins because for this onboarding iteration the tab would be empty (for not admins)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Starts a JN site and connect Jetpack
* Login as editor, verify that `Products` tab is not visible

<img width="1138" alt="SCR-20250529-mnjz" src="https://github.com/user-attachments/assets/ad601d9c-1089-4adc-82c2-4dccb82c1d2c" />

