### PR TITLE
Jetpack Forms: update masterbar menu registration

### DIFF
--- a/projects/packages/masterbar/changelog/change-jetpack-forms-legacy-urls-update-2
+++ b/projects/packages/masterbar/changelog/change-jetpack-forms-legacy-urls-update-2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Forms: update Feedback menu slug to aim at forms inbox

--- a/projects/packages/masterbar/src/admin-menu/class-jetpack-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-jetpack-admin-menu.php
@@ -155,7 +155,7 @@ class Jetpack_Admin_Menu extends Admin_Menu {
 			return;
 		}
 
-		$slug       = 'edit.php?post_type=' . $post_type;
+		$slug       = 'admin.php?page=jetpack-forms';
 		$name       = __( 'Feedback', 'jetpack-masterbar' );
 		$capability = $ptype_obj->cap->edit_posts;
 		$icon       = $ptype_obj->menu_icon;

--- a/projects/packages/masterbar/tests/php/Jetpack_Admin_Menu_Test.php
+++ b/projects/packages/masterbar/tests/php/Jetpack_Admin_Menu_Test.php
@@ -193,7 +193,7 @@ class Jetpack_Admin_Menu_Test extends TestCase {
 
 		static::$admin_menu->add_feedback_menu();
 
-		$this->assertSame( 'edit.php?post_type=feedback', array_shift( $menu )[2] );
+		$this->assertSame( 'admin.php?page=jetpack-forms', array_shift( $menu )[2] );
 	}
 
 	/**


### PR DESCRIPTION


## Proposed changes:
This PR updates the menu registration removing the menu Feedback and adding Jetpack > Forms submenu

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion


## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
TBD