### PR TITLE
boost: Fix sass deprecation warnings

### DIFF
--- a/projects/plugins/boost/app/assets/src/css/admin-banner.scss
+++ b/projects/plugins/boost/app/assets/src/css/admin-banner.scss
@@ -1,7 +1,7 @@
-@import 'main/variables';
+@use 'main/variables';
 
 .jb-setup-banner {
-    border: 1px solid $gray_5;
+    border: 1px solid variables.$gray_5;
     box-shadow: 0 2px 6px rgb(0 0 0 / 3%), 0 1px 2px rgb(0 0 0 / 3%);
     display: block;
     margin: 3rem 1.25rem 1.25rem 0;
@@ -10,7 +10,7 @@
 
     &__content-top-text {
         align-items: baseline;
-        background-color: $jetpack_green_40;
+        background-color: variables.$jetpack_green_40;
         color: #fff;
         display: flex;
         padding: 1rem 2.25rem 1.5rem 1rem;
@@ -100,13 +100,13 @@
 
         &:hover {
             color: #fff;
-            background-color: $gray_80;
+            background-color: variables.$gray_80;
         }
 
         &:focus {
             color: #fff;
             box-shadow: none;
-            outline: solid 1px $primary-black;
+            outline: solid 1px variables.$primary-black;
             outline-offset: 1px;
         }
     }

--- a/projects/plugins/boost/app/assets/src/css/admin-style.scss
+++ b/projects/plugins/boost/app/assets/src/css/admin-style.scss
@@ -1,7 +1,7 @@
 // Main
-@import 'main/variables';
-@import 'main/mixins';
-@import 'main/wp-admin';
-@import 'main/dashboard';
-@import 'main/common';
+@use 'main/variables';
+@use 'main/mixins';
+@use 'main/wp-admin';
+@use 'main/dashboard';
+@use 'main/common';
 

--- a/projects/plugins/boost/app/assets/src/css/main/common.scss
+++ b/projects/plugins/boost/app/assets/src/css/main/common.scss
@@ -3,6 +3,8 @@
  */
 
 @use 'sass:math';
+@use 'mixins';
+@use 'variables';
 
 $definition-combinations: (
 		'' : ['top', 'left', 'bottom', 'right'],
@@ -19,7 +21,7 @@ $definition-combinations: (
   @each $postfixes, $properties in $definition-combinations {
 
 	@for $i from 1 to 5 {
-	  $spacing: math.pow(2, $i - 1) * $spacing-unit !important;
+	  $spacing: math.pow(2, $i - 1) * variables.$spacing-unit !important;
 
 	  .#{$acronym}#{$postfixes}-#{$i} {
 
@@ -35,14 +37,14 @@ $definition-combinations: (
 .visible-md {
 	display: none !important;
 
-	@include breakpoint( 'md' ) {
+	@include mixins.breakpoint( 'md' ) {
 		display: unset !important;
 	}
 }
 
 .hidden-md {
 
-	@include breakpoint( 'md' ) {
+	@include mixins.breakpoint( 'md' ) {
 		display: none !important;
 	}
 }

--- a/projects/plugins/boost/app/assets/src/css/main/dashboard.scss
+++ b/projects/plugins/boost/app/assets/src/css/main/dashboard.scss
@@ -1,7 +1,9 @@
+@use 'mixins';
+@use 'variables';
 
 .jb-section {
-	padding-top: $padding;
-	padding-bottom: $padding;
+	padding-top: variables.$padding;
+	padding-bottom: variables.$padding;
 	isolation: isolate;
 	z-index: 10;
 
@@ -12,7 +14,7 @@
 }
 
 .jb-section--alt {
-	background-color: $alt_white;
+	background-color: variables.$alt_white;
 }
 
 .jb-section--scores {
@@ -47,10 +49,10 @@
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
-	margin-top: $padding;
-	margin-bottom: $padding;
+	margin-top: variables.$padding;
+	margin-bottom: variables.$padding;
 
-	@include breakpoint( xs ) {
+	@include mixins.breakpoint( xs ) {
 		flex-direction: column;
 		justify-content: flex-start;
 	}

--- a/projects/plugins/boost/app/assets/src/css/main/wp-admin.scss
+++ b/projects/plugins/boost/app/assets/src/css/main/wp-admin.scss
@@ -1,3 +1,5 @@
+@use 'variables';
+
 // Style everything with border box turned on
 #jb-dashboard * {
 	box-sizing: border-box;
@@ -5,14 +7,14 @@
 
 p {
 	font-size: 16px;
-	color: $gray_80;
+	color: variables.$gray_80;
 }
 // Override WordPress component styles
 .jb-dashboard {
-	--wp-admin-theme-color: #{$jetpack_green_50};
-	--wp-admin-theme-link-color: #{$gray_90};
-	--wp-admin-theme-color-darker-10: #{$jetpack_green_60};
-	--wp-admin-theme-color-darker-20: #{$jetpack_green_70};
+	--wp-admin-theme-color: #{variables.$jetpack_green_50};
+	--wp-admin-theme-link-color: #{variables.$gray_90};
+	--wp-admin-theme-color-darker-10: #{variables.$jetpack_green_60};
+	--wp-admin-theme-color-darker-20: #{variables.$jetpack_green_70};
 
 	--font-headline-medium: 48px;
 	--font-title-medium: 24px;
@@ -32,7 +34,7 @@ p {
 
 
 	&--main {
-		background-color: $primary-white;
+		background-color: variables.$primary-white;
 	}
 
 	a {
@@ -50,7 +52,7 @@ p {
 	h5,
 	h6 {
 		margin: 0;
-		color: $primary-black;
+		color: variables.$primary-black;
 		line-height: 1.3;
 		font-weight: 500;
 		outline-color: transparent;
@@ -74,9 +76,9 @@ p {
 
 	button.secondary,
 	a.button-secondary {
-		color: $primary-black;
+		color: variables.$primary-black;
 		background: none;
-		border: 1px solid $primary-black;
+		border: 1px solid variables.$primary-black;
 		padding: 8px 24px;
 		border-radius: 3px;
 		font-weight: 600;
@@ -85,9 +87,9 @@ p {
 		line-height: 24px;
 
 		&:hover {
-			background: $gray_0;
-			border-color: $primary-black;
-			color: $primary-black;
+			background: variables.$gray_0;
+			border-color: variables.$primary-black;
+			color: variables.$primary-black;
 		}
 	}
 

--- a/projects/plugins/boost/app/assets/src/js/features/critical-css/status/status.module.scss
+++ b/projects/plugins/boost/app/assets/src/js/features/critical-css/status/status.module.scss
@@ -1,5 +1,5 @@
-@import "$css/main/mixins";
-@import "$css/main/variables";
+@use "$css/main/mixins";
+@use "$css/main/variables";
 
 .status {
 	margin-bottom: 32px;
@@ -13,7 +13,7 @@
 		margin-bottom: 0;
 	}
 
-	@include breakpoint(xs) {
+	@include mixins.breakpoint(xs) {
 		display: block;
 	}
 
@@ -23,18 +23,18 @@
 		position: relative;
 
 		.successes, .generating {
-			color: $gray_40;
+			color: variables.$gray_40;
 
-			@include breakpoint(md) {
+			@include mixins.breakpoint(md) {
 				margin-right: 115px;
 			}
 		}
 
 		.failures {
 			margin-top: 1em;
-			color: $gray_100;
+			color: variables.$gray_100;
 
-			@include breakpoint(xs) {
+			@include mixins.breakpoint(xs) {
 				margin-bottom: 1em;
 			}
 
@@ -54,7 +54,7 @@
 		}
 
 		svg {
-			fill: $jetpack-green;
+			fill: variables.$jetpack-green;
 		}
 	}
 

--- a/projects/plugins/boost/app/assets/src/js/features/error-notice/error-notice.module.scss
+++ b/projects/plugins/boost/app/assets/src/js/features/error-notice/error-notice.module.scss
@@ -1,5 +1,5 @@
-@import "$css/main/mixins";
-@import "$css/main/variables";
+@use "$css/main/mixins";
+@use "$css/main/variables";
 
 .error-notice {
 	position: relative;
@@ -8,14 +8,14 @@
 	margin: 0;
 	padding: 0;
 
-	@include breakpoint(sm) {
+	@include mixins.breakpoint(sm) {
 		display: flex;
 		align-items: flex-start;
 		justify-content: left;
 	}
 
 	:global(.raw-error) {
-		color: $primary-black;
+		color: variables.$primary-black;
 	}
 
 	pre {
@@ -52,36 +52,36 @@
 		button {
 			margin-left: 0;
 
-			@include breakpoint(sm) {
+			@include mixins.breakpoint(sm) {
 				margin-left: 20px;
 			}
 		}
 	}
 
 	.description {
-		color: $red_50;
+		color: variables.$red_50;
 		font-weight: 700;
 		margin-bottom: .5em;
 	}
 
 	.message {
 		list-style-type: disc;
-		color: $red_50;
+		color: variables.$red_50;
 
 		p {
 			margin: .25em 0;
-			color: $red_50;
+			color: variables.$red_50;
 		}
 
 		button {
-			color: $primary-black;
+			color: variables.$primary-black;
 			font-size: 16px;
 			margin: 16px auto;
 		}
 
 		li {
 
-			@include word-wrap();
+			@include mixins.word-wrap();
 		}
 	}
 }

--- a/projects/plugins/boost/app/assets/src/js/features/image-size-analysis/recommendations-meta/recommendations-meta.module.scss
+++ b/projects/plugins/boost/app/assets/src/js/features/image-size-analysis/recommendations-meta/recommendations-meta.module.scss
@@ -1,4 +1,4 @@
-@import "$css/main/variables";
+@use "$css/main/variables";
 
 .summary-line {
 	font-size: 14px;
@@ -15,7 +15,7 @@
 	button {
 
 		svg {
-			fill: $jetpack-green;
+			fill: variables.$jetpack-green;
 		}
 
 		@media (max-width: 600px) {
@@ -28,7 +28,7 @@
 	margin-right: 5px;
 	flex-grow: 1;
 	position: relative;
-	color: $jetpack-green;
+	color: variables.$jetpack-green;
 }
 
 .has-issues {
@@ -64,8 +64,8 @@
 	align-items: center;
 	padding: 16px 24px;
 	margin: 32px 0;
-	border: 2px solid $jetpack-green;
-	border-radius: $border-radius;
+	border: 2px solid variables.$jetpack-green;
+	border-radius: variables.$border-radius;
 	background-color: #fff;
 	text-align: left;
 }

--- a/projects/plugins/boost/app/assets/src/js/features/lcp/status/error-details.module.scss
+++ b/projects/plugins/boost/app/assets/src/js/features/lcp/status/error-details.module.scss
@@ -1,10 +1,10 @@
-@import '$css/main/mixins';
+@use '$css/main/mixins';
 
 .summary {
 	margin-top: 16px;
 	margin-bottom: 16px;
 
-	@include breakpoint( xs ) {
+	@include mixins.breakpoint( xs ) {
 		margin-bottom: 1em;
 	}
 

--- a/projects/plugins/boost/app/assets/src/js/features/lcp/status/status.module.scss
+++ b/projects/plugins/boost/app/assets/src/js/features/lcp/status/status.module.scss
@@ -1,5 +1,5 @@
-@import '$css/main/mixins';
-@import '$css/main/variables';
+@use '$css/main/mixins';
+@use '$css/main/variables';
 
 // TODO: This is a copy of the styles from the critical-css/status component.
 // We should move this to a shared location.
@@ -16,7 +16,7 @@
 		margin-bottom: 0;
 	}
 
-	@include breakpoint( xs ) {
+	@include mixins.breakpoint( xs ) {
 		display: block;
 	}
 
@@ -27,9 +27,9 @@
 
 		.successes,
 		.generating {
-			color: $gray_40;
+			color: variables.$gray_40;
 
-			@include breakpoint( md ) {
+			@include mixins.breakpoint( md ) {
 				margin-right: 115px;
 			}
 		}

--- a/projects/plugins/boost/app/assets/src/js/features/minify-meta/minify-meta.module.scss
+++ b/projects/plugins/boost/app/assets/src/js/features/minify-meta/minify-meta.module.scss
@@ -1,5 +1,5 @@
-@import "$css/main/variables";
-@import "$css/main/mixins";
+@use "$css/main/variables";
+@use "$css/main/mixins";
 
 .wrapper {
 	font-size: 14px;
@@ -20,7 +20,7 @@
 		font-size: 14px;
 		line-height: 22px;
 
-		@include breakpoint(xs) {
+		@include mixins.breakpoint(xs) {
 			display: block;
 		}
 	}
@@ -62,11 +62,11 @@
 		width: 100%;
 		padding: 10px;
 		border-radius: 4px;
-		border: 1px solid $gray_10;
+		border: 1px solid variables.$gray_10;
 	}
 
 	.edit-button svg {
-		fill: $jetpack-green;
+		fill: variables.$jetpack-green;
 	}
 
 	.sub-header {

--- a/projects/plugins/boost/app/assets/src/js/features/speed-score/speed-score.module.scss
+++ b/projects/plugins/boost/app/assets/src/js/features/speed-score/speed-score.module.scss
@@ -1,5 +1,5 @@
-@import '$css/main/variables';
-@import '$css/main/mixins';
+@use '$css/main/variables';
+@use '$css/main/mixins';
 
 .speed-scores {
 
@@ -15,7 +15,7 @@
 		font-weight: 400;
 		max-width: 560px;
 		line-height: 1.5;
-		color: $gray_70;
+		color: variables.$gray_70;
 	}
 
 	.top {
@@ -25,12 +25,12 @@
 	}
 
 	.action-button {
-		color: $gray_90;
+		color: variables.$gray_90;
 		margin-left: auto;
 		min-width: auto;
 
 		svg {
-			fill: $jetpack-green;
+			fill: variables.$jetpack-green;
 		}
 	}
 
@@ -48,12 +48,12 @@
 :global(.jb-dashboard) .speed-scores h2 {
 	font-weight: 700;
 
-	@include breakpoint(xs) {
+	@include mixins.breakpoint(xs) {
 		font-size: 27px;
 	}
 }
 
-@include breakpoint(xs) {
+@include mixins.breakpoint(xs) {
 
 	.speed-scores :global(.icon-tooltip-helper.is-wide .components-popover) {
 		left: -60px !important;

--- a/projects/plugins/boost/app/assets/src/js/features/ui/back-button/back-button.module.scss
+++ b/projects/plugins/boost/app/assets/src/js/features/ui/back-button/back-button.module.scss
@@ -1,8 +1,8 @@
-@import '$css/main/variables';
+@use '$css/main/variables';
 
 .back-button {
 	text-decoration: none !important;
-	color: $gray_90;
+	color: variables.$gray_90;
 	line-height: 24px;
 
 	// Specify the global class for specificity so that it overrides the default styles.

--- a/projects/plugins/boost/app/assets/src/js/features/upgrade-cta/upgrade-cta.module.scss
+++ b/projects/plugins/boost/app/assets/src/js/features/upgrade-cta/upgrade-cta.module.scss
@@ -1,4 +1,4 @@
-@import '$css/main/variables';
+@use '$css/main/variables';
 
 .upgrade-cta {
 	width: 100%;
@@ -7,8 +7,8 @@
 	align-items: center;
 	padding: 16px 24px;
 	margin: 32px 0;
-	border: 2px solid $jetpack-green;
-	border-radius: $border-radius;
+	border: 2px solid variables.$jetpack-green;
+	border-radius: variables.$border-radius;
 	background-color: #fff;
 	text-align: left;
 	cursor: pointer;
@@ -22,6 +22,6 @@
 	}
 
 	.icon svg {
-		fill: $jetpack-green;
+		fill: variables.$jetpack-green;
 	}
 }

--- a/projects/plugins/boost/app/assets/src/js/layout/card-page/card-page.module.scss
+++ b/projects/plugins/boost/app/assets/src/js/layout/card-page/card-page.module.scss
@@ -1,16 +1,16 @@
-@import "$css/main/variables";
-@import "$css/main/mixins";
-@import "$css/main/common";
+@use "$css/main/variables";
+@use "$css/main/mixins";
+@use "$css/main/common";
 
 .card {
 	background: #FFF url(\$images/color-shift.svg) no-repeat top right;
 	border: 1px solid #DCDCDE;
-	border-radius: $border-radius;
+	border-radius: variables.$border-radius;
 
 	.content {
 
 		@extend .p-4; // stylelint-disable-line scss/at-extend-no-missing-placeholder -- This is a generated class from css/main/common.scss.
-		color: $primary-black;
+		color: variables.$primary-black;
 
 		ul li {
 			padding-top: 2px;
@@ -33,14 +33,14 @@
 		}
 	}
 
-	@include breakpoint( xs ) {
+	@include mixins.breakpoint( xs ) {
 
 		.content {
-			padding: $spacing-unit * 3;
+			padding: variables.$spacing-unit * 3;
 		}
 	}
 
-	@include breakpoint( lg ) {
+	@include mixins.breakpoint( lg ) {
 		display: grid;
 		grid-template-columns: auto 460px;
 	}
@@ -48,8 +48,8 @@
 
 .footer-note {
 	text-align: center;
-	margin-top: $halfling;
-	color: $gray_70;
+	margin-top: variables.$halfling;
+	color: variables.$gray_70;
 }
 
 .body {

--- a/projects/plugins/boost/app/assets/src/js/layout/settings-page/tips/tips.module.scss
+++ b/projects/plugins/boost/app/assets/src/js/layout/settings-page/tips/tips.module.scss
@@ -1,16 +1,16 @@
-@import '$css/main/variables';
-@import '$css/main/mixins';
+@use '$css/main/variables';
+@use '$css/main/mixins';
 
 .tips {
 	margin: 0 auto;
 
 	.tips-title {
-		margin-bottom: $padding;
+		margin-bottom: variables.$padding;
 	}
 
 	.tips-items {
 
-		@include breakpoint(md) {
+		@include mixins.breakpoint(md) {
 			display: grid;
 			grid-template-columns: 1fr 1fr;
 			grid-gap: 2em;
@@ -20,7 +20,7 @@
 	.item {
 		margin-bottom: 2em;
 
-		@include breakpoint(sm) {
+		@include mixins.breakpoint(sm) {
 			display: grid;
 			grid-template-columns: 80px 1fr;
 			grid-gap: 1em;
@@ -30,9 +30,9 @@
 			font-size: 24px;
 			font-weight: 400;
 			line-height: 30px;
-			color: $primary-black;
+			color: variables.$primary-black;
 
-			@include breakpoint(md) {
+			@include mixins.breakpoint(md) {
 				flex-basis: 20%;
 				font-size: 36px;
 				line-height: 43px;
@@ -43,14 +43,14 @@
 			flex-basis: 70%;
 			font-weight: 400;
 			line-height: 24px;
-			color: $primary-grey;
+			color: variables.$primary-grey;
 
-			@include breakpoint(md) {
+			@include mixins.breakpoint(md) {
 				flex-basis: 80%;
 			}
 
 			a {
-				color: $gray_90;
+				color: variables.$gray_90;
 			}
 		}
 	}

--- a/projects/plugins/boost/app/assets/src/js/pages/cache-debug-log/cache-debug-log.module.scss
+++ b/projects/plugins/boost/app/assets/src/js/pages/cache-debug-log/cache-debug-log.module.scss
@@ -1,4 +1,4 @@
-@import "$css/main/variables";
+@use "$css/main/variables";
 
 .header {
 	display: flex;
@@ -16,5 +16,5 @@
 }
 
 .section {
-	border-top: 1px solid $gray_5;
+	border-top: 1px solid variables.$gray_5;
 }

--- a/projects/plugins/boost/app/assets/src/js/pages/critical-css-advanced/critical-css-advanced.module.scss
+++ b/projects/plugins/boost/app/assets/src/js/pages/critical-css-advanced/critical-css-advanced.module.scss
@@ -1,5 +1,5 @@
-@import "$css/main/mixins";
-@import "$css/main/variables";
+@use "$css/main/mixins";
+@use "$css/main/variables";
 
 .problem {
 
@@ -17,13 +17,13 @@
 .panel {
 	margin-top: 0;
 	position: relative;
-	border: 1px solid $gray_5;
+	border: 1px solid variables.$gray_5;
 	border-radius: 4px;
 	padding: 24px 69px 24px 27px;
 
 	li {
 
-		@include word-wrap();
+		@include mixins.word-wrap();
 	}
 
 	h4 {
@@ -35,7 +35,7 @@
 			vertical-align: sub;
 			margin: 4px 4px 2px 0;
 			height: 20px;
-			fill: $color_warning;
+			fill: variables.$color_warning;
 		}
 	}
 }

--- a/projects/plugins/boost/changelog/fix-sass-deprecations-in-boost
+++ b/projects/plugins/boost/changelog/fix-sass-deprecations-in-boost
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix sass deprecation warnings. No changes to built CSS.
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This was pretty straightforward, although complicated a little bit by the use of webpack aliasing.

I note there's one existing file that is already doing `@use '$css/main/variables.scss' as *`. I didn't change that, but I also didn't follow suit.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Should be no changes to the built CSS artifacts.
