### PR TITLE
Forms: Add date picker translations

### DIFF
--- a/projects/packages/forms/changelog/add-date-picker-translations
+++ b/projects/packages/forms/changelog/add-date-picker-translations
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: adding variables to be translated

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -1471,6 +1471,40 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 				'label' => __( 'YYYY-MM-DD', 'jetpack-forms' ),
 			),
 		);
+		// phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		$local = array(
+			// translators: These are the two letter abbreviated name of the week.
+			'days'      => array( __( 'Su', 'jetpack-forms' ), __( 'Mo', 'jetpack-forms' ), __( 'Tu', 'jetpack-forms' ), __( 'We', 'jetpack-forms' ), __( 'Th', 'jetpack-forms' ), __( 'Fr', 'jetpack-forms' ), __( 'Sa', 'jetpack-forms' ) ),
+			'months'    => array(
+				__( 'January', 'jetpack-forms' ),
+				__( 'February', 'jetpack-forms' ),
+				__( 'March', 'jetpack-forms' ),
+				__( 'April', 'jetpack-forms' ),
+				__( 'May', 'jetpack-forms' ),
+				__( 'June', 'jetpack-forms' ),
+				__( 'July', 'jetpack-forms' ),
+				__( 'August', 'jetpack-forms' ),
+				__( 'September', 'jetpack-forms' ),
+				__( 'October', 'jetpack-forms' ),
+				__( 'November', 'jetpack-forms' ),
+				__( 'December', 'jetpack-forms' ),
+			),
+			'today'     => __( 'Today', 'jetpack-forms' ),
+			'clear'     => __( 'Clear', 'jetpack-forms' ),
+			'close'     => __( 'Close', 'jetpack-forms' ),
+			'ariaLabel' => array(
+				'enterPicker'       => __( 'You are on a date picker input. Use the down key to focus into the date picker. Or type the date in the format MM/DD/YYYY', 'jetpack-forms' ),
+				'dayPicker'         => __( 'You are currently inside the date picker, use the arrow keys to navigate between the dates. Use tab key to jump to more controls.', 'jetpack-forms' ),
+				'monthPicker'       => __( 'You are currently inside the month picker, use the arrow keys to navigate between the months. Use the space key to select it.', 'jetpack-forms' ),
+				'yearPicker'        => __( 'You are currently inside the year picker, use the up and down arrow keys to navigate between the years. Use the space key to select it.', 'jetpack-forms' ),
+				'monthPickerButton' => __( 'Month picker. Use the space key to enter the month picker.', 'jetpack-forms' ),
+				'yearPickerButton'  => __( 'Year picker. Use the space key to enter the month picker.', 'jetpack-forms' ),
+				'dayButton'         => __( 'Use the space key to select the date.', 'jetpack-forms' ),
+				'todayButton'       => __( 'Today button. Use the space key to select the current date.', 'jetpack-forms' ),
+				'clearButton'       => __( 'Clear button. Use the space key to clear the date picker.', 'jetpack-forms' ),
+				'closeButton'       => __( 'Close button. Use the space key to close the date picker.', 'jetpack-forms' ),
+			),
+		);
 
 		$date_format = $this->get_attribute( 'dateformat' );
 		$date_format = isset( $date_format ) && ! empty( $date_format ) ? $date_format : 'yy-mm-dd';

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -1493,7 +1493,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 			'clear'     => __( 'Clear', 'jetpack-forms' ),
 			'close'     => __( 'Close', 'jetpack-forms' ),
 			'ariaLabel' => array(
-				'enterPicker'       => __( 'You are on a date picker input. Use the down key to focus into the date picker. Or type the date in the format MM/DD/YYYY', 'jetpack-forms' ),
+				'enterPicker'       => __( 'You are on a date picker input. Use the down key to focus into the date picker.', 'jetpack-forms' ),
 				'dayPicker'         => __( 'You are currently inside the date picker, use the arrow keys to navigate between the dates. Use tab key to jump to more controls.', 'jetpack-forms' ),
 				'monthPicker'       => __( 'You are currently inside the month picker, use the arrow keys to navigate between the months. Use the space key to select it.', 'jetpack-forms' ),
 				'yearPicker'        => __( 'You are currently inside the year picker, use the up and down arrow keys to navigate between the years. Use the space key to select it.', 'jetpack-forms' ),

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -1473,7 +1473,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		);
 		// phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		$local = array(
-			// translators: These are the two letter abbreviated name of the week.
+			// translators: These are the two letter abbreviated names of the days of the week.
 			'days'      => array( __( 'Su', 'jetpack-forms' ), __( 'Mo', 'jetpack-forms' ), __( 'Tu', 'jetpack-forms' ), __( 'We', 'jetpack-forms' ), __( 'Th', 'jetpack-forms' ), __( 'Fr', 'jetpack-forms' ), __( 'Sa', 'jetpack-forms' ) ),
 			'months'    => array(
 				__( 'January', 'jetpack-forms' ),


### PR DESCRIPTION
This PR only adds the date picker translations so that the strings get translated before we deploy the change more widely. 

## Proposed changes:
* Add date picker translations

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1749852431315949/1749758456.068639-slack-C052XEUUBL4

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
* Do the tests pass? 
* The code should do nothing but trigger the translations.