### PR TITLE
Social: Hide preview modal if there are no connections

### DIFF
--- a/projects/js-packages/publicize-components/changelog/fix-social-hide-preview-with-no-connections
+++ b/projects/js-packages/publicize-components/changelog/fix-social-hide-preview-with-no-connections
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Social: Hide preview modal if there are no connections

--- a/projects/js-packages/publicize-components/src/components/social-post-modal/modal.tsx
+++ b/projects/js-packages/publicize-components/src/components/social-post-modal/modal.tsx
@@ -9,6 +9,7 @@ import { store as editorStore } from '@wordpress/editor';
 import { useCallback } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
 import { close } from '@wordpress/icons';
+import useSocialMediaConnections from '../../hooks/use-social-media-connections';
 import { store as socialStore } from '../../social-store';
 import { PreviewSection } from './preview-section';
 import { SettingsSection } from './settings-section';
@@ -57,6 +58,7 @@ export function SocialPostModal() {
 	const isModalOpen = useSelect( select => select( socialStore ).isSharePostModalOpen(), [] );
 	const { openSharePostModal, closeSharePostModal } = useDispatch( socialStore );
 	const { recordEvent } = useAnalytics();
+	const { hasConnections } = useSocialMediaConnections();
 	const isPostPublished = useSelect( select => select( editorStore ).isCurrentPostPublished(), [] );
 
 	const handleOpenModal = useCallback( () => {
@@ -73,6 +75,10 @@ export function SocialPostModal() {
 			removeJetpackEditorAction();
 		}
 	}, [ closeSharePostModal ] );
+
+	if ( ! hasConnections ) {
+		return null;
+	}
 
 	return (
 		<PanelRow className={ styles.panel }>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://linear.app/a8c/issue/SOCIAL-3/hide-the-preview-and-share-button-when-there-are-no-connections

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Return early in the modal if there are no connections

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://linear.app/a8c/issue/SOCIAL-3/hide-the-preview-and-share-button-when-there-are-no-connections
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Remove all your connections or switch to an account that has none.
* Make sure that in the editor for a shared post you do not see the Preview & Share modal 
* Now do the same with having connections and make sure the button is there

![CleanShot 2025-05-30 at 14 43 12 png](https://github.com/user-attachments/assets/1db424fa-8954-4a7f-9e6c-fa555991a27c)
