### PR TITLE
Boost: Ensure decimals can used for img sizes within LCP Optimization

### DIFF
--- a/projects/plugins/boost/app/modules/optimizations/lcp/class-lcp-optimize-img-tag.php
+++ b/projects/plugins/boost/app/modules/optimizations/lcp/class-lcp-optimize-img-tag.php
@@ -221,7 +221,7 @@ class LCP_Optimize_Img_Tag {
 		$sizes = array();
 		foreach ( $this->lcp_data['breakpoints'] as $breakpoint ) {
 			// Make sure widthValue is a known format.
-			if ( ! isset( $breakpoint['widthValue'] ) || ! preg_match( '/^[0-9]+(?:px|vw)$/', $breakpoint['widthValue'] ) ) {
+			if ( ! isset( $breakpoint['widthValue'] ) || ! preg_match( '/^[0-9]+(?:\.[0-9]+)?(?:px|vw)$/', $breakpoint['widthValue'] ) ) {
 				continue;
 			}
 

--- a/projects/plugins/boost/changelog/fix-boost-lcp-widthValue-decimals
+++ b/projects/plugins/boost/changelog/fix-boost-lcp-widthValue-decimals
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: LCP: Changes to an unreleased feature.
+
+


### PR DESCRIPTION
## Proposed changes:
* Updates the regex pattern in LCP optimization to accept decimal values in CSS width measurements (e.g., `123.5px`, `45.2vw`)
* Previously, the regex only accepted whole numbers, which could cause valid CSS width values with decimals to be skipped during LCP optimization
* The pattern now supports formats like `123px`, `123.45px`, `123vw`, and `123.45vw`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
* WordPress site with Jetpack Boost plugin installed
* A page with images that have CSS width values containing decimals (e.g., `width: 123.5px` or `width: 45.2vw`)

### Testing Steps:
1. Enable LCP optimization in Jetpack Boost settings
2. Create or edit a Cornerstone page with an image that has a CSS width value containing decimals (e.g., `<img style="width: 123.5px" src="...">`)
  a. I have noticed that JN sites that have an image block added to the page like below have triggered this:
  <details>
  <summary>Example HTML</summary>
<figure class="wp-block-image alignwide size-large"><img src="https://funnel-of-tundras.jurassic.ninja/wp-content/uploads/2025/06/BlackHoleDisk_desktop-1024x576.png" alt="" class="wp-image-13"/></figure>\
  </details>

3. Optimize the LCP
4. View the page source or inspect the optimized image
5. Verify that the LCP optimization is properly applied to images with decimal width values
6. Check that images with both whole number widths (e.g., `123px`) and decimal widths (e.g., `123.5px`) are both processed correctly

### Expected Results:
* Images with decimal CSS width values should now be included in LCP optimization
* Previously, such images would be skipped due to the stricter reg
