### PR TITLE
Add/jetpack forms unread count submenu

### DIFF
--- a/projects/packages/forms/changelog/add-jetpack-forms-unread-count-submenu
+++ b/projects/packages/forms/changelog/add-jetpack-forms-unread-count-submenu
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: show unread count on Jetpack > Forms submenu

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -897,17 +897,26 @@ class Contact_Form_Plugin {
 		if ( isset( $screen->post_type ) && 'feedback' === $screen->post_type || $screen->id === 'jetpack_page_jetpack-forms-admin' ) {
 			update_option( 'feedback_unread_count', 0 );
 		} else {
-			global $submenu;
-			if ( apply_filters( 'jetpack_forms_use_new_menu_parent', true ) ) {
-				// show the count on Jetpack → Forms
-				$unread = get_option( 'feedback_unread_count', 0 );
+			global $submenu, $menu;
+			if ( apply_filters( 'jetpack_forms_use_new_menu_parent', true ) && current_user_can( 'edit_pages' ) ) {
+				// show the count on Jetpack and Jetpack → Forms
+				$unread           = get_option( 'feedback_unread_count', 0 );
+				$unread_count_tag = " <span class='feedback-unread count-{$unread} awaiting-mod'><span class='feedback-unread-count'>" . number_format_i18n( $unread ) . '</span></span>';
 
 				if ( $unread > 0 && isset( $submenu['jetpack'] ) && is_array( $submenu['jetpack'] ) && ! empty( $submenu['jetpack'] ) ) {
+					// Main menu entries
+					foreach ( $menu as $index => $main_menu_item ) {
+						if ( isset( $main_menu_item[1] ) && 'jetpack_admin_page' === $main_menu_item[1] ) {
+							// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+							$menu[ $index ][0] .= $unread_count_tag;
+						}
+					}
+
+					// Jetpack submenu entries
 					foreach ( $submenu['jetpack'] as $index => $menu_item ) {
 						if ( 'jetpack-forms-admin' === $menu_item[2] ) {
-							$unread_count = current_user_can( 'publish_pages' ) ? " <span class='feedback-unread count-{$unread} awaiting-mod'><span class='feedback-unread-count'>" . number_format_i18n( $unread ) . '</span></span>' : '';
 							// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-							$submenu['jetpack'][ $index ][0] .= $unread_count;
+							$submenu['jetpack'][ $index ][0] .= $unread_count_tag;
 						}
 					}
 				}

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -894,10 +894,25 @@ class Contact_Form_Plugin {
 	 * @param object $screen Information about the current screen.
 	 */
 	public function unread_count( $screen ) {
-		if ( isset( $screen->post_type ) && 'feedback' === $screen->post_type ) {
+		if ( isset( $screen->post_type ) && 'feedback' === $screen->post_type || $screen->id === 'jetpack_page_jetpack-forms-admin' ) {
 			update_option( 'feedback_unread_count', 0 );
 		} else {
 			global $submenu;
+			if ( apply_filters( 'jetpack_forms_use_new_menu_parent', true ) ) {
+				// show the count on Jetpack → Forms
+				$unread = get_option( 'feedback_unread_count', 0 );
+
+				if ( $unread > 0 && isset( $submenu['jetpack'] ) && is_array( $submenu['jetpack'] ) && ! empty( $submenu['jetpack'] ) ) {
+					foreach ( $submenu['jetpack'] as $index => $menu_item ) {
+						if ( 'jetpack-forms-admin' === $menu_item[2] ) {
+							$unread_count = current_user_can( 'publish_pages' ) ? " <span class='feedback-unread count-{$unread} awaiting-mod'><span class='feedback-unread-count'>" . number_format_i18n( $unread ) . '</span></span>' : '';
+							// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+							$submenu['jetpack'][ $index ][0] .= $unread_count;
+						}
+					}
+				}
+				return;
+			}
 			if ( isset( $submenu['feedback'] ) && is_array( $submenu['feedback'] ) && ! empty( $submenu['feedback'] ) ) {
 				foreach ( $submenu['feedback'] as $index => $menu_item ) {
 					if ( 'edit.php?post_type=feedback' === $menu_item[2] ) {


### PR DESCRIPTION
Related to FORMS-27
Part of FORMS-99

## Proposed changes:
This PR adds an unread count badge to Jetpack > Forms submenu:

<img width="342" alt="image" src="https://github.com/user-attachments/assets/f3f1be03-4458-4308-9ac1-8ae2d64447f2" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1747924149856699-slack-C052XEUUBL4

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
Add a form to a post, visit it and submit some fields. Go to your wp-admin, don't get into Forms dashboard yet, just hover the Jetpack menu so it shows the subitems. You should see an unread count bubble on it, like the screenshot above.

NOTE: this doesn't work on Calypso, only on self hosted/JN/AT.