### PR TITLE
Charts: Ensure chart and legend combined height equals the specified height prop

### DIFF
--- a/projects/js-packages/charts/changelog/charts-30-linebar-chart-height-prop-does-not-account-for-legend-height
+++ b/projects/js-packages/charts/changelog/charts-30-linebar-chart-height-prop-does-not-account-for-legend-height
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+Chart components now subtract legend height from total height, ensuring the rendered chart (including legend) does not exceed the specified height prop

--- a/projects/js-packages/charts/src/components/bar-chart/bar-chart.tsx
+++ b/projects/js-packages/charts/src/components/bar-chart/bar-chart.tsx
@@ -4,6 +4,7 @@ import { useCallback } from 'react';
 import { useXYChartTheme } from '../../providers/theme';
 import { Legend } from '../legend';
 import { useChartMargin } from '../shared/use-chart-margin';
+import { useElementHeight } from '../shared/use-element-height';
 import { withResponsive } from '../shared/with-responsive';
 import styles from './bar-chart.module.scss';
 import { useBarChartOptions } from './use-bar-chart-options';
@@ -53,6 +54,7 @@ const BarChart: FC< BarChartProps > = ( {
 	const theme = useXYChartTheme( data );
 	const chartOptions = useBarChartOptions( data, horizontal, options );
 	const defaultMargin = useChartMargin( height, chartOptions, data, theme, horizontal );
+	const [ legendRef, legendHeight ] = useElementHeight< HTMLDivElement >();
 
 	const renderDefaultTooltip = useCallback(
 		( { tooltipData }: RenderTooltipParams< DataPointDate > ) => {
@@ -103,11 +105,15 @@ const BarChart: FC< BarChartProps > = ( {
 			data-testid="bar-chart"
 			role="img"
 			aria-label="bar chart"
+			style={ {
+				width,
+				height,
+			} }
 		>
 			<XYChart
 				theme={ theme }
 				width={ width }
-				height={ height }
+				height={ height - legendHeight }
 				margin={ { ...defaultMargin, ...margin } }
 				xScale={ chartOptions.xScale }
 				yScale={ chartOptions.yScale }
@@ -153,6 +159,7 @@ const BarChart: FC< BarChartProps > = ( {
 					orientation={ legendOrientation }
 					className={ styles[ 'bar-chart__legend' ] }
 					shape={ legendShape }
+					ref={ legendRef }
 				/>
 			) }
 		</div>

--- a/projects/js-packages/charts/src/components/bar-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/components/bar-chart/stories/index.stories.tsx
@@ -138,9 +138,9 @@ export const WithLegend = {
 export const WithVerticalLegend = {
 	args: {
 		...WithLegend.args,
-		data: [ data[ 0 ] ],
 		showLegend: true,
 		legendOrientation: 'vertical',
+		height: 600,
 	},
 };
 

--- a/projects/js-packages/charts/src/components/legend/base-legend.tsx
+++ b/projects/js-packages/charts/src/components/legend/base-legend.tsx
@@ -1,7 +1,7 @@
 import { LegendItem, LegendLabel, LegendOrdinal, LegendShape } from '@visx/legend';
 import { scaleOrdinal } from '@visx/scale';
 import clsx from 'clsx';
-import { useCallback, type FC } from 'react';
+import { forwardRef, useCallback } from 'react';
 import { useChartTheme } from '../../providers/theme';
 import styles from './legend.module.scss';
 import { valueOrIdentity, valueOrIdentityString, labelTransformFactory } from './utils';
@@ -16,97 +16,101 @@ const orientationToFlexDirection = {
  * Base legend component that displays color-coded items with labels based on visx LegendOrdinal.
  * We avoid using LegendOrdinal directly to enable support for advanced features such as interactivity.
  */
-export const BaseLegend: FC< LegendProps > = ( {
-	items,
-	className,
-	orientation = 'horizontal',
-	shape = 'rect',
-	fill = valueOrIdentityString,
-	size = valueOrIdentityString,
-	labelFormat = valueOrIdentity,
-	labelTransform = labelTransformFactory,
-	shapeWidth = 16,
-	shapeHeight = 16,
-	shapeMargin = '2px 4px 2px 0',
-	labelAlign = 'left',
-	labelFlex = '1',
-	labelMargin = '0 4px',
-	itemMargin = '0',
-	itemDirection = 'row',
-	legendLabelProps,
-	...legendItemProps
-} ) => {
-	const theme = useChartTheme();
-	const legendScale = scaleOrdinal( {
-		domain: items.map( item => item.label ),
-		range: items.map( item => item.color ),
-	} );
-	const domain = legendScale.domain();
+export const BaseLegend = forwardRef< HTMLDivElement, LegendProps >(
+	( {
+		ref,
+		items,
+		className,
+		orientation = 'horizontal',
+		shape = 'rect',
+		fill = valueOrIdentityString,
+		size = valueOrIdentityString,
+		labelFormat = valueOrIdentity,
+		labelTransform = labelTransformFactory,
+		shapeWidth = 16,
+		shapeHeight = 16,
+		shapeMargin = '2px 4px 2px 0',
+		labelAlign = 'left',
+		labelFlex = '1',
+		labelMargin = '0 4px',
+		itemMargin = '0',
+		itemDirection = 'row',
+		legendLabelProps,
+		...legendItemProps
+	} ) => {
+		const theme = useChartTheme();
+		const legendScale = scaleOrdinal( {
+			domain: items.map( item => item.label ),
+			range: items.map( item => item.color ),
+		} );
+		const domain = legendScale.domain();
 
-	const getShapeStyle = useCallback(
-		( { index }: { index: number } ) => {
-			return items[ index ]?.shapeStyle ?? theme.legendShapeStyles?.[ index ] ?? {};
-		},
-		[ items, theme ]
-	);
+		const getShapeStyle = useCallback(
+			( { index }: { index: number } ) => {
+				return items[ index ]?.shapeStyle ?? theme.legendShapeStyles?.[ index ] ?? {};
+			},
+			[ items, theme ]
+		);
 
-	return (
-		<LegendOrdinal
-			scale={ legendScale }
-			labelFormat={ labelFormat }
-			labelTransform={ labelTransform }
-		>
-			{ labels => (
-				<div
-					role="list"
-					data-testid={ `legend-${ orientation }` }
-					className={ clsx( styles.legend, styles[ `legend--${ orientation }` ], className ) }
-					style={ {
-						flexDirection: orientationToFlexDirection[ orientation ],
-						...theme.legendContainerStyles,
-					} }
-				>
-					{ labels.map( ( label, i ) => (
-						<LegendItem
-							className={ styles[ 'legend-item' ] }
-							data-testid="legend-item"
-							key={ `legend-${ label.text }-${ i }` }
-							margin={ itemMargin }
-							flexDirection={ itemDirection }
-							{ ...legendItemProps }
-						>
-							<LegendShape
-								shape={ shape }
-								height={ shapeHeight }
-								width={ shapeWidth }
-								margin={ shapeMargin }
-								item={ domain[ i ] }
-								itemIndex={ i }
-								label={ label }
-								fill={ fill }
-								size={ size }
-								shapeStyle={ getShapeStyle }
-							/>
-							<LegendLabel
-								style={ {
-									justifyContent: labelAlign,
-									flex: labelFlex,
-									margin: labelMargin,
-									...theme.legendLabelStyles,
-								} }
-								{ ...legendLabelProps }
+		return (
+			<LegendOrdinal
+				scale={ legendScale }
+				labelFormat={ labelFormat }
+				labelTransform={ labelTransform }
+			>
+				{ labels => (
+					<div
+						ref={ ref }
+						role="list"
+						data-testid={ `legend-${ orientation }` }
+						className={ clsx( styles.legend, styles[ `legend--${ orientation }` ], className ) }
+						style={ {
+							flexDirection: orientationToFlexDirection[ orientation ],
+							...theme.legendContainerStyles,
+						} }
+					>
+						{ labels.map( ( label, i ) => (
+							<LegendItem
+								className={ styles[ 'legend-item' ] }
+								data-testid="legend-item"
+								key={ `legend-${ label.text }-${ i }` }
+								margin={ itemMargin }
+								flexDirection={ itemDirection }
+								{ ...legendItemProps }
 							>
-								{ label.text }
-								{ items.find( item => item.label === label.text )?.value && (
-									<span className={ styles[ 'legend-item-value' ] }>
-										{ items.find( item => item.label === label.text )?.value }
-									</span>
-								) }
-							</LegendLabel>
-						</LegendItem>
-					) ) }
-				</div>
-			) }
-		</LegendOrdinal>
-	);
-};
+								<LegendShape
+									shape={ shape }
+									height={ shapeHeight }
+									width={ shapeWidth }
+									margin={ shapeMargin }
+									item={ domain[ i ] }
+									itemIndex={ i }
+									label={ label }
+									fill={ fill }
+									size={ size }
+									shapeStyle={ getShapeStyle }
+								/>
+								<LegendLabel
+									style={ {
+										justifyContent: labelAlign,
+										flex: labelFlex,
+										margin: labelMargin,
+										...theme.legendLabelStyles,
+									} }
+									{ ...legendLabelProps }
+								>
+									{ label.text }
+									{ items.find( item => item.label === label.text )?.value && (
+										<span className={ styles[ 'legend-item-value' ] }>
+											{ items.find( item => item.label === label.text )?.value }
+										</span>
+									) }
+								</LegendLabel>
+							</LegendItem>
+						) ) }
+					</div>
+				) }
+			</LegendOrdinal>
+		);
+	}
+);

--- a/projects/js-packages/charts/src/components/legend/base-legend.tsx
+++ b/projects/js-packages/charts/src/components/legend/base-legend.tsx
@@ -17,27 +17,29 @@ const orientationToFlexDirection = {
  * We avoid using LegendOrdinal directly to enable support for advanced features such as interactivity.
  */
 export const BaseLegend = forwardRef< HTMLDivElement, LegendProps >(
-	( {
-		ref,
-		items,
-		className,
-		orientation = 'horizontal',
-		shape = 'rect',
-		fill = valueOrIdentityString,
-		size = valueOrIdentityString,
-		labelFormat = valueOrIdentity,
-		labelTransform = labelTransformFactory,
-		shapeWidth = 16,
-		shapeHeight = 16,
-		shapeMargin = '2px 4px 2px 0',
-		labelAlign = 'left',
-		labelFlex = '1',
-		labelMargin = '0 4px',
-		itemMargin = '0',
-		itemDirection = 'row',
-		legendLabelProps,
-		...legendItemProps
-	} ) => {
+	(
+		{
+			items,
+			className,
+			orientation = 'horizontal',
+			shape = 'rect',
+			fill = valueOrIdentityString,
+			size = valueOrIdentityString,
+			labelFormat = valueOrIdentity,
+			labelTransform = labelTransformFactory,
+			shapeWidth = 16,
+			shapeHeight = 16,
+			shapeMargin = '2px 4px 2px 0',
+			labelAlign = 'left',
+			labelFlex = '1',
+			labelMargin = '0 4px',
+			itemMargin = '0',
+			itemDirection = 'row',
+			legendLabelProps,
+			...legendItemProps
+		},
+		ref
+	) => {
 		const theme = useChartTheme();
 		const legendScale = scaleOrdinal( {
 			domain: items.map( item => item.label ),

--- a/projects/js-packages/charts/src/components/legend/types.ts
+++ b/projects/js-packages/charts/src/components/legend/types.ts
@@ -1,5 +1,5 @@
 import { LegendOrdinal } from '@visx/legend';
-import type { ComponentProps, CSSProperties } from 'react';
+import type { ComponentProps, CSSProperties, RefObject } from 'react';
 
 // See https://airbnb.io/visx/docs/legend#Ordinal for more details.
 type LegendOrdinalProps = Omit< ComponentProps< typeof LegendOrdinal >, 'scale' | 'direction' >;
@@ -14,4 +14,5 @@ export type LegendItem = {
 export type LegendProps = Omit< LegendOrdinalProps, 'shapeStyle' > & {
 	items: LegendItem[];
 	orientation?: 'horizontal' | 'vertical';
+	ref?: RefObject< HTMLDivElement >;
 };

--- a/projects/js-packages/charts/src/components/line-chart/line-chart.tsx
+++ b/projects/js-packages/charts/src/components/line-chart/line-chart.tsx
@@ -8,6 +8,7 @@ import { useXYChartTheme, useChartTheme } from '../../providers/theme/theme-prov
 import { Legend } from '../legend';
 import { parseAsLocalDate } from '../shared/date-parsing';
 import { useChartMargin } from '../shared/use-chart-margin';
+import { useElementHeight } from '../shared/use-element-height';
 import { withResponsive } from '../shared/with-responsive';
 import styles from './line-chart.module.scss';
 import type { BaseChartProps, DataPoint, DataPointDate, SeriesData } from '../../types';
@@ -209,6 +210,7 @@ const LineChart: FC< LineChartProps > = ( {
 	const providerTheme = useChartTheme();
 	const theme = useXYChartTheme( data );
 	const chartId = useId(); // Ensure unique ids for gradient fill.
+	const [ legendRef, legendHeight ] = useElementHeight< HTMLDivElement >();
 
 	const dataSorted = useMemo(
 		() =>
@@ -280,11 +282,15 @@ const LineChart: FC< LineChartProps > = ( {
 			data-testid="line-chart"
 			role="img"
 			aria-label="line chart"
+			style={ {
+				width,
+				height,
+			} }
 		>
 			<XYChart
 				theme={ theme }
 				width={ width }
-				height={ height }
+				height={ height - legendHeight }
 				margin={ { ...defaultMargin, ...margin } }
 				// xScale and yScale could be set in Axis as well, but they are `scale` props there.
 				xScale={ chartOptions.xScale }
@@ -363,6 +369,7 @@ const LineChart: FC< LineChartProps > = ( {
 					orientation={ legendOrientation }
 					className={ styles[ 'line-chart-legend' ] }
 					shape={ legendShape }
+					ref={ legendRef }
 				/>
 			) }
 		</div>

--- a/projects/js-packages/charts/src/components/line-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/components/line-chart/stories/index.stories.tsx
@@ -106,6 +106,7 @@ export const WithLegend: StoryObj< typeof LineChart > = Template.bind( {} );
 WithLegend.args = {
 	...Default.args,
 	showLegend: true,
+	height: 400,
 };
 
 // Story with vertical legend

--- a/projects/js-packages/charts/src/components/shared/use-element-height.ts
+++ b/projects/js-packages/charts/src/components/shared/use-element-height.ts
@@ -1,0 +1,38 @@
+import { useRef, useState, useLayoutEffect, RefObject } from 'react';
+
+/**
+ * Hook to measure the height of a DOM element.
+ * Returns a ref to attach to the element and the current height in pixels.
+ *
+ * @param {object} props               - Optional props.
+ * @param {number} props.initialHeight - The initial height to use.
+ *
+ * @return {[RefObject<T>, number]} A tuple containing a ref to attach to the element and the current height in pixels
+ */
+export function useElementHeight< T extends HTMLElement = HTMLDivElement >( {
+	initialHeight = 0,
+}: {
+	initialHeight?: number;
+} = {} ): [ RefObject< T >, number ] {
+	const ref = useRef< T >( null );
+	const [ height, setHeight ] = useState( initialHeight );
+
+	useLayoutEffect( () => {
+		if ( ! ref.current ) return;
+
+		const handleResize = () => {
+			setHeight( ref.current?.getBoundingClientRect().height || 0 );
+		};
+
+		handleResize(); // Initial measurement
+
+		const resizeObserver = new window.ResizeObserver( handleResize );
+		resizeObserver.observe( ref.current );
+
+		return () => {
+			resizeObserver.disconnect();
+		};
+	}, [] );
+
+	return [ ref, height ];
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->



## Proposed changes:
<!--- Explain what functional changes your PR includes -->

When users set the height property for line/bar charts, they expect the chart and legend to be aligned with the container height, not just the chart height.

This PR dynamically measures the legend’s height and subtracts it from the chart area when rendering `<XYChart />`, so the total rendered height (chart + legend) matches the specified height prop.

The enhancement fixes layout issues that occur when charts are placed in fixed-height containers. For example, when a chart is placed in a container with a fixed height, the chart and legend may exceed the container height, causing the legend to be invisible.



### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Run `pnpm --filter="@automattic/charts" storybook`
* Go to http://localhost:50240/?path=/story/js-packages-charts-types-line-chart--with-legend
* Check that the total height of chart + legend matches the specified height prop (400px).
* Check that the vertical legend story displays correctly
* Check the bar chart legend stories display correctly


Before:
<img width="655" alt="Screenshot 2025-06-09 at 15 48 15" src="https://github.com/user-attachments/assets/bd047e21-d99f-45a1-b33a-f5fb05dc3d49" />

After:
<img width="658" alt="Screenshot 2025-06-09 at 15 58 49" src="https://github.com/user-attachments/assets/2e042a0b-9eba-4be4-8ba6-7a61dcf8d70d" />


Vertical legend:

I initially had concerns about potential layout shifts during chart rendering, but testing shows minimal impact. However, if layout shifts become problematic, we could consider adding an optional prop allowing consumers to specify an initial legend height to minimize any initial rendering adjustments.


https://github.com/user-attachments/assets/b13bc20f-04fc-4d70-9d9a-7bd7024407e7

