### PR TITLE
Don't export wp_navigation posts by non-current users

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/filter-export-for-exusers
+++ b/projects/packages/jetpack-mu-wpcom/changelog/filter-export-for-exusers
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Export: Don't export wp_navigation CPT if it came from a user that doesn't belong to the site

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -284,6 +284,7 @@ class Jetpack_Mu_Wpcom {
 		require_once __DIR__ . '/features/wpcom-post-list/wpcom-post-types-tracking.php';
 		require_once __DIR__ . '/features/wpcom-widgets/wpcom-widgets.php';
 		require_once __DIR__ . '/features/wpcom-wpadmin-page-view/wpcom-wpadmin-page-view.php';
+		require_once __DIR__ . '/features/wpcom-navigation-export-filter/class-export-filter.php';
 
 		// Initializers, if needed.
 		\Marketplace_Products_Updater::init();
@@ -291,6 +292,11 @@ class Jetpack_Mu_Wpcom {
 		\Automattic\Jetpack\Classic_Theme_Helper\Featured_Content::setup();
 
 		\Automattic\Jetpack\Jetpack_Mu_Wpcom\Holiday_Snow::init();
+
+		// Initialize WPCOM Navigation Export Filter
+		if ( class_exists( '\Automattic\Jetpack\Jetpack_Mu_Wpcom\Wpcom_Navigation_Export_Filter\Export_Filter' ) ) {
+			new \Automattic\Jetpack\Jetpack_Mu_Wpcom\Wpcom_Navigation_Export_Filter\Export_Filter();
+		}
 
 		// Gets autoloaded from the Scheduled_Updates package.
 		if ( class_exists( 'Automattic\Jetpack\Scheduled_Updates' ) ) {

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-navigation-export-filter/class-export-filter.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-navigation-export-filter/class-export-filter.php
@@ -24,13 +24,6 @@ class Export_Filter {
 	private $is_exporting = false;
 
 	/**
-	 * Cached list of valid user IDs for the current blog.
-	 *
-	 * @var array|null
-	 */
-	private $valid_user_ids = null;
-
-	/**
 	 * Constructor to set up the export filter.
 	 */
 	public function __construct() {
@@ -44,7 +37,6 @@ class Export_Filter {
 	 */
 	public function start_export_filtering(): void {
 		$this->is_exporting = true;
-		$this->load_valid_user_ids();
 		add_filter( 'query', array( $this, 'filter_export_queries' ) );
 	}
 
@@ -54,25 +46,8 @@ class Export_Filter {
 	 * @return void
 	 */
 	public function stop_export_filtering(): void {
-		$this->is_exporting   = false;
-		$this->valid_user_ids = null; // Clear cached user IDs
+		$this->is_exporting = false;
 		remove_filter( 'query', array( $this, 'filter_export_queries' ) );
-	}
-
-	/**
-	 * Loads and caches valid user IDs for the current blog.
-	 *
-	 * @return void
-	 */
-	private function load_valid_user_ids(): void {
-		// Get all user IDs for the current blog
-		$users = get_users(
-			array(
-				'fields' => 'ID', // Only return user IDs for efficiency
-			)
-		);
-
-		$this->valid_user_ids = array_map( 'intval', $users );
 	}
 
 	/**
@@ -95,24 +70,26 @@ class Export_Filter {
 			return $query;
 		}
 
-		// Handle the filtering condition based on whether we have valid users
-		if ( empty( $this->valid_user_ids ) ) {
-			// No valid users on the site - exclude all wp_navigation posts with post_author > 0 otherwise
-			// all will be included. This is good for privacy but bad for export integrity.
+		// Get current users for this site
+		$users = get_users( array( 'fields' => 'ID' ) );
+
+		// Handle the filtering condition based on whether we have current users
+		if ( empty( $users ) ) {
+			// No current users on the site - exclude all wp_navigation posts with post_author > 0
 			$additional_where = " AND NOT (
 					{$wpdb->posts}.post_type = 'wp_navigation'
 					AND {$wpdb->posts}.post_author > 0
 				)";
 		} else {
-			// We have valid users - create a comma-separated list for the IN clause
-			$valid_user_ids_string = implode( ',', $this->valid_user_ids );
+			// We have current users - create a comma-separated list for the IN clause
+			$current_users = implode( ',', array_map( 'intval', $users ) );
 
 			// Add our filter condition to exclude wp_navigation posts that have users that are
 			// not valid on the current site.
 			$additional_where = " AND NOT (
 					{$wpdb->posts}.post_type = 'wp_navigation'
 					AND {$wpdb->posts}.post_author > 0
-					AND {$wpdb->posts}.post_author NOT IN ({$valid_user_ids_string})
+					AND {$wpdb->posts}.post_author NOT IN ({$current_users})
 				)";
 		}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-navigation-export-filter/class-export-filter.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-navigation-export-filter/class-export-filter.php
@@ -24,6 +24,13 @@ class Export_Filter {
 	private $is_exporting = false;
 
 	/**
+	 * Cached list of valid user IDs for the current blog.
+	 *
+	 * @var array|null
+	 */
+	private $valid_user_ids = null;
+
+	/**
 	 * Constructor to set up the export filter.
 	 */
 	public function __construct() {
@@ -37,6 +44,7 @@ class Export_Filter {
 	 */
 	public function start_export_filtering(): void {
 		$this->is_exporting = true;
+		$this->load_valid_user_ids();
 		add_filter( 'query', array( $this, 'filter_export_queries' ) );
 	}
 
@@ -46,8 +54,25 @@ class Export_Filter {
 	 * @return void
 	 */
 	public function stop_export_filtering(): void {
-		$this->is_exporting = false;
+		$this->is_exporting   = false;
+		$this->valid_user_ids = null; // Clear cached user IDs
 		remove_filter( 'query', array( $this, 'filter_export_queries' ) );
+	}
+
+	/**
+	 * Loads and caches valid user IDs for the current blog.
+	 *
+	 * @return void
+	 */
+	private function load_valid_user_ids(): void {
+		// Get all user IDs for the current blog
+		$users = get_users(
+			array(
+				'fields' => 'ID', // Only return user IDs for efficiency
+			)
+		);
+
+		$this->valid_user_ids = array_map( 'intval', $users );
 	}
 
 	/**
@@ -70,14 +95,26 @@ class Export_Filter {
 			return $query;
 		}
 
-		// Add our filter condition to exclude wp_navigation posts that have users that are
-		// not valid on the current site.
-		$meta_key         = 'wp_' . $wpdb->get_blog_prefix() . '_user_level';
-		$additional_where = " AND NOT (
-				{$wpdb->posts}.post_type = 'wp_navigation'
-				AND {$wpdb->posts}.post_author > 0
-				AND {$wpdb->posts}.post_author NOT IN (SELECT user_id FROM {$wpdb->usermeta} WHERE meta_key = '{$meta_key}')
-			)";
+		// Handle the filtering condition based on whether we have valid users
+		if ( empty( $this->valid_user_ids ) ) {
+			// No valid users on the site - exclude all wp_navigation posts with post_author > 0 otherwise
+			// all will be included. This is good for privacy but bad for export integrity.
+			$additional_where = " AND NOT (
+					{$wpdb->posts}.post_type = 'wp_navigation'
+					AND {$wpdb->posts}.post_author > 0
+				)";
+		} else {
+			// We have valid users - create a comma-separated list for the IN clause
+			$valid_user_ids_string = implode( ',', $this->valid_user_ids );
+
+			// Add our filter condition to exclude wp_navigation posts that have users that are
+			// not valid on the current site.
+			$additional_where = " AND NOT (
+					{$wpdb->posts}.post_type = 'wp_navigation'
+					AND {$wpdb->posts}.post_author > 0
+					AND {$wpdb->posts}.post_author NOT IN ({$valid_user_ids_string})
+				)";
+		}
 
 		return $query . $additional_where;
 	}

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-navigation-export-filter/class-export-filter.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-navigation-export-filter/class-export-filter.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * WPCOM Navigation Export Filter
+ *
+ * Filters wp_navigation posts from WXR exports when the post_author
+ * is not a valid user on the current site.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\Jetpack\Jetpack_Mu_Wpcom\Wpcom_Navigation_Export_Filter;
+
+/**
+ * Export Filter class to handle wp_navigation post filtering during WordPress exports.
+ */
+class Export_Filter {
+	/**
+	 * Tracks whether an export is currently in progress.
+	 *
+	 * @var bool
+	 */
+	private $is_exporting = false;
+
+	/**
+	 * Constructor to set up the export filter.
+	 */
+	public function __construct() {
+		add_action( 'export_wp', array( $this, 'start_export_filtering' ), 5 );
+	}
+
+	/**
+	 * Starts filtering export queries by hooking into the query filter.
+	 *
+	 * @return void
+	 */
+	public function start_export_filtering(): void {
+		$this->is_exporting = true;
+		add_filter( 'query', array( $this, 'filter_export_queries' ) );
+	}
+
+	/**
+	 * Stops filtering export queries by removing the query filter.
+	 *
+	 * @return void
+	 */
+	public function stop_export_filtering(): void {
+		$this->is_exporting = false;
+		remove_filter( 'query', array( $this, 'filter_export_queries' ) );
+	}
+
+	/**
+	 * Filters database queries during export to exclude wp_navigation posts
+	 * with invalid authors.
+	 *
+	 * @param string $query The database query.
+	 * @return string The modified query.
+	 */
+	public function filter_export_queries( string $query ): string {
+		global $wpdb;
+
+		if ( ! $this->is_exporting ) {
+			return $query;
+		}
+
+		// Target the specific query pattern from export_wp() that selects post IDs
+		$pattern = '/^SELECT ID FROM ' . preg_quote( $wpdb->posts, '/' ) . '.*WHERE/i';
+		if ( ! preg_match( $pattern, $query ) ) {
+			return $query;
+		}
+
+		// Add our filter condition to exclude wp_navigation posts that have users that are
+		// not valid on the current site.
+		$meta_key         = 'wp_' . $wpdb->get_blog_prefix() . '_user_level';
+		$additional_where = " AND NOT (
+				{$wpdb->posts}.post_type = 'wp_navigation'
+				AND {$wpdb->posts}.post_author > 0
+				AND {$wpdb->posts}.post_author NOT IN (SELECT user_id FROM {$wpdb->usermeta} WHERE meta_key = '{$meta_key}')
+			)";
+
+		return $query . $additional_where;
+	}
+}

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-navigation-export-filter/Wpcom_Navigation_Export_Filter_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-navigation-export-filter/Wpcom_Navigation_Export_Filter_Test.php
@@ -1,0 +1,163 @@
+<?php
+/**
+ * WPCOM Navigation Export Filter Tests
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\Jetpack\Jetpack_Mu_Wpcom\Wpcom_Navigation_Export_Filter;
+
+use Automattic\Jetpack\Jetpack_Mu_Wpcom;
+
+require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/wpcom-navigation-export-filter/class-export-filter.php';
+
+/**
+ * Tests for the WPCOM Navigation Export Filter feature.
+ */
+class Wpcom_Navigation_Export_Filter_Test extends \WorDBless\BaseTestCase {
+
+	/**
+	 * Export filter instance for testing.
+	 *
+	 * @var Export_Filter
+	 */
+	private $export_filter;
+
+	/**
+	 * Pre-test setup.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		// Initialize the feature the same way it's done in the main class
+		\Automattic\Jetpack\Jetpack_Mu_Wpcom::load_features();
+
+		$this->export_filter = new Export_Filter();
+	}
+
+	/**
+	 * Test that export filter hooks are properly registered.
+	 */
+	public function test_export_filter_hooks_are_registered(): void {
+		// Test that start_export_filtering is registered
+		$this->assertNotFalse( \has_action( 'export_wp', array( $this->export_filter, 'start_export_filtering' ) ) );
+	}
+
+	/**
+	 * Test that the filter is not active by default.
+	 */
+	public function test_filter_not_active_by_default(): void {
+		$this->assertFalse( \has_filter( 'query', array( $this->export_filter, 'filter_export_queries' ) ) );
+	}
+
+	/**
+	 * Test that the filter can be removed.
+	 */
+	public function test_filter_can_be_removed(): void {
+		// Simulate export cycle
+		$this->export_filter->start_export_filtering();
+		$this->assertNotFalse( \has_filter( 'query', array( $this->export_filter, 'filter_export_queries' ) ) );
+
+		$this->export_filter->stop_export_filtering();
+		$this->assertFalse( \has_filter( 'query', array( $this->export_filter, 'filter_export_queries' ) ) );
+	}
+
+	/**
+	 * Test that export queries are properly modified to filter navigation posts.
+	 */
+	public function test_export_queries_are_filtered(): void {
+		global $wpdb;
+
+		$this->export_filter->start_export_filtering();
+
+		// Test that export queries are modified for filtering
+		$export_query   = "SELECT ID FROM {$wpdb->posts} WHERE post_status != 'auto-draft'";
+		$filtered_query = $this->export_filter->filter_export_queries( $export_query );
+
+		// The query should be modified to include the filter
+		$this->assertNotEquals( $export_query, $filtered_query, 'Export query should be modified when filtering is active' );
+
+		// The filter should target wp_navigation posts specifically
+		$this->assertStringContainsString( 'wp_navigation', $filtered_query, 'Filter should target wp_navigation posts' );
+
+		// The filter should exclude posts with invalid authors (post_author > 0 AND NOT IN users table)
+		$this->assertStringContainsString( 'post_author > 0', $filtered_query, 'Filter should check for non-system authors' );
+		$this->assertStringContainsString( 'NOT IN (SELECT ID FROM', $filtered_query, 'Filter should check against users table' );
+
+		// The exclusion should use AND NOT (...) logic
+		$this->assertStringContainsString( 'AND NOT (', $filtered_query, 'Filter should use exclusion logic' );
+
+		$this->export_filter->stop_export_filtering();
+	}
+
+	/**
+	 * Test that the filter properly targets only wp_navigation posts.
+	 */
+	public function test_filter_targets_only_navigation_posts(): void {
+		global $wpdb;
+
+		$this->export_filter->start_export_filtering();
+
+		// Test that export queries are modified to target wp_navigation specifically
+		$export_query   = "SELECT ID FROM {$wpdb->posts} WHERE post_status != 'auto-draft'";
+		$filtered_query = $this->export_filter->filter_export_queries( $export_query );
+
+		// The filter should specifically target wp_navigation posts
+		$this->assertStringContainsString( "post_type = 'wp_navigation'", $filtered_query, 'Filter should specifically target wp_navigation posts' );
+
+		// The filter should not mention other post types like 'post'
+		$this->assertStringNotContainsString( "post_type = 'post'", $filtered_query, 'Filter should not target regular posts' );
+
+		// The condition should be within the exclusion logic (AND NOT (...))
+		$this->assertMatchesRegularExpression(
+			'/AND NOT \([^)]*post_type = \'wp_navigation\'[^)]*\)/',
+			$filtered_query,
+			'wp_navigation condition should be within the exclusion logic'
+		);
+
+		$this->export_filter->stop_export_filtering();
+	}
+
+	/**
+	 * Test complete export workflow with hooks.
+	 */
+	public function test_complete_export_workflow_with_results(): void {
+		// Test that export_wp action activates filtering and it stays active
+		$this->assertFalse( \has_filter( 'query', array( $this->export_filter, 'filter_export_queries' ) ) );
+
+		// Simulate export via action
+		\do_action( 'export_wp' );
+
+		// Filter should now be active (it will stay active until manually stopped)
+		$this->assertNotFalse( \has_filter( 'query', array( $this->export_filter, 'filter_export_queries' ) ) );
+
+		// Manually cleanup the filter.
+		$this->export_filter->stop_export_filtering();
+		$this->assertFalse( \has_filter( 'query', array( $this->export_filter, 'filter_export_queries' ) ) );
+	}
+
+	/**
+	 * Test that the filter only affects export-type queries.
+	 */
+	public function test_filter_only_affects_export_queries(): void {
+		global $wpdb;
+
+		$this->export_filter->start_export_filtering();
+
+		// Test that non-export queries are not modified
+		$non_export_queries = array(
+			"SELECT * FROM {$wpdb->posts} WHERE post_status = 'publish'",
+			"UPDATE {$wpdb->posts} SET post_status = 'publish' WHERE ID = 1",
+			"INSERT INTO {$wpdb->posts} (post_title) VALUES ('Test')",
+		);
+
+		foreach ( $non_export_queries as $query ) {
+			$filtered_query = $this->export_filter->filter_export_queries( $query );
+			$this->assertEquals( $query, $filtered_query, "Non-export query should not be modified: {$query}" );
+		}
+
+		$this->export_filter->stop_export_filtering();
+	}
+}

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-navigation-export-filter/Wpcom_Navigation_Export_Filter_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-navigation-export-filter/Wpcom_Navigation_Export_Filter_Test.php
@@ -82,9 +82,11 @@ class Wpcom_Navigation_Export_Filter_Test extends \WorDBless\BaseTestCase {
 		// The filter should target wp_navigation posts specifically
 		$this->assertStringContainsString( 'wp_navigation', $filtered_query, 'Filter should target wp_navigation posts' );
 
-		// The filter should exclude posts with invalid authors (post_author > 0 AND NOT IN users table)
+		// The filter should exclude posts with invalid authors (post_author > 0 AND NOT IN usermeta table)
 		$this->assertStringContainsString( 'post_author > 0', $filtered_query, 'Filter should check for non-system authors' );
-		$this->assertStringContainsString( 'NOT IN (SELECT ID FROM', $filtered_query, 'Filter should check against users table' );
+		$this->assertStringContainsString( 'NOT IN (SELECT user_id FROM', $filtered_query, 'Filter should check against usermeta table' );
+		$this->assertStringContainsString( 'usermeta', $filtered_query, 'Filter should use usermeta table' );
+		$this->assertStringContainsString( 'meta_key =', $filtered_query, 'Filter should check for specific meta_key' );
 
 		// The exclusion should use AND NOT (...) logic
 		$this->assertStringContainsString( 'AND NOT (', $filtered_query, 'Filter should use exclusion logic' );
@@ -151,6 +153,7 @@ class Wpcom_Navigation_Export_Filter_Test extends \WorDBless\BaseTestCase {
 			"SELECT * FROM {$wpdb->posts} WHERE post_status = 'publish'",
 			"UPDATE {$wpdb->posts} SET post_status = 'publish' WHERE ID = 1",
 			"INSERT INTO {$wpdb->posts} (post_title) VALUES ('Test')",
+			"SELECT post_title FROM {$wpdb->posts} WHERE post_status != 'auto-draft'", // Different SELECT pattern
 		);
 
 		foreach ( $non_export_queries as $query ) {

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-navigation-export-filter/Wpcom_Navigation_Export_Filter_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-navigation-export-filter/Wpcom_Navigation_Export_Filter_Test.php
@@ -82,14 +82,29 @@ class Wpcom_Navigation_Export_Filter_Test extends \WorDBless\BaseTestCase {
 		// The filter should target wp_navigation posts specifically
 		$this->assertStringContainsString( 'wp_navigation', $filtered_query, 'Filter should target wp_navigation posts' );
 
-		// The filter should exclude posts with invalid authors (post_author > 0 AND NOT IN usermeta table)
+		// The filter should exclude posts with invalid authors (post_author > 0)
 		$this->assertStringContainsString( 'post_author > 0', $filtered_query, 'Filter should check for non-system authors' );
-		$this->assertStringContainsString( 'NOT IN (SELECT user_id FROM', $filtered_query, 'Filter should check against usermeta table' );
-		$this->assertStringContainsString( 'usermeta', $filtered_query, 'Filter should use usermeta table' );
-		$this->assertStringContainsString( 'meta_key =', $filtered_query, 'Filter should check for specific meta_key' );
 
 		// The exclusion should use AND NOT (...) logic
 		$this->assertStringContainsString( 'AND NOT (', $filtered_query, 'Filter should use exclusion logic' );
+
+		$this->export_filter->stop_export_filtering();
+	}
+
+	/**
+	 * Test that the filter properly handles the case when there are no valid users.
+	 */
+	public function test_filter_handles_no_valid_users(): void {
+		global $wpdb;
+
+		$this->export_filter->start_export_filtering();
+
+		$export_query   = "SELECT ID FROM {$wpdb->posts} WHERE post_status != 'auto-draft'";
+		$filtered_query = $this->export_filter->filter_export_queries( $export_query );
+
+		// When there are no valid users, all wp_navigation posts with post_author > 0 should be excluded
+		$this->assertStringContainsString( "post_type = 'wp_navigation'", $filtered_query );
+		$this->assertStringContainsString( 'post_author > 0', $filtered_query );
 
 		$this->export_filter->stop_export_filtering();
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://linear.app/a8c/issue/DOTCOM-13020

## Proposed changes:

> [!WARNING]  
> **This code is overly broad and a hack**. Maybe that's ok. 😞 

In the past a fallback navigation was created when one didn't exist. This used to be created in `render_block_core_navigation` (see WordPress/gutenberg#47684) but no longer happens.

This has lead to a number of blogs having this fallback navigation created when an a12 visited their site. This means that the a12s details including - wpcom username, email address, etc are in the generated export file.

It feels unhelpful to have this in the export file, partly because it might need explaining if the legal team share an export as part of their operating procedures and fail to remove the non-material data, and partly because a12s data is shared to anyone exporting an affected blog.

This change tries to remove the information when generating the export file, but is somewhat hampered by a lack of relevant hooks and also by a way of identifying current and former a12s. Instead it chooses a relevant SQL generation, hackily identifies whether the query is the relevant part of the export, and then modifies it to add some SQL excluding wp_navigation post types that were created by users that are not currently part of the blog.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

 1. go to .wordpress.com/wp-admin/export.php for the second site mentioned in this P2 pcgXQF-2um-p2
 2. Download the file
 3. Apply this patch to your wpcom-sandbox, sandbox the site.
 4. Download the file again

You should see that the wp_navigation CPT (and it's author) don't show up in the export, while the About page and it's author do.