### PR TITLE
Forms: Fix required field and form validation for single and multiple options blocks

### DIFF
--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -1248,13 +1248,13 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 			 */
 			$field = "<fieldset {$fieldset_id} class='grunion-checkbox-multiple-options " . $options_classes . "' style='" . $options_styles . "' " . ( $required ? 'data-required' : '' ) . '>';
 		} else {
-			$field = "<fieldset {$fieldset_id} class='jetpack-field-multiple__fieldset'>";
+			$field = "<fieldset {$fieldset_id} class='jetpack-field-multiple__fieldset'" . ( $required ? 'data-required' : '' ) . '>';
 		}
 
 		$field .= $this->render_legend_as_label( '', $id, $label, $required, $required_field_text );
 
 		if ( ! $is_outlined_style ) {
-			$field .= "<div class='grunion-checkbox-multiple-options " . $options_classes . "' style='" . $options_styles . "' " . ( $required ? 'data-required' : '' ) . '>';
+			$field .= "<div class='grunion-checkbox-multiple-options " . $options_classes . "' style='" . $options_styles . "' " . '>';
 		}
 
 		$options_data  = $this->get_attribute( 'optionsdata' );

--- a/projects/packages/forms/src/contact-form/js/accessible-form.js
+++ b/projects/packages/forms/src/contact-form/js/accessible-form.js
@@ -186,7 +186,8 @@ const isFormSubmitting = form => {
 const isMultipleChoiceField = elt => {
 	return (
 		elt.tagName.toLowerCase() === 'fieldset' &&
-		elt.classList.contains( 'grunion-checkbox-multiple-options' )
+		( elt.classList.contains( 'grunion-checkbox-multiple-options' ) ||
+			elt.querySelector( '.grunion-checkbox-multiple-options' ) !== null )
 	);
 };
 
@@ -197,7 +198,9 @@ const isMultipleChoiceField = elt => {
  */
 const isSingleChoiceField = elt => {
 	return (
-		elt.tagName.toLowerCase() === 'fieldset' && elt.classList.contains( 'grunion-radio-options' )
+		elt.tagName.toLowerCase() === 'fieldset' &&
+		( elt.classList.contains( 'grunion-radio-options' ) ||
+			elt.querySelector( '.grunion-radio-options' ) !== null )
 	);
 };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Proposes to merge into https://github.com/Automattic/jetpack/pull/42890, not trunk.

While testing required Options fields (both individual option, and multiple choice), I noticed that the validation wasn't working properly.

* For single choice fields, the field name wasn't being included in the validation error message.
* For multiple choice fields, it looked like the validation was being ignored.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Update the JS checks so that it's if the classname exists in the target element _or_ if it exists anywhere within the current node (so it accepts if the options block is a child of the fieldset).
* Move the `data-required` up to the `fieldset` for multiple choice options, where it appears to be expected for the validation to work.

## Screenshots

In a test post that contains name, email, phone, date, and required "time" and "choose several options" fields, in the Before screenshot 5 errors and only 4 fields are listed. In the After, there are correctly 6 errors and 6 fields listed.

| Before | After |
| --- | --- |
| <img width="679" alt="image" src="https://github.com/user-attachments/assets/44fe6595-0ba8-4788-90eb-8e6e93c3e4cd" /> | <img width="689" alt="image" src="https://github.com/user-attachments/assets/b0ff2d80-e5c4-4e9a-8a8a-119bac3c0b70" /> |

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Note, if you've already been working locally, you might need to shift-reload your site frontend to receive the updated JS in this PR.

* Add a Contact Form with a single choice options block and a multiple choice options block
* Set them to required
* With this PR try submitting without selecting anything
* The correct number of errors should be displayed

