### PR TITLE
Forms: clarify Trash filtere as noun, not verb

### DIFF
--- a/projects/packages/forms/changelog/update-forms-dashboard-verbs
+++ b/projects/packages/forms/changelog/update-forms-dashboard-verbs
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: clarify Trash filtere as noun, not verb

--- a/projects/packages/forms/src/dashboard/components/InboxStatusToggle/index.js
+++ b/projects/packages/forms/src/dashboard/components/InboxStatusToggle/index.js
@@ -5,7 +5,7 @@ import {
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 } from '@wordpress/components';
 import { useEntityRecords } from '@wordpress/core-data';
-import { __, sprintf } from '@wordpress/i18n';
+import { __, _x, sprintf } from '@wordpress/i18n';
 import { useCallback } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import './style.scss';
@@ -50,7 +50,10 @@ export default function InboxStatusToggle( { currentQuery } ) {
 	const statusTabs = [
 		{ label: getTabLabel( __( 'Inbox', 'jetpack-forms' ), totalItemsInbox ), value: 'inbox' },
 		{ label: getTabLabel( __( 'Spam', 'jetpack-forms' ), totalItemsSpam ), value: 'spam' },
-		{ label: getTabLabel( __( 'Trash', 'jetpack-forms' ), totalItemsTrash ), value: 'trash' },
+		{
+			label: getTabLabel( _x( 'Trash', 'noun', 'jetpack-forms' ), totalItemsTrash ),
+			value: 'trash',
+		},
 	];
 
 	const handleChange = useCallback(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

I noticed Trash label was not translated, even if we should have translations for them:

<img width="858" alt="Screenshot 2025-05-30 at 18 33 32" src="https://github.com/user-attachments/assets/1d6a0816-ac9d-4ed9-95d5-f99770591194" />

<img width="438" alt="image" src="https://github.com/user-attachments/assets/0416a16e-5771-4dc8-b1ab-46bfb21c580c" />


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

