### PR TITLE
Forms: Fix plugin connection badges

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-connection-badges
+++ b/projects/packages/forms/changelog/fix-forms-connection-badges
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Fix plugin connection badges.

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/integration-card-header.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/integration-card-header.tsx
@@ -24,6 +24,7 @@ type IntegrationCardData = {
 	isInstalled?: boolean;
 	isActive?: boolean;
 	isConnected?: boolean;
+	needsConnection?: boolean;
 	type?: string;
 	showHeaderToggle?: boolean;
 	headerToggleValue?: boolean;
@@ -58,6 +59,7 @@ const IntegrationCardHeader = ( {
 		isInstalled,
 		isActive,
 		isConnected,
+		needsConnection,
 		type,
 		showHeaderToggle,
 		headerToggleValue,
@@ -67,11 +69,11 @@ const IntegrationCardHeader = ( {
 		setupBadge,
 	} = cardData;
 	const showPluginAction = type === 'plugin' && ( ! isInstalled || ! isActive );
-	const showConnectedBadge = isActive && isConnected;
+	const showConnectedBadge = isConnected || ( isActive && ! needsConnection );
 	const disableFormText = __( 'Disable for this form', 'jetpack-forms' );
 	const enableFormText = __( 'Enable for this form', 'jetpack-forms' );
 
-	const showPendingBadge = ! showPluginAction && ! isConnected;
+	const showPendingBadge = ! showPluginAction && ! isConnected && needsConnection;
 	const pendingBadge = setupBadge || (
 		<span className="integration-card__plugin-badge">
 			{ __( 'Needs connection', 'jetpack-forms' ) }

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -764,15 +764,16 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 
 		// Default response for all integrations
 		$response = array(
-			'type'        => $config['type'],
-			'slug'        => $slug,
-			'isConnected' => false,
-			'settingsUrl' => $config['settings_url'] ?? null,
-			'pluginFile'  => null,
-			'isInstalled' => false,
-			'isActive'    => false,
-			'version'     => null,
-			'details'     => array(),
+			'type'            => $config['type'],
+			'slug'            => $slug,
+			'needsConnection' => true,
+			'isConnected'     => false,
+			'settingsUrl'     => $config['settings_url'] ?? null,
+			'pluginFile'      => null,
+			'isInstalled'     => false,
+			'isActive'        => false,
+			'version'         => null,
+			'details'         => array(),
 		);
 
 		// Process settingsUrl to return a full URL if present (for services only)
@@ -816,15 +817,16 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 		$is_active         = is_plugin_active( $plugin_config['file'] );
 
 		$response = array(
-			'type'        => 'plugin',
-			'slug'        => $plugin_slug,
-			'pluginFile'  => str_replace( '.php', '', $plugin_config['file'] ),
-			'isInstalled' => $is_installed,
-			'isActive'    => $is_active,
-			'isConnected' => false,
-			'version'     => $is_installed ? $installed_plugins[ $plugin_config['file'] ]['Version'] : null,
-			'settingsUrl' => $is_active ? admin_url( $plugin_config['settings_url'] ) : null,
-			'details'     => array(),
+			'type'            => 'plugin',
+			'slug'            => $plugin_slug,
+			'pluginFile'      => str_replace( '.php', '', $plugin_config['file'] ),
+			'isInstalled'     => $is_installed,
+			'isActive'        => $is_active,
+			'needsConnection' => false,
+			'isConnected'     => false,
+			'version'         => $is_installed ? $installed_plugins[ $plugin_config['file'] ]['Version'] : null,
+			'settingsUrl'     => $is_active ? admin_url( $plugin_config['settings_url'] ) : null,
+			'details'         => array(),
 		);
 
 		// Plugin-specific customizations
@@ -832,6 +834,7 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 			$dashboard_view_switch                         = new Dashboard_View_Switch();
 			$response['isConnected']                       = class_exists( 'Jetpack' ) && \Jetpack::is_akismet_active();
 			$response['details']['formSubmissionsSpamUrl'] = $dashboard_view_switch->get_forms_admin_url( 'spam' );
+			$response['needsConnection']                   = true;
 		} elseif ( 'zero-bs-crm' === $plugin_slug && $is_active ) {
 			$has_extension       = function_exists( 'zeroBSCRM_isExtensionInstalled' ) && zeroBSCRM_isExtensionInstalled( 'jetpackforms' ); // @phan-suppress-current-line PhanUndeclaredFunction -- We're checking the function exists first
 			$response['details'] = array(

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Endpoint_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Endpoint_Test.php
@@ -147,6 +147,13 @@ class Contact_Form_Endpoint_Test extends TestCase {
 		$this->assertArrayHasKey( 'isActive', $data['akismet'] );
 		$this->assertArrayHasKey( 'isConnected', $data['akismet'] );
 		$this->assertArrayHasKey( 'needsConnection', $data['akismet'] );
+
+		// Verify structure of google-drive
+		$this->assertArrayHasKey( 'type', $data['google-drive'] );
+		$this->assertArrayHasKey( 'isInstalled', $data['google-drive'] );
+		$this->assertArrayHasKey( 'isActive', $data['google-drive'] );
+		$this->assertArrayHasKey( 'isConnected', $data['google-drive'] );
+		$this->assertArrayHasKey( 'needsConnection', $data['google-drive'] );
 	}
 
 	/**
@@ -186,6 +193,19 @@ class Contact_Form_Endpoint_Test extends TestCase {
 			$this->assertArrayHasKey( 'version', $integration );
 			$this->assertArrayHasKey( 'details', $integration );
 			$this->assertArrayHasKey( 'needsConnection', $integration );
+
+			// Verify expected data types
+			$this->assertIsString( $integration['id'] );
+			$this->assertIsString( $integration['type'] );
+			$this->assertIsString( $integration['slug'] );
+			$this->assertIsBool( $integration['isInstalled'] );
+			$this->assertIsBool( $integration['isActive'] );
+			$this->assertIsBool( $integration['needsConnection'] );
+			$this->assertIsBool( $integration['isConnected'] );
+			$this->assertTrue( $integration['settingsUrl'] === null || is_string( $integration['settingsUrl'] ) );
+			$this->assertTrue( $integration['pluginFile'] === null || is_string( $integration['pluginFile'] ) );
+			$this->assertTrue( $integration['version'] === null || is_string( $integration['version'] ) );
+			$this->assertIsArray( $integration['details'] );
 		}
 	}
 

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Endpoint_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Endpoint_Test.php
@@ -146,12 +146,7 @@ class Contact_Form_Endpoint_Test extends TestCase {
 		$this->assertArrayHasKey( 'isInstalled', $data['akismet'] );
 		$this->assertArrayHasKey( 'isActive', $data['akismet'] );
 		$this->assertArrayHasKey( 'isConnected', $data['akismet'] );
-
-		// Verify structure of google-drive
-		$this->assertArrayHasKey( 'type', $data['google-drive'] );
-		$this->assertArrayHasKey( 'isInstalled', $data['google-drive'] );
-		$this->assertArrayHasKey( 'isActive', $data['google-drive'] );
-		$this->assertArrayHasKey( 'isConnected', $data['google-drive'] );
+		$this->assertArrayHasKey( 'needsConnection', $data['akismet'] );
 	}
 
 	/**
@@ -190,18 +185,7 @@ class Contact_Form_Endpoint_Test extends TestCase {
 			$this->assertArrayHasKey( 'pluginFile', $integration );
 			$this->assertArrayHasKey( 'version', $integration );
 			$this->assertArrayHasKey( 'details', $integration );
-
-			// Verify expected data types
-			$this->assertIsString( $integration['id'] );
-			$this->assertIsString( $integration['type'] );
-			$this->assertIsString( $integration['slug'] );
-			$this->assertIsBool( $integration['isInstalled'] );
-			$this->assertIsBool( $integration['isActive'] );
-			$this->assertIsBool( $integration['isConnected'] );
-			$this->assertTrue( $integration['settingsUrl'] === null || is_string( $integration['settingsUrl'] ) );
-			$this->assertTrue( $integration['pluginFile'] === null || is_string( $integration['pluginFile'] ) );
-			$this->assertTrue( $integration['version'] === null || is_string( $integration['version'] ) );
-			$this->assertIsArray( $integration['details'] );
+			$this->assertArrayHasKey( 'needsConnection', $integration );
 		}
 	}
 
@@ -232,6 +216,7 @@ class Contact_Form_Endpoint_Test extends TestCase {
 		$this->assertArrayHasKey( 'pluginFile', $data );
 		$this->assertArrayHasKey( 'version', $data );
 		$this->assertArrayHasKey( 'details', $data );
+		$this->assertArrayHasKey( 'needsConnection', $data );
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes:

**Context:** For forms integrations, we added a `Needs connection` badge in this PR. But we are showing that for plugin integrations like Jetpack CRM and Creative Mail that do not need connections. 

**Changes:**
- Return a `needsConnection` property for each integration from our endpoint
- Make the 'Needs Connection' badge conditional on `needsConnection`. 
- Show 'Enabled' badge for plugins that are active and do not need a connection, since no other actions are needed
- Updates associated endpoint tests

**Before**
<img width="941" alt="connectionStatus" src="https://github.com/user-attachments/assets/334899eb-5637-4935-bafb-5a976c5771b7" />

**After**
<img width="930" alt="connection-status-2" src="https://github.com/user-attachments/assets/e2b87b38-1c8c-4818-945f-83aac7071266" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Slack: 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No. 

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

*Test the form block > integration modal*
- Add a form block and click to open integrations
- If Jetpack CRM and Creative Mail are installed, confirm they show the Enabled badge, not the Needs Connection badge.

*Test the form dashboard > integration tab*
- You'll need enable the feature flag to see the integrations tab. Add this: `add_filter( 'jetpack_forms_enable_integrations_tab', '__return_true' );`
- Go to Jetpack > Forms > Integrations
- If Jetpack CRM and Creative Mail are installed, confirm they show the Enabled badge, not the Needs Connection badge.

*Confirm endpoint tests pass*
- Navigate to forms package: `cd projects/packages/forms`
- Run tests: `composer test-php tests/php/contact-form/Contact_Form_Endpoint_Test.php`