### PR TITLE
Inline Search: Address Blaskan theme body class conflict with inline highlighter

### DIFF
--- a/projects/packages/search/changelog/fix-blaskan_theme_body_class_conflict_with_inline_highlighter
+++ b/projects/packages/search/changelog/fix-blaskan_theme_body_class_conflict_with_inline_highlighter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+Addresses body_class filter fatal in older versions of the Blaskan theme.

--- a/projects/packages/search/src/inline-search/class-inline-search-highlighter.php
+++ b/projects/packages/search/src/inline-search/class-inline-search-highlighter.php
@@ -77,10 +77,19 @@ class Inline_Search_Highlighter {
 	 * @return string The filtered title.
 	 */
 	public function filter_highlighted_title( string $title, ?int $post_id = null ): string {
-		// o2 is currently rendering <mark> tags in post titles, so we need to return the original.
-		$body_class = get_body_class();
-		if ( is_array( $body_class ) && in_array( 'o2', $body_class, true ) ) {
-			return $title;
+		$incompatible_themes = array(
+			'blaskan', // Blaskan incorrectly uses wp_nav_menu() in body_class filter, causing infinite recursion.
+			'p2020',   // P2 loads o2 as a plugin, which calls the_title() filter incorrectly.
+		);
+
+		$theme          = wp_get_theme();
+		$theme_name     = strtolower( $theme->get( 'Name' ) );
+		$theme_template = strtolower( $theme->get_template() );
+
+		foreach ( $incompatible_themes as $incompatible_theme ) {
+			if ( $theme_name === $incompatible_theme || $theme_template === $incompatible_theme ) {
+				return $title;
+			}
 		}
 
 		if ( ! $this->is_search_result( $post_id ) ) {

--- a/projects/plugins/jetpack/changelog/fix-blaskan_theme_body_class_conflict_with_inline_highlighter
+++ b/projects/plugins/jetpack/changelog/fix-blaskan_theme_body_class_conflict_with_inline_highlighter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: bugfix
+
+Addresses body_class filter fatal in older versions of the Blaskan theme.

--- a/projects/plugins/search/changelog/fix-blaskan_theme_body_class_conflict_with_inline_highlighter
+++ b/projects/plugins/search/changelog/fix-blaskan_theme_body_class_conflict_with_inline_highlighter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+Addresses body_class filter fatal in older versions of the Blaskan theme.


### PR DESCRIPTION
Fixes p1749054774731169-slack-C081BEZPLAZ

## Proposed changes:

This PR moves away from the `body_class` detection approach introduced in https://github.com/Automattic/jetpack/pull/43511, and moves instead to theme detection using `wp_get_theme()`. While this approach worked for its intended purpose, it seems there are themes that call the `body_class` filter incorrectly, such as earlier versions of the Blaskan theme:

https://themes.trac.wordpress.org/browser/blaskan/2.6.6/functions.php#L285

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A

## Does this pull request change what data or activity we track or use?

N/A

## Testing instructions:

- On your environment, make sure Jetpack Search is active, but Instant Search is disabled.
- Either set `add_filter( 'jetpack_search_replace_classic', '__return_true', 20 )`; somewhere (e.g. using  the`Code Snippets` plugin) or add an early `return true` to `should_replace_classic_search()`.
- With this branch checked out on your local environment, ensure that search highlighting works for both Block themes (e.g. `Twenty Twenty Four`) and Classic themes (e.g. `Dara`), that use `the_excerpt()` and `the_title()` to return search results. `Twenty Twenty Five` returns search results using `the_concent()`, and this is not compatible with highlighting at this point.
- Point PfsEZG-r-p2 to your WordPress.com sandbox
- On your sandbox, check out this branch, or manually add the changes to`class-inline-search-highlighter.php`.
- Ensure you encounter no fatals while browsing the P2 above, and that search results are returned without `<mark>` tags in the title. Highlighting is not expected to function on P2 at this point.