### PR TITLE
Forms: sentence case all UI components

### DIFF
--- a/projects/packages/forms/changelog/update-forms-sentence-case-v2
+++ b/projects/packages/forms/changelog/update-forms-sentence-case-v2
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: sentence case UI instead of Title Case

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-controls.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-controls.js
@@ -165,10 +165,10 @@ const JetpackFieldControls = ( {
 			</BlockControls>
 
 			<InspectorControls>
-				<PanelBody title={ __( 'Manage Responses', 'jetpack-forms' ) }>
+				<PanelBody title={ __( 'Manage responses', 'jetpack-forms' ) }>
 					<JetpackManageResponsesSettings isChildBlock />
 				</PanelBody>
-				<PanelBody title={ __( 'Field Settings', 'jetpack-forms' ) }>
+				<PanelBody title={ __( 'Field settings', 'jetpack-forms' ) }>
 					<>{ fieldSettings }</>
 				</PanelBody>
 				<PanelColorSettings
@@ -198,7 +198,7 @@ const JetpackFieldControls = ( {
 					{ ( isChoicesBlock || blockStyle === 'button' ) && (
 						<>
 							<RangeControl
-								label={ __( 'Button Border Width', 'jetpack-forms' ) }
+								label={ __( 'Button border width', 'jetpack-forms' ) }
 								value={ attributes.buttonBorderWidth }
 								initialPosition={ 1 }
 								onChange={ setNumberAttribute( 'buttonBorderWidth' ) }
@@ -208,7 +208,7 @@ const JetpackFieldControls = ( {
 								__next40pxDefaultSize={ true }
 							/>
 							<RangeControl
-								label={ __( 'Button Border Radius', 'jetpack-forms' ) }
+								label={ __( 'Button border radius', 'jetpack-forms' ) }
 								value={ attributes.buttonBorderRadius }
 								initialPosition={ 0 }
 								onChange={ setNumberAttribute( 'buttonBorderRadius' ) }
@@ -222,7 +222,7 @@ const JetpackFieldControls = ( {
 					{ ( ! isChoicesBlock || formStyle === FORM_STYLE.OUTLINED ) && (
 						<>
 							<RangeControl
-								label={ __( 'Border Width', 'jetpack-forms' ) }
+								label={ __( 'Border width', 'jetpack-forms' ) }
 								value={ attributes.borderWidth }
 								initialPosition={ 1 }
 								onChange={ setNumberAttribute( 'borderWidth' ) }
@@ -232,7 +232,7 @@ const JetpackFieldControls = ( {
 								__next40pxDefaultSize={ true }
 							/>
 							<RangeControl
-								label={ __( 'Border Radius', 'jetpack-forms' ) }
+								label={ __( 'Border radius', 'jetpack-forms' ) }
 								value={ attributes.borderRadius }
 								initialPosition={ 0 }
 								onChange={ setNumberAttribute( 'borderRadius' ) }
@@ -244,7 +244,7 @@ const JetpackFieldControls = ( {
 						</>
 					) }
 				</PanelBody>
-				<PanelBody title={ __( 'Label Styles', 'jetpack-forms' ) } initialOpen={ false }>
+				<PanelBody title={ __( 'Label styles', 'jetpack-forms' ) } initialOpen={ false }>
 					<BaseControl __nextHasNoMarginBottom={ true }>
 						<FontSizePicker
 							withReset={ true }

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-manage-responses-settings.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-manage-responses-settings.js
@@ -10,7 +10,7 @@ const JetpackManageResponsesSettings = () => {
 				{ __( 'Manage and export your form responses in WPAdmin:', 'jetpack-forms' ) }
 			</InspectorHint>
 			<Button variant="secondary" href={ FULL_RESPONSES_PATH } __next40pxDefaultSize={ true }>
-				{ __( 'View Form Responses', 'jetpack-forms' ) }
+				{ __( 'View form responses', 'jetpack-forms' ) }
 				<span className="screen-reader-text">
 					{ __( '(opens in a new tab)', 'jetpack-forms' ) }
 				</span>

--- a/projects/packages/forms/src/blocks/contact-form/edit.js
+++ b/projects/packages/forms/src/blocks/contact-form/edit.js
@@ -155,7 +155,7 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 							{ __( 'Customize the view after form submission:', 'jetpack-forms' ) }
 						</InspectorHint>
 						<SelectControl
-							label={ __( 'On Submission', 'jetpack-forms' ) }
+							label={ __( 'On submission', 'jetpack-forms' ) }
 							value={ customThankyou }
 							options={ [
 								{ label: __( 'Show a summary of submitted fields', 'jetpack-forms' ), value: '' },
@@ -172,7 +172,7 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 
 						{ 'redirect' !== customThankyou && (
 							<TextControl
-								label={ __( 'Message Heading', 'jetpack-forms' ) }
+								label={ __( 'Message heading', 'jetpack-forms' ) }
 								value={ customThankyouHeading }
 								placeholder={ __( 'Your message has been sent', 'jetpack-forms' ) }
 								onChange={ newHeading => setAttributes( { customThankyouHeading: newHeading } ) }
@@ -183,7 +183,7 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 
 						{ 'message' === customThankyou && (
 							<TextareaControl
-								label={ __( 'Message Text', 'jetpack-forms' ) }
+								label={ __( 'Message text', 'jetpack-forms' ) }
 								value={ customThankyouMessage }
 								placeholder={ __( 'Thank you for your submission!', 'jetpack-forms' ) }
 								onChange={ newMessage => setAttributes( { customThankyouMessage: newMessage } ) }
@@ -194,7 +194,7 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 						{ 'redirect' === customThankyou && (
 							<div>
 								<URLInput
-									label={ __( 'Redirect Address', 'jetpack-forms' ) }
+									label={ __( 'Redirect address', 'jetpack-forms' ) }
 									value={ customThankyouRedirect }
 									className="jetpack-contact-form__thankyou-redirect-url"
 									onChange={ newURL => setAttributes( { customThankyouRedirect: newURL } ) }

--- a/projects/packages/forms/src/blocks/contact-form/variations.js
+++ b/projects/packages/forms/src/blocks/contact-form/variations.js
@@ -121,7 +121,7 @@ const variations = compact( [
 				'jetpack/field-textarea',
 				{},
 				[
-					[ 'jetpack/label', { label: __( 'Other Details', 'jetpack-forms' ) } ],
+					[ 'jetpack/label', { label: __( 'Other details', 'jetpack-forms' ) } ],
 					[ 'jetpack/input', { type: 'textarea' } ],
 				],
 			],
@@ -187,7 +187,7 @@ const variations = compact( [
 					innerBlocks: [
 						{
 							name: 'jetpack/label',
-							attributes: { label: __( 'Other Details', 'jetpack-forms' ) },
+							attributes: { label: __( 'Other details', 'jetpack-forms' ) },
 						},
 						{ name: 'jetpack/input', attributes: { type: 'textarea' } },
 					],
@@ -245,11 +245,11 @@ const variations = compact( [
 				'jetpack/field-select',
 				{
 					options: [
-						__( 'Search Engine', 'jetpack-forms' ),
-						__( 'Social Media', 'jetpack-forms' ),
+						__( 'Search engine', 'jetpack-forms' ),
+						__( 'Social media', 'jetpack-forms' ),
 						__( 'TV', 'jetpack-forms' ),
 						__( 'Radio', 'jetpack-forms' ),
-						__( 'Friend or Family', 'jetpack-forms' ),
+						__( 'Friend or family', 'jetpack-forms' ),
 					],
 				},
 				[
@@ -270,7 +270,7 @@ const variations = compact( [
 					[
 						'jetpack/label',
 						{
-							label: __( 'Other Details', 'jetpack-forms' ),
+							label: __( 'Other details', 'jetpack-forms' ),
 						},
 					],
 					[ 'jetpack/input', { type: 'textarea' } ],
@@ -361,7 +361,7 @@ const variations = compact( [
 						{
 							name: 'jetpack/label',
 							attributes: {
-								label: __( 'Other Details', 'jetpack-forms' ),
+								label: __( 'Other details', 'jetpack-forms' ),
 							},
 						},
 						{
@@ -466,7 +466,7 @@ const variations = compact( [
 			[
 				'jetpack/button',
 				{
-					text: __( 'Book Appointment', 'jetpack-forms' ),
+					text: __( 'Book appointment', 'jetpack-forms' ),
 					element: 'button',
 					lock: { remove: true },
 				},
@@ -546,7 +546,7 @@ const variations = compact( [
 				{
 					name: 'jetpack/button',
 					attributes: {
-						text: __( 'Book Appointment', 'jetpack-forms' ),
+						text: __( 'Book appointment', 'jetpack-forms' ),
 						element: 'button',
 						lock: { remove: true },
 					},
@@ -557,7 +557,7 @@ const variations = compact( [
 	{
 		name: 'feedback-form',
 		title: __( 'Feedback Form', 'jetpack-forms' ),
-		description: __( 'Add a Feedback form to your page', 'jetpack-forms' ),
+		description: __( 'Add a feedback form to your page', 'jetpack-forms' ),
 		icon: {
 			foreground: getIconColor(),
 			src: renderMaterialIcon(

--- a/projects/packages/forms/src/blocks/field-checkbox/edit.js
+++ b/projects/packages/forms/src/blocks/field-checkbox/edit.js
@@ -66,7 +66,7 @@ export default function CheckboxFieldEdit( props ) {
 				<ToolbarRequiredGroup required={ required } onClick={ onRequiredToggle } />
 			</BlockControls>
 			<InspectorControls>
-				<PanelBody title={ __( 'Checkbox Settings', 'jetpack-forms' ) }>
+				<PanelBody title={ __( 'Checkbox settings', 'jetpack-forms' ) }>
 					<ToggleControl
 						label={ __( 'Checked by default', 'jetpack-forms' ) }
 						checked={ !! defaultValue }
@@ -76,10 +76,10 @@ export default function CheckboxFieldEdit( props ) {
 				</PanelBody>
 			</InspectorControls>
 			<InspectorControls>
-				<PanelBody title={ __( 'Manage Responses', 'jetpack-forms' ) }>
+				<PanelBody title={ __( 'Manage responses', 'jetpack-forms' ) }>
 					<JetpackManageResponsesSettings isChildBlock />
 				</PanelBody>
-				<PanelBody title={ __( 'Field Settings', 'jetpack-forms' ) }>
+				<PanelBody title={ __( 'Field settings', 'jetpack-forms' ) }>
 					<ToggleControl
 						label={ __( 'Field is required', 'jetpack-forms' ) }
 						checked={ required }

--- a/projects/packages/forms/src/blocks/field-consent/edit.js
+++ b/projects/packages/forms/src/blocks/field-consent/edit.js
@@ -149,10 +149,10 @@ export default function ConsentFieldEdit( props ) {
 		<>
 			<div { ...innerBlocksProps } />
 			<InspectorControls>
-				<PanelBody title={ __( 'Manage Responses', 'jetpack-forms' ) }>
+				<PanelBody title={ __( 'Manage responses', 'jetpack-forms' ) }>
 					<JetpackManageResponsesSettings isChildBlock />
 				</PanelBody>
-				<PanelBody title={ __( 'Field Settings', 'jetpack-forms' ) }>
+				<PanelBody title={ __( 'Field settings', 'jetpack-forms' ) }>
 					<JetpackFieldWidth setAttributes={ setAttributes } width={ width } />
 					<ToggleControl
 						label={ __( 'Sync fields style', 'jetpack-forms' ) }
@@ -162,7 +162,7 @@ export default function ConsentFieldEdit( props ) {
 						__nextHasNoMarginBottom
 					/>
 				</PanelBody>
-				<PanelBody title={ __( 'Consent Settings', 'jetpack-forms' ) }>
+				<PanelBody title={ __( 'Consent settings', 'jetpack-forms' ) }>
 					<BaseControl __nextHasNoMarginBottom>
 						<SelectControl
 							label={ __( 'Permission to email', 'jetpack-forms' ) }

--- a/projects/packages/forms/src/blocks/field-multiple-choice/index.js
+++ b/projects/packages/forms/src/blocks/field-multiple-choice/index.js
@@ -11,7 +11,7 @@ const name = 'field-checkbox-multiple';
 const settings = {
 	...defaultSettings,
 	title: __( 'Multiple Choice (Checkbox)', 'jetpack-forms' ),
-	keywords: [ __( 'Choose Multiple', 'jetpack-forms' ), __( 'Option', 'jetpack-forms' ) ],
+	keywords: [ __( 'Choose multiple', 'jetpack-forms' ), __( 'Option', 'jetpack-forms' ) ],
 	description: __(
 		'Offer users a list of choices, and allow them to select multiple options.',
 		'jetpack-forms'

--- a/projects/packages/forms/src/blocks/shared/components/jetpack-field-controls.js
+++ b/projects/packages/forms/src/blocks/shared/components/jetpack-field-controls.js
@@ -69,10 +69,10 @@ const JetpackFieldControls = ( {
 			</BlockControls>
 
 			<InspectorControls>
-				<PanelBody title={ __( 'Manage Responses', 'jetpack-forms' ) }>
+				<PanelBody title={ __( 'Manage responses', 'jetpack-forms' ) }>
 					<JetpackManageResponsesSettings isChildBlock />
 				</PanelBody>
-				<PanelBody title={ __( 'Field Settings', 'jetpack-forms' ) }>
+				<PanelBody title={ __( 'Field settings', 'jetpack-forms' ) }>
 					<>{ fieldSettings }</>
 				</PanelBody>
 			</InspectorControls>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Our in-house style is to use sentence casing. In the interim this might mean inconsistencies across UIs like the editor, but longer term this will settle and we have to start somewhere.

Internal references:
- PCYsg-5n-p2#capitalization
- pgijrj-42-p2

See [another PR](https://github.com/Automattic/jetpack/pull/43818) for sentence casing field names.

E2E tests updated in separate PR:
- https://github.com/Automattic/wp-calypso/pull/104066

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Sentence case ALL UI elements, minus field names

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Forms continue work just fine

