### PR TITLE
Forms: improves the validation error animation

### DIFF
--- a/projects/packages/forms/changelog/add-forms-validation-animation
+++ b/projects/packages/forms/changelog/add-forms-validation-animation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Form: improve the error validation animation

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -1101,20 +1101,24 @@ on production builds, the attributes are being reordered, causing side-effects
 
 .contact-form__input-error {
 	margin: 0.25rem 0;
+	position: relative;
 	gap: 0.33em;
 	font-size: 1rem;
 	color: var(--jetpack--contact-form--error-color);
 	opacity: 0;
 	max-height: 0;
 	overflow: hidden;
-	transition: max-height 0.2s ease-in,opacity 0.2s ease;
+	transform: translateY( -5px);
+	padding-left: 20px;
+	transition: max-height 100ms ease-out, opacity 100ms ease-out, transform 100ms ease-out;
 }
 
 .contact-form__input-error.has-errors {
 	display: flex;
 	opacity: 1;
 	max-height: 2em;
-	transition: max-height 0.3s ease-in,opacity 0.3s ease;
+	transform: translateY(0);
+	transition: opacity 200ms ease-out, transform 200ms ease-in;
 }
 
 .contact-form [aria-invalid="true"]:not(fieldset),
@@ -1129,8 +1133,10 @@ on production builds, the attributes are being reordered, causing side-effects
 }
 
 .contact-form__warning-icon {
-	display: flex;
-	margin: .3em 0 0;
+	position: absolute;
+	top: 50%;
+	left: 0;
+	transform: translateY(-50%);
 }
 
 .contact-form__warning-icon svg {

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -1101,16 +1101,14 @@ on production builds, the attributes are being reordered, causing side-effects
 
 .contact-form__input-error {
 	margin: 0.25rem 0;
-	position: relative;
 	gap: 0.33em;
 	font-size: 1rem;
 	color: var(--jetpack--contact-form--error-color);
 	opacity: 0;
 	max-height: 0;
 	overflow: hidden;
-	transform: translateY( -5px);
-	padding-left: 20px;
-	transition: max-height 100ms ease-out, opacity 100ms ease-out, transform 100ms ease-out;
+	transform: translateY( -0.33em );
+	transition: max-height 200ms cubic-bezier(0.34, 0.8, 0.34, 1), opacity 200ms cubic-bezier(0.34, 0.8, 0.34, 1), transform 100ms cubic-bezier(0.34, 0.8, 0.34, 1);
 }
 
 .contact-form__input-error.has-errors {
@@ -1118,7 +1116,7 @@ on production builds, the attributes are being reordered, causing side-effects
 	opacity: 1;
 	max-height: 2em;
 	transform: translateY(0);
-	transition: opacity 200ms ease-out, transform 200ms ease-in;
+	transition: opacity 200ms cubic-bezier(0.34, 0.8, 0.34, 1), transform 200ms cubic-bezier(0.34, 0.8, 0.34, 1);
 }
 
 .contact-form [aria-invalid="true"]:not(fieldset),
@@ -1133,10 +1131,10 @@ on production builds, the attributes are being reordered, causing side-effects
 }
 
 .contact-form__warning-icon {
-	position: absolute;
-	top: 50%;
-	left: 0;
-	transform: translateY(-50%);
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	margin: auto 0;
 }
 
 .contact-form__warning-icon svg {

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -1106,17 +1106,27 @@ on production builds, the attributes are being reordered, causing side-effects
 	color: var(--jetpack--contact-form--error-color);
 	opacity: 0;
 	height: 0;
-	display: none;
 	overflow: hidden;
-	transition: opacity 0.3s ease-out, height 0.3s ease-out;
+	transition: opacity 0.2s ease;
 }
 
 .contact-form__input-error.has-errors {
-
 	display: flex;
-	gap: 0.33em;
 	opacity: 1;
 	height: auto;
+	animation-name: jp-grow;
+  	animation-duration: 0.2s;
+}
+
+@keyframes jp-grow {
+
+  0% {
+    height: 0;
+  }
+
+  100% {
+    height: 1.5em;
+  }
 }
 
 .contact-form [aria-invalid="true"]:not(fieldset),
@@ -1132,15 +1142,13 @@ on production builds, the attributes are being reordered, causing side-effects
 
 .contact-form__warning-icon {
 	display: flex;
-	align-items: center;
-	justify-content: center;
-	margin: auto 0;
+	margin: .3em 0 0;
 }
 
 .contact-form__warning-icon svg {
 	fill: currentColor;
-  	display: block; /* Prevents extra space */
-  	margin: 0 auto; /* Centers horizontally */
+  	display: block;
+  	margin: 0 auto;
 }
 
 .contact-form__checkbox-wrap {

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -1105,28 +1105,16 @@ on production builds, the attributes are being reordered, causing side-effects
 	font-size: 1rem;
 	color: var(--jetpack--contact-form--error-color);
 	opacity: 0;
-	height: 0;
+	max-height: 0;
 	overflow: hidden;
-	transition: opacity 0.2s ease;
+	transition: max-height 0.2s ease-in,opacity 0.2s ease;
 }
 
 .contact-form__input-error.has-errors {
 	display: flex;
 	opacity: 1;
-	height: auto;
-	animation-name: jp-grow;
-  	animation-duration: 0.2s;
-}
-
-@keyframes jp-grow {
-
-  0% {
-    height: 0;
-  }
-
-  100% {
-    height: 1.5em;
-  }
+	max-height: 2em;
+	transition: max-height 0.3s ease-in,opacity 0.3s ease;
 }
 
 .contact-form [aria-invalid="true"]:not(fieldset),
@@ -1147,8 +1135,8 @@ on production builds, the attributes are being reordered, causing side-effects
 
 .contact-form__warning-icon svg {
 	fill: currentColor;
-  	display: block;
-  	margin: 0 auto;
+	display: block;
+	margin: 0 auto;
 }
 
 .contact-form__checkbox-wrap {

--- a/projects/plugins/jetpack/changelog/add-forms-validation-animation
+++ b/projects/plugins/jetpack/changelog/add-forms-validation-animation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Form: improve the error validation animation


### PR DESCRIPTION
Before:

https://github.com/user-attachments/assets/1d1a45f3-d2e7-4972-bd5c-d7b485bbb661

After:

https://github.com/user-attachments/assets/6f2f2345-1307-4b9b-abad-f9445d0fcbbf


Improved the animation 

## Proposed changes:
* Animate the error message by changing the max-height. 
* Add a fixed height to the warning triangle so that it moved as expected. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1HpG7-wPD-p2

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:

Add a form that has an email field. 
On the front end you should notice that the field's error message now animates differetntly. 

