### PR TITLE
Jetpack Forms: enable dashboard migration menu and announcement page

### DIFF
--- a/projects/packages/forms/changelog/change-jetpack-forms-enable-dashboard-migration
+++ b/projects/packages/forms/changelog/change-jetpack-forms-enable-dashboard-migration
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: enable feature filters by default to migrate forms dashboard page and menu

--- a/projects/packages/forms/src/dashboard/admin-migrate-page/index.tsx
+++ b/projects/packages/forms/src/dashboard/admin-migrate-page/index.tsx
@@ -109,10 +109,10 @@ const AdminMigratePage = () => {
 					<Container>
 						<Col lg={ 12 } md={ 8 } sm={ 4 }>
 							<h1 style={ { fontSize: '2.5em', marginBottom: '0.5em' } }>
-								{ __( 'Forms moved', 'jetpack-forms' ) }
+								{ __( 'Forms Responses have moved', 'jetpack-forms' ) }
 							</h1>
 							<p style={ { fontSize: '1.7em', marginTop: '0.5em' } }>
-								{ __( "Now it's part of Jetpack → Forms", 'jetpack-forms' ) }
+								{ __( 'They can now be found at Jetpack → Forms', 'jetpack-forms' ) }
 							</p>
 							<p>
 								<Button variant="primary" onClick={ onCheckNewFormsClick }>

--- a/projects/packages/forms/src/dashboard/admin-migrate-page/index.tsx
+++ b/projects/packages/forms/src/dashboard/admin-migrate-page/index.tsx
@@ -109,7 +109,7 @@ const AdminMigratePage = () => {
 					<Container>
 						<Col lg={ 12 } md={ 8 } sm={ 4 }>
 							<h1 style={ { fontSize: '2.5em', marginBottom: '0.5em' } }>
-								{ __( 'Forms Responses have moved', 'jetpack-forms' ) }
+								{ __( 'Forms responses have moved', 'jetpack-forms' ) }
 							</h1>
 							<p style={ { fontSize: '1.7em', marginTop: '0.5em' } }>
 								{ __( 'They can now be found at Jetpack → Forms', 'jetpack-forms' ) }

--- a/projects/packages/forms/src/dashboard/class-dashboard-view-switch.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard-view-switch.php
@@ -353,7 +353,7 @@ CSS
 	 * @return boolean
 	 */
 	public static function is_jetpack_forms_admin_page_available() {
-		return apply_filters( 'jetpack_forms_use_new_menu_parent', false );
+		return apply_filters( 'jetpack_forms_use_new_menu_parent', true );
 	}
 
 	/**
@@ -362,7 +362,7 @@ CSS
 	 * @return boolean
 	 */
 	public static function is_jetpack_forms_view_switch_available() {
-		return ! apply_filters( 'jetpack_forms_retire_view_switch', false );
+		return ! apply_filters( 'jetpack_forms_retire_view_switch', true );
 	}
 
 	/**
@@ -371,7 +371,7 @@ CSS
 	 * @return boolean
 	 */
 	public static function is_jetpack_forms_announcing_new_menu() {
-		return apply_filters( 'jetpack_forms_announce_new_menu', false );
+		return apply_filters( 'jetpack_forms_announce_new_menu', true );
 	}
 
 	/**

--- a/projects/plugins/jetpack/changelog/change-jetpack-forms-enable-dashboard-migration
+++ b/projects/plugins/jetpack/changelog/change-jetpack-forms-enable-dashboard-migration
@@ -1,0 +1,4 @@
+Significance: minor
+Type: major
+
+Jetpack Forms: Feedback > Forms responses menu is being moved to Jetpack > Forms. The old menu now shows an announcement page with a link to the new location for forms responses.


### PR DESCRIPTION
Fixes FORMS-27

## Proposed changes:
This PR turns the feature filters default value so the new Jetpack > Forms menu is enabled and the announcement page is shown on the legacy Feedback > Forms responses page.

Before:
<img width="975" alt="image" src="https://github.com/user-attachments/assets/71a2a133-e3e0-4cf8-b89d-6b43f1ccec86" />


After:
<img width="973" alt="image" src="https://github.com/user-attachments/assets/d26ef453-8b5d-4989-8f35-812b096509e6" />

<img width="974" alt="image" src="https://github.com/user-attachments/assets/4f479c7d-a160-4320-a38b-f1047ee997d2" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
FORMS-27
p1748263145273509-slack-C052XEUUBL4

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Visit wp-admin area. See that Feedback > Form responses now show the migration announcement page. Use the button there to go to the new dashboard location.

See that a new submenu Jetpack > Forms exists and it takes you to the Forms dashboard inbox.

Verify you can rollback all these changes by turning the feature filters back to `false`:

```php
add_filter( 'jetpack_forms_use_new_menu_parent', '__return_false' );
add_filter( 'jetpack_forms_retire_view_switch', '__return_false' );
add_filter( 'jetpack_forms_announce_new_menu', '__return_false' );
```