### PR TITLE
Forms: Fix Salesforce form fields

### DIFF
--- a/projects/packages/forms/changelog/fix-salesforce-form-fields
+++ b/projects/packages/forms/changelog/fix-salesforce-form-fields
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Fix Salesforce form fields.

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/salesforce-card.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/salesforce-card.js
@@ -139,13 +139,13 @@ const SalesforceCard = ( {
 							{ __( 'Email (ID must be', 'jetpack-forms' ) } <code>email</code>)
 						</li>
 						<li>
-							{ __( 'Phone (ID must be', 'jetpack-forms' ) } <code>phone_number</code>)
+							{ __( 'Phone (ID must be', 'jetpack-forms' ) } <code>phone</code>)
 						</li>
 						<li>
 							{ __( 'Company (ID must be', 'jetpack-forms' ) } <code>company</code>)
 						</li>
 						<li>
-							{ __( 'Job Title (ID must be', 'jetpack-forms' ) } <code>job_title</code>)
+							{ __( 'Job Title (ID must be', 'jetpack-forms' ) } <code>title</code>)
 						</li>
 					</ul>
 				</div>

--- a/projects/packages/forms/src/contact-form/class-util.php
+++ b/projects/packages/forms/src/contact-form/class-util.php
@@ -137,12 +137,12 @@ class Util {
 				'categories' => array( $category_slug ),
 				'content'    => '<!-- wp:jetpack/contact-form {"formTitle":"Salesforce Lead Form"} -->
 					<div class="wp-block-jetpack-contact-form">
-						<!-- wp:jetpack/field-text {"label":"First Name","required":true,"id":"first_name"} /-->
-						<!-- wp:jetpack/field-text {"label":"Last Name","required":true,"id":"last_name"} /-->
+						<!-- wp:jetpack/field-name {"label":"First Name","required":true,"id":"first_name"} /-->
+						<!-- wp:jetpack/field-name {"label":"Last Name","required":true,"id":"last_name"} /-->
 						<!-- wp:jetpack/field-email {"label":"Email","required":true,"id":"email"} /-->
-						<!-- wp:jetpack/field-telephone {"label":"Phone","id":"phone_number"} /-->
+						<!-- wp:jetpack/field-telephone {"label":"Phone","id":"phone"} /-->
 						<!-- wp:jetpack/field-text {"label":"Company","id":"company"} /-->
-						<!-- wp:jetpack/field-text {"label":"Job Title","id":"job_title"} /-->
+						<!-- wp:jetpack/field-text {"label":"Job Title","id":"title"} /-->
 						<!-- wp:jetpack/button {"element":"button","text":"Submit","lock":{"remove":true}} /-->
 					</div>
 					<!-- /wp:jetpack/contact-form -->',

--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-salesforce-form-fields
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-salesforce-form-fields
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Exclude Salesforce lead form on WordPress.com.

--- a/projects/packages/jetpack-mu-wpcom/src/features/block-patterns/block-patterns.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/block-patterns/block-patterns.php
@@ -19,6 +19,7 @@ function wpcom_unregister_jetpack_patterns() {
 		'registration-form',
 		'appointment-form',
 		'feedback-form',
+		'salesforce-lead-form',
 	);
 	foreach ( $pattern_names as $pattern_name ) {
 		$pattern = \WP_Block_Patterns_Registry::get_instance()->get_registered( $pattern_name );


### PR DESCRIPTION
## Proposed changes:

We recently re-added a Salesforce form pattern to make it easier for users to add Salesforce-compatible forms. This is a follow up.
- We were using the wrong IDs for `phone` and `title` fields
- We were using `text` fields for First and Last Name fields. While this works, it's better semantically to use `name` fields for names
- This PR adds the Salesforce form to the list of excluded pattens on WordPress.com (we should reconsider this for all our patterns)
- Fix E2E tests. The last two changes, separately or together, also fix Calypso E2E tests. They were failing because the Salesforce form was being inserted and our tests always expect a name field to be present in a form, and were not finding one for Salesforce lead forms. We now excluded it, but if even we did not, the test do pass. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Slack on e2e tests: p1749673080994839-slack-C052XEUUBL4

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* You'll need access to a salesforce account. 
* Enable the feature flag to see the Forms > Integration tab: `add_filter( 'jetpack_forms_enable_integrations_tab', '__return_true' );`
* Go to Jetpack > Forms > Integrations, and open the Salesforce card
* Click the new button and confirm it takes you to a new page with a form created that has the recommended fields, along with each needed ID set for each field.
* In the integrations modal, add your Salesforce ID.
* Publish, and submit a form.
* In your salesforce account, confirm the relevant fields are added to your Salesforce lead/contact.