### PR TITLE
Forms: Add preview and download file links

### DIFF
--- a/projects/packages/forms/changelog/update-forms-dashboard-file-upload-links
+++ b/projects/packages/forms/changelog/update-forms-dashboard-file-upload-links
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added a preview link to the response view for files

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -333,28 +333,34 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 							'items' => array(
 								'type'       => 'object',
 								'properties' => array(
-									'file_id' => array(
+									'file_id'        => array(
 										'type'        => 'integer',
 										'arg_options' => array(
 											'sanitize_callback' => 'sanitize_text_field',
 										),
 									),
-									'name'    => array(
+									'name'           => array(
 										'type'        => 'string',
 										'arg_options' => array(
 											'sanitize_callback' => 'sanitize_text_field',
 										),
 									),
-									'size'    => array(
+									'size'           => array(
 										'type'        => 'string',
 										'arg_options' => array(
 											'sanitize_callback' => 'sanitize_text_field',
 										),
 									),
-									'url'     => array(
+									'url'            => array(
 										'type'        => 'string',
 										'arg_options' => array(
 											'sanitize_callback' => 'esc_url_raw',
+										),
+									),
+									'is_previewable' => array(
+										'type'        => 'boolean',
+										'arg_options' => array(
+											'sanitize_callback' => 'rest_sanitize_boolean',
 										),
 									),
 								),
@@ -552,11 +558,12 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 							// this shouldn't happen, todo: log this
 							continue;
 						}
-						$file_id         = absint( $file['file_id'] );
-						$file['file_id'] = $file_id;
-						$file['size']    = size_format( $file['size'] );
-						$file['url']     = apply_filters( 'jetpack_unauth_file_download_url', '', $file_id );
-						$has_file        = true;
+						$file_id                = absint( $file['file_id'] );
+						$file['file_id']        = $file_id;
+						$file['size']           = size_format( $file['size'] );
+						$file['url']            = apply_filters( 'jetpack_unauth_file_download_url', '', $file_id );
+						$file['is_previewable'] = self::is_previewable_file( $file );
+						$has_file               = true;
 					}
 				}
 			}
@@ -565,6 +572,19 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 			$data['has_file'] = $has_file;
 		}
 		return rest_ensure_response( $data );
+	}
+	/**
+	 * Checks if the file is previewable based on its type or extension.
+	 *
+	 * @param array $file File data.
+	 * @return bool True if the file is previewable, false otherwise.
+	 */
+	private static function is_previewable_file( $file ) {
+		$file_type = strtolower( pathinfo( $file['name'], PATHINFO_EXTENSION ) );
+		// Check if the file is previewable based on its type or extension.
+		// Note: This is a simplified check and does not cover all possible image upload formats.
+		$previewable_types = array( 'jpg', 'jpeg', 'png', 'gif', 'webp' );
+		return in_array( $file_type, $previewable_types, true );
 	}
 
 	/**

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -582,8 +582,8 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 	private static function is_previewable_file( $file ) {
 		$file_type = strtolower( pathinfo( $file['name'], PATHINFO_EXTENSION ) );
 		// Check if the file is previewable based on its type or extension.
-		// Note: This is a simplified check and does not cover all possible image upload formats.
-		$previewable_types = array( 'jpg', 'jpeg', 'png', 'gif', 'webp', 'pdf' );
+		// Note: This is a simplified check and does not match if the file is allowed to be uploaded by the server.
+		$previewable_types = array( 'jpg', 'jpeg', 'png', 'gif', 'webp' );
 		return in_array( $file_type, $previewable_types, true );
 	}
 

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -583,7 +583,7 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 		$file_type = strtolower( pathinfo( $file['name'], PATHINFO_EXTENSION ) );
 		// Check if the file is previewable based on its type or extension.
 		// Note: This is a simplified check and does not cover all possible image upload formats.
-		$previewable_types = array( 'jpg', 'jpeg', 'png', 'gif', 'webp' );
+		$previewable_types = array( 'jpg', 'jpeg', 'png', 'gif', 'webp', 'pdf' );
 		return in_array( $file_type, $previewable_types, true );
 	}
 

--- a/projects/packages/forms/src/contact-form/css/file-field.css
+++ b/projects/packages/forms/src/contact-form/css/file-field.css
@@ -301,6 +301,7 @@
 	right: 3px;
 	border-radius: 50%;
 	background-color: var(--jetpack--contact-form--border-color, #333 );
+	filter: invert(0.7);
 }
 
 @media not (prefers-reduced-motion) {
@@ -354,8 +355,8 @@
 
 @keyframes jpShowFileField {
 
-	0% { 
-		transform: translate3d(0,-10px, 0) scale(.90); 
+	0% {
+		transform: translate3d(0,-10px, 0) scale(.90);
 		opacity:.5;
 	}
 

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
@@ -359,7 +359,7 @@ const SingleResponse = ( { sidePanelItem, setSidePanelItem, isLoadingData, isMob
 			title={ __( 'View response', 'jetpack-forms' ) }
 			size="medium"
 			onRequestClose={ onRequestClose }
-			style={ isChildModalOpen ? 'display:none' : '' }
+			style={ isChildModalOpen ? 'display:none' : null }
 		>
 			{ contents }
 		</Modal>

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
@@ -359,7 +359,6 @@ const SingleResponse = ( { sidePanelItem, setSidePanelItem, isLoadingData, isMob
 			title={ __( 'View response', 'jetpack-forms' ) }
 			size="medium"
 			onRequestClose={ onRequestClose }
-			style={ isChildModalOpen ? 'display:none' : null }
 		>
 			{ contents }
 		</Modal>

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
@@ -336,13 +336,10 @@ const SingleResponse = ( { sidePanelItem, setSidePanelItem, isLoadingData, isMob
 
 	const handleModalStateChange = useCallback(
 		isOpen => {
-			console.log( 'handleModalStateChange', isOpen );
 			setIsChildModalOpen( isOpen );
 		},
 		[ setIsChildModalOpen ]
 	);
-
-	console.log( 'SingleResponse', { handleModalStateChange } );
 
 	if ( ! sidePanelItem ) {
 		return null;

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
@@ -82,6 +82,7 @@ export default function InboxView() {
 	const [ searchParams, setSearchParams ] = useSearchParams();
 	const [ containerWidth, setContainerWidth ] = useState( 0 );
 	const [ queryArgs, setQueryArgs ] = useState( EMPTY_OBJECT );
+
 	const dateSettings = getDateSettings();
 	const containerRef = useResizeObserver(
 		resizeObserverEntries => {
@@ -325,13 +326,34 @@ export default function InboxView() {
 }
 
 const SingleResponse = ( { sidePanelItem, setSidePanelItem, isLoadingData, isMobile } ) => {
+	const [ isChildModalOpen, setIsChildModalOpen ] = useState( false );
+
 	const onRequestClose = useCallback( () => {
-		setSidePanelItem();
-	}, [ setSidePanelItem ] );
+		if ( ! isChildModalOpen ) {
+			setSidePanelItem();
+		}
+	}, [ setSidePanelItem, isChildModalOpen ] );
+
+	const handleModalStateChange = useCallback(
+		isOpen => {
+			console.log( 'handleModalStateChange', isOpen );
+			setIsChildModalOpen( isOpen );
+		},
+		[ setIsChildModalOpen ]
+	);
+
+	console.log( 'SingleResponse', { handleModalStateChange } );
+
 	if ( ! sidePanelItem ) {
 		return null;
 	}
-	const contents = <InboxResponse response={ sidePanelItem } isLoading={ isLoadingData } />;
+	const contents = (
+		<InboxResponse
+			response={ sidePanelItem }
+			isLoading={ isLoadingData }
+			onModalStateChange={ handleModalStateChange }
+		/>
+	);
 	if ( ! isMobile ) {
 		return <div className="jp-forms__inbox__dataviews-response">{ contents }</div>;
 	}
@@ -340,6 +362,7 @@ const SingleResponse = ( { sidePanelItem, setSidePanelItem, isLoadingData, isMob
 			title={ __( 'View response', 'jetpack-forms' ) }
 			size="medium"
 			onRequestClose={ onRequestClose }
+			style={ isChildModalOpen ? 'display:none' : '' }
 		>
 			{ contents }
 		</Modal>

--- a/projects/packages/forms/src/dashboard/inbox/response.js
+++ b/projects/packages/forms/src/dashboard/inbox/response.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { Button, ExternalLink } from '@wordpress/components';
+import { Button, ExternalLink, Modal } from '@wordpress/components';
 import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
 import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
@@ -19,38 +19,68 @@ const isFileUploadField = value => {
 	return value && typeof value === 'object' && 'files' in value && 'field_id' in value;
 };
 
-const renderFieldValue = value => {
-	if ( isFileUploadField( value ) ) {
-		return (
-			<div className="file-field">
-				{ value.files?.length
-					? value.files.map( ( file, index ) => {
-							return (
-								<div key={ index } className="file-field__item">
-									<Button variant="link" href={ file.url } target="_blank">
-										{ decodeEntities( file.name ) } | { file.size }
-									</Button>
-								</div>
-							);
-					  } )
-					: '-' }
-			</div>
-		);
-	}
+const InboxResponse = props => {
+	const { response, loading, onModalStateChange } = props;
 
-	// Emails
-	const emailRegex = /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i;
-	if ( emailRegex.test( value ) ) {
-		return <a href={ `mailto:${ value }` }>{ value }</a>;
-	}
-
-	return value;
-};
-
-const InboxResponse = ( { loading, response } ) => {
 	const [ emailCopied, setEmailCopied ] = useState( false );
+	const [ isPreviewModalOpen, setIsPreviewModalOpen ] = useState( false );
+	const [ previewFile, setPreviewFile ] = useState( null );
+	const [ isImageLoading, setIsImageLoading ] = useState( true );
 
 	const ref = useRef( undefined );
+
+	console.log( 'InboxResponse', { onModalStateChange, props } );
+
+	const openFilePreview = useCallback(
+		( file, e ) => {
+			e.preventDefault();
+
+			setPreviewFile( file );
+			setIsPreviewModalOpen( true );
+			onModalStateChange( true );
+		},
+		[ onModalStateChange, setPreviewFile, setIsPreviewModalOpen ]
+	);
+
+	const closePreviewModal = useCallback( () => {
+		setIsPreviewModalOpen( false );
+		setIsImageLoading( true );
+		// Notify parent component that this modal is closed
+		onModalStateChange( false );
+	}, [ onModalStateChange, setIsPreviewModalOpen, setIsImageLoading ] );
+
+	const renderFieldValue = value => {
+		if ( isFileUploadField( value ) ) {
+			return (
+				<div className="file-field">
+					{ value.files.map( ( file, index ) => {
+						return (
+							<div key={ index } className="file-field__item">
+								<span>
+									{ decodeEntities( file.name ) } | { file.size }
+								</span>
+								<Button
+									variant="link"
+									target="_blank"
+									onClick={ e => {
+										setIsImageLoading( true );
+										openFilePreview( file, e );
+									} }
+								>
+									{ __( 'Preview', 'jetpack-forms' ) }
+								</Button>
+
+								<Button variant="link" href={ file.url } target="_blank">
+									{ __( 'Download', 'jetpack-forms' ) }
+								</Button>
+							</div>
+						);
+					} ) }
+				</div>
+			);
+		}
+		return value;
+	};
 
 	useEffect( () => {
 		if ( ! ref.current ) {
@@ -140,6 +170,32 @@ const InboxResponse = ( { loading, response } ) => {
 					</div>
 				) ) }
 			</div>
+
+			{ isPreviewModalOpen && previewFile && (
+				<Modal
+					title={ decodeEntities( previewFile.name ) }
+					onRequestClose={ closePreviewModal }
+					className="jp-forms__inbox-file-preview-modal"
+				>
+					<div className="jp-forms__inbox-file-preview-container">
+						{ isImageLoading && (
+							<div className="jp-forms__inbox-file-loading">
+								<div className="components-spinner" />
+								<div className="jp-forms__inbox-file-loading-message">
+									{ __( 'Loading file preview…', 'jetpack-forms' ) }
+								</div>
+							</div>
+						) }
+						<img
+							src={ previewFile.preview_url || previewFile.url }
+							alt={ decodeEntities( previewFile.name ) }
+							onLoad={ () => setIsImageLoading( false ) }
+							className="jp-forms__inbox-file-preview-image"
+							style={ { display: isImageLoading ? 'none' : 'block' } }
+						/>
+					</div>
+				</Modal>
+			) }
 		</div>
 	);
 };

--- a/projects/packages/forms/src/dashboard/inbox/response.js
+++ b/projects/packages/forms/src/dashboard/inbox/response.js
@@ -64,9 +64,7 @@ const InboxResponse = ( { response, loading, onModalStateChange } ) => {
 	);
 
 	const handleFilePreview = useCallback(
-		file => {
-			return openFilePreview.bind( null, file );
-		},
+		file => openFilePreview.bind( null, file ),
 		[ openFilePreview ]
 	);
 

--- a/projects/packages/forms/src/dashboard/inbox/response.js
+++ b/projects/packages/forms/src/dashboard/inbox/response.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { Button, ExternalLink, Modal } from '@wordpress/components';
+import { Button, ExternalLink, Modal, Spinner } from '@wordpress/components';
 import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
 import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
@@ -19,9 +19,30 @@ const isFileUploadField = value => {
 	return value && typeof value === 'object' && 'files' in value && 'field_id' in value;
 };
 
-const InboxResponse = props => {
-	const { response, loading, onModalStateChange } = props;
+const PreviewImage = ( { file, isLoading, onImageLoaded } ) => {
+	return (
+		<div className="jp-forms__inbox-file-preview-container">
+			{ isLoading && (
+				<div className="jp-forms__inbox-file-loading">
+					<div className="components-spinner" />
+					<div className="jp-forms__inbox-file-loading-message">
+						<Spinner />
+						{ __( 'Loading file preview…', 'jetpack-forms' ) }
+					</div>
+				</div>
+			) }
+			<img
+				src={ file.preview_url || file.url }
+				alt={ decodeEntities( file.name ) }
+				onLoad={ onImageLoaded }
+				className="jp-forms__inbox-file-preview-image"
+				style={ { display: isLoading ? 'none' : 'block' } }
+			/>
+		</div>
+	);
+};
 
+const InboxResponse = ( { response, loading, onModalStateChange } ) => {
 	const [ emailCopied, setEmailCopied ] = useState( false );
 	const [ isPreviewModalOpen, setIsPreviewModalOpen ] = useState( false );
 	const [ previewFile, setPreviewFile ] = useState( null );
@@ -32,19 +53,30 @@ const InboxResponse = props => {
 	const openFilePreview = useCallback(
 		( file, e ) => {
 			e.preventDefault();
-
+			setIsImageLoading( true );
 			setPreviewFile( file );
 			setIsPreviewModalOpen( true );
-			onModalStateChange( true );
+			if ( onModalStateChange ) {
+				onModalStateChange( true );
+			}
 		},
 		[ onModalStateChange, setPreviewFile, setIsPreviewModalOpen ]
+	);
+
+	const handleFilePreview = useCallback(
+		file => {
+			return openFilePreview.bind( null, file );
+		},
+		[ openFilePreview ]
 	);
 
 	const closePreviewModal = useCallback( () => {
 		setIsPreviewModalOpen( false );
 		setIsImageLoading( true );
 		// Notify parent component that this modal is closed
-		onModalStateChange( false );
+		if ( onModalStateChange ) {
+			onModalStateChange( false );
+		}
 	}, [ onModalStateChange, setIsPreviewModalOpen, setIsImageLoading ] );
 
 	const renderFieldValue = value => {
@@ -54,23 +86,17 @@ const InboxResponse = props => {
 					{ value.files.map( ( file, index ) => {
 						return (
 							<div key={ index } className="file-field__item">
-								<span>
-									{ decodeEntities( file.name ) } | { file.size }
-								</span>
-								<Button
-									variant="link"
-									target="_blank"
-									onClick={ e => {
-										setIsImageLoading( true );
-										openFilePreview( file, e );
-									} }
-								>
-									{ __( 'Preview', 'jetpack-forms' ) }
-								</Button>
+								<span className="file-field__item-name">{ decodeEntities( file.name ) }</span>
+								<span className="file-field__item-actions">
+									<span>{ file.size }</span>
+									<Button variant="link" target="_blank" onClick={ handleFilePreview( file ) }>
+										{ __( 'Preview', 'jetpack-forms' ) }
+									</Button>
 
-								<Button variant="link" href={ file.url } target="_blank">
-									{ __( 'Download', 'jetpack-forms' ) }
-								</Button>
+									<Button variant="link" href={ file.url } target="_blank">
+										{ __( 'Download', 'jetpack-forms' ) }
+									</Button>
+								</span>
 							</div>
 						);
 					} ) }
@@ -94,6 +120,10 @@ const InboxResponse = props => {
 		setTimeout( () => setEmailCopied( false ), 3000 );
 	}, [ response, setEmailCopied ] );
 
+	const handelImageLoaded = useCallback( () => {
+		return setIsImageLoading( false );
+	}, [ setIsImageLoading ] );
+
 	if ( ! loading && ! response ) {
 		return null;
 	}
@@ -104,6 +134,15 @@ const InboxResponse = props => {
 		'is-name': response && response.author_name,
 	} );
 
+	if ( isPreviewModalOpen && ! onModalStateChange ) {
+		return (
+			<PreviewImage
+				file={ previewFile }
+				isLoading={ isImageLoading }
+				onImageLoaded={ handelImageLoaded }
+			/>
+		);
+	}
 	return (
 		<div ref={ ref } className="jp-forms__inbox-response">
 			<div className="jp-forms__inbox-response-avatar">
@@ -169,29 +208,17 @@ const InboxResponse = props => {
 				) ) }
 			</div>
 
-			{ isPreviewModalOpen && previewFile && (
+			{ isPreviewModalOpen && previewFile && onModalStateChange && (
 				<Modal
 					title={ decodeEntities( previewFile.name ) }
 					onRequestClose={ closePreviewModal }
 					className="jp-forms__inbox-file-preview-modal"
 				>
-					<div className="jp-forms__inbox-file-preview-container">
-						{ isImageLoading && (
-							<div className="jp-forms__inbox-file-loading">
-								<div className="components-spinner" />
-								<div className="jp-forms__inbox-file-loading-message">
-									{ __( 'Loading file preview…', 'jetpack-forms' ) }
-								</div>
-							</div>
-						) }
-						<img
-							src={ previewFile.preview_url || previewFile.url }
-							alt={ decodeEntities( previewFile.name ) }
-							onLoad={ () => setIsImageLoading( false ) }
-							className="jp-forms__inbox-file-preview-image"
-							style={ { display: isImageLoading ? 'none' : 'block' } }
-						/>
-					</div>
+					<PreviewImage
+						file={ previewFile }
+						isLoading={ isImageLoading }
+						onImageLoaded={ handelImageLoaded }
+					/>
 				</Modal>
 			) }
 		</div>

--- a/projects/packages/forms/src/dashboard/inbox/response.js
+++ b/projects/packages/forms/src/dashboard/inbox/response.js
@@ -32,7 +32,7 @@ const PreviewImage = ( { file, isLoading, onImageLoaded } ) => {
 				</div>
 			) }
 			<img
-				src={ file.preview_url || file.url }
+				src={ file.url }
 				alt={ decodeEntities( file.name ) }
 				onLoad={ onImageLoaded }
 				className="jp-forms__inbox-file-preview-image"
@@ -89,9 +89,12 @@ const InboxResponse = ( { response, loading, onModalStateChange } ) => {
 								<span className="file-field__item-name">{ decodeEntities( file.name ) }</span>
 								<span className="file-field__item-actions">
 									<span>{ file.size }</span>
-									<Button variant="link" target="_blank" onClick={ handleFilePreview( file ) }>
-										{ __( 'Preview', 'jetpack-forms' ) }
-									</Button>
+
+									{ file.is_previewable && (
+										<Button variant="link" target="_blank" onClick={ handleFilePreview( file ) }>
+											{ __( 'Preview', 'jetpack-forms' ) }
+										</Button>
+									) }
 
 									<Button variant="link" href={ file.url } target="_blank">
 										{ __( 'Download', 'jetpack-forms' ) }

--- a/projects/packages/forms/src/dashboard/inbox/response.js
+++ b/projects/packages/forms/src/dashboard/inbox/response.js
@@ -65,14 +65,14 @@ const FileField = ( { file, onClick, key } ) => {
 							{ decodeEntities( file.name ) }
 						</ExternalLink>
 					) }
-				</div>
-				<div className="file-field__meta-info">
-					{ sprintf(
-						/* translators: %1$s size of the file and %2$s is the file extension */
-						__( '%1$s, %2$s', 'jetpack-forms' ),
-						file.size,
-						extension
-					) }
+					<div className="file-field__meta-info">
+						{ sprintf(
+							/* translators: %1$s size of the file and %2$s is the file extension */
+							__( '%1$s, %2$s', 'jetpack-forms' ),
+							file.size,
+							extension
+						) }
+					</div>
 				</div>
 			</div>
 			<span className="file-field__item-actions">

--- a/projects/packages/forms/src/dashboard/inbox/response.js
+++ b/projects/packages/forms/src/dashboard/inbox/response.js
@@ -1,11 +1,12 @@
 /**
  * External dependencies
  */
-import { Button, ExternalLink, Modal, Spinner } from '@wordpress/components';
+import { Button, ExternalLink, Modal, Tooltip, Spinner, Icon } from '@wordpress/components';
 import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
 import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __, sprintf } from '@wordpress/i18n';
+import { download } from '@wordpress/icons';
 import clsx from 'clsx';
 import { map } from 'lodash';
 import { getPath } from './utils';
@@ -119,23 +120,29 @@ const InboxResponse = ( { response, loading, onModalStateChange } ) => {
 						if ( ! file || ! file.name ) {
 							return null;
 						}
+						const extension = file.name.split( '.' ).pop().toLowerCase();
 						return (
 							<div key={ index } className="file-field__item">
-								<span className="file-field__item-name">{ decodeEntities( file.name ) }</span>
+								<div className="file-field__info">
+									<div className="file-field__name">
+										{ file.is_previewable && (
+											<Button target="_blank" variant="link" onClick={ handleFilePreview( file ) }>
+												{ decodeEntities( file.name ) }
+											</Button>
+										) }
+										{ ! file.is_previewable && (
+											<ExternalLink href="#">{ decodeEntities( file.name ) }</ExternalLink>
+										) }
+									</div>
+									<span className="file-field__size">{ file.size }</span>
+									<span className="file-field__extenstion">{ extension }</span>
+								</div>
 								<span className="file-field__item-actions">
-									<span>{ file.size }</span>
-
-									{ file.is_previewable && (
-										<Button target="_blank" variant="link" onClick={ handleFilePreview( file ) }>
-											{ __( 'Preview', 'jetpack-forms' ) }
+									<Tooltip text={ __( 'Download', 'jetpack-forms' ) }>
+										<Button variant="secondary" href={ file.url } target="_blank">
+											<Icon icon={ download } />
 										</Button>
-									) }
-
-									{ file.url && (
-										<Button variant="link" href={ file.url } target="_blank">
-											{ __( 'Download', 'jetpack-forms' ) }
-										</Button>
-									) }
+									</Tooltip>
 								</span>
 							</div>
 						);

--- a/projects/packages/forms/src/dashboard/inbox/response.js
+++ b/projects/packages/forms/src/dashboard/inbox/response.js
@@ -29,8 +29,6 @@ const InboxResponse = props => {
 
 	const ref = useRef( undefined );
 
-	console.log( 'InboxResponse', { onModalStateChange, props } );
-
 	const openFilePreview = useCallback(
 		( file, e ) => {
 			e.preventDefault();

--- a/projects/packages/forms/src/dashboard/inbox/response.js
+++ b/projects/packages/forms/src/dashboard/inbox/response.js
@@ -20,18 +20,9 @@ const isFileUploadField = value => {
 	return value && typeof value === 'object' && 'files' in value && 'field_id' in value;
 };
 
-const isFilePdf = file => {
-	return file.name?.toLowerCase().endsWith( '.pdf' ) || file.type === 'application/pdf';
-};
-
 const PreviewFile = ( { file, isLoading, onImageLoaded } ) => {
-	const isPdf = isFilePdf( file );
 	const imageClass = clsx( 'jp-forms__inbox-file-preview-container', {
 		'is-loading': isLoading,
-	} );
-
-	const iframeClass = clsx( 'jp-forms__inbox-file-preview-container-iframe', {
-		'is-loading': false,
 	} );
 
 	return (
@@ -45,27 +36,52 @@ const PreviewFile = ( { file, isLoading, onImageLoaded } ) => {
 				</div>
 			) }
 
-			{ isPdf ? (
-				<div className={ iframeClass }>
-					<iframe
-						src={ file.url + '&preview=true' }
-						className="jp-forms__inbox-file-preview-iframe"
-						height={ '70vh' }
-						width={ '100%' }
-						title={ decodeEntities( file.name ) }
-						onLoad={ onImageLoaded }
-					/>
+			<div className={ imageClass }>
+				<img
+					src={ file.url }
+					alt={ decodeEntities( file.name ) }
+					onLoad={ onImageLoaded }
+					className="jp-forms__inbox-file-preview-image"
+				/>
+			</div>
+		</div>
+	);
+};
+
+const FileField = ( { file, onClick, key } ) => {
+	const extension = file.name.split( '.' ).pop().toUpperCase();
+	return (
+		<div key={ key } className="file-field__item">
+			<div className="file-field__info">
+				<div className="file-field__icon"></div>
+				<div className="file-field__name">
+					{ file.is_previewable && (
+						<Button target="_blank" variant="link" onClick={ onClick }>
+							{ decodeEntities( file.name ) }
+						</Button>
+					) }
+					{ ! file.is_previewable && (
+						<ExternalLink href={ file.url + '?preview=true' }>
+							{ decodeEntities( file.name ) }
+						</ExternalLink>
+					) }
 				</div>
-			) : (
-				<div className={ imageClass }>
-					<img
-						src={ file.url }
-						alt={ decodeEntities( file.name ) }
-						onLoad={ onImageLoaded }
-						className="jp-forms__inbox-file-preview-image"
-					/>
+				<div className="file-field__meta-info">
+					{ sprintf(
+						/* translators: %1$s size of the file and %2$s is the file extension */
+						__( '%1$s, %2$s', 'jetpack-forms' ),
+						file.size,
+						extension
+					) }
 				</div>
-			) }
+			</div>
+			<span className="file-field__item-actions">
+				<Tooltip text={ __( 'Download', 'jetpack-forms' ) }>
+					<Button variant="secondary" href={ file.url } target="_blank">
+						<Icon icon={ download } />
+					</Button>
+				</Tooltip>
+			</span>
 		</div>
 	);
 };
@@ -79,15 +95,7 @@ const InboxResponse = ( { response, loading, onModalStateChange } ) => {
 	const ref = useRef( undefined );
 
 	const openFilePreview = useCallback(
-		( file, e ) => {
-			e.preventDefault();
-
-			const isSafari = window.safari !== undefined;
-			if ( isSafari && isFilePdf( file ) ) {
-				window.open( file.url + '&preview=true', 'pdf', 'popup' );
-				return;
-			}
-
+		file => {
 			setIsImageLoading( true );
 			setPreviewFile( file );
 			setIsPreviewModalOpen( true );
@@ -116,40 +124,26 @@ const InboxResponse = ( { response, loading, onModalStateChange } ) => {
 		if ( isFileUploadField( value ) ) {
 			return (
 				<div className="file-field">
-					{ value.files.map( ( file, index ) => {
-						if ( ! file || ! file.name ) {
-							return null;
-						}
-						const extension = file.name.split( '.' ).pop().toLowerCase();
-						return (
-							<div key={ index } className="file-field__item">
-								<div className="file-field__info">
-									<div className="file-field__name">
-										{ file.is_previewable && (
-											<Button target="_blank" variant="link" onClick={ handleFilePreview( file ) }>
-												{ decodeEntities( file.name ) }
-											</Button>
-										) }
-										{ ! file.is_previewable && (
-											<ExternalLink href="#">{ decodeEntities( file.name ) }</ExternalLink>
-										) }
-									</div>
-									<span className="file-field__size">{ file.size }</span>
-									<span className="file-field__extenstion">{ extension }</span>
-								</div>
-								<span className="file-field__item-actions">
-									<Tooltip text={ __( 'Download', 'jetpack-forms' ) }>
-										<Button variant="secondary" href={ file.url } target="_blank">
-											<Icon icon={ download } />
-										</Button>
-									</Tooltip>
-								</span>
-							</div>
-						);
-					} ) }
+					{ value.files?.length
+						? value.files.map( ( file, index ) => {
+								if ( ! file || ! file.name ) {
+									return null;
+								}
+								return (
+									<FileField file={ file } onClick={ handleFilePreview( file ) } key={ index } />
+								);
+						  } )
+						: '-' }
 				</div>
 			);
 		}
+
+		// Emails
+		const emailRegex = /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i;
+		if ( emailRegex.test( value ) ) {
+			return <a href={ `mailto:${ value }` }>{ value }</a>;
+		}
+
 		return value;
 	};
 

--- a/projects/packages/forms/src/dashboard/inbox/response.js
+++ b/projects/packages/forms/src/dashboard/inbox/response.js
@@ -49,11 +49,44 @@ const PreviewFile = ( { file, isLoading, onImageLoaded } ) => {
 };
 
 const FileField = ( { file, onClick, key } ) => {
-	const extension = file.name.split( '.' ).pop().toUpperCase();
+	const fileExtension = file.name.split( '.' ).pop().toLowerCase();
+	const fileType = file.type.split( '/' )[ 0 ];
+
+	const iconMap = {
+		image: 'png',
+		video: 'mp4',
+		audio: 'mp3',
+		document: 'pdf',
+		application: 'txt',
+	};
+
+	const extensionMap = {
+		pdf: 'pdf',
+		png: 'png',
+		jpg: 'png',
+		jpeg: 'png',
+		gif: 'png',
+		mp4: 'mp4',
+		mp3: 'mp3',
+		webm: 'webm',
+		doc: 'doc',
+		docx: 'doc',
+		txt: 'txt',
+		ppt: 'ppt',
+		pptx: 'ppt',
+		xls: 'xls',
+		xlsx: 'xls',
+		csv: 'xls',
+		zip: 'zip',
+		sql: 'sql',
+		cal: 'cal',
+	};
+	const iconType = extensionMap[ fileExtension ] || iconMap[ fileType ] || 'txt';
+	const iconClass = clsx( 'file-field__icon', 'icon-' + iconType );
 	return (
 		<div key={ key } className="file-field__item">
 			<div className="file-field__info">
-				<div className="file-field__icon"></div>
+				<div className={ iconClass }></div>
 				<div className="file-field__name">
 					{ file.is_previewable && (
 						<Button target="_blank" variant="link" onClick={ onClick }>
@@ -61,7 +94,7 @@ const FileField = ( { file, onClick, key } ) => {
 						</Button>
 					) }
 					{ ! file.is_previewable && (
-						<ExternalLink href={ file.url + '?preview=true' }>
+						<ExternalLink href={ file.url + '&preview=true' }>
 							{ decodeEntities( file.name ) }
 						</ExternalLink>
 					) }
@@ -70,7 +103,7 @@ const FileField = ( { file, onClick, key } ) => {
 							/* translators: %1$s size of the file and %2$s is the file extension */
 							__( '%1$s, %2$s', 'jetpack-forms' ),
 							file.size,
-							extension
+							fileExtension.toUpperCase()
 						) }
 					</div>
 				</div>

--- a/projects/packages/forms/src/dashboard/inbox/response.js
+++ b/projects/packages/forms/src/dashboard/inbox/response.js
@@ -19,23 +19,52 @@ const isFileUploadField = value => {
 	return value && typeof value === 'object' && 'files' in value && 'field_id' in value;
 };
 
-const PreviewImage = ( { file, isLoading, onImageLoaded } ) => {
+const isFilePdf = file => {
+	return file.name?.toLowerCase().endsWith( '.pdf' ) || file.type === 'application/pdf';
+};
+
+const PreviewFile = ( { file, isLoading, onImageLoaded } ) => {
+	const isPdf = isFilePdf( file );
+	const imageClass = clsx( 'jp-forms__inbox-file-preview-container', {
+		'is-loading': isLoading,
+	} );
+
+	const iframeClass = clsx( 'jp-forms__inbox-file-preview-container-iframe', {
+		'is-loading': false,
+	} );
+
 	return (
-		<div className="jp-forms__inbox-file-preview-container">
+		<div className="jp-forms__inbox-file-preview-shell">
 			{ isLoading && (
 				<div className="jp-forms__inbox-file-loading">
 					<Spinner className="jp-forms__inbox-spinner" />
-					<div className="jp-forms__inbox-file-loading-message">
+					<div className="jp-forms__inbox-file-loading-message ">
 						{ __( 'Loading preview…', 'jetpack-forms' ) }
 					</div>
 				</div>
 			) }
-			<img
-				src={ file.url }
-				alt={ decodeEntities( file.name ) }
-				onLoad={ onImageLoaded }
-				className="jp-forms__inbox-file-preview-image"
-			/>
+
+			{ isPdf ? (
+				<div className={ iframeClass }>
+					<iframe
+						src={ file.url + '&preview=true' }
+						className="jp-forms__inbox-file-preview-iframe"
+						height={ '70vh' }
+						width={ '100%' }
+						title={ decodeEntities( file.name ) }
+						onLoad={ onImageLoaded }
+					/>
+				</div>
+			) : (
+				<div className={ imageClass }>
+					<img
+						src={ file.url }
+						alt={ decodeEntities( file.name ) }
+						onLoad={ onImageLoaded }
+						className="jp-forms__inbox-file-preview-image"
+					/>
+				</div>
+			) }
 		</div>
 	);
 };
@@ -51,6 +80,13 @@ const InboxResponse = ( { response, loading, onModalStateChange } ) => {
 	const openFilePreview = useCallback(
 		( file, e ) => {
 			e.preventDefault();
+
+			const isSafari = window.safari !== undefined;
+			if ( isSafari && isFilePdf( file ) ) {
+				window.open( file.url + '&preview=true', 'pdf', 'popup' );
+				return;
+			}
+
 			setIsImageLoading( true );
 			setPreviewFile( file );
 			setIsPreviewModalOpen( true );
@@ -80,6 +116,9 @@ const InboxResponse = ( { response, loading, onModalStateChange } ) => {
 			return (
 				<div className="file-field">
 					{ value.files.map( ( file, index ) => {
+						if ( ! file || ! file.name ) {
+							return null;
+						}
 						return (
 							<div key={ index } className="file-field__item">
 								<span className="file-field__item-name">{ decodeEntities( file.name ) }</span>
@@ -87,14 +126,16 @@ const InboxResponse = ( { response, loading, onModalStateChange } ) => {
 									<span>{ file.size }</span>
 
 									{ file.is_previewable && (
-										<Button variant="link" target="_blank" onClick={ handleFilePreview( file ) }>
+										<Button target="_blank" variant="link" onClick={ handleFilePreview( file ) }>
 											{ __( 'Preview', 'jetpack-forms' ) }
 										</Button>
 									) }
 
-									<Button variant="link" href={ file.url } target="_blank">
-										{ __( 'Download', 'jetpack-forms' ) }
-									</Button>
+									{ file.url && (
+										<Button variant="link" href={ file.url } target="_blank">
+											{ __( 'Download', 'jetpack-forms' ) }
+										</Button>
+									) }
 								</span>
 							</div>
 						);
@@ -135,7 +176,7 @@ const InboxResponse = ( { response, loading, onModalStateChange } ) => {
 
 	if ( isPreviewModalOpen && ! onModalStateChange ) {
 		return (
-			<PreviewImage
+			<PreviewFile
 				file={ previewFile }
 				isLoading={ isImageLoading }
 				onImageLoaded={ handelImageLoaded }
@@ -213,7 +254,7 @@ const InboxResponse = ( { response, loading, onModalStateChange } ) => {
 					onRequestClose={ closePreviewModal }
 					className="jp-forms__inbox-file-preview-modal"
 				>
-					<PreviewImage
+					<PreviewFile
 						file={ previewFile }
 						isLoading={ isImageLoading }
 						onImageLoaded={ handelImageLoaded }

--- a/projects/packages/forms/src/dashboard/inbox/response.js
+++ b/projects/packages/forms/src/dashboard/inbox/response.js
@@ -24,10 +24,9 @@ const PreviewImage = ( { file, isLoading, onImageLoaded } ) => {
 		<div className="jp-forms__inbox-file-preview-container">
 			{ isLoading && (
 				<div className="jp-forms__inbox-file-loading">
-					<div className="components-spinner" />
+					<Spinner className="jp-forms__inbox-spinner" />
 					<div className="jp-forms__inbox-file-loading-message">
-						<Spinner />
-						{ __( 'Loading file preview…', 'jetpack-forms' ) }
+						{ __( 'Loading preview…', 'jetpack-forms' ) }
 					</div>
 				</div>
 			) }
@@ -36,7 +35,6 @@ const PreviewImage = ( { file, isLoading, onImageLoaded } ) => {
 				alt={ decodeEntities( file.name ) }
 				onLoad={ onImageLoaded }
 				className="jp-forms__inbox-file-preview-image"
-				style={ { display: isLoading ? 'none' : 'block' } }
 			/>
 		</div>
 	);

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -395,18 +395,42 @@ body.jetpack_page_jetpack-forms-admin {
 	min-height: 0;;
 }
 
+.jp-forms__inbox-file-preview-shell {
+	max-height: 70vh;
+	overflow: hidden;
+}
 
 .jp-forms__inbox-file-preview-container {
-  display: flex;
-  justify-content: center;
-  align-items: center;
   margin-bottom: 16px;
   max-height: 70vh;
+  aspect-ratio: 16 / 9;
+}
+
+.jp-forms__inbox-file-preview-container-iframe.is-loading,
+.jp-forms__inbox-file-preview-container.is-loading {
+	display: none;
+}
+
+.jp-forms__inbox-file-preview-container-iframe {
+	margin-bottom: 16px;
+  	max-height: 70vh;
 }
 
 .jp-forms__inbox-file-preview-image {
-  max-width: 100%;
-  height: auto;
+  height: 100%;
+  width: 100%;
+  max-height: 66vh;
+  object-fit: contain;
+}
+
+
+.jp-forms__inbox-file-preview-iframe {
+	display: block;
+  	width: 100%;
+	min-width: 80vw;
+	min-height: 50vh;
+	border: none;
+	object-fit: contain;
 }
 
 .components-modal__content .jp-forms__inbox-file-preview-modal {
@@ -423,8 +447,20 @@ body.jetpack_page_jetpack-forms-admin {
 .jp-forms__inbox-file-loading {
 	display: flex;
 	align-content: center;
+	justify-content: center;
+	height: 150px;
+	flex-wrap: wrap;
 }
 
 .jp-forms__inbox-spinner.jp-forms__inbox-spinner {
 	margin-top: 0;
+}
+
+.jp-forms__inbox-file-preview-fallback {
+	padding: 20px;
+	text-align: center;
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
+	align-items: center;
 }

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -278,12 +278,23 @@ $action-bar-height: 88px;
 }
 
 .jp-forms__inbox-response-data-value .file-field {
-	display: flex;
-	gap: 12px;
 	
 	.file-field__item {
 		display: flex;
+		justify-content: space-between;
 		gap: 12px;
+	}
+
+	.file-field__item-name {
+		display: block;
+	}
+
+	.file-field__item-actions.file-field__item-actions {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		justify-content: flex-end;
+		gap: 8px;
 	}
 }
 

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -278,28 +278,28 @@ $action-bar-height: 88px;
 }
 
 .jp-forms__inbox-response-data-value .file-field {
-	
+
 	.file-field__item {
 		display: flex;
 		justify-content: space-between;
 		gap: 12px;
+		--wp-admin-theme-color: #2271b1;
+		--wp-components-color-accent: var(--wp-admin-theme-color, #2271b1);
 	}
 
-	.file-field__item-name {
-		display: block;
+	.file-field__icon {
+		width: 40px;
+		height: 40px;
+		border-radius: 50%;
+		background-color: #f6f6f7;
 	}
 
-	.file-field__item-actions.file-field__item-actions {
+	.file-field__info {
 		display: flex;
-		flex-wrap: wrap;
-		align-items: center;
-		justify-content: flex-end;
-		gap: 8px;
+		flex-direction: column;
+		gap: 4px;
 	}
-}
 
-.jp-forms__inbox-response-data-value .file-field svg {
-	min-width: 24px;
 }
 
 .jp-forms__header-subtext {

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -280,6 +280,11 @@ $action-bar-height: 88px;
 .jp-forms__inbox-response-data-value .file-field {
 	display: flex;
 	gap: 12px;
+	
+	.file-field__item {
+		display: flex;
+		gap: 12px;
+	}
 }
 
 .jp-forms__inbox-response-data-value .file-field svg {
@@ -377,4 +382,30 @@ body.jetpack_page_jetpack-forms-admin {
 
 	/* Important to pair with flex-shrink */
 	min-height: 0;;
+}
+
+
+.jp-forms__inbox-file-preview-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-bottom: 16px;
+  max-height: 70vh;
+  overflow: auto;
+}
+
+.jp-forms__inbox-file-preview-image {
+  max-width: 100%;
+  height: auto;
+}
+
+.components-modal__content .jp-forms__inbox-file-preview-modal {
+  max-width: 90vw;
+  width: auto;
+  z-index: 100010; // Higher than parent modal
+}
+
+// Make sure backdrop is below the file preview modal but above the response modal
+.components-modal__screen-overlay:nth-of-type(2) {
+  z-index: 100005;
 }

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -472,7 +472,6 @@ body.jetpack_page_jetpack-forms-admin {
   object-fit: contain;
 }
 
-
 .jp-forms__inbox-file-preview-iframe {
 	display: block;
   	width: 100%;

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -402,7 +402,6 @@ body.jetpack_page_jetpack-forms-admin {
   align-items: center;
   margin-bottom: 16px;
   max-height: 70vh;
-  overflow: auto;
 }
 
 .jp-forms__inbox-file-preview-image {

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -278,6 +278,7 @@ $action-bar-height: 88px;
 }
 
 .jp-forms__inbox-response-data-value .file-field {
+	margin-top: 4px;
 
 	.file-field__item {
 		display: flex;
@@ -296,7 +297,50 @@ $action-bar-height: 88px;
 		background-repeat: no-repeat;
 		background-position: center;
 		background-size: 24px;
+	}
 
+	.file-field__icon.icon-cal {
+		background-image: url( ../../contact-form/images/file-icons/cal.svg);
+	}
+
+	.file-field__icon.icon-html {
+		background-image: url( ../../contact-form/images/file-icons/html.svg);
+	}
+
+	.file-field__icon.icon-mp3 {
+		background-image: url( ../../contact-form/images/file-icons/mp3.svg);
+	}
+
+	.file-field__icon.icon-mp4 {
+		background-image: url( ../../contact-form/images/file-icons/mp4.svg);
+	}
+
+	.file-field__icon.icon-pdf {
+		background-image: url( ../../contact-form/images/file-icons/pdf.svg);
+	}
+
+	.file-field__icon.icon-png {
+		background-image: url( ../../contact-form/images/file-icons/png.svg);
+	}
+
+	.file-field__icon.icon-ppt {
+		background-image: url( ../../contact-form/images/file-icons/ppt.svg);
+	}
+
+	.file-field__icon.icon-sql {
+		background-image: url( ../../contact-form/images/file-icons/sql.svg);
+	}
+
+	.file-field__icon.icon-txt {
+		background-image: url( ../../contact-form/images/file-icons/txt.svg);
+	}
+
+	.file-field__icon.icon-xls {
+		background-image: url( ../../contact-form/images/file-icons/xls.svg);
+	}
+
+	.file-field__icon.icon-zip {
+		background-image: url( ../../contact-form/images/file-icons/zip.svg);
 	}
 
 	.file-field__info {

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -419,3 +419,12 @@ body.jetpack_page_jetpack-forms-admin {
 .components-modal__screen-overlay:nth-of-type(2) {
   z-index: 100005;
 }
+
+.jp-forms__inbox-file-loading {
+	display: flex;
+	align-content: center;
+}
+
+.jp-forms__inbox-spinner.jp-forms__inbox-spinner {
+	margin-top: 0;
+}

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -292,12 +292,17 @@ $action-bar-height: 88px;
 		height: 40px;
 		border-radius: 50%;
 		background-color: #f6f6f7;
+		background-image: url( ../../contact-form/images/file-icons/txt.svg);
+		background-repeat: no-repeat;
+		background-position: center;
+		background-size: 24px;
+
 	}
 
 	.file-field__info {
 		display: flex;
-		flex-direction: column;
-		gap: 4px;
+		flex-direction: row;
+		gap: 12px;
 	}
 
 }

--- a/projects/plugins/jetpack/changelog/update-forms-dashboard-file-upload-links
+++ b/projects/plugins/jetpack/changelog/update-forms-dashboard-file-upload-links
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Make it possible to preview file by just visitng the url. 

--- a/projects/plugins/jetpack/unauth-file-upload.php
+++ b/projects/plugins/jetpack/unauth-file-upload.php
@@ -82,14 +82,22 @@ function handle_file_download() {
 		wp_die( esc_html__( 'Error retrieving file content.', 'jetpack' ) );
 	}
 
+	$is_preview = isset( $_GET['preview'] ) && 'true' === $_GET['preview'];
+
 	// Clean output buffer
 	if ( ob_get_length() ) {
 		ob_clean();
 	}
 	// Set headers for download
 	header( 'Content-Type: ' . $file['type'] );
-	// Forcing the file to be downloaded is important to prevent XSS attacks.
-	header( 'Content-Disposition: attachment; filename="' . sanitize_file_name( $file['name'] ) . '"' );
+
+	if ( ! $is_preview ) {
+		// Forcing the file to be downloaded is important to prevent XSS attacks.
+		header( 'Content-Disposition: attachment; filename="' . sanitize_file_name( $file['name'] ) . '"' );
+	} else {
+		// For preview mode, use inline disposition
+		header( 'Content-Disposition: inline; filename="' . sanitize_file_name( $file['name'] ) . '"' );
+	}
 	header( 'Content-Length: ' . strlen( $file['content'] ) );
 	header( 'Content-Transfer-Encoding: binary' );
 	header( 'Cache-Control: no-cache, must-revalidate, max-age=0' );


### PR DESCRIPTION
This PR add a preview and download links to the response entry views so that user can choose between downloading or previewing the file. 

Before:
![Screenshot 2025-06-02 at 8 44 09 AM](https://github.com/user-attachments/assets/3ffa2161-ccdc-4ace-a63d-f881a5f2cdb0)


After:
![Screenshot 2025-06-09 at 10 48 13 AM](https://github.com/user-attachments/assets/a4e64dd5-c22a-45d0-9e15-7645659e4b8d)

![Screenshot 2025-06-09 at 10 48 01 AM](https://github.com/user-attachments/assets/0eac787c-38f2-43bc-9ae5-314e00f8ebd5)


![Screenshot 2025-06-02 at 8 13 14 AM](https://github.com/user-attachments/assets/d689d440-8c06-4f7b-b4bc-1103365956cb)

![Screenshot 2025-06-02 at 8 41 12 AM](https://github.com/user-attachments/assets/46ca3e6f-2df0-4858-85aa-5d00816ab7f4)


## Proposed changes:
* Add a modal that lets preview images in a modal. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
See the CFT (pdtkmj-3Ch-p2#comment-69 83) where this was brought up.

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
* View file upload entries. 
* Notice that you can preview images. Notice that other file types preview is not visible. 
* Notice that it works as expected on mobile as well.