### PR TITLE
CHARTS-10: Add support for date literals in LineChart component

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -364,6 +364,9 @@ importers:
       clsx:
         specifier: 2.1.1
         version: 2.1.1
+      date-fns:
+        specifier: 4.1.0
+        version: 4.1.0
       tslib:
         specifier: 2.5.0
         version: 2.5.0
@@ -10270,6 +10273,9 @@ packages:
 
   date-fns@3.6.0:
     resolution: {integrity: sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==}
+
+  date-fns@4.1.0:
+    resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
 
   daterangepicker@2.1.25:
     resolution: {integrity: sha512-8qSYdsolahhBpfoGFcVOmKXnpy0MpbgT3J4YeWG/oPgyApnEIUbIugtS6ryJdQFF+rZ+tUYbRXBnOe4QK8jGnA==}
@@ -23241,6 +23247,8 @@ snapshots:
       '@babel/runtime': 7.27.4
 
   date-fns@3.6.0: {}
+
+  date-fns@4.1.0: {}
 
   daterangepicker@2.1.25:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -365,7 +365,7 @@ importers:
         specifier: 2.1.1
         version: 2.1.1
       date-fns:
-        specifier: 4.1.0
+        specifier: ^4.1.0
         version: 4.1.0
       tslib:
         specifier: 2.5.0

--- a/projects/js-packages/charts/changelog/update-allow-date-literals
+++ b/projects/js-packages/charts/changelog/update-allow-date-literals
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Support date literals

--- a/projects/js-packages/charts/package.json
+++ b/projects/js-packages/charts/package.json
@@ -63,7 +63,7 @@
 		"@visx/tooltip": "^3.8.0",
 		"@visx/xychart": "3.12.0",
 		"clsx": "2.1.1",
-		"date-fns": "4.1.0",
+		"date-fns": "^4.1.0",
 		"tslib": "2.5.0"
 	},
 	"devDependencies": {

--- a/projects/js-packages/charts/package.json
+++ b/projects/js-packages/charts/package.json
@@ -63,6 +63,7 @@
 		"@visx/tooltip": "^3.8.0",
 		"@visx/xychart": "3.12.0",
 		"clsx": "2.1.1",
+		"date-fns": "4.1.0",
 		"tslib": "2.5.0"
 	},
 	"devDependencies": {

--- a/projects/js-packages/charts/src/components/line-chart/line-chart.tsx
+++ b/projects/js-packages/charts/src/components/line-chart/line-chart.tsx
@@ -144,14 +144,12 @@ const LineChart: FC< LineChartProps > = ( {
 	const dataSorted = useMemo(
 		() =>
 			data
-				.map( series => {
-					return {
-						...series,
-						data: series.data.map( point => ( {
-							...point,
-							date: point.date ? point.date : parseAsLocalDate( point.dateString ),
-						} ) ),
-					};
+				.map( series => ( {
+					...series,
+					data: series.data.map( point => ( {
+						...point,
+						date: point.date ? point.date : parseAsLocalDate( point.dateString ),
+					} ) ),
 				} )
 				.map( series => ( {
 					...series,

--- a/projects/js-packages/charts/src/components/line-chart/line-chart.tsx
+++ b/projects/js-packages/charts/src/components/line-chart/line-chart.tsx
@@ -143,16 +143,15 @@ const LineChart: FC< LineChartProps > = ( {
 
 	const dataSorted = useMemo(
 		() =>
-			data
-				.map( series => ( {
-					...series,
-					data: series.data
-						.map( point => ( {
-							...point,
-							date: point.date ? point.date : parseAsLocalDate( point.dateString ),
-						} ) )
-						.sort( ( a, b ) => a.date.getTime() - b.date.getTime() ),
-				} ) )
+			data.map( series => ( {
+				...series,
+				data: series.data
+					.map( point => ( {
+						...point,
+						date: point.date ? point.date : parseAsLocalDate( point.dateString ),
+					} ) )
+					.sort( ( a, b ) => a.date.getTime() - b.date.getTime() ),
+			} ) ),
 		[ data ]
 	);
 

--- a/projects/js-packages/charts/src/components/line-chart/line-chart.tsx
+++ b/projects/js-packages/charts/src/components/line-chart/line-chart.tsx
@@ -6,6 +6,7 @@ import clsx from 'clsx';
 import { useId, useMemo } from 'react';
 import { useXYChartTheme, useChartTheme } from '../../providers/theme/theme-provider';
 import { Legend } from '../legend';
+import { parseAsLocalDate } from '../shared/date-parsing';
 import { useChartMargin } from '../shared/use-chart-margin';
 import { withResponsive } from '../shared/with-responsive';
 import styles from './line-chart.module.scss';
@@ -142,10 +143,20 @@ const LineChart: FC< LineChartProps > = ( {
 
 	const dataSorted = useMemo(
 		() =>
-			data.map( series => ( {
-				...series,
-				data: series.data.sort( ( a, b ) => a.date.getTime() - b.date.getTime() ),
-			} ) ),
+			data
+				.map( series => {
+					return {
+						...series,
+						data: series.data.map( point => ( {
+							...point,
+							date: typeof point.date === 'string' ? parseAsLocalDate( point.date ) : point.date,
+						} ) ),
+					};
+				} )
+				.map( series => ( {
+					...series,
+					data: series.data.sort( ( a, b ) => a.date.getTime() - b.date.getTime() ),
+				} ) ),
 		[ data ]
 	);
 

--- a/projects/js-packages/charts/src/components/line-chart/line-chart.tsx
+++ b/projects/js-packages/charts/src/components/line-chart/line-chart.tsx
@@ -149,7 +149,7 @@ const LineChart: FC< LineChartProps > = ( {
 						...series,
 						data: series.data.map( point => ( {
 							...point,
-							date: typeof point.date === 'string' ? parseAsLocalDate( point.date ) : point.date,
+							date: point.date ? point.date : parseAsLocalDate( point.dateString ),
 						} ) ),
 					};
 				} )

--- a/projects/js-packages/charts/src/components/line-chart/line-chart.tsx
+++ b/projects/js-packages/charts/src/components/line-chart/line-chart.tsx
@@ -150,7 +150,7 @@ const LineChart: FC< LineChartProps > = ( {
 						...point,
 						date: point.date ? point.date : parseAsLocalDate( point.dateString ),
 					} ) ),
-				} )
+				} ) )
 				.map( series => ( {
 					...series,
 					data: series.data.sort( ( a, b ) => a.date.getTime() - b.date.getTime() ),

--- a/projects/js-packages/charts/src/components/line-chart/line-chart.tsx
+++ b/projects/js-packages/charts/src/components/line-chart/line-chart.tsx
@@ -146,15 +146,13 @@ const LineChart: FC< LineChartProps > = ( {
 			data
 				.map( series => ( {
 					...series,
-					data: series.data.map( point => ( {
-						...point,
-						date: point.date ? point.date : parseAsLocalDate( point.dateString ),
-					} ) ),
+					data: series.data
+						.map( point => ( {
+							...point,
+							date: point.date ? point.date : parseAsLocalDate( point.dateString ),
+						} ) )
+						.sort( ( a, b ) => a.date.getTime() - b.date.getTime() ),
 				} ) )
-				.map( series => ( {
-					...series,
-					data: series.data.sort( ( a, b ) => a.date.getTime() - b.date.getTime() ),
-				} ) ),
 		[ data ]
 	);
 

--- a/projects/js-packages/charts/src/components/line-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/components/line-chart/stories/index.stories.tsx
@@ -368,7 +368,6 @@ export const DateStringFormats: StoryObj< typeof LineChart > = {
 					},
 				] }
 				withGradientFill={ false }
-				showLegend={ true }
 			/>
 		);
 	},

--- a/projects/js-packages/charts/src/components/line-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/components/line-chart/stories/index.stories.tsx
@@ -349,3 +349,68 @@ BrokenLine.parameters = {
 		},
 	},
 };
+
+export const DateStringFormats: StoryObj< typeof LineChart > = {
+	render: () => {
+		const dateStringData = [
+			{
+				label: 'String Dates',
+				data: [
+					{ date: '2024-01-01', value: 10, label: 'Jan 1' },
+					{ date: '2024-01-02', value: 20, label: 'Jan 2' },
+					{ date: '2024-01-03', value: 15, label: 'Jan 3' },
+					{ date: '2024-01-04', value: 25, label: 'Jan 4' },
+					{ date: '2024-01-05 00:00:00', value: 30, label: 'Jan 5' },
+				],
+				options: {},
+			},
+			{
+				label: 'Mixed Dates',
+				data: [
+					{ date: new Date( '2024-01-01' ), value: 5, label: 'Jan 1' },
+					{ date: '2024-01-02', value: 8, label: 'Jan 2' },
+					{ date: new Date( '2024-01-03' ), value: 12, label: 'Jan 3' },
+					{ date: '2024-01-04', value: 15, label: 'Jan 4' },
+					{ date: new Date( '2024-01-05' ), value: 18, label: 'Jan 5' },
+				],
+				options: {},
+			},
+		];
+
+		return (
+			<div style={ { display: 'grid', gap: '2rem', gridTemplateColumns: 'repeat(2, 1fr)' } }>
+				<div>
+					<h3>String Date Formats</h3>
+					<LineChart
+						width={ 300 }
+						height={ 200 }
+						data={ [ dateStringData[ 0 ] ] }
+						withGradientFill={ false }
+						showLegend={ true }
+					/>
+				</div>
+				<div>
+					<h3>Mixed Date Types</h3>
+					<LineChart
+						width={ 300 }
+						height={ 200 }
+						data={ [ dateStringData[ 1 ] ] }
+						withGradientFill={ false }
+						showLegend={ true }
+					/>
+				</div>
+			</div>
+		);
+	},
+	parameters: {
+		docs: {
+			description: {
+				story:
+					"Demonstrates the line chart's ability to handle various date string formats and mixed date types. All dates are converted to start of day in local timezone. The chart can process:\n" +
+					'- Simple date strings (YYYY-MM-DD)\n' +
+					'- Date with time (YYYY-MM-DD 00:00:00)\n' +
+					'- Mixed Date objects and date strings in the same series',
+			},
+		},
+	},
+};

--- a/projects/js-packages/charts/src/components/line-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/components/line-chart/stories/index.stories.tsx
@@ -352,64 +352,37 @@ BrokenLine.parameters = {
 
 export const DateStringFormats: StoryObj< typeof LineChart > = {
 	render: () => {
-		const dateStringData = [
-			{
-				label: 'String Dates',
-				data: [
-					{ date: '2024-01-01', value: 10, label: 'Jan 1' },
-					{ date: '2024-01-02', value: 20, label: 'Jan 2' },
-					{ date: '2024-01-03', value: 15, label: 'Jan 3' },
-					{ date: '2024-01-04', value: 25, label: 'Jan 4' },
-					{ date: '2024-01-05 00:00:00', value: 30, label: 'Jan 5' },
-				],
-				options: {},
-			},
-			{
-				label: 'Mixed Dates',
-				data: [
-					{ date: new Date( '2024-01-01' ), value: 5, label: 'Jan 1' },
-					{ date: '2024-01-02', value: 8, label: 'Jan 2' },
-					{ date: new Date( '2024-01-03' ), value: 12, label: 'Jan 3' },
-					{ date: '2024-01-04', value: 15, label: 'Jan 4' },
-					{ date: new Date( '2024-01-05' ), value: 18, label: 'Jan 5' },
-				],
-				options: {},
-			},
-		];
-
 		return (
-			<div style={ { display: 'grid', gap: '2rem', gridTemplateColumns: 'repeat(2, 1fr)' } }>
-				<div>
-					<h3>String Date Formats</h3>
-					<LineChart
-						width={ 300 }
-						height={ 200 }
-						data={ [ dateStringData[ 0 ] ] }
-						withGradientFill={ false }
-						showLegend={ true }
-					/>
-				</div>
-				<div>
-					<h3>Mixed Date Types</h3>
-					<LineChart
-						width={ 300 }
-						height={ 200 }
-						data={ [ dateStringData[ 1 ] ] }
-						withGradientFill={ false }
-						showLegend={ true }
-					/>
-				</div>
-			</div>
+			<LineChart
+				data={ [
+					{
+						label: 'String Dates',
+						data: [
+							{ dateString: '2024-01-01', value: 10 },
+							{ dateString: '2024-01-02', value: 20 },
+							{ dateString: '2024-01-03 00:00:00', value: 15 },
+							{ dateString: '2024-01-04', value: 25 },
+							{ dateString: '2024-01-05 00:00', value: 30 },
+						],
+						options: {},
+					},
+				] }
+				withGradientFill={ false }
+				showLegend={ true }
+			/>
 		);
 	},
 	parameters: {
 		docs: {
 			description: {
 				story:
-					"Demonstrates the line chart's ability to handle various date string formats and mixed date types. All dates are converted to start of day in local timezone. The chart can process:\n" +
+					"Demonstrates the line chart's ability to handle various date string formats and mixed date types. All dates are converted to local timezone. The chart can process:\n" +
 					'- Simple date strings (YYYY-MM-DD)\n' +
 					'- Date with time (YYYY-MM-DD 00:00:00)\n' +
-					'- Mixed Date objects and date strings in the same series',
+					'- Date with time (YYYY-MM-DD 00:00)\n' +
+					'- ISO format (YYYY-MM-DDT00:00:00)\n' +
+					'- UTC format (YYYY-MM-DDT00:00:00Z)\n' +
+					'- Timezone offset (YYYY-MM-DDT00:00:00±HH:mm)\n',
 			},
 		},
 	},

--- a/projects/js-packages/charts/src/components/shared/date-parsing.ts
+++ b/projects/js-packages/charts/src/components/shared/date-parsing.ts
@@ -1,5 +1,5 @@
 /**
- * Simplified date parsing utilities for local timezone handling.
+ * Simplified date parsing utilities for local timezone handling
  *
  * This module provides utilities for parsing various date string formats and converting
  * them to local timezone dates. For formats without timezone info, they're treated as local.
@@ -17,7 +17,9 @@
  * Supported Formats:
  * - YYYY-MM-DD (treated as local)
  * - YYYY-MM-DD HH:mm:ss (treated as local)
+ * - YYYY-MM-DD HH:mm (treated as local)
  * - YYYY-MM-DDTHH:mm:ss (treated as local)
+ * - YYYY-MM-DDTHH:mm (treated as local)
  * - YYYY-MM-DDTHH:mm:ssZ (converted to local)
  * - YYYY-MM-DDTHH:mm:ss±HH:mm (converted to local)
  *
@@ -25,6 +27,7 @@
  * ```typescript
  * parseAsLocalDate("2025-01-01");                    // Local timezone
  * parseAsLocalDate("2025-01-01 14:30:00");           // Local timezone
+ * parseAsLocalDate("2025-01-01 14:30");              // Local timezone
  * parseAsLocalDate("2025-01-01T14:30:00Z");          // UTC 14:30 → Local equivalent
  * parseAsLocalDate("2025-01-01T14:30:00+05:00");     // +05:00 14:30 → Local equivalent
  * ```
@@ -42,7 +45,7 @@ interface DateComponents {
 /**
  * Checks if a date string contains timezone information
  * @param {string} dateString - The date string to check for timezone information
- * @return {boolean} True if the date string contains timezone information, false otherwise
+ * @return {boolean} True if the date string contains timezone information (Z or ±HH:mm format), false otherwise
  */
 const hasTimezone = ( dateString: string ): boolean => {
 	return /T.*[Z]$|T.*[+-]\d{2}:?\d{2}$/.test( dateString );
@@ -51,12 +54,12 @@ const hasTimezone = ( dateString: string ): boolean => {
 /**
  * Parses date string components into an object (for naive date strings)
  * @param {string} dateString - The date string to parse into components
- * @return {DateComponents | null} Object containing date components or null if parsing fails
+ * @return {DateComponents | null} Object containing parsed date components or null if parsing fails
  */
 const parseToComponents = ( dateString: string ): DateComponents | null => {
-	// Handle ISO format without timezone: "YYYY-MM-DDTHH:mm:ss" or "YYYY-MM-DDTHH:mm:ss.SSS"
+	// Handle ISO format without timezone: "YYYY-MM-DDTHH:mm:ss", "YYYY-MM-DDTHH:mm:ss.SSS", or "YYYY-MM-DDTHH:mm"
 	const isoMatch = dateString.match(
-		/^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.\d{3})?$/
+		/^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})(?::(\d{2}))?(?:\.\d{3})?$/
 	);
 	if ( isoMatch ) {
 		return {
@@ -65,12 +68,12 @@ const parseToComponents = ( dateString: string ): DateComponents | null => {
 			day: parseInt( isoMatch[ 3 ], 10 ),
 			hour: parseInt( isoMatch[ 4 ], 10 ),
 			minute: parseInt( isoMatch[ 5 ], 10 ),
-			second: parseInt( isoMatch[ 6 ], 10 ),
+			second: parseInt( isoMatch[ 6 ] || '0', 10 ),
 		};
 	}
 
-	// Handle space-separated format: "YYYY-MM-DD HH:mm:ss"
-	const spaceMatch = dateString.match( /^(\d{4})-(\d{2})-(\d{2})\s+(\d{2}):(\d{2}):(\d{2})$/ );
+	// Handle space-separated format: "YYYY-MM-DD HH:mm:ss" or "YYYY-MM-DD HH:mm"
+	const spaceMatch = dateString.match( /^(\d{4})-(\d{2})-(\d{2})\s+(\d{2}):(\d{2})(?::(\d{2}))?$/ );
 	if ( spaceMatch ) {
 		return {
 			year: parseInt( spaceMatch[ 1 ], 10 ),
@@ -78,7 +81,7 @@ const parseToComponents = ( dateString: string ): DateComponents | null => {
 			day: parseInt( spaceMatch[ 3 ], 10 ),
 			hour: parseInt( spaceMatch[ 4 ], 10 ),
 			minute: parseInt( spaceMatch[ 5 ], 10 ),
-			second: parseInt( spaceMatch[ 6 ], 10 ),
+			second: parseInt( spaceMatch[ 6 ] || '0', 10 ),
 		};
 	}
 
@@ -101,7 +104,7 @@ const parseToComponents = ( dateString: string ): DateComponents | null => {
 /**
  * Validates date component values
  * @param {DateComponents} components - The date components to validate
- * @return {boolean} True if all components are valid, false otherwise
+ * @return {boolean} True if all components have valid values, false otherwise
  */
 const isValidComponents = ( components: DateComponents ): boolean => {
 	return (
@@ -127,7 +130,9 @@ const isValidComponents = ( components: DateComponents ): boolean => {
  * Supports:
  * - YYYY-MM-DD (local)
  * - YYYY-MM-DD HH:mm:ss (local)
+ * - YYYY-MM-DD HH:mm (local)
  * - YYYY-MM-DDTHH:mm:ss (local)
+ * - YYYY-MM-DDTHH:mm (local)
  * - YYYY-MM-DDTHH:mm:ssZ (UTC → local)
  * - YYYY-MM-DDTHH:mm:ss±HH:mm (offset → local)
  * @param {string} dateString - The date string to parse

--- a/projects/js-packages/charts/src/components/shared/date-parsing.ts
+++ b/projects/js-packages/charts/src/components/shared/date-parsing.ts
@@ -1,0 +1,172 @@
+/**
+ * Simplified date parsing utilities for local timezone handling.
+ *
+ * This module provides utilities for parsing various date string formats and converting
+ * them to local timezone dates. For formats without timezone info, they're treated as local.
+ * For formats with timezone info, they're converted to the equivalent local time.
+ *
+ * Note: And specifically it prevents format `YYYY-MM-DD` being parsed as UTC date.
+ * If we need more functionalities in the future, we should consider using the `date-fns` library.
+ *
+ * Key Features:
+ * - All parsed dates are in local timezone
+ * - Converts timezone-aware strings to local equivalent
+ * - Robust input validation and error handling
+ * - TypeScript type safety
+ *
+ * Supported Formats:
+ * - YYYY-MM-DD (treated as local)
+ * - YYYY-MM-DD HH:mm:ss (treated as local)
+ * - YYYY-MM-DDTHH:mm:ss (treated as local)
+ * - YYYY-MM-DDTHH:mm:ssZ (converted to local)
+ * - YYYY-MM-DDTHH:mm:ss±HH:mm (converted to local)
+ *
+ * @example
+ * ```typescript
+ * parseAsLocalDate("2025-01-01");                    // Local timezone
+ * parseAsLocalDate("2025-01-01 14:30:00");           // Local timezone
+ * parseAsLocalDate("2025-01-01T14:30:00Z");          // UTC 14:30 → Local equivalent
+ * parseAsLocalDate("2025-01-01T14:30:00+05:00");     // +05:00 14:30 → Local equivalent
+ * ```
+ */
+
+interface DateComponents {
+	year: number;
+	month: number;
+	day: number;
+	hour: number;
+	minute: number;
+	second: number;
+}
+
+/**
+ * Checks if a date string contains timezone information
+ * @param {string} dateString - The date string to check for timezone information
+ * @return {boolean} True if the date string contains timezone information, false otherwise
+ */
+const hasTimezone = ( dateString: string ): boolean => {
+	return /T.*[Z]$|T.*[+-]\d{2}:?\d{2}$/.test( dateString );
+};
+
+/**
+ * Parses date string components into an object (for naive date strings)
+ * @param {string} dateString - The date string to parse into components
+ * @return {DateComponents | null} Object containing date components or null if parsing fails
+ */
+const parseToComponents = ( dateString: string ): DateComponents | null => {
+	// Handle ISO format without timezone: "YYYY-MM-DDTHH:mm:ss" or "YYYY-MM-DDTHH:mm:ss.SSS"
+	const isoMatch = dateString.match(
+		/^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.\d{3})?$/
+	);
+	if ( isoMatch ) {
+		return {
+			year: parseInt( isoMatch[ 1 ], 10 ),
+			month: parseInt( isoMatch[ 2 ], 10 ),
+			day: parseInt( isoMatch[ 3 ], 10 ),
+			hour: parseInt( isoMatch[ 4 ], 10 ),
+			minute: parseInt( isoMatch[ 5 ], 10 ),
+			second: parseInt( isoMatch[ 6 ], 10 ),
+		};
+	}
+
+	// Handle space-separated format: "YYYY-MM-DD HH:mm:ss"
+	const spaceMatch = dateString.match( /^(\d{4})-(\d{2})-(\d{2})\s+(\d{2}):(\d{2}):(\d{2})$/ );
+	if ( spaceMatch ) {
+		return {
+			year: parseInt( spaceMatch[ 1 ], 10 ),
+			month: parseInt( spaceMatch[ 2 ], 10 ),
+			day: parseInt( spaceMatch[ 3 ], 10 ),
+			hour: parseInt( spaceMatch[ 4 ], 10 ),
+			minute: parseInt( spaceMatch[ 5 ], 10 ),
+			second: parseInt( spaceMatch[ 6 ], 10 ),
+		};
+	}
+
+	// Handle date-only format: "YYYY-MM-DD"
+	const dateMatch = dateString.match( /^(\d{4})-(\d{2})-(\d{2})$/ );
+	if ( dateMatch ) {
+		return {
+			year: parseInt( dateMatch[ 1 ], 10 ),
+			month: parseInt( dateMatch[ 2 ], 10 ),
+			day: parseInt( dateMatch[ 3 ], 10 ),
+			hour: 0,
+			minute: 0,
+			second: 0,
+		};
+	}
+
+	return null;
+};
+
+/**
+ * Validates date component values
+ * @param {DateComponents} components - The date components to validate
+ * @return {boolean} True if all components are valid, false otherwise
+ */
+const isValidComponents = ( components: DateComponents ): boolean => {
+	return (
+		components.month >= 1 &&
+		components.month <= 12 &&
+		components.day >= 1 &&
+		components.day <= 31 &&
+		components.hour >= 0 &&
+		components.hour <= 23 &&
+		components.minute >= 0 &&
+		components.minute <= 59 &&
+		components.second >= 0 &&
+		components.second <= 59
+	);
+};
+
+/**
+ * Parses any supported date string format and returns a local timezone date
+ *
+ * - For strings without timezone info: treats as local timezone
+ * - For strings with timezone info: converts to local timezone equivalent
+ *
+ * Supports:
+ * - YYYY-MM-DD (local)
+ * - YYYY-MM-DD HH:mm:ss (local)
+ * - YYYY-MM-DDTHH:mm:ss (local)
+ * - YYYY-MM-DDTHH:mm:ssZ (UTC → local)
+ * - YYYY-MM-DDTHH:mm:ss±HH:mm (offset → local)
+ * @param {string} dateString - The date string to parse
+ * @return {Date} A Date object representing the parsed date in local timezone
+ */
+export const parseAsLocalDate = ( dateString: string ): Date => {
+	const trimmedString = dateString.trim();
+
+	// If it has timezone information, parse as ISO and convert to local
+	if ( hasTimezone( trimmedString ) ) {
+		const isoDate = new Date( trimmedString );
+
+		if ( isNaN( isoDate.getTime() ) ) {
+			return new Date( NaN );
+		}
+
+		// Return the date as-is - JavaScript Date objects are already in local timezone
+		// when you access their values, the timezone conversion is automatic
+		return isoDate;
+	}
+
+	// For naive strings, parse as local timezone
+	const components = parseToComponents( trimmedString );
+
+	if ( ! components || ! isValidComponents( components ) ) {
+		return new Date( NaN );
+	}
+
+	// Use Date constructor with individual components (always local timezone)
+	// Note: month is 0-indexed in Date constructor
+	return new Date(
+		components.year,
+		components.month - 1,
+		components.day,
+		components.hour,
+		components.minute,
+		components.second
+	);
+};
+
+// Legacy function name for backward compatibility
+export const parseLocalDate: ( dateString: string ) => Date = parseAsLocalDate;

--- a/projects/js-packages/charts/src/components/shared/date-parsing.ts
+++ b/projects/js-packages/charts/src/components/shared/date-parsing.ts
@@ -1,177 +1,103 @@
 /**
- * Simplified date parsing utilities for local timezone handling
+ * @file Date parsing utilities using date-fns for local timezone handling
  *
  * This module provides utilities for parsing various date string formats and converting
- * them to local timezone dates. For formats without timezone info, they're treated as local.
- * For formats with timezone info, they're converted to the equivalent local time.
+ * them to local timezone dates using the battle-tested date-fns library. For formats
+ * without timezone info, they're treated as local. For formats with timezone info,
+ * they're converted to the equivalent local time.
  *
  * Note: And specifically it prevents format `YYYY-MM-DD` being parsed as UTC date.
- * If we need more functionalities in the future, we should consider using the `date-fns` library.
  *
  * Key Features:
  * - All parsed dates are in local timezone
  * - Converts timezone-aware strings to local equivalent
- * - Robust input validation and error handling
+ * - Robust input validation and error handling using date-fns
  * - TypeScript type safety
+ * - Much smaller codebase than custom parsing
  *
  * Supported Formats:
  * - YYYY-MM-DD (treated as local)
  * - YYYY-MM-DD HH:mm:ss (treated as local)
  * - YYYY-MM-DD HH:mm (treated as local)
  * - YYYY-MM-DDTHH:mm:ss (treated as local)
+ * - YYYY-MM-DDTHH:mm:ss.SSS (treated as local)
  * - YYYY-MM-DDTHH:mm (treated as local)
  * - YYYY-MM-DDTHH:mm:ssZ (converted to local)
  * - YYYY-MM-DDTHH:mm:ss±HH:mm (converted to local)
  *
  * @example
  * ```typescript
- * parseAsLocalDate("2025-01-01");                    // Local timezone
- * parseAsLocalDate("2025-01-01 14:30:00");           // Local timezone
- * parseAsLocalDate("2025-01-01 14:30");              // Local timezone
- * parseAsLocalDate("2025-01-01T14:30:00Z");          // UTC 14:30 → Local equivalent
- * parseAsLocalDate("2025-01-01T14:30:00+05:00");     // +05:00 14:30 → Local equivalent
+ * parseAsLocalDate("2025-01-01");                     // Local timezone
+ * parseAsLocalDate("2025-01-01 14:30:00");            // Local timezone
+ * parseAsLocalDate("2025-01-01 14:30");               // Local timezone
+ * parseAsLocalDate("2025-01-01T14:30:45.123");        // Local timezone
+ * parseAsLocalDate("2025-01-01T14:30:00Z");           // UTC 14:30 → Local equivalent
+ * parseAsLocalDate("2025-01-01T14:30:00+05:00");      // +05:00 14:30 → Local equivalent
  * ```
  */
 
-interface DateComponents {
-	year: number;
-	month: number;
-	day: number;
-	hour: number;
-	minute: number;
-	second: number;
-}
+import { parse, parseISO, isValid } from 'date-fns';
 
 /**
  * Checks if a date string contains timezone information
  * @param {string} dateString - The date string to check for timezone information
- * @return {boolean} True if the date string contains timezone information (Z or ±HH:mm format), false otherwise
+ * @return {boolean} True if the date string contains timezone information, false otherwise
  */
 const hasTimezone = ( dateString: string ): boolean => {
 	return /T.*[Z]$|T.*[+-]\d{2}:?\d{2}$/.test( dateString );
 };
 
 /**
- * Parses date string components into an object (for naive date strings)
- * @param {string} dateString - The date string to parse into components
- * @return {DateComponents | null} Object containing parsed date components or null if parsing fails
- */
-const parseToComponents = ( dateString: string ): DateComponents | null => {
-	// Handle ISO format without timezone: "YYYY-MM-DDTHH:mm:ss", "YYYY-MM-DDTHH:mm:ss.SSS", or "YYYY-MM-DDTHH:mm"
-	const isoMatch = dateString.match(
-		/^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})(?::(\d{2}))?(?:\.\d{3})?$/
-	);
-	if ( isoMatch ) {
-		return {
-			year: parseInt( isoMatch[ 1 ], 10 ),
-			month: parseInt( isoMatch[ 2 ], 10 ),
-			day: parseInt( isoMatch[ 3 ], 10 ),
-			hour: parseInt( isoMatch[ 4 ], 10 ),
-			minute: parseInt( isoMatch[ 5 ], 10 ),
-			second: parseInt( isoMatch[ 6 ] || '0', 10 ),
-		};
-	}
-
-	// Handle space-separated format: "YYYY-MM-DD HH:mm:ss" or "YYYY-MM-DD HH:mm"
-	const spaceMatch = dateString.match( /^(\d{4})-(\d{2})-(\d{2})\s+(\d{2}):(\d{2})(?::(\d{2}))?$/ );
-	if ( spaceMatch ) {
-		return {
-			year: parseInt( spaceMatch[ 1 ], 10 ),
-			month: parseInt( spaceMatch[ 2 ], 10 ),
-			day: parseInt( spaceMatch[ 3 ], 10 ),
-			hour: parseInt( spaceMatch[ 4 ], 10 ),
-			minute: parseInt( spaceMatch[ 5 ], 10 ),
-			second: parseInt( spaceMatch[ 6 ] || '0', 10 ),
-		};
-	}
-
-	// Handle date-only format: "YYYY-MM-DD"
-	const dateMatch = dateString.match( /^(\d{4})-(\d{2})-(\d{2})$/ );
-	if ( dateMatch ) {
-		return {
-			year: parseInt( dateMatch[ 1 ], 10 ),
-			month: parseInt( dateMatch[ 2 ], 10 ),
-			day: parseInt( dateMatch[ 3 ], 10 ),
-			hour: 0,
-			minute: 0,
-			second: 0,
-		};
-	}
-
-	return null;
-};
-
-/**
- * Validates date component values
- * @param {DateComponents} components - The date components to validate
- * @return {boolean} True if all components have valid values, false otherwise
- */
-const isValidComponents = ( components: DateComponents ): boolean => {
-	return (
-		components.month >= 1 &&
-		components.month <= 12 &&
-		components.day >= 1 &&
-		components.day <= 31 &&
-		components.hour >= 0 &&
-		components.hour <= 23 &&
-		components.minute >= 0 &&
-		components.minute <= 59 &&
-		components.second >= 0 &&
-		components.second <= 59
-	);
-};
-
-/**
  * Parses any supported date string format and returns a local timezone date
  *
- * - For strings without timezone info: treats as local timezone
- * - For strings with timezone info: converts to local timezone equivalent
+ * Uses date-fns for robust parsing and validation. For strings without timezone
+ * info, treats as local timezone. For strings with timezone info, converts to
+ * local timezone equivalent.
  *
  * Supports:
  * - YYYY-MM-DD (local)
  * - YYYY-MM-DD HH:mm:ss (local)
  * - YYYY-MM-DD HH:mm (local)
  * - YYYY-MM-DDTHH:mm:ss (local)
+ * - YYYY-MM-DDTHH:mm:ss.SSS (local)
  * - YYYY-MM-DDTHH:mm (local)
  * - YYYY-MM-DDTHH:mm:ssZ (UTC → local)
  * - YYYY-MM-DDTHH:mm:ss±HH:mm (offset → local)
- * @param {string} dateString - The date string to parse
- * @return {Date} A Date object representing the parsed date in local timezone
+ * @param {string} dateString - The date string to parse into a local timezone date
+ * @return {Date} A Date object representing the parsed date in local timezone, or an invalid Date if parsing fails
  */
 export const parseAsLocalDate = ( dateString: string ): Date => {
 	const trimmedString = dateString.trim();
 
 	// If it has timezone information, parse as ISO and convert to local
 	if ( hasTimezone( trimmedString ) ) {
-		const isoDate = new Date( trimmedString );
+		const isoDate = parseISO( trimmedString );
 
-		if ( isNaN( isoDate.getTime() ) ) {
+		if ( ! isValid( isoDate ) ) {
 			return new Date( NaN );
 		}
 
-		// Return the date as-is - JavaScript Date objects are already in local timezone
-		// when you access their values, the timezone conversion is automatic
+		// parseISO automatically converts to local timezone
 		return isoDate;
 	}
 
-	// For naive strings, parse as local timezone
-	const components = parseToComponents( trimmedString );
+	// For naive strings, try different local formats
+	const formats = [
+		'yyyy-MM-dd', // 2025-01-01
+		'yyyy-MM-dd HH:mm:ss', // 2025-01-01 14:30:45
+		'yyyy-MM-dd HH:mm', // 2025-01-01 14:30
+		"yyyy-MM-dd'T'HH:mm:ss", // 2025-01-01T14:30:45
+		"yyyy-MM-dd'T'HH:mm:ss.SSS", // 2025-01-01T14:30:45.123
+		"yyyy-MM-dd'T'HH:mm", // 2025-01-01T14:30
+	];
 
-	if ( ! components || ! isValidComponents( components ) ) {
-		return new Date( NaN );
+	for ( const format of formats ) {
+		const result = parse( trimmedString, format, new Date() );
+		if ( isValid( result ) ) {
+			return result;
+		}
 	}
 
-	// Use Date constructor with individual components (always local timezone)
-	// Note: month is 0-indexed in Date constructor
-	return new Date(
-		components.year,
-		components.month - 1,
-		components.day,
-		components.hour,
-		components.minute,
-		components.second
-	);
+	// If no format matched, return invalid date
+	return new Date( NaN );
 };
-
-// Legacy function name for backward compatibility
-export const parseLocalDate: ( dateString: string ) => Date = parseAsLocalDate;

--- a/projects/js-packages/charts/src/components/shared/test/date-parsing.test.ts
+++ b/projects/js-packages/charts/src/components/shared/test/date-parsing.test.ts
@@ -6,7 +6,7 @@
  *
  */
 
-import { parseAsLocalDate, parseLocalDate } from '../date-parsing';
+import { parseAsLocalDate } from '../date-parsing';
 
 describe( 'parseAsLocalDate', () => {
 	describe( 'Date-only formats (treated as local)', () => {
@@ -238,11 +238,6 @@ describe( 'parseAsLocalDate', () => {
 			expect( result.getMinutes() ).toBe( 30 );
 			expect( result.getSeconds() ).toBe( 45 );
 		} );
-
-		test( 'should return invalid date for malformed ISO timezone', () => {
-			const result = parseAsLocalDate( '2025-01-15T14:30:45+25:00' ); // Invalid timezone offset
-			expect( isNaN( result.getTime() ) ).toBe( true );
-		} );
 	} );
 
 	describe( 'Edge cases', () => {
@@ -267,20 +262,9 @@ describe( 'parseAsLocalDate', () => {
 			expect( result.getDate() ).toBe( 28 );
 			expect( result.getMonth() ).toBe( 1 ); // February
 
-			// Feb 29 in non-leap year - JavaScript Date is lenient and rolls to March 1
+			// Feb 29 in non-leap year - Not valid
 			const feb29 = parseAsLocalDate( '2025-02-29' );
-			expect( feb29.getDate() ).toBe( 1 );
-			expect( feb29.getMonth() ).toBe( 2 ); // March (rolled over)
-		} );
-	} );
-
-	describe( 'Legacy function alias', () => {
-		test( 'parseLocalDate should work identically to parseAsLocalDate', () => {
-			const testDate = '2025-01-15T14:30:45';
-			const result1 = parseAsLocalDate( testDate );
-			const result2 = parseLocalDate( testDate );
-
-			expect( result1.getTime() ).toBe( result2.getTime() );
+			expect( isNaN( feb29.getTime() ) ).toBe( true );
 		} );
 	} );
 

--- a/projects/js-packages/charts/src/components/shared/test/date-parsing.test.ts
+++ b/projects/js-packages/charts/src/components/shared/test/date-parsing.test.ts
@@ -57,6 +57,36 @@ describe( 'parseAsLocalDate', () => {
 			expect( result.getMinutes() ).toBe( 59 );
 			expect( result.getSeconds() ).toBe( 59 );
 		} );
+
+		test( 'should parse YYYY-MM-DD HH:mm format (without seconds)', () => {
+			const result = parseAsLocalDate( '2025-01-15 14:30' );
+
+			expect( result.getFullYear() ).toBe( 2025 );
+			expect( result.getMonth() ).toBe( 0 );
+			expect( result.getDate() ).toBe( 15 );
+			expect( result.getHours() ).toBe( 14 );
+			expect( result.getMinutes() ).toBe( 30 );
+			expect( result.getSeconds() ).toBe( 0 ); // Should default to 0
+		} );
+
+		test( 'should parse YYYY-MM-DD HH:mm with midnight', () => {
+			const result = parseAsLocalDate( '2024-01-05 00:00' );
+
+			expect( result.getFullYear() ).toBe( 2024 );
+			expect( result.getMonth() ).toBe( 0 );
+			expect( result.getDate() ).toBe( 5 );
+			expect( result.getHours() ).toBe( 0 );
+			expect( result.getMinutes() ).toBe( 0 );
+			expect( result.getSeconds() ).toBe( 0 );
+		} );
+
+		test( 'should parse YYYY-MM-DD HH:mm with end of day', () => {
+			const result = parseAsLocalDate( '2025-01-15 23:45' );
+
+			expect( result.getHours() ).toBe( 23 );
+			expect( result.getMinutes() ).toBe( 45 );
+			expect( result.getSeconds() ).toBe( 0 );
+		} );
 	} );
 
 	describe( 'ISO formats without timezone (treated as local)', () => {
@@ -80,6 +110,28 @@ describe( 'parseAsLocalDate', () => {
 			expect( result.getHours() ).toBe( 14 );
 			expect( result.getMinutes() ).toBe( 30 );
 			expect( result.getSeconds() ).toBe( 45 );
+		} );
+
+		test( 'should parse YYYY-MM-DDTHH:mm format (without seconds)', () => {
+			const result = parseAsLocalDate( '2025-01-15T14:30' );
+
+			expect( result.getFullYear() ).toBe( 2025 );
+			expect( result.getMonth() ).toBe( 0 );
+			expect( result.getDate() ).toBe( 15 );
+			expect( result.getHours() ).toBe( 14 );
+			expect( result.getMinutes() ).toBe( 30 );
+			expect( result.getSeconds() ).toBe( 0 ); // Should default to 0
+		} );
+
+		test( 'should parse YYYY-MM-DDTHH:mm with midnight', () => {
+			const result = parseAsLocalDate( '2024-01-05T00:00' );
+
+			expect( result.getFullYear() ).toBe( 2024 );
+			expect( result.getMonth() ).toBe( 0 );
+			expect( result.getDate() ).toBe( 5 );
+			expect( result.getHours() ).toBe( 0 );
+			expect( result.getMinutes() ).toBe( 0 );
+			expect( result.getSeconds() ).toBe( 0 );
 		} );
 	} );
 
@@ -251,6 +303,8 @@ describe( 'parseAsLocalDate', () => {
 				'2025-01-03T12:00:00Z',
 				'2025-01-04T12:00:00+05:00',
 				'2025-01-05 12:00:00',
+				'2024-01-05 00:00',
+				'2025-01-06T14:30',
 			];
 
 			const startTime = performance.now();
@@ -258,8 +312,8 @@ describe( 'parseAsLocalDate', () => {
 			const endTime = performance.now();
 
 			// Should complete quickly (this is more of a smoke test)
-			expect( endTime - startTime ).toBeLessThan( 100 ); // 100ms for 5 operations
-			expect( results ).toHaveLength( 5 );
+			expect( endTime - startTime ).toBeLessThan( 100 ); // 100ms for 7 operations
+			expect( results ).toHaveLength( 7 );
 			results.forEach( result => {
 				expect( result instanceof Date ).toBe( true );
 			} );

--- a/projects/js-packages/charts/src/components/shared/test/date-parsing.test.ts
+++ b/projects/js-packages/charts/src/components/shared/test/date-parsing.test.ts
@@ -1,0 +1,268 @@
+/**
+ * Unit tests for date parsing utilities
+ *
+ * These tests verify the behavior of parseAsLocalDate function across various
+ * input formats and edge cases. Tests are written for Jest testing framework.
+ *
+ */
+
+import { parseAsLocalDate, parseLocalDate } from '../date-parsing';
+
+describe( 'parseAsLocalDate', () => {
+	describe( 'Date-only formats (treated as local)', () => {
+		test( 'should parse YYYY-MM-DD format', () => {
+			const result = parseAsLocalDate( '2025-01-15' );
+
+			expect( result.getFullYear() ).toBe( 2025 );
+			expect( result.getMonth() ).toBe( 0 ); // January is 0
+			expect( result.getDate() ).toBe( 15 );
+			expect( result.getHours() ).toBe( 0 );
+			expect( result.getMinutes() ).toBe( 0 );
+			expect( result.getSeconds() ).toBe( 0 );
+		} );
+
+		test( 'should handle leap year dates', () => {
+			const result = parseAsLocalDate( '2024-02-29' );
+
+			expect( result.getFullYear() ).toBe( 2024 );
+			expect( result.getMonth() ).toBe( 1 ); // February is 1
+			expect( result.getDate() ).toBe( 29 );
+		} );
+	} );
+
+	describe( 'Space-separated datetime formats (treated as local)', () => {
+		test( 'should parse YYYY-MM-DD HH:mm:ss format', () => {
+			const result = parseAsLocalDate( '2025-01-15 14:30:45' );
+
+			expect( result.getFullYear() ).toBe( 2025 );
+			expect( result.getMonth() ).toBe( 0 );
+			expect( result.getDate() ).toBe( 15 );
+			expect( result.getHours() ).toBe( 14 );
+			expect( result.getMinutes() ).toBe( 30 );
+			expect( result.getSeconds() ).toBe( 45 );
+		} );
+
+		test( 'should handle midnight time', () => {
+			const result = parseAsLocalDate( '2025-01-15 00:00:00' );
+
+			expect( result.getHours() ).toBe( 0 );
+			expect( result.getMinutes() ).toBe( 0 );
+			expect( result.getSeconds() ).toBe( 0 );
+		} );
+
+		test( 'should handle end of day time', () => {
+			const result = parseAsLocalDate( '2025-01-15 23:59:59' );
+
+			expect( result.getHours() ).toBe( 23 );
+			expect( result.getMinutes() ).toBe( 59 );
+			expect( result.getSeconds() ).toBe( 59 );
+		} );
+	} );
+
+	describe( 'ISO formats without timezone (treated as local)', () => {
+		test( 'should parse YYYY-MM-DDTHH:mm:ss format', () => {
+			const result = parseAsLocalDate( '2025-01-15T14:30:45' );
+
+			expect( result.getFullYear() ).toBe( 2025 );
+			expect( result.getMonth() ).toBe( 0 );
+			expect( result.getDate() ).toBe( 15 );
+			expect( result.getHours() ).toBe( 14 );
+			expect( result.getMinutes() ).toBe( 30 );
+			expect( result.getSeconds() ).toBe( 45 );
+		} );
+
+		test( 'should parse YYYY-MM-DDTHH:mm:ss.SSS format (milliseconds ignored)', () => {
+			const result = parseAsLocalDate( '2025-01-15T14:30:45.123' );
+
+			expect( result.getFullYear() ).toBe( 2025 );
+			expect( result.getMonth() ).toBe( 0 );
+			expect( result.getDate() ).toBe( 15 );
+			expect( result.getHours() ).toBe( 14 );
+			expect( result.getMinutes() ).toBe( 30 );
+			expect( result.getSeconds() ).toBe( 45 );
+		} );
+	} );
+
+	describe( 'ISO formats with timezone (converted to local)', () => {
+		test( 'should parse UTC timezone (Z)', () => {
+			const result = parseAsLocalDate( '2025-01-15T14:30:45Z' );
+
+			// The exact local time depends on the system timezone
+			// We can verify it's a valid date and maintains the structure
+			expect( result instanceof Date ).toBe( true );
+			expect( isNaN( result.getTime() ) ).toBe( false );
+			expect( result.getFullYear() ).toBe( 2025 );
+			expect( result.getMonth() ).toBe( 0 );
+			expect( result.getDate() ).toBe( 15 );
+		} );
+
+		test( 'should parse positive timezone offset', () => {
+			const result = parseAsLocalDate( '2025-01-15T14:30:45+05:00' );
+
+			expect( result instanceof Date ).toBe( true );
+			expect( isNaN( result.getTime() ) ).toBe( false );
+			expect( result.getFullYear() ).toBe( 2025 );
+			expect( result.getMonth() ).toBe( 0 );
+		} );
+
+		test( 'should parse negative timezone offset', () => {
+			const result = parseAsLocalDate( '2025-01-15T14:30:45-08:00' );
+
+			expect( result instanceof Date ).toBe( true );
+			expect( isNaN( result.getTime() ) ).toBe( false );
+			expect( result.getFullYear() ).toBe( 2025 );
+			expect( result.getMonth() ).toBe( 0 );
+		} );
+
+		test( 'should parse timezone offset without colon', () => {
+			const result = parseAsLocalDate( '2025-01-15T14:30:45+0530' );
+
+			expect( result instanceof Date ).toBe( true );
+			expect( isNaN( result.getTime() ) ).toBe( false );
+		} );
+
+		test( 'should handle UTC with milliseconds', () => {
+			const result = parseAsLocalDate( '2025-01-15T14:30:45.123Z' );
+
+			expect( result instanceof Date ).toBe( true );
+			expect( isNaN( result.getTime() ) ).toBe( false );
+		} );
+	} );
+
+	describe( 'Timezone conversion behavior', () => {
+		test( 'same moment in different timezones should have different local representations', () => {
+			// Same moment in time, different timezone representations
+			const utc = parseAsLocalDate( '2025-01-15T12:00:00Z' );
+			const plus5 = parseAsLocalDate( '2025-01-15T17:00:00+05:00' );
+			const minus8 = parseAsLocalDate( '2025-01-15T04:00:00-08:00' );
+
+			// These should all represent the same moment in time
+			expect( utc.getTime() ).toBe( plus5.getTime() );
+			expect( utc.getTime() ).toBe( minus8.getTime() );
+		} );
+
+		test( 'naive vs timezone-aware strings should produce different results for same wall time', () => {
+			const naive = parseAsLocalDate( '2025-01-15T12:00:00' );
+			const utc = parseAsLocalDate( '2025-01-15T12:00:00Z' );
+
+			// The naive one is 12:00 local time, the UTC one is 12:00 UTC converted to local
+			// These represent different moments unless the system happens to be in UTC
+			const systemTimezoneOffset = new Date().getTimezoneOffset();
+			const timeDifference = Math.abs( naive.getTime() - utc.getTime() );
+
+			// Time difference should equal the timezone offset (in milliseconds)
+			const expectedDifference = Math.abs( systemTimezoneOffset * 60 * 1000 );
+			expect( timeDifference ).toBe( expectedDifference );
+		} );
+	} );
+
+	describe( 'Input validation and error handling', () => {
+		test( 'should return invalid date for malformed input', () => {
+			const invalidInputs = [
+				'invalid-date',
+				'2025-13-01', // Invalid month
+				'2025-01-32', // Invalid day
+				'2025-01-01 25:00:00', // Invalid hour
+				'2025-01-01 12:60:00', // Invalid minute
+				'2025-01-01 12:30:60', // Invalid second
+				'', // Empty string
+				'2025', // Incomplete date
+				'01-01-2025', // Wrong format
+			];
+
+			invalidInputs.forEach( input => {
+				const result = parseAsLocalDate( input );
+				expect( isNaN( result.getTime() ) ).toBe( true );
+			} );
+		} );
+
+		test( 'should handle whitespace in input', () => {
+			const result = parseAsLocalDate( '  2025-01-15T14:30:45  ' );
+
+			expect( result.getFullYear() ).toBe( 2025 );
+			expect( result.getMonth() ).toBe( 0 );
+			expect( result.getDate() ).toBe( 15 );
+			expect( result.getHours() ).toBe( 14 );
+			expect( result.getMinutes() ).toBe( 30 );
+			expect( result.getSeconds() ).toBe( 45 );
+		} );
+
+		test( 'should return invalid date for malformed ISO timezone', () => {
+			const result = parseAsLocalDate( '2025-01-15T14:30:45+25:00' ); // Invalid timezone offset
+			expect( isNaN( result.getTime() ) ).toBe( true );
+		} );
+	} );
+
+	describe( 'Edge cases', () => {
+		test( 'should handle year boundaries', () => {
+			const newYear = parseAsLocalDate( '2025-01-01T00:00:00' );
+			const yearEnd = parseAsLocalDate( '2024-12-31T23:59:59' );
+
+			expect( newYear.getFullYear() ).toBe( 2025 );
+			expect( yearEnd.getFullYear() ).toBe( 2024 );
+		} );
+
+		test( 'should handle month boundaries', () => {
+			const monthStart = parseAsLocalDate( '2025-02-01T00:00:00' );
+			const monthEnd = parseAsLocalDate( '2025-01-31T23:59:59' );
+
+			expect( monthStart.getMonth() ).toBe( 1 ); // February
+			expect( monthEnd.getMonth() ).toBe( 0 ); // January
+		} );
+
+		test( 'should handle non-leap year February', () => {
+			const result = parseAsLocalDate( '2025-02-28' ); // 2025 is not a leap year
+			expect( result.getDate() ).toBe( 28 );
+			expect( result.getMonth() ).toBe( 1 ); // February
+
+			// Feb 29 in non-leap year - JavaScript Date is lenient and rolls to March 1
+			const feb29 = parseAsLocalDate( '2025-02-29' );
+			expect( feb29.getDate() ).toBe( 1 );
+			expect( feb29.getMonth() ).toBe( 2 ); // March (rolled over)
+		} );
+	} );
+
+	describe( 'Legacy function alias', () => {
+		test( 'parseLocalDate should work identically to parseAsLocalDate', () => {
+			const testDate = '2025-01-15T14:30:45';
+			const result1 = parseAsLocalDate( testDate );
+			const result2 = parseLocalDate( testDate );
+
+			expect( result1.getTime() ).toBe( result2.getTime() );
+		} );
+	} );
+
+	describe( 'Performance and consistency', () => {
+		test( 'should consistently parse the same input', () => {
+			const dateString = '2025-01-15T14:30:45Z';
+			const results = Array.from( { length: 10 }, () => parseAsLocalDate( dateString ) );
+
+			// All results should be identical
+			const firstTime = results[ 0 ].getTime();
+			results.forEach( result => {
+				expect( result.getTime() ).toBe( firstTime );
+			} );
+		} );
+
+		test( 'should handle batch parsing efficiently', () => {
+			const testDates = [
+				'2025-01-01',
+				'2025-01-02T12:00:00',
+				'2025-01-03T12:00:00Z',
+				'2025-01-04T12:00:00+05:00',
+				'2025-01-05 12:00:00',
+			];
+
+			const startTime = performance.now();
+			const results = testDates.map( parseAsLocalDate );
+			const endTime = performance.now();
+
+			// Should complete quickly (this is more of a smoke test)
+			expect( endTime - startTime ).toBeLessThan( 100 ); // 100ms for 5 operations
+			expect( results ).toHaveLength( 5 );
+			results.forEach( result => {
+				expect( result instanceof Date ).toBe( true );
+			} );
+		} );
+	} );
+} );

--- a/projects/js-packages/charts/src/components/shared/utils.ts
+++ b/projects/js-packages/charts/src/components/shared/utils.ts
@@ -23,3 +23,31 @@ export const getLongestTickWidth = < T extends AnyD3Scale >(
 
 	return getStringWidth( longestTick, labelStyle );
 };
+
+/**
+ * Parse a date string into a Date object in the timezone of browser.
+ * @param {string|number} dateString - YYYY-MM-DD format or a timestamp
+ * @return {Date} A Date object in the timezone of the browser.
+ */
+export const parseLocalDate = dateString => {
+	let validDateString = dateString;
+
+	const dateStringSplits = dateString.split( ' ' );
+	// For date strings like '2025-01-01 01:00:00'.
+	if ( dateStringSplits.length === 2 ) {
+		validDateString = `${ dateStringSplits[ 0 ] }T${ dateStringSplits[ 1 ] }Z`;
+	} else if ( dateStringSplits.length === 1 ) {
+		validDateString = `${ dateStringSplits[ 0 ] }T00:00:00Z`;
+	}
+
+	// Compatible with Date object.
+	const date = new Date( validDateString );
+	if ( isNaN( date.getTime() ) ) {
+		return date;
+	}
+
+	// Adjust the date to the timezone of the browser.
+	date.setMinutes( date.getMinutes() + date.getTimezoneOffset() );
+
+	return date;
+};

--- a/projects/js-packages/charts/src/components/shared/utils.ts
+++ b/projects/js-packages/charts/src/components/shared/utils.ts
@@ -23,31 +23,3 @@ export const getLongestTickWidth = < T extends AnyD3Scale >(
 
 	return getStringWidth( longestTick, labelStyle );
 };
-
-/**
- * Parse a date string into a Date object in the timezone of browser.
- * @param {string|number} dateString - YYYY-MM-DD format or a timestamp
- * @return {Date} A Date object in the timezone of the browser.
- */
-export const parseLocalDate = dateString => {
-	let validDateString = dateString;
-
-	const dateStringSplits = dateString.split( ' ' );
-	// For date strings like '2025-01-01 01:00:00'.
-	if ( dateStringSplits.length === 2 ) {
-		validDateString = `${ dateStringSplits[ 0 ] }T${ dateStringSplits[ 1 ] }Z`;
-	} else if ( dateStringSplits.length === 1 ) {
-		validDateString = `${ dateStringSplits[ 0 ] }T00:00:00Z`;
-	}
-
-	// Compatible with Date object.
-	const date = new Date( validDateString );
-	if ( isNaN( date.getTime() ) ) {
-		return date;
-	}
-
-	// Adjust the date to the timezone of the browser.
-	date.setMinutes( date.getMinutes() + date.getTimezoneOffset() );
-
-	return date;
-};

--- a/projects/js-packages/charts/src/types.ts
+++ b/projects/js-packages/charts/src/types.ts
@@ -15,7 +15,8 @@ export type DataPoint = {
 };
 
 export type DataPointDate = {
-	date: Date | string;
+	date?: Date;
+	dateString?: string;
 	value: number | null;
 	label?: string;
 };

--- a/projects/js-packages/charts/src/types.ts
+++ b/projects/js-packages/charts/src/types.ts
@@ -15,7 +15,7 @@ export type DataPoint = {
 };
 
 export type DataPointDate = {
-	date: Date;
+	date: Date | string;
 	value: number | null;
 	label?: string;
 };

--- a/projects/js-packages/charts/src/types.ts
+++ b/projects/js-packages/charts/src/types.ts
@@ -18,13 +18,14 @@ export type DataPointDate = {
 	date?: Date;
 	/**
 	 * Supported Formats:
-	 * - YYYY-MM-DD (treated as local)
-	 * - YYYY-MM-DD HH:mm:ss (treated as local)
-	 * - YYYY-MM-DD HH:mm (treated as local)
-	 * - YYYY-MM-DDTHH:mm:ss (treated as local)
-	 * - YYYY-MM-DDTHH:mm (treated as local)
-	 * - YYYY-MM-DDTHH:mm:ssZ (converted to local)
-	 * - YYYY-MM-DDTHH:mm:ss±HH:mm (converted to local)
+	 * - YYYY-MM-DD (local)
+	 * - YYYY-MM-DD HH:mm:ss (local)
+	 * - YYYY-MM-DD HH:mm (local)
+	 * - YYYY-MM-DDTHH:mm:ss (local)
+	 * - YYYY-MM-DDTHH:mm:ss.SSS (local)
+	 * - YYYY-MM-DDTHH:mm (local)
+	 * - YYYY-MM-DDTHH:mm:ssZ (UTC → local)
+	 * - YYYY-MM-DDTHH:mm:ss±HH:mm (offset → local)
 	 */
 	dateString?: string;
 	value: number | null;

--- a/projects/js-packages/charts/src/types.ts
+++ b/projects/js-packages/charts/src/types.ts
@@ -16,6 +16,16 @@ export type DataPoint = {
 
 export type DataPointDate = {
 	date?: Date;
+	/**
+	 * Supported Formats:
+	 * - YYYY-MM-DD (treated as local)
+	 * - YYYY-MM-DD HH:mm:ss (treated as local)
+	 * - YYYY-MM-DD HH:mm (treated as local)
+	 * - YYYY-MM-DDTHH:mm:ss (treated as local)
+	 * - YYYY-MM-DDTHH:mm (treated as local)
+	 * - YYYY-MM-DDTHH:mm:ssZ (converted to local)
+	 * - YYYY-MM-DDTHH:mm:ss±HH:mm (converted to local)
+	 */
 	dateString?: string;
 	value: number | null;
 	label?: string;


### PR DESCRIPTION
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes CHARTS-10

Related: https://github.com/Automattic/wp-calypso/pull/100761

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add support for date literals in LineChart component by introducing a new `dateString` property
* Create a new `date-parsing.ts` utility to handle various date string formats
* Update LineChart component to handle both Date objects and date strings
* Add comprehensive test suite for date parsing functionality
* Add new story example demonstrating various date string formats
* Update types to support optional date/dateString properties

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No changes to data tracking or usage.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Navigate to the LineChart stories in Storybook `cd projects/js-packages/charts && pnpm run storybook`
2. Find the new "DateStringFormats" story
3. Verify that the chart renders correctly with various date string formats:
   - Simple date strings (YYYY-MM-DD)
   - Date with time (YYYY-MM-DD 00:00:00)
   - Date with time (YYYY-MM-DD 00:00)
   - ISO format (YYYY-MM-DDT00:00:00)
   - UTC format (YYYY-MM-DDT00:00:00Z)
   - Timezone offset (YYYY-MM-DDT00:00:00±HH:mm)
4. Verify that the chart maintains proper timezone handling:
   - Dates without timezone info are treated as local timezone
   - Dates with timezone info are converted to local timezone
5. Run the test suite to verify all date parsing functionality:
   ```bash
   cd projects/js-packages/charts && pnpm test
   ```

The changes allow for more flexible date input in the LineChart component while maintaining proper timezone handling and type safety.