### PR TITLE
feat: Editor assets endpoint includes manifest data

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-block-editor-assets.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-block-editor-assets.php
@@ -261,13 +261,15 @@ class WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets extends WP_REST_Controller 
 		sort( $script_urls );
 		sort( $style_urls );
 
+		$allowed_block_types = array_merge(
+			$this->get_core_block_types(),
+			self::ALLOWED_PLUGIN_BLOCKS
+		);
+
 		return rest_ensure_response(
 			array(
-				'allowed_block_types' => array_merge(
-					$this->get_core_block_types(),
-					self::ALLOWED_PLUGIN_BLOCKS
-				),
-				'hash'                => hash( 'sha256', implode( $script_urls ) . implode( $style_urls ) ),
+				'allowed_block_types' => $allowed_block_types,
+				'hash'                => hash( 'sha256', implode( $allowed_block_types ) . implode( $script_urls ) . implode( $style_urls ) ),
 				'styles_html'         => $styles,
 				'scripts_html'        => $scripts,
 				'scripts'             => $script_urls,

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-block-editor-assets.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-block-editor-assets.php
@@ -255,14 +255,23 @@ class WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets extends WP_REST_Controller 
 		$wp_styles  = $current_wp_styles;
 		$wp_scripts = $current_wp_scripts;
 
+		$script_urls = $this->parse_scripts( $scripts );
+		$style_urls  = $this->parse_styles( $styles );
+
+		sort( $script_urls );
+		sort( $style_urls );
+
 		return rest_ensure_response(
 			array(
 				'allowed_block_types' => array_merge(
 					$this->get_core_block_types(),
 					self::ALLOWED_PLUGIN_BLOCKS
 				),
-				'scripts'             => $scripts,
-				'styles'              => $styles,
+				'hash'                => hash( 'sha256', implode( $script_urls ) . implode( $style_urls ) ),
+				'styles_html'         => $styles,
+				'scripts_html'        => $scripts,
+				'scripts'             => $script_urls,
+				'styles'              => $style_urls,
 			)
 		);
 	}
@@ -343,6 +352,50 @@ class WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets extends WP_REST_Controller 
 		}
 
 		return false;
+	}
+
+	/**
+	 * Parse the scripts from the HTML.
+	 *
+	 * @param string $scripts The HTML to parse.
+	 *
+	 * @return array The parsed scripts.
+	 */
+	private function parse_scripts( $scripts ) {
+			$dom = new DOMDocument();
+			$dom->loadHTML( $scripts );
+
+			$scripts = $dom->getElementsByTagName( 'script' );
+
+			$urls = array();
+
+		foreach ( $scripts as $script ) {
+			$urls[] = $script->getAttribute( 'src' );
+		}
+
+			return array_values( array_filter( $urls ) );
+	}
+
+	/**
+	 * Parse the styles from the HTML.
+	 *
+	 * @param string $styles The HTML to parse.
+	 *
+	 * @return array The parsed styles.
+	 */
+	private function parse_styles( $styles ) {
+		$dom = new DOMDocument();
+		$dom->loadHTML( $styles );
+
+		$styles = $dom->getElementsByTagName( 'link' );
+
+		$urls = array();
+
+		foreach ( $styles as $style ) {
+			$urls[] = $style->getAttribute( 'href' );
+		}
+
+		return array_values( array_filter( $urls ) );
 	}
 
 	/**

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-block-editor-assets.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-block-editor-assets.php
@@ -443,13 +443,31 @@ class WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets extends WP_REST_Controller 
 						'type' => 'string',
 					),
 				),
-				'scripts'             => array(
+				'hash'                => array(
+					'description' => esc_html__( 'Hash of the block editor assets.', 'jetpack' ),
+					'type'        => 'string',
+				),
+				'styles_html'         => array(
+					'description' => esc_html__( 'Style link tags for the block editor.', 'jetpack' ),
+					'type'        => 'string',
+				),
+				'scripts_html'        => array(
 					'description' => esc_html__( 'Script tags for the block editor.', 'jetpack' ),
 					'type'        => 'string',
 				),
+				'scripts'             => array(
+					'description' => esc_html__( 'Script URLs for the block editor.', 'jetpack' ),
+					'type'        => 'array',
+					'items'       => array(
+						'type' => 'string',
+					),
+				),
 				'styles'              => array(
-					'description' => esc_html__( 'Style link tags for the block editor.', 'jetpack' ),
-					'type'        => 'string',
+					'description' => esc_html__( 'Style URLs for the block editor.', 'jetpack' ),
+					'type'        => 'array',
+					'items'       => array(
+						'type' => 'string',
+					),
 				),
 			),
 		);

--- a/projects/plugins/jetpack/changelog/feat-editor-assets-endpoint-includes-manifest-data
+++ b/projects/plugins/jetpack/changelog/feat-editor-assets-endpoint-includes-manifest-data
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Block editor: include manifest data in editor assets endpoint

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test.php
@@ -124,11 +124,22 @@ class WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test extends Jetpack_REST_T
 
 		$this->assertInstanceOf( WP_REST_Response::class, $response );
 		$data = $response->get_data();
+
 		$this->assertIsArray( $data );
+
+		$this->assertArrayHasKey( 'allowed_block_types', $data );
+		$this->assertArrayHasKey( 'hash', $data );
 		$this->assertArrayHasKey( 'styles', $data );
 		$this->assertArrayHasKey( 'scripts', $data );
-		$this->assertIsString( $data['styles'] );
-		$this->assertIsString( $data['scripts'] );
+		$this->assertArrayHasKey( 'styles_html', $data );
+		$this->assertArrayHasKey( 'scripts_html', $data );
+
+		$this->assertIsArray( $data['allowed_block_types'] );
+		$this->assertIsString( $data['hash'] );
+		$this->assertIsArray( $data['styles'] );
+		$this->assertIsArray( $data['scripts'] );
+		$this->assertIsString( $data['styles_html'] );
+		$this->assertIsString( $data['scripts_html'] );
 	}
 
 	/**
@@ -183,7 +194,7 @@ class WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test extends Jetpack_REST_T
 		$data     = $response->get_data();
 
 		// Verify the disallowed plugin script is not in the output
-		$this->assertStringNotContainsString( 'disallowed-plugin/script.js', $data['scripts'] );
+		$this->assertStringNotContainsString( 'disallowed-plugin/script.js', $data['scripts_html'] );
 	}
 
 	/**
@@ -200,7 +211,7 @@ class WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test extends Jetpack_REST_T
 		$data     = $response->get_data();
 
 		// Verify jQuery is in the output
-		$this->assertStringContainsString( 'jquery', $data['scripts'] );
+		$this->assertStringContainsString( 'jquery', $data['scripts_html'] );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test.php
@@ -303,8 +303,8 @@ class WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test extends Jetpack_REST_T
 		$this->assertEquals( 64, strlen( $data['hash'] ) );
 		$this->assertMatchesRegularExpression( '/^[a-f0-9]{64}$/', $data['hash'] );
 
-		// Verify hash is generated from scripts and styles arrays
-		$expected_hash = hash( 'sha256', implode( $data['scripts'] ) . implode( $data['styles'] ) );
+		// Verify hash is generated from scripts, styles, and allowed_block_types arrays
+		$expected_hash = hash( 'sha256', implode( $data['allowed_block_types'] ) . implode( $data['scripts'] ) . implode( $data['styles'] ) );
 		$this->assertEquals( $expected_hash, $data['hash'] );
 	}
 

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test.php
@@ -286,4 +286,62 @@ class WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test extends Jetpack_REST_T
 		unregister_post_type( 'custom_type' );
 		remove_role( 'custom_editor' );
 	}
+
+	/**
+	 * Test that the hash is correctly generated from scripts and styles.
+	 */
+	public function test_hash_is_correctly_generated() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
+
+		$request  = new WP_REST_Request( Requests::GET, '/wpcom/v2/editor-assets' );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		// Verify hash is present and is a valid SHA256 hash
+		$this->assertArrayHasKey( 'hash', $data );
+		$this->assertIsString( $data['hash'] );
+		$this->assertEquals( 64, strlen( $data['hash'] ) );
+		$this->assertMatchesRegularExpression( '/^[a-f0-9]{64}$/', $data['hash'] );
+
+		// Verify hash is generated from scripts and styles arrays
+		$expected_hash = hash( 'sha256', implode( $data['scripts'] ) . implode( $data['styles'] ) );
+		$this->assertEquals( $expected_hash, $data['hash'] );
+	}
+
+	/**
+	 * Test that allowed block types contain both core and plugin blocks.
+	 */
+	public function test_allowed_block_types_contain_core_and_plugin_blocks() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
+
+		$request  = new WP_REST_Request( Requests::GET, '/wpcom/v2/editor-assets' );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$allowed_blocks = $data['allowed_block_types'];
+
+		// Verify we have both core and plugin blocks
+		$core_blocks   = array_filter(
+			$allowed_blocks,
+			function ( $block ) {
+				return strpos( $block, 'core/' ) === 0;
+			}
+		);
+		$plugin_blocks = array_filter(
+			$allowed_blocks,
+			function ( $block ) {
+				return strpos( $block, 'core/' ) !== 0;
+			}
+		);
+
+		$this->assertNotEmpty( $core_blocks, 'Core blocks should be present' );
+		$this->assertNotEmpty( $plugin_blocks, 'Plugin blocks should be present' );
+
+		// Verify all blocks are unique
+		$this->assertSameSize( $allowed_blocks, array_unique( $allowed_blocks ) );
+
+		// Verify specific expected blocks are present
+		$this->assertContains( 'core/paragraph', $allowed_blocks );
+		$this->assertContains( 'jetpack/contact-form', $allowed_blocks );
+	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Close CMM-505. Close CMM-506. Add additional manifest data necessary for loading and caching assets within the mobile apps. 

Inspired by https://github.com/wordpress-mobile/block-editor-assets-endpoint/pull/1. 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
- Add `hash` key for tracking when the endpoint return changes. 
- Add `styles_html` and `scripts_html` keys for returning HTML for scripts and styles. 
- Return array of asset URLs in `styles` and `script` keys for iterating and downloading assets. 
- Add additional automated tests. 

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Apply these Jetpack changes (see [comment](https://github.com/Automattic/jetpack/pull/44032#issuecomment-2989100376)) to your WPCOM site—Simple or Atomic.  
1. Make a request to the `/wpcom/v2/sites/<site_id>/editor-assets` endpoint for WPCOM Simple site—via [API Console](https://developer.wordpress.com/docs/api/console/), `curl`, etc. 
1. Verify the 200 response includes the expected keys: 
    ```
    {
      allowed_block_types: string[]
      hash: string
      styles_html: string
      scripts_html: string
      styles: string[]
      scripts: string[]
    }
    ```

