### PR TITLE
Subscriptions: do not attempt to fetch or display elements from WordPress.com when user is not connected

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-newsletter-non-connected-editor
+++ b/projects/plugins/jetpack/changelog/fix-newsletter-non-connected-editor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Newsletters: avoid errors in the post editor when editors are not connected to WordPress.com.

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/edit.js
@@ -1,4 +1,6 @@
 import { ThemeProvider } from '@automattic/jetpack-components';
+import { useConnection } from '@automattic/jetpack-connection';
+import { isSimpleSite } from '@automattic/jetpack-shared-extension-utils';
 import { formatNumberCompact } from '@automattic/number-formatters';
 import {
 	BlockControls,
@@ -61,6 +63,37 @@ const applyFallbackStyles = withFallbackStyles( ( node, ownProps ) => {
 	};
 } );
 
+function PaidPlanBlockControls() {
+	const { isUserConnected } = useConnection();
+	const canManagePlans = isSimpleSite() || isUserConnected;
+
+	const hasTierPlans = useSelect(
+		select => {
+			if ( ! isUserConnected ) {
+				return false;
+			}
+			return !! select( 'jetpack/membership-products' )?.getNewsletterTierProducts()?.length;
+		},
+		[ isUserConnected ]
+	);
+
+	if ( ! canManagePlans ) {
+		return null;
+	}
+
+	return (
+		<BlockControls>
+			<ToolbarGroup>
+				<ToolbarButton href={ getPaidPlanLink( hasTierPlans ) } target="_blank">
+					{ hasTierPlans
+						? _x( 'Manage plans', 'unused context to distinguish translations', 'jetpack' )
+						: __( 'Set up a paid plan', 'jetpack' ) }
+				</ToolbarButton>
+			</ToolbarGroup>
+		</BlockControls>
+	);
+}
+
 export function SubscriptionEdit( props ) {
 	const {
 		attributes,
@@ -76,10 +109,7 @@ export function SubscriptionEdit( props ) {
 		setBorderColor,
 		fontSize,
 	} = props;
-	const hasTierPlans = useSelect(
-		select => !! select( 'jetpack/membership-products' )?.getNewsletterTierProducts()?.length,
-		[]
-	);
+
 	const blockProps = useBlockProps();
 	const validatedAttributes = getValidatedAttributes( metadata.attributes, attributes );
 	if ( ! isEqual( validatedAttributes, attributes ) ) {
@@ -276,15 +306,7 @@ export function SubscriptionEdit( props ) {
 					successMessage={ successMessage }
 				/>
 			</InspectorControls>
-			<BlockControls>
-				<ToolbarGroup>
-					<ToolbarButton href={ getPaidPlanLink( hasTierPlans ) } target="_blank">
-						{ hasTierPlans
-							? _x( 'Manage plans', 'unused context to distinguish translations', 'jetpack' )
-							: __( 'Set up a paid plan', 'jetpack' ) }
-					</ToolbarButton>
-				</ToolbarGroup>
-			</BlockControls>
+			<PaidPlanBlockControls />
 			<div style={ cssVars }>
 				<div className="wp-block-jetpack-subscriptions__container is-not-subscriber">
 					<div className="wp-block-jetpack-subscriptions__form" role="form">

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/menu.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/menu.js
@@ -47,12 +47,16 @@ const NewsletterMenu = ( { openPreviewModal } ) => {
 			className="jetpack-newsletter-settings-sidebar"
 		>
 			<PanelBody>
+				{ ! isPublished && ! shouldPromptForConnection && (
+					<>
+						<NewsletterEmailDocumentSettings />
+						<SubscribersAffirmation accessLevel={ accessLevel } prePublish={ ! isPublished } />
+					</>
+				) }
 				{ isSendEmailEnabled && ! isPublished && (
 					<>
 						{ ! shouldPromptForConnection ? (
 							<>
-								{ ! isPublished && <NewsletterEmailDocumentSettings /> }
-								<SubscribersAffirmation accessLevel={ accessLevel } prePublish={ ! isPublished } />
 								<p>
 									{ __(
 										'Ensure your email looks perfect. Use the buttons below to view a preview or send a test email.',

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/menu.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/menu.js
@@ -47,12 +47,12 @@ const NewsletterMenu = ( { openPreviewModal } ) => {
 			className="jetpack-newsletter-settings-sidebar"
 		>
 			<PanelBody>
-				{ ! isPublished && <NewsletterEmailDocumentSettings /> }
-				<SubscribersAffirmation accessLevel={ accessLevel } prePublish={ ! isPublished } />
 				{ isSendEmailEnabled && ! isPublished && (
 					<>
 						{ ! shouldPromptForConnection ? (
 							<>
+								{ ! isPublished && <NewsletterEmailDocumentSettings /> }
+								<SubscribersAffirmation accessLevel={ accessLevel } prePublish={ ! isPublished } />
 								<p>
 									{ __(
 										'Ensure your email looks perfect. Use the buttons below to view a preview or send a test email.',

--- a/projects/plugins/jetpack/extensions/store/membership-products/resolvers.js
+++ b/projects/plugins/jetpack/extensions/store/membership-products/resolvers.js
@@ -1,3 +1,4 @@
+import { CONNECTION_STORE_ID } from '@automattic/jetpack-connection';
 import apiFetch from '@wordpress/api-fetch';
 import { store as editorStore } from '@wordpress/editor';
 import { addQueryArgs, getQueryArg } from '@wordpress/url';
@@ -194,6 +195,13 @@ export const getProducts =
 		shouldDisplayProductCreationNotice = true
 	) =>
 	async ( { dispatch, registry, select } ) => {
+		// Early return if user is not connected to avoid unnecessary API calls
+		const { isUserConnected } = registry.select( CONNECTION_STORE_ID ).getConnectionStatus();
+		if ( ! isUserConnected ) {
+			dispatch( setApiState( API_STATE_NOTCONNECTED ) );
+			return;
+		}
+
 		await executionLock.blockExecution( EXECUTION_KEY );
 		if ( hydratedFromAPI ) {
 			setDefaultProductIfNeeded( selectedProductIds, setSelectedProductIds, select );
@@ -230,6 +238,13 @@ export const getProducts =
 export const getSubscriberCounts =
 	() =>
 	async ( { dispatch, registry } ) => {
+		// Early return if user is not connected to avoid unnecessary API calls
+		const { isUserConnected } = registry.select( CONNECTION_STORE_ID ).getConnectionStatus();
+		if ( ! isUserConnected ) {
+			dispatch( setApiState( API_STATE_NOTCONNECTED ) );
+			return;
+		}
+
 		await executionLock.blockExecution( SUBSCRIBER_COUNT_EXECUTION_KEY );
 
 		const lock = executionLock.acquire( SUBSCRIBER_COUNT_EXECUTION_KEY );
@@ -253,6 +268,13 @@ export const getSubscriberCounts =
 export const getNewsletterCategories =
 	() =>
 	async ( { dispatch, registry } ) => {
+		// Early return if user is not connected to avoid unnecessary API calls
+		const { isUserConnected } = registry.select( CONNECTION_STORE_ID ).getConnectionStatus();
+		if ( ! isUserConnected ) {
+			dispatch( setApiState( API_STATE_NOTCONNECTED ) );
+			return;
+		}
+
 		await executionLock.blockExecution( GET_NEWSLETTER_CATEGORIES_EXECUTION_KEY );
 
 		const lock = executionLock.acquire( GET_NEWSLETTER_CATEGORIES_EXECUTION_KEY );
@@ -276,6 +298,13 @@ export const getNewsletterCategories =
 export const getNewsletterCategoriesSubscriptionsCount =
 	( termIds = [] ) =>
 	async ( { dispatch, registry } ) => {
+		// Early return if user is not connected to avoid unnecessary API calls
+		const { isUserConnected } = registry.select( CONNECTION_STORE_ID ).getConnectionStatus();
+		if ( ! isUserConnected ) {
+			dispatch( setApiState( API_STATE_NOTCONNECTED ) );
+			return;
+		}
+
 		await executionLock.blockExecution(
 			GET_NEWSLETTER_CATEGORIES_SUBSCRIPTIONS_COUNT_EXECUTION_KEY
 		);


### PR DESCRIPTION
Fixes #39911
Fixes CML-537

## Proposed changes:

This PR brings in changes that will impact the Newsletter features' display for non-connected users. **For users that are connected to WordPress.com already, there should be no change.**

- We no longer show Newsletter panels that require a connection when the user is not connected.
- We do not show the plan management toolbar item when the user is not connected.
- We do not attempt to make requests to WordPress.com when the user is not connected.

<img width="269" alt="image" src="https://github.com/user-attachments/assets/a681e6ab-e36d-4cae-b970-57d7fd5b2a50" />
<img width="360" alt="image" src="https://github.com/user-attachments/assets/481e18b3-ce43-4dce-a4c0-b9506507840c" />

> [!NOTE]
> This is a replay of #40208 plus some added elements.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

> [!WARNING]
> This will need to be tested:
> - **On simple as well as on self-hosted or WoA**
> - **With both a connected admin and a non-connected user (can be admin or editor)**

* Start with a site that's connected to WordPress.com
* Create a new user.
* In another browser, access the site with that new user.
* **Run the next tests in both windows, when connected and when not connected**
* Open your browser's network tools, and watch for XHR requests made by Jetpack (filter by `wpcom`)
* Go to Posts > Add New
    * When not connected, you should not see any requests or error messages brought up by Jetpack
* Insert a Subscribe block
    * When connected, you should see a toolbar item to add or manage plans (see screenshot above).
    * When not connected, you should not see that button but the block should otherwise work as expected.
* Click on the Newsletter plugin icon in the top right bar
    * When not connected, you should only see an invitation to connect.
