### PR TITLE
My Jetpack: Products tab visibility for users without unowned products

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/index.tsx
@@ -1,6 +1,7 @@
 import { TabPanel } from '@wordpress/components';
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
+import useFilteredProducts from '../../hooks/use-filtered-products';
 import { MY_JETPACK_SECTION_OVERVIEW } from './constants';
 import styles from './styles.module.scss';
 import { TabContent } from './tab-content';
@@ -15,6 +16,22 @@ import { getMyJetpackSections, isValidMyJetpackSection } from './utils';
 export function MyJetpackTabPanel() {
 	const params = useParams();
 	const navigate = useNavigate();
+	const { filteredUnownedProducts, isLoading } = useFilteredProducts();
+
+	const showProductsTab = useMemo( () => {
+		return filteredUnownedProducts.length > 0 && ! isLoading;
+	}, [ filteredUnownedProducts.length, isLoading ] );
+
+	const availableTabs = useMemo(
+		() => getMyJetpackSections( showProductsTab ),
+		[ showProductsTab ]
+	);
+
+	// If the tab is not valid, use the default one.
+	const initialTab = useMemo( () => {
+		const validTab = isValidMyJetpackSection( params.section, showProductsTab );
+		return validTab ? params.section : MY_JETPACK_SECTION_OVERVIEW;
+	}, [ params.section, showProductsTab ] );
 
 	const onTabSelect = useCallback(
 		( tabName: string ) => {
@@ -29,11 +46,6 @@ export function MyJetpackTabPanel() {
 		return <TabContent name={ tab.name } />;
 	}, [] );
 
-	// If the tab is not valid, use the default one.
-	const initialTab = isValidMyJetpackSection( params.section )
-		? params.section
-		: MY_JETPACK_SECTION_OVERVIEW;
-
 	return (
 		<TabPanel
 			key={ initialTab }
@@ -41,7 +53,7 @@ export function MyJetpackTabPanel() {
 			initialTabName={ initialTab }
 			onSelect={ onTabSelect }
 			children={ tabRenderer }
-			tabs={ getMyJetpackSections() }
+			tabs={ availableTabs }
 		/>
 	);
 }

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/utils.ts
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/utils.ts
@@ -10,9 +10,10 @@ import {
 /**
  * Get the My Jetpack sections.
  *
+ * @param showProductsTab - Whether to show the products tab.
  * @return The sections for the My Jetpack tab panel.
  */
-export function getMyJetpackSections(): TabPanelProps[ 'tabs' ] {
+export function getMyJetpackSections( showProductsTab: boolean ): TabPanelProps[ 'tabs' ] {
 	const showAdminTab = currentUserCan( 'manage_options' );
 
 	const tabs = [
@@ -23,7 +24,6 @@ export function getMyJetpackSections(): TabPanelProps[ 'tabs' ] {
 		{
 			name: MY_JETPACK_SECTION_PRODUCTS,
 			title: __( 'Products', 'jetpack-my-jetpack' ),
-			isAdminOnly: true,
 		},
 		{
 			name: MY_JETPACK_SECTION_HELP,
@@ -31,15 +31,16 @@ export function getMyJetpackSections(): TabPanelProps[ 'tabs' ] {
 		},
 	];
 
-	return tabs.filter( tab => ! ( tab.isAdminOnly && ! showAdminTab ) );
+	return [ tabs[ 0 ], ...( showProductsTab && showAdminTab ? [ tabs[ 1 ] ] : [] ), tabs[ 2 ] ];
 }
 
 /**
  * Check if the given section is a valid My Jetpack section.
  *
- * @param section - The section to check.
+ * @param section         - The section to check.
+ * @param showProductsTab - Whether to show the products tab.
  * @return True if the section is valid, false otherwise.
  */
-export function isValidMyJetpackSection( section: string ) {
-	return getMyJetpackSections().some( item => item.name === section );
+export function isValidMyJetpackSection( section: string, showProductsTab: boolean ) {
+	return getMyJetpackSections( showProductsTab ).some( item => item.name === section );
 }

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-products-tab-visibility
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-products-tab-visibility
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+My Jetpack: Onboarding - Updated Products tab visiblity for users that own all products.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes MYJP-143

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* hide `Products` tab for users that own all products that would be displayed on this tab (this will be updated as part of the next project iteration)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Crate a JN site for this branch
* verify that you see content in the Products tab after connecting Jetpack
* purchase a complete plan and verify that you no longer see `Products` on the horizontal My Jetpack tab bar

