### PR TITLE
Comments: Catch PHP errors when malformed POST is submitted

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-php_errors_with_malformed_POST
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-php_errors_with_malformed_POST
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Comments: Prevent PHP error on malformed submissions.

--- a/projects/plugins/jetpack/modules/comments/comments.php
+++ b/projects/plugins/jetpack/modules/comments/comments.php
@@ -637,7 +637,7 @@ HTML;
 		$post_array = stripslashes_deep( $_POST );
 
 		// Bail if missing the Jetpack token.
-		if ( ! isset( $post_array['sig'] ) || ! isset( $post_array['token_key'] ) ) {
+		if ( ! isset( $post_array['sig'] ) || ! isset( $post_array['token_key'] ) || ! is_string( $post_array['sig'] ) ) {
 			unset( $_POST['hc_post_as'] );
 			return;
 		}
@@ -649,7 +649,7 @@ HTML;
 			wp_die( esc_html__( 'Nonce verification failed.', 'jetpack' ), 400 );
 		}
 
-		if ( str_contains( $post_array['hc_avatar'], '.gravatar.com' ) ) {
+		if ( is_string( $post_array['hc_avatar'] ) && str_contains( $post_array['hc_avatar'], '.gravatar.com' ) ) {
 			$post_array['hc_avatar'] = htmlentities( $post_array['hc_avatar'], ENT_COMPAT );
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

I saw these errors in the WP Cloud logs:
```
PHP Fatal error: Uncaught TypeError: str_contains(): Argument #1 ($haystack) must be of type string, array given in /wordpress/plugins/jetpack/14.7/modules/comments/comments.php:652
PHP Fatal error: Uncaught TypeError: hash_equals(): Argument #2 ($user_string) must be of type string, array given in /wordpress/plugins/jetpack/14.7/modules/comments/comments.php:666
```

The method is triggered by the `pre_comment_on_post` action. As we know, anything can happen in actions, so I'm not sure if `$POST` was manipulated somewhere there or by some other thing that sent bad data, but this PR adds two `is_string()` checks to prevent the fatal.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

I'm not sure the best way to reproduce this. 🤷 