### PR TITLE
Boost: Fix scores refreshing before Cloud CSS or LCP are done

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/features/speed-score/speed-score.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/speed-score/speed-score.tsx
@@ -83,8 +83,8 @@ const SpeedScore = () => {
 			moduleStates,
 			pendingStates: {
 				criticalCss: {
-					isPending: criticalCssIsGenerating,
-					timestamp: cssState.created || 0,
+					isPending: cssState.status === 'pending' || criticalCssIsGenerating,
+					timestamp: cssState.updated || 0,
 				},
 				lcp: {
 					isPending: lcpState?.status === 'pending',

--- a/projects/plugins/boost/changelog/fix-boost-speed-scores-dispatching-on-toggles
+++ b/projects/plugins/boost/changelog/fix-boost-speed-scores-dispatching-on-toggles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Speed Scores: Fix not waiting for Cloud CSS to finish generating before refreshing the scores.


### PR DESCRIPTION
Fixes HOG-109
Fixes HOG-111

This already works when using Critical CSS and LCP, but this PR fixes the problem for Cloud CSS and LCP. Previously speed scores didn't wait for Cloud CSS to complete and users could get lower scores if the Page Speed request finished before critical css was generated. I wanted to prevent this from happening with LCP when we release it.

## Proposed changes:

* Boost will no longer refresh speed scores as soon as the LCP module is turned "on" (while Cloud CSS is available);
* Boost will no longer refresh speed scores as soon as the Cloud CSS module is turned "on".

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

HOG-109

## Does this pull request change what data or activity we track or use?

no

## Testing instructions:

**Pre-requisites**

- Make sure you have LCP available locally;
- Make sure speed scores have successfully loaded;
- If you're using free, Critical CSS should be "off". If you're using premium, Cloud CSS should be "off";
- LCP should be "off" as well.

### Page Speed waits for Cloud CSS - new, fixed behavior

- Turn on Cloud CSS;
- Scores shouldn't refresh until the module finishes working.

### Page Speed waits for LCP (with Cloud CSS available) - new, fixed behavior

- Turn on LCP;
- Scores shouldn't refresh until the module finishes working.

### Page Speed waits for LCP (with Critical CSS available) - old behavior, shouldn't have changed

- Turn on LCP;
- Scores shouldn't refresh until the module finishes working.

### Page Speed waits for Critical CSS - old behavior, shouldn't have changed

- Turn on Critical CSS;
- Scores shouldn't refresh until the module finishes working.