### PR TITLE
Jetpack Forms: store user option for migration announcement

### DIFF
--- a/projects/packages/forms/changelog/add-jetpack-forms-announce-migration-only-once
+++ b/projects/packages/forms/changelog/add-jetpack-forms-announce-migration-only-once
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Forms: once the migration page is shown and the user clicks on the new dashboard URL, update user option and not render the old menu entry anymore

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -77,7 +77,6 @@ class Jetpack_Forms {
 	 * @return boolean
 	 */
 	public static function is_legacy_menu_item_retired() {
-
 		$default                      = false; // Don't retire the legacy menu item by default.
 		$largest_legacy_connection_id = 245807300; // The connection ID after which the legacy menu item is retired.
 
@@ -85,6 +84,11 @@ class Jetpack_Forms {
 
 		if ( $connection_id > $largest_legacy_connection_id ) {
 			$default = true; // Retire the legacy menu item for connections after the specified ID.
+		}
+
+		// If the user has seen the migration announcement, also default to true.
+		if ( ! $default && get_user_option( 'jetpack_forms_migration_announcement_seen' ) ) {
+			$default = true;
 		}
 
 		return apply_filters( 'jetpack_forms_retire_legacy_menu_item', $default );

--- a/projects/packages/forms/src/dashboard/class-dashboard-view-switch.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard-view-switch.php
@@ -47,6 +47,9 @@ class Dashboard_View_Switch {
 			return;
 		}
 
+		$modern_view_url = $this->is_jetpack_forms_admin_page_available()
+			? 'admin.php?page=jetpack-forms-admin'
+			: add_query_arg( 'dashboard-preferred-view', self::MODERN_VIEW, 'admin.php?page=jetpack-forms' );
 		?>
 		<div id="jetpack-forms__view-link-wrap" class="hide-if-no-js screen-meta-toggle">
 			<button type="button" id="jetpack-forms__view-link" class="button show-settings" aria-expanded="false"><?php echo esc_html_x( 'View', 'View options to switch between', 'jetpack-forms' ); ?></button>
@@ -58,7 +61,7 @@ class Dashboard_View_Switch {
 						<strong><?php esc_html_e( 'Classic', 'jetpack-forms' ); ?></strong>
 						<?php esc_html_e( 'The classic WP-Admin WordPress interface.', 'jetpack-forms' ); ?>
 					</a>
-					<a class="jp-forms__view-switcher-button <?php echo $this->is_modern_view() ? 'is-active' : ''; ?>" href="<?php echo esc_url( add_query_arg( 'dashboard-preferred-view', self::MODERN_VIEW, 'admin.php?page=jetpack-forms' ) ); ?>">
+					<a class="jp-forms__view-switcher-button <?php echo $this->is_modern_view() ? 'is-active' : ''; ?>" href="<?php echo esc_url( $modern_view_url ); ?>">
 						<strong><?php esc_html_e( 'Inbox', 'jetpack-forms' ); ?></strong>
 						<?php esc_html_e( 'The new Jetpack Forms inbox interface for form responses.', 'jetpack-forms' ); ?>
 					</a>

--- a/projects/packages/forms/src/dashboard/class-dashboard-view-switch.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard-view-switch.php
@@ -37,7 +37,7 @@ class Dashboard_View_Switch {
 		add_filter( 'in_admin_header', array( $this, 'render_switch' ) );
 		add_action( 'admin_footer', array( $this, 'add_scripts' ) );
 		add_action( 'current_screen', array( $this, 'handle_preferred_view' ) );
-		add_action( 'current_screen', array( $this, 'update_user_seen_announcement' ) );
+		add_action( 'current_screen', array( $this, 'update_user_seen_announcement' ), 9 );
 	}
 
 	/**

--- a/projects/packages/forms/src/dashboard/class-dashboard-view-switch.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard-view-switch.php
@@ -37,6 +37,7 @@ class Dashboard_View_Switch {
 		add_filter( 'in_admin_header', array( $this, 'render_switch' ) );
 		add_action( 'admin_footer', array( $this, 'add_scripts' ) );
 		add_action( 'current_screen', array( $this, 'handle_preferred_view' ) );
+		add_action( 'current_screen', array( $this, 'update_user_seen_announcement' ) );
 	}
 
 	/**
@@ -256,6 +257,18 @@ CSS
 		if ( ! Jetpack_Forms::is_legacy_menu_item_retired() ) {
 			wp_safe_redirect( remove_query_arg( 'dashboard-preferred-view' ) );
 			exit( 0 );
+		}
+	}
+
+	/**
+	 * Update user seeing the announcement.
+	 */
+	public function update_user_seen_announcement() {
+		// phpcs:disable WordPress.Security.NonceVerification
+		if ( $this->is_jetpack_forms_admin_page() && isset( $_GET['jetpack_forms_migration_announcement_seen'] ) ) {
+			update_user_option( get_current_user_id(), 'jetpack_forms_migration_announcement_seen', true );
+			wp_safe_redirect( remove_query_arg( 'jetpack_forms_migration_announcement_seen', $this->get_forms_admin_url() ) );
+			exit;
 		}
 	}
 

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -225,8 +225,9 @@ class Dashboard {
 			'hasAI'                   => $has_ai,
 			'enableIntegrationsTab'   => self::$show_integrations,
 			'renderMigrationPage'     => $this->switch->is_jetpack_forms_announcing_new_menu(),
-			'dashboardURL'            => $this->switch->get_forms_admin_url(),
+			'dashboardURL'            => add_query_arg( 'jetpack_forms_migration_announcement_seen', 'yes', $this->switch->get_forms_admin_url() ),
 		);
+
 		if ( ! empty( $extra_config ) ) {
 			$config = array_merge( $config, $extra_config );
 		}


### PR DESCRIPTION
WIP

## Proposed changes:
This PR adds the mechanics to update user option `jetpack_forms_migration_announcement_seen` when clicking on the migration announcement page CTA. Based on that user option the legacy menu entry Feedback > Forms responses should not be added anymore.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1748619744457269-slack-C052XEUUBL4

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

Visit Feedback > Forms responses, the migration announcement page should render.

Click on the CTA button, you should land on the new dashboard location and the legacy menu item should not be available anymore.