### PR TITLE
My Jetpack: Onboarding i4 | Fix section and card spacing

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/product-section.tsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/product-section.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @wordpress/no-unsafe-wp-apis */
-import { __experimentalGrid as Grid } from '@wordpress/components';
+import { Flex, __experimentalGrid as Grid } from '@wordpress/components';
 import { ModulesList } from '../../modules-list';
 import { ProductCard } from './product-card';
 import styles from './styles.module.scss';
@@ -22,7 +22,14 @@ export function ProductSection( { section }: ProductSectionProps ) {
 	}
 
 	return (
-		<section key={ section.id } className={ styles[ 'product-section' ] }>
+		<Flex
+			as="section"
+			direction="column"
+			justify="start"
+			gap={ 6 }
+			expanded={ false }
+			className={ styles[ 'product-section' ] }
+		>
 			<h2 className={ styles[ 'section-heading' ] }>{ section.title }</h2>
 			{ section.cards?.length ? (
 				<Grid as="ul" gap={ 6 } columns={ [ 1, 1, 1, 2 ] } className={ styles[ 'product-cards' ] }>
@@ -34,6 +41,6 @@ export function ProductSection( { section }: ProductSectionProps ) {
 				</Grid>
 			) : null }
 			{ section.modules?.length ? <ModulesList modules={ section.modules } /> : null }
-		</section>
+		</Flex>
 	);
 }

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/styles.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/styles.module.scss
@@ -76,9 +76,14 @@
 .product-section {
 
 	.product-cards {
+		margin-block: 0;
 
 		div[data-wp-component="Card"] {
 			height: 100%;
+		}
+
+		li {
+			margin-bottom: 0;
 		}
 
 		// Make last card full width when there's an odd number of cards
@@ -90,7 +95,7 @@
 	.section-heading {
 
 		@include gb.heading-x-large;
-		margin-bottom: 1.5rem;
+		margin-bottom: 0;
 	}
 }
 


### PR DESCRIPTION
Completes MYJP-197

Fixes the card and section spacing issue reported by @grbicsanja in https://github.com/Automattic/jetpack/pull/44053#issuecomment-2998403537

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fix section and card spacing to make it 24px for all

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to My Jetpack > Products
* Confirm that the spacing between cards and modules list is all 24px (1.5rem)

| Before | After |
|--------|--------|
| <img width="786" alt="Screenshot 2025-06-24 at 12 05 42 PM" src="https://github.com/user-attachments/assets/5b53a18d-4da0-4633-a0aa-1b042f794e85" /> | <img width="786" alt="Screenshot 2025-06-24 at 12 04 13 PM" src="https://github.com/user-attachments/assets/6e31514f-a755-4617-ae9d-b0854c4afa87" /> | 
