### PR TITLE
Jetpack Forms: fix Calypso menu issues

### DIFF
--- a/projects/packages/forms/changelog/fix-jetpack-forms-calypso-menu
+++ b/projects/packages/forms/changelog/fix-jetpack-forms-calypso-menu
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: remove is_admin fencing for menu registration. Move Forms down on submenu order.

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -22,7 +22,7 @@ class Jetpack_Forms {
 	public static function load_contact_form() {
 		Util::init();
 
-		if ( is_admin() && self::is_feedback_dashboard_enabled() ) {
+		if ( self::is_feedback_dashboard_enabled() ) {
 			$dashboard = new Dashboard();
 			$dashboard->init();
 		}

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -13,7 +13,6 @@ use Automattic\Jetpack\Extensions\Contact_Form\Contact_Form_Block;
 use Automattic\Jetpack\Forms\Jetpack_Forms;
 use Automattic\Jetpack\Forms\Service\Post_To_Url;
 use Automattic\Jetpack\Status;
-use Automattic\Jetpack\Status\Host;
 use Automattic\Jetpack\Terms_Of_Service;
 use Automattic\Jetpack\Tracking;
 use Jetpack_Options;
@@ -563,10 +562,9 @@ class Contact_Form_Plugin {
 	 * Add the 'Form Responses' menu item as a submenu of Feedback.
 	 */
 	public function admin_menu() {
-		$slug     = 'feedback';
-		$is_wpcom = ( new Host() )->is_wpcom_simple();
+		$slug = 'feedback';
 
-		if ( $is_wpcom || is_plugin_active( 'polldaddy/polldaddy.php' ) || ! Jetpack_Forms::is_legacy_menu_item_retired() ) {
+		if ( is_plugin_active( 'polldaddy/polldaddy.php' ) || ! Jetpack_Forms::is_legacy_menu_item_retired() ) {
 			add_menu_page(
 				__( 'Feedback', 'jetpack-forms' ),
 				__( 'Feedback', 'jetpack-forms' ),

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -180,7 +180,8 @@ class Dashboard {
 			_x( 'Forms', 'submenu title for Jetpack Forms', 'jetpack-forms' ),
 			'edit_pages',
 			'jetpack-forms-admin',
-			array( $this, 'render_new_dashboard' )
+			array( $this, 'render_new_dashboard' ),
+			10
 		);
 	}
 


### PR DESCRIPTION
Related to FORMS-27

## Proposed changes:
This PR removes the `is_admin` fencing to initialize the Dashboard, as it only initializes through admin hooks, `is_admin` is only preventing it to register properly for Calypso.
It also moves Forms down on the submenu order.


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1748966399472039-slack-C052XEUUBL4

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Apply/rsync on your sandbox. Visit wp-admin area of a sandboxed simple site. You should see the new entry Jetpack > Forms.

Add this filter:

```php
add_filter( 'jetpack_forms_retire_legacy_menu_item', '__return_true' );
```

In addition to the new Forms submenu, now there should be no Feedback > Forms responses menu