### PR TITLE
Forms: Add button to create Salesforce form

### DIFF
--- a/projects/packages/forms/changelog/add-create-salesforce-form-button
+++ b/projects/packages/forms/changelog/add-create-salesforce-form-button
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: Add button to create Salesforce form.

--- a/projects/packages/forms/src/contact-form/class-util.php
+++ b/projects/packages/forms/src/contact-form/class-util.php
@@ -46,7 +46,7 @@ class Util {
 		register_block_pattern_category( $category_slug, array( 'label' => __( 'Forms', 'jetpack-forms' ) ) );
 
 		$patterns = array(
-			'contact-form'      => array(
+			'contact-form'         => array(
 				'title'      => __( 'Contact Form', 'jetpack-forms' ),
 				'blockTypes' => array( 'jetpack/contact-form' ),
 				'categories' => array( $category_slug ),
@@ -59,7 +59,7 @@ class Util {
                     </div>
                     <!-- /wp:jetpack/contact-form -->',
 			),
-			'newsletter-form'   => array(
+			'newsletter-form'      => array(
 				'title'      => __( 'Lead Capture Form', 'jetpack-forms' ),
 				'blockTypes' => array( 'jetpack/contact-form' ),
 				'categories' => array( $category_slug ),
@@ -72,7 +72,7 @@ class Util {
                     </div>
                     <!-- /wp:jetpack/contact-form -->',
 			),
-			'rsvp-form'         => array(
+			'rsvp-form'            => array(
 				'title'      => __( 'RSVP Form', 'jetpack-forms' ),
 				'blockTypes' => array( 'jetpack/contact-form' ),
 				'categories' => array( $category_slug ),
@@ -86,7 +86,7 @@ class Util {
                     </div>
                     <!-- /wp:jetpack/contact-form -->',
 			),
-			'registration-form' => array(
+			'registration-form'    => array(
 				'title'      => __( 'Registration Form', 'jetpack-forms' ),
 				'blockTypes' => array( 'jetpack/contact-form' ),
 				'categories' => array( $category_slug ),
@@ -101,7 +101,7 @@ class Util {
                     </div>
                     <!-- /wp:jetpack/contact-form -->',
 			),
-			'appointment-form'  => array(
+			'appointment-form'     => array(
 				'title'      => __( 'Appointment Form', 'jetpack-forms' ),
 				'blockTypes' => array( 'jetpack/contact-form' ),
 				'categories' => array( $category_slug ),
@@ -117,7 +117,7 @@ class Util {
                     </div>
                     <!-- /wp:jetpack/contact-form -->',
 			),
-			'feedback-form'     => array(
+			'feedback-form'        => array(
 				'title'      => __( 'Feedback Form', 'jetpack-forms' ),
 				'blockTypes' => array( 'jetpack/contact-form' ),
 				'categories' => array( $category_slug ),
@@ -130,6 +130,22 @@ class Util {
                         <!-- wp:jetpack/button {"element":"button","text":"Send Feedback","lock":{"remove":true}} /-->
                     </div>
                     <!-- /wp:jetpack/contact-form -->',
+			),
+			'salesforce-lead-form' => array(
+				'title'      => __( 'Salesforce Lead Form', 'jetpack-forms' ),
+				'blockTypes' => array( 'jetpack/contact-form' ),
+				'categories' => array( $category_slug ),
+				'content'    => '<!-- wp:jetpack/contact-form {"formTitle":"Salesforce Lead Form"} -->
+					<div class="wp-block-jetpack-contact-form">
+						<!-- wp:jetpack/field-text {"label":"First Name","required":true,"id":"first_name"} /-->
+						<!-- wp:jetpack/field-text {"label":"Last Name","required":true,"id":"last_name"} /-->
+						<!-- wp:jetpack/field-email {"label":"Email","required":true,"id":"email"} /-->
+						<!-- wp:jetpack/field-telephone {"label":"Phone","id":"phone_number"} /-->
+						<!-- wp:jetpack/field-text {"label":"Company","id":"company"} /-->
+						<!-- wp:jetpack/field-text {"label":"Job Title","id":"job_title"} /-->
+						<!-- wp:jetpack/button {"element":"button","text":"Submit","lock":{"remove":true}} /-->
+					</div>
+					<!-- /wp:jetpack/contact-form -->',
 			),
 		);
 

--- a/projects/packages/forms/src/dashboard/integrations/salesforce-card.tsx
+++ b/projects/packages/forms/src/dashboard/integrations/salesforce-card.tsx
@@ -1,8 +1,10 @@
-import { Icon } from '@wordpress/components';
+import { Icon, Button } from '@wordpress/components';
+import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import IntegrationCard from '../../blocks/contact-form/components/jetpack-integrations-modal/integration-card';
 import SalesforceIcon from '../../icons/salesforce';
 import { IntegrationCardProps } from '../../types';
+import useCreateForm from '../hooks/use-create-form';
 
 const SalesforceDashboardCard = ( {
 	isExpanded,
@@ -10,6 +12,17 @@ const SalesforceDashboardCard = ( {
 	data,
 	refreshStatus,
 }: IntegrationCardProps ) => {
+	const { openNewForm } = useCreateForm();
+	const handleCreateSalesforceForm = useCallback( () => {
+		openNewForm( {
+			formPattern: 'salesforce-lead-form',
+			analyticsEvent: () => {
+				if ( window.jetpackAnalytics?.tracks ) {
+					window.jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_salesforce_lead_form_click' );
+				}
+			},
+		} );
+	}, [ openNewForm ] );
 	const cardData = {
 		...data,
 		showHeaderToggle: false, // Always off for dashboard
@@ -40,6 +53,13 @@ const SalesforceDashboardCard = ( {
 						'jetpack-forms'
 					) }
 				</p>
+				<Button
+					variant="primary"
+					onClick={ handleCreateSalesforceForm }
+					className="jp-forms__create-form-button--large-green"
+				>
+					{ __( 'Create Salesforce Lead Form', 'jetpack-forms' ) }
+				</Button>
 			</div>
 		</IntegrationCard>
 	);

--- a/projects/packages/forms/src/types/index.ts
+++ b/projects/packages/forms/src/types/index.ts
@@ -73,5 +73,10 @@ declare global {
 		jpFormsBlocks?: {
 			defaults?: JPFormsBlocksDefaults;
 		};
+		jetpackAnalytics?: {
+			tracks?: {
+				recordEvent: ( event: string, props?: Record< string, unknown > ) => void;
+			};
+		};
 	}
 }


### PR DESCRIPTION
## Proposed changes:

Salesforce requires specific form fields for its integrations. We make it a bit simpler for users to get started by adding a Create Salesforce Form button in the Forms > Integrations tab for Salesforce. 

<img width="929" alt="salesforce-lead-form" src="https://github.com/user-attachments/assets/69ceb71a-cb29-463b-a69f-926d2f81abd2" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Slack: p1749578142886769-slack-C052XEUUBL4

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Enable the feature flag to see the Forms > Integration tab: `add_filter( 'jetpack_forms_enable_integrations_tab', '__return_true' );`
* Go to Jetpack > Forms > Integrations, and open the Salesforce card
* Click the new button and confirm it takes you to a new page with a form created that has the recommended fields, along with each needed ID set for each field.