### PR TITLE
phpcs-filter: Allow specifying filter by class name

### DIFF
--- a/.phpcs.config.xml
+++ b/.phpcs.config.xml
@@ -6,7 +6,7 @@
 	<config name="testVersion" value="7.2-"/>
 
 	<!-- Use our custom filter for `.phpcsignore` and `.phpcs.dir.xml` support. -->
-	<arg name="filter" value="vendor/automattic/jetpack-phpcs-filter/src/PhpcsFilter.php" />
+	<arg name="filter" value="Automattic\JetpackPhpcsFilter" />
 	<!-- The bootstrap file is needed to get phpcs-changed to work right. -->
 	<arg name="bootstrap" value="vendor/automattic/jetpack-phpcs-filter/stdin-bootstrap.php" />
 

--- a/projects/packages/phpcs-filter/README.md
+++ b/projects/packages/phpcs-filter/README.md
@@ -15,12 +15,12 @@ Require using `composer require automattic/jetpack-phpcs-filter`.
 
 Basic usage is to pass the filter to `phpcs` or `phpcbf` via the `--filter` command line option:
 ```
-vendor/bin/phpcs --filter=vendor/automattic/jetpack-phpcs-filter/src/PhpcsFilter.php .
+vendor/bin/phpcs --filter='Automattic\JetpackPhpcsFilter' .
 ```
 
 It may be more convenient to do so by adding the following to your `.phpcs.xml.dist`:
 ```xml
-<arg name="filter" value="vendor/automattic/jetpack-phpcs-filter/src/PhpcsFilter.php" />
+<arg name="filter" value="Automattic\JetpackPhpcsFilter" />
 ```
 
 If you make use of phpcs's `--stdinPath` option (e.g. with [phpcs-changed](https://packagist.org/packages/sirbrillig/phpcs-changed)),

--- a/projects/packages/phpcs-filter/changelog/add-phpcs-filter-class
+++ b/projects/packages/phpcs-filter/changelog/add-phpcs-filter-class
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Filter may now be loaded by using `--filter=Automattic\JetpackPhpcsFilter` instead of requiring a vendor path.

--- a/projects/packages/phpcs-filter/changelog/add-phpcs-filter-class#2
+++ b/projects/packages/phpcs-filter/changelog/add-phpcs-filter-class#2
@@ -1,0 +1,4 @@
+Significance: minor
+Type: deprecated
+
+Loading via `--filter=vendor/automattic/jetpack-phpcs-filter/src/PhpcsFilter.php` is deprecated. If you need to use a path rather than a classname, use `vendor/automattic/jetpack-phpcs-filter/src/JetpackPhpcsFilter.php`.

--- a/projects/packages/phpcs-filter/src/JetpackPhpcsFilter.php
+++ b/projects/packages/phpcs-filter/src/JetpackPhpcsFilter.php
@@ -1,0 +1,345 @@
+<?php
+/**
+ * A filter for PHP CodeSniffer to add support for .phpcsignore files and per-directory configuration files.
+ *
+ * @package automattic/jetpack-phpcs-filter
+ */
+
+namespace PHP_CodeSniffer\Filters\Automattic;
+
+use Automattic\IgnoreFile;
+use PHP_CodeSniffer\Config;
+use PHP_CodeSniffer\Exceptions\DeepExitException;
+use PHP_CodeSniffer\Exceptions\RuntimeException;
+use PHP_CodeSniffer\Files\LocalFile;
+use PHP_CodeSniffer\Filters\Filter;
+use PHP_CodeSniffer\Ruleset;
+use PHP_CodeSniffer\Util;
+use SplFileInfo;
+
+/**
+ * A filter for PHP CodeSniffer to add support for .phpcsignore files and per-directory configuration files.
+ */
+class JetpackPhpcsFilter extends Filter {
+
+	/**
+	 * Enable generation of LocalFile objects instead of string|SplFileInfo.
+	 *
+	 * @var boolean
+	 */
+	protected $produceLocalFileObjects = true;
+
+	/**
+	 * Base directory for the scan.
+	 *
+	 * @var string
+	 */
+	protected $filterBaseDir;
+
+	/**
+	 * Per-directory config file name.
+	 *
+	 * @var string
+	 */
+	protected $perDirFileName = '.phpcs.dir.xml';
+
+	/**
+	 * Process ignore files.
+	 *
+	 * @var boolean
+	 */
+	protected $doIgnore = true;
+
+	/**
+	 * Process .gitignore files.
+	 *
+	 * @var boolean
+	 */
+	protected $useGitignore = true;
+
+	/**
+	 * IgnoreFile instance for processing .phpcsignore.
+	 *
+	 * @var IgnoreFile
+	 */
+	protected $ignoreFile;
+
+	/**
+	 * Whether a .phpcsignore was checked for for a path.
+	 *
+	 * @var bool[]
+	 */
+	protected $ignoreLoaded = array();
+
+	/**
+	 * Cache of Config and Ruleset objects by directory.
+	 *
+	 * @var array
+	 */
+	protected $configCache = array();
+
+	/**
+	 * Constructs a filter.
+	 *
+	 * @param \RecursiveIterator       $iterator The iterator we are using to get file paths.
+	 * @param string                   $basedir The top-level path we are filtering.
+	 * @param \PHP_CodeSniffer\Config  $config The config data for the run.
+	 * @param \PHP_CodeSniffer\Ruleset $ruleset The ruleset used for the run.
+	 * @param JetpackPhpcsFilter|null  $copyFrom Used from getChildren().
+	 * @throws DeepExitException On error.
+	 */
+	public function __construct( $iterator, $basedir, Config $config, Ruleset $ruleset, ?JetpackPhpcsFilter $copyFrom = null ) {
+		parent::__construct( $iterator, $basedir, $config, $ruleset );
+
+		if ( $copyFrom ) {
+			if ( $this->ruleset === $copyFrom->ruleset ) {
+				// Only copy these if the ruleset is the same. If it changed, these need to be regenerated.
+				$this->ignoreDirPatterns  = $copyFrom->ignoreDirPatterns;
+				$this->ignoreFilePatterns = $copyFrom->ignoreFilePatterns;
+			}
+			$this->acceptedPaths  = $copyFrom->acceptedPaths;
+			$this->filterBaseDir  = $copyFrom->filterBaseDir;
+			$this->perDirFileName = $copyFrom->perDirFileName;
+			$this->doIgnore       = $copyFrom->doIgnore;
+			$this->useGitignore   = $copyFrom->useGitignore;
+			$this->ignoreFile     = $copyFrom->ignoreFile;
+			$this->ignoreLoaded   = &$copyFrom->ignoreLoaded;
+			$this->configCache    = &$copyFrom->configCache;
+			return;
+		}
+
+		$noIgnore = $config->getConfigData( 'jetpack-filter-no-ignore' );
+		if ( null !== $noIgnore ) {
+			$this->doIgnore = ! $noIgnore;
+		}
+
+		$useGitignore = $config->getConfigData( 'jetpack-filter-use-gitignore' );
+		if ( null !== $useGitignore ) {
+			$this->useGitignore = (bool) $useGitignore;
+		}
+
+		$perDirFileName = $config->getConfigData( 'jetpack-filter-perdir-file' );
+		if ( null !== $perDirFileName ) {
+			$this->perDirFileName = $perDirFileName;
+		}
+
+		$dir = $config->getConfigData( 'jetpack-filter-basedir' );
+		if ( null === $dir ) {
+			$dir = '.';
+		}
+
+		$realDir = Util\Common::realpath( $dir );
+		// @codeCoverageIgnoreStart
+		if ( false === $realDir ) {
+			throw new DeepExitException( 'ERROR: ' . static::class . ": Specified base dir $dir does not exist.", 3 );
+		}
+		if ( ! is_dir( $realDir ) ) {
+			throw new DeepExitException( 'ERROR: ' . static::class . ": Specified base dir $dir is not a directory.", 3 );
+		}
+		// @codeCoverageIgnoreEnd
+		$this->filterBaseDir = $realDir;
+
+		// @codeCoverageIgnoreStart
+		if ( PHP_CODESNIFFER_VERBOSITY > 0 ) {
+			echo "\n" . static::class . ": Using base directory $this->filterBaseDir\n";
+		}
+		// @codeCoverageIgnoreEnd
+
+		$this->ignoreFile = new IgnoreFile();
+
+		$this->configCache[ $this->filterBaseDir ] = array( $config, $ruleset );
+	}
+
+	/**
+	 * Test if we've reached the base directory.
+	 *
+	 * @param string $dir Dir to match.
+	 * @return bool
+	 */
+	protected function reachedBaseDir( $dir ) {
+		$realDir = Util\Common::realpath( $dir );
+		return ( $realDir === $this->filterBaseDir || substr( "$this->filterBaseDir/", 0, strlen( $realDir ) + 1 ) === "$realDir/" );
+	}
+
+	/**
+	 * Load the .phpcsignore file for a path.
+	 *
+	 * @param string $path Path.
+	 */
+	protected function loadIgnoreFiles( $path ) {
+		if ( ! $this->doIgnore ) {
+			return;
+		}
+
+		$dir = is_dir( $path ) ? (string) $path : dirname( $path );
+
+		// Already cached?
+		if ( ! empty( $this->ignoreLoaded[ $dir ] ) ) {
+			return;
+		}
+
+		// Have we passed the base dir? But still process if this *is* the base dir.
+		if ( $this->reachedBaseDir( $dir ) && Util\Common::realpath( $dir ) !== $this->filterBaseDir ) {
+			return;
+		}
+
+		// Mark as loaded, since we're doing so now.
+		$this->ignoreLoaded[ $dir ] = true;
+
+		// Load any parent .phpcsignore.
+		$parent = dirname( $dir );
+		if ( $parent !== $dir ) {
+			$this->loadIgnoreFiles( $parent );
+		}
+
+		// Read any .gitignore and .phpcsignore in the current dir now.
+		if ( $this->useGitignore && file_exists( "$dir/.gitignore" ) ) {
+			// @codeCoverageIgnoreStart
+			if ( PHP_CODESNIFFER_VERBOSITY > 0 ) {
+				echo static::class . ": Loading $dir/.gitignore\n";
+			}
+			// @codeCoverageIgnoreEnd
+			$data = file_get_contents( "$dir/.gitignore" );
+			if ( false === $data ) {
+				fprintf( STDERR, "WARN: Failed to read gitignore file %s\n", "$dir/.gitignore" ); // @codeCoverageIgnore
+			} else {
+				$this->ignoreFile->add( $data, "$dir/" );
+			}
+		}
+		if ( file_exists( "$dir/.phpcsignore" ) ) {
+			// @codeCoverageIgnoreStart
+			if ( PHP_CODESNIFFER_VERBOSITY > 0 ) {
+				echo static::class . ": Loading $dir/.phpcsignore\n";
+			}
+			// @codeCoverageIgnoreEnd
+			$data = file_get_contents( "$dir/.phpcsignore" );
+			if ( false === $data ) {
+				fprintf( STDERR, "WARN: Failed to read phpcsignore file %s\n", "$dir/.phpcsignore" ); // @codeCoverageIgnore
+			} else {
+				$this->ignoreFile->add( $data, "$dir/" );
+			}
+		}
+	}
+
+	/**
+	 * Fetch the Config and Ruleset for a path.
+	 *
+	 * @param string $path Path.
+	 * @return array [ Config, Ruleset ]
+	 * @throws DeepExitException On error.
+	 */
+	public function getConfigAndRuleset( $path ) {
+		$dir = is_dir( $path ) ? (string) $path : dirname( $path );
+		if ( $this->reachedBaseDir( $dir ) ) {
+			$dir = $this->filterBaseDir;
+		}
+
+		// Already cached?
+		if ( isset( $this->configCache[ $dir ] ) ) {
+			return $this->configCache[ $dir ];
+		}
+
+		// Nope. Fetch parent, then possibly modify.
+		$parent                   = dirname( $dir );
+		list( $config, $ruleset ) = $this->getConfigAndRuleset( $parent === $dir ? $this->filterBaseDir : $parent );
+
+		// Per directory config file found? Create a new Config and Ruleset for it.
+		if ( file_exists( "$dir/$this->perDirFileName" ) ) {
+			// @codeCoverageIgnoreStart
+			if ( PHP_CODESNIFFER_VERBOSITY > 0 ) {
+				echo static::class . ": Loading $dir/$this->perDirFileName\n";
+			}
+			// @codeCoverageIgnoreEnd
+			$config            = clone $config;
+			$config->standards = array_merge( $config->standards, array( "$dir/$this->perDirFileName" ) );
+			try {
+				$ruleset = new Ruleset( $config );
+				// @codeCoverageIgnoreStart
+			} catch ( RuntimeException $e ) {
+				$error  = 'ERROR: ' . $e->getMessage() . PHP_EOL . PHP_EOL;
+				$error .= $this->config->printShortUsage( true );
+				throw new DeepExitException( $error, 3 );
+			}
+			// @codeCoverageIgnoreEnd
+		}
+
+		$this->configCache[ $dir ] = array( $config, $ruleset );
+		return $this->configCache[ $dir ];
+	}
+
+	/**
+	 * Check if a path should be processed.
+	 *
+	 * @param string|SplFileInfo $path The path to the file or directory being checked.
+	 * @return bool
+	 */
+	protected function shouldProcessFile( $path ) {
+		$old = array( $this->config, $this->ruleset );
+		try {
+			list( $this->config, $this->ruleset ) = $this->getConfigAndRuleset( $path );
+			$ret                                  = parent::shouldProcessFile( $path );
+		} finally {
+			list( $this->config, $this->ruleset ) = $old;
+		}
+		// @phan-suppress-next-line PhanPossiblyUndeclaredVariable,PhanTypeMismatchReturnNullable -- https://github.com/phan/phan/issues/4419
+		return $ret;
+	}
+
+	/**
+	 * Check if a path should be ignored.
+	 *
+	 * @param string|SplFileInfo $path The path to the file or directory being checked.
+	 * @return bool
+	 */
+	protected function shouldIgnorePath( $path ) {
+		$this->loadIgnoreFiles( $path );
+		if ( $this->ignoreFile->ignores( is_dir( $path ) ? "$path/" : $path ) ) {
+			return true;
+		}
+
+		$old = array( $this->config, $this->ruleset );
+		try {
+			list( $this->config, $this->ruleset ) = $this->getConfigAndRuleset( $path );
+			$ret                                  = parent::shouldIgnorePath( $path );
+		} finally {
+			list( $this->config, $this->ruleset ) = $old;
+		}
+		// @phan-suppress-next-line PhanPossiblyUndeclaredVariable,PhanTypeMismatchReturnNullable -- https://github.com/phan/phan/issues/4419
+		return $ret;
+	}
+
+	/**
+	 * Map the input string or SplFileInfo into a LocalFile.
+	 *
+	 * @return string|LocalFile
+	 */
+	public function current() {
+		$iterator = $this->getInnerIterator();
+		'@phan-var \RecursiveIterator $iterator'; // Phan has the type wrong somehow. This is the iterator passed to `__construct()`.
+		$filePath = (string) $iterator->current();
+		if ( is_dir( $filePath ) ) {
+			return $filePath;
+		}
+		list( $config, $ruleset ) = $this->getConfigAndRuleset( $filePath );
+		return new LocalFile( $filePath, $ruleset, $config );
+	}
+
+	/**
+	 * Returns an iterator for the current entry.
+	 *
+	 * @return static
+	 */
+	public function getChildren() {
+		$iterator = $this->getInnerIterator();
+		'@phan-var \RecursiveIterator $iterator'; // Phan has the type wrong somehow. This is the iterator passed to `__construct()`.
+		$filePath                 = (string) $iterator->current();
+		list( $config, $ruleset ) = $this->getConfigAndRuleset( $filePath );
+		return new static(
+			new \RecursiveDirectoryIterator( $filePath, \RecursiveDirectoryIterator::SKIP_DOTS | \FilesystemIterator::FOLLOW_SYMLINKS ),
+			$this->basedir,
+			$config,
+			$ruleset,
+			$this
+		);
+	}
+}

--- a/projects/packages/phpcs-filter/src/PhpcsFilter.php
+++ b/projects/packages/phpcs-filter/src/PhpcsFilter.php
@@ -1,82 +1,24 @@
 <?php
 /**
- * A filter for PHP CodeSniffer to add support for .phpcsignore files and per-directory configuration files.
+ * Deprecated.
  *
+ * @deprecated Since $$next-version$$. Use PHP_CodeSniffer\Filters\Automattic\JetpackPhpcsFilter instead.
  * @package automattic/jetpack-phpcs-filter
  */
 
 namespace Automattic\Jetpack;
 
-use Automattic\IgnoreFile;
 use PHP_CodeSniffer\Config;
 use PHP_CodeSniffer\Exceptions\DeepExitException;
-use PHP_CodeSniffer\Exceptions\RuntimeException;
-use PHP_CodeSniffer\Files\LocalFile;
-use PHP_CodeSniffer\Filters\Filter;
+use PHP_CodeSniffer\Filters\Automattic\JetpackPhpcsFilter;
 use PHP_CodeSniffer\Ruleset;
-use PHP_CodeSniffer\Util;
-use SplFileInfo;
 
 /**
- * A filter for PHP CodeSniffer to add support for .phpcsignore files and per-directory configuration files.
+ * Deprecated.
+ *
+ * @deprecated Since $$next-version$$. Use PHP_CodeSniffer\Filters\Automattic\JetpackPhpcsFilter instead.
  */
-class PhpcsFilter extends Filter {
-
-	/**
-	 * Enable generation of LocalFile objects instead of string|SplFileInfo.
-	 *
-	 * @var boolean
-	 */
-	protected $produceLocalFileObjects = true;
-
-	/**
-	 * Base directory for the scan.
-	 *
-	 * @var string
-	 */
-	protected $filterBaseDir;
-
-	/**
-	 * Per-directory config file name.
-	 *
-	 * @var string
-	 */
-	protected $perDirFileName = '.phpcs.dir.xml';
-
-	/**
-	 * Process ignore files.
-	 *
-	 * @var boolean
-	 */
-	protected $doIgnore = true;
-
-	/**
-	 * Process .gitignore files.
-	 *
-	 * @var boolean
-	 */
-	protected $useGitignore = true;
-
-	/**
-	 * IgnoreFile instance for processing .phpcsignore.
-	 *
-	 * @var IgnoreFile
-	 */
-	protected $ignoreFile;
-
-	/**
-	 * Whether a .phpcsignore was checked for for a path.
-	 *
-	 * @var bool[]
-	 */
-	protected $ignoreLoaded = array();
-
-	/**
-	 * Cache of Config and Ruleset objects by directory.
-	 *
-	 * @var array
-	 */
-	protected $configCache = array();
+class PhpcsFilter extends JetpackPhpcsFilter {
 
 	/**
 	 * Constructs a filter.
@@ -85,261 +27,16 @@ class PhpcsFilter extends Filter {
 	 * @param string                   $basedir The top-level path we are filtering.
 	 * @param \PHP_CodeSniffer\Config  $config The config data for the run.
 	 * @param \PHP_CodeSniffer\Ruleset $ruleset The ruleset used for the run.
-	 * @param PhpcsFilter|null         $copyFrom Used from getChildren().
+	 * @param JetpackPhpcsFilter|null  $copyFrom Used from getChildren().
 	 * @throws DeepExitException On error.
 	 */
-	public function __construct( $iterator, $basedir, Config $config, Ruleset $ruleset, ?PhpcsFilter $copyFrom = null ) {
-		parent::__construct( $iterator, $basedir, $config, $ruleset );
-
-		if ( $copyFrom ) {
-			if ( $this->ruleset === $copyFrom->ruleset ) {
-				// Only copy these if the ruleset is the same. If it changed, these need to be regenerated.
-				$this->ignoreDirPatterns  = $copyFrom->ignoreDirPatterns;
-				$this->ignoreFilePatterns = $copyFrom->ignoreFilePatterns;
-			}
-			$this->acceptedPaths  = $copyFrom->acceptedPaths;
-			$this->filterBaseDir  = $copyFrom->filterBaseDir;
-			$this->perDirFileName = $copyFrom->perDirFileName;
-			$this->doIgnore       = $copyFrom->doIgnore;
-			$this->useGitignore   = $copyFrom->useGitignore;
-			$this->ignoreFile     = $copyFrom->ignoreFile;
-			$this->ignoreLoaded   = &$copyFrom->ignoreLoaded;
-			$this->configCache    = &$copyFrom->configCache;
-			return;
+	public function __construct( $iterator, $basedir, Config $config, Ruleset $ruleset, ?JetpackPhpcsFilter $copyFrom = null ) {
+		static $logged = false;
+		if ( ! $logged ) {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+			trigger_error( sprintf( '%s is deprecated. Use %s instead.', __CLASS__, JetpackPhpcsFilter::class ), E_USER_DEPRECATED );
+			$logged = true;
 		}
-
-		$noIgnore = $config->getConfigData( 'jetpack-filter-no-ignore' );
-		if ( null !== $noIgnore ) {
-			$this->doIgnore = ! $noIgnore;
-		}
-
-		$useGitignore = $config->getConfigData( 'jetpack-filter-use-gitignore' );
-		if ( null !== $useGitignore ) {
-			$this->useGitignore = (bool) $useGitignore;
-		}
-
-		$perDirFileName = $config->getConfigData( 'jetpack-filter-perdir-file' );
-		if ( null !== $perDirFileName ) {
-			$this->perDirFileName = $perDirFileName;
-		}
-
-		$dir = $config->getConfigData( 'jetpack-filter-basedir' );
-		if ( null === $dir ) {
-			$dir = '.';
-		}
-
-		$realDir = Util\Common::realpath( $dir );
-		// @codeCoverageIgnoreStart
-		if ( false === $realDir ) {
-			throw new DeepExitException( 'ERROR: ' . static::class . ": Specified base dir $dir does not exist.", 3 );
-		}
-		if ( ! is_dir( $realDir ) ) {
-			throw new DeepExitException( 'ERROR: ' . static::class . ": Specified base dir $dir is not a directory.", 3 );
-		}
-		// @codeCoverageIgnoreEnd
-		$this->filterBaseDir = $realDir;
-
-		// @codeCoverageIgnoreStart
-		if ( PHP_CODESNIFFER_VERBOSITY > 0 ) {
-			echo "\n" . static::class . ": Using base directory $this->filterBaseDir\n";
-		}
-		// @codeCoverageIgnoreEnd
-
-		$this->ignoreFile = new IgnoreFile();
-
-		$this->configCache[ $this->filterBaseDir ] = array( $config, $ruleset );
-	}
-
-	/**
-	 * Test if we've reached the base directory.
-	 *
-	 * @param string $dir Dir to match.
-	 * @return bool
-	 */
-	protected function reachedBaseDir( $dir ) {
-		$realDir = Util\Common::realpath( $dir );
-		return ( $realDir === $this->filterBaseDir || substr( "$this->filterBaseDir/", 0, strlen( $realDir ) + 1 ) === "$realDir/" );
-	}
-
-	/**
-	 * Load the .phpcsignore file for a path.
-	 *
-	 * @param string $path Path.
-	 */
-	protected function loadIgnoreFiles( $path ) {
-		if ( ! $this->doIgnore ) {
-			return;
-		}
-
-		$dir = is_dir( $path ) ? (string) $path : dirname( $path );
-
-		// Already cached?
-		if ( ! empty( $this->ignoreLoaded[ $dir ] ) ) {
-			return;
-		}
-
-		// Have we passed the base dir? But still process if this *is* the base dir.
-		if ( $this->reachedBaseDir( $dir ) && Util\Common::realpath( $dir ) !== $this->filterBaseDir ) {
-			return;
-		}
-
-		// Mark as loaded, since we're doing so now.
-		$this->ignoreLoaded[ $dir ] = true;
-
-		// Load any parent .phpcsignore.
-		$parent = dirname( $dir );
-		if ( $parent !== $dir ) {
-			$this->loadIgnoreFiles( $parent );
-		}
-
-		// Read any .gitignore and .phpcsignore in the current dir now.
-		if ( $this->useGitignore && file_exists( "$dir/.gitignore" ) ) {
-			// @codeCoverageIgnoreStart
-			if ( PHP_CODESNIFFER_VERBOSITY > 0 ) {
-				echo static::class . ": Loading $dir/.gitignore\n";
-			}
-			// @codeCoverageIgnoreEnd
-			$data = file_get_contents( "$dir/.gitignore" );
-			if ( false === $data ) {
-				fprintf( STDERR, "WARN: Failed to read gitignore file %s\n", "$dir/.gitignore" ); // @codeCoverageIgnore
-			} else {
-				$this->ignoreFile->add( $data, "$dir/" );
-			}
-		}
-		if ( file_exists( "$dir/.phpcsignore" ) ) {
-			// @codeCoverageIgnoreStart
-			if ( PHP_CODESNIFFER_VERBOSITY > 0 ) {
-				echo static::class . ": Loading $dir/.phpcsignore\n";
-			}
-			// @codeCoverageIgnoreEnd
-			$data = file_get_contents( "$dir/.phpcsignore" );
-			if ( false === $data ) {
-				fprintf( STDERR, "WARN: Failed to read phpcsignore file %s\n", "$dir/.phpcsignore" ); // @codeCoverageIgnore
-			} else {
-				$this->ignoreFile->add( $data, "$dir/" );
-			}
-		}
-	}
-
-	/**
-	 * Fetch the Config and Ruleset for a path.
-	 *
-	 * @param string $path Path.
-	 * @return array [ Config, Ruleset ]
-	 * @throws DeepExitException On error.
-	 */
-	public function getConfigAndRuleset( $path ) {
-		$dir = is_dir( $path ) ? (string) $path : dirname( $path );
-		if ( $this->reachedBaseDir( $dir ) ) {
-			$dir = $this->filterBaseDir;
-		}
-
-		// Already cached?
-		if ( isset( $this->configCache[ $dir ] ) ) {
-			return $this->configCache[ $dir ];
-		}
-
-		// Nope. Fetch parent, then possibly modify.
-		$parent                   = dirname( $dir );
-		list( $config, $ruleset ) = $this->getConfigAndRuleset( $parent === $dir ? $this->filterBaseDir : $parent );
-
-		// Per directory config file found? Create a new Config and Ruleset for it.
-		if ( file_exists( "$dir/$this->perDirFileName" ) ) {
-			// @codeCoverageIgnoreStart
-			if ( PHP_CODESNIFFER_VERBOSITY > 0 ) {
-				echo static::class . ": Loading $dir/$this->perDirFileName\n";
-			}
-			// @codeCoverageIgnoreEnd
-			$config            = clone $config;
-			$config->standards = array_merge( $config->standards, array( "$dir/$this->perDirFileName" ) );
-			try {
-				$ruleset = new Ruleset( $config );
-				// @codeCoverageIgnoreStart
-			} catch ( RuntimeException $e ) {
-				$error  = 'ERROR: ' . $e->getMessage() . PHP_EOL . PHP_EOL;
-				$error .= $this->config->printShortUsage( true );
-				throw new DeepExitException( $error, 3 );
-			}
-			// @codeCoverageIgnoreEnd
-		}
-
-		$this->configCache[ $dir ] = array( $config, $ruleset );
-		return $this->configCache[ $dir ];
-	}
-
-	/**
-	 * Check if a path should be processed.
-	 *
-	 * @param string|SplFileInfo $path The path to the file or directory being checked.
-	 * @return bool
-	 */
-	protected function shouldProcessFile( $path ) {
-		$old = array( $this->config, $this->ruleset );
-		try {
-			list( $this->config, $this->ruleset ) = $this->getConfigAndRuleset( $path );
-			$ret                                  = parent::shouldProcessFile( $path );
-		} finally {
-			list( $this->config, $this->ruleset ) = $old;
-		}
-		// @phan-suppress-next-line PhanPossiblyUndeclaredVariable,PhanTypeMismatchReturnNullable -- https://github.com/phan/phan/issues/4419
-		return $ret;
-	}
-
-	/**
-	 * Check if a path should be ignored.
-	 *
-	 * @param string|SplFileInfo $path The path to the file or directory being checked.
-	 * @return bool
-	 */
-	protected function shouldIgnorePath( $path ) {
-		$this->loadIgnoreFiles( $path );
-		if ( $this->ignoreFile->ignores( is_dir( $path ) ? "$path/" : $path ) ) {
-			return true;
-		}
-
-		$old = array( $this->config, $this->ruleset );
-		try {
-			list( $this->config, $this->ruleset ) = $this->getConfigAndRuleset( $path );
-			$ret                                  = parent::shouldIgnorePath( $path );
-		} finally {
-			list( $this->config, $this->ruleset ) = $old;
-		}
-		// @phan-suppress-next-line PhanPossiblyUndeclaredVariable,PhanTypeMismatchReturnNullable -- https://github.com/phan/phan/issues/4419
-		return $ret;
-	}
-
-	/**
-	 * Map the input string or SplFileInfo into a LocalFile.
-	 *
-	 * @return string|LocalFile
-	 */
-	public function current() {
-		$iterator = $this->getInnerIterator();
-		'@phan-var \RecursiveIterator $iterator'; // Phan has the type wrong somehow. This is the iterator passed to `__construct()`.
-		$filePath = (string) $iterator->current();
-		if ( is_dir( $filePath ) ) {
-			return $filePath;
-		}
-		list( $config, $ruleset ) = $this->getConfigAndRuleset( $filePath );
-		return new LocalFile( $filePath, $ruleset, $config );
-	}
-
-	/**
-	 * Returns an iterator for the current entry.
-	 *
-	 * @return static
-	 */
-	public function getChildren() {
-		$iterator = $this->getInnerIterator();
-		'@phan-var \RecursiveIterator $iterator'; // Phan has the type wrong somehow. This is the iterator passed to `__construct()`.
-		$filePath                 = (string) $iterator->current();
-		list( $config, $ruleset ) = $this->getConfigAndRuleset( $filePath );
-		return new static(
-			new \RecursiveDirectoryIterator( $filePath, \RecursiveDirectoryIterator::SKIP_DOTS | \FilesystemIterator::FOLLOW_SYMLINKS ),
-			$this->basedir,
-			$config,
-			$ruleset,
-			$this
-		);
+		parent::__construct( $iterator, $basedir, $config, $ruleset, $copyFrom );
 	}
 }

--- a/projects/packages/phpcs-filter/tests/php/JetpackPhpcsFilterTest.php
+++ b/projects/packages/phpcs-filter/tests/php/JetpackPhpcsFilterTest.php
@@ -1,16 +1,16 @@
 <?php
 /**
- * Tests for PhpcsFilter.php.
+ * Tests for JetpackPhpcsFilter.php.
  *
  * @package automattic/jetpack-phpcs-filter
  */
 
 namespace Automattic\Jetpack\PhpcsFilter\Tests;
 
-use Automattic\Jetpack\PhpcsFilter;
 use PHP_CodeSniffer\Config;
 use PHP_CodeSniffer\Files\FileList;
 use PHP_CodeSniffer\Files\LocalFile;
+use PHP_CodeSniffer\Filters\Automattic\JetpackPhpcsFilter;
 use PHP_CodeSniffer\Ruleset;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -18,9 +18,9 @@ use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 
 /**
- * Tests for PhpcsFilter.php.
+ * Tests for JetpackPhpcsFilter.php.
  */
-class PhpcsFilterTest extends TestCase {
+class JetpackPhpcsFilterTest extends TestCase {
 
 	/**
 	 * Old CWD to restore after the test.
@@ -71,13 +71,13 @@ class PhpcsFilterTest extends TestCase {
 		// When run from the base of the repo, it reads tests/fixtures/.phpcsignore and so ignores everything.
 		chdir( __DIR__ . '/../../' );
 		$di     = new RecursiveDirectoryIterator( 'tests/fixtures/phpcsignore', RecursiveDirectoryIterator::SKIP_DOTS | RecursiveDirectoryIterator::FOLLOW_SYMLINKS );
-		$filter = new RecursiveIteratorIterator( new PhpcsFilter( $di, 'tests/fixtures/phpcsignore', $config, new Ruleset( $config ) ) );
+		$filter = new RecursiveIteratorIterator( new JetpackPhpcsFilter( $di, 'tests/fixtures/phpcsignore', $config, new Ruleset( $config ) ) );
 		$this->assertSame( array(), array_keys( iterator_to_array( $filter ) ) );
 
 		// When run from the fixture dir, it reads only .phpcsignore in that dir and below.
 		chdir( __DIR__ . '/../../tests/fixtures/phpcsignore' );
 		$di     = new RecursiveDirectoryIterator( '.', RecursiveDirectoryIterator::SKIP_DOTS | RecursiveDirectoryIterator::FOLLOW_SYMLINKS );
-		$filter = new RecursiveIteratorIterator( new PhpcsFilter( $di, '.', $config, new Ruleset( $config ) ) );
+		$filter = new RecursiveIteratorIterator( new JetpackPhpcsFilter( $di, '.', $config, new Ruleset( $config ) ) );
 		$files  = array();
 		foreach ( $filter as $file ) {
 			$this->assertInstanceOf( LocalFile::class, $file );
@@ -90,7 +90,7 @@ class PhpcsFilterTest extends TestCase {
 		chdir( __DIR__ . '/../../' );
 		Config::setConfigData( 'jetpack-filter-basedir', 'tests/fixtures/phpcsignore', true );
 		$di     = new RecursiveDirectoryIterator( 'tests/fixtures/phpcsignore', RecursiveDirectoryIterator::SKIP_DOTS | RecursiveDirectoryIterator::FOLLOW_SYMLINKS );
-		$filter = new RecursiveIteratorIterator( new PhpcsFilter( $di, 'tests/fixtures/phpcsignore', $config, new Ruleset( $config ) ) );
+		$filter = new RecursiveIteratorIterator( new JetpackPhpcsFilter( $di, 'tests/fixtures/phpcsignore', $config, new Ruleset( $config ) ) );
 		$files  = array();
 		foreach ( $filter as $file ) {
 			$this->assertInstanceOf( LocalFile::class, $file );
@@ -108,7 +108,7 @@ class PhpcsFilterTest extends TestCase {
 
 		chdir( __DIR__ . '/../../tests/fixtures/phpcsignore' );
 		$di     = new RecursiveDirectoryIterator( '.', RecursiveDirectoryIterator::SKIP_DOTS | RecursiveDirectoryIterator::FOLLOW_SYMLINKS );
-		$filter = new RecursiveIteratorIterator( new PhpcsFilter( $di, '.', $config, new Ruleset( $config ) ) );
+		$filter = new RecursiveIteratorIterator( new JetpackPhpcsFilter( $di, '.', $config, new Ruleset( $config ) ) );
 		$files  = array();
 		foreach ( $filter as $file ) {
 			$this->assertInstanceOf( LocalFile::class, $file );
@@ -143,7 +143,7 @@ class PhpcsFilterTest extends TestCase {
 
 		chdir( __DIR__ . '/../../tests/fixtures/phpcsignore' );
 		$di     = new RecursiveDirectoryIterator( '.', RecursiveDirectoryIterator::SKIP_DOTS | RecursiveDirectoryIterator::FOLLOW_SYMLINKS );
-		$filter = new RecursiveIteratorIterator( new PhpcsFilter( $di, '.', $config, new Ruleset( $config ) ) );
+		$filter = new RecursiveIteratorIterator( new JetpackPhpcsFilter( $di, '.', $config, new Ruleset( $config ) ) );
 		$files  = array();
 		foreach ( $filter as $file ) {
 			$this->assertInstanceOf( LocalFile::class, $file );
@@ -197,7 +197,7 @@ class PhpcsFilterTest extends TestCase {
 		$this->assertIsArray( $expect, 'expect.json contains a JSON object' );
 
 		$config         = new Config();
-		$config->filter = __DIR__ . '/../../src/PhpcsFilter.php';
+		$config->filter = 'Automattic\\JetpackPhpcsFilter';
 		$config->files  = array( $path );
 		$ruleset        = new Ruleset( $config );
 		$files          = new FileList( $config, $ruleset );

--- a/projects/packages/phpcs-filter/tests/php/StdinBootstrapTest.php
+++ b/projects/packages/phpcs-filter/tests/php/StdinBootstrapTest.php
@@ -23,7 +23,7 @@ class StdinBootstrapTest extends TestCase {
 			array(
 				'--report=json',
 				'--bootstrap=' . __DIR__ . '/../../stdin-bootstrap.php',
-				'--filter=' . __DIR__ . '/../../src/PhpcsFilter.php',
+				'--filter=Automattic\\JetpackPhpcsFilter',
 			),
 			$args
 		);

--- a/tools/class-jetpack-phpcs-exclude-filter.php
+++ b/tools/class-jetpack-phpcs-exclude-filter.php
@@ -6,12 +6,13 @@
  */
 
 use PHP_CodeSniffer\Files\LocalFile;
+use PHP_CodeSniffer\Filters\Automattic\JetpackPhpcsFilter;
 use PHP_CodeSniffer\Util;
 
 /**
  * Filter for PHPCS to exclude files in bin/phpcs-excludelist.json.
  */
-class Jetpack_Phpcs_Exclude_Filter extends Automattic\Jetpack\PhpcsFilter {
+class Jetpack_Phpcs_Exclude_Filter extends JetpackPhpcsFilter {
 	/**
 	 * Files to exclude.
 	 *


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
If we place the filter class in the right namespace, it can be loaded by name instead of having to supply a vendor path to `--filter`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* CI happy?
* Try reverting the change to `.phpcs.config.xml` and run `composer phpcs:lint` on some files. There should be (one) deprecation warning printed.
  * Then try changing the path as mentioned in one of the change entries. Should work with no deprecation warning.