### PR TITLE
refactor: Improve editor assets endpoint readability

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-block-editor-assets.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-block-editor-assets.php
@@ -162,69 +162,6 @@ class WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets extends WP_REST_Controller 
 	}
 
 	/**
-	 * Unregisters all assets except those from core or allowed plugins.
-	 */
-	private function unregister_disallowed_plugin_assets() {
-		global $wp_scripts, $wp_styles;
-
-		// Helper function to check if an asset is from an allowed plugin
-		$is_allowed_plugin_asset = function ( $src ) {
-			if ( ! is_string( $src ) || empty( $src ) ) {
-				return false;
-			}
-
-			foreach ( self::ALLOWED_PLUGINS as $allowed_plugin ) {
-				if ( strpos( $src, $allowed_plugin ) !== false ) {
-					return true;
-				}
-			}
-
-			return false;
-		};
-
-			// Helper function to check if an asset is a core asset
-			$is_core_asset = function ( $src ) {
-				if ( ! is_string( $src ) ) {
-					return false;
-				}
-
-				return empty( $src ) ||
-					$src[0] === '/' ||
-					strpos( $src, 'wp-includes/' ) !== false ||
-					strpos( $src, 'wp-admin/' ) !== false;
-			};
-
-			// Helper function to check if a handle should be protected
-			$is_protected_handle = function ( $handle ) {
-				return in_array( $handle, self::PROTECTED_HANDLES, true );
-			};
-
-			// Unregister disallowed plugin scripts
-		foreach ( $wp_scripts->registered as $handle => $script ) {
-			// Skip core scripts and protected handles
-			if ( $is_core_asset( $script->src ) || $is_protected_handle( $handle ) ) {
-				continue;
-			}
-
-			if ( ! $is_allowed_plugin_asset( $script->src ) ) {
-				unset( $wp_scripts->registered[ $handle ] );
-			}
-		}
-
-			// Unregister disallowed plugin styles
-		foreach ( $wp_styles->registered as $handle => $style ) {
-			// Skip core styles and protected handles
-			if ( $is_core_asset( $style->src ) || $is_protected_handle( $handle ) ) {
-				continue;
-			}
-
-			if ( ! $is_allowed_plugin_asset( $style->src ) ) {
-				unset( $wp_styles->registered[ $handle ] );
-			}
-		}
-	}
-
-	/**
 	 * Retrieves a collection of items.
 	 *
 	 * @param WP_REST_Request $request The request object.
@@ -328,6 +265,84 @@ class WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets extends WP_REST_Controller 
 				'styles'              => $styles,
 			)
 		);
+	}
+
+	/**
+	 * Unregisters all assets except those from core or allowed plugins.
+	 */
+	private function unregister_disallowed_plugin_assets() {
+		global $wp_scripts, $wp_styles;
+
+		// Unregister disallowed plugin scripts
+		foreach ( $wp_scripts->registered as $handle => $script ) {
+			// Skip core scripts and protected handles
+			if ( $this->is_core_asset( $script->src ) || $this->is_protected_handle( $handle ) ) {
+				continue;
+			}
+
+			if ( ! $this->is_allowed_plugin_asset( $script->src ) ) {
+				unset( $wp_scripts->registered[ $handle ] );
+			}
+		}
+
+		// Unregister disallowed plugin styles
+		foreach ( $wp_styles->registered as $handle => $style ) {
+			// Skip core styles and protected handles
+			if ( $this->is_core_asset( $style->src ) || $this->is_protected_handle( $handle ) ) {
+				continue;
+			}
+
+			if ( ! $this->is_allowed_plugin_asset( $style->src ) ) {
+				unset( $wp_styles->registered[ $handle ] );
+			}
+		}
+	}
+
+	/**
+	 * Check if an asset is a core asset.
+	 *
+	 * @param string $src The asset source URL.
+	 * @return bool True if the asset is a core asset, false otherwise.
+	 */
+	private function is_core_asset( $src ) {
+		if ( ! is_string( $src ) ) {
+			return false;
+		}
+
+		return empty( $src ) ||
+			$src[0] === '/' ||
+			strpos( $src, 'wp-includes/' ) !== false ||
+			strpos( $src, 'wp-admin/' ) !== false;
+	}
+
+	/**
+	 * Check if a handle should be protected.
+	 *
+	 * @param string $handle The asset handle.
+	 * @return bool True if the handle should be protected, false otherwise.
+	 */
+	private function is_protected_handle( $handle ) {
+		return in_array( $handle, self::PROTECTED_HANDLES, true );
+	}
+
+	/**
+	 * Check if an asset is from an allowed plugin.
+	 *
+	 * @param string $src The asset source URL.
+	 * @return bool True if the asset is from an allowed plugin, false otherwise.
+	 */
+	private function is_allowed_plugin_asset( $src ) {
+		if ( ! is_string( $src ) || empty( $src ) ) {
+			return false;
+		}
+
+		foreach ( self::ALLOWED_PLUGINS as $allowed_plugin ) {
+			if ( strpos( $src, $allowed_plugin ) !== false ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/projects/plugins/jetpack/changelog/refactor-improve-editor-assets-endpoint-readability
+++ b/projects/plugins/jetpack/changelog/refactor-improve-editor-assets-endpoint-readability
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Block editor: refactor editor assets endpoint for readability


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Close CMM-286. Address feedback shared in https://github.com/Automattic/jetpack/pull/42835#pullrequestreview-2747333024. 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Change inline functions to be private methods. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

The existing automated tests should suffice. 