### PR TITLE
Connection: display info on WoA sites

### DIFF
--- a/projects/js-packages/connection/changelog/update-at-connection-card
+++ b/projects/js-packages/connection/changelog/update-at-connection-card
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Connection: Display connection info on WoA sites

--- a/projects/js-packages/connection/components/manage-connection-dialog/index.jsx
+++ b/projects/js-packages/connection/components/manage-connection-dialog/index.jsx
@@ -4,6 +4,7 @@
 import jetpackAnalytics from '@automattic/jetpack-analytics';
 import restApi from '@automattic/jetpack-api';
 import { Button, getRedirectUrl, Text } from '@automattic/jetpack-components';
+import { isWoASite } from '@automattic/jetpack-script-data';
 import { ExternalLink, Modal } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -204,7 +205,7 @@ const ManageConnectionDialog = props => {
 									/>
 								</>
 							) }
-							{ isCurrentUserAdmin && (
+							{ isCurrentUserAdmin && ! isWoASite() && (
 								<ManageConnectionActionCard
 									title={ __( 'Disconnect Jetpack', 'jetpack-connection-js' ) }
 									onClick={ openDisconnectDialog }

--- a/projects/js-packages/connection/components/manage-connection-dialog/index.jsx
+++ b/projects/js-packages/connection/components/manage-connection-dialog/index.jsx
@@ -4,7 +4,7 @@
 import jetpackAnalytics from '@automattic/jetpack-analytics';
 import restApi from '@automattic/jetpack-api';
 import { Button, getRedirectUrl, Text } from '@automattic/jetpack-components';
-import { isWoASite } from '@automattic/jetpack-script-data';
+import { getScriptData } from '@automattic/jetpack-script-data';
 import { ExternalLink, Modal } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -19,6 +19,17 @@ import ConnectionErrorNotice from '../connection-error-notice/index.jsx';
 import DisconnectDialog from '../disconnect-dialog';
 import OwnerDisconnectDialog from '../owner-disconnect-dialog';
 import './style.scss';
+
+const initialState = getScriptData()?.connection || {};
+
+/**
+ * Check if the current site is a WoA site using connection data
+ *
+ * @return {boolean} True if the site is a WoA site
+ */
+const isWoASite = () => {
+	return initialState.siteHost === 'woa';
+};
 
 /**
  * The RNA Manage Connection Dialog component.

--- a/projects/js-packages/connection/components/manage-connection-dialog/index.jsx
+++ b/projects/js-packages/connection/components/manage-connection-dialog/index.jsx
@@ -4,7 +4,7 @@
 import jetpackAnalytics from '@automattic/jetpack-analytics';
 import restApi from '@automattic/jetpack-api';
 import { Button, getRedirectUrl, Text } from '@automattic/jetpack-components';
-import { getScriptData } from '@automattic/jetpack-script-data';
+import { isWoASite } from '@automattic/jetpack-script-data';
 import { ExternalLink, Modal } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -19,17 +19,6 @@ import ConnectionErrorNotice from '../connection-error-notice/index.jsx';
 import DisconnectDialog from '../disconnect-dialog';
 import OwnerDisconnectDialog from '../owner-disconnect-dialog';
 import './style.scss';
-
-const initialState = getScriptData()?.connection || {};
-
-/**
- * Check if the current site is a WoA site using connection data
- *
- * @return {boolean} True if the site is a WoA site
- */
-const isWoASite = () => {
-	return initialState.siteHost === 'woa';
-};
 
 /**
  * The RNA Manage Connection Dialog component.

--- a/projects/js-packages/connection/components/manage-connection-dialog/stories/index.stories.jsx
+++ b/projects/js-packages/connection/components/manage-connection-dialog/stories/index.stories.jsx
@@ -6,10 +6,13 @@ export default {
 	component: ManageConnectionDialog,
 	decorators: [
 		( Story, context ) => {
-			// Mock connection initial state based on story args
-			window.JP_CONNECTION_INITIAL_STATE = {
-				...( window.JP_CONNECTION_INITIAL_STATE || {} ),
-				siteHost: context.args.siteHost || 'standard',
+			// Mock JetpackScriptData for WoA detection
+			window.JetpackScriptData = {
+				...( window.JetpackScriptData || {} ),
+				site: {
+					...( window.JetpackScriptData?.site || {} ),
+					host: context.args.siteHost || 'standard',
+				},
 			};
 			return <Story />;
 		},

--- a/projects/js-packages/connection/components/manage-connection-dialog/stories/index.stories.jsx
+++ b/projects/js-packages/connection/components/manage-connection-dialog/stories/index.stories.jsx
@@ -4,6 +4,17 @@ import ManageConnectionDialog from '..';
 export default {
 	title: 'JS Packages/Connection/Manage Connection Dialog',
 	component: ManageConnectionDialog,
+	decorators: [
+		( Story, context ) => {
+			// Mock JetpackScriptData based on story args
+			window.JetpackScriptData = {
+				site: {
+					host: context.args.siteHost || 'standard',
+				},
+			};
+			return <Story />;
+		},
+	],
 };
 
 const Template = args => <ManageConnectionDialog { ...args } />;
@@ -14,4 +25,28 @@ _default.args = {
 	apiNonce: 'test',
 	apiRoot: 'https://example.org/wp-json/',
 	title: 'Manage your Jetpack connection',
+	connectedUser: {
+		currentUser: {
+			permissions: {
+				manage_options: true,
+			},
+			isConnected: true,
+			isMaster: false,
+		},
+	},
+};
+
+export const WoASite = Template.bind( {} );
+WoASite.args = {
+	..._default.args,
+	siteHost: 'woa', // This will set the mock to WoA site
+};
+WoASite.storyName = 'WoA Site (Disconnect Hidden)';
+WoASite.parameters = {
+	docs: {
+		description: {
+			story:
+				'On WoA sites, the "Disconnect Jetpack" option is hidden for all users to prevent accidental disconnection.',
+		},
+	},
 };

--- a/projects/js-packages/connection/components/manage-connection-dialog/stories/index.stories.jsx
+++ b/projects/js-packages/connection/components/manage-connection-dialog/stories/index.stories.jsx
@@ -6,11 +6,10 @@ export default {
 	component: ManageConnectionDialog,
 	decorators: [
 		( Story, context ) => {
-			// Mock JetpackScriptData based on story args
-			window.JetpackScriptData = {
-				site: {
-					host: context.args.siteHost || 'standard',
-				},
+			// Mock connection initial state based on story args
+			window.JP_CONNECTION_INITIAL_STATE = {
+				...( window.JP_CONNECTION_INITIAL_STATE || {} ),
+				siteHost: context.args.siteHost || 'standard',
 			};
 			return <Story />;
 		},

--- a/projects/packages/connection/changelog/update-at-connection-card
+++ b/projects/packages/connection/changelog/update-at-connection-card
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Limit access to manage connection dialog on WoA sites.

--- a/projects/packages/connection/src/class-initial-state.php
+++ b/projects/packages/connection/src/class-initial-state.php
@@ -51,8 +51,7 @@ class Initial_State {
 
 		// Ensure site.host is set for WoA detection
 		if ( ! isset( $data['site']['host'] ) ) {
-			$host                 = new Status\Host();
-			$data['site']['host'] = $host->get_known_host_guess();
+			$data['site']['host'] = ( new Status\Host() )->get_known_host_guess();
 		}
 
 		return $data;

--- a/projects/packages/connection/src/class-initial-state.php
+++ b/projects/packages/connection/src/class-initial-state.php
@@ -23,6 +23,7 @@ class Initial_State {
 		global $wp_version;
 
 		$status = new Status();
+		$host   = new Status\Host();
 
 		return array(
 			'apiRoot'            => esc_url_raw( rest_url() ),
@@ -35,7 +36,8 @@ class Initial_State {
 			'siteSuffix'         => $status->get_site_suffix(),
 			'connectionErrors'   => Error_Handler::get_instance()->get_verified_errors(),
 			'isOfflineMode'      => $status->is_offline_mode(),
-			'calypsoEnv'         => ( new Status\Host() )->get_calypso_env(),
+			'calypsoEnv'         => $host->get_calypso_env(),
+			'siteHost'           => $host->get_known_host_guess(),
 		);
 	}
 

--- a/projects/packages/connection/src/class-initial-state.php
+++ b/projects/packages/connection/src/class-initial-state.php
@@ -37,7 +37,6 @@ class Initial_State {
 			'connectionErrors'   => Error_Handler::get_instance()->get_verified_errors(),
 			'isOfflineMode'      => $status->is_offline_mode(),
 			'calypsoEnv'         => $host->get_calypso_env(),
-			'siteHost'           => $host->get_known_host_guess(),
 		);
 	}
 
@@ -49,6 +48,12 @@ class Initial_State {
 	public static function set_connection_script_data( $data ) {
 
 		$data['connection'] = self::get_data();
+
+		// Ensure site.host is set for WoA detection
+		if ( ! isset( $data['site']['host'] ) ) {
+			$host                 = new Status\Host();
+			$data['site']['host'] = $host->get_known_host_guess();
+		}
 
 		return $data;
 	}

--- a/projects/packages/connection/tests/php/Initial_State_Test.php
+++ b/projects/packages/connection/tests/php/Initial_State_Test.php
@@ -48,6 +48,7 @@ class Initial_State_Test extends TestCase {
 			'connectionErrors'   => Error_Handler::get_instance()->get_verified_errors(),
 			'isOfflineMode'      => ( new Status() )->is_offline_mode(),
 			'calypsoEnv'         => 'wpcalypso',
+			'siteHost'           => ( new Status\Host() )->get_known_host_guess(),
 		);
 		$expected_value = 'var JP_CONNECTION_INITIAL_STATE; typeof JP_CONNECTION_INITIAL_STATE === "object" || (JP_CONNECTION_INITIAL_STATE = JSON.parse(decodeURIComponent("' . rawurlencode( wp_json_encode( $expected_state ) ) . '")));';
 

--- a/projects/packages/connection/tests/php/Initial_State_Test.php
+++ b/projects/packages/connection/tests/php/Initial_State_Test.php
@@ -48,7 +48,6 @@ class Initial_State_Test extends TestCase {
 			'connectionErrors'   => Error_Handler::get_instance()->get_verified_errors(),
 			'isOfflineMode'      => ( new Status() )->is_offline_mode(),
 			'calypsoEnv'         => 'wpcalypso',
-			'siteHost'           => ( new Status\Host() )->get_known_host_guess(),
 		);
 		$expected_value = 'var JP_CONNECTION_INITIAL_STATE; typeof JP_CONNECTION_INITIAL_STATE === "object" || (JP_CONNECTION_INITIAL_STATE = JSON.parse(decodeURIComponent("' . rawurlencode( wp_json_encode( $expected_state ) ) . '")));';
 

--- a/projects/packages/my-jetpack/_inc/components/connection-status-card/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/connection-status-card/index.tsx
@@ -122,7 +122,9 @@ const ConnectionStatusCard: ConnectionStatusCardType = ( {
 	const isConnectionOwner = userConnectionData.currentUser?.isMaster;
 	const shouldPreventDialog = isWoASite() && isConnectionOwner;
 	const allowDisconnect =
-		( currentUserCan( 'manage_options' ) || isUserConnected ) && ! shouldPreventDialog;
+		( currentUserCan( 'manage_options' ) || isUserConnected ) &&
+		isUserConnected &&
+		! shouldPreventDialog;
 
 	return (
 		<section className={ styles[ 'connection-status-card' ] }>
@@ -151,18 +153,20 @@ const ConnectionStatusCard: ConnectionStatusCardType = ( {
 						disabled={ ! allowDisconnect }
 					>
 						{ state.label }
-						<svg
-							xmlns="http://www.w3.org/2000/svg"
-							width="24"
-							height="24"
-							viewBox="0 0 24 24"
-							role="presentation"
-						>
-							<path
-								d="M10.6004 6L9.40039 7L14.0004 12L9.40039 17L10.6004 18L16.0004 12L10.6004 6Z"
-								fill="currentColor"
-							/>
-						</svg>
+						{ allowDisconnect && (
+							<svg
+								xmlns="http://www.w3.org/2000/svg"
+								width="24"
+								height="24"
+								viewBox="0 0 24 24"
+								role="presentation"
+							>
+								<path
+									d="M10.6004 6L9.40039 7L14.0004 12L9.40039 17L10.6004 18L16.0004 12L10.6004 6Z"
+									fill="currentColor"
+								/>
+							</svg>
+						) }
 					</Button>
 				</h4>
 				<div>

--- a/projects/packages/my-jetpack/_inc/components/connection-status-card/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/connection-status-card/index.tsx
@@ -1,6 +1,6 @@
 import { Text } from '@automattic/jetpack-components';
 import { CONNECTION_STORE_ID, ManageConnectionDialog } from '@automattic/jetpack-connection';
-import { currentUserCan } from '@automattic/jetpack-script-data';
+import { currentUserCan, isWoASite } from '@automattic/jetpack-script-data';
 import { Button } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
@@ -118,7 +118,11 @@ const ConnectionStatusCard: ConnectionStatusCardType = ( {
 
 	const state = useConnectionState();
 
-	const allowDisconnect = currentUserCan( 'manage_options' ) || isUserConnected;
+	// Prevent opening dialog for WoA sites when user is connection owner
+	const isConnectionOwner = userConnectionData.currentUser?.isMaster;
+	const shouldPreventDialog = isWoASite() && isConnectionOwner;
+	const allowDisconnect =
+		( currentUserCan( 'manage_options' ) || isUserConnected ) && ! shouldPreventDialog;
 
 	return (
 		<section className={ styles[ 'connection-status-card' ] }>

--- a/projects/packages/my-jetpack/_inc/components/connection-status-card/test/component.tsx
+++ b/projects/packages/my-jetpack/_inc/components/connection-status-card/test/component.tsx
@@ -62,6 +62,7 @@ const adminUserConnectionData = {
 			display_name: 'test',
 			email: 'email@example.com',
 		},
+		isMaster: false,
 	},
 };
 
@@ -100,6 +101,9 @@ beforeAll( () => {
 			current_user: {
 				capabilities: {},
 			},
+		},
+		site: {
+			host: 'standard',
 		},
 	};
 } );
@@ -233,6 +237,48 @@ describe( 'ConnectionStatusCard', () => {
 		} );
 	} );
 
+	describe( 'When on WoA site and user is connection owner', () => {
+		const setup = () => {
+			global.JetpackScriptData.site.host = 'woa';
+
+			const woaOwnerConnectionData = {
+				currentUser: {
+					permissions: {
+						manage_options: true,
+					},
+					wpcomUser: {
+						display_name: 'test',
+						email: 'email@example.com',
+					},
+					isMaster: true,
+				},
+			};
+
+			setConnectionStore( {
+				isRegistered: true,
+				isUserConnected: true,
+				hasConnectedOwner: true,
+				userConnectionData: woaOwnerConnectionData,
+			} );
+
+			return render(
+				<Providers>
+					<ConnectionStatusCard { ...testProps } />
+				</Providers>
+			);
+		};
+
+		afterEach( () => {
+			global.JetpackScriptData.site.host = 'standard';
+		} );
+
+		it( 'disables the manage connection button for WoA connection owners', () => {
+			setup();
+			const button = screen.getByRole( 'button', { name: /Site and account connected/ } );
+			expect( button ).toBeDisabled();
+		} );
+	} );
+
 	describe( 'When a user has account errors', () => {
 		const setup = () => {
 			const userDataWithErrors = {
@@ -244,6 +290,7 @@ describe( 'ConnectionStatusCard', () => {
 						display_name: 'test',
 						email: 'email@example.com',
 					},
+					isMaster: false,
 					possibleAccountErrors: {
 						mismatch: {
 							type: 'mismatch',

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/overview/content.tsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/overview/content.tsx
@@ -1,5 +1,5 @@
 import { Col, Container } from '@automattic/jetpack-components';
-import { currentUserCan, isWoASite } from '@automattic/jetpack-script-data';
+import { currentUserCan } from '@automattic/jetpack-script-data';
 import ConnectionsSection from '../../connections-section';
 import PlansSection from '../../plans-section';
 import ProductCardsSection from '../../product-cards-section';
@@ -32,7 +32,7 @@ export function OverviewContent() {
 						<PlansSection />
 					</Col>
 					<Col sm={ 4 } md={ 4 } lg={ 6 }>
-						{ ! isWoASite() && <ConnectionsSection /> }
+						<ConnectionsSection />
 					</Col>
 				</Container>
 			</div>

--- a/projects/packages/my-jetpack/changelog/update-at-connection-card
+++ b/projects/packages/my-jetpack/changelog/update-at-connection-card
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Connection: Display connection info on WoA sites


### PR DESCRIPTION
This PR removes logic for hiding ConnectionStatusCard on WoA sites and instead adds:

* logic to diasble ManageConnectionDialog for connection owners
* logic to remove option to disconnect site for all users

These changes are necessary to enhance the connection experience on WoA sites.

How things should look:

Connected owner (The title is grayed out as access to user and site connection management is disabled)
<img width="533" alt="Screenshot 2025-06-05 at 12 32 30" src="https://github.com/user-attachments/assets/37833b1a-a2eb-4047-8e20-f813057907aa" />

Other user connected (connection management link is working but the disconnect site option will be missing from the modal)
<img width="463" alt="Screenshot 2025-06-05 at 12 35 11" src="https://github.com/user-attachments/assets/4224b263-91a2-4c7c-9cc4-00b0fa5c795e" />

Other user disconnected. The connection management link is disabled as they have no account to disconnect and site connection management is not available.
<img width="470" alt="Screenshot 2025-06-05 at 12 36 57" src="https://github.com/user-attachments/assets/500a0c5b-da4d-4543-a8ad-b805aec2d75d" />

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes VULCAN-96

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Use the beta plugin to enable this PR on the WoA dev site.
* Make sure the connection owner can't access ManageConnectionDialog.
* Create a secondary admin and make sure they can connect and they can disconnect their account, but can't affect the site connection.
* Create a secondary lower role user and confirm they have the same experience as the secondary admin.

