### PR TITLE
Boost: Do not request LCP analysis from frontend

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/features/cornerstone-pages/meta/meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/cornerstone-pages/meta/meta.tsx
@@ -16,7 +16,7 @@ import { useRegenerateCriticalCssAction } from '$features/critical-css/lib/store
 import { isSameSiteUrl } from '$lib/utils/is-same-site-url';
 import InterstitialModalCTA from '$features/upgrade-cta/interstitial-modal-cta';
 import { useNotices } from '$features/notice/context';
-import { useOptimizeLcpAction } from '$features/lcp/lib/stores/lcp-state';
+import { useLcpState } from '$features/lcp/lib/stores/lcp-state';
 import { ExternalLink } from '@wordpress/components';
 
 const Meta = () => {
@@ -27,7 +27,7 @@ const Meta = () => {
 	const premiumFeatures = usePremiumFeatures();
 	const isPremium = premiumFeatures.includes( 'cornerstone-10-pages' );
 	const regenerateAction = useRegenerateCriticalCssAction();
-	const optimizeLcpAction = useOptimizeLcpAction();
+	const [ lcpState ] = useLcpState( { enabled: false } );
 	const { setNotice } = useNotices();
 
 	const updateCornerstonePages = ( newValue: string ) => {
@@ -43,7 +43,9 @@ const Meta = () => {
 			if ( isPremium ) {
 				regenerateAction.mutate();
 			}
-			optimizeLcpAction.mutate();
+
+			// If the CS Pages were updated, the LCP state should be set to pending if it was enabled. This will trigger the LCP Module to listen until the LCP is optimized.
+			lcpState.refetch();
 		} );
 	};
 

--- a/projects/plugins/boost/app/assets/src/js/features/lcp/lib/stores/lcp-state.ts
+++ b/projects/plugins/boost/app/assets/src/js/features/lcp/lib/stores/lcp-state.ts
@@ -6,20 +6,22 @@ import { LcpStateSchema } from './lcp-state-types';
 
 /**
  * Hook for accessing and writing to the overall Lcp state.
+ * @param queryArgs
+ * @param queryArgs.enabled
  */
-export function useLcpState() {
+export function useLcpState( queryArgs: { enabled?: boolean } = {} ) {
 	const [ lcp ] = useSingleModuleState( 'lcp' );
-	const enabled = lcp?.active;
 
 	return useDataSync( 'jetpack_boost_ds', 'lcp_state', LcpStateSchema, {
 		query: {
 			refetchInterval: refetch => {
-				if ( ! enabled ) {
+				if ( lcp?.active === false ) {
 					return false;
 				}
 
 				return refetch.state.data?.status === 'pending' ? 2000 : 30000;
 			},
+			...queryArgs,
 		},
 	} );
 }

--- a/projects/plugins/boost/changelog/fix-boost-lcp-cs-page-invalidating-lcp
+++ b/projects/plugins/boost/changelog/fix-boost-lcp-cs-page-invalidating-lcp
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: LCP: Changes to an unreleased feature.
+
+


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fixes an issue where LCP is requested when a user updates their CS pages regardless if LCP is enabled/available or not.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
**When LCP is unavailable/disabled**
1. Ensure latest Boost Cloud trunk is checked out
2. Latest Jetpack Boost Developer plugin installed and activated.
3. Your local Boost Cloud is connected to your local WP instance.
4. At least one Cornerstone Page set.
5. Update your CS page list. Verify that an analysis request does **not** trigger, but a fetching of LCP status does.

**When LCP is available, and enabled**

1. Ensure latest Boost Cloud trunk is checked out
2. Latest Jetpack Boost Developer plugin installed and activated.
3. Your local Boost Cloud is connected to your local WP instance.
4. At least one Cornerstone Page set.
6. Boost Feature Flag enabled within the install (`JETPACK_BOOST_DEVELOPMENT_FEATURES`)
7. LCP Optimization feature enabled.
8. Update your CS page list. Verify that an analysis request does **not** trigger, but a fetching of LCP status does.
9. The page should show that LCP is currently being optimized.
