### PR TITLE
Charts: Prefer color from data if it is available for legend

### DIFF
--- a/projects/js-packages/charts/changelog/charts-use-stroke-color-in-legend
+++ b/projects/js-packages/charts/changelog/charts-use-stroke-color-in-legend
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Charts: use color set from the data for the stroke as legend if available and fallback to theme color if it was not available

--- a/projects/js-packages/charts/src/components/line-chart/line-chart.tsx
+++ b/projects/js-packages/charts/src/components/line-chart/line-chart.tsx
@@ -190,8 +190,7 @@ const LineChart: FC< LineChartProps > = ( {
 	const legendItems = dataSorted.map( ( group, index ) => ( {
 		label: group.label, // Label for each unique group
 		value: '', // Empty string since we don't want to show a specific value
-		color:
-			data[ index ]?.options?.stroke ?? providerTheme.colors[ index % providerTheme.colors.length ],
+		color: group?.options?.stroke ?? providerTheme.colors[ index % providerTheme.colors.length ],
 	} ) );
 
 	const accessors = {

--- a/projects/js-packages/charts/src/components/line-chart/line-chart.tsx
+++ b/projects/js-packages/charts/src/components/line-chart/line-chart.tsx
@@ -190,7 +190,8 @@ const LineChart: FC< LineChartProps > = ( {
 	const legendItems = dataSorted.map( ( group, index ) => ( {
 		label: group.label, // Label for each unique group
 		value: '', // Empty string since we don't want to show a specific value
-		color: providerTheme.colors[ index % providerTheme.colors.length ],
+		color:
+			data[ index ]?.options?.stroke ?? providerTheme.colors[ index % providerTheme.colors.length ],
 	} ) );
 
 	const accessors = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Legend always uses a fallback color but stroke prefers the color set from the data for the chart
* Use the color set from the data if available and then fallback to the theme color

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Enable legend on the [`GridientFilled` story](https://github.com/Automattic/jetpack/blob/2dfff828ad17d6c132abe1975eed9c49cc56e006/projects/js-packages/charts/src/components/line-chart/stories/index.stories.tsx#L111-L120) 
* Notice the legend color does not match the color of the stroke
* This PR should fix this bug

Before

![Arc -2025-06-04 at 17 41 46@2x](https://github.com/user-attachments/assets/14c7e3d6-111e-4ebe-8449-1ceca72373fb)


After 

![Arc -2025-06-04 at 17 42 12@2x](https://github.com/user-attachments/assets/f69dc499-694a-4b8a-bff0-72e59b9e2b5d)


