### PR TITLE
Boost: Ensure correct LCP element is extracted from buffer

### DIFF
--- a/projects/plugins/boost/changelog/fix-boost-lcp-optimizer-not-apply-attrs-correctly
+++ b/projects/plugins/boost/changelog/fix-boost-lcp-optimizer-not-apply-attrs-correctly
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: LCP: Changes to an unreleased feature.
+
+


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Increases accuracy on how the LCP element within the HTML processor is extracted

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
**Prerequisites:**

- Ensure https://github.com/Automattic/boost-cloud/pull/688 is checked out within Boost Cloud
- Latest Jetpack Boost Developer plugin installed and activated.
- Your local Boost Cloud is connected to your local WP instance.
- At least one Cornerstone Page set.
- Boost Feature Flag enabled within the install (`JETPACK_BOOST_DEVELOPMENT_FEATURES`)
- LCP Optimization feature enabled.

* Create 2 images on said Cornerstone Page.
* Ensure 1 is small, and is first.
* The 2nd is large enough to be the LCP on the page.
* Optimize the LCP.
* Ensure that the img tag element that has the LCP attributes applied is indeed the correct LCP element.

