### PR TITLE
Slideshow block: reduce layout shifts during page load

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-slideshow-block-layout-shifts
+++ b/projects/plugins/jetpack/changelog/fix-slideshow-block-layout-shifts
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Slideshow block: reduce layout shifts during page load.

--- a/projects/plugins/jetpack/extensions/blocks/slideshow/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/slideshow/block.json
@@ -56,6 +56,11 @@
 					"source": "attribute",
 					"selector": "img",
 					"attribute": "src"
+				},
+				"aspectRatio": {
+					"source": "attribute",
+					"selector": "img",
+					"attribute": "data-aspect-ratio"
 				}
 			}
 		},

--- a/projects/plugins/jetpack/extensions/blocks/slideshow/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/slideshow/edit.js
@@ -29,6 +29,14 @@ export const pickRelevantMediaFiles = ( image, sizeSlug ) => {
 		get( image, [ 'sizes', sizeSlug, 'url' ] ) ||
 		get( image, [ 'media_details', 'sizes', sizeSlug, 'source_url' ] ) ||
 		image.url;
+	const imageSize =
+		get( image, [ 'sizes', sizeSlug ] ) ||
+		get( image, [ 'media_details', 'sizes', sizeSlug ] ) ||
+		image;
+	imageProps.aspectRatio =
+		imageSize.width && imageSize.height
+			? `calc(${ imageSize.width } / ${ imageSize.height })`
+			: null;
 	return imageProps;
 };
 

--- a/projects/plugins/jetpack/extensions/blocks/slideshow/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/slideshow/edit.js
@@ -34,9 +34,7 @@ export const pickRelevantMediaFiles = ( image, sizeSlug ) => {
 		get( image, [ 'media_details', 'sizes', sizeSlug ] ) ||
 		image;
 	imageProps.aspectRatio =
-		imageSize.width && imageSize.height
-			? `calc(${ imageSize.width } / ${ imageSize.height })`
-			: null;
+		imageSize.width && imageSize.height ? `${ imageSize.width } / ${ imageSize.height }` : null;
 	return imageProps;
 };
 

--- a/projects/plugins/jetpack/extensions/blocks/slideshow/slideshow.js
+++ b/projects/plugins/jetpack/extensions/blocks/slideshow/slideshow.js
@@ -129,14 +129,18 @@ class Slideshow extends Component {
 				data-autoplay={ autoplay || null }
 				data-delay={ autoplay ? delay : null }
 				data-effect={ effect }
-				style={ { '--aspect-ratio': images[ 0 ].aspectRatio } }
+				style={ {
+					'--aspect-ratio': images[ 0 ]?.aspectRatio
+						? `calc(${ images[ 0 ].aspectRatio })`
+						: undefined,
+				} }
 			>
 				<div
 					className="wp-block-jetpack-slideshow_container swiper-container"
 					ref={ this.slideshowRef }
 				>
 					<ul className="wp-block-jetpack-slideshow_swiper-wrapper swiper-wrapper">
-						{ images.map( ( { alt, caption, id, url }, index ) => (
+						{ images.map( ( { alt, caption, id, url, aspectRatio }, index ) => (
 							<li
 								className={ clsx(
 									'wp-block-jetpack-slideshow_slide',
@@ -152,6 +156,7 @@ class Slideshow extends Component {
 											`wp-block-jetpack-slideshow_image wp-image-${ id }` /* wp-image-${ id } makes WordPress add a srcset */
 										}
 										data-id={ id }
+										data-aspect-ratio={ aspectRatio }
 										src={ url }
 									/>
 									{ isBlobURL( url ) && <Spinner /> }

--- a/projects/plugins/jetpack/extensions/blocks/slideshow/slideshow.js
+++ b/projects/plugins/jetpack/extensions/blocks/slideshow/slideshow.js
@@ -129,6 +129,7 @@ class Slideshow extends Component {
 				data-autoplay={ autoplay || null }
 				data-delay={ autoplay ? delay : null }
 				data-effect={ effect }
+				style={ { '--aspect-ratio': images[ 0 ].aspectRatio } }
 			>
 				<div
 					className="wp-block-jetpack-slideshow_container swiper-container"

--- a/projects/plugins/jetpack/extensions/blocks/slideshow/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/slideshow/style.scss
@@ -41,13 +41,13 @@
 		// Prevent layout shifts during loading, by using serialized aspect ratio.
 		// These rules mimic the conditions in swiperResize() on swiper-callbacks.js.
 		&:not(.wp-swiper-initialized) .wp-block-jetpack-slideshow_swiper-wrapper {
-      aspect-ratio: max(min(var(--aspect-ratio), calc(16 / 9)), 1);
-      max-height: 80vh;
-    }
+			aspect-ratio: max(min(var(--aspect-ratio), calc(16 / 9)), 1);
+			max-height: 80vh;
+		}
 
-    // For older slideshows, where the aspect ratio wasn't serialized,
-    // we can partially mitigate layout shifts during loading.
-    // Since the aspect ratio is always calculated based on the first slide,
+		// For older slideshows, where the aspect ratio wasn't serialized,
+		// we can partially mitigate layout shifts during loading.
+		// Since the aspect ratio is always calculated based on the first slide,
 		// we ensure that other slides don't affect the block height while loading.
 		// This reduces layout shifts if a later image is taller than the first one.
 		&:not(.wp-swiper-initialized) .wp-block-jetpack-slideshow_slide:not(:first-of-type) {

--- a/projects/plugins/jetpack/extensions/blocks/slideshow/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/slideshow/style.scss
@@ -38,6 +38,22 @@
 			opacity: 1;
 		}
 
+		// Prevent layout shifts during loading, by using serialized aspect ratio.
+		// These rules mimic the conditions in swiperResize() on swiper-callbacks.js.
+		&:not(.wp-swiper-initialized) .wp-block-jetpack-slideshow_swiper-wrapper {
+      aspect-ratio: max(min(var(--aspect-ratio), calc(16 / 9)), 1);
+      max-height: 80vh;
+    }
+
+    // For older slideshows, where the aspect ratio wasn't serialized,
+    // we can partially mitigate layout shifts during loading.
+    // Since the aspect ratio is always calculated based on the first slide,
+		// we ensure that other slides don't affect the block height while loading.
+		// This reduces layout shifts if a later image is taller than the first one.
+		&:not(.wp-swiper-initialized) .wp-block-jetpack-slideshow_slide:not(:first-of-type) {
+			height: 1px;
+		}
+
 	  	//overide display collision with coblocks plugin styles which causes a gap
 		//see https://github.com/Automattic/wp-calypso/issues/63082#issuecomment-1175225512
 		&.swiper-container {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

_Note @coder-karen : Looking at the commit history you seem to have some experience with this block, so I would really appreciate it if you could take a look! But please feel free to skip this review if I got that wrong 👍_

The slideshow block can currently cause some large layout shifts, depending on the chosen images. In the below example, I set up a slideshow where the first image is wide and the second one is tall. The aspect ratio that gets applied to the slideshow at the end of the loading process is based on the first image, but during the loading process this is not the case, and the tallest image ends up being the one that determines how far the content gets pushed down.

Notice how the text below the slideshow gets pushed below the bottom edge of the screen during loading, and then comes back up once the images load:

https://github.com/user-attachments/assets/ed5961b6-d896-42f4-b4b4-91a8be548fc2

This PR significantly reduces layout shifting, by serializing the aspect ratio when saving the block, and using it to size the slideshow during load. This closely matches the final size that gets calculated in JS:

https://github.com/user-attachments/assets/416ff472-dd64-4f49-8d67-03e3fa33a078

Since this only works for new or updated slideshows, this PR also includes a mitigation for older slideshows that don't have a serialized aspect ratio. The mitigation works by forcing the image height to `1px` on every image except the first one, since that's the one whose dimensions will be used to determine the aspect ratio in JS, at the end of the loading process. This doesn't work quite as well, but it does still somewhat reduce the amount of shifting:

https://github.com/user-attachments/assets/9cd5dc4f-544d-4e41-90c8-4d5e7c3d64f0


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Serialize aspect ratio when saving slideshow block
* Use serialized aspect ratio (when present) to size slideshow block during load
* Reduce slides beyond the first to a single pixel height during load, as a layout shift mitigation for older blocks

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

To test new slideshows:
* Using this branch, create a new slideshow
* Pick a wide (landscape) image for the first image, and a tall (portrait) one for the second
* Save the page
* Load the page (preferably using network throttling), and ensure the layout shifting is minimal

To test old slideshows with the mitigation:
* Using trunk, create a new slideshow
* Pick a wide (landscape) image for the first image, and a tall (portrait) one for the second
* Save the page
* Switch to this branch to ensure you have the CSS mitigation when loading
* Load the page (preferably using network throttling), and ensure the layout shifting is minimal

Please feel free to try using different themes, different media, and any other conditions you think may have an impact here. Both the full fix and the mitigation should always result in smaller layout shifts than trunk, and should never break existing pages.

Thank you so much! 🙏