### PR TITLE
Forms: Fix: Update render-material-icon import path in dropzone block

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-package-build
+++ b/projects/packages/forms/changelog/fix-forms-package-build
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+fix import

--- a/projects/packages/forms/src/blocks/dropzone/index.js
+++ b/projects/packages/forms/src/blocks/dropzone/index.js
@@ -1,7 +1,7 @@
 import { Path } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { getIconColor } from '../contact-form/util/block-icons';
-import renderMaterialIcon from '../contact-form/util/render-material-icon';
+import renderMaterialIcon from '../shared/components/render-material-icon';
 import edit from './edit';
 import save from './save';
 


### PR DESCRIPTION

Rebase after #43816 merge

## Proposed changes:
* Updates the import path for `render-material-icon` in the dropzone block to point to the correct location in shared components
* This fixes a build error that occurred after the component was moved to the shared components directory in PR #43816

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- Not applicable - this is a build fix -->

## Does this pull request change what data or activity we track or use?
No - this is a build fix that updates an import path to match the new location of a shared component.

## Testing instructions:
1. Build the forms package:
   ```bash
   cd projects/packages/forms
   npm run build
   ```
2. Verify that the build completes successfully without any module resolution errors
3. Test the dropzone block in the editor to ensure it renders correctly with its icon

* Go to 'Block Editor'
* Add a Contact Form block
* Add a File Upload field
* Verify that the dropzone block renders correctly with its icon