### PR TITLE
Forms: account for missing placeholder when transforming input fields to select dropdown and fix z-index

### DIFF
--- a/projects/packages/forms/src/blocks/shared/settings/transforms.js
+++ b/projects/packages/forms/src/blocks/shared/settings/transforms.js
@@ -129,22 +129,6 @@ const createTextFieldInnerBlocks = ( blockName, existingInnerBlocks = [] ) => {
 
 	const existingLabel = existingInnerBlocks.find( block => block.name === 'jetpack/label' );
 	const existingInput = existingInnerBlocks.find( block => block.name === 'jetpack/input' );
-	const existingInputAttributes = existingInput?.attributes ?? {};
-
-	if ( blockName === 'jetpack/field-select' ) {
-		/**
-		 * When transforming to a select field, add a default placeholder to the input block if none exists.
-		 * The select block's edit.js checks for the placeholder attribute on the input block,
-		 * and add the `has-placeholder` class to the field if it exists.
-		 * However if the incoming transformed block doesn't have a placeholder, the edit.js will
-		 * not add the class because it's trying to honor the placeholder attribute,
-		 * BUT adds a default placeholder anyway.
-		 */
-
-		if ( ! existingInputAttributes?.placeholder ) {
-			existingInputAttributes.placeholder = __( 'Select one option', 'jetpack-forms' );
-		}
-	}
 
 	return [
 		createBlock( 'jetpack/label', {
@@ -153,7 +137,7 @@ const createTextFieldInnerBlocks = ( blockName, existingInnerBlocks = [] ) => {
 			defaultLabel: config.defaultLabel,
 		} ),
 		createBlock( 'jetpack/input', {
-			...existingInputAttributes,
+			...( existingInput?.attributes || {} ),
 			type: config.type,
 		} ),
 	];
@@ -272,14 +256,40 @@ const transforms = {
 			blocks: [ 'jetpack/field-select' ],
 			transform: ( attributes, innerBlocks = [] ) => {
 				const optionLabels = getOptionLabelsFromInnerBlocks( innerBlocks );
-
 				return createBlock(
 					'jetpack/field-select',
 					{
 						...getFieldAttributes( attributes ),
 						options: optionLabels.length ? optionLabels : [ '' ],
 					},
-					createTextFieldInnerBlocks( 'jetpack/field-select', innerBlocks )
+					createTextFieldInnerBlocks(
+						'jetpack/field-select',
+						/**
+						 * When transforming to a select field, add a default placeholder in a non mutating way
+						 * to the input block if none exists.
+						 *
+						 * This is because the input block is created by the textFieldTransforms,
+						 * and we want to avoid mutating the original block.
+						 * The select block's edit.js checks for the placeholder attribute on the input block,
+						 * and add the `has-placeholder` class to the field if it exists.
+						 * However if the incoming transformed block doesn't have a placeholder, the edit.js will
+						 * not add the class because it's trying to honor the placeholder attribute,
+						 * BUT adds a default placeholder anyway.
+						 */
+						innerBlocks.map( block => {
+							if ( block.name === 'jetpack/input' ) {
+								return {
+									...block,
+									attributes: {
+										...block.attributes,
+										placeholder:
+											block?.attributes?.placeholder || __( 'Select one option', 'jetpack-forms' ),
+									},
+								};
+							}
+							return block;
+						} )
+					)
 				);
 			},
 		},

--- a/projects/packages/forms/src/blocks/shared/settings/transforms.js
+++ b/projects/packages/forms/src/blocks/shared/settings/transforms.js
@@ -129,6 +129,22 @@ const createTextFieldInnerBlocks = ( blockName, existingInnerBlocks = [] ) => {
 
 	const existingLabel = existingInnerBlocks.find( block => block.name === 'jetpack/label' );
 	const existingInput = existingInnerBlocks.find( block => block.name === 'jetpack/input' );
+	const existingInputAttributes = existingInput?.attributes ?? {};
+
+	if ( blockName === 'jetpack/field-select' ) {
+		/**
+		 * When transforming to a select field, add a default placeholder to the input block if none exists.
+		 * The select block's edit.js checks for the placeholder attribute on the input block,
+		 * and add the `has-placeholder` class to the field if it exists.
+		 * However if the incoming transformed block doesn't have a placeholder, the edit.js will
+		 * not add the class because it's trying to honor the placeholder attribute,
+		 * BUT adds a default placeholder anyway.
+		 */
+
+		if ( ! existingInputAttributes?.placeholder ) {
+			existingInputAttributes.placeholder = __( 'Select one option', 'jetpack-forms' );
+		}
+	}
 
 	return [
 		createBlock( 'jetpack/label', {
@@ -137,7 +153,7 @@ const createTextFieldInnerBlocks = ( blockName, existingInnerBlocks = [] ) => {
 			defaultLabel: config.defaultLabel,
 		} ),
 		createBlock( 'jetpack/input', {
-			...( existingInput?.attributes || {} ),
+			...existingInputAttributes,
 			type: config.type,
 		} ),
 	];
@@ -256,15 +272,12 @@ const transforms = {
 			blocks: [ 'jetpack/field-select' ],
 			transform: ( attributes, innerBlocks = [] ) => {
 				const optionLabels = getOptionLabelsFromInnerBlocks( innerBlocks );
-				const placeholder = attributes.placeholder ?? __( 'Select one option', 'jetpack-forms' );
 
 				return createBlock(
 					'jetpack/field-select',
 					{
 						...getFieldAttributes( attributes ),
 						options: optionLabels.length ? optionLabels : [ '' ],
-						placeholder,
-						className: placeholder ? 'has-placeholder' : '',
 					},
 					createTextFieldInnerBlocks( 'jetpack/field-select', innerBlocks )
 				);

--- a/projects/packages/forms/src/blocks/shared/settings/transforms.js
+++ b/projects/packages/forms/src/blocks/shared/settings/transforms.js
@@ -131,20 +131,6 @@ const createTextFieldInnerBlocks = ( blockName, existingInnerBlocks = [] ) => {
 	const existingInput = existingInnerBlocks.find( block => block.name === 'jetpack/input' );
 	const existingInputAttributes = existingInput?.attributes ?? {};
 
-	if ( blockName === 'jetpack/field-select' ) {
-		/**
-		 * When transforming to a select field, add a default placeholder to the input block if none exists.
-		 * The select block's edit.js checks for the placeholder attribute on the input block,
-		 * and add the `has-placeholder` class to the field if it exists.
-		 * However if the incoming transformed block doesn't have a placeholder, the edit.js will
-		 * not add the class, BUT adds a default placeholder anyway.
-		 */
-
-		if ( ! existingInputAttributes?.placeholder ) {
-			existingInputAttributes.placeholder = __( 'Select one option', 'jetpack-forms' );
-		}
-	}
-
 	return [
 		createBlock( 'jetpack/label', {
 			...( existingLabel?.attributes || {} ),
@@ -271,12 +257,15 @@ const transforms = {
 			blocks: [ 'jetpack/field-select' ],
 			transform: ( attributes, innerBlocks = [] ) => {
 				const optionLabels = getOptionLabelsFromInnerBlocks( innerBlocks );
+				const placeholder = attributes.placeholder ?? __( 'Select one option', 'jetpack-forms' );
 
 				return createBlock(
 					'jetpack/field-select',
 					{
 						...getFieldAttributes( attributes ),
 						options: optionLabels.length ? optionLabels : [ '' ],
+						placeholder,
+						className: placeholder ? 'has-placeholder' : '',
 					},
 					createTextFieldInnerBlocks( 'jetpack/field-select', innerBlocks )
 				);

--- a/projects/packages/forms/src/blocks/shared/settings/transforms.js
+++ b/projects/packages/forms/src/blocks/shared/settings/transforms.js
@@ -129,7 +129,6 @@ const createTextFieldInnerBlocks = ( blockName, existingInnerBlocks = [] ) => {
 
 	const existingLabel = existingInnerBlocks.find( block => block.name === 'jetpack/label' );
 	const existingInput = existingInnerBlocks.find( block => block.name === 'jetpack/input' );
-	const existingInputAttributes = existingInput?.attributes ?? {};
 
 	return [
 		createBlock( 'jetpack/label', {
@@ -138,7 +137,7 @@ const createTextFieldInnerBlocks = ( blockName, existingInnerBlocks = [] ) => {
 			defaultLabel: config.defaultLabel,
 		} ),
 		createBlock( 'jetpack/input', {
-			...existingInputAttributes,
+			...( existingInput?.attributes || {} ),
 			type: config.type,
 		} ),
 	];

--- a/projects/packages/forms/src/blocks/shared/settings/transforms.js
+++ b/projects/packages/forms/src/blocks/shared/settings/transforms.js
@@ -129,6 +129,21 @@ const createTextFieldInnerBlocks = ( blockName, existingInnerBlocks = [] ) => {
 
 	const existingLabel = existingInnerBlocks.find( block => block.name === 'jetpack/label' );
 	const existingInput = existingInnerBlocks.find( block => block.name === 'jetpack/input' );
+	const existingInputAttributes = existingInput?.attributes ?? {};
+
+	if ( blockName === 'jetpack/field-select' ) {
+		/**
+		 * When transforming to a select field, add a default placeholder to the input block if none exists.
+		 * The select block's edit.js checks for the placeholder attribute on the input block,
+		 * and add the `has-placeholder` class to the field if it exists.
+		 * However if the incoming transformed block doesn't have a placeholder, the edit.js will
+		 * not add the class, BUT adds a default placeholder anyway.
+		 */
+
+		if ( ! existingInputAttributes?.placeholder ) {
+			existingInputAttributes.placeholder = __( 'Select one option', 'jetpack-forms' );
+		}
+	}
 
 	return [
 		createBlock( 'jetpack/label', {
@@ -137,7 +152,7 @@ const createTextFieldInnerBlocks = ( blockName, existingInnerBlocks = [] ) => {
 			defaultLabel: config.defaultLabel,
 		} ),
 		createBlock( 'jetpack/input', {
-			...( existingInput?.attributes || {} ),
+			...existingInputAttributes,
 			type: config.type,
 		} ),
 	];

--- a/projects/packages/forms/src/blocks/shared/settings/transforms.js
+++ b/projects/packages/forms/src/blocks/shared/settings/transforms.js
@@ -277,11 +277,11 @@ const transforms = {
 						 * BUT adds a default placeholder anyway.
 						 */
 						innerBlocks.map( block => {
-							if ( block.name === 'jetpack/input' ) {
+							if ( block?.name === 'jetpack/input' ) {
 								return {
 									...block,
 									attributes: {
-										...block.attributes,
+										...( block?.attributes || {} ),
 										placeholder:
 											block?.attributes?.placeholder || __( 'Select one option', 'jetpack-forms' ),
 									},

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -470,7 +470,7 @@ class Contact_Form_Plugin {
 					$atts['inputstyles']   = $input_attrs['style'] ?? null;
 
 					if ( 'jetpack/field-select' === $block->name ) {
-						$atts['togglelabel'] = $inner_block['attrs']['placeholder'];
+						$atts['togglelabel'] = $atts['placeholder'];
 					}
 
 					/*

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -762,7 +762,7 @@ on production builds, the attributes are being reordered, causing side-effects
 	transform: translateY(-50%);
 	transition: all 150ms cubic-bezier(0.4, 0, 0.2, 1);
 	will-change: transform, top;
-	z-index: 2;
+	z-index: 1;
 }
 
 .contact-form .is-style-animated .grunion-field-wrap .grunion-label-text {
@@ -827,8 +827,7 @@ on production builds, the attributes are being reordered, causing side-effects
 }
 
 /* Ensure that */
-.contact-form .is-style-outlined .grunion-field:not(.contact-form__select-wrapper),
-.contact-form .is-style-animated .grunion-field:not(.contact-form__select-wrapper) {
+.contact-form .is-style-outlined .grunion-field:not(.contact-form__select-wrapper) {
 	z-index: 1;
 }
 

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -826,7 +826,7 @@ on production builds, the attributes are being reordered, causing side-effects
 	transform: translateY(0);
 }
 
-/* Ensure that */
+/* Ensure that the outlined field is not hidden by the absolutely positioned label */
 .contact-form .is-style-outlined .grunion-field:not(.contact-form__select-wrapper) {
 	z-index: 1;
 }

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -762,7 +762,7 @@ on production builds, the attributes are being reordered, causing side-effects
 	transform: translateY(-50%);
 	transition: all 150ms cubic-bezier(0.4, 0, 0.2, 1);
 	will-change: transform, top;
-	z-index: 3;
+	z-index: 2;
 }
 
 .contact-form .is-style-animated .grunion-field-wrap .grunion-label-text {
@@ -826,9 +826,10 @@ on production builds, the attributes are being reordered, causing side-effects
 	transform: translateY(0);
 }
 
-.contact-form .is-style-outlined .wp-block-jetpack-input:not(.contact-form__select-wrapper),
-.contact-form .is-style-animated .wp-block-jetpack-input:not(.contact-form__select-wrapper) {
-	z-index: 2;
+/* Ensure that */
+.contact-form .is-style-outlined .grunion-field:not(.contact-form__select-wrapper),
+.contact-form .is-style-animated .grunion-field:not(.contact-form__select-wrapper) {
+	z-index: 1;
 }
 
 .contact-form .is-style-below .grunion-field-wrap .below-label__label {


### PR DESCRIPTION
Fixes JETPACK-514

## Proposed changes:

We're doing a couple of things here:

1. In the Animated and Outlined styles, ensure that that the label is correctly positioned when transforming an input to a select dropdown field
2. In the Animated styles, fix the z-index values so that they don't interfere with the date calendar popover.



## Testing instructions:

### 1. Transforming inputs to selects

Insert a form and switch to the Outline style or Animated style

In the editor, transform an input that doesn't have a placeholder (e.g., name) to a dropdown field.

Save.

Ensure that the `has-placeholder` className appears on the field.

### Before

| Editor | Frontend |
|--------|--------|
| <img width="745" alt="Screenshot 2025-06-02 at 2 48 40 pm" src="https://github.com/user-attachments/assets/77b1061f-65ec-4207-a392-b3f2f6fabcae" /> | <img width="774" alt="Screenshot 2025-06-02 at 2 48 35 pm" src="https://github.com/user-attachments/assets/da6d869a-a5b2-4c92-93e2-f5693ec0893f" /> | 


### After

| Editor | Frontend |
|--------|--------|
| <img width="757" alt="Screenshot 2025-06-02 at 2 53 41 pm" src="https://github.com/user-attachments/assets/181c8ee4-40a7-48cd-9abc-6217c16f2901" /> | <img width="712" alt="Screenshot 2025-06-02 at 2 53 46 pm" src="https://github.com/user-attachments/assets/041c6b52-8b69-4738-ba48-bc6b8b89db26" /> | 


### 1. Animated z-index

Insert a form with several inputs and a data field. Switch to the Animated style.

In the frontend, check that date field calendar float above all field elements. 

Also check that the input field labels and input are always shown when selected and where there's input text.


### Before
<img width="422" alt="Screenshot 2025-06-02 at 2 58 41 pm" src="https://github.com/user-attachments/assets/82739e6d-062c-46f4-9ddd-6a2e15369aa1" />



### After
<img width="492" alt="Screenshot 2025-06-02 at 2 33 45 pm" src="https://github.com/user-attachments/assets/426bf570-3384-4d19-9c87-5877c11a181c" />

