### PR TITLE
Forms: remove all notice on forms dashboard

### DIFF
--- a/projects/packages/forms/changelog/fix-remove-all-notice-on-forms
+++ b/projects/packages/forms/changelog/fix-remove-all-notice-on-forms
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+Forms: remove all admin notices from the jetpack forms admin

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -28,6 +28,8 @@ class Dashboard {
 	 */
 	const SCRIPT_HANDLE = 'jp-forms-dashboard';
 
+	const ADMIN_SLUG = 'jetpack-forms-admin';
+
 	/**
 	 * Priority for the dashboard menu.
 	 * Needs to be high enough for us to be able to unregister the default edit.php menu item.
@@ -72,7 +74,7 @@ class Dashboard {
 		add_action( 'admin_enqueue_scripts', array( $this, 'load_admin_scripts' ) );
 
 		// Removed all admin notices on the Jetpack Forms admin page.
-		if ( isset( $_GET['page'] ) && $_GET['page'] === 'jetpack-forms-admin' ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( isset( $_GET['page'] ) && $_GET['page'] === self::ADMIN_SLUG ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			remove_all_actions( 'admin_notices' );
 		}
 
@@ -184,7 +186,7 @@ class Dashboard {
 			__( 'Jetpack Forms', 'jetpack-forms' ),
 			_x( 'Forms', 'submenu title for Jetpack Forms', 'jetpack-forms' ),
 			'edit_pages',
-			'jetpack-forms-admin',
+			self::ADMIN_SLUG,
 			array( $this, 'render_new_dashboard' ),
 			10
 		);

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -71,6 +71,11 @@ class Dashboard {
 
 		add_action( 'admin_enqueue_scripts', array( $this, 'load_admin_scripts' ) );
 
+		// Removed all admin notices on the Jetpack Forms admin page.
+		if ( isset( $_GET['page'] ) && $_GET['page'] === 'jetpack-forms-admin' ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			remove_all_actions( 'admin_notices' );
+		}
+
 		$this->switch->init();
 	}
 


### PR DESCRIPTION
This PR prevents admin dashboard notices from being added to the form admin page. 

Before:
![image](https://github.com/user-attachments/assets/ff265126-d033-4491-8078-5797376188b2)


After:
![Screenshot 2025-06-04 at 9 09 10 AM](https://github.com/user-attachments/assets/a8efe269-4c06-42f3-bc12-5219cc396476)




## Proposed changes:
* Only removed the admin notices from the new jetpack forms dashboard. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
Add a plugin or a theme that adds a admin dashboard notice. Such as https://en-ca.wordpress.org/themes/bizboost/ theme. 
Visit the new forms dashboard notice that the notice are not there. Switch to a different branch. Notice that the admin notice shows up. 

