### PR TITLE
My Jetpack: Onboarding i3 | Fix layout on wider screens

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/full-width-separator.tsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/full-width-separator.tsx
@@ -1,0 +1,14 @@
+import { clsx } from 'clsx';
+import styles from './styles.module.scss';
+
+/**
+ * Full Width Separator component that goes beyond the parent container.
+ *
+ * @param {React.HTMLAttributes< HTMLDivElement >} props - The component props.
+ * @return The rendered component.
+ */
+export function FullWidthSeparator( props: React.HTMLAttributes< HTMLDivElement > ) {
+	return (
+		<div { ...props } className={ clsx( styles[ 'full-width-separator' ], props.className ) }></div>
+	);
+}

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/help/content.tsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/help/content.tsx
@@ -1,6 +1,7 @@
 import { getRedirectUrl } from '@automattic/jetpack-components';
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { FullWidthSeparator } from '../full-width-separator';
 import { HelpCards } from './cards';
 import { HelpFooter } from './footer';
 import styles from './styles.module.scss';
@@ -36,6 +37,7 @@ export function HelpContent() {
 				</span>
 			</Button>
 			<HelpCards />
+			<FullWidthSeparator />
 			<HelpFooter />
 		</div>
 	);

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/help/styles.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/help/styles.module.scss
@@ -43,7 +43,6 @@
 .footer {
 	padding-top: 2.5rem;
 	padding-bottom: 3.5rem;
-	border-top: 1px solid var(--jp-gray);
 
 	// Ensure that the top border is full width
 	margin-inline: -3rem;

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/overview/content.tsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/overview/content.tsx
@@ -3,6 +3,7 @@ import { currentUserCan, isWoASite } from '@automattic/jetpack-script-data';
 import ConnectionsSection from '../../connections-section';
 import PlansSection from '../../plans-section';
 import ProductCardsSection from '../../product-cards-section';
+import { FullWidthSeparator } from '../full-width-separator';
 import { JetpackManageUpsell } from './jetpack-manage-upsell';
 import styles from './styles.module.scss';
 
@@ -24,6 +25,7 @@ export function OverviewContent() {
 				</div>
 			) : null }
 
+			<FullWidthSeparator />
 			<div className={ styles.footer }>
 				<Container horizontalSpacing={ 0 } className={ styles[ 'footer-container' ] }>
 					<Col sm={ 4 } md={ 4 } lg={ 6 }>

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/overview/styles.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/overview/styles.module.scss
@@ -11,7 +11,6 @@
 .footer {
 	padding-top: 2.5rem;
 	padding-bottom: 1.5rem;
-	border-top: 1px solid var(--jp-gray);
 
 	// Ensure that the top border is full width
 	margin-inline: -3rem;

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/styles.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/styles.module.scss
@@ -2,6 +2,9 @@
 
 .tab-panel {
 
+    max-width: var(--max-container-width);
+    margin: 0 auto;
+
 	// Make all the links green
 	a,
 	:global(.components-external-link),
@@ -10,16 +13,14 @@
 	}
 
 	:global(.components-tab-panel__tabs) {
+		position: relative;
+		z-index: 1;
 		padding-inline-start: 2rem;
 		margin-block-end: -1px;
 
 		@media (max-width: $break-medium ) {
 			padding-inline-start: 1rem;
 		}
-	}
-
-	:global(.components-tab-panel__tab-content) {
-		border-top: 1px solid var(--jp-gray);
 	}
 }
 
@@ -50,3 +51,10 @@
 	}
 }
 
+.full-width-separator {
+	border-top: 1px solid var(--jp-gray);
+	width: 100vw;
+	position: relative;
+	inset-inline: 50%;
+	margin-inline-start: -50vw;
+}

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/tab-content.tsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/tab-content.tsx
@@ -1,3 +1,4 @@
+import { FullWidthSeparator } from './full-width-separator';
 import { HelpContent } from './help/content';
 import { OverviewContent } from './overview/content';
 import { ProductsContent } from './products-content';
@@ -29,8 +30,11 @@ export function TabContent( { name }: TabContentProps ) {
 	}
 
 	return (
-		<div className={ styles[ 'tab-content-wrapper' ] }>
-			<ContentComponent />
-		</div>
+		<>
+			<FullWidthSeparator />
+			<div className={ styles[ 'tab-content-wrapper' ] }>
+				<ContentComponent />
+			</div>
+		</>
 	);
 }


### PR DESCRIPTION
We need to set the max width for My Jetpack and also make the whole UI center-aligned on wider screens

Supercedes #43696

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Create a `FullWidthSeparator` component to reuse it everywhere.
* Set the max width for the tab panel and center align it

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to My Jetpack on a wider screen
* Confirm that the layout is center aligned
* Confirm that the tab and footer separators work fine

<img width="1654" alt="Screenshot 2025-05-30 at 4 06 01 PM" src="https://github.com/user-attachments/assets/e9aa97a9-d613-43d1-bbe8-d7662a5c3c3b" />
<img width="1901" alt="Screenshot 2025-05-30 at 4 07 31 PM" src="https://github.com/user-attachments/assets/cd9fb2c3-b759-48de-ac48-4b0eccacc26e" />


