### PR TITLE
Forms: fixes php warning

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-php-warning
+++ b/projects/packages/forms/changelog/fix-forms-php-warning
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: fixes a PHP warning 

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -2573,7 +2573,7 @@ class Contact_Form_Plugin {
 		if ( ! is_array( $all_values ) ) {
 			$all_values = array();
 		}
-
+		$fields['_feedback_all_fields'] = array();
 		foreach ( $all_values as $key => $value ) {
 			$fields['_feedback_all_fields'][ wp_strip_all_tags( $key ) ] = $value;
 		}


### PR DESCRIPTION
Fixes a PHP warning where the that shows up when functions are expecting to be able to access $fields['_feedback_all_fields']

## Proposed changes:
* Add the $fields['_feedback_all_fields'] always. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
Do the tests pass?

