### PR TITLE
ci: Update test-wpcom-filename-restrictions

### DIFF
--- a/.github/files/test-wpcom-filename-restrictions.sh
+++ b/.github/files/test-wpcom-filename-restrictions.sh
@@ -36,7 +36,7 @@ function check_invalid_chars {
 	fi
 }
 
-# Based on Automattic/pre-receive-hooks/blob/221f27e6/common/130-stop-executables.sh
+# Based on Automattic/pre-receive-hooks/blob/376c99d3/common/130-stop-executables.sh
 function check_executable {
 	local FILE="$1"
 	if [[ "$( git ls-files -s "${FILE}" | awk '{ print $1 }' )" == "100755" ]]; then
@@ -159,7 +159,7 @@ while IFS=$'\t' read -r SRC MIRROR SLUG; do
 		echo "- $FILE"
 		check_underscores "$FILE"
 		check_invalid_chars "$FILE"
-		# check_executable "$FILE" # Not enabled for wpcom?
+		check_executable "$FILE"
 		check_symlink "$FILE"
 	done < <( git -c core.quotepath=off diff --cached --name-only --no-renames --diff-filter=A )
 
@@ -167,7 +167,6 @@ while IFS=$'\t' read -r SRC MIRROR SLUG; do
 	echo 'Modified files:'
 	while IFS= read -r FILE; do
 		echo "- $FILE"
-		# check_executable "$FILE" # Not enabled for wpcom?
 		check_symlink "$FILE"
 	done < <( git -c core.quotepath=off diff --cached --name-only --no-renames --diff-filter=M )
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Looks like they've enabled the executable check on wpcom, and have now adjusted it to only check added files (not modified ones).

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Try making a PR based on this one that adds a new executable file that would make it into Jetpack or jetpack-mu-wpcom-plugin. See if the appropriate Post-Build check fails.