### PR TITLE
Connection: display connection in dashboard on WoA 

### DIFF
--- a/projects/plugins/wpcomsh/assets/admin-style.css
+++ b/projects/plugins/wpcomsh/assets/admin-style.css
@@ -29,12 +29,6 @@
 	display: none;
 }
 
-/* Hide the connections info and disconnect button in Jetpack Dashboard */
-#jp-plugin-container .jp-lower .jp-dash-section-header__connections,
-#jp-plugin-container .jp-lower .jp-connection-type {
-	display: none;
-}
-
 /************* Plugins Page **************/
 
 .wp-list-table tr[data-slug="akismet"] > *,

--- a/projects/plugins/wpcomsh/changelog/update-dashboard-connection-card-wpcomsh
+++ b/projects/plugins/wpcomsh/changelog/update-dashboard-connection-card-wpcomsh
@@ -1,0 +1,4 @@
+Significance: minor
+Type: removed
+
+Removed css that hides connection info from the dashboard.


### PR DESCRIPTION
This PR removes css that hides connection details on WoA sites.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes VULCAN-96

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Load the PR using beta plugin on a dev WoA site.
* Go to Jetpack dashboard and confirm that the connection info is showing up.
* If everything is OK, continue testing https://github.com/Automattic/jetpack/pull/43876

