### PR TITLE
My Jetpack: Onboarding i4 | Wire up toggle success and error notices

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/module-toggle/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/module-toggle/index.tsx
@@ -1,3 +1,4 @@
+import { useGlobalNotices } from '@automattic/jetpack-components';
 import { store as modulesStore } from '@automattic/jetpack-shared-extension-utils';
 import { FormToggle } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -19,20 +20,70 @@ export type ModuleToggleProps = {
  */
 export function ModuleToggle( { module: $module }: ModuleToggleProps ) {
 	const { updateJetpackModuleStatus: toggleModule } = useDispatch( modulesStore );
+	const { createSuccessNotice, createErrorNotice } = useGlobalNotices();
 
 	const isUpdating = useSelect(
 		select => select( modulesStore ).isModuleUpdating( $module.module ),
 		[ $module.module ]
 	);
 
+	const showToggleNotice = useCallback(
+		async ( {
+			noticeType,
+			action,
+		}: {
+			noticeType: 'success' | 'error';
+			action: 'activation' | 'deactivation';
+		} ) => {
+			if ( noticeType === 'success' ) {
+				const message =
+					action === 'activation'
+						? sprintf(
+								/* translators: %s is the module name */
+								__( '%s has been activated.', 'jetpack-my-jetpack' ),
+								$module.name
+						  )
+						: sprintf(
+								/* translators: %s is the module name */
+								__( '%s has been deactivated.', 'jetpack-my-jetpack' ),
+								$module.name
+						  );
+				createSuccessNotice( message );
+			} else {
+				const message =
+					action === 'activation'
+						? sprintf(
+								/* translators: %s is the module name */
+								__( 'Failed to activate %s.', 'jetpack-my-jetpack' ),
+								$module.name
+						  )
+						: sprintf(
+								/* translators: %s is the module name */
+								__( 'Failed to deactivate %s.', 'jetpack-my-jetpack' ),
+								$module.name
+						  );
+
+				createErrorNotice( message );
+			}
+		},
+		[ $module.name, createErrorNotice, createSuccessNotice ]
+	);
+
 	const onChange = useCallback(
-		( event: React.ChangeEvent< HTMLInputElement > ) => {
-			toggleModule( {
+		async ( event: React.ChangeEvent< HTMLInputElement > ) => {
+			const active = event.target.checked;
+
+			const success = await toggleModule( {
 				name: $module.module,
-				active: event.target.checked,
+				active,
+			} );
+
+			await showToggleNotice( {
+				noticeType: success ? 'success' : 'error',
+				action: active ? 'activation' : 'deactivation',
 			} );
 		},
-		[ toggleModule, $module.module ]
+		[ toggleModule, $module.module, showToggleNotice ]
 	);
 
 	return (


### PR DESCRIPTION
Completes MYJP-194

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Show notices for module toggles in My Jetpack > Products

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to My Jetpack > Products
* Toggle a module ON and OFF
* Confirm that you see the success notice ([Snackbar](https://wordpress.github.io/gutenberg/?path=/docs/components-snackbar--docs)) accordingly
* Simulate a failure by modifying the endpoint [here](https://github.com/Automattic/jetpack/blob/7805ca2effc690a5077a47049f6648250cbac110/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php#L318) as shown in the video below.
* Confirm that you see the error message


https://github.com/user-attachments/assets/748eaaca-d6fc-4e0d-ba8a-e2fb7807b824


