### PR TITLE
Newsletter: Makes "Set Up" settings button dynamic

### DIFF
--- a/projects/plugins/jetpack/_inc/client/newsletter/paid-newsletter.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/paid-newsletter.jsx
@@ -19,8 +19,13 @@ import { SUBSCRIPTIONS_MODULE_NAME } from './constants';
  * @return {React.Component} Paid Newsletter component.
  */
 function PaidNewsletter( props ) {
-	const { isSubscriptionsActive, setupPaymentPlansUrl, subscriptionsModule, siteHasConnectedUser } =
-		props;
+	const {
+		haveNewsletterPlans,
+		isSubscriptionsActive,
+		setupPaymentPlansUrl,
+		subscriptionsModule,
+		siteHasConnectedUser,
+	} = props;
 
 	const setupPaymentPlansButtonDisabled = ! isSubscriptionsActive;
 
@@ -43,7 +48,7 @@ function PaidNewsletter( props ) {
 			>
 				<p className="jp-settings-card__email-settings">
 					{ __(
-						'Earn money through your Newsletter. Reward your most loyal subscribers with exclusive content or add a paywall to monetize content.',
+						'Earn money through your Newsletter. Reward your most loyal subscribers with exclusive content or add a paywall to monetize content.',
 						'jetpack'
 					) }
 				</p>
@@ -55,7 +60,7 @@ function PaidNewsletter( props ) {
 					primary
 					rna
 				>
-					{ __( 'Set up', 'jetpack' ) }
+					{ haveNewsletterPlans ? __( 'Manage Plans', 'jetpack' ) : __( 'Add Plans', 'jetpack' ) }
 				</Button>
 			</SettingsGroup>
 		</SettingsCard>
@@ -65,6 +70,7 @@ function PaidNewsletter( props ) {
 export default withModuleSettingsFormHelpers(
 	connect( ( state, ownProps ) => {
 		return {
+			haveNewsletterPlans: ownProps.getOptionValue( 'newsletter_plans_configured' ),
 			isSubscriptionsActive: ownProps.getOptionValue( SUBSCRIPTIONS_MODULE_NAME ),
 			setupPaymentPlansUrl: getJetpackCloudUrl( state, 'monetize/payments' ),
 			subscriptionsModule: getModule( state, SUBSCRIPTIONS_MODULE_NAME ),

--- a/projects/plugins/jetpack/_inc/client/newsletter/paid-newsletter.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/paid-newsletter.jsx
@@ -33,6 +33,12 @@ function PaidNewsletter( props ) {
 		analytics.tracks.recordJetpackClick( 'newsletter_settings_setup_payment_plans_button_click' );
 	}, [] );
 
+	// Avoiding ternary to prevent bad minification error.
+	let plansBtnText = __( 'Add Plans', 'jetpack' );
+	if ( haveNewsletterPlans ) {
+		plansBtnText = __( 'Manage Plans', 'jetpack' );
+	}
+
 	return (
 		<SettingsCard
 			{ ...props }
@@ -60,7 +66,7 @@ function PaidNewsletter( props ) {
 					primary
 					rna
 				>
-					{ haveNewsletterPlans ? __( 'Manage Plans', 'jetpack' ) : __( 'Add Plans', 'jetpack' ) }
+					{ plansBtnText }
 				</Button>
 			</SettingsGroup>
 		</SettingsCard>
@@ -70,7 +76,7 @@ function PaidNewsletter( props ) {
 export default withModuleSettingsFormHelpers(
 	connect( ( state, ownProps ) => {
 		return {
-			haveNewsletterPlans: ownProps.getOptionValue( 'newsletter_plans_configured' ),
+			haveNewsletterPlans: ownProps.getOptionValue( 'newsletter_has_active_plan' ),
 			isSubscriptionsActive: ownProps.getOptionValue( SUBSCRIPTIONS_MODULE_NAME ),
 			setupPaymentPlansUrl: getJetpackCloudUrl( state, 'monetize/payments' ),
 			subscriptionsModule: getModule( state, SUBSCRIPTIONS_MODULE_NAME ),

--- a/projects/plugins/jetpack/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -499,6 +499,11 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 
 		$response['akismet'] = is_plugin_active( 'akismet/akismet.php' );
 
+		require_once JETPACK__PLUGIN_DIR . '/modules/memberships/class-jetpack-memberships.php';
+		if ( class_exists( 'Jetpack_Memberships' ) ) {
+			$response['newsletter_plans_configured'] = Jetpack_Memberships::has_configured_plans_jetpack_recurring_payments( 'newsletter' );
+		}
+
 		return rest_ensure_response( $response );
 	}
 

--- a/projects/plugins/jetpack/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -501,7 +501,7 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 
 		require_once JETPACK__PLUGIN_DIR . '/modules/memberships/class-jetpack-memberships.php';
 		if ( class_exists( 'Jetpack_Memberships' ) ) {
-			$response['newsletter_plans_configured'] = Jetpack_Memberships::has_configured_plans_jetpack_recurring_payments( 'newsletter' );
+			$response['newsletter_has_active_plan'] = count( Jetpack_Memberships::get_all_newsletter_plan_ids( false ) ) > 0;
 		}
 
 		return rest_ensure_response( $response );

--- a/projects/plugins/jetpack/changelog/makes-paid-newsletter-setup-button-dynamic
+++ b/projects/plugins/jetpack/changelog/makes-paid-newsletter-setup-button-dynamic
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Newsletter:Update "Set Up" button to show "Add Plans" or "Manage Plans" depending on the plans configuration.

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -514,7 +514,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 
 					require_once JETPACK__PLUGIN_DIR . '/modules/memberships/class-jetpack-memberships.php';
 					if ( class_exists( 'Jetpack_Memberships' ) ) {
-						$response['newsletter_plans_configured'] = Jetpack_Memberships::has_configured_plans_jetpack_recurring_payments( 'newsletter' );
+						$response[ $key ]['newsletter_plans_configured'] = Jetpack_Memberships::has_configured_plans_jetpack_recurring_payments( 'newsletter' );
 					}
 
 					if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -512,6 +512,11 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 						'wpcom_hide_action_bar'            => (bool) get_option( 'wpcom_hide_action_bar' ),
 					);
 
+					require_once JETPACK__PLUGIN_DIR . '/modules/memberships/class-jetpack-memberships.php';
+					if ( class_exists( 'Jetpack_Memberships' ) ) {
+						$response['newsletter_plans_configured'] = Jetpack_Memberships::has_configured_plans_jetpack_recurring_payments( 'newsletter' );
+					}
+
 					if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
 						$response[ $key ]['wpcom_publish_posts_with_markdown']    = (bool) WPCom_Markdown::get_instance()->is_posting_enabled();
 						$response[ $key ]['wpcom_publish_comments_with_markdown'] = (bool) WPCom_Markdown::get_instance()->is_commenting_enabled();

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -514,7 +514,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 
 					require_once JETPACK__PLUGIN_DIR . '/modules/memberships/class-jetpack-memberships.php';
 					if ( class_exists( 'Jetpack_Memberships' ) ) {
-						$response[ $key ]['newsletter_plans_configured'] = Jetpack_Memberships::has_configured_plans_jetpack_recurring_payments( 'newsletter' );
+						$response[ $key ]['newsletter_has_active_plan'] = count( Jetpack_Memberships::get_all_newsletter_plan_ids( false ) ) > 0;
 					}
 
 					if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-4-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-4-endpoint.php
@@ -125,7 +125,7 @@ new WPCOM_JSON_API_Site_Settings_V1_4_Endpoint(
 			'jetpack_post_date_in_email'                => '(bool) Whether to show date in the email byline',
 			'wpcom_newsletter_categories'               => '(array) Array of post category ids that are marked as newsletter categories',
 			'wpcom_newsletter_categories_enabled'       => '(bool) Whether the newsletter categories are enabled or not',
-			'newsletter_plans_configured'               => '(bool) Whether the newsletter plans are configured for the site',
+			'newsletter_has_active_plan'                => '(bool) Whether there is an active newsletter plan for the site',
 			'sm_enabled'                                => '(bool) Whether the newsletter Subscribe Modal is enabled or not',
 			'jetpack_subscribe_overlay_enabled'         => '(bool) Whether the newsletter Subscribe Overlay is enabled or not',
 			'jetpack_subscribe_floating_button_enabled' => '(bool) Whether the newsletter floating subscribe button is enabled or not',

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-4-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-4-endpoint.php
@@ -125,6 +125,7 @@ new WPCOM_JSON_API_Site_Settings_V1_4_Endpoint(
 			'jetpack_post_date_in_email'                => '(bool) Whether to show date in the email byline',
 			'wpcom_newsletter_categories'               => '(array) Array of post category ids that are marked as newsletter categories',
 			'wpcom_newsletter_categories_enabled'       => '(bool) Whether the newsletter categories are enabled or not',
+			'newsletter_plans_configured'               => '(bool) Whether the newsletter plans are configured for the site',
 			'sm_enabled'                                => '(bool) Whether the newsletter Subscribe Modal is enabled or not',
 			'jetpack_subscribe_overlay_enabled'         => '(bool) Whether the newsletter Subscribe Overlay is enabled or not',
 			'jetpack_subscribe_floating_button_enabled' => '(bool) Whether the newsletter floating subscribe button is enabled or not',

--- a/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
+++ b/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
@@ -923,7 +923,6 @@ class Jetpack_Memberships {
 		$is_cached_site = ( new Host() )->is_wpcom_simple() && is_jetpack_site();
 		if ( ! $is_cached_site ) {
 			$meta_query = array(
-				'relation' => 'AND',
 				array(
 					'key'   => 'jetpack_memberships_type',
 					'value' => self::$type_tier,

--- a/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
+++ b/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
@@ -909,9 +909,11 @@ class Jetpack_Memberships {
 	 * This function is used both on WPCOM or on Jetpack self-hosted.
 	 * Depending on the environment we need to mitigate where the data is retrieved from.
 	 *
+	 * @param bool $allow_deleted Whether to allow deleted plans to be returned. Defaults to true.
+	 *
 	 * @return array
 	 */
-	public static function get_all_newsletter_plan_ids() {
+	public static function get_all_newsletter_plan_ids( $allow_deleted = true ) {
 
 		if ( ! self::is_enabled_jetpack_recurring_payments() ) {
 			return array();
@@ -920,21 +922,34 @@ class Jetpack_Memberships {
 		// We can retrieve the data directly except on a Jetpack/Atomic cached site or
 		$is_cached_site = ( new Host() )->is_wpcom_simple() && is_jetpack_site();
 		if ( ! $is_cached_site ) {
+			$meta_query = array(
+				'relation' => 'AND',
+				array(
+					'key'   => 'jetpack_memberships_type',
+					'value' => self::$type_tier,
+				),
+			);
+
+			if ( $allow_deleted === false ) {
+				$meta_query[] = array(
+					'key'     => 'jetpack_memberships_is_deleted',
+					'compare' => 'NOT EXISTS',
+				);
+			}
+
 			return get_posts(
 				array(
 					'posts_per_page' => -1,
 					'fields'         => 'ids',
 					'post_type'      => self::$post_type_plan,
-					'meta_key'       => 'jetpack_memberships_type',
-					'meta_value'     => self::$type_tier,
+					'meta_query'     => $meta_query,
 				)
 			);
 
 		} else {
 			// On cached site on WPCOM
 			require_lib( 'memberships' );
-			$allow_deleted = true;
-			$list          = Memberships_Product::get_product_list( get_current_blog_id(), self::$type_tier, null, $allow_deleted );
+			$list = Memberships_Product::get_product_list( get_current_blog_id(), self::$type_tier, null, $allow_deleted );
 
 			if ( is_wp_error( $list ) ) {
 				return array();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes [CML-512](https://linear.app/a8c/issue/CML-512/paid-newsletter-setting-says-set-up-when-it-already-exists)

## Proposed changes:

On "Jetpack > Settings > Newsletter > Paid Newsletter" section update the currently present static "Set Up" button to show values "Add Plans" / "Manage Plans" depending on the plans configuration. Before this change the text was static which is confusing for users if they have plans configured already.

| Before | After |
| -------|------| 
| ![image](https://github.com/user-attachments/assets/36e9b428-f60a-481f-bfdd-87e2d1249479) | ![image](https://github.com/user-attachments/assets/9e681b26-8aec-4f55-8188-5718e5b02141) |
| ![image](https://github.com/user-attachments/assets/36e9b428-f60a-481f-bfdd-87e2d1249479) | ![image](https://github.com/user-attachments/assets/aadb7a70-6ad2-4bae-962d-0f176e83ed61) |

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

Kindly view the attached issue.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### Testing on Simple:

There will be a separate Calypso PR.

### Testing on Atomic:

1. Go to your test Atomic Site.
1. Use Jetpack Beta Plugin to download the branch on your test site.
1. Navigate to "Jetpack > Newsletter > Settings".
1. Verify "Paid Newsletter" section is showing "Add Plans" button when no plans are configured.
1. Setup Plans. 
1. Verify "Paid Newsletter" section is showing "Manage Plans" button.

### Testing on Self Hosted:

- Repeat the above mentioned steps.
