### PR TITLE
Docker: update to jmcombs/sftp to add multi-platform support ( apple silicon )

### DIFF
--- a/tools/cli/helpers/docker-config.js
+++ b/tools/cli/helpers/docker-config.js
@@ -1,4 +1,4 @@
-import { readFileSync, writeFileSync, existsSync } from 'fs';
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'fs';
 import path from 'path';
 import chalk from 'chalk';
 import yaml from 'js-yaml';
@@ -202,6 +202,20 @@ const setExtrasConfig = ( argv, config ) => {
 };
 
 /**
+ * Generates empty host key files for the sftp container.
+ */
+const setSftpHostKeys = () => {
+	const dir = `${ dockerFolder }/data/sshd.keys`;
+	mkdirSync( dir, { recursive: true } );
+	for ( const filename of [ 'ssh_host_ed25519_key', 'ssh_host_rsa_key' ] ) {
+		const file = `${ dir }/${ filename }`;
+		if ( ! existsSync( file ) ) {
+			writeFileSync( file, '' );
+		}
+	}
+};
+
+/**
  * Generates required configuration files according to passed argv flags
  *
  * @param {object} argv - Argv
@@ -211,4 +225,5 @@ export function setConfig( argv ) {
 
 	setMappings( argv, config );
 	setExtrasConfig( argv, config );
+	setSftpHostKeys();
 }

--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -238,6 +238,16 @@ You can access WordPress and Jetpack files via SFTP server container.
 - Pass: `wordpress`
 - WordPress path: `/var/www/html`
 
+Note that the SSH host key changes each time the container is started, so you might consider one of these variants to avoid strict host key checking:
+
+```sh
+sftp -o NoHostAuthenticationForLocalhost=yes -P 1022 wordpress@localhost
+```
+
+```sh
+sftp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -P 1022 wordpress@localhost
+```
+
 You can tunnel to this container using [Ngrok](https://ngrok.com) or [other similar service](https://alternativeto.net/software/ngrok/). If you intend to do so, change the password in the `SFTP_USERS` variable in `./tools/docker/.env`!
 
 Tunnelling makes testing [Jetpack Backup & Scan](https://jetpack.com/support/backup/) possible. Read more from ["Using Ngrok with Jetpack"](#using-ngrok-with-jetpack) section below.

--- a/tools/docker/bin/sftp-make-keys.sh
+++ b/tools/docker/bin/sftp-make-keys.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -Eeo pipefail
+
+# The container will only create the keys if they don't exist, while in our setup
+# they'll always exist but may be zero size and have incorrect ownership.
+
+if [[ ! -s /etc/ssh/ssh_host_ed25519_key ]]; then
+	rm -f /etc/ssh/ssh_host_ed25519_key.tmp
+	ssh-keygen -t ed25519 -f /etc/ssh/ssh_host_ed25519_key.tmp -N ''
+	cat /etc/ssh/ssh_host_ed25519_key.tmp > /etc/ssh/ssh_host_ed25519_key
+	rm /etc/ssh/ssh_host_ed25519_key.tmp
+fi
+if [[ ! -s /etc/ssh/ssh_host_rsa_key ]]; then
+	rm -f /etc/ssh/ssh_host_rsa_key.tmp
+	ssh-keygen -t rsa -b 4096 -f /etc/ssh/ssh_host_rsa_key.tmp -N ''
+	cat /etc/ssh/ssh_host_rsa_key.tmp > /etc/ssh/ssh_host_rsa_key
+	rm /etc/ssh/ssh_host_rsa_key.tmp
+fi
+
+chown root:root /etc/ssh/ssh_host_ed25519_key
+chown root:root /etc/ssh/ssh_host_rsa_key

--- a/tools/docker/default.env
+++ b/tools/docker/default.env
@@ -35,7 +35,7 @@ MYSQL_ROOT_PASSWORD=wordpress
 #
 # Define multiple users separated by space
 #
-# Read more: https://github.com/atmoz/sftp
+# Read more: https://github.com/jmcombs/sftp
 #
 # If this site is or will be publicly accessible, change the password below (the middle part) to something unique and secure
 SFTP_USERS=wordpress:wordpress:1001

--- a/tools/docker/jetpack-docker-config-default.yml
+++ b/tools/docker/jetpack-docker-config-default.yml
@@ -47,6 +47,9 @@ dev:
           ## That avoids having to define them both here and in the "wordpress" service.
           - dockerdirectory:/usr/local/src/jetpack-monorepo/tools/docker
           - ./data/ssh.keys:/home/wordpress/.ssh/keys:ro
+          - ./bin/sftp-make-keys.sh:/etc/sftp.d/sftp-make-keys.sh
+          - ./data/sshd.keys/ssh_host_ed25519_key:/etc/ssh/ssh_host_ed25519_key
+          - ./data/sshd.keys/ssh_host_rsa_key:/etc/ssh/ssh_host_rsa_key
         ports:
           - '${PORT_SFTP:-1022}:22'
         env_file:

--- a/tools/docker/jetpack-docker-config-default.yml
+++ b/tools/docker/jetpack-docker-config-default.yml
@@ -41,7 +41,7 @@ dev:
 
       ## SFTP server running at localhost:1022
       sftp:
-        image: atmoz/sftp
+        image: jmcombs/sftp
         volumes:
           ## WordPress and its plugins and themes should be defined in volumeMappings in jetpack-docker-config-default.yml or jetpack-docker-config.yml, not here!
           ## That avoids having to define them both here and in the "wordpress" service.

--- a/tools/docker/jetpack-docker-config-default.yml
+++ b/tools/docker/jetpack-docker-config-default.yml
@@ -41,7 +41,7 @@ dev:
 
       ## SFTP server running at localhost:1022
       sftp:
-        image: jmcombs/sftp
+        image: jmcombs/sftp:alpine
         volumes:
           ## WordPress and its plugins and themes should be defined in volumeMappings in jetpack-docker-config-default.yml or jetpack-docker-config.yml, not here!
           ## That avoids having to define them both here and in the "wordpress" service.


### PR DESCRIPTION
This PR improves the compatibility with the apple silicon. 

I notice that Orbstack was showing me a warning that the previous version of the sft docker image we were using does not support apple silicone well. 

This PR fixes it by making the warning go away. 

## Proposed changes:
* Improve compatibility with apple silicon machines. 

### Other information:
- https://github.com/atmoz/sftp/issues/364 
- https://hub.docker.com/r/jmcombs/sftp ( the new image )

## Jetpack product discussion
none

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
run `jetpack docker up` does it still work as expected? 
