### PR TITLE
Forms: Add items count to export button labels

### DIFF
--- a/projects/packages/forms/changelog/update-forms-export-count
+++ b/projects/packages/forms/changelog/update-forms-export-count
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Forms: Add items count to export button labels

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -22,7 +22,7 @@
 		"build:dashboard": "webpack --config ./tools/webpack.config.dashboard.js",
 		"clean": "rm -rf dist/ .cache/",
 		"test": "jest --config=tests/jest.config.js",
-		"test:contact-form": "jest --testPathPatterns=tests/js/contact-form",
+		"test:contact-form": "jest --testPathPatterns=tests/js",
 		"test-coverage": "pnpm run test --coverage",
 		"typecheck": "tsc --noEmit",
 		"validate": "pnpm exec validate-es --no-error-on-unmatched-pattern dist/",

--- a/projects/packages/forms/src/dashboard/components/actions-dropdown-menu/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/actions-dropdown-menu/index.tsx
@@ -40,10 +40,12 @@ const CreateFormDropdownItem = () => {
 };
 
 const ExportDropdownItem = ( { onClick }: { onClick: () => void } ) => {
+	const { exportLabel } = useExportResponses();
+
 	return {
 		icon: download,
 		onClick,
-		title: __( 'Export', 'jetpack-forms' ),
+		title: exportLabel,
 	};
 };
 

--- a/projects/packages/forms/src/dashboard/hooks/use-export-responses.ts
+++ b/projects/packages/forms/src/dashboard/hooks/use-export-responses.ts
@@ -6,6 +6,7 @@ import { useBreakpointMatch } from '@automattic/jetpack-components';
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 import { useState, useCallback, useEffect } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
@@ -19,6 +20,9 @@ type ExportHookReturn = {
 	autoConnectGdrive: boolean;
 	userCanExport: boolean;
 	onExport: ( action: string, nonceName: string ) => Promise< Response >;
+	selectedResponsesCount: number;
+	currentStatus: string;
+	exportLabel: string;
 };
 
 /**
@@ -31,6 +35,26 @@ export default function useExportResponses(): ExportHookReturn {
 	const [ showExportModal, setShowExportModal ] = useState( false );
 	const closeModal = useCallback( () => setShowExportModal( false ), [ setShowExportModal ] );
 	const [ autoConnectGdrive, setAutoConnectGdrive ] = useState( false );
+	const { selectedResponsesCount, currentStatus } = useSelect(
+		select => ( {
+			selectedResponsesCount: select( dashboardStore ).getSelectedResponsesCount(),
+			currentStatus: select( dashboardStore ).getCurrentStatus(),
+		} ),
+		[]
+	);
+	const isSpam = currentStatus.includes( 'spam' );
+	const isTrash = currentStatus.includes( 'trash' );
+
+	let statusLabel = __( 'Export', 'jetpack-forms' );
+
+	if ( isSpam ) {
+		statusLabel = __( 'Export spam', 'jetpack-forms' );
+	} else if ( isTrash ) {
+		statusLabel = __( 'Export trash', 'jetpack-forms' );
+	}
+
+	const exportLabel =
+		selectedResponsesCount > 0 ? `${ statusLabel } (${ selectedResponsesCount })` : statusLabel;
 
 	const openModal = useCallback( () => {
 		setShowExportModal( true );
@@ -91,5 +115,8 @@ export default function useExportResponses(): ExportHookReturn {
 		autoConnectGdrive,
 		userCanExport,
 		onExport,
+		selectedResponsesCount,
+		currentStatus,
+		exportLabel,
 	};
 }

--- a/projects/packages/forms/src/dashboard/inbox/export-responses/index.tsx
+++ b/projects/packages/forms/src/dashboard/inbox/export-responses/index.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { Button } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
 import { download } from '@wordpress/icons';
 /**
  * Internal dependencies
@@ -13,8 +12,15 @@ import useExportResponses from '../../hooks/use-export-responses';
 import './style.scss';
 
 const ExportResponsesButton = () => {
-	const { showExportModal, openModal, closeModal, userCanExport, onExport, autoConnectGdrive } =
-		useExportResponses();
+	const {
+		showExportModal,
+		openModal,
+		closeModal,
+		userCanExport,
+		onExport,
+		autoConnectGdrive,
+		exportLabel,
+	} = useExportResponses();
 
 	if ( ! userCanExport ) {
 		return null;
@@ -29,7 +35,7 @@ const ExportResponsesButton = () => {
 				icon={ download }
 				onClick={ openModal }
 			>
-				{ __( 'Export', 'jetpack-forms' ) }
+				{ exportLabel }
 			</Button>
 
 			{ showExportModal && (

--- a/projects/packages/forms/src/dashboard/store/selectors.js
+++ b/projects/packages/forms/src/dashboard/store/selectors.js
@@ -1,5 +1,6 @@
 export const getFilters = state => state.filters;
 export const getCurrentQuery = state => state.currentQuery;
+export const getCurrentStatus = state => state.currentQuery?.status ?? 'draft,publish';
 export const getSelectedResponsesFromCurrentDataset = state =>
 	state.selectedResponsesFromCurrentDataset;
 export const getSelectedResponsesCount = state => state.selectedResponsesFromCurrentDataset.length;

--- a/projects/packages/forms/src/dashboard/store/selectors.js
+++ b/projects/packages/forms/src/dashboard/store/selectors.js
@@ -2,3 +2,4 @@ export const getFilters = state => state.filters;
 export const getCurrentQuery = state => state.currentQuery;
 export const getSelectedResponsesFromCurrentDataset = state =>
 	state.selectedResponsesFromCurrentDataset;
+export const getSelectedResponsesCount = state => state.selectedResponsesFromCurrentDataset.length;

--- a/projects/packages/forms/tests/js/dashboard/store.test.js
+++ b/projects/packages/forms/tests/js/dashboard/store.test.js
@@ -2,7 +2,7 @@ import { createRegistry } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { store } from '..';
+import { store } from '../../../src/dashboard/store';
 
 const createRegistryWithStores = () => {
 	// Create a registry and register used stores.
@@ -13,25 +13,34 @@ const createRegistryWithStores = () => {
 
 describe( 'actions', () => {
 	let registry;
+
 	beforeEach( () => {
 		registry = createRegistryWithStores();
 	} );
+
 	it( 'receiveFilters', () => {
 		const filters = { date: [ { month: 1, year: 2025 } ], source: [ { id: 29 } ] };
 		registry.dispatch( store ).receiveFilters( filters );
+
 		expect( registry.select( store ).getFilters() ).toMatchObject( filters );
 	} );
+
 	it( 'setSelectedResponses', () => {
 		expect( registry.select( store ).getSelectedResponsesFromCurrentDataset() ).toEqual( [] );
+
 		const args = [ 1, 2, 3 ];
 		registry.dispatch( store ).setSelectedResponses( args );
+
+		expect( registry.select( store ).getSelectedResponsesCount() ).toEqual( args.length );
 		expect( registry.select( store ).getSelectedResponsesFromCurrentDataset() ).toEqual(
 			expect.arrayContaining( args )
 		);
 	} );
+
 	it( 'setCurrentQuery', () => {
 		const args = { page: 1, search: 'r' };
 		registry.dispatch( store ).setCurrentQuery( args );
+
 		expect( registry.select( store ).getCurrentQuery() ).toMatchObject( args );
 	} );
 } );

--- a/projects/packages/forms/tests/js/dashboard/store.test.js
+++ b/projects/packages/forms/tests/js/dashboard/store.test.js
@@ -38,9 +38,10 @@ describe( 'actions', () => {
 	} );
 
 	it( 'setCurrentQuery', () => {
-		const args = { page: 1, search: 'r' };
+		const args = { page: 1, search: 'r', status: 'spam' };
 		registry.dispatch( store ).setCurrentQuery( args );
 
 		expect( registry.select( store ).getCurrentQuery() ).toMatchObject( args );
+		expect( registry.select( store ).getCurrentStatus() ).toEqual( args.status );
 	} );
 } );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes FORMS-100

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds the selected number of items to the export button
* Fixes the test script and move the store test file so that the store tests are included

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the Forms dashboard
* Check that the "Export" button reflects the status (Inbox, Spam or Trash) and the number of selected items, if any (see screenshots)
* Run the tests locally with `jetpack test -v js packages/forms` and check that the store tests are included and passing

![2025-06-23_20-30](https://github.com/user-attachments/assets/15b2fcca-f16a-4059-8912-06b3fcb0c0ab)
![Screenshot from 2025-06-23 20-31-26](https://github.com/user-attachments/assets/d35e4a64-ef1b-4465-8b46-1c8902aa7b8d)
![Screenshot from 2025-06-23 20-30-59](https://github.com/user-attachments/assets/00fbb0c4-79bf-4baa-a28b-b56c9416e0d9)
![Screenshot from 2025-06-23 20-30-52](https://github.com/user-attachments/assets/e9f76d68-f5b8-426e-a2c0-84ed8857f40a)
![Screenshot from 2025-06-23 20-30-46](https://github.com/user-attachments/assets/d966fae7-d7a4-47e7-9e6e-ed8bf4d72a04)
![Screenshot from 2025-06-23 20-30-39](https://github.com/user-attachments/assets/7abacbbf-d310-4999-93ac-7a340cf598bf)
![Screenshot from 2025-06-23 20-30-29](https://github.com/user-attachments/assets/a403f5b5-420a-4a41-b9c8-d3bc2cd6ae14)

