### PR TITLE
Revert "Subscriptions: do not attempt to fetch or display elements from WordPress.com when user is not connected

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-newsletter-non-connected-editor
+++ b/projects/plugins/jetpack/changelog/fix-newsletter-non-connected-editor
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Newsletters: avoid errors in the post editor when editors are not connected to WordPress.com.

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/edit.js
@@ -1,6 +1,4 @@
 import { ThemeProvider } from '@automattic/jetpack-components';
-import { useConnection } from '@automattic/jetpack-connection';
-import { isSimpleSite } from '@automattic/jetpack-shared-extension-utils';
 import { formatNumberCompact } from '@automattic/number-formatters';
 import {
 	BlockControls,
@@ -63,37 +61,6 @@ const applyFallbackStyles = withFallbackStyles( ( node, ownProps ) => {
 	};
 } );
 
-function PaidPlanBlockControls() {
-	const { isUserConnected } = useConnection();
-	const canManagePlans = isSimpleSite() || isUserConnected;
-
-	const hasTierPlans = useSelect(
-		select => {
-			if ( ! isUserConnected ) {
-				return false;
-			}
-			return !! select( 'jetpack/membership-products' )?.getNewsletterTierProducts()?.length;
-		},
-		[ isUserConnected ]
-	);
-
-	if ( ! canManagePlans ) {
-		return null;
-	}
-
-	return (
-		<BlockControls>
-			<ToolbarGroup>
-				<ToolbarButton href={ getPaidPlanLink( hasTierPlans ) } target="_blank">
-					{ hasTierPlans
-						? _x( 'Manage plans', 'unused context to distinguish translations', 'jetpack' )
-						: __( 'Set up a paid plan', 'jetpack' ) }
-				</ToolbarButton>
-			</ToolbarGroup>
-		</BlockControls>
-	);
-}
-
 export function SubscriptionEdit( props ) {
 	const {
 		attributes,
@@ -109,7 +76,10 @@ export function SubscriptionEdit( props ) {
 		setBorderColor,
 		fontSize,
 	} = props;
-
+	const hasTierPlans = useSelect(
+		select => !! select( 'jetpack/membership-products' )?.getNewsletterTierProducts()?.length,
+		[]
+	);
 	const blockProps = useBlockProps();
 	const validatedAttributes = getValidatedAttributes( metadata.attributes, attributes );
 	if ( ! isEqual( validatedAttributes, attributes ) ) {
@@ -306,7 +276,15 @@ export function SubscriptionEdit( props ) {
 					successMessage={ successMessage }
 				/>
 			</InspectorControls>
-			<PaidPlanBlockControls />
+			<BlockControls>
+				<ToolbarGroup>
+					<ToolbarButton href={ getPaidPlanLink( hasTierPlans ) } target="_blank">
+						{ hasTierPlans
+							? _x( 'Manage plans', 'unused context to distinguish translations', 'jetpack' )
+							: __( 'Set up a paid plan', 'jetpack' ) }
+					</ToolbarButton>
+				</ToolbarGroup>
+			</BlockControls>
 			<div style={ cssVars }>
 				<div className="wp-block-jetpack-subscriptions__container is-not-subscriber">
 					<div className="wp-block-jetpack-subscriptions__form" role="form">

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/menu.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/menu.js
@@ -47,12 +47,8 @@ const NewsletterMenu = ( { openPreviewModal } ) => {
 			className="jetpack-newsletter-settings-sidebar"
 		>
 			<PanelBody>
-				{ ! isPublished && ! shouldPromptForConnection && (
-					<>
-						<NewsletterEmailDocumentSettings />
-						<SubscribersAffirmation accessLevel={ accessLevel } prePublish={ ! isPublished } />
-					</>
-				) }
+				{ ! isPublished && <NewsletterEmailDocumentSettings /> }
+				<SubscribersAffirmation accessLevel={ accessLevel } prePublish={ ! isPublished } />
 				{ isSendEmailEnabled && ! isPublished && (
 					<>
 						{ ! shouldPromptForConnection ? (

--- a/projects/plugins/jetpack/extensions/store/membership-products/resolvers.js
+++ b/projects/plugins/jetpack/extensions/store/membership-products/resolvers.js
@@ -1,4 +1,3 @@
-import { CONNECTION_STORE_ID } from '@automattic/jetpack-connection';
 import apiFetch from '@wordpress/api-fetch';
 import { store as editorStore } from '@wordpress/editor';
 import { addQueryArgs, getQueryArg } from '@wordpress/url';
@@ -195,13 +194,6 @@ export const getProducts =
 		shouldDisplayProductCreationNotice = true
 	) =>
 	async ( { dispatch, registry, select } ) => {
-		// Early return if user is not connected to avoid unnecessary API calls
-		const { isUserConnected } = registry.select( CONNECTION_STORE_ID ).getConnectionStatus();
-		if ( ! isUserConnected ) {
-			dispatch( setApiState( API_STATE_NOTCONNECTED ) );
-			return;
-		}
-
 		await executionLock.blockExecution( EXECUTION_KEY );
 		if ( hydratedFromAPI ) {
 			setDefaultProductIfNeeded( selectedProductIds, setSelectedProductIds, select );
@@ -238,13 +230,6 @@ export const getProducts =
 export const getSubscriberCounts =
 	() =>
 	async ( { dispatch, registry } ) => {
-		// Early return if user is not connected to avoid unnecessary API calls
-		const { isUserConnected } = registry.select( CONNECTION_STORE_ID ).getConnectionStatus();
-		if ( ! isUserConnected ) {
-			dispatch( setApiState( API_STATE_NOTCONNECTED ) );
-			return;
-		}
-
 		await executionLock.blockExecution( SUBSCRIBER_COUNT_EXECUTION_KEY );
 
 		const lock = executionLock.acquire( SUBSCRIBER_COUNT_EXECUTION_KEY );
@@ -269,13 +254,6 @@ export const getSubscriberCounts =
 export const getNewsletterCategories =
 	() =>
 	async ( { dispatch, registry } ) => {
-		// Early return if user is not connected to avoid unnecessary API calls
-		const { isUserConnected } = registry.select( CONNECTION_STORE_ID ).getConnectionStatus();
-		if ( ! isUserConnected ) {
-			dispatch( setApiState( API_STATE_NOTCONNECTED ) );
-			return;
-		}
-
 		await executionLock.blockExecution( GET_NEWSLETTER_CATEGORIES_EXECUTION_KEY );
 
 		const lock = executionLock.acquire( GET_NEWSLETTER_CATEGORIES_EXECUTION_KEY );
@@ -299,13 +277,6 @@ export const getNewsletterCategories =
 export const getNewsletterCategoriesSubscriptionsCount =
 	( termIds = [] ) =>
 	async ( { dispatch, registry } ) => {
-		// Early return if user is not connected to avoid unnecessary API calls
-		const { isUserConnected } = registry.select( CONNECTION_STORE_ID ).getConnectionStatus();
-		if ( ! isUserConnected ) {
-			dispatch( setApiState( API_STATE_NOTCONNECTED ) );
-			return;
-		}
-
 		await executionLock.blockExecution(
 			GET_NEWSLETTER_CATEGORIES_SUBSCRIPTIONS_COUNT_EXECUTION_KEY
 		);


### PR DESCRIPTION
This reverts commit f7cd4861048b3a7e050dd96b2c4ed4299caa2431.
PR: #43731
Slack Thread: p1749238272938439/1749232472.264439-slack-C03NLNTPZ2T

------

Fixes #39911
Fixes CML-537

## Proposed changes:

This PR brings in changes that will impact the Newsletter features' display for non-connected users. **For users that are connected to WordPress.com already, there should be no change.**

- We no longer show Newsletter panels that require a connection when the user is not connected.
- We do not show the plan management toolbar item when the user is not connected.
- We do not attempt to make requests to WordPress.com when the user is not connected.

<img width="269" alt="image" src="https://github.com/user-attachments/assets/a681e6ab-e36d-4cae-b970-57d7fd5b2a50" />
<img width="360" alt="image" src="https://github.com/user-attachments/assets/481e18b3-ce43-4dce-a4c0-b9506507840c" />

> [!NOTE]
> This is a replay of #40208 plus some added elements.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

> [!WARNING]
> This will need to be tested:
> - **On simple as well as on self-hosted or WoA**
> - **With both a connected admin and a non-connected user (can be admin or editor)**

* Start with a site that's connected to WordPress.com
* Create a new user.
* In another browser, access the site with that new user.
* **Run the next tests in both windows, when connected and when not connected**
* Open your browser's network tools, and watch for XHR requests made by Jetpack (filter by `wpcom`)
* Go to Posts > Add New
    * When not connected, you should not see any requests or error messages brought up by Jetpack
* Insert a Subscribe block
    * When connected, you should see a toolbar item to add or manage plans (see screenshot above).
    * When not connected, you should not see that button but the block should otherwise work as expected.
* Click on the Newsletter plugin icon in the top right bar
    * When not connected, you should only see an invitation to connect.
