### PR TITLE
Add Jetpack Monitor uptime in get site endpoint response

### DIFF
--- a/projects/plugins/jetpack/changelog/add-site-endpoint-uptime-field
+++ b/projects/plugins/jetpack/changelog/add-site-endpoint-uptime-field
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+WordPress.com: Add Jetpack Monitor uptime in API response

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -241,6 +241,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'was_hosting_trial',
 		'was_upgraded_from_trial',
 		'is_a4a_dev_site',
+		'uptime',
 	);
 
 	/**

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -89,6 +89,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'is_deleted'                  => '(bool) If the site flagged as deleted.',
 		'is_a4a_client'               => '(bool) If the site is an A4A client site.',
 		'is_a4a_dev_site'             => '(bool) If the site is an A4A dev site.',
+		'uptime'                      => '(array) An array keyed by unit of time that contains the site uptime for each day.',
 	);
 
 	/**
@@ -625,6 +626,9 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 				break;
 			case 'is_a4a_dev_site':
 				$response[ $key ] = $this->site->is_a4a_dev_site();
+				break;
+			case 'uptime':
+				$response[ $key ] = $this->site->get_uptime();
 				break;
 		}
 

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-v1-2-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-v1-2-endpoint.php
@@ -82,7 +82,6 @@ class WPCOM_JSON_API_GET_Site_V1_2_Endpoint extends WPCOM_JSON_API_GET_Site_Endp
 		'is_deleted'                  => '(bool) If the site flagged as deleted.',
 		'is_a4a_client'               => '(bool) If the site is an A4A client site.',
 		'is_a4a_dev_site'             => '(bool) If the site is an A4A dev site.',
-		'uptime'                      => '(array) An array keyed by unit of time that contains the site uptime for each day.',
 	);
 
 	/**

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-v1-2-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-v1-2-endpoint.php
@@ -82,6 +82,7 @@ class WPCOM_JSON_API_GET_Site_V1_2_Endpoint extends WPCOM_JSON_API_GET_Site_Endp
 		'is_deleted'                  => '(bool) If the site flagged as deleted.',
 		'is_a4a_client'               => '(bool) If the site is an A4A client site.',
 		'is_a4a_dev_site'             => '(bool) If the site is an A4A dev site.',
+		'uptime'                      => '(array) An array keyed by unit of time that contains the site uptime for each day.',
 	);
 
 	/**

--- a/projects/plugins/jetpack/sal/class.json-api-site-base.php
+++ b/projects/plugins/jetpack/sal/class.json-api-site-base.php
@@ -445,6 +445,15 @@ abstract class SAL_Site {
 	}
 
 	/**
+	 * Returns the site update status for a given timeframe.
+	 *
+	 * @return array
+	 */
+	public function get_uptime() {
+		return array();
+	}
+
+	/**
 	 * Return the user interactions with a site. Not used in Jetpack.
 	 *
 	 * @param string $role The capability to check.

--- a/projects/plugins/jetpack/sal/class.json-api-site-base.php
+++ b/projects/plugins/jetpack/sal/class.json-api-site-base.php
@@ -450,7 +450,7 @@ abstract class SAL_Site {
 	 * @return array
 	 */
 	public function get_uptime() {
-		return array();
+		return null;
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Ref DOTDASH-55.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR introduces the `uptime` field to the GET site endpoint. This field will be used to populate Jetpack Monitor uptime data for WP.com site/sites endpoints.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

This PR does not introduce any behavioral changes.

