### PR TITLE
Jetpack: update Creative Mail redirect

### DIFF
--- a/projects/packages/jitm/changelog/change-jetpack-forms-legacy-urls-update
+++ b/projects/packages/jitm/changelog/change-jetpack-forms-legacy-urls-update
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update nonce url handlers for install and activation

--- a/projects/packages/jitm/src/class-post-connection-jitm.php
+++ b/projects/packages/jitm/src/class-post-connection-jitm.php
@@ -113,7 +113,7 @@ class Post_Connection_JITM extends JITM {
 				array(
 					'creative-mail-action' => 'install',
 				),
-				admin_url( 'edit.php?post_type=feedback' )
+				admin_url( 'admin.php?page=jetpack-forms-admin' )
 			),
 			'creative-mail-install'
 		);
@@ -130,7 +130,7 @@ class Post_Connection_JITM extends JITM {
 				array(
 					'creative-mail-action' => 'activate',
 				),
-				admin_url( 'edit.php?post_type=feedback' )
+				admin_url( 'admin.php?page=jetpack-forms-admin' )
 			),
 			'creative-mail-install'
 		);

--- a/projects/plugins/jetpack/3rd-party/creative-mail.php
+++ b/projects/plugins/jetpack/3rd-party/creative-mail.php
@@ -41,7 +41,7 @@ function try_install() {
 	check_admin_referer( 'creative-mail-install' );
 
 	$result   = false;
-	$redirect = admin_url( 'edit.php?post_type=feedback' );
+	$redirect = admin_url( 'admin.php?page=jetpack-forms-admin' );
 
 	// Attempt to install and activate the plugin.
 	if ( current_user_can( 'activate_plugins' ) ) {

--- a/projects/plugins/jetpack/changelog/change-jetpack-forms-legacy-urls-update
+++ b/projects/plugins/jetpack/changelog/change-jetpack-forms-legacy-urls-update
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Forms: update redirect URL when Creative Mail installation fails


### PR DESCRIPTION


## Proposed changes:
This PR updates the Forms dashboard URL where Creative Mail redirects after an installation failure

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion


## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
TBD