### PR TITLE
My Jetpack: Replace deprecated sass APIs with alternatives

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/help/styles.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/help/styles.module.scss
@@ -1,4 +1,4 @@
-@import '@automattic/jetpack-base-styles/gutenberg-base-styles';
+@use '@automattic/jetpack-base-styles/gutenberg-base-styles' as gb;
 
 .content {
 
@@ -35,7 +35,7 @@
 	grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
 	gap: 1.5rem;
 
-	@media (max-width: $break-medium ) {
+	@media (max-width: gb.$break-medium ) {
 		grid-template-columns: 1fr;
 	}
 }
@@ -48,7 +48,7 @@
 	margin-inline: -3rem;
 	padding-inline: 3rem;
 
-	@media (max-width: $break-medium ) {
+	@media (max-width: gb.$break-medium ) {
 		margin-inline: -1rem;
 		padding-inline: 1rem;
 	}

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/overview/styles.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/overview/styles.module.scss
@@ -1,4 +1,4 @@
-@import '@automattic/jetpack-base-styles/gutenberg-base-styles';
+@use '@automattic/jetpack-base-styles/gutenberg-base-styles' as gb;
 
 .products {
 	margin-bottom: 3rem;
@@ -16,7 +16,7 @@
 	margin-inline: -3rem;
 	padding-inline: 3rem;
 
-	@media (max-width: $break-medium ) {
+	@media (max-width: gb.$break-medium ) {
 		margin-inline: -1rem;
 		padding-inline: 1rem;
 	}

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/styles.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/styles.module.scss
@@ -1,4 +1,4 @@
-@import '@automattic/jetpack-base-styles/gutenberg-base-styles';
+@use '@automattic/jetpack-base-styles/gutenberg-base-styles' as gb;
 
 .tab-panel {
 
@@ -18,7 +18,7 @@
 		padding-inline-start: 2rem;
 		margin-block-end: -1px;
 
-		@media (max-width: $break-medium ) {
+		@media (max-width: gb.$break-medium ) {
 			padding-inline-start: 0.5rem;
 		}
 	}
@@ -28,24 +28,24 @@
 	padding-block-start: 2.5rem;
 	padding-inline: 3rem;
 
-	@media (max-width: $break-medium ) {
+	@media (max-width: gb.$break-medium ) {
 		padding-inline: 1.5rem;
 	}
 }
 
 .my-jetpack-tab--content {
-	--my-jetpack-tab-description-color: #{$gray-700};
+	--my-jetpack-tab-description-color: #{gb.$gray-700};
 
 	h2 {
 
-		@include heading-2x-large;
+		@include gb.heading-2x-large;
 		margin-top: 0;
 		margin-bottom: 0.5rem;
 	}
 
 	.my-jetpack-tab--content-description {
 
-		@include body-medium;
+		@include gb.body-medium;
 		margin: 0;
 		color: var( --my-jetpack-tab-description-color );
 	}


### PR DESCRIPTION
While we worked on the feature branch, @anomiex replaced the deprecated sass APIs with their alternatives in #43607. So, just need to do the same.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Replace `@import` with `@use` in onboarding i3 changes.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to My Jetpack
* Confirm that everything is the same as before, especially the responsiveness of the UI.

