### PR TITLE
Forms: Prevent PHP warning when parsed block is malformed

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-parsed_block_warning
+++ b/projects/packages/forms/changelog/fix-forms-parsed_block_warning
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Catch PHP warning when parsed block data is malformed.

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -58,7 +58,7 @@ class Contact_Form_Block {
 	 *  @return array
 	 */
 	public static function find_nested_html_block( $parsed_block, $source_block, $parent_block ) {
-		if ( $parsed_block['blockName'] === 'core/html' && isset( $parent_block->parsed_block ) && $parent_block->parsed_block['blockName'] === 'jetpack/contact-form' ) {
+		if ( ! empty( $parsed_block['blockName'] ) && $parsed_block['blockName'] === 'core/html' && isset( $parent_block->parsed_block ) && $parent_block->parsed_block['blockName'] === 'jetpack/contact-form' ) {
 			$parsed_block['hasJPFormParent'] = true;
 		}
 		return $parsed_block;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This catches a common PHP warning (120K+/month):
```
PHP Warning: Undefined array key "blockName" in /wordpress/plugins/jetpack/14.8-a.1/jetpack_vendor/automattic/jetpack-forms/src/blocks/contact-form/class-contact-form-block.php on line 61
```

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

I'm not sure the best way to reproduce, but filters are often unreliable data sources, as third-party code manipulates them.