### PR TITLE
Jetpack Forms move method to Util class

### DIFF
--- a/projects/packages/forms/changelog/change-jetpack-forms-utils-move-method
+++ b/projects/packages/forms/changelog/change-jetpack-forms-utils-move-method
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: move get_export_filename method from Admin to Util

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -2201,13 +2201,13 @@ class Contact_Form_Plugin {
 		if ( ! empty( $post_data['post'] ) && $post_data['post'] !== 'all' ) {
 			$filename = sprintf(
 				'%s - %s.csv',
-				Admin::init()->get_export_filename( get_the_title( (int) $post_data['post'] ) ),
+				Util::get_export_filename( get_the_title( (int) $post_data['post'] ) ),
 				gmdate( 'Y-m-d H:i' )
 			);
 		} else {
 			$filename = sprintf(
 				'%s - %s.csv',
-				Admin::init()->get_export_filename(),
+				Util::get_export_filename(),
 				gmdate( 'Y-m-d H:i' )
 			);
 		}

--- a/projects/packages/forms/src/contact-form/class-util.php
+++ b/projects/packages/forms/src/contact-form/class-util.php
@@ -339,4 +339,25 @@ class Util {
 			$content
 		);
 	}
+
+	/**
+	 * Get a filename for export tasks
+	 *
+	 * @param string $source The filtered source for exported data.
+	 * @return string The filename without source nor date suffix.
+	 */
+	public static function get_export_filename( $source = '' ) {
+		return $source === ''
+			? sprintf(
+				/* translators: Site title, used to craft the export filename, eg "MySite - Jetpack Form Responses" */
+				__( '%s - Jetpack Form Responses', 'jetpack-forms' ),
+				sanitize_file_name( get_bloginfo( 'name' ) )
+			)
+			: sprintf(
+				/* translators: 1: Site title; 2: post title. Used to craft the export filename, eg "MySite - Jetpack Form Responses - Contact" */
+				__( '%1$s - Jetpack Form Responses - %2$s', 'jetpack-forms' ),
+				sanitize_file_name( get_bloginfo( 'name' ) ),
+				sanitize_file_name( $source )
+			);
+	}
 }


### PR DESCRIPTION
Related to #43821

Part of FORMS-132

## Proposed changes:
This PR moves get_export_filename method from Admin class to Util class, getting things ready to remove Admin class entirely. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion


## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Go to Forms dashboard and click on export button, choose CSV. A file should download and no errors occur.