### PR TITLE
My Jetpack: Onboarding i4 | Fix module toggle and status styling

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2934,6 +2934,9 @@ importers:
       '@automattic/number-formatters':
         specifier: workspace:*
         version: link:../../js-packages/number-formatters
+      '@automattic/ui':
+        specifier: 1.0.1
+        version: 1.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@tanstack/react-query':
         specifier: 5.75.1
         version: 5.75.1(react@18.3.1)
@@ -5732,6 +5735,12 @@ packages:
   '@automattic/typography@1.0.0':
     resolution: {integrity: sha512-TnT+vPaNUXQYwDsPCPxhNY0d4LnOKvrb0SizUCC5iybo5sfOlX/rYalGDyz6nPQDF0EBaQwMf7qhVsflFR0cBg==}
 
+  '@automattic/ui@1.0.1':
+    resolution: {integrity: sha512-SPjnWrn9ouhjBMUZXR7s+E+y7+neKpM/YARYnH2TwbiKoetAg8+Qjp+LOZbMsMGfiKNRpB9i+cOvW9Is7zUUGw==}
+    peerDependencies:
+      react: ^18.3.1
+      react-dom: ^18.3.1
+
   '@automattic/urls@1.0.0':
     resolution: {integrity: sha512-dTunk7PqvF/w0b7DFb8aUW85XbkqEwChTllManUq1uMDdeA6S6YWeCs7t5bBei0D1RFUs9FDdyspeLisNxfbAg==}
 
@@ -6455,6 +6464,9 @@ packages:
 
   '@dabh/diagnostics@2.0.3':
     resolution: {integrity: sha512-hrlQOIi7hAfzsMqlGSFyVucrx38O+j6wiGOf//H2ecvIEqYN4ADBSS2iLMh5UFyDunCNniUIPk/q3riFv45xRA==}
+
+  '@date-fns/tz@1.2.0':
+    resolution: {integrity: sha512-LBrd7MiJZ9McsOgxqWX7AaxrDjcFVjWH/tIKJd7pnR7McaslGYOP1QmmiBXdJH/H/yLCT+rcQ7FaPBUxRGUtrg==}
 
   '@discoveryjs/json-ext@0.6.3':
     resolution: {integrity: sha512-4B4OijXeVNOPZlYA2oEwWOTkzyltLao+xbotHQeqN++Rv27Y6s818+n2Qkp8q+Fxhn0t/5lA5X1Mxktud8eayQ==}
@@ -8910,6 +8922,10 @@ packages:
     resolution: {integrity: sha512-8Sf4pkH7/4pcKt/jOkVNLOoScypMOM2xEHtyiTE5tHgX4z7UZRNbXFKqJ9fxDDb/cniDdNyeG5QhOLIZbO7hlg==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
+  '@wordpress/base-styles@5.23.0':
+    resolution: {integrity: sha512-1mtX3jA9el2ZDkAJp7YEN1bX+DzfX0h496uxpRk+evmQJLZxBMPeu5datJFtwkWbVitOsR88WCDvUoNoKJMSuw==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
   '@wordpress/base-styles@6.1.0':
     resolution: {integrity: sha512-5AC4M7jXQaSknrSiuBbUWJa00jYr6i3yABf93VFuVzy9QGZQTvupQo2/bi6uAZ98pDruniScrnJJq8UG6JsoJQ==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -8959,6 +8975,12 @@ packages:
     peerDependencies:
       react: ^18.0.0
       react-dom: ^18.0.0
+
+  '@wordpress/compose@7.23.0':
+    resolution: {integrity: sha512-lEYneHPPrbQ9ki1yzq/8RsCEKcT3c0+iYi59c+RyPdnXNKWUTg/4QPklgut6Yp/85ZyWr0LMGy0/WoMqGypEAw==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
 
   '@wordpress/compose@7.25.0':
     resolution: {integrity: sha512-nfjtMZgrhdHU8/zOLUyA5o8ShLot1vbHZ0I2+IxLyNskRMVyR9pm4BAJSYKJ9XqBUom2/N51gfeKg5uhd9Y0TQ==}
@@ -10406,6 +10428,9 @@ packages:
   data-view-byte-offset@1.0.1:
     resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
     engines: {node: '>= 0.4'}
+
+  date-fns-jalali@4.1.0-0:
+    resolution: {integrity: sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg==}
 
   date-fns@1.30.1:
     resolution: {integrity: sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==}
@@ -13941,6 +13966,12 @@ packages:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
 
+  react-day-picker@9.7.0:
+    resolution: {integrity: sha512-urlK4C9XJZVpQ81tmVgd2O7lZ0VQldZeHzNejbwLWZSkzHH498KnArT0EHNfKBOWwKc935iMLGZdxXPRISzUxQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: '>=16.8.0'
+
   react-docgen-typescript@2.2.2:
     resolution: {integrity: sha512-tvg2ZtOpOi6QDwsb3GZhOjDkkX0h8Z2gipvTg6OVMUyoYoURhEiRNePT8NZItTVCDh39JJHnLdfCOkzoLbFnTg==}
     peerDependencies:
@@ -16320,6 +16351,20 @@ snapshots:
 
   '@automattic/typography@1.0.0': {}
 
+  '@automattic/ui@1.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@wordpress/base-styles': 5.23.0
+      '@wordpress/compose': 7.23.0(react@18.3.1)
+      '@wordpress/element': 6.25.0
+      '@wordpress/i18n': 5.25.0
+      '@wordpress/icons': 10.25.0(react@18.3.1)
+      '@wordpress/primitives': 4.25.0(react@18.3.1)
+      clsx: 2.1.1
+      date-fns: 4.1.0
+      react: 18.3.1
+      react-day-picker: 9.7.0(react@18.3.1)
+      react-dom: 18.3.1(react@18.3.1)
+
   '@automattic/urls@1.0.0': {}
 
   '@automattic/viewport-react@1.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
@@ -17200,6 +17245,8 @@ snapshots:
       colorspace: 1.1.4
       enabled: 2.0.0
       kuler: 2.0.0
+
+  '@date-fns/tz@1.2.0': {}
 
   '@discoveryjs/json-ext@0.6.3': {}
 
@@ -20284,6 +20331,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@wordpress/base-styles@5.23.0': {}
+
   '@wordpress/base-styles@6.1.0': {}
 
   '@wordpress/blob@4.25.0':
@@ -20784,6 +20833,23 @@ snapshots:
       - '@emotion/is-prop-valid'
       - '@types/react'
       - supports-color
+
+  '@wordpress/compose@7.23.0(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.27.4
+      '@types/mousetrap': 1.6.15
+      '@wordpress/deprecated': 4.25.0
+      '@wordpress/dom': 4.25.0
+      '@wordpress/element': 6.25.0
+      '@wordpress/is-shallow-equal': 5.25.0
+      '@wordpress/keycodes': 4.25.0
+      '@wordpress/priority-queue': 3.25.0
+      '@wordpress/undo-manager': 1.25.0
+      change-case: 4.1.2
+      clipboard: 2.0.11
+      mousetrap: 1.6.5
+      react: 18.3.1
+      use-memo-one: 1.1.3(react@18.3.1)
 
   '@wordpress/compose@7.25.0(react@18.3.1)':
     dependencies:
@@ -23470,6 +23536,8 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       is-data-view: 1.0.2
+
+  date-fns-jalali@4.1.0-0: {}
 
   date-fns@1.30.1: {}
 
@@ -27783,6 +27851,13 @@ snapshots:
     dependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
+
+  react-day-picker@9.7.0(react@18.3.1):
+    dependencies:
+      '@date-fns/tz': 1.2.0
+      date-fns: 4.1.0
+      date-fns-jalali: 4.1.0-0
+      react: 18.3.1
 
   react-docgen-typescript@2.2.2(typescript@5.8.3):
     dependencies:

--- a/projects/packages/my-jetpack/_inc/components/module-status/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/module-status/index.tsx
@@ -1,6 +1,8 @@
-import { Badge } from '@automattic/jetpack-components';
+import { Badge } from '@automattic/ui';
 import { __ } from '@wordpress/i18n';
 import { MyJetpackModule } from '../types';
+
+import '@automattic/ui/style.css';
 
 export type ModuleStatusProps = {
 	module: MyJetpackModule;
@@ -15,8 +17,7 @@ export type ModuleStatusProps = {
  */
 export function ModuleStatus( { module: $module }: ModuleStatusProps ) {
 	if ( $module.activated ) {
-		// TODO replace this with Badge component from @automattic/ui when it's ready.
-		return <Badge variant="success">{ __( 'Active', 'jetpack-my-jetpack' ) }</Badge>;
+		return <Badge intent="success">{ __( 'Active', 'jetpack-my-jetpack' ) }</Badge>;
 	}
 
 	return null;

--- a/projects/packages/my-jetpack/_inc/components/module-toggle/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/module-toggle/index.tsx
@@ -4,6 +4,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { __, sprintf } from '@wordpress/i18n';
 import { useCallback } from 'react';
 import { MyJetpackModule } from '../types';
+import styles from './styles.module.scss';
 
 export type ModuleToggleProps = {
 	module: MyJetpackModule;
@@ -39,6 +40,7 @@ export function ModuleToggle( { module: $module }: ModuleToggleProps ) {
 			disabled={ isUpdating }
 			checked={ $module.activated }
 			onChange={ onChange }
+			className={ styles.toggle }
 			aria-label={ sprintf(
 				/* translators: %s is the module name */
 				__( 'Toggle %s module', 'jetpack-my-jetpack' ),

--- a/projects/packages/my-jetpack/_inc/components/module-toggle/styles.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/module-toggle/styles.module.scss
@@ -1,0 +1,7 @@
+.toggle {
+
+	&:global(.components-form-toggle.is-checked) :global(.components-form-toggle__track) {
+		background-color: var(--jp-green-50);
+		border-color: var(--jp-green-50);
+	}
+}

--- a/projects/packages/my-jetpack/_inc/components/modules-list/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/modules-list/index.tsx
@@ -39,7 +39,7 @@ export function ModulesList( { modules }: ModulesListProps ) {
 				label: __( 'Toggle', 'jetpack-my-jetpack' ),
 				render: ( { item } ) => {
 					return (
-						<Flex className={ styles[ 'toggle-wrap' ] }>
+						<Flex gap={ 4 } className={ styles[ 'toggle-wrap' ] }>
 							<ModuleStatus module={ item } />
 							<ModuleToggle module={ item } />
 						</Flex>

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/product-card.tsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/product-card.tsx
@@ -41,7 +41,7 @@ export function ProductCard( { product, headingLevel = 3, module: $module }: Pro
 					</FlexBlock>
 					<FlexItem>
 						{ $module?.available ? (
-							<Flex>
+							<Flex gap={ 4 }>
 								<ModuleStatus module={ $module } />
 								<ModuleToggle module={ $module } />
 							</Flex>

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -36,6 +36,7 @@
 		"@automattic/jetpack-script-data": "workspace:*",
 		"@automattic/jetpack-shared-extension-utils": "workspace:*",
 		"@automattic/number-formatters": "workspace:*",
+		"@automattic/ui": "1.0.1",
 		"@tanstack/react-query": "5.75.1",
 		"@wordpress/api-fetch": "7.25.0",
 		"@wordpress/components": "29.11.0",


### PR DESCRIPTION
Completes MYJP-191

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Use JP Green color for ON state of the module toggles
* Use the `Badge` component from `@automattic/ui` package

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to My Jetpack > Products
* Confirm that the toggles for modules are JP green when ON
* Confirm that the "Active" badge matches the design

| Before | After |
|--------|--------|
| <img width="806" alt="Screenshot 2025-06-20 at 6 30 38 PM" src="https://github.com/user-attachments/assets/19df495b-4105-4451-8097-a19953fa5d70" /> | <img width="784" alt="Screenshot 2025-06-20 at 6 29 36 PM" src="https://github.com/user-attachments/assets/07653e08-f037-4c22-9e88-b0714088f5d3" /> | 

