### PR TITLE
Boost: Add LCP state to jetpack sync whitelist

### DIFF
--- a/projects/plugins/boost/app/class-jetpack-boost.php
+++ b/projects/plugins/boost/app/class-jetpack-boost.php
@@ -34,6 +34,7 @@ use Automattic\Jetpack_Boost\Lib\Status;
 use Automattic\Jetpack_Boost\Lib\Super_Cache_Tracking;
 use Automattic\Jetpack_Boost\Modules\Module;
 use Automattic\Jetpack_Boost\Modules\Modules_Setup;
+use Automattic\Jetpack_Boost\Modules\Optimizations\Lcp\LCP_State;
 use Automattic\Jetpack_Boost\Modules\Optimizations\Page_Cache\Cache_Preload;
 use Automattic\Jetpack_Boost\Modules\Optimizations\Page_Cache\Page_Cache;
 use Automattic\Jetpack_Boost\Modules\Optimizations\Page_Cache\Page_Cache_Setup;
@@ -283,6 +284,7 @@ class Jetpack_Boost {
 					'boost_latest_scores'          => array( new Speed_Score_History( get_home_url() ), 'latest' ),
 					'boost_latest_no_boost_scores' => array( new Speed_Score_History( add_query_arg( Module::DISABLE_MODULE_QUERY_VAR, 'all', get_home_url() ) ), 'latest' ),
 					'critical_css_state'           => array( new Critical_CSS_State(), 'get' ),
+					'lcp_state'                    => array( new LCP_State(), 'get' ),
 				),
 			)
 		);

--- a/projects/plugins/boost/changelog/update-boost-sync-lcp-state
+++ b/projects/plugins/boost/changelog/update-boost-sync-lcp-state
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: LCP: Add LCP state to Jetpack Sync.
+
+


### PR DESCRIPTION
Partially addresses HOG-102

## Proposed changes:

* Add LCP state when syncing settings with Jetpack sync.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

HOG-102

## Does this pull request change what data or activity we track or use?

no

## Testing instructions:

- Nothing to test. Check to make sure changes make sense.