### PR TITLE
VideoPress: Fix more PHP notices

### DIFF
--- a/projects/packages/videopress/changelog/fix-videopress-more_PHP_notices
+++ b/projects/packages/videopress/changelog/fix-videopress-more_PHP_notices
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Catch PHP notices when handling unexpected data types.

--- a/projects/packages/videopress/src/utility-functions.php
+++ b/projects/packages/videopress/src/utility-functions.php
@@ -731,6 +731,9 @@ function videopress_get_attachment_url( $post_id ) {
  * @return string filtered content
  */
 function jetpack_videopress_flash_embed_filter( $content ) {
+	if ( ! is_string( $content ) ) {
+		return $content;
+	}
 	$regex   = '%<embed[^>]*+>(?:\s*</embed>)?%i';
 	$content = preg_replace_callback(
 		$regex,

--- a/projects/packages/videopress/src/utility-functions.php
+++ b/projects/packages/videopress/src/utility-functions.php
@@ -424,7 +424,7 @@ function videopress_is_attachment_without_guid( $post_id ) {
 function is_videopress_attachment( $post_id ) {
 	$post = get_post( $post_id );
 
-	if ( ! is_a( $post, 'WP_Post' ) ) {
+	if ( ! $post instanceof WP_Post ) {
 		return false;
 	}
 

--- a/projects/packages/videopress/src/utility-functions.php
+++ b/projects/packages/videopress/src/utility-functions.php
@@ -424,7 +424,7 @@ function videopress_is_attachment_without_guid( $post_id ) {
 function is_videopress_attachment( $post_id ) {
 	$post = get_post( $post_id );
 
-	if ( is_wp_error( $post ) ) {
+	if ( ! is_a( $post, 'WP_Post' ) ) {
 		return false;
 	}
 
@@ -731,6 +731,7 @@ function videopress_get_attachment_url( $post_id ) {
  * @return string filtered content
  */
 function jetpack_videopress_flash_embed_filter( $content ) {
+	// This receives data from the `the_content` filter, which unfortunately sometimes has bad content passed along as a param.
 	if ( ! is_string( $content ) ) {
 		return $content;
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This addresses two PHP notices:

1. This is triggered by the quite-common `the_content` filter, so it's good to safeguard this regardless.
```
PHP Deprecated: preg_replace_callback(): Passing null to parameter #3 ($subject) of type array|string is deprecated in /wordpress/plugins/jetpack/14.7-a.7/jetpack_vendor/automattic/jetpack-videopress/src/utility-functions.php on line 735
```

2. There was a check for `is_wp_error()` on a potential post object from [`get_post()`](https://developer.wordpress.org/reference/functions/get_post/), but failure returns `null`, not a `WP_Error`. I made it explicitly check for `WP_Post` instead.
```
PHP Warning: Attempt to read property "post_mime_type" on null in /wordpress/plugins/jetpack/14.7-a.7/jetpack_vendor/automattic/jetpack-videopress/src/utility-functions.php on line 431
```

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Make sure the checks are valid.
