### PR TITLE
Forms: Fix select dropdown that has labels

### DIFF
--- a/projects/packages/forms/changelog/fix-select-dropdown
+++ b/projects/packages/forms/changelog/fix-select-dropdown
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: fix styling of the select input in animated styles. 

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -941,7 +941,7 @@
 
 			.animated-label__label {
 				position: absolute;
-				z-index: 1;
+				z-index: 2;
 				top: calc(50% + (var(--jetpack--contact-form--border-top-size, 0px) * 0.5) - (var(--jetpack--contact-form--border-bottom-size, 0px) * 0.5));
 				left: calc(var(--jetpack--contact-form--border-left-size, 1px) + var(--jetpack--contact-form--animated-left-offset));
 				width: auto;

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -1781,7 +1781,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		$wrap_classes          = empty( $class ) ? '' : implode( '-wrap ', array_filter( explode( ' ', $class ) ) ) . '-wrap';
 		$field_wrapper_classes = $this->get_attribute( 'fieldwrapperclasses' ) ? $this->get_attribute( 'fieldwrapperclasses' ) . ' ' : '';
 
-		if ( empty( $label ) ) {
+		if ( empty( $label ) && ! $required ) {
 			$wrap_classes .= ' no-label';
 		}
 

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -771,7 +771,7 @@ on production builds, the attributes are being reordered, causing side-effects
 	transform: translateY(-50%);
 	transition: all 150ms cubic-bezier(0.4, 0, 0.2, 1);
 	will-change: transform, top;
-	z-index: 1;
+	z-index: 2;
 }
 
 .contact-form .is-style-animated .grunion-field-wrap .grunion-label-text {


### PR DESCRIPTION
Before:
![Screenshot 2025-06-12 at 10 48 16 AM](https://github.com/user-attachments/assets/82814667-3b2c-495a-9241-d78b2badabf2)

Notice the missing label. 

After:
![Screenshot 2025-06-12 at 10 43 10 AM](https://github.com/user-attachments/assets/bc0c033b-b762-4138-9a8a-8c76c512bd6b)

^ you can see the fix. 

![Screenshot 2025-06-12 at 10 44 07 AM](https://github.com/user-attachments/assets/b00b7694-6052-47bd-9668-74653ec1428c)

![Screenshot 2025-06-12 at 10 43 41 AM](https://github.com/user-attachments/assets/6bd12704-ab1f-4f87-9732-b8f2fb2caac3)


## Proposed changes:
* Increase the z index so that the label shows up. 
* Take into account if we should show the 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
Add a form with the select field. 
create variations of the field. ( with label, without label, required & no label, required & label )
Notice that it the label displays as expected on the animation style form variation. 
Notice that it still works as expected across the other variations. 

