### PR TITLE
Jetpack Forms: update fallback URLs

### DIFF
--- a/projects/packages/forms/changelog/change-jetpack-formms-migration-urls
+++ b/projects/packages/forms/changelog/change-jetpack-formms-migration-urls
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Forms: update inbox fallback and redirect URLs

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/google-sheets-card.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/google-sheets-card.js
@@ -5,7 +5,8 @@ import GoogleSheetsIcon from '../../../../icons/google-sheets';
 import IntegrationCard from './integration-card';
 
 const FORM_RESPONSES_URL =
-	window?.jpFormsBlocks?.defaults?.formsResponsesUrl || '/wp-admin/admin.php?page=jetpack-forms';
+	window?.jpFormsBlocks?.defaults?.formsResponsesUrl ||
+	'/wp-admin/admin.php?page=jetpack-forms-admin';
 
 const GoogleSheetsCard = ( { isExpanded, onToggle, data, refreshStatus } ) => {
 	const [ isPolling, setIsPolling ] = useState( false );

--- a/projects/packages/forms/src/dashboard/integrations/google-sheets-card.tsx
+++ b/projects/packages/forms/src/dashboard/integrations/google-sheets-card.tsx
@@ -1,13 +1,10 @@
 import { Button } from '@wordpress/components';
 import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { config } from '../';
 import IntegrationCard from '../../blocks/contact-form/components/jetpack-integrations-modal/integration-card';
 import GoogleSheetsIcon from '../../icons/google-sheets';
-import type { IntegrationCardProps, JPFormsBlocksWindow } from './types';
-
-const FORM_RESPONSES_URL =
-	( window as JPFormsBlocksWindow ).jpFormsBlocks?.defaults?.formsResponsesUrl ||
-	'/wp-admin/admin.php?page=jetpack-forms';
+import type { IntegrationCardProps } from './types';
 
 const GoogleSheetsDashboardCard = ( {
 	isExpanded,
@@ -17,6 +14,8 @@ const GoogleSheetsDashboardCard = ( {
 }: IntegrationCardProps ) => {
 	const isConnected = !! data?.isConnected;
 	const settingsUrl = data?.settingsUrl;
+	const FORM_RESPONSES_URL =
+		config( 'dashboardURL' ) || '/wp-admin/admin.php?page=jetpack-forms-admin';
 
 	const cardData = {
 		...data,

--- a/projects/packages/forms/src/util/get-preferred-responses-view.js
+++ b/projects/packages/forms/src/util/get-preferred-responses-view.js
@@ -1,6 +1,5 @@
 import { getJetpackData } from '@automattic/jetpack-shared-extension-utils';
 
 export const PREFERRED_VIEW = window?.jpFormsBlocks?.defaults?.preferredView;
-export const PARTIAL_RESPONSES_PATH =
-	PREFERRED_VIEW === 'classic' ? 'edit.php?post_type=feedback' : 'admin.php?page=jetpack-forms';
+export const PARTIAL_RESPONSES_PATH = 'admin.php?page=jetpack-forms-admin';
 export const FULL_RESPONSES_PATH = getJetpackData()?.adminUrl + PARTIAL_RESPONSES_PATH;


### PR DESCRIPTION

Related to FORMS-27

## Proposed changes:
This PR updates some hardcoded fallback URLs on the our integration cards. It also updates a helper used throughout the connection as a return URL, unsure if it's still in use.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion


## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Enable integrations tab with `add_filter( 'jetpack_forms_enable_integrations_tab', '__return_true' );`. Visit the dashboard and check the Google card on the integrations tab. Connect if needed. See the link "View Form responses" points to the right dashboard (jetpack-forms-admin).

Check for the same on the editor's integration modal.