### PR TITLE
Jetpack Forms: remove legacy menu item

### DIFF
--- a/projects/packages/forms/changelog/remove-jetpack-forms-legacy-menu-item
+++ b/projects/packages/forms/changelog/remove-jetpack-forms-legacy-menu-item
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: remove legacy menu item by defaulting the filter to true

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -77,21 +77,7 @@ class Jetpack_Forms {
 	 * @return boolean
 	 */
 	public static function is_legacy_menu_item_retired() {
-		$default                      = false; // Don't retire the legacy menu item by default.
-		$largest_legacy_connection_id = 245807300; // The connection ID after which the legacy menu item is retired.
-
-		$connection_id = defined( 'IS_WPCOM' ) && IS_WPCOM ? get_current_blog_id() : intval( \Jetpack_Options::get_option( 'id' ) );
-
-		if ( $connection_id > $largest_legacy_connection_id ) {
-			$default = true; // Retire the legacy menu item for connections after the specified ID.
-		}
-
-		// If the user has seen the migration announcement, also default to true.
-		if ( ! $default && get_user_option( 'jetpack_forms_migration_announcement_seen' ) ) {
-			$default = true;
-		}
-
-		return apply_filters( 'jetpack_forms_retire_legacy_menu_item', $default );
+		return apply_filters( 'jetpack_forms_retire_legacy_menu_item', true );
 	}
 
 	/**


### PR DESCRIPTION
Part of FORMS-27

## Proposed changes:
This PR changes the default value for the filter controlling whether we add the legacy menu item (Feedback > Forms responses) or not. Effectively not creating/showing such menu item anymore.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
FORMS-27

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Load wp-admin. The menu item Feedback > Forms responses should not show anymore.
Calypso gets the menu through the public-api, be sure to sandbox it when testing.

Test on local, AT and simple sites.
Test with and without Crowdsignal installed.