### PR TITLE
jetpack: Fix Sass deprecation warnings

### DIFF
--- a/projects/plugins/jetpack/_inc/client/at-a-glance/backup-getting-started/style.scss
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/backup-getting-started/style.scss
@@ -1,4 +1,4 @@
-@import '../../scss/calypso-mixins';
+@use '../../scss/calypso-mixins';
 
 .dash-backup-getting-started {
     position: relative;
@@ -8,12 +8,12 @@
     padding: 2rem;
     margin-top: 0.625rem;
 
-    @include breakpoint( '>480px' ) {
+    @include calypso-mixins.breakpoint( '>480px' ) {
         margin-top: 1rem;
         margin-bottom: 2rem;
     }
 
-    @include breakpoint( '>660px' ) {
+    @include calypso-mixins.breakpoint( '>660px' ) {
 		flex-direction: row;
         align-items: center;
 	}
@@ -38,7 +38,7 @@
     flex: 1 1 auto;
     margin: 1rem 0 2rem;
 
-    @include breakpoint( '>660px' ) {
+    @include calypso-mixins.breakpoint( '>660px' ) {
         margin: 0 1rem;
 	}
 }
@@ -61,7 +61,7 @@
 .dash-backup-getting-started__cta {
     flex-shrink: 0;
 
-    @include breakpoint( '>660px' ) {
+    @include calypso-mixins.breakpoint( '>660px' ) {
         margin-left: auto;
 	}
 }

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/boost/style.scss
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/boost/style.scss
@@ -1,7 +1,7 @@
-@import '../../scss/calypso-colors';
-@import '../../scss/mixin_breakpoint';
+@use '../../scss/calypso-colors';
+@use '../../scss/mixin_breakpoint';
 
-$border: 1px solid $gray-5;
+$border: 1px solid calypso-colors.$gray-5;
 
 .boost-grade-info,
 .boost-conversion-loss-info,
@@ -48,9 +48,9 @@ $border: 1px solid $gray-5;
 }
 
 .dash-boost-speed-score {
-    background-color: $white;
+    background-color: calypso-colors.$white;
     border: $border;
-    color: $gray-80;
+    color: calypso-colors.$gray-80;
     border-radius: 0.25rem;
 
     .dops-card {
@@ -60,7 +60,7 @@ $border: 1px solid $gray-5;
 
     .dops-banner__title {
         line-height: 1.57;
-        color: $gray-80;
+        color: calypso-colors.$gray-80;
     }
 
     .jb-score-bar {
@@ -69,15 +69,15 @@ $border: 1px solid $gray-5;
 
     .jb-score-bar__label,
     .jb-score-bar__filler.fill-loading {
-        background-color: $gray-0;
+        background-color: calypso-colors.$gray-0;
 
-        @include breakpoint( "<782px" ) {
-            background-color: $white;
+        @include mixin_breakpoint.breakpoint( "<782px" ) {
+            background-color: calypso-colors.$white;
         }
     }
 
     .warning {
-        color: $orange-warning;
+        color: calypso-colors.$orange-warning;
     }
 
     &__score-bars,
@@ -91,7 +91,7 @@ $border: 1px solid $gray-5;
         
         padding: 1rem;
 
-        @include breakpoint( "<660px" ) {
+        @include mixin_breakpoint.breakpoint( "<660px" ) {
             flex-direction: column;
         }
     }
@@ -110,7 +110,7 @@ $border: 1px solid $gray-5;
     &__last-tested {
         margin: 0 0 0.25rem 0;
         
-        color: $gray-30;
+        color: calypso-colors.$gray-30;
         text-align: left;
     }
 
@@ -122,7 +122,7 @@ $border: 1px solid $gray-5;
 
         cursor: pointer;
 
-        color: $black;
+        color: calypso-colors.$black;
         text-decoration: underline;
         text-align: right;
 

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/security-bundle/style.scss
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/security-bundle/style.scss
@@ -1,6 +1,6 @@
-@import '../../scss/calypso-mixins';
-@import '../../scss/mixins/ui';
-@import '../../scss/typography';
+@use '../../scss/calypso-mixins';
+@use '../../scss/mixins/ui';
+@use '../../scss/typography';
 
 .dash-security-bundle {
 	display: flex;
@@ -10,10 +10,10 @@
 	background: rgb(249, 249, 246);
 	background: linear-gradient(133deg, rgb(206, 217, 242) 0%, rgb(249, 249, 246) 10%, rgb(249, 249, 246) 80%, rgb(245, 230, 179) 100%);
 
-	@include dashboard-card-shadow;
+	@include ui.dashboard-card-shadow;
 
 	// match aag responsive styling
-	@include breakpoint( '>660px' ) {
+	@include calypso-mixins.breakpoint( '>660px' ) {
 		flex-direction: row;
 	}
 
@@ -24,7 +24,7 @@
 		margin-right: 0;
 		margin-top: 16px;
 
-		@include breakpoint( '>660px' ) {
+		@include calypso-mixins.breakpoint( '>660px' ) {
 			align-items: center;
 			margin-bottom: 0;
 			margin-right: 32px;
@@ -38,7 +38,7 @@
 		flex: 1;
 		justify-content: space-between;
 
-		@include breakpoint( '>660px' ) {
+		@include calypso-mixins.breakpoint( '>660px' ) {
 			flex-direction: row;
 		}
 
@@ -47,14 +47,14 @@
 			flex-direction: column;
 
 			h3 {
-				font-size: $font-title-medium;
+				font-size: typography.$font-title-medium;
 				line-height: 32px;
 				font-weight: 500;
 				margin: 8px 0 0 0;
 			}
 
 			p {
-				font-size: $font-body;
+				font-size: typography.$font-body;
 				margin: 8px 0 0 0;
 			}
 		}
@@ -66,7 +66,7 @@
 			margin-top: 16px;
 			margin-left: 0;
 
-			@include breakpoint( '>660px' ) {
+			@include calypso-mixins.breakpoint( '>660px' ) {
 				margin-top: 0;
 				margin-left: 16px;
 			}

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/style.scss
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/style.scss
@@ -2,7 +2,11 @@
 // For more precise styles, dig into the styles of each component. ie. dash-item
 @use 'sass:color';
 @use '../scss/functions/rem';
-@import '../scss/calypso-colors';
+@use '../scss/calypso-colors';
+@use "../scss/mixins/breakpoints";
+@use "../scss/mixins/ui";
+@use "../scss/typography";
+@use "../scss/variables/colors";
 
 .jp-at-a-glance {
 	margin-bottom: rem.convert( 48px );
@@ -27,7 +31,7 @@
 	}
 
 	.dops-button .dashicons-no {
-		color: $black;
+		color: colors.$black;
 	}
 
 	.dops-banner__title {
@@ -58,11 +62,11 @@
 .jp-at-a-glance__stats-card {
 	padding: 0;
 
-	@include dashboard-card-shadow;
+	@include ui.dashboard-card-shadow;
 	margin-bottom: 24px;
 
 	.jp-link-button {
-		background: $white;
+		background: colors.$white;
 		border: none;
 		padding: 2px 0;
 	}
@@ -71,7 +75,7 @@
 .dops-banner__content {
 
 	.jp-link-button {
-		background: $white;
+		background: colors.$white;
 		border: none;
 		font-size: 0.75rem;
 		padding: 1px 0;
@@ -83,15 +87,15 @@
 	margin-bottom: 0;
 
 	p {
-		font-size: $font-body-small;
-		color: $gray-80;
+		font-size: typography.$font-body-small;
+		color: calypso-colors.$gray-80;
 	}
 }
 
 .jp-at-a-glance__stats-inactive {
 	padding: rem.convert( 16px );
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoints.breakpoint( '>660px' ) {
 		display: flex;
 		flex-wrap: nowrap;
 		flex-direction: row;
@@ -104,16 +108,16 @@
 	display: flex;
 	flex-grow: 0;
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoints.breakpoint( '<660px' ) {
 		display: none;
 	}
 }
 
 .jp-at-a-glance__stats-inactive-text {
-	font-size: $font-body-small;
+	font-size: typography.$font-body-small;
 	line-height: 1.5;
 	letter-spacing: -0.3px;
-	color: $gray-80;
+	color: calypso-colors.$gray-80;
 	flex-grow: 1;
 
 	h3 {
@@ -122,14 +126,14 @@
 		font-weight: 700;
 		// stylelint-disable-next-line declaration-property-unit-allowed-list -- this should be changed to a unitless value: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/#values
 		line-height: 136%;
-		color: $black;
+		color: colors.$black;
 	}
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoints.breakpoint( '<660px' ) {
 		padding: 0 0 rem.convert( 16px );
 	}
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoints.breakpoint( '>660px' ) {
 		flex-basis: 50%;
 		padding: 0 rem.convert( 16px );
 	}
@@ -140,15 +144,15 @@
 
 	button.dops-button.is-primary {
 		padding: 4px 20px;
-		font-size: $font-body-small;
+		font-size: typography.$font-body-small;
 
 		&:focus {
-			border: 1px solid $white;
-			box-shadow: 0 0 0 1px $black;
+			border: 1px solid colors.$white;
+			box-shadow: 0 0 0 1px colors.$black;
 		}
 	}
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoints.breakpoint( '>660px' ) {
 		flex-grow: 0;
 		margin-left: 64px;
 	}
@@ -169,8 +173,8 @@
 .jp-at-a-glance__stats-bottom {
 	margin: rem.convert( 8px ) 0 0;
 
-	@include breakpoint( '<480px' ) {
-		box-shadow: 0 0 0 1px $light-gray-700;
+	@include breakpoints.breakpoint( '<480px' ) {
+		box-shadow: 0 0 0 1px calypso-colors.$light-gray-700;
 	}
 }
 
@@ -203,13 +207,13 @@
 .jp-at-a-glance__stats-summary {
 	text-align: center;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoints.breakpoint( '>660px' ) {
 		flex-wrap: nowrap;
 		display: flex;
 		flex-direction: row;
 	}
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoints.breakpoint( '<660px' ) {
 		display: block;
 	}
 }
@@ -227,7 +231,7 @@
 	border-style: solid;
 	border-color: #DCDCDE;
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoints.breakpoint( '<660px' ) {
 		margin-top: rem.convert( -1px );
 	}
 }
@@ -237,7 +241,7 @@
 	border-style: solid;
 	border-color: #DCDCDE;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoints.breakpoint( '>660px' ) {
 		margin: 0 rem.convert( 1px );
 	}
 }
@@ -258,7 +262,7 @@
 .jp-at-a-glance__stats-summary-alltime-views,
 .jp-at-a-glance__stats-summary-alltime-comments {
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoints.breakpoint( '<660px' ) {
 		margin-top: rem.convert( 1px );
 	}
 }
@@ -266,36 +270,36 @@
 .jp-at-a-glance__stats-cta {
 	padding: rem.convert( 12px );
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoints.breakpoint( '>660px' ) {
 		display: flex;
 		flex-direction: row;
 		flex-wrap: nowrap;
 		align-items: center;
 	}
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoints.breakpoint( '<660px' ) {
 		display: block;
 	}
 }
 
 .jp-at-a-glance__stats-cta-description {
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoints.breakpoint( '>660px' ) {
 		flex-basis: 30%;
 	}
 }
 
 .jp-at-a-glance__stat-details {
 	margin: 0;
-	font-size: $font-body;
+	font-size: typography.$font-body;
 	line-height: 24px;
-	color: $gray-80;
+	color: calypso-colors.$gray-80;
 	letter-spacing: -0.02em;
 }
 
 .jp-at-a-glance__stat-number {
-	color: $black;
-	font-size: $font-title-small;
+	color: colors.$black;
+	font-size: typography.$font-title-small;
 	line-height: 30px;
 	font-weight: 500;
 	margin: rem.convert( 6px ) 0 rem.convert( 4px );
@@ -307,12 +311,12 @@
 	align-items: center;
 	justify-content: flex-end;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoints.breakpoint( '>660px' ) {
 		text-align: right;
 		flex-basis: 70%;
 	}
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoints.breakpoint( '<660px' ) {
 		text-align: center;
 		flex-direction: column;
 
@@ -348,7 +352,7 @@
 		outline: 0;
 	}
 
-	@include breakpoint('<480px') {
+	@include breakpoints.breakpoint('<480px') {
 		margin-left: 0;
 		margin-right: rem.convert(16px);
 	}
@@ -356,7 +360,7 @@
 	.jp-at-a-glance__stats-view-link,
 	.jp-at-a-glance__stats-view-link:hover,
 	.jp-at-a-glance__stats-view-link:visited {
-		color: $gray-60;
+		color: calypso-colors.$gray-60;
 		text-decoration: none;
 		font-size: 16px;
 		line-height: 24px;
@@ -366,10 +370,10 @@
 		&.is-current,
 		&:visited.is-current,
 		&:focus.is-current {
-			color: $black;
+			color: colors.$black;
 			text-decoration: none;
 			padding-bottom: rem.convert(11px);
-			border-bottom: 2px solid $black;
+			border-bottom: 2px solid colors.$black;
 		}
 	}
 }
@@ -383,7 +387,7 @@
 .jp-at-a-glance__item-grid {
 	display: flex;
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoints.breakpoint( '<660px' ) {
 		display: block; // don't need flexbox on smaller screens
 	}
 }
@@ -393,12 +397,12 @@
 	display: flex;
 	min-width: 0;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoints.breakpoint( '>660px' ) {
 		flex-basis: 50%;
 		margin-bottom: rem.convert( 16px );
 	}
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoints.breakpoint( '<660px' ) {
 		margin-bottom: rem.convert( 12px );
 	}
 
@@ -432,7 +436,7 @@
 				margin-left: 0;
 				padding-left: 0;
 
-				@include breakpoint( '<480px' ) {
+				@include breakpoints.breakpoint( '<480px' ) {
 					text-transform: none;
 				}
 			}
@@ -451,7 +455,7 @@
 .jp-at-a-glance__left {
 	display: flex;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoints.breakpoint( '>660px' ) {
 		margin-right: rem.convert( 16px );
 
 		&:last-child {
@@ -477,8 +481,8 @@
 .jp-connection-settings__text {
 	margin-left: rem.convert( 16px );
 	word-break: break-word;
-	color: $gray-80;
-	font-size: $font-body-small;
+	color: calypso-colors.$gray-80;
+	font-size: typography.$font-body-small;
 	line-height: 24px;
 	letter-spacing: -0.02em;
 
@@ -505,7 +509,7 @@
 	.jp-connection-settings__gravatar {
 		display: inline-block;
 		min-width: rem.convert( 64px );
-		background: $gray;
+		background: colors.$gray;
 		border-radius: 50%;
 		margin-bottom: 0;
 	}
@@ -515,7 +519,7 @@
 	max-width: 635px;
 	min-height: 400px;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoints.breakpoint( '>660px' ) {
 		min-height: auto;
 	}
 }
@@ -523,33 +527,33 @@
 .jp-connection-settings__modal-body {
 	margin: 0;
 	padding: rem.convert( 24px ) rem.convert( 32px );
-	font-size: $font-body-small;
-	color: $blue-dark-text;
+	font-size: typography.$font-body-small;
+	color: colors.$blue-dark-text;
 	text-align: center;
 
 	h2 {
 		margin: rem.convert( 32px ) 0 rem.convert( 24px );
-		font-size: $font-title-large;
+		font-size: typography.$font-title-large;
 		font-weight: 300;
-		color: $blue-dark-text;
+		color: colors.$blue-dark-text;
 	}
 
 	h4 {
 		margin: rem.convert( 16px ) rem.convert( 24px ) 0;
-		font-size: $font-body;
+		font-size: typography.$font-body;
 		font-weight: 400;
 		// stylelint-disable-next-line declaration-property-unit-allowed-list -- this should be changed to a unitless value: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/#values
 		line-height: 1.5em;
-		color: $blue-heading;
+		color: colors.$blue-heading;
 	}
 
 	p {
-		font-size: $font-body-small;
+		font-size: typography.$font-body-small;
 	}
 
 	ul {
 		margin: rem.convert( 24px ) 0 rem.convert( 36px );
-		color: $blue-text;
+		color: colors.$blue-text;
 	}
 
 	li {
@@ -557,11 +561,11 @@
 		display: block;
 		margin: 0;
 		padding: rem.convert( 16px ) rem.convert( 8px ) rem.convert( 16px ) rem.convert( 44px );
-		border-bottom: 1px solid color.adjust( $gray, $lightness: 25% );
+		border-bottom: 1px solid color.adjust( colors.$gray, $lightness: 25% );
 		text-align: left;
 
 		&:first-of-type {
-			border-top: 1px solid color.adjust( $gray, $lightness: 25% );
+			border-top: 1px solid color.adjust( colors.$gray, $lightness: 25% );
 		}
 	}
 
@@ -570,7 +574,7 @@
 		left: rem.convert( 16px );
 		top: rem.convert( 16px );
 		vertical-align: text-bottom;
-		color: $blue-text;
+		color: colors.$blue-text;
 	}
 }
 
@@ -579,7 +583,7 @@
 }
 
 .jp-connection-settings__modal-more a {
-	color: $blue-wordpress;
+	color: colors.$blue-wordpress;
 	text-decoration: underline;
 }
 
@@ -625,11 +629,11 @@ a.jp-dash-item__manage-in-wpcom,
 	&, &:active, &:visited, &:hover, &:focus {
 		cursor: pointer;
 		font-weight: 400;
-		font-size: $font-body-small;
+		font-size: typography.$font-body-small;
 		line-height: 24px;
 		letter-spacing: -0.02em;
 		text-decoration: underline;
-		color: $black;
+		color: colors.$black;
 
 		&:hover {
 			text-decoration-thickness: 3px;
@@ -647,18 +651,18 @@ a.jp-dash-item__manage-in-wpcom,
 .jp-connection-settings__actions a {
 
 	&, &:active, &:visited, &:hover, &:focus {
-		color: $gray-80;
+		color: calypso-colors.$gray-80;
 	}
 }
 
 .jp-dash-item.dash-backups {
 
-	@include dashboard-card-shadow;
+	@include ui.dashboard-card-shadow;
 
 	.dops-section-header {
 		box-shadow: none;
 		border: 0;
-		border-bottom: 1px solid $gray-5;
+		border-bottom: 1px solid calypso-colors.$gray-5;
 		margin: 0;
 	}
 
@@ -670,14 +674,14 @@ a.jp-dash-item__manage-in-wpcom,
 	.dops-banner {
 		box-shadow: none;
 		border: 0;
-		border-top: 1px solid $gray-5;
+		border-top: 1px solid calypso-colors.$gray-5;
 	}
 
 	.dash-backup-undo {
 		display: flex;
 		flex-direction: row;
 		align-items: center;
-		border-bottom: 1px solid $gray-5;
+		border-bottom: 1px solid calypso-colors.$gray-5;
 	}
 
 	.dash-backup-undo__activity-log {
@@ -688,7 +692,7 @@ a.jp-dash-item__manage-in-wpcom,
 		font-size: 0.75rem;
 
 		.dash-backup-undo__activity-log-date {
-			color: $gray-60;
+			color: calypso-colors.$gray-60;
 		}
 
 		.dash-backup-undo__activity-log-action,
@@ -698,12 +702,12 @@ a.jp-dash-item__manage-in-wpcom,
 		}
 
 		.dash-backup-undo__activity-log-action {
-			font-size: $font-body;
+			font-size: typography.$font-body;
 			font-weight: 600;
 		}
 
 		.dash-backup-undo__activity-log-description {
-			font-size: $font-body-small;
+			font-size: typography.$font-body-small;
 		}
 
 		.dash-backup-undo__activity-log-user-meta {
@@ -729,7 +733,7 @@ a.jp-dash-item__manage-in-wpcom,
 	}
 
 	.dash-backup-undo__cta svg {
-		fill: $white;
+		fill: colors.$white;
 		position: relative;
 		top: 5px;
 		margin-top: -6px;
@@ -740,7 +744,7 @@ a.jp-dash-item__manage-in-wpcom,
 
 	.dops-banner {
 		margin-bottom: 0;
-		border-top: 1px solid $gray-5;
+		border-top: 1px solid calypso-colors.$gray-5;
 	}
 }
 

--- a/projects/plugins/jetpack/_inc/client/components/about-page/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/about-page/style.scss
@@ -1,3 +1,5 @@
+@use "../../scss/mixins/breakpoints";
+@use "../../scss/variables/colors";
 @use 'sass:color';
 
 $color__border: #dcdcde;
@@ -5,7 +7,7 @@ $color__back-link: #787c82;
 
 .jetpack-about__main,
 .jetpack-about__plugin {
-	background-color: $white;
+	background-color: colors.$white;
 	box-shadow: 0 0 40px rgba(0, 0, 0, 0.08);
 	border-radius: 4px;
 }
@@ -162,7 +164,7 @@ $color__back-link: #787c82;
 	}
 
   	.button {
-	  background: $white;
+	  background: colors.$white;
 	  border: none;
 	  border-radius: var(--jp-border-radius);
 	  outline: solid 1.5px var(--jp-black);
@@ -208,7 +210,7 @@ $color__back-link: #787c82;
 	grid-template-columns: 1fr 1fr;
 	grid-gap: 24px;
 
-	@include breakpoint( "<960px" ) {
+	@include breakpoints.breakpoint( "<960px" ) {
 	  display: block;
 	}
 }
@@ -244,7 +246,7 @@ $color__back-link: #787c82;
 
 	.plugin-card-bottom {
 		align-items: center;
-		background-color: $white;
+		background-color: colors.$white;
 		display: flex;
 		flex-wrap: wrap;
 		justify-content: space-between;
@@ -269,7 +271,7 @@ $color__back-link: #787c82;
 		}
 	}
 
-	@include breakpoint( "<960px" ) {
+	@include breakpoints.breakpoint( "<960px" ) {
 	  margin-bottom: 24px;
 	}
 }

--- a/projects/plugins/jetpack/_inc/client/components/apps-card/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/apps-card/style.scss
@@ -1,5 +1,6 @@
 @use '../../scss/functions/rem';
-@import '../../scss/mixins/ui';
+@use '../../scss/mixins/ui';
+@use "../../scss/mixins/breakpoints";
 
 .jp-apps-card {
 	margin-top: rem.convert( 24px );
@@ -8,7 +9,7 @@
 
 .jp-apps-card__content {
 
-	@include dashboard-card-shadow;
+	@include ui.dashboard-card-shadow;
 
 	display: flex;
 	justify-content: space-between;
@@ -40,7 +41,7 @@
 		}
 	}
 
-	@include breakpoint( '<782px' ) {
+	@include breakpoints.breakpoint( '<782px' ) {
 		flex-direction: column;
 
 		.jp-apps-card__description {
@@ -115,7 +116,7 @@
 	justify-content: center;
 	align-items: center;
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoints.breakpoint( '<480px' ) {
 
 		.apps-badge:first-child {
 			margin-right: 0;

--- a/projects/plugins/jetpack/_inc/client/components/banner/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/banner/style.scss
@@ -1,8 +1,8 @@
 @use 'sass:color';
-@import '../../scss/layout';
-@import '../../scss/variables/colors';
-@import '../../scss/color-functions';
-@import '../../scss/typography';
+@use '../../scss/layout';
+@use '../../scss/variables/colors';
+@use '../../scss/color-functions';
+@use '../../scss/typography';
 
 @mixin banner-color( $color ) {
 
@@ -33,51 +33,51 @@
 		padding-right: 48px;
 	}
 
-	@include banner-color( $blue-wordpress );
+	@include banner-color( colors.$blue-wordpress );
 
 	&.is-jetpack-info {
 
-		@include banner-color( $green-primary );
+		@include banner-color( colors.$green-primary );
 	}
 
 	&.is-product {
 
-		@include banner-color( $color-product );
+		@include banner-color( colors.$color-product );
 	}
 
 	&.is-plan {
 
-		@include banner-color( $color-plan );
+		@include banner-color( colors.$color-plan );
 
 		&.is-upgrade-personal {
 
-			@include banner-color( $alert-yellow );
+			@include banner-color( colors.$alert-yellow );
 		}
 
 		&.is-upgrade-premium {
 
-			@include banner-color( $alert-green );
+			@include banner-color( colors.$alert-green );
 		}
 
 		&.is-upgrade-business {
 
-			@include banner-color( $alert-purple );
+			@include banner-color( colors.$alert-purple );
 		}
 
 		&.is-bundle {
 
-			@include banner-color( $color-bundle );
+			@include banner-color( colors.$color-bundle );
 		}
 
 		&.is-jetpack-warning {
 
-			@include banner-color( $alert-yellow );
+			@include banner-color( colors.$alert-yellow );
 		}
 	}
 
 	.dops-card__link-indicator {
 		align-items: center;
-		color: $blue-wordpress;
+		color: colors.$blue-wordpress;
 		display: flex;
 	}
 
@@ -85,15 +85,15 @@
 		transition: all 100ms ease-in-out;
 
 		&.is-card-link {
-			box-shadow: 0 0 0 1px $gray, 0 2px 4px color.adjust( $gray, $lightness: 20% );
+			box-shadow: 0 0 0 1px colors.$gray, 0 2px 4px color.adjust( colors.$gray, $lightness: 20% );
 		}
 
 		.dops-card__link-indicator {
-			color: $blue-dark;
+			color: colors.$blue-dark;
 		}
 	}
 
-	@include breakpoint( '>480px' ) {
+	@include layout.breakpoint( '>480px' ) {
 		padding: 16px;
 
 		&.is-dismissible {
@@ -119,7 +119,7 @@
 
 	.dops-banner__icon {
 		align-self: center;
-		color: $white;
+		color: colors.$white;
 		display: block;
 	}
 
@@ -133,7 +133,7 @@
 		transform: translate( 1px, 4px );
 	}
 
-	@include breakpoint( '>480px' ) {
+	@include layout.breakpoint( '>480px' ) {
 		align-items: center;
 
 		.dops-banner__icon {
@@ -155,7 +155,7 @@
 		width: 32px;
 	}
 
-	@include breakpoint( '>480px' ) {
+	@include layout.breakpoint( '>480px' ) {
 		align-items: center;
 		align-self: center;
 	}
@@ -173,7 +173,7 @@
 	flex-grow: 1;
 	flex-wrap: wrap;
 
-	@include breakpoint( '>480px' ) {
+	@include layout.breakpoint( '>480px' ) {
 		flex-wrap: nowrap;
 	}
 }
@@ -186,21 +186,21 @@
 	.dops-banner__title,
 	.dops-banner__description,
 	.dops-banner__list {
-		color: $gray-dark;
+		color: colors.$gray-dark;
 	}
 
 	.dops-banner__title {
-		font-size: $font-body-small;
+		font-size: typography.$font-body-small;
 	}
 
 	.dops-banner__description {
-		font-size: $font-body-extra-small;
+		font-size: typography.$font-body-extra-small;
 		margin-top: 3px;
 
 		.jp-link-button {
 
 			&, &:active, &:visited, &:hover, &:focus {
-				font-size: $font-body-extra-small;
+				font-size: typography.$font-body-extra-small;
 				line-height: 1.4;
 				box-shadow: none;
 				background: none;
@@ -209,7 +209,7 @@
 	}
 
 	.dops-banner__list {
-		font-size: $font-body-extra-small;
+		font-size: typography.$font-body-extra-small;
 		list-style: none;
 		margin: 0;
 
@@ -217,13 +217,13 @@
 			margin: 6px 0;
 
 			.gridicon {
-				color: $gray;
+				color: colors.$gray;
 				display: none;
 			}
 		}
 	}
 
-	@include breakpoint( '>480px' ) {
+	@include layout.breakpoint( '>480px' ) {
 		width: auto;
 
 		.dops-banner__list li .gridicon {
@@ -236,7 +236,7 @@
 
 .dops-banner__action {
 	align-self: center;
-	font-size: $font-body-extra-small;
+	font-size: typography.$font-body-extra-small;
 	margin: 8px 0 0 8px;
 	text-align: left;
 	width: 100%;
@@ -251,7 +251,7 @@
 
 		.dops-plan-price.is-discounted,
 		.dops-plan-price.is-discounted .dops-plan-price__currency-symbol {
-			color: $gray-dark;
+			color: colors.$gray-dark;
 		}
 
 		.has-call-to-action & .dops-plan-price {
@@ -259,7 +259,7 @@
 		}
 	}
 
-	@include breakpoint( '>480px' ) {
+	@include layout.breakpoint( '>480px' ) {
 		margin: 0 4px 0 8px;
 		text-align: center;
 		width: auto;

--- a/projects/plugins/jetpack/_inc/client/components/button-group/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/button-group/style.scss
@@ -1,6 +1,6 @@
 @use 'sass:color';
 @use '../../scss/z-index';
-@import "../../scss/calypso-colors";
+@use "../../scss/calypso-colors";
 
 .dops-button-group {
 
@@ -16,20 +16,20 @@
 
 		&.is-primary:focus {
 			box-shadow:
-				0 0 0 1px $white,
-				0 0 0 3px $blue-medium-dark;
+				0 0 0 1px calypso-colors.$white,
+				0 0 0 3px calypso-colors.$blue-medium-dark;
 		}
 
 		&.is-scary:focus {
-			box-shadow: inset 1px 0 0 $alert-red, 0 0 0 2px color.adjust( $alert-red, $lightness: 20% );
+			box-shadow: inset 1px 0 0 calypso-colors.$alert-red, 0 0 0 2px color.adjust( calypso-colors.$alert-red, $lightness: 20% );
 		}
 
 		&.is-primary.is-scary:focus {
-			box-shadow: inset 1px 0 0 color.adjust( $alert-red, $lightness: -30% ), 0 0 0 2px color.adjust( $alert-red, $lightness: 20% );
+			box-shadow: inset 1px 0 0 color.adjust( calypso-colors.$alert-red, $lightness: -30% ), 0 0 0 2px color.adjust( calypso-colors.$alert-red, $lightness: 20% );
 		}
 
 		&.is-scary:first-child:focus {
-			box-shadow: 0 0 0 2px color.adjust( $alert-red, $lightness: 20% );
+			box-shadow: 0 0 0 2px color.adjust( calypso-colors.$alert-red, $lightness: 20% );
 		}
 	}
 

--- a/projects/plugins/jetpack/_inc/client/components/button/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/button/style.scss
@@ -1,23 +1,23 @@
 @use 'sass:color';
 @use "../../scss/functions/rem";
-@import "../../scss/calypso-colors";
-@import "../../scss/color-functions";
-@import "../../scss/typography";
+@use "../../scss/calypso-colors";
+@use "../../scss/color-functions";
+@use "../../scss/typography";
 
 // ==========================================================================
 // Buttons
 // ==========================================================================
 
 .dops-button {
-	background: $white;
-	box-shadow: inset 0 0 0 1.5px $black;
+	background: calypso-colors.$white;
+	box-shadow: inset 0 0 0 1.5px calypso-colors.$black;
 	border: none;
-	color: $black;
+	color: calypso-colors.$black;
 	display: inline-block;
 	margin: 0;
 	outline: 0;
 	overflow: hidden;
-	font-size: $font-body;
+	font-size: typography.$font-body;
 	line-height: 24px;
 	text-overflow: ellipsis;
 	text-decoration: none;
@@ -30,31 +30,31 @@
 	cursor: pointer;
 
 	&:hover {
-		background: $blue-grey-light;
-		box-shadow: inset 0 0 0 1px $black;
-		color: $gray-80;
+		background: calypso-colors.$blue-grey-light;
+		box-shadow: inset 0 0 0 1px calypso-colors.$black;
+		color: calypso-colors.$gray-80;
 	}
 
 	&[disabled],
 	&:disabled {
-		color: color.adjust( $gray, $lightness: 30% );
-		background: $white;
-		border-color: color.adjust( $gray, $lightness: 30% );
+		color: color.adjust( calypso-colors.$gray, $lightness: 30% );
+		background: calypso-colors.$white;
+		border-color: color.adjust( calypso-colors.$gray, $lightness: 30% );
 		cursor: default;
 	}
 
 	&:focus {
-		background: $white;
-		border-color: $black;
+		background: calypso-colors.$white;
+		border-color: calypso-colors.$black;
 	}
 
 	&.is-compact {
 		padding: 4px 8px;
 		line-height: 20px;
-		font-size: $font-body-extra-small;
+		font-size: typography.$font-body-extra-small;
 
 		&:disabled {
-			color: color.adjust( $gray, $lightness: 30% );
+			color: color.adjust( calypso-colors.$gray, $lightness: 30% );
 		}
 
 		.gridicon {
@@ -92,9 +92,9 @@
 
 // Primary buttons
 .dops-button.is-primary {
-	background: $black;
-	box-shadow: inset 0 0 0 1.5px $black;
-	color: $white;
+	background: calypso-colors.$black;
+	box-shadow: inset 0 0 0 1.5px calypso-colors.$black;
+	color: calypso-colors.$white;
 
 	&:hover {
 		background: var( --jp-gray-80 )
@@ -111,56 +111,56 @@
 	}
 
 	&.is-compact {
-		color: $white;
+		color: calypso-colors.$white;
 		white-space: nowrap;
 	}
 }
 
 // Scary buttons
 .dops-button.is-scary {
-  color: $alert-red;
+  color: calypso-colors.$alert-red;
 
   &:hover,
   &:focus {
-	border-color: $alert-red;
+	border-color: calypso-colors.$alert-red;
   }
 
   &:focus {
-	box-shadow: 0 0 0 2px color.adjust( $alert-red, $lightness: 20% );
+	box-shadow: 0 0 0 2px color.adjust( calypso-colors.$alert-red, $lightness: 20% );
   }
 
   &[disabled],
   &:disabled {
-	color: color.adjust( $alert-red, $lightness: 30% );
-	border-color: color.adjust( $gray, $lightness: 30% );
+	color: color.adjust( calypso-colors.$alert-red, $lightness: 30% );
+	border-color: color.adjust( calypso-colors.$gray, $lightness: 30% );
   }
 }
 
 .dops-button.is-primary.is-scary {
-  background: $alert-red;
-  border-color: color.adjust( $alert-red, $lightness: -20% );
-  color: $white;
+  background: calypso-colors.$alert-red;
+  border-color: color.adjust( calypso-colors.$alert-red, $lightness: -20% );
+  color: calypso-colors.$white;
 
   &:hover,
   &:focus {
-	border-color: color.adjust( $alert-red, $lightness: -40% );
+	border-color: color.adjust( calypso-colors.$alert-red, $lightness: -40% );
   }
 
   &[disabled],
   &:disabled {
-	background: color.adjust( $alert-red, $lightness: 20% );
-	border-color: tint( $alert-red, 30% );
+	background: color.adjust( calypso-colors.$alert-red, $lightness: 20% );
+	border-color: color-functions.tint( calypso-colors.$alert-red, 30% );
   }
 }
 
 .dops-button.is-borderless {
   box-shadow: none;
-  color: color.adjust( $gray, $lightness: -10% );
+  color: color.adjust( calypso-colors.$gray, $lightness: -10% );
   padding-left: 0;
   padding-right: 0;
 
   &:hover {
-	color: $gray-dark;
+	color: calypso-colors.$gray-dark;
   }
 
   &:focus {
@@ -179,8 +179,8 @@
 
   &[disabled],
   &:disabled {
-	color: color.adjust( $gray, $lightness: 30% );
-	background: $white;
+	color: color.adjust( calypso-colors.$gray, $lightness: 30% );
+	background: calypso-colors.$white;
 	cursor: default;
 
 	&:active {
@@ -189,15 +189,15 @@
   }
 
   &.is-scary {
-	color: $alert-red;
+	color: calypso-colors.$alert-red;
 
 	&:hover,
 	&:focus {
-	  color: color.adjust( $alert-red, $lightness: -20% );
+	  color: color.adjust( calypso-colors.$alert-red, $lightness: -20% );
 	}
 
 	&[disabled] {
-	  color: color.adjust( $alert-red, $lightness: 30% );
+	  color: color.adjust( calypso-colors.$alert-red, $lightness: 30% );
 	}
   }
 
@@ -290,5 +290,5 @@
 
 a .components-external-link,
 button .components-external-link {
-	color: $black;
+	color: calypso-colors.$black;
 }

--- a/projects/plugins/jetpack/_inc/client/components/card/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/card/style.scss
@@ -1,6 +1,6 @@
-@import '../../scss/layout';
-@import '../../scss/typography';
-@import '../../scss/calypso-colors';
+@use '../../scss/layout';
+@use '../../scss/typography';
+@use '../../scss/calypso-colors';
 
 $title: #f6f7f7;
 $meta: #a7aaad;
@@ -15,11 +15,11 @@ $section-border: #dcdcde;
 	margin: 0 auto 10px auto;
 	padding: 16px;
 	box-sizing: border-box;
-	background: $white;
+	background: calypso-colors.$white;
 
-	@include clear-fix;
+	@include layout.clear-fix;
 
-	@include breakpoint( ">480px" ) {
+	@include layout.breakpoint( ">480px" ) {
 		margin-bottom: 16px;
 		padding: 24px;
 	}
@@ -28,7 +28,7 @@ $section-border: #dcdcde;
 	&.is-compact {
 		margin-bottom: 1px;
 
-		@include breakpoint( ">480px" ) {
+		@include layout.breakpoint( ">480px" ) {
 			margin-bottom: 1px;
 			padding: 16px 24px;
 		}
@@ -40,7 +40,7 @@ $section-border: #dcdcde;
 }
 
 h2.dops-card-title {
-	font-size: $font-title-small;
+	font-size: typography.$font-title-small;
 }
 
 a.dops-card:focus {

--- a/projects/plugins/jetpack/_inc/client/components/chart/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/chart/style.scss
@@ -3,16 +3,16 @@
 
 @use 'sass:color';
 @use '../../scss/z-index';
-@import '../../scss/calypso-colors';
-@import '../../scss/layout';
-@import '../../scss/mixin_clear-fix';
-@import '../../scss/mixin_long-content-fade';
-@import '../../scss/mixin_icons';
+@use '../../scss/calypso-colors';
+@use '../../scss/layout';
+@use '../../scss/mixin_clear-fix';
+@use '../../scss/mixin_long-content-fade';
+@use '../../scss/mixin_icons';
 
 .dops-chart {
 	position: relative;
 	box-sizing: border-box;
-	background-color: $white;
+	background-color: calypso-colors.$white;
 	padding: 8px 0 0 20px;
 }
 
@@ -34,7 +34,7 @@
 		top: 0;
 	width: 100%;
 	height: 1px;
-	border-top: 1px solid color.adjust( $gray, $lightness: 30% );
+	border-top: 1px solid color.adjust( calypso-colors.$gray, $lightness: 30% );
 }
 
 // Y-axis marker lines inside each chart__bar
@@ -45,7 +45,7 @@
 		top: 0;
 	width: 100%;
 	height: 1px;
-	border-top: 1px solid rgba( color.adjust( $gray, $lightness: 30% ), .1 );
+	border-top: 1px solid rgba( color.adjust( calypso-colors.$gray, $lightness: 30% ), .1 );
 }
 
 .dops-chart__bar-marker,
@@ -70,7 +70,7 @@
 	height: 200px;
 	padding: 0 20px 0 10px;
 	font-size: 11px;
-	color: $gray-80;
+	color: calypso-colors.$gray-80;
 	margin-bottom: 30px;
 }
 
@@ -83,7 +83,7 @@
 
 // For forcing the width of y-axis to the width of the label
 .dops-chart__y-axis-width-fix {
-	color: $transparent;
+	color: calypso-colors.$transparent;
 }
 
 // X-axis
@@ -94,7 +94,7 @@
 	font-size: 0; // 1
 	padding: 5px 0 0;
 	min-height: 18px;
-	color: $black;
+	color: calypso-colors.$black;
 }
 
 .dops-chart__x-axis-label {
@@ -117,8 +117,8 @@
 	margin-left: -.5px;
 	width: 1px;
 	height: 5px;
-	background: $gray-light;
-	background-image: linear-gradient(to bottom, $gray-light 0%, color.adjust( $gray, $lightness: 20% ) 100%);
+	background: calypso-colors.$gray-light;
+	background-image: linear-gradient(to bottom, calypso-colors.$gray-light 0%, color.adjust( calypso-colors.$gray, $lightness: 20% ) 100%);
 }
 
 // Bar wrapper
@@ -146,21 +146,21 @@
 
 
 	&.is-weekend {
-		background-color: rgba( color.adjust( $gray, $lightness: 30% ), .5 );
+		background-color: rgba( color.adjust( calypso-colors.$gray, $lightness: 30% ), .5 );
 	}
 
 	&:focus {
-		background-color: rgba( $orange-jazzy, .1 );
+		background-color: rgba( calypso-colors.$orange-jazzy, .1 );
 	}
 
 	&:hover {
 		cursor: pointer;
-		background-color: rgba( color.adjust( $gray, $lightness: 30% ), .25 );
+		background-color: rgba( color.adjust( calypso-colors.$gray, $lightness: 30% ), .25 );
 	}
 
 	&.is-selected {
 		cursor: default;
-		background-color: rgba( $orange-jazzy, .1 );
+		background-color: rgba( calypso-colors.$orange-jazzy, .1 );
 	}
 }
 
@@ -172,7 +172,7 @@
 
 .dops-chart__bar-section {
 	display: inline-block;
-	background-color: $black;
+	background-color: calypso-colors.$black;
 	position: absolute;
 		top: 0; // 2
 		right: 16%; // 1
@@ -185,12 +185,12 @@
 	}
 
 	.dops-chart__bar.is-selected &.is-bar {
-		background-color: $orange-jazzy;
+		background-color: calypso-colors.$orange-jazzy;
 	}
 
 	&.is-spacer {
 		z-index: z-index.z-index( 'root', '.dops-chart__bar-section.is-spacer' );
-		background-color: $transparent;
+		background-color: calypso-colors.$transparent;
 	}
 
 	&.is-ghost::after {
@@ -203,7 +203,7 @@
 		z-index: z-index.z-index( 'root', '.dops-chart__bar-section.is-ghost::after' );
 		width: 100%;
 		height: 40px;
-		background-image: linear-gradient(to bottom, $transparent, rgba( color.adjust( $gray, $lightness: 30% ), .5 ) ); // TODO: needs to use default color for gradient
+		background-image: linear-gradient(to bottom, calypso-colors.$transparent, rgba( color.adjust( calypso-colors.$gray, $lightness: 30% ), .5 ) ); // TODO: needs to use default color for gradient
 
 		.dops-chart__bar:hover & {
 			display: none;
@@ -212,14 +212,14 @@
 }
 
 .dops-chart__bar-section-inner {
-	background: color.adjust( $blue-dark, $lightness: -5% );
+	background: color.adjust( calypso-colors.$blue-dark, $lightness: -5% );
 	position: absolute;
 		right: 23.33%;
 		bottom: 0;
 		left: 23.33%;
 
 	.dops-chart__bar.is-selected & {
-		background-color: $orange-fire;
+		background-color: calypso-colors.$orange-fire;
 	}
 }
 
@@ -228,7 +228,7 @@
 
 .dops-chart__legend {
 
-	@include clear-fix;
+	@include mixin_clear-fix.clear-fix;
 	margin-bottom: -8px;
 }
 
@@ -236,14 +236,14 @@
 
 .dops-chart__legend .dops-chart__legend-options {
 	float: right;
-	color: color.adjust( $gray-dark, $lightness: 20% );
+	color: color.adjust( calypso-colors.$gray-dark, $lightness: 20% );
 	list-style-type: none;
 	margin: 0;
 	font-size: 11px;
 	text-transform: uppercase;
 	letter-spacing: 0.1em;
 
-	@include breakpoint( "<480px" ) {
+	@include layout.breakpoint( "<480px" ) {
 		width: 100%;
 	}
 
@@ -256,7 +256,7 @@
 	text-align: left;
 
 	// Expand labels to create bigger touch targets
-	@include breakpoint( "<480px") {
+	@include layout.breakpoint( "<480px") {
 		width: 50%;
 		display: inline-block;
 	}
@@ -274,11 +274,11 @@
 
 		&:focus,
 		&:hover {
-			color: $link-highlight;
+			color: calypso-colors.$link-highlight;
 		}
 	}
 
-	@include breakpoint( "<480px" ) {
+	@include layout.breakpoint( "<480px" ) {
 		display: block;
 	}
 }
@@ -290,14 +290,14 @@
 .dops-chart__legend-option .dops-chart__legend-color {
 	width: 10px;
 	height: 10px;
-	background: $blue-wordpress;
+	background: calypso-colors.$blue-wordpress;
 	display: inline-block;
 	border-radius: 1px;
 	vertical-align: top;
 	margin: 3px 5px 3px 8px; // 1
 }
 
-@include breakpoint( "<480px" ) {
+@include layout.breakpoint( "<480px" ) {
 
 	.dops-chart__legend-option:first-child .dops-chart__legend-color {
 		margin-left: 2px; // 2
@@ -305,7 +305,7 @@
 }
 
 .dops-chart__legend-color.is-dark-blue {
-	background: color.adjust( $blue-dark, $lightness: -5% );
+	background: color.adjust( calypso-colors.$blue-dark, $lightness: -5% );
 }
 
 // Chart legend checkbox
@@ -343,16 +343,16 @@
 	font-size: 14px;
 	line-height: 1.4285;
 	animation: appear .3s ease-in-out;
-	box-shadow: 0 0 0 1px color.adjust( $gray, $lightness: 20%, $alpha: -.5 ),
-		0 1px 2px color.adjust( $gray, $lightness: 30% );
+	box-shadow: 0 0 0 1px color.adjust( calypso-colors.$gray, $lightness: 20%, $alpha: -.5 ),
+		0 1px 2px color.adjust( calypso-colors.$gray, $lightness: 30% );
 
-	@include breakpoint( ">660px" ) {
+	@include layout.breakpoint( ">660px" ) {
 		padding: 13px 48px;
 		font-size: inherit;
 
 		&::before {
 
-			@include noticons;
+			@include mixin_icons.noticons;
 			content: '\f456';
 			position: absolute;
 				top: 23px;
@@ -377,7 +377,7 @@
 
 		ul {
 
-			@include clear-fix;
+			@include mixin_clear-fix.clear-fix;
 			list-style: none;
 			margin: 0;
 			padding: 0;
@@ -466,7 +466,7 @@
 		margin-bottom: 2px;
 		text-transform: uppercase;
 		font-weight: 700;
-		border-bottom: 1px solid color.adjust( $gray, $lightness: -27% );
+		border-bottom: 1px solid color.adjust( calypso-colors.$gray, $lightness: -27% );
 		padding-bottom: 2px;
 	}
 
@@ -476,7 +476,7 @@
 
 		.label {
 			text-transform: none;
-			color: color.adjust( $gray, $lightness: 20% );
+			color: color.adjust( calypso-colors.$gray, $lightness: 20% );
 			overflow: hidden;
 			letter-spacing: 0;
 			height: 19px;

--- a/projects/plugins/jetpack/_inc/client/components/clipboard-button-input/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/clipboard-button-input/style.scss
@@ -1,4 +1,4 @@
-@import '../../scss/mixin_long-content-fade';
+@use '../../scss/mixin_long-content-fade';
 
 .dops-clipboard-button-input {
 	position: relative;
@@ -13,7 +13,7 @@
 
 		&:not( :disabled )::before {
 
-			@include long-content-fade( $size: 16px );
+			@include mixin_long-content-fade.long-content-fade( $size: 16px );
 			right: calc( 100% + 1px );
 		}
 

--- a/projects/plugins/jetpack/_inc/client/components/connect-button/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/connect-button/style.scss
@@ -1,4 +1,4 @@
-@import "../../scss/variables/colors";
+@use "../../scss/variables/colors";
 
 // ==========================================================================
 // Buttons

--- a/projects/plugins/jetpack/_inc/client/components/count/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/count/style.scss
@@ -1,14 +1,14 @@
 @use '../../scss/functions/rem';
-@import '../../scss/calypso-colors';
+@use '../../scss/calypso-colors';
 
 .dops-count {
 	display: inline-block;
 	padding: rem.convert( 1px ) rem.convert( 6px );
-	border: solid 1px $gray;
+	border: solid 1px calypso-colors.$gray;
 	border-radius: rem.convert( 12px );
 	font-size: rem.convert( 11px );
 	font-weight: 600;
 	line-height: rem.convert( 14px );
-	color: $gray;
+	color: calypso-colors.$gray;
 	text-align: center;
 }

--- a/projects/plugins/jetpack/_inc/client/components/dash-item/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/dash-item/style.scss
@@ -1,11 +1,15 @@
 @use 'sass:color';
 @use '../../scss/functions/rem';
-@import '../../scss/calypso-colors';
-@import '../../scss/mixins/ui';
+@use '../../scss/calypso-colors';
+@use '../../scss/mixins/ui';
+@use "../../scss/mixins/breakpoints";
+@use "../../scss/mixins/long-content-fade";
+@use "../../scss/typography";
+@use "../../scss/variables/colors";
 
 .jp-dash-item {
 
-	@include dashboard-card-shadow;
+	@include ui.dashboard-card-shadow;
 
 	.dops-section-header__actions {
 
@@ -44,15 +48,15 @@
 
 .jp-dash-item__count {
 	margin: 0;
-	color: $black;
+	color: colors.$black;
 	font-weight: 400;
-	font-size: $font-headline-small;
+	font-size: typography.$font-headline-small;
 	line-height: 40px;
 	display: inline-block;
 	padding: 0;
 	text-align: center;
 
-	@include breakpoint( "<660px" ) {
+	@include breakpoints.breakpoint( "<660px" ) {
 		font-size: rem.convert( 23px );
 	}
 
@@ -81,7 +85,7 @@
 	margin: 0 50px 0 0;
 	font-size: rem.convert( 14px );
 	max-width: calc( 100% - 18px ); // For the support icon
-	color: $gray-80;
+	color: calypso-colors.$gray-80;
 	letter-spacing: -0.02em;
 	line-height: 24px;
 	font-weight: 400;
@@ -93,9 +97,9 @@
 	.jp-link-button {
 		border: none;
 		box-shadow: none;
-		color: $black;
+		color: colors.$black;
 		font-weight: 400;
-		font-size: $font-body-small;
+		font-size: typography.$font-body-small;
 		text-decoration: underline;
 		transition-duration: .05s;
 		transition-property: border,background,color;
@@ -127,15 +131,15 @@
 	&.is-premium-inactive {
 
 		.dops-section-header__actions {
-			color: $gray-text-min;
+			color: colors.$gray-text-min;
 		}
 	}
 }
 
 .jp-dash-item__active-label {
 	display: inline-block;
-	color: color.adjust( $gray, $lightness: -10% );
-	color: $gray;
+	color: color.adjust( colors.$gray, $lightness: -10% );
+	color: colors.$gray;
 	font-size: rem.convert( 12px );
 	font-weight: 400;
 	text-transform: uppercase;
@@ -146,7 +150,7 @@
 
 	.jp-at-a-glance__left &,
 	.jp-at-a-glance__right & {
-		border: 1px solid $gray-5;
+		border: 1px solid calypso-colors.$gray-5;
 		background: #F9F9F6;
 		box-shadow: none;
 
@@ -179,7 +183,7 @@
 
 		&::before {
 
-			@include long-content-fade( $size: 8px, $color : $white );
+			@include long-content-fade.long-content-fade( $size: 8px, $color : colors.$white );
 		}
 	}
 }

--- a/projects/plugins/jetpack/_inc/client/components/dash-section-header/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/dash-section-header/style.scss
@@ -1,3 +1,6 @@
+@use "../../scss/mixins/breakpoints";
+@use "../../scss/typography";
+@use "../../scss/variables/colors";
 @use 'sass:color';
 @use '../../scss/functions/rem';
 
@@ -6,20 +9,20 @@
 	flex-wrap: wrap;
 	margin: rem.convert( 12px ) 0 rem.convert( 12px );
 
-	@include breakpoint( "<660px" ) {
+	@include breakpoints.breakpoint( "<660px" ) {
 		margin-bottom: rem.convert( 24px );
 	}
 
-	@include breakpoint( "<480px" ) {
+	@include breakpoints.breakpoint( "<480px" ) {
 		display: block;
 	}
 
 	a {
-		font-size: $font-body;
+		font-size: typography.$font-body;
 		font-weight: 400;
 		font-style: normal;
 		line-height: 24px;
-		color: $black;
+		color: colors.$black;
 		text-decoration: underline;
 
 		&:hover {
@@ -44,20 +47,20 @@
 	display: inline-block;
 	margin-top: 0;
 	margin-bottom: 0;
-	font-size: $font-title-medium;
+	font-size: typography.$font-title-medium;
 	line-height: 32px;
 	font-weight: 500;
 	white-space: nowrap;
-	color: $black;
+	color: colors.$black;
 
-	@include breakpoint( ">480px" ) {
+	@include breakpoints.breakpoint( ">480px" ) {
 		display: inline-block;
 	}
 
 	// need to clean up ClassName nesting
 	.jp-dash-section-header__label {
 
-		@include breakpoint( "<480px" ) {
+		@include breakpoints.breakpoint( "<480px" ) {
 			display: inline-block;
 		}
 	}
@@ -67,14 +70,14 @@
 	display: inline-block;
 	min-width: rem.convert( 40px );
 	text-align: center;
-	color: color.adjust( $gray, $lightness: -10% );
+	color: color.adjust( colors.$gray, $lightness: -10% );
 
 	&:focus {
 		outline: 0;
 		box-shadow: none;
 
 		.gridicon {
-			color: $blue-wordpress;
+			color: colors.$blue-wordpress;
 		}
 	}
 
@@ -88,11 +91,11 @@
 	align-self: center;
 	font-style: italic;
 
-	@include breakpoint( "<660px" ) {
+	@include breakpoints.breakpoint( "<660px" ) {
 		margin-top: rem.convert( 4px );
 	}
 
-	@include breakpoint( "<480px" ) {
+	@include breakpoints.breakpoint( "<480px" ) {
 		display: block;
 		width: 100%;
 		// margin-top: rem.convert( 32px );
@@ -102,7 +105,7 @@
 .jp-dash-section-header__children {
 	align-self: center;
 
-	@include breakpoint( "<480px" ) {
+	@include breakpoints.breakpoint( "<480px" ) {
 		width: 100%;
 	}
 }

--- a/projects/plugins/jetpack/_inc/client/components/dev-card/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/dev-card/style.scss
@@ -1,3 +1,4 @@
+@use "../../scss/variables/colors";
 @use 'sass:color';
 
 .jp-dev-card.jp-dev-card {
@@ -32,7 +33,7 @@
 
 .jp-dev-card__subheading {
 	font-size: 11px;
-	color: color.adjust( $gray, $lightness: -10% );
+	color: color.adjust( colors.$gray, $lightness: -10% );
 }
 
 .jp-dev-card__close {

--- a/projects/plugins/jetpack/_inc/client/components/foldable-card/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/foldable-card/style.scss
@@ -1,14 +1,14 @@
 @use 'sass:color';
 @use '../../scss/functions/rem';
-@import '../../scss/calypso-colors';
-@import '../../scss/calypso-mixins';
-@import '../../scss/mixin_clear-fix';
+@use '../../scss/calypso-colors';
+@use '../../scss/calypso-mixins';
+@use '../../scss/mixin_clear-fix';
 
 
 // Multisite
 .dops-foldable-card.dops-card {
 
-	@include clear-fix;
+	@include mixin_clear-fix.clear-fix;
 	position: relative;
 	transition: margin .15s linear;
 	padding: 0;
@@ -40,7 +40,7 @@
 		}
 
 		.dops-foldable-card__expand {
-			border-left: 1px $gray-light solid;
+			border-left: 1px calypso-colors.$gray-light solid;
 		}
 	}
 
@@ -97,7 +97,7 @@ button.dops-foldable-card__action {
 	width: 100%;
 	margin-right: 5px;
 
-	@include breakpoint( '<480px' ) {
+	@include calypso-mixins.breakpoint( '<480px' ) {
 		flex: 1 1;
 	}
 }
@@ -113,7 +113,7 @@ button.dops-foldable-card__action {
 	width: 48px;
 
 	.gridicon {
-		fill: $gray;
+		fill: calypso-colors.$gray;
 		display: flex;
 		align-items: center;
 		width: 100%;
@@ -127,14 +127,14 @@ button.dops-foldable-card__action {
 	}
 
 	.gridicon:hover {
-		fill: $gray;
+		fill: calypso-colors.$gray;
 	}
 
 	&:focus,
 	&:hover {
 
 		.gridicon {
-			fill: $blue-medium;
+			fill: calypso-colors.$blue-medium;
 		}
 	}
 }
@@ -148,7 +148,7 @@ button.dops-foldable-card__action {
 	margin-top: rem.convert( 2px );
 	margin-bottom: rem.convert( 2px );
 	font-size: rem.convert( 14px );
-	color: color.adjust( $gray, $lightness: -20% );
+	color: color.adjust( calypso-colors.$gray, $lightness: -20% );
 }
 
 .dops-foldable-card__content {
@@ -157,7 +157,7 @@ button.dops-foldable-card__action {
 	.dops-foldable-card.is-expanded & {
 		display: block;
 		padding: 16px;
-		border-top: 1px solid $gray-light;
+		border-top: 1px solid calypso-colors.$gray-light;
 
 
 		.dops-foldable-card.is-compact & {
@@ -177,7 +177,7 @@ button.dops-foldable-card__action {
 .dops-foldable-card__summary,
 .dops-foldable-card__summary_expanded {
 	margin-right: 40px;
-	color: $gray;
+	color: calypso-colors.$gray;
 	font-size: 12px;
 	transition: opacity 0.2s linear;
 	display: inline-block;
@@ -188,7 +188,7 @@ button.dops-foldable-card__action {
 		text-align: right;
 	}
 
-	@include breakpoint( "<480px" ) {
+	@include calypso-mixins.breakpoint( "<480px" ) {
 		display: none;
 	}
 }

--- a/projects/plugins/jetpack/_inc/client/components/foldable-card/style2.scss
+++ b/projects/plugins/jetpack/_inc/client/components/foldable-card/style2.scss
@@ -1,3 +1,5 @@
+@use "../../scss/mixins/breakpoints";
+
 // Jetpack specific foldable card mods
 @use '../../scss/functions/rem';
 
@@ -26,29 +28,29 @@
 
 .dops-foldable-card__main {
 
-	@include breakpoint( ">660px" ) {
+	@include breakpoints.breakpoint( ">660px" ) {
 		max-width: 85%;
 	}
 
-	@include breakpoint( ">480px" ) {
+	@include breakpoints.breakpoint( ">480px" ) {
 		max-width: 60%;
 	}
 
-	@include breakpoint( "<480px" ) {
+	@include breakpoints.breakpoint( "<480px" ) {
 		flex-basis: 100%;
 	}
 }
 
 .dops-foldable-card__header {
 
-	@include breakpoint( "<480px" ) {
+	@include breakpoints.breakpoint( "<480px" ) {
 		flex-wrap: wrap;
 	}
 }
 
 .dops-foldable-card__header-text {
 
-	@include breakpoint( "<480px" ) {
+	@include breakpoints.breakpoint( "<480px" ) {
 		font-size: rem.convert( 14px );
 	}
 
@@ -59,7 +61,7 @@
 
 .dops-foldable-card__subheader {
 
-	@include breakpoint( "<480px" ) {
+	@include breakpoints.breakpoint( "<480px" ) {
 		display: none;
 	}
 }
@@ -69,7 +71,7 @@
 	.dops-foldable-card__summary,
 	.dops-foldable-card__summary_expanded {
 
-		@include breakpoint( "<480px" ) {
+		@include breakpoints.breakpoint( "<480px" ) {
 			text-align: left;
 			margin-top: rem.convert( 8px );
 		}

--- a/projects/plugins/jetpack/_inc/client/components/footer/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/footer/style.scss
@@ -1,3 +1,5 @@
+@use "../../scss/mixins/breakpoints";
+
 .jp-footer {
 	--jp-white: #fff;
 
@@ -29,7 +31,7 @@
 		line-height: 1.333;
 		width: 100%;
 
-		@include breakpoint( '<960px' ) {
+		@include breakpoints.breakpoint( '<960px' ) {
 			flex-direction: column;
 			align-items: flex-start;
 		}
@@ -50,12 +52,12 @@
 	.jp-footer__logo {
 		margin-right: 32px;
 
-		@include breakpoint( '<960px' ) {
+		@include breakpoints.breakpoint( '<960px' ) {
 			margin-right: 0;
 			margin-bottom: 24px;
 		}
 
-		@include breakpoint( '<660px' ) {
+		@include breakpoints.breakpoint( '<660px' ) {
 			margin-bottom: 48px;
 		}
 	}
@@ -74,11 +76,11 @@
 	.jp-footer__menu {
 		display: flex;
 
-		@include breakpoint( '<960px' ) {
+		@include breakpoints.breakpoint( '<960px' ) {
 			margin-bottom: 24px;
 		}
 
-		@include breakpoint( '<660px' ) {
+		@include breakpoints.breakpoint( '<660px' ) {
 			flex-direction: column;
 			align-items: flex-start;
 			margin-bottom: 48px;
@@ -137,7 +139,7 @@
 .jp-footer__a8c-logo {
 	margin-left: auto;
 
-	@include breakpoint( '<960px' ) {
+	@include breakpoints.breakpoint( '<960px' ) {
 		margin-left: 0;
 	}
 }

--- a/projects/plugins/jetpack/_inc/client/components/form-input-validation/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/form-input-validation/style.scss
@@ -1,8 +1,8 @@
-@import '../../scss/calypso-colors';
-@import '../../scss/layout';
+@use '../../scss/calypso-colors';
+@use '../../scss/layout';
 
 .form-input-validation {
-	color: $alert-green;
+	color: calypso-colors.$alert-green;
 	position: relative;
 	padding: 6px 24px 11px 34px;
 	border-radius: 1px;
@@ -11,11 +11,11 @@
 	animation: appear .3s ease-in-out;
 
 	&.is-error {
-		color: $alert-red;
+		color: calypso-colors.$alert-red;
 	}
 
 	&.is-warning{
-		color: $alert-yellow;
+		color: calypso-colors.$alert-yellow;
 	}
 
 	.gridicon {

--- a/projects/plugins/jetpack/_inc/client/components/form/form-toggle/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/form/form-toggle/style.scss
@@ -1,5 +1,5 @@
 @use 'sass:color';
-@import '../../../scss/calypso-colors';
+@use '../../../scss/calypso-colors';
 // ==========================================================================
 // FormToggle
 // ==========================================================================
@@ -34,7 +34,7 @@
 	&::after {
 		left: 0;
 		border-radius: 50%;
-		background: $white;
+		background: calypso-colors.$white;
 		transition: all .2s ease;
 	}
 
@@ -43,7 +43,7 @@
 	}
 
 	.dops-accessible-focus &:focus{
-		box-shadow: 0 0 0 2px $blue-medium;
+		box-shadow: 0 0 0 2px calypso-colors.$blue-medium;
 	}
 }
 
@@ -66,29 +66,29 @@
 	.dops-accessible-focus &:focus {
 
 		+ .form-toggle__label .form-toggle__switch {
-			box-shadow: 0 0 0 2px $blue-medium;
+			box-shadow: 0 0 0 2px calypso-colors.$blue-medium;
 		}
 
 		&:checked + .form-toggle__label .form-toggle__switch {
-			box-shadow: 0 0 0 2px $blue-light;
+			box-shadow: 0 0 0 2px calypso-colors.$blue-light;
 		}
 	}
 
 	+ .form-toggle__label .form-toggle__switch {
-		background: color.adjust( $gray, $lightness: 10% );
+		background: color.adjust( calypso-colors.$gray, $lightness: 10% );
 	}
 
 	&:not( :disabled ) {
 
 		+ .form-toggle__label:hover .form-toggle__switch {
-			background: color.adjust( $gray, $lightness: 20% );
+			background: color.adjust( calypso-colors.$gray, $lightness: 20% );
 		}
 	}
 
 	&:checked{
 
 		+ .form-toggle__label .form-toggle__switch {
-			background: $blue-medium;
+			background: calypso-colors.$blue-medium;
 
 			&::after {
 				left: 16px;
@@ -99,7 +99,7 @@
 	&:checked:not( :disabled ) {
 
 		+ .form-toggle__label:hover .form-toggle__switch {
-			background: $blue-light;
+			background: calypso-colors.$blue-light;
 		}
 	}
 
@@ -116,13 +116,13 @@
 .form-toggle.is-toggling {
 
 	+ .form-toggle__label .form-toggle__switch {
-		background: $blue-medium;
+		background: calypso-colors.$blue-medium;
 	}
 
 	&:checked {
 
 		+ .form-toggle__label .form-toggle__switch {
-			background: color.adjust( $gray, $lightness: 20% );
+			background: color.adjust( calypso-colors.$gray, $lightness: 20% );
 		}
 	}
 }

--- a/projects/plugins/jetpack/_inc/client/components/forms/styles.scss
+++ b/projects/plugins/jetpack/_inc/client/components/forms/styles.scss
@@ -1,3 +1,5 @@
+@use "../../scss/mixins/breakpoints";
+@use "../../scss/variables/colors";
 @use '../../scss/functions/rem';
 
 .jp-form-legend,
@@ -35,7 +37,7 @@
 .jp-form-button {
 	margin-top: rem.convert( 16px );
 
-	@include breakpoint( ">480px" ) {
+	@include breakpoints.breakpoint( ">480px" ) {
 		position: absolute;
 			right: rem.convert( 16px );
 			bottom: rem.convert( 16px );
@@ -50,7 +52,7 @@
 	.jp-form-toggle-privacy-info {
 		margin-left: rem.convert( 5px );
 		padding-left: rem.convert( 5px );
-		border-left: 1px solid rgba( $gray, 0.5 );
+		border-left: 1px solid rgba( colors.$gray, 0.5 );
 	}
 }
 
@@ -78,7 +80,7 @@
 		padding: rem.convert( 8px ) rem.convert( 14px );
 		white-space: nowrap;
 
-		@include breakpoint( '<660px' ) {
+		@include breakpoints.breakpoint( '<660px' ) {
 			display: block;
 			text-align: left;
 		}
@@ -87,16 +89,16 @@
 	input[type="text"] {
 		width: 100%;
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoints.breakpoint( '>660px' ) {
 			border-left: 0;
 		}
 
-		@include breakpoint( '<660px' ) {
+		@include breakpoints.breakpoint( '<660px' ) {
 			border-top: 0;
 		}
 	}
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoints.breakpoint( '<660px' ) {
 		display: block;
 		box-sizing: border-box;
 	}

--- a/projects/plugins/jetpack/_inc/client/components/global-notices/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/global-notices/style.scss
@@ -1,6 +1,6 @@
 @use '../../scss/z-index';
-@import "../../scss/calypso-colors";
-@import "../../scss/calypso-mixins";
+@use "../../scss/calypso-colors";
+@use "../../scss/calypso-mixins";
 
 .global-notices {
 	text-align: right;
@@ -13,7 +13,7 @@
 	bottom: 0;
 	left: 0;
 
-	@include breakpoint( ">660px" ) {
+	@include calypso-mixins.breakpoint( ">660px" ) {
 		top: 47px + 16px;
 		right: 16px;
 		bottom: auto;
@@ -23,7 +23,7 @@
 		max-width: calc( 100% - 32px - 36px );
 	}
 
-	@include breakpoint( ">960px" ) {
+	@include calypso-mixins.breakpoint( ">960px" ) {
 		top: 47px + 24px;
 		right: 24px;
 
@@ -31,7 +31,7 @@
 		max-width: calc( 100% - 48px - 160px );
 	}
 
-	@include breakpoint( ">1040px" ) {
+	@include calypso-mixins.breakpoint( ">1040px" ) {
 		right: 32px;
 
 		/* `160px` being the width of the WP-admin sidebar */
@@ -52,7 +52,7 @@
 		border-radius: 0;
 	}
 
-	@include breakpoint( ">660px" ) {
+	@include calypso-mixins.breakpoint( ">660px" ) {
 		display: flex;
 		overflow: hidden;
 		margin-bottom: 24px;
@@ -66,7 +66,7 @@
 
 .global-notices .dops-notice a.dops-notice__action {
 
-	@include breakpoint( ">660px" ) {
+	@include calypso-mixins.breakpoint( ">660px" ) {
 		font-size: 14px;
 		padding: 13px 16px;
 	}
@@ -75,7 +75,7 @@
 .global-notices .dops-notice__dismiss {
 	flex-shrink: 0;
 
-	@include breakpoint( ">660px" ) {
+	@include calypso-mixins.breakpoint( ">660px" ) {
 		padding: 13px 16px 0;
 	}
 }

--- a/projects/plugins/jetpack/_inc/client/components/info-popover/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/info-popover/style.scss
@@ -1,14 +1,14 @@
 @use 'sass:color';
-@import '../../scss/calypso-colors';
+@use '../../scss/calypso-colors';
 
 .dops-info-popover-button {
 	background: transparent;
 	border: none;
-	color: color.adjust( $gray, $lightness: -10% );
+	color: color.adjust( calypso-colors.$gray, $lightness: -10% );
 	padding: 0;
 
 	&:hover {
-		color: $gray-dark;
+		color: calypso-colors.$gray-dark;
 	}
 
 	&:focus {
@@ -22,21 +22,21 @@
 
 .dops-info-popover .gridicon {
 	cursor: pointer;
-	color: color.adjust( $gray, $lightness: 15% );
+	color: color.adjust( calypso-colors.$gray, $lightness: 15% );
 
 	&:hover {
-		color: $gray-dark;
+		color: calypso-colors.$gray-dark;
 	}
 }
 
 .dops-info-popover.is_active .gridicon {
-	color: $gray-dark;
+	color: calypso-colors.$gray-dark;
 }
 
 .dops-popover.dops-info-popover__tooltip {
 
 	.dops-popover__inner {
-		color: color.adjust( $gray, $lightness: -20% );
+		color: color.adjust( calypso-colors.$gray, $lightness: -20% );
 		font-size: 13px;
 		max-width: 220px;
 		padding: 16px;

--- a/projects/plugins/jetpack/_inc/client/components/install-button/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/install-button/style.scss
@@ -1,4 +1,4 @@
-@import '../../scss/calypso-colors';
+@use '../../scss/calypso-colors';
 
 .jp-install-button__spinner-container {
 	display: flex;

--- a/projects/plugins/jetpack/_inc/client/components/jetpack-dialogue-modern/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/jetpack-dialogue-modern/style.scss
@@ -1,3 +1,5 @@
+@use "../../scss/mixins/breakpoints";
+@use "../../scss/variables/colors";
 @use '../../scss/functions/rem';
 
 .jp-dialogue-modern-full__container {
@@ -8,12 +10,12 @@
 	bottom: 0;
 	left: 0;
 	z-index: 1000; // to sit over other elements
-	background: rgba($gray-light, .95);
+	background: rgba(colors.$gray-light, .95);
 	padding: 1rem 0 0 0;
 	height: 100%;
 	overflow: auto;
 
-	@include breakpoint( ">960px" ) {
+	@include breakpoints.breakpoint( ">960px" ) {
 		padding: 2rem;
 		left: 160px;
 	}

--- a/projects/plugins/jetpack/_inc/client/components/jetpack-notices/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/jetpack-notices/style.scss
@@ -1,11 +1,13 @@
 @use '../../scss/functions/rem';
-@import '../../scss/calypso-colors';
+@use '../../scss/calypso-colors';
+@use "../../scss/mixins/breakpoints";
+@use "../../scss/variables/colors";
 
 .dops-notice {
 
 	ul {
 
-		@include breakpoint( "<480px" ) {
+		@include breakpoints.breakpoint( "<480px" ) {
 			font-size: rem.convert( 12px );
 		}
 	}
@@ -19,7 +21,7 @@
 }
 
 .jp-unlinked-notice {
-	background: $white;
+	background: colors.$white;
 
 	.jp-connection-banner__icon {
 		align-self: center;

--- a/projects/plugins/jetpack/_inc/client/components/jetpack-product-card/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/jetpack-product-card/style.scss
@@ -1,24 +1,24 @@
 @use '../../scss/functions/rem';
-@import '../../scss/calypso-colors';
-@import '../../scss/mixin_breakpoint';
-@import '../../scss/typography';
-@import '../../scss/variables/colors';
+@use '../../scss/calypso-colors';
+@use '../../scss/mixin_breakpoint';
+@use '../../scss/typography';
+@use '../../scss/variables/colors';
 
 .jp-product-card {
 	position: relative;
 	box-sizing: border-box;
 	padding: 30px 24px 45px;
 	width: 100%;
-	background: $white;
+	background: colors.$white;
 	box-shadow: 0 2px 6px rgba( 0, 0, 0, 0.03 ), 0 1px 2px rgba( 0, 0, 0, 0.03 );
-	border: 1px solid $gray-lighten-20;
+	border: 1px solid calypso-colors.$gray-lighten-20;
 	border-radius: 4px;
 
-	@include breakpoint( '>660px' ) {
+	@include mixin_breakpoint.breakpoint( '>660px' ) {
 		padding: 40px 48px 60px;
 	}
 
-	@include breakpoint( '>960px' ) {
+	@include mixin_breakpoint.breakpoint( '>960px' ) {
 		padding-top: 60px;
 	}
 }
@@ -35,7 +35,7 @@
 	margin-bottom: 24px;
 	display: none;
 
-	@include breakpoint( '>960px' ) {
+	@include mixin_breakpoint.breakpoint( '>960px' ) {
 		display: block;
 	}
 }
@@ -46,14 +46,14 @@
 }
 
 .jp-product-card__title {
-	color: $black;
-	font-size: $font-title-large;
-	font-weight: $bold;
+	color: colors.$black;
+	font-size: typography.$font-title-large;
+	font-weight: typography.$bold;
 	margin: 0 0 18px;
 }
 
 .jp-product-card__description {
-	color: $black;
+	color: colors.$black;
 	font-size: rem.convert( 15px );
 	line-height: 1.5;
 	margin: 0 0 22px;
@@ -64,7 +64,7 @@
 }
 
 .jp-product-card__feature {
-	color: $black;
+	color: colors.$black;
 	display: flex;
 	align-items: center;
 	margin-bottom: 8px;
@@ -72,7 +72,7 @@
 
 .jp-product-card__feature svg {
 	margin-right: 10px;
-	fill: $color-plan;
+	fill: colors.$color-plan;
 }
 
 .jp-product-card__price {
@@ -133,37 +133,37 @@
 	text-align: center;
 
 	&--primary {
-		background: $black;
-		border-color: $black;
-		color: $white;
+		background: colors.$black;
+		border-color: colors.$black;
+		color: colors.$white;
 
 		&:hover,
 		&:focus {
-			border-color: $black;
-			background: $black;
-			color: $white;
+			border-color: colors.$black;
+			background: colors.$black;
+			color: colors.$white;
 		}
 
 		&:focus {
-			box-shadow: 0 0 0 1px $white, 0 0 0 3px $black;
+			box-shadow: 0 0 0 1px colors.$white, 0 0 0 3px colors.$black;
 		}
 	}
 
 	&--secondary {
 		background: transparent;
-		border: 2px solid $black;
-		color: $black;
+		border: 2px solid colors.$black;
+		color: colors.$black;
 		transition: all 150ms ease-in-out;
 
 		&:hover,
 		&:focus {
-			border-color: $black;
-			background: $black;
-			color: $white;
+			border-color: colors.$black;
+			background: colors.$black;
+			color: colors.$white;
 		}
 
 		&:focus {
-			box-shadow: 0 0 0 1px $white, 0 0 0 3px $black;
+			box-shadow: 0 0 0 1px colors.$white, 0 0 0 3px colors.$black;
 		}
 	}
 }
@@ -176,8 +176,8 @@
 	left: 0;
 	right: 0;
 	padding: 9px 10px;
-	background: $black;
-	color: $white;
+	background: colors.$black;
+	color: colors.$white;
 	font-size: rem.convert( 13px );
 	font-weight: 600;
 	letter-spacing: 0.3px;
@@ -203,32 +203,32 @@
 	height: auto;
 	margin-top: 36px;
 
-	@include breakpoint( '>480px' ) {
+	@include mixin_breakpoint.breakpoint( '>480px' ) {
 		display: block;
 	}
 
-	@include breakpoint( '>660px' ) {
+	@include mixin_breakpoint.breakpoint( '>660px' ) {
 		min-width: 240px;
 	}
 
-	@include breakpoint( '>960px' ) {
+	@include mixin_breakpoint.breakpoint( '>960px' ) {
 		margin-top: 0;
 	}
 }
 
 .jp-product-card--has-media {
 
-	@include breakpoint( '>480px' ) {
+	@include mixin_breakpoint.breakpoint( '>480px' ) {
 		display: block;
 	}
 
-	@include breakpoint( '>960px' ) {
+	@include mixin_breakpoint.breakpoint( '>960px' ) {
 		display: grid;
 		grid-template-columns: 55% 45%;
 		column-gap: 26px;
 	}
 
-	@include breakpoint( '>1040px' ) {
+	@include mixin_breakpoint.breakpoint( '>1040px' ) {
 		grid-template-columns: auto auto;
 	}
 

--- a/projects/plugins/jetpack/_inc/client/components/loading-placeholder/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/loading-placeholder/style.scss
@@ -1,3 +1,5 @@
+@use "../../scss/mixins/breakpoints";
+@use "../../scss/variables/colors";
 @use 'sass:color';
 
 .jp-loading-placeholder {
@@ -5,11 +7,11 @@
 
 	margin-top: 30vh;
 	margin-bottom: 25vh;
-	color: color.adjust( $gray, $lightness: 20% );
+	color: color.adjust( colors.$gray, $lightness: 20% );
 	font-size: $size;
 	text-align: center;
 
-	@include breakpoint( ">960px" ) {
+	@include breakpoints.breakpoint( ">960px" ) {
 		font-size: 120px;
 	}
 

--- a/projects/plugins/jetpack/_inc/client/components/masthead/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/masthead/style.scss
@@ -1,8 +1,10 @@
 @use '../../scss/functions/rem';
-@import '../../scss/calypso-colors';
+@use '../../scss/calypso-colors';
+@use "../../scss/mixins/breakpoints";
+@use "../../scss/variables/colors";
 
 .jp-masthead {
-	background-color: $white;
+	background-color: colors.$white;
 	text-align: center;
 
 	@media (max-width: rem.convert( 782px ) ) {
@@ -35,7 +37,7 @@
 	flex-shrink: 0;
 	padding: rem.convert( 40px ) 0 rem.convert( 20px ) 0;
 
-	@include breakpoint( "<480px" ) {
+	@include breakpoints.breakpoint( "<480px" ) {
 		padding: rem.convert( 11px ) 0 0;
 		margin-right: rem.convert( 16px );
 	}
@@ -48,7 +50,7 @@
 
 	&:focus {
 		line-height: 0; // fixes rectangle gap
-		box-shadow: 0 0 0 2px $blue-light;
+		box-shadow: 0 0 0 2px colors.$blue-light;
 	}
 
 	+ code {
@@ -79,15 +81,15 @@
 		font-size: 0;
 	}
 
-	@include breakpoint( "<480px" ) {
+	@include breakpoints.breakpoint( "<480px" ) {
 		text-align: left;
 	}
 
 	.dops-button {
-		background: $white;
-		color: $black;
+		background: colors.$white;
+		color: colors.$black;
 		font-weight: 600;
-		border: 1.5px solid $black;
+		border: 1.5px solid colors.$black;
 		box-shadow: none;
 
 		&:first-child {
@@ -95,9 +97,9 @@
 		}
 
 		&.is-primary {
-			background: $black;
+			background: colors.$black;
 			color: #fff;
-			border: 1.5px solid $black;
+			border: 1.5px solid colors.$black;
 
 			&:last-child {
 				border-left: 0;

--- a/projects/plugins/jetpack/_inc/client/components/modal/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/modal/style.scss
@@ -1,5 +1,5 @@
-@import '../../scss/layout';
-@import '../../scss/calypso-colors';
+@use '../../scss/layout';
+@use '../../scss/calypso-colors';
 
 /* This hack is used to prevent the body from scrolling when the modal is showing */
 body.dops-modal-showing {
@@ -44,7 +44,7 @@ body.dops-modal-showing {
 		clear: both;
 		cursor: default;
 
-		@include breakpoint( ">480px" ) {
+		@include layout.breakpoint( ">480px" ) {
 			margin: 0 auto;
 			height: auto;
 			border-radius: 5px;

--- a/projects/plugins/jetpack/_inc/client/components/module-settings/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/module-settings/style.scss
@@ -1,3 +1,4 @@
+@use "../../scss/mixins/breakpoints";
 @use '../../scss/functions/rem';
 
 .jp-module-settings__external-link {
@@ -8,7 +9,7 @@
 	clear: both;
 	margin-top: rem.convert( 16px );
 
-	@include breakpoint( ">480px" ) {
+	@include breakpoints.breakpoint( ">480px" ) {
 		margin-top: rem.convert( 32px );
 	}
 
@@ -61,7 +62,7 @@
 	padding: rem.convert( 8px );
 	vertical-align: top;
 
-	@include breakpoint( "<480px" ) {
+	@include breakpoints.breakpoint( "<480px" ) {
 		width: 100%;
 	}
 

--- a/projects/plugins/jetpack/_inc/client/components/money-back-guarantee/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/money-back-guarantee/style.scss
@@ -1,12 +1,12 @@
 @use '../../scss/functions/rem';
-@import '../../scss/variables/colors';
+@use '../../scss/variables/colors';
 
 .jetpack-money-back-guarantee {
 	display: flex;
 	justify-content: center;
 	align-items: center;
 
-	color: $wpui-header-dark;
+	color: colors.$wpui-header-dark;
 	font-size: rem.convert( 14px );
 	line-height: 1.5;
 }

--- a/projects/plugins/jetpack/_inc/client/components/notice/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/notice/style.scss
@@ -1,7 +1,7 @@
-@import "../../scss/calypso-colors";
-@import '../../scss/layout';
-@import "../../scss/calypso-mixins";
-@import '../../scss/mixin_icons';
+@use "../../scss/calypso-colors";
+@use '../../scss/layout';
+@use "../../scss/calypso-mixins";
+@use '../../scss/mixin_icons';
 
 .dops-notice {
 	display: flex;
@@ -10,8 +10,8 @@
 	margin-bottom: 24px;
 	box-sizing: border-box;
 	animation: appear .3s ease-in-out;
-	background: $gray-dark;
-	color: $white;
+	background: calypso-colors.$gray-dark;
+	color: calypso-colors.$white;
 	border-radius: 3px;
 	line-height: 1.5;
 
@@ -19,7 +19,7 @@
 	&.is-success {
 
 		.dops-notice__icon-wrapper {
-			background: $alert-green;
+			background: calypso-colors.$alert-green;
 		}
 	}
 
@@ -27,7 +27,7 @@
 	&.is-warning {
 
 		.dops-notice__icon-wrapper {
-			background: $alert-yellow;
+			background: calypso-colors.$alert-yellow;
 		}
 	}
 
@@ -35,7 +35,7 @@
 	&.is-error {
 
 		.dops-notice__icon-wrapper {
-			background: $alert-red;
+			background: calypso-colors.$alert-red;
 		}
 	}
 
@@ -43,7 +43,7 @@
 	&.is-info {
 
 		.dops-notice__icon-wrapper {
-			background: $blue-medium;
+			background: calypso-colors.$blue-medium;
 		}
 	}
 
@@ -63,8 +63,8 @@
 }
 
 .dops-notice__icon-wrapper {
-	background: $gray-text-min;
-	color: $white;
+	background: calypso-colors.$gray-text-min;
+	color: calypso-colors.$white;
 	display: flex;
 	align-items: baseline;
 	width: 47px;
@@ -76,7 +76,7 @@
 	.gridicon {
 		margin-top: 10px;
 
-		@include breakpoint( ">480px" ) {
+		@include calypso-mixins.breakpoint( ">480px" ) {
 			margin-top: 12px;
 		}
 	}
@@ -87,13 +87,13 @@
 	font-size: 12px;
 	flex-grow: 1;
 
-	@include breakpoint( ">480px" ) {
+	@include calypso-mixins.breakpoint( ">480px" ) {
 		font-size: 14px;
 	}
 
 	a {
 		text-decoration: underline;
-		color: $white;
+		color: calypso-colors.$white;
 	}
 
 	a:hover {
@@ -110,10 +110,10 @@
 	a,
 	a:visited {
 		text-decoration: underline;
-		color: $white;
+		color: calypso-colors.$white;
 
 		&:hover {
-			color: $white;
+			color: calypso-colors.$white;
 			text-decoration: none;
 		}
 	}
@@ -155,7 +155,7 @@
 		height: 18px;
 	}
 
-	@include breakpoint( ">480px" ) {
+	@include calypso-mixins.breakpoint( ">480px" ) {
 		padding: 11px;
 		padding-bottom: 0;
 
@@ -167,11 +167,11 @@
 
 	.dops-notice & {
 		overflow: hidden;
-		color: $gray-lighten-10;
+		color: calypso-colors.$gray-lighten-10;
 
 		&:hover,
 		&:focus {
-			color: $white;
+			color: calypso-colors.$white;
 		}
 	}
 }
@@ -183,12 +183,12 @@ a.dops-notice__action {
 	font-weight: 400;
 	text-decoration: none;
 	white-space: nowrap;
-	color: $gray-lighten-10;
+	color: calypso-colors.$gray-lighten-10;
 	padding: 13px;
 	display: flex;
 	align-items: center;
 
-	@include breakpoint( ">480px" ) {
+	@include calypso-mixins.breakpoint( ">480px" ) {
 		flex-shrink: 1;
 		flex-grow: 0;
 		align-items: center;
@@ -204,11 +204,11 @@ a.dops-notice__action {
 	}
 
 	&:visited {
-		color: $gray-lighten-10;
+		color: calypso-colors.$gray-lighten-10;
 	}
 
 	&:hover {
-		color: $white;
+		color: calypso-colors.$white;
 	}
 
 	.gridicon {

--- a/projects/plugins/jetpack/_inc/client/components/plans/plan-icon/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/plans/plan-icon/style.scss
@@ -1,6 +1,6 @@
 @use 'sass:color';
-@import "../../../scss/calypso-colors";
-@import "../../../scss/color-functions";
+@use "../../../scss/calypso-colors";
+@use "../../../scss/color-functions";
 
 .dops-plan-icon {
 	width: inherit;
@@ -10,58 +10,58 @@
 
 .dops-plan-icon__free {
 
-	.dops-plan-icon__free-0 { fill: $blue-light; }
+	.dops-plan-icon__free-0 { fill: calypso-colors.$blue-light; }
 
-	.dops-plan-icon__free-1 { fill: $white; }
+	.dops-plan-icon__free-1 { fill: calypso-colors.$white; }
 
-	.dops-plan-icon__free-2 { fill: color.adjust( $blue-wordpress, $lightness: -8% ); }
+	.dops-plan-icon__free-2 { fill: color.adjust( calypso-colors.$blue-wordpress, $lightness: -8% ); }
 
-	.dops-plan-icon__free-3 { fill: $blue-wordpress; }
+	.dops-plan-icon__free-3 { fill: calypso-colors.$blue-wordpress; }
 
-	.dops-plan-icon__free-4 { fill: color.adjust( $blue-wordpress, $lightness: 8% ); }
+	.dops-plan-icon__free-4 { fill: color.adjust( calypso-colors.$blue-wordpress, $lightness: 8% ); }
 }
 
 .dops-plan-icon__personal {
 
-	.dops-plan-icon__personal-0 { fill: $alert-yellow; }
+	.dops-plan-icon__personal-0 { fill: calypso-colors.$alert-yellow; }
 
-	.dops-plan-icon__personal-1 { fill: $gray; }
+	.dops-plan-icon__personal-1 { fill: calypso-colors.$gray; }
 
-	.dops-plan-icon__personal-2 { fill: color.adjust( $gray, $lightness: 20% ); }
+	.dops-plan-icon__personal-2 { fill: color.adjust( calypso-colors.$gray, $lightness: 20% ); }
 
-	.dops-plan-icon__personal-3 { fill: $white; }
+	.dops-plan-icon__personal-3 { fill: calypso-colors.$white; }
 
-	.dops-plan-icon__personal-4 { fill: color.adjust( $gray, $lightness: -10% ); }
+	.dops-plan-icon__personal-4 { fill: color.adjust( calypso-colors.$gray, $lightness: -10% ); }
 
-	.dops-plan-icon__personal-5 { fill: color.adjust( $gray, $lightness: -20% ); }
+	.dops-plan-icon__personal-5 { fill: color.adjust( calypso-colors.$gray, $lightness: -20% ); }
 }
 
 .dops-plan-icon__premium {
 
- 	.dops-plan-icon__premium-0 { fill: $alert-green; }
+ 	.dops-plan-icon__premium-0 { fill: calypso-colors.$alert-green; }
 
-	.dops-plan-icon__premium-1 { fill: $gray; }
+	.dops-plan-icon__premium-1 { fill: calypso-colors.$gray; }
 
-	.dops-plan-icon__premium-2 { fill: color.adjust( $gray, $lightness: -20% ); }
+	.dops-plan-icon__premium-2 { fill: color.adjust( calypso-colors.$gray, $lightness: -20% ); }
 
-	.dops-plan-icon__premium-3 { fill: $white; }
+	.dops-plan-icon__premium-3 { fill: calypso-colors.$white; }
 
-	.dops-plan-icon__premium-4 { fill: color.adjust( $gray, $lightness: 20% ); }
+	.dops-plan-icon__premium-4 { fill: color.adjust( calypso-colors.$gray, $lightness: 20% ); }
 
-	.dops-plan-icon__premium-5 { fill: color.adjust( $gray, $lightness: -20% ); }
+	.dops-plan-icon__premium-5 { fill: color.adjust( calypso-colors.$gray, $lightness: -20% ); }
 
-	.dops-plan-icon__premium-6 { fill: color.adjust( $gray, $lightness: -30% ); }
+	.dops-plan-icon__premium-6 { fill: color.adjust( calypso-colors.$gray, $lightness: -30% ); }
 }
 
 .dops-plan-icon__business {
 
-	.dops-plan-icon__business-0 { fill: $alert-purple; }
+	.dops-plan-icon__business-0 { fill: calypso-colors.$alert-purple; }
 
-	.dops-plan-icon__business-1 { fill: $white; }
+	.dops-plan-icon__business-1 { fill: calypso-colors.$white; }
 
-	.dops-plan-icon__business-2 { fill: color.adjust( $gray, $lightness: 30% ); }
+	.dops-plan-icon__business-2 { fill: color.adjust( calypso-colors.$gray, $lightness: 30% ); }
 
-	.dops-plan-icon__business-3 { fill: $blue-wordpress; }
+	.dops-plan-icon__business-3 { fill: calypso-colors.$blue-wordpress; }
 
-	.dops-plan-icon__business-4 { fill: $blue-dark; }
+	.dops-plan-icon__business-4 { fill: calypso-colors.$blue-dark; }
 }

--- a/projects/plugins/jetpack/_inc/client/components/plugin-dash-item/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/plugin-dash-item/style.scss
@@ -1,11 +1,11 @@
 @use '@automattic/jetpack-base-styles/style';
-@import '../../scss/variables/colors';
-@import '../../scss/mixin_breakpoint';
-@import '../../scss/mixins/ui';
+@use '../../scss/variables/colors';
+@use '../../scss/mixin_breakpoint';
+@use '../../scss/mixins/ui';
 
 .plugin-dash-item {
 
-	@include dashboard-card-shadow;
+	@include ui.dashboard-card-shadow;
 
 	p {
 		font-size: var( --font-body-small );
@@ -26,7 +26,7 @@
 		.dops-banner__icons {
 
 			.dops-banner__icon-circle{
-				background-color: $color-product;
+				background-color: colors.$color-product;
 				height: 32px;
 				width: 32px;
 
@@ -39,7 +39,7 @@
 				}
 			}
 
-			@include breakpoint( '<480px' ) {
+			@include mixin_breakpoint.breakpoint( '<480px' ) {
 
 				.dops-banner__icon {
 					display: none;

--- a/projects/plugins/jetpack/_inc/client/components/popover/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/popover/style.scss
@@ -1,6 +1,6 @@
 @use 'sass:color';
 @use '../../scss/z-index';
-@import '../../scss/calypso-colors';
+@use '../../scss/calypso-colors';
 
 /**
  * "popover" theme for `component/tip`.
@@ -15,15 +15,15 @@
 	right: auto #{"/*rtl:ignore*/"};
 
 	.dops-popover__inner {
-		background-color: $white;
-		border: 1px solid color.adjust( $gray, $lightness: 20% );
+		background-color: calypso-colors.$white;
+		border: 1px solid color.adjust( calypso-colors.$gray, $lightness: 20% );
 		border-radius: 4px;
 		box-shadow: 0 2px 5px rgba( 0, 0, 0, 0.1 ), 0 0 56px rgba( 0, 0, 0, 0.075 );
 		text-align: center;
 		position: relative;
 
 		a {
-			color: $black;
+			color: calypso-colors.$black;
 			text-decoration: underline;
 
 			&:hover {
@@ -40,7 +40,7 @@
 	}
 
 	.dops-popover__arrow {
-		border: 10px dashed color.adjust( $gray, $lightness: 20% );
+		border: 10px dashed color.adjust( calypso-colors.$gray, $lightness: 20% );
 		height: 0;
 		line-height: 0;
 		position: absolute;
@@ -116,7 +116,7 @@
 
 			&::before {
 				#{$opposite-side}: 2px #{"/*rtl:ignore*/"};
-				border: 10px solid $white;
+				border: 10px solid calypso-colors.$white;
 				content: " ";
 				position: absolute;
 
@@ -190,7 +190,7 @@
 	background: inherit;
 	border: none;
 	border-radius: 0;
-	color: $gray-dark;
+	color: calypso-colors.$gray-dark;
 	cursor: pointer;
 	display: block;
 	font-size: 14px;
@@ -206,13 +206,13 @@
 
 	&:hover,
 	&:focus {
-		background-color: $blue-medium;
+		background-color: calypso-colors.$blue-medium;
 		border: 0;
 		box-shadow: none;
 		color: #fff;
 
 		.gridicon {
-			color: $white;
+			color: calypso-colors.$white;
 		}
 	}
 
@@ -237,7 +237,7 @@
 
 	// with gridicons
 	.gridicon {
-		color: color.adjust( $gray, $lightness: 10% );
+		color: color.adjust( calypso-colors.$gray, $lightness: 10% );
 		vertical-align: bottom;
 		margin-right: 8px;
 	}
@@ -245,5 +245,5 @@
 
 .dops-popover__hr {
 	margin: 8px 0;
-	background: color.adjust( $gray, $lightness: 30% );
+	background: color.adjust( calypso-colors.$gray, $lightness: 30% );
 }

--- a/projects/plugins/jetpack/_inc/client/components/product-activated/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/product-activated/style.scss
@@ -1,17 +1,17 @@
-@import '../../scss/mixin_breakpoint';
-@import '../../scss/variables/colors';
+@use '../../scss/mixin_breakpoint';
+@use '../../scss/variables/colors';
 
 .jp-product-activated-label {
 	display: flex;
 	font-weight: 600;
-	color: $green-primary;
+	color: colors.$green-primary;
 	padding: 0 0 8px 0;
 
   	&.expired {
-	  color: $alert-red;
+	  color: colors.$alert-red;
 
 	  ::before {
-	    background: $alert-red;
+	    background: colors.$alert-red;
 	  }
 	}
 
@@ -33,7 +33,7 @@
 	  background: var(--jp-green-50);
 	}
 
-	@include breakpoint( '>960px' ) {
+	@include mixin_breakpoint.breakpoint( '>960px' ) {
 		justify-content: flex-end;
 	}
 

--- a/projects/plugins/jetpack/_inc/client/components/reconnect-modal/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/reconnect-modal/style.scss
@@ -1,18 +1,18 @@
 @use '../../scss/functions/rem';
-@import "../../scss/variables/colors";
+@use "../../scss/variables/colors";
 
 .reconnect__modal__body {
 	margin: 0;
 	padding: rem.convert( 24px ) rem.convert( 32px );
 	font-size: rem.convert( 14px );
-	color: $blue-dark-text;
+	color: colors.$blue-dark-text;
 	text-align: center;
 
 	h2 {
 		margin: rem.convert( 32px ) 0 rem.convert( 24px );
 		font-size: rem.convert( 32px );
 		font-weight: 300;
-		color: $blue-dark-text;
+		color: colors.$blue-dark-text;
 	}
 
 	h4 {
@@ -21,7 +21,7 @@
 		font-weight: 400;
 		// stylelint-disable-next-line declaration-property-unit-allowed-list -- this should be changed to a unitless value: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/#values
 		line-height: 1.5em;
-		color: $blue-heading;
+		color: colors.$blue-heading;
 	}
 }
 

--- a/projects/plugins/jetpack/_inc/client/components/search/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/search/style.scss
@@ -1,8 +1,8 @@
 @use 'sass:color';
 @use '../../scss/z-index';
-@import '../../scss/calypso-colors';
-@import '../../scss/mixin_breakpoint';
-@import '../../scss/mixin_long-content-fade';
+@use '../../scss/calypso-colors';
+@use '../../scss/mixin_breakpoint';
+@use '../../scss/mixin_long-content-fade';
 
 /**
  * @component Search
@@ -23,7 +23,7 @@
 		flex: 0 0 auto;
 		display: flex;
 		align-items: center;
-		background-color: $white;
+		background-color: calypso-colors.$white;
 		border-radius: inherit;
 		height: 100%;
 
@@ -118,7 +118,7 @@
 	border: none;
 	border-radius: inherit;
 	height: 100%;
-	background: $white;
+	background: calypso-colors.$white;
 	appearance: none;
 	box-sizing: border-box;
 	padding: 0;
@@ -139,7 +139,7 @@
 	width: 100%;
 
 	.dops-search__open-icon {
-		color: color.adjust( $gray, $lightness: -30% );
+		color: color.adjust( calypso-colors.$gray, $lightness: -30% );
 	}
 
 	.dops-search__close-icon {
@@ -164,14 +164,14 @@
 
 		&::before {
 
-			@include long-content-fade( $size: 32px, $color: $white, $z-index: z-index.z-index( '.dops-search', '.dops-search__input' ) + 2 );
+			@include mixin_long-content-fade.long-content-fade( $size: 32px, $color: calypso-colors.$white, $z-index: z-index.z-index( '.dops-search', '.dops-search__input' ) + 2 );
 			border-radius: inherit;
 		}
 
 		&.ltr { /*rtl:ignore*/
 			&::before {
 
-				@include long-content-fade( $direction: right, $size: 32px, $color: $white, $z-index: z-index.z-index( '.dops-search', '.dops-search__input' ) + 2 );
+				@include mixin_long-content-fade.long-content-fade( $direction: right, $size: 32px, $color: calypso-colors.$white, $z-index: z-index.z-index( '.dops-search', '.dops-search__input' ) + 2 );
 				border-radius: inherit;
 			}
 		}

--- a/projects/plugins/jetpack/_inc/client/components/section-header/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/section-header/style.scss
@@ -1,7 +1,7 @@
 @use '../../scss/functions/rem';
-@import '../../scss/calypso-colors';
-@import '../../scss/mixin_clear-fix';
-@import '../../scss/mixin_long-content-fade';
+@use '../../scss/calypso-colors';
+@use '../../scss/mixin_clear-fix';
+@use '../../scss/mixin_long-content-fade';
 
 .dops-section-header.dops-card {
 	display: flex;
@@ -25,7 +25,7 @@
 	min-width: 0; // weird fix for overflowing items
 	line-height: rem.convert( 30px );
 	position: relative;
-	color: $black;
+	color: calypso-colors.$black;
 	font-size: rem.convert( 20px );
 	font-weight: 500;
 
@@ -45,7 +45,7 @@
 
 	&::before {
 
-		@include long-content-fade( $size: 8px, $color : $white );
+		@include mixin_long-content-fade.long-content-fade( $size: 8px, $color : calypso-colors.$white );
 	}
 
 	.has-card-badge & {

--- a/projects/plugins/jetpack/_inc/client/components/section-nav/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/section-nav/style.scss
@@ -1,9 +1,9 @@
 @use 'sass:color';
 @use '../../scss/z-index';
-@import '../../scss/calypso-colors';
-@import '../../scss/mixin_breakpoint';
-@import '../../scss/mixin_icons';
-@import '../../scss/typography';
+@use '../../scss/calypso-colors';
+@use '../../scss/mixin_breakpoint';
+@use '../../scss/mixin_icons';
+@use '../../scss/typography';
 
 /**
  * Section Nav
@@ -15,39 +15,39 @@
 	width: 100%;
 	padding: 0;
 	margin: 0 0 17px 0;
-	background: $white;
+	background: calypso-colors.$white;
 	box-sizing: border-box;
 
 	&.is-empty .dops-section-nav__panel {
 		visibility: hidden;
 	}
 
-	@include breakpoint( "<660px" ) {
+	@include mixin_breakpoint.breakpoint( "<660px" ) {
 		box-shadow:
-			0 0 0 1px $light-gray-700,
+			0 0 0 1px calypso-colors.$light-gray-700,
 			0 1px 1px 1px  rgba(0,0,0,.04);
 
 		&.is-open {
-			box-shadow: 0 0 0 1px $gray,
-				0 2px 4px color.adjust( $gray, $lightness: 20% );
+			box-shadow: 0 0 0 1px calypso-colors.$gray,
+				0 2px 4px color.adjust( calypso-colors.$gray, $lightness: 20% );
 		}
 	}
 
-	@include breakpoint( ">660px" ) {
+	@include mixin_breakpoint.breakpoint( ">660px" ) {
 
 		&.has-pinned-items {
 			padding-right: 60px;
 		}
 	}
 
-	@include breakpoint( "660px-660px" ) {
+	@include mixin_breakpoint.breakpoint( "660px-660px" ) {
 
 		&.has-pinned-items {
 			padding-right: 50px;
 		}
 	}
 
-	@include breakpoint( "<660px" ) {
+	@include mixin_breakpoint.breakpoint( "<660px" ) {
 		margin-bottom: 9px;
 	}
 }
@@ -58,23 +58,23 @@
 	padding: 15px;
 	font-size: 14px;
 	line-height: 16px;
-	color: $gray-dark;
+	color: calypso-colors.$gray-dark;
 	font-weight: 600;
 	cursor: pointer;
 
 	&::after {
 
-		@include dashicons;
+		@include mixin_icons.dashicons;
 		content: '\f347';
 		line-height: 16px;
-		color: rgba( $gray, 0.5 );
+		color: rgba( calypso-colors.$gray, 0.5 );
 	}
 
 	.dops-section-nav.is-open & {
 
 		&::after {
 
-			@include dashicons;
+			@include mixin_icons.dashicons;
 			content: '\f343';
 		}
 	}
@@ -87,7 +87,7 @@
 		}
 	}
 
-	@include breakpoint( ">660px" ) {
+	@include mixin_breakpoint.breakpoint( ">660px" ) {
 		display: none;
 	}
 }
@@ -102,7 +102,7 @@
 	small {
 		margin-left: 5px;
 		font-size: 11px;
-		color: $gray;
+		color: calypso-colors.$gray;
 		font-weight: 600;
 		text-transform: uppercase;
 	}
@@ -117,16 +117,16 @@
 	box-sizing: border-box;
 	width: 100%;
 
-	@include breakpoint( "<660px" ) {
+	@include mixin_breakpoint.breakpoint( "<660px" ) {
 
 		.dops-section-nav.is-open & {
 			padding-bottom: 15px;
-			border-top: solid 1px color.adjust( $gray, $lightness: 20% );
-			background: linear-gradient(to bottom, $gray-light 0%, $white 4px);
+			border-top: solid 1px color.adjust( calypso-colors.$gray, $lightness: 20% );
+			background: linear-gradient(to bottom, calypso-colors.$gray-light 0%, calypso-colors.$white 4px);
 		}
 	}
 
-	@include breakpoint( ">660px" ) {
+	@include mixin_breakpoint.breakpoint( ">660px" ) {
 		display: flex;
 		align-items: center;
 
@@ -141,14 +141,14 @@
 	position: relative;
 	margin-top: 16px;
 	padding-top: 16px;
-	border-top: solid 1px color.adjust( $gray, $lightness: 20% );
+	border-top: solid 1px color.adjust( calypso-colors.$gray, $lightness: 20% );
 
 	&:first-child {
 		padding-top: 0;
 		border-top: none;
 	}
 
-	@include breakpoint( "<660px" ) {
+	@include mixin_breakpoint.breakpoint( "<660px" ) {
 		display: none;
 
 		.dops-section-nav.is-open & {
@@ -156,7 +156,7 @@
 		}
 	}
 
-	@include breakpoint( ">660px" ) {
+	@include mixin_breakpoint.breakpoint( ">660px" ) {
 		margin-top: 0;
 		padding-top: 0;
 		border-top: none;
@@ -175,7 +175,7 @@
 }
 
 .dops-section-nav__hr {
-	background: color.adjust( $gray, $lightness: 30% );
+	background: color.adjust( calypso-colors.$gray, $lightness: 30% );
 }
 
 // -------- Labels --------
@@ -185,12 +185,12 @@
 	margin-bottom: 8px;
 	padding: 0 15px;
 	font-size: 11px;
-	color: $black;
+	color: calypso-colors.$black;
 	font-weight: 600;
 	text-transform: uppercase;
 	line-height: 12px;
 
-	@include breakpoint( "<660px" ) {
+	@include mixin_breakpoint.breakpoint( "<660px" ) {
 
 		.has-siblings & {
 			display: block;
@@ -213,7 +213,7 @@
 // which contain items
 .dops-section-nav-tabs {
 
-	@include breakpoint( ">660px" ) {
+	@include mixin_breakpoint.breakpoint( ">660px" ) {
 		width: 0;
 		flex: 1 0 auto;
 
@@ -231,7 +231,7 @@
 	margin: 0;
 	list-style: none;
 
-	@include breakpoint( ">660px" ) {
+	@include mixin_breakpoint.breakpoint( ">660px" ) {
 		display: flex;
 		width: 100%;
 		overflow: hidden;
@@ -253,7 +253,7 @@
 		}
 	}
 
-	@include breakpoint( ">660px" ) {
+	@include mixin_breakpoint.breakpoint( ">660px" ) {
 		width: auto;
 		flex: none;
 		border-bottom: 2px solid transparent;
@@ -270,7 +270,7 @@
 		}
 
 		&.is-selected {
-			box-shadow: inset 0 -1px 0 $black;
+			box-shadow: inset 0 -1px 0 calypso-colors.$black;
 		}
 	}
 }
@@ -288,21 +288,21 @@
 	box-sizing: border-box;
 	padding: 15px;
 	width: 100%;
-	font-size: $font-body;
+	font-size: typography.$font-body;
 	font-weight: 400;
 	line-height: 24px;
-	color: $black;
+	color: calypso-colors.$black;
 	cursor: pointer;
 
 	&[disabled],
 	.notouch &[disabled]:hover {
-		color: color.adjust( $black, $lightness: 30% );
+		color: color.adjust( calypso-colors.$black, $lightness: 30% );
 		cursor: default;
 	}
 
 	.is-selected & {
-		color: $white;
-		background-color: $blue-medium-dark;
+		color: calypso-colors.$white;
+		background-color: calypso-colors.$blue-medium-dark;
 	}
 
 	&:focus {
@@ -310,7 +310,7 @@
 		box-shadow: none;
 
 		.dops-accessible-focus & {
-			outline: solid $gray 1px;
+			outline: solid calypso-colors.$gray 1px;
 		}
 	}
 
@@ -330,23 +330,23 @@
 	.notouch .is-selected & {
 
 		&:hover {
-			color: $white;
+			color: calypso-colors.$white;
 		}
 	}
 
-	@include breakpoint( ">660px" ) {
+	@include mixin_breakpoint.breakpoint( ">660px" ) {
 		display: block;
 		width: auto;
 		padding: 8px 0;
 		font-weight: 400;
 
 		&:hover {
-			color: $black;
-			box-shadow: inset 0 -1px 0 $black;
+			color: calypso-colors.$black;
+			box-shadow: inset 0 -1px 0 calypso-colors.$black;
 		}
 
 		.is-selected & {
-			color: $black;
+			color: calypso-colors.$black;
 			background-color: transparent;
 
 			&::after {
@@ -357,7 +357,7 @@
 		.notouch .is-selected & {
 
 			&:hover {
-				color: $black;
+				color: calypso-colors.$black;
 			}
 		}
 	}
@@ -375,7 +375,7 @@
 	min-width: 20px;
 	height: 20px;
 	border-radius: 10px;
-	background-color: $orange-fire;
+	background-color: calypso-colors.$orange-fire;
 	color: #fff;
 	font-size: 12px;
 	line-height: 1.6;
@@ -424,7 +424,7 @@
 // stylelint-disable-next-line no-duplicate-selectors -- This is a styling section for a distinct purpose.
 .dops-section-nav {
 
-	@include breakpoint( "<660px" ) {
+	@include mixin_breakpoint.breakpoint( "<660px" ) {
 
 		.dops-search.is-pinned {
 			height: 46px;

--- a/projects/plugins/jetpack/_inc/client/components/select-dropdown/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/select-dropdown/style.scss
@@ -1,7 +1,7 @@
 @use 'sass:color';
 @use '../../scss/z-index';
-@import '../../scss/calypso-colors';
-@import '../../scss/mixin_icons';
+@use '../../scss/calypso-colors';
+@use '../../scss/mixin_icons';
 
 /**
  * Select Dropdown
@@ -15,10 +15,10 @@
 	}
 
 	&.is-disabled .dops-select-dropdown__header {
-		background: $gray-light;
-		border-color: color.adjust( $gray, $lightness: 30% );
-		color: color.adjust( $gray, $lightness: 10% );
-		-webkit-text-fill-color: color.adjust( $gray, $lightness: 10% );
+		background: calypso-colors.$gray-light;
+		border-color: color.adjust( calypso-colors.$gray, $lightness: 30% );
+		color: color.adjust( calypso-colors.$gray, $lightness: 10% );
+		-webkit-text-fill-color: color.adjust( calypso-colors.$gray, $lightness: 10% );
 	}
 }
 
@@ -36,10 +36,10 @@
 	.dops-accessible-focus &:focus,
 	.dops-accessible-focus .dops-select-dropdown.is-open & {
 		z-index: z-index.z-index( 'root', '.dops-accessible-focus .dops-select-dropdown.is-open .dops-select-dropdown__container' );
-		box-shadow: 0 0 0 2px $blue-light;
+		box-shadow: 0 0 0 2px calypso-colors.$blue-light;
 
 		.select-dropdown__header {
-			border-color: $blue-wordpress;
+			border-color: calypso-colors.$blue-wordpress;
 		}
 	}
 
@@ -55,21 +55,21 @@
 	box-sizing: content-box;
 	padding: 11px 44px 11px 16px; // 44 = padding (16) + arrow width (20) + arrow margin (8)
 	border-style: solid;
-	border-color: color.adjust( $gray, $lightness: 20% );
+	border-color: color.adjust( calypso-colors.$gray, $lightness: 20% );
 	border-width: 1px 1px 2px;
 	border-radius: 4px;
-	background-color: $white;
+	background-color: calypso-colors.$white;
 	font-size: 14px;
 	font-weight: 600;
 	line-height: 18px;
 	height: 18px;
-	color: $gray-dark;
+	color: calypso-colors.$gray-dark;
 	transition: background-color 0.2s ease;
 	cursor: pointer;
 
 	&::after {
 
-		@include dashicons;
+		@include mixin_icons.dashicons;
 		content: '\f347';
 		position: absolute;
 			right: 13px;
@@ -82,13 +82,13 @@
 
 		display: block;
 		line-height: 18px;
-		color: rgba( $gray, 0.5 );
+		color: rgba( calypso-colors.$gray, 0.5 );
 	}
 
 
 	.is-compact & {
 		padding: 7px;
-		color: color.adjust( $gray, $lightness: -10% );
+		color: color.adjust( calypso-colors.$gray, $lightness: -10% );
 		font-size: 11px;
 		line-height: 1;
 		text-transform: uppercase;
@@ -103,11 +103,11 @@
 	.dops-select-dropdown.is-open & {
 		border-radius: 4px 4px 0 0;
 		box-shadow: none;
-		background-color: $gray-light;
+		background-color: calypso-colors.$gray-light;
 
 		&::after {
 
-			@include dashicons;
+			@include mixin_icons.dashicons;
 			content: '\f343';
 		}
 	}
@@ -131,14 +131,14 @@
 	padding: 0;
 	list-style: none;
 	margin: -2px 0 0 0; // account for border overlap with .select-dropdown__header
-	background-color: $white;
-	border: 1px solid color.adjust( $gray, $lightness: 20% );
+	background-color: calypso-colors.$white;
+	border: 1px solid color.adjust( calypso-colors.$gray, $lightness: 20% );
 	// $blue-wordpress for outer (with focus shadow), $gray for border with header
 	border-radius: 0 0 4px 4px;
 
 	.dops-accessible-focus & {
-		border: solid 1px $blue-wordpress;
-		border-top-color: color.adjust( $gray, $lightness: 20% );
+		border: solid 1px calypso-colors.$blue-wordpress;
+		border-top-color: color.adjust( calypso-colors.$gray, $lightness: 20% );
 	}
 
 	.dops-select-dropdown.is-open & {
@@ -165,7 +165,7 @@
 	font-size: 14px;
 	font-weight: 400;
 	line-height: 18px;
-	color: $gray-dark;
+	color: calypso-colors.$gray-dark;
 	white-space: nowrap;
 	text-overflow: ellipsis;
 	overflow: hidden;
@@ -178,17 +178,17 @@
 	}
 
 	&:visited {
-		color: $gray-dark;
+		color: calypso-colors.$gray-dark;
 	}
 
 	&.is-selected {
-		background-color: $blue-medium;
-		color: $white;
+		background-color: calypso-colors.$blue-medium;
+		color: calypso-colors.$white;
 	}
 
 	&.is-disabled {
-		background-color: $white;
-		color: $gray;
+		background-color: calypso-colors.$white;
+		color: calypso-colors.$gray;
 		cursor: default;
 		opacity: .5;
 	}
@@ -196,11 +196,11 @@
 	.notouch & {
 		// Make sure :visited links stay blue
 		&:hover {
-			color: $blue-medium;
+			color: calypso-colors.$blue-medium;
 		}
 
 		&.is-selected:hover {
-			color: $white;
+			color: calypso-colors.$white;
 		}
 	}
 }
@@ -227,14 +227,14 @@
 }
 
 .dops-select-dropdown__separator {
-	border-top: 1px solid color.adjust($gray, $lightness: 20% );
+	border-top: 1px solid color.adjust(calypso-colors.$gray, $lightness: 20% );
 	display: block;
 	margin: 8px 0;
 }
 
 .dops-select-dropdown__label {
 	display: block;
-	color: color.adjust($gray, $lightness: 10% );
+	color: color.adjust(calypso-colors.$gray, $lightness: 10% );
 	margin-top: 5px;
 	line-height: 20px;
 
@@ -301,7 +301,7 @@
 			}
 
 			&.is-selected:hover {
-				color: $white;
+				color: calypso-colors.$white;
 			}
 		}
 	}

--- a/projects/plugins/jetpack/_inc/client/components/settings-card/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/settings-card/style.scss
@@ -1,3 +1,4 @@
+@use "../../scss/mixins/breakpoints";
 @use '../../scss/functions/rem';
 
 .jp-form-settings-card {
@@ -111,7 +112,7 @@
 
 		.dops-foldable-card__main {
 
-			@include breakpoint( ">480px" ) {
+			@include breakpoints.breakpoint( ">480px" ) {
 				max-width: 85%;
 			}
 		}
@@ -120,7 +121,7 @@
 			right: rem.convert( -21px );
 			top: rem.convert( 7px );
 
-			@include breakpoint( "<480px" ) {
+			@include breakpoints.breakpoint( "<480px" ) {
 				right: rem.convert( -30px );
 			}
 		}
@@ -170,7 +171,7 @@
 		font-size: rem.convert( 14px );
 	}
 
-	@include breakpoint( ">480px" ) {
+	@include breakpoints.breakpoint( ">480px" ) {
 
 		.dops-foldable-card__action {
 			right: rem.convert( 10px );
@@ -182,7 +183,7 @@
 		}
 	}
 
-	@include breakpoint( "<480px" ) {
+	@include breakpoints.breakpoint( "<480px" ) {
 
 		.jp-form-settings-group .jp-support-info {
 			right: rem.convert( -31px );

--- a/projects/plugins/jetpack/_inc/client/components/settings-group/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/settings-group/style.scss
@@ -1,3 +1,5 @@
+@use "../../scss/typography";
+@use "../../scss/variables/colors";
 @use '../../scss/functions/rem';
 
 .jp-form-settings-group {
@@ -5,7 +7,7 @@
 	margin-bottom: 0;
 
 	p {
-		font-size: $font-body-small;
+		font-size: typography.$font-body-small;
 		margin-top: 0;
 		margin-bottom: rem.convert( 24px );
 
@@ -28,10 +30,10 @@
 	}
 
 	.jp-form-setting-explanation {
-		color: $gray-text-min;
+		color: colors.$gray-text-min;
 		display: block;
 		margin: rem.convert( 5px ) rem.convert( 14px ) rem.convert( 5px ) 0;
-		font-size: $font-body-small;
+		font-size: typography.$font-body-small;
 		font-style: italic;
 		font-weight: 400;
 		word-break: break-word;
@@ -41,7 +43,7 @@
 		}
 
 		&.is-warning {
-			color: $alert-red;
+			color: colors.$alert-red;
 		}
 
 		a {

--- a/projects/plugins/jetpack/_inc/client/components/support-card/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/support-card/style.scss
@@ -1,17 +1,20 @@
 @use 'sass:color';
 @use '../../scss/functions/rem';
-@import '../../scss/mixins/ui';
+@use '../../scss/mixins/ui';
+@use "../../scss/mixins/breakpoints";
+@use "../../scss/typography";
+@use "../../scss/variables/colors";
 
 .jp-support-card {
 
-	@include dashboard-card-shadow;
+	@include ui.dashboard-card-shadow;
 
 	margin-top: rem.convert( 16px );
 	margin-bottom: 0;
 }
 
 .jp-support-card__description {
-	font-size: $font-body-small;
+	font-size: typography.$font-body-small;
 	line-height: 1.65;
 
 	&:first-of-type {
@@ -26,7 +29,7 @@
 	.dops-button {
 		margin: 0 16px 0 0;
 
-		@include breakpoint( "<960px" ) {
+		@include breakpoints.breakpoint( "<960px" ) {
 			margin: 0 16px 8px 0;
 		}
 	}
@@ -35,11 +38,11 @@
 .jp-support-card__link {
 	font-style: italic;
 
-	@include breakpoint( "<660px" ) {
+	@include breakpoints.breakpoint( "<660px" ) {
 		display: block;
 		width: 100%;
 		padding: rem.convert( 10px ) 0;
-		border-top: 1px color.adjust( $gray, $lightness: 20%, $alpha: -.5 ) solid;
+		border-top: 1px color.adjust( colors.$gray, $lightness: 20%, $alpha: -.5 ) solid;
 
 		&::first-letter {
 			text-transform: capitalize;
@@ -56,7 +59,7 @@
 	display: flex;
 	flex-flow: row nowrap;
 
-	@include breakpoint( "<660px" ) {
+	@include breakpoints.breakpoint( "<660px" ) {
 
 		.jp-support-card__description:first-of-type {
 			margin-bottom: rem.convert( 16px );
@@ -65,11 +68,11 @@
 }
 
 .jp-support-card__social {
-	background-color: color.adjust( $gray, $lightness: 35% );
+	background-color: color.adjust( colors.$gray, $lightness: 35% );
 	padding: rem.convert( 16px );
 
-		@include breakpoint( "<660px" ) {
-			background: $white;
+		@include breakpoints.breakpoint( "<660px" ) {
+			background: colors.$white;
 			margin-top: rem.convert( 16px );
 			padding: 0 rem.convert( 16px );
 	}
@@ -77,7 +80,7 @@
 
 .jp-support-card__header {
 	font-weight: 400;
-	font-size: $font-title-small;
+	font-size: typography.$font-title-small;
 	margin: 0;
 }
 

--- a/projects/plugins/jetpack/_inc/client/components/support-info/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/support-info/style.scss
@@ -1,6 +1,6 @@
 @use '../../scss/functions/rem';
-@import '../../scss/layout';
-@import '../../scss/calypso-colors';
+@use '../../scss/layout';
+@use '../../scss/calypso-colors';
 
 .jp-support-info {
 	position: absolute;
@@ -8,7 +8,7 @@
 	right: rem.convert( 25px );
 	z-index: 1;
 
-	@include breakpoint( "<480px" ) {
+	@include layout.breakpoint( "<480px" ) {
 		top: rem.convert( 20px );
 		right: rem.convert( 16px );
 	}
@@ -21,7 +21,7 @@
 		white-space: nowrap;
 
 		.gridicon {
-			color: $gray-30;
+			color: calypso-colors.$gray-30;
 
 			&:hover {
 				color: #414141;
@@ -36,6 +36,6 @@
 		display: block;
 		margin-top: rem.convert( 14px );
 		padding-top: rem.convert( 12px );
-		border-top: 1px solid rgba( $gray, 0.5 );
+		border-top: 1px solid rgba( calypso-colors.$gray, 0.5 );
 	}
 }

--- a/projects/plugins/jetpack/_inc/client/components/text-input/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/text-input/style.scss
@@ -1,5 +1,5 @@
 @use 'sass:color';
-@import '../../scss/calypso-colors';
+@use '../../scss/calypso-colors';
 
 // ==========================================================================
 // Text Inputs
@@ -11,21 +11,21 @@
 	margin: 0;
 	padding: 7px 14px;
 	width: 100%;
-	color: $gray-dark;
+	color: calypso-colors.$gray-dark;
 	font-size: 1rem;
 	line-height: 1.5;
-	border: 1px solid color.adjust( $gray, $lightness: 20% );
-	background-color: $white;
+	border: 1px solid color.adjust( calypso-colors.$gray, $lightness: 20% );
+	background-color: calypso-colors.$white;
 	transition: all .15s ease-in-out, box-shadow 0s;
 	box-shadow: none;
 	-webkit-appearance: none;
 
 	&::placeholder {
-		color: $gray;
+		color: calypso-colors.$gray;
 	}
 
 	&:focus {
-		border-color: color.adjust( $gray, $lightness: 20% );
+		border-color: color.adjust( calypso-colors.$gray, $lightness: 20% );
 		box-shadow: 0 0 0 2px #fff, 0 0 0 4px #069e08;
 
 		&::-ms-clear {
@@ -33,56 +33,56 @@
 		}
 
 		&.is-valid {
-			box-shadow: 0 0 0 2px color.adjust( $alert-green, $lightness: 35% );
+			box-shadow: 0 0 0 2px color.adjust( calypso-colors.$alert-green, $lightness: 35% );
 
 			&:hover {
-				box-shadow: 0 0 0 2px color.adjust( $alert-green, $lightness: 25% );
+				box-shadow: 0 0 0 2px color.adjust( calypso-colors.$alert-green, $lightness: 25% );
 			}
 		}
 
 		&.is-error {
-			box-shadow: 0 0 0 2px color.adjust( $alert-red, $lightness: 35% );
+			box-shadow: 0 0 0 2px color.adjust( calypso-colors.$alert-red, $lightness: 35% );
 
 			&:hover {
-				box-shadow: 0 0 0 2px color.adjust( $alert-red, $lightness: 25% );
+				box-shadow: 0 0 0 2px color.adjust( calypso-colors.$alert-red, $lightness: 25% );
 			}
 		}
 	}
 
 	&:hover,
 	&:focus:hover {
-		border-color: color.adjust( $gray, $lightness: 10% );
+		border-color: color.adjust( calypso-colors.$gray, $lightness: 10% );
 	}
 
 	&:disabled {
-		background: $gray-light;
-		border-color: color.adjust( $gray, $lightness: 30% );
-		color: color.adjust( $gray, $lightness: 10% );
-		-webkit-text-fill-color: color.adjust( $gray, $lightness: 10% );
+		background: calypso-colors.$gray-light;
+		border-color: color.adjust( calypso-colors.$gray, $lightness: 30% );
+		color: color.adjust( calypso-colors.$gray, $lightness: 10% );
+		-webkit-text-fill-color: color.adjust( calypso-colors.$gray, $lightness: 10% );
 
 		&:hover {
 			cursor: default;
 		}
 
 		&::placeholder {
-			color: color.adjust( $gray, $lightness: 10% );
+			color: color.adjust( calypso-colors.$gray, $lightness: 10% );
 		}
 	}
 
 	&.is-valid {
-		border-color: $alert-green;
+		border-color: calypso-colors.$alert-green;
 
 		&:hover {
-			border-color: color.adjust( $alert-green, $lightness: -10% );
+			border-color: color.adjust( calypso-colors.$alert-green, $lightness: -10% );
 		}
 	}
 
 
 	&.is-error {
-		border-color: $alert-red;
+		border-color: calypso-colors.$alert-red;
 
 		&:hover {
-			border-color: color.adjust( $alert-red, $lightness: -10% );
+			border-color: color.adjust( calypso-colors.$alert-red, $lightness: -10% );
 		}
 	}
 }

--- a/projects/plugins/jetpack/_inc/client/components/textarea/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/textarea/style.scss
@@ -1,6 +1,6 @@
 @use 'sass:color';
 @use '../../scss/functions/rem';
-@import '../../scss/calypso-colors';
+@use '../../scss/calypso-colors';
 
 // ==========================================================================
 // Text Inputs
@@ -13,26 +13,26 @@
 	padding: rem.convert( 7px ) rem.convert( 14px );
 	min-height: rem.convert( 92px );
 	width: 100%;
-	color: $gray-dark;
+	color: calypso-colors.$gray-dark;
 	font-size: rem.convert( 16px );
 	line-height: 1.5;
-	border: 1px solid color.adjust( $gray, $lightness: 20% );
-	background-color: $white;
+	border: 1px solid color.adjust( calypso-colors.$gray, $lightness: 20% );
+	background-color: calypso-colors.$white;
 	transition: all .15s ease-in-out;
 	box-shadow: none;
 
 	&::placeholder {
-		color: $gray;
+		color: calypso-colors.$gray;
 	}
 
 	&:hover {
-		border-color: color.adjust( $gray, $lightness: 10% );
+		border-color: color.adjust( calypso-colors.$gray, $lightness: 10% );
 	}
 
 	&:focus {
-		border-color: $blue-wordpress;
+		border-color: calypso-colors.$blue-wordpress;
 		outline: none;
-		box-shadow: 0 0 0 2px $blue-light;
+		box-shadow: 0 0 0 2px calypso-colors.$blue-light;
 
 		&::-ms-clear {
 			display: none;
@@ -40,17 +40,17 @@
 	}
 
 	&:disabled {
-		background: $gray-light;
-		border-color: color.adjust( $gray, $lightness: 30% );
-		color: color.adjust( $gray, $lightness: 10% );
-		-webkit-text-fill-color: color.adjust( $gray, $lightness: 10% );
+		background: calypso-colors.$gray-light;
+		border-color: color.adjust( calypso-colors.$gray, $lightness: 30% );
+		color: color.adjust( calypso-colors.$gray, $lightness: 10% );
+		-webkit-text-fill-color: color.adjust( calypso-colors.$gray, $lightness: 10% );
 
 		&:hover {
 			cursor: default;
 		}
 
 		&::placeholder {
-			color: color.adjust( $gray, $lightness: 10% );
+			color: color.adjust( calypso-colors.$gray, $lightness: 10% );
 		}
 	}
 }

--- a/projects/plugins/jetpack/_inc/client/components/tooltip/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/tooltip/style.scss
@@ -1,5 +1,5 @@
 @use 'sass:color';
-@import '../../scss/calypso-colors';
+@use '../../scss/calypso-colors';
 
 .dops-tooltip.dops-popover {
 
@@ -12,7 +12,7 @@
 	&.is-bottom {
 
 		.dops-popover__arrow {
-			border-bottom-color: color.adjust( $gray, $lightness: -30% );
+			border-bottom-color: color.adjust( calypso-colors.$gray, $lightness: -30% );
 			top: 4px;
 			right: 10px;
 
@@ -24,21 +24,21 @@
 		&.is-error {
 
 			.dops-popover__arrow {
-				border-bottom-color: $alert-red;
+				border-bottom-color: calypso-colors.$alert-red;
 			}
 		}
 
 		&.is-warning {
 
 			.dops-popover__arrow {
-				border-bottom-color: $alert-yellow;
+				border-bottom-color: calypso-colors.$alert-yellow;
 			}
 		}
 
 		&.is-success {
 
 			.dops-popover__arrow {
-				border-bottom-color: $alert-green;
+				border-bottom-color: calypso-colors.$alert-green;
 			}
 		}
 	}
@@ -48,7 +48,7 @@
 	&.is-top-right {
 
 		.dops-popover__arrow {
-			border-top-color: color.adjust( $gray, $lightness: -30% );
+			border-top-color: color.adjust( calypso-colors.$gray, $lightness: -30% );
 			bottom: 4px;
 			right: 10px;
 
@@ -60,21 +60,21 @@
 		&.is-error {
 
 			.dops-popover__arrow {
-				border-top-color: $alert-red;
+				border-top-color: calypso-colors.$alert-red;
 			}
 		}
 
 		&.is-warning {
 
 			.dops-popover__arrow {
-				border-top-color: $alert-yellow;
+				border-top-color: calypso-colors.$alert-yellow;
 			}
 		}
 
 		&.is-success {
 
 			.dops-popover__arrow {
-				border-top-color: $alert-green;
+				border-top-color: calypso-colors.$alert-green;
 			}
 		}
 	}
@@ -102,21 +102,21 @@
 		&.is-error {
 
 			.dops-popover__arrow {
-				border-right-color: $alert-red;
+				border-right-color: calypso-colors.$alert-red;
 			}
 		}
 
 		&.is-warning {
 
 			.dops-popover__arrow {
-				border-right-color: $alert-yellow;
+				border-right-color: calypso-colors.$alert-yellow;
 			}
 		}
 
 		&.is-success {
 
 			.dops-popover__arrow {
-				border-right-color: $alert-green;
+				border-right-color: calypso-colors.$alert-green;
 			}
 		}
 	}
@@ -125,7 +125,7 @@
 
 		.dops-popover__arrow {
 			margin-right: 4px;
-			border-left-color: color.adjust( $gray, $lightness: -30% );
+			border-left-color: color.adjust( calypso-colors.$gray, $lightness: -30% );
 		}
 	}
 
@@ -133,7 +133,7 @@
 
 		.dops-popover__arrow {
 			margin-left: 4px;
-			border-right-color: color.adjust( $gray, $lightness: -30% );
+			border-right-color: color.adjust( calypso-colors.$gray, $lightness: -30% );
 		}
 	}
 
@@ -141,8 +141,8 @@
 		border: 0;
 		box-shadow: none;
 		border-radius: 2px;
-		color: $white;
-		background: color.adjust( $gray, $lightness: -30% );
+		color: calypso-colors.$white;
+		background: color.adjust( calypso-colors.$gray, $lightness: -30% );
 		font-size: 12px;
 		padding: 6px 10px;
 		text-align: left;
@@ -151,21 +151,21 @@
 	&.is-error {
 
 		.dops-popover__inner {
-			background: $alert-red;
+			background: calypso-colors.$alert-red;
 		}
 	}
 
 	&.is-warning {
 
 		.dops-popover__inner {
-			background: $alert-yellow;
+			background: calypso-colors.$alert-yellow;
 		}
 	}
 
 	&.is-success {
 
 		.dops-popover__inner {
-			background: $alert-green;
+			background: calypso-colors.$alert-green;
 		}
 	}
 
@@ -184,5 +184,5 @@
 
 .dops-tooltip__hr {
 	margin: 8px 0;
-	background: $gray;
+	background: calypso-colors.$gray;
 }

--- a/projects/plugins/jetpack/_inc/client/components/tree-dropdown/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/tree-dropdown/style.scss
@@ -1,10 +1,10 @@
-@import '../../scss/calypso-colors';
+@use '../../scss/calypso-colors';
 
 
 @keyframes dropdown-slide-down {
 
 	from {
-		border: solid 1px $gray-5;
+		border: solid 1px calypso-colors.$gray-5;
 	}
 
 	to {
@@ -15,12 +15,12 @@
 @keyframes dropdown-slide-up {
 
 	0% {
-		border: solid 1px $gray-5;
+		border: solid 1px calypso-colors.$gray-5;
 		border-top: none;
 	}
 
 	99% {
-		border: solid 1px $gray-5;
+		border: solid 1px calypso-colors.$gray-5;
 		border-top: none;
 	}
 
@@ -67,7 +67,7 @@
 		flex-wrap: wrap;
 		align-items: center;
 		gap: 6px;
-		border: solid 1px $gray-5;
+		border: solid 1px calypso-colors.$gray-5;
 		border-radius: 4px;
 		min-height: 40px;
 		padding: 4px 8px;
@@ -100,8 +100,8 @@
 			display: flex;
 			gap: 4px;
 			height: 24px;
-			background-color: $white;
-			border: solid 1px $gray-80;
+			background-color: calypso-colors.$white;
+			border: solid 1px calypso-colors.$gray-80;
 			border-radius: 12px;
 			padding: 2px 4px 2px 8px;
 			margin: 3px 0;
@@ -139,7 +139,7 @@
 			position: absolute;
 			top: 100%;
 			width: 100%;
-			background-color: $white;	
+			background-color: calypso-colors.$white;	
 			z-index: 1000;
 			padding: 8px;
 
@@ -157,7 +157,7 @@
 					left: -1px;
 					right: -1px;
 					height: 5px;
-					background-color: $white;
+					background-color: calypso-colors.$white;
 					border-left: solid 1px var(--jp-green);
 					border-right: solid 1px var(--jp-green);
 				}

--- a/projects/plugins/jetpack/_inc/client/dashboard-widget/style.scss
+++ b/projects/plugins/jetpack/_inc/client/dashboard-widget/style.scss
@@ -1,3 +1,4 @@
+@use "../scss/variables/colors";
 @use '@automattic/jetpack-base-styles/root-variables';
 
 @mixin emerald-button-colors() {
@@ -230,7 +231,7 @@
 			height: 40px;
 
 			path {
-				fill: $green-primary;
+				fill: colors.$green-primary;
 			}
 		}
 
@@ -246,7 +247,7 @@
 		}
 
 		p {
-			color: $wpui_dark_medium_gray;
+			color: colors.$wpui_dark_medium_gray;
 			margin-top: 0;
 			padding: 0 15px;
 		}

--- a/projects/plugins/jetpack/_inc/client/discussion/style.scss
+++ b/projects/plugins/jetpack/_inc/client/discussion/style.scss
@@ -1,5 +1,5 @@
 @use '../scss/functions/rem';
-@import '../scss/layout';
+@use '../scss/layout';
 
 .jp-form-settings-group .jp-toggle-set {
 	position: relative;
@@ -9,7 +9,7 @@
 		right: rem.convert( -20px );
 		top: rem.convert( 5px );
 
-		@include breakpoint( "<480px" ) {
+		@include layout.breakpoint( "<480px" ) {
 			right: rem.convert( -32px );
 			top: rem.convert( 5px );
 		}

--- a/projects/plugins/jetpack/_inc/client/my-plan/my-plan-banner/style.scss
+++ b/projects/plugins/jetpack/_inc/client/my-plan/my-plan-banner/style.scss
@@ -1,7 +1,7 @@
-@import '../../scss/calypso-colors';
+@use '../../scss/calypso-colors';
 
 .jp-my-plan-banner__card {
-	background-color: $white;
+	background-color: calypso-colors.$white;
 	background-position: 100%;
 	background-size: 50% 100%;
 	background-repeat: no-repeat;

--- a/projects/plugins/jetpack/_inc/client/my-plan/my-plan-card/style.scss
+++ b/projects/plugins/jetpack/_inc/client/my-plan/my-plan-card/style.scss
@@ -1,11 +1,11 @@
-@import '../../scss/mixin_breakpoint';
-@import '../../scss/calypso-colors';
-@import '../../scss/typography';
+@use '../../scss/mixin_breakpoint';
+@use '../../scss/calypso-colors';
+@use '../../scss/typography';
 
 // My Plan Card
 .my-plan-card {
 
-	@include breakpoint( '>960px' ) {
+	@include mixin_breakpoint.breakpoint( '>960px' ) {
 		display: flex;
 		flex-flow: row nowrap;
 		justify-content: space-between;
@@ -45,9 +45,9 @@
 	font-weight: 500;
 	line-height: 30px;
 	margin: 4px 0;
-	color: $black;
+	color: calypso-colors.$black;
 
-  @include breakpoint( '<960px' ) {
+  @include mixin_breakpoint.breakpoint( '<960px' ) {
 	padding-top: 16px;
   }
 }
@@ -58,7 +58,7 @@
 	line-height: 1.65;
 	margin: 0 0 4px 0;
 
-	@include breakpoint( '<960px' ) {
+	@include mixin_breakpoint.breakpoint( '<960px' ) {
 	  margin-bottom: 8px;
 	}
 }
@@ -71,7 +71,7 @@
 	justify-content: center;
 	align-items: center;
 
-	@include breakpoint( '<660px' ) {
+	@include mixin_breakpoint.breakpoint( '<660px' ) {
 		order: 99;
 		width: 80px;
 		height: 80px;
@@ -85,7 +85,7 @@
 	height: 48px;
 	margin: 16px 24px 16px 0;
 
-	@include breakpoint( '<660px' ) {
+	@include mixin_breakpoint.breakpoint( '<660px' ) {
 		display: none;
 	}
 
@@ -103,7 +103,7 @@
 	justify-content: space-between;
 	padding: 0;
 
-	@include breakpoint( '>960px' ) {
+	@include mixin_breakpoint.breakpoint( '>960px' ) {
 		flex-flow: column nowrap;
 		justify-content: center;
 		align-items: flex-end;
@@ -118,12 +118,12 @@
 		border-bottom: 1px solid var(--jp-gray);
 	  	bottom: 0;
 
-		@include breakpoint( '>480px' ) {
+		@include mixin_breakpoint.breakpoint( '>480px' ) {
 			left: -24px;
 			right: -24px;
 		}
 
-		@include breakpoint( '>960px' ) {
+		@include mixin_breakpoint.breakpoint( '>960px' ) {
 			content: none;
 		}
 	}
@@ -140,23 +140,23 @@
 
 .my-plan-card__details {
 	padding: 8px 0 16px;
-	color: $gray-darken-10;
+	color: calypso-colors.$gray-darken-10;
   	display: contents;
 
-	@include breakpoint( '<960px' ) {
+	@include mixin_breakpoint.breakpoint( '<960px' ) {
 	  display: block;
 	}
 
-	@include breakpoint( '>480px' ) {
+	@include mixin_breakpoint.breakpoint( '>480px' ) {
 		white-space: nowrap;
 	}
 
-	@include breakpoint( '>960px' ) {
+	@include mixin_breakpoint.breakpoint( '>960px' ) {
 		padding-top: 0;
 	}
 
 	&.is-error {
-		color: $alert-red;
+		color: calypso-colors.$alert-red;
 	}
 
 	a.my-plan-card__renew {
@@ -165,7 +165,7 @@
 
 	  &:hover {
 		text-decoration-thickness: 3px;
-		color: $black;
+		color: calypso-colors.$black;
 	  }
 
 	  &:focus {
@@ -173,11 +173,11 @@
 		border-radius: 2px;
 		box-shadow: 0 0 0 var(--wp-admin-border-width-focus) #000;
 		outline: 3px solid transparent;
-		color: $black;
+		color: calypso-colors.$black;
 	  }
 
 	  &:active {
-		color: $black;
+		color: calypso-colors.$black;
 	  }
 	}
 }
@@ -192,19 +192,19 @@
 }
 
 .my-plan-card__expired {
-	color: $alert-red;
+	color: calypso-colors.$alert-red;
 }
 
 .my-plan-card__renew {
 	display: flex;
 	justify-content: flex-end;
-	color: $black;
+	color: calypso-colors.$black;
 
 	.components-external-link__icon {
 	  align-self: center;
 	}
 
-	@include breakpoint( '<960px' ) {
+	@include mixin_breakpoint.breakpoint( '<960px' ) {
 	  justify-content: flex-start;
 	}
 }

--- a/projects/plugins/jetpack/_inc/client/my-plan/style.scss
+++ b/projects/plugins/jetpack/_inc/client/my-plan/style.scss
@@ -1,6 +1,8 @@
 @use '../scss/functions/rem';
-@import '../scss/calypso-colors';
-@import '../scss/typography';
+@use '../scss/calypso-colors';
+@use '../scss/typography';
+@use "../scss/mixins/breakpoints";
+@use "../scss/variables/colors";
 
 .jp-landing__plans {
 	margin-top: 48px;
@@ -15,7 +17,7 @@
 		margin-bottom: 0;
 		border-bottom: 1px solid var(--jp-gray);
 
-		@include breakpoint( "<960px" ) {
+		@include breakpoints.breakpoint( "<960px" ) {
 			border-bottom: 0;
 		}
 	}
@@ -27,21 +29,21 @@
 	.dops-card:last-child {
 		border-radius: 0 0 4px 4px;
 
-		@include breakpoint( "<960px" ) {
+		@include breakpoints.breakpoint( "<960px" ) {
 			padding-top: 0;
 		}
 	}
 
 	.dops-card:nth-last-child(2) {
 
-		@include breakpoint( "<960px" ) {
+		@include breakpoints.breakpoint( "<960px" ) {
 			border-bottom: 0;
 		}
 	}
 
 	.my-plan-card__tag-line a,
 	a.jp-landing__licensing-actions-link {
-		color: $black;
+		color: colors.$black;
 		text-decoration-line: underline;
 
 		&:hover {
@@ -62,7 +64,7 @@
 	margin-bottom: 8px;
 	font-size: 20px;
 	font-weight: 500;
-	color: $black;
+	color: colors.$black;
 }
 
 .jp-landing__licensing-actions {
@@ -72,12 +74,12 @@
 
 	span {
 
-		@include breakpoint( "<660px" ) {
+		@include breakpoints.breakpoint( "<660px" ) {
 			display: none;
 		}
 	}
 
-	@include breakpoint( ">480px" ) {
+	@include breakpoints.breakpoint( ">480px" ) {
 		justify-content: space-between;
 	}
 
@@ -89,11 +91,11 @@
 
 		text-align: center;
 
-		@include breakpoint( ">480px" ) {
+		@include breakpoints.breakpoint( ">480px" ) {
 			flex-direction: row;
 		}
 
-		@include breakpoint( "<660px" ) {
+		@include breakpoints.breakpoint( "<660px" ) {
 			flex-direction: unset;
 			flex: 1;
 		}
@@ -108,7 +110,7 @@
 		flex: 1;
 		justify-content: flex-end;
 
-		@include breakpoint( "<660px" ) {
+		@include breakpoints.breakpoint( "<660px" ) {
 			justify-content: space-around;
 
 			a {
@@ -127,7 +129,7 @@
 	box-sizing: border-box;
 	padding: 7px 20px 9px 0;
 
-	@include breakpoint( "<480px" ) {
+	@include breakpoints.breakpoint( "<480px" ) {
 		padding: 0;
 		margin-bottom: 15px;
 	}
@@ -151,7 +153,7 @@
 	flex-grow: 1;
 	box-sizing: border-box;
 	margin: 0 rem.convert( 8px );
-	background-color: $white;
+	background-color: colors.$white;
 	box-shadow: 0 0 40px rgba(0, 0, 0, 0.08);
 	border-radius: 4px;
 
@@ -163,16 +165,16 @@
 		width: 49.5%;
 	}
 
-	@include breakpoint( "<660px" ) {
+	@include breakpoints.breakpoint( "<660px" ) {
 		max-width: 100%;
 		margin-bottom: rem.convert( 8px );
 	}
 
-	@include breakpoint( ">480px" ) {
+	@include breakpoints.breakpoint( ">480px" ) {
 		padding: rem.convert( 24px );
 	}
 
-	@include breakpoint( "<480px" ) {
+	@include breakpoints.breakpoint( "<480px" ) {
 		padding: rem.convert( 16px );
 	}
 }
@@ -188,7 +190,7 @@
 	line-height: 1;
 	display: flex;
 
-	@include breakpoint( ">960px" ) {
+	@include breakpoints.breakpoint( ">960px" ) {
 		width: rem.convert( 48px );
 	}
 }
@@ -201,7 +203,7 @@
 .jp-landing__plan-features-text,
 .jp-landing__licensing-actions{
 	flex: 1;
-	font-size: $font-body-small;
+	font-size: typography.$font-body-small;
 	color: var(--jp-gray-80);
 
 	a,
@@ -231,14 +233,14 @@
 	margin-left: rem.convert( -8px );
 	margin-right: rem.convert( -8px );
 
-	@include breakpoint( "<660px" ) {
+	@include breakpoints.breakpoint( "<660px" ) {
 		display: block;
 	}
 }
 
 .jp-landing__plan-features-card:nth-child(odd) {
 
-	@include breakpoint( "<660px" ) {
+	@include breakpoints.breakpoint( "<660px" ) {
 		margin-right: 8px;
 	}
 }
@@ -246,7 +248,7 @@
 .jp-landing__plan-features-card:nth-child(even) {
 	margin-left: 0;
 
-	@include breakpoint( "<660px" ) {
+	@include breakpoints.breakpoint( "<660px" ) {
 		margin-left: 8px;
 	}
 }
@@ -264,7 +266,7 @@
 .jp-landing__plan-features-link {
 	width: 100%;
 
-	@include breakpoint( ">660px" ) {
+	@include breakpoints.breakpoint( ">660px" ) {
 		text-align: center;
 	}
 }

--- a/projects/plugins/jetpack/_inc/client/performance/style.scss
+++ b/projects/plugins/jetpack/_inc/client/performance/style.scss
@@ -1,5 +1,5 @@
 @use '../scss/functions/rem';
-@import '../scss/calypso-colors';
+@use '../scss/calypso-colors';
 
 .jp-form-settings-group .jp-form-shortcode-setting-explanation {
 	margin-left: 60px;
@@ -18,7 +18,7 @@
 
 
 .media__videopress-upgrade {
-	border-top: 1px solid $gray-5;
+	border-top: 1px solid calypso-colors.$gray-5;
 
 	&.dops-banner.dops-card.is-product {
 		border-left: none;

--- a/projects/plugins/jetpack/_inc/client/product-descriptions/product-description/style.scss
+++ b/projects/plugins/jetpack/_inc/client/product-descriptions/product-description/style.scss
@@ -1,6 +1,6 @@
-@import '../../scss/mixin_breakpoint';
-@import '../../scss/typography';
-@import '../../scss/variables/colors';
+@use '../../scss/mixin_breakpoint';
+@use '../../scss/typography';
+@use '../../scss/variables/colors';
 
 .jp-product-description > * {
 	margin-bottom: 26px;
@@ -8,20 +8,20 @@
 
 .jp-product-description--split {
 
-	@include breakpoint( '>960px' ) {
+	@include mixin_breakpoint.breakpoint( '>960px' ) {
 		display: grid;
 		grid-template-columns: 50% 50%;
 		column-gap: 26px;
 	}
 
-	@include breakpoint( '>1040px' ) {
+	@include mixin_breakpoint.breakpoint( '>1040px' ) {
 		grid-template-columns: auto 410px;
 	}
 }
 
 .jp-product-description__introductory-pricing {
-	color: $black;
-	font-size: $font-body-small;
+	color: colors.$black;
+	font-size: typography.$font-body-small;
 	line-height: 1.5;
 	letter-spacing: 0.1px;
 	text-align: center;

--- a/projects/plugins/jetpack/_inc/client/product-descriptions/style.scss
+++ b/projects/plugins/jetpack/_inc/client/product-descriptions/style.scss
@@ -1,8 +1,8 @@
-@import '../scss/mixin_breakpoint';
+@use '../scss/mixin_breakpoint';
 
 .jp-product-description {
 
-	@include breakpoint( '<960px' ) {
+	@include mixin_breakpoint.breakpoint( '<960px' ) {
 		max-width: 550px;
 		margin-left: auto;
 		margin-right: auto;

--- a/projects/plugins/jetpack/_inc/client/recommendations/back-button/style.scss
+++ b/projects/plugins/jetpack/_inc/client/recommendations/back-button/style.scss
@@ -1,5 +1,5 @@
-@import '../../scss/variables/colors';
-@import '../../scss/typography';
+@use '../../scss/variables/colors';
+@use '../../scss/typography';
 
 .jp-recommendations-back-btn {
 	display: flex;
@@ -12,7 +12,7 @@
 	color: var( --jp-gray-70 );
 	fill: currentColor;
 
-	font-size: $font-body;
+	font-size: typography.$font-body;
 
 	cursor: pointer;
 

--- a/projects/plugins/jetpack/_inc/client/recommendations/discount-badge/style.scss
+++ b/projects/plugins/jetpack/_inc/client/recommendations/discount-badge/style.scss
@@ -1,5 +1,5 @@
 @use '@automattic/jetpack-base-styles/style';
-@import '../../scss/typography';
+@use '../../scss/typography';
 
 .jp-recommendations-discount-badge {
 	padding: 0.375rem 0.75rem;
@@ -8,8 +8,8 @@
 	border-radius: var( --jp-border-radius );
 	color: var( --jp-gray-100 );
 
-	font-size: $font-body-small;
-	font-weight: $bold;
+	font-size: typography.$font-body-small;
+	font-weight: typography.$bold;
 	line-height: 1;
 	text-align: center;
 }

--- a/projects/plugins/jetpack/_inc/client/recommendations/feature-summary/style.scss
+++ b/projects/plugins/jetpack/_inc/client/recommendations/feature-summary/style.scss
@@ -1,5 +1,5 @@
-@import '../../scss/variables/colors';
-@import '../../scss/typography';
+@use '../../scss/variables/colors';
+@use '../../scss/typography';
 
 .jp-recommendations-feature-summary {
 	display: flex;
@@ -8,7 +8,7 @@
 	border-bottom: 1px solid #e1e1e1;
 
 	.gridicons-checkmark-circle {
-		fill: $green-primary;
+		fill: colors.$green-primary;
 	}
 
 	&:last-child {
@@ -60,7 +60,7 @@
 	justify-content: flex-start;
 	flex-grow: 1;
 	background: none;
-	font-size: $font-body;
+	font-size: typography.$font-body;
 
 	// These names are managed as borderless buttons that link back to the respective steps
 	&.is-borderless {

--- a/projects/plugins/jetpack/_inc/client/recommendations/product-card-upsell/style.scss
+++ b/projects/plugins/jetpack/_inc/client/recommendations/product-card-upsell/style.scss
@@ -1,18 +1,18 @@
 @use '@automattic/jetpack-base-styles/style';
-@import '../../scss/mixins/ui';
-@import '../../scss/variables/colors';
-@import '../../scss/typography';
-@import '../../scss/mixin_breakpoint';
+@use '../../scss/mixins/ui';
+@use '../../scss/variables/colors';
+@use '../../scss/typography';
+@use '../../scss/mixin_breakpoint';
 
 .jp-recommendations-product-card-upsell {
 
-	@include card;
+	@include ui.card;
 
 	position: relative;
 
 	padding: 3.25rem 2rem 2rem;
 
-	@include breakpoint( '<480px' ) {
+	@include mixin_breakpoint.breakpoint( '<480px' ) {
 		padding: 1rem;
 
 		&.with-header {
@@ -33,14 +33,14 @@
 
 	color: var( --jp-gray-100 );
 
-	font-size: $font-title-large;
-	font-weight: $bold;
+	font-size: typography.$font-title-large;
+	font-weight: typography.$bold;
 }
 
 .jp-recommendations-product-card-upsell__description {
 	margin-bottom: 1.5rem;
 
-	font-size: $font-body-small;
+	font-size: typography.$font-body-small;
 }
 
 .jp-recommendations-product-card-upsell__features {
@@ -120,7 +120,7 @@
 	padding-inline-start: 4rem !important;
 	padding-inline-end: 4rem !important;
 
-	font-size: $font-body;
+	font-size: typography.$font-body;
 
 	.gridicons-external {
 		margin-left: 0.25rem;

--- a/projects/plugins/jetpack/_inc/client/recommendations/product-purchased/style.scss
+++ b/projects/plugins/jetpack/_inc/client/recommendations/product-purchased/style.scss
@@ -1,5 +1,5 @@
-@import '../../scss/variables/colors';
-@import '../../scss/mixin_breakpoint';
+@use '../../scss/variables/colors';
+@use '../../scss/mixin_breakpoint';
 
 .jp-recommendations-product-purchased {
 	display: flex;
@@ -9,7 +9,7 @@
 
 	height: 100%;
 
-	@include breakpoint( '>480px' ) {
+	@include mixin_breakpoint.breakpoint( '>480px' ) {
 		margin-left: 32px;
 		margin-right: 32px;
 	}
@@ -27,13 +27,13 @@
 .jp-recommendations-product-purchased svg {
 	margin-right: 10px;
 
-	fill: $color-plan;
+	fill: colors.$color-plan;
 }
 
 .jp-recommendations-product-purchased__next {
 	align-self: center;
 
-	@include breakpoint( '>480px' ) {
+	@include mixin_breakpoint.breakpoint( '>480px' ) {
 		margin-top: auto;
 	}
 }

--- a/projects/plugins/jetpack/_inc/client/recommendations/prompts/checkbox-answer/style.scss
+++ b/projects/plugins/jetpack/_inc/client/recommendations/prompts/checkbox-answer/style.scss
@@ -1,5 +1,5 @@
-@import '../../../scss/mixin_breakpoint';
-@import '../../../scss/calypso-colors';
+@use '../../../scss/mixin_breakpoint';
+@use '../../../scss/calypso-colors';
 
 .jp-checkbox-answer__container {
 	position: relative;

--- a/projects/plugins/jetpack/_inc/client/recommendations/prompts/product-suggestions/style.scss
+++ b/projects/plugins/jetpack/_inc/client/recommendations/prompts/product-suggestions/style.scss
@@ -1,11 +1,11 @@
-@import '../../../scss/variables/colors';
-@import '../../../scss/mixin_breakpoint';
-@import '../../../scss/typography';
+@use '../../../scss/variables/colors';
+@use '../../../scss/mixin_breakpoint';
+@use '../../../scss/typography';
 
 .jp-recommendations-product-suggestion__header {
 	padding: 2rem 2.5rem 1.5rem;
 
-	@include breakpoint( '<782px' ) {
+	@include mixin_breakpoint.breakpoint( '<782px' ) {
 		padding-left: 1rem;
 		padding-right: 1rem;
 	}
@@ -14,7 +14,7 @@
 .jp-recommendations-product-suggestion__container {
 	padding: 0 2.5rem;
 
-	@include breakpoint( '<782px' ) {
+	@include mixin_breakpoint.breakpoint( '<782px' ) {
 		padding-left: 1rem;
 		padding-right: 1rem;
 	}
@@ -25,7 +25,7 @@
 	gap: 2rem;
 	grid-template-columns: 1fr 1fr;
 
-	@include breakpoint( '<782px' ) {
+	@include mixin_breakpoint.breakpoint( '<782px' ) {
 		display: block;
 
 		max-width: 360px;
@@ -35,7 +35,7 @@
 
 .jp-recommendations-product-suggestion__item {
 
-	@include breakpoint( '<782px' ) {
+	@include mixin_breakpoint.breakpoint( '<782px' ) {
 		margin-bottom: 2rem;
 
 		&:last-child {
@@ -60,9 +60,9 @@
 	background: var( --jp-white-off );
 	color: var( --jp-gray-30 );
 
-	font-size: $font-body-small;
+	font-size: typography.$font-body-small;
 
-	@include breakpoint( '<782px' ) {
+	@include mixin_breakpoint.breakpoint( '<782px' ) {
 		flex-direction: column;
 		justify-content: flex-start;
 
@@ -76,7 +76,7 @@
 .jp-recommendations-product-suggestion__timer {
 	color: var( --jp-gray-60 );
 
-	@include breakpoint( '<782px' ) {
+	@include mixin_breakpoint.breakpoint( '<782px' ) {
 		flex-direction: column;
 		justify-content: flex-start;
 	}

--- a/projects/plugins/jetpack/_inc/client/recommendations/prompts/prompt-layout/style.scss
+++ b/projects/plugins/jetpack/_inc/client/recommendations/prompts/prompt-layout/style.scss
@@ -1,6 +1,6 @@
-@import '../../mixin';
-@import '../../../scss/mixin_breakpoint';
-@import '../../../scss/variables/colors';
+@use '../../mixin';
+@use '../../../scss/mixin_breakpoint';
+@use '../../../scss/variables/colors';
 
 .jp-recommendations-question__content {
 	display: flex;
@@ -9,7 +9,7 @@
 
 .jp-recommendations-question__main--with-sidebar .jp-recommendations-question__content {
 
-	@include breakpoint( '>660px' ) {
+	@include mixin_breakpoint.breakpoint( '>660px' ) {
 		padding-right: 48px;
 	}
 }
@@ -31,7 +31,7 @@
 	align-items: center;
 	margin: 32px 32px 0 32px;
 
-	@include breakpoint( '<480px' ) {
+	@include mixin_breakpoint.breakpoint( '<480px' ) {
 		margin: 16px 16px 32px 16px;
 	}
 
@@ -46,7 +46,7 @@
 	font-size: 1.5rem;
 	margin: 2.5rem 2.5rem 1rem 2.5rem;
 
-	@include breakpoint( '<480px' ) {
+	@include mixin_breakpoint.breakpoint( '<480px' ) {
 		margin: 0 1rem 2rem 1rem;
 	}
 }
@@ -58,7 +58,7 @@
 
 	margin: 1rem 2rem 2rem 2.5rem;
 
-	@include breakpoint( '<480px' ) {
+	@include mixin_breakpoint.breakpoint( '<480px' ) {
 		margin: 0 1rem 1rem 1rem;
 	}
 
@@ -90,7 +90,7 @@
 		margin-bottom: 0.5rem;
 	}
 
-	@include breakpoint( '<480px' ) {
+	@include mixin_breakpoint.breakpoint( '<480px' ) {
 		margin: 0 1rem 0 1rem;
 	}
 }
@@ -103,7 +103,7 @@
 .jp-recommendations-question__main--with-sidebar .jp-recommendations-question__description {
 	margin-right: 0;
 
-	@include breakpoint( '<782px' ) {
+	@include mixin_breakpoint.breakpoint( '<782px' ) {
 		margin-right: 32px;
 	}
 }
@@ -122,7 +122,7 @@
 	width: 100%;
 	height: 100%;
 
-	@include breakpoint( '<1040px' ) {
+	@include mixin_breakpoint.breakpoint( '<1040px' ) {
 		display: none;
 	}
 }
@@ -158,7 +158,7 @@
 	margin-bottom: 16px;
 
 	.gridicons-checkmark-circle {
-		fill: $green-primary;
+		fill: colors.$green-primary;
 	}
 }
 
@@ -194,7 +194,7 @@
 			margin-bottom: 16px;
 			text-align: center;
 
-			@include breakpoint( '<480px' ) {
+			@include mixin_breakpoint.breakpoint( '<480px' ) {
 				width: 100%;
 			}
 		}
@@ -204,7 +204,7 @@
 		}
 	}
 
-	@include breakpoint( '<480px' ) {
+	@include mixin_breakpoint.breakpoint( '<480px' ) {
 		padding: 64px 16px 0 16px;
 	}
 }

--- a/projects/plugins/jetpack/_inc/client/recommendations/prompts/site-type/style.scss
+++ b/projects/plugins/jetpack/_inc/client/recommendations/prompts/site-type/style.scss
@@ -1,6 +1,6 @@
 @use '@automattic/jetpack-base-styles/style';
-@import '../../../scss/mixin_breakpoint';
-@import '../../../scss/calypso-colors';
+@use '../../../scss/mixin_breakpoint';
+@use '../../../scss/calypso-colors';
 
 .jp-recommendations-question__site-type-checkboxes {
 	display: flex;
@@ -16,17 +16,17 @@
 
 	margin: 0 0 32px 32px;
 
-	@include breakpoint( '<660px' ) {
+	@include mixin_breakpoint.breakpoint( '<660px' ) {
 		margin: 0 32px 32px 32px;
 	}
 
-	@include breakpoint( '<480px' ) {
+	@include mixin_breakpoint.breakpoint( '<480px' ) {
 		margin: 0 16px 16px 16px;
 	}
 
 	.dops-button {
 
-		@include breakpoint( '<480px' ) {
+		@include mixin_breakpoint.breakpoint( '<480px' ) {
 			width: 100%;
 		}
 	}
@@ -37,7 +37,7 @@
 	margin: 14px auto 0 auto;
 	max-width: 300px;
 
-	@include breakpoint( '<480px' ) {
+	@include mixin_breakpoint.breakpoint( '<480px' ) {
 		display: none;
 	}
 }

--- a/projects/plugins/jetpack/_inc/client/recommendations/sidebar/discount-card/style.scss
+++ b/projects/plugins/jetpack/_inc/client/recommendations/sidebar/discount-card/style.scss
@@ -1,8 +1,8 @@
 @use '@automattic/jetpack-base-styles/style';
-@import '../../mixin';
-@import '../../../scss/mixins/ui';
-@import '../../../scss/mixin_breakpoint';
-@import '../../../scss/typography';
+@use '../../mixin';
+@use '../../../scss/mixins/ui';
+@use '../../../scss/mixin_breakpoint';
+@use '../../../scss/typography';
 
 .jp-recommendations-discount-card {
 	display: flex;
@@ -12,13 +12,13 @@
 	height: 100%;
 	padding: 3rem 0;
 
-	@include breakpoint( '<782px' ) {
+	@include mixin_breakpoint.breakpoint( '<782px' ) {
 		justify-content: center;
 		padding-inline-start: 1rem;
 		padding-inline-end: 1rem;
 	}
 
-	@include breakpoint( '>1040px' ) {
+	@include mixin_breakpoint.breakpoint( '>1040px' ) {
 		justify-content: flex-end;
 		padding-left: 3rem;
 		padding-right: 3rem;
@@ -31,7 +31,7 @@
 
 	&__card {
 
-		@include card( $borderless: true );
+		@include ui.card( $borderless: true );
 
 		box-shadow: 0 0 40px rgba( 0, 0, 0, 0.08 );
 	}
@@ -78,7 +78,7 @@
 
 	&__feature-list {
 
-		@include features-list;
+		@include ui.features-list;
 	}
 
 	&__disclaimer {
@@ -93,7 +93,7 @@
 	&__button {
 		align-self: center;
 		margin-top: 0.25rem;
-		font-size: $font-body;
+		font-size: typography.$font-body;
 		display: flex;
 		align-items: center;
 
@@ -111,7 +111,7 @@
 
 		color: var( --jp-gray-60 );
 
-		font-size: $font-body-small;
+		font-size: typography.$font-body-small;
 		text-align: center;
 	}
 

--- a/projects/plugins/jetpack/_inc/client/recommendations/sidebar/mobile-app/style.scss
+++ b/projects/plugins/jetpack/_inc/client/recommendations/sidebar/mobile-app/style.scss
@@ -1,6 +1,6 @@
-@import '../../../scss/variables/colors';
-@import '../../../scss/typography';
-@import '../../../scss/mixin_breakpoint';
+@use '../../../scss/variables/colors';
+@use '../../../scss/typography';
+@use '../../../scss/mixin_breakpoint';
 
 .jp-recommendations-sidebar-mobile__apps-badge {
 	display: flex;
@@ -37,9 +37,9 @@ h2.jp-recommendation-sidebar-mobile__heading {
 
 	padding: 0.625rem;
 
-	background-color: $gray-light;
+	background-color: colors.$gray-light;
 
-	@include breakpoint( '<1040px' ) {
+	@include mixin_breakpoint.breakpoint( '<1040px' ) {
 		flex-direction: column;
 	}
 }
@@ -47,7 +47,7 @@ h2.jp-recommendation-sidebar-mobile__heading {
 p.jp-recommendations-sidebar-mobile__qr-code-body {
 	flex-shrink: 2;
 
-	font-size: $font-body-extra-small;
+	font-size: typography.$font-body-extra-small;
 	padding: 0 1rem 0 1.5rem;
 	word-wrap: break-word;
 
@@ -60,7 +60,7 @@ p.jp-recommendations-sidebar-mobile__qr-code-body {
 .jp-recommendations-sidebar-mobile__qr-code-image {
 	flex-shrink: 0;
 
-	@include breakpoint( '<1040px' ) {
+	@include mixin_breakpoint.breakpoint( '<1040px' ) {
 		margin-top: 0.75rem;
 
 		width: 125px;

--- a/projects/plugins/jetpack/_inc/client/recommendations/sidebar/one-click-restores/style.scss
+++ b/projects/plugins/jetpack/_inc/client/recommendations/sidebar/one-click-restores/style.scss
@@ -1,4 +1,4 @@
-@import '../../../scss/mixin_breakpoint';
+@use '../../../scss/mixin_breakpoint';
 
 .jp-recommendations-one-click-restores {
 
@@ -22,7 +22,7 @@
 	grid-template-columns: minmax(0, 130px) minmax(0, 150px);
 	grid-gap: 1rem;
 
-	@include breakpoint( '660px-1040px' ) {
+	@include mixin_breakpoint.breakpoint( '660px-1040px' ) {
 		grid-template-columns: 1fr;
 	}
 

--- a/projects/plugins/jetpack/_inc/client/recommendations/sidebar/recommended-header/style.scss
+++ b/projects/plugins/jetpack/_inc/client/recommendations/sidebar/recommended-header/style.scss
@@ -1,5 +1,5 @@
 @use '@automattic/jetpack-base-styles/style';
-@import "../../../scss/typography";
+@use "../../../scss/typography";
 
 .jp-recommendations-recommended-header {
 	display: flex;
@@ -12,7 +12,7 @@
 	border-top-right-radius: inherit;
 	color: var( --jp-black );
 
-	font-weight: $bold;
+	font-weight: typography.$bold;
 
 	.gridicon {
 		margin-inline-end: 0.5rem;

--- a/projects/plugins/jetpack/_inc/client/recommendations/sidebar/sidebar-card/style.scss
+++ b/projects/plugins/jetpack/_inc/client/recommendations/sidebar/sidebar-card/style.scss
@@ -1,11 +1,11 @@
 @use '@automattic/jetpack-base-styles/style';
-@import '../../../scss/variables/colors';
-@import '../../../scss/mixins/ui';
-@import '../../../scss/typography';
+@use '../../../scss/variables/colors';
+@use '../../../scss/mixins/ui';
+@use '../../../scss/typography';
 
 .jp-recommendations-sidebar-card {
 
-	@include card;
+	@include ui.card;
 
 	width: 100%;
 	margin-bottom: 1rem;
@@ -22,12 +22,12 @@
 	box-shadow: none;
 
 	h2 {
-		font-size: $font-title-large;
+		font-size: typography.$font-title-large;
 		margin-bottom: 0.75rem;
 	}
 
 	p {
-		font-size: $font-body;
+		font-size: typography.$font-body;
 	}
 }
 
@@ -41,11 +41,11 @@
 	h2 {
 		margin-top: 1.75rem;
 
-		font-size: $font-body;
+		font-size: typography.$font-body;
 	}
 
 	p {
-		font-size: $font-body-small;
+		font-size: typography.$font-body-small;
 	}
 
 	.dops-button {
@@ -65,12 +65,12 @@
 	height: 115px;
 	margin-top: 24px;
 	padding: 8px;
-	background: $white;
+	background: colors.$white;
 	border-radius: 3px;
 	box-shadow: 0 0 24px rgba( 0, 0, 0, 0.16 );
 }
 
 .jp-recommendations-sidebar-card__features {
 
-	@include features-list;
+	@include ui.features-list;
 }

--- a/projects/plugins/jetpack/_inc/client/recommendations/style.scss
+++ b/projects/plugins/jetpack/_inc/client/recommendations/style.scss
@@ -1,17 +1,18 @@
 @use '@automattic/jetpack-base-styles/style';
-@import './mixin';
-@import '../scss/mixin_breakpoint';
-@import '../scss/mixins/rna';
+@use 'mixin';
+@use '../scss/mixin_breakpoint';
+@use '../scss/mixins/rna';
+@use "../scss/calypso-colors";
 
 .jp-recommendations-question__main {
 	min-height: 480px;
 	box-shadow: 0 2px 6px rgba( 0, 0, 0, 0.03 ), 0 1px 2px rgba( 0, 0, 0, 0.03 );
-	border: 1px solid $gray-lighten-20;
+	border: 1px solid calypso-colors.$gray-lighten-20;
 	background: var( --jp-white );
 
 	a:not( [type="button"] ) {
 		// $has-focus-state: false - as we don't need a focus state for navigation links
-		@include rna-link( $has-focus-state: false );
+		@include rna.rna-link( $has-focus-state: false );
 	}
 }
 
@@ -19,7 +20,7 @@
 	display: grid;
 	grid-template-columns: repeat( 2, 1fr );
 
-	@include breakpoint( '<1040px' ) {
+	@include mixin_breakpoint.breakpoint( '<1040px' ) {
 		grid-template-columns: auto;
 		background: var( --jp-white );
 	}
@@ -42,9 +43,9 @@
 
 .jp-recommendations-question__sidebar {
 
-	@include recommendation-sidebar-blob;
+	@include mixin.recommendation-sidebar-blob;
 
-	@include breakpoint( '<1040px' ) {
+	@include mixin_breakpoint.breakpoint( '<1040px' ) {
 		background: none;
 	}
 }
@@ -56,7 +57,7 @@
 	a {
 		margin-right: 16px;
 
-		@include breakpoint( '<660px' ) {
+		@include mixin_breakpoint.breakpoint( '<660px' ) {
 			display: block;
 			margin-right: 0;
 			margin-bottom: 16px;
@@ -65,7 +66,7 @@
 		&:last-child {
 			margin-right: 0;
 
-			@include breakpoint( '<660px' ) {
+			@include mixin_breakpoint.breakpoint( '<660px' ) {
 				margin-bottom: 0;
 			}
 		}

--- a/projects/plugins/jetpack/_inc/client/recommendations/summary/style.scss
+++ b/projects/plugins/jetpack/_inc/client/recommendations/summary/style.scss
@@ -1,8 +1,8 @@
-@import '../mixin';
-@import '../../scss/mixin_breakpoint';
-@import '../../scss/calypso-colors';
-@import '../../scss/mixins/rna';
-@import '../../scss/typography';
+@use '../mixin';
+@use '../../scss/mixin_breakpoint';
+@use '../../scss/calypso-colors';
+@use '../../scss/mixins/rna';
+@use '../../scss/typography';
 
 .jp-recommendations-summary__main {
 	display: grid;
@@ -11,18 +11,18 @@
 	background: var( --jp-white-off );
 
 	box-shadow: 0 2px 6px rgba( 0, 0, 0, 0.03 ), 0 1px 2px rgba( 0, 0, 0, 0.03 );
-	border: 1px solid $gray-lighten-20;
+	border: 1px solid calypso-colors.$gray-lighten-20;
 
-	@include breakpoint( '<782px' ) {
+	@include mixin_breakpoint.breakpoint( '<782px' ) {
 		display: flex;
 		flex-direction: column;
 	}
 }
 
 .jp-recommendations-summary__content {
-	background: $white;
+	background: calypso-colors.$white;
 
-	@include breakpoint( '<480px' ) {
+	@include mixin_breakpoint.breakpoint( '<480px' ) {
 		padding-bottom: 1rem;
 	}
 
@@ -37,12 +37,12 @@
 .jp-recommendations-summary__configuration {
 	margin: 3rem 3rem 2rem 3rem;
 
-	@include breakpoint( '<480px' ) {
+	@include mixin_breakpoint.breakpoint( '<480px' ) {
 		margin: 1rem 1rem 0 1rem;
 	}
 
 	h1 {
-		font-size: $font-title-medium;
+		font-size: typography.$font-title-medium;
 
 		color: var( --jp-gray-80 );
 	}
@@ -52,12 +52,12 @@
 
 		color: var( --jp-gray-100 );
 
-		font-size: $font-body;
+		font-size: typography.$font-body;
 	}
 }
 
 .jp-recommendations-summary__recommendation-notice {
-	font-size: $font-body-small;
+	font-size: typography.$font-body-small;
 
 	color: var( --jp-gray-50 );
 }
@@ -68,11 +68,11 @@
 	justify-content: flex-start;
 	flex-direction: column;
 
-	@include recommendation-sidebar-blob;
+	@include mixin.recommendation-sidebar-blob;
 
 	padding: 2rem 2.5rem 4.5rem;
 
-	@include breakpoint( '<782px' ) {
+	@include mixin_breakpoint.breakpoint( '<782px' ) {
 		padding: 1rem;
 	}
 
@@ -141,6 +141,6 @@
 
 	color: var( --jp-gray-30 );
 
-	font-size: $font-body-small;
+	font-size: typography.$font-body-small;
 	text-align: center;
 }

--- a/projects/plugins/jetpack/_inc/client/scss/shared/_main.scss
+++ b/projects/plugins/jetpack/_inc/client/scss/shared/_main.scss
@@ -1,3 +1,7 @@
+@use "../mixins/breakpoints";
+@use "../typography";
+@use "../variables/colors";
+
 // ==========================================================================
 // Global Shared Jetpack Styles
 // ==========================================================================
@@ -9,7 +13,7 @@
 
 .jp-hidden-on-mobile {
 
-	@include breakpoint( "<660px" ) {
+	@include breakpoints.breakpoint( "<660px" ) {
 		display: none;
 	}
 }
@@ -17,7 +21,7 @@
 // General Elements
 
 .wp-admin.toplevel_page_jetpack {
-	background-color: $gray-light;
+	background-color: colors.$gray-light;
 	line-height: 1.4; // fixes core bug that sets an em unit on body
 	height: auto;
 }
@@ -27,7 +31,7 @@
 }
 
 .jetpack-pagestyles {
-	font-size: $font-body-small;
+	font-size: typography.$font-body-small;
 }
 
 	.jetpack-pagestyles a {
@@ -47,13 +51,13 @@
 		top: 0;
 		padding: rem.convert( 10px );
 		text-align: right;
-		background: $white;
+		background: colors.$white;
 		font-size: rem.convert( 12px );
 		font-style: italic;
-		color: $gray;
-		border-bottom: 1px color.adjust( $gray, $lightness: 30% ) solid;
+		color: colors.$gray;
+		border-bottom: 1px color.adjust( colors.$gray, $lightness: 30% ) solid;
 
-		@include breakpoint( "<660px" ) {
+		@include breakpoints.breakpoint( "<660px" ) {
 			display: none;
 		}
 	}
@@ -64,7 +68,7 @@
 
 // restyled the arrow to match our gray
 .toplevel_page_jetpack ul#adminmenu a.wp-has-current-submenu::after {
-	border-right-color: $gray-light;
+	border-right-color: colors.$gray-light;
 }
 
 .jp-top {
@@ -116,12 +120,12 @@
 
 .is-placeholder {
 	animation: pulse-light 0.8s ease-in-out infinite;
-	background: color.adjust( $gray, $lightness: 20% );
+	background: color.adjust( colors.$gray, $lightness: 20% );
 }
 
 @keyframes pulse-light {
 
-	50% { background-color: color.adjust( $gray, $lightness: 30% ); }
+	50% { background-color: color.adjust( colors.$gray, $lightness: 30% ); }
 }
 
 .blur {

--- a/projects/plugins/jetpack/_inc/client/scss/shared/admin-static.scss
+++ b/projects/plugins/jetpack/_inc/client/scss/shared/admin-static.scss
@@ -1,4 +1,5 @@
-@import '../calypso-colors';
+@use '../calypso-colors';
+@use "../variables/colors";
 
 #wpcontent {
 	padding-left: 0 !important;
@@ -23,7 +24,7 @@
 	.jp-static-block {
 		display: block;
 		margin-top: 24px;
-		background: $white;
+		background: colors.$white;
 		box-shadow: 0 0 40px rgba(0, 0, 0, 0.08);
 		border-radius: 4px;
 
@@ -32,7 +33,7 @@
 		}
 
 		h2 {
-			border-bottom: 1px solid $gray-5;
+			border-bottom: 1px solid calypso-colors.$gray-5;
 			margin: 0 0 8px 0;
 			padding: 16px 24px;
 			font-size: 20px;
@@ -46,7 +47,7 @@
 			line-height: 30px;
 			padding: 8px 0 4px 0;
 			margin: 0;
-			color: $gray-80;
+			color: calypso-colors.$gray-80;
 		}
 
 		p {
@@ -54,7 +55,7 @@
 			line-height: 24px;
 			padding: 4px 0;
 			margin: 0;
-			color: $gray-80;
+			color: calypso-colors.$gray-80;
 		}
 
 		ol, ul {
@@ -62,7 +63,7 @@
 			margin: 0;
 			font-size: 14px;
 			line-height: 24px;
-			color: $gray-80;
+			color: calypso-colors.$gray-80;
 			list-style-position: outside;
 
 			li {
@@ -86,14 +87,14 @@
 		}
 
 		a, a:visited, a:active, a:hover, a:focus {
-			color: $gray-80;
+			color: calypso-colors.$gray-80;
 			text-decoration: underline;
 		}
 
 		.notice {
 			margin: 16px 24px;
 			padding: 24px 31px 27px 18px;
-			border: 1px solid $gray-5;
+			border: 1px solid calypso-colors.$gray-5;
 			border-left-width: 6px;
 			border-radius: 4px;
 			display: flex;
@@ -119,7 +120,7 @@
 			}
 
 			&.notice-warning {
-				border-left-color: $black;
+				border-left-color: colors.$black;
 			}
 
 			&.notice-error {

--- a/projects/plugins/jetpack/_inc/client/scss/style.scss
+++ b/projects/plugins/jetpack/_inc/client/scss/style.scss
@@ -5,54 +5,56 @@
  * Please keep these imports sorted and use specificity to ensure that
  * stylesheet order does not matter.
  *
- * example: @import '../components/card/style';
+ * example: @include meta.load-css( '../components/card/style' );
  */
 
+@use 'sass:meta';
+
 // Variables
-@forward '@automattic/color-studio/dist/color-variables';
-@import 'variables/colors';
-@import 'variables/layout';
+@use '@automattic/color-studio/dist/color-variables';
+@use 'variables/colors';
+@use 'variables/layout';
 
 // Mixins
-@import 'mixins/breakpoints';
-@import 'mixins/clear-fix';
-@import 'mixins/long-content-fade';
-@import 'mixins/ui';
+@use 'mixins/breakpoints';
+@use 'mixins/clear-fix';
+@use 'mixins/long-content-fade';
+@use 'mixins/ui';
 
 // Typography
-@import 'typography';
+@use 'typography';
 
 // General
-@import 'shared/main';
-@import 'shared/admin-static';
+@use 'shared/main';
+@use 'shared/admin-static';
 
 // Components
-@import '../components/dash-item/style';
-@import '../components/dash-section-header/style';
-@import '../components/foldable-card/style2';
-@import '../components/footer/style';
-@import '../components/dev-card/style';
-@import '../components/loading-placeholder/style';
-@import '../components/jetpack-notices/style';
-@import '../components/masthead/style';
-@import '../components/module-settings/style';
-@import '../components/support-card/style';
-@import '../components/forms/styles';
-@import '../components/admin-notices/style';
-@import '../components/module-toggle/style';
-@import '../components/navigation-settings/style';
-@import '../components/settings-card/style';
-@import '../components/settings-group/style';
-@import '../components/apps-card/style';
-@import '../components/upgrade-notice-content/style';
-@import '../components/jetpack-dialogue-modern/style';
-@import '../components/about-page/style';
+@include meta.load-css( '../components/dash-item/style' );
+@include meta.load-css( '../components/dash-section-header/style' );
+@include meta.load-css( '../components/foldable-card/style2' );
+@include meta.load-css( '../components/footer/style' );
+@include meta.load-css( '../components/dev-card/style' );
+@include meta.load-css( '../components/loading-placeholder/style' );
+@include meta.load-css( '../components/jetpack-notices/style' );
+@include meta.load-css( '../components/masthead/style' );
+@include meta.load-css( '../components/module-settings/style' );
+@include meta.load-css( '../components/support-card/style' );
+@include meta.load-css( '../components/forms/styles' );
+@include meta.load-css( '../components/admin-notices/style' );
+@include meta.load-css( '../components/module-toggle/style' );
+@include meta.load-css( '../components/navigation-settings/style' );
+@include meta.load-css( '../components/settings-card/style' );
+@include meta.load-css( '../components/settings-group/style' );
+@include meta.load-css( '../components/apps-card/style' );
+@include meta.load-css( '../components/upgrade-notice-content/style' );
+@include meta.load-css( '../components/jetpack-dialogue-modern/style' );
+@include meta.load-css( '../components/about-page/style' );
 
 // Page Templates
-@import '../at-a-glance/style';
-@import '../my-plan/style';
-@import '../performance/style';
-@import '../recommendations/style';
-@import '../security/style';
-@import '../settings/style';
-@import '../traffic/style';
+@include meta.load-css( '../at-a-glance/style' );
+@include meta.load-css( '../my-plan/style' );
+@include meta.load-css( '../performance/style' );
+@include meta.load-css( '../recommendations/style' );
+@include meta.load-css( '../security/style' );
+@include meta.load-css( '../settings/style' );
+@include meta.load-css( '../traffic/style' );

--- a/projects/plugins/jetpack/_inc/client/scss/variables/_colors.scss
+++ b/projects/plugins/jetpack/_inc/client/scss/variables/_colors.scss
@@ -1,5 +1,5 @@
 @use 'sass:color';
-@import '../functions/colors';
+@use '../functions/colors';
 
 // ==========================================================================
 // WordPress.com Colors
@@ -59,7 +59,7 @@ $alert-purple: #855da6;
 $alert-hot-red: #eb0001; // 2019
 
 // Link hovers
-$link-highlight: tint( $blue-medium, 20% );
+$link-highlight: colors.tint( $blue-medium, 20% );
 
 // Essentials
 $black: #000;

--- a/projects/plugins/jetpack/_inc/client/settings/style.scss
+++ b/projects/plugins/jetpack/_inc/client/settings/style.scss
@@ -1,3 +1,4 @@
+@use "../scss/mixin_breakpoint";
 @use '../scss/functions/rem';
 
 .jp-settings-container {
@@ -102,7 +103,7 @@
 		}
 	}
 
-	@include breakpoint( "<480px" ) {
+	@include mixin_breakpoint.breakpoint( "<480px" ) {
 
 		.dops-search.is-expanded-to-container {
 			height: 46px;

--- a/projects/plugins/jetpack/_inc/client/traffic/style.scss
+++ b/projects/plugins/jetpack/_inc/client/traffic/style.scss
@@ -1,13 +1,14 @@
 @use '../scss/functions/rem';
-@import "../scss/variables/colors";
-@import "../scss/mixin_breakpoint";
+@use "../scss/variables/colors";
+@use "../scss/mixin_breakpoint";
+@use "../scss/typography";
 
 .jp-form-google-label-unverified {
 
 	.dops-button {
 		margin: 0 15px;
 
-		@include breakpoint( '<660px' ) {
+		@include mixin_breakpoint.breakpoint( '<660px' ) {
 			margin-top: 10px;
 			width: 40%;
 		}
@@ -16,7 +17,7 @@
 	.jp-form-google-separator {
 		padding: .5rem 0;
 
-		@include breakpoint( '<660px' ) {
+		@include mixin_breakpoint.breakpoint( '<660px' ) {
 			margin: 25px 0 0;
 			display: inline-block;
 		}
@@ -50,8 +51,8 @@
 }
 
 .jp-form-site-verification-verified {
-	background-color: $white;
-	color: $green-primary;
+	background-color: colors.$white;
+	color: colors.$green-primary;
 	box-sizing: border-box;
 	margin: 0;
 	padding: 7px 14px;
@@ -68,11 +69,11 @@
 		margin-right: 5px;
 	}
 
-	@include breakpoint( '>660px' ) {
+	@include mixin_breakpoint.breakpoint( '>660px' ) {
 		border-left: 0;
 	}
 
-	@include breakpoint( '<660px' ) {
+	@include mixin_breakpoint.breakpoint( '<660px' ) {
 		border-top: 0;
 	}
 }
@@ -81,7 +82,7 @@
 	margin-left: 10px;
 	overflow: visible;
 
-	@include breakpoint( '<660px' ) {
+	@include mixin_breakpoint.breakpoint( '<660px' ) {
 		margin-left: 0;
 		margin-right: 5px;
 		margin-top: 5px;
@@ -126,7 +127,7 @@
 	}
 
 	&-container {
-		background: $gray-light;
+		background: colors.$gray-light;
 		border-radius: 4px;
 	}
 
@@ -135,14 +136,14 @@
 	}
 
 	&-count-warn {
-		background-color: $alert-yellow;
-		font-weight: $bold;
+		background-color: colors.$alert-yellow;
+		font-weight: typography.$bold;
 		border-radius: 4px;
 	}
 
 	&-count-max {
-		background-color: $alert-red;
-		font-weight: $bold;
+		background-color: colors.$alert-red;
+		font-weight: typography.$bold;
 		border-radius: 4px;
 		color: #fff;
 	}
@@ -257,7 +258,7 @@ $twitter-pofile-image-padding: 17px;
 
 .jp-stats-odyssey-disabled-notice {
 
-	@include breakpoint('<480px') {
+	@include mixin_breakpoint.breakpoint('<480px') {
 
 		a.dops-notice__action {
 			white-space: initial;
@@ -268,7 +269,7 @@ $twitter-pofile-image-padding: 17px;
 		}
 	}
 
-	@include breakpoint('>480px') {
+	@include mixin_breakpoint.breakpoint('>480px') {
 		width: calc(100% - 26px);
 	}
 }

--- a/projects/plugins/jetpack/changelog/fix-sass-deprecations-in-jetpack-the-plugin
+++ b/projects/plugins/jetpack/changelog/fix-sass-deprecations-in-jetpack-the-plugin
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Fix sass deprecation warnings.
+
+

--- a/projects/plugins/jetpack/extensions/blocks/ai-chat/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/ai-chat/editor.scss
@@ -1,4 +1,4 @@
 /**
  * Editor styles for Jetpack AI Chat
  */
-@import './view';
+@use 'view';

--- a/projects/plugins/jetpack/extensions/blocks/ai-chat/view.scss
+++ b/projects/plugins/jetpack/extensions/blocks/ai-chat/view.scss
@@ -1,6 +1,7 @@
-@import './components/feedback/style';
-@import './components/copy-button/style';
-@import './components/display-error/style';
+@use 'sass:meta';
+@include meta.load-css( 'components/feedback/style' );
+@include meta.load-css( 'components/copy-button/style' );
+@include meta.load-css( 'components/display-error/style' );
 
 .wp-block-jetpack-ai-chat {
 

--- a/projects/plugins/jetpack/extensions/blocks/blogroll/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/blogroll/editor.scss
@@ -1,4 +1,4 @@
-@import './common';
+@use 'common';
 
 .wp-block-jetpack-blogroll {
 

--- a/projects/plugins/jetpack/extensions/blocks/blogroll/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/blogroll/style.scss
@@ -1,4 +1,4 @@
-@import './common';
+@use 'common';
 
 .wp-block-jetpack-blogroll {
 
@@ -81,7 +81,7 @@
 		.jetpack-blogroll-item-subscribe-button {
 			white-space: nowrap;
 
-			@include break-bloroll-container-mobile() {
+			@include common.break-bloroll-container-mobile() {
 				margin-left: auto;
 				align-self: center;
 			}
@@ -115,7 +115,7 @@
 			align-items: center;
 			justify-content: center;
 
-			@include break-bloroll-container-mobile() {
+			@include common.break-bloroll-container-mobile() {
 				flex-direction: row;
 
 				.jetpack-blogroll-item-email-input {

--- a/projects/plugins/jetpack/extensions/blocks/button/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/button/editor.scss
@@ -1,9 +1,9 @@
-@import "../../shared/styles/align";
+@use "../../shared/styles/align";
 
 // This level of CSS specificity is required to overwrite existing styles
 .editor-styles-wrapper .block-editor-block-list__block.wp-block-jetpack-button {
 
-	@include align-block;
+	@include align.align-block;
 	max-width: 100%;
 	width: fit-content;
 	margin: 0;

--- a/projects/plugins/jetpack/extensions/blocks/button/view.scss
+++ b/projects/plugins/jetpack/extensions/blocks/button/view.scss
@@ -1,4 +1,4 @@
-@import "../../shared/styles/align";
+@use "../../shared/styles/align";
 
 .amp-wp-article .wp-block-jetpack-button {
 	color: #fff;
@@ -6,7 +6,7 @@
 
 .wp-block-jetpack-button {
 
-	@include align-block;
+	@include align.align-block;
 	max-width: 100%;
 	width: fit-content;
 	height: fit-content; // Since .wp-block-button__link has a 100% height, this prevents the button from matching its container's height.

--- a/projects/plugins/jetpack/extensions/blocks/calendly/view.scss
+++ b/projects/plugins/jetpack/extensions/blocks/calendly/view.scss
@@ -1,4 +1,4 @@
-@import "../../shared/styles/align";
+@use "../../shared/styles/align";
 
 .admin-bar .calendly-overlay .calendly-popup-close {
 	top: 47px;
@@ -19,7 +19,7 @@
 
 .wp-block-jetpack-calendly .wp-block-jetpack-button {
 
-	@include align-block;
+	@include align.align-block;
 
 	color: #fff;
 }

--- a/projects/plugins/jetpack/extensions/blocks/contact-info/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/contact-info/style.scss
@@ -1,5 +1,5 @@
-@import '../../shared/styles/jetpack-variables';
+@use '../../shared/styles/jetpack-variables';
 
 .wp-block-jetpack-contact-info {
-	margin-bottom: $jetpack-block-margin-bottom;
+	margin-bottom: jetpack-variables.$jetpack-block-margin-bottom;
 }

--- a/projects/plugins/jetpack/extensions/blocks/cookie-consent/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/cookie-consent/editor.scss
@@ -2,7 +2,7 @@
  * Editor styles for Cookie Consent
  */
 
-@import './common';
+@use 'common';
 
 .wp-block-jetpack-cookie-consent {
 	position: initial;

--- a/projects/plugins/jetpack/extensions/blocks/cookie-consent/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/cookie-consent/style.scss
@@ -1,4 +1,4 @@
-@import './common';
+@use 'common';
 
 .wp-block-jetpack-cookie-consent:not([role='document']) {
 	transition: opacity 0.2s ease-in-out;

--- a/projects/plugins/jetpack/extensions/blocks/donations/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/donations/editor.scss
@@ -1,5 +1,5 @@
 @use '@automattic/jetpack-base-styles/gutenberg-base-styles' as gb;
-@import './common';
+@use 'common';
 
 .editor-styles-wrapper .wp-block-jetpack-donations {
 

--- a/projects/plugins/jetpack/extensions/blocks/donations/view.scss
+++ b/projects/plugins/jetpack/extensions/blocks/donations/view.scss
@@ -1,7 +1,7 @@
 @use "sass:math";
 @use '@automattic/jetpack-base-styles/gutenberg-base-styles' as gb;
-@import './common';
-@import '../../shared/memberships';
+@use 'common';
+@use '../../shared/memberships';
 
 .wp-block-jetpack-donations {
 

--- a/projects/plugins/jetpack/extensions/blocks/eventbrite/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/eventbrite/editor.scss
@@ -1,11 +1,11 @@
-@import '../../shared/styles/align';
+@use '../../shared/styles/align';
 
 .wp-block-jetpack-eventbrite {
 	position: relative;
 
 	.wp-block-jetpack-button {
 
-		@include align-block;
+		@include align.align-block;
 	}
 
 	.components-placeholder__learn-more {

--- a/projects/plugins/jetpack/extensions/blocks/eventbrite/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/eventbrite/style.scss
@@ -1,4 +1,4 @@
-@import "../../shared/styles/align";
+@use "../../shared/styles/align";
 // Hide the link if an iframe got appended to the container.
 .eventbrite__direct-link:not(:only-child) {
 	display: none;
@@ -74,6 +74,6 @@
 
 	.wp-block-jetpack-button {
 
-		@include align-block;
+		@include align.align-block;
 	}
 }

--- a/projects/plugins/jetpack/extensions/blocks/goodreads/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/goodreads/style.scss
@@ -1,7 +1,7 @@
-@import '../../shared/styles/jetpack-variables';
+@use '../../shared/styles/jetpack-variables';
 
 .wp-block-jetpack-goodreads {
-	margin-bottom: $jetpack-block-margin-bottom;
+	margin-bottom: jetpack-variables.$jetpack-block-margin-bottom;
 
 	// These styles are directly from Goodreads and
 	// shared with the Goodreads Widget in Jetpack.

--- a/projects/plugins/jetpack/extensions/blocks/google-calendar/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/google-calendar/editor.scss
@@ -1,7 +1,7 @@
 /**
  * Editor styles for Google Calendar
  */
- @import './view';
+ @use 'view';
 
 .wp-block-jetpack-google-calendar {
 

--- a/projects/plugins/jetpack/extensions/blocks/google-docs-embed/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/google-docs-embed/editor.scss
@@ -1,5 +1,5 @@
 @use '@automattic/jetpack-base-styles/gutenberg-base-styles' as gb;
-@import './view';
+@use 'view';
 
 .wp-block-jetpack-google-docs-embed {
 	margin: 0 0 1.5em 0;

--- a/projects/plugins/jetpack/extensions/blocks/instagram-gallery/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/instagram-gallery/editor.scss
@@ -1,5 +1,5 @@
 @use '@automattic/jetpack-base-styles/gutenberg-base-styles' as gb;
-@import './view';
+@use 'view';
 
 .wp-block-jetpack-instagram-gallery .components-placeholder {
 

--- a/projects/plugins/jetpack/extensions/blocks/mailchimp/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/mailchimp/editor.scss
@@ -1,4 +1,4 @@
-@import './view';
+@use 'view';
 
 .wp-block-jetpack-mailchimp {
 

--- a/projects/plugins/jetpack/extensions/blocks/mailchimp/view.scss
+++ b/projects/plugins/jetpack/extensions/blocks/mailchimp/view.scss
@@ -1,6 +1,6 @@
 @use '@automattic/jetpack-base-styles/gutenberg-base-styles' as gb;
-@import '../../shared/styles/jetpack-variables';
-@import "../../shared/styles/align";
+@use '../../shared/styles/jetpack-variables';
+@use "../../shared/styles/align";
 
 .wp-block-jetpack-mailchimp {
 
@@ -13,7 +13,7 @@
 
 	.wp-block-jetpack-button, p {
 
-		@include align-block;
+		@include align.align-block;
 
 		margin-bottom: 1em;
 	}
@@ -33,7 +33,7 @@
 
 	.wp-block-jetpack-mailchimp_notification {
 		display: none;
-		margin-bottom: $jetpack-block-margin-bottom;
+		margin-bottom: jetpack-variables.$jetpack-block-margin-bottom;
 		padding: 0.75em;
 
 		&.is-visible {

--- a/projects/plugins/jetpack/extensions/blocks/rating-star/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/rating-star/style.scss
@@ -1,9 +1,9 @@
 @use '@automattic/jetpack-base-styles/gutenberg-base-styles' as gb;
-@import '../../shared/styles/jetpack-variables';
+@use '../../shared/styles/jetpack-variables';
 
 // Editor and View styles
 .wp-block-jetpack-rating-star {
-	margin-bottom: $jetpack-block-margin-bottom;
+	margin-bottom: jetpack-variables.$jetpack-block-margin-bottom;
 	line-height: 0;
 	stroke-width: 0;
 

--- a/projects/plugins/jetpack/extensions/blocks/recurring-payments/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/recurring-payments/editor.scss
@@ -1,5 +1,5 @@
 @use '@automattic/jetpack-base-styles/gutenberg-base-styles' as gb;
-@import './view';
+@use 'view';
 
 .wp-block-jetpack-recurring-payments {
 	width: 100%;

--- a/projects/plugins/jetpack/extensions/blocks/recurring-payments/view.scss
+++ b/projects/plugins/jetpack/extensions/blocks/recurring-payments/view.scss
@@ -1,4 +1,4 @@
-@import '../../shared/memberships';
+@use '../../shared/memberships';
 
 .wp-block-jetpack-recurring-payments.aligncenter .wp-block-jetpack-button {
 	text-align: center;

--- a/projects/plugins/jetpack/extensions/blocks/simple-payments/product-placeholder.scss
+++ b/projects/plugins/jetpack/extensions/blocks/simple-payments/product-placeholder.scss
@@ -1,5 +1,5 @@
 @use '@automattic/jetpack-base-styles/gutenberg-base-styles' as gb;
-@import '../../shared/styles/jetpack-variables';
+@use '../../shared/styles/jetpack-variables';
 
 .simple-payments__loading {
 	animation: simple-payments-loading 1600ms ease-in-out infinite;
@@ -21,12 +21,12 @@
 }
 
 .jetpack-simple-payments-wrapper {
-	margin-bottom: $jetpack-block-margin-bottom;
+	margin-bottom: jetpack-variables.$jetpack-block-margin-bottom;
 }
 
 /* Higher specificity in order to reset paragraph style */
 body .jetpack-simple-payments-wrapper .jetpack-simple-payments-details p {
-	margin: 0 0 $jetpack-block-margin-bottom;
+	margin: 0 0 jetpack-variables.$jetpack-block-margin-bottom;
 	padding: 0;
 }
 
@@ -41,7 +41,7 @@ body .jetpack-simple-payments-wrapper .jetpack-simple-payments-details p {
 
 .jetpack-simple-payments-product-image {
 	flex: 0 0 30%;
-	margin-bottom: $jetpack-block-margin-bottom;
+	margin-bottom: jetpack-variables.$jetpack-block-margin-bottom;
 }
 
 .jetpack-simple-payments-image {

--- a/projects/plugins/jetpack/extensions/blocks/slideshow/deprecated/v1/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/slideshow/deprecated/v1/style.scss
@@ -1,8 +1,8 @@
 @use '@automattic/jetpack-base-styles/gutenberg-base-styles' as gb;
-@import '../../../../shared/styles/jetpack-variables';
+@use '../../../../shared/styles/jetpack-variables';
 
 .wp-block-jetpack-slideshow {
-	margin-bottom: $jetpack-block-margin-bottom;
+	margin-bottom: jetpack-variables.$jetpack-block-margin-bottom;
 	position: relative;
 
 	[tabindex='-1']:focus {

--- a/projects/plugins/jetpack/extensions/blocks/slideshow/deprecated/v2/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/slideshow/deprecated/v2/style.scss
@@ -1,8 +1,8 @@
 @use '@automattic/jetpack-base-styles/gutenberg-base-styles' as gb;
-@import '../../../../shared/styles/jetpack-variables';
+@use '../../../../shared/styles/jetpack-variables';
 
 .wp-block-jetpack-slideshow {
-	margin-bottom: $jetpack-block-margin-bottom;
+	margin-bottom: jetpack-variables.$jetpack-block-margin-bottom;
 	position: relative;
 
 	[tabindex='-1']:focus {

--- a/projects/plugins/jetpack/extensions/blocks/slideshow/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/slideshow/style.scss
@@ -1,9 +1,9 @@
 @use '@automattic/jetpack-base-styles/gutenberg-base-styles' as gb;
-@import '../../shared/styles/jetpack-variables';
+@use '../../shared/styles/jetpack-variables';
 
 .wp-block-jetpack-slideshow {
 	min-width: 0;
-	margin-bottom: $jetpack-block-margin-bottom;
+	margin-bottom: jetpack-variables.$jetpack-block-margin-bottom;
 	position: relative;
 
 	[tabindex='-1']:focus {

--- a/projects/plugins/jetpack/extensions/blocks/story/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/story/editor.scss
@@ -1,5 +1,5 @@
 @use '@automattic/jetpack-base-styles/gutenberg-base-styles' as gb;
-@import './player/style';
+@use 'player/style';
 
 .wp-block-jetpack-story__add-item {
 	margin-top: 4px;

--- a/projects/plugins/jetpack/extensions/blocks/story/player/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/story/player/style.scss
@@ -1,7 +1,7 @@
 @use "sass:math";
 @use '@automattic/jetpack-base-styles/gutenberg-base-styles' as gb;
-@import '../../../shared/styles/jetpack-variables';
-@import './variables';
+@use '../../../shared/styles/jetpack-variables';
+@use 'variables';
 
 .wp-story-display-contents {
 	display: contents;
@@ -78,7 +78,7 @@
 		right: 0;
 		z-index: -1;
 		border-radius: 15px;
-		background-color: $wp-story-background-color;
+		background-color: variables.$wp-story-background-color;
 	}
 
 	.wp-story-slide {
@@ -292,14 +292,14 @@
 				min-width: 12px;
 				width: 100%;
 				height: 4px;
-				background: $wp-story-pagination-bullet-color;
+				background: variables.$wp-story-pagination-bullet-color;
 			}
 
 			.wp-story-pagination-bullet-bar-progress {
 				width: 0;
 				opacity: 1;
 				height: 4px;
-				background-color: $wp-story-pagination-bullet-progress-color;
+				background-color: variables.$wp-story-pagination-bullet-progress-color;
 				transition: width 0.1s ease;
 			}
 		}
@@ -626,7 +626,7 @@
 	top: 0;
 	bottom: 0;
 	z-index: -2;
-	background-color: $wp-story-background-color;
+	background-color: variables.$wp-story-background-color;
 
 	svg {
 		width: 0;

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/css-gram.scss
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/css-gram.scss
@@ -43,7 +43,7 @@
  * 1977
  * From https://github.com/una/CSSgram/blob/0.1.12/source/scss/1977.scss
  */
-@mixin _1977( $filters... ) {
+@mixin gram1977( $filters... ) {
 
 	@include filter-base;
 	filter: contrast( 1.1 ) brightness( 1.1 ) saturate( 1.3 ) $filters;

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/editor.scss
@@ -1,6 +1,6 @@
 @use '@automattic/jetpack-base-styles/gutenberg-base-styles' as gb;
-@import './view';
-@import './variables';
+@use 'view';
+@use 'variables';
 
 // inspired by from assets/shared/_animations loading-fade
 @keyframes tiled-gallery-img-placeholder {
@@ -49,7 +49,7 @@
 		}
 
 		&.is-selected {
-			outline: 4px solid $tiled-gallery-selection;
+			outline: 4px solid variables.$tiled-gallery-selection;
 
 			// Disable filters when selected
 			filter: none;
@@ -114,7 +114,7 @@
 	}
 
 	.tiled-gallery__add-item {
-		margin-top: $tiled-gallery-gutter;
+		margin-top: variables.$tiled-gallery-gutter;
 		width: 100%;
 
 		.components-form-file-upload,

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/view.scss
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/view.scss
@@ -1,6 +1,6 @@
-@import '../../shared/styles/jetpack-variables';
-@import './variables';
-@import './css-gram';
+@use '../../shared/styles/jetpack-variables';
+@use 'variables';
+@use 'css-gram';
 
 $tiled-gallery-max-column-count: 20;
 $tiled-gallery-max-rounded-corners: 20; // See constants.js for JS counterpart
@@ -28,7 +28,7 @@ $tiled-gallery-max-rounded-corners: 20; // See constants.js for JS counterpart
 				&.columns-#{$cols} {
 
 					.tiled-gallery__col {
-						width: calc( ( 100% - #{ $tiled-gallery-gutter * ( $cols - 1 ) } ) / #{$cols} );
+						width: calc( ( 100% - #{ variables.$tiled-gallery-gutter * ( $cols - 1 ) } ) / #{$cols} );
 					}
 				}
 			}
@@ -71,7 +71,7 @@ $tiled-gallery-max-rounded-corners: 20; // See constants.js for JS counterpart
 	margin: 0;
 
 	& + & {
-		margin-top: $tiled-gallery-gutter;
+		margin-top: variables.$tiled-gallery-gutter;
 	}
 }
 
@@ -82,7 +82,7 @@ $tiled-gallery-max-rounded-corners: 20; // See constants.js for JS counterpart
 	margin: 0;
 
 	& + & {
-		margin-inline-start: $tiled-gallery-gutter;
+		margin-inline-start: variables.$tiled-gallery-gutter;
 	}
 }
 
@@ -104,21 +104,21 @@ $tiled-gallery-max-rounded-corners: 20; // See constants.js for JS counterpart
 
 	&.filter__1977 {
 
-		@include _1977;
+		@include css-gram.gram1977;
 	}
 
 	&.filter__clarendon {
 
-		@include clarendon;
+		@include css-gram.clarendon;
 	}
 
 	&.filter__gingham {
 
-		@include gingham;
+		@include css-gram.gingham;
 	}
 
 	& + & {
-		margin-top: $tiled-gallery-gutter;
+		margin-top: variables.$tiled-gallery-gutter;
 	}
 
 	&:focus-within {

--- a/projects/plugins/jetpack/extensions/blocks/tock/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/tock/editor.scss
@@ -1,4 +1,4 @@
-@import './style';
+@use 'style';
 
 .jetpack-tock-url-settings {
 	margin: 8px;

--- a/projects/plugins/jetpack/extensions/blocks/top-posts/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/top-posts/style.scss
@@ -2,10 +2,10 @@
  * Styles for Top Posts
  */
 @use '@automattic/jetpack-base-styles/gutenberg-base-styles' as gb;
-@import '../../shared/styles/jetpack-variables';
+@use '../../shared/styles/jetpack-variables';
 
 .wp-block-jetpack-top-posts {
-	margin-bottom: $jetpack-block-margin-bottom;
+	margin-bottom: jetpack-variables.$jetpack-block-margin-bottom;
 
 	img {
 		width: 100%;
@@ -17,7 +17,7 @@
 	}
 
 	&.is-list-layout .jetpack-top-posts-item {
-		margin-bottom: $jetpack-block-margin-bottom;
+		margin-bottom: jetpack-variables.$jetpack-block-margin-bottom;
 	}
 
 	&.is-grid-layout {
@@ -36,7 +36,7 @@
 				}
 
 				.jetpack-top-posts-item {
-					margin-bottom: $jetpack-block-margin-bottom;
+					margin-bottom: jetpack-variables.$jetpack-block-margin-bottom;
 				}
 			}
 		}

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/breve.scss
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/breve.scss
@@ -1,4 +1,4 @@
-@import './features/features.colors';
+@use 'features/features.colors';
 
 .jetpack-ai-proofread {
 
@@ -6,11 +6,11 @@
 
 		&__input:not( :disabled ) {
 
-			@include features-colors( ( 'border-color' ) );
+			@include features.features-colors( ( 'border-color' ) );
 
 			&:checked {
 
-				@include features-colors( ( 'background-color' ) );
+				@include features.features-colors( ( 'background-color' ) );
 			}
 		}
 

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/highlight/style.scss
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/highlight/style.scss
@@ -1,20 +1,20 @@
-@import '../features/features.colors';
+@use '../features/features.colors';
 
 [class^='jetpack-ai-breve__has-proofread-highlight'] {
 	transition: background-color;
 	transition-duration: 0.3s;
 	border-bottom: 3px solid;
 
-	@include features-colors( ( 'border-bottom-color' ) );
+	@include features.features-colors( ( 'border-bottom-color' ) );
 
 	&.jetpack-ai-breve__is-loading {
 
-		@include pulse();
+		@include features.pulse();
 	}
 
 	&.jetpack-ai-breve__highlight-hovered {
 
-		@include features-colors( ( 'background-color' ), 0.2 );
+		@include features.features-colors( ( 'background-color' ), 0.2 );
 	}
 }
 
@@ -69,7 +69,7 @@
 					height: 10px;
 					border-radius: 50%;
 
-					@include features-colors( ( 'background-color' ) );
+					@include features.features-colors( ( 'background-color' ) );
 				}
 			}
 

--- a/projects/plugins/jetpack/scss/_utilities/_grid.scss
+++ b/projects/plugins/jetpack/scss/_utilities/_grid.scss
@@ -1,3 +1,5 @@
+@use "mixins/breakpoint";
+
 // ==========================================================================
 // Grid styles
 // 12 column grid
@@ -43,7 +45,7 @@
 
 // Medium grid
 // 530px and up
-@include minbreakpoint(large-phone) {
+@include breakpoint.minbreakpoint(large-phone) {
 	// .j-md-1		{width: 8.33333%;}
 	// .j-md-2		{width: 16.66667%;}
 	// .j-md-3		{width: 25%;}
@@ -60,7 +62,7 @@
 
 // Large grid
 // 782px and up
-@include minbreakpoint(tablet) {
+@include breakpoint.minbreakpoint(tablet) {
 	// .j-lrg-1	{width: 8.33333%;}
 	// .j-lrg-2	{width: 16.66667%;}
 	// .j-lrg-3	{width: 25%;}

--- a/projects/plugins/jetpack/scss/atoms/_buttons.scss
+++ b/projects/plugins/jetpack/scss/atoms/_buttons.scss
@@ -1,3 +1,6 @@
+@use "../_utilities/mixins/breakpoint";
+@use "typography/functions" as typography-functions;
+
 // ==========================================================================
 // Buttony button buttons
 // ==========================================================================
@@ -10,7 +13,7 @@
 .jp-button, %jp-button {
 	display: inline-block;
 	position: relative;
-	padding: em(10px, 13px) em(19px, 13px);
+	padding: typography-functions.em(10px, 13px) typography-functions.em(19px, 13px);
 	color: #efefef;
 	font-weight: 700;
 	font-size: 0.9285714286em; // 13/14
@@ -63,7 +66,7 @@
 .download-jetpack {
 	display: inline-block;
 	position: relative;
-	padding: em(18px, 28px) em(50px, 46px) em(15px, 28px);
+	padding: typography-functions.em(18px, 28px) typography-functions.em(50px, 46px) typography-functions.em(15px, 28px);
 	color: #fff;
 	font-weight: 400;
 	font-size: 20px;
@@ -123,8 +126,8 @@
 		height: 100%;
 	}
 
-	@include breakpoint(large-desktop){
-		font-size: em(18px);
+	@include breakpoint.breakpoint(large-desktop){
+		font-size: typography-functions.em(18px);
 
 		&::before {
 			top: -1px;
@@ -133,15 +136,15 @@
 		}
 	};
 
-	@include breakpoint(desktop){
+	@include breakpoint.breakpoint(desktop){
 
 		&:active {
 			top: 0;
 		}
 	};
 
-	@include breakpoint(large-phone){
-		font-size: em(17px);
+	@include breakpoint.breakpoint(large-phone){
+		font-size: typography-functions.em(17px);
 		font-weight: 600;
 
 		&::before {

--- a/projects/plugins/jetpack/scss/atoms/typography/_functions.scss
+++ b/projects/plugins/jetpack/scss/atoms/typography/_functions.scss
@@ -1,3 +1,5 @@
+@use "variables";
+
 /**
  * em()
  *
@@ -11,7 +13,7 @@
  @use 'sass:map';
  @use "sass:math";
 
-@function em($value, $context: map.get($root-font, font-size)) {
+@function em($value, $context: map.get(variables.$root-font, font-size)) {
 
 	@return (math.div($value, $context) * 1em);
 }

--- a/projects/plugins/jetpack/scss/dashboard-widget.scss
+++ b/projects/plugins/jetpack/scss/dashboard-widget.scss
@@ -1,11 +1,11 @@
 // Variables
-@import '../_inc/client/scss/variables/colors';
-@import '../_inc/client/scss/variables/layout';
+@use '../_inc/client/scss/variables/colors';
+@use '../_inc/client/scss/variables/layout';
 
 // Mixins
-@import '../_inc/client/scss/mixins/breakpoints';
-@import '../_inc/client/scss/mixins/clear-fix';
-@import '../_inc/client/scss/mixins/long-content-fade';
+@use '../_inc/client/scss/mixins/breakpoints';
+@use '../_inc/client/scss/mixins/clear-fix';
+@use '../_inc/client/scss/mixins/long-content-fade';
 
 // Styles
-@import "../_inc/client/dashboard-widget/style";
+@use "../_inc/client/dashboard-widget/style";

--- a/projects/plugins/jetpack/scss/jetpack-admin.scss
+++ b/projects/plugins/jetpack/scss/jetpack-admin.scss
@@ -1,15 +1,11 @@
-@import "atoms/colors/colors", // Color variables
-	"atoms/typography/functions",
-	"atoms/typography/variables",
-	"_utilities/mixins/breakpoint", // Mixins
-	"_utilities/grid",
-	"atoms/animations",
-	"atoms/buttons",
-	"atoms/loading-spinner",
-	"atoms/icons/automatticons",
-	"molecules/nav-horizontal",
-	"templates/main", // Main template
-	"templates/settings", // Settings page
-	"pages/protect", // Protect config page
-	"pages/manage", // Actiavte and confirm manage
-	"templates/connection-landing"; // jetpack connection landing, main admin
+@use "_utilities/grid";
+@use "atoms/animations";
+@use "atoms/buttons";
+@use "atoms/loading-spinner";
+@use "atoms/icons/automatticons";
+@use "molecules/nav-horizontal";
+@use "templates/main"; // Main template
+@use "templates/settings"; // Settings page
+@use "pages/protect"; // Protect config page
+@use "pages/manage"; // Actiavte and confirm manage
+@use "templates/connection-landing"; // jetpack connection landing, main admin

--- a/projects/plugins/jetpack/scss/jetpack-deactivate-dialog.scss
+++ b/projects/plugins/jetpack/scss/jetpack-deactivate-dialog.scss
@@ -1,6 +1,7 @@
 @use 'sass:color';
-@import '../_inc/client/scss/variables/colors';
-@import '../_inc/client/scss/calypso-colors';
+@use '../_inc/client/scss/variables/colors';
+@use '../_inc/client/scss/functions/colors' as colorfuncs;
+@use '../_inc/client/scss/calypso-colors';
 
 #TB_window.jetpack-disconnect-modal {
 
@@ -17,7 +18,7 @@
 		font-weight: 600;
 		height: 24px;
 		padding: 24px;
-		color: $wpui-header-dark;
+		color: colors.$wpui-header-dark;
 	}
 
 	#TB_ajaxWindowTitle {
@@ -63,7 +64,7 @@
 						vertical-align: middle;
 
 						&.dashicons {
-							color: $alert-hot-red;
+							color: colors.$alert-hot-red;
 						}
 
 					}
@@ -78,7 +79,7 @@
 	#TB_closeWindowButton {
 		left: auto;
 		right: 22px;
-		color: $wpui-dark-medium-gray;
+		color: colors.$wpui-dark-medium-gray;
 		top: 22px;
 
 		&::after {
@@ -90,7 +91,7 @@
 
 		&:hover,
 		&:focus {
-			color: $gray;
+			color: colors.$gray;
 			outline: none;
 			box-shadow: none;
 		}
@@ -104,8 +105,8 @@
 		position: absolute;
 		bottom: 0;
 		width: 100%;
-		border-top: 1px solid $light-gray-700;
-		background-color: $white;
+		border-top: 1px solid calypso-colors.$light-gray-700;
+		background-color: colors.$white;
 	}
 
 	.jetpack_deactivation_dialog_content__buttons-row {
@@ -137,11 +138,11 @@
 		.jetpack_deactivation_dialog_content__buttons {
 
 			button {
-				background: $blue-grey-light;
-				border-color: $blue-medium-dark;
+				background: calypso-colors.$blue-grey-light;
+				border-color: calypso-colors.$blue-medium-dark;
 				border-style: solid;
 				border-width: 1px;
-				color: $blue-medium-dark;
+				color: calypso-colors.$blue-medium-dark;
 				cursor: pointer;
 				display: inline-block;
 				margin: 0;
@@ -167,15 +168,15 @@
 				}
 
 				&#jetpack_deactivation_dialog_content__button-deactivate {
-					background: $alert-red;
-					border-color: color.adjust( $alert-red, $lightness: -20% );
-					color: $white;
+					background: colors.$alert-red;
+					border-color: color.adjust( colors.$alert-red, $lightness: -20% );
+					color: colors.$white;
 					margin-bottom: 0;
 
 					&[disabled],
 					&:disabled {
-						background: color.adjust( $alert-red, $lightness: 20% );
-						border-color: tint( $alert-red, 30% );
+						background: color.adjust( colors.$alert-red, $lightness: 20% );
+						border-color: colorfuncs.tint( colors.$alert-red, 30% );
 					}
 				}
 			}

--- a/projects/plugins/jetpack/scss/pages/_protect.scss
+++ b/projects/plugins/jetpack/scss/pages/_protect.scss
@@ -1,3 +1,5 @@
+@use "../atoms/colors/colors";
+
 /* 'Pages' is a temporary location for these styles, until we can break them up into their proper atmoic locations */
 
 // ==========================================================================
@@ -9,16 +11,16 @@
 	font-size: 14px;
 
 	&.success, &.error {
-		color: $white;
+		color: colors.$white;
 		padding: 10px;
 	}
 
 	&.success {
-		background-color: $green;
+		background-color: colors.$green;
 	}
 
 	&.error {
-		background-color: $red;
+		background-color: colors.$red;
 	}
 }
 
@@ -40,11 +42,11 @@
 	}
 
 	&.attn {
-		color: $red;
+		color: colors.$red;
 	}
 
 	&.working {
-		color: $green;
+		color: colors.$green;
 	}
 } // .protect-status
 

--- a/projects/plugins/jetpack/scss/templates/_connection-landing.scss
+++ b/projects/plugins/jetpack/scss/templates/_connection-landing.scss
@@ -1,3 +1,6 @@
+@use "../_utilities/mixins/breakpoint";
+@use "../atoms/colors/colors";
+
 // ==========================================================================
 // Jetpack Connection Landing Page ('Please connect jetpack')
 //===========================================================================
@@ -32,7 +35,7 @@
 		text-align: center;
 
 		&.success {
-			color: $green;
+			color: colors.$green;
 		}
 	}
 
@@ -66,7 +69,7 @@
 }
 
 // Breakpoints
-@include breakpoint(large-desktop) {
+@include breakpoint.breakpoint(large-desktop) {
 
 	.jp-content {
 
@@ -80,7 +83,7 @@
 	}
 } // large-desktop
 
-@include breakpoint(large-phone) {
+@include breakpoint.breakpoint(large-phone) {
 
 	.jp-content {
 

--- a/projects/plugins/jetpack/scss/templates/_main.scss
+++ b/projects/plugins/jetpack/scss/templates/_main.scss
@@ -1,3 +1,9 @@
+@use "../_utilities/mixins/breakpoint";
+@use "../atoms/colors/colors";
+@use "../atoms/icons/automatticons";
+@use "../atoms/typography/functions" as typography-functions;
+@use "../atoms/typography/variables" as typography-variables;
+
 // ==========================================================================
 // Main Layout
 // ==========================================================================
@@ -5,7 +11,7 @@
 
 .configure .frame.top.fixed {
 
-	@include breakpoint(tablet){
+	@include breakpoint.breakpoint(tablet){
 		padding-left: 0;
 	};
 }
@@ -26,20 +32,20 @@
 
 .page-content {
 
-	@include breakpoint(large-phone){
+	@include breakpoint.breakpoint(large-phone){
 		margin-top: 0;
 	};
 }
 
 .wrap.inner {
 
-	@include breakpoint(large-desktop) {
-		background: $clouds;
+	@include breakpoint.breakpoint(large-desktop) {
+		background: colors.$clouds;
 		padding: 15px;
 	};
 
-	@include breakpoint(large-phone) {
-		margin-top: em(24px);
+	@include breakpoint.breakpoint(large-phone) {
+		margin-top: typography-functions.em(24px);
 	};
 }
 
@@ -47,16 +53,16 @@
 	position: relative;
 	z-index: 10;
 
-	@include breakpoint(large-desktop){
-		background: $clouds;
+	@include breakpoint.breakpoint(large-desktop){
+		background: colors.$clouds;
 		padding: 15px;
 	};
 }
 
 .page-content.configure {
 
-	@include breakpoint(large-desktop){
-		background: $clouds;
+	@include breakpoint.breakpoint(large-desktop){
+		background: colors.$clouds;
 	};
 }
 
@@ -73,7 +79,7 @@
 .header {
 	left: 0;
 	right: 0;
-	background: $green;
+	background: colors.$green;
 }
 
 .header-nav {
@@ -84,7 +90,7 @@
 	}
 
 	a {
-		padding: 0 em(10px);
+		padding: 0 typography-functions.em(10px);
 		line-height: 24px;
 	}
 
@@ -133,7 +139,7 @@
 		margin: 0;
 	}
 
-	@include breakpoint(desktop){
+	@include breakpoint.breakpoint(desktop){
 		font-size: 13px;
 	};
 }
@@ -189,11 +195,11 @@
 		position: absolute;
 		top: 0;
 		right: 0;
-		font: 300 em(24px) Genericons !important;
+		font: 300 typography-functions.em(24px) Genericons !important;
 		color: #777;
 		content: '\f405';
 		display: inline-block;
-		padding: em(4px) em(10px) em(6px);
+		padding: typography-functions.em(4px) typography-functions.em(10px) typography-functions.em(6px);
 		z-index: 5;
 
 		&:hover {
@@ -214,7 +220,7 @@
 		bottom: 0;
 		left: 0;
 		overflow: auto;
-		padding: em(30px, 14px);
+		padding: typography-functions.em(30px, 14px);
 	}
 
 	.content {
@@ -231,7 +237,7 @@
 		line-height: 32px;
 		text-shadow: 0 1px 1px #fff;
 
-		@include breakpoint(large-phone){
+		@include breakpoint.breakpoint(large-phone){
 			font-size: 26px;
 		};
 	}
@@ -241,7 +247,7 @@
 	}
 
 	p {
-		font-size: em(16px, 13px);
+		font-size: typography-functions.em(16px, 13px);
 	}
 
 	footer {
@@ -270,7 +276,7 @@
 		vertical-align: baseline;
 	}
 
-	@include breakpoint(desktop){
+	@include breakpoint.breakpoint(desktop){
 		bottom: 5%;
 		margin-left: 36px;
 		font-size: 80%;
@@ -280,12 +286,12 @@
 		}
 	};
 
-	@include breakpoint(tablet){
+	@include breakpoint.breakpoint(tablet){
 		top: 66px;
 		margin-left: 0;
 	};
 
-	@include breakpoint(phablet){
+	@include breakpoint.breakpoint(phablet){
 		top: 10px;
 		right: 10px;
 		bottom: 10px;
@@ -307,7 +313,7 @@
 		}
 	}
 
-	@include breakpoint(tablet){
+	@include breakpoint.breakpoint(tablet){
 		float: none;
 		margin: 0 0 15px;
 	};
@@ -336,9 +342,9 @@
 
 // NOTE: .download-jetpack is in _buttons.scss
 .footer {
-	margin-top: em(20px);
+	margin-top: typography-functions.em(20px);
 	position: relative;
-	padding: em(140px) 0 em(60px);
+	padding: typography-functions.em(140px) 0 typography-functions.em(60px);
 	text-align: center;
 
 	&::before,
@@ -364,11 +370,11 @@
 		margin-bottom: 33px;
 	}
 
-	@include minbreakpoint(large-desktop){
+	@include breakpoint.minbreakpoint(large-desktop){
 			padding-bottom: 35px;
 	};
 
-	@include breakpoint(large-desktop) {
+	@include breakpoint.breakpoint(large-desktop) {
 		padding-top: 165px;
 		padding-bottom: 0;
 
@@ -382,20 +388,20 @@
 		}
 	};
 
-	@include breakpoint(desktop){
+	@include breakpoint.breakpoint(desktop){
 		padding-top: 146px;
 	};
 
-	@include breakpoint(tablet){
+	@include breakpoint.breakpoint(tablet){
 		margin-top: 0;
 	};
 
-	@include breakpoint(large-phone){
+	@include breakpoint.breakpoint(large-phone){
 		margin-top: 0;
 		padding-top: 135px;
 	};
 
-	@include breakpoint(phone){
+	@include breakpoint.breakpoint(phone){
 		padding-top: 76px;
 	};
 }
@@ -411,23 +417,23 @@
 
 		&:hover,
 		&:focus {
-			color: $green;
+			color: colors.$green;
 		}
 	}
 
-	@include breakpoint(large-desktop){
+	@include breakpoint.breakpoint(large-desktop){
 
 		a,
 		a:visited {
 
 			&:hover,
 			&:focus {
-				color: $green;
+				color: colors.$green;
 			}
 		}
 	};
 
-	@include breakpoint(large-phone){
+	@include breakpoint.breakpoint(large-phone){
 
 		li {
 			display: block;
@@ -456,22 +462,22 @@
 		margin-right: 5px;
 	}
 
-	@include minbreakpoint(tablet){
+	@include breakpoint.minbreakpoint(tablet){
 		padding: 8px 15px 10px;
 		margin-bottom: 30px;
 		border-bottom: 1px solid #f0f0f1;
 	};
 
-	@include minbreakpoint(large-desktop){
+	@include breakpoint.minbreakpoint(large-desktop){
 			margin-bottom: 0;
 	};
 
-	@include breakpoint(tablet){
+	@include breakpoint.breakpoint(tablet){
 		padding: 8px 15px 8px;
 		border-bottom: none;
 	};
 
-	@include breakpoint(large-phone){
+	@include breakpoint.breakpoint(large-phone){
 		margin: 0;
 		padding: 0;
 		border: none;
@@ -487,8 +493,8 @@
 	margin: 0;
 	padding: 0 6px;
 	color: #bbb;
-	font-size: em(11px);
-	font-family: $gill;
+	font-size: typography-functions.em(11px);
+	font-family: typography-variables.$gill;
 	text-transform: uppercase;
 
 	a {
@@ -508,8 +514,8 @@
 			right: -9999px;
 			height: 100%;
 			color: #999;
-			font-size: em(17px, 11px);
-			font-family: $automatticons;
+			font-size: typography-functions.em(17px, 11px);
+			font-family: automatticons.$automatticons;
 			text-align: center;
 		}
 
@@ -524,12 +530,12 @@
 
 .secondary {
 
-		@include minbreakpoint(tablet){
+		@include breakpoint.minbreakpoint(tablet){
 			padding: 0 15px 10px 15px;
 			border-bottom: 1px solid #f0f0f1;
 		}
 
-		@include minbreakpoint(large-desktop){
+		@include breakpoint.minbreakpoint(large-desktop){
 			padding: 0 15px 10px 15px;
 			border-bottom: none;
 		}
@@ -541,8 +547,8 @@
 // ==========================================================================
 
 .jetpack-message {
-	background: color.adjust($green, $lightness: 5%);
-	border: 1px solid color.adjust($green, $lightness: -5%);
+	background: color.adjust(colors.$green, $lightness: 5%);
+	border: 1px solid color.adjust(colors.$green, $lightness: -5%);
 	margin: 33px auto 0;
 	max-width: 90%;
 	position: relative;
@@ -613,7 +619,7 @@
 			font-size: 1em;
 		}
 
-		@include breakpoint(large-phone){
+		@include breakpoint.breakpoint(large-phone){
 			padding: 23px;
 
 			&::before {
@@ -645,7 +651,7 @@
 // Uncategorized
 // ==========================================================================
 
-@include breakpoint(large-phone){
+@include breakpoint.breakpoint(large-phone){
 
 	.wrap.inner.jp-support { // Used anywhere?
 		.jp-support-column-left {

--- a/projects/plugins/jetpack/scss/templates/_settings.scss
+++ b/projects/plugins/jetpack/scss/templates/_settings.scss
@@ -1,8 +1,10 @@
 // ==========================================================================
 // Settings
 // ==========================================================================
-@import '../../_inc/client/scss/calypso-colors';
-@import '../../_inc/client/scss/typography';
+@use '../../_inc/client/scss/calypso-colors';
+@use '../../_inc/client/scss/typography';
+@use "../atoms/colors/colors";
+@use "../atoms/typography/functions" as typography-functions;
 
 .page-content.configure {
 	margin-top: 0;
@@ -13,7 +15,7 @@
 	&.top {
 		border: none;
 		box-shadow: none;
-		padding-top: em(20px);
+		padding-top: typography-functions.em(20px);
 		position: relative;
 		top: auto;
 
@@ -32,7 +34,7 @@
 			@media (max-width: 782px) {
 				border: none;
 				box-shadow: none;
-				padding-top: em(20px);
+				padding-top: typography-functions.em(20px);
 				position: relative;
 				top: auto;
 			}
@@ -62,20 +64,20 @@
 	}
 
 	.button {
-		background: $white;
-		border: 1.5px solid $black;
+		background: colors.$white;
+		border: 1.5px solid calypso-colors.$black;
 		border-radius: 4px;
-		font-size: $font-body;
+		font-size: typography.$font-body;
 		line-height: 24px;
 		letter-spacing: -0.01em;
-		color: $black;
+		color: calypso-colors.$black;
 	}
 }
 
 // Bulk select table header area.
 .fixed-top {
 	box-sizing: border-box;
-	border-bottom: 1px solid $gray-5;
+	border-bottom: 1px solid calypso-colors.$gray-5;
 
 	/* Auto layout */
 	display: flex;
@@ -99,8 +101,8 @@
 		padding: 8px 16px;
 		margin-right: 8px;
 		line-height: normal;
-		color: $black;
-		font-size: $font-body-small;
+		color: calypso-colors.$black;
+		font-size: typography.$font-body-small;
 		letter-spacing: -0.02em;
 	}
 
@@ -115,15 +117,15 @@
 			align-items: center;
 			padding: 6px 24px;
 			height: 40px;
-			background: $white;
-			border: 1.5px solid $black;
+			background: colors.$white;
+			border: 1.5px solid calypso-colors.$black;
 			border-radius: 4px;
 
 			// Button label.
-			font-size: $font-body;
+			font-size: typography.$font-body;
 			line-height: 24px;
 			letter-spacing: -0.01em;
-			color: $black;
+			color: calypso-colors.$black;
 		}
 
 		.button:hover {
@@ -145,7 +147,7 @@
 
 			&::before {
 				margin: -2px;
-				color: $black;
+				color: calypso-colors.$black;
 				width: 21px;
 				height: 21px;
 			}
@@ -159,12 +161,12 @@
 	.row-actions {
 
 		a.dops-button.is-compact {
-			color: $black;
+			color: calypso-colors.$black;
 			line-height: 20px;
-			font-size: $font-body-extra-small;
+			font-size: typography.$font-body-extra-small;
 			font-weight: 600;
-			background: $white;
-			border: 1.5px solid $black;
+			background: colors.$white;
+			border: 1.5px solid calypso-colors.$black;
 			border-radius: 4px;
 			box-shadow: none;
 			text-decoration: none;
@@ -172,13 +174,13 @@
 		}
 
 		.delete a.dops-button.is-compact {
-			color: $red-50;
-			border: 1px solid $gray-5;
+			color: calypso-colors.$red-50;
+			border: 1px solid calypso-colors.$gray-5;
 		}
 
 		.configure a {
-			color: $black;
-			font-size: $font-body-extra-small;
+			color: calypso-colors.$black;
+			font-size: typography.$font-body-extra-small;
 			line-height: 20px;
 			font-weight: 600;
 			text-decoration: none;
@@ -226,11 +228,11 @@
 		z-index: 1;
 
 		p {
-			font-size: $font-body-small;
+			font-size: typography.$font-body-small;
 			line-height: 24px;
 			letter-spacing: -0.02em;
 			font-weight: 700;
-			color: $gray-80;
+			color: calypso-colors.$gray-80;
 			margin: 16px 0 4px 0;
 		}
 
@@ -260,13 +262,13 @@
 			position: static;
 
 			input[type="search"] {
-				border: 1px solid $gray-5;
+				border: 1px solid calypso-colors.$gray-5;
 				border-radius: 4px;
 				padding: 8px 16px 8px 40px;
 				line-height: 24px;
-				font-size: $font-body;
+				font-size: typography.$font-body;
 				letter-spacing: -0.02em;
-				color: $black;
+				color: calypso-colors.$black;
 				font-weight: 400;
 				height: 40px;
 				width: 100%;
@@ -276,7 +278,7 @@
 				float: none;
 
 				&::placeholder {
-					color: $gray-30;
+					color: calypso-colors.$gray-30;
 				}
 
 				@media (max-width: 782px) {
@@ -300,35 +302,35 @@
 				padding-left: 24px;
 				padding-right: 24px;
 				min-width: 90px;
-				border: 1px solid $gray-5;
-				color: $black;
+				border: 1px solid calypso-colors.$gray-5;
+				color: calypso-colors.$black;
 				height: 40px;
 				font-size: 13px;
 				line-height: 18px;
 				font-weight: 400;
-				background: $white;
+				background: colors.$white;
 
 				&:hover {
-					background: $gray-0;
+					background: calypso-colors.$gray-0;
 				}
 
 				&:focus {
-					border-color: $black;
+					border-color: calypso-colors.$black;
 				}
 			}
 
 			button.dops-button.button.active {
-				background: $black;
-				color: $white;
+				background: calypso-colors.$black;
+				color: colors.$white;
 				font-weight: 600;
 
 				&:hover {
-					background: $gray-80;
+					background: calypso-colors.$gray-80;
 				}
 
 				&:focus {
-					border-color: $white;
-					box-shadow: 0 0 0 1px $black;
+					border-color: colors.$white;
+					box-shadow: 0 0 0 1px calypso-colors.$black;
 				}
 			}
 		}
@@ -345,9 +347,9 @@
 
 				a {
 					padding: 0;
-					color: $black;
+					color: calypso-colors.$black;
 					text-decoration: underline;
-					font-size: $font-body-small;
+					font-size: typography.$font-body-small;
 					line-height: 24px;
 					letter-spacing: -0.02em;
 
@@ -358,11 +360,11 @@
 
 				&.current {
 					border-radius: 4px;
-					background: $black;
+					background: calypso-colors.$black;
 					padding: 2px 6px;
 
 					a, .count {
-						color: $white;
+						color: colors.$white;
 						text-decoration: none;
 						font-weight: 700;
 					}
@@ -462,8 +464,8 @@ tr.jetpack-module {
 	gap: 16px;
 	width: 100%;
 	height: 60px;
-	background: $white;
-	border-bottom: 1px solid $gray-5;
+	background: colors.$white;
+	border-bottom: 1px solid calypso-colors.$gray-5;
 
 	@media (max-width: 782px) {
 		padding: 4px 10px;
@@ -499,7 +501,7 @@ tr.jetpack-module.active {
 }
 
 tr.jetpack-module .column-name {
-	color: $gray-80;
+	color: calypso-colors.$gray-80;
 	float: left;
 	align-items: center;
 	display: flex;

--- a/projects/plugins/jetpack/scss/wordads-ccpa.scss
+++ b/projects/plugins/jetpack/scss/wordads-ccpa.scss
@@ -1,7 +1,7 @@
 $z-index-max: 2147483647;
 
 /* Include Cleanslate */
-@import "cleanslate";
+@use "cleanslate";
 
 body.admin-bar .cleanslate .components-modal__frame {
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
The changes here are mostly straightforward, although getting there was somewhat of a pain due to the interconnections of a lot of the different files. Sass's migrator wanted to overwrite variables in a bunch of places that didn't really work.

In a few places I went with `@include meta.load-css()` rather than `@use`. As far as styles go these are equivalent; the former doesn't make any functions, variables, or mixins available to the current module, but in these cases there aren't any of those and it lets us avoid having to `@use ... as style2`, `@use ... as style3`, etc.

There are some deprecation warnings coming from `@automattic/social-previews` that will need to be fixed upstream.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* No Sass deprecation warnings in the build of plugins/jetpack.
* No changes to built CSS, except for the non-minified `css/jetpack-admin.css` and `css/jetpack-admin-rtl.css` which have some comments moved and some colors changed from `rgb(255, 255, 255)` to the equivalent `#fff`.
