### PR TITLE
Update to-test.md for Jetpack 14.8

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-add_to-test.md_for_14.8
+++ b/projects/plugins/jetpack/changelog/update-jetpack-add_to-test.md_for_14.8
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Tests: Add instructions for Jetpack 14.8.

--- a/projects/plugins/jetpack/to-test.md
+++ b/projects/plugins/jetpack/to-test.md
@@ -8,7 +8,6 @@
 - Blocks in beta status require a small change for you to be able to test them. You can do either of the following:
   - Edit your `wp-config.php` file to include: `define( 'JETPACK_BLOCKS_VARIATION', 'beta' );`
   - Or add the following to something like a code snippet plugin: `add_filter( 'jetpack_blocks_variation', function () { return 'beta'; } );`
-	- To test Breve further in the document please enable the feature with the following snippet: `add_filter( 'breve_enabled', '__return_true' );`
 
 You can see a [full list of changes in this release here](https://github.com/Automattic/jetpack-production/blob/trunk/CHANGELOG.md). Please feel free to test any and all functionality mentioned!
 

--- a/projects/plugins/jetpack/to-test.md
+++ b/projects/plugins/jetpack/to-test.md
@@ -12,4 +12,44 @@
 
 You can see a [full list of changes in this release here](https://github.com/Automattic/jetpack-production/blob/trunk/CHANGELOG.md). Please feel free to test any and all functionality mentioned!
 
+### Tiled Gallery Block
+
+Updates have been made to prevent block validation warnings (in the editor and in the browser console). Thorough testing of the Tiled Gallery block is recommended, though the issues fixed primarily affected multisites (including Simple sites). Here are some steps to follow:
+
+* Create a Tiled Gallery. Set link type to anything, with carousel enabled (`/wp-admin/admin.php?page=jetpack#writing`).
+* There should be no block validation issues. Both in the editor and front-end, behavior should be as expected.
+* On the front-end you should be able to click on the post title then press tab to tab onto the images, and click enter to open them in Carousel - image markup (in the Tiled Gallery, not for Carousel images) should include tabindex of 0, role of button, and an aria-label. In the editor the image markup should not include an `aria-label`, `role` or `tabindex`.
+* Disable Carousel, and images on the front-end should have no `tabindex`, `aria-label` or `role`. If link is set to "none", you won't be able to click on the images (it won't do anything). For any of the other link options, the link should work. There should still be no `aria-label`, `tabindex` or `role` - as the image is no longer the clickable element but instead is wrapped in an anchor tag.
+* Ensure general functionality works as expected, as before.
+* Duplicate a post or page with a Tiled Gallery block (to duplicate, enable the option to copy posts from `/wp-admin/admin.php?page=jetpack#writing`). On saving, there should be no block validation errors.
+* Make sure custom links work, and adding them (and saving then refreshing the page) does not result in any layout issues, and the links remain (front-end as well).
+
+Ideally testing would also be done both before and after updating to the new Jetpack version to ensure there are no block validation issues due to the update. If testing updating the version and using an existing Tiled Gallery, make sure to refresh the editor page with the block. You may need to resave the post and refresh to ensure that changes are applied, but subsequent page refreshes should show no issues in the editor or console.
+
+### Multi-Step Form block
+
+This is a beta block that could use some rigorous testing. This includes:
+
+* Creating, editing, updating, and removing steps, fields, and the block itself.
+* Navigating between steps, both with the mouse and the keyboard.
+* Validation and submission
+* Design should inherit site theme styles and be responsive.
+
+Feel free to push its limits, trying the following:
+
+* Large numbers of steps
+* Large numbers of fields per step
+* Language support (including RTL)
+
+### Forms block changes
+
+Things to test include the following:
+
+* The File Upload field (beta) is nearly ready to go live.
+* The Integrations panel (Forms block toolbar -> Integrations) has seen a bunch of UX improvements.
+* The Feedback menu item should be fully removed (along with any references). It has been replaced by Jetpack -> Forms.
+* New error validation UX on the frontend validates right away when unfocusing a field, instead of on form submit.
+* There's now an Undo option in all FOrms inbox trash and spam actions.
+* Removing items from the Options field is now possible with a little "X" next to each line.
+
 **Thank you for all your help!**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Adds testing instructions for upcoming release.

Also removes an irrelevant line related to testing setup (see p1750688521312829/1750434080.390439-slack-C086RGTJT1D).

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*