### PR TITLE
Charts: Fix dependency issue

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -316,6 +316,9 @@ importers:
 
   projects/js-packages/charts:
     dependencies:
+      '@automattic/number-formatters':
+        specifier: workspace:*
+        version: link:../number-formatters
       '@babel/runtime':
         specifier: 7.27.4
         version: 7.27.4
@@ -371,9 +374,6 @@ importers:
       '@automattic/jetpack-webpack-config':
         specifier: workspace:*
         version: link:../webpack-config
-      '@automattic/number-formatters':
-        specifier: workspace:*
-        version: link:../number-formatters
       '@babel/core':
         specifier: 7.27.4
         version: 7.27.4

--- a/projects/js-packages/charts/changelog/fix-chart-dependencies
+++ b/projects/js-packages/charts/changelog/fix-chart-dependencies
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix @automattic/number-formatters dependency issue

--- a/projects/js-packages/charts/package.json
+++ b/projects/js-packages/charts/package.json
@@ -47,6 +47,7 @@
 		"./style.css": "./dist/mjs/style.css"
 	},
 	"dependencies": {
+		"@automattic/number-formatters": "workspace:*",
 		"@babel/runtime": "7.27.4",
 		"@react-spring/web": "9.7.5",
 		"@visx/axis": "^3.12.0",
@@ -67,7 +68,6 @@
 	},
 	"devDependencies": {
 		"@automattic/jetpack-webpack-config": "workspace:*",
-		"@automattic/number-formatters": "workspace:*",
 		"@babel/core": "7.27.4",
 		"@babel/plugin-transform-react-jsx": "7.27.1",
 		"@babel/plugin-transform-runtime": "7.27.4",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

Moved `@automattic/number-formatters` from `devDependencies` to `dependencies` in `package.json` to fix a build issue when using `@automattic/charts` in other projects. 


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Testing is not necessary, reviewing the change is sufficient.

