### PR TITLE
Help Center: Open media export link in the Help Center

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/dotsup-65-open-monetize-support-links-in-help-center
+++ b/projects/packages/jetpack-mu-wpcom/changelog/dotsup-65-open-monetize-support-links-in-help-center
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+WP.COM: Open learn more link in the Help Center

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-media/wpcom-export-media-files.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-media/wpcom-export-media-files.php
@@ -60,7 +60,7 @@ function wpcom_render_export_media_files_page() {
 
 		<?php if ( $media_export_url ) : ?>
 			<p><?php esc_html_e( 'Download all the media library files (images, videos, audio, and documents) from your site.', 'jetpack-mu-wpcom' ); ?>
-			<a href="https://wordpress.com/support/export-your-media-library/" target="_blank"><?php esc_html_e( 'Learn more', 'jetpack-mu-wpcom' ); ?></a></p>
+			<a href="https://wordpress.com/support/export-your-media-library/" target="_blank" data-target="wpcom-help-center"><?php esc_html_e( 'Learn more', 'jetpack-mu-wpcom' ); ?></a></p>
 
 			<p><a href="<?php echo esc_url( $media_export_url ); ?>" class="button button-primary"><?php esc_html_e( 'Download', 'jetpack-mu-wpcom' ); ?></a></p>
 


### PR DESCRIPTION
Requires: https://github.com/Automattic/wp-calypso/pull/104172

## Does this pull request change what data or activity we track or use?
No.

## Demo

https://github.com/user-attachments/assets/18d14750-06d9-49bd-8a61-2a9d389f0c3f


## Testing instructions:

1. Apply to your sandbox.
2. Go to /wp-admin/tools.php?page=export-media-files
3. Click Learn More.
4. It should open the Help Center.