### PR TITLE
ci: Better error logging in packagist-proxy

### DIFF
--- a/.github/actions/tool-setup/packagist-proxy.mjs
+++ b/.github/actions/tool-setup/packagist-proxy.mjs
@@ -116,7 +116,7 @@ server.on( 'request', ( req, res ) => {
 	} );
 
 	upstreamReq.on( 'error', e => {
-		console.log( `!![${ reqid }] Network error: ${ e }` );
+		console.log( `!![${ reqid }] Network error:`, e );
 
 		if ( sentResponse ) {
 			console.log( `!![${ reqid }] Already got a (partial) response, just closing.` );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Seems we often get instances of AggregateError, which just stringify as "AggregateError". Pass the error object as a separate parameter to `console.log`, which will produce more detailed output, including the stack trace and sub-errors.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1749646628659319/1749610175.262719-slack-C034JEXD1RD

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
None

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* 🤷 You'd have to run the proxy and then arrange for it to run into network errors.