### PR TITLE
Forms: Fix Saleforce badge

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-saleforce-badge
+++ b/projects/packages/forms/changelog/fix-forms-saleforce-badge
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Fix Saleforce badge.

--- a/projects/packages/forms/src/dashboard/integrations/salesforce-card.tsx
+++ b/projects/packages/forms/src/dashboard/integrations/salesforce-card.tsx
@@ -18,7 +18,7 @@ const SalesforceDashboardCard = ( {
 		setupBadge: (
 			<span className="integration-card__setup-badge">
 				<Icon icon="info-outline" size={ 12 } />
-				{ __( 'Enter organization ID', 'jetpack-forms' ) }
+				{ __( 'Configured per form', 'jetpack-forms' ) }
 			</span>
 		),
 	};


### PR DESCRIPTION
## Proposed changes:

In Jetpack > Forms > Integrations, we are showing an 'Enter organization ID' for Salesforce integrations. But this can only be done on a per-form basis in the block editor. This PR simply updates the badge to say 'Configured per form'. 

<img width="929" alt="salesforce-badge" src="https://github.com/user-attachments/assets/378b0fb6-3a1e-4e49-9717-f4a992a6ff7d" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None. 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No. 

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- You'll need enable the feature flag to see the integrations tab. Add this: add_filter( 'jetpack_forms_enable_integrations_tab', '__return_true' );
- Go to Jetpack > Forms > Integrations and confirm the status badge for Salesforce says 'Configure per form' 
