### PR TITLE
Forms: use correct select box padding

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-select-padding
+++ b/projects/packages/forms/changelog/fix-forms-select-padding
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: ensure that the select control uses the correct padding for top, left, bottom, right

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -466,7 +466,7 @@
 	appearance: none;
 	text-overflow: ellipsis;
 	white-space: nowrap;
-	padding: var(--jetpack--contact-form--input-padding-left, 16px);
+	padding: var(--jetpack--contact-form--input-padding, 16px);
 }
 
 .contact-form .is-style-outlined,
@@ -858,7 +858,7 @@ on production builds, the attributes are being reordered, causing side-effects
 }
 
 :where(.wp-block-jetpack-options.has-background) {
-	padding: var(--jetpack--contact-form--input-padding-left, 16px) 16px;
+	padding: var(--jetpack--contact-form--input-padding, 16px) 16px;
 }
 
 /* Ensure global styles can ovewrite the default border color. */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Partially addresses FORMS-161

## Proposed changes:

Use `--jetpack--contact-form--input-padding` instead of `--jetpack--contact-form--input-padding-left` for all sides padding on the select form control.

Why? The left padding value shouldn't be used for other sides.

Furthermore, multi option fields receive padding when they have backgrounds. They should also use `--jetpack--contact-form--input-padding` instead of `--jetpack--contact-form--input-padding-left`.

See the bug in action here: https://www.printmag.com/submit-event/


## Jetpack product discussion

FORMS-161

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

This is only apparent affects themes that have a different value for `--jetpack--contact-form--input-padding-left`.

The value is computed so it depends on the CSS for the inputNode. That could be anything and is out of our control.

You can manually check the bug by hardcoding a value:

```
diff --git a/projects/packages/forms/src/blocks/contact-form/util/form-styles.js b/projects/packages/forms/src/blocks/contact-form/util/form-styles.js
index 2121e7026a..50e9f869d5 100644
--- a/projects/packages/forms/src/blocks/contact-form/util/form-styles.js
+++ b/projects/packages/forms/src/blocks/contact-form/util/form-styles.js
@@ -111,7 +111,7 @@ window.jetpackForms.generateStyleVariables = function ( formNode ) {
 		'--jetpack--contact-form--input-background-fallback': inputBackgroundFallback,
 		'--jetpack--contact-form--input-padding': inputPadding,
 		'--jetpack--contact-form--input-padding-top': inputPaddingTop,
-		'--jetpack--contact-form--input-padding-left': inputPaddingLeft,
+		'--jetpack--contact-form--input-padding-left': '45px',
 		'--jetpack--contact-form--font-size': fontSize,
 		'--jetpack--contact-form--font-family': fontFamily,
 		'--jetpack--contact-form--line-height': lineHeight,
diff --git a/projects/packages/forms/src/contact-form/css/grunion.css b/projects/packages/forms/src/contact-form/css/grunion.css
index 8f21dac345..229ec515ef 100644
--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -466,7 +466,7 @@
 	appearance: none;
 	text-overflow: ellipsis;
 	white-space: nowrap;
-	padding: var(--jetpack--contact-form--input-padding, 16px);
+	padding: var(--jetpack--contact-form--input-padding-left, 16px);
 }
 
 .contact-form .is-style-outlined,
```

You can also manually check on https://www.printmag.com/submit-event/ by selecting the `<select />` element and replacing `--jetpack--contact-form--input-padding` with `--jetpack--contact-form--input-padding-left` in the CSS.

<img width="1307" alt="Screenshot 2025-06-12 at 1 28 21 pm" src="https://github.com/user-attachments/assets/fbc992b8-0895-4b2b-9b68-f79fb788daf9" />

| Before | After |
|--------|--------|
| <img width="770" alt="Screenshot 2025-06-12 at 1 22 11 pm" src="https://github.com/user-attachments/assets/8e86420d-c638-4381-abbf-2c8d595087b8" /> | <img width="818" alt="Screenshot 2025-06-12 at 1 22 03 pm" src="https://github.com/user-attachments/assets/e870c1a1-35e6-4bf1-af77-c32ebdd74e03" /> | 


For the multi option fields, insert a multi option checkbox and give it a background color. Ensure that there's consistent padding around the options. 

<img width="705" alt="Screenshot 2025-06-12 at 1 41 06 pm" src="https://github.com/user-attachments/assets/2e323422-f222-4eed-80dd-f1c6f008c086" />


