### PR TITLE
Jetpack Forms: fix notched label focus

### DIFF
--- a/projects/packages/forms/changelog/fix-jetpack-forms-notched-label-focus
+++ b/projects/packages/forms/changelog/fix-jetpack-forms-notched-label-focus
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: elevate outline style notched labels with z-index so they are more easily selectable

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -817,6 +817,7 @@
 				transform: translateY(-50%);
 				transition: all 150ms cubic-bezier(0.4, 0, 0.2, 1);
 				margin: 0;
+				z-index: 1;
 
 				.jetpack-field-label__suffix {
 					font-weight: 300;

--- a/projects/packages/forms/src/blocks/label/edit.js
+++ b/projects/packages/forms/src/blocks/label/edit.js
@@ -1,5 +1,6 @@
 import { RichText, store as blockEditorStore, useBlockProps } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
+import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { clsx } from 'clsx';
 import { useSyncedAttributes } from '../shared/hooks/use-synced-attributes';
@@ -104,6 +105,17 @@ const LabelEdit = ( { clientId, attributes, name, setAttributes, context } ) => 
 		style: variationProps?.cssVars,
 	} );
 
+	// Do not allow enter key to create a new line in the label if the form style is not default.
+	// Animated and Outlined styles have a notched label, so we don't want to allow new lines in the label.
+	const onKeyDown = useCallback(
+		event => {
+			if ( event.key === 'Enter' && FORM_STYLE.DEFAULT !== formStyle ) {
+				event.preventDefault();
+			}
+		},
+		[ formStyle ]
+	);
+
 	// The label value to use for the RichText field must manually fall back to the
 	// placeholder to be rendered in previews.
 	const isPreviewMode = useSelect( select => {
@@ -125,6 +137,7 @@ const LabelEdit = ( { clientId, attributes, name, setAttributes, context } ) => 
 					className="jetpack-field-label__input"
 					onChange={ value => setAttributes( { label: value } ) }
 					placeholder={ placeholderValue }
+					onKeyDown={ onKeyDown }
 					tagName="label"
 					value={ labelValue }
 					withoutInteractiveFormatting


### PR DESCRIPTION
Part of FORMS-148
Fixes FORMS-148

## Proposed changes:
This PR elevates outline styled notched labels so they are more easily selectable. The main bug remains (hitting enter on a notched label) but this already helps the user deal with labels that are empty.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
FORMS-148

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Create a form and add some text input. Select the form and make it style Outline.
On a text input, see that you can now delete the contents of the label (it'll show "Add label...") and as _per style_ the label will be at the same position as the input. Click on "Add label..." to verify the focus remains on the label and not on the input.