### PR TITLE
STATS-39: Atomic site's help center shows curated messages.

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-stats-39-make-atomic-help-center-similar-to-others
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-stats-39-make-atomic-help-center-similar-to-others
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Very insignificant change.
+
+

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-wp-rest-help-center-search.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-wp-rest-help-center-search.php
@@ -33,12 +33,15 @@ class WP_REST_Help_Center_Search extends \WP_REST_Controller {
 				'callback'            => array( $this, 'get_search_results' ),
 				'permission_callback' => 'is_user_logged_in',
 				'args'                => array(
-					'query'  => array(
+					'query'   => array(
 						'type' => 'string',
 					),
-					'locale' => array(
+					'locale'  => array(
 						'type'    => 'string',
 						'default' => 'en',
+					),
+					'section' => array(
+						'type' => 'string',
 					),
 				),
 			)
@@ -51,14 +54,20 @@ class WP_REST_Help_Center_Search extends \WP_REST_Controller {
 	 * @param \WP_REST_Request $request    The request sent to the API.
 	 */
 	public function get_search_results( \WP_REST_Request $request ) {
-		$query  = $request['query'];
-		$locale = $request['locale'];
+		$query   = $request['query'];
+		$locale  = $request['locale'];
+		$section = $request['section'];
 
 		$query_parameters = array(
 			'query'  => $query,
 			'locale' => $locale,
 		);
-		$body             = Client::wpcom_json_api_request_as_user(
+
+		if ( ! empty( $section ) ) {
+			$query_parameters['section'] = $section;
+		}
+
+		$body = Client::wpcom_json_api_request_as_user(
 			'/help/search/wpcom?' . http_build_query( $query_parameters )
 		);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #STATS-39

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* The proxy help center API was not providing the `section` query param to WPCOM API. This PR adds it.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Follow the WoA Testing for a PR instruction in PCYsg-Osp-p2
* Open the help center by clicking on the '?' icon.
* The help center should show curated result based on the page.