### PR TITLE
push-to-mirrors: Check for misordered Actions runs

### DIFF
--- a/projects/github-actions/push-to-mirrors/README.md
+++ b/projects/github-actions/push-to-mirrors/README.md
@@ -42,7 +42,7 @@ This action is intended to be triggered by a `push` event.
     commit-message:
 
     # Set to `true` to suppress the addition of "Upstream-Ref" footers in the
-    # mirrored commits.
+    # mirrored commits. Not recommended.
     no-upstream-refs:
 
     # Directory containing a checkout of the monorepo revision being mirrored.

--- a/projects/github-actions/push-to-mirrors/action.yml
+++ b/projects/github-actions/push-to-mirrors/action.yml
@@ -12,6 +12,7 @@ inputs:
   no-upstream-refs:
     description: >
       Set to `true` to suppress the "Upstream-Ref" footers in mirrored commits.
+      Not recommended.
     required: false
   source-directory:
     description: >

--- a/projects/github-actions/push-to-mirrors/changelog/add-push-to-mirrors-misordering-check
+++ b/projects/github-actions/push-to-mirrors/changelog/add-push-to-mirrors-misordering-check
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+When updating an existing mirror branch, check that the commit we're mirroring is not an ancestor of the commit already there. This avoids accidental reverts if Actions runs are misordered.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
One problem with this action is that, if runs for source-repo commits are misordered, then the mirror repo branch may wind up on an older commit than the source repo.

We can avoid that by making use of the Upstream-Ref footers: if the mirror repo branch we're about to update has an Upstream-Ref footer referencing a commit that's a descendent of the commit we're about to mirror, we should skip mirroring it.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1749648271716989/1749647290.026039-slack-C01U2KGS2PQ

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Basic test:

* Download and extract a build for an old commit to Automattic/jetpack-production.
* Replace the mirror.txt in the extracted build with a single line "Automattic/jetpack-production".
* Create a "source" directory, checked out to the sha of the build you downloaded: In an empty directory, run `git init . && git remote add origin git@github.com:Automattic/jetpack && git fetch --depth=1 origin $SHA && git checkout FETCH_HEAD`
* Set various environment variables:
  * `BUILD_BASE` to the `build` directory extracted above.
  * `SOURCE_DIR` to the "source" directory created above.
  * `GITHUB_ACTOR` to your github username.
  * `GITHUB_RUN_ID` to any integer.
  * `GITHUB_REF=refs/heads/trunk`
  * `GITHUB_REPOSITORY=Automattic/jetpack`
  * `GITHUB_SERVER_URL=https://github.com`
  * `DEFAULT_BRANCH=trunk`
  * `UPSTREAM_REF_SINCE=2024-04-10`
  * `USER_NAME=matticbot`
* Run `./push-to-mirrors.sh`.

Output should indicate it skipped mirroring, with a message like
  > xxxx is a descendent of yyyy, which probably means this is a re-run and some other run already updated the mirror. Skipping Automattic/jetpack-production.

Then repeat the test, but set `GITHUB_REF=refs/heads/some-other-branch`. It should indicate that it would push the mirror.
> Committing to Automattic/jetpack-production
> https​://github.com/Automattic/jetpack-production/commit/xxxx
> Completed Automattic/jetpack-production

Then repeat the original test, but use the build and commit SHA corresponding to the current head of Automattic/jetpack-production. This should indicate no mirroring with a message like
> That's the same as what we're trying to commit now! Skipping Automattic/jetpack-production.

Repeat the original test, but using Automattic/eslint-config-target-es rather than Automattic/jetpack-production and a monorepo commit from today. That should indicate it would mirror but then skip because there's no change
> xxxx is an ancestor of yyyy, good.
> No changes, skipping Automattic/eslint-config-target-es
