### PR TITLE
Forms: fix html in labels for animated forms

### DIFF
--- a/projects/packages/forms/changelog/fix-form-html-in-labels
+++ b/projects/packages/forms/changelog/fix-form-html-in-labels
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: labels in animated style support html

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -1754,7 +1754,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 				class="' . $classes . '"
 				style="' . $this->label_styles . '"
 			>
-				<span class="grunion-label-text">' . esc_html( $label ) . '</span>'
+				<span class="grunion-label-text">' . wp_kses_post( $label ) . '</span>'
 				. ( $required ? '<span class="grunion-label-required" aria-hidden="true">' . $required_field_text . '</span>' : '' ) .
 			'</label>';
 	}


### PR DESCRIPTION
Before:
![Screenshot 2025-06-14 at 10 07 32 AM](https://github.com/user-attachments/assets/c16aa44e-76b0-4a8d-83ae-9fd7f5cd072b)



After: 
![Screenshot 2025-06-14 at 10 09 51 AM](https://github.com/user-attachments/assets/7a6a1e76-6f10-4c17-9762-760fe3dedb11)


Fixes [FORMS-172](https://linear.app/a8c/issue/FORMS-172/support-html-in-animated-form-labels)

## Proposed changes:
* It update the rendering of the render_animated_label to use add support for a html. Vs escaping it. 
* This form style does have support for html in labels. 

We are not updating the outline form styles since labels in that form style don't have such support yet. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
non

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
1. Add a form block to a page or post. 
2. Switch the form style to animated. 
3. Update the label to be bold or have italics. 
4. Save the page. 
5. Notice the label has the correct HTML applied. 



