### PR TITLE
Critical CSS Gen: Allow generation to work after a redirect

### DIFF
--- a/projects/js-packages/critical-css-gen/changelog/fix-critical-css-gen-redirect-breaking-generation-playwright
+++ b/projects/js-packages/critical-css-gen/changelog/fix-critical-css-gen-redirect-breaking-generation-playwright
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Playwright interface: Fix page redirects from breaking the generation process.

--- a/projects/js-packages/critical-css-gen/src/browser-interface-playwright.ts
+++ b/projects/js-packages/critical-css-gen/src/browser-interface-playwright.ts
@@ -102,7 +102,7 @@ export class BrowserInterfacePlaywright extends BrowserInterface {
 			throw new Error( `Playwright interface does not include URL ${ pageUrl }` );
 		}
 
-		// Bail early if the page returned a non-200 status code.
+		// Bail early if the page returned a non-200 or non-300 status code.
 		if ( ! tab.statusCode || ! this.isOkStatus( tab.statusCode ) ) {
 			const error = new HttpError( { url: pageUrl, code: tab.statusCode } );
 			this.trackUrlError( pageUrl, error );
@@ -111,6 +111,20 @@ export class BrowserInterfacePlaywright extends BrowserInterface {
 
 		if ( ! this.isSameOrigin( pageUrl, tab.page.url() ) ) {
 			// If the origin isn't the same, that means that the page has been redirected.
+			const error = new RedirectError( {
+				url: pageUrl,
+				redirectUrl: tab.page.url(),
+			} );
+			this.trackUrlError( pageUrl, error );
+			throw error;
+		}
+
+		const originalPath = new URL( pageUrl ).pathname;
+		const redirectedPath = new URL( tab.page.url() ).pathname;
+
+		// Check if the paths match.
+		// Critical CSS should only be generated for the original page.
+		if ( originalPath !== redirectedPath ) {
 			const error = new RedirectError( {
 				url: pageUrl,
 				redirectUrl: tab.page.url(),

--- a/projects/js-packages/critical-css-gen/src/browser-interface-playwright.ts
+++ b/projects/js-packages/critical-css-gen/src/browser-interface-playwright.ts
@@ -1,6 +1,6 @@
 import { BrowserContext, Page } from 'playwright-core';
 import { BrowserInterface, BrowserRunnable, FetchOptions } from './browser-interface.ts';
-import { HttpError } from './errors.ts';
+import { HttpError, RedirectError } from './errors.ts';
 import { objectPromiseAll } from './object-promise-all.ts';
 import { Viewport } from './types.ts';
 
@@ -109,6 +109,16 @@ export class BrowserInterfacePlaywright extends BrowserInterface {
 			throw error;
 		}
 
+		if ( ! this.isSameOrigin( pageUrl, tab.page.url() ) ) {
+			// If the origin isn't the same, that means that the page has been redirected.
+			const error = new RedirectError( {
+				url: pageUrl,
+				redirectUrl: tab.page.url(),
+			} );
+			this.trackUrlError( pageUrl, error );
+			throw error;
+		}
+
 		if ( viewport ) {
 			await tab.page.setViewportSize( viewport );
 		}
@@ -133,6 +143,14 @@ export class BrowserInterfacePlaywright extends BrowserInterface {
 	}
 
 	private isOkStatus( statusCode: number ) {
-		return statusCode >= 200 && statusCode < 300;
+		return statusCode >= 200 && statusCode < 400;
+	}
+
+	private isSameOrigin( url: string, pageUrl: string ): boolean {
+		try {
+			return new URL( url ).origin === new URL( pageUrl ).origin;
+		} catch ( error ) {
+			return false;
+		}
 	}
 }


### PR DESCRIPTION
Fixes HOG-15

## Proposed changes:

* Add support for page redirects in Playwright interface. This will allow the package to generate Critical CSS for a page that was redirected (if it's actually the same page and not another one).

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

HOG-15

## Does this pull request change what data or activity we track or use?

no

## Testing instructions:

**Pre-requisites**

- Boost Cloud running this PR and Cloud CSS enabled on your test website. Easiest way to test this is locally.
- Four pages:
  - page 1 - opens up normally;
  - page 2 - redirects to another domain;
  - page 3 - redirects to another page;
  - page 4 - redirects to the same URL but with a GET param.
- Once you have these pages, add them to the cornerstone pages UI.

We're testing to make sure that generation works for pages 1 and 4 (previously it didn't work for 4 because of the redirect). There should be an advanced recommendation for pages 2 and 3, since they redirect to other places.

The snippet below will:
- add a GET arg to every page on your site;
- redirect a page with the slug `redirects-to-same-site-page` to `shop`;
- redirect a page with the slug `redirects-off-site` to `https://unrealduck.wpcomstaging.com/`.

You can adjust the snippet to match the URLs of the pages you created in the above steps.

```php
add_action( 'template_redirect', function() {
	$current_url = home_url( remove_query_arg( 'NONEXISTENTQUERYARG' ) );
	$query_args = $_GET;

	if ( ! isset( $query_args['v'] ) ) {
		$query_args['v'] = '1';
		$redirect_url = add_query_arg( $query_args, $current_url );
		wp_redirect( $redirect_url );
		exit;
	}

	if ( is_page( 'redirects-to-same-site-page' ) ) {
		wp_redirect( home_url( '/shop/' ) );
		exit;
	}

	if ( is_page( 'redirects-off-site' ) ) {
		wp_redirect( 'https://unrealduck.wpcomstaging.com/' );
		exit;
	}
} );
```

### Test that it works

- Generate Cloud CSS for your site;
- 2 pages should fail (it should be 2 and 3 from the list above), and you'll see advanced recommendations for them;
- Make sure critical css is generated for the rest of the pages on your site.