### PR TITLE
Removed "Select a design" task from build launchpad definition

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-remove-select-design-step-from-build-task
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-remove-select-design-step-from-build-task
@@ -1,0 +1,4 @@
+Significance: minor
+Type: removed
+
+Launchpad: Removed "Select a design" step from build task list

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -37,7 +37,6 @@ function wpcom_launchpad_get_task_list_definitions() {
 			},
 			'task_ids'            => array(
 				'setup_general',
-				'design_selected',
 				'plan_selected',
 				'first_post_published',
 				'design_edited',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://linear.app/a8c/issue/DOTCOM-13450/focused-launchpad-shows-select-a-design-but-we-didnt-do-it

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Since we removed the Design picker from onboarding, we don't want to show that as selected, which can confuse the user, as they didn't perform that action. 
* As we're almost sure of removing the focused Launchpad, we decided not to spend much time implementing a "Select a design" step where users would have to select it to complete that step, as we do for other steps.

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/5f006659-0fde-4c43-a03c-420487e328b1) | ![image](https://github.com/user-attachments/assets/ddefe9bd-c8a9-4990-b231-bbe56b50446a) | 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this to your sandbox [following the instructions bellow](https://github.com/Automattic/jetpack/pull/43820#issuecomment-2949237868)
* Create a new site at the [/setup/onboarding](https://wordpress.com/setup/onboarding) flow
* Make sure you won't see "Select a design" step again

