### PR TITLE
Top Posts Widget: Enable transient caching of results to reduce DB calls.

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-top-posts-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-top-posts-helper.php
@@ -40,8 +40,9 @@ class Jetpack_Top_Posts_Helper {
 		);
 
 		// Use a transient key that should be unique based on the query and accepted types.
-		$transient_key = 'jp_top_posts_' . md5( serialize( array_merge( $query_args, $types ) ) );
-		if ( $cached && false !== ( $top_posts = get_transient( $transient_key ) ) ) {
+		$transient_key = 'jp_top_posts_' . md5( wp_json_encode( $query_args ) . $types );
+		$top_posts     = get_transient( $transient_key );
+		if ( $cached && false !== $top_posts ) {
 			return $top_posts;
 		}
 

--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-top-posts-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-top-posts-helper.php
@@ -20,7 +20,7 @@ class Jetpack_Top_Posts_Helper {
 	 * @return array
 	 */
 	public static function get_top_posts( $period, $items_count = null, $types = null ) {
-		$all_time_days = floor( ( time() - strtotime( get_option( 'site_created_date' ) ) ) / ( 60 * 60 * 24 * 365 ) );
+		$all_time_days = floor( ( time() - strtotime( get_option( 'site_created_date' ) ) ) / ( YEAR_IN_SECONDS ) );
 
 		// While we only display ten posts, users can filter out content types.
 		// As such, we should obtain a few spare posts from the Stats endpoint.

--- a/projects/plugins/jetpack/changelog/fix-top-posts-transient-caching
+++ b/projects/plugins/jetpack/changelog/fix-top-posts-transient-caching
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Update Jetpack_Top_Posts_Helper::get_top_posts to cache the result in a transient to reduce extraneous db queries.


### PR DESCRIPTION
In my testing, using the widget on a page on a client site has resulted in over 2,000 additional db queries, based on the loop to `get_attached_media()` for every potential top post firing off numerous subsequent db queries --

```
830 are querying wp_posts to do WP_Post::get_instance()
878 are update_meta_cache()
517 are WP_Term_Query->get_terms()
133 are WP_Query->get_posts()
```

## Proposed changes:
* Add transient caching for the top posts.

## Testing instructions:
* Load a page with the widget and Query Monitor -- with a lot of past traffic.
* See the queries go down?

## Does this pull request change what data or activity we track or use?

Nope