### PR TITLE
Add/multi step auto advance handler

### DIFF
--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -704,6 +704,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 					data-wp-on--input='actions.onFieldChange'
 					data-wp-on--blur='actions.onFieldBlur'
 					data-wp-class--has-value='state.hasFieldValue'
+					data-wp-on--keydown='actions.onInputKeyDown'
 
 					" . $class . $placeholder . '
 					' . ( $required ? "required='true' aria-required='true' " : '' ) .
@@ -848,6 +849,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 						data-wp-on--blur='actions.onFieldBlur'
 						data-wp-class--has-value='state.hasFieldValue'
 						data-wp-bind--aria-invalid='state.fieldHasErrors'
+						data-wp-on--keydown='actions.onInputKeyDown'
 						aria-errormessage='" . esc_attr( $id ) . "-textarea-error-message'
 						"
 						. $class
@@ -1848,6 +1850,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 			'fieldIsRequired'   => $required,
 			'fieldErrorMessage' => '',
 			'fieldExtra'        => $this->get_field_extra( $type, $extra_attrs ),
+			'formHash'          => $this->form->hash,
 		);
 
 		$interactivity_attrs = ' data-wp-interactive="jetpack/form" ' . wp_interactivity_data_wp_context( $context ) . ' ';

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -704,7 +704,6 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 					data-wp-on--input='actions.onFieldChange'
 					data-wp-on--blur='actions.onFieldBlur'
 					data-wp-class--has-value='state.hasFieldValue'
-					data-wp-on--keydown='actions.onInputKeyDown'
 
 					" . $class . $placeholder . '
 					' . ( $required ? "required='true' aria-required='true' " : '' ) .
@@ -849,7 +848,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 						data-wp-on--blur='actions.onFieldBlur'
 						data-wp-class--has-value='state.hasFieldValue'
 						data-wp-bind--aria-invalid='state.fieldHasErrors'
-						data-wp-on--keydown='actions.onInputKeyDown'
+						data-wp-on--keydown='actions.onKeyDownTextarea'
 						aria-errormessage='" . esc_attr( $id ) . "-textarea-error-message'
 						"
 						. $class

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -842,7 +842,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		$field .= "<textarea
 		                style='" . $this->field_styles . "'
 		                name='" . esc_attr( $id ) . "'
-		                id='contact-form-comment-" . esc_attr( $id ) . "'
+		                id='" . esc_attr( $id ) . "'
 		                rows='20'
 						data-wp-text='state.getFieldValue'
 						data-wp-on--input='actions.onFieldChange'

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -841,7 +841,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		$field .= "<textarea
 		                style='" . $this->field_styles . "'
 		                name='" . esc_attr( $id ) . "'
-		                id='" . esc_attr( $id ) . "'
+		                id='contact-form-comment-" . esc_attr( $id ) . "'
 		                rows='20'
 						data-wp-text='state.getFieldValue'
 						data-wp-on--input='actions.onFieldChange'

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -436,6 +436,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 
 			if ( $max_steps > 0 ) {
 				$multistep_context = array(
+					'isMultistep' => true,
 					'currentStep' => isset( $_GET[ $id . '-step' ] ) ? absint( $_GET[ $id . '-step' ] ) : 1,
 					'maxSteps'    => $max_steps,
 					'direction'   => 'forward', // Default direction for animations

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -425,6 +425,8 @@ class Contact_Form extends Contact_Form_Shortcode {
 				}
 			}
 
+			$is_multistep = boolval( $max_steps > 0 );
+
 			$default_context = array(
 				'formId'      => $id,
 				'formHash'    => $form->hash,
@@ -436,7 +438,6 @@ class Contact_Form extends Contact_Form_Shortcode {
 
 			if ( $max_steps > 0 ) {
 				$multistep_context = array(
-					'isMultistep' => true,
 					'currentStep' => isset( $_GET[ $id . '-step' ] ) ? absint( $_GET[ $id . '-step' ] ) : 1,
 					'maxSteps'    => $max_steps,
 					'direction'   => 'forward', // Default direction for animations
@@ -460,6 +461,10 @@ class Contact_Form extends Contact_Form_Shortcode {
 				data-wp-class--is-first-step=\"state.isFirstStep\"
 				data-wp-class--is-last-step=\"state.isLastStep\"
 				novalidate >\n";
+
+			if ( $is_multistep ) { // This makes the "enter" key work in multi-step forms as expected.
+				$r .= '<input type="submit" style="display: none;" />';
+			}
 
 			$r .= $form->body;
 

--- a/projects/packages/forms/src/modules/form-step-navigation/view.js
+++ b/projects/packages/forms/src/modules/form-step-navigation/view.js
@@ -1,14 +1,8 @@
 import { getContext, store, withSyncEvent } from '@wordpress/interactivity';
+import { focusNextInput } from '../form/shared';
 
 const NAMESPACE = 'jetpack/form';
-const focusNextInput = formHash => {
-	const form = document.getElementById( 'jp-form-' + formHash );
-	const currentStep = form.querySelector( '.is-current-step' );
-	const focusableElements = currentStep.querySelectorAll(
-		'input, select, textarea, .jetpack-form-file-field__dropzone-inner, [tabindex]:not([disabled])'
-	);
-	focusableElements[ 0 ]?.focus();
-};
+
 const { state } = store( NAMESPACE, {
 	state: {
 		get isFirstStep() {

--- a/projects/packages/forms/src/modules/form-step/view.js
+++ b/projects/packages/forms/src/modules/form-step/view.js
@@ -2,7 +2,7 @@ import { getContext, store } from '@wordpress/interactivity';
 
 const NAMESPACE = 'jetpack/form';
 
-const { state } = store( NAMESPACE, {
+store( NAMESPACE, {
 	state: {
 		get isCurrentStep() {
 			const context = getContext();
@@ -17,14 +17,6 @@ const { state } = store( NAMESPACE, {
 		get isBeforeCurrent() {
 			const context = getContext();
 			return context.currentStep > context.step;
-		},
-
-		get step() {
-			return state.form.querySelector( '.jetpack-form-step.is-current-step' );
-		},
-
-		get stepInputs() {
-			return state.step.querySelectorAll( '.grunion-field' );
 		},
 	},
 } );

--- a/projects/packages/forms/src/modules/form-step/view.js
+++ b/projects/packages/forms/src/modules/form-step/view.js
@@ -2,7 +2,7 @@ import { getContext, store } from '@wordpress/interactivity';
 
 const NAMESPACE = 'jetpack/form';
 
-store( NAMESPACE, {
+const { state } = store( NAMESPACE, {
 	state: {
 		get isCurrentStep() {
 			const context = getContext();
@@ -17,6 +17,14 @@ store( NAMESPACE, {
 		get isBeforeCurrent() {
 			const context = getContext();
 			return context.currentStep > context.step;
+		},
+
+		get step() {
+			return state.form.querySelector( '.jetpack-form-step.is-current-step' );
+		},
+
+		get stepInputs() {
+			return state.step.querySelectorAll( '.grunion-field' );
 		},
 	},
 } );

--- a/projects/packages/forms/src/modules/form/shared.js
+++ b/projects/packages/forms/src/modules/form/shared.js
@@ -1,0 +1,28 @@
+const getForm = formHash => {
+	return document.getElementById( 'jp-form-' + formHash );
+};
+
+export const focusNextInput = formHash => {
+	const form = getForm( formHash );
+	if ( ! form ) {
+		return;
+	}
+	const currentStep = form.querySelector( '.is-current-step' );
+	const focusableElements = currentStep.querySelectorAll(
+		'input, select, textarea, .jetpack-form-file-field__dropzone-inner, [tabindex]:not([disabled])'
+	);
+	focusableElements[ 0 ]?.focus();
+};
+
+export const submitForm = formHash => {
+	const form = getForm( formHash );
+	if ( ! form ) {
+		return;
+	}
+	form.dispatchEvent(
+		new Event( 'submit', {
+			bubbles: true,
+			cancelable: true,
+		} )
+	);
+};

--- a/projects/packages/forms/src/modules/form/view.js
+++ b/projects/packages/forms/src/modules/form/view.js
@@ -204,6 +204,20 @@ const { state, actions } = store( NAMESPACE, {
 		get submitButton() {
 			return state.form.querySelector( 'button[data-id-attr="submit-step"]' );
 		},
+
+		get isMultistep() {
+			const context = getContext();
+			return context.isMultistep;
+		},
+
+		get isLastInputInStep() {
+			const context = getContext();
+			return context.fieldId === state.stepInputs[ state.stepInputs.length - 1 ].id;
+		},
+
+		get shouldAutoAdvance() {
+			return state.isMultiStep && state.isLastInputInStep;
+		},
 	},
 
 	actions: {

--- a/projects/packages/forms/src/modules/form/view.js
+++ b/projects/packages/forms/src/modules/form/view.js
@@ -5,6 +5,7 @@ import {
 	withSyncEvent as originalWithSyncEvent,
 } from '@wordpress/interactivity';
 import { validateField } from '../../contact-form/js/validate-helper';
+import { focusNextInput, submitForm } from './shared';
 
 const withSyncEvent =
 	originalWithSyncEvent ||
@@ -14,9 +15,6 @@ const withSyncEvent =
 
 const NAMESPACE = 'jetpack/form';
 const config = getConfig( NAMESPACE );
-// Enter auto advance fields
-const enterAdvanceFields = [ 'name', 'text', 'email', 'telephone', 'url', 'number' ];
-const cmdAdvanceFields = [ 'textarea' ];
 
 const updateField = ( fieldId, value, showFieldError = false ) => {
 	const context = getContext();
@@ -73,7 +71,7 @@ const getError = field => {
 	return config.error_types && config.error_types[ field.error ];
 };
 
-const { state, actions } = store( NAMESPACE, {
+const { state } = store( NAMESPACE, {
 	state: {
 		get fieldHasErrors() {
 			const context = getContext();
@@ -119,8 +117,7 @@ const { state, actions } = store( NAMESPACE, {
 		},
 
 		get isAriaDisabled() {
-			const context = getContext();
-			return context.isSubmitting;
+			return state.isSubmitting;
 		},
 
 		get errorMessage() {
@@ -177,6 +174,7 @@ const { state, actions } = store( NAMESPACE, {
 					if ( context.isMultiStep && field.step !== context.currentStep ) {
 						return;
 					}
+
 					if ( field.error && field.error !== 'yes' ) {
 						errors.push( {
 							anchor: '#' + field.id,
@@ -194,29 +192,6 @@ const { state, actions } = store( NAMESPACE, {
 			const fieldId = context.fieldId;
 			const field = context.fields[ fieldId ];
 			return field.value;
-		},
-
-		get form() {
-			const context = getContext();
-			return document.getElementById( 'jp-form-' + context.formHash );
-		},
-
-		get submitButton() {
-			return state.form.querySelector( 'button[data-id-attr="submit-step"]' );
-		},
-
-		get isMultistep() {
-			const context = getContext();
-			return context.isMultistep;
-		},
-
-		get isLastInputInStep() {
-			const context = getContext();
-			return context.fieldId === state.stepInputs[ state.stepInputs.length - 1 ].id;
-		},
-
-		get shouldAutoAdvance() {
-			return state.isMultistep && state.isLastInputInStep;
 		},
 	},
 
@@ -277,17 +252,37 @@ const { state, actions } = store( NAMESPACE, {
 				context.showErrors = true;
 				event.preventDefault();
 				event.stopPropagation();
-				return false;
+				return;
+			}
+
+			if ( context.isMultiStep && context.currentStep < context.maxSteps ) {
+				// If this is a multistep form and the current input is not the last in the step,
+				// we don't want to submit the form, but rather advance to the next step.
+				context.currentStep += 1;
+				context.showErrors = false;
+
+				event.preventDefault();
+				event.stopPropagation();
+				const formHash = context.formHash;
+				setTimeout( () => {
+					focusNextInput( formHash );
+				}, 100 );
+				return;
 			}
 			context.isSubmitting = true;
-			return true;
 		} ),
 
-		triggerSubmit: withSyncEvent( event => {
-			if ( actions.onFormSubmit( event ) ) {
-				state.form.requestSubmit( state.submitButton );
+		onKeyDownTextarea: withSyncEvent( event => {
+			if ( ! ( event.key === 'Enter' && ! event.shiftKey ) ) {
+				return;
 			}
-			state.form.requestSubmit( state.submitButton );
+			// Prevent the default behavior of adding a new line.
+			event.preventDefault();
+			event.stopPropagation();
+
+			const context = getContext();
+
+			submitForm( context.formHash );
 		} ),
 
 		scrollIntoView: withSyncEvent( event => {
@@ -317,37 +312,6 @@ const { state, actions } = store( NAMESPACE, {
 				fieldset.querySelector( 'input' ).focus( { preventScroll: true } );
 				fieldset.scrollIntoView( { behavior: 'smooth' } );
 				event.preventDefault();
-			}
-		} ),
-
-		onInputKeyDown: withSyncEvent( event => {
-			if ( ! state.shouldAutoAdvance ) {
-				return;
-			}
-			const context = getContext();
-
-			if ( enterAdvanceFields.includes( context.fieldType ) && event.key === 'Enter' ) {
-				event.preventDefault();
-				if ( ! state.isLastStep ) {
-					actions.nextStep( event );
-				} else {
-					actions.triggerSubmit( event );
-				}
-				return;
-			}
-
-			if (
-				cmdAdvanceFields.includes( context.fieldType ) &&
-				event.key === 'Enter' &&
-				// cmd/meta for Mac, ctrl for Windows
-				( event.metaKey || event.ctrlKey )
-			) {
-				event.preventDefault();
-				if ( ! state.isLastStep ) {
-					actions.nextStep( event );
-				} else {
-					actions.triggerSubmit( event );
-				}
 			}
 		} ),
 	},

--- a/projects/packages/forms/src/modules/form/view.js
+++ b/projects/packages/forms/src/modules/form/view.js
@@ -216,7 +216,7 @@ const { state, actions } = store( NAMESPACE, {
 		},
 
 		get shouldAutoAdvance() {
-			return state.isMultiStep && state.isLastInputInStep;
+			return state.isMultistep && state.isLastInputInStep;
 		},
 	},
 
@@ -321,14 +321,17 @@ const { state, actions } = store( NAMESPACE, {
 		} ),
 
 		onInputKeyDown: withSyncEvent( event => {
+			if ( ! state.shouldAutoAdvance ) {
+				return;
+			}
 			const context = getContext();
 
 			if ( enterAdvanceFields.includes( context.fieldType ) && event.key === 'Enter' ) {
 				event.preventDefault();
-				if ( state.isLastStep ) {
-					actions.triggerSubmit( event );
-				} else {
+				if ( ! state.isLastStep ) {
 					actions.nextStep( event );
+				} else {
+					actions.triggerSubmit( event );
 				}
 				return;
 			}
@@ -340,10 +343,10 @@ const { state, actions } = store( NAMESPACE, {
 				( event.metaKey || event.ctrlKey )
 			) {
 				event.preventDefault();
-				if ( state.isLastStep ) {
-					actions.triggerSubmit( event );
-				} else {
+				if ( ! state.isLastStep ) {
 					actions.nextStep( event );
+				} else {
+					actions.triggerSubmit( event );
 				}
 			}
 		} ),

--- a/projects/packages/forms/src/modules/form/view.js
+++ b/projects/packages/forms/src/modules/form/view.js
@@ -174,7 +174,6 @@ const { state } = store( NAMESPACE, {
 					if ( context.isMultiStep && field.step !== context.currentStep ) {
 						return;
 					}
-
 					if ( field.error && field.error !== 'yes' ) {
 						errors.push( {
 							anchor: '#' + field.id,

--- a/projects/packages/forms/src/modules/form/view.js
+++ b/projects/packages/forms/src/modules/form/view.js
@@ -14,6 +14,9 @@ const withSyncEvent =
 
 const NAMESPACE = 'jetpack/form';
 const config = getConfig( NAMESPACE );
+// Enter auto advance fields
+const enterAdvanceFields = [ 'name', 'text', 'email', 'tel', 'url', 'number' ];
+const cmdAdvanceFields = [ 'textarea' ];
 
 const updateField = ( fieldId, value, showFieldError = false ) => {
 	const context = getContext();
@@ -70,7 +73,7 @@ const getError = field => {
 	return config.error_types && config.error_types[ field.error ];
 };
 
-const { state } = store( NAMESPACE, {
+const { state, actions } = store( NAMESPACE, {
 	state: {
 		get fieldHasErrors() {
 			const context = getContext();
@@ -192,6 +195,15 @@ const { state } = store( NAMESPACE, {
 			const field = context.fields[ fieldId ];
 			return field.value;
 		},
+
+		get form() {
+			const context = getContext();
+			return document.getElementById( 'jp-form-' + context.formHash );
+		},
+
+		get submitButton() {
+			return state.form.querySelector( 'button[data-id-attr="submit-step"]' );
+		},
 	},
 
 	actions: {
@@ -251,9 +263,17 @@ const { state } = store( NAMESPACE, {
 				context.showErrors = true;
 				event.preventDefault();
 				event.stopPropagation();
-			} else {
-				context.isSubmitting = true;
+				return false;
 			}
+			context.isSubmitting = true;
+			return true;
+		} ),
+
+		triggerSubmit: withSyncEvent( event => {
+			if ( actions.onFormSubmit( event ) ) {
+				state.form.requestSubmit( state.submitButton );
+			}
+			state.form.requestSubmit( state.submitButton );
 		} ),
 
 		scrollIntoView: withSyncEvent( event => {
@@ -283,6 +303,34 @@ const { state } = store( NAMESPACE, {
 				fieldset.querySelector( 'input' ).focus( { preventScroll: true } );
 				fieldset.scrollIntoView( { behavior: 'smooth' } );
 				event.preventDefault();
+			}
+		} ),
+
+		onInputKeyDown: withSyncEvent( event => {
+			const context = getContext();
+
+			if ( enterAdvanceFields.includes( context.fieldType ) && event.key === 'Enter' ) {
+				event.preventDefault();
+				if ( state.isLastStep ) {
+					actions.triggerSubmit( event );
+				} else {
+					actions.nextStep( event );
+				}
+				return;
+			}
+
+			if (
+				cmdAdvanceFields.includes( context.fieldType ) &&
+				event.key === 'Enter' &&
+				// cmd/meta for Mac, ctrl for Windows
+				( event.metaKey || event.ctrlKey )
+			) {
+				event.preventDefault();
+				if ( state.isLastStep ) {
+					actions.triggerSubmit( event );
+				} else {
+					actions.nextStep( event );
+				}
 			}
 		} ),
 	},

--- a/projects/packages/forms/src/modules/form/view.js
+++ b/projects/packages/forms/src/modules/form/view.js
@@ -15,7 +15,7 @@ const withSyncEvent =
 const NAMESPACE = 'jetpack/form';
 const config = getConfig( NAMESPACE );
 // Enter auto advance fields
-const enterAdvanceFields = [ 'name', 'text', 'email', 'tel', 'url', 'number' ];
+const enterAdvanceFields = [ 'name', 'text', 'email', 'telephone', 'url', 'number' ];
 const cmdAdvanceFields = [ 'textarea' ];
 
 const updateField = ( fieldId, value, showFieldError = false ) => {


### PR DESCRIPTION
## Proposed changes:
This PR implements keyDown handler for multi-step inputs to progress to next step or submit the form when "Enter" key is pressed on the last input of a step. So:

- if is a multistep form
- if it's the last input (enter key) or textarea (cmd/ctrl enter key) on the step

It will:

- move to next step
- submit the form if it's the last step

NOTE: as all text fields are rendered from a central method a single keyDown handler is needed. This PR moves the keyDown handler used by number field types inside the newly added handler.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1750099700826579/1750099620.144959-slack-C086RGTJT1D

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

Add forms on a post:

- 1 multistep form with a single or multiple inputs per step
- 1 multistep form where the last input on some (or all) steps is a multiple line text (textarea)
- 1 regular form

Publish and visit the post. Test the described behavior:

- last input on multi step forms should move to next step or submit the form with the enter key, or with cmd/ctrl enter key when last input is a textarea
- regular forms should have not changed (enter key always tries to submit the form)