### PR TITLE
tools, ci: Fix tests on plugin release branches

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -106,6 +106,8 @@ jobs:
         run: .github/files/select-wordpress-tag.sh
 
       - name: Composer Install
+        env:
+          CHANGED: ${{ steps.changed.outputs.projects }}
         run: |
           # If we're going to be making WorDBless use WP "nightlies", remove the relevant package from Composer's cache to get the latest version.
           if [[ "$WP_BRANCH" == 'trunk' && ( "$TEST_SCRIPT" == "test-php" || "$TEST_SCRIPT" == "test-coverage" ) ]]; then
@@ -130,6 +132,19 @@ jobs:
             fi
           fi
           echo "::endgroup::"
+
+          echo "Checking for non-mirrored require-dev packages, in case this is testing a release branch"
+          for SLUG in $( jq -r 'keys[]' <<<"$CHANGED" ); do
+            PKGS=()
+            readarray -t PKGS < <( jq -r '.extra["non-mirrored-require-dev"] // empty | .[] | . += "=@dev"' "projects/$SLUG/composer.json" )
+            if [[ ${#PKGS[@]} -gt 0 ]]; then
+              echo "Adding packages for $SLUG: ${PKGS[*]}"
+              # Make sure monorepo repositories entry is present.
+              JSON=$( jq --tab '.repositories //= [] | if any( .repositories[]; .type == "path" and ( .url | startswith( "../" ) ) and .options?.monorepo? ) then . else .repositories += [ { type: "path", url: "../../packages/*", options: { monorepo: true } } ] end' "projects/$SLUG/composer.json" )
+              echo "$JSON" > "projects/$SLUG/composer.json"
+              composer require --working-dir="projects/$SLUG/" --dev --no-install "${PKGS[@]}"
+            fi
+          done
 
       - name: Setup WordPress environment for plugin tests
         env:

--- a/tools/version-packages.sh
+++ b/tools/version-packages.sh
@@ -103,6 +103,7 @@ mapfile -t TO_UPDATE < <(jq -r --argjson packages "$RMPACKAGES" '.["require-dev"
 if [[ ${#TO_UPDATE[@]} -gt 0 ]]; then
 	info "Remove no-mirror dev packages: ${TO_UPDATE[*]}..."
 	composer remove "${COMPOSER_ARGS[@]}" --no-update --working-dir="$DIR" --dev -- "${TO_UPDATE[@]}"
+	composer config --working-dir="$DIR" 'extra.non-mirrored-require-dev' --json "$( jq -nc '$ARGS.positional' --args "${TO_UPDATE[@]}" )"
 fi
 TO_UPDATE=()
 mapfile -t TO_UPDATE < <(jq -r --argjson packages "$PACKAGES" '.["require-dev"] // {} | to_entries[] | select( ( .value | test( "^@dev$|\\.x-dev$" ) ) and $packages[.key] ) | "\(.key)=^\($packages[.key])"' "$DIR/composer.json")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Plugin tests on release branches for plugins that use packages/test-environment have been failing since #41515 because in the release branch we now remove the non-mirrored package.

To fix this, let's record removed packages when creating the release branch, and restore them to composer.json before trying to run the tests.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1743714234262549/1742213391.095319-slack-C01U2KGS2PQ

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Probably your best bet is to run a release of an affected plugin. Starter-plugin seems like a good candidate.
* If you don't want to do that, you can probably try it in parts (maybe on a fork):
  * `tools/create-release-branch.sh plugins/starter-plugin 0.7.1`. Answer "no" when it asks about changing branches, and "no" when it asks to push. Observe the added `.extra.non-mirrored-require-dev` key in `projects/plugins/starter-plugin/composer.json`.
  * Check out the starter-plugin/branch-0.7.0 branch. Add the `.extra.non-mirrored-require-dev` to `projects/plugins/starter-plugin/composer.json` and cherry-pick the changes from this PR. Commit and push, tests should pass now.