### PR TITLE
Settings: Open support links in Help Center

### DIFF
--- a/projects/packages/classic-theme-helper/changelog/dotsup-66-open-settings-support-links-in-help-center
+++ b/projects/packages/classic-theme-helper/changelog/dotsup-66-open-settings-support-links-in-help-center
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Settings: Open support links in Help Center

--- a/projects/packages/classic-theme-helper/src/custom-post-types/class-jetpack-portfolio.php
+++ b/projects/packages/classic-theme-helper/src/custom-post-types/class-jetpack-portfolio.php
@@ -232,7 +232,7 @@ if ( ! class_exists( __NAMESPACE__ . '\Jetpack_Portfolio' ) ) {
 				<label for="<?php echo esc_attr( self::OPTION_NAME ); ?>">
 					<input name="<?php echo esc_attr( self::OPTION_NAME ); ?>" id="<?php echo esc_attr( self::OPTION_NAME ); ?>" <?php echo checked( get_option( self::OPTION_NAME, '0' ), true, false ); ?> type="checkbox" value="1" />
 					<?php esc_html_e( 'Enable Portfolio Projects for this site.', 'jetpack-classic-theme-helper' ); ?>
-					<a target="_blank" href="https://en.support.wordpress.com/portfolios/"><?php esc_html_e( 'Learn More', 'jetpack-classic-theme-helper' ); ?></a>
+					<a target="_blank" href="https://en.support.wordpress.com/portfolios/" data-wpcom-support-link="true"><?php esc_html_e( 'Learn More', 'jetpack-classic-theme-helper' ); ?></a>
 				</label>
 					<?php
 				endif;

--- a/projects/packages/classic-theme-helper/src/custom-post-types/class-jetpack-portfolio.php
+++ b/projects/packages/classic-theme-helper/src/custom-post-types/class-jetpack-portfolio.php
@@ -232,7 +232,7 @@ if ( ! class_exists( __NAMESPACE__ . '\Jetpack_Portfolio' ) ) {
 				<label for="<?php echo esc_attr( self::OPTION_NAME ); ?>">
 					<input name="<?php echo esc_attr( self::OPTION_NAME ); ?>" id="<?php echo esc_attr( self::OPTION_NAME ); ?>" <?php echo checked( get_option( self::OPTION_NAME, '0' ), true, false ); ?> type="checkbox" value="1" />
 					<?php esc_html_e( 'Enable Portfolio Projects for this site.', 'jetpack-classic-theme-helper' ); ?>
-					<a target="_blank" href="https://en.support.wordpress.com/portfolios/" data-wpcom-support-link="true"><?php esc_html_e( 'Learn More', 'jetpack-classic-theme-helper' ); ?></a>
+					<a target="_blank" href="https://en.support.wordpress.com/portfolios/" data-target="wpcom-help-center"><?php esc_html_e( 'Learn More', 'jetpack-classic-theme-helper' ); ?></a>
 				</label>
 					<?php
 				endif;

--- a/projects/packages/classic-theme-helper/src/custom-post-types/class-jetpack-testimonial.php
+++ b/projects/packages/classic-theme-helper/src/custom-post-types/class-jetpack-testimonial.php
@@ -220,7 +220,7 @@ if ( ! class_exists( __NAMESPACE__ . '\Jetpack_Testimonial' ) ) {
 				<label for="<?php echo esc_attr( self::OPTION_NAME ); ?>">
 					<input name="<?php echo esc_attr( self::OPTION_NAME ); ?>" id="<?php echo esc_attr( self::OPTION_NAME ); ?>" <?php echo checked( get_option( self::OPTION_NAME, '0' ), true, false ); ?> type="checkbox" value="1" />
 					<?php esc_html_e( 'Enable Testimonials for this site.', 'jetpack-classic-theme-helper' ); ?>
-					<a target="_blank" href="https://en.support.wordpress.com/testimonials/" data-wpcom-support-link="true"><?php esc_html_e( 'Learn More', 'jetpack-classic-theme-helper' ); ?></a>
+					<a target="_blank" href="https://en.support.wordpress.com/testimonials/" data-target="wpcom-help-center"><?php esc_html_e( 'Learn More', 'jetpack-classic-theme-helper' ); ?></a>
 				</label>
 				<?php
 			endif;

--- a/projects/packages/classic-theme-helper/src/custom-post-types/class-jetpack-testimonial.php
+++ b/projects/packages/classic-theme-helper/src/custom-post-types/class-jetpack-testimonial.php
@@ -220,7 +220,7 @@ if ( ! class_exists( __NAMESPACE__ . '\Jetpack_Testimonial' ) ) {
 				<label for="<?php echo esc_attr( self::OPTION_NAME ); ?>">
 					<input name="<?php echo esc_attr( self::OPTION_NAME ); ?>" id="<?php echo esc_attr( self::OPTION_NAME ); ?>" <?php echo checked( get_option( self::OPTION_NAME, '0' ), true, false ); ?> type="checkbox" value="1" />
 					<?php esc_html_e( 'Enable Testimonials for this site.', 'jetpack-classic-theme-helper' ); ?>
-					<a target="_blank" href="https://en.support.wordpress.com/testimonials/"><?php esc_html_e( 'Learn More', 'jetpack-classic-theme-helper' ); ?></a>
+					<a target="_blank" href="https://en.support.wordpress.com/testimonials/" data-wpcom-support-link="true"><?php esc_html_e( 'Learn More', 'jetpack-classic-theme-helper' ); ?></a>
 				</label>
 				<?php
 			endif;

--- a/projects/packages/jetpack-mu-wpcom/changelog/dotsup-66-open-settings-support-links-in-help-center
+++ b/projects/packages/jetpack-mu-wpcom/changelog/dotsup-66-open-settings-support-links-in-help-center
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Settings: Open support links in Help Center

--- a/projects/packages/jetpack-mu-wpcom/src/features/replace-site-visibility/site-visibility/index.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/replace-site-visibility/site-visibility/index.tsx
@@ -1,3 +1,4 @@
+import { WpcomSupportLink } from '@automattic/jetpack-shared-extension-utils/components';
 import { ExternalLink } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { sprintf, __ } from '@wordpress/i18n';
@@ -59,13 +60,12 @@ const SiteVisibility = ( {
 			<p className="description">
 				{ __( 'Control who can view your site.', 'jetpack-mu-wpcom' ) }
 				&nbsp;
-				<a
-					href="https://wordpress.com/support/privacy-settings/"
-					target="_blank"
-					rel="noopener noreferrer"
+				<WpcomSupportLink
+					supportLink="https://wordpress.com/support/privacy-settings/"
+					supportPostId="1507"
 				>
 					{ __( 'Learn more', 'jetpack-mu-wpcom' ) }
-				</a>
+				</WpcomSupportLink>
 			</p>
 			<ul>
 				<li>
@@ -235,13 +235,12 @@ const SiteVisibility = ( {
 										'jetpack-mu-wpcom'
 									) }
 									&nbsp;
-									<a
-										href="https://wordpress.com/support/privacy-settings/make-your-website-public/#prevent-third-party-sharing"
-										target="_blank"
-										rel="noopener noreferrer"
+									<WpcomSupportLink
+										supportLink="https://wordpress.com/support/privacy-settings/make-your-website-public/#prevent-third-party-sharing"
+										supportPostId="390291"
 									>
 										{ __( 'Learn more', 'jetpack-mu-wpcom' ) }
-									</a>
+									</WpcomSupportLink>
 								</p>
 							</li>
 						</ul>

--- a/projects/plugins/jetpack/changelog/dotsup-66-open-settings-support-links-in-help-center
+++ b/projects/plugins/jetpack/changelog/dotsup-66-open-settings-support-links-in-help-center
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: WP.com-only change
+
+

--- a/projects/plugins/jetpack/modules/markdown/easy-markdown.php
+++ b/projects/plugins/jetpack/modules/markdown/easy-markdown.php
@@ -313,7 +313,7 @@ class WPCom_Markdown {
 			esc_attr( self::POST_OPTION ),
 			checked( $this->is_posting_enabled(), true, false ),
 			esc_html__( 'Use Markdown for posts and pages.', 'jetpack' ),
-			sprintf( '<a href="%s" data-wpcom-support-link="true">%s</a>', esc_url( $this->get_support_url() ), esc_html__( 'Learn more about Markdown.', 'jetpack' ) )
+			sprintf( '<a href="%s" data-target="wpcom-help-center">%s</a>', esc_url( $this->get_support_url() ), esc_html__( 'Learn more about Markdown.', 'jetpack' ) )
 		);
 	}
 
@@ -326,7 +326,7 @@ class WPCom_Markdown {
 			esc_attr( self::COMMENT_OPTION ),
 			checked( $this->is_commenting_enabled(), true, false ),
 			esc_html__( 'Use Markdown for comments.', 'jetpack' ),
-			sprintf( '<a href="%s" data-wpcom-support-link="true">%s</a>', esc_url( $this->get_support_url() ), esc_html__( 'Learn more about Markdown.', 'jetpack' ) )
+			sprintf( '<a href="%s" data-target="wpcom-help-center">%s</a>', esc_url( $this->get_support_url() ), esc_html__( 'Learn more about Markdown.', 'jetpack' ) )
 		);
 	}
 

--- a/projects/plugins/jetpack/modules/markdown/easy-markdown.php
+++ b/projects/plugins/jetpack/modules/markdown/easy-markdown.php
@@ -313,7 +313,7 @@ class WPCom_Markdown {
 			esc_attr( self::POST_OPTION ),
 			checked( $this->is_posting_enabled(), true, false ),
 			esc_html__( 'Use Markdown for posts and pages.', 'jetpack' ),
-			sprintf( '<a href="%s">%s</a>', esc_url( $this->get_support_url() ), esc_html__( 'Learn more about Markdown.', 'jetpack' ) )
+			sprintf( '<a href="%s" data-wpcom-support-link="true">%s</a>', esc_url( $this->get_support_url() ), esc_html__( 'Learn more about Markdown.', 'jetpack' ) )
 		);
 	}
 
@@ -326,7 +326,7 @@ class WPCom_Markdown {
 			esc_attr( self::COMMENT_OPTION ),
 			checked( $this->is_commenting_enabled(), true, false ),
 			esc_html__( 'Use Markdown for comments.', 'jetpack' ),
-			sprintf( '<a href="%s">%s</a>', esc_url( $this->get_support_url() ), esc_html__( 'Learn more about Markdown.', 'jetpack' ) )
+			sprintf( '<a href="%s" data-wpcom-support-link="true">%s</a>', esc_url( $this->get_support_url() ), esc_html__( 'Learn more about Markdown.', 'jetpack' ) )
 		);
 	}
 


### PR DESCRIPTION
Part of [DOTSUP-66](https://linear.app/a8c/issue/DOTSUP-66/open-settings-support-links-in-help-center)
Requires https://github.com/Automattic/wp-calypso/pull/104172

## Proposed changes:

This PR adds the `data-target="wpcom-help-center"` attribute to several support links in the WP Admin settings page so they are opened in the Help Center directly rather than in a new tab.

https://github.com/user-attachments/assets/ede60109-d118-4de5-b03d-bb2a72fbcb4c

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

- Apply these changes to your sandbox, along with https://github.com/Automattic/wp-calypso/pull/104172 and 185363-ghe-Automattic/wpcom:

```
git checkout origin/dotsup-66-open-settings-support-links-in-help-center
install-plugin.sh help-center dotsup-66-open-settings-support-links-in-help-center
bin/jetpack-downloader test jetpack dotsup-66-open-settings-support-links-in-help-center
bin/jetpack-downloader test jetpack-mu-wpcom-plugin dotsup-66-open-settings-support-links-in-help-center
```

- Sandbox `widgets.wp.com` and a Simple site
- Go to the following screens, and make sure that the supports links are opened in the Help Center:
  - `/wp-admin/options-general.php`:
    - Action Bar visibility > [Learn more about the Action Bar](https://wordpress.com/support/action-bar/).
  - `/wp-admin/options-writing.php`:
    - Markdown > [Learn more about Markdown.](https://en.support.wordpress.com/markdown-quick-reference/)
    - Post by Email > You can publish posts using emails with the [Post by Email](https://wordpress.com/support/post-by-email/) feature.
    - Post by Voice > You can publish posts using voice with the [Post by Voice](https://wordpress.com/support/post-by-voice/) feature.
    - Portfolio Projects > [Learn More](https://en.support.wordpress.com/portfolios/)
    - Testimonials > [Learn More](https://en.support.wordpress.com/testimonials/)
  - `/wp-admin/options-reading.php`:
    - Site visibility > Control who can view your site. [Learn more](https://wordpress.com/support/privacy-settings/)
    - Site visibility > ...including those that train AI models. [Learn more](https://wordpress.com/support/privacy-settings/make-your-website-public/#prevent-third-party-sharing)
  - `/wp-admin/options-discussion.php`:
    - Markdown > [Learn more about Markdown.](https://en.support.wordpress.com/markdown-quick-reference/)