### PR TITLE
Launchpad checklists - Update newsletter checklists to show manage subscribers regardless of import goal.

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-newsletter-checklists-to-show-manage-subscribers
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-newsletter-checklists-to-show-manage-subscribers
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+dont restrict manage subscribers task to importing goal for newsletter launchpads

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -517,7 +517,6 @@ function wpcom_launchpad_get_task_definitions() {
 				return __( 'Manage your subscribers', 'jetpack-mu-wpcom' );
 			},
 			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
-			'is_visible_callback'  => 'wpcom_launchpad_has_goal_import_subscribers',
 			'get_calypso_path'     => function ( $task, $default, $data ) {
 				return '/subscribers/' . $data['site_slug_encoded'];
 			},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes # https://linear.app/a8c/issue/CML-509/wasnt-asked-to-add-subscribers#comment-5db85623

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
 
* Removes the custom is visible callback from the manage_subscribers task that is used for free and paid newsletter intents.
    * This callback was only making the task visible if the sites had an import subscribers goal. While this makes sense to use for other checklists and tasks like the import subscribers task, this doesn't make sense for the general "manage subscribers" task. All newsletter users should have this task to introduce them to the subscribers management interface, as it is a key part of using the newsletter product.  

BEFORE
(free)
![Screenshot 2025-05-29 at 11 46 08 AM](https://github.com/user-attachments/assets/d2ba1057-4e9c-4a70-9b10-e92dac2e12b3)
(paid)
![Screenshot 2025-05-29 at 11 46 27 AM](https://github.com/user-attachments/assets/ff6a027a-9345-44c6-8709-63e9a8460a5b)


AFTER
(free)
![Screenshot 2025-05-29 at 11 44 52 AM](https://github.com/user-attachments/assets/50c416cc-73e8-4a71-a6b8-a0ba72ced8fb)
(paid)
![Screenshot 2025-05-29 at 11 43 24 AM](https://github.com/user-attachments/assets/a7f1ac23-a8e8-4d91-80b2-92eb982ce048)



### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this build to your sandbox via the command in comment below.
* sandbox the public-api
* create a site at /newsletter, select the free or paid forks (test both)
* when landing at the focused launchpad select "skip to dashboard".
* click the last task for this flow (start writing) and publish the post. This completes the checklist and allows the follow up intent checklist to be shown.
* Go back to my home and see the new checklist. Verify it now shows the "manage subscribers" task.
* You shouldn't need to test task action or completion as we aren't changing any of that functionality, but if you do, note that you will need to enable write access on your sandbox to mark the task as complete. Clicking the task navigates to subscribers management and marks the task as complete.

