### PR TITLE
Fix Backup and Account Protection modules on search

### DIFF
--- a/projects/plugins/jetpack/_inc/client/security/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/security/index.jsx
@@ -74,13 +74,22 @@ export class Security extends Component {
 		}
 
 		const foundProtect = this.props.isModuleFound( 'protect' ),
+			foundAccountProtection = this.props.isModuleFound( 'account-protection' ),
 			foundSso = this.props.isModuleFound( 'sso' ),
 			foundAkismet = this.isAkismetFound(),
-			rewindActive = 'active' === get( this.props.rewindStatus, [ 'state' ], false ),
+			rewindActive =
+				! isSearchTerm && 'active' === get( this.props.rewindStatus, [ 'state' ], false ),
 			foundBackups = this.props.isModuleFound( 'vaultpress' ) || rewindActive,
 			foundMonitor = this.props.isModuleFound( 'monitor' );
 
-		if ( ! foundSso && ! foundProtect && ! foundAkismet && ! foundBackups && ! foundMonitor ) {
+		if (
+			! foundSso &&
+			! foundProtect &&
+			! foundAccountProtection &&
+			! foundAkismet &&
+			! foundBackups &&
+			! foundMonitor
+		) {
 			return null;
 		}
 
@@ -113,7 +122,9 @@ export class Security extends Component {
 						<QueryAkismetKeyCheck />
 					</>
 				) }
-				<AccountProtection isModuleFound={ this.props.isModuleFound } { ...commonProps } />
+				{ foundAccountProtection && (
+					<AccountProtection isModuleFound={ this.props.isModuleFound } { ...commonProps } />
+				) }
 				{ foundWaf && <Waf { ...commonProps } /> }
 				{ foundProtect && <Protect { ...commonProps } /> }
 				{ ( foundWaf || foundProtect ) && <AllowList { ...commonProps } /> }

--- a/projects/plugins/jetpack/changelog/fix-acc-protect-backup-module-search
+++ b/projects/plugins/jetpack/changelog/fix-acc-protect-backup-module-search
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Settings: avoid showing Backup and Account Protection modules with any search terms


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes [PROTECT-108][1].

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

The `Backups and security scanning` and `Account protection` modules where always being shown in the `Settings` page, no matter the search term, like:

| Search | Result |
| - | - |
| `asdf` | <img alt="image" src="https://github.com/user-attachments/assets/0771d565-ae40-4267-aa3d-2d6b0995b34d" /> |

This PR fixes this behavior, ensuring they only appear when there are actual matches for their respective modules.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Go to the `Settings` page.
- Try different search terms.
- Ensure that the  `Backups and security scanning` and `Account protection` modules don't appear when they shouldn't.

| Search | Result |
| - | - |
| `asdf` | <img alt="image" src="https://github.com/user-attachments/assets/451dc3c7-0888-4231-bded-924d26b24da8" /> |
| `account protection` | <img alt="image" src="https://github.com/user-attachments/assets/9bfee1f9-8869-4421-9474-406290dd8915" /> |
| `backup` | <img alt="image" src="https://github.com/user-attachments/assets/fe885208-1f76-4c2e-91aa-e4bf87d421a3" /> | 

[1]: https://linear.app/a8c/issue/PROTECT-108/