### PR TITLE
Connection: display connection in dashboard on WoA no2

### DIFF
--- a/projects/plugins/jetpack/_inc/client/at-a-glance/connections.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/connections.jsx
@@ -116,9 +116,9 @@ export class DashConnections extends Component {
 	userConnection() {
 		// Hide disconnect button for connection owners on WoA sites
 		const shouldShowDisconnectButton = ! ( isWoASite() && this.props.isConnectionOwner );
-		const maybeShowLinkUnlinkBtn = shouldShowDisconnectButton ? (
+		const LinkUnlinkBtn = (
 			<ConnectButton asBanner connectUser={ true } from="connection-settings" />
-		) : null;
+		);
 
 		let cardContent = '';
 
@@ -148,7 +148,7 @@ export class DashConnections extends Component {
 		}
 
 		if ( ! this.props.isLinked ) {
-			cardContent = <div className="jp-connection-settings__info">{ maybeShowLinkUnlinkBtn }</div>;
+			cardContent = <div className="jp-connection-settings__info">{ LinkUnlinkBtn }</div>;
 		} else if ( this.props.isFetchingUserData ) {
 			cardContent = __( 'Loading…', 'jetpack' );
 		} else if ( ! this.props.wpComConnectedUser?.email ) {
@@ -190,8 +190,8 @@ export class DashConnections extends Component {
 							</div>
 						</div>
 					</div>
-					{ maybeShowLinkUnlinkBtn && (
-						<div className="jp-connection-settings__actions">{ maybeShowLinkUnlinkBtn }</div>
+					{ shouldShowDisconnectButton && (
+						<div className="jp-connection-settings__actions">{ LinkUnlinkBtn }</div>
 					) }
 				</div>
 			);

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/connections.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/connections.jsx
@@ -1,3 +1,4 @@
+import { isWoASite } from '@automattic/jetpack-script-data';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf, _x } from '@wordpress/i18n';
 import PropTypes from 'prop-types';
@@ -113,9 +114,11 @@ export class DashConnections extends Component {
 	 * @returns {string}
 	 */
 	userConnection() {
-		const maybeShowLinkUnlinkBtn = (
+		// Hide disconnect button for connection owners on WoA sites
+		const shouldShowDisconnectButton = ! ( isWoASite() && this.props.isConnectionOwner );
+		const maybeShowLinkUnlinkBtn = shouldShowDisconnectButton ? (
 			<ConnectButton asBanner connectUser={ true } from="connection-settings" />
-		);
+		) : null;
 
 		let cardContent = '';
 
@@ -187,7 +190,9 @@ export class DashConnections extends Component {
 							</div>
 						</div>
 					</div>
-					<div className="jp-connection-settings__actions">{ maybeShowLinkUnlinkBtn }</div>
+					{ maybeShowLinkUnlinkBtn && (
+						<div className="jp-connection-settings__actions">{ maybeShowLinkUnlinkBtn }</div>
+					) }
 				</div>
 			);
 		}

--- a/projects/plugins/jetpack/_inc/client/components/connect-button/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/connect-button/index.jsx
@@ -1,5 +1,6 @@
 import { getRedirectUrl } from '@automattic/jetpack-components';
 import { DisconnectDialog } from '@automattic/jetpack-connection';
+import { isWoASite } from '@automattic/jetpack-script-data';
 import { ExternalLink } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -210,18 +211,22 @@ export class ConnectButton extends React.Component {
 		}
 
 		if ( this.props.isSiteConnected ) {
-			return (
-				<JetpackBanner
-					title={ __( 'Your site is connected to WordPress.com.', 'jetpack' ) }
-					noIcon
-					callToAction={ this.props.connectLegend || __( 'Manage', 'jetpack' ) }
-					onClick={ this.handleOpenModal }
-					eventFeature="manage-site-connection"
-					path="dashboard"
-					eventProps={ { type: 'manage' } }
-					isPromotion={ false }
-				/>
-			);
+			const bannerProps = {
+				title: __( 'Your site is connected to WordPress.com.', 'jetpack' ),
+				noIcon: true,
+				eventFeature: 'manage-site-connection',
+				path: 'dashboard',
+				eventProps: { type: 'manage' },
+				isPromotion: false,
+			};
+
+			// Don't show Manage button on WoA sites
+			if ( ! isWoASite() ) {
+				bannerProps.callToAction = this.props.connectLegend || __( 'Manage', 'jetpack' );
+				bannerProps.onClick = this.handleOpenModal;
+			}
+
+			return <JetpackBanner { ...bannerProps } />;
 		}
 
 		let connectUrl = this.props.connectUrl;

--- a/projects/plugins/jetpack/changelog/update-dashboard-connection-card
+++ b/projects/plugins/jetpack/changelog/update-dashboard-connection-card
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Dashboard: Added connection infor on WoA sites.


### PR DESCRIPTION
This is the second PR to add a connection info card to the Jetpack dashboard. 
Related to: https://github.com/Automattic/jetpack/pull/43874 

Similar to what was done for My Jetpack in https://github.com/Automattic/jetpack/pull/43777 the PR removes the Manage button (ability to disconnect the site) for all users and the `Disconnect your WordPress.com account` link for connection owners.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes VULCAN-96

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Use the beta tester plugin on dev WoA site to load the PR.
* The wpcomsh PR needs to be applied too to test this. https://github.com/Automattic/jetpack/pull/43874
* Go to Jetpack dashboard and confirm connection owner can't disconnect the site or the user account.
* Create another account (try different roles) and confirm you can connect/disconnect that account.

