### PR TITLE
Post editor: Fix support link in SEO upsell

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-seo-upsell
+++ b/projects/plugins/jetpack/changelog/fix-seo-upsell
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+

--- a/projects/plugins/jetpack/extensions/plugins/seo/components/upsell.js
+++ b/projects/plugins/jetpack/extensions/plugins/seo/components/upsell.js
@@ -34,7 +34,7 @@ const UpsellNotice = ( { requiredPlan } ) => {
 			</div>
 
 			<div className="components-seo-upsell__learn-more">
-				<WpcomSupportLink url={ supportUrl } postId={ 120916 }>
+				<WpcomSupportLink supportLink={ supportUrl } supportPostId={ 120916 }>
 					{ supportLinkTitle }
 				</WpcomSupportLink>
 			</div>

--- a/projects/plugins/jetpack/extensions/plugins/seo/components/upsell.js
+++ b/projects/plugins/jetpack/extensions/plugins/seo/components/upsell.js
@@ -34,7 +34,9 @@ const UpsellNotice = ( { requiredPlan } ) => {
 			</div>
 
 			<div className="components-seo-upsell__learn-more">
-				<WpcomSupportLink url={ supportUrl } postId={ 120916 } text={ supportLinkTitle } />
+				<WpcomSupportLink url={ supportUrl } postId={ 120916 }>
+					{ supportLinkTitle }
+				</WpcomSupportLink>
 			</div>
 
 			<Button


### PR DESCRIPTION
Follow-up of https://github.com/Automattic/jetpack/pull/43883

## Proposed changes:

Before | After
--- | ---
<img width="298" alt="Screenshot 2025-06-12 at 10 45 47" src="https://github.com/user-attachments/assets/1520cac5-86d1-466b-a8b2-4d5e189346a6" /> | <img width="323" alt="Screenshot 2025-06-12 at 10 45 05" src="https://github.com/user-attachments/assets/69ca63a2-1c39-42e3-b239-3ae57ec97141" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
- Apply these changes to a WP.com site
- Open the post editor
- Open the Jetpack sidebar
- Expand the SEO panel
- Make sure the support link is displayed correctly

