### PR TITLE
Add/jetpack forms file upload nudge event

### DIFF
--- a/projects/packages/forms/changelog/add-jetpack-forms-file-upload-nudge-event
+++ b/projects/packages/forms/changelog/add-jetpack-forms-file-upload-nudge-event
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Forms: add track event for upsell nudge on file upload block

--- a/projects/packages/forms/src/blocks/shared/components/upsell-nudge/index.js
+++ b/projects/packages/forms/src/blocks/shared/components/upsell-nudge/index.js
@@ -9,7 +9,7 @@ export const UpsellNudge = ( { requiredPlan } ) => {
 		jetpackAnalytics.tracks.recordEvent( 'jetpack_editor_block_upgrade_click', {
 			plan: requiredPlan,
 			context: 'editor-canvas',
-			block: 'jetpack/file-field',
+			block: 'jetpack/field-file',
 		} );
 	} );
 	return (

--- a/projects/packages/forms/src/blocks/shared/components/upsell-nudge/index.js
+++ b/projects/packages/forms/src/blocks/shared/components/upsell-nudge/index.js
@@ -5,9 +5,11 @@ import { __ } from '@wordpress/i18n';
 
 export const UpsellNudge = ( { requiredPlan } ) => {
 	const [ checkoutUrl, goToCheckoutPage, isRedirecting ] = useUpgradeFlow( requiredPlan, () => {
-		jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_file_upload_upsell_click', {
+		// This mimics the logic on jetpack/extensions/extended-blocks/paid-blocks/utils.js
+		jetpackAnalytics.tracks.recordEvent( 'jetpack_editor_block_upgrade_click', {
 			plan: requiredPlan,
-			context: 'block-editor',
+			context: 'editor-canvas',
+			block: 'jetpack/file-field',
 		} );
 	} );
 	return (

--- a/projects/packages/forms/src/blocks/shared/components/upsell-nudge/index.js
+++ b/projects/packages/forms/src/blocks/shared/components/upsell-nudge/index.js
@@ -1,9 +1,15 @@
+import jetpackAnalytics from '@automattic/jetpack-analytics';
 import { useUpgradeFlow } from '@automattic/jetpack-shared-extension-utils';
 import { Nudge } from '@automattic/jetpack-shared-extension-utils/components';
 import { __ } from '@wordpress/i18n';
 
 export const UpsellNudge = ( { requiredPlan } ) => {
-	const [ checkoutUrl, goToCheckoutPage, isRedirecting ] = useUpgradeFlow( requiredPlan );
+	const [ checkoutUrl, goToCheckoutPage, isRedirecting ] = useUpgradeFlow( requiredPlan, () => {
+		jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_file_upload_upsell_click', {
+			plan: requiredPlan,
+			context: 'block-editor',
+		} );
+	} );
 	return (
 		<div className="jetpack-forms-upsell-nudge">
 			<Nudge


### PR DESCRIPTION
## Proposed changes:
This PR adds tracking to the file upload block upsell nudge.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1749497574495759/1749211638.031689-slack-C052XEUUBL4

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Open the editor and enable debugging from the console with `localStorage.setItem( 'debug', '*' );`. Reload.

Add a file upload block on a site without a purchased plan. See the upsell nudge shows.

SUGGESTION: go to network tab and enable some really slow throttling, so you get to see the even on the console before the redirect happens.

Click on the nudge, see the event triggered on the console:
<img width="507" alt="image" src="https://github.com/user-attachments/assets/8555feaf-d1e7-44bb-9e35-300827edc06b" />
