### PR TITLE
Forms: Fix button style checkbox alignment

### DIFF
--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -491,6 +491,15 @@
 
 	.jetpack-field-option .jetpack-option__type {
 		color: inherit;
+
+		&::before {
+
+			/*
+			 * Options typically have a transform applied to line the checkbox/radio with the label.
+			 * This is not needed for the button style.
+			 */
+			transform: unset !important;
+		}
 	}
 
 	.wp-block-jetpack-field-option-radio {

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -977,6 +977,15 @@ on production builds, the attributes are being reordered, causing side-effects
 	font-family: var(--wp--preset--font-family--body);
 }
 
+.contact-form .grunion-field-wrap.is-style-button-wrap .grunion-field.checkbox-multiple {
+
+	/*
+	* Options typically have a transform applied to line the checkbox/radio with the label.
+	* This is not needed for the button style.
+	*/
+	transform: unset !important;
+}
+
 .contact-form .grunion-field-wrap.is-style-button-wrap .grunion-field.checkbox-multiple:focus {
 	outline-width: 0; /* focus style defined on parent */
 }


### PR DESCRIPTION
## Proposed changes:
Fixes the alignment of the checkbox and label for multiple choice option blocks when the Button style is used.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
1. Add a form
2. Add a multiple choice block to the form
3. Add some options
4. Check that the checkboxes and labels are aligned properly in the editor and on the frontend
5. Select the multiple choice block and switch it to the Button block style variation
6. Check that the checkboxes and labels are aligned properly in the editor and on the frontend

### Expected
<img width="295" alt="Screenshot 2025-06-05 at 11 15 10 am" src="https://github.com/user-attachments/assets/2cd7ac5a-3004-4d5f-bb99-8f7820056f7b" />

### Before this PR
<img width="307" alt="Screenshot 2025-06-05 at 11 15 54 am" src="https://github.com/user-attachments/assets/1173ae35-074f-4728-a9e4-7c53da196867" />
