### PR TITLE
My Jetpack: Fix products dataviews settings icon visibility on re-render

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/products-table-view/style.scss
+++ b/projects/packages/my-jetpack/_inc/components/products-table-view/style.scss
@@ -16,7 +16,7 @@ div.dataviews-wrapper {
         height: 52px;
     }
     
-    button[aria-controls="dataviews-view-config-dropdown-0"] {
+    button[aria-controls^="dataviews-view-config-dropdown-"] {
         display: none;
     }  
     

--- a/projects/packages/my-jetpack/changelog/fix-my-jetpack-dataviews-settings-button-visibility
+++ b/projects/packages/my-jetpack/changelog/fix-my-jetpack-dataviews-settings-button-visibility
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed products dataviews settings icon visibility on re-render.


### PR DESCRIPTION
Currently, if you

- Go to My Jetpack on a fresh JN site with a free plan.
- In the Discover section, click on "Learn more" for any product.
- Click on "Go back".

You will see the settings icon being visible for the Dataviews component

<img width="1094" alt="Screenshot 2025-06-02 at 1 17 09 PM" src="https://github.com/user-attachments/assets/f4bb3dd4-ae6c-4da9-a43e-8c3a99b20fc7" />

#### Reason:

We used this CSS selector to hide the settings button.

```css
button[aria-controls="dataviews-view-config-dropdown-0"]
```
That `id` comes from [here](https://github.com/WordPress/gutenberg/blob/0af268b6e7cb0e43aaf27378d0ac714d184c29f5/packages/dataviews/src/components/dataviews-view-config/index.tsx#L766-L769) and changes on subsequent re-renders and becomes:
- `dataviews-view-config-dropdown-1`
- `dataviews-view-config-dropdown-2`
- and so on

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Change the CSS selector for hiding the settings button in the Dataviews to make it begin with the `id` instead of doing a full comparison.

Fixes MYJP-144

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Go to My Jetpack on a fresh JN site with a free plan on this branch
- In the Discover section, click on "Learn more" for any product.
- Click on "Go back".
- Confirm that the settings icon is not visible

