### PR TITLE
Jetpack_Carousel: Fix fatal error on array-like url POST

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-carousel-2
+++ b/projects/plugins/jetpack/changelog/fix-carousel-2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Security: Fixed issue where array-type url parameters could cause errors in carousel comment submissions

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
@@ -1270,7 +1270,7 @@ class Jetpack_Carousel {
 			if ( isset( $_POST['email'] ) && is_string( $_POST['email'] ) ) {
 				$email = wp_unslash( $_POST['email'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Checked or sanitized below.
 			}
-			$url = isset( $_POST['url'] ) ? esc_url_raw( wp_unslash( $_POST['url'] ) ) : null;
+			$url = isset( $_POST['url'] ) && is_string( $_POST['url'] ) ? esc_url_raw( wp_unslash( $_POST['url'] ) ) : null;
 
 			if ( get_option( 'require_name_email' ) ) {
 				if ( empty( $display_name ) ) {


### PR DESCRIPTION
Fixes #

## Proposed changes:

Fix this fatal error
```
[18-Jun-2025 21:12:58 UTC] Fatal error: Uncaught TypeError: ltrim(): Argument #1 ($string) must be of type string, array given in /home/wpcom/public_html/wp-includes/formatting.php:4506
Stack trace:
#0 /home/wpcom/public_html/wp-includes/formatting.php(4506): ltrim(Array)
#1 /home/wpcom/public_html/wp-includes/formatting.php(4632): esc_url(Array, NULL, 'db')
#2 /home/wpcom/public_html/wp-includes/formatting.php(4614): sanitize_url(Array, NULL)
#3 /home/wpcom/public_html/wp-content/mu-plugins/jetpack-plugin/moon/modules/carousel/jetpack-carousel.php(1273): esc_url_raw(Array)
#4 /home/wpcom/public_html/wp-includes/class-wp-hook.php(324): Jetpack_Carousel->post_attachment_comment('')
```

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?

## Testing instructions:

* Go to '..'
*

