### PR TITLE
Forms: Hide integrations tab on simple sites

### DIFF
--- a/projects/packages/forms/changelog/update-forms-hide-integrations-on-wpcom
+++ b/projects/packages/forms/changelog/update-forms-hide-integrations-on-wpcom
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Hide integrations tab on simple sites.

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -53,15 +53,23 @@ class Dashboard {
 	private $switch;
 
 	/**
+	 * Whether this is a WordPress.com Simple site.
+	 *
+	 * @var bool
+	 */
+	private $is_wpcom_simple;
+
+	/**
 	 * Creates a new Dashboard instance.
 	 *
 	 * @param Dashboard_View_Switch|null $switch Dashboard_View_Switch instance to use.
 	 */
 	public function __construct( ?Dashboard_View_Switch $switch = null ) {
-		$this->switch = $switch ?? new Dashboard_View_Switch();
+		$this->switch          = $switch ?? new Dashboard_View_Switch();
+		$this->is_wpcom_simple = ( new Host() )->is_wpcom_simple();
 
-		// Set the integrations tab feature flag
-		self::$show_integrations = apply_filters( 'jetpack_forms_enable_integrations_tab', true );
+		// Set the integrations tab feature flag - off by default on WP.com Simple sites.
+		self::$show_integrations = apply_filters( 'jetpack_forms_enable_integrations_tab', ! $this->is_wpcom_simple );
 	}
 
 	/**
@@ -143,11 +151,9 @@ class Dashboard {
 			return;
 		}
 
-		$is_wpcom = ( new Host() )->is_wpcom_simple();
-
 		// MODERN VIEW -- remove the old submenu and add the new one.
 		// Check if Polldaddy/Crowdsignal plugin is active
-		if ( ! $is_wpcom && ! is_plugin_active( 'polldaddy/polldaddy.php' ) ) {
+		if ( ! $this->is_wpcom_simple && ! is_plugin_active( 'polldaddy/polldaddy.php' ) ) {
 			remove_menu_page( 'feedback' );
 
 			add_menu_page(


### PR DESCRIPTION
## Proposed changes:

We're showing the Jetpack > Forms > Integrations tab on WordPress.com simple sites, but should not be. This leverages our existing feature flag to hide the tab on WordPress.com.

**On simple sites, the forms dashboard should look like this:**
<img width="837" alt="integrations-on-simple" src="https://github.com/user-attachments/assets/af055fac-b5c5-4240-b1d1-8562d36f8995" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Confirm the integrations tab still shows like usual in your Jetpack dev environment
* Confirm the integrations tab does not show on a WordPress.com simple site
  - SSH into your sandbox
  - Use command below to load this branch in your sandbox
  - Sandbox the domain of a WordPress.com simple site
  - Navigate that simple site to Jetpack > Forms and confirm the Integrations tab does not show

