### PR TITLE
My Jetpack: Onboarding i4 | Change filters to dropdown on smaller screens

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/filters.tsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/filters.tsx
@@ -48,6 +48,7 @@ export function Filters( { onChangeFilter, onSearch, search, selectedFilter }: F
 					options={ getProductsFilterChoices() }
 					aria-label={ __( 'Filter products', 'jetpack-my-jetpack' ) }
 					onChange={ onChangeFilter }
+					value={ selectedFilter }
 				/>
 			) : (
 				<NavigableMenu

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/filters.tsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/filters.tsx
@@ -1,4 +1,5 @@
-import { MenuItem, NavigableMenu, SearchControl } from '@wordpress/components';
+import { useBreakpointMatch } from '@automattic/jetpack-components';
+import { MenuItem, NavigableMenu, SearchControl, SelectControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useCallback } from 'react';
 import styles from './styles.module.scss';
@@ -28,6 +29,8 @@ export function Filters( { onChangeFilter, onSearch, search, selectedFilter }: F
 		[ onChangeFilter, selectedFilter ]
 	);
 
+	const [ isSm ] = useBreakpointMatch( 'sm' );
+
 	return (
 		<div className={ styles.filters }>
 			<SearchControl
@@ -38,22 +41,35 @@ export function Filters( { onChangeFilter, onSearch, search, selectedFilter }: F
 				onChange={ onSearch }
 				className={ styles[ 'search-control' ] }
 			/>
-			<NavigableMenu>
-				{ getProductsFilterChoices().map( item => {
-					const isSelected = selectedFilter === item.value;
+			{ isSm ? (
+				<SelectControl
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+					options={ getProductsFilterChoices() }
+					aria-label={ __( 'Filter products', 'jetpack-my-jetpack' ) }
+					onChange={ onChangeFilter }
+				/>
+			) : (
+				<NavigableMenu
+					aria-label={ __( 'Filter products', 'jetpack-my-jetpack' ) }
+					className={ styles[ 'products-filter' ] }
+				>
+					{ getProductsFilterChoices().map( item => {
+						const isSelected = selectedFilter === item.value;
 
-					return (
-						<MenuItem
-							key={ item.value }
-							role="menuitemradio"
-							isSelected={ isSelected }
-							onClick={ onSelectFilter( item.value ) }
-						>
-							{ item.label }
-						</MenuItem>
-					);
-				} ) }
-			</NavigableMenu>
+						return (
+							<MenuItem
+								key={ item.value }
+								role="menuitemradio"
+								isSelected={ isSelected }
+								onClick={ onSelectFilter( item.value ) }
+							>
+								{ item.label }
+							</MenuItem>
+						);
+					} ) }
+				</NavigableMenu>
+			) }
 		</div>
 	);
 }

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/filters.tsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/filters.tsx
@@ -29,7 +29,7 @@ export function Filters( { onChangeFilter, onSearch, search, selectedFilter }: F
 		[ onChangeFilter, selectedFilter ]
 	);
 
-	const [ isSm ] = useBreakpointMatch( 'sm' );
+	const [ isSmall ] = useBreakpointMatch( 'sm' );
 
 	return (
 		<div className={ styles.filters }>
@@ -41,7 +41,7 @@ export function Filters( { onChangeFilter, onSearch, search, selectedFilter }: F
 				onChange={ onSearch }
 				className={ styles[ 'search-control' ] }
 			/>
-			{ isSm ? (
+			{ isSmall ? (
 				<SelectControl
 					__next40pxDefaultSize
 					__nextHasNoMarginBottom

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/styles.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/styles.module.scss
@@ -12,12 +12,29 @@
 
 .products-wrapper {
 	display: flex;
-	gap: 4.5rem;
+	flex-direction: column;
+	gap: 2rem;
 	margin-top: 2rem;
+
+	@include gb.break-small {
+		flex-direction: row;
+		gap: 3rem;
+	}
+
+	@include gb.break-medium {
+		gap: 4.5rem;
+	}
 }
 
 .filters-wrapper {
-	max-width: 15rem;
+
+	@include gb.break-small{
+		max-width: 12rem;
+	}
+
+	@include gb.break-medium {
+		max-width: 15rem;
+	}
 }
 
 .filtered-products-wrapper {

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/utils.ts
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/utils.ts
@@ -1,4 +1,3 @@
-import { MenuItemsChoiceProps } from '@wordpress/components/build-types/menu-items-choice/types';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -6,7 +5,7 @@ import { __ } from '@wordpress/i18n';
  *
  * @return The choices for the products filter.
  */
-export function getProductsFilterChoices(): MenuItemsChoiceProps[ 'choices' ] {
+export function getProductsFilterChoices(): Array< { label: string; value: string } > {
 	const choices = [
 		{
 			label: __( 'All categories', 'jetpack-my-jetpack' ),


### PR DESCRIPTION
Completes MYJP-178

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Convert product filters menu to dropdown on smaller screens in My Jepack products section

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to My Jetpack > Products
* Resize the window
* Confirm that the filters change to a dropdown on smaller screens

<img width="835" alt="Screenshot 2025-06-12 at 9 52 03 AM" src="https://github.com/user-attachments/assets/0134e2ea-072f-4408-a80c-433e1a89a69d" />
<img width="740" alt="Screenshot 2025-06-12 at 9 52 34 AM" src="https://github.com/user-attachments/assets/708e9427-f5a0-47ee-887b-4dddc96ba917" />
<img width="471" alt="Screenshot 2025-06-12 at 9 53 04 AM" src="https://github.com/user-attachments/assets/0116b416-863e-4fec-b00f-8c34ab8458c1" />

