### PR TITLE
ci: Further fix tests on plugin release branches

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -138,12 +138,13 @@ jobs:
             PKGS=()
             readarray -t PKGS < <( jq -r '.extra["non-mirrored-require-dev"] // empty | .[] | . += "=@dev"' "projects/$SLUG/composer.json" )
             if [[ ${#PKGS[@]} -gt 0 ]]; then
-              echo "Adding packages for $SLUG: ${PKGS[*]}"
+              echo "::group::Adding packages for $SLUG: ${PKGS[*]}"
               # Make sure monorepo repositories entry is present.
               JSON=$( jq --tab '.repositories //= [] | if any( .repositories[]; .type == "path" and ( .url | startswith( "../" ) ) and .options?.monorepo? ) then . else .repositories += [ { type: "path", url: "../../packages/*", options: { monorepo: true } } ] end' "projects/$SLUG/composer.json" )
               echo "$JSON" > "projects/$SLUG/composer.json"
               # Use --no-install and --ignore-platform-reqs here. Code below (either in .github/files/setup-wordpress-env.sh or the "Run project tests" step) will do a `composer install` or `composer update` as necessary.
               composer require --working-dir="projects/$SLUG/" --dev --no-install --ignore-platform-reqs "${PKGS[@]}"
+              echo "::endgroup::"
             fi
           done
 
@@ -481,11 +482,12 @@ jobs:
             PKGS=()
             readarray -t PKGS < <( jq -r '.extra["non-mirrored-require-dev"] // empty | .[] | . += "=@dev"' "$FILE" )
             if [[ ${#PKGS[@]} -gt 0 ]]; then
-              echo "Adding packages for $FILE: ${PKGS[*]}"
+              echo "::group::Adding packages for $FILE: ${PKGS[*]}"
               # Make sure monorepo repositories entry is present.
               JSON=$( jq --tab '.repositories //= [] | if any( .repositories[]; .type == "path" and ( .url | startswith( "../" ) ) and .options?.monorepo? ) then . else .repositories += [ { type: "path", url: "../../packages/*", options: { monorepo: true } } ] end' "$FILE" )
               echo "$JSON" > "$FILE"
               composer require --working-dir="${FILE%/composer.json}" --dev "${PKGS[@]}"
+              echo "::endgroup::"
             fi
           done
       - name: Run phan

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -142,7 +142,8 @@ jobs:
               # Make sure monorepo repositories entry is present.
               JSON=$( jq --tab '.repositories //= [] | if any( .repositories[]; .type == "path" and ( .url | startswith( "../" ) ) and .options?.monorepo? ) then . else .repositories += [ { type: "path", url: "../../packages/*", options: { monorepo: true } } ] end' "projects/$SLUG/composer.json" )
               echo "$JSON" > "projects/$SLUG/composer.json"
-              composer require --working-dir="projects/$SLUG/" --dev --no-install "${PKGS[@]}"
+              # Use --no-install and --ignore-platform-reqs here. Code below (either in .github/files/setup-wordpress-env.sh or the "Run project tests" step) will do a `composer install` or `composer update` as necessary.
+              composer require --working-dir="projects/$SLUG/" --dev --no-install --ignore-platform-reqs "${PKGS[@]}"
             fi
           done
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -474,6 +474,20 @@ jobs:
         uses: ./.github/actions/tool-setup
       - name: Pnpm install
         run: pnpm install
+      - name: Add back removed packages in case of a release branch.
+        run: |
+          echo "Checking for non-mirrored require-dev packages, in case this is testing a release branch"
+          for FILE in projects/*/*/composer.json; do
+            PKGS=()
+            readarray -t PKGS < <( jq -r '.extra["non-mirrored-require-dev"] // empty | .[] | . += "=@dev"' "$FILE" )
+            if [[ ${#PKGS[@]} -gt 0 ]]; then
+              echo "Adding packages for $FILE: ${PKGS[*]}"
+              # Make sure monorepo repositories entry is present.
+              JSON=$( jq --tab '.repositories //= [] | if any( .repositories[]; .type == "path" and ( .url | startswith( "../" ) ) and .options?.monorepo? ) then . else .repositories += [ { type: "path", url: "../../packages/*", options: { monorepo: true } } ] end' "$FILE" )
+              echo "$JSON" > "$FILE"
+              composer require --working-dir="${FILE%/composer.json}" --dev "${PKGS[@]}"
+            fi
+          done
       - name: Run phan
         run: pnpm jetpack phan --all -v --update-baseline --format github
       - name: Run phan for previous WP version too


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
PR #43953 added a `composer require` to add missing packages, but it breaks on older PHP versions because the composer.lock has too-new of packages locked. Use `--ignore-platform-reqs` to avoid that problem; later code will handle doing the needed `composer update`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1750256416028259/1750254758.455859-slack-C01U2KGS2PQ

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Merge this then do a release. Or cherry-pick this to an existing release branch.