### PR TITLE
Move gemini test flag to production

### DIFF
--- a/projects/plugins/jetpack/changelog/change-chrome-gemini-feature-production
+++ b/projects/plugins/jetpack/changelog/change-chrome-gemini-feature-production
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Move chrome gemini tests flag to production

--- a/projects/plugins/jetpack/extensions/index.json
+++ b/projects/plugins/jetpack/extensions/index.json
@@ -73,7 +73,8 @@
 		"ai-title-optimization-keywords-support",
 		"ai-response-feedback",
 		"ai-assistant-image-extension",
-		"ai-seo-enhancer"
+		"ai-seo-enhancer",
+		"ai-use-chrome-ai-sometimes"
 	],
 	"beta": [
 		"google-docs-embed",
@@ -81,8 +82,7 @@
 		"v6-video-frame-poster",
 		"videopress/video-chapters",
 		"ai-assistant-backend-prompts",
-		"ai-list-to-table-transform",
-		"ai-use-chrome-ai-sometimes"
+		"ai-list-to-table-transform"
 	],
 	"experimental": [],
 	"no-post-editor": [


### PR DESCRIPTION
## Proposed changes:
This PR moves the feature flag `ai-use-chrome-ai-sometimes` to production section.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1749565066108139-slack-C7HH3V5AS

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
TBD