### PR TITLE
coverage: Let Composer choose the correct version of phpunit/phpcov

### DIFF
--- a/.github/files/coverage-munger/composer.json
+++ b/.github/files/coverage-munger/composer.json
@@ -1,6 +1,6 @@
 {
 	"require-dev": {
 		"yoast/phpunit-polyfills": "^4.0.0",
-		"phpunit/phpcov": "^10.0.1"
+		"phpunit/phpcov": "*"
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
The version of phpunit/phpcov used has to match the version of PHPUnit used, otherwise things break. It looks like Composer will do the right thing if we use `*` as the version, thanks to phpcov depending on the corresponding version of phpunit, so let's do that.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1748872450893059-slack-CDLH4C1UZ

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Try running `jetpack test coverage` with various versions of PHP 8.2+ as `php`.
  * Earlier versions of PHP probably won't work for coverage, as we removed coverage configuration for PHPUnit <11 in #42517.
  * Note you may need to use the `--no-use-uncommitted-composer-lock` flag or do `jetpack clean all composer.lock` after changing PHP versions, or just use a clean checkout for each test.