### PR TITLE
Boost: Prevent Defer JS from duplicating deferred scripts

### DIFF
--- a/projects/plugins/boost/app/modules/optimizations/render-blocking-js/class-render-blocking-js.php
+++ b/projects/plugins/boost/app/modules/optimizations/render-blocking-js/class-render-blocking-js.php
@@ -298,7 +298,7 @@ class Render_Blocking_JS implements Feature, Changes_Output_On_Activation, Optim
 		if ( str_contains( $buffer, '</body>' ) ) {
 			$buffer = str_replace( '</body>', $script_tags . '</body>', $buffer );
 		} else {
-			$buffer = $buffer . $script_tags;
+			$buffer .= $script_tags;
 		}
 
 		return $buffer;

--- a/projects/plugins/boost/app/modules/optimizations/render-blocking-js/class-render-blocking-js.php
+++ b/projects/plugins/boost/app/modules/optimizations/render-blocking-js/class-render-blocking-js.php
@@ -291,11 +291,17 @@ class Render_Blocking_JS implements Feature, Changes_Output_On_Activation, Optim
 	 * @return string
 	 */
 	public function append_script_tags( $buffer ) {
+		$script_tags = implode( '', $this->buffered_script_tags );
+		// Reset tags in case there's another buffer after this one.
+		$this->buffered_script_tags = array();
+
 		if ( str_contains( $buffer, '</body>' ) ) {
-			return str_replace( '</body>', implode( '', $this->buffered_script_tags ) . '</body>', $buffer );
+			$buffer = str_replace( '</body>', $script_tags . '</body>', $buffer );
+		} else {
+			$buffer = $buffer . $script_tags;
 		}
 
-		return $buffer . implode( '', $this->buffered_script_tags );
+		return $buffer;
 	}
 
 	/**

--- a/projects/plugins/boost/changelog/fix-boost-defer-js-output-twice
+++ b/projects/plugins/boost/changelog/fix-boost-defer-js-output-twice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Defer JS: Fix duplicating deferred scripts on the page.


### PR DESCRIPTION
Fixes HOG-172

## Proposed changes:

* Fix `Defer Non-Essential JavaScript` adding deferred scripts twice on the same page if `Optimize LCP Images` is also enabled.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

HOG-172

## Does this pull request change what data or activity we track or use?

no

## Testing instructions:

**Pre-requisites**

- Add this script to an mu plugin:

```php
add_action( 'wp_footer', function() {
	?>
	<script>
		console.log('hi');
	</script>
	<?php
});
```
- Open a page to make sure it works. You should see `hi` in the console.

### Test that it breaks

- Setup latest production version of Boost (free);
- Enable "Defer Non-Essential JavaScript";
- Enable "Optimize LCP Images";
- Open any page and check the browser console - there should be two `hi` entries.

### Test that it works

- Switch to this branch;
- Open any page and check the browser console - there should be just one `hi` entry.