### PR TITLE
Slideshow block: fix unwanted image cropping

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-slideshow-image-cropping
+++ b/projects/plugins/jetpack/changelog/fix-slideshow-image-cropping
@@ -1,0 +1,3 @@
+Significance: patch
+Type: other
+Comment: Fixes bug in unreleased version.

--- a/projects/plugins/jetpack/extensions/blocks/slideshow/swiper-callbacks.js
+++ b/projects/plugins/jetpack/extensions/blocks/slideshow/swiper-callbacks.js
@@ -36,7 +36,7 @@ function swiperResize( swiper ) {
 	if ( ! img ) {
 		return;
 	}
-	const aspectRatio = img.clientWidth / img.clientHeight;
+	const aspectRatio = img.naturalWidth / img.naturalHeight;
 	const sanityAspectRatio = Math.max( Math.min( aspectRatio, SIXTEEN_BY_NINE ), 1 );
 	const sanityHeight =
 		typeof window !== 'undefined'


### PR DESCRIPTION
#43689 reduced layout shifts in the slideshow block, but it introduced an issue where wide aligned slideshows are cropped.

This PR fixes that issue by using the correct image dimensions to size the slideshow.

## Proposed changes:
* Look at image natural size instead of rendered size when calculating the final aspect ratio.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
- Create a new slideshow
- Add images to the slideshow
- Set the image sizes to Full
- Set the alignment to Wide
- Save the page
- Load the page in the frontend, and ensure that the first image is not being cropped

Please also be sure to test other size and alignment options, or anything else that you think may have the potential for cropping or alignment bugs.

