### PR TITLE
Add TS type checking for forms package

### DIFF
--- a/projects/packages/forms/changelog/add-forms-type-checking
+++ b/projects/packages/forms/changelog/add-forms-type-checking
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Added TS type checking for the package.

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -24,6 +24,7 @@
 		"test": "jest --config=tests/jest.config.js",
 		"test:contact-form": "jest --testPathPattern=tests/js/contact-form",
 		"test-coverage": "pnpm run test --coverage",
+		"typecheck": "tsc --noEmit",
 		"validate": "pnpm exec validate-es --no-error-on-unmatched-pattern dist/",
 		"watch": "concurrently 'pnpm:build:blocks --watch' 'pnpm:build:contact-form --watch' 'pnpm:build:dashboard --watch' 'pnpm:module:watch'",
 		"module:build": "webpack --config ./tools/webpack.config.modules.js",

--- a/projects/packages/forms/tsconfig.json
+++ b/projects/packages/forms/tsconfig.json
@@ -1,6 +1,5 @@
 {
 	"extends": "jetpack-js-tools/tsconfig.base.json",
 	// List all sources and source-containing subdirs.
-	"include": [ "./src", "./declarations.d.ts" ],
-	"files": [ "./global.d.ts" ]
+	"include": [ "src", "declarations.d.ts", "global.d.ts" ]
 }


### PR DESCRIPTION
The forms package uses TypeScript but is not type-checked on CI because the `typecheck` script is missing from package.json.

Addresses https://github.com/Automattic/jetpack/pull/43733#issuecomment-2957578396

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add `typecheck` script to forms package

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* CI should be happy

