### PR TITLE
Boost: Remove unnecessary Photon params for LCP img Analysis

### DIFF
--- a/projects/plugins/boost/app/modules/optimizations/lcp/class-lcp-optimize-img-tag.php
+++ b/projects/plugins/boost/app/modules/optimizations/lcp/class-lcp-optimize-img-tag.php
@@ -67,8 +67,20 @@ class LCP_Optimize_Img_Tag {
 		$buffer_processor->set_attribute( 'data-jp-lcp-optimized', 'true' );
 
 		$image_url = $buffer_processor->get_attribute( 'src' );
+		// Validate URL syntax using WordPress function
+		if ( ! wp_http_validate_url( $image_url ) ) {
+			return $buffer_processor->get_updated_html();
+		}
 
-		$buffer_processor->set_attribute( 'src', Image_CDN_Core::cdn_url( $image_url ) );
+		// Remove unwanted query parameters that would be used unnecessarily by Photon.
+		$clean_url = remove_query_arg( array( 'resize', 'w', 'h' ), $image_url );
+
+		// Additional validation after cleaning
+		if ( ! wp_http_validate_url( $clean_url ) ) {
+			return $buffer_processor->get_updated_html();
+		}
+
+		$buffer_processor->set_attribute( 'src', Image_CDN_Core::cdn_url( $clean_url ) );
 
 		$this->add_responsive_image_attributes( $buffer_processor, $image_url );
 

--- a/projects/plugins/boost/app/modules/optimizations/lcp/class-lcp-optimize-img-tag.php
+++ b/projects/plugins/boost/app/modules/optimizations/lcp/class-lcp-optimize-img-tag.php
@@ -67,20 +67,20 @@ class LCP_Optimize_Img_Tag {
 		$buffer_processor->set_attribute( 'data-jp-lcp-optimized', 'true' );
 
 		$image_url = $buffer_processor->get_attribute( 'src' );
-		// Validate URL syntax using WordPress function
+		// Ensure the image URL is valid.
 		if ( ! wp_http_validate_url( $image_url ) ) {
 			return $buffer_processor->get_updated_html();
 		}
 
 		// Remove unwanted query parameters that would be used unnecessarily by Photon.
-		$clean_url = remove_query_arg( array( 'resize', 'w', 'h' ), $image_url );
+		$image_url = remove_query_arg( array( 'resize', 'w', 'h' ), $image_url );
 
-		// Additional validation after cleaning
-		if ( ! wp_http_validate_url( $clean_url ) ) {
+		// Additional validation after cleaning.
+		if ( ! wp_http_validate_url( $image_url ) ) {
 			return $buffer_processor->get_updated_html();
 		}
 
-		$buffer_processor->set_attribute( 'src', Image_CDN_Core::cdn_url( $clean_url ) );
+		$buffer_processor->set_attribute( 'src', Image_CDN_Core::cdn_url( $image_url ) );
 
 		$this->add_responsive_image_attributes( $buffer_processor, $image_url );
 

--- a/projects/plugins/boost/changelog/update-boost-lcp-remove-unwanted-photon-params
+++ b/projects/plugins/boost/changelog/update-boost-lcp-remove-unwanted-photon-params
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: LCP: Changes to an unreleased feature.
+
+


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Ensure that GET params that are used by Photon to determine what resolution is displayed is not included when passing the Image src to Photon.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
* Enable Image CDN.
* Create a page that triggers a Photon parameter such as `resize`. (The WooCommerce shop placeholder image when displaying products has this, for example).
* Set said page (e.g. /shop) to your Cornerstone page.
* Verify said page has its LCP image as it's placeholder (By default the /shop page should have this already)
* Enable LCP Optimization.
* Once LCP is optimized, ensure that `resize` is removed, and that the LCP image placeholder appears as expected.

