### PR TITLE
Boost: Ensure Background Images also preserve Aspect Ratio

### DIFF
--- a/projects/plugins/boost/app/modules/optimizations/lcp/class-lcp-optimize-bg-image.php
+++ b/projects/plugins/boost/app/modules/optimizations/lcp/class-lcp-optimize-bg-image.php
@@ -146,11 +146,21 @@ class LCP_Optimize_Bg_Image {
 			}
 
 			// The Cloud should always return a fixed pixel width for background images, so catering for that is easy peasy.
-			if ( ! isset( $breakpoint['imageWidths'][0] ) ) {
+			if ( empty( $breakpoint['imageDimensions'] ) || ! is_array( $breakpoint['imageDimensions'] ) ) {
 				continue;
 			}
 
-			$image_width = $breakpoint['imageWidths'][0];
+			if ( ! isset( $breakpoint['imageDimensions'][0]['width'] ) || ! is_numeric( $breakpoint['imageDimensions'][0]['width'] ) ) {
+				continue;
+			}
+
+			if ( ! isset( $breakpoint['imageDimensions'][0]['height'] ) || ! is_numeric( $breakpoint['imageDimensions'][0]['height'] ) ) {
+				continue;
+			}
+
+			// The width and height should already be an integer, but just in case.
+			$image_width  = (int) $breakpoint['imageDimensions'][0]['width'];
+			$image_height = (int) $breakpoint['imageDimensions'][0]['height'];
 
 			$media_query = array();
 			if ( isset( $breakpoint['minWidth'] ) ) {
@@ -162,30 +172,40 @@ class LCP_Optimize_Bg_Image {
 
 			$styles[] = array(
 				'media_query' => empty( $media_query ) ? 'all' : implode( ' and ', $media_query ),
-				'image_set'   => $this->get_image_set( $image_url, $image_width ),
-				'base_image'  => Image_CDN_Core::cdn_url( $image_url, array( 'w' => $image_width ) ),
+				'image_set'   => $this->get_image_set( $image_url, $image_width, $image_height ),
+				'base_image'  => Image_CDN_Core::cdn_url(
+					$image_url,
+					array(
+						'resize' => array( $image_width, $image_height ),
+					)
+				),
 			);
 		}
 		return $styles;
 	}
 
-	private function get_image_set( $image_url, $image_width ) {
+	private function get_image_set( $url, $width, $height ) {
 		$dprs = array( 1, 2 );
 
 		// Mobile devices usually have a DPR of 3 which is not common for desktop.
-		if ( $image_width <= 480 ) {
+		if ( $width <= 480 ) {
 			$dprs[] = 3;
 		}
 
 		// Accurately reflect the performance improvement in lighthouse by including a 1.75x DPR image for the Moto G Power.
-		if ( $image_width === 412 ) {
+		if ( $width === 412 ) {
 			$dprs[] = 1.75;
 		}
 
 		$image_set = array();
 		foreach ( $dprs as $dpr ) {
 			$image_set[] = array(
-				'url' => Image_CDN_Core::cdn_url( $image_url, array( 'w' => $image_width * $dpr ) ),
+				'url' => Image_CDN_Core::cdn_url(
+					$url,
+					array(
+						'resize' => array( $width * $dpr, $height * $dpr ),
+					)
+				),
 				'dpr' => $dpr,
 			);
 		}

--- a/projects/plugins/boost/app/modules/optimizations/lcp/class-lcp-optimize-bg-image.php
+++ b/projects/plugins/boost/app/modules/optimizations/lcp/class-lcp-optimize-bg-image.php
@@ -150,17 +150,19 @@ class LCP_Optimize_Bg_Image {
 				continue;
 			}
 
-			if ( ! isset( $breakpoint['imageDimensions'][0]['width'] ) || ! is_numeric( $breakpoint['imageDimensions'][0]['width'] ) ) {
+			$image_dimensions = $breakpoint['imageDimensions'][0];
+
+			if ( ! isset( $image_dimensions['width'] ) || ! is_numeric( $image_dimensions['width'] ) ) {
 				continue;
 			}
 
-			if ( ! isset( $breakpoint['imageDimensions'][0]['height'] ) || ! is_numeric( $breakpoint['imageDimensions'][0]['height'] ) ) {
+			if ( ! isset( $image_dimensions['height'] ) || ! is_numeric( $image_dimensions['height'] ) ) {
 				continue;
 			}
 
 			// The width and height should already be an integer, but just in case.
-			$image_width  = (int) $breakpoint['imageDimensions'][0]['width'];
-			$image_height = (int) $breakpoint['imageDimensions'][0]['height'];
+			$image_width  = (int) $image_dimensions['width'];
+			$image_height = (int) $image_dimensions['height'];
 
 			$media_query = array();
 			if ( isset( $breakpoint['minWidth'] ) ) {

--- a/projects/plugins/boost/changelog/fix-boost-lcp-bg-images-aspect-ratio-preservation
+++ b/projects/plugins/boost/changelog/fix-boost-lcp-bg-images-aspect-ratio-preservation
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: LCP: Changes to an unreleased feature.
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes [HOG-171: LCP: Ensure BG Images also preserve original aspect ration](https://linear.app/a8c/issue/HOG-171/lcp-ensure-bg-images-also-preserve-original-aspect-ration)

## Proposed changes:
* Ensure that LCP Background Images also use the `resize` property
* Ensure that LCP Background Images also respect the response changes made in https://github.com/Automattic/boost-cloud/pull/697 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
- Ensure that Latest Boost Cloud trunk is checked out locally.
- Latest Boost Developer plugin is installed, and LCP Type is set to Background Image.
- At least one Cornerstone Page set.
- LCP Optimization feature enabled.
- Image CDN is enabled.

Apply the following snippet below to test for multiple responsive changes of the LCP Background Image.
  <details>
  <summary>Width Changes</summary>

  ```php
add_action('wp_head', function() {
    ?>
    <style>
        #jb-test-lcp {
            width: 100%;
            max-width: 800px;
            height: 400px;
            margin: 0 auto 20px;
            display: block;
            border: 1px dashed #ccc;
            position: relative;
        }

        /* Grows to 360px at 360px viewport */
        @media (min-width: 360px) {
            #jb-test-lcp {
                width: 360px;
                height: 200px;
            }
        }

        /* Grows to 400px at 440px viewport */
        @media (min-width: 440px) {
            #jb-test-lcp {
                width: 400px;
                height: 225px;
            }
        }

        /* Full width at 768px viewport */
        @media (min-width: 768px) {
            #jb-test-lcp {
                width: 768px;
                height: 432px;
            }
        }

        /* Becomes 600px width at 1024px viewport */
        @media (min-width: 1024px) {
            #jb-test-lcp {
                width: 600px;
                height: 337px;
            }
        }

        /* Becomes 400px width again at 1366px viewport (same as 440px) */
        @media (min-width: 1366px) {
            #jb-test-lcp {
                width: 400px;
                height: 225px;
            }
        }

        /* Full width again at 1920px viewport */
        @media (min-width: 1600px) {
            #jb-test-lcp {
                width: 100%;
                height: 1080px;
            }
        }
    </style>
    <?php
});
  ```
</details>

1. Enable up Jurassic Tube/Localhost tunnel and login to the public URL available.
2. Click Optimize on the LCP Feature and wait for it to be completed.
3. Once completed, open your network tab, and go to a Cornerstone Page.
4. Filter the network tab, and find the LCP image being fetched. You should notice the Photon CDN URL, with an appropriate resize of the image.
5. **Ensure that the image was not requested twice for different widths, as this indicates the BG Media Query, or the preloading is not applying the correct image.**
6. Change the viewport from the dev tools, you should see the LCP image BG URL width is changing in relation to the actual width of the image itself.
7. When a new width is being requested, refresh the page to ensure that the same width is being requested by the preloading, and it's not being changed once the loading has been finished.

