### PR TITLE
fix: Register foundational Jetpack scripts for Atomic sites

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-block-editor-assets.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-block-editor-assets.php
@@ -24,6 +24,7 @@ class WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets extends WP_REST_Controller 
 		'/plugins/gutenberg-core/', // WPCOM Simple site
 		'/plugins/jetpack/',
 		'/mu-plugins/jetpack-mu-wpcom-plugin/', // WPCOM Simple site
+		'/mu-plugins/wpcomsh/', // WoW helpers
 	);
 
 	/**

--- a/projects/plugins/jetpack/changelog/fix-atomic-editor-assets-endpoint
+++ b/projects/plugins/jetpack/changelog/fix-atomic-editor-assets-endpoint
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Block editor: repair editor assets endpoint for Atomic sites


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fix missing `jetpack-script-data` and `jetpack-connection` assets in the returned scripts. These two assets appear to be placed in a "vendor" directory within the `wpcomsh` directory, we must allow this plugin to avoid excluding these scripts, as they are necessary for loading script for Jetpack blocks. 

We rely upon a strict allow list to mitigate breakages from unexpected scripts. 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Update the allowed plugins list to include the `/mu-plugins/wpcomsh/` directory. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
0b1591ec5132-linear-project

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Create a WPCOM Atomic site. 
1. Make a request to the `/wpcom/v2/sites/<site_id>/editor-assets` endpoint for WPCOM Simple site—via [API Console](https://developer.wordpress.com/docs/api/console/), `curl`, etc. 
1. Note the response does not include a script with an ID of `jetpack-connection-js`. 
3. Apply these Jetpack changes (see [comment](https://github.com/Automattic/jetpack/pull/44032#issuecomment-2989100376)) to your Atomic site.  
1. Make a request to the `/wpcom/v2/sites/<site_id>/editor-assets` endpoint for WPCOM Simple site—via [API Console](https://developer.wordpress.com/docs/api/console/), `curl`, etc. 
1. Verify the 200 response the `jetpack-connection-js` script. 