### PR TITLE
Forms: Multistep round of feedback

### DIFF
--- a/projects/packages/forms/changelog/change-forms-multistep-logic
+++ b/projects/packages/forms/changelog/change-forms-multistep-logic
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Contact Form: simplify multistep form detection and improve error wrapper placement for multistep navigation blocks. 

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -61,7 +61,6 @@
 
 			&.wp-block-jetpack-button {
 				flex-basis: auto;
-				align-self: flex-end; // Ensure button is aligned with the bottom of the previous field when on a same row
 			}
 
 			&.jetpack-field__width-25,

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -425,7 +425,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 				}
 			}
 
-			$is_multistep = boolval( $max_steps > 0 );
+			$is_multistep = $max_steps > 0;
 
 			$default_context = array(
 				'formId'      => $id,
@@ -433,10 +433,10 @@ class Contact_Form extends Contact_Form_Shortcode {
 				'showErrors'  => false, // We toggle this to true when we want to show the user errors right away.
 				'errors'      => array(), // This should be a associative array.
 				'fields'      => array(),
-				'isMultiStep' => boolval( $max_steps > 0 ), // Whether the form is a multistep form.
+				'isMultiStep' => boolval( $is_multistep ), // Whether the form is a multistep form.
 			);
 
-			if ( $max_steps > 0 ) {
+			if ( $is_multistep ) {
 				$multistep_context = array(
 					'currentStep' => isset( $_GET[ $id . '-step' ] ) ? absint( $_GET[ $id . '-step' ] ) : 1,
 					'maxSteps'    => $max_steps,
@@ -468,7 +468,9 @@ class Contact_Form extends Contact_Form_Shortcode {
 
 			$r .= $form->body;
 
-			if ( $has_submit_button_block ) {
+			if ( $is_multistep ) {
+				$r = preg_replace( '/<div class="wp-block-jetpack-form-step-navigation__wrapper/', self::render_error_wrapper() . ' <div class="wp-block-jetpack-form-step-navigation__wrapper', $r, 1 );
+			} elseif ( $has_submit_button_block ) {
 				// Place the error wrapper before the FIRST button block only to avoid duplicates (e.g., navigation buttons in multistep forms).
 				// Replace only the first occurrence.
 				$r = preg_replace( '/<div class="wp-block-jetpack-button/', self::render_error_wrapper() . ' <div class="wp-block-jetpack-button', $r, 1 );

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -313,7 +313,6 @@
 
 .wp-block-jetpack-contact-form .wp-block-jetpack-button {
 	width: fit-content;
-	align-self: flex-end;
 }
 
 .wp-block-jetpack-contact-form .wp-block-jetpack-button.aligncenter {


### PR DESCRIPTION
This PR fixes a number of Multi-step form issues that were found during CFT. 

## Proposed changes:
1. The error box, wrapping  since move the placement of the error box. So that it doesn't cause wrapping with buttons. 
2. Fix vertical aliment of buttons. 

See p8oabR-1Fx-p2#comment-8499 and p8oabR-1Fx-p2#comment-8502

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
See p8oabR-1Fx-p2#comment-8499 and p8oabR-1Fx-p2#comment-8502

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
* Insert a multi step form. 
* Switch to the 2025 theme. Notice that the when the error is displayed that things work out well. 
* Update the muti step navigation block to display the submit buttons in different ways. 
* Notice that they work as expected both in the editor and the front end. 