### PR TITLE
Stats: Fix tracking of search terms, tags & parsing of tax queries

### DIFF
--- a/projects/packages/stats/changelog/fix-search-stats-missing-fields
+++ b/projects/packages/stats/changelog/fix-search-stats-missing-fields
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Stats: Fix tracking of search terms, tags and parsing of taxonomies query.

--- a/projects/packages/stats/src/class-tracking-pixel.php
+++ b/projects/packages/stats/src/class-tracking-pixel.php
@@ -91,7 +91,8 @@ class Tracking_Pixel {
 			if ( $wp_the_query->is_home() ) {
 				$view_data['arch_home'] = '1';
 			} elseif ( $wp_the_query->is_search() ) {
-				$view_data['arch_search']  = sanitize_text_field( $wp_the_query->query['s'] );
+				$search_term               = $wp_the_query->query['s'] ?? $wp_the_query->query_vars['s'] ?? '';
+				$view_data['arch_search']  = sanitize_text_field( $search_term );
 				$view_data['arch_filters'] = sanitize_text_field( self::build_search_filters( $wp_the_query ) );
 				$view_data['arch_results'] = $wp_the_query->posts ? $wp_the_query->post_count : 0;
 			} elseif ( $wp_the_query->is_archive() ) {
@@ -105,7 +106,7 @@ class Tracking_Pixel {
 					$view_data['arch_cat'] = $wp_the_query->query['category_name'] ?? $wp_the_query->query_vars['category_name'] ?? '';
 				}
 				if ( $wp_the_query->is_tag ) {
-					$view_data['arch_tag'] = $wp_the_query->query['tag'];
+					$view_data['arch_tag'] = $wp_the_query->query['tag'] ?? $wp_the_query->query_vars['tag'] ?? '';
 				}
 				if ( $wp_the_query->is_author ) {
 					$view_data['arch_author'] = $wp_the_query->query['author_name'] ?? '';
@@ -150,7 +151,7 @@ class Tracking_Pixel {
 		$terms         = array();
 		if ( ! empty( $the_tax_query->queried_terms ) && is_array( $the_tax_query->queried_terms ) ) {
 			foreach ( $the_tax_query->queries as $tax_query ) {
-				if ( ! is_array( $tax_query ) || 'slug' !== $tax_query['field'] ) {
+				if ( ! is_array( $tax_query ) || ! isset( $tax_query['taxonomy'] ) ) {
 					continue;
 				}
 				$taxonomy = $tax_query['taxonomy'];


### PR DESCRIPTION
Fixes
- Cases where the search term can't be tracked by the WP_Query array.
- Cases where the tag slug is not used in the WP_Query when visiting a tag's archive page.
- Fixes an invalid check on taxonomies' slugs when collecting the search filters for Jetpack Stats.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Handle relevant warnings by checking both `query` and `query_vars` arrays.
* Removed a check on the taxonomy's slug field when building the relevant taxonomies search filters.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- At your test site, set up a tag and a custom taxonomy. Add posts to them.
- Add Jetpack Search but disable the Instant Search toggle and install a theme that supports the search widget (e.g. Twenty Twenty-One).
- Log out from your admin account
- Visit your tag's page and verify that the pixel request contains the expected payload.
- Make a search request using the `s` URL parameter and another that makes a taxonomy query too (e.g. `?s=searchterm&testtax=taxonomy`) and verify that both pixel requests contain the expected payload.
- Try different searches with different combinations of search terms, taxonomies, and tags.

