### PR TITLE
Status: add new class used to classify requests on a site.

### DIFF
--- a/projects/packages/status/changelog/add-is-frontend-status
+++ b/projects/packages/status/changelog/add-is-frontend-status
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Request: add new class used to classify requests on a site.

--- a/projects/packages/status/class-request.php
+++ b/projects/packages/status/class-request.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * Get information about the current request.
+ *
+ * @package automattic/jetpack-status
+ */
+
+namespace Automattic\Jetpack\Status;
+
+/**
+ * Get information about the current request.
+ */
+class Request {
+	/**
+	 * Determine whether the current request is for accessing the frontend.
+	 * Also update Vary headers to indicate that the response may vary by Accept header.
+	 *
+	 * @return bool True if it's a frontend request, false otherwise.
+	 */
+	public static function is_frontend() {
+		$is_frontend        = true;
+		$is_varying_request = true;
+
+		if (
+			is_admin()
+			|| wp_doing_ajax()
+			|| wp_is_jsonp_request()
+			|| is_feed()
+			|| ( defined( 'REST_REQUEST' ) && \REST_REQUEST )
+			|| ( defined( 'REST_API_REQUEST' ) && \REST_API_REQUEST )
+			|| ( defined( 'WP_CLI' ) && \WP_CLI )
+		) {
+			$is_frontend        = false;
+			$is_varying_request = false;
+		} elseif (
+			wp_is_json_request()
+			|| wp_is_xml_request()
+		) {
+			$is_frontend = false;
+		}
+
+		/*
+		* Check existing headers for the request.
+		* If there is no existing Vary Accept header, add one.
+		*/
+		if ( $is_varying_request && ! headers_sent() ) {
+			$headers           = headers_list();
+			$vary_header_parts = self::get_vary_headers( $headers );
+
+			header( 'Vary: ' . implode( ', ', $vary_header_parts ) );
+		}
+
+		/**
+		 * Filter whether the current request is for accessing the frontend.
+		 *
+		 * @since jetpack-9.0.0
+		 *
+		 * @param bool $is_frontend Whether the current request is for accessing the frontend.
+		 */
+		return (bool) apply_filters( 'jetpack_is_frontend', $is_frontend );
+	}
+
+	/**
+	 * Go through headers and get a list of Vary headers to add,
+	 * including a Vary Accept header if necessary.
+	 *
+	 * @since 12.2
+	 *
+	 * @param array $headers The headers to be sent.
+	 *
+	 * @return array $vary_header_parts Vary Headers to be sent.
+	 */
+	public static function get_vary_headers( $headers = array() ) {
+		$vary_header_parts = array( 'accept', 'content-type' );
+
+		foreach ( $headers as $header ) {
+			// Check for a Vary header.
+			if ( ! str_starts_with( strtolower( $header ), 'vary:' ) ) {
+				continue;
+			}
+
+			// If the header is a wildcard, we'll return that.
+			if ( str_contains( $header, '*' ) ) {
+				$vary_header_parts = array( '*' );
+				break;
+			}
+
+			// Remove the Vary: part of the header.
+			$header = preg_replace( '/^vary\:\s?/i', '', $header );
+
+			// Remove spaces from the header.
+			$header = str_replace( ' ', '', $header );
+
+			// Break the header into parts.
+			$header_parts = explode( ',', strtolower( $header ) );
+
+			// Build an array with the Accept header and what was already there.
+			$vary_header_parts = array_values( array_unique( array_merge( $vary_header_parts, $header_parts ) ) );
+		}
+
+		return $vary_header_parts;
+	}
+}

--- a/projects/packages/status/src/class-request.php
+++ b/projects/packages/status/src/class-request.php
@@ -7,6 +7,8 @@
 
 namespace Automattic\Jetpack\Status;
 
+use Automattic\Jetpack\Constants;
+
 /**
  * Get information about the current request.
  */
@@ -26,9 +28,9 @@ class Request {
 			|| wp_doing_ajax()
 			|| wp_is_jsonp_request()
 			|| is_feed()
-			|| ( defined( 'REST_REQUEST' ) && \REST_REQUEST )
-			|| ( defined( 'REST_API_REQUEST' ) && \REST_API_REQUEST )
-			|| ( defined( 'WP_CLI' ) && \WP_CLI )
+			|| Constants::is_true( 'REST_REQUEST' )
+			|| Constants::is_true( 'REST_API_REQUEST' )
+			|| Constants::is_true( 'WP_CLI' )
 		) {
 			$is_frontend        = false;
 			$is_varying_request = false;

--- a/projects/packages/status/src/class-request.php
+++ b/projects/packages/status/src/class-request.php
@@ -66,7 +66,7 @@ class Request {
 	 * Go through headers and get a list of Vary headers to add,
 	 * including Vary on Accept and Content-Type if necessary.
 	 *
-	 * @since 12.2
+	 * @since jetpack-12.2
 	 *
 	 * @param array $headers The headers to be sent.
 	 *

--- a/projects/packages/status/src/class-request.php
+++ b/projects/packages/status/src/class-request.php
@@ -64,7 +64,7 @@ class Request {
 
 	/**
 	 * Go through headers and get a list of Vary headers to add,
-	 * including a Vary Accept header if necessary.
+	 * including Vary on Accept and Content-Type if necessary.
 	 *
 	 * @since 12.2
 	 *

--- a/projects/packages/status/tests/php/Request_Test.php
+++ b/projects/packages/status/tests/php/Request_Test.php
@@ -44,14 +44,13 @@ class Request_Test extends TestCase {
 	 *
 	 * @dataProvider get_is_frontend_scenarios
 	 *
-	 * @param string $scenario_name    Name of the scenario being tested.
-	 * @param array  $function_mocks   WordPress functions and their return values.
-	 * @param array  $constants        Constants to mock and their values.
-	 * @param bool   $expected_result  Expected result from is_frontend().
-	 * @param bool   $should_set_headers Whether Vary headers should be set.
+	 * @param array $function_mocks   WordPress functions and their return values.
+	 * @param array $constants        Constants to mock and their values.
+	 * @param bool  $expected_result  Expected result from is_frontend().
+	 * @param bool  $should_set_headers Whether Vary headers should be set.
 	 */
 	#[DataProvider( 'get_is_frontend_scenarios' )]
-	public function test_is_frontend_scenarios( $scenario_name, $function_mocks, $constants, $expected_result, $should_set_headers ) {
+	public function test_is_frontend_scenarios( $function_mocks, $constants, $expected_result, $should_set_headers ) {
 		// Set up constants using Constants package
 		foreach ( $constants as $constant_name => $constant_value ) {
 			Constants::set_constant( $constant_name, $constant_value );
@@ -74,7 +73,7 @@ class Request_Test extends TestCase {
 		Filters\expectApplied( 'jetpack_is_frontend' )->once()->with( $expected_result )->andReturn( $expected_result );
 
 		$result = Request::is_frontend();
-		$this->assertEquals( $expected_result, $result, "Failed scenario: {$scenario_name}" );
+		$this->assertEquals( $expected_result, $result );
 	}
 
 	/**
@@ -95,77 +94,66 @@ class Request_Test extends TestCase {
 
 		return array(
 			'frontend request'          => array(
-				'scenario_name'      => 'frontend request',
 				'function_mocks'     => $default_functions,
 				'constants'          => array(),
 				'expected_result'    => true,
 				'should_set_headers' => true,
 			),
 			'admin request'             => array(
-				'scenario_name'      => 'admin request',
 				'function_mocks'     => array_merge( $default_functions, array( 'is_admin' => true ) ),
 				'constants'          => array(),
 				'expected_result'    => false,
 				'should_set_headers' => false,
 			),
 			'ajax request'              => array(
-				'scenario_name'      => 'ajax request',
 				'function_mocks'     => array_merge( $default_functions, array( 'wp_doing_ajax' => true ) ),
 				'constants'          => array(),
 				'expected_result'    => false,
 				'should_set_headers' => false,
 			),
 			'jsonp request'             => array(
-				'scenario_name'      => 'jsonp request',
 				'function_mocks'     => array_merge( $default_functions, array( 'wp_is_jsonp_request' => true ) ),
 				'constants'          => array(),
 				'expected_result'    => false,
 				'should_set_headers' => false,
 			),
 			'feed request'              => array(
-				'scenario_name'      => 'feed request',
 				'function_mocks'     => array_merge( $default_functions, array( 'is_feed' => true ) ),
 				'constants'          => array(),
 				'expected_result'    => false,
 				'should_set_headers' => false,
 			),
 			'REST_REQUEST constant'     => array(
-				'scenario_name'      => 'REST_REQUEST constant',
 				'function_mocks'     => $default_functions,
 				'constants'          => array( 'REST_REQUEST' => true ),
 				'expected_result'    => false,
 				'should_set_headers' => false,
 			),
 			'REST_API_REQUEST constant' => array(
-				'scenario_name'      => 'REST_API_REQUEST constant',
 				'function_mocks'     => $default_functions,
 				'constants'          => array( 'REST_API_REQUEST' => true ),
 				'expected_result'    => false,
 				'should_set_headers' => false,
 			),
 			'WP_CLI constant'           => array(
-				'scenario_name'      => 'WP_CLI constant',
 				'function_mocks'     => $default_functions,
 				'constants'          => array( 'WP_CLI' => true ),
 				'expected_result'    => false,
 				'should_set_headers' => false,
 			),
 			'json request'              => array(
-				'scenario_name'      => 'json request',
 				'function_mocks'     => array_merge( $default_functions, array( 'wp_is_json_request' => true ) ),
 				'constants'          => array(),
 				'expected_result'    => false,
 				'should_set_headers' => true, // JSON requests are varying requests
 			),
 			'xml request'               => array(
-				'scenario_name'      => 'xml request',
 				'function_mocks'     => array_merge( $default_functions, array( 'wp_is_xml_request' => true ) ),
 				'constants'          => array(),
 				'expected_result'    => false,
 				'should_set_headers' => true, // XML requests are varying requests
 			),
 			'headers already sent'      => array(
-				'scenario_name'      => 'headers already sent',
 				'function_mocks'     => array_merge( $default_functions, array( 'headers_sent' => true ) ),
 				'constants'          => array(),
 				'expected_result'    => true,
@@ -178,12 +166,11 @@ class Request_Test extends TestCase {
 	 * Test is_frontend with various existing header scenarios
 	 *
 	 * @dataProvider get_header_scenarios
-	 * @param string $scenario_name    Name of the scenario being tested.
 	 * @param array  $existing_headers Existing headers to mock.
 	 * @param string $expected_header  Expected Vary header to be set.
 	 */
 	#[DataProvider( 'get_header_scenarios' )]
-	public function test_is_frontend_with_existing_headers( $scenario_name, $existing_headers, $expected_header ) {
+	public function test_is_frontend_with_existing_headers( $existing_headers, $expected_header ) {
 		// Set up for frontend request (all conditions false)
 		Functions\when( 'is_admin' )->justReturn( false );
 		Functions\when( 'wp_doing_ajax' )->justReturn( false );
@@ -199,7 +186,7 @@ class Request_Test extends TestCase {
 		Filters\expectApplied( 'jetpack_is_frontend' )->once()->with( true )->andReturn( true );
 
 		$result = Request::is_frontend();
-		$this->assertTrue( $result, "Failed scenario: {$scenario_name}" );
+		$this->assertTrue( $result );
 	}
 
 	/**
@@ -210,12 +197,10 @@ class Request_Test extends TestCase {
 	public static function get_header_scenarios() {
 		return array(
 			'no existing headers'                       => array(
-				'scenario_name'    => 'no existing headers',
 				'existing_headers' => array(),
 				'expected_header'  => 'Vary: accept, content-type',
 			),
 			'existing Accept-Encoding header'           => array(
-				'scenario_name'    => 'existing Accept-Encoding header',
 				'existing_headers' => array(
 					'Cache-Control: no-cache, must-revalidate, max-age=0',
 					'Content-Type: text/html; charset=UTF-8',
@@ -224,7 +209,6 @@ class Request_Test extends TestCase {
 				'expected_header'  => 'Vary: accept, content-type, accept-encoding',
 			),
 			'multiple Vary headers'                     => array(
-				'scenario_name'    => 'multiple Vary headers',
 				'existing_headers' => array(
 					'Cache-Control: no-cache, must-revalidate, max-age=0',
 					'Content-Type: text/html; charset=UTF-8',
@@ -234,7 +218,6 @@ class Request_Test extends TestCase {
 				'expected_header'  => 'Vary: accept, content-type, accept-encoding',
 			),
 			'wildcard Vary header'                      => array(
-				'scenario_name'    => 'wildcard Vary header',
 				'existing_headers' => array(
 					'Cache-Control: no-cache, must-revalidate, max-age=0',
 					'Content-Type: text/html; charset=UTF-8',
@@ -243,7 +226,6 @@ class Request_Test extends TestCase {
 				'expected_header'  => 'Vary: *',
 			),
 			'existing Accept header (already included)' => array(
-				'scenario_name'    => 'existing Accept header (already included)',
 				'existing_headers' => array(
 					'Cache-Control: no-cache, must-revalidate, max-age=0',
 					'Content-Type: text/html; charset=UTF-8',
@@ -252,7 +234,6 @@ class Request_Test extends TestCase {
 				'expected_header'  => 'Vary: accept, content-type',
 			),
 			'mixed case Vary header'                    => array(
-				'scenario_name'    => 'mixed case Vary header',
 				'existing_headers' => array(
 					'Cache-Control: no-cache, must-revalidate, max-age=0',
 					'Content-Type: text/html; charset=UTF-8',
@@ -267,13 +248,12 @@ class Request_Test extends TestCase {
 	 * Test is_frontend filter behavior
 	 *
 	 * @dataProvider get_filter_override_scenarios
-	 * @param string $scenario_name     Name of the scenario being tested.
-	 * @param bool   $initial_result    The initial result before filter is applied.
-	 * @param bool   $filter_return     What the filter should return.
-	 * @param bool   $expected_result   The expected final result.
+	 * @param bool $initial_result    The initial result before filter is applied.
+	 * @param bool $filter_return     What the filter should return.
+	 * @param bool $expected_result   The expected final result.
 	 */
 	#[DataProvider( 'get_filter_override_scenarios' )]
-	public function test_is_frontend_filter_behavior( $scenario_name, $initial_result, $filter_return, $expected_result ) {
+	public function test_is_frontend_filter_behavior( $initial_result, $filter_return, $expected_result ) {
 		// Set up WordPress functions based on the initial result we want
 		if ( $initial_result ) {
 			// Frontend request setup
@@ -302,7 +282,7 @@ class Request_Test extends TestCase {
 		Filters\expectApplied( 'jetpack_is_frontend' )->once()->with( $initial_result )->andReturn( $filter_return );
 
 		$result = Request::is_frontend();
-		$this->assertEquals( $expected_result, $result, "Failed scenario: {$scenario_name}" );
+		$this->assertEquals( $expected_result, $result );
 	}
 
 	/**
@@ -313,25 +293,21 @@ class Request_Test extends TestCase {
 	public static function get_filter_override_scenarios() {
 		return array(
 			'frontend request - filter returns same (true)' => array(
-				'scenario_name'   => 'frontend request - filter returns same (true)',
 				'initial_result'  => true,
 				'filter_return'   => true,
 				'expected_result' => true,
 			),
 			'frontend request - filter overrides to false' => array(
-				'scenario_name'   => 'frontend request - filter overrides to false',
 				'initial_result'  => true,
 				'filter_return'   => false,
 				'expected_result' => false,
 			),
 			'admin request - filter returns same (false)'  => array(
-				'scenario_name'   => 'admin request - filter returns same (false)',
 				'initial_result'  => false,
 				'filter_return'   => false,
 				'expected_result' => false,
 			),
 			'admin request - filter overrides to true'     => array(
-				'scenario_name'   => 'admin request - filter overrides to true',
 				'initial_result'  => false,
 				'filter_return'   => true,
 				'expected_result' => true,

--- a/projects/packages/status/tests/php/Request_Test.php
+++ b/projects/packages/status/tests/php/Request_Test.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Tests for Automattic\Jetpack\Status\Request methods
+ *
+ * @package automattic/jetpack-status
+ */
+
+namespace Automattic\Jetpack\Status;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Status test suite.
+ *
+ * @covers \Automattic\Jetpack\Status\Request
+ */
+#[CoversClass( Request::class )]
+class Request_Test extends TestCase {
+	/**
+	 * Test jetpack_get_vary_headers.
+	 *
+	 * @dataProvider get_test_headers
+	 * @param array $headers  Array of headers.
+	 * @param array $expected Expected array of headers, to be used as Vary header.
+	 */
+	#[DataProvider( 'get_test_headers' )]
+	public function test_get_vary_headers( $headers, $expected ) {
+		$vary_header_parts = Request::get_vary_headers( $headers );
+
+		$this->assertEquals( $expected, $vary_header_parts );
+	}
+
+	/**
+	 * Data provider for the test_get_vary_headers() test.
+	 *
+	 * @return array
+	 */
+	public static function get_test_headers() {
+		return array(
+			'no headers'                             => array(
+				array(),
+				array( 'accept', 'content-type' ),
+			),
+			'Single Vary Encoding header'            => array(
+				array(
+					'Vary: Accept-Encoding',
+				),
+				array( 'accept', 'content-type', 'accept-encoding' ),
+			),
+			'Double Vary: Accept-Encoding & Accept'  => array(
+				array(
+					'Vary: Accept, Accept-Encoding',
+				),
+				array( 'accept', 'content-type', 'accept-encoding' ),
+			),
+			'vary header'                            => array(
+				array(
+					'Cache-Control: no-cache, must-revalidate, max-age=0',
+					'Content-Type: text/html; charset=UTF-8',
+					'Vary: Accept',
+				),
+				array( 'accept', 'content-type' ),
+			),
+			'Wildcard Vary header'                   => array(
+				array(
+					'Cache-Control: no-cache, must-revalidate, max-age=0',
+					'Content-Type: text/html; charset=UTF-8',
+					'Vary: *',
+				),
+				array( '*' ),
+			),
+			'Multiple Vary headers'                  => array(
+				array(
+					'Cache-Control: no-cache, must-revalidate, max-age=0',
+					'Content-Type: text/html; charset=UTF-8',
+					'Vary: Accept',
+					'Vary: Accept-Encoding',
+				),
+				array( 'accept', 'content-type', 'accept-encoding' ),
+			),
+			'Multiple Vary headers, with a wildcard' => array(
+				array(
+					'Cache-Control: no-cache, must-revalidate, max-age=0',
+					'Content-Type: text/html; charset=UTF-8',
+					'Vary: *',
+					'Vary: Accept-Encoding',
+				),
+				array( '*' ),
+			),
+		);
+	}
+}

--- a/projects/packages/status/tests/php/Request_Test.php
+++ b/projects/packages/status/tests/php/Request_Test.php
@@ -7,6 +7,10 @@
 
 namespace Automattic\Jetpack\Status;
 
+use Automattic\Jetpack\Constants;
+use Brain\Monkey;
+use Brain\Monkey\Filters;
+use Brain\Monkey\Functions;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -18,6 +22,323 @@ use PHPUnit\Framework\TestCase;
  */
 #[CoversClass( Request::class )]
 class Request_Test extends TestCase {
+	/**
+	 * Test setup.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+	}
+
+	/**
+	 * Test teardown.
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+		Monkey\tearDown();
+		Constants::clear_constants();
+	}
+
+	/**
+	 * Test is_frontend with various scenarios
+	 *
+	 * @dataProvider get_is_frontend_scenarios
+	 *
+	 * @param string $scenario_name    Name of the scenario being tested.
+	 * @param array  $function_mocks   WordPress functions and their return values.
+	 * @param array  $constants        Constants to mock and their values.
+	 * @param bool   $expected_result  Expected result from is_frontend().
+	 * @param bool   $should_set_headers Whether Vary headers should be set.
+	 */
+	#[DataProvider( 'get_is_frontend_scenarios' )]
+	public function test_is_frontend_scenarios( $scenario_name, $function_mocks, $constants, $expected_result, $should_set_headers ) {
+		// Set up constants using Constants package
+		foreach ( $constants as $constant_name => $constant_value ) {
+			Constants::set_constant( $constant_name, $constant_value );
+		}
+
+		// Mock WordPress functions
+		foreach ( $function_mocks as $function_name => $return_value ) {
+			Functions\when( $function_name )->justReturn( $return_value );
+		}
+
+		// Set up header expectations
+		if ( $should_set_headers ) {
+			Functions\when( 'headers_list' )->justReturn( array() );
+			Functions\expect( 'header' )->once()->with( 'Vary: accept, content-type' );
+		} else {
+			Functions\expect( 'header' )->never();
+		}
+
+		// Mock the apply_filters function
+		Filters\expectApplied( 'jetpack_is_frontend' )->once()->with( $expected_result )->andReturn( $expected_result );
+
+		$result = Request::is_frontend();
+		$this->assertEquals( $expected_result, $result, "Failed scenario: {$scenario_name}" );
+	}
+
+	/**
+	 * Data provider for is_frontend scenarios
+	 *
+	 * @return array
+	 */
+	public static function get_is_frontend_scenarios() {
+		$default_functions = array(
+			'is_admin'            => false,
+			'wp_doing_ajax'       => false,
+			'wp_is_jsonp_request' => false,
+			'is_feed'             => false,
+			'wp_is_json_request'  => false,
+			'wp_is_xml_request'   => false,
+			'headers_sent'        => false,
+		);
+
+		return array(
+			'frontend request'          => array(
+				'scenario_name'      => 'frontend request',
+				'function_mocks'     => $default_functions,
+				'constants'          => array(),
+				'expected_result'    => true,
+				'should_set_headers' => true,
+			),
+			'admin request'             => array(
+				'scenario_name'      => 'admin request',
+				'function_mocks'     => array_merge( $default_functions, array( 'is_admin' => true ) ),
+				'constants'          => array(),
+				'expected_result'    => false,
+				'should_set_headers' => false,
+			),
+			'ajax request'              => array(
+				'scenario_name'      => 'ajax request',
+				'function_mocks'     => array_merge( $default_functions, array( 'wp_doing_ajax' => true ) ),
+				'constants'          => array(),
+				'expected_result'    => false,
+				'should_set_headers' => false,
+			),
+			'jsonp request'             => array(
+				'scenario_name'      => 'jsonp request',
+				'function_mocks'     => array_merge( $default_functions, array( 'wp_is_jsonp_request' => true ) ),
+				'constants'          => array(),
+				'expected_result'    => false,
+				'should_set_headers' => false,
+			),
+			'feed request'              => array(
+				'scenario_name'      => 'feed request',
+				'function_mocks'     => array_merge( $default_functions, array( 'is_feed' => true ) ),
+				'constants'          => array(),
+				'expected_result'    => false,
+				'should_set_headers' => false,
+			),
+			'REST_REQUEST constant'     => array(
+				'scenario_name'      => 'REST_REQUEST constant',
+				'function_mocks'     => $default_functions,
+				'constants'          => array( 'REST_REQUEST' => true ),
+				'expected_result'    => false,
+				'should_set_headers' => false,
+			),
+			'REST_API_REQUEST constant' => array(
+				'scenario_name'      => 'REST_API_REQUEST constant',
+				'function_mocks'     => $default_functions,
+				'constants'          => array( 'REST_API_REQUEST' => true ),
+				'expected_result'    => false,
+				'should_set_headers' => false,
+			),
+			'WP_CLI constant'           => array(
+				'scenario_name'      => 'WP_CLI constant',
+				'function_mocks'     => $default_functions,
+				'constants'          => array( 'WP_CLI' => true ),
+				'expected_result'    => false,
+				'should_set_headers' => false,
+			),
+			'json request'              => array(
+				'scenario_name'      => 'json request',
+				'function_mocks'     => array_merge( $default_functions, array( 'wp_is_json_request' => true ) ),
+				'constants'          => array(),
+				'expected_result'    => false,
+				'should_set_headers' => true, // JSON requests are varying requests
+			),
+			'xml request'               => array(
+				'scenario_name'      => 'xml request',
+				'function_mocks'     => array_merge( $default_functions, array( 'wp_is_xml_request' => true ) ),
+				'constants'          => array(),
+				'expected_result'    => false,
+				'should_set_headers' => true, // XML requests are varying requests
+			),
+			'headers already sent'      => array(
+				'scenario_name'      => 'headers already sent',
+				'function_mocks'     => array_merge( $default_functions, array( 'headers_sent' => true ) ),
+				'constants'          => array(),
+				'expected_result'    => true,
+				'should_set_headers' => false, // No headers set when headers_sent is true
+			),
+		);
+	}
+
+	/**
+	 * Test is_frontend with various existing header scenarios
+	 *
+	 * @dataProvider get_header_scenarios
+	 * @param string $scenario_name    Name of the scenario being tested.
+	 * @param array  $existing_headers Existing headers to mock.
+	 * @param string $expected_header  Expected Vary header to be set.
+	 */
+	#[DataProvider( 'get_header_scenarios' )]
+	public function test_is_frontend_with_existing_headers( $scenario_name, $existing_headers, $expected_header ) {
+		// Set up for frontend request (all conditions false)
+		Functions\when( 'is_admin' )->justReturn( false );
+		Functions\when( 'wp_doing_ajax' )->justReturn( false );
+		Functions\when( 'wp_is_jsonp_request' )->justReturn( false );
+		Functions\when( 'is_feed' )->justReturn( false );
+		Functions\when( 'wp_is_json_request' )->justReturn( false );
+		Functions\when( 'wp_is_xml_request' )->justReturn( false );
+		Functions\when( 'headers_sent' )->justReturn( false );
+		Functions\when( 'headers_list' )->justReturn( $existing_headers );
+
+		// Expect the header to be set with the combined Vary values
+		Functions\expect( 'header' )->once()->with( $expected_header );
+		Filters\expectApplied( 'jetpack_is_frontend' )->once()->with( true )->andReturn( true );
+
+		$result = Request::is_frontend();
+		$this->assertTrue( $result, "Failed scenario: {$scenario_name}" );
+	}
+
+	/**
+	 * Data provider for header scenarios
+	 *
+	 * @return array
+	 */
+	public static function get_header_scenarios() {
+		return array(
+			'no existing headers'                       => array(
+				'scenario_name'    => 'no existing headers',
+				'existing_headers' => array(),
+				'expected_header'  => 'Vary: accept, content-type',
+			),
+			'existing Accept-Encoding header'           => array(
+				'scenario_name'    => 'existing Accept-Encoding header',
+				'existing_headers' => array(
+					'Cache-Control: no-cache, must-revalidate, max-age=0',
+					'Content-Type: text/html; charset=UTF-8',
+					'Vary: Accept-Encoding',
+				),
+				'expected_header'  => 'Vary: accept, content-type, accept-encoding',
+			),
+			'multiple Vary headers'                     => array(
+				'scenario_name'    => 'multiple Vary headers',
+				'existing_headers' => array(
+					'Cache-Control: no-cache, must-revalidate, max-age=0',
+					'Content-Type: text/html; charset=UTF-8',
+					'Vary: Accept',
+					'Vary: Accept-Encoding',
+				),
+				'expected_header'  => 'Vary: accept, content-type, accept-encoding',
+			),
+			'wildcard Vary header'                      => array(
+				'scenario_name'    => 'wildcard Vary header',
+				'existing_headers' => array(
+					'Cache-Control: no-cache, must-revalidate, max-age=0',
+					'Content-Type: text/html; charset=UTF-8',
+					'Vary: *',
+				),
+				'expected_header'  => 'Vary: *',
+			),
+			'existing Accept header (already included)' => array(
+				'scenario_name'    => 'existing Accept header (already included)',
+				'existing_headers' => array(
+					'Cache-Control: no-cache, must-revalidate, max-age=0',
+					'Content-Type: text/html; charset=UTF-8',
+					'Vary: Accept',
+				),
+				'expected_header'  => 'Vary: accept, content-type',
+			),
+			'mixed case Vary header'                    => array(
+				'scenario_name'    => 'mixed case Vary header',
+				'existing_headers' => array(
+					'Cache-Control: no-cache, must-revalidate, max-age=0',
+					'Content-Type: text/html; charset=UTF-8',
+					'Vary: Accept-Language, Accept-Encoding',
+				),
+				'expected_header'  => 'Vary: accept, content-type, accept-language, accept-encoding',
+			),
+		);
+	}
+
+	/**
+	 * Test is_frontend filter behavior
+	 *
+	 * @dataProvider get_filter_override_scenarios
+	 * @param string $scenario_name     Name of the scenario being tested.
+	 * @param bool   $initial_result    The initial result before filter is applied.
+	 * @param bool   $filter_return     What the filter should return.
+	 * @param bool   $expected_result   The expected final result.
+	 */
+	#[DataProvider( 'get_filter_override_scenarios' )]
+	public function test_is_frontend_filter_behavior( $scenario_name, $initial_result, $filter_return, $expected_result ) {
+		// Set up WordPress functions based on the initial result we want
+		if ( $initial_result ) {
+			// Frontend request setup
+			Functions\when( 'is_admin' )->justReturn( false );
+			Functions\when( 'wp_doing_ajax' )->justReturn( false );
+			Functions\when( 'wp_is_jsonp_request' )->justReturn( false );
+			Functions\when( 'is_feed' )->justReturn( false );
+			Functions\when( 'wp_is_json_request' )->justReturn( false );
+			Functions\when( 'wp_is_xml_request' )->justReturn( false );
+			Functions\when( 'headers_sent' )->justReturn( false );
+			Functions\when( 'headers_list' )->justReturn( array() );
+			Functions\expect( 'header' )->once()->with( 'Vary: accept, content-type' );
+		} else {
+			// Non-frontend request setup (admin)
+			Functions\when( 'is_admin' )->justReturn( true );
+			Functions\when( 'wp_doing_ajax' )->justReturn( false );
+			Functions\when( 'wp_is_jsonp_request' )->justReturn( false );
+			Functions\when( 'is_feed' )->justReturn( false );
+			Functions\when( 'wp_is_json_request' )->justReturn( false );
+			Functions\when( 'wp_is_xml_request' )->justReturn( false );
+			Functions\when( 'headers_sent' )->justReturn( false );
+			Functions\expect( 'header' )->never();
+		}
+
+		// Set up the filter expectation
+		Filters\expectApplied( 'jetpack_is_frontend' )->once()->with( $initial_result )->andReturn( $filter_return );
+
+		$result = Request::is_frontend();
+		$this->assertEquals( $expected_result, $result, "Failed scenario: {$scenario_name}" );
+	}
+
+	/**
+	 * Data provider for filter override scenarios
+	 *
+	 * @return array
+	 */
+	public static function get_filter_override_scenarios() {
+		return array(
+			'frontend request - filter returns same (true)' => array(
+				'scenario_name'   => 'frontend request - filter returns same (true)',
+				'initial_result'  => true,
+				'filter_return'   => true,
+				'expected_result' => true,
+			),
+			'frontend request - filter overrides to false' => array(
+				'scenario_name'   => 'frontend request - filter overrides to false',
+				'initial_result'  => true,
+				'filter_return'   => false,
+				'expected_result' => false,
+			),
+			'admin request - filter returns same (false)'  => array(
+				'scenario_name'   => 'admin request - filter returns same (false)',
+				'initial_result'  => false,
+				'filter_return'   => false,
+				'expected_result' => false,
+			),
+			'admin request - filter overrides to true'     => array(
+				'scenario_name'   => 'admin request - filter overrides to true',
+				'initial_result'  => false,
+				'filter_return'   => true,
+				'expected_result' => true,
+			),
+		);
+	}
+
 	/**
 	 * Test jetpack_get_vary_headers.
 	 *
@@ -82,7 +403,7 @@ class Request_Test extends TestCase {
 			),
 			'Multiple Vary headers, with a wildcard' => array(
 				array(
-					'Cache-Control: no-cache, must-revalidate, max-age=0',
+					'Cache-Control: no-cache, must revalidate, max-age=0',
 					'Content-Type: text/html; charset=UTF-8',
 					'Vary: *',
 					'Vary: Accept-Encoding',

--- a/projects/packages/status/tests/php/patchwork.json
+++ b/projects/packages/status/tests/php/patchwork.json
@@ -1,3 +1,10 @@
 {
-	"redefinable-internals": [ "defined", "constant", "dns_get_record" ]
+	"redefinable-internals": [
+		"defined",
+		"constant",
+		"dns_get_record",
+		"headers_sent",
+		"headers_list",
+		"header"
+	]
 }


### PR DESCRIPTION
## Proposed changes:

`jetpack_is_frontend` currently lives in the Jetpack plugin only, but would be needed outside of the Jetpack plugin (for example for #43413).

In phase 2, we'll replace usage of the function everywhere where it is used, and deprecate the function.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Is CI happy?
