### PR TITLE
Forms: widen rich text for empty labels

### DIFF
--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -324,6 +324,7 @@
 	min-height: unset;
     pointer-events: auto;
 	padding: 0;
+	min-width: 20px !important;
 }
 
 .jetpack-field__textarea {

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -324,7 +324,16 @@
 	min-height: unset;
     pointer-events: auto;
 	padding: 0;
+	width: 100%;
 	min-width: 20px !important;
+}
+
+/* If there is no required field, the label input will be 100% width.
+ * If there is a required field, the label input will be auto width.
+ * This makes the label easier to select when it's empty.
+ */
+.jetpack-field-label__input:has(+ .block-editor-rich-text__editable) {
+	width: auto;
 }
 
 .jetpack-field__textarea {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Trying something for JETPACK-308

## Proposed changes:

A small quality of life PR that enforces a min-width on label rich text components of `20px`, and ensures it spans the entire width in the absence of a required field.

Why? Make it easier for users to select the component when it's empty.


https://github.com/user-attachments/assets/4c8eba07-b504-46f4-9374-f9061976240c


## Testing instructions:

1. Create a form with some fields, some required some not.
2. Delete the field contents
3. Try to add new field content
4. The fields without required should be selectable along their full widths
5. The fields with required should be selectable in the new, improved 20px gap