### PR TITLE
Help Center: Persist router state - proxy the request

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-hc-route-persistence
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-hc-route-persistence
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Persist the Help Center Router state in user preferences

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-wp-rest-help-center-persisted-open-state.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-wp-rest-help-center-persisted-open-state.php
@@ -68,7 +68,7 @@ class WP_REST_Help_Center_Persisted_Open_State extends \WP_REST_Controller {
 
 		$projected_response = array(
 			'help_center_open' => (bool) $is_open,
-			'help_center_router_history' => router_history,
+			'help_center_router_history' => $router_history,
 		);
 
 		return rest_ensure_response( $projected_response );

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-wp-rest-help-center-persisted-open-state.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-wp-rest-help-center-persisted-open-state.php
@@ -64,9 +64,11 @@ class WP_REST_Help_Center_Persisted_Open_State extends \WP_REST_Controller {
 		$response = json_decode( wp_remote_retrieve_body( $body ) );
 
 		$is_open = $response->help_center_open ?? false;
+		$router_history = $response->help_center_router_history ?? null;
 
 		$projected_response = array(
 			'help_center_open' => (bool) $is_open,
+			'help_center_router_history' => router_history,
 		);
 
 		return rest_ensure_response( $projected_response );
@@ -79,6 +81,7 @@ class WP_REST_Help_Center_Persisted_Open_State extends \WP_REST_Controller {
 	 */
 	public function set_state( \WP_REST_Request $request ) {
 		$state = $request['help_center_open'];
+		$router_history = $request['help_center_router_history'];
 
 		$data = array(
 			'calypso_preferences' => array(),
@@ -86,6 +89,10 @@ class WP_REST_Help_Center_Persisted_Open_State extends \WP_REST_Controller {
 
 		if ( $request->has_param( 'help_center_open' ) ) {
 			$data['calypso_preferences']['help_center_open'] = $state;
+		}
+
+		if ( $request->has_param( 'help_center_router_history' ) ) {
+			$data['calypso_preferences']['help_center_router_history'] = $router_history;
 		}
 
 		$body = Client::wpcom_json_api_request_as_user(
@@ -102,10 +109,12 @@ class WP_REST_Help_Center_Persisted_Open_State extends \WP_REST_Controller {
 		$response = json_decode( wp_remote_retrieve_body( $body ) );
 
 		$is_open = $response->calypso_preferences->help_center_open ?? false;
+		$router_history = $response->calypso_preferences->help_center_router_history ?? null;
 
 		$projected_response = array(
 			'calypso_preferences' => array(
 				'help_center_open' => (bool) $is_open,
+				'help_center_router_history' => $router_history,
 			),
 		);
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-wp-rest-help-center-persisted-open-state.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-wp-rest-help-center-persisted-open-state.php
@@ -63,11 +63,11 @@ class WP_REST_Help_Center_Persisted_Open_State extends \WP_REST_Controller {
 
 		$response = json_decode( wp_remote_retrieve_body( $body ) );
 
-		$is_open = $response->help_center_open ?? false;
+		$is_open        = $response->help_center_open ?? false;
 		$router_history = $response->help_center_router_history ?? null;
 
 		$projected_response = array(
-			'help_center_open' => (bool) $is_open,
+			'help_center_open'           => (bool) $is_open,
 			'help_center_router_history' => $router_history,
 		);
 
@@ -80,7 +80,7 @@ class WP_REST_Help_Center_Persisted_Open_State extends \WP_REST_Controller {
 	 * @param \WP_REST_Request $request The request sent to the API.
 	 */
 	public function set_state( \WP_REST_Request $request ) {
-		$state = $request['help_center_open'];
+		$state          = $request['help_center_open'];
 		$router_history = $request['help_center_router_history'];
 
 		$data = array(
@@ -108,12 +108,12 @@ class WP_REST_Help_Center_Persisted_Open_State extends \WP_REST_Controller {
 
 		$response = json_decode( wp_remote_retrieve_body( $body ) );
 
-		$is_open = $response->calypso_preferences->help_center_open ?? false;
+		$is_open        = $response->calypso_preferences->help_center_open ?? false;
 		$router_history = $response->calypso_preferences->help_center_router_history ?? null;
 
 		$projected_response = array(
 			'calypso_preferences' => array(
-				'help_center_open' => (bool) $is_open,
+				'help_center_open'           => (bool) $is_open,
 				'help_center_router_history' => $router_history,
 			),
 		);


### PR DESCRIPTION
Required for https://github.com/Automattic/wp-calypso/pull/104038

## Proposed changes:
This proxies the router state for Atomic sites.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
1. Apply via Jetpack Beta Plugin.
2. Run the HC as explained in https://github.com/Automattic/wp-calypso/pull/104038
3. Visit the Help Center in a wp-admin part of the site.
4. Open an article
5. Refresh the page.
6. The HC should pop open at the same address.
