### PR TITLE
Boost: LCP - make sure there's no half pixel within the srcset

### DIFF
--- a/projects/plugins/boost/app/modules/optimizations/lcp/class-lcp-optimize-img-tag.php
+++ b/projects/plugins/boost/app/modules/optimizations/lcp/class-lcp-optimize-img-tag.php
@@ -131,7 +131,7 @@ class LCP_Optimize_Img_Tag {
 
 				// If it's a Moto G Power, include a 1.75 DPR for accurate lighthouse representation of the optimized image.
 				if ( isset( $breakpoint['maxWidth'] ) && $breakpoint['maxWidth'] === 412 ) {
-					$breakpoint_widths[] = (int) $width * 1.75;
+					$breakpoint_widths[] = round( (int) $width * 1.75 );
 				}
 
 				// Include 2x DPR.

--- a/projects/plugins/boost/changelog/fix-boost-lcp-sizes-with-half-pixels
+++ b/projects/plugins/boost/changelog/fix-boost-lcp-sizes-with-half-pixels
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: LCP: Fix for an unreleased feature.
+
+


### PR DESCRIPTION
This fixes a bug where Boost outputs an invalid width in the srcset for the LCP.

<img width="562" alt="CleanShot 2025-06-13 at 11 52 58@2x" src="https://github.com/user-attachments/assets/4910f54d-74ac-4f74-b9d7-4948b48f61db" />

## Proposed changes:

* Make sure there's no half pixels in the srcset.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

n/a

## Does this pull request change what data or activity we track or use?

no

## Testing instructions:

- Setup Boost free;
- Make sure you're running on the twenty-twenty-five theme;
- Request an LCP optimization;
- After that's done, check the home page LCP image and make sure there's no widths with a decimal point.

You can repeat this on trunk and you'll see `605.5w` in the list which is invalid.