### PR TITLE
Forms: account for missing placeholder when transforming input and options fields to select dropdown

### DIFF
--- a/projects/packages/forms/src/blocks/shared/settings/transforms.js
+++ b/projects/packages/forms/src/blocks/shared/settings/transforms.js
@@ -129,7 +129,6 @@ const createTextFieldInnerBlocks = ( blockName, existingInnerBlocks = [] ) => {
 
 	const existingLabel = existingInnerBlocks.find( block => block.name === 'jetpack/label' );
 	const existingInput = existingInnerBlocks.find( block => block.name === 'jetpack/input' );
-	const existingInputAttributes = existingInput?.attributes || {};
 
 	/**
 	 * When transforming to a select field, add a default placeholder in a non mutating way
@@ -143,6 +142,7 @@ const createTextFieldInnerBlocks = ( blockName, existingInnerBlocks = [] ) => {
 	 * not add the class because it's trying to honor the placeholder attribute,
 	 * BUT adds a default placeholder anyway.
 	 */
+	const existingInputAttributes = existingInput?.attributes ? { ...existingInput?.attributes } : {}; // Destructure the attributes to avoid mutating the original block.
 	if ( 'jetpack/field-select' === blockName ) {
 		existingInputAttributes.placeholder =
 			existingInputAttributes?.placeholder || __( 'Select one option', 'jetpack-forms' );

--- a/projects/packages/forms/src/blocks/shared/settings/transforms.js
+++ b/projects/packages/forms/src/blocks/shared/settings/transforms.js
@@ -129,6 +129,24 @@ const createTextFieldInnerBlocks = ( blockName, existingInnerBlocks = [] ) => {
 
 	const existingLabel = existingInnerBlocks.find( block => block.name === 'jetpack/label' );
 	const existingInput = existingInnerBlocks.find( block => block.name === 'jetpack/input' );
+	const existingInputAttributes = existingInput?.attributes || {};
+
+	/**
+	 * When transforming to a select field, add a default placeholder in a non mutating way
+	 * to the input block if none exists.
+	 *
+	 * This is because the input block is created by the textFieldTransforms,
+	 * and we want to avoid mutating the original block.
+	 * The select block's edit.js checks for the placeholder attribute on the input block,
+	 * and add the `has-placeholder` class to the field if it exists.
+	 * However if the incoming transformed block doesn't have a placeholder, the edit.js will
+	 * not add the class because it's trying to honor the placeholder attribute,
+	 * BUT adds a default placeholder anyway.
+	 */
+	if ( 'jetpack/field-select' === blockName ) {
+		existingInputAttributes.placeholder =
+			existingInputAttributes?.placeholder || __( 'Select one option', 'jetpack-forms' );
+	}
 
 	return [
 		createBlock( 'jetpack/label', {
@@ -137,7 +155,7 @@ const createTextFieldInnerBlocks = ( blockName, existingInnerBlocks = [] ) => {
 			defaultLabel: config.defaultLabel,
 		} ),
 		createBlock( 'jetpack/input', {
-			...( existingInput?.attributes || {} ),
+			...existingInputAttributes,
 			type: config.type,
 		} ),
 	];
@@ -262,34 +280,7 @@ const transforms = {
 						...getFieldAttributes( attributes ),
 						options: optionLabels.length ? optionLabels : [ '' ],
 					},
-					createTextFieldInnerBlocks(
-						'jetpack/field-select',
-						/**
-						 * When transforming to a select field, add a default placeholder in a non mutating way
-						 * to the input block if none exists.
-						 *
-						 * This is because the input block is created by the textFieldTransforms,
-						 * and we want to avoid mutating the original block.
-						 * The select block's edit.js checks for the placeholder attribute on the input block,
-						 * and add the `has-placeholder` class to the field if it exists.
-						 * However if the incoming transformed block doesn't have a placeholder, the edit.js will
-						 * not add the class because it's trying to honor the placeholder attribute,
-						 * BUT adds a default placeholder anyway.
-						 */
-						innerBlocks.map( block => {
-							if ( block?.name === 'jetpack/input' ) {
-								return {
-									...block,
-									attributes: {
-										...( block?.attributes || {} ),
-										placeholder:
-											block?.attributes?.placeholder || __( 'Select one option', 'jetpack-forms' ),
-									},
-								};
-							}
-							return block;
-						} )
-					)
+					createTextFieldInnerBlocks( 'jetpack/field-select', innerBlocks )
 				);
 			},
 		},


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes JETPACK-514

## Proposed changes:

This PR implements the original approach applied in https://github.com/Automattic/jetpack/pull/43721 by adding a default placeholder to the select field during transformation.

Why?

The approach does not work when transforming from options blocks.

Adding the default placeholder in the transform callback is too early. We need to add the placeholder _after_ the inner block conversion to guarantee that there's an input block to update.

## Testing instructions:

Insert a form and switch to the Outline style or Animated style

In the editor, transform  an existing options block  (e.g., multi checkbox) to a dropdown field.

Save.

Ensure that the has-placeholder className appears on the field and the label doesn't sit in the middle of the placeholder.

<img width="702" alt="Screenshot 2025-06-05 at 9 35 35 am" src="https://github.com/user-attachments/assets/de211ca5-b331-4197-9164-5c80dc8d4c23" />

Check that attribute object mutation doesn't occur (see comment https://github.com/Automattic/jetpack/pull/43721#discussion_r2122445757) but transforming other inputs, e.g., from name to number.

