### PR TITLE
Launchpad: Updated task_id plan_selected order to be the first one

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-plan-selected-order-step-from-build-task
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-plan-selected-order-step-from-build-task
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Launchpad: Updated task_id plan_selected order to be the first one

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -36,8 +36,8 @@ function wpcom_launchpad_get_task_list_definitions() {
 				return __( 'Next steps for your site', 'jetpack-mu-wpcom' );
 			},
 			'task_ids'            => array(
-				'setup_general',
 				'plan_selected',
+				'setup_general',
 				'first_post_published',
 				'design_edited',
 				'site_launched',

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -214,9 +214,9 @@ function wpcom_launchpad_get_task_list_definitions() {
 				return __( 'Next steps for your site', 'jetpack-mu-wpcom' );
 			},
 			'task_ids'            => array(
+				'enable_subscribers_modal',
 				'verify_email',
 				'share_site',
-				'enable_subscribers_modal',
 				'manage_subscribers',
 				'update_about_page',
 				'add_about_page',
@@ -228,10 +228,10 @@ function wpcom_launchpad_get_task_list_definitions() {
 				return __( 'Next steps for your site', 'jetpack-mu-wpcom' );
 			},
 			'task_ids'            => array(
+				'enable_subscribers_modal',
 				'verify_email',
 				'share_site',
 				'set_up_payments',
-				'enable_subscribers_modal',
 				'manage_subscribers',
 				'manage_paid_newsletter_plan',
 				'update_about_page',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://linear.app/a8c/issue/DOTCOM-13604/launchpad-dont-change-the-items-order-after-completion

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Since we're not reordering tasks anymore as part of [this Calypso change](https://github.com/Automattic/wp-calypso/pull/104189), we want the Plan selected to be the first one

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Follow [Calypso PR test description](https://github.com/Automattic/wp-calypso/pull/104189)

