### PR TITLE
Admin Menu: Add "Dashboard > Updates" screen to Simple sites

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/dotcom-13619-untangling-ia-dashboard-updates
+++ b/projects/packages/jetpack-mu-wpcom/changelog/dotcom-13619-untangling-ia-dashboard-updates
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Admin Menu: Add "Dashboard > Updates" screen to Simple sites

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
@@ -39,7 +39,7 @@ function current_user_has_wpcom_account() {
  */
 function wpcom_add_dashboard_updates_menu() {
 	$is_simple_site = defined( 'IS_WPCOM' ) && IS_WPCOM;
-	if ( ! $is_simple_site ) {
+	if ( ! $is_simple_site || wpcom_is_vip() ) {
 		return;
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
@@ -35,6 +35,54 @@ function current_user_has_wpcom_account() {
 }
 
 /**
+ * Adds the Dashboard > Updates menu on Simple sites
+ */
+function wpcom_add_dashboard_updates_menu() {
+	$is_simple_site = defined( 'IS_WPCOM' ) && IS_WPCOM;
+	if ( ! $is_simple_site ) {
+		return;
+	}
+
+	add_submenu_page(
+		'index.php',
+		__( 'WordPress Updates', 'jetpack-mu-wpcom' ),
+		__( 'Updates', 'jetpack-mu-wpcom' ),
+		'manage_options',
+		'wpcom-dashboard-updates',
+		'wpcom_display_dashboard_updates_page'
+	);
+}
+add_action( 'admin_menu', 'wpcom_add_dashboard_updates_menu' );
+
+/**
+ * Displays a WordPress Updates page for Simple sites.
+ */
+function wpcom_display_dashboard_updates_page() {
+	require_once ABSPATH . 'wp-admin/admin-header.php';
+	?>
+	<div class="wrap">
+		<h1><?php esc_html_e( 'WordPress Updates', 'jetpack-mu-wpcom' ); ?></h1>
+		<p><?php esc_html_e( "WordPress.com automatically keeps your site's plugins, themes, and WordPress version up to date.", 'jetpack-mu-wpcom' ); ?></p>
+		<h2>
+			<?php
+				printf(
+					/* translators: Link to Jetpack installation instructions. */
+					esc_html__( 'WordPress version: %s', 'jetpack-mu-wpcom' ),
+					esc_html( wp_get_wp_version() )
+				);
+			?>
+		</h2>
+		<p><?php esc_html_e( 'Your WordPress version is up to date.', 'jetpack-mu-wpcom' ); ?></p>
+		<h2><?php esc_html_e( 'Plugins', 'jetpack-mu-wpcom' ); ?></h2>
+		<p><?php esc_html_e( 'Your plugins are all up to date.', 'jetpack-mu-wpcom' ); ?>
+		<h2><?php esc_html_e( 'Themes', 'jetpack-mu-wpcom' ); ?></h2>
+		<p><?php esc_html_e( 'Your themes are all up to date.', 'jetpack-mu-wpcom' ); ?>
+	</div>
+	<?php
+	require_once ABSPATH . 'wp-admin/admin-footer.php';
+}
+
+/**
  * Checks if menu items can link to Calypso.
  *
  * This way we can avoid a broken nav experience for super admins who are not members of the current site,

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
@@ -63,16 +63,8 @@ function wpcom_display_dashboard_updates_page() {
 	<div class="wrap">
 		<h1><?php esc_html_e( 'WordPress Updates', 'jetpack-mu-wpcom' ); ?></h1>
 		<p><?php esc_html_e( "WordPress.com automatically keeps your site's plugins, themes, and WordPress version up to date.", 'jetpack-mu-wpcom' ); ?></p>
-		<h2>
-			<?php
-				printf(
-					/* translators: Link to Jetpack installation instructions. */
-					esc_html__( 'WordPress version: %s', 'jetpack-mu-wpcom' ),
-					esc_html( wp_get_wp_version() )
-				);
-			?>
-		</h2>
-		<p><?php esc_html_e( 'Your WordPress version is up to date.', 'jetpack-mu-wpcom' ); ?></p>
+		<h2><?php esc_html_e( 'WordPress', 'jetpack-mu-wpcom' ); ?></h2>
+		<p><?php esc_html_e( 'Your version of WordPress is up to date.', 'jetpack-mu-wpcom' ); ?></p>
 		<h2><?php esc_html_e( 'Plugins', 'jetpack-mu-wpcom' ); ?></h2>
 		<p><?php esc_html_e( 'Your plugins are all up to date.', 'jetpack-mu-wpcom' ); ?>
 		<h2><?php esc_html_e( 'Themes', 'jetpack-mu-wpcom' ); ?></h2>

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
@@ -39,7 +39,7 @@ function current_user_has_wpcom_account() {
  */
 function wpcom_add_dashboard_updates_menu() {
 	$is_simple_site = defined( 'IS_WPCOM' ) && IS_WPCOM;
-	if ( ! $is_simple_site || wpcom_is_vip() ) {
+	if ( ! $is_simple_site || ( function_exists( 'wpcom_is_vip' ) && wpcom_is_vip() ) ) {
 		return;
 	}
 


### PR DESCRIPTION
Fixes DOTCOM-13619

## Proposed changes:

Includes a replica of the "Dashboard > Updates" Core screen on Simple sites, so the "Dashboard > Updates" menu exists in both Simple and Atomic sites.

<img width="1278" alt="Screenshot 2025-06-19 at 15 59 24" src="https://github.com/user-attachments/assets/6ec0b895-6289-4a10-8978-4f21307352fd" />

In Core, the menu links to `/wp-admin/update-core.php` which does not exist on Simple sites for security reasons (and because we automatically manage all the updates). So we had to manually create a text-only version of the screen, which lives in the `/wp-admin/index.php?page=wpcom-dashboard-updates` path.

On a follow-up, we may ask Systems to implement a redirect from `/wp-admin/update-core.php` to `/wp-admin/index.php?page=wpcom-dashboard-updates`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
- Apply these changes to your WP.com site
- Make sure the "Dashboard > Updates" menu is visible
- Click on it
- Make sure you see the new (and fake) WordPress updates
- Make sure that these changes don't affect Atomic sites (Dashboard > Updates should keep pointing to the Core screen)

