### PR TITLE
Replace renamed `pkg-dir` → `package-directory`

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2785,9 +2785,9 @@ importers:
       babel-plugin-transform-rename-properties:
         specifier: 0.1.0
         version: 0.1.0(@babel/core@7.27.4)
-      pkg-dir:
-        specifier: ^5.0.0
-        version: 5.0.0
+      package-directory:
+        specifier: ^8.1.0
+        version: 8.1.0
       sass-embedded:
         specifier: 1.87.0
         version: 1.87.0
@@ -3480,9 +3480,6 @@ importers:
       jest-environment-jsdom:
         specifier: 29.7.0
         version: 29.7.0
-      pkg-dir:
-        specifier: ^5.0.0
-        version: 5.0.0
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -13349,6 +13346,10 @@ packages:
     resolution: {integrity: sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==}
     engines: {node: '>= 14'}
 
+  package-directory@8.1.0:
+    resolution: {integrity: sha512-qHKRW0pw3lYdZMQVkjDBqh8HlamH/LCww2PH7OWEp4Qrt3SFeYMNpnJrQzlSnGrDD5zGR51XqBh7FnNCdVNEHA==}
+    engines: {node: '>=18'}
+
   package-hash@4.0.0:
     resolution: {integrity: sha512-whdkPIooSu/bASggZ96BWVvZTRMOFxnyUG5PnTSGKoJE2gd5mbVNmR2Nj20QFzxYYgAXpoqC+AiXzl+UMRh7zQ==}
     engines: {node: '>=8'}
@@ -13502,10 +13503,6 @@ packages:
   pkg-dir@4.2.0:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
     engines: {node: '>=8'}
-
-  pkg-dir@5.0.0:
-    resolution: {integrity: sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==}
-    engines: {node: '>=10'}
 
   pkg-dir@7.0.0:
     resolution: {integrity: sha512-Ie9z/WINcxxLp27BKOCHGde4ITq9UklYKDzVo1nhk5sqGEXU3FpkwP5GM2voTGJkGd9B3Otl+Q4uwSOeSUtOBA==}
@@ -27758,6 +27755,10 @@ snapshots:
       degenerator: 5.0.1
       netmask: 2.0.2
 
+  package-directory@8.1.0:
+    dependencies:
+      find-up-simple: 1.0.1
+
   package-hash@4.0.0:
     dependencies:
       graceful-fs: 4.2.11
@@ -27902,10 +27903,6 @@ snapshots:
   pkg-dir@4.2.0:
     dependencies:
       find-up: 4.1.0
-
-  pkg-dir@5.0.0:
-    dependencies:
-      find-up: 5.0.0
 
   pkg-dir@7.0.0:
     dependencies:

--- a/projects/packages/jetpack-mu-wpcom/changelog/update-renamed-pkg-dir-dep
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-renamed-pkg-dir-dep
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Replace deprecated `pkg-dir` dep with `package-directory`, and jump through a hoop to make the ESM-only package work.
+
+

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -39,7 +39,7 @@
 		"@types/react": "^18.2.28",
 		"@types/react-dom": "18.3.7",
 		"babel-plugin-transform-rename-properties": "0.1.0",
-		"pkg-dir": "^5.0.0",
+		"package-directory": "^8.1.0",
 		"sass-embedded": "1.87.0",
 		"sass-loader": "16.0.5",
 		"typescript": "^5.0.4",

--- a/projects/packages/jetpack-mu-wpcom/webpack.config.js
+++ b/projects/packages/jetpack-mu-wpcom/webpack.config.js
@@ -1,133 +1,134 @@
 const path = require( 'path' );
 const jetpackWebpackConfig = require( '@automattic/jetpack-webpack-config/webpack' );
-const pkgDir = require( 'pkg-dir' );
 const verbumConfig = require( './verbum.webpack.config.js' );
 
-module.exports = [
-	...verbumConfig,
-	{
-		entry: {
-			'a8c-posts-list': './src/features/wpcom-blocks/a8c-posts-list/blocks/posts-list/index.js',
-			'block-inserter-modifications': './src/features/block-inserter-modifications/index.js',
-			'core-customizer-css':
-				'./src/features/custom-css/custom-css/js/core-customizer-css.core-4.9.js',
-			'core-customizer-css-preview':
-				'./src/features/custom-css/custom-css/js/core-customizer-css-preview.js',
-			'customizer-control': './src/features/custom-css/custom-css/css/customizer-control.css',
-			'error-reporting': './src/features/error-reporting/index.js',
-			'holiday-snow': './src/features/holiday-snow/holiday-snow.scss',
-			'jetpack-global-styles': './src/features/jetpack-global-styles/index.js',
-			'jetpack-global-styles-customizer-fonts':
-				'./src/features/jetpack-global-styles/customizer-fonts/index.js',
-			'mailerlite-subscriber-popup': './src/features/mailerlite/subscriber-popup.js',
-			'newspack-blocks-blog-posts-editor': './src/features/newspack-blocks/blog-posts/editor.js',
-			'newspack-blocks-blog-posts-view': './src/features/newspack-blocks/blog-posts/view.js',
-			'newspack-blocks-carousel-editor': './src/features/newspack-blocks/carousel/editor.js',
-			'newspack-blocks-carousel-view': './src/features/newspack-blocks/carousel/view.js',
-			'override-preview-button-url':
-				'./src/features/override-preview-button-url/override-preview-button-url.js',
-			'paragraph-block-placeholder':
-				'./src/features/paragraph-block-placeholder/paragraph-block-placeholder.js',
-			'tags-education': './src/features/tags-education/tags-education.js',
-			'wpcom-admin-bar': './src/features/wpcom-admin-bar/wpcom-admin-bar.scss',
-			'wpcom-blocks-event-countdown-editor':
-				'./src/features/wpcom-blocks/event-countdown/editor.js',
-			'wpcom-blocks-event-countdown-view': './src/features/wpcom-blocks/event-countdown/view.js',
-			'wpcom-blocks-timeline-editor': './src/features/wpcom-blocks/timeline/editor.js',
-			'wpcom-blocks-timeline-view': './src/features/wpcom-blocks/timeline/view.js',
-			'wpcom-block-description-links': './src/features/wpcom-block-description-links/index.tsx',
-			'wpcom-block-editor-nux': './src/features/wpcom-block-editor-nux/index.js',
-			'wpcom-comment-like': [
-				'./src/features/wpcom-comments/wpcom-comment-like.js',
-				'./src/features/wpcom-comments/wpcom-comment-like.css',
-			],
-			'wpcom-hotfixes-colors-modern': './src/features/wpcom-hotfixes/colors/modern/colors.css',
-			'wpcom-dashboard-widgets':
-				'./src/features/wpcom-dashboard-widgets/wpcom-dashboard-widgets.js',
-			'wpcom-global-styles-editor': './src/features/wpcom-global-styles/index.js',
-			'wpcom-global-styles-frontend':
-				'./src/features/wpcom-global-styles/wpcom-global-styles-view.js',
-			'wpcom-documentation-links':
-				'./src/features/wpcom-documentation-links/wpcom-documentation-links.ts',
-			'wpcom-media-url-upload': './src/features/wpcom-media/wpcom-media-url-upload.js',
-			'wpcom-options-general': [
-				'./src/features/wpcom-options-general/options-general.ts',
-				'./src/features/wpcom-options-general/options-general.scss',
-			],
-			'wpcom-post-list-tracks': './src/features/wpcom-post-list/js/wpcom-post-list-tracks.ts',
-			'wpcom-plugins-banner': './src/features/wpcom-plugins/js/banner.js',
-			'wpcom-plugins-banner-style': './src/features/wpcom-plugins/css/banner.css',
-			'wpcom-profile-settings-link-to-wpcom':
-				'./src/features/wpcom-profile-settings/profile-settings-link-to-wpcom.ts',
-			'wpcom-replace-site-visibility':
-				'./src/features/replace-site-visibility/replace-site-visibility.tsx',
-			'wpcom-sidebar-notice': './src/features/wpcom-sidebar-notice/wpcom-sidebar-notice.js',
-			'adminbar-launch-button': './src/features/launch-button/index.js',
-		},
-		mode: jetpackWebpackConfig.mode,
-		devtool: jetpackWebpackConfig.devtool,
-		output: {
-			...jetpackWebpackConfig.output,
-			filename: '[name]/[name].js',
-			path: path.resolve( __dirname, 'src/build' ),
-		},
-		optimization: {
-			...jetpackWebpackConfig.optimization,
-		},
-		resolve: {
-			...jetpackWebpackConfig.resolve,
-			alias: {
-				...jetpackWebpackConfig.resolve.alias,
-				/** Replace the classnames used by @automattic/newspack-blocks with clsx because we changed to use clsx */
-				classnames: findPackage( 'clsx' ),
+module.exports = async () => {
+	return [
+		...verbumConfig,
+		{
+			entry: {
+				'a8c-posts-list': './src/features/wpcom-blocks/a8c-posts-list/blocks/posts-list/index.js',
+				'block-inserter-modifications': './src/features/block-inserter-modifications/index.js',
+				'core-customizer-css':
+					'./src/features/custom-css/custom-css/js/core-customizer-css.core-4.9.js',
+				'core-customizer-css-preview':
+					'./src/features/custom-css/custom-css/js/core-customizer-css-preview.js',
+				'customizer-control': './src/features/custom-css/custom-css/css/customizer-control.css',
+				'error-reporting': './src/features/error-reporting/index.js',
+				'holiday-snow': './src/features/holiday-snow/holiday-snow.scss',
+				'jetpack-global-styles': './src/features/jetpack-global-styles/index.js',
+				'jetpack-global-styles-customizer-fonts':
+					'./src/features/jetpack-global-styles/customizer-fonts/index.js',
+				'mailerlite-subscriber-popup': './src/features/mailerlite/subscriber-popup.js',
+				'newspack-blocks-blog-posts-editor': './src/features/newspack-blocks/blog-posts/editor.js',
+				'newspack-blocks-blog-posts-view': './src/features/newspack-blocks/blog-posts/view.js',
+				'newspack-blocks-carousel-editor': './src/features/newspack-blocks/carousel/editor.js',
+				'newspack-blocks-carousel-view': './src/features/newspack-blocks/carousel/view.js',
+				'override-preview-button-url':
+					'./src/features/override-preview-button-url/override-preview-button-url.js',
+				'paragraph-block-placeholder':
+					'./src/features/paragraph-block-placeholder/paragraph-block-placeholder.js',
+				'tags-education': './src/features/tags-education/tags-education.js',
+				'wpcom-admin-bar': './src/features/wpcom-admin-bar/wpcom-admin-bar.scss',
+				'wpcom-blocks-event-countdown-editor':
+					'./src/features/wpcom-blocks/event-countdown/editor.js',
+				'wpcom-blocks-event-countdown-view': './src/features/wpcom-blocks/event-countdown/view.js',
+				'wpcom-blocks-timeline-editor': './src/features/wpcom-blocks/timeline/editor.js',
+				'wpcom-blocks-timeline-view': './src/features/wpcom-blocks/timeline/view.js',
+				'wpcom-block-description-links': './src/features/wpcom-block-description-links/index.tsx',
+				'wpcom-block-editor-nux': './src/features/wpcom-block-editor-nux/index.js',
+				'wpcom-comment-like': [
+					'./src/features/wpcom-comments/wpcom-comment-like.js',
+					'./src/features/wpcom-comments/wpcom-comment-like.css',
+				],
+				'wpcom-hotfixes-colors-modern': './src/features/wpcom-hotfixes/colors/modern/colors.css',
+				'wpcom-dashboard-widgets':
+					'./src/features/wpcom-dashboard-widgets/wpcom-dashboard-widgets.js',
+				'wpcom-global-styles-editor': './src/features/wpcom-global-styles/index.js',
+				'wpcom-global-styles-frontend':
+					'./src/features/wpcom-global-styles/wpcom-global-styles-view.js',
+				'wpcom-documentation-links':
+					'./src/features/wpcom-documentation-links/wpcom-documentation-links.ts',
+				'wpcom-media-url-upload': './src/features/wpcom-media/wpcom-media-url-upload.js',
+				'wpcom-options-general': [
+					'./src/features/wpcom-options-general/options-general.ts',
+					'./src/features/wpcom-options-general/options-general.scss',
+				],
+				'wpcom-post-list-tracks': './src/features/wpcom-post-list/js/wpcom-post-list-tracks.ts',
+				'wpcom-plugins-banner': './src/features/wpcom-plugins/js/banner.js',
+				'wpcom-plugins-banner-style': './src/features/wpcom-plugins/css/banner.css',
+				'wpcom-profile-settings-link-to-wpcom':
+					'./src/features/wpcom-profile-settings/profile-settings-link-to-wpcom.ts',
+				'wpcom-replace-site-visibility':
+					'./src/features/replace-site-visibility/replace-site-visibility.tsx',
+				'wpcom-sidebar-notice': './src/features/wpcom-sidebar-notice/wpcom-sidebar-notice.js',
+				'adminbar-launch-button': './src/features/launch-button/index.js',
 			},
-			fallback: {
-				...jetpackWebpackConfig.resolve.fallback,
-				events: require.resolve( 'events/' ),
+			mode: jetpackWebpackConfig.mode,
+			devtool: jetpackWebpackConfig.devtool,
+			output: {
+				...jetpackWebpackConfig.output,
+				filename: '[name]/[name].js',
+				path: path.resolve( __dirname, 'src/build' ),
 			},
-		},
-		node: false,
-		plugins: [
-			...jetpackWebpackConfig.StandardPlugins( {
-				MiniCssExtractPlugin: { filename: '[name]/[name].css' },
-				DefinePlugin: {
-					// __i18n_text_domain__ is used in page-pattern-modal npm package, which is used only by starter-page-templates feature.
-					// Consider moving page-pattern-modal package to starter-page-templates and remove this.
-					__i18n_text_domain__: JSON.stringify( 'jetpack-mu-wpcom' ),
+			optimization: {
+				...jetpackWebpackConfig.optimization,
+			},
+			resolve: {
+				...jetpackWebpackConfig.resolve,
+				alias: {
+					...jetpackWebpackConfig.resolve.alias,
+					/** Replace the classnames used by @automattic/newspack-blocks with clsx because we changed to use clsx */
+					classnames: await findPackage( 'clsx' ),
 				},
-			} ),
-		],
-		module: {
-			strictExportPresence: true,
-			rules: [
-				// Transpile JavaScript.
-				jetpackWebpackConfig.TranspileRule( {
-					exclude: /node_modules\//,
+				fallback: {
+					...jetpackWebpackConfig.resolve.fallback,
+					events: require.resolve( 'events/' ),
+				},
+			},
+			node: false,
+			plugins: [
+				...jetpackWebpackConfig.StandardPlugins( {
+					MiniCssExtractPlugin: { filename: '[name]/[name].css' },
+					DefinePlugin: {
+						// __i18n_text_domain__ is used in page-pattern-modal npm package, which is used only by starter-page-templates feature.
+						// Consider moving page-pattern-modal package to starter-page-templates and remove this.
+						__i18n_text_domain__: JSON.stringify( 'jetpack-mu-wpcom' ),
+					},
 				} ),
-
-				// Transpile @automattic/* in node_modules too.
-				jetpackWebpackConfig.TranspileRule( {
-					includeNodeModules: [ '@automattic/' ],
-				} ),
-
-				// Handle CSS.
-				jetpackWebpackConfig.CssRule( {
-					extensions: [ 'css', 'scss' ],
-					extraLoaders: [ { loader: 'sass-loader', options: { api: 'modern-compiler' } } ],
-				} ),
-
-				// Handle images.
-				jetpackWebpackConfig.FileRule(),
 			],
+			module: {
+				strictExportPresence: true,
+				rules: [
+					// Transpile JavaScript.
+					jetpackWebpackConfig.TranspileRule( {
+						exclude: /node_modules\//,
+					} ),
+
+					// Transpile @automattic/* in node_modules too.
+					jetpackWebpackConfig.TranspileRule( {
+						includeNodeModules: [ '@automattic/' ],
+					} ),
+
+					// Handle CSS.
+					jetpackWebpackConfig.CssRule( {
+						extensions: [ 'css', 'scss' ],
+						extraLoaders: [ { loader: 'sass-loader', options: { api: 'modern-compiler' } } ],
+					} ),
+
+					// Handle images.
+					jetpackWebpackConfig.FileRule(),
+				],
+			},
+			externals: {
+				...jetpackWebpackConfig.externals,
+				jetpackConfig: JSON.stringify( {
+					consumer_slug: 'jetpack-mu-wpcom',
+				} ),
+			},
 		},
-		externals: {
-			...jetpackWebpackConfig.externals,
-			jetpackConfig: JSON.stringify( {
-				consumer_slug: 'jetpack-mu-wpcom',
-			} ),
-		},
-	},
-];
+	];
+};
 
 /**
  * Given a package name, finds the absolute path for it.
@@ -143,8 +144,9 @@ module.exports = [
  * @param {string} pkgName - Name of the package to search for.
  * @return {string} - The absolute path of the package.
  */
-function findPackage( pkgName ) {
+async function findPackage( pkgName ) {
+	const { packageDirectory } = await import( 'package-directory' ); // Whee ESM-only.
 	const fullPath = require.resolve( pkgName );
-	const packagePath = pkgDir.sync( fullPath );
+	const packagePath = await packageDirectory( { cwd: fullPath } );
 	return packagePath;
 }

--- a/projects/packages/subscribers-dashboard/changelog/update-renamed-pkg-dir-dep
+++ b/projects/packages/subscribers-dashboard/changelog/update-renamed-pkg-dir-dep
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: Remove unnecessary copy-pasted dep.
+
+

--- a/projects/packages/subscribers-dashboard/package.json
+++ b/projects/packages/subscribers-dashboard/package.json
@@ -83,7 +83,6 @@
 		"concurrently": "7.6.0",
 		"jest": "29.7.0",
 		"jest-environment-jsdom": "29.7.0",
-		"pkg-dir": "^5.0.0",
 		"react": "18.3.1",
 		"react-dom": "18.3.1",
 		"require-from-string": "2.0.2",

--- a/projects/packages/subscribers-dashboard/webpack.config.js
+++ b/projects/packages/subscribers-dashboard/webpack.config.js
@@ -1,6 +1,5 @@
 const path = require( 'path' );
 const jetpackWebpackConfig = require( '@automattic/jetpack-webpack-config/webpack' );
-const pkgDir = require( 'pkg-dir' );
 
 module.exports = [
 	{
@@ -21,8 +20,6 @@ module.exports = [
 			alias: {
 				...jetpackWebpackConfig.resolve.alias,
 				'@automattic/calypso-config': '@automattic/calypso-config/src/client.js',
-				/** Replace the classnames used by @automattic/newspack-blocks with clsx because we changed to use clsx */
-				classnames: findPackage( 'clsx' ),
 			},
 			fallback: {
 				...jetpackWebpackConfig.resolve.fallback,
@@ -90,23 +87,3 @@ module.exports = [
 		},
 	},
 ];
-
-/**
- * Given a package name, finds the absolute path for it.
- *
- * require.resolve() will resolve to the main file of the package, using Node's resolution algorithm to find
- * a `package.json` and looking at the field `main`. This function will return the folder that contains `package.json`
- * instead of trying to resolve the main file.
- *
- * Example: `@wordpress/data` may resolve to `/home/myUser/wp-calypso/node_modules/@wordpress/data`.
- *
- * Note this is not the same as looking for `__dirname+'/node_modules/'+pkgName`, as the package may be in a parent
- * `node_modules`
- * @param {string} pkgName - Name of the package to search for.
- * @return {string} - The absolute path of the package.
- */
-function findPackage( pkgName ) {
-	const fullPath = require.resolve( pkgName );
-	const packagePath = pkgDir.sync( fullPath );
-	return packagePath;
-}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
In packages/subscribers-dashboard it seems this isn't needed at all. It was apparently copy-pasted from packages/jetpack-mu-wpcom. Remove it.

For packages/jetpack-mu-wpcom we do need it. Unfortunately, since the package went ESM-only, we have to jump through a hoop to be able to use it from the CommonJS config file. Fortunately Webpack supports an async function as the config.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Should be no changes in the built artifacts.
