### PR TITLE
Forms: Fix transitions multistep form 

### DIFF
--- a/projects/packages/forms/changelog/fix-transitions-multistep-form
+++ b/projects/packages/forms/changelog/fix-transitions-multistep-form
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: feature is no public
+
+

--- a/projects/packages/forms/src/blocks/contact-form/edit.js
+++ b/projects/packages/forms/src/blocks/contact-form/edit.js
@@ -46,6 +46,12 @@ import IntegrationControls from './components/jetpack-integration-controls';
 import VariationPicker from './variation-picker';
 import './util/form-styles.js';
 
+// Transforms
+const TO_MULTISTEP = 'to-multistep';
+const TO_FORM = 'to-form';
+const IS_MULTISTEP = 'is-multistep';
+const IS_FORM = 'is-form';
+
 const validFields = filter( childBlocks, ( { settings } ) => {
 	return (
 		! settings.parent ||
@@ -219,31 +225,34 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 	}, [] );
 
 	// Detect a conversion to a multistep form and structure inner blocks only once.
-	const hasStructuredRef = useRef( false );
+	const hasTranformRef = useRef( false );
 
 	useEffect( () => {
-		/*───────────────────────────────────────────────────────────────────────────
-		 * 1. Early-exit guards
-		 *───────────────────────────────────────────────────────────────────────────
-		 * – The `variationName` gate ensures we only run this effect when the form
-		 *   actually *is* (or has just become) a multistep form. If the user is
-		 *   working with a regular single-step form we leave everything untouched.
-		 * – `hasStructuredRef` prevents the body from executing more than once per
-		 *   block instance (avoids extra undo levels and wasted processing).
-		 *
-		 *───────────────────────────────────────────────────────────────────────────
-		 * 2. Detect whether the form is *already* correctly structured
-		 *───────────────────────────────────────────────────────────────────────────
-		 * Strategy:
-		 *   • If there is exactly ONE `step-container` anywhere in the tree **and**
-		 *   • There are NO `form-step` blocks that live outside that container,
-		 *     we assume the layout came from the Variation Picker (or has already
-		 *     been normalised) and we skip the heavy restructuring.
-		 */
-		const needsMultistep =
-			variationName === 'multistep' || containsMultistepBlock( currentInnerBlocks );
+		const hasMultistepBlock = containsMultistepBlock( currentInnerBlocks );
 
-		if ( ! needsMultistep || hasStructuredRef.current ) {
+		if ( ! hasMultistepBlock && variationName !== 'multistep' ) {
+			hasTranformRef.current = IS_FORM;
+			return;
+		}
+
+		if ( variationName === 'multistep' && hasMultistepBlock ) {
+			hasTranformRef.current = IS_MULTISTEP;
+			return;
+		}
+
+		if ( hasTranformRef.current === IS_MULTISTEP ) {
+			hasTranformRef.current = TO_FORM;
+			return;
+		}
+		hasTranformRef.current = TO_MULTISTEP;
+
+		// If the form is not multistep, we don't need to do anything.
+	}, [ variationName, currentInnerBlocks, containsMultistepBlock ] );
+
+	useEffect( () => {
+		// Early exit if we are still on the multistep variation or if there are
+		// no multistep-specific blocks to clean up.
+		if ( hasTranformRef.current !== TO_MULTISTEP ) {
 			return;
 		}
 
@@ -285,12 +294,8 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 			stepContainerCount === 1 && ! hasStrayFormStep( currentInnerBlocks );
 
 		if ( formIsFullyStructured ) {
-			hasStructuredRef.current = true;
 			return;
 		}
-
-		// Mark that we'll process the conversion now so we don't repeat it.
-		hasStructuredRef.current = true;
 
 		// Helper functions
 		const findButtonBlock = () => {
@@ -464,6 +469,7 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 		if ( variationName !== 'multistep' ) {
 			setAttributes( { variationName: 'multistep' } );
 		}
+		hasTranformRef.current = IS_MULTISTEP;
 	}, [
 		variationName,
 		currentInnerBlocks,
@@ -474,23 +480,13 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 		__unstableMarkNextChangeAsNotPersistent,
 	] );
 
-	// --- Reset logic -----------------------------------------------------------
-	// When all multistep-specific blocks are removed, clear the structured flag so
-	// that the auto-structuring effect can run again if the user later re-adds
-	// multistep blocks.
-	useEffect( () => {
-		if ( hasStructuredRef.current && ! containsMultistepBlock( currentInnerBlocks ) ) {
-			hasStructuredRef.current = false;
-		}
-	}, [ currentInnerBlocks, containsMultistepBlock ] );
-
 	/*───────────────────────────────────────────────────────────────────────────
 	 * Flatten multistep structure → standard form
 	 *───────────────────────────────────────────────────────────────────────*/
 	useEffect( () => {
 		// Early exit if we are still on the multistep variation or if there are
 		// no multistep-specific blocks to clean up.
-		if ( variationName === 'multistep' || ! containsMultistepBlock( currentInnerBlocks ) ) {
+		if ( TO_FORM !== hasTranformRef.current ) {
 			return;
 		}
 
@@ -554,14 +550,13 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 
 		__unstableMarkNextChangeAsNotPersistent();
 		replaceInnerBlocks( clientId, finalBlocks, false );
-
 		// Reset the variation attribute if still set to something else.
 		if ( variationName !== 'default-empty' ) {
+			__unstableMarkNextChangeAsNotPersistent();
 			setAttributes( { variationName: 'default-empty' } );
 		}
 
-		// Allow the structuring effect to run again later if needed.
-		hasStructuredRef.current = false;
+		hasTranformRef.current = IS_FORM;
 	}, [
 		variationName,
 		currentInnerBlocks,

--- a/projects/packages/forms/src/blocks/contact-form/edit.js
+++ b/projects/packages/forms/src/blocks/contact-form/edit.js
@@ -91,10 +91,15 @@ const ALLOWED_MULTI_STEP_BLOCKS = [
 	'jetpack/form-step-divider',
 ].concat( ALLOWED_CORE_BLOCKS );
 
-const ALLOWED_FORM_BLOCKS = ALLOWED_BLOCKS.concat( [
-	'jetpack/form-step-divider',
+const REMOVE_FIELDS_FROM_FORM = [
+	'jetpack/form-step-navigation',
+	'jetpack/form-progress-indicator',
 	'jetpack/form-step-container',
-] ).concat( ALLOWED_CORE_BLOCKS );
+];
+
+const ALLOWED_FORM_BLOCKS = ALLOWED_BLOCKS.concat( ALLOWED_CORE_BLOCKS ).filter(
+	block => ! REMOVE_FIELDS_FROM_FORM.includes( block )
+);
 
 const PRIORITIZED_INSERTER_BLOCKS = [ ...map( validFields, block => `jetpack/${ block.name }` ) ];
 

--- a/projects/packages/forms/src/blocks/contact-form/edit.js
+++ b/projects/packages/forms/src/blocks/contact-form/edit.js
@@ -47,10 +47,12 @@ import VariationPicker from './variation-picker';
 import './util/form-styles.js';
 
 // Transforms
-const TO_MULTISTEP = 'to-multistep';
-const TO_FORM = 'to-form';
-const IS_MULTISTEP = 'is-multistep';
-const IS_FORM = 'is-form';
+const FormTransitionState = {
+	TO_MULTISTEP: 'to-multistep',
+	TO_FORM: 'to-form',
+	IS_MULTISTEP: 'is-multistep',
+	IS_FORM: 'is-form',
+};
 
 const validFields = filter( childBlocks, ( { settings } ) => {
 	return (
@@ -225,7 +227,7 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 	}, [] );
 
 	// Detect a conversion to a multistep form and structure inner blocks only once.
-	const hasTranformRef = useRef( false );
+	const formTransitionStateRef = useRef( false );
 
 	useEffect( () => {
 		const hasMultistepBlock = containsMultistepBlock( currentInnerBlocks );
@@ -233,25 +235,25 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 		// Transition to single-step form state if no multistep blocks are present
 		// and the variation is not set to 'multistep'.
 		if ( ! hasMultistepBlock && variationName !== 'multistep' ) {
-			hasTranformRef.current = IS_FORM;
+			formTransitionStateRef.current = FormTransitionState.IS_FORM;
 			return;
 		}
 
 		// Transition to multistep form state if multistep blocks are present
 		// and the variation is set to 'multistep'.
 		if ( variationName === 'multistep' && hasMultistepBlock ) {
-			hasTranformRef.current = IS_MULTISTEP;
+			formTransitionStateRef.current = FormTransitionState.IS_MULTISTEP;
 			return;
 		}
 
 		// Transition from multistep form state to single-step form state.
-		if ( hasTranformRef.current === IS_MULTISTEP ) {
-			hasTranformRef.current = TO_FORM;
+		if ( formTransitionStateRef.current === FormTransitionState.IS_MULTISTEP ) {
+			formTransitionStateRef.current = FormTransitionState.TO_FORM;
 			return;
 		}
 
 		// Transition from single-step form state to multistep form state.
-		hasTranformRef.current = TO_MULTISTEP;
+		formTransitionStateRef.current = FormTransitionState.TO_MULTISTEP;
 
 		// If the form is not multistep, we don't need to do anything.
 	}, [ variationName, currentInnerBlocks, containsMultistepBlock ] );
@@ -259,7 +261,7 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 	useEffect( () => {
 		// Early exit if we are still on the multistep variation or if there are
 		// no multistep-specific blocks to clean up.
-		if ( hasTranformRef.current !== TO_MULTISTEP ) {
+		if ( formTransitionStateRef.current !== FormTransitionState.TO_MULTISTEP ) {
 			return;
 		}
 
@@ -476,7 +478,7 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 		if ( variationName !== 'multistep' ) {
 			setAttributes( { variationName: 'multistep' } );
 		}
-		hasTranformRef.current = IS_MULTISTEP;
+		formTransitionStateRef.current = FormTransitionState.IS_MULTISTEP;
 	}, [
 		variationName,
 		currentInnerBlocks,
@@ -493,7 +495,7 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 	useEffect( () => {
 		// Early exit if we are still on the multistep variation or if there are
 		// no multistep-specific blocks to clean up.
-		if ( TO_FORM !== hasTranformRef.current ) {
+		if ( FormTransitionState.TO_FORM !== formTransitionStateRef.current ) {
 			return;
 		}
 
@@ -563,7 +565,7 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 			setAttributes( { variationName: 'default-empty' } );
 		}
 
-		hasTranformRef.current = IS_FORM;
+		formTransitionStateRef.current = FormTransitionState.IS_FORM;
 	}, [
 		variationName,
 		currentInnerBlocks,

--- a/projects/packages/forms/src/blocks/contact-form/edit.js
+++ b/projects/packages/forms/src/blocks/contact-form/edit.js
@@ -230,20 +230,27 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 	useEffect( () => {
 		const hasMultistepBlock = containsMultistepBlock( currentInnerBlocks );
 
+		// Transition to single-step form state if no multistep blocks are present
+		// and the variation is not set to 'multistep'.
 		if ( ! hasMultistepBlock && variationName !== 'multistep' ) {
 			hasTranformRef.current = IS_FORM;
 			return;
 		}
 
+		// Transition to multistep form state if multistep blocks are present
+		// and the variation is set to 'multistep'.
 		if ( variationName === 'multistep' && hasMultistepBlock ) {
 			hasTranformRef.current = IS_MULTISTEP;
 			return;
 		}
 
+		// Transition from multistep form state to single-step form state.
 		if ( hasTranformRef.current === IS_MULTISTEP ) {
 			hasTranformRef.current = TO_FORM;
 			return;
 		}
+
+		// Transition from single-step form state to multistep form state.
 		hasTranformRef.current = TO_MULTISTEP;
 
 		// If the form is not multistep, we don't need to do anything.

--- a/projects/packages/forms/src/blocks/form-step-divider/index.js
+++ b/projects/packages/forms/src/blocks/form-step-divider/index.js
@@ -11,7 +11,7 @@ export const settings = {
 	title: __( 'Step Divider', 'jetpack-forms' ),
 	description: __( 'Split the current step into two steps.', 'jetpack-forms' ),
 	category: 'contact-form',
-	parent: [ 'jetpack/form-step' ],
+	parent: [ 'jetpack/form-step', 'jetpack/contact-form' ],
 	icon: {
 		foreground: getIconColor(),
 		src: renderMaterialIcon( <Path d="M19 13H5v-2h14v2z" /> ),


### PR DESCRIPTION
Currently we don't have good transition any more when you add a new multi step block. 

This PR fixes it. 

## Proposed changes:
* Instead of just tracking the current should transition state. What state the form is in in order to continue with the transition. 


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
no

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
* All the possible ways you can trigger a form => multi step transition. 
-  Add step devider. 
- Undo works as expected. 
- Notice that you can't add steps, step navigation, form progress. 
 
* All the possible ways transition back from multi step => form block
- Undo works as expected. 
