### PR TITLE
Help Center: add SSP flag to the Help Center data

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-add-ssp-flag-to-hc
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-add-ssp-flag-to-hc
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: It's internal to WPCOM
+
+

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
@@ -171,6 +171,7 @@ class Help_Center {
 					array(
 						'isProxied'   => boolval( self::is_proxied() ),
 						'isSU'        => defined( 'WPCOM_SUPPORT_SESSION' ) && WPCOM_SUPPORT_SESSION,
+						'isSSP'       => isset( $_COOKIE['ssp'] ),
 						'currentUser' => array(
 							'ID'           => $user_id,
 							'username'     => $username,


### PR DESCRIPTION
## Proposed changes:
Follow up to https://github.com/Automattic/jetpack/pull/43752

We need the SSP flag for the same purpose.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
1. Apply this.
2. Go to any page in wp-admin.
3. Open DevTools console and log `helpCenterData`.
4. Make sure `isSSP` exists.
