### PR TITLE
ci: Fix conditions for skipping the coverage upload

### DIFF
--- a/.github/workflows/coverage-check.yml
+++ b/.github/workflows/coverage-check.yml
@@ -22,7 +22,9 @@ jobs:
   code-coverage-label:
     name: "Update code coverage check"
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch' || github.event.label.name == 'I don''t care about code coverage for this PR' || github.event.label.name == 'Covered by non-unit tests' || github.event.label.name == 'Coverage tests to be added later'
+    if: >
+      ( github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name ) &&
+      ( github.event_name == 'workflow_dispatch' || github.event.label.name == 'I don''t care about code coverage for this PR' || github.event.label.name == 'Covered by non-unit tests' || github.event.label.name == 'Coverage tests to be added later' )
     timeout-minutes: 5  # 2025-02-06: Should be pretty quick.
     steps:
       - name: Checkout

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -299,7 +299,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10 # 2025-01-10 Wild guess
     needs: run-tests
-    if: always() && needs.run-tests.outputs.did-coverage == 'true' && github.repository == 'Automattic/jetpack' && ( github.event_name == 'pull_request' || github.ref == 'refs/heads/trunk' )
+    if: always() && needs.run-tests.outputs.did-coverage == 'true' && github.repository == 'Automattic/jetpack' && ( github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name || github.event_name == 'push' && github.ref == 'refs/heads/trunk' )
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
There are two repository checks we need:

* We only want uploads from the actual monorepo, not any fork, so check for `github.repository === 'Automattic/jetpack'`.
* We also can't do the upload for PRs from forks, even when they target the monorepo, because it requires access to secrets. That check is `github.event.pull_request.head.repo.full_name === github.event.pull_request.base.repo.full_name`

We were missing the second one. Either we overlooked it entirely, or we were confused into thinking the first check covered both needs.

Also, for good measure, tighten the condition for `github.ref == 'refs/heads/trunk'` to only apply on pushes. It shouldn't be possible to get a pull_request event for that, but it doesn't hurt to check.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1749540705640549/1749503499.873009-slack-C08PN0LHCCT

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* It might work to create a PR from a fork that attempts to merge into this branch rather than trunk (and also will run coverage for at least one project).
* Otherwise, 🤷.