### PR TITLE
Jetpack Forms: disallow form attributes as field name

### DIFF
--- a/projects/packages/forms/changelog/fix-jetpack-forms-disallow-form-attributes-as-field-name
+++ b/projects/packages/forms/changelog/fix-jetpack-forms-disallow-form-attributes-as-field-name
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+Forms: don't allow form element attribute names to be set as field names

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -1078,6 +1078,16 @@
 	margin-bottom: 0;
 }
 
+.block-editor-block-inspector .components-base-control.jetpack-forms-field-controls__input-error {
+
+	.components-text-control__input,
+	.components-text-control__input[type="text"],
+	.components-text-control__input[type="text"]:focus,
+	.components-text-control__input:focus {
+		border-color: var( --wp--preset--color--vivid-red, #f00 );
+	}
+}
+
 .is-style-outlined .jetpack-field.is-selected .notched-label__label[style*="--jetpack--contact-form--label--font-size"],
 .is-style-outlined .jetpack-field.has-placeholder .notched-label__label[style*="--jetpack--contact-form--label--font-size"] {
     font-size: calc(var(--jetpack--contact-form--label--font-size) * 0.8);


### PR DESCRIPTION
## Proposed changes:
This PR adds a list of restricted words (form HTML element attribute names) to be used as field names on the editor. 

Restricted words:

- accept
- action
- autocomplete
- enctype
- method
- name
- novalidate
- target
- type
- value

See: https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fe-name

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1750960644990619/1750882996.668199-slack-C052XEUUBL4

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Insert a form and select a field (not the input or label, the field). On the inspector look for the Advanced panel and uncollapse it. Try setting the name/ID of the field to one of the restricted words, you should get restricted upon typing, input border should turn red and the help text below give you an explanation.