### PR TITLE
Forms: Unauth Upload remove beta check

### DIFF
--- a/projects/plugins/jetpack/changelog/update-forms-upload-remove-beta
+++ b/projects/plugins/jetpack/changelog/update-forms-upload-remove-beta
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: new feature fix
+
+

--- a/projects/plugins/jetpack/unauth-file-upload.php
+++ b/projects/plugins/jetpack/unauth-file-upload.php
@@ -37,20 +37,11 @@ function filter_get_download_url( $url, $file_id ) {
  * @return never This method never returns as it exits directly
  */
 function handle_file_download() {
-	/**
-	 * Check if the file is availabe for download.
-	 *
-	 * @since 14.6
-	 *
-	 * @param array $data The script data.
-	 */
-	$blocks_variation = apply_filters( 'jetpack_blocks_variation', \Automattic\Jetpack\Constants::get_constant( 'JETPACK_BLOCKS_VARIATION' ) );
-
-	if ( apply_filters( 'jetpack_unauth_file_download_available', $blocks_variation !== 'beta' ) ) {
-		wp_die( esc_html__( 'File download is not available.', 'jetpack' ) );
+	if ( ! current_user_can( 'edit_pages' ) ) {
+		wp_die( esc_html__( 'Sorry, you are not allowed to access this page.', 'jetpack' ) );
 	}
 
-	if ( ! current_user_can( 'edit_pages' ) ) {
+	if ( ! wpcom_site_has_feature( 'field-file', get_current_blog_id() ) ) {
 		wp_die( esc_html__( 'Sorry, you are not allowed to access this page.', 'jetpack' ) );
 	}
 

--- a/projects/plugins/jetpack/unauth-file-upload.php
+++ b/projects/plugins/jetpack/unauth-file-upload.php
@@ -41,12 +41,6 @@ function handle_file_download() {
 		wp_die( esc_html__( 'Sorry, you are not allowed to access this page.', 'jetpack' ) );
 	}
 
-	if ( function_exists( 'wpcom_site_has_feature' ) ) {
-		if ( ! wpcom_site_has_feature( 'field-file', get_current_blog_id() ) ) {
-			wp_die( esc_html__( 'Sorry, you are not allowed to access this page.', 'jetpack' ) );
-		}
-	}
-
 	$file_id = isset( $_GET['file_id'] ) ? absint( wp_unslash( $_GET['file_id'] ) ) : 0;
 
 	if ( ! $file_id ) {

--- a/projects/plugins/jetpack/unauth-file-upload.php
+++ b/projects/plugins/jetpack/unauth-file-upload.php
@@ -41,8 +41,10 @@ function handle_file_download() {
 		wp_die( esc_html__( 'Sorry, you are not allowed to access this page.', 'jetpack' ) );
 	}
 
-	if ( ! wpcom_site_has_feature( 'field-file', get_current_blog_id() ) ) {
-		wp_die( esc_html__( 'Sorry, you are not allowed to access this page.', 'jetpack' ) );
+	if ( function_exists( 'wpcom_site_has_feature' ) ) {
+		if ( ! wpcom_site_has_feature( 'field-file', get_current_blog_id() ) ) {
+			wp_die( esc_html__( 'Sorry, you are not allowed to access this page.', 'jetpack' ) );
+		}
 	}
 
 	$file_id = isset( $_GET['file_id'] ) ? absint( wp_unslash( $_GET['file_id'] ) ) : 0;


### PR DESCRIPTION

## Proposed changes:

* Removed the beta check for file upload downloading. 


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
none

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
Do the tests pass? 

