### PR TITLE
Forms: Use routing for integrations tab

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-google-routing
+++ b/projects/packages/forms/changelog/fix-forms-google-routing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Fix routing on new integrations tab.

--- a/projects/packages/forms/src/dashboard/components/layout/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/layout/index.tsx
@@ -113,6 +113,7 @@ const Layout = ( {
 				tabs={ tabs }
 				initialTabName={ getCurrentTab() }
 				onSelect={ handleTabSelect }
+				key={ getCurrentTab() }
 			>
 				{ () => <Outlet /> }
 			</TabPanel>

--- a/projects/packages/forms/src/dashboard/integrations/akismet-card.tsx
+++ b/projects/packages/forms/src/dashboard/integrations/akismet-card.tsx
@@ -81,12 +81,7 @@ const AkismetDashboardCard = ( {
 						{ __( 'Your forms are automatically protected with Akismet.', 'jetpack-forms' ) }
 					</p>
 					<div className="integration-card__links">
-						<Button
-							variant="link"
-							onClick={ handleViewSpamClick }
-							target="_self"
-							rel="noopener noreferrer"
-						>
+						<Button variant="link" onClick={ handleViewSpamClick } rel="noopener noreferrer">
 							{ __( 'View spam', 'jetpack-forms' ) }
 						</Button>
 						<span>|</span>

--- a/projects/packages/forms/src/dashboard/integrations/akismet-card.tsx
+++ b/projects/packages/forms/src/dashboard/integrations/akismet-card.tsx
@@ -1,7 +1,8 @@
 import { getRedirectUrl } from '@automattic/jetpack-components';
 import { Button, ExternalLink } from '@wordpress/components';
-import { createInterpolateElement } from '@wordpress/element';
+import { createInterpolateElement, useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { useNavigate } from 'react-router-dom';
 import IntegrationCard from '../../blocks/contact-form/components/jetpack-integrations-modal/integration-card';
 import AkismetIcon from '../../icons/akismet';
 import type { IntegrationCardProps } from './types';
@@ -12,8 +13,8 @@ const AkismetDashboardCard = ( {
 	data,
 	refreshStatus,
 }: IntegrationCardProps ) => {
-	const formSubmissionsUrl = data?.details?.formSubmissionsSpamUrl || '';
 	const { isConnected: akismetActiveWithKey = false, settingsUrl = '' } = data || {};
+	const navigate = useNavigate();
 
 	const cardData = {
 		...data,
@@ -35,6 +36,10 @@ const AkismetDashboardCard = ( {
 			'jetpack-forms'
 		),
 	};
+
+	const handleViewSpamClick = useCallback( () => {
+		navigate( '/responses?status=spam' );
+	}, [ navigate ] );
 
 	return (
 		<IntegrationCard
@@ -78,8 +83,8 @@ const AkismetDashboardCard = ( {
 					<div className="integration-card__links">
 						<Button
 							variant="link"
-							href={ formSubmissionsUrl }
-							target="_blank"
+							onClick={ handleViewSpamClick }
+							target="_self"
 							rel="noopener noreferrer"
 						>
 							{ __( 'View spam', 'jetpack-forms' ) }

--- a/projects/packages/forms/src/dashboard/integrations/akismet-card.tsx
+++ b/projects/packages/forms/src/dashboard/integrations/akismet-card.tsx
@@ -81,7 +81,7 @@ const AkismetDashboardCard = ( {
 						{ __( 'Your forms are automatically protected with Akismet.', 'jetpack-forms' ) }
 					</p>
 					<div className="integration-card__links">
-						<Button variant="link" onClick={ handleViewSpamClick } rel="noopener noreferrer">
+						<Button variant="link" onClick={ handleViewSpamClick }>
 							{ __( 'View spam', 'jetpack-forms' ) }
 						</Button>
 						<span>|</span>

--- a/projects/packages/forms/src/dashboard/integrations/google-sheets-card.tsx
+++ b/projects/packages/forms/src/dashboard/integrations/google-sheets-card.tsx
@@ -78,12 +78,7 @@ const GoogleSheetsDashboardCard = ( {
 						) }
 					</p>
 					<div className="integration-card__links">
-						<Button
-							variant="link"
-							onClick={ handleViewResponsesClick }
-							target="_self"
-							rel="noopener noreferrer"
-						>
+						<Button variant="link" onClick={ handleViewResponsesClick } rel="noopener noreferrer">
 							{ __( 'View Form Responses', 'jetpack-forms' ) }
 						</Button>
 					</div>

--- a/projects/packages/forms/src/dashboard/integrations/google-sheets-card.tsx
+++ b/projects/packages/forms/src/dashboard/integrations/google-sheets-card.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@wordpress/components';
 import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { config } from '../';
+import { useNavigate } from 'react-router-dom';
 import IntegrationCard from '../../blocks/contact-form/components/jetpack-integrations-modal/integration-card';
 import GoogleSheetsIcon from '../../icons/google-sheets';
 import type { IntegrationCardProps } from './types';
@@ -14,8 +14,7 @@ const GoogleSheetsDashboardCard = ( {
 }: IntegrationCardProps ) => {
 	const isConnected = !! data?.isConnected;
 	const settingsUrl = data?.settingsUrl;
-	const FORM_RESPONSES_URL =
-		config( 'dashboardURL' ) || '/wp-admin/admin.php?page=jetpack-forms-admin';
+	const navigate = useNavigate();
 
 	const cardData = {
 		...data,
@@ -31,6 +30,10 @@ const GoogleSheetsDashboardCard = ( {
 		if ( ! settingsUrl ) return;
 		window.open( settingsUrl, '_blank', 'noopener,noreferrer' );
 	}, [ settingsUrl ] );
+
+	const handleViewResponsesClick = useCallback( () => {
+		navigate( '/responses' );
+	}, [ navigate ] );
 
 	return (
 		<IntegrationCard
@@ -77,8 +80,8 @@ const GoogleSheetsDashboardCard = ( {
 					<div className="integration-card__links">
 						<Button
 							variant="link"
-							href={ FORM_RESPONSES_URL }
-							target="_blank"
+							onClick={ handleViewResponsesClick }
+							target="_self"
 							rel="noopener noreferrer"
 						>
 							{ __( 'View Form Responses', 'jetpack-forms' ) }

--- a/projects/packages/forms/src/dashboard/integrations/google-sheets-card.tsx
+++ b/projects/packages/forms/src/dashboard/integrations/google-sheets-card.tsx
@@ -78,7 +78,7 @@ const GoogleSheetsDashboardCard = ( {
 						) }
 					</p>
 					<div className="integration-card__links">
-						<Button variant="link" onClick={ handleViewResponsesClick } rel="noopener noreferrer">
+						<Button variant="link" onClick={ handleViewResponsesClick }>
 							{ __( 'View Form Responses', 'jetpack-forms' ) }
 						</Button>
 					</div>


### PR DESCRIPTION
## Proposed changes:

We've added a new integrations tab, still behind a feature flag. The Google and Akismet cards include links to the responses page, and they were using real links that reload the page. But the responses tab is just another tab on the same screen. This updates both link to use React routing. 

This is a small follow up to: https://github.com/Automattic/jetpack/pull/43757

In a later PR, we should update the Google Sheets link directly to the export modal, but that requires prepping the modal to have a url first. 

<img width="1314" alt="form-responses-routing" src="https://github.com/user-attachments/assets/9ea83d16-2859-4870-afc1-deafaae39f5b" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None. 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No. 

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Enable the feature flag to see the integrations tab by adding: `add_filter( 'jetpack_forms_enable_integrations_tab', '__return_true' );`
* Go to Jetpack > Forms > Integrations
* Akismet: If you haven't already, you'll be prompted to install Akismet and add a key. Once done, you'll see a View Spam link. Click that and confirm it seamlessly goes to Responses > Spam on the same page with no page reload. 
* Google Sheets: If you haven't already, you'll be prompted to connect Google Sheets. Once done, you'll see a View Form Respones. Click that and confirm it seamlessly goes to Responses on the same page with no page reload. 
