### PR TITLE
Forms: Enable central integrations dashboard

### DIFF
--- a/projects/packages/forms/changelog/update-forms-show-integrations-filter
+++ b/projects/packages/forms/changelog/update-forms-show-integrations-filter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: Show central integrations dashboard.

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -61,7 +61,7 @@ class Dashboard {
 		$this->switch = $switch ?? new Dashboard_View_Switch();
 
 		// Set the integrations tab feature flag
-		self::$show_integrations = apply_filters( 'jetpack_forms_enable_integrations_tab', false );
+		self::$show_integrations = apply_filters( 'jetpack_forms_enable_integrations_tab', true );
 	}
 
 	/**

--- a/projects/plugins/jetpack/changelog/update-forms-show-integrations-filter
+++ b/projects/plugins/jetpack/changelog/update-forms-show-integrations-filter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: Show central integrations dashboard.


### PR DESCRIPTION
## Proposed changes:

We have been preparing an 'Integrations' tab for the central forms dashboard behind a feature flag. This removes the feature flag. There are incremental changes we can continue to make to the content for each integrations, but it is release ready as is, and largely follows what is already released in the form block integrations modal.

<img width="1507" alt="forms-integrations-tab" src="https://github.com/user-attachments/assets/18fd2050-4ac8-4da3-9e0a-7ce30b99189c" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Linear project: https://linear.app/a8c/project/forms-add-integrations-dashboard-245f3c6cefce/overview

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No. 

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Be sure to remove the feature flag if you have it set (ie you should no long have or need `add_filter( 'jetpack_forms_enable_integrations_tab', '__return_true' );`
* Go to Jetpack > Forms and confirm that the Integrations tab now shows at the top
* Go through the cards and confirm they correctly reflect the status of each integrations. 
* Try deactivating or uninstalling plugins, refresh the page, and confirm status is updated.
* Confirm status is shown correctly if you have an Akismet key added (or not) or have Google Drive connected (or not)
