### PR TITLE
Forms: hide feedback menu from new users 

### DIFF
--- a/projects/packages/forms/changelog/udpate-new-users-hide-feedback
+++ b/projects/packages/forms/changelog/udpate-new-users-hide-feedback
@@ -1,0 +1,4 @@
+Significance: major
+Type: changed
+
+Forms: hide feedback menu from new site

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -77,6 +77,16 @@ class Jetpack_Forms {
 	 * @return boolean
 	 */
 	public static function is_legacy_menu_item_retired() {
-		return apply_filters( 'jetpack_forms_retire_legacy_menu_item', false );
+
+		$default                      = false; // don't retire the legacy menu item by default
+		$largest_legacy_connection_id = 245807300; // the connection ID after which the legacy menu item is retired
+
+		$connection_id = defined( 'IS_WPCOM' ) && IS_WPCOM ? get_current_blog_id() : \Jetpack_Options::get_option( 'id' );
+
+		if ( $connection_id > $largest_legacy_connection_id ) {
+			$default = true;
+		}
+
+		return apply_filters( 'jetpack_forms_retire_legacy_menu_item', $default );
 	}
 }

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -78,13 +78,13 @@ class Jetpack_Forms {
 	 */
 	public static function is_legacy_menu_item_retired() {
 
-		$default                      = false; // don't retire the legacy menu item by default
-		$largest_legacy_connection_id = 245807300; // the connection ID after which the legacy menu item is retired
+		$default                      = false; // Don't retire the legacy menu item by default.
+		$largest_legacy_connection_id = 245807300; // The connection ID after which the legacy menu item is retired.
 
-		$connection_id = defined( 'IS_WPCOM' ) && IS_WPCOM ? get_current_blog_id() : \Jetpack_Options::get_option( 'id' );
+		$connection_id = defined( 'IS_WPCOM' ) && IS_WPCOM ? get_current_blog_id() : intval( \Jetpack_Options::get_option( 'id' ) );
 
 		if ( $connection_id > $largest_legacy_connection_id ) {
-			$default = true;
+			$default = true; // Retire the legacy menu item for connections after the specified ID.
 		}
 
 		return apply_filters( 'jetpack_forms_retire_legacy_menu_item', $default );

--- a/projects/plugins/jetpack/changelog/udpate-new-users-hide-feedback
+++ b/projects/plugins/jetpack/changelog/udpate-new-users-hide-feedback
@@ -1,0 +1,4 @@
+Significance: major
+Type: bugfix
+
+Forms: hide feedback menu from newly connected sites


### PR DESCRIPTION
Currently we show the legacy "Feedback menu to all jetpack sites" 

This PR updates the code to hide the menu for newly connected sites.

## Proposed changes:
* Check the blog id for when the site was added and determine where to show it or not.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1750438360490459/1750436776.542049-slack-C08LJ97DJ6A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* Notice that you still see the menu if you are on a legacy site. 
* Notice that you don't see the menu on a new simple or jetpack site.