### PR TITLE
CRM: Switch font-awesome dependency to pnpm instead of Composer

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4367,6 +4367,9 @@ importers:
       daterangepicker:
         specifier: 2.1.25
         version: 2.1.25
+      font-awesome:
+        specifier: 4.7.0
+        version: 4.7.0
       glob:
         specifier: 11.0.0
         version: 11.0.0
@@ -11175,6 +11178,10 @@ packages:
     peerDependenciesMeta:
       debug:
         optional: true
+
+  font-awesome@4.7.0:
+    resolution: {integrity: sha512-U6kGnykA/6bFmg1M/oT9EkFeIYv7JlX3bozwQJWiiLz6L0w3F5vBVPxHlwyX/vtNq1ckcpRKOB9f2Qal/VtFpg==}
+    engines: {node: '>=0.10.3'}
 
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
@@ -24329,6 +24336,8 @@ snapshots:
   follow-redirects@1.15.9(debug@4.4.1):
     optionalDependencies:
       debug: 4.4.1
+
+  font-awesome@4.7.0: {}
 
   for-each@0.3.5:
     dependencies:

--- a/projects/plugins/crm/.gitattributes
+++ b/projects/plugins/crm/.gitattributes
@@ -9,9 +9,6 @@
 /vendor/composer/**                             production-include
 /vendor/jetpack-autoloader/**                   production-include
 /vendor/dompdf/**                               production-include
-/vendor/fortawesome/font-awesome/file           production-include
-/vendor/fortawesome/font-awesome/css/**         production-include
-/vendor/fortawesome/font-awesome/fonts/**       production-include
 /vendor/phenx/**                                production-include
 /vendor/masterminds/html5/**                    production-include
 /vendor/sabberworm/php-css-parser/**            production-include

--- a/projects/plugins/crm/changelog/fix-crm-switch_font-awesome_to_pnpm
+++ b/projects/plugins/crm/changelog/fix-crm-switch_font-awesome_to_pnpm
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Use font-awesome from pnpm instead of composer.

--- a/projects/plugins/crm/composer.json
+++ b/projects/plugins/crm/composer.json
@@ -59,8 +59,7 @@
 		"automattic/jetpack-autoloader": "@dev",
 		"automattic/jetpack-composer-plugin": "@dev",
 		"automattic/woocommerce": "^3.1",
-		"dompdf/dompdf": "^2.0",
-		"fortawesome/font-awesome": "4.7.0"
+		"dompdf/dompdf": "^2.0"
 	},
 	"repositories": [
 		{

--- a/projects/plugins/crm/composer.lock
+++ b/projects/plugins/crm/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "59b422a0bf3608880ec91402b73b9a71",
+    "content-hash": "10648b2e74e2b57260d08c23a3ad4195",
     "packages": [
         {
             "name": "automattic/jetpack-assets",
@@ -441,58 +441,6 @@
                 "source": "https://github.com/dompdf/dompdf/tree/v2.0.8"
             },
             "time": "2024-04-29T13:06:17+00:00"
-        },
-        {
-            "name": "fortawesome/font-awesome",
-            "version": "v4.7.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/FortAwesome/Font-Awesome.git",
-                "reference": "a8386aae19e200ddb0f6845b5feeee5eb7013687"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/FortAwesome/Font-Awesome/zipball/a8386aae19e200ddb0f6845b5feeee5eb7013687",
-                "reference": "a8386aae19e200ddb0f6845b5feeee5eb7013687",
-                "shasum": ""
-            },
-            "require-dev": {
-                "jekyll": "1.0.2",
-                "lessc": "1.4.2"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "4.6.x-dev"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "OFL-1.1",
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Dave Gandy",
-                    "email": "dave@fontawesome.io",
-                    "homepage": "http://twitter.com/davegandy",
-                    "role": "Developer"
-                }
-            ],
-            "description": "The iconic font and CSS framework",
-            "homepage": "http://fontawesome.io/",
-            "keywords": [
-                "FontAwesome",
-                "awesome",
-                "bootstrap",
-                "font",
-                "icon"
-            ],
-            "support": {
-                "issues": "https://github.com/FortAwesome/Font-Awesome/issues",
-                "source": "https://github.com/FortAwesome/Font-Awesome/tree/v4.7.0"
-            },
-            "time": "2016-10-24T15:52:54+00:00"
         },
         {
             "name": "masterminds/html5",

--- a/projects/plugins/crm/includes/ZeroBSCRM.ScriptsStyles.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.ScriptsStyles.php
@@ -98,7 +98,7 @@ function zeroBSCRM_scriptStyles_initStyleRegister(){
 			wp_register_script( 'jpcrm-jquery-modal', plugins_url( '/build/lib/jquery-modal/jquery.modal.min.js', ZBS_ROOTFILE ), array( 'jquery' ), $zbs::VERSION );
 
 			// font awesome
-			wp_register_style( 'jpcrm-fontawesome', plugins_url( '/vendor/fortawesome/font-awesome/css/font-awesome' . wp_scripts_get_suffix() . '.css', ZBS_ROOTFILE ), array(), $zbs::VERSION );
+			wp_register_style( 'jpcrm-fontawesome', plugins_url( '/build/lib/font-awesome/css/font-awesome.min.css', ZBS_ROOTFILE ), array(), $zbs::VERSION );
 
 			// chart.js
 			wp_register_script( 'zerobscrmchartjs', plugins_url( '/build/lib/chart.js/chart.min.js', ZBS_ROOTFILE ), array( 'jquery' ), $zbs::VERSION );

--- a/projects/plugins/crm/modules/portal/class-client-portal.php
+++ b/projects/plugins/crm/modules/portal/class-client-portal.php
@@ -118,7 +118,7 @@ class Client_Portal {
 		global $zbs;
 
 		wp_enqueue_style( 'zbs-portal', plugins_url( '/css/jpcrm-public-portal' . wp_scripts_get_suffix() . '.css', __FILE__ ), array(), $zbs::VERSION );
-		wp_enqueue_style( 'zbs-fa', ZEROBSCRM_URL . 'vendor/fortawesome/font-awesome/css/font-awesome' . wp_scripts_get_suffix() . '.css', array(), $zbs::VERSION );
+		wp_enqueue_style( 'zbs-fa', ZEROBSCRM_URL . 'build/lib/font-awesome/css/font-awesome.min.css', array(), $zbs::VERSION );
 
 		// This do_action call was left here for compatibility purposes (legacy).
 		do_action('zbs_enqueue_portal', 'zeroBS_portal_enqueue_stuff');

--- a/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-my-account-integration.php
+++ b/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-my-account-integration.php
@@ -168,7 +168,7 @@ class Woo_Sync_My_Account_Integration {
 	public function register_styles_scripts() {
 		global $zbs;
 		wp_register_style( 'jpcrm-woo-sync-my-account', plugins_url( '/css/jpcrm-woo-sync-my-account' . wp_scripts_get_suffix() . '.css', JPCRM_WOO_SYNC_ROOT_FILE ), array(), $zbs::VERSION );
-		wp_register_style( 'jpcrm-woo-sync-fa', plugins_url( '/vendor/fortawesome/font-awesome/css/font-awesome' . wp_scripts_get_suffix() . '.css', ZBS_ROOTFILE ), array(), $zbs::VERSION );
+		wp_register_style( 'jpcrm-woo-sync-fa', plugins_url( '/build/lib/font-awesome/css/font-awesome.min.css', ZBS_ROOTFILE ), array(), $zbs::VERSION );
 	}
 
 	/**

--- a/projects/plugins/crm/package.json
+++ b/projects/plugins/crm/package.json
@@ -51,6 +51,7 @@
 		"copy-webpack-plugin": "11.0.0",
 		"css-loader": "6.11.0",
 		"daterangepicker": "2.1.25",
+		"font-awesome": "4.7.0",
 		"glob": "11.0.0",
 		"hopscotch": "0.3.1",
 		"jest": "29.7.0",

--- a/projects/plugins/crm/webpack.config.js
+++ b/projects/plugins/crm/webpack.config.js
@@ -340,6 +340,16 @@ module.exports = [
 						from: path.resolve( __dirname, 'node_modules/hopscotch/dist/css/hopscotch.min.css' ),
 						to: `${ buildLibPath }/hopscotch/`,
 					},
+					// Used by extensively as a font icon
+					{
+						from: path.resolve( __dirname, 'node_modules/font-awesome/css/font-awesome.min.css' ),
+						to: `${ buildLibPath }/font-awesome/css`,
+					},
+					// Used by extensively as a font icon
+					{
+						from: path.resolve( __dirname, 'node_modules/font-awesome/fonts' ),
+						to: `${ buildLibPath }/font-awesome/fonts`,
+					},
 					// Used extensively for alerts
 					{
 						from: path.resolve( __dirname, 'node_modules/sweetalert2/dist/sweetalert2.min.js' ),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

In #43464 we added font-awesome as a dependency via Composer. This meant we had to include a few more files than needed in the `vendor` folder, and we had to use a hack in the `.gitattributes` file.

Now that we have a simple mechanism in the webpack config to copy just the files we need, let's use that and pnpm.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

The bell icon in the upper right should still load:
![image](https://github.com/user-attachments/assets/e111951d-c7f5-4b23-98bc-e328f28af5c9)


