### PR TITLE
Newsletter: Use total_subscribers field while displaying all subscribers

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/subscribers.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/subscribers.php
@@ -87,7 +87,7 @@ class WPCOM_REST_API_V2_Endpoint_Subscribers extends WP_REST_Controller {
 	/**
 	 * Retrieves splitted subscriber counts
 	 *
-	 * @return array data object containing subscriber counts ['email_subscribers' => 0, 'social_followers' => 0]
+	 * @return array data object containing subscriber counts.
 	 */
 	public function get_subscriber_counts() {
 		if ( ! Constants::is_defined( 'TESTING_IN_JETPACK' ) ) {

--- a/projects/plugins/jetpack/changelog/use-total-subscribers-field-from-counts
+++ b/projects/plugins/jetpack/changelog/use-total-subscribers-field-from-counts
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Newsletters:  Use total_subscribers field while displaying all subscribers.

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/edit.js
@@ -106,9 +106,9 @@ export function SubscriptionEdit( props ) {
 	const activeStyleName = getActiveStyleName( metadata.styles, className );
 
 	const { subscriberCount, subscriberCountString } = useSelect( select => {
-		const { emailSubscribers, socialFollowers } =
+		const { totalSubscribers, socialFollowers } =
 			select( membershipProductsStore ).getSubscriberCounts();
-		let count = emailSubscribers;
+		let count = totalSubscribers;
 		if ( includeSocialFollowers ) {
 			count += socialFollowers;
 		}

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -279,9 +279,9 @@ function newsletter_access_column_styles() {
 }
 
 /**
- * Determine the amount of folks currently subscribed to the blog, splitted out in email_subscribers & social_followers & paid_subscribers
+ * Determine the amount of folks currently subscribed to the blog, splitted out in total_subscribers, email_subscribers, social_followers & paid_subscribers.
  *
- * @return array containing ['value' => ['email_subscribers' => 0, 'paid_subscribers' => 0, 'social_followers' => 0]]
+ * @return array containing ['value' => ['total_subscribers' => 0, 'email_subscribers' => 0, 'paid_subscribers' => 0, 'social_followers' => 0]]
  */
 function fetch_subscriber_counts() {
 	$subs_count = 0;
@@ -302,6 +302,7 @@ function fetch_subscriber_counts() {
 					'code'    => $xml->getErrorCode(),
 					'message' => $xml->getErrorMessage(),
 					'value'   => ( isset( $subs_count['value'] ) ) ? $subs_count['value'] : array(
+						'total_subscribers' => 0,
 						'email_subscribers' => 0,
 						'social_followers'  => 0,
 						'paid_subscribers'  => 0,
@@ -329,9 +330,9 @@ function get_subscriber_count( $include_social_followers ) {
 	$counts = fetch_subscriber_counts();
 
 	if ( $include_social_followers ) {
-		$subscriber_count = $counts['value']['email_subscribers'] + $counts['value']['social_followers'];
+		$subscriber_count = $counts['value']['total_subscribers'] + $counts['value']['social_followers'];
 	} else {
-		$subscriber_count = $counts['value']['email_subscribers'];
+		$subscriber_count = $counts['value']['total_subscribers'];
 	}
 	return $subscriber_count;
 }

--- a/projects/plugins/jetpack/extensions/shared/memberships/settings.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships/settings.js
@@ -41,20 +41,20 @@ export function Link( { href, children } ) {
 
 export function getReachForAccessLevelKey( {
 	accessLevel,
-	emailSubscribers,
+	subscribers, // This can be either total subscribers or email subscribers depending on the view where this is used.
 	paidSubscribers,
 	postHasPaywallBlock = false,
 } ) {
-	emailSubscribers = emailSubscribers ?? 0;
+	subscribers = subscribers ?? 0;
 	paidSubscribers = paidSubscribers ?? 0;
 
 	switch ( accessOptions[ accessLevel ]?.key ) {
 		case accessOptions.everybody.key:
-			return emailSubscribers;
+			return subscribers;
 		case accessOptions.subscribers.key:
-			return emailSubscribers;
+			return subscribers;
 		case accessOptions.paid_subscribers.key:
-			return postHasPaywallBlock ? emailSubscribers : paidSubscribers;
+			return postHasPaywallBlock ? subscribers : paidSubscribers;
 		default:
 			return 0;
 	}
@@ -133,7 +133,7 @@ export function NewsletterAccessRadioButtons( {
 	postHasPaywallBlock: postHasPaywallBlock = false,
 } ) {
 	const isStripeConnected = stripeConnectUrl === null;
-	const { emailSubscribers, paidSubscribers } = useSelect( select =>
+	const { totalSubscribers, paidSubscribers } = useSelect( select =>
 		select( membershipProductsStore ).getSubscriberCounts()
 	);
 	const [ showDialog, setShowDialog ] = useState( false );
@@ -142,12 +142,12 @@ export function NewsletterAccessRadioButtons( {
 	const setAccess = useSetAccess();
 	const subscribersReach = getReachForAccessLevelKey( {
 		accessLevel: accessOptions.subscribers.key,
-		emailSubscribers,
+		subscribers: totalSubscribers,
 		paidSubscribers,
 	} );
 	const paidSubscribersReach = getReachForAccessLevelKey( {
 		accessLevel: accessOptions.paid_subscribers.key,
-		emailSubscribers,
+		subscribers: totalSubscribers,
 		paidSubscribers,
 	} );
 

--- a/projects/plugins/jetpack/extensions/shared/memberships/subscribers-affirmation.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships/subscribers-affirmation.js
@@ -253,7 +253,7 @@ function SubscribersAffirmation( { accessLevel, prePublish = false } ) {
 
 	const reachForAccessLevel = getReachForAccessLevelKey( {
 		accessLevel,
-		emailSubscribers: emailSubscribersCount,
+		subscribers: emailSubscribersCount,
 		paidSubscribers: paidSubscribersCount,
 		postHasPaywallBlock,
 	} );

--- a/projects/plugins/jetpack/extensions/store/membership-products/reducer.js
+++ b/projects/plugins/jetpack/extensions/store/membership-products/reducer.js
@@ -7,6 +7,7 @@ export const DEFAULT_STATE = {
 	siteSlug: '',
 	connectedAccountDefaultCurrency: '',
 	subscriberCounts: {
+		totalSubscribers: null,
 		socialFollowers: null,
 		emailSubscribers: null,
 		paidSubscribers: null,

--- a/projects/plugins/jetpack/extensions/store/membership-products/resolvers.js
+++ b/projects/plugins/jetpack/extensions/store/membership-products/resolvers.js
@@ -237,6 +237,7 @@ export const getSubscriberCounts =
 			const response = await fetchSubscriberCounts();
 			dispatch(
 				setSubscriberCounts( {
+					totalSubscribers: response.counts.total_subscribers,
 					socialFollowers: response.counts.social_followers,
 					emailSubscribers: response.counts.email_subscribers,
 					paidSubscribers: response.counts.paid_subscribers,

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-fields/WPCOM_REST_API_V2_Subscribers_Endpoint_Test.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-fields/WPCOM_REST_API_V2_Subscribers_Endpoint_Test.php
@@ -39,9 +39,9 @@ class WPCOM_REST_API_V2_Subscribers_Endpoint_Test extends Jetpack_REST_TestCase 
 		}
 	}
 
-	public static function set_subscribers_counts( $email_subscribers, $social_followers ) {
+	public static function set_subscribers_counts( $total_subscribers, $email_subscribers, $social_followers ) {
 		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-			wp_cache_set( 'wpcom_blog_subscriber_total_' . get_current_blog_id(), $email_subscribers, 'subs' );
+			wp_cache_set( 'wpcom_blog_subscriber_total_' . get_current_blog_id(), $total_subscribers, 'subs' );
 			wp_cache_set( 'wpcom_blog_social_followers_total_' . get_current_blog_id(), $social_followers, 'subs' );
 
 		} else {
@@ -49,6 +49,7 @@ class WPCOM_REST_API_V2_Subscribers_Endpoint_Test extends Jetpack_REST_TestCase 
 				'wpcom_subscribers_totals',
 				array(
 					'value'  => array(
+						'total_subscribers' => $total_subscribers,
 						'email_subscribers' => $email_subscribers,
 						'social_followers'  => $social_followers,
 					),
@@ -82,13 +83,14 @@ class WPCOM_REST_API_V2_Subscribers_Endpoint_Test extends Jetpack_REST_TestCase 
 
 	public function test_get_subscriber_counts_with_edit_permission() {
 		wp_set_current_user( self::$editor_user_id );
-		self::set_subscribers_counts( 100, 200 );
+		self::set_subscribers_counts( 100, 75, 200 );
 
 		$request  = new WP_REST_Request( WP_REST_Server::READABLE, '/wpcom/v2/subscribers/counts' );
 		$response = $this->server->dispatch( $request );
 		$data     = $response->get_data();
 
-		$this->assertEquals( 100, $data['counts']['email_subscribers'] );
+		$this->assertEquals( 100, $data['counts']['total_subscribers'] );
+		$this->assertEquals( 75, $data['counts']['email_subscribers'] );
 		$this->assertEquals( 200, $data['counts']['social_followers'] );
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #CML-212

## Proposed changes:

We have both `total_subscribers` and `email_subscribers` fields in the `subscribers/counts` API. Currently we are using `email_subscribers` field even while displaying all subscribers so this PR changes those instances to `total_subscribers`.

## Why are these changes being made?

Before we only had `email_subscribers` field in the API which were returning all subscribers instead of email only so we have fixed it in the API (182194-ghe-Automattic/wpcom) and now we are making changes to use the new field.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

View details in issue.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

## Testing instructions:

Currently both `total_subscribers` field and `email_subscribers` field have same data so just make sure count is appearing, we'll verify the numbers in another PR.

#### Simple:

1. Download the branch to your sandbox by following the instructions given in comment.
2. Create a new post.
3. Verify "Subscribe" block:
    1. Add "Subscribe" block.
    1. Go to block settings.
    1. Verify the notice stating "[COUNT] readers are subscribed".
    1. Expand "Settings" panel > toggle "Show subscriber count".
    1. Verify the count on block Edit screen and View screen.

![image](https://github.com/user-attachments/assets/e1937412-123d-4bb7-878a-9cc69ade1c61)

4. Verify the count on "Newsletter" panel:

![image](https://github.com/user-attachments/assets/116643f7-deba-4f1d-8dd0-2e92bb307f61)

5. Verify the counts on "Post" panel:

![image](https://github.com/user-attachments/assets/cd65cccf-f2ec-493b-b949-c79355b5a097)

#### Self Hosted and Atomic

1. Go to your test Atomic Site.
2. Use Jetpack Beta Plugin to download the branch on your test site.
3. Repeat above steps from 3 to onward.
