### PR TITLE
Update default cookie expiration to match Core

### DIFF
--- a/projects/plugins/jetpack/changelog/update-38027
+++ b/projects/plugins/jetpack/changelog/update-38027
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Updated default cookie expiration from 30000000 to YEAR_IN_SECONDS to match recent WordPress Core changes

--- a/projects/plugins/jetpack/modules/subscriptions.php
+++ b/projects/plugins/jetpack/modules/subscriptions.php
@@ -861,7 +861,7 @@ class Jetpack_Subscriptions {
 		$post_id = (int) $post_id;
 
 		/** This filter is already documented in core/wp-includes/comment-functions.php */
-		$cookie_lifetime = apply_filters( 'comment_cookie_lifetime', 30000000 );
+		$cookie_lifetime = apply_filters( 'comment_cookie_lifetime', YEAR_IN_SECONDS );
 
 		/**
 		 * Filter the Jetpack Comment cookie path.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #38027 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

This PR updates the default value of the comment_cookie_lifetime filter from 30000000 to `YEAR_IN_SECONDS` in:
`projects/plugins/jetpack/modules/subscriptions.php`

The same update has already been applied to `comments/base.php` previously

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?

No, this PR does not introduce any changes to data collection, tracking, or usage

## Testing instructions:

_No special testing needed_
