### PR TITLE
Full sync terms send taxonomies as empty array

### DIFF
--- a/projects/packages/sync/changelog/update-full-sync-terms-send-taxonomies-as-empty-array
+++ b/projects/packages/sync/changelog/update-full-sync-terms-send-taxonomies-as-empty-array
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Sync: Added taxonomies as empty array whne using get_terms for better support of plugins/themes

--- a/projects/packages/sync/src/modules/class-terms.php
+++ b/projects/packages/sync/src/modules/class-terms.php
@@ -342,9 +342,10 @@ class Terms extends Module {
 			'terms'        => get_terms(
 				array(
 					'hide_empty'       => false,
-					'term_taxonomy_id' => $term_taxonomy_ids,
 					'orderby'          => 'term_taxonomy_id',
 					'order'            => 'DESC',
+					'taxonomy'         => array(),
+					'term_taxonomy_id' => $term_taxonomy_ids,
 				)
 			),
 			'previous_end' => $previous_end,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes [VULCAN-203](https://linear.app/a8c/issue/VULCAN-203/full-sync-not-sending-taxonomies-in-get-terms-causes-brittle)

Our usage in full sync [here](https://github.com/Automattic/jetpack/blob/trunk/projects/packages/sync/src/modules/class-terms.php#L342) triggers errors when a plugin/theme hooks into the `get_terms` filter and assumes the $taxonomies argument is always an array. [Documentation](https://developer.wordpress.org/reference/hooks/get_terms/) shows that taxonomies can be null, but let's send an empty array, which works the same and does not break for those plugins/themes that expect an array.
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Send taxonomies as empty array

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Let's try first in trunk and reproduce the error.
- For a Jetpack Connected site with Woo, install [Hide Categories On Shop Page](https://wordpress.org/plugins/hide-categories-on-shop-page)
- Run a Full Sync for terms only. If using docker you can use `jetpack docker wp -- jetpack sync start --modules=terms`
- You should notice a Fatal Error in your logs, and full sync will never finish.

Try with the branch in this PR, 
- No errors should appear and the full sync should finish normally. 
- If possible check logs for the `jetpack_full_sync_terms` action and ensure that the terms are being sent.
