### PR TITLE
Forms: Fix consent field spacing between checkbox and label (in the editor)

### DIFF
--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -364,8 +364,8 @@
 		margin-bottom: 0;
 	}
 
-	&.jetpack-field-checkbox .jetpack-field-checkbox__checkbox,
-	&.jetpack-field-consent .jetpack-field-consent__checkbox {
+	&.jetpack-field-checkbox .jetpack-field-option__checkbox,
+	&.jetpack-field-consent .jetpack-field-option__checkbox {
 		margin: 0 0.75rem 0 0;
 		border-color: currentColor;
 		opacity: 1;

--- a/projects/packages/forms/src/blocks/option/edit.js
+++ b/projects/packages/forms/src/blocks/option/edit.js
@@ -66,7 +66,7 @@ const OptionEdit = ( { attributes, clientId, context, name, setAttributes } ) =>
 			<div { ...blockProps }>
 				{ ! hideInput && (
 					<input
-						className="jetpack-field-checkbox__checkbox"
+						className="jetpack-field-option__checkbox"
 						checked={ !! defaultValue }
 						disabled
 						type={ type }


### PR DESCRIPTION
Note: This merges into #42890 instead of trunk

Fixes FORMS-104

In #42890, the consent field with a checkbox has incorrect spacing between its checkbox and label. 

I found that CSS is still present to apply the correct margin, but the selector is no longer matching. It expects an input with the classname `jetpack-field-consent__checkbox`, but the input now has the `jetpack-field-checkbox__checkbox`. The block that implements this classname is the **option** block.

`jetpack-field-checkbox__checkbox` actually seems like the incorrect classname, elsewhere the option block uses `jetpack-field-option` as its classname prefix (which partly makes sense, though I'm not sure I understand the `jetpack-field` part, surely it should be just `jetpack-option` 😬 ).

In this PR I'm changing the classname to `jetpack-field-option__checkbox` and updating the css selectors to match.

## Proposed changes:
- Changes the `jetpack-field-checkbox__checkbox` classname to `jetpack-field-option__checkbox`.
- Update the CSS selectors to use `jetpack-field-option__checkbox`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
1. Add a form
2. Add a checkbox and a consent block to the form
3. Select the consent block and from the block inspector choose "Permission to Email" > "Add a privacy checkbox"
4. Observe the spacing difference between Checkbox and Consent (the gap between the input and the label to its right)

**Before**: it's noticeably inconsistent:

<img width="238" alt="Screenshot 2025-06-03 at 5 27 47 pm" src="https://github.com/user-attachments/assets/9bff6fd5-e294-4222-939b-8cbf6b13dcdb" />


**In this PR**: both Checkbox and Consent fields should have the same (`0.75em`) margin-right on the input.

<img width="272" alt="Screenshot 2025-06-03 at 5 24 32 pm" src="https://github.com/user-attachments/assets/92d7f063-d72f-431a-af08-25a56f483b6f" />
