### PR TITLE
My Jetpack: Make last product card full width when odd count

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/styles.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/styles.module.scss
@@ -80,6 +80,11 @@
 		div[data-wp-component="Card"] {
 			height: 100%;
 		}
+
+		// Make last card full width when there's an odd number of cards
+		li:last-child:nth-child(odd) {
+			grid-column: 1 / -1;
+		}
 	}
 
 	.section-heading {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes MYJP-168

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Made last element full width if odd.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the products page
* Check that if the number of cards is odd, the card is full width

![CleanShot 2025-06-23 at 13 28 58 png](https://github.com/user-attachments/assets/f8b30c18-6724-45fd-9bdf-3dec42c3841e)

![CleanShot 2025-06-23 at 13 28 54 png](https://github.com/user-attachments/assets/9ead3a68-71ee-4faf-a860-0b3540303009)


