### PR TITLE
Forms: Fix multi step step navigation loading

### DIFF
--- a/projects/packages/forms/changelog/fix-form-multi-step-step-navigation
+++ b/projects/packages/forms/changelog/fix-form-multi-step-step-navigation
@@ -1,4 +1,4 @@
 Significance: minor
 Type: fixed
 
-Forms: Load the inital steps as if the form has more then on step in it.
+Forms: Load the initial steps as if the form has more than one step in it.

--- a/projects/packages/forms/changelog/fix-form-multi-step-step-navigation
+++ b/projects/packages/forms/changelog/fix-form-multi-step-step-navigation
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+Forms: Load the inital steps as if the form has more then on step in it.

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -708,7 +708,7 @@ class Contact_Form_Plugin {
 			$id = $processor->get_attribute( 'data-id-attr' );
 			if ( 'previous-step' === $id ) {
 				$processor->remove_attribute( 'id' );
-				$processor->add_class( 'disable-spinner is-previous' );
+				$processor->add_class( 'disable-spinner is-previous is-hidden' );
 				$processor->set_attribute( 'data-wp-on--click', 'actions.previousStep' );
 				$processor->set_attribute( 'data-wp-class--is-hidden', 'state.isFirstStep' );
 			}
@@ -720,7 +720,7 @@ class Contact_Form_Plugin {
 			}
 			if ( 'submit-step' === $id ) {
 				$processor->remove_attribute( 'id' );
-				$processor->add_class( 'is-submit' );
+				$processor->add_class( 'is-submit is-hidden' );
 				$processor->set_attribute( 'data-wp-class--is-hidden', 'state.isNotLastStep' );
 			}
 		}


### PR DESCRIPTION
Currently when you load the step navigation we see a flash of buttons. This happends because there is a moment before the JS loads and the styles kick in. 

## Proposed changes:
* Lets make the assumption that the user has more then one step. Otherwise they wouldn't need the step navigation. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p8oabR-1Fx-p2#comment-8515

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* Create a multi step form. By inserting the multi step block
* Load the form on the front end. Notice that you don't see the flash of buttons. 