### PR TITLE
Forms: Make default consent text sentence case

### DIFF
--- a/projects/packages/forms/changelog/update-form-consent-block-font
+++ b/projects/packages/forms/changelog/update-form-consent-block-font
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: Make default consent test sentence case.

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -630,7 +630,6 @@
 
 	:where(.wp-block-jetpack-option) {
 		font-size: 13px;
-		text-transform: uppercase;
 	}
 }
 

--- a/projects/packages/forms/src/blocks/field-consent/edit.js
+++ b/projects/packages/forms/src/blocks/field-consent/edit.js
@@ -48,11 +48,6 @@ export default function ConsentFieldEdit( props ) {
 					),
 					isStandalone: true,
 					hideInput: true,
-					style: {
-						typography: {
-							textTransform: 'none',
-						},
-					},
 				},
 			],
 		],

--- a/projects/packages/forms/src/blocks/field-consent/edit.js
+++ b/projects/packages/forms/src/blocks/field-consent/edit.js
@@ -48,6 +48,11 @@ export default function ConsentFieldEdit( props ) {
 					),
 					isStandalone: true,
 					hideInput: true,
+					style: {
+						typography: {
+							textTransform: 'none',
+						},
+					},
 				},
 			],
 		],

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -114,7 +114,6 @@
 .contact-form :where(label.consent) {
 	font-size: var(--jetpack--contact-form--label--font-size, 13px);
 	font-weight: 400;
-	text-transform: uppercase;
 }
 
 .contact-form label.consent {

--- a/projects/plugins/jetpack/changelog/update-form-consent-block-font
+++ b/projects/plugins/jetpack/changelog/update-form-consent-block-font
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: Make default consent test sentence case.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes [FORMS-197](https://linear.app/a8c/issue/FORMS-197/forms-consent-block-make-it-lowercase)

## Proposed changes:

UPDATED: The first version of this leveraged block settings. But doing so risks overriding global styles. So we're going to solve this by simply removing the low-specificity CSS that was adding the ALL CAPS. This means it will be active for all users on the frontend, but we're comfortable with that. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Fixes [FORMS-197](https://linear.app/a8c/issue/FORMS-197/forms-consent-block-make-it-lowercase)

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add a form block to a page or post
* Add a consent block and confirm the text is now sentence case.
* Save, check frontend, and confirm the text is now sentence case.