### PR TITLE
Sharing buttons blocks: add ability to count sharing events

### DIFF
--- a/projects/plugins/jetpack/changelog/add-sharing-stats-block
+++ b/projects/plugins/jetpack/changelog/add-sharing-stats-block
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Sharing: add ability to count sharing events on sharing buttons blocks.

--- a/projects/plugins/jetpack/extensions/blocks/sharing-button/class-sharing-source-block.php
+++ b/projects/plugins/jetpack/extensions/blocks/sharing-button/class-sharing-source-block.php
@@ -64,12 +64,38 @@ abstract class Sharing_Source_Block {
 	}
 
 	/**
-	 * Get sharing stats for a specific post or sharing service.
+	 * Get stats for a site, a post, or a sharing service.
+	 * Soon to come to a .org plugin near you!
 	 *
-	 * @return int This is a placeholder that returns 0 at the moment. We might want to implement this in the future.
+	 * @param WP_Post|bool $post Post object.
+	 *
+	 * @return int
 	 */
-	public function get_total() {
-		return 0;
+	public function get_total( $post = false ) {
+		global $wpdb, $blog_id;
+
+		$name = strtolower( $this->get_id() );
+
+		if ( $post === false ) {
+			// get total number of shares for service
+			return (int) $wpdb->get_var( // phpcs:ignore WordPress.DB.DirectDatabaseQuery
+				$wpdb->prepare(
+					'SELECT SUM( count ) FROM sharing_stats WHERE blog_id = %d AND share_service = %s',
+					$blog_id,
+					$name
+				)
+			);
+		}
+
+		// get total shares for a post
+		return (int) $wpdb->get_var( // phpcs:ignore WordPress.DB.DirectDatabaseQuery
+			$wpdb->prepare(
+				'SELECT count FROM sharing_stats WHERE blog_id = %d AND post_id = %d AND share_service = %s',
+				$blog_id,
+				$post->ID,
+				$name
+			)
+		);
 	}
 
 	/**

--- a/projects/plugins/jetpack/extensions/blocks/sharing-button/class-sharing-source-block.php
+++ b/projects/plugins/jetpack/extensions/blocks/sharing-button/class-sharing-source-block.php
@@ -74,7 +74,7 @@ abstract class Sharing_Source_Block {
 	public function get_total( $post = false ) {
 		global $wpdb, $blog_id;
 
-		$name = strtolower( $this->get_id() );
+		$name = strtolower( (string) $this->get_id() );
 
 		if ( $post === false ) {
 			// get total number of shares for service


### PR DESCRIPTION
## Proposed changes:

This is only useful and necessary for WordPress.com simple, and avoids issues when counting shares there.

The contents of the methods are directly copied from the existing method for the legacy sharing buttons, in Sharing_Source. I only added the phpcs:ignore.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

See pejTkB-25H-p2

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* On a WordPress.com site, go to Appearance > Editor > Templates > Single posts
* Add sharing buttons using the sharing buttons block, anywhere in your template.
* Save your changes.
* Edit `wp-content/mu-plugins/post-flair/sharing.php`, add some logging of the results of `$count = $data['service']->get_total( $data['post'] );`
* On the frontend of your site, click on one of the sharing buttons you added.
* Notice that the count returns 0.
