### PR TITLE
Charts: Refactor `withResponsive` HOC to Allow Custom Responsive Config for Chart Component

### DIFF
--- a/projects/js-packages/charts/changelog/charts-28-enhance-responsive-handling-for-chart-components
+++ b/projects/js-packages/charts/changelog/charts-28-enhance-responsive-handling-for-chart-components
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add responsive configuration options for charts

--- a/projects/js-packages/charts/src/components/bar-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/components/bar-chart/stories/index.stories.tsx
@@ -27,7 +27,30 @@ const meta: Meta< typeof BarChart > = {
 			</div>
 		),
 	],
-};
+	argTypes: {
+		maxWidth: {
+			control: {
+				type: 'number',
+				min: 100,
+				max: 1200,
+			},
+		},
+		aspectRatio: {
+			control: {
+				type: 'number',
+				min: 0,
+				max: 1,
+			},
+		},
+		resizeDebounceTime: {
+			control: {
+				type: 'number',
+				min: 0,
+				max: 10000,
+			},
+		},
+	},
+} satisfies Meta< typeof BarChart >;
 
 export default meta;
 
@@ -41,6 +64,9 @@ export const Default: Story = {
 		showLegend: false,
 		legendOrientation: 'horizontal',
 		gridVisibility: 'x',
+		maxWidth: 1200,
+		aspectRatio: 0.5,
+		resizeDebounceTime: 300,
 	},
 };
 

--- a/projects/js-packages/charts/src/components/line-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/components/line-chart/stories/index.stories.tsx
@@ -28,7 +28,30 @@ const meta: Meta< typeof LineChart > = {
 			</div>
 		),
 	],
-};
+	argTypes: {
+		maxWidth: {
+			control: {
+				type: 'number',
+				min: 100,
+				max: 1200,
+			},
+		},
+		aspectRatio: {
+			control: {
+				type: 'number',
+				min: 0,
+				max: 1,
+			},
+		},
+		resizeDebounceTime: {
+			control: {
+				type: 'number',
+				min: 0,
+				max: 10000,
+			},
+		},
+	},
+} satisfies Meta< typeof LineChart >;
 
 export default meta;
 
@@ -42,6 +65,9 @@ Default.args = {
 	legendOrientation: 'horizontal',
 	withGradientFill: false,
 	smoothing: true,
+	maxWidth: 1200,
+	aspectRatio: 0.5,
+	resizeDebounceTime: 300,
 	options: {
 		axis: {
 			x: {

--- a/projects/js-packages/charts/src/components/pie-chart/stories/donut.stories.tsx
+++ b/projects/js-packages/charts/src/components/pie-chart/stories/donut.stories.tsx
@@ -89,6 +89,27 @@ const meta = {
 			},
 			defaultValue: undefined,
 		},
+		maxWidth: {
+			control: {
+				type: 'number',
+				min: 100,
+				max: 1200,
+			},
+		},
+		aspectRatio: {
+			control: {
+				type: 'number',
+				min: 0,
+				max: 1,
+			},
+		},
+		resizeDebounceTime: {
+			control: {
+				type: 'number',
+				min: 0,
+				max: 10000,
+			},
+		},
 	},
 } satisfies Meta< typeof PieChart >;
 

--- a/projects/js-packages/charts/src/components/pie-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/components/pie-chart/stories/index.stories.tsx
@@ -107,6 +107,27 @@ const meta = {
 			},
 			defaultValue: undefined,
 		},
+		maxWidth: {
+			control: {
+				type: 'number',
+				min: 100,
+				max: 1200,
+			},
+		},
+		aspectRatio: {
+			control: {
+				type: 'number',
+				min: 0,
+				max: 1,
+			},
+		},
+		resizeDebounceTime: {
+			control: {
+				type: 'number',
+				min: 0,
+				max: 10000,
+			},
+		},
 	},
 } satisfies Meta< typeof PieChart >;
 

--- a/projects/js-packages/charts/src/components/pie-semi-circle-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/components/pie-semi-circle-chart/stories/index.stories.tsx
@@ -72,6 +72,27 @@ const meta = {
 				step: 5,
 			},
 		},
+		maxWidth: {
+			control: {
+				type: 'number',
+				min: 100,
+				max: 1200,
+			},
+		},
+		aspectRatio: {
+			control: {
+				type: 'number',
+				min: 0,
+				max: 1,
+			},
+		},
+		resizeDebounceTime: {
+			control: {
+				type: 'number',
+				min: 0,
+				max: 10000,
+			},
+		},
 	},
 } satisfies Meta< typeof PieSemiCircleChart >;
 

--- a/projects/js-packages/charts/src/components/shared/test/with-responsive.test.tsx
+++ b/projects/js-packages/charts/src/components/shared/test/with-responsive.test.tsx
@@ -18,15 +18,15 @@ describe( 'withResponsive', () => {
 	} );
 
 	test( 'respects maxWidth configuration', () => {
-		const ResponsiveWithConfig = withResponsive( MockComponent, { maxWidth: 400 } );
-		render( <ResponsiveWithConfig data={ [] } /> );
+		const ResponsiveWithConfig = withResponsive( MockComponent );
+		render( <ResponsiveWithConfig data={ [] } maxWidth={ 400 } /> );
 		const component = screen.getByTestId( 'mock-component' );
 		expect( component ).toHaveStyle( { width: '400px' } );
 	} );
 
 	test( 'applies custom aspect ratio', () => {
-		const ResponsiveWithConfig = withResponsive( MockComponent, { aspectRatio: 0.75 } );
-		render( <ResponsiveWithConfig data={ [] } /> );
+		const ResponsiveWithConfig = withResponsive( MockComponent );
+		render( <ResponsiveWithConfig data={ [] } aspectRatio={ 0.75 } /> );
 		const component = screen.getByTestId( 'mock-component' );
 		const styles = window.getComputedStyle( component );
 		const height = parseFloat( styles.height );
@@ -35,8 +35,8 @@ describe( 'withResponsive', () => {
 	} );
 
 	test( 'applies custom debounce time', () => {
-		const ResponsiveWithConfig = withResponsive( MockComponent, { debounceTime: 100 } );
-		render( <ResponsiveWithConfig data={ [] } /> );
+		const ResponsiveWithConfig = withResponsive( MockComponent );
+		render( <ResponsiveWithConfig data={ [] } resizeDebounceTime={ 100 } /> );
 		const component = screen.getByTestId( 'mock-component' );
 		expect( component ).toBeInTheDocument();
 	} );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes CHARTS-28

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

Previously, all chart components were exported only as versions wrapped with the `withResponsive` higher-order component (HOC), with responsive configuration (e.g., aspectRatio, maxWidth, resizeDebounceTime) set statically at the time of wrapping. This prevented consumers from customizing responsive behavior for their specific use cases. 

This PR refactors the `withResponsive` HOC to allow consumers to pass custom responsive configuration props (aspectRatio, maxWidth, resizeDebounceTime, etc.) directly to the wrapped chart components. Now, consumers can easily adjust responsive behavior per instance.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to http://localhost:50240/?path=/story/js-packages-charts-types-line-chart--default
* Try with different responsive configurations and verify that they are applied correctly


https://github.com/user-attachments/assets/a1744920-c929-4c32-93e2-00016b99fce9

