### PR TITLE
Forms: Dedupe unread count when there's another badge number on Jetpack menu item

### DIFF
--- a/projects/packages/forms/changelog/fix-jetpack-forms-double-badge-count
+++ b/projects/packages/forms/changelog/fix-jetpack-forms-double-badge-count
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: dedupe unread count when there's another badge number on Jetpack menu item

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -1132,15 +1132,30 @@ class Contact_Form_Plugin {
 			global $submenu, $menu;
 			if ( apply_filters( 'jetpack_forms_use_new_menu_parent', true ) && current_user_can( 'edit_pages' ) ) {
 				// show the count on Jetpack and Jetpack → Forms
-				$unread           = get_option( 'feedback_unread_count', 0 );
-				$unread_count_tag = " <span class='feedback-unread count-{$unread} awaiting-mod'><span class='feedback-unread-count'>" . number_format_i18n( $unread ) . '</span></span>';
+				$unread = get_option( 'feedback_unread_count', 0 );
 
 				if ( $unread > 0 && isset( $submenu['jetpack'] ) && is_array( $submenu['jetpack'] ) && ! empty( $submenu['jetpack'] ) ) {
+					$forms_unread_count_tag = " <span class='count-{$unread} awaiting-mod'><span>" . number_format_i18n( $unread ) . '</span></span>';
+					$jetpack_badge_count    = $unread;
+
 					// Main menu entries
 					foreach ( $menu as $index => $main_menu_item ) {
 						if ( isset( $main_menu_item[1] ) && 'jetpack_admin_page' === $main_menu_item[1] ) {
+							// Parse the menu item
+							$jetpack_menu_item = $this->parse_menu_item( $menu[ $index ][0] );
+
+							if ( isset( $jetpack_menu_item['badge'] ) && is_numeric( $jetpack_menu_item['badge'] ) && intval( $jetpack_menu_item['badge'] ) ) {
+								$jetpack_badge_count += intval( $jetpack_menu_item['badge'] );
+							}
+
+							if ( isset( $jetpack_menu_item['count'] ) && is_numeric( $jetpack_menu_item['count'] ) && intval( $jetpack_menu_item['count'] ) ) {
+								$jetpack_badge_count += intval( $jetpack_menu_item['count'] );
+							}
+
+							$jetpack_unread_tag = " <span class='count-{$jetpack_badge_count} awaiting-mod'><span>" . number_format_i18n( $jetpack_badge_count ) . '</span></span>';
+
 							// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-							$menu[ $index ][0] .= $unread_count_tag;
+							$menu[ $index ][0] = $jetpack_menu_item['title'] . ' ' . $jetpack_unread_tag;
 						}
 					}
 
@@ -1148,7 +1163,7 @@ class Contact_Form_Plugin {
 					foreach ( $submenu['jetpack'] as $index => $menu_item ) {
 						if ( 'jetpack-forms-admin' === $menu_item[2] ) {
 							// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-							$submenu['jetpack'][ $index ][0] .= $unread_count_tag;
+							$submenu['jetpack'][ $index ][0] .= $forms_unread_count_tag;
 						}
 					}
 				}
@@ -2979,5 +2994,70 @@ class Contact_Form_Plugin {
 		$should_enable_tracking = $tracking->should_enable_tracking( new Terms_Of_Service(), $status );
 
 		return $is_wpcom || $should_enable_tracking;
+	}
+
+	/**
+	 * Jetpack menu item might have a count badge when there are updates available.
+	 * This method parses that information, removes the associated markup and adds it to the response.
+	 * Copied verbatim from WPCOM_REST_API_V2_Endpoint_Admin_Menu::prepare_menu_item.
+	 *
+	 * Also sanitizes the titles from remaining unexpected markup.
+	 *
+	 * @param string $title Title to parse.
+	 * @return array
+	 */
+	private function parse_menu_item( $title ) {
+		$item = array();
+
+		if (
+			str_contains( $title, 'count-' )
+			&& preg_match( '/<span class=".+\s?count-(\d*).+\s?<\/span><\/span>/', $title, $matches )
+		) {
+
+			$count = (int) ( $matches[1] );
+			if ( $count > 0 ) {
+				// Keep the counter in the item array.
+				$item['count'] = $count;
+			}
+
+			// Finally remove the markup.
+			$title = trim( str_replace( $matches[0], '', $title ) );
+		}
+
+		if (
+			str_contains( $title, 'inline-text' )
+			&& preg_match( '/<span class="inline-text".+\s?>(.+)<\/span>/', $title, $matches )
+		) {
+
+			$text = $matches[1];
+			if ( $text ) {
+				// Keep the text in the item array.
+				$item['inlineText'] = $text;
+			}
+
+			// Finally remove the markup.
+			$title = trim( str_replace( $matches[0], '', $title ) );
+		}
+
+		if (
+			str_contains( $title, 'awaiting-mod' )
+			&& preg_match( '/<span class="awaiting-mod">(.+)<\/span>/', $title, $matches )
+		) {
+
+			$text = $matches[1];
+			if ( $text ) {
+				// Keep the text in the item array.
+				$item['badge'] = $text;
+			}
+
+			// Finally remove the markup.
+			$title = trim( str_replace( $matches[0], '', $title ) );
+		}
+
+		// It's important we sanitize the title after parsing data to remove any unexpected markup but keep the content.
+		// We are also capitalizing the first letter in case there was a counter (now parsed) in front of the title.
+		$item['title'] = ucfirst( wp_strip_all_tags( $title ) );
+
+		return $item;
 	}
 }


### PR DESCRIPTION
Part of FORMS-99

## Proposed changes:
This PR parses the main Jetpack menu entry in case there was some badge already in it and adds that value to the unread count of form submissions.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
FORMS-99

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
I don't have a consistent way of getting a new badge on Jetpack menu item, these steps have been suggested:

- Purchase a Jetpack Complete plan
- Ensure that the Akismet plugin is not installed on your site ; deactivate and delete it if it was installed
- At this point, when refreshing wp-admin, you should have the first bubble from My Jetpack
- Create a form, and submit a new entry to the form
- At that point, you should have your second bubble

See that there's a single badge adding any value from Jetpack badge to the amount of unread form responses.