### PR TITLE
Dashboard: Ensure support links open in new tab

### DIFF
--- a/projects/plugins/jetpack/_inc/client/components/button/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/button/index.jsx
@@ -2,6 +2,7 @@ import clsx from 'clsx';
 import { noop } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
+import Gridicon from 'components/gridicon';
 
 import './style.scss';
 
@@ -19,6 +20,7 @@ export default class Button extends React.Component {
 		borderless: PropTypes.bool,
 		rna: PropTypes.bool,
 		className: PropTypes.string,
+		isExternalLink: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -26,13 +28,16 @@ export default class Button extends React.Component {
 		type: 'button',
 		onClick: noop,
 		borderless: false,
+		isExternalLink: false,
 	};
 
 	domNode = null;
 
 	render() {
 		const element = this.props.href ? 'a' : 'button';
-		const { primary, compact, scary, borderless, rna, className, ...props } = this.props;
+		const isLink = element === 'a';
+		const { primary, compact, scary, borderless, rna, className, isExternalLink, ...props } =
+			this.props;
 
 		const buttonClasses = clsx( {
 			'dops-button': true,
@@ -48,6 +53,20 @@ export default class Button extends React.Component {
 			this.domNode = node;
 		};
 
-		return React.createElement( element, props, this.props.children );
+		// Open external links in new window.
+		if ( isLink && isExternalLink ) {
+			props.target = '_blank';
+		}
+
+		return React.createElement(
+			element,
+			props,
+			<>
+				{ this.props.children }
+				{ isLink && isExternalLink && (
+					<Gridicon className="dops-card__link-indicator" icon="external" />
+				) }
+			</>
+		);
 	}
 }

--- a/projects/plugins/jetpack/_inc/client/components/support-card/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/support-card/index.jsx
@@ -95,6 +95,7 @@ class SupportCard extends React.Component {
 								<Button
 									onClick={ this.trackGettingStartedClick }
 									href={ getRedirectUrl( 'jetpack-support-getting-started' ) }
+									target="_blank"
 								>
 									{ __( 'Getting started with Jetpack', 'jetpack' ) }
 									<Gridicon className="dops-card__link-indicator" icon="external" />
@@ -107,6 +108,7 @@ class SupportCard extends React.Component {
 										? getRedirectUrl( 'calypso-help' )
 										: getRedirectUrl( 'jetpack-support' )
 								}
+								target="_blank"
 							>
 								{ __( 'Search our support site', 'jetpack' ) }
 								<Gridicon className="dops-card__link-indicator" icon="external" />

--- a/projects/plugins/jetpack/_inc/client/components/support-card/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/support-card/index.jsx
@@ -6,7 +6,6 @@ import React from 'react';
 import { connect } from 'react-redux';
 import Button from 'components/button';
 import Card from 'components/card';
-import Gridicon from 'components/gridicon';
 import JetpackBanner from 'components/jetpack-banner';
 import analytics from 'lib/analytics';
 import {
@@ -95,10 +94,9 @@ class SupportCard extends React.Component {
 								<Button
 									onClick={ this.trackGettingStartedClick }
 									href={ getRedirectUrl( 'jetpack-support-getting-started' ) }
-									target="_blank"
+									isExternalLink={ true }
 								>
 									{ __( 'Getting started with Jetpack', 'jetpack' ) }
-									<Gridicon className="dops-card__link-indicator" icon="external" />
 								</Button>
 							) }
 							<Button
@@ -108,10 +106,9 @@ class SupportCard extends React.Component {
 										? getRedirectUrl( 'calypso-help' )
 										: getRedirectUrl( 'jetpack-support' )
 								}
-								target="_blank"
+								isExternalLink={ true }
 							>
 								{ __( 'Search our support site', 'jetpack' ) }
-								<Gridicon className="dops-card__link-indicator" icon="external" />
 							</Button>
 						</p>
 					</div>

--- a/projects/plugins/jetpack/changelog/fix-jetpack-make_dashboard_support_links_open_in_new_tab
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-make_dashboard_support_links_open_in_new_tab
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Dashboard: Ensure links labeled as external links open in a new tab.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

On the dash we have two links that have external link icons but that don't open in a new tab:
![image](https://github.com/user-attachments/assets/0e565a8a-f94f-4aeb-8702-8d02bb3c182f)

This PR adds `target="_blank"` to those links. It's a bit of a hack, but this page will be replaced anyway.

Reported here: p8oabR-1Fk-p2#comment-8492

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

On a site connected to Jetpack, go here: `/wp-admin/admin.php?page=jetpack#/dashboard`

In `trunk`, the links open in the same tab.

In the `fix/jetpack/make_dashboard_support_links_open_in_new_tab` branch, they open in a new tab.