### PR TITLE
Boost: Ensure new error types unsupported by the plugin version show as Unknown

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/features/lcp/lib/stores/lcp-state-types.ts
+++ b/projects/plugins/boost/app/assets/src/js/features/lcp/lib/stores/lcp-state-types.ts
@@ -23,7 +23,8 @@ export const LcpErrorMetaSchema = z.object( {
 } );
 
 export const LcpErrorDetailsSchema = z.object( {
-	type: LcpErrorTypeSchema,
+	// Adding a generic string type to handle the case where the error type is not in the enum, so the schema is still valid.
+	type: z.union( [ LcpErrorTypeSchema, z.string() ] ),
 	meta: LcpErrorMetaSchema.optional(),
 } );
 

--- a/projects/plugins/boost/changelog/fix-lcp-support-new-error-types
+++ b/projects/plugins/boost/changelog/fix-lcp-support-new-error-types
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+LCP Optimization: Ensure new error types unsupported by the plugin version show as Unknown


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Ensure that new error types unsupported by the plugin version show as Unknown

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
* Within the Boost developer plugin, change "Force Critical CSS generation Error" to Showstopper.
* Within local Boost Cloud, change the error type for `http-error` to something different to imititate a new error type.
* Run LCP Optimization
* Verify that an unknown LCP error is reported within the Boost Settings.
  * Previously it would report that LCP Optimization was not analyzed. This is because the DS schema would not accept a different error type, and fallback the LCP state as not optimized.

