### PR TITLE
fix: Ensure editor assets endpoint excludes disallowed plugin assets

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-block-editor-assets.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-block-editor-assets.php
@@ -20,11 +20,12 @@ class WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets extends WP_REST_Controller 
 	 * @var array
 	 */
 	const ALLOWED_PLUGINS = array(
-		'/plugins/gutenberg/',
-		'/plugins/gutenberg-core/', // WPCOM Simple site
-		'/plugins/jetpack/',
-		'/mu-plugins/jetpack-mu-wpcom-plugin/', // WPCOM Simple site
-		'/mu-plugins/wpcomsh/', // WoW helpers
+		'/plugins/gutenberg/', // Default plugin location
+		'/plugins/gutenberg-core/', // WPCOM Simple site location
+		'/plugins/jetpack/', // Default plugin location
+		'/plugins/jetpack-dev/', // Used for loading in-progress work
+		'/mu-plugins/jetpack-mu-wpcom-plugin/', // WPCOM Simple site location
+		'/mu-plugins/wpcomsh/', // WoA helpers, including Jetpack assets in vendor directories
 	);
 
 	/**

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-block-editor-assets.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-block-editor-assets.php
@@ -181,9 +181,6 @@ class WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets extends WP_REST_Controller 
 		// Trigger an action frequently used by plugins to enqueue assets.
 		do_action( 'wp_loaded' );
 
-		// Unregister disallowed plugin assets before proceeding with asset collection
-		$this->unregister_disallowed_plugin_assets();
-
 		// We generally do not need reset styles for the block editor. However, if
 		// it's a classic theme, margins will be added to every block, which is
 		// reset specifically for list items, so classic themes rely on these
@@ -238,6 +235,9 @@ class WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets extends WP_REST_Controller 
 		if ( $has_emoji_styles ) {
 			remove_action( 'wp_print_styles', 'print_emoji_styles' );
 		}
+
+		// Unregister disallowed plugin assets before proceeding with asset collection
+		$this->unregister_disallowed_plugin_assets();
 
 		ob_start();
 		wp_print_styles();

--- a/projects/plugins/jetpack/changelog/fix-ensure-editor-assets-endpoint-excludes-disallowed-plugin-assets
+++ b/projects/plugins/jetpack/changelog/fix-ensure-editor-assets-endpoint-excludes-disallowed-plugin-assets
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Block editor: ensure editor assets endpoint excludes disallowed plugin assets

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test.php
@@ -49,12 +49,16 @@ class WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test extends Jetpack_REST_T
 	 */
 	public function mock_block_editor_assets() {
 		// Register minimal mock assets that don't require actual files
-		wp_register_script( 'mock-editor-script', 'http://example.org/mock-editor.js', array(), '1.0', true );
-		wp_register_style( 'mock-editor-style', 'http://example.org/mock-editor.css', array(), '1.0' );
+		wp_register_script( 'mock-editor-script', 'http://example.org/plugins/jetpack/mock-editor.js', array(), '1.0', true );
+		wp_register_style( 'mock-editor-style', 'http://example.org/plugins/jetpack/mock-editor.css', array(), '1.0' );
+		wp_register_script( 'disallowed-plugin-script', 'http://example.org/plugins/disallowed-plugin/script.js', array(), '1.0', true );
+		wp_register_script( 'disallowed-plugin-style', 'http://example.org/plugins/disallowed-plugin/style.css', array(), '1.0', true );
 
 		// Enqueue our mock assets
 		wp_enqueue_script( 'mock-editor-script' );
 		wp_enqueue_style( 'mock-editor-style' );
+		wp_enqueue_script( 'disallowed-plugin-script' );
+		wp_enqueue_style( 'disallowed-plugin-style' );
 	}
 
 	/**
@@ -169,21 +173,33 @@ class WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test extends Jetpack_REST_T
 	}
 
 	/**
-	 * Test that disallowed plugin assets are filtered out.
+	 * Test that allowed plugins assets are included.
 	 */
-	public function test_disallowed_plugin_assets_are_filtered() {
+	public function test_get_items_returns_allowed_plugin_assets() {
 		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
-
-		// Register a disallowed plugin asset
-		wp_register_script( 'disallowed-plugin', 'http://example.org/disallowed-plugin/script.js', array(), '1.0', true );
-		wp_enqueue_script( 'disallowed-plugin' );
 
 		$request  = new WP_REST_Request( Requests::GET, '/wpcom/v2/editor-assets' );
 		$response = $this->server->dispatch( $request );
 		$data     = $response->get_data();
 
-		// Verify the disallowed plugin script is not in the output
-		$this->assertStringNotContainsString( 'disallowed-plugin/script.js', $data['scripts'] );
+		// Verify the allowed plugin script and style are in the output
+		$this->assertStringContainsString( 'mock-editor-script', $data['scripts'] );
+		$this->assertStringContainsString( 'mock-editor-style', $data['styles'] );
+	}
+
+	/**
+	 * Test that disallowed plugin assets are filtered out.
+	 */
+	public function test_disallowed_plugin_assets_are_filtered() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
+
+		$request  = new WP_REST_Request( Requests::GET, '/wpcom/v2/editor-assets' );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		// Verify the disallowed plugin script and style are not in the output
+		$this->assertStringNotContainsString( 'disallowed-plugin-script', $data['scripts'] );
+		$this->assertStringNotContainsString( 'disallowed-plugin-style', $data['styles'] );
 	}
 
 	/**
@@ -191,9 +207,6 @@ class WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test extends Jetpack_REST_T
 	 */
 	public function test_protected_handles_are_preserved() {
 		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
-
-		// Ensure jQuery (a protected handle) is enqueued
-		wp_enqueue_script( 'jquery' );
 
 		$request  = new WP_REST_Request( Requests::GET, '/wpcom/v2/editor-assets' );
 		$response = $this->server->dispatch( $request );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

The previous tests were false-positives, as the `disallowed-script` registration had no impact on the environment and test outcome.

After fixing the test setup, it was evident the de-registration of assets was invoked too earlier in the logic.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fix false-positive tests focused on the plugins allowed list. 
* Postpone logic for unregistering plugin assets until after 
* Add `jetpack-dev` plugin to allow list to allow testing in-progress work. 

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Create a WPCOM site. 
3. Apply these Jetpack changes to your site (see [comment](https://github.com/Automattic/jetpack/pull/44093#issuecomment-3005252223)).  
1. Make a request to the `/wpcom/v2/sites/<site_id>/editor-assets` endpoint for the WPCOM site—via [API Console](https://developer.wordpress.com/docs/api/console/), `curl`, etc. 
1. Verify the 200 response that contains the `jetpack-connection-js` script. 