### PR TITLE
My Jetpack: Updating page horizontal tab position

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/index.tsx
@@ -1,3 +1,4 @@
+import { Container, Col } from '@automattic/jetpack-components';
 import { TabPanel } from '@wordpress/components';
 import { useCallback } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
@@ -26,7 +27,13 @@ export function MyJetpackTabPanel() {
 	);
 
 	const tabRenderer = useCallback( ( tab: { name: MyJetpackSection } ) => {
-		return <TabContent name={ tab.name } />;
+		return (
+			<Container horizontalSpacing={ 3 } horizontalGap={ 3 }>
+				<Col>
+					<TabContent name={ tab.name } />
+				</Col>
+			</Container>
+		);
 	}, [] );
 
 	// If the tab is not valid, use the default one.

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/styles.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/styles.module.scss
@@ -6,6 +6,9 @@
 		padding-inline-start: 2rem;
 		margin-block-end: -1px;
 
+		margin: 0 auto;
+		max-width: var(--max-container-width);
+
 		@media (max-width: $break-medium ) {
 			padding-inline-start: 1rem;
 		}
@@ -18,7 +21,6 @@
 
 .tab-content-wrapper {
 	padding-block-start: 2.5rem;
-	padding-inline: 3rem;
 
 	@media (max-width: $break-medium ) {
 		padding-inline: 1rem;

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-tab-panel-position
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-tab-panel-position
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+My Jetpack: Onboarding - Updated Tab panel to align with the main content.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes MYJP-139

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* updating tabs to align with the content

<img width="1986" alt="SCR-20250530-odbm" src="https://github.com/user-attachments/assets/90a810c1-15a4-48d8-ad98-7a3c95922689" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a JN site for the branch
* verify that on wide screen the tabs align with the content instead of aligning to the left

