### PR TITLE
Forms: Adjust About page layout to fit any text on feature cards

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-about-layout
+++ b/projects/packages/forms/changelog/fix-forms-about-layout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Adjust About page layout to fit any text on feature cards

--- a/projects/packages/forms/src/dashboard/about/index.tsx
+++ b/projects/packages/forms/src/dashboard/about/index.tsx
@@ -121,7 +121,7 @@ const About = () => {
 					<h1>{ __( 'Empower your workflow.', 'jetpack-forms' ) }</h1>
 					<div className="section-data__features">
 						<div className="section-data__features-feature feature-connect">
-							<div className="app-icons-wrapper">
+							<div className="app-icons-wrapper feature-header">
 								<AkismetIcon width={ 32 } height={ 32 } className="icon-round" />
 								<JetpackIcon size={ 32 } className="jetpack-icon" />
 								<CreativeMailIcon width={ 32 } height={ 32 } className="icon-round" />
@@ -139,23 +139,23 @@ const About = () => {
 							<WordpressSVG />
 						</div>
 						<div className="section-data__features-feature feature-akismet">
-							<AkismetIcon />
+							<AkismetIcon className="feature-header" />
 							<h2>{ __( 'No spam with Akismet', 'jetpack-forms' ) }</h2>
 						</div>
 						<div className="section-data__features-feature feature-export">
-							<ExportSVG />
+							<ExportSVG className="feature-header" />
 							<h2>{ __( 'Export your data anytime', 'jetpack-forms' ) }</h2>
 						</div>
 						<div className="section-data__features-feature feature-notifications">
-							<NotificationsSVG />
+							<NotificationsSVG className="feature-header" />
 							<h2>{ __( 'Real-time notifications via email', 'jetpack-forms' ) }</h2>
 						</div>
 						<div className="section-data__features-feature feature-dependencies">
-							<h1 className="zero-plugins"> { __( 'Zero', 'jetpack-forms' ) }</h1>
+							<h1 className="zero-plugins feature-header"> { __( 'Zero', 'jetpack-forms' ) }</h1>
 							<h2>{ __( 'No additional plugins required', 'jetpack-forms' ) }</h2>
 						</div>
 						<div className="section-data__features-feature feature-validation">
-							<div className="validation-icons-wrapper">
+							<div className="validation-icons-wrapper feature-header">
 								<CheckSVG />
 								<CloseSVG />
 							</div>

--- a/projects/packages/forms/src/dashboard/about/style.scss
+++ b/projects/packages/forms/src/dashboard/about/style.scss
@@ -175,7 +175,10 @@
 				overflow: hidden;
 				padding: 24px 32px;
 				position: relative;
-				height: 183px;
+
+				.feature-header {
+					margin-bottom: 24px;
+				}
 			}
 
 			.feature-connect {
@@ -220,6 +223,10 @@
 
 			.feature-akismet {
 				grid-area: ak;
+
+				svg {
+					flex-shrink: 0;
+				}
 			}
 
 			.feature-export {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes FORMS-166

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Small layout fix, removing the fixed card height

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Jetpack > Forms > About
* Change your site language (the issue was caught in French)
* If Jetpack's language is not updated, go to Dashboard > Updates and install the language files (should be the last button)
* Reload the About page. It should be in the selected language now
* Check that the visual problem is fixed like in the screenshots

Before:
![image](https://github.com/user-attachments/assets/b58171e2-da1b-4a21-8a89-f732fc220d87)

After:

| Desktop | Tablet |
| - | - |
| ![Screenshot from 2025-06-12 19-00-12](https://github.com/user-attachments/assets/1ae9f19f-24eb-4247-957e-e9fdedf2ec74) | ![Screenshot from 2025-06-12 19-02-33](https://github.com/user-attachments/assets/46ab4a06-82bc-4050-be79-4e888cf2eee8) |
| ![Screenshot from 2025-06-12 19-00-57](https://github.com/user-attachments/assets/687bf64c-f283-4f0f-8f86-30a22bc37168) | ![Screenshot from 2025-06-12 19-01-26](https://github.com/user-attachments/assets/2489620c-1400-4d60-8edf-fde175e033f0) |
| ![Screenshot from 2025-06-12 18-59-25](https://github.com/user-attachments/assets/5b28fc11-1d68-426a-a389-689e15a8961e) | ![Screenshot from 2025-06-12 19-01-39](https://github.com/user-attachments/assets/d3c61e36-b256-4d6c-83cd-f0859ce7384e) |
