### PR TITLE
Sync Posts: is_whitelisted_post_meta: Allow post metas beginning with attribute_ (WooCommerce Variation attributes)

### DIFF
--- a/projects/packages/sync/changelog/post-meta-attribute-sync
+++ b/projects/packages/sync/changelog/post-meta-attribute-sync
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Sync: Posts: Allow post meta keys beginning with attribute_

--- a/projects/packages/sync/src/modules/class-posts.php
+++ b/projects/packages/sync/src/modules/class-posts.php
@@ -396,8 +396,9 @@ class Posts extends Module {
 	 * @return boolean Whether the post meta key is whitelisted.
 	 */
 	public function is_whitelisted_post_meta( $meta_key ) {
-		// The _wpas_skip_ meta key is used by Publicize.
-		return in_array( $meta_key, Settings::get_setting( 'post_meta_whitelist' ), true ) || str_starts_with( $meta_key, '_wpas_skip_' );
+		return in_array( $meta_key, Settings::get_setting( 'post_meta_whitelist' ), true )
+			|| str_starts_with( $meta_key, '_wpas_skip_' ) // The _wpas_skip_ meta key is used by Publicize.
+			|| str_starts_with( $meta_key, 'attribute_' ); // WooCommerce variation attributes.
 	}
 
 	/**

--- a/projects/packages/sync/src/modules/class-woocommerce.php
+++ b/projects/packages/sync/src/modules/class-woocommerce.php
@@ -122,6 +122,7 @@ class WooCommerce extends Module {
 		add_filter( 'jetpack_sync_options_whitelist', array( $this, 'add_woocommerce_options_whitelist' ), 10 );
 		add_filter( 'jetpack_sync_constants_whitelist', array( $this, 'add_woocommerce_constants_whitelist' ), 10 );
 		add_filter( 'jetpack_sync_post_meta_whitelist', array( $this, 'add_woocommerce_post_meta_whitelist' ), 10 );
+		add_filter( 'jetpack_sync_post_meta_whitelist', array( $this, 'add_woocommerce_dynamic_attribute_meta_whitelist' ), 11 );
 		add_filter( 'jetpack_sync_comment_meta_whitelist', array( $this, 'add_woocommerce_comment_meta_whitelist' ), 10 );
 
 		add_filter( 'jetpack_sync_before_enqueue_woocommerce_new_order_item', array( $this, 'filter_order_item' ) );
@@ -377,6 +378,40 @@ class WooCommerce extends Module {
 	 */
 	public function add_woocommerce_post_meta_whitelist( $list ) {
 		return array_merge( $list, self::$wc_post_meta_whitelist );
+	}
+
+	/**
+	 * Add dynamic WooCommerce product attribute meta keys to the post meta whitelist.
+	 *
+	 * This method queries the database for all meta keys that follow the pattern 'attribute_*'
+	 * which are used by WooCommerce for product variations. These keys are dynamically created
+	 * based on the attribute names, so we need to discover them at runtime.
+	 *
+	 * @access public
+	 *
+	 * @param array $list Existing post meta whitelist.
+	 * @return array Updated post meta whitelist with dynamic attribute keys.
+	 */
+	public function add_woocommerce_dynamic_attribute_meta_whitelist( $list ) {
+		global $wpdb;
+
+		$cache_key = 'jp_sync_wc_attribute_meta_keys';
+		$keys      = wp_cache_get( $cache_key, 'jetpack' );
+
+		if ( false === $keys ) {
+			// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery
+			$keys = $wpdb->get_col(
+				"SELECT DISTINCT meta_key
+					FROM $wpdb->postmeta
+					WHERE meta_key LIKE 'attribute_%'
+					LIMIT 1000"
+			);
+			// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery
+
+			wp_cache_set( $cache_key, $keys, 'jetpack', 3 * HOUR_IN_SECONDS );
+		}
+
+		return array_merge( $list, $keys );
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes:

* When looking at [Search: Include Support for WooCommerce Variable Products], I found that the Cache Sites don't have enough information on them to generate the permalinks needed for Variation Products.  The attribute meta, like if you have a blue variation of a shirt, is missing.

Without this, WooCommerce cannot make the url ending with `?attribute_color=blue`. Solution: Change the `is_whitelisted_post_meta()` function to allow metas belonging with `attribute_`.

There is a corresponding change on the WPCOM side on 185272-ghe-Automattic/wpcom.

### Goal

* To eventually allow Woo Product Variations to generate proper permalinks when we ES index them.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*