### PR TITLE
Infinite_Scroll: Fix fatal error on non-string currentday parameter

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-infinite-scroll
+++ b/projects/plugins/jetpack/changelog/fix-infinite-scroll
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fixed issue where non-string currentday parameters could cause errors in infinite scroll AJAX requests

--- a/projects/plugins/jetpack/modules/infinite-scroll/infinity.php
+++ b/projects/plugins/jetpack/modules/infinite-scroll/infinity.php
@@ -1358,7 +1358,7 @@ class The_Neverending_Home_Page {
 		$page = (int) $_REQUEST['page']; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- we're casting this to an int and not making changes to the site.
 
 		// Sanitize and set $previousday. Expected format: dd.mm.yy
-		if ( isset( $_REQUEST['currentday'] ) && preg_match( '/^\d{2}\.\d{2}\.\d{2}$/', $_REQUEST['currentday'] ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput, WordPress.Security.NonceVerification.Recommended -- manually validating, no changes to site
+		if ( isset( $_REQUEST['currentday'] ) && is_string( $_REQUEST['currentday'] ) && preg_match( '/^\d{2}\.\d{2}\.\d{2}$/', $_REQUEST['currentday'] ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput, WordPress.Security.NonceVerification.Recommended -- manually validating, no changes to site
 			global $previousday;
 			$previousday = $_REQUEST['currentday']; // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput
 		}


### PR DESCRIPTION


## Proposed changes:

Fix this type of fatal error:
```
[18-Jun-2025 17:09:26 UTC] PHP Fatal error:  Uncaught TypeError: preg_match(): Argument #2 ($subject) must be of type string, array given in /home/wpcom/public_html/wp-content/mu-plugins/jetpack-plugin/sun/modules/infinite-scroll/infinity.php:1361
Stack trace:
#0 /home/wpcom/public_html/wp-content/mu-plugins/jetpack-plugin/sun/modules/infinite-scroll/infinity.php(1361): preg_match('/^\\d{2}\\.\\d{2}\\...', Array)
#1 /home/wpcom/public_html/wp-includes/class-wp-hook.php(324): The_Neverending_Home_Page->query('')
#2 /home/wpcom/public_html/wp-includes/class-wp-hook.php(348): WP_Hook->apply_filters('', Array)
#3 /home/wpcom/public_html/wp-includes/plugin.php(517): WP_Hook->do_action(Array)
```

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?

## Testing instructions:

* Go to '..'
*

