### PR TITLE
Fix/jetpack forms placeholder issues

### DIFF
--- a/projects/packages/forms/changelog/fix-jetpack-forms-placeholder-issues
+++ b/projects/packages/forms/changelog/fix-jetpack-forms-placeholder-issues
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: address placeholder issues on animated and outlined styles

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -1801,7 +1801,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		$block_style       = 'style="' . $this->block_styles . '"';
 		$has_inset_label   = $this->has_inset_label();
 		$field             = '';
-		$field_placeholder = ! empty( $placeholder ) ? "placeholder='" . esc_attr( $placeholder ) . "'" : 'placeholder=" "'; // ensure that we can use :placeholder-shown CSS selector
+		$field_placeholder = ! empty( $placeholder ) ? "placeholder='" . esc_attr( $placeholder ) . "'" : '';
 
 		$context = array(
 			'fieldId'           => $id,

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -662,7 +662,7 @@ on production builds, the attributes are being reordered, causing side-effects
 	max-width: 100px;
 }
 
-.contact-form .is-style-outlined .grunion-field-wrap .notched-label:has(~ .grunion-field:not(:placeholder-shown)) .notched-label__notch,
+.contact-form .is-style-outlined .grunion-field-wrap .notched-label:has(~ .grunion-field:not(:empty)) .notched-label__notch,
 .contact-form .is-style-outlined .grunion-field-wrap .notched-label:has(~ .grunion-field:focus) .notched-label__notch,
 .contact-form .is-style-outlined .grunion-field-wrap .notched-label:has(~ .grunion-field.has-placeholder) .notched-label__notch,
 .contact-form .is-style-outlined .grunion-field-wrap.grunion-field-select-wrap .notched-label .notched-label__notch
@@ -670,7 +670,7 @@ on production builds, the attributes are being reordered, causing side-effects
 	border-top-color: transparent !important;
 }
 
-.contact-form .is-style-outlined .grunion-field-wrap .notched-label:has(~ .grunion-field:not(:placeholder-shown)) .notched-label__label,
+.contact-form .is-style-outlined .grunion-field-wrap .notched-label:has(~ .grunion-field:not(:empty)) .notched-label__label,
 .contact-form .is-style-outlined .grunion-field-wrap .notched-label:has(~ .grunion-field:focus) .notched-label__label,
 .contact-form .is-style-outlined .grunion-field-wrap .notched-label:has(~ .grunion-field.has-placeholder) .notched-label__label,
 .contact-form .is-style-outlined .grunion-field-wrap.grunion-field-select-wrap .notched-label .notched-label__label
@@ -680,14 +680,14 @@ on production builds, the attributes are being reordered, causing side-effects
 }
 
 /* Form that upgrade to use inner blocks look to the global styles border size accessible via the CSS vars. See Contact_Form_Field::get_form_variation_style_properties() .*/
-.contact-form .is-style-outlined .wp-block-jetpack-input-wrap .notched-label:has(~ .grunion-field:not(:placeholder-shown)) .notched-label__label,
+.contact-form .is-style-outlined .wp-block-jetpack-input-wrap .notched-label:has(~ .grunion-field:not(:empty)) .notched-label__label,
 .contact-form .is-style-outlined .wp-block-jetpack-input-wrap .notched-label:has(~ .grunion-field:focus) .notched-label__label,
 .contact-form .is-style-outlined .wp-block-jetpack-input-wrap .notched-label:has(~ .grunion-field.has-placeholder) .notched-label__label,
 .contact-form .is-style-outlined .wp-block-jetpack-field-select.wp-block-jetpack-input-wrap .notched-label .notched-label__label {
 	top: calc( var(--jetpack--contact-form--border-top-size, var(--jetpack--contact-form--border-size)) * -1 );
 }
 
-.contact-form .is-style-outlined .grunion-field-wrap .notched-label:has(~ .grunion-field:not(:placeholder-shown)) .grunion-label-text,
+.contact-form .is-style-outlined .grunion-field-wrap .notched-label:has(~ .grunion-field:not(:empty)) .grunion-label-text,
 .contact-form .is-style-outlined .grunion-field-wrap .notched-label:has(~ .grunion-field:focus) .grunion-label-text,
 .contact-form .is-style-outlined .grunion-field-wrap .notched-label:has(~ .grunion-field.has-placeholder) .grunion-label-text,
 .contact-form .is-style-outlined .grunion-field-wrap .grunion-checkbox-multiple-options .grunion-label-text,
@@ -696,7 +696,7 @@ on production builds, the attributes are being reordered, causing side-effects
 	font-size: 0.8em;
 }
 
-.contact-form .is-style-outlined .grunion-field-wrap .notched-label:has(~ .grunion-field:not(:placeholder-shown)) .grunion-label-required,
+.contact-form .is-style-outlined .grunion-field-wrap .notched-label:has(~ .grunion-field:not(:empty)) .grunion-label-required,
 .contact-form .is-style-outlined .grunion-field-wrap .notched-label:has(~ .grunion-field:focus) .grunion-label-required,
 .contact-form .is-style-outlined .grunion-field-wrap .notched-label:has(~ .grunion-field.has-placeholder) .grunion-label-required,
 .contact-form .is-style-outlined .grunion-field-wrap .grunion-checkbox-multiple-options .grunion-label-required,
@@ -789,7 +789,7 @@ on production builds, the attributes are being reordered, causing side-effects
 	top: calc(2px + var(--jetpack--contact-form--border-top-size, var( --jetpack--contact-form--border-size, 1px )));
 }
 
-.contact-form .is-style-animated .grunion-field-wrap .animated-label__label:has(~ .grunion-field:not(:placeholder-shown)),
+.contact-form .is-style-animated .grunion-field-wrap .animated-label__label:has(~ .grunion-field:not(:empty)),
 .contact-form .is-style-animated .grunion-field-wrap .animated-label__label:has(~ .grunion-field:focus),
 .contact-form .is-style-animated .grunion-field-wrap .animated-label__label:has(~ .grunion-field.has-placeholder),
 .contact-form .is-style-animated .grunion-field-wrap.grunion-field-select-wrap .animated-label__label
@@ -798,7 +798,7 @@ on production builds, the attributes are being reordered, causing side-effects
 	top: calc(2px + var(--jetpack--contact-form--border-top-size, var( --jetpack--contact-form--border-size, 1px )));
 }
 
-.contact-form .is-style-animated .grunion-field-wrap .animated-label__label:has(~ .grunion-field:not(:placeholder-shown)) .grunion-label-text,
+.contact-form .is-style-animated .grunion-field-wrap .animated-label__label:has(~ .grunion-field:not(:empty)) .grunion-label-text,
 .contact-form .is-style-animated .grunion-field-wrap .animated-label__label:has(~ .grunion-field:focus) .grunion-label-text,
 .contact-form .is-style-animated .grunion-field-wrap .animated-label__label:has(~ .grunion-field.has-placeholder) .grunion-label-text,
 .contact-form .is-style-animated .grunion-field-wrap.grunion-field-select-wrap .animated-label__label .grunion-label-text
@@ -806,7 +806,7 @@ on production builds, the attributes are being reordered, causing side-effects
 	font-size: 0.75em;
 }
 
-.contact-form .is-style-animated .grunion-field-wrap .animated-label__label:has(~ .grunion-field:not(:placeholder-shown)) .grunion-label-required,
+.contact-form .is-style-animated .grunion-field-wrap .animated-label__label:has(~ .grunion-field:not(:empty)) .grunion-label-required,
 .contact-form .is-style-animated .grunion-field-wrap .animated-label__label:has(~ .grunion-field:focus) .grunion-label-required,
 .contact-form .is-style-animated .grunion-field-wrap .animated-label__label:has(~ .grunion-field.has-placeholder) .grunion-label-required,
 .contact-form .is-style-animated .grunion-field-wrap.grunion-field-select-wrap .animated-label__label .grunion-label-required
@@ -821,7 +821,7 @@ on production builds, the attributes are being reordered, causing side-effects
 }
 
 /* The following is scoped by the presence of the custom font size CSS var to avoid needing conditional fallback within the var() */
-.contact-form .is-style-animated .grunion-field-wrap .animated-label__label[style*="--jetpack--contact-form--label--font-size"]:has(~ .grunion-field:not(:placeholder-shown)),
+.contact-form .is-style-animated .grunion-field-wrap .animated-label__label[style*="--jetpack--contact-form--label--font-size"]:has(~ .grunion-field:not(:empty)),
 .contact-form .is-style-animated .grunion-field-wrap .animated-label__label[style*="--jetpack--contact-form--label--font-size"]:has(~ .grunion-field:focus),
 .contact-form .is-style-animated .grunion-field-wrap .animated-label__label[style*="--jetpack--contact-form--label--font-size"]:has(~ .grunion-field.has-placeholder),
 .contact-form .is-style-animated .grunion-field-wrap.grunion-field-select-wrap .animated-label__label[style*="--jetpack--contact-form--label--font-size"] {


### PR DESCRIPTION

Part of FORMS-163

## Proposed changes:
This PR switches to use `:empty` pseudo class instead of `:placeholder-shown` as Safari shows inconsistencies.

Chrome vs Safari:
![image](https://github.com/user-attachments/assets/9243c5a8-d0c9-41f1-a656-33bf78e78d07)


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
FORMS-163

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

Use this post content, it holds most cases variations/combinations (label, placeholder, required):

```
<!-- wp:jetpack/contact-form {"className":"is-style-animated"} -->
<div class="wp-block-jetpack-contact-form is-style-animated"><!-- wp:jetpack/field-text {"id":""} -->
<div><!-- wp:jetpack/label {"label":"With label","requiredText":"(required)"} /-->

<!-- wp:jetpack/input {"style":{"border":{"style":"solid"},"typography":{"textDecoration":"line-through"}}} /--></div>
<!-- /wp:jetpack/field-text -->

<!-- wp:jetpack/field-text {"required":true} -->
<div><!-- wp:jetpack/label {"label":"With label and required"} /-->

<!-- wp:jetpack/input {"type":"text","style":{"border":{"style":"solid"},"typography":{"textDecoration":"line-through"}}} /--></div>
<!-- /wp:jetpack/field-text -->

<!-- wp:jetpack/field-text -->
<div><!-- wp:jetpack/label {"label":"With label and placeholder"} /-->

<!-- wp:jetpack/input {"placeholder":"some placeholder","type":"text","style":{"border":{"style":"solid"},"typography":{"textDecoration":"line-through"}}} /--></div>
<!-- /wp:jetpack/field-text -->

<!-- wp:jetpack/field-text -->
<div><!-- wp:jetpack/label {"label":"With label, placeholder and required"} /-->

<!-- wp:jetpack/input {"placeholder":"some placeholder","type":"text","style":{"border":{"style":"solid"},"typography":{"textDecoration":"line-through"}}} /--></div>
<!-- /wp:jetpack/field-text -->

<!-- wp:paragraph -->
<p>Below, same cases but without label</p>
<!-- /wp:paragraph -->

<!-- wp:jetpack/field-text -->
<div><!-- wp:jetpack/label /-->

<!-- wp:jetpack/input {"type":"text","style":{"border":{"style":"solid"},"typography":{"textDecoration":"line-through"}}} /--></div>
<!-- /wp:jetpack/field-text -->

<!-- wp:jetpack/field-text {"required":true} -->
<div><!-- wp:jetpack/label /-->

<!-- wp:jetpack/input {"type":"text","style":{"border":{"style":"solid"},"typography":{"textDecoration":"line-through"}}} /--></div>
<!-- /wp:jetpack/field-text -->

<!-- wp:jetpack/field-text -->
<div><!-- wp:jetpack/label /-->

<!-- wp:jetpack/input {"placeholder":"some placeholder","type":"text","style":{"border":{"style":"solid"},"typography":{"textDecoration":"line-through"}}} /--></div>
<!-- /wp:jetpack/field-text -->

<!-- wp:jetpack/field-text {"required":true} -->
<div><!-- wp:jetpack/label /-->

<!-- wp:jetpack/input {"placeholder":"some placeholder","type":"text","style":{"border":{"style":"solid"},"typography":{"textDecoration":"line-through"}}} /--></div>
<!-- /wp:jetpack/field-text -->

<!-- wp:jetpack/button {"element":"button","text":"Submit","lock":{"remove":true}} /--></div>
<!-- /wp:jetpack/contact-form -->
```

Try switching form styles: Default, Animated and Outline. Try testing on multiple browsers. The bug mentioned in the issue should be gone and all 3 styles should behave properly on all browsers.