### PR TITLE
Charts: Replace absolute positioning with flexbox layout for chart legends

### DIFF
--- a/projects/js-packages/charts/changelog/fix-charts-42-remove-absolute-positioning-in-legend-module
+++ b/projects/js-packages/charts/changelog/fix-charts-42-remove-absolute-positioning-in-legend-module
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+charts: Replace absolute positioning with flexbox

--- a/projects/js-packages/charts/src/components/bar-chart/bar-chart.module.scss
+++ b/projects/js-packages/charts/src/components/bar-chart/bar-chart.module.scss
@@ -1,5 +1,6 @@
 .bar-chart {
-	position: relative;
+	display: flex;
+	flex-direction: column;
 
 	svg {
 		overflow: visible;

--- a/projects/js-packages/charts/src/components/bar-chart/bar-chart.tsx
+++ b/projects/js-packages/charts/src/components/bar-chart/bar-chart.tsx
@@ -176,7 +176,9 @@ const BarChart: FC< BarChartProps > = ( {
 			style={ {
 				width,
 				height,
-				position: 'relative',
+				display: 'flex',
+				flexDirection:
+					showLegend && legendAlignmentVertical === 'top' ? 'column-reverse' : 'column',
 			} }
 		>
 			<XYChart

--- a/projects/js-packages/charts/src/components/legend/legend.module.scss
+++ b/projects/js-packages/charts/src/components/legend/legend.module.scss
@@ -15,21 +15,18 @@
 
 	// Vertical alignment positioning
 	&--vertical-align-top {
-		position: absolute;
-		top: 0;
-		z-index: 10;
+		position: relative;
 
 		&.legend--horizontal-align-left {
-			left: 0;
+			justify-content: flex-start;
 		}
 
 		&.legend--horizontal-align-center {
-			left: 50%;
-			transform: translateX(-50%);
+			justify-content: center;
 		}
 
 		&.legend--horizontal-align-right {
-			right: 0;
+			justify-content: flex-end;
 		}
 	}
 

--- a/projects/js-packages/charts/src/components/line-chart/line-chart.module.scss
+++ b/projects/js-packages/charts/src/components/line-chart/line-chart.module.scss
@@ -1,5 +1,6 @@
 .line-chart {
-	position: relative;
+	display: flex;
+	flex-direction: column;
 
 	svg {
 		overflow: visible;

--- a/projects/js-packages/charts/src/components/line-chart/line-chart.tsx
+++ b/projects/js-packages/charts/src/components/line-chart/line-chart.tsx
@@ -289,7 +289,9 @@ const LineChart: FC< LineChartProps > = ( {
 			style={ {
 				width,
 				height,
-				position: 'relative',
+				display: 'flex',
+				flexDirection:
+					showLegend && legendAlignmentVertical === 'top' ? 'column-reverse' : 'column',
 			} }
 		>
 			<XYChart

--- a/projects/js-packages/charts/src/components/pie-chart/pie-chart.module.scss
+++ b/projects/js-packages/charts/src/components/pie-chart/pie-chart.module.scss
@@ -1,3 +1,4 @@
 .pie-chart {
-	position: relative;
+	display: flex;
+	flex-direction: column;
 }

--- a/projects/js-packages/charts/src/components/pie-chart/pie-chart.tsx
+++ b/projects/js-packages/charts/src/components/pie-chart/pie-chart.tsx
@@ -157,7 +157,11 @@ const PieChart = ( {
 	return (
 		<div
 			className={ clsx( 'pie-chart', styles[ 'pie-chart' ], className ) }
-			style={ { position: 'relative' } }
+			style={ {
+				display: 'flex',
+				flexDirection:
+					showLegend && legendAlignmentVertical === 'top' ? 'column-reverse' : 'column',
+			} }
 		>
 			<svg
 				viewBox={ `0 0 ${ size } ${ size }` }

--- a/projects/js-packages/charts/src/components/pie-semi-circle-chart/pie-semi-circle-chart.module.scss
+++ b/projects/js-packages/charts/src/components/pie-semi-circle-chart/pie-semi-circle-chart.module.scss
@@ -1,5 +1,6 @@
 .pie-semi-circle-chart {
-	position: relative;
+	display: flex;
+	flex-direction: column;
 	text-align: center;
 
 	&-legend {

--- a/projects/js-packages/charts/src/components/pie-semi-circle-chart/pie-semi-circle-chart.tsx
+++ b/projects/js-packages/charts/src/components/pie-semi-circle-chart/pie-semi-circle-chart.tsx
@@ -172,7 +172,11 @@ const PieSemiCircleChart: FC< PieSemiCircleChartProps > = ( {
 		<div
 			className={ clsx( 'pie-semi-circle-chart', styles[ 'pie-semi-circle-chart' ], className ) }
 			data-testid="pie-chart-container"
-			style={ { position: 'relative' } }
+			style={ {
+				display: 'flex',
+				flexDirection:
+					showLegend && legendAlignmentVertical === 'top' ? 'column-reverse' : 'column',
+			} }
 		>
 			<svg
 				width={ width }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #CHARTS-42

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
- Replace absolute positioning with flexbox layout for chart legends
- Changed `position: absolute` to `position: relative` in legend CSS
- Replaced `left: 50%; transform: translateX(-50%)` with `justify-content: center/flex-start/flex-end`
- Updated chart containers to use `display: flex` with `column-reverse` for top-aligned legends
- Migrated all chart component CSS from `position: relative` to `display: flex` for consistency

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* In your Jetpack local environment, navigate to the Storybook development environment:

```bash
pnpm i
cd projects/js-packages/storybook
pnpm run storybook:dev
```

* Find the following stories in the sidebar to test legend positioning:
  - `JS Packages/Charts/BarChart/Legend Positioning`
  - `JS Packages/Charts/LineChart/Legend Positioning` 
  - `JS Packages/Charts/PieChart/Legend Positioning`
  - `JS Packages/Charts/PieSemiCircleChart/Legend Positioning`

* Test each combination of positioning options:
  - **Horizontal alignment**: left, center, right
  - **Vertical alignment**: top, bottom
  - Verify legends appear in the correct positions
  - Check that existing charts without positioning props still work correctly

* Verify backwards compatibility by checking existing chart stories still render properly

**Expected behavior:**
- Legends should position correctly according to horizontalAlign/verticalAlign props
- Default behavior (no positioning props) should remain unchanged
- All chart types should support the new positioning options consistently - confirm legend displays properly across all chart types (line, bar, pie,  semi-circle etc.)   
- Check for any other chart styling or resizing inconsistencies or regressions

