### PR TITLE
Fix Protect "Logins Blocked" count

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/protect-card/logins-blocked-status.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/protect-card/logins-blocked-status.tsx
@@ -1,4 +1,4 @@
-import { formatNumber } from '@automattic/number-formatters';
+import { formatNumberCompact } from '@automattic/number-formatters';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import useProduct from '../../../data/products/use-product';
@@ -58,7 +58,7 @@ const BlockedStatus: FC< BlockedStatusProps > = ( { status, data } ) => {
 					{ __( 'Logins Blocked', 'jetpack-my-jetpack' ) }
 				</div>
 				<div className="value-section__data">
-					<div className="logins_blocked__count">{ formatNumber( blockedLoginsCount ) }</div>
+					<div className="logins_blocked__count">{ formatNumberCompact( blockedLoginsCount ) }</div>
 				</div>
 			</>
 		) : (
@@ -123,7 +123,9 @@ const BlockedStatus: FC< BlockedStatusProps > = ( { status, data } ) => {
 									) }
 								/>
 							</div>
-							<div className="logins_blocked__count">{ formatNumber( blockedLoginsCount ) }</div>
+							<div className="logins_blocked__count">
+								{ formatNumberCompact( blockedLoginsCount ) }
+							</div>
 						</>
 					) : (
 						<div>

--- a/projects/packages/my-jetpack/changelog/fix-logins-blocked-count
+++ b/projects/packages/my-jetpack/changelog/fix-logins-blocked-count
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Use compact number notation in the Protect card


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes [PROTECT-96][1].

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

Use the compact number format (`5.9M`) instead of the full number format (`5,931,700`) for `Logins Blocked` in the `Protect` card under `My Jetpack`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to `My Jetpack`.
* Look at the `Protect` card.
* The `Logins Blocked` count should show compact number format instead of the full number format.

| Before | After |
| - | - |
| ![image](https://github.com/user-attachments/assets/d24813ba-2092-45be-862b-05985c809518) | ![image](https://github.com/user-attachments/assets/511724c2-e6f1-4e7b-864a-000e5bc92670) |

If you don't have access to a blog with a significant number of blocked logins, you can [edit the same `logins-blocked-status.tsx` file][2] and set `blockedLoginsCount` to any number, like:

```diff
diff --git a/projects/packages/my-jetpack/_inc/components/product-cards-section/protect-card/logins-blocked-status.tsx b/projects/packages/my-jetpack/_inc/components/product-cards-section/protect-card/logins-blocked-status.tsx
index 0f7a6f49c8..eb9849bd12 100644
--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/protect-card/logins-blocked-status.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/protect-card/logins-blocked-status.tsx
@@ -46,7 +46,7 @@ interface BlockedStatusProps {
 }

 const BlockedStatus: FC< BlockedStatusProps > = ( { status, data } ) => {
-       const { blocked_logins: blockedLoginsCount } = data?.wafConfig || {};
+       const blockedLoginsCount = 5931700;

        const tooltipContent = useProtectTooltipCopy( data );
        const { blockedLoginsTooltip } = tooltipContent;
```

[1]: https://linear.app/a8c/issue/PROTECT-96/
[2]: https://github.com/Automattic/jetpack/blob/754e1ca918931f9d133aa76c7843175a56e4dcf9/projects/packages/my-jetpack/_inc/components/product-cards-section/protect-card/logins-blocked-status.tsx#L49
