### PR TITLE
crm: Resolve Sass deprecation warnings

### DIFF
--- a/projects/plugins/crm/changelog/fix-sass-deprecations-in-crm
+++ b/projects/plugins/crm/changelog/fix-sass-deprecations-in-crm
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Resolve sass deprecation warnings.
+
+

--- a/projects/plugins/crm/modules/portal/sass/jpcrm-public-portal.scss
+++ b/projects/plugins/crm/modules/portal/sass/jpcrm-public-portal.scss
@@ -8,10 +8,10 @@
  */
   
 // theme compatibility fixes
-@import '../../../sass/ZeroBSCRM.ThemeCompat';
+@use '../../../sass/ZeroBSCRM.ThemeCompat';
 
 // Import JS CSS vars
-@import '../../../sass/emerald/jp_vars';
+@use '../../../sass/emerald/jp_vars';
  
 .zbs-client-portal-wrap {
    position: relative;

--- a/projects/plugins/crm/modules/woo-sync/sass/jpcrm-woo-sync-my-account.scss
+++ b/projects/plugins/crm/modules/woo-sync/sass/jpcrm-woo-sync-my-account.scss
@@ -3,13 +3,13 @@
  * https://jetpackcrm.com
  */
 // Daterangepicker styles
-@import 'daterangepicker/daterangepicker';
+@use 'daterangepicker/daterangepicker';
 
 // Daterangepicker fix
-@import '../../../sass/daterangepicker.fix';
+@use '../../../sass/daterangepicker.fix' as daterangepicker2;
 
 // Daterangepicker dirty fix
-@import '../../../sass/daterangepicker.dirty.fix';
+@use '../../../sass/daterangepicker.dirty.fix' as daterangepicker3;
 
  .zbs-invoice-list{
 

--- a/projects/plugins/crm/sass/ZeroBSCRM.admin.editview.scss
+++ b/projects/plugins/crm/sass/ZeroBSCRM.admin.editview.scss
@@ -7,7 +7,7 @@
 	@charset "UTF-8";
 	
 	// main
-	@import 'ZeroBSCRM.editview';
+	@use 'ZeroBSCRM.editview';
 
 	// sub: Contact
-	@import 'ZeroBSCRM.editcontact';
+	@use 'ZeroBSCRM.editcontact' as ZeroBSCRM2;

--- a/projects/plugins/crm/sass/ZeroBSCRM.admin.frontendforms.scss
+++ b/projects/plugins/crm/sass/ZeroBSCRM.admin.frontendforms.scss
@@ -6,4 +6,4 @@
 // Front end form CSS (FOR EDITS, BEHIND SCENES)
 
 // import actual form styles (shared from front end + backend)
-@import 'ZeroBSCRM.frontendforms';
+@use 'ZeroBSCRM.frontendforms';

--- a/projects/plugins/crm/sass/ZeroBSCRM.admin.global.scss
+++ b/projects/plugins/crm/sass/ZeroBSCRM.admin.global.scss
@@ -10,62 +10,61 @@
 // Mike's also made a clone of the following in \master\sass\ZeroBSCRM.admin.invoicepreview.scss
 // ... which could be updated if / when needs to be, (to largely match this... won't need all)
 
-// Import Color Studio
-@use '@automattic/color-studio/dist/color-variables' as *;
+@use 'sass:meta';
 
 // block wp notifications:]
-@import 'wp-hide-admin-notices';
+@include meta.load-css( 'wp-hide-admin-notices' );
 
 // Import generic edit page styles (old legacy of wh from taxibooker! :o to rewrite)
-@import 'ZeroBSCRM.genericeditpages';
+@include meta.load-css( 'ZeroBSCRM.genericeditpages' );
 
 // Import "core" styles
-@import 'ZeroBSCRM.prevadmincore';
+@include meta.load-css( 'ZeroBSCRM.prevadmincore' );
 
 // Daterangepicker styles
-@import 'daterangepicker/daterangepicker';
+@include meta.load-css( 'daterangepicker/daterangepicker' );
 
 // Daterangepicker fix
-@import 'daterangepicker.fix';
+@include meta.load-css( 'daterangepicker.fix' );
 
 // menu mods
-@import 'ZeroBSCRM.adminmenu';
+@include meta.load-css( 'ZeroBSCRM.adminmenu' );
 
 // customer filters gui
-@import 'ZeroBSCRM.customerfilters';
+@include meta.load-css( 'ZeroBSCRM.customerfilters' );
 
 // Import form styles - DO THESE need to be global?
-@import 'ZeroBSCRM.forms';
+@include meta.load-css( 'ZeroBSCRM.forms' );
 
 // Import "Log" styles
-@import 'ZeroBSCRM.logs';
+@include meta.load-css( 'ZeroBSCRM.logs' );
 
 // Import "Typeahead" styles
-@import 'ZeroBSCRM.typeahead';
+@include meta.load-css( 'ZeroBSCRM.typeahead' );
 
 // Import "Spinner" styles
-@import 'ZeroBSCRM.spinners';
+@include meta.load-css( 'ZeroBSCRM.spinners' );
 
 // Import ZBSmetabox styles
-@import 'ZeroBSCRM.metaboxes';
+@include meta.load-css( 'ZeroBSCRM.metaboxes' );
 
 // Import "Admin Pages" styles
-@import 'ZeroBSCRM.adminpages';
+@include meta.load-css( 'ZeroBSCRM.adminpages' );
 
 // Import "Hide WP Features" styles
-@import 'ZeroBSCRM.hidewpfeatures';
+@include meta.load-css( 'ZeroBSCRM.hidewpfeatures' );
 
 // Import "animation" styles
-@import 'ZeroBSCRM.animations';
+@include meta.load-css( 'ZeroBSCRM.animations' );
 
 // Import "mobile" styles
-@import 'ZeroBSCRM.mobile';
+@include meta.load-css( 'ZeroBSCRM.mobile' );
 
 // Import "nag" module
-@import 'ZeroBSCRM.nag';
+@include meta.load-css( 'ZeroBSCRM.nag' );
 
 // Import "learn menu" styles
-@import 'JetpackCRM.admin.learnmenu';
+@include meta.load-css( 'JetpackCRM.admin.learnmenu' );
 
 // Import Jetpack Style overrides
-@import 'JetpackCRM.admin.overrides';
+@include meta.load-css( 'JetpackCRM.admin.overrides' );

--- a/projects/plugins/crm/sass/ZeroBSCRM.admin.invoicepreview.scss
+++ b/projects/plugins/crm/sass/ZeroBSCRM.admin.invoicepreview.scss
@@ -1,3 +1,4 @@
+@use "sass:meta";
 
 /*!
  * Jetpack CRM
@@ -6,12 +7,6 @@
 @use '@automattic/color-studio/dist/color-variables' as *;
 
 // The invoice preview CSS
-%zbs-admin-label {
-	
-	font-weight:800; 
-
-}
-
 .previnvzbs{
 	background: #f5f5f5;
 }
@@ -592,37 +587,37 @@
 // Import generic edit page styles (old legacy of wh from taxibooker! :o to rewrite)
 /* stylelint-disable no-invalid-position-at-import-rule -- these are intentional overrides */
 
-@import 'ZeroBSCRM.genericeditpages';
+@include meta.load-css('ZeroBSCRM.genericeditpages');
 
 // Import "core" styles
-@import 'ZeroBSCRM.prevadmincore';
+@include meta.load-css('ZeroBSCRM.prevadmincore');
 
 // Daterangepicker styles
-@import 'daterangepicker/daterangepicker';
+@include meta.load-css('daterangepicker/daterangepicker');
 
 // Daterangepicker fix
-@import 'daterangepicker.fix';
+@include meta.load-css('daterangepicker.fix');
 
 // menu mods
-@import 'ZeroBSCRM.adminmenu';
+@include meta.load-css('ZeroBSCRM.adminmenu');
 
 // customer filters gui
-@import 'ZeroBSCRM.customerfilters';  
+@include meta.load-css('ZeroBSCRM.customerfilters');
  
 // Import form styles
-@import 'ZeroBSCRM.forms';
+@include meta.load-css('ZeroBSCRM.forms');
 
 // Import "Log" styles 
-@import 'ZeroBSCRM.logs';
+@include meta.load-css('ZeroBSCRM.logs');
 
 // Import "Typeahead" styles  
-@import 'ZeroBSCRM.typeahead';
+@include meta.load-css('ZeroBSCRM.typeahead');
 
 // Import "Spinner" styles  
-@import 'ZeroBSCRM.spinners';
+@include meta.load-css('ZeroBSCRM.spinners');
 
 // Import "Admin Pages" styles  
-@import 'ZeroBSCRM.adminpages';
+@include meta.load-css('ZeroBSCRM.adminpages');
 
 // Import "Hide WP Features" styles
-@import 'ZeroBSCRM.hidewpfeatures';
+@include meta.load-css('ZeroBSCRM.hidewpfeatures');

--- a/projects/plugins/crm/sass/ZeroBSCRM.admin.maildeliverywizard.scss
+++ b/projects/plugins/crm/sass/ZeroBSCRM.admin.maildeliverywizard.scss
@@ -4,4 +4,4 @@
  */
 
 // my actual list view page styles
-@import 'ZeroBSCRM.maildeliverywizard';
+@use 'ZeroBSCRM.maildeliverywizard';

--- a/projects/plugins/crm/sass/ZeroBSCRM.admin.semantic-ui.scss
+++ b/projects/plugins/crm/sass/ZeroBSCRM.admin.semantic-ui.scss
@@ -11,10 +11,10 @@
 @charset "UTF-8";
 
 // WH fixes for clashes between wp + semantic when nested
-@import 'wp-semantic-fixes';
+@use 'wp-semantic-fixes';
 
 // WH/MS semantic add ins/additions
-@import 'semantic-ui-additions';
+@use 'semantic-ui-additions';
 
 // This Semantic UI bug messes with the email composer layout in Safari
 // https://github.com/Semantic-Org/Semantic-UI/issues/3919

--- a/projects/plugins/crm/sass/ZeroBSCRM.admin.singleview.scss
+++ b/projects/plugins/crm/sass/ZeroBSCRM.admin.singleview.scss
@@ -9,7 +9,7 @@
  */
 
 // Import generic edit page styles (old legacy of wh from taxibooker! :o to rewrite)
-@import 'ZeroBSCRM.timelines';
+@use 'ZeroBSCRM.timelines';
 
 // hide these, they look bad/inaccessible on this page:
 #wpwrap .update-nag {display:none !important;}

--- a/projects/plugins/crm/sass/ZeroBSCRM.public.frontendforms.scss
+++ b/projects/plugins/crm/sass/ZeroBSCRM.public.frontendforms.scss
@@ -6,7 +6,7 @@
 // Front end forms, for front-end (public)
 
 // import actual form styles (shared from front end + backend)
-@import 'ZeroBSCRM.frontendforms';
+@use 'ZeroBSCRM.frontendforms';
 
 .widget, .mh-sidebar{
 

--- a/projects/plugins/crm/sass/_ZeroBSCRM.customerfilters.scss
+++ b/projects/plugins/crm/sass/_ZeroBSCRM.customerfilters.scss
@@ -57,11 +57,9 @@
 		// label
 		label {
     		
-			// use our generic label first
-  			@extend %zbs-admin-label;
-
     		margin: 4px 8px;
 		    font-size: 13px;
+		    font-weight:800;
 
 
 		}

--- a/projects/plugins/crm/sass/_ZeroBSCRM.prevadmincore.scss
+++ b/projects/plugins/crm/sass/_ZeroBSCRM.prevadmincore.scss
@@ -4570,12 +4570,6 @@ th.column-ID {
 
 
 
-%zbs-admin-label {
-    
-    font-weight:800; 
-
-}
-
 // for small column metaboxes
 .wh-metatab-side {
 

--- a/projects/plugins/crm/sass/_semantic-ui.scss
+++ b/projects/plugins/crm/sass/_semantic-ui.scss
@@ -1,5 +1,5 @@
-@import 'semantic-ui/globals/all';
-@import 'semantic-ui/elements/all';
-@import 'semantic-ui/collections/all';
-@import 'semantic-ui/views/all';
-@import 'semantic-ui/modules/all';
+@forward 'semantic-ui/globals/all';
+@forward 'semantic-ui/elements/all';
+@forward 'semantic-ui/collections/all';
+@forward 'semantic-ui/views/all';
+@forward 'semantic-ui/modules/all';

--- a/projects/plugins/crm/sass/_semantic-ui.scss
+++ b/projects/plugins/crm/sass/_semantic-ui.scss
@@ -1,5 +1,0 @@
-@forward 'semantic-ui/globals/all';
-@forward 'semantic-ui/elements/all';
-@forward 'semantic-ui/collections/all';
-@forward 'semantic-ui/views/all';
-@forward 'semantic-ui/modules/all';

--- a/projects/plugins/crm/sass/_wp-semantic-fixes.scss
+++ b/projects/plugins/crm/sass/_wp-semantic-fixes.scss
@@ -1,3 +1,5 @@
+@use "sass:meta";
+
 /*!
  * Jetpack CRM
  * https://jetpackcrm.com
@@ -170,4 +172,4 @@ i.alternate {
 
   // pull in modal css
   /* stylelint-disable-next-line no-invalid-position-at-import-rule -- this is an intentional override */
-  @import 'JetpackCRM.admin.modals';
+  @include meta.load-css('JetpackCRM.admin.modals');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Mostly straightforward. In a few places I went with `meta.load-css()` rather than `@use` where the module was being imported only for its CSS to avoid having to have `as styles1`, `as styles2`, ... `as styles24`.

Also there was one odd bit, if A uses B then A can `@extend` selectors from B but not vice versa, and there's one place in here that was trying to do the vice versa. Since it was only being extended in the one place, from two places that declared identical styles, I just copied it into the extended location. This moves the rule around in the built file, but AFAICT it won't make any difference to the styling.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* No more Sass deprecation warnings?
* Only change to the built artifacts as described above?
