### PR TITLE
Charts: Fix @rollup/plugin-typescript warnings

### DIFF
--- a/projects/js-packages/charts/changelog/charts-25-fix-plugin-typescript-rollupplugin-typescript-warnings
+++ b/projects/js-packages/charts/changelog/charts-25-fix-plugin-typescript-rollupplugin-typescript-warnings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix @rollup/plugin-typescript warnings

--- a/projects/js-packages/charts/rollup.config.mjs
+++ b/projects/js-packages/charts/rollup.config.mjs
@@ -50,6 +50,7 @@ const mainConfig = {
 			compilerOptions: {
 				verbatimModuleSyntax: true,
 			},
+			exclude: [ 'node_modules', 'dist', '**/stories/**', '**/*.test.{ts,tsx}' ],
 		} ),
 		terser(),
 	],

--- a/projects/js-packages/charts/src/components/bar-chart/bar-chart.tsx
+++ b/projects/js-packages/charts/src/components/bar-chart/bar-chart.tsx
@@ -7,9 +7,8 @@ import {
 	Tooltip,
 	XYChart,
 } from '@visx/xychart';
-import { RenderTooltipParams } from '@visx/xychart/lib/components/Tooltip';
 import clsx from 'clsx';
-import { FC, ReactNode, useCallback, useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useXYChartTheme } from '../../providers/theme';
 import { Legend } from '../legend';
 import { useChartMargin } from '../shared/use-chart-margin';
@@ -17,6 +16,8 @@ import { withResponsive } from '../shared/with-responsive';
 import styles from './bar-chart.module.scss';
 import type { BaseChartProps, DataPointDate, SeriesData } from '../../types';
 import type { TickFormatter } from '@visx/axis';
+import type { RenderTooltipParams } from '@visx/xychart/lib/components/Tooltip';
+import type { FC, ReactNode } from 'react';
 
 interface BarChartProps extends BaseChartProps< SeriesData[] > {
 	renderTooltip?: ( params: RenderTooltipParams< DataPointDate > ) => ReactNode;

--- a/projects/js-packages/charts/src/components/legend/base-legend.tsx
+++ b/projects/js-packages/charts/src/components/legend/base-legend.tsx
@@ -1,9 +1,9 @@
 import { LegendOrdinal } from '@visx/legend';
 import { scaleOrdinal } from '@visx/scale';
 import clsx from 'clsx';
-import { FC } from 'react';
 import styles from './legend.module.scss';
 import type { LegendProps } from './types';
+import type { FC } from 'react';
 
 /**
  * Base legend component that displays color-coded items with labels using visx

--- a/projects/js-packages/charts/src/components/line-chart/line-chart.tsx
+++ b/projects/js-packages/charts/src/components/line-chart/line-chart.tsx
@@ -3,7 +3,7 @@ import { curveCatmullRom, curveLinear, curveMonotoneX } from '@visx/curve';
 import { LinearGradient } from '@visx/gradient';
 import { XYChart, AnimatedAreaSeries, AnimatedAxis, AnimatedGrid, Tooltip } from '@visx/xychart';
 import clsx from 'clsx';
-import { FC, ReactNode, useId, useMemo } from 'react';
+import { useId, useMemo } from 'react';
 import { useXYChartTheme, useChartTheme } from '../../providers/theme/theme-provider';
 import { Legend } from '../legend';
 import { useChartMargin } from '../shared/use-chart-margin';
@@ -12,6 +12,7 @@ import styles from './line-chart.module.scss';
 import type { BaseChartProps, DataPointDate, SeriesData } from '../../types';
 import type { TickFormatter } from '@visx/axis';
 import type { RenderTooltipParams } from '@visx/xychart/lib/components/Tooltip';
+import type { FC, ReactNode } from 'react';
 
 type CurveType = 'smooth' | 'linear' | 'monotone';
 

--- a/projects/js-packages/charts/src/components/pie-chart/pie-chart.tsx
+++ b/projects/js-packages/charts/src/components/pie-chart/pie-chart.tsx
@@ -1,7 +1,6 @@
 import { Group } from '@visx/group';
 import { Pie } from '@visx/shape';
 import clsx from 'clsx';
-import { SVGProps, type MouseEvent } from 'react';
 import useChartMouseHandler from '../../hooks/use-chart-mouse-handler';
 import { useChartTheme, defaultTheme } from '../../providers/theme';
 import { Legend } from '../legend';
@@ -9,6 +8,7 @@ import { withResponsive } from '../shared/with-responsive';
 import { BaseTooltip } from '../tooltip';
 import styles from './pie-chart.module.scss';
 import type { BaseChartProps, DataPointPercentage } from '../../types';
+import type { SVGProps, MouseEvent } from 'react';
 
 // TODO: add animation
 

--- a/projects/js-packages/charts/src/components/pie-semi-circle-chart/pie-semi-circle-chart.tsx
+++ b/projects/js-packages/charts/src/components/pie-semi-circle-chart/pie-semi-circle-chart.tsx
@@ -4,7 +4,7 @@ import { Pie } from '@visx/shape';
 import { Text } from '@visx/text';
 import { useTooltip } from '@visx/tooltip';
 import clsx from 'clsx';
-import { FC, useCallback } from 'react';
+import { useCallback } from 'react';
 import { useChartTheme } from '../../providers/theme/theme-provider';
 import { Legend } from '../legend';
 import { withResponsive } from '../shared/with-responsive';
@@ -12,6 +12,7 @@ import { BaseTooltip } from '../tooltip';
 import styles from './pie-semi-circle-chart.module.scss';
 import type { BaseChartProps, DataPointPercentage } from '../../types';
 import type { PieArcDatum } from '@visx/shape/lib/shapes/Pie';
+import type { FC } from 'react';
 
 interface PieSemiCircleChartProps extends BaseChartProps< DataPointPercentage[] > {
 	/**

--- a/projects/js-packages/charts/src/components/shared/test/use-chart-margin.test.tsx
+++ b/projects/js-packages/charts/src/components/shared/test/use-chart-margin.test.tsx
@@ -1,7 +1,7 @@
 import { renderHook } from '@testing-library/react';
 import { Orientation } from '@visx/axis';
-import { XYChartTheme } from '@visx/xychart';
 import { useChartMargin } from '../use-chart-margin';
+import type { XYChartTheme } from '@visx/xychart';
 
 const mockGetLongestTickWidth = jest.fn();
 jest.mock( '../utils', () => ( {

--- a/projects/js-packages/charts/src/components/shared/test/with-responsive.test.tsx
+++ b/projects/js-packages/charts/src/components/shared/test/with-responsive.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
-import { BaseChartProps } from '../../../types';
 import { withResponsive } from '../with-responsive';
+import type { BaseChartProps } from '../../../types';
 
 describe( 'withResponsive', () => {
 	const MockComponent = ( { width = 0, height = 0 }: BaseChartProps ) => (

--- a/projects/js-packages/charts/src/components/shared/utils.ts
+++ b/projects/js-packages/charts/src/components/shared/utils.ts
@@ -1,6 +1,6 @@
-import { TickFormatter } from '@visx/axis';
-import { AnyD3Scale, ScaleInput } from '@visx/scale';
 import { getStringWidth } from '@visx/text';
+import type { TickFormatter } from '@visx/axis';
+import type { AnyD3Scale, ScaleInput } from '@visx/scale';
 
 /**
  * Returns the width of the longest tick.

--- a/projects/js-packages/charts/src/components/shared/with-responsive.tsx
+++ b/projects/js-packages/charts/src/components/shared/with-responsive.tsx
@@ -1,6 +1,6 @@
 import { useParentSize } from '@visx/responsive';
-import { ComponentType } from 'react';
 import type { BaseChartProps, Optional } from '../../types';
+import type { ComponentType } from 'react';
 
 type ResponsiveConfig = {
 	maxWidth?: number;

--- a/projects/js-packages/charts/src/declarations.d.ts
+++ b/projects/js-packages/charts/src/declarations.d.ts
@@ -1,0 +1,5 @@
+// scss.d.ts
+declare module '*.module.scss' {
+	const classes: { [ key: string ]: string };
+	export default classes;
+}

--- a/projects/js-packages/charts/src/providers/theme/theme-provider.tsx
+++ b/projects/js-packages/charts/src/providers/theme/theme-provider.tsx
@@ -1,7 +1,8 @@
 import { buildChartTheme } from '@visx/xychart';
-import { createContext, useContext, useMemo, FC, type ReactNode } from 'react';
+import { createContext, useContext, useMemo } from 'react';
 import { defaultTheme } from './themes';
 import type { ChartTheme, SeriesData } from '../../types';
+import type { FC, ReactNode } from 'react';
 
 /**
  * Context for sharing theme configuration across components

--- a/projects/js-packages/charts/src/types.ts
+++ b/projects/js-packages/charts/src/types.ts
@@ -1,6 +1,6 @@
-import { AxisScale, Orientation, TickFormatter } from '@visx/axis';
-import { ScaleInput, ScaleType } from '@visx/scale';
-import { EventHandlerParams, LineStyles } from '@visx/xychart';
+import type { AxisScale, Orientation, TickFormatter } from '@visx/axis';
+import type { ScaleInput, ScaleType } from '@visx/scale';
+import type { EventHandlerParams, LineStyles } from '@visx/xychart';
 import type { CSSProperties, PointerEvent } from 'react';
 
 type ValueOf< T > = T[ keyof T ];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes CHARTS-25

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

* Fixes the TypeScript warnings for chart packages when running `pnpm build`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Run `pnpm --filter="@automattic/number-formatter" build` if you haven't built the number-formatter package yet.
- Run `pnpm --filter="@automattic/charts" build` and confirm no TypeScript warnings are present.


Before:

<img width="1141" alt="Screenshot 2025-06-03 at 17 08 41" src="https://github.com/user-attachments/assets/234d74a3-cd88-40a2-a54a-dc48c808bb30" />


After:

<img width="1258" alt="Screenshot 2025-06-03 at 17 14 48" src="https://github.com/user-attachments/assets/8cd0a7ce-c23a-4237-a3cb-67a40684084e" />
