### PR TITLE
My Jetpack: Onboarding i4 | Fix loading of modules in plans section

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/filtered-plans.tsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/filtered-plans.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @wordpress/no-unsafe-wp-apis */
-import { __experimentalText as Text } from '@wordpress/components';
+import { Flex, __experimentalText as Text } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { ProductSection } from './product-section';
 import { Skeleton } from './skeleton';
@@ -17,9 +17,9 @@ export type FilteredPlansProps = {
  * @return The rendered component.
  */
 export function FilteredPlans( { search }: FilteredPlansProps ) {
-	const { plans, isLoadingPlans, errorPlans } = useFilteredPlans( { search } );
+	const { plans, isLoading, errorPlans } = useFilteredPlans( { search } );
 
-	if ( isLoadingPlans ) {
+	if ( isLoading ) {
 		return <Skeleton />;
 	}
 
@@ -36,10 +36,10 @@ export function FilteredPlans( { search }: FilteredPlansProps ) {
 	}
 
 	return (
-		<div>
+		<Flex gap={ 12 } direction="column">
 			{ plans.map( section => {
 				return <ProductSection key={ section.id } section={ section } />;
 			} ) }
-		</div>
+		</Flex>
 	);
 }

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/use-filtered-plans.ts
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/use-filtered-plans.ts
@@ -21,7 +21,7 @@ export type UseFilteredPlansOptions = {
  */
 export function useFilteredPlans( { search }: UseFilteredPlansOptions ): {
 	plans: Array< ProductSection >;
-	isLoadingPlans: boolean;
+	isLoading: boolean;
 	errorPlans: WP_Error;
 } {
 	const {
@@ -35,7 +35,7 @@ export function useFilteredPlans( { search }: UseFilteredPlansOptions ): {
 
 	const { data: products } = useAllProducts();
 
-	const allModules = useAllJetpackModules();
+	const { modules: allModules, isLoading: isLoadingModules } = useAllJetpackModules();
 
 	const list = ( purchases || [] ).map< ProductSection >( purchase => {
 		const $products = Object.entries( products || {} ).filter(
@@ -62,7 +62,7 @@ export function useFilteredPlans( { search }: UseFilteredPlansOptions ): {
 
 	return {
 		plans: filterSections( list, { search } ),
-		isLoadingPlans,
+		isLoading: isLoadingPlans || isLoadingModules,
 		errorPlans,
 	};
 }


### PR DESCRIPTION
#44057 seems to have caused a slight regression where the modules in "Included in plan" section did not load.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fix loading of modules in plans section

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to My Jetpack > Products
* Go to "Included in plan" tab
* Confirm that the Free modules load fine

| Before | After |
|--------|--------|
| <img width="1111" alt="Screenshot 2025-06-25 at 4 54 52 PM" src="https://github.com/user-attachments/assets/b66b71c0-27fd-4fd0-bcc3-6823f1943c30" /> | <img width="1077" alt="Screenshot 2025-06-25 at 4 56 05 PM" src="https://github.com/user-attachments/assets/3ecd085b-ed9f-4af5-a859-26b586eedcf2" /> | 
