### PR TITLE
Forms: Change form creation method

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-about-safari-create-form
+++ b/projects/packages/forms/changelog/fix-forms-about-safari-create-form
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Forms: Change form creation method

--- a/projects/packages/forms/src/dashboard/hooks/use-create-form.ts
+++ b/projects/packages/forms/src/dashboard/hooks/use-create-form.ts
@@ -57,9 +57,20 @@ export default function useCreateForm(): CreateFormReturn {
 				if ( postUrl ) {
 					analyticsEvent?.( { formPattern } );
 
-					window.open(
-						`${ postUrl }${ showPatterns && ! formPattern ? '&showJetpackFormsPatterns' : '' }`
-					);
+					const url = `${ postUrl }${
+						showPatterns && ! formPattern ? '&showJetpackFormsPatterns' : ''
+					}`;
+
+					const link = document.createElement( 'a' );
+
+					link.setAttribute( 'href', url );
+					link.setAttribute( 'target', '_blank' );
+					link.setAttribute( 'rel', 'noopener noreferrer' );
+					link.style.display = 'none';
+
+					document.body.appendChild( link );
+					link.click();
+					document.body.removeChild( link );
 				}
 			} catch ( error ) {
 				console.error( error.message ); // eslint-disable-line no-console

--- a/projects/packages/forms/src/dashboard/hooks/use-create-form.ts
+++ b/projects/packages/forms/src/dashboard/hooks/use-create-form.ts
@@ -57,6 +57,10 @@ export default function useCreateForm(): CreateFormReturn {
 				if ( postUrl ) {
 					analyticsEvent?.( { formPattern } );
 
+					/*
+					 * We are using a temporary link click to open the new form page, as it is created in the backend and we need
+					 * to wait for it before we have the post URL. Using window.open() does not work due to Safari's popup blocker.
+					 */
 					const url = `${ postUrl }${
 						showPatterns && ! formPattern ? '&showJetpackFormsPatterns' : ''
 					}`;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes FORMS-169

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Changes how the newly-created form is opened to avoid block in Safari

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Jetpack > Forms and click on the Create a Form button
* Check that a new tab is opened with the created form in a new page
* Check on different browsers
