### PR TITLE
Status: Add hosting check for vip sites

### DIFF
--- a/projects/packages/status/changelog/fix-vip-site-check-in-status-class
+++ b/projects/packages/status/changelog/fix-vip-site-check-in-status-class
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+VIP: Change hosting check method.

--- a/projects/packages/status/src/class-host.php
+++ b/projects/packages/status/src/class-host.php
@@ -55,7 +55,11 @@ class Host {
 	 * @return bool
 	 */
 	public function is_vip_site() {
-		return Constants::is_defined( 'WPCOM_IS_VIP_ENV' ) && true === Constants::get_constant( 'WPCOM_IS_VIP_ENV' );
+		$_blog_id = get_current_blog_id();
+		if ( function_exists( 'wpcom_is_vip' ) ) {
+			return wpcom_is_vip( $_blog_id );
+		}
+		return false;
 	}
 
 	/**

--- a/projects/packages/waf/changelog/fix-vip-site-check-in-status-class
+++ b/projects/packages/waf/changelog/fix-vip-site-check-in-status-class
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Tests: Modify environment check in tests to match new requirements

--- a/projects/packages/waf/tests/php/integration/WafUnsupportedEnvironmentIntegrationTest.php
+++ b/projects/packages/waf/tests/php/integration/WafUnsupportedEnvironmentIntegrationTest.php
@@ -47,6 +47,8 @@ final class WafUnsupportedEnvironmentIntegrationTest extends WorDBless\BaseTestC
 	 * Test teardown.
 	 */
 	protected function tear_down() {
+		global $wpcom_is_vip;
+		$wpcom_is_vip = false;
 		Constants::clear_constants();
 		Cache::clear();
 	}
@@ -102,17 +104,8 @@ final class WafUnsupportedEnvironmentIntegrationTest extends WorDBless\BaseTestC
 	 * Test WAF init in a VIP environment.
 	 */
 	public function testWafInitVipEnvironment() {
-		if ( ! function_exists( 'wpcom_is_vip' ) ) {
-			/**
-			 * Mock function for wpcom_is_vip that returns true for testing VIP sites.
-			 *
-			 * @param int|null $blog_id Blog ID.
-			 * @return bool
-			 */
-			function wpcom_is_vip( $blog_id = null ) { // phpcs:ignore MediaWiki.Usage.NestedFunctions.NestedFunction,VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-				return true;
-			}
-		}
+		global $wpcom_is_vip;
+		$wpcom_is_vip = true;
 
 		$available_modules = ( new Modules() )->get_available();
 

--- a/projects/packages/waf/tests/php/integration/WafUnsupportedEnvironmentIntegrationTest.php
+++ b/projects/packages/waf/tests/php/integration/WafUnsupportedEnvironmentIntegrationTest.php
@@ -102,13 +102,17 @@ final class WafUnsupportedEnvironmentIntegrationTest extends WorDBless\BaseTestC
 	 * Test WAF init in a VIP environment.
 	 */
 	public function testWafInitVipEnvironment() {
-		$host_mock = $this->getMockBuilder( \Automattic\Jetpack\Status\Host::class )
-		->disableOriginalConstructor()
-		->onlyMethods( array( 'is_vip_site' ) )
-		->getMock();
-
-		$host_mock->method( 'is_vip_site' )
-		->willReturn( true );
+		if ( ! function_exists( 'wpcom_is_vip' ) ) {
+			/**
+			 * Mock function for wpcom_is_vip that returns true for testing VIP sites.
+			 *
+			 * @param int|null $blog_id Blog ID.
+			 * @return bool
+			 */
+			function wpcom_is_vip( $blog_id = null ) { // phpcs:ignore MediaWiki.Usage.NestedFunctions.NestedFunction,VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+				return true;
+			}
+		}
 
 		$available_modules = ( new Modules() )->get_available();
 

--- a/projects/packages/waf/tests/php/integration/WafUnsupportedEnvironmentIntegrationTest.php
+++ b/projects/packages/waf/tests/php/integration/WafUnsupportedEnvironmentIntegrationTest.php
@@ -102,7 +102,6 @@ final class WafUnsupportedEnvironmentIntegrationTest extends WorDBless\BaseTestC
 	 * Test WAF init in a VIP environment.
 	 */
 	public function testWafInitVipEnvironment() {
-		// Mock the Host class to return true for is_vip_site()
 		$host_mock = $this->getMockBuilder( \Automattic\Jetpack\Status\Host::class )
 		->disableOriginalConstructor()
 		->onlyMethods( array( 'is_vip_site' ) )
@@ -110,9 +109,6 @@ final class WafUnsupportedEnvironmentIntegrationTest extends WorDBless\BaseTestC
 
 		$host_mock->method( 'is_vip_site' )
 		->willReturn( true );
-
-		// Inject the mock into the WAF runner or wherever it's used
-		// You might need to use dependency injection or a filter to replace the Host instance
 
 		$available_modules = ( new Modules() )->get_available();
 

--- a/projects/packages/waf/tests/php/integration/WafUnsupportedEnvironmentIntegrationTest.php
+++ b/projects/packages/waf/tests/php/integration/WafUnsupportedEnvironmentIntegrationTest.php
@@ -102,7 +102,17 @@ final class WafUnsupportedEnvironmentIntegrationTest extends WorDBless\BaseTestC
 	 * Test WAF init in a VIP environment.
 	 */
 	public function testWafInitVipEnvironment() {
-		Constants::set_constant( 'WPCOM_IS_VIP_ENV', true );
+		// Mock the Host class to return true for is_vip_site()
+		$host_mock = $this->getMockBuilder( \Automattic\Jetpack\Status\Host::class )
+		->disableOriginalConstructor()
+		->onlyMethods( array( 'is_vip_site' ) )
+		->getMock();
+
+		$host_mock->method( 'is_vip_site' )
+		->willReturn( true );
+
+		// Inject the mock into the WAF runner or wherever it's used
+		// You might need to use dependency injection or a filter to replace the Host instance
 
 		$available_modules = ( new Modules() )->get_available();
 

--- a/projects/packages/waf/tests/php/integration/bootstrap.php
+++ b/projects/packages/waf/tests/php/integration/bootstrap.php
@@ -13,6 +13,7 @@ require_once __DIR__ . '/../../../vendor/autoload.php';
 // Initialize WordPress test environment
 \Automattic\Jetpack\Test_Environment::init();
 
+// Mock version of `wpcom_is_vip()` function for testing `Host::is_vip_site()`.
 $wpcom_is_vip = false; // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 function wpcom_is_vip( $blog_id = null ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 	global $wpcom_is_vip;

--- a/projects/packages/waf/tests/php/integration/bootstrap.php
+++ b/projects/packages/waf/tests/php/integration/bootstrap.php
@@ -12,3 +12,9 @@ require_once __DIR__ . '/../../../vendor/autoload.php';
 
 // Initialize WordPress test environment
 \Automattic\Jetpack\Test_Environment::init();
+
+$wpcom_is_vip = false; // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+function wpcom_is_vip( $blog_id = null ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+	global $wpcom_is_vip;
+	return $wpcom_is_vip;
+}


### PR DESCRIPTION
## Proposed changes:

* This PR changes the method that we use to check for VIP sites within the Status package.
The reason for this is that the previous approach, when combined [with changes in this PR](https://github.com/Automattic/jetpack/pull/43972), was resulting in failing E2E tests on deploy. The reason for that was that the Simple site used for testing was being defined as a VIP site, thus failing tests. 
* Slack: p1750691245800779/1750681477.544699-slack-C01U2KGS2PQ

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

p1750691245800779/1750681477.544699-slack-C01U2KGS2PQ

## Testing instructions:

This can be tested on the Simple site in question - see p1750691245800779/1750681477.544699-slack-C01U2KGS2PQ, by using the commands in the generated comment below and sandboxing that site. 