### PR TITLE
Forms: Fix confusion over label/defaultLabel/placeholder

### DIFF
--- a/projects/packages/forms/src/blocks/contact-form/variations.js
+++ b/projects/packages/forms/src/blocks/contact-form/variations.js
@@ -270,7 +270,7 @@ const variations = compact( [
 					[
 						'jetpack/label',
 						{
-							label: __( 'Message', 'jetpack-forms' ),
+							label: __( 'Other Details', 'jetpack-forms' ),
 						},
 					],
 					[ 'jetpack/input', { type: 'textarea' } ],
@@ -361,7 +361,7 @@ const variations = compact( [
 						{
 							name: 'jetpack/label',
 							attributes: {
-								label: __( 'Message', 'jetpack-forms' ),
+								label: __( 'Other Details', 'jetpack-forms' ),
 							},
 						},
 						{

--- a/projects/packages/forms/src/blocks/contact-form/variations.js
+++ b/projects/packages/forms/src/blocks/contact-form/variations.js
@@ -103,14 +103,14 @@ const variations = compact( [
 								'jetpack/option',
 								{
 									label: __( 'Yes', 'jetpack-forms' ),
-									defaultLabel: __( 'Add option…', 'jetpack-forms' ),
+									placeholder: __( 'Add option…', 'jetpack-forms' ),
 								},
 							],
 							[
 								'jetpack/option',
 								{
 									label: __( 'No', 'jetpack-forms' ),
-									defaultLabel: __( 'Add option…', 'jetpack-forms' ),
+									placeholder: __( 'Add option…', 'jetpack-forms' ),
 								},
 							],
 						],
@@ -168,14 +168,14 @@ const variations = compact( [
 									name: 'jetpack/option',
 									attributes: {
 										label: __( 'Yes', 'jetpack-forms' ),
-										defaultLabel: __( 'Add option…', 'jetpack-forms' ),
+										placeholder: __( 'Add option…', 'jetpack-forms' ),
 									},
 								},
 								{
 									name: 'jetpack/option',
 									attributes: {
 										label: __( 'No', 'jetpack-forms' ),
-										defaultLabel: __( 'Add option…', 'jetpack-forms' ),
+										placeholder: __( 'Add option…', 'jetpack-forms' ),
 									},
 								},
 							],
@@ -270,8 +270,7 @@ const variations = compact( [
 					[
 						'jetpack/label',
 						{
-							label: __( 'Other Details', 'jetpack-forms' ),
-							defaultLabel: __( 'Message', 'jetpack-forms' ),
+							label: __( 'Message', 'jetpack-forms' ),
 						},
 					],
 					[ 'jetpack/input', { type: 'textarea' } ],
@@ -362,8 +361,7 @@ const variations = compact( [
 						{
 							name: 'jetpack/label',
 							attributes: {
-								label: __( 'Other Details', 'jetpack-forms' ),
-								defaultLabel: __( 'Message', 'jetpack-forms' ),
+								label: __( 'Message', 'jetpack-forms' ),
 							},
 						},
 						{
@@ -443,14 +441,14 @@ const variations = compact( [
 								'jetpack/option',
 								{
 									label: __( 'Morning', 'jetpack-forms' ),
-									defaultLabel: __( 'Add option…', 'jetpack-forms' ),
+									placeholder: __( 'Add option…', 'jetpack-forms' ),
 								},
 							],
 							[
 								'jetpack/option',
 								{
 									label: __( 'Afternoon', 'jetpack-forms' ),
-									defaultLabel: __( 'Add option…', 'jetpack-forms' ),
+									placeholder: __( 'Add option…', 'jetpack-forms' ),
 								},
 							],
 						],
@@ -524,14 +522,14 @@ const variations = compact( [
 									name: 'jetpack/option',
 									attributes: {
 										label: __( 'Morning', 'jetpack-forms' ),
-										defaultLabel: __( 'Add option…', 'jetpack-forms' ),
+										placeholder: __( 'Add option…', 'jetpack-forms' ),
 									},
 								},
 								{
 									name: 'jetpack/option',
 									attributes: {
 										label: __( 'Afternoon', 'jetpack-forms' ),
-										defaultLabel: __( 'Add option…', 'jetpack-forms' ),
+										placeholder: __( 'Add option…', 'jetpack-forms' ),
 									},
 								},
 							],
@@ -612,35 +610,35 @@ const variations = compact( [
 								'jetpack/option',
 								{
 									label: __( '1 - Very Bad', 'jetpack-forms' ),
-									defaultLabel: __( 'Add option…', 'jetpack-forms' ),
+									placeholder: __( 'Add option…', 'jetpack-forms' ),
 								},
 							],
 							[
 								'jetpack/option',
 								{
 									label: __( '2 - Poor', 'jetpack-forms' ),
-									defaultLabel: __( 'Add option…', 'jetpack-forms' ),
+									placeholder: __( 'Add option…', 'jetpack-forms' ),
 								},
 							],
 							[
 								'jetpack/option',
 								{
 									label: __( '3 - Average', 'jetpack-forms' ),
-									defaultLabel: __( 'Add option…', 'jetpack-forms' ),
+									placeholder: __( 'Add option…', 'jetpack-forms' ),
 								},
 							],
 							[
 								'jetpack/option',
 								{
 									label: __( '4 - Good', 'jetpack-forms' ),
-									defaultLabel: __( 'Add option…', 'jetpack-forms' ),
+									placeholder: __( 'Add option…', 'jetpack-forms' ),
 								},
 							],
 							[
 								'jetpack/option',
 								{
 									label: __( '5 - Excellent', 'jetpack-forms' ),
-									defaultLabel: __( 'Add option…', 'jetpack-forms' ),
+									placeholder: __( 'Add option…', 'jetpack-forms' ),
 								},
 							],
 						],
@@ -701,35 +699,35 @@ const variations = compact( [
 									name: 'jetpack/option',
 									attributes: {
 										label: __( '1 - Very Bad', 'jetpack-forms' ),
-										defaultLabel: __( 'Add option…', 'jetpack-forms' ),
+										placeholder: __( 'Add option…', 'jetpack-forms' ),
 									},
 								},
 								{
 									name: 'jetpack/option',
 									attributes: {
 										label: __( '2 - Poor', 'jetpack-forms' ),
-										defaultLabel: __( 'Add option…', 'jetpack-forms' ),
+										placeholder: __( 'Add option…', 'jetpack-forms' ),
 									},
 								},
 								{
 									name: 'jetpack/option',
 									attributes: {
 										label: __( '3 - Average', 'jetpack-forms' ),
-										defaultLabel: __( 'Add option…', 'jetpack-forms' ),
+										placeholder: __( 'Add option…', 'jetpack-forms' ),
 									},
 								},
 								{
 									name: 'jetpack/option',
 									attributes: {
 										label: __( '4 - Good', 'jetpack-forms' ),
-										defaultLabel: __( 'Add option…', 'jetpack-forms' ),
+										placeholder: __( 'Add option…', 'jetpack-forms' ),
 									},
 								},
 								{
 									name: 'jetpack/option',
 									attributes: {
 										label: __( '5 - Excellent', 'jetpack-forms' ),
-										defaultLabel: __( 'Add option…', 'jetpack-forms' ),
+										placeholder: __( 'Add option…', 'jetpack-forms' ),
 									},
 								},
 							],

--- a/projects/packages/forms/src/blocks/field-checkbox/deprecated.js
+++ b/projects/packages/forms/src/blocks/field-checkbox/deprecated.js
@@ -19,7 +19,7 @@ export default [
 			const newInnerBlocks = [
 				createBlock( 'jetpack/option', {
 					label: attributes.label,
-					defaultLabel: __( 'Add option…', 'jetpack-forms' ),
+					placeholder: __( 'Add option…', 'jetpack-forms' ),
 					isStandalone: true,
 					style: labelStyles,
 				} ),

--- a/projects/packages/forms/src/blocks/field-checkbox/edit.js
+++ b/projects/packages/forms/src/blocks/field-checkbox/edit.js
@@ -30,7 +30,9 @@ export default function CheckboxFieldEdit( props ) {
 		},
 	} );
 
-	const template = [ [ 'jetpack/option', { isStandalone: true } ] ];
+	const template = [
+		[ 'jetpack/option', { isStandalone: true, placeholder: __( 'Add label…', 'jetpack-forms' ) } ],
+	];
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		allowedBlocks: ALLOWED_INNER_BLOCKS,
 		template,

--- a/projects/packages/forms/src/blocks/field-consent/deprecated.js
+++ b/projects/packages/forms/src/blocks/field-consent/deprecated.js
@@ -32,7 +32,7 @@ export default [
 			const { restAttributes, labelStyles } = deprecateFieldStyles( attributes );
 			const newInnerBlocks = [
 				createBlock( 'jetpack/option', {
-					defaultLabel: __( 'Add option…', 'jetpack-forms' ),
+					placeholder: __( 'Add option…', 'jetpack-forms' ),
 					hideInput: attributes.consentType === 'implicit',
 					isStandalone: true,
 					label: attributes.label,

--- a/projects/packages/forms/src/blocks/field-consent/edit.js
+++ b/projects/packages/forms/src/blocks/field-consent/edit.js
@@ -42,7 +42,7 @@ export default function ConsentFieldEdit( props ) {
 				'jetpack/option',
 				{
 					label: implicitConsentMessage,
-					defaultLabel: sprintf(
+					placeholder: sprintf(
 						/* translators: placeholder is a type of consent: implicit or explicit */
 						__( 'Add %s consent message…', 'jetpack-forms' ),
 						'implicit'
@@ -83,7 +83,7 @@ export default function ConsentFieldEdit( props ) {
 			__unstableMarkNextChangeAsNotPersistent();
 			updateBlockAttributes( optionBlockId, {
 				label,
-				defaultLabel: sprintf(
+				placeholder: sprintf(
 					/* translators: placeholder is a type of consent: implicit or explicit */
 					__( 'Add %s consent message…', 'jetpack-forms' ),
 					consentType

--- a/projects/packages/forms/src/blocks/field-date/edit.js
+++ b/projects/packages/forms/src/blocks/field-date/edit.js
@@ -1,5 +1,4 @@
 import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
-import { getBlockType } from '@wordpress/blocks';
 import { SelectControl } from '@wordpress/components';
 import { useCallback, useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -25,14 +24,12 @@ export default function DateFieldEdit( props ) {
 		style: blockStyle,
 	} );
 
-	const labelBlockType = getBlockType( 'jetpack/label' );
-	const defaultLabel = labelBlockType.attributes.label.default;
 	const template = useMemo( () => {
 		return [
-			[ 'jetpack/label', { label: __( 'Date', 'jetpack-forms' ), required, defaultLabel } ],
+			[ 'jetpack/label', { label: __( 'Date', 'jetpack-forms' ), required } ],
 			[ 'jetpack/input' ],
 		];
-	}, [ defaultLabel, required ] );
+	}, [ required ] );
 
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		allowedBlocks: ALLOWED_INNER_BLOCKS,

--- a/projects/packages/forms/src/blocks/field-multiple-choice/edit.js
+++ b/projects/packages/forms/src/blocks/field-multiple-choice/edit.js
@@ -33,7 +33,7 @@ export default function MultipleChoiceFieldEdit( props ) {
 				'jetpack/label',
 				{
 					label: __( 'Choose several options', 'jetpack-forms' ),
-					defaultLabel: __( 'Add label…', 'jetpack-forms' ),
+					placeholder: __( 'Add label…', 'jetpack-forms' ),
 				},
 			],
 			[ 'jetpack/options', { type: 'checkbox' } ],

--- a/projects/packages/forms/src/blocks/field-single-choice/edit.js
+++ b/projects/packages/forms/src/blocks/field-single-choice/edit.js
@@ -33,7 +33,7 @@ export default function SingleChoiceFieldEdit( props ) {
 				'jetpack/label',
 				{
 					label: __( 'Choose one option', 'jetpack-forms' ),
-					defaultLabel: __( 'Add label…', 'jetpack-forms' ),
+					placeholder: __( 'Add label…', 'jetpack-forms' ),
 				},
 			],
 			[ 'jetpack/options', { type: 'radio' } ],

--- a/projects/packages/forms/src/blocks/field-textarea/deprecated.js
+++ b/projects/packages/forms/src/blocks/field-textarea/deprecated.js
@@ -10,8 +10,7 @@ export default [
 			const { restAttributes, labelStyles, inputStyles } = deprecateFieldStyles( attributes );
 			const newInnerBlocks = [
 				createBlock( 'jetpack/label', {
-					label: attributes.label,
-					defaultLabel: __( 'Message', 'jetpack-forms' ),
+					label: attributes.label ?? __( 'Message', 'jetpack-forms' ),
 					requiredText: attributes.requiredText,
 					style: labelStyles,
 				} ),

--- a/projects/packages/forms/src/blocks/field-textarea/edit.js
+++ b/projects/packages/forms/src/blocks/field-textarea/edit.js
@@ -9,8 +9,8 @@ import useJetpackFieldStyles from '../shared/hooks/use-jetpack-field-styles';
 import { ALLOWED_INNER_BLOCKS } from '../shared/util/constants';
 
 export default function TextareaFieldEdit( props ) {
-	const { attributes, clientId, id, isSelected, label, requiredText, setAttributes } = props;
-	const { required, width } = attributes;
+	const { attributes, clientId, isSelected, setAttributes } = props;
+	const { id, required, requiredText, width } = attributes;
 
 	useFormWrapper( props );
 	const { blockStyle } = useJetpackFieldStyles( attributes );
@@ -22,15 +22,13 @@ export default function TextareaFieldEdit( props ) {
 		} ),
 		style: blockStyle,
 	} );
-	const defaultLabel = __( 'Message', 'jetpack-forms' );
 
-	const templateLabel = label ?? '';
 	const template = useMemo( () => {
 		return [
-			[ 'jetpack/label', { label: templateLabel, defaultLabel, requiredText } ],
+			[ 'jetpack/label', { label: __( 'Message', 'jetpack-forms' ), requiredText } ],
 			[ 'jetpack/input', { type: 'textarea' } ],
 		];
-	}, [ templateLabel, defaultLabel, requiredText ] );
+	}, [ requiredText ] );
 
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		allowedBlocks: ALLOWED_INNER_BLOCKS,

--- a/projects/packages/forms/src/blocks/field-textarea/edit.js
+++ b/projects/packages/forms/src/blocks/field-textarea/edit.js
@@ -10,7 +10,7 @@ import { ALLOWED_INNER_BLOCKS } from '../shared/util/constants';
 
 export default function TextareaFieldEdit( props ) {
 	const { attributes, clientId, isSelected, setAttributes } = props;
-	const { id, required, requiredText, width } = attributes;
+	const { id, required, width } = attributes;
 
 	useFormWrapper( props );
 	const { blockStyle } = useJetpackFieldStyles( attributes );
@@ -25,10 +25,10 @@ export default function TextareaFieldEdit( props ) {
 
 	const template = useMemo( () => {
 		return [
-			[ 'jetpack/label', { label: __( 'Message', 'jetpack-forms' ), requiredText } ],
+			[ 'jetpack/label', { label: __( 'Message', 'jetpack-forms' ) } ],
 			[ 'jetpack/input', { type: 'textarea' } ],
 		];
-	}, [ requiredText ] );
+	}, [] );
 
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		allowedBlocks: ALLOWED_INNER_BLOCKS,

--- a/projects/packages/forms/src/blocks/label/edit.js
+++ b/projects/packages/forms/src/blocks/label/edit.js
@@ -9,7 +9,6 @@ import getBlockStyle from '../shared/util/get-block-style.js';
 
 const SYNCED_ATTRIBUTE_KEYS = [ 'textColor', 'fontFamily', 'fontSize', 'style' ];
 
-const emptyToNull = str => ( str === '' ? null : str );
 const getLabelOrFallback = ( label, placeholder ) => {
 	if ( label === '' ) {
 		return placeholder;
@@ -74,9 +73,8 @@ const LabelEdit = ( { clientId, attributes, name, setAttributes, context } ) => 
 	} = context;
 	useSyncedAttributes( name, isSynced, SYNCED_ATTRIBUTE_KEYS, attributes, setAttributes );
 
-	const { label, defaultLabel, requiredText } = attributes;
-	const defaultPlaceholder = __( 'Add label…', 'jetpack-forms' );
-	const placeholder = emptyToNull( defaultLabel ) ?? emptyToNull( label ) ?? defaultPlaceholder;
+	const { label, placeholder, requiredText } = attributes;
+	const placeholderValue = placeholder !== '' ? placeholder : __( 'Add label…', 'jetpack-forms' );
 	const suffix = dateFormat
 		? `(${ DATE_FORMATS.find( f => f.value === dateFormat )?.label })`
 		: undefined;
@@ -104,7 +102,7 @@ const LabelEdit = ( { clientId, attributes, name, setAttributes, context } ) => 
 	const isPreviewMode = useSelect( select => {
 		return select( blockEditorStore ).getSettings().isPreviewMode;
 	}, [] );
-	const labelValue = isPreviewMode ? getLabelOrFallback( label, defaultPlaceholder ) : label;
+	const labelValue = isPreviewMode ? getLabelOrFallback( label, placeholderValue ) : label;
 
 	return (
 		<WithNotchedWrapper
@@ -118,7 +116,7 @@ const LabelEdit = ( { clientId, attributes, name, setAttributes, context } ) => 
 					allowedFormats={ ALLOWED_FORMATS }
 					className="jetpack-field-label__input"
 					onChange={ value => setAttributes( { label: value } ) }
-					placeholder={ placeholder }
+					placeholder={ placeholderValue }
 					tagName="label"
 					value={ labelValue }
 					withoutInteractiveFormatting

--- a/projects/packages/forms/src/blocks/label/index.js
+++ b/projects/packages/forms/src/blocks/label/index.js
@@ -54,7 +54,7 @@ const settings = {
 			type: 'string',
 			default: '',
 		},
-		defaultLabel: {
+		placeholder: {
 			type: 'string',
 			default: '',
 		},

--- a/projects/packages/forms/src/blocks/option/edit.js
+++ b/projects/packages/forms/src/blocks/option/edit.js
@@ -22,7 +22,7 @@ const OptionEdit = ( { attributes, clientId, context, name, setAttributes } ) =>
 		'jetpack/field-required': required,
 		'jetpack/field-share-attributes': isSynced,
 	} = context;
-	const { hideInput, label, isStandalone, requiredText } = attributes;
+	const { hideInput, label, isStandalone, requiredText, placeholder } = attributes;
 
 	useSyncedAttributes( name, isSynced, SYNCED_ATTRIBUTE_KEYS, attributes, setAttributes );
 
@@ -53,10 +53,10 @@ const OptionEdit = ( { attributes, clientId, context, name, setAttributes } ) =>
 	const isPreviewMode = useSelect( select => {
 		return select( blockEditorStore ).getSettings().isPreviewMode;
 	}, [] );
-	const placeholder = __( 'Add label…', 'jetpack-forms' );
+	const placeholderValue = placeholder !== '' ? placeholder : __( 'Add option…', 'jetpack-forms' );
 	// The label value to use for the RichText field must manually fall back to the
 	// placeholder to be rendered in previews.
-	const labelValue = isPreviewMode ? getLabelOrFallback( label, placeholder ) : label;
+	const labelValue = isPreviewMode ? getLabelOrFallback( label, placeholderValue ) : label;
 
 	// Some fields such as Checkbox or Consent, do not have a list of options.
 	// Additionally, a checkbox field may also be flagged as required so we need
@@ -79,7 +79,7 @@ const OptionEdit = ( { attributes, clientId, context, name, setAttributes } ) =>
 						tagName="div"
 						className="wp-block"
 						value={ labelValue }
-						placeholder={ placeholder }
+						placeholder={ placeholderValue }
 						__unstableDisableFormats
 						onChange={ newLabel => setAttributes( { label: newLabel } ) }
 						onRemove={ onRemove }

--- a/projects/packages/forms/src/blocks/option/index.js
+++ b/projects/packages/forms/src/blocks/option/index.js
@@ -38,7 +38,7 @@ const settings = {
 		},
 	},
 	attributes: {
-		defaultLabel: {
+		placeholder: {
 			type: 'string',
 			default: '',
 		},

--- a/projects/packages/forms/src/blocks/shared/components/jetpack-field.js
+++ b/projects/packages/forms/src/blocks/shared/components/jetpack-field.js
@@ -1,5 +1,4 @@
 import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
-import { getBlockType } from '@wordpress/blocks';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { useMemo } from '@wordpress/element';
 import { addFilter } from '@wordpress/hooks';
@@ -32,14 +31,12 @@ const JetpackField = props => {
 		style: blockStyle,
 	} );
 
-	const labelBlockType = getBlockType( 'jetpack/label' );
-	const defaultLabel = labelBlockType.attributes.label.default;
 	const template = useMemo( () => {
 		return [
-			[ 'jetpack/label', { label, required, defaultLabel, requiredText } ],
+			[ 'jetpack/label', { label, required, requiredText } ],
 			[ 'jetpack/input', { type } ],
 		];
-	}, [ label, defaultLabel, required, requiredText, type ] );
+	}, [ label, required, requiredText, type ] );
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		allowedBlocks: ALLOWED_INNER_BLOCKS,
 		template,

--- a/projects/packages/forms/src/blocks/shared/deprecations/migrate-inner-option-blocks.js
+++ b/projects/packages/forms/src/blocks/shared/deprecations/migrate-inner-option-blocks.js
@@ -12,7 +12,7 @@ export default function migrateInnerOptionBlocks( attributes, innerBlocks, field
 	const optionBlocks = innerBlocks.map( optionBlock =>
 		createBlock( 'jetpack/option', {
 			label: optionBlock.attributes.label,
-			defaultLabel: __( 'Add option…', 'jetpack-forms' ),
+			placeholder: __( 'Add option…', 'jetpack-forms' ),
 			style: optionStyles,
 		} )
 	);

--- a/projects/packages/forms/src/blocks/shared/deprecations/migrate-options-to-inner-blocks.js
+++ b/projects/packages/forms/src/blocks/shared/deprecations/migrate-options-to-inner-blocks.js
@@ -12,7 +12,7 @@ export default function migrateOptionsToInnerBlocks( attributes, fieldType ) {
 	const optionBlocks = nonEmptyOptions.map( option =>
 		createBlock( 'jetpack/option', {
 			label: option,
-			defaultLabel: __( 'Add option…', 'jetpack-forms' ),
+			placeholder: __( 'Add option…', 'jetpack-forms' ),
 			style: optionStyles,
 		} )
 	);

--- a/projects/packages/forms/src/blocks/shared/deprecations/multiple-choice-field-deprecation.js
+++ b/projects/packages/forms/src/blocks/shared/deprecations/multiple-choice-field-deprecation.js
@@ -27,7 +27,7 @@ export default function multiFieldV1( fieldType ) {
 			const optionBlocks = nonEmptyOptions.map( option =>
 				createBlock( 'jetpack/option', {
 					label: option,
-					defaultLabel: __( 'Add option…', 'jetpack-forms' ),
+					placeholder: __( 'Add option…', 'jetpack-forms' ),
 					style: optionStyles,
 				} )
 			);

--- a/projects/packages/forms/src/blocks/shared/settings/transforms.js
+++ b/projects/packages/forms/src/blocks/shared/settings/transforms.js
@@ -20,64 +20,64 @@ const fieldConfig = {
 	'jetpack/field-text': {
 		type: 'text',
 		label: __( 'Text', 'jetpack-forms' ),
-		defaultLabel: __( 'Add label…', 'jetpack-forms' ),
+		labelPlaceholder: __( 'Add label…', 'jetpack-forms' ),
 	},
 	'jetpack/field-name': {
 		type: 'text',
 		label: __( 'Name', 'jetpack-forms' ),
-		defaultLabel: __( 'Add label…', 'jetpack-forms' ),
+		labelPlaceholder: __( 'Add label…', 'jetpack-forms' ),
 	},
 	'jetpack/field-email': {
 		type: 'email',
 		label: __( 'Email', 'jetpack-forms' ),
-		defaultLabel: __( 'Add label…', 'jetpack-forms' ),
+		labelPlaceholder: __( 'Add label…', 'jetpack-forms' ),
 	},
 	'jetpack/field-url': {
 		type: 'url',
 		label: __( 'Website', 'jetpack-forms' ),
-		defaultLabel: __( 'Add label…', 'jetpack-forms' ),
+		labelPlaceholder: __( 'Add label…', 'jetpack-forms' ),
 	},
 	'jetpack/field-telephone': {
 		type: 'tel',
 		label: __( 'Phone', 'jetpack-forms' ),
-		defaultLabel: __( 'Add label…', 'jetpack-forms' ),
+		labelPlaceholder: __( 'Add label…', 'jetpack-forms' ),
 	},
 	'jetpack/field-textarea': {
 		type: 'textarea',
 		label: __( 'Message', 'jetpack-forms' ),
-		defaultLabel: __( 'Add label…', 'jetpack-forms' ),
+		labelPlaceholder: __( 'Add label…', 'jetpack-forms' ),
 	},
 	'jetpack/field-number': {
 		type: 'number',
 		label: __( 'Number', 'jetpack-forms' ),
-		defaultLabel: __( 'Add label…', 'jetpack-forms' ),
+		labelPlaceholder: __( 'Add label…', 'jetpack-forms' ),
 	},
 	'jetpack/field-date': {
 		type: 'text',
 		label: __( 'Date', 'jetpack-forms' ),
-		defaultLabel: __( 'Add label…', 'jetpack-forms' ),
+		labelPlaceholder: __( 'Add label…', 'jetpack-forms' ),
 	},
 	'jetpack/field-select': {
 		type: 'dropdown',
 		label: '',
-		defaultLabel: __( 'Add label…', 'jetpack-forms' ),
+		labelPlaceholder: __( 'Add label…', 'jetpack-forms' ),
 	},
 	// Choice-based fields.
 	'jetpack/field-checkbox-multiple': {
 		type: 'checkbox',
 		label: __( 'Choose several options', 'jetpack-forms' ),
-		defaultLabel: __( 'Add label…', 'jetpack-forms' ),
+		labelPlaceholder: __( 'Add label…', 'jetpack-forms' ),
 	},
 	'jetpack/field-radio': {
 		type: 'radio',
 		label: __( 'Choose one option', 'jetpack-forms' ),
-		defaultLabel: __( 'Add label…', 'jetpack-forms' ),
+		labelPlaceholder: __( 'Add label…', 'jetpack-forms' ),
 	},
 	// Single option fields.
 	'jetpack/field-checkbox': {
 		type: 'checkbox',
 		label: '',
-		defaultLabel: __( 'Add label…', 'jetpack-forms' ),
+		labelPlaceholder: __( 'Add label…', 'jetpack-forms' ),
 		extraAttributes: {
 			isStandalone: true,
 			hideInput: false,
@@ -86,7 +86,7 @@ const fieldConfig = {
 	'jetpack/field-consent': {
 		type: 'checkbox',
 		label: '',
-		defaultLabel: sprintf(
+		labelPlaceholder: sprintf(
 			/* translators: placeholder is a type of consent: implicit or explicit */
 			__( 'Add %s consent message…', 'jetpack-forms' ),
 			'implicit'
@@ -134,7 +134,7 @@ const createTextFieldInnerBlocks = ( blockName, existingInnerBlocks = [] ) => {
 		createBlock( 'jetpack/label', {
 			...( existingLabel?.attributes || {} ),
 			label: config.label,
-			defaultLabel: config.defaultLabel,
+			placeholder: config.labelPlaceholder,
 		} ),
 		createBlock( 'jetpack/input', {
 			...( existingInput?.attributes || {} ),
@@ -155,7 +155,7 @@ const createChoiceFieldInnerBlocks = ( blockName, existingInnerBlocks = [], attr
 	const label = createBlock( 'jetpack/label', {
 		...( existingLabel?.attributes || {} ),
 		label: config.label,
-		defaultLabel: config.defaultLabel,
+		placeholder: config.labelPlaceholder,
 	} );
 
 	let optionBlocks = [];
@@ -199,7 +199,7 @@ const createSingleOptionFieldInnerBlocks = ( blockName, existingInnerBlocks = []
 		createBlock( 'jetpack/option', {
 			...( existingOption?.attributes || {} ),
 			label: config.label,
-			defaultLabel: config.defaultLabel,
+			placeholder: config.labelPlaceholder,
 			...config.extraAttributes,
 		} ),
 	];

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
@@ -68,10 +68,10 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 				array(
 					'blockName' => 'jetpack/label',
 					'attrs'     => array(
-						'label'        => 'Choose several options',
-						'defaultLabel' => 'Add label…',
-						'textColor'    => 'swamp-green',
-						'style'        => array(
+						'label'       => 'Choose several options',
+						'placeholder' => 'Add label…',
+						'textColor'   => 'swamp-green',
+						'style'       => array(
 							'elements' => array(
 								'link' => array( 'color' => array( 'text' => 'var:preset|color|accent-3' ) ),
 							),
@@ -229,10 +229,10 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 				array(
 					'blockName' => 'jetpack/label',
 					'attrs'     => array(
-						'label'        => 'Radio gaga',
-						'defaultLabel' => 'Radio gaga…',
-						'textColor'    => 'turmoil-purple',
-						'style'        => array(
+						'label'       => 'Radio gaga',
+						'placeholder' => 'Radio gaga…',
+						'textColor'   => 'turmoil-purple',
+						'style'       => array(
 							'elements' => array(
 								'link' => array( 'color' => array( 'text' => 'var:preset|color|turmoil-purple' ) ),
 							),


### PR DESCRIPTION
Note: merges into #43765 and not trunk

In #43765 it looks like there's some confusion over the concepts of a placeholder and a default label for the label block. This is what caused the tests to fail when there was an initial attempt to merge #42890.

My take on it is that:
-  `placeholder` should be what the label block shows in the editor when there’s no label value.
- `defaultLabel` should be the value of the label when first inserted, and what the label block shows on the frontend when there’s no label.

In most cases when the code used an attribute called `defaultLabel` it seems like it should have instead been using an attribute called `placeholder` (which wasn't a thing before, but it's being added in this PR to replace `defaultLabel`). The placeholder is only shown in the editor and is used for the label block's aria label, so this is used for text like 'Add label...' and 'Add option...'.

There are a couple of exceptions:
- The textarea block was actually using `defaultLabel` differently, to specify a default value of 'Message' or 'Other Details' for the label (which is not a placeholder).
- The consent block has two different default labels depending on whether the consent type is explicit or not.

In this PR I try to preserve those, but just pass them through as the `label` value rather than keeping a separate `defaultLabel` attribute.

Fixes #

## Proposed changes:
- Rename the label block's `defaultLabel` attribute to `placeholder`
- Rename the option block's `defaultLabel` attribute to `placeholder` (it has similar ambiguity)
- Update everywhere to use `placeholder` where the code was legitimately passing a placeholder value through to the blocks
- In other instances (Textarea / Consent) where there actually was a default label value, instead pass through that value to the `label` prop.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

