### PR TITLE
Bump wpcomsh podcast

### DIFF
--- a/projects/plugins/wpcomsh/changelog/bump-wpcomsh-podcast
+++ b/projects/plugins/wpcomsh/changelog/bump-wpcomsh-podcast
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+WoA podcasting: Make episode images comply with apple requirements

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -8,23 +8,23 @@
     "packages": [
         {
             "name": "automattic/at-pressable-podcasting",
-            "version": "v2.0.2",
+            "version": "v2.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/automattic/at-pressable-podcasting.git",
-                "reference": "113461a854d3d6551c173ca4c02dbc901bbefd27"
+                "reference": "f3564cdc408f5354cfd70ce66ac131c891831a33"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/automattic/at-pressable-podcasting/zipball/113461a854d3d6551c173ca4c02dbc901bbefd27",
-                "reference": "113461a854d3d6551c173ca4c02dbc901bbefd27",
+                "url": "https://api.github.com/repos/automattic/at-pressable-podcasting/zipball/f3564cdc408f5354cfd70ce66ac131c891831a33",
+                "reference": "f3564cdc408f5354cfd70ce66ac131c891831a33",
                 "shasum": ""
             },
             "type": "wordpress-plugin",
             "license": [
                 "GPL-2.0-or-later"
             ],
-            "time": "2024-06-06T16:58:27+00:00"
+            "time": "2025-06-04T10:44:48+00:00"
         },
         {
             "name": "automattic/custom-fonts",


### PR DESCRIPTION
Synchronises 184467-ghe-Automattic/wpcom for simple sites to WoA sites via https://github.com/Automattic/at-pressable-podcasting/commit/a39c54ceabba00718784b88e89306195af20d869 and https://github.com/Automattic/at-pressable-podcasting/commit/f3564cdc408f5354cfd70ce66ac131c891831a33.

Please see 184467-ghe-Automattic/wpcom / https://linear.app/a8c/issue/DOTCOM-13448/itunes-does-not-display-episode-cover-art for full details.

## Testing instructions:

1. Get a WoA Dev atomic site
2. Apply this to the dev site using the steps in the comment below.
3. Go to Settings → Podcasting and fill out the form
4. Create a post in the nominated category, give it a large (>1024px wide and tall) featured image and a podcast block with a file
5. Look at the RSS feed for the nominated category - the image for the episode should be > 1024px.

## Does this pull request change what data or activity we track or use?

No.