### PR TITLE
Forms: fix interactivity field is undefined

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-interactivity-undefined
+++ b/projects/packages/forms/changelog/fix-forms-interactivity-undefined
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: fix interactivity bug where the field is not registed yet

--- a/projects/packages/forms/src/modules/form/view.js
+++ b/projects/packages/forms/src/modules/form/view.js
@@ -18,8 +18,8 @@ const config = getConfig( NAMESPACE );
 const updateField = ( fieldId, value, showFieldError = false ) => {
 	const context = getContext();
 	const field = context.fields[ fieldId ];
-	const { type, isRequired, extra } = field;
 	if ( field ) {
+		const { type, isRequired, extra } = field;
 		field.value = value;
 		field.error = validateField( type, value, isRequired, extra );
 		field.showFieldError = showFieldError;

--- a/projects/packages/forms/src/modules/form/view.js
+++ b/projects/packages/forms/src/modules/form/view.js
@@ -17,7 +17,13 @@ const config = getConfig( NAMESPACE );
 
 const updateField = ( fieldId, value, showFieldError = false ) => {
 	const context = getContext();
-	const field = context.fields[ fieldId ];
+	let field = context.fields[ fieldId ];
+
+	if ( ! field ) {
+		const { fieldType, fieldLabel, fieldValue, fieldIsRequired, fieldExtra } = context;
+		registerField( fieldId, fieldType, fieldLabel, fieldValue, fieldIsRequired, fieldExtra );
+		field = context.fields[ fieldId ];
+	}
 	if ( field ) {
 		const { type, isRequired, extra } = field;
 		field.value = value;


### PR DESCRIPTION
Sometimes in my testing (only on FF) the field was not defined yet as the user was interactiing with it so the field value was causing an error. 



## Proposed changes:
* This Pr fixes the error by checking if field is defined already and if that is not the case then register it. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion


## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
* Go to a .com sandbox. 
* Create a new form. with an email field. 
* publish it. 
* visit the page. Notice that now you see the validation error when you blur the field. 


