### PR TITLE
Add Advanced SEO to A8C Sites - Sync changes from wpcom-185424

### DIFF
--- a/projects/plugins/wpcomsh/changelog/sync-advanced-seo-settings-changes
+++ b/projects/plugins/wpcomsh/changelog/sync-advanced-seo-settings-changes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Enabled Advanced SEO features for localized version of developer.wordpress.com

--- a/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
+++ b/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
@@ -1441,7 +1441,15 @@ class WPCOM_Features {
 		163161552, // brwpgo.wordpress.com
 		53424024, // discover.wordpress.com
 		489937, // dailypost.wordpress.com
-		33534099, // developer.wordpress.com
+		33534099,  // developer.wordpress.com
+		233643880, // eswpcomdeveloper.wordpress.com
+		244311505, // jawpcomdeveloper.wordpress.com
+		244447807, // frwpcomdeveloper.wordpress.com
+		244448116, // dewpcomdeveloper.wordpress.com
+		244448279, // ptbrwpcomdeveloper.wordpress.com
+		244517526, // idwpcomdeveloper.wordpress.com
+		244516213, // itwpcomdeveloper.wordpress.com
+		244518337, // nlwpcomdeveloper.wordpress.com
 		22994, // theme.wordpress.com
 		16390, // learn.wordpress.com
 		54117, // automattic.wordpress.com


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds the Jetpack Advanced SEO Tools configuration to mirror the changes from 185424-ghe-Automattic/wpcom

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Code review, confirm that the changes match 185424-ghe-Automattic/wpcom.

