### PR TITLE
Protect/improve readme clarity

### DIFF
--- a/projects/plugins/protect/changelog/protect-improve-readme-clarity
+++ b/projects/plugins/protect/changelog/protect-improve-readme-clarity
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Protect: Clarified language in the plugin readme to clarify malware and vulnerability scanning.

--- a/projects/plugins/protect/readme.txt
+++ b/projects/plugins/protect/readme.txt
@@ -8,7 +8,7 @@ Stable tag: 1.4.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
-Free daily malware scanning and WordPress site security. Jetpack Protect leverages the extensive database of WPScan, an Automattic brand, that has over 25,000 registered malware and vulnerabilities. No configuration required!
+Free daily vulnerability scans & WordPress security, powered by WPScan (an Automattic brand) and its 60,000+ vulnerability database. No setup needed!
 
 == Description ==
 
@@ -53,9 +53,9 @@ To clean up your site, we suggest using a malware removal tool, or if possible r
 Jetpack Protect blocks unwanted login attempts from malicious botnets and distributed attacks.
 
 = Is my site under attack? =
-Brute force attacks are the most common form of hacking — and hackers don’t discriminate. As the most commonly used Content Management System on the web, WordPress sites make an attractive target for hackers looking to exploit code vulnerabilities unique to WordPress. 
+Brute force attacks are the most common form of hacking — and hackers don’t discriminate. As the most commonly used Content Management System on the web, WordPress sites make an attractive target for hackers looking to exploit code vulnerabilities unique to WordPress.
 
-Using large networks of computers known as botnets, hackers can try to gain access to your site by using thousands of different combinations of usernames and passwords until they find the right one. 
+Using large networks of computers known as botnets, hackers can try to gain access to your site by using thousands of different combinations of usernames and passwords until they find the right one.
 
 Recently, attackers have found a way to “amplify” these attacks against the WordPress XML-RPC file – making it easier for attackers to try and break into your site.
 
@@ -118,7 +118,7 @@ We are working hard to bring more features and improvements to Jetpack Protect. 
 
 = How does Jetpack Protect help your WordPress Site security? =
 
-Protect is a free WordPress security and malware scanner plugin that scans your site and lets you know possible malware and security threats on your installed plugins, themes, and core files.
+Protect is a free WordPress security scanner plugin that scans your site and lets you know possible vulnerability and other security threats on your installed plugins, themes, and core files.
 
 The free plan scans your site for WordPress version, plugin, and theme vulnerabilities from our extensive vulnerability database (53,500) that is powered by WPScan.
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Ticket: https://linear.app/a8c/issue/PROTECT-91 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Made the language around malware and vulnerability scanning in the readme for Jetpack Protect more clear
* Shortened the length of the short description so it fits into the officially allowed 150 characters.


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

No functional change, but you can check that the description now fits the length limit with this validator: https://wordpress.org/plugins/developers/readme-validator/

(use the old readme text to see that it actually triggers the issue of the description being too long)

Additionally, verify that the language looks correct and clear now.
