### PR TITLE
Forms: visually separate empty fields from submissions containing just -

### DIFF
--- a/projects/packages/forms/changelog/update-forms-empty-field
+++ b/projects/packages/forms/changelog/update-forms-empty-field
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: visually separate empty fields from submissions containing just "-"

--- a/projects/packages/forms/src/dashboard/components/empty-field/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/empty-field/index.tsx
@@ -1,0 +1,17 @@
+import { Tooltip } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { Icon, lineSolid } from '@wordpress/icons';
+import './style.scss';
+
+/**
+ * Render how empty field responses look like.
+ *
+ * @return {JSX.Element} Empty field response
+ */
+export default function EmptyResponse(): JSX.Element {
+	return (
+		<Tooltip text={ __( 'No response to this field.', 'jetpack-forms' ) }>
+			<Icon icon={ lineSolid } className="jp-forms_empty-response" />
+		</Tooltip>
+	);
+}

--- a/projects/packages/forms/src/dashboard/components/empty-field/style.scss
+++ b/projects/packages/forms/src/dashboard/components/empty-field/style.scss
@@ -1,0 +1,3 @@
+.jp-forms_empty-response {
+	fill: var(--jp-gray-50);
+}

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
@@ -21,6 +21,7 @@ import { useSearchParams } from 'react-router-dom';
 /**
  * Internal dependencies
  */
+import EmptyField from '../../components/empty-field';
 import InboxStatusToggle from '../../components/inbox-status-toggle';
 import { store as dashboardStore } from '../../store';
 import InboxResponse from '../response';
@@ -51,7 +52,7 @@ const formatFieldName = fieldName => {
 
 const formatFieldValue = fieldValue => {
 	if ( isEmpty( fieldValue ) ) {
-		return '-';
+		return <EmptyField />;
 	} else if ( isArray( fieldValue ) ) {
 		return join( fieldValue, ', ' );
 	}

--- a/projects/packages/forms/src/dashboard/inbox/response.js
+++ b/projects/packages/forms/src/dashboard/inbox/response.js
@@ -9,6 +9,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { download } from '@wordpress/icons';
 import clsx from 'clsx';
 import { map } from 'lodash';
+import EmptyField from '../components/empty-field';
 import { getPath } from './utils';
 
 const getDisplayName = response => {
@@ -157,16 +158,18 @@ const InboxResponse = ( { response, loading, onModalStateChange } ) => {
 		if ( isFileUploadField( value ) ) {
 			return (
 				<div className="file-field">
-					{ value.files?.length
-						? value.files.map( ( file, index ) => {
-								if ( ! file || ! file.name ) {
-									return null;
-								}
-								return (
-									<FileField file={ file } onClick={ handleFilePreview( file ) } key={ index } />
-								);
-						  } )
-						: '-' }
+					{ value.files?.length ? (
+						value.files.map( ( file, index ) => {
+							if ( ! file || ! file.name ) {
+								return null;
+							}
+							return (
+								<FileField file={ file } onClick={ handleFilePreview( file ) } key={ index } />
+							);
+						} )
+					) : (
+						<EmptyField />
+					) }
 				</div>
 			);
 		}

--- a/projects/plugins/jetpack/changelog/update-forms-empty-field
+++ b/projects/plugins/jetpack/changelog/update-forms-empty-field
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: visually separate empty fields from submissions containing just "-"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Resolves FORMS-146

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Use visually different way to show when field is empty compared to regular text.

Uses solid line icon from WP icons:
<img width="242" alt="image" src="https://github.com/user-attachments/assets/12e92e58-0b5c-4d7f-ba0d-624fe323293a" />

and "Jetpack gray 50" color with a tooltip.

Before

<img width="673" alt="image" src="https://github.com/user-attachments/assets/c56d07d1-e58b-4712-9341-dee5a86e9c53" />


After
<img width="715" alt="Screenshot 2025-06-10 at 16 23 15" src="https://github.com/user-attachments/assets/9f02bdfe-b5ac-4464-a2fe-469d420656a7" />
<img width="706" alt="Screenshot 2025-06-10 at 16 24 13" src="https://github.com/user-attachments/assets/a9e82faf-db27-4948-9b90-94221268e7e7" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

