### PR TITLE
Jetpack Script Data: Ensure that getScriptData is defined before checking the site property.

### DIFF
--- a/projects/js-packages/script-data/changelog/update-jetpack-script-data-function-property-checks
+++ b/projects/js-packages/script-data/changelog/update-jetpack-script-data-function-property-checks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Script Data: Ensure functions in utils.js allow for getScriptData being undefined.

--- a/projects/js-packages/script-data/src/utils.ts
+++ b/projects/js-packages/script-data/src/utils.ts
@@ -6,7 +6,7 @@ import { CurrentUserData } from './types.ts';
  * @return {import('./types').JetpackScriptData} The script data.
  */
 export function getScriptData() {
-	return window.JetpackScriptData;
+	return window?.JetpackScriptData || {};
 }
 
 /**
@@ -15,7 +15,7 @@ export function getScriptData() {
  * @return {import('./types').SiteData} The site data.
  */
 export function getSiteData() {
-	return getScriptData()?.site;
+	return getScriptData().site;
 }
 
 /**
@@ -26,7 +26,7 @@ export function getSiteData() {
  * @return {string} The admin URL.
  */
 export function getAdminUrl( path = '' ) {
-	return `${ getScriptData()?.site.admin_url }${ path }`;
+	return `${ getScriptData().site.admin_url }${ path }`;
 }
 
 /**
@@ -57,7 +57,7 @@ export function getMyJetpackUrl( section = '' ) {
  * @return {import('./types').SitePlan['features']['active']} The active features.
  */
 export function getActiveFeatures() {
-	return getScriptData()?.site.plan?.features?.active ?? [];
+	return getScriptData().site.plan?.features?.active ?? [];
 }
 
 /**
@@ -77,7 +77,7 @@ export function siteHasFeature( feature: string ) {
  * @return {boolean} Whether the site host is wpcom.
  */
 export function isSimpleSite() {
-	return getScriptData()?.site?.host === 'wpcom';
+	return getScriptData().site?.host === 'wpcom';
 }
 
 /**
@@ -87,7 +87,7 @@ export function isSimpleSite() {
  * @return {boolean} Whether the site is an Atomic site.
  */
 export function isAtomicSite() {
-	return getScriptData()?.site?.host === 'atomic';
+	return getScriptData().site?.host === 'atomic';
 }
 
 /**
@@ -97,7 +97,7 @@ export function isAtomicSite() {
  * @return Whether the site is woa.
  */
 export function isWoASite() {
-	return getScriptData()?.site?.host === 'woa' || false;
+	return getScriptData().site?.host === 'woa';
 }
 
 /**
@@ -108,7 +108,7 @@ export function isWoASite() {
  * @return Whether the site is a WordPress.com site.
  */
 export function isWpcomPlatformSite() {
-	return getScriptData()?.site?.is_wpcom_platform;
+	return getScriptData().site?.is_wpcom_platform;
 }
 
 /**
@@ -118,7 +118,7 @@ export function isWpcomPlatformSite() {
  * @return {boolean} Whether the site is self-hosted Jetpack site.
  */
 export function isJetpackSelfHostedSite() {
-	return getScriptData()?.site?.host === 'unknown';
+	return getScriptData().site?.host === 'unknown';
 }
 
 /**
@@ -128,5 +128,5 @@ export function isJetpackSelfHostedSite() {
  * @return Whether the current user has that capability.
  */
 export function currentUserCan( capability: keyof CurrentUserData[ 'capabilities' ] ): boolean {
-	return getScriptData()?.user.current_user.capabilities[ capability ];
+	return getScriptData().user.current_user.capabilities[ capability ];
 }

--- a/projects/js-packages/script-data/src/utils.ts
+++ b/projects/js-packages/script-data/src/utils.ts
@@ -15,7 +15,7 @@ export function getScriptData() {
  * @return {import('./types').SiteData} The site data.
  */
 export function getSiteData() {
-	return getScriptData().site;
+	return getScriptData()?.site;
 }
 
 /**
@@ -26,7 +26,7 @@ export function getSiteData() {
  * @return {string} The admin URL.
  */
 export function getAdminUrl( path = '' ) {
-	return `${ getScriptData().site.admin_url }${ path }`;
+	return `${ getScriptData()?.site.admin_url }${ path }`;
 }
 
 /**
@@ -57,7 +57,7 @@ export function getMyJetpackUrl( section = '' ) {
  * @return {import('./types').SitePlan['features']['active']} The active features.
  */
 export function getActiveFeatures() {
-	return getScriptData().site.plan?.features?.active ?? [];
+	return getScriptData()?.site.plan?.features?.active ?? [];
 }
 
 /**
@@ -77,7 +77,7 @@ export function siteHasFeature( feature: string ) {
  * @return {boolean} Whether the site host is wpcom.
  */
 export function isSimpleSite() {
-	return getScriptData().site?.host === 'wpcom';
+	return getScriptData()?.site?.host === 'wpcom';
 }
 
 /**
@@ -87,7 +87,7 @@ export function isSimpleSite() {
  * @return {boolean} Whether the site is an Atomic site.
  */
 export function isAtomicSite() {
-	return getScriptData().site?.host === 'atomic';
+	return getScriptData()?.site?.host === 'atomic';
 }
 
 /**
@@ -128,5 +128,5 @@ export function isJetpackSelfHostedSite() {
  * @return Whether the current user has that capability.
  */
 export function currentUserCan( capability: keyof CurrentUserData[ 'capabilities' ] ): boolean {
-	return getScriptData().user.current_user.capabilities[ capability ];
+	return getScriptData()?.user.current_user.capabilities[ capability ];
 }

--- a/projects/js-packages/script-data/src/utils.ts
+++ b/projects/js-packages/script-data/src/utils.ts
@@ -108,7 +108,7 @@ export function isWoASite() {
  * @return Whether the site is a WordPress.com site.
  */
 export function isWpcomPlatformSite() {
-	return getScriptData().site?.is_wpcom_platform;
+	return getScriptData()?.site?.is_wpcom_platform;
 }
 
 /**

--- a/projects/js-packages/script-data/src/utils.ts
+++ b/projects/js-packages/script-data/src/utils.ts
@@ -6,7 +6,7 @@ import { CurrentUserData } from './types.ts';
  * @return {import('./types').JetpackScriptData} The script data.
  */
 export function getScriptData() {
-	return window?.JetpackScriptData || {};
+	return window.JetpackScriptData;
 }
 
 /**
@@ -15,7 +15,7 @@ export function getScriptData() {
  * @return {import('./types').SiteData} The site data.
  */
 export function getSiteData() {
-	return getScriptData().site;
+	return getScriptData()?.site;
 }
 
 /**
@@ -26,7 +26,7 @@ export function getSiteData() {
  * @return {string} The admin URL.
  */
 export function getAdminUrl( path = '' ) {
-	return `${ getScriptData().site.admin_url }${ path }`;
+	return `${ getScriptData()?.site.admin_url }${ path }`;
 }
 
 /**
@@ -57,7 +57,7 @@ export function getMyJetpackUrl( section = '' ) {
  * @return {import('./types').SitePlan['features']['active']} The active features.
  */
 export function getActiveFeatures() {
-	return getScriptData().site.plan?.features?.active ?? [];
+	return getScriptData()?.site.plan?.features?.active ?? [];
 }
 
 /**
@@ -77,7 +77,7 @@ export function siteHasFeature( feature: string ) {
  * @return {boolean} Whether the site host is wpcom.
  */
 export function isSimpleSite() {
-	return getScriptData().site?.host === 'wpcom';
+	return getScriptData()?.site?.host === 'wpcom';
 }
 
 /**
@@ -87,7 +87,7 @@ export function isSimpleSite() {
  * @return {boolean} Whether the site is an Atomic site.
  */
 export function isAtomicSite() {
-	return getScriptData().site?.host === 'atomic';
+	return getScriptData()?.site?.host === 'atomic';
 }
 
 /**
@@ -97,7 +97,7 @@ export function isAtomicSite() {
  * @return Whether the site is woa.
  */
 export function isWoASite() {
-	return getScriptData().site?.host === 'woa';
+	return getScriptData()?.site?.host === 'woa';
 }
 
 /**
@@ -108,7 +108,7 @@ export function isWoASite() {
  * @return Whether the site is a WordPress.com site.
  */
 export function isWpcomPlatformSite() {
-	return getScriptData().site?.is_wpcom_platform;
+	return getScriptData()?.site?.is_wpcom_platform;
 }
 
 /**
@@ -118,7 +118,7 @@ export function isWpcomPlatformSite() {
  * @return {boolean} Whether the site is self-hosted Jetpack site.
  */
 export function isJetpackSelfHostedSite() {
-	return getScriptData().site?.host === 'unknown';
+	return getScriptData()?.site?.host === 'unknown';
 }
 
 /**
@@ -128,5 +128,5 @@ export function isJetpackSelfHostedSite() {
  * @return Whether the current user has that capability.
  */
 export function currentUserCan( capability: keyof CurrentUserData[ 'capabilities' ] ): boolean {
-	return getScriptData().user.current_user.capabilities[ capability ];
+	return getScriptData()?.user.current_user.capabilities[ capability ];
 }


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/44063
Fixes VULCAN-197

## Proposed changes:

* The changes in https://github.com/Automattic/jetpack/pull/43972 highlighted some issues with functions in the `js-packages/script-data/src/utils.ts` file. Specifically, in some cases, we are not checking to see if `getScriptData()` is defined before trying to access the `site` property. 
* This resulted in the above issue (specific to the `isWpcomPlatformSite` function). Changes have been made to the main `getScriptData` function, with other functions having the optional chaining removed as a result (two included the chaining to prevent issues previously).

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

To replicate the issue: 

On a Jurassic Ninja site testing with bleeding edge (with the Jetpack Beta tester plugin), similar on WoA, and on Simple (live):

* Make sure you are using a block theme such as Twenty Twenty Four.
* Open up the site editor, and open up the console. You should see warnings similar to those in the linked issue. If not, try navigating around to different pages in the site editor such as 'templates'.

To test the fix:

* Apply this PR (for Simple, use the commands in the generated comment below for a sandboxed Simple site), and follow the same steps.
* Those warnings should be gone.
* Functionality should not be affected - try testing some of the blocks covered in the testing steps in this PR: https://github.com/Automattic/jetpack/pull/43972
