### PR TITLE
Forms: Update context types to use kebab casing

### DIFF
--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -123,7 +123,7 @@ class Contact_Form_Block {
 					'border' => '.wp-block-jetpack-input, .is-style-outlined .notched-label:has(+ .wp-block-jetpack-input) > *,.is-style-outlined .wp-block-jetpack-input + .notched-label > *, .is-style-outlined .wp-block-jetpack-field-select .notched-label > *',
 					'color'  => '.wp-block-jetpack-input, .is-style-outlined .notched-label:has(+ .wp-block-jetpack-input) > *,.is-style-outlined .wp-block-jetpack-input + .notched-label > *, .is-style-outlined .wp-block-jetpack-field-select .notched-label > *',
 				),
-				'uses_context' => array( 'jetpack/field-defaultValue' ),
+				'uses_context' => array( 'jetpack/field-default-value' ),
 			)
 		);
 		Blocks::jetpack_register_block(
@@ -148,7 +148,7 @@ class Contact_Form_Block {
 				),
 				'uses_context' => array(
 					'jetpack/field-required',
-					'jetpack/field-dateFormat',
+					'jetpack/field-date-format',
 				),
 			)
 		);
@@ -200,7 +200,7 @@ class Contact_Form_Block {
 					),
 				),
 				'uses_context' => array(
-					'jetpack/field-defaultValue',
+					'jetpack/field-default-value',
 					'jetpack/field-options-type',
 					'jetpack/field-required',
 				),
@@ -240,8 +240,8 @@ class Contact_Form_Block {
 			array(
 				'render_callback'  => array( Contact_Form_Plugin::class, 'gutenblock_render_field_date' ),
 				'provides_context' => array(
-					'jetpack/field-required'   => 'required',
-					'jetpack/field-dateFormat' => 'dateFormat',
+					'jetpack/field-required'    => 'required',
+					'jetpack/field-date-format' => 'dateFormat',
 				),
 			)
 		);
@@ -264,8 +264,8 @@ class Contact_Form_Block {
 			array(
 				'render_callback'  => array( Contact_Form_Plugin::class, 'gutenblock_render_field_checkbox' ),
 				'provides_context' => array(
-					'jetpack/field-required'     => 'required',
-					'jetpack/field-defaultValue' => 'defaultValue',
+					'jetpack/field-required'      => 'required',
+					'jetpack/field-default-value' => 'defaultValue',
 				),
 			)
 		);

--- a/projects/packages/forms/src/blocks/contact-form/index.js
+++ b/projects/packages/forms/src/blocks/contact-form/index.js
@@ -61,7 +61,7 @@ export const settings = {
 	},
 	attributes: defaultAttributes,
 	providesContext: {
-		'jetpack/form-className': 'className',
+		'jetpack/form-class-name': 'className',
 	},
 	edit,
 	save: () => {

--- a/projects/packages/forms/src/blocks/field-checkbox/index.js
+++ b/projects/packages/forms/src/blocks/field-checkbox/index.js
@@ -32,7 +32,7 @@ const settings = {
 	},
 	providesContext: {
 		...defaultSettings.providesContext,
-		'jetpack/field-defaultValue': 'defaultValue',
+		'jetpack/field-default-value': 'defaultValue',
 	},
 	deprecated,
 	save,

--- a/projects/packages/forms/src/blocks/field-consent/index.js
+++ b/projects/packages/forms/src/blocks/field-consent/index.js
@@ -50,7 +50,7 @@ const settings = {
 	},
 	providesContext: {
 		...defaultSettings.providesContext,
-		'jetpack/field-defaultValue': 'defaultValue',
+		'jetpack/field-default-value': 'defaultValue',
 	},
 	deprecated,
 	save,

--- a/projects/packages/forms/src/blocks/field-date/index.js
+++ b/projects/packages/forms/src/blocks/field-date/index.js
@@ -28,7 +28,7 @@ const settings = {
 	edit,
 	providesContext: {
 		...defaultSettings.providesContext,
-		'jetpack/field-dateFormat': 'dateFormat',
+		'jetpack/field-date-format': 'dateFormat',
 	},
 	attributes: {
 		...defaultSettings.attributes,

--- a/projects/packages/forms/src/blocks/label/edit.js
+++ b/projects/packages/forms/src/blocks/label/edit.js
@@ -67,9 +67,9 @@ const WithNotchedWrapper = ( { formStyle, styles, cssVars, className, children }
 
 const LabelEdit = ( { clientId, attributes, name, setAttributes, context } ) => {
 	const {
-		'jetpack/form-className': formClassName,
+		'jetpack/form-class-name': formClassName,
 		'jetpack/field-required': required,
-		'jetpack/field-dateFormat': dateFormat,
+		'jetpack/field-date-format': dateFormat,
 		'jetpack/field-share-attributes': isSynced,
 	} = context;
 	useSyncedAttributes( name, isSynced, SYNCED_ATTRIBUTE_KEYS, attributes, setAttributes );

--- a/projects/packages/forms/src/blocks/label/index.js
+++ b/projects/packages/forms/src/blocks/label/index.js
@@ -64,9 +64,9 @@ const settings = {
 		},
 	},
 	usesContext: [
-		'jetpack/form-className',
+		'jetpack/form-class-name',
 		'jetpack/field-required',
-		'jetpack/field-dateFormat',
+		'jetpack/field-date-format',
 		'jetpack/field-share-attributes',
 	],
 	edit,

--- a/projects/packages/forms/src/blocks/option/edit.js
+++ b/projects/packages/forms/src/blocks/option/edit.js
@@ -17,7 +17,7 @@ const getLabelOrFallback = ( label, placeholder ) => {
 
 const OptionEdit = ( { attributes, clientId, context, name, setAttributes } ) => {
 	const {
-		'jetpack/field-defaultValue': defaultValue,
+		'jetpack/field-default-value': defaultValue,
 		'jetpack/field-options-type': type = 'checkbox',
 		'jetpack/field-required': required,
 		'jetpack/field-share-attributes': isSynced,

--- a/projects/packages/forms/src/blocks/option/index.js
+++ b/projects/packages/forms/src/blocks/option/index.js
@@ -60,7 +60,7 @@ const settings = {
 		},
 	},
 	usesContext: [
-		'jetpack/field-defaultValue',
+		'jetpack/field-default-value',
 		'jetpack/field-options-type',
 		'jetpack/field-required',
 		'jetpack/field-share-attributes',


### PR DESCRIPTION
Note: Merges into #42890 rather than trunk.

## Proposed changes:
Addresses some code review feedback on #42890.

In places, that PR was introducing new block context types that have a mixture of kebab and camel cased names.

There's a pretty strong lean towards only kebab cased names in the package, so this PR updates to that convention.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
### Form style syncing
1. Insert a contact form
2. Select an input or label
3. Change one of the block styles (e.g. text color to something else)
4. Check that all other fields update to the same style

### Date format
1. Insert a contact form
2. Add a Date Picker block
3. Select that block and in the block inspector change the date format
4. Check that the block's label updates to show the correct format.
5. Save and check the frontend too has the correct format in the label

### Default value
1. Insert a contact form
2. Add a Checkbox block
3. Select that block and in the block inspector enable 'Checked by default'
4. Check that the block's checkbox is now checked
5. Also save and check the frontend, ensuring the checkbox is checked.