### PR TITLE
Jetpack_Carousel: Fix fatal error on array-like email POST

### DIFF
--- a/projects/plugins/jetpack/changelog/Jetpack_Carousel-email-fix
+++ b/projects/plugins/jetpack/changelog/Jetpack_Carousel-email-fix
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Security: Fixed issue where array-type email parameters could cause errors in carousel comment submissions

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
@@ -1266,8 +1266,11 @@ class Jetpack_Carousel {
 		} else {
 			$user_id      = 0;
 			$display_name = isset( $_POST['author'] ) ? sanitize_text_field( wp_unslash( $_POST['author'] ) ) : null;
-			$email        = isset( $_POST['email'] ) ? wp_unslash( $_POST['email'] ) : null; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Checked or sanitized below.
-			$url          = isset( $_POST['url'] ) ? esc_url_raw( wp_unslash( $_POST['url'] ) ) : null;
+			$email        = null;
+			if ( isset( $_POST['email'] ) && is_string( $_POST['email'] ) ) {
+				$email = wp_unslash( $_POST['email'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Checked or sanitized below.
+			}
+			$url = isset( $_POST['url'] ) ? esc_url_raw( wp_unslash( $_POST['url'] ) ) : null;
 
 			if ( get_option( 'require_name_email' ) ) {
 				if ( empty( $display_name ) ) {


### PR DESCRIPTION
Fixes #

## Proposed changes:
* Fix a fatal error when an array-like parameter is sent through the 'email' key
```
PHP Fatal error: Uncaught TypeError: strlen(): Argument #1 ($string) must be of type string, array given in /home/wpcom/public_html/wp-includes/formatting.php:3783
```

```
				$email = $email !== null ? sanitize_email( $email ) : null;
```

sanitize_email cannot handle an array - so if `$email` is an array, it crashes. This is from security scanners sending data like `email[]=...` in the post

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?

## Testing instructions:

* Go to '..'
*

