### PR TITLE
feat: Provide script data to authenticated REST API requests

### DIFF
--- a/projects/packages/assets/changelog/feat-provide-script-data-to-authenticated-rest-api-requests
+++ b/projects/packages/assets/changelog/feat-provide-script-data-to-authenticated-rest-api-requests
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Script data: provide script data to authenticated REST API requests

--- a/projects/packages/assets/src/class-script-data.php
+++ b/projects/packages/assets/src/class-script-data.php
@@ -86,7 +86,9 @@ class Script_Data {
 
 		self::$did_render_script_data = true;
 
-		$script_data = is_admin() ? self::get_admin_script_data() : self::get_public_script_data();
+		$script_data = is_admin() || self::is_authenticated_rest_request()
+			? self::get_admin_script_data()
+			: self::get_public_script_data();
 
 		if ( ! empty( $script_data ) ) {
 			$script_data = wp_json_encode(
@@ -102,6 +104,15 @@ class Script_Data {
 				wp_print_inline_script_tag( sprintf( 'window.JetpackScriptData = %s;', $script_data ) );
 			}
 		}
+	}
+
+	/**
+	 * Whether the current request is an authenticated REST API request.
+	 *
+	 * @return bool
+	 */
+	protected static function is_authenticated_rest_request() {
+		return wp_is_serving_rest_request() && current_user_can( 'read' );
 	}
 
 	/**

--- a/projects/packages/assets/tests/php/ScriptDataTest.php
+++ b/projects/packages/assets/tests/php/ScriptDataTest.php
@@ -1,0 +1,175 @@
+<?php
+
+namespace Automattic\Jetpack\Assets;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use PHPUnit\Framework\TestCase;
+
+class ScriptDataTest extends TestCase {
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+		// Stub esc_url_raw and other common WP functions to avoid undefined errors.
+		Functions\when( 'esc_url_raw' )->alias(
+			function ( $url ) {
+				return $url;
+			}
+		);
+		Functions\when( 'admin_url' )->alias(
+			function () {
+				return 'http://example.com/wp-admin/';
+			}
+		);
+		Functions\when( 'get_option' )->alias(
+			function () {
+				return 'option_value';
+			}
+		);
+		Functions\when( 'is_multisite' )->justReturn( false );
+		Functions\when( 'wp_create_nonce' )->alias(
+			function () {
+				return 'nonce';
+			}
+		);
+		Functions\when( 'rest_url' )->alias(
+			function () {
+				return 'http://example.com/wp-json/';
+			}
+		);
+		Functions\when( 'get_bloginfo' )->alias(
+			function () {
+				return 'Test Blog';
+			}
+		);
+		Functions\when( 'get_site_url' )->alias(
+			function () {
+				return 'http://example.com/';
+			}
+		);
+		Functions\when( 'has_site_icon' )->justReturn( false );
+		Functions\when( 'wp_get_current_user' )->alias(
+			function () {
+				return (object) array(
+					'display_name' => 'Test User',
+					'ID'           => 1,
+				);
+			}
+		);
+		Functions\when( 'get_current_blog_id' )->justReturn( 1 );
+		Functions\when( 'home_url' )->alias(
+			function () {
+				return 'http://example.com/';
+			}
+		);
+	}
+
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		// Reset the static property for isolation between tests.
+		$ref = new \ReflectionProperty( Script_Data::class, 'did_render_script_data' );
+		$ref->setAccessible( true );
+		$ref->setValue( null, false );
+		parent::tearDown();
+	}
+
+	public function test_render_script_data_for_authenticated_rest_request() {
+		Functions\when( 'is_admin' )->justReturn( false );
+		Functions\when( 'wp_is_serving_rest_request' )->justReturn( true );
+		Functions\when( 'current_user_can' )->justReturn( true );
+		Functions\when( 'did_action' )->alias(
+			function () {
+				return false;
+			}
+		);
+
+		Monkey\Filters\expectApplied( 'jetpack_admin_js_script_data' )->andReturn( array( 'foo' => 'bar' ) );
+
+		$captured = null;
+		Functions\when( 'wp_print_inline_script_tag' )->alias(
+			function ( $arg ) use ( &$captured ) {
+				$captured = $arg;
+			}
+		);
+		// wp_add_inline_script should not be called in this context.
+		Functions\expect( 'wp_add_inline_script' )->never();
+
+		Script_Data::render_script_data();
+
+		if ( ! is_string( $captured ) ) {
+			$this->fail( 'wp_print_inline_script_tag should be called' );
+		}
+		$this->assertStringContainsString( 'window.JetpackScriptData', $captured );
+		$this->assertStringContainsString( '"foo":"bar"', $captured );
+	}
+
+	public function test_render_script_data_for_unauthenticated_rest_request() {
+		// Reset static property in case previous test set it.
+		$ref = new \ReflectionProperty( Script_Data::class, 'did_render_script_data' );
+		$ref->setAccessible( true );
+		$ref->setValue( null, false );
+
+		Functions\when( 'is_admin' )->justReturn( false );
+		Functions\when( 'wp_is_serving_rest_request' )->justReturn( true );
+		Functions\when( 'current_user_can' )->justReturn( false );
+		Functions\when( 'did_action' )->alias(
+			function () {
+				return false;
+			}
+		);
+
+		Monkey\Filters\expectApplied( 'jetpack_public_js_script_data' )->andReturn( array( 'public' => 'baz' ) );
+
+		$captured = null;
+		Functions\when( 'wp_print_inline_script_tag' )->alias(
+			function ( $arg ) use ( &$captured ) {
+				$captured = $arg;
+			}
+		);
+		// wp_add_inline_script should not be called in this context.
+		Functions\expect( 'wp_add_inline_script' )->never();
+
+		Script_Data::render_script_data();
+
+		if ( ! is_string( $captured ) ) {
+			$this->fail( 'wp_print_inline_script_tag should be called' );
+		}
+		$this->assertStringContainsString( 'window.JetpackScriptData', $captured );
+		$this->assertStringContainsString( '"public":"baz"', $captured );
+	}
+
+	public function test_render_script_data_for_authenticated_rest_request_with_block_editor_assets() {
+		// Reset static property in case previous test set it.
+		$ref = new \ReflectionProperty( Script_Data::class, 'did_render_script_data' );
+		$ref->setAccessible( true );
+		$ref->setValue( null, false );
+
+		Functions\when( 'is_admin' )->justReturn( false );
+		Functions\when( 'wp_is_serving_rest_request' )->justReturn( true );
+		Functions\when( 'current_user_can' )->justReturn( true );
+		Functions\when( 'did_action' )->alias(
+			function ( $hook ) {
+				return $hook === 'enqueue_block_editor_assets';
+			}
+		);
+
+		Monkey\Filters\expectApplied( 'jetpack_admin_js_script_data' )->andReturn( array( 'foo' => 'bar' ) );
+
+		$add_inline_args = array();
+		Functions\when( 'wp_add_inline_script' )->alias(
+			function ( $handle, $data, $position ) use ( &$add_inline_args ) {
+				$add_inline_args = array( $handle, $data, $position );
+			}
+		);
+		Functions\expect( 'wp_print_inline_script_tag' )->never();
+
+		Script_Data::render_script_data();
+
+		$this->assertNotEmpty( $add_inline_args, 'wp_add_inline_script should be called' );
+		list( $handle, $data, $position ) = $add_inline_args;
+		$this->assertSame( Script_Data::SCRIPT_HANDLE, $handle );
+		$this->assertStringContainsString( 'window.JetpackScriptData', $data );
+		$this->assertStringContainsString( '"foo":"bar"', $data );
+		$this->assertSame( 'before', $position );
+	}
+}

--- a/projects/packages/assets/tests/php/ScriptDataTest.php
+++ b/projects/packages/assets/tests/php/ScriptDataTest.php
@@ -155,7 +155,7 @@ class ScriptDataTest extends TestCase {
 
 		Monkey\Filters\expectApplied( 'jetpack_admin_js_script_data' )->andReturn( array( 'foo' => 'bar' ) );
 
-		$add_inline_args = array();
+		$add_inline_args = array( null, '', null );
 		Functions\when( 'wp_add_inline_script' )->alias(
 			function ( $handle, $data, $position ) use ( &$add_inline_args ) {
 				$add_inline_args = array( $handle, $data, $position );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fix CMM-522. 

Make recent changes (https://github.com/Automattic/jetpack/pull/43972, https://github.com/Automattic/jetpack/pull/44072, https://github.com/Automattic/jetpack/pull/44241) compatible with the [`editor-assets` REST API endpoint](https://github.com/Automattic/jetpack/blob/fa03729444472ff99552dac67e9946e37d6fc375/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-block-editor-assets.php). 

Enable REST API endpoints to utilize foundational Jetpack configuration data. E.g., the mobile [GutenbergKit](https://github.com/wordpress-mobile/GutenbergKit) editor retrieves and loads block editor assets via a REST API endpoint. Without this data, certain Jetpack blocks types (e.g., Jetpack AI Assistant) fail to detect a connected account due to missing globals like `window.JetpackScriptData.site.host`. 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Populate script data with `get_admin_script_data` if the current requests is the REST API and the current user has baseline `read` permissions. 

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

It's worthwhile verifying the `JetpackScriptData` is returned for Simple sites in one of the following ways: 

Via the REST API:

1. Apply these Jetpack changes to your Simple site (see [comment](https://github.com/Automattic/jetpack/pull/44077#issuecomment-3001026437)).  
1. Make a request to the `/wpcom/v2/sites/<site_id>/editor-assets` endpoint for the WPCOM site—via [API Console](https://developer.wordpress.com/docs/api/console/), `curl`, etc. 
1. Verify the 200 response contains the `JetpackScriptData` value.

Via the Jetpack mobile app: 

1. Apply these Jetpack changes to your Simple site (see [comment](https://github.com/Automattic/jetpack/pull/44077#issuecomment-3001026437)).  
1. Using a debug build, log into an account with a WPCOM Simple site in the Jetpack mobile app. 
1. Enable the following features: 
    - `Experimental Block Editor` experimental feature
    - `Experimental Block Editor Plugins` debug flag
1. Create a new post and insert the AI Assistant block. 
1. Verify the block does not render a connection warning. 