### PR TITLE
Prevent PHP warnings due to non-WP_POST $post global and malformed block data

### DIFF
--- a/projects/packages/forms/changelog/fix-jetpack-php_warning_in_carousel
+++ b/projects/packages/forms/changelog/fix-jetpack-php_warning_in_carousel
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Prevent PHP warning when rendering blocks.

--- a/projects/packages/forms/src/contact-form/class-util.php
+++ b/projects/packages/forms/src/contact-form/class-util.php
@@ -183,7 +183,8 @@ class Util {
 	 * @return string
 	 */
 	public static function grunion_contact_form_unset_block_template_part_id_global( $content, $block ) {
-		if ( 'core/template-part' === $block['blockName']
+		if ( isset( $block['blockName'] )
+			&& 'core/template-part' === $block['blockName']
 			&& isset( $GLOBALS['grunion_block_template_part_id'] ) ) {
 			unset( $GLOBALS['grunion_block_template_part_id'] );
 		}

--- a/projects/packages/videopress/changelog/fix-jetpack-php_warning_in_carousel
+++ b/projects/packages/videopress/changelog/fix-jetpack-php_warning_in_carousel
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Prevent PHP warning when rendering blocks.

--- a/projects/packages/videopress/src/class-block-replacement.php
+++ b/projects/packages/videopress/src/class-block-replacement.php
@@ -36,7 +36,7 @@ class Block_Replacement {
 	 * @return string
 	 */
 	public static function replace_media_text_with_videopress( $block_content, $block ) {
-		if ( $block['blockName'] === 'core/media-text' ) {
+		if ( isset( $block['blockName'] ) && $block['blockName'] === 'core/media-text' ) {
 
 			// Make sure we have a $post_id that could be valid; if we don't, then video_get_info_by_blogpostid()
 			// will fail, so there's no point in calling it.

--- a/projects/packages/woocommerce-analytics/changelog/fix-jetpack-php_warning_in_carousel
+++ b/projects/packages/woocommerce-analytics/changelog/fix-jetpack-php_warning_in_carousel
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Prevent PHP warning in checkout view.

--- a/projects/packages/woocommerce-analytics/src/class-universal.php
+++ b/projects/packages/woocommerce-analytics/src/class-universal.php
@@ -686,6 +686,10 @@ class Universal {
 	 */
 	public function capture_checkout_view() {
 		global $post;
+		if ( ! $post instanceof \WP_Post ) {
+			return;
+		}
+
 		$checkout_page_id = wc_get_page_id( 'checkout' );
 
 		$is_checkout = $checkout_page_id && is_page( $checkout_page_id )

--- a/projects/plugins/jetpack/changelog/fix-jetpack-php_warning_in_carousel
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-php_warning_in_carousel
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Prevent PHP warning in Gallery block..

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
@@ -380,7 +380,7 @@ class Jetpack_Carousel {
 
 		$this->enqueue_assets();
 
-		if ( ! isset( $post ) || ! $post instanceof WP_Post ) {
+		if ( ! $post instanceof WP_Post ) {
 			return $block_content;
 		}
 

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
@@ -380,7 +380,7 @@ class Jetpack_Carousel {
 
 		$this->enqueue_assets();
 
-		if ( ! isset( $post ) ) {
+		if ( ! isset( $post ) || ! $post instanceof WP_Post ) {
 			return $block_content;
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

We get over 60K of these every month on WP Cloud:
```
PHP Warning: Attempt to read property "ID" on int in /wordpress/plugins/jetpack/14.8-a.3/modules/carousel/jetpack-carousel.php on line 392
```

And over 200K of these:
```
PHP Warning: Attempt to read property "ID" on null in /wordpress/plugins/jetpack/14.8-a.3/jetpack_vendor/automattic/woocommerce-analytics/src/class-universal.php on line 701
```

Generally `$post` should be of type `WP_Post`, but it's a global that anything can modify, and it seems for some reason something modifies it to be an int or `null`. 🤷

---

The other commits were meant for #43889, but I'll just leave 'em here.

Addresses 130K per month of these:
```
PHP Warning: Undefined array key "blockName" in /wordpress/plugins/jetpack/14.8-a.3/jetpack_vendor/automattic/jetpack-videopress/src/class-block-replacement.php on line 39
```

And 125K per month of these:
```
PHP Warning: Undefined array key "blockName" in /wordpress/plugins/jetpack/14.8-a.3/jetpack_vendor/automattic/jetpack-forms/src/contact-form/class-util.php on line 186
```

This PR adds checks to verify the `blockName` key exists before using it.

I'm not sure the best way to reproduce this, but the methods in question are triggered by the `render_block` filter, which means any third-party code could manipulate it.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

