### PR TITLE
Boost: LCP try to use original image when applying optimization

### DIFF
--- a/projects/plugins/boost/app/modules/optimizations/lcp/class-lcp-optimize-img-tag.php
+++ b/projects/plugins/boost/app/modules/optimizations/lcp/class-lcp-optimize-img-tag.php
@@ -2,6 +2,7 @@
 
 namespace Automattic\Jetpack_Boost\Modules\Optimizations\Lcp;
 
+use Automattic\Jetpack\Image_CDN\Image_CDN;
 use Automattic\Jetpack\Image_CDN\Image_CDN_Core;
 use WP_HTML_Tag_Processor;
 
@@ -72,8 +73,15 @@ class LCP_Optimize_Img_Tag {
 			return $buffer_processor->get_updated_html();
 		}
 
-		// Remove unwanted query parameters that would be used unnecessarily by Photon.
-		$image_url = remove_query_arg( array( 'resize', 'w', 'h' ), $image_url );
+		// If the image isn't photonized, it might be resized by WP.
+		// We need the original image URL, as we'll be generating
+		// the necessary sizes based on it.
+		if ( ! Image_CDN_Core::is_cdn_url( $image_url ) ) {
+			$image_url = Image_CDN::strip_image_dimensions_maybe( $image_url );
+		} else {
+			// In case it's Photonized, we need to remove any size change arguments.
+			$image_url = remove_query_arg( array( 'resize', 'w', 'h' ), $image_url );
+		}
 
 		// Additional validation after cleaning.
 		if ( ! wp_http_validate_url( $image_url ) ) {

--- a/projects/plugins/boost/changelog/fix-boost-lcp-using-incorrect-image-when-optimizing
+++ b/projects/plugins/boost/changelog/fix-boost-lcp-using-incorrect-image-when-optimizing
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: LCP: Fix for unreleased feature. Fix not using original image for optimized version.
+
+


### PR DESCRIPTION
Fixes HOG-165

If photon is disabled when Boost tries to apply the LCP optimization, it might use a resized image to generate sizes. When those are photonized, they would be lower resolution.

## Proposed changes:

* Update LCP optimization to base the URL changes on the original image URL instead of a resized one.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

n/a

## Does this pull request change what data or activity we track or use?

no

## Testing instructions:

* Setup Boost free;
* Add an image to your home page (it should be a cornerstone page) and make sure it uses an image size. It shouldn't show the original. The URL should contain `-300x300` for example;
* Make sure Image CDN isn't enabled;
* Enable LCP and analyze;
* After the analysis, the page should show a photonized image URL, but of the original URL - not the resized one.
* Since the image will be with its original dimensions (before any resizes), a follow-up PR will make sure that the final photonized image URL has the necessary resize parameters and the image shows correctly.