### PR TITLE
My Jetpack: Onboarding i4 | Always show the Products tab

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/index.tsx
@@ -58,6 +58,8 @@ export function MyJetpackTabPanel() {
 		tabStartTimeRef.current = Date.now();
 	}, [ initialTab ] );
 
+	const tabs = useMemo( () => getMyJetpackSections(), [] );
+
 	return (
 		<TabPanel
 			key={ initialTab }
@@ -65,7 +67,7 @@ export function MyJetpackTabPanel() {
 			initialTabName={ initialTab }
 			onSelect={ onTabSelect }
 			children={ tabRenderer }
-			tabs={ getMyJetpackSections() }
+			tabs={ tabs }
 		/>
 	);
 }

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/index.tsx
@@ -2,7 +2,6 @@ import { TabPanel } from '@wordpress/components';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useNavigate, useParams } from 'react-router';
 import useAnalytics from '../../hooks/use-analytics';
-import useFilteredProducts from '../../hooks/use-filtered-products';
 import useIsJetpackUserNew from '../../hooks/use-is-jetpack-user-new';
 import { MY_JETPACK_SECTION_OVERVIEW } from './constants';
 import styles from './styles.module.scss';
@@ -21,23 +20,12 @@ export function MyJetpackTabPanel() {
 	const { recordEvent } = useAnalytics();
 	const isNewUser = useIsJetpackUserNew();
 	const tabStartTimeRef = useRef< number >( Date.now() );
-	const { filteredUnownedProducts, isLoading } = useFilteredProducts();
-
-	const showProductsTab = useMemo( () => {
-		return filteredUnownedProducts.length > 0 && ! isLoading;
-	}, [ filteredUnownedProducts.length, isLoading ] );
-
-	const availableTabs = useMemo(
-		() => getMyJetpackSections( showProductsTab ),
-		[ showProductsTab ]
-	);
 
 	// If the tab is not valid, use the default one.
 	const initialTab = useMemo( () => {
-		const validTab = isValidMyJetpackSection( params.section, showProductsTab );
+		const validTab = isValidMyJetpackSection( params.section );
 		return validTab ? params.section : MY_JETPACK_SECTION_OVERVIEW;
-	}, [ params.section, showProductsTab ] );
-
+	}, [ params.section ] );
 	const onTabSelect = useCallback(
 		( tabName: string ) => {
 			if ( tabName !== params.section ) {
@@ -61,8 +49,8 @@ export function MyJetpackTabPanel() {
 		[ navigate, params.section, recordEvent, isNewUser ]
 	);
 
-	const tabRenderer = useCallback( ( tab: { name: MyJetpackSection } ) => {
-		return <TabContent name={ tab.name } />;
+	const tabRenderer = useCallback( ( tab: { name: string } ) => {
+		return <TabContent name={ tab.name as MyJetpackSection } />;
 	}, [] );
 
 	// Reset timer when component mounts or tab changes from external navigation
@@ -77,7 +65,7 @@ export function MyJetpackTabPanel() {
 			initialTabName={ initialTab }
 			onSelect={ onTabSelect }
 			children={ tabRenderer }
-			tabs={ availableTabs }
+			tabs={ getMyJetpackSections() }
 		/>
 	);
 }

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/utils.ts
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/utils.ts
@@ -10,11 +10,10 @@ import {
 /**
  * Get the My Jetpack sections.
  *
- * @param showProductsTab - Whether to show the products tab.
  * @return The sections for the My Jetpack tab panel.
  */
-export function getMyJetpackSections( showProductsTab: boolean ): TabPanelProps[ 'tabs' ] {
-	const showAdminTab = currentUserCan( 'manage_options' );
+export function getMyJetpackSections(): TabPanelProps[ 'tabs' ] {
+	const isAdmin = currentUserCan( 'manage_options' );
 
 	const tabs = [
 		{
@@ -31,16 +30,20 @@ export function getMyJetpackSections( showProductsTab: boolean ): TabPanelProps[
 		},
 	];
 
-	return [ tabs[ 0 ], ...( showProductsTab && showAdminTab ? [ tabs[ 1 ] ] : [] ), tabs[ 2 ] ];
+	if ( isAdmin ) {
+		return tabs;
+	}
+
+	// If the user is not an admin, remove the Products tab.
+	return tabs.filter( tab => tab.name !== MY_JETPACK_SECTION_PRODUCTS );
 }
 
 /**
  * Check if the given section is a valid My Jetpack section.
  *
- * @param section         - The section to check.
- * @param showProductsTab - Whether to show the products tab.
+ * @param section - The section to check.
  * @return True if the section is valid, false otherwise.
  */
-export function isValidMyJetpackSection( section: string, showProductsTab: boolean ) {
-	return getMyJetpackSections( showProductsTab ).some( item => item.name === section );
+export function isValidMyJetpackSection( section: string ) {
+	return getMyJetpackSections().some( item => item.name === section );
 }


### PR DESCRIPTION
Completes MYJP-188

In i3, we conditionally displayed the Products tab depending upon whether the user owns any products to avoid showing an empty tab in case there were no products to show. But, that is not the case with i4 and we alway want to show the Products tab

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Always show the Products tab in My Jetpack

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to My Jetpack
* Confirm that the Products tab is always visible for admins
* Confirm that it's not visible for non-admins

