### PR TITLE
Boost: Allow generation to continue after a page is redirected

### DIFF
--- a/projects/js-packages/critical-css-gen/changelog/fix-redirect-breaking-critical-css
+++ b/projects/js-packages/critical-css-gen/changelog/fix-redirect-breaking-critical-css
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix redirects breaking Critical CSS generation in iframe interface.

--- a/projects/js-packages/critical-css-gen/src/browser-interface-iframe.ts
+++ b/projects/js-packages/critical-css-gen/src/browser-interface-iframe.ts
@@ -146,13 +146,15 @@ export class BrowserInterfaceIframe extends BrowserInterface {
 			return;
 		}
 
+		let urlToLoad = rawUrl;
+
 		// Make sure URL is valid.
 		let url;
 		try {
-			url = new URL( rawUrl );
+			url = new URL( urlToLoad );
 		} catch ( err ) {
 			this.trackUrlError( rawUrl, err );
-			throw new InvalidURLError( { url: rawUrl } );
+			throw new InvalidURLError( { url: urlToLoad } );
 		}
 
 		const fullUrl = this.addGetParameters( url );
@@ -178,33 +180,52 @@ export class BrowserInterfaceIframe extends BrowserInterface {
 
 			// Catch load event.
 			this.iframe.onload = async () => {
+				const loadedUrl = new URL( this.iframe.contentWindow.location.href );
+
+				// In case there's a redirect, let's make sure that the loaded URL
+				// is on the same origin as the main page.
+				if ( ! this.sameOrigin( loadedUrl.toString() ) ) {
+					reject( new CrossDomainError( { url: fullUrl } ) );
+					return;
+				}
+
+				// If the loaded URL is not using ugly permalinks, use it to run the checks.
+				// Otherwise, we can't rely that the loaded URL is the same as the original URL,
+				// since ugly permalinks are different only by the value of the 'p' parameter.
+				const usesUglyPermalinks = loadedUrl.searchParams.has( 'p' );
+				if ( ! usesUglyPermalinks ) {
+					urlToLoad = loadedUrl.toString();
+				}
+
 				try {
 					this.iframe.onload = null;
 					clearTimeout( timeoutId );
 
 					// Check HTTP status code first.
-					const is404 = await this.is404Page( fullUrl );
+					const is404 = await this.is404Page( urlToLoad );
 					if ( is404 ) {
-						throw new HttpError( { url: fullUrl, code: 404 } );
+						throw new HttpError( { url: urlToLoad, code: 404 } );
 					}
 
 					// Verify the inner document is readable.
 					if ( ! this.iframe.contentDocument || ! this.iframe.contentWindow ) {
 						throw (
-							( await this.diagnoseUrlError( fullUrl ) ) || new CrossDomainError( { url: fullUrl } )
+							( await this.diagnoseUrlError( urlToLoad ) ) ||
+							new CrossDomainError( { url: urlToLoad } )
 						);
 					}
 
 					if (
-						! this.verifyPage( rawUrl, this.iframe.contentWindow, this.iframe.contentDocument )
+						! this.verifyPage( urlToLoad, this.iframe.contentWindow, this.iframe.contentDocument )
 					) {
 						// Diagnose and throw an appropriate error.
 						throw (
-							( await this.diagnoseUrlError( fullUrl ) ) || new UrlVerifyError( { url: fullUrl } )
+							( await this.diagnoseUrlError( urlToLoad ) ) ||
+							new UrlVerifyError( { url: urlToLoad } )
 						);
 					}
 
-					this.currentUrl = rawUrl;
+					this.currentUrl = urlToLoad;
 					resolve();
 				} catch ( err ) {
 					reject( err );

--- a/projects/plugins/boost/changelog/fix-boost-critical-css-support-generation-on-redirect
+++ b/projects/plugins/boost/changelog/fix-boost-critical-css-support-generation-on-redirect
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Critical CSS: Fix redirects preventing Critical CSS from being generated.


### PR DESCRIPTION
Partially addresses HOG-15

## Proposed changes:

* Allow Critical CSS to be generated for a page even after it was redirected (in case it was redirected to the same place but with get arguments).

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

https://github.com/Automattic/jetpack/issues/37404

## Does this pull request change what data or activity we track or use?

no

## Testing instructions:

The easiest way to test this is with a snippet that redirects a page to the same url **but** with a GET parameter.
For example:

```php
add_action( 'template_redirect', function() {
	// Get current URL using WP functions
	$current_url = home_url( remove_query_arg( 'NONEXISTENTQUERYARG' ) );
	$query_args = $_GET;

	// If v param not present, add it and redirect
	if ( ! isset( $query_args['v'] ) ) {
		$query_args['v'] = '1';
		$redirect_url = add_query_arg( $query_args, $current_url );
		wp_redirect( $redirect_url );
		exit;
	}
} );
```

- Add the snippet to your site.
- Open a page and make sure that the browser redirects to the same URL with `?v=1`.
- Setup Boost free;
- Try generating Critical CSS;
- You shouldn't see any errors;
- If you were to try this on `trunk`, you will see a redirect error like the one below:

