### PR TITLE
Forms: fix html labels in subject line mapping

### DIFF
--- a/projects/packages/forms/changelog/forms-test-sepcial-characters
+++ b/projects/packages/forms/changelog/forms-test-sepcial-characters
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: just adding a test
+
+

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -2571,7 +2571,10 @@ class Contact_Form_Plugin {
 		if ( ! is_array( $all_values ) ) {
 			$all_values = array();
 		}
-		$fields['_feedback_all_fields'] = $all_values;
+
+		foreach ( $all_values as $key => $value ) {
+			$fields['_feedback_all_fields'][ wp_strip_all_tags( $key ) ] = $value;
+		}
 
 		return $fields;
 	}

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -1228,7 +1228,7 @@ class Contact_Form_Plugin {
 	 * @return string
 	 */
 	public static function tokenize_label( $label ) {
-		return '{' . trim( preg_replace( '#^\d+_#', '', $label ) ) . '}';
+		return '{' . trim( wp_strip_all_tags( preg_replace( '#^\d+_#', '', $label ) ) ) . '}';
 	}
 
 	/**

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1267,7 +1267,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 				continue;
 			}
 
-			$label = $i . '_' . $field->get_attribute( 'label' );
+			$label = $i . '_' . wp_strip_all_tags( $field->get_attribute( 'label' ) );
 			if ( $field->get_attribute( 'type' ) === 'file' ) {
 				$field->value = $this->process_file_upload_field( $field_id, $field );
 			}
@@ -1288,7 +1288,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 				continue;
 			}
 
-			$label = $i . '_' . $field->get_attribute( 'label' );
+			$label = $i . '_' . wp_strip_all_tags( $field->get_attribute( 'label' ) );
 			$value = $field->value;
 			if ( ! ( $field->get_attribute( 'type' ) === 'file' ) ) {
 				if ( is_array( $value ) ) {

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -941,6 +941,21 @@ class Contact_Form_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Tests that token in curly brackets is replaced with the value when the name has whitespace.
+	 *
+	 * @author tonykova
+	 */
+	public function test_token_can_replace_entire_subject_with_token_field_has_html() {
+		$plugin       = Contact_Form_Plugin::init();
+		$subject      = '{email}';
+		$field_values = array(
+			'2_<strong>Email</strong>' => 'note',
+		);
+
+		$this->assertEquals( 'note', $plugin->replace_tokens_with_input( $subject, $field_values ) );
+	}
+
+	/**
 	 * Tests that token with curly brackets is replaced with value.
 	 *
 	 * @author tonykova

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -903,6 +903,30 @@ class Contact_Form_Test extends BaseTestCase {
 	}
 
 	/**
+	 * This tests make sure that we don't store HTML when labels do have HTML tags.
+	 */
+	public function test_parse_fields_from_content_form_submission_do_not_store_label_html() {
+		// Fill field values.
+		$this->add_field_values(
+			array(
+				'name' => 'John Doe',
+			)
+		);
+
+		// Initialize a form with name, dropdown and radiobutton (first, second
+		// and third option), text field.
+		$form = new Contact_Form( array(), "[contact-field label='<strong>Name</strong>' type='name' required='1'/][contact-field label='Dropdown' type='select' options='First option,Second option,Third option'/][contact-field label='Radio' type='radio' options='First option,Second option,Third option'/][contact-field label='Text' type='text'/]" );
+		$form->process_submission();
+
+		$post    = end( Posts::init()->posts );
+		$post_id = $post->ID;
+
+		$this->assertStringContainsString( '1_Name', $post->post_content, 'Post content should contain the field name without HTML tags' );
+
+		wp_delete_post( $post_id, true );
+	}
+
+	/**
 	 * Tests that token is left intact when there is not matching field.
 	 *
 	 * @author tonykova

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -818,6 +818,8 @@ class Contact_Form_Test extends BaseTestCase {
 		wp_delete_post( $post_id, true );
 	}
 
+	}
+
 	public function test_parse_fields_from_content_form_submission() {
 		// Fill field values.
 		$this->add_field_values(
@@ -912,8 +914,6 @@ class Contact_Form_Test extends BaseTestCase {
 
 	/**
 	 * Tests that token in curly brackets is replaced with the value when the name has whitespace.
-	 *
-	 * @author tonykova
 	 */
 	public function test_token_can_replace_entire_subject_with_token_field_has_japanese() {
 		$plugin       = Contact_Form_Plugin::init();
@@ -927,8 +927,6 @@ class Contact_Form_Test extends BaseTestCase {
 
 	/**
 	 * Tests that token in curly brackets is replaced with the value when the name has whitespace.
-	 *
-	 * @author tonykova
 	 */
 	public function test_token_can_replace_entire_subject_with_token_field_has_emoji() {
 		$plugin       = Contact_Form_Plugin::init();
@@ -942,8 +940,6 @@ class Contact_Form_Test extends BaseTestCase {
 
 	/**
 	 * Tests that token in curly brackets is replaced with the value when the name has whitespace.
-	 *
-	 * @author tonykova
 	 */
 	public function test_token_can_replace_entire_subject_with_token_field_has_html() {
 		$plugin       = Contact_Form_Plugin::init();

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -818,6 +818,41 @@ class Contact_Form_Test extends BaseTestCase {
 		wp_delete_post( $post_id, true );
 	}
 
+	/**
+	 * We test that if the all fields keys do have HTML content, they are escaped correctly.
+	 */
+	public function test_parse_fields_from_content_all_field_has_html_content() {
+
+		$comment_content      = 'This is a test comment content.';
+		$comment_author       = 'Test User';
+		$comment_author_email = 'test@email.com';
+		$comment_author_url   = 'http://example.com';
+		$comment_ip_text      = 'https://127.0.0.1';
+		$subject              = 'Test Subject';
+		$all_values           = array(
+			'<strong>field2</strong>' => 'value2',
+		);
+
+		$content = addslashes( wp_kses( "$comment_content\n<!--more-->\nAUTHOR: {$comment_author}\nAUTHOR EMAIL: {$comment_author_email}\nAUTHOR URL: {$comment_author_url}\nSUBJECT: {$subject}\nIP: {$comment_ip_text}\nJSON_DATA\n" . wp_json_encode( $all_values ), array() ) );
+		// Create a mock post with JSON_DATA format
+		$post_id = wp_insert_post(
+			array(
+				'post_type'    => 'feedback',
+				'post_status'  => 'publish',
+				'post_content' => $content,
+			)
+		);
+
+		// Parse fields from the post
+		$fields = Contact_Form_Plugin::parse_fields_from_content( $post_id );
+
+		// Assert that JSON data fields were parsed correctly
+		$this->assertIsArray( $fields['_feedback_all_fields'] );
+		$this->assertArrayHasKey( 'field2', $fields['_feedback_all_fields'] ); // note that we should escape HTML tags here.
+		$this->assertEquals( $all_values['<strong>field2</strong>'], $fields['_feedback_all_fields']['field2'] );
+
+		// Clean up
+		wp_delete_post( $post_id, true );
 	}
 
 	public function test_parse_fields_from_content_form_submission() {

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -911,6 +911,36 @@ class Contact_Form_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Tests that token in curly brackets is replaced with the value when the name has whitespace.
+	 *
+	 * @author tonykova
+	 */
+	public function test_token_can_replace_entire_subject_with_token_field_has_japanese() {
+		$plugin       = Contact_Form_Plugin::init();
+		$subject      = '{名前}';
+		$field_values = array(
+			'名前' => 'Hello',
+		);
+
+		$this->assertEquals( 'Hello', $plugin->replace_tokens_with_input( $subject, $field_values ) );
+	}
+
+	/**
+	 * Tests that token in curly brackets is replaced with the value when the name has whitespace.
+	 *
+	 * @author tonykova
+	 */
+	public function test_token_can_replace_entire_subject_with_token_field_has_emoji() {
+		$plugin       = Contact_Form_Plugin::init();
+		$subject      = '{🙈}';
+		$field_values = array(
+			'🙈' => 'Chicago',
+		);
+
+		$this->assertEquals( 'Chicago', $plugin->replace_tokens_with_input( $subject, $field_values ) );
+	}
+
+	/**
 	 * Tests that token with curly brackets is replaced with value.
 	 *
 	 * @author tonykova


### PR DESCRIPTION
This PR fixes an issue where if the field label contains any html. 
The email subject line (that gets sent to the admin) mapping didn't quite work as expected. 

Here is an example. Notice the bold Email label. ( 
```
<!-- wp:jetpack/contact-form {"subject":"A new RSVP from your website - {email}"} -->
<div class="wp-block-jetpack-contact-form">

<!-- wp:jetpack/field-email {"required":true} -->
<div><!-- wp:jetpack/label {"label":"\u003cstrong\u003eEmail\u003c/strong\u003e"} /-->

<!-- wp:jetpack/input /--></div>
<!-- /wp:jetpack/field-email -->

<!-- wp:jetpack/button {"element":"button","text":"Send RSVP","lock":{"remove":true}} /--></div>
<!-- /wp:jetpack/contact-form -->
```

## Proposed changes:
* This PR fixes this by removing any HTML from the label before applying any mapping of the subject line. 

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1749630581973109-slack-C086RGTJT1D

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
Create a form.
with a field label containing html. 
Try including the html in the subject line. (See got form block sidebar => Email Connection => A new RSVP from your website - {email}

Submit the form. Notice that the email subject line now contains the email that was submitted. 

Do the tests pass?