### PR TITLE
Forms: preserve text color of the label in global styles

### DIFF
--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -796,6 +796,10 @@
 				border-left: none !important;
 				border-right: none !important;
 				box-sizing: content-box;
+
+				// This is required to ensure the color is not overridden by the global styles.
+				// See the selector in class-contact-form-block.php for 'jetpack/input' registration.
+				color: unset !important;
 			}
 
 			.notched-label__label {

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -524,6 +524,12 @@
 	border-radius: unset;
 	padding: 0 4px;
 	transition: border 150ms linear;
+
+	/*
+	 * This is required to ensure the color is not overridden by the global styles.
+	 * See the selector in class-contact-form-block.php for 'jetpack/input' registration.
+	 */
+	color: unset !important;
 }
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes FORMS-98

This PR's base branch is https://github.com/Automattic/jetpack/pull/42890

## Proposed changes:

This PR updates contact form styles to prevent color overrides by global styles. 


## Testing instructions:

1. In global styles (Site Editor > Styles > Blocks) set the input block's text color to something other than the default (e.g. red)
2. Insert a simple contact form
3. Change the form's block style variation to 'Outlined'
4. Check that the label's color does not take on the input's
5. Check also that global and block-level label colors work.


| Before | After |
|--------|--------|
| <img width="685" alt="Screenshot 2025-06-03 at 3 11 57 pm" src="https://github.com/user-attachments/assets/d443b45c-5f31-4e0d-abe2-1744ca69a9b1" /> | <img width="723" alt="Screenshot 2025-06-03 at 3 12 02 pm" src="https://github.com/user-attachments/assets/92322967-ab74-4b2a-bec7-e242c81020d0" /> | 





