### PR TITLE
Forms: Add events to Forms dashboard

### DIFF
--- a/projects/packages/forms/changelog/update-forms-check-new-forms-event
+++ b/projects/packages/forms/changelog/update-forms-check-new-forms-event
@@ -1,4 +1,4 @@
 Significance: patch
 Type: added
 
-Forms: Add event to "check new forms" button on transition page
+Forms: Add events to Forms dashboard pages

--- a/projects/packages/forms/changelog/update-forms-check-new-forms-event
+++ b/projects/packages/forms/changelog/update-forms-check-new-forms-event
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Forms: Add event to "check new forms" button on transition page

--- a/projects/packages/forms/src/dashboard/admin-migrate-page/index.tsx
+++ b/projects/packages/forms/src/dashboard/admin-migrate-page/index.tsx
@@ -86,9 +86,12 @@ const AdminMigratePage = () => {
 	);
 
 	const onCheckNewFormsClick = useCallback( () => {
-		jetpackAnalytics.tracks.recordEvent( 'jetpack_wpa_forms_new_forms_page_cta_click', {
-			viewport: isSm ? 'mobile' : 'desktop',
-		} );
+		jetpackAnalytics.tracks.recordEvent(
+			'jetpack_forms_admin_migrate_page_check_new_forms_button_click',
+			{
+				viewport: isSm ? 'mobile' : 'desktop',
+			}
+		);
 
 		window.location.href = dashboardURL;
 	}, [ isSm, dashboardURL ] );

--- a/projects/packages/forms/src/dashboard/admin-migrate-page/index.tsx
+++ b/projects/packages/forms/src/dashboard/admin-migrate-page/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import jetpackAnalytics from '@automattic/jetpack-analytics';
 import {
 	AdminPage,
 	AdminSectionHero,
@@ -11,7 +12,7 @@ import {
 	getUserLocale,
 } from '@automattic/jetpack-components';
 import { Button } from '@wordpress/components';
-import { useMemo } from '@wordpress/element';
+import { useMemo, useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
@@ -62,6 +63,7 @@ const AdminMigratePage = () => {
 	const [ isSm ] = useBreakpointMatch( 'sm' );
 	const ASSETS_URL = useMemo( () => config( 'pluginAssetsURL' ), [] );
 	const dashboardURL = useMemo( () => config( 'dashboardURL' ), [] );
+
 	const header = (
 		<div>
 			<JetpackLogo />{ ' ' }
@@ -82,6 +84,15 @@ const AdminMigratePage = () => {
 		() => getLocaleScreenshotName( getUserLocale(), isSm ),
 		[ isSm ]
 	);
+
+	const onCheckNewFormsClick = useCallback( () => {
+		jetpackAnalytics.tracks.recordEvent( 'jetpack_wpa_forms_new_forms_page_cta_click', {
+			viewport: isSm ? 'mobile' : 'desktop',
+		} );
+
+		window.location.href = dashboardURL;
+	}, [ isSm, dashboardURL ] );
+
 	return (
 		<div className="jp-forms__admin-migrate-page-wrapper">
 			<AdminPage moduleName={ __( 'Jetpack Forms', 'jetpack-forms' ) } header={ header }>
@@ -95,7 +106,7 @@ const AdminMigratePage = () => {
 								{ __( "Now it's part of Jetpack → Forms", 'jetpack-forms' ) }
 							</p>
 							<p>
-								<Button variant="primary" href={ dashboardURL }>
+								<Button variant="primary" onClick={ onCheckNewFormsClick }>
 									{ __( 'Check new Forms', 'jetpack-forms' ) }
 								</Button>
 							</p>

--- a/projects/packages/forms/src/dashboard/admin-migrate-page/index.tsx
+++ b/projects/packages/forms/src/dashboard/admin-migrate-page/index.tsx
@@ -12,7 +12,7 @@ import {
 	getUserLocale,
 } from '@automattic/jetpack-components';
 import { Button } from '@wordpress/components';
-import { useMemo, useCallback } from '@wordpress/element';
+import { useEffect, useMemo, useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
@@ -84,6 +84,12 @@ const AdminMigratePage = () => {
 		() => getLocaleScreenshotName( getUserLocale(), isSm ),
 		[ isSm ]
 	);
+
+	useEffect( () => {
+		jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_admin_migrate_page_view', {
+			viewport: isSm ? 'mobile' : 'desktop',
+		} );
+	}, [ isSm ] );
 
 	const onCheckNewFormsClick = useCallback( () => {
 		jetpackAnalytics.tracks.recordEvent(

--- a/projects/packages/forms/src/dashboard/components/layout/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/layout/index.tsx
@@ -5,7 +5,7 @@ import jetpackAnalytics from '@automattic/jetpack-analytics';
 import { JetpackFooter, useBreakpointMatch } from '@automattic/jetpack-components';
 import { shouldUseInternalLinks } from '@automattic/jetpack-shared-extension-utils';
 import { TabPanel } from '@wordpress/components';
-import { useCallback, useMemo } from '@wordpress/element';
+import { useCallback, useEffect, useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import { Outlet, useLocation, useNavigate } from 'react-router-dom';
@@ -32,6 +32,12 @@ const Layout = ( {
 	const [ isSm ] = useBreakpointMatch( 'sm' );
 
 	const enableIntegrationsTab = config( 'enableIntegrationsTab' );
+
+	useEffect( () => {
+		jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_dashboard_page_view', {
+			viewport: isSm ? 'mobile' : 'desktop',
+		} );
+	}, [ isSm ] );
 
 	const tabs = useMemo(
 		() => [

--- a/projects/packages/forms/src/dashboard/components/layout/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/layout/index.tsx
@@ -1,10 +1,11 @@
 /**
  * External dependencies
  */
+import jetpackAnalytics from '@automattic/jetpack-analytics';
 import { JetpackFooter, useBreakpointMatch } from '@automattic/jetpack-components';
 import { shouldUseInternalLinks } from '@automattic/jetpack-shared-extension-utils';
 import { TabPanel } from '@wordpress/components';
-import { useCallback } from '@wordpress/element';
+import { useCallback, useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import { Outlet, useLocation, useNavigate } from 'react-router-dom';
@@ -32,21 +33,24 @@ const Layout = ( {
 
 	const enableIntegrationsTab = config( 'enableIntegrationsTab' );
 
-	const tabs = [
-		{
-			name: 'responses',
-			title: __( 'Responses', 'jetpack-forms' ),
-		},
-		...( enableIntegrationsTab
-			? [ { name: 'integrations', title: __( 'Integrations', 'jetpack-forms' ) } ]
-			: [] ),
-		{
-			name: 'about',
-			title: __( 'About', 'jetpack-forms' ),
-		},
-	];
+	const tabs = useMemo(
+		() => [
+			{
+				name: 'responses',
+				title: __( 'Responses', 'jetpack-forms' ),
+			},
+			...( enableIntegrationsTab
+				? [ { name: 'integrations', title: __( 'Integrations', 'jetpack-forms' ) } ]
+				: [] ),
+			{
+				name: 'about',
+				title: __( 'About', 'jetpack-forms' ),
+			},
+		],
+		[ enableIntegrationsTab ]
+	);
 
-	const getCurrentTab = () => {
+	const getCurrentTab = useCallback( () => {
 		const path = location.pathname.split( '/' )[ 1 ];
 		const validTabNames = tabs.map( tab => tab.name );
 
@@ -55,7 +59,7 @@ const Layout = ( {
 		}
 
 		return config( 'hasFeedback' ) ? 'responses' : 'about';
-	};
+	}, [ location.pathname, tabs ] );
 
 	const isResponsesTab = getCurrentTab() === 'responses';
 
@@ -64,12 +68,23 @@ const Layout = ( {
 			if ( ! tabName ) {
 				tabName = config( 'hasFeedback' ) ? 'responses' : 'about';
 			}
+
+			const currentTab = getCurrentTab();
+
+			if ( currentTab !== tabName ) {
+				jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_dashboard_tab_change', {
+					tab: tabName,
+					viewport: isSm ? 'mobile' : 'desktop',
+					previous_tab: currentTab,
+				} );
+			}
+
 			navigate( {
 				pathname: `/${ tabName }`,
 				search: tabName === 'responses' ? location.search : '',
 			} );
 		},
-		[ navigate, location.search ]
+		[ navigate, location.search, isSm, getCurrentTab ]
 	);
 
 	return (

--- a/projects/packages/forms/src/dashboard/hooks/use-export-responses.ts
+++ b/projects/packages/forms/src/dashboard/hooks/use-export-responses.ts
@@ -1,6 +1,8 @@
 /**
  * External dependencies
  */
+import jetpackAnalytics from '@automattic/jetpack-analytics';
+import { useBreakpointMatch } from '@automattic/jetpack-components';
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 import { useState, useCallback, useEffect } from '@wordpress/element';
@@ -25,10 +27,18 @@ type ExportHookReturn = {
  * @return {ExportHookReturn} The export modal state and actions.
  */
 export default function useExportResponses(): ExportHookReturn {
+	const [ isSm ] = useBreakpointMatch( 'sm' );
 	const [ showExportModal, setShowExportModal ] = useState( false );
-	const openModal = useCallback( () => setShowExportModal( true ), [ setShowExportModal ] );
 	const closeModal = useCallback( () => setShowExportModal( false ), [ setShowExportModal ] );
 	const [ autoConnectGdrive, setAutoConnectGdrive ] = useState( false );
+
+	const openModal = useCallback( () => {
+		setShowExportModal( true );
+
+		jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_export_responses_modal_open', {
+			viewport: isSm ? 'mobile' : 'desktop',
+		} );
+	}, [ isSm ] );
 
 	const userCanExport = useSelect(
 		select => select( coreStore ).canUser( 'update', 'settings' ),

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
@@ -21,7 +21,7 @@ import { useSearchParams } from 'react-router-dom';
 /**
  * Internal dependencies
  */
-import InboxStatusToggle from '../../components/InboxStatusToggle';
+import InboxStatusToggle from '../../components/inbox-status-toggle';
 import { store as dashboardStore } from '../../store';
 import InboxResponse from '../response';
 import { getPath } from '../utils.js';

--- a/projects/packages/forms/src/dashboard/inbox/export-responses/csv.tsx
+++ b/projects/packages/forms/src/dashboard/inbox/export-responses/csv.tsx
@@ -1,13 +1,21 @@
 /**
  * External dependencies
  */
+import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { Button, Path, SVG } from '@wordpress/components';
 import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 
 const CSVExport = ( { onExport } ) => {
+	const { tracks } = useAnalytics();
+
 	const downloadCSV = useCallback( () => {
+		tracks.recordEvent( 'jetpack_forms_export_click', {
+			destination: 'csv',
+			screen: 'form-responses-inbox',
+		} );
+
 		onExport( 'feedback_export', 'feedback_export_nonce_csv' ).then( async response => {
 			const blob = await response.blob();
 
@@ -23,7 +31,7 @@ const CSVExport = ( { onExport } ) => {
 			document.body.removeChild( a );
 			window.URL.revokeObjectURL( a.href );
 		} );
-	}, [ onExport ] );
+	}, [ onExport, tracks ] );
 
 	const buttonClasses = clsx( 'button', 'export-button', 'export-csv' );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of FORMS-116

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds an event to the button leading to the new page tracking the viewport

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

To check events, enable debugging with `localStorage.setItem('debug', '*') and filter the console for `Record event "jetpack_forms_`.

* Go to the Feedback menu
* Check that there is an event for the page view
* Click on the "Check new Forms" button
* Check the tracks live view some minutes later (the page is redirected, so there is no time to check the developer console log)
* Once in the dashboard, check that a pageview event is fired
* Click on a different tab
* Check that an event is fired
* On the Responses tab, go to "Trash" or Spam" and check that an event is fired
* On the Responses tab, click on "Export"
* Check that an event is fired
* On the Export modal, click to export a CSV file
* Check that an event is fired as well
