### PR TITLE
Social Notes: update filter name

### DIFF
--- a/projects/plugins/social/changelog/fix-notes-deprecation-filter
+++ b/projects/plugins/social/changelog/fix-notes-deprecation-filter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Social Notes: update filter name to match recent changes in WordPress.

--- a/projects/plugins/social/src/class-note.php
+++ b/projects/plugins/social/src/class-note.php
@@ -31,7 +31,7 @@ class Note {
 		if ( ! self::enabled() ) {
 			return;
 		}
-		add_filter( 'allowed_block_types', array( $this, 'restrict_blocks_for_social_note' ), 10, 2 );
+		add_filter( 'allowed_block_types_all', array( $this, 'restrict_blocks_for_social_note' ), 10, 2 );
 
 		/*
 		 * The ActivityPub plugin has a block to set a Fediverse post that a new post is in reply to. This is perfect for Social Notes.
@@ -150,12 +150,16 @@ class Note {
 	/**
 	 * Restrict the blocks for the Social Note CPT.
 	 *
-	 * @param array    $allowed_blocks The allowed blocks.
-	 * @param \WP_Post $post The post.
+	 * @param array                    $allowed_blocks The allowed blocks.
+	 * @param \WP_Block_Editor_Context $block_editor_context The current block editor context.
 	 * @return array The allowed blocks.
 	 */
-	public function restrict_blocks_for_social_note( $allowed_blocks, $post ) {
-		if ( 'jetpack-social-note' !== $post->post_type ) { // Let 'em pass.
+	public function restrict_blocks_for_social_note( $allowed_blocks, $block_editor_context ) {
+		if (
+			! isset( $block_editor_context->post )
+			|| ! $block_editor_context->post instanceof \WP_Post
+			|| 'jetpack-social-note' !== $block_editor_context->post->post_type
+		) {
 			return $allowed_blocks;
 		}
 


### PR DESCRIPTION
## Proposed changes:

This should avoid deprecation notices like this one:

```
PHP Deprecated:  allowed_block_types est <strong>obsolète</strong> depuis la version 5.8.0 ! Utilisez allowed_block_types_all à la place. in /var/www/html/wp-includes/functions.php on line 6121
```

-> https://developer.wordpress.org/reference/hooks/allowed_block_types/
-> https://developer.wordpress.org/reference/hooks/allowed_block_types_all/

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Start with a site running the Jetpack Social plugin
* In Jetpack > Social, enable social notes
* Go to Posts > Add New
* Click on the + icon to open the block inserter.
    * You should see all blocks available to pick.
* Go to Social Notes > Add New
* Click on the + icon to open the block inserter.
    * Only the paragraph and featured image block should be available.
