### PR TITLE
Test: Imitate IPONWEB is terminated

### DIFF
--- a/projects/plugins/jetpack/changelog/test-iponweb-is-terminated
+++ b/projects/plugins/jetpack/changelog/test-iponweb-is-terminated
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Test: we want to check how the WordAds will work when IPONWEB's partnership is terminated.

--- a/projects/plugins/jetpack/modules/wordads/class-wordads.php
+++ b/projects/plugins/jetpack/modules/wordads/class-wordads.php
@@ -472,12 +472,14 @@ HTML;
 		$data_tags = ( $this->params->cloudflare ) ? ' data-cfasync="false"' : '';
 		?>
 		<script<?php echo esc_attr( $data_tags ); ?> type="text/javascript">
+		// TODO: Remove this imitation of previous implementation when IPONWEB's code is always loaded.
 		function loadIPONWEB() { // TODO: Remove this after June 30th, 2025
+		}
 		(function(){var g=Date.now||function(){return+new Date};function h(a,b){a:{for(var c=a.length,d="string"==typeof a?a.split(""):a,e=0;e<c;e++)if(e in d&&b.call(void 0,d[e],e,a)){b=e;break a}b=-1}return 0>b?null:"string"==typeof a?a.charAt(b):a[b]};function k(a,b,c){c=null!=c?"="+encodeURIComponent(String(c)):"";if(b+=c){c=a.indexOf("#");0>c&&(c=a.length);var d=a.indexOf("?");if(0>d||d>c){d=c;var e=""}else e=a.substring(d+1,c);a=[a.substr(0,d),e,a.substr(c)];c=a[1];a[1]=b?c?c+"&"+b:b:c;a=a[0]+(a[1]?"?"+a[1]:"")+a[2]}return a};var l=0;function m(a,b){var c=document.createElement("script");c.src=a;c.onload=function(){b&&b(void 0)};c.onerror=function(){b&&b("error")};a=document.getElementsByTagName("head");var d;a&&0!==a.length?d=a[0]:d=document.documentElement;d.appendChild(c)}function n(a){var b=void 0===b?document.cookie:b;return(b=h(b.split("; "),function(c){return-1!=c.indexOf(a+"=")}))?b.split("=")[1]:""}function p(a){return"string"==typeof a&&0<a.length}
-		function r(a,b,c){b=void 0===b?"":b;c=void 0===c?".":c;var d=[];Object.keys(a).forEach(function(e){var f=a[e],q=typeof f;"object"==q&&null!=f||"function"==q?d.push(r(f,b+e+c)):null!==f&&void 0!==f&&(e=encodeURIComponent(b+e),d.push(e+"="+encodeURIComponent(f)))});return d.filter(p).join("&")}function t(a,b){a||((window.__ATA||{}).config=b.c,m(b.url))}var u=Math.floor(1E13*Math.random()),v=window.__ATA||{};window.__ATA=v;window.__ATA.cmd=v.cmd||[];v.rid=u;v.createdAt=g();var w=window.__ATA||{},x="s.pubmine.com";
+		function r(a,b,c){b=void 0===b?"":b;c=void 0===c?".":c;var d=[];Object.keys(a).forEach(function(e){var f=a[e],q=typeof f;"object"==q&&null!=f||"function"==q?d.push(r(f,b+e+c)):null!==f&&void 0!==f&&(e=encodeURIComponent(b+e),d.push(e+"="+encodeURIComponent(f)))});return d.filter(p).join("&")}function t(a,b){a||((window.__ATA||{}).config=b.c,m(b.url))}var u=Math.floor(1E13*Math.random()),v=window.__ATA||{};window.__ATA=v;window.__ATA.cmd=v.cmd||[];v.rid=u;v.createdAt=g();var w=window.__ATA||{},x="undefined.pubmine.com"; // Here we changed s.pubmine.com to undefined.pubmine.com to imitate IPONWEB's server does not work.
 		w&&w.serverDomain&&(x=w.serverDomain);var y="//"+x+"/conf",z=window.top===window,A=window.__ATA_PP&&window.__ATA_PP.gdpr_applies,B="boolean"===typeof A?Number(A):null,C=window.__ATA_PP||null,D=z?document.referrer?document.referrer:null:null,E=z?window.location.href:document.referrer?document.referrer:null,F,G=n("__ATA_tuuid");F=G?G:null;var H=window.innerWidth+"x"+window.innerHeight,I=n("usprivacy"),J=r({gdpr:B,pp:C,rid:u,src:D,ref:E,tuuid:F,vp:H,us_privacy:I?I:null},"",".");
 		(function(a){var b=void 0===b?"cb":b;l++;var c="callback__"+g().toString(36)+"_"+l.toString(36);a=k(a,b,c);window[c]=function(d){t(void 0,d)};m(a,function(d){d&&t(d)})})(y+"?"+J);}).call(this);
-		}
+		// }
 		</script>
 		<?php
 	}


### PR DESCRIPTION
⚠️  There's no intention to merge it, it's only for testing purposes.

(please don't close this PR / connected branch until migration to Aditude is over which happens on July 1st, 2025)

We want to check how WordAds will work on Jetpack sites with outdated Jetpack plugin when IPONWEB's server is down and Aditude scripts are provided.

## Does this pull request change what data or activity we track or use?

My PR should be used only for testing purposes.
What it does, it changes the domain for IPONWEB (`s.pubmine.com`) to an inexisting one (`undefined.pubmine.com`) to test how Jetpack sites with outdated Jetpack plugin will work when `watl-v2.js` library is provided.

## Testing instructions

- Use Jetpack Beta tester plugin,
- Choose this branch,
- Open a post you want to see Ads on,
- Make sure that even though `undefined.pubmine.com` is used, Aditude ads were loaded properly.