### PR TITLE
Forms: dont translate product name in the sidebar

### DIFF
--- a/projects/packages/forms/changelog/update-forms-dont-translate-product-name
+++ b/projects/packages/forms/changelog/update-forms-dont-translate-product-name
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Forms: don't translate Forms product name in the sidebar

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -183,8 +183,9 @@ class Dashboard {
 		}
 
 		Admin_Menu::add_menu(
-			__( 'Jetpack Forms', 'jetpack-forms' ),
-			_x( 'Forms', 'submenu title for Jetpack Forms', 'jetpack-forms' ),
+			/** "Jetpack Forms" and "Forms" are Product names, do not translate. */
+			'Jetpack Forms',
+			'Forms',
 			'edit_pages',
 			self::ADMIN_SLUG,
 			array( $this, 'render_new_dashboard' ),

--- a/projects/plugins/jetpack/changelog/update-forms-dont-translate-product-name
+++ b/projects/plugins/jetpack/changelog/update-forms-dont-translate-product-name
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: don't translate Forms product name in the sidebar


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Slack convo p1749722435337249-slack-C086RGTJT1D
Internal ref p1HpG7-wSr-p2

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Remove translation functions for the sidebar item

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Change WP locale
* See sidebar