### PR TITLE
Forms: Add mark as spam link to response email

### DIFF
--- a/projects/packages/forms/changelog/update-forms-email-mark-as-spam-link
+++ b/projects/packages/forms/changelog/update-forms-email-mark-as-spam-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Forms: Add mark as spam link to response email

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1690,6 +1690,20 @@ class Contact_Form extends Contact_Form_Shortcode {
 			esc_url( $url )
 		);
 
+		// Get the status of the feedback
+		$status = $is_spam ? 'spam' : 'inbox';
+
+		// Build the dashboard URL with the status and the feedback's post id
+		$dashboard_url = ( new Dashboard_View_Switch() )->get_forms_admin_url( $status, true ) . '&r=' . $post_id;
+
+		$mark_as_spam_url = $dashboard_url . '&mark_as_spam';
+
+		$footer_mark_as_spam_url = sprintf(
+			'<a href="%1$s">%2$s</a>',
+			esc_url( $mark_as_spam_url ),
+			__( 'Mark as spam', 'jetpack-forms' )
+		);
+
 		$footer = implode(
 			'',
 			/**
@@ -1707,7 +1721,8 @@ class Contact_Form extends Contact_Form_Shortcode {
 					'<span style="font-size: 12px">',
 					$footer_time . '<br />',
 					$footer_ip ? $footer_ip . '<br />' : null,
-					$footer_url . '<br />',
+					$footer_url . '<br /><br />',
+					$footer_mark_as_spam_url . '<br />',
 					$sent_by_text,
 					'</span>',
 				)
@@ -1719,12 +1734,6 @@ class Contact_Form extends Contact_Form_Shortcode {
 		$are_email_actions_enabled = true;
 
 		if ( $are_email_actions_enabled ) {
-			// Get the status of the feedback
-			$status = $is_spam ? 'spam' : 'inbox';
-
-			// Build the dashboard URL with the status and the feedback's post id
-			$dashboard_url = ( new Dashboard_View_Switch() )->get_forms_admin_url( $status, true ) . '&r=' . $post_id;
-
 			$actions = sprintf(
 				'<table class="button_block" border="0" cellpadding="0" cellspacing="0" role="presentation">
 					<tr>

--- a/projects/packages/forms/src/dashboard/hooks/use-mark-as-spam.ts
+++ b/projects/packages/forms/src/dashboard/hooks/use-mark-as-spam.ts
@@ -1,0 +1,43 @@
+/**
+ * External dependencies
+ */
+import { store as coreStore } from '@wordpress/core-data';
+import { useDispatch } from '@wordpress/data';
+import { useCallback, useEffect, useState } from '@wordpress/element';
+/**
+ * Types
+ */
+import type { FormResponse } from '../../types';
+
+export const useMarkAsSpam = ( response: FormResponse ) => {
+	const [ isConfirmDialogOpen, setIsConfirmDialogOpen ] = useState( false );
+	const { saveEntityRecord } = useDispatch( coreStore );
+
+	const onConfirmMarkAsSpam = useCallback( async () => {
+		setIsConfirmDialogOpen( false );
+
+		await saveEntityRecord( 'postType', 'feedback', {
+			id: response.id,
+			status: 'spam',
+		} );
+
+		window.location.hash = window.location.hash.replace( 'status=inbox', 'status=spam' );
+	}, [ response, saveEntityRecord ] );
+
+	const onCancelMarkAsSpam = useCallback( () => {
+		setIsConfirmDialogOpen( false );
+	}, [ setIsConfirmDialogOpen ] );
+
+	// Email links have a query param that triggers the confirmation dialog.
+	useEffect( () => {
+		if ( window.location.hash.includes( '&mark_as_spam' ) ) {
+			window.location.hash = window.location.hash.replace( '&mark_as_spam', '' );
+
+			if ( ! [ 'spam', 'trash' ].includes( response.status ) ) {
+				setIsConfirmDialogOpen( true );
+			}
+		}
+	}, [ response ] );
+
+	return { isConfirmDialogOpen, onConfirmMarkAsSpam, onCancelMarkAsSpam };
+};

--- a/projects/packages/forms/src/dashboard/inbox/response.js
+++ b/projects/packages/forms/src/dashboard/inbox/response.js
@@ -2,6 +2,8 @@
  * External dependencies
  */
 import { Button, ExternalLink, Modal, Tooltip, Spinner, Icon } from '@wordpress/components';
+import { store as coreStore } from '@wordpress/core-data';
+import { useDispatch } from '@wordpress/data';
 import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
 import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
@@ -124,6 +126,19 @@ const InboxResponse = ( { response, loading, onModalStateChange } ) => {
 	const [ isPreviewModalOpen, setIsPreviewModalOpen ] = useState( false );
 	const [ previewFile, setPreviewFile ] = useState( null );
 	const [ isImageLoading, setIsImageLoading ] = useState( true );
+	const { saveEntityRecord } = useDispatch( coreStore );
+
+	// When opening a "Mark as spam" link from the email, the InboxResponse component is rendered, so we check for the query param and mark the response as spam.
+	useEffect( () => {
+		if ( window.location.hash.includes( '&mark_as_spam' ) ) {
+			window.location.hash = window.location.hash.replace( '&mark_as_spam', '' );
+
+			if ( ! [ 'spam', 'trash' ].includes( response.status ) ) {
+				window.location.hash = window.location.hash.replace( 'status=inbox', 'status=spam' );
+				saveEntityRecord( 'postType', 'feedback', { id: response.id, status: 'spam' } );
+			}
+		}
+	}, [ response, saveEntityRecord ] );
 
 	const ref = useRef( undefined );
 

--- a/projects/packages/forms/src/dashboard/inbox/response.js
+++ b/projects/packages/forms/src/dashboard/inbox/response.js
@@ -1,9 +1,15 @@
 /**
  * External dependencies
  */
-import { Button, ExternalLink, Modal, Tooltip, Spinner, Icon } from '@wordpress/components';
-import { store as coreStore } from '@wordpress/core-data';
-import { useDispatch } from '@wordpress/data';
+import {
+	Button,
+	ExternalLink,
+	Modal,
+	Tooltip,
+	Spinner,
+	Icon,
+	__experimentalConfirmDialog as ConfirmDialog, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+} from '@wordpress/components';
 import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
 import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
@@ -11,6 +17,10 @@ import { __, sprintf } from '@wordpress/i18n';
 import { download } from '@wordpress/icons';
 import clsx from 'clsx';
 import { map } from 'lodash';
+/**
+ * Internal dependencies
+ */
+import { useMarkAsSpam } from '../hooks/use-mark-as-spam';
 import { getPath } from './utils';
 
 const getDisplayName = response => {
@@ -126,19 +136,10 @@ const InboxResponse = ( { response, loading, onModalStateChange } ) => {
 	const [ isPreviewModalOpen, setIsPreviewModalOpen ] = useState( false );
 	const [ previewFile, setPreviewFile ] = useState( null );
 	const [ isImageLoading, setIsImageLoading ] = useState( true );
-	const { saveEntityRecord } = useDispatch( coreStore );
 
-	// When opening a "Mark as spam" link from the email, the InboxResponse component is rendered, so we check for the query param and mark the response as spam.
-	useEffect( () => {
-		if ( window.location.hash.includes( '&mark_as_spam' ) ) {
-			window.location.hash = window.location.hash.replace( '&mark_as_spam', '' );
-
-			if ( ! [ 'spam', 'trash' ].includes( response.status ) ) {
-				window.location.hash = window.location.hash.replace( 'status=inbox', 'status=spam' );
-				saveEntityRecord( 'postType', 'feedback', { id: response.id, status: 'spam' } );
-			}
-		}
-	}, [ response, saveEntityRecord ] );
+	// When opening a "Mark as spam" link from the email, the InboxResponse component is rendered, so we use a hook here to handle it.
+	const { isConfirmDialogOpen, onConfirmMarkAsSpam, onCancelMarkAsSpam } =
+		useMarkAsSpam( response );
 
 	const ref = useRef( undefined );
 
@@ -310,6 +311,14 @@ const InboxResponse = ( { response, loading, onModalStateChange } ) => {
 					/>
 				</Modal>
 			) }
+
+			<ConfirmDialog
+				isOpen={ isConfirmDialogOpen }
+				onConfirm={ onConfirmMarkAsSpam }
+				onCancel={ onCancelMarkAsSpam }
+			>
+				{ __( 'Are you sure you want to mark this response as spam?', 'jetpack-forms' ) }
+			</ConfirmDialog>
 		</div>
 	);
 };

--- a/projects/packages/forms/src/types/index.ts
+++ b/projects/packages/forms/src/types/index.ts
@@ -58,6 +58,38 @@ export type Pattern = {
 };
 
 /**
+ * Represents a form response.
+ */
+export interface FormResponse {
+	/** The unique identifier for the response. */
+	id: number;
+	/** The status of the response. */
+	status: 'publish' | 'spam' | 'trash';
+	/** The date and time the response was created. */
+	date: string;
+	/** The date and time the response was created in GMT. */
+	date_gmt: string;
+	/** The name of the response author. */
+	author_name: string;
+	/** The email of the response author. */
+	author_email: string;
+	/** The URL of the response author. */
+	author_url: string;
+	/** The avatar of the response author. */
+	author_avatar: string;
+	/** The IP address of the response author. */
+	ip: string;
+	/** The title of the form that the response was submitted to. */
+	entry_title: string;
+	/** The permalink of the form that the response was submitted to. */
+	entry_permalink: string;
+	/** Whether the response has a file attached. */
+	has_file: boolean;
+	/** The fields of the response. */
+	fields: Record< string, unknown >;
+}
+
+/**
  * Default URLs for Jetpack Forms blocks, such as responses and spam responses.
  */
 export interface JPFormsBlocksDefaults {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes FORMS-61
Follow-up to https://github.com/Automattic/jetpack/pull/43834 and needs to be rebased after it is merged

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds a way for an administrator to mark a response as spam from a link
* Adds the "mark as spam" link to the email sent after submission
* Adds a confirmation dialog before proceeding to prevent unintended status modifications

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* In a site where you receive emails after form submissions, submit a response to a form
* Check that the email now has another link: "Mark as spam"
* Click on the this link
* Check that the "mark_as_spam" query param disappears
* Check that you see a confirmation dialog
* Cancel it
* Check that no change was made
* Click on the email link again
* This time, confirm it
* Check that you are sent to the Spam tab, where the response is pre-selected

![2025-06-11_17-56](https://github.com/user-attachments/assets/ec37772d-6b21-4f32-a019-dbc307e62afe)
![Screenshot from 2025-06-09 20-18-03](https://github.com/user-attachments/assets/c74edf77-f44d-4e41-bdf8-bc7df72b5261)
