### PR TITLE
My Jetpack: Onboarding i4 | Add barebones UI

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/content.tsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/content.tsx
@@ -1,5 +1,5 @@
 import { __ } from '@wordpress/i18n';
-import UnownedProductsCard from '../../product-cards-section/unowned-products-card';
+import { Products } from './products';
 import styles from './styles.module.scss';
 
 /**
@@ -17,7 +17,7 @@ const ProductsContent = () => {
 					'jetpack-my-jetpack'
 				) }
 			</p>
-			<UnownedProductsCard />
+			<Products />
 		</section>
 	);
 };

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/filtered-products.tsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/filtered-products.tsx
@@ -1,0 +1,20 @@
+export type FilteredProductsProps = {
+	selectedFilter?: string;
+	search?: string;
+};
+
+/**
+ * Render the filtered products component.
+ *
+ * @param {FilteredProductsProps} props - The component props.
+ *
+ * @return The rendered component.
+ */
+export function FilteredProducts( { search, selectedFilter }: FilteredProductsProps ) {
+	return (
+		<div>
+			<p>Selected filter: { selectedFilter }</p>
+			<p>Search term: &quot;{ search }&quot;</p>
+		</div>
+	);
+}

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/filters.tsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/filters.tsx
@@ -48,7 +48,6 @@ export function Filters( { onChangeFilter, onSearch, search, selectedFilter }: F
 							role="menuitemradio"
 							isSelected={ isSelected }
 							onClick={ onSelectFilter( item.value ) }
-							aria-label={ item[ 'aria-label' ] }
 						>
 							{ item.label }
 						</MenuItem>

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/filters.tsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/filters.tsx
@@ -1,0 +1,60 @@
+import { MenuItem, NavigableMenu, SearchControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useCallback } from 'react';
+import styles from './styles.module.scss';
+import { getProductsFilterChoices } from './utils';
+
+type FiltersProps = {
+	onChangeFilter: ( filter: string ) => void;
+	selectedFilter?: string;
+	search?: string;
+	onSearch: ( search: string ) => void;
+};
+
+/**
+ * Render the filters for the products tab.
+ *
+ * @param {FiltersProps} props - The component props.
+ *
+ * @return The rendered component.
+ */
+export function Filters( { onChangeFilter, onSearch, search, selectedFilter }: FiltersProps ) {
+	const onSelectFilter = useCallback(
+		( filter: string ) => () => {
+			if ( selectedFilter !== filter ) {
+				onChangeFilter( filter );
+			}
+		},
+		[ onChangeFilter, selectedFilter ]
+	);
+
+	return (
+		<div className={ styles.filters }>
+			<SearchControl
+				__nextHasNoMarginBottom
+				aria-label={ __( 'Search products', 'jetpack-my-jetpack' ) }
+				placeholder={ __( 'Search products', 'jetpack-my-jetpack' ) }
+				value={ search }
+				onChange={ onSearch }
+				className={ styles[ 'search-control' ] }
+			/>
+			<NavigableMenu>
+				{ getProductsFilterChoices().map( item => {
+					const isSelected = selectedFilter === item.value;
+
+					return (
+						<MenuItem
+							key={ item.value }
+							role="menuitemradio"
+							isSelected={ isSelected }
+							onClick={ onSelectFilter( item.value ) }
+							aria-label={ item[ 'aria-label' ] }
+						>
+							{ item.label }
+						</MenuItem>
+					);
+				} ) }
+			</NavigableMenu>
+		</div>
+	);
+}

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/products.tsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/products.tsx
@@ -1,0 +1,30 @@
+import { useState } from 'react';
+import { FilteredProducts } from './filtered-products';
+import { Filters } from './filters';
+import styles from './styles.module.scss';
+
+/**
+ * Render the products.
+ *
+ * @return The rendered component.
+ */
+export function Products() {
+	const [ selectedFilter, setSelectedFilter ] = useState( 'all' );
+	const [ search, setSearch ] = useState( '' );
+
+	return (
+		<div className={ styles[ 'products-wrapper' ] }>
+			<div className={ styles[ 'filters-wrapper' ] }>
+				<Filters
+					onChangeFilter={ setSelectedFilter }
+					onSearch={ setSearch }
+					search={ search }
+					selectedFilter={ selectedFilter }
+				/>
+			</div>
+			<div className={ styles[ 'filtered-products-wrapper' ] }>
+				<FilteredProducts search={ search } selectedFilter={ selectedFilter } />
+			</div>
+		</div>
+	);
+}

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/styles.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/styles.module.scss
@@ -9,3 +9,45 @@
 		color: #{gb.$gray-700};
 	}
 }
+
+.products-wrapper {
+	display: flex;
+	gap: 4.5rem;
+	margin-top: 2rem;
+}
+
+.filters-wrapper {
+	max-width: 15rem;
+}
+
+.filtered-products-wrapper {
+	flex-grow: 1;
+}
+
+.filters {
+	display: flex;
+	flex-direction: column;
+	gap: 1rem;
+
+	div[role="menu"] {
+		margin-inline-start: -12px; // Adjustment for the padding for buttons
+	}
+
+	button[role="menuitemradio"] {
+		font-weight: 400;
+		color: #{gb.$gray-700};
+	}
+
+	button[aria-checked="true"] {
+		font-weight: 600;
+		color: #{gb.$gray-900};
+	}
+
+	.search-control {
+
+		:global(.components-input-control__container) {
+			background-color: transparent;
+			border: 1px solid #{gb.$gray-600};
+		}
+	}
+}

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/utils.ts
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/utils.ts
@@ -1,0 +1,50 @@
+import { MenuItemsChoiceProps } from '@wordpress/components/build-types/menu-items-choice/types';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Get the choices for the products filter.
+ *
+ * @return The choices for the products filter.
+ */
+export function getProductsFilterChoices(): MenuItemsChoiceProps[ 'choices' ] {
+	const choices = [
+		{
+			label: __( 'All categories', 'jetpack-my-jetpack' ),
+			value: 'all',
+		},
+		{
+			label: __( 'Recommended', 'jetpack-my-jetpack' ),
+			value: 'recommended',
+		},
+		{
+			label: __( 'Installed', 'jetpack-my-jetpack' ),
+			value: 'installed',
+		},
+		{
+			label: __( 'Included in plan', 'jetpack-my-jetpack' ),
+			value: 'included',
+		},
+		{
+			label: __( 'Security', 'jetpack-my-jetpack' ),
+			value: 'security',
+		},
+		{
+			label: __( 'Growth', 'jetpack-my-jetpack' ),
+			value: 'growth',
+		},
+		{
+			label: __( 'Performance', 'jetpack-my-jetpack' ),
+			value: 'performance',
+		},
+		{
+			label: __( 'Management', 'jetpack-my-jetpack' ),
+			value: 'management',
+		},
+		{
+			label: __( 'Create', 'jetpack-my-jetpack' ),
+			value: 'create',
+		},
+	];
+
+	return choices;
+}


### PR DESCRIPTION
Completes MYJP-176

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add the barebones UI for products section in My Jetpack

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to My Jetpack > Products
* Confirm that you see the barebones UI for search and filter menu

<img width="817" alt="Screenshot 2025-06-11 at 2 21 18 PM" src="https://github.com/user-attachments/assets/742053ef-a35f-44c1-b89f-945b8eb9078a" />


<img width="823" alt="Screenshot 2025-06-11 at 2 18 12 PM" src="https://github.com/user-attachments/assets/66547fb6-9894-46e1-90c5-f28c2b0b70f6" />

