### PR TITLE
My jetpack: Onboarding i3 | Fix layout and alignment issues

### DIFF
--- a/projects/js-packages/components/changelog/fix-my-jetpack-layout-and-alighment-issues
+++ b/projects/js-packages/components/changelog/fix-my-jetpack-layout-and-alighment-issues
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Added className prop to AdminPage component.

--- a/projects/js-packages/components/components/admin-page/index.tsx
+++ b/projects/js-packages/components/components/admin-page/index.tsx
@@ -20,6 +20,7 @@ import type React from 'react';
  */
 const AdminPage: React.FC< AdminPageProps > = ( {
 	children,
+	className,
 	moduleName = __( 'Jetpack', 'jetpack-components' ),
 	moduleNameHref,
 	showHeader = true,
@@ -37,7 +38,7 @@ const AdminPage: React.FC< AdminPageProps > = ( {
 		restApi.setApiNonce( apiNonce );
 	}, [ apiRoot, apiNonce ] );
 
-	const rootClassName = clsx( styles[ 'admin-page' ], {
+	const rootClassName = clsx( styles[ 'admin-page' ], className, {
 		[ styles.background ]: showBackground,
 	} );
 

--- a/projects/js-packages/components/components/admin-page/types.ts
+++ b/projects/js-packages/components/components/admin-page/types.ts
@@ -65,4 +65,9 @@ export type AdminPageProps = {
 	 * Optional menu items to be displayed
 	 */
 	optionalMenuItems?: JetpackFooterMenuItem[];
+
+	/**
+	 * Class name to be applied to the root element of the component.
+	 */
+	className?: string;
 };

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
@@ -169,6 +169,7 @@ export default function MyJetpackScreen() {
 			apiNonce={ apiNonce }
 			optionalMenuItems={ isDevVersion && userIsAdmin ? [ resetOptionsMenuItem ] : [] }
 			useInternalLinks={ shouldUseInternalLinks() }
+			className={ styles[ 'my-jetpack-screen' ] }
 		>
 			<h1 className="screen-reader-text">{ __( 'My Jetpack', 'jetpack-my-jetpack' ) }</h1>
 

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/styles.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/styles.module.scss
@@ -2,6 +2,18 @@
 
 .my-jetpack-screen {
 	overflow: hidden;
+
+	:global(.jp-admin-page-header) {
+		padding-inline: 0.5rem;
+
+		@include gb.break-medium {
+			padding-inline: 2rem;
+		}
+
+		@include gb.break-large {
+			padding-inline: 1.5rem;
+		}
+	}
 }
 
 .heading {

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/styles.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/styles.module.scss
@@ -1,7 +1,7 @@
 @use '@automattic/jetpack-base-styles/gutenberg-base-styles' as gb;
 
 .my-jetpack-screen {
-	overflow: hidden;
+	overflow-x: hidden;
 
 	:global(.jp-admin-page-header) {
 		padding-inline: 0.5rem;

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/styles.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/styles.module.scss
@@ -1,3 +1,9 @@
+@use '@automattic/jetpack-base-styles/gutenberg-base-styles' as gb;
+
+.my-jetpack-screen {
+	overflow: hidden;
+}
+
 .heading {
 	margin-bottom: 0;
 }

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/styles.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/styles.module.scss
@@ -19,7 +19,7 @@
 		margin-block-end: -1px;
 
 		@media (max-width: $break-medium ) {
-			padding-inline-start: 1rem;
+			padding-inline-start: 0.5rem;
 		}
 	}
 }
@@ -29,7 +29,7 @@
 	padding-inline: 3rem;
 
 	@media (max-width: $break-medium ) {
-		padding-inline: 1rem;
+		padding-inline: 1.5rem;
 	}
 }
 

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/styles.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/styles.module.scss
@@ -55,6 +55,6 @@
 	border-top: 1px solid var(--jp-gray);
 	width: 100vw;
 	position: relative;
-	inset-inline: 50%;
+	inset-inline-start: 50%;
 	margin-inline-start: -50vw;
 }


### PR DESCRIPTION
On the feature branch, we have some alignment and layout issues.

1. Extra space, which creates a horizontal scrollbar
    <img width="600" alt="Screenshot 2025-06-02 at 4 55 17 PM" src="https://github.com/user-attachments/assets/37d33f96-35c5-438d-971c-22b85bff5252" />
2. Jetpack logo and tabs are not aligned as per the design

| Design | Current UI |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/f0a4cb02-bfe3-47d2-9d75-cf9dfe597ceb) | ![image](https://github.com/user-attachments/assets/aa7b8a76-9f67-4918-99a1-108d07d137fa) | 

## Proposed changes:
- Fix the extra scrollable space by setting overflow `hidden` for My Jetpack screen
- Improve the alignment of Jetpack logo and tab sections

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to My Jetpack
* Confirm that there is no horizontal scrollbars
* Confirm that the Jetpack logo and tabs are aligned properly

<table>
    <tbody>
        <tr>
            <th>BEFORE</th>
            <th>AFTER</th>
        </tr>
        <tr>
            <th colspan="2">Scrollable space</th>
        </tr>
        <tr>
            <td><img width="1037" alt="Screenshot 2025-06-02 at 4 55 17 PM" src="https://github.com/user-attachments/assets/37d33f96-35c5-438d-971c-22b85bff5252" /></td>
            <td>
<img width="1033" alt="Screenshot 2025-06-02 at 4 56 21 PM" src="https://github.com/user-attachments/assets/2ed505bf-ed5e-4ee9-96b1-677d9ef3d578" />
</td>
        </tr>
        <tr>
            <th colspan="2">Alignments</th>
        </tr>
        <tr>
            <td>
<img width="670" alt="Screenshot 2025-06-02 at 4 50 50 PM" src="https://github.com/user-attachments/assets/e955dfcd-a917-4d6e-91cd-8a8c6ab4dfdf" />
</td>
            <td>
<img width="674" alt="Screenshot 2025-06-02 at 4 50 15 PM" src="https://github.com/user-attachments/assets/a01866e8-39af-4983-85c1-5be6e3980f36" />
</td>
        </tr>
        <tr>
            <td>
<img width="866" alt="Screenshot 2025-06-02 at 4 52 22 PM" src="https://github.com/user-attachments/assets/82d0b188-a98e-4365-99ba-d83a14596df6" />
</td>
            <td>
<img width="795" alt="Screenshot 2025-06-02 at 4 51 45 PM" src="https://github.com/user-attachments/assets/258da433-3043-4fe4-9a9c-c062933aaa76" />
</td>
        </tr>
        <tr>
            <td>
<img width="1260" alt="Screenshot 2025-06-02 at 4 53 21 PM" src="https://github.com/user-attachments/assets/3a97b894-2c1c-4ffe-acf2-73ff4233d2c9" />
</td>
            <td>
<img width="1265" alt="Screenshot 2025-06-02 at 4 52 59 PM" src="https://github.com/user-attachments/assets/c04b7766-e1c3-478b-bc18-f2591345e0da" />
</td>
        </tr>
    </tbody>
</table>

