### PR TITLE
Forms: Fix forms transformations due to AI

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-forms-transformations
+++ b/projects/plugins/jetpack/changelog/fix-forms-transformations
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: beta block not released yet
+
+

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/text-blocks/lib/is-block-variation-supported.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/text-blocks/lib/is-block-variation-supported.ts
@@ -37,9 +37,8 @@ export function isBlockVariationSupported( props: Block ): boolean {
 		return true;
 	}
 
-	// If the block is a Jetpack Form, do not support the multistep variation.
 	if ( name === 'jetpack/contact-form' ) {
-		return attributes.variationName !== 'multistep';
+		return true;
 	}
 
 	// If the block is a Jetpack Form child, check its parent Form block.

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/text-blocks/with-ai-text-extension.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/text-blocks/with-ai-text-extension.tsx
@@ -26,7 +26,6 @@ import { mapInternalPromptTypeToBackendPromptType } from '../../lib/prompt/backe
 import AiAssistantInput from './components/ai-assistant-input';
 import AiAssistantExtensionToolbarDropdown from './components/ai-assistant-toolbar-dropdown';
 import { getBlockHandler, InlineExtensionsContext } from './get-block-handler';
-import { isBlockVariationSupported } from './lib/is-block-variation-supported';
 import { isPossibleToExtendTextBlock } from './lib/is-possible-to-extend-text-block';
 /*
  * Types
@@ -583,11 +582,6 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 
 		// If the required module is not enabled, return the original block edit component early.
 		if ( ! isRequiredModulePresent ) {
-			return <BlockEdit { ...props } />;
-		}
-
-		// If the block variation is not supported, also return early.
-		if ( ! isBlockVariationSupported( props ) ) {
 			return <BlockEdit { ...props } />;
 		}
 


### PR DESCRIPTION
This fixes the `multi-step => form` transformation when the user has the AI assistant. Enabled. 

## Proposed changes:
* This works because we are not mounting and mounting and unmounting the block. Which breaks the use of `useRef()` state. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
ask Enej

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
On a site with AI assistant enabled insert the form block. 
Then use the tranformation to turn it into a multi-step block. 
Then use use another tranformation to turn in back into the (default) form block. 

