### PR TITLE
Jetpack forms migration page: fix heading line-height

### DIFF
--- a/projects/packages/forms/changelog/fix-jetpack-forms-migration-page-heading
+++ b/projects/packages/forms/changelog/fix-jetpack-forms-migration-page-heading
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: migration page heading needs line-height for when it wraps

--- a/projects/packages/forms/src/dashboard/admin-migrate-page/style.scss
+++ b/projects/packages/forms/src/dashboard/admin-migrate-page/style.scss
@@ -4,4 +4,8 @@
 	> div:first-child {
 		margin-left: 0;
 	}
+
+	h1 {
+		line-height: 1.2;
+	}
 }


### PR DESCRIPTION


## Proposed changes:
Wee fix for migration page heading. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion


## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
TBD