### PR TITLE
Zendesk: Add CSAT endpoint

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-csat-endpoint
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-csat-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added support for new endpoint

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
@@ -306,6 +306,10 @@ class Help_Center {
 		require_once __DIR__ . '/class-wp-rest-help-center-email-support-enabled.php';
 		$controller = new WP_REST_Help_Center_Email_Support_Enabled();
 		$controller->register_rest_route();
+
+		require_once __DIR__ . '/class-wp-rest-help-center-ticket-csat.php';
+		$controller = new WP_REST_Help_Center_Ticket_CSAT();
+		$controller->register_rest_route();
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-wp-rest-help-center-ticket-csat.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-wp-rest-help-center-ticket-csat.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * WP_REST_Help_Center_Ticket_CSAT file.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+namespace A8C\FSE;
+
+use Automattic\Jetpack\Connection\Client;
+
+/**
+ * Class WP_REST_Help_Center_Ticket_CSAT.
+ */
+class WP_REST_Help_Center_Ticket_CSAT extends \WP_REST_Controller {
+	/**
+	 * WP_REST_Help_Center_Ticket_CSAT constructor.
+	 */
+	public function __construct() {
+		$this->namespace = 'help-center';
+		$this->rest_base = '/help/csat';
+	}
+
+	/**
+	 * Register available routes.
+	 */
+	public function register_rest_route() {
+		register_rest_route(
+			$this->namespace,
+			$this->rest_base,
+			array(
+				'methods'             => \WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'submit_rating' ),
+				'permission_callback' => 'is_user_logged_in',
+				'args'                => array(
+					'ticket_id' => array(
+						'required' => true,
+						'type'     => 'int',
+					),
+					'score'     => array(
+						'required' => true,
+						'enum'     => array( 'good', 'bad' ),
+						'type'     => 'string',
+					),
+					'comment'   => array(
+						'required' => false,
+						'type'     => 'string',
+					),
+					'reason_id' => array(
+						'required' => false,
+						'type'     => 'string',
+					),
+					'test_mode' => array(
+						'required' => false,
+						'type'     => 'boolean',
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Post customer satisfaction for a ticket.
+	 *
+	 * @param \WP_REST_Request $request    The request sent to the API.
+	 */
+	public function submit_rating( \WP_REST_Request $request ) {
+		$body = Client::wpcom_json_api_request_as_user(
+			'/help/csat',
+			'2',
+			array(
+				'method' => 'POST',
+			),
+			$request
+		);
+
+		if ( is_wp_error( $body ) ) {
+			return $body;
+		}
+
+		$response = json_decode( wp_remote_retrieve_body( $body ) );
+
+		return rest_ensure_response( $response );
+	}
+}

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-wp-rest-help-center-ticket-csat.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-wp-rest-help-center-ticket-csat.php
@@ -18,7 +18,7 @@ class WP_REST_Help_Center_Ticket_CSAT extends \WP_REST_Controller {
 	 */
 	public function __construct() {
 		$this->namespace = 'help-center';
-		$this->rest_base = '/help/csat';
+		$this->rest_base = '/csat';
 	}
 
 	/**
@@ -65,13 +65,21 @@ class WP_REST_Help_Center_Ticket_CSAT extends \WP_REST_Controller {
 	 * @param \WP_REST_Request $request    The request sent to the API.
 	 */
 	public function submit_rating( \WP_REST_Request $request ) {
+		$payload = array(
+			'ticket_id' => $request['ticket_id'],
+			'score'     => $request['score'],
+			'comment'   => $request['comment'],
+			'reason_id' => $request['reason_id'],
+			'test_mode' => $request['test_mode'],
+		);
+
 		$body = Client::wpcom_json_api_request_as_user(
 			'/help/csat',
 			'2',
 			array(
 				'method' => 'POST',
 			),
-			$request
+			$payload
 		);
 
 		if ( is_wp_error( $body ) ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes DOTCOM-13662

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add CSAT endpoint

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Sync this PR to your site via the Beta Tester
* Send the post request to `help-center/csat`


