### PR TITLE
Forms: Fix dropdown field option background color

### DIFF
--- a/projects/packages/forms/changelog/fix-dropdown-field-option-background-color
+++ b/projects/packages/forms/changelog/fix-dropdown-field-option-background-color
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Fix dropdown field background color on Windows.

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -441,6 +441,7 @@
 .contact-form :where( .contact-form__select-wrapper select ) {
 	border: 0 !important;
 	background: inherit !important;
+	border-radius: inherit !important;
 	font-family: inherit;
 	font-size: inherit;
 	color: inherit;

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -440,7 +440,7 @@
 .contact-form :where( .contact-form__select-element-wrapper ),
 .contact-form :where( .contact-form__select-wrapper select ) {
 	border: 0 !important;
-	background: transparent !important;
+	background: inherit !important;
 	font-family: inherit;
 	font-size: inherit;
 	color: inherit;

--- a/projects/plugins/jetpack/changelog/fix-dropdown-field-option-background-color
+++ b/projects/plugins/jetpack/changelog/fix-dropdown-field-option-background-color
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: Fix dropdown field background color on Windows.


### PR DESCRIPTION
Fixes FORMS-134

I think this problem was introduced in #43674. To fix that issue an extra wrapper was added around the `<select>` element, and all the dropdown field styles were applied to this wrapper.

To make the `<select>` element not obscure those styles its background was set to `transparent`.

On Windows, the native select element can have a background color applied through CSS, but that change meant it was always white and could have contrast issues with light text colors.

This change ensure that the background color is inherited by the select element so that the user specified colors also apply to the Windows native select UI element.

Border radius is also inherited, otherwise the `select` element's background might overlap its parent element's border.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1749282002478399-slack-C086RGTJT1D

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
1. Create a form
2. Add a dropdown field to the form
3. Add some options to the dropdown field
4. Apply a dark background and white (or light) text color to the dropdown
5. Preview the post
6. Click on the dropdown and check that the options are readable