### PR TITLE
Fix line chart story groupings

### DIFF
--- a/projects/js-packages/charts/changelog/fix-line-chart-story-groupings
+++ b/projects/js-packages/charts/changelog/fix-line-chart-story-groupings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Line chart: Remove duplicate stories and centralize story config 

--- a/projects/js-packages/charts/src/components/line-chart/stories/config.tsx
+++ b/projects/js-packages/charts/src/components/line-chart/stories/config.tsx
@@ -1,7 +1,40 @@
+import { GlyphDiamond, GlyphStar } from '@visx/glyph';
 import React from 'react';
+import { jetpackTheme, wooTheme, ThemeProvider } from '../../../providers/theme';
+import { DefaultGlyph } from '../../shared/default-glyph';
 import LineChart from '../line-chart';
 import sampleData from './sample-data';
 import type { Meta } from '@storybook/react';
+
+const customStorybookTheme = {
+	...jetpackTheme,
+	glyphs: [
+		props => React.createElement( DefaultGlyph, { ...props, key: props.key } ),
+		props =>
+			React.createElement( GlyphStar, {
+				key: props.key,
+				top: props.y,
+				left: props.x,
+				size: props.size * props.size,
+				fill: props.color,
+			} ),
+		props =>
+			React.createElement( GlyphDiamond, {
+				key: props.key,
+				top: props.y,
+				left: props.x,
+				size: props.size * props.size,
+				fill: props.color,
+			} ),
+	],
+};
+
+const THEME_MAP = {
+	default: undefined,
+	jetpack: jetpackTheme,
+	woo: wooTheme,
+	customStorybook: customStorybookTheme,
+};
 
 export const lineChartMetaArgs = {
 	title: 'JS Packages/Charts/Types/Line Chart',
@@ -10,23 +43,34 @@ export const lineChartMetaArgs = {
 		layout: 'centered',
 	},
 	decorators: [
-		Story => (
-			<div
-				style={ {
-					resize: 'both',
-					overflow: 'auto',
-					padding: '2rem',
-					width: '800px',
-					maxWidth: '1200px',
-					border: '1px dashed #ccc',
-					display: 'inline-block',
-				} }
-			>
-				<Story />
-			</div>
-		),
+		( Story, { args } ) => {
+			const theme = THEME_MAP[ args.themeName ];
+
+			return (
+				<ThemeProvider theme={ theme }>
+					<div
+						style={ {
+							resize: 'both',
+							overflow: 'auto',
+							padding: '2rem',
+							width: '800px',
+							maxWidth: '1200px',
+							border: '1px dashed #ccc',
+							display: 'inline-block',
+						} }
+					>
+						<Story />
+					</div>
+				</ThemeProvider>
+			);
+		},
 	],
 	argTypes: {
+		themeName: {
+			control: 'select',
+			options: [ 'default', 'jetpack', 'woo', 'customStorybook' ],
+			defaultValue: 'default',
+		},
 		maxWidth: {
 			control: {
 				type: 'number',

--- a/projects/js-packages/charts/src/components/line-chart/stories/glyph.stories.tsx
+++ b/projects/js-packages/charts/src/components/line-chart/stories/glyph.stories.tsx
@@ -129,3 +129,15 @@ InTooltip.args = {
 	},
 	renderTooltip: ToolTipWithGlyph,
 };
+
+export const CustomPerDataPoint: StoryObj< typeof LineChart > = Template.bind( {} );
+CustomPerDataPoint.args = {
+	...glyphStoryArgs,
+	showLegend: true,
+	withStartGlyphs: true,
+	withLegendGlyph: true,
+	themeName: 'customStorybook', // Mock prop used to switch the rendered theme in the storybook.
+	glyphStyle: {
+		radius: 8,
+	},
+};

--- a/projects/js-packages/charts/src/components/line-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/components/line-chart/stories/index.stories.tsx
@@ -1,7 +1,4 @@
-import { GlyphDiamond, GlyphStar } from '@visx/glyph';
 import React from 'react';
-import { ThemeProvider, jetpackTheme, wooTheme } from '../../../providers/theme';
-import { DefaultGlyph } from '../../shared/default-glyph';
 import LineChart from '../line-chart';
 import { lineChartStoryArgs, lineChartMetaArgs } from './config';
 import largeValuesData from './large-values-sample';
@@ -9,94 +6,9 @@ import sampleData from './sample-data';
 import webTrafficData from './site-traffic-sample';
 import type { Meta, StoryFn, StoryObj } from '@storybook/react';
 
-const customStorybookTheme = {
-	...jetpackTheme,
-	glyphs: [
-		props => React.createElement( DefaultGlyph, { ...props, key: props.key } ),
-		props =>
-			React.createElement( GlyphStar, {
-				key: props.key,
-				top: props.y,
-				left: props.x,
-				size: props.size * props.size,
-				fill: props.color,
-			} ),
-		props =>
-			React.createElement( GlyphDiamond, {
-				key: props.key,
-				top: props.y,
-				left: props.x,
-				size: props.size * props.size,
-				fill: props.color,
-			} ),
-	],
-};
-
-const THEME_MAP = {
-	default: undefined,
-	jetpack: jetpackTheme,
-	woo: wooTheme,
-	customStorybook: customStorybookTheme,
-};
-
 const meta: Meta< typeof LineChart > = {
 	...lineChartMetaArgs,
 	title: 'JS Packages/Charts/Types/Line Chart',
-	component: LineChart,
-	parameters: {
-		layout: 'centered',
-	},
-	decorators: [
-		( Story, { args } ) => {
-			const theme = THEME_MAP[ args.themeName ];
-
-			return (
-				<ThemeProvider theme={ theme }>
-					<div
-						style={ {
-							resize: 'both',
-							overflow: 'auto',
-							padding: '2rem',
-							width: '800px',
-							maxWidth: '1200px',
-							border: '1px dashed #ccc',
-							display: 'inline-block',
-						} }
-					>
-						<Story />
-					</div>
-				</ThemeProvider>
-			);
-		},
-	],
-	argTypes: {
-		themeName: {
-			control: 'select',
-			options: [ 'default', 'jetpack', 'woo', 'customStorybook' ],
-			defaultValue: 'default',
-		},
-		maxWidth: {
-			control: {
-				type: 'number',
-				min: 100,
-				max: 1200,
-			},
-		},
-		aspectRatio: {
-			control: {
-				type: 'number',
-				min: 0,
-				max: 1,
-			},
-		},
-		resizeDebounceTime: {
-			control: {
-				type: 'number',
-				min: 0,
-				max: 10000,
-			},
-		},
-	},
 } satisfies Meta< typeof LineChart >;
 
 export default meta;
@@ -356,78 +268,6 @@ BrokenLine.parameters = {
 		description: {
 			story: 'Demonstrates the option of setting a seriesLineStyle to a dash array.',
 		},
-	},
-};
-
-export const WithStartGlyphs: StoryObj< typeof LineChart > = Template.bind( {} );
-WithStartGlyphs.args = {
-	...Default.args,
-	withStartGlyphs: true,
-};
-
-export const WithCustomGlyph: StoryObj< typeof LineChart > = Template.bind( {} );
-WithCustomGlyph.args = {
-	...Default.args,
-	showLegend: true,
-	withStartGlyphs: true,
-	withLegendGlyph: true,
-	renderGlyph: ( { color, size, x, y } ) => {
-		return <GlyphStar top={ y } left={ x } size={ size * size } fill={ color } />;
-	},
-	glyphStyle: {
-		radius: 10,
-	},
-};
-
-const CustomStarGlyph = ( { color, size, x, y } ) => {
-	const hasXY = typeof x === 'number' && typeof y === 'number' && ( x !== 0 || y !== 0 );
-	const groupProps = hasXY ? { transform: `translate(${ x }, ${ y })` } : {};
-	return (
-		<g { ...groupProps }>
-			<svg
-				xmlns="http://www.w3.org/2000/svg"
-				width={ size * 2 }
-				height={ size * 2 }
-				viewBox="0 0 24 24"
-				style={ { overflow: 'visible', pointerEvents: 'none' } }
-			>
-				<path
-					d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"
-					fill={ color }
-					stroke={ color }
-					strokeWidth="2"
-					strokeLinecap="round"
-					strokeLinejoin="round"
-					transform="translate(-12, -12)"
-				/>
-			</svg>
-		</g>
-	);
-};
-
-export const WithCustomSvgGlyph: StoryObj< typeof LineChart > = Template.bind( {} );
-WithCustomSvgGlyph.args = {
-	...Default.args,
-	showLegend: true,
-	withStartGlyphs: true,
-	withLegendGlyph: true,
-	renderGlyph: ( { color, size, x, y } ) => (
-		<CustomStarGlyph color={ color } size={ size } x={ x } y={ y } />
-	),
-	glyphStyle: {
-		radius: 8,
-	},
-};
-
-export const WithCustomGlyphsPerDataPoint: StoryObj< typeof LineChart > = Template.bind( {} );
-WithCustomGlyphsPerDataPoint.args = {
-	...Default.args,
-	showLegend: true,
-	withStartGlyphs: true,
-	withLegendGlyph: true,
-	themeName: 'customStorybook', // Mock prop used to switch the rendered theme in the storybook.
-	glyphStyle: {
-		radius: 8,
 	},
 };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

We've ended up with duplicate Line Chart glyph stories probably due to a conflict. This PR cleans that up.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Removes duplicate stories now moved to the glyph.stories.tsx
* Moves new story to glyph.stories.tsx and associated config to the shared file

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Run pnpm storybook from the charts directory
* Observe that glyph stories for the line chart are grouped in the Glyphs sub folder and do not exist at the top level, including the new story at http://localhost:50240/?path=/story/js-packages-charts-types-line-chart-glyphs--custom-per-data-point
* Ensure that the `themeName` switcher control is still present and functional on all line chart stories

