### PR TITLE
Remove extra slash from autoloader paths

### DIFF
--- a/projects/packages/autoloader/README.md
+++ b/projects/packages/autoloader/README.md
@@ -33,7 +33,7 @@ Load the file in your plugin via main plugin file.
 
 In the main plugin you will also need to include the files like this.
 ```php
-require_once  plugin_dir_path( __FILE__ ) . 'vendor/autoload_packages.php';
+require_once plugin_dir_path( __FILE__ ) . 'vendor/autoload_packages.php';
 ```
 
 Working with Development Versions of Packages

--- a/projects/packages/autoloader/README.md
+++ b/projects/packages/autoloader/README.md
@@ -33,7 +33,7 @@ Load the file in your plugin via main plugin file.
 
 In the main plugin you will also need to include the files like this.
 ```php
-require_once  plugin_dir_path( __FILE__ ) . '/vendor/autoload_packages.php';
+require_once  plugin_dir_path( __FILE__ ) . 'vendor/autoload_packages.php';
 ```
 
 Working with Development Versions of Packages

--- a/projects/packages/autoloader/changelog/fix-remove_extra_slash_from_autoloader_requires
+++ b/projects/packages/autoloader/changelog/fix-remove_extra_slash_from_autoloader_requires
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Autoloader: Prevent double slash in autoloader path.

--- a/projects/packages/connection/changelog/fix-remove_extra_slash_from_autoloader_requires
+++ b/projects/packages/connection/changelog/fix-remove_extra_slash_from_autoloader_requires
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Autoloader: Prevent double slash in autoloader path.

--- a/projects/packages/connection/docs/register-site.md
+++ b/projects/packages/connection/docs/register-site.md
@@ -41,7 +41,7 @@ This is where the `jetpack-config` and `jetpack-autoload` packages come into pla
 ```php
 use Automattic\Jetpack\Config;
 
-require_once plugin_dir_path( __FILE__ ) . '/vendor/autoload_packages.php';
+require_once plugin_dir_path( __FILE__ ) . 'vendor/autoload_packages.php';
 
 function jpcs_load_plugin() {
 

--- a/projects/packages/stats/README.md
+++ b/projects/packages/stats/README.md
@@ -19,7 +19,7 @@ This is where the `jetpack-config` and `jetpack-autoload` packages come into pla
 ```php
 use Automattic\Jetpack\Config;
 
-require_once plugin_dir_path( __FILE__ ) . '/vendor/autoload_packages.php';
+require_once plugin_dir_path( __FILE__ ) . 'vendor/autoload_packages.php';
 
 function jpcs_load_plugin() {
 

--- a/projects/packages/stats/changelog/fix-remove_extra_slash_from_autoloader_requires
+++ b/projects/packages/stats/changelog/fix-remove_extra_slash_from_autoloader_requires
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Autoloader: Prevent double slash in autoloader path.

--- a/projects/packages/videopress/README.md
+++ b/projects/packages/videopress/README.md
@@ -19,7 +19,7 @@ This is where the `jetpack-config` and `jetpack-autoload` packages come into pla
 ```php
 use Automattic\Jetpack\Config;
 
-require_once plugin_dir_path( __FILE__ ) . '/vendor/autoload_packages.php';
+require_once plugin_dir_path( __FILE__ ) . 'vendor/autoload_packages.php';
 
 function jpcs_load_plugin() {
 

--- a/projects/packages/videopress/changelog/fix-remove_extra_slash_from_autoloader_requires
+++ b/projects/packages/videopress/changelog/fix-remove_extra_slash_from_autoloader_requires
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Autoloader: Prevent double slash in autoloader path.

--- a/projects/plugins/beta/changelog/fix-remove_extra_slash_from_autoloader_requires
+++ b/projects/plugins/beta/changelog/fix-remove_extra_slash_from_autoloader_requires
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Autoloader: Prevent double slash in autoloader path.

--- a/projects/plugins/beta/jetpack-beta.php
+++ b/projects/plugins/beta/jetpack-beta.php
@@ -49,7 +49,7 @@ define( 'JETPACK_BETA_PLUGINS_URL', 'https://betadownload.jetpack.me/plugins.jso
  *   (We want to fail gracefully if `composer install` has not been executed yet, so we are checking for the autoloader.)
  * - If it succeeds, we continue.
  */
-$jetpack_beta_autoloader = plugin_dir_path( __FILE__ ) . '/vendor/autoload_packages.php';
+$jetpack_beta_autoloader = plugin_dir_path( __FILE__ ) . 'vendor/autoload_packages.php';
 if ( is_readable( $jetpack_beta_autoloader ) ) {
 	require $jetpack_beta_autoloader;
 } else {

--- a/projects/plugins/inspect/changelog/fix-remove_extra_slash_from_autoloader_requires
+++ b/projects/plugins/inspect/changelog/fix-remove_extra_slash_from_autoloader_requires
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Autoloader: Prevent double slash in autoloader path.

--- a/projects/plugins/inspect/jetpack-inspect.php
+++ b/projects/plugins/inspect/jetpack-inspect.php
@@ -29,7 +29,7 @@ use Automattic\Jetpack_Inspect\REST_API\Endpoints\Send_Request;
 use Automattic\Jetpack_Inspect\REST_API\Endpoints\Test_Request;
 use Automattic\Jetpack_Inspect\REST_API\REST_API;
 
-require_once plugin_dir_path( __FILE__ ) . '/vendor/autoload_packages.php';
+require_once plugin_dir_path( __FILE__ ) . 'vendor/autoload_packages.php';
 
 if ( method_exists( \Automattic\Jetpack\Assets::class, 'alias_textdomains_from_file' ) ) {
 	\Automattic\Jetpack\Assets::alias_textdomains_from_file( plugin_dir_path( __FILE__ ) . 'jetpack_vendor/i18n-map.php' );

--- a/projects/plugins/search/changelog/fix-remove_extra_slash_from_autoloader_requires
+++ b/projects/plugins/search/changelog/fix-remove_extra_slash_from_autoloader_requires
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Autoloader: Prevent double slash in autoloader path.

--- a/projects/plugins/search/jetpack-search.php
+++ b/projects/plugins/search/jetpack-search.php
@@ -42,7 +42,7 @@ defined( 'JETPACK__SANDBOX_DOMAIN' ) || define( 'JETPACK__SANDBOX_DOMAIN', '' );
 defined( 'JETPACK_SIGNATURE__HTTP_PORT' ) || define( 'JETPACK_SIGNATURE__HTTP_PORT', 80 );
 defined( 'JETPACK_SIGNATURE__HTTPS_PORT' ) || define( 'JETPACK_SIGNATURE__HTTPS_PORT', 443 );
 
-$autoload_packages_path = JETPACK_SEARCH_PLUGIN__DIR . '/vendor/autoload_packages.php';
+$autoload_packages_path = JETPACK_SEARCH_PLUGIN__DIR . 'vendor/autoload_packages.php';
 if ( ! is_readable( $autoload_packages_path ) ) {
 	if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 		error_log( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This is a pretty simple PR. It updates the few instances like this:

```
plugin_dir_path( __FILE__ ) . '/vendor/autoload_packages.php'
```

to remove the slash prior to `vendor`:

```
plugin_dir_path( __FILE__ ) . 'vendor/autoload_packages.php'
```

[`plugin_dir_path()`](https://developer.wordpress.org/reference/functions/plugin_dir_path/) always returns a trailing slash. Some instances are direct concatenations, some are in documentation, and one is an indirect concatenation.

I also did a rudimentary search for other direct concats with `plugin_dir_path\(.+?\) \. '/`, but didn't turn up anything.

Discovered while helping out here: p1750356440162809/1750353827.763979-slack-CDLH4C1UZ

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Hopefully everything continues to build and work fine...it should, barring typos.