### PR TITLE
Forms: Add dashboard link to response email

### DIFF
--- a/projects/packages/forms/changelog/update-forms-email-dashboard-link
+++ b/projects/packages/forms/changelog/update-forms-email-dashboard-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Forms: Add dashboard link to response email

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1653,6 +1653,18 @@ class Contact_Form extends Contact_Form_Shortcode {
 			esc_url( $url )
 		);
 
+		// Get the status of the feedback
+		$status = $is_spam ? 'spam' : 'inbox';
+
+		// Build the dashboard URL with the status and the feedback's post id
+		$dashboard_url = ( new Dashboard_View_Switch() )->get_forms_admin_url( $status ) . '&r=' . $post_id;
+
+		$footer_dashboard_response_url = sprintf(
+			/* translators: Placeholder is the URL of the response in the dashboard. */
+			__( 'Dashboard response URL: %1$s', 'jetpack-forms' ),
+			$dashboard_url
+		);
+
 		$footer = implode(
 			'',
 			/**
@@ -1670,7 +1682,8 @@ class Contact_Form extends Contact_Form_Shortcode {
 					'<span style="font-size: 12px">',
 					$footer_time . '<br />',
 					$footer_ip ? $footer_ip . '<br />' : null,
-					$footer_url . '<br />',
+					$footer_url . '<br /><br />',
+					$footer_dashboard_response_url . '<br />',
 					$sent_by_text,
 					'</span>',
 				)

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1657,12 +1657,12 @@ class Contact_Form extends Contact_Form_Shortcode {
 		$status = $is_spam ? 'spam' : 'inbox';
 
 		// Build the dashboard URL with the status and the feedback's post id
-		$dashboard_url = ( new Dashboard_View_Switch() )->get_forms_admin_url( $status ) . '&r=' . $post_id;
+		$dashboard_url = ( new Dashboard_View_Switch() )->get_forms_admin_url( $status, true ) . '&r=' . $post_id;
 
 		$footer_dashboard_response_url = sprintf(
-			/* translators: Placeholder is the URL of the response in the dashboard. */
-			__( 'Dashboard response URL: %1$s', 'jetpack-forms' ),
-			$dashboard_url
+			'<a href="%1$s">%2$s</a>',
+			esc_url( $dashboard_url ),
+			__( 'Click here to view the response in the Forms dashboard', 'jetpack-forms' )
 		);
 
 		$footer = implode(

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1653,18 +1653,6 @@ class Contact_Form extends Contact_Form_Shortcode {
 			esc_url( $url )
 		);
 
-		// Get the status of the feedback
-		$status = $is_spam ? 'spam' : 'inbox';
-
-		// Build the dashboard URL with the status and the feedback's post id
-		$dashboard_url = ( new Dashboard_View_Switch() )->get_forms_admin_url( $status, true ) . '&r=' . $post_id;
-
-		$footer_dashboard_response_url = sprintf(
-			'<a href="%1$s">%2$s</a>',
-			esc_url( $dashboard_url ),
-			__( 'Click here to view the response in the Forms dashboard', 'jetpack-forms' )
-		);
-
 		$footer = implode(
 			'',
 			/**
@@ -1682,13 +1670,44 @@ class Contact_Form extends Contact_Form_Shortcode {
 					'<span style="font-size: 12px">',
 					$footer_time . '<br />',
 					$footer_ip ? $footer_ip . '<br />' : null,
-					$footer_url . '<br /><br />',
-					$footer_dashboard_response_url . '<br />',
+					$footer_url . '<br />',
 					$sent_by_text,
 					'</span>',
 				)
 			)
 		);
+
+		$actions = '';
+		// TODO: Update this once we have a way to enable/disable email actions.
+		$are_email_actions_enabled = true;
+
+		if ( $are_email_actions_enabled ) {
+			// Get the status of the feedback
+			$status = $is_spam ? 'spam' : 'inbox';
+
+			// Build the dashboard URL with the status and the feedback's post id
+			$dashboard_url = ( new Dashboard_View_Switch() )->get_forms_admin_url( $status, true ) . '&r=' . $post_id;
+
+			$actions = sprintf(
+				'<table class="button_block" border="0" cellpadding="0" cellspacing="0" role="presentation">
+					<tr>
+						<td class="pad" align="center">
+							<a rel="noopener" target="_blank" href="%1$s" data-tracks-link-desc="">
+								<!--[if mso]>
+								<i style="mso-text-raise: 30pt;">&nbsp;</i>
+								<![endif]-->
+								<span>%2$s</span>
+								<!--[if mso]>
+								<i>&nbsp;</i>
+								<![endif]-->
+							</a>
+						</td>
+					</tr>
+				</table>',
+				esc_url( $dashboard_url ),
+				__( 'View in dashboard', 'jetpack-forms' )
+			);
+		}
 
 		/**
 		 * Filters the message sent via email after a successful form submission.
@@ -1703,7 +1722,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 		$message = apply_filters( 'contact_form_message', implode( '', $message ), $message );
 
 		// This is called after `contact_form_message`, in order to preserve back-compat
-		$message = self::wrap_message_in_html_tags( $title, $message, $footer );
+		$message = self::wrap_message_in_html_tags( $title, $message, $footer, $actions );
 
 		update_post_meta( $post_id, '_feedback_email', $this->addslashes_deep( compact( 'to', 'message' ) ) );
 
@@ -1910,10 +1929,11 @@ class Contact_Form extends Contact_Form_Shortcode {
 	 * @param string $title - title of the email.
 	 * @param string $body - the message body.
 	 * @param string $footer - the footer containing meta information.
+	 * @param string $actions - HTML for actions displayed in the email.
 	 *
 	 * @return string
 	 */
-	public static function wrap_message_in_html_tags( $title, $body, $footer ) {
+	public static function wrap_message_in_html_tags( $title, $body, $footer, $actions = '' ) {
 		// Don't do anything if the message was already wrapped in HTML tags
 		// That could have be done by a plugin via filters
 		if ( str_contains( $body, '<html' ) ) {
@@ -1959,7 +1979,8 @@ class Contact_Form extends Contact_Form_Shortcode {
 			'',
 			$footer,
 			$style,
-			$tracking_pixel
+			$tracking_pixel,
+			$actions
 		);
 
 		return $html_message;

--- a/projects/packages/forms/src/contact-form/templates/email-response.php
+++ b/projects/packages/forms/src/contact-form/templates/email-response.php
@@ -4,11 +4,12 @@
  * The template contains several placeholders:
  * %1$s is the hero text to display above the response
  * %2$s is the response itself.
- * %3$s is a link to the response page in wp-admin
- * %4$s is a link to the embedded form to allow the site owner to edit it to change their email address.
+ * %3$s was a link to the response page in wp-admin (left empty for backwards compatibility)
+ * %4$s was a link to the embedded form to allow the site owner to edit it to change their email address (left empty for backwards compatibility)
  * %5$s is the footer HTML.
  * %6$s style HTML tag.
- * %7$s tracking pixel.
+ * %7$s tracking pixel
+ * %8$s is the actions HTML.
  *
  * @package automattic/jetpack
  */
@@ -36,6 +37,9 @@ $template = '
 							<p>%2$s</p>
 							%3$s
 							%4$s
+							<div class="actions">
+								%8$s
+							</div>
 						</td>
 						</tr>
 					</table>
@@ -131,9 +135,46 @@ $style = '<style media="all" type="text/css">
 		box-sizing: border-box;
 		padding: 24px;
 	}
+
 	.content-block {
 		box-sizing: border-box;
 		padding: 0 24px 24px;
+	}
+
+	.actions .button_block {
+		mso-table-lspace: 0pt;
+		mso-table-rspace: 0pt;
+		width: unset;
+		margin-top: 24px;
+	}
+
+	.actions .button_block .pad,
+	.actions .button_block .pad a {
+		border-radius: 4px;
+		background-image: url(\'https://s0.wordpress.com/i/emails/marketing/wpcom/2024/blueberry-px.png\');
+		background-size: cover;
+		background-color: #3858E9;
+	}
+
+	.actions .button_block .pad a {
+		font-size: 16px;
+		font-family: Inter, Helvetica, Arial, sans-serif;
+		font-weight: 500;
+		text-decoration: none;
+		padding: 13px 24px;
+		color: #ffffff;
+		border-radius: 4px;
+		display: inline-block;
+		mso-padding-alt: 0;
+	}
+
+	.actions .button_block .pad a span {
+		mso-text-raise: 15pt;
+	}
+	
+	.actions .button_block .pad i {
+		letter-spacing: 25px;
+		mso-font-width: -100%;
 	}
 
 	.footer {
@@ -141,6 +182,7 @@ $style = '<style media="all" type="text/css">
 		padding: 24px 0;
 		width: 100%;
 	}
+
 	.footer td,
 	.footer p,
 	.footer span,
@@ -148,9 +190,11 @@ $style = '<style media="all" type="text/css">
 		color: #101517;
 		font-size: 12px;
 	}
+
 	h1 {
 		font-size: 20px;
 	}
+
 	p {
 		font-family: sans-serif;
 		font-size: 16px;
@@ -162,32 +206,40 @@ $style = '<style media="all" type="text/css">
 	.powered-by a {
 		text-decoration: none;
 	}
+
 	@media only screen and (max-width: 640px) {
 		.main p,
 		.main td,
 		.main span {
 			font-size: 16px !important;
 		}
+
 		.wrapper {
 			padding: 8px 16px !important;
 		}
+
 		.powered-by {
 			padding: 0 16px 16px!important;
 		}
+
 		.content {
 			padding: 0 !important;
 		}
+
 		.container {
 			padding: 0 !important;
 			padding-top: 8px !important;
 			width: 100% !important;
 		}
+
 		.main {
 			border-left-width: 0 !important;
 			border-radius: 0 !important;
 			border-right-width: 0 !important;
 		}
+
 		.collapse { display: none; }
+
 		h1 { padding:0 16px; }
 	}
 
@@ -195,6 +247,7 @@ $style = '<style media="all" type="text/css">
 		.ExternalClass {
 			width: 100%;
 		}
+
 		.ExternalClass,
 		.ExternalClass p,
 		.ExternalClass span,
@@ -203,6 +256,7 @@ $style = '<style media="all" type="text/css">
 		.ExternalClass div {
 			line-height: 100%;
 		}
+
 		.apple-link a {
 			color: inherit !important;
 			font-family: inherit !important;
@@ -211,6 +265,7 @@ $style = '<style media="all" type="text/css">
 			line-height: inherit !important;
 			text-decoration: none !important;
 		}
+
 		#MessageViewBody a {
 			color: inherit;
 			text-decoration: none;

--- a/projects/packages/forms/src/dashboard/class-dashboard-view-switch.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard-view-switch.php
@@ -329,22 +329,40 @@ CSS
 		$is_classic          = $this->get_preferred_view() === self::CLASSIC_VIEW;
 		$switch_is_available = $this->is_jetpack_forms_view_switch_available();
 
-		$admin_dashboard_url = $this->is_jetpack_forms_admin_page_available()
-			? 'admin.php?page=jetpack-forms-admin'
-			: 'admin.php?page=jetpack-forms';
-
-		$url = $is_classic && $switch_is_available
+		$base_url = $is_classic && $switch_is_available
 			? get_admin_url() . 'edit.php?post_type=feedback'
-			: get_admin_url() . $admin_dashboard_url;
+			: get_admin_url() . ( $this->is_jetpack_forms_admin_page_available() ? 'admin.php?page=jetpack-forms-admin' : 'admin.php?page=jetpack-forms' );
 
-		// Return url directly to spam tab.
-		if ( $tab === 'spam' ) {
-			$url = $is_classic && $switch_is_available
-				? add_query_arg( 'post_status', 'spam', $url )
-				: $url . '#/responses?status=spam';
+		return $this->append_tab_to_url( $base_url, $tab, $is_classic && $switch_is_available );
+	}
+
+	/**
+	 * Appends the appropriate tab parameter to the URL based on the view type.
+	 *
+	 * @param string  $url              Base URL to append to.
+	 * @param string  $tab              Tab to open.
+	 * @param boolean $is_classic_view  Whether we're using the classic view.
+	 *
+	 * @return string
+	 */
+	private function append_tab_to_url( $url, $tab, $is_classic_view ) {
+		if ( ! $tab ) {
+			return $url;
 		}
 
-		return $url;
+		$status_map = array(
+			'spam'  => 'spam',
+			'inbox' => 'inbox',
+			'trash' => 'trash',
+		);
+
+		if ( ! isset( $status_map[ $tab ] ) ) {
+			return $url;
+		}
+
+		return $is_classic_view
+			? add_query_arg( 'post_status', $status_map[ $tab ], $url )
+			: $url . '#/responses?status=' . $status_map[ $tab ];
 	}
 
 	/**

--- a/projects/packages/forms/src/dashboard/class-dashboard-view-switch.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard-view-switch.php
@@ -322,18 +322,19 @@ CSS
 	 * Returns url of forms admin page.
 	 *
 	 * @param string|null $tab Tab to open in the forms admin page.
+	 * @param boolean     $force_inbox Whether to force the inbox view URL.
 	 *
 	 * @return string
 	 */
-	public function get_forms_admin_url( $tab = null ) {
+	public function get_forms_admin_url( $tab = null, $force_inbox = false ) {
 		$is_classic          = $this->get_preferred_view() === self::CLASSIC_VIEW;
 		$switch_is_available = $this->is_jetpack_forms_view_switch_available();
 
-		$base_url = $is_classic && $switch_is_available
+		$base_url = $is_classic && $switch_is_available && ! $force_inbox
 			? get_admin_url() . 'edit.php?post_type=feedback'
 			: get_admin_url() . ( $this->is_jetpack_forms_admin_page_available() ? 'admin.php?page=jetpack-forms-admin' : 'admin.php?page=jetpack-forms' );
 
-		return $this->append_tab_to_url( $base_url, $tab, $is_classic && $switch_is_available );
+		return $this->append_tab_to_url( $base_url, $tab, $is_classic && $switch_is_available && ! $force_inbox );
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of FORMS-61

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds the response link to the email sent after submission

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* In a site where you receive emails after form submissions, submit a response to a form
* Check that the email now has a button: "View in dashboard"
* Click on this button
* Check that you are sent to the dashboard with the correct response pre-selected

![2025-06-11_17-56_1](https://github.com/user-attachments/assets/a2687780-a76f-4f64-8175-26fddc377c07)



