### PR TITLE
Forms: add context to About tab translation

### DIFF
--- a/projects/packages/forms/changelog/update-forms-about-add-context
+++ b/projects/packages/forms/changelog/update-forms-about-add-context
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: add context to About tab translation

--- a/projects/packages/forms/src/dashboard/components/layout/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/layout/index.tsx
@@ -6,7 +6,7 @@ import { JetpackFooter, useBreakpointMatch } from '@automattic/jetpack-component
 import { shouldUseInternalLinks } from '@automattic/jetpack-shared-extension-utils';
 import { TabPanel } from '@wordpress/components';
 import { useCallback, useEffect, useMemo } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import clsx from 'clsx';
 import { Outlet, useLocation, useNavigate } from 'react-router-dom';
 /**
@@ -50,7 +50,7 @@ const Layout = ( {
 				: [] ),
 			{
 				name: 'about',
-				title: __( 'About', 'jetpack-forms' ),
+				title: _x( 'About', 'About Forms', 'jetpack-forms' ),
 			},
 		],
 		[ enableIntegrationsTab ]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

We realised "About" was translated "O Jetpack" in Russian:

![image](https://github.com/user-attachments/assets/570dee53-fffe-4c0d-8a29-7526d2f38c52)
![image](https://github.com/user-attachments/assets/f1f629a1-025c-4a63-b52b-0c79d4e30805)

"About" is "O" in Russian it seems:
![image](https://github.com/user-attachments/assets/72bdf027-a1ca-41d8-9d34-530e8bece3b7)

English version for reference:
![image](https://github.com/user-attachments/assets/0bfbe608-ac92-4ed8-8846-360103d30eb8)

Since the string is present also elsewhere for Jetpack ([link](https://plugins.trac.wordpress.org/browser/jetpack/trunk/_inc/lib/admin-pages/class.jetpack-admin-page.php#L363)), let's add context to our version for translation clarity.
 
Tab will keep saying "About" in English and other languages, this is purely just for translators to see.

Internal slack ref p1748625534207349-slack-C02AED43D

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Feedback
* See "About" tab