### PR TITLE
AI Assistant: Add chrome ai token script

### DIFF
--- a/projects/js-packages/ai-client/changelog/remove-chrome-ai-token-injection
+++ b/projects/js-packages/ai-client/changelog/remove-chrome-ai-token-injection
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+We've changed how we inject Chrome's built-in AI API tokens. It will be done from another script.

--- a/projects/js-packages/ai-client/src/hooks/use-ai-feature/index.ts
+++ b/projects/js-packages/ai-client/src/hooks/use-ai-feature/index.ts
@@ -6,8 +6,7 @@ import {
 	usePlanType as getPlanType,
 } from '@automattic/jetpack-shared-extension-utils';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { useMemo, useEffect } from '@wordpress/element';
-import isChromeAIAvailable from '../../chrome-ai/get-availability.ts';
+import { useMemo } from '@wordpress/element';
 import type { WordPressPlansSelectors } from '@automattic/jetpack-shared-extension-utils/store/wordpress-com';
 
 /**
@@ -34,22 +33,6 @@ export default function useAiFeature() {
 		increaseAiAssistantRequestsCount: increaseRequestsCount,
 		dequeueAiAssistantFeatureAsyncRequest: dequeueAsyncRequest,
 	} = useDispatch( 'wordpress-com/plans' );
-
-	useEffect( () => {
-		if ( ! loading && data ) {
-			// Check if the meta tag already exists
-			const existingMeta = document.querySelector( 'meta[http-equiv="origin-trial"]' );
-			if ( isChromeAIAvailable() && ! existingMeta && data?.chromeAiTokens ) {
-				// iterate through chromeAiTokens and create a meta tag for each one
-				Object.keys( data.chromeAiTokens ).forEach( token => {
-					const otMeta = document.createElement( 'meta' );
-					otMeta.httpEquiv = 'origin-trial';
-					otMeta.content = data.chromeAiTokens[ token ];
-					document.head.appendChild( otMeta );
-				} );
-			}
-		}
-	}, [ loading, data ] );
 
 	return useMemo( () => {
 		const planType = getPlanType( data?.currentTier );

--- a/projects/plugins/jetpack/changelog/add-chrome-ai-token-script
+++ b/projects/plugins/jetpack/changelog/add-chrome-ai-token-script
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Load a script that injects the tokens needed to enable Chrome's built-in AI API

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -795,7 +795,7 @@ class Jetpack_Gutenberg {
 			'jetpack-chrome-ai-token',
 			'https://widgets.wp.com/jetpack-chrome-ai/v1/3p-token.js',
 			array(),
-			gmdate( 'Ymd' ) . floor( gmdate( 'G' ) / 12 ), // Cache buster: changes twice daily (morning/afternoon) in case we need to rotate the tokens
+			gmdate( 'Ymd' ) . floor( (int) gmdate( 'G' ) / 12 ), // Cache buster: changes twice daily (morning/afternoon) in case we need to rotate the tokens
 			true
 		);
 		wp_enqueue_script( 'jetpack-chrome-ai-token' );

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -795,7 +795,7 @@ class Jetpack_Gutenberg {
 			'jetpack-chrome-ai-token',
 			'https://widgets.wp.com/jetpack-chrome-ai/v1/3p-token.js',
 			array(),
-			gmdate( 'Ymd' ), // Changes daily at midnight UTC in case we need to rotate the token
+			gmdate( 'Ymd' ) . floor( gmdate( 'G' ) / 12 ), // Cache buster: changes twice daily (morning/afternoon) in case we need to rotate the tokens
 			true
 		);
 		wp_enqueue_script( 'jetpack-chrome-ai-token' );

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -789,6 +789,16 @@ class Jetpack_Gutenberg {
 
 		// Adds Connection package initial state.
 		Connection_Initial_State::render_script( 'jetpack-blocks-editor' );
+
+		// Register and enqueue the Jetpack Chrome AI token script
+		wp_register_script(
+			'jetpack-chrome-ai-token',
+			'https://widgets.wp.com/jetpack-chrome-ai/v1/3p-token.js',
+			array(),
+			gmdate( 'Ymd' ), // Changes daily at midnight UTC in case we need to rotate the token
+			true
+		);
+		wp_enqueue_script( 'jetpack-chrome-ai-token' );
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

I'm changing how we load Chrome AI Origin Trial tokens to being able to  use Chrome's bult-in AI API from any domain. To do so, we have to inject the tokens that we registered for the Origin Trials from a domain that matches the one we used in the registration form (in this case, widgets.wp.com).

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Load a script in the block editor that takes care of injecting the tokens

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Spin a JN site with this branch.
* Open the JN site in a Chrome browser.
* Go to the post editor and open the developer tools.
* Go to the Application tab, then select Frames, top. Check that you have three entries under the Origin Trials section (Summarization, Language Detector, and Translation)

![Screenshot 2025-05-29 at 14 44 05](https://github.com/user-attachments/assets/8c08d03d-2c67-4c6d-ac08-4dafdee087f8)


