### PR TITLE
Atomic: Fix Jetpack menus on untangled screens

### DIFF
--- a/projects/plugins/wpcomsh/changelog/fix-jetpack-menus-on-atomic
+++ b/projects/plugins/wpcomsh/changelog/fix-jetpack-menus-on-atomic
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix Jetpack menu on untangled screens

--- a/projects/plugins/wpcomsh/class-jetpack-plugin-compatibility.php
+++ b/projects/plugins/wpcomsh/class-jetpack-plugin-compatibility.php
@@ -204,7 +204,13 @@ class Jetpack_Plugin_Compatibility {
 		add_filter(
 			'jetpack_my_jetpack_should_initialize',
 			function () {
+				$has_override = has_filter( 'pre_option_wpcom_admin_interface', 'wpcom_admin_interface_pre_get_option' );
+				remove_filter( 'pre_option_wpcom_admin_interface', 'wpcom_admin_interface_pre_get_option' );
 				$should_init = get_option( 'wpcom_admin_interface' ) === 'wp-admin';
+				if ( $has_override ) {
+					add_filter( 'pre_option_wpcom_admin_interface', 'wpcom_admin_interface_pre_get_option' );
+				}
+
 				if ( ! $should_init && class_exists( '\Automattic\Jetpack\My_Jetpack\Initializer' ) ) {
 					// My Jetpack REST API endpoints are used for more than just My Jetpack UI.
 					add_action( 'rest_api_init', array( '\Automattic\Jetpack\My_Jetpack\Initializer', 'register_rest_endpoints' ) ); // @phan-suppress-current-line PhanUndeclaredClassInCallable


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

On Atomic, when a user visits an untangled screen, the Jetpack menu contains the My Jetpack admin item. This PR fixes this issue by removing the Jetpack menu item depending on the `wpcom_admin_interface` option.

Fixes DOTOTHR-7

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Disable the wpcom_admin_interface filter when we register the Jetpack menu.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this wpcomsh to your atomic site
* Go to wp-admin > Pages
* Hover over the "Jetpack" menu and notice we don't have the "My Jetpack" item

