### PR TITLE
Sync: Hpos orders Module get objects in descending order

### DIFF
--- a/projects/packages/sync/changelog/update-sync-hpos-orders-module-get-objects-in-descending-order
+++ b/projects/packages/sync/changelog/update-sync-hpos-orders-module-get-objects-in-descending-order
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Sync: Ensure HPOS Orders are retrieved in Descending Order

--- a/projects/packages/sync/src/modules/class-woocommerce-hpos-orders.php
+++ b/projects/packages/sync/src/modules/class-woocommerce-hpos-orders.php
@@ -189,7 +189,7 @@ class WooCommerce_HPOS_Orders extends Module {
 	}
 
 	/**
-	 * Retrieves multiple orders data by their ID.
+	 * Retrieves multiple orders data by their ID. Sorted by ID in descending order.
 	 *
 	 * @access public
 	 *
@@ -209,6 +209,8 @@ class WooCommerce_HPOS_Orders extends Module {
 				'type'        => self::get_order_types_to_sync( true ),
 				'post_status' => self::get_all_possible_order_status_keys(),
 				'limit'       => -1,
+				'orderby'     => 'ID',
+				'order'       => 'DESC',
 			)
 		);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes VULCAN-149

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Ensure descending order when retrieving HPOS Orders 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
It's a bit complicated to test since there are scenarios where orders are already returned in the expected order. But the idea is to run a Full Sync for the Woocommerce HPOS module and check that Full Sync is working fine and last sent in `object_id` in the ES logs is advancing at good pace (It should be at least higher than 100 in difference between items)
Test in trunk first

* In a site that has WooCommerce, And Jetpack activated with a big number of orders
* Ensure HPOS Orders is active in WooCommerce -> Settings -> Advanced -> Features -> Order Data Storage
* Go to Jetpack Debugger and run a Full SYnc for HPOS Orders

Repeat the same steps in this branch

* By checking logs, you should see that `object_id` in subsequent actions jump by 100 or more in this branch, while in trunk might not be the case.

