### PR TITLE
JITM: Fix ineffective caching due to expired plugin sync transient

### DIFF
--- a/projects/packages/jitm/changelog/reish20250626-update-jitm-cache
+++ b/projects/packages/jitm/changelog/reish20250626-update-jitm-cache
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+JITM: Fix ineffective caching due to expired plugin sync transient

--- a/projects/packages/jitm/src/class-post-connection-jitm.php
+++ b/projects/packages/jitm/src/class-post-connection-jitm.php
@@ -296,8 +296,16 @@ class Post_Connection_JITM extends JITM {
 		}
 
 		if ( $use_cache ) {
-			$last_sync  = (int) get_transient( 'jetpack_last_plugin_sync' );
-			$from_cache = $envelopes && $last_sync > 0 && $last_sync < $envelopes['last_response_time'];
+			$last_sync = (int) get_transient( 'jetpack_last_plugin_sync' );
+			// The sync timestamp indicates when a plugin change was last sent to Jetpack, however,
+			// it's stored in a transient and doesn't stay forever. Therefore, an admin who last changed
+			// a plugin a month ago is likely to have $last_sync=0.
+			//
+			// If the sync timestamp is missing (value 0): use the cache.
+			// If the timestamp exists and is older than the cached envelope: use the cache.
+			// If the timestamp exists and is newer: bypass and refresh.
+			// (This case means the JITM was created before the last plugin activate/deactivate and is invalid).
+			$from_cache = $envelopes && ( 0 === $last_sync || $last_sync < $envelopes['last_response_time'] );
 		} else {
 			$from_cache = false;
 		}

--- a/projects/plugins/backup/changelog/reish20250626-update-jitm-cache
+++ b/projects/plugins/backup/changelog/reish20250626-update-jitm-cache
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+JITM: Fix ineffective caching due to expired plugin sync transient

--- a/projects/plugins/boost/changelog/reish20250626-update-jitm-cache
+++ b/projects/plugins/boost/changelog/reish20250626-update-jitm-cache
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+JITM: Fix ineffective caching due to expired plugin sync transient

--- a/projects/plugins/jetpack/changelog/reish20250626-update-jitm-cache
+++ b/projects/plugins/jetpack/changelog/reish20250626-update-jitm-cache
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+JITM: Fix ineffective caching due to expired plugin sync transient

--- a/projects/plugins/mu-wpcom-plugin/changelog/reish20250626-update-jitm-cache
+++ b/projects/plugins/mu-wpcom-plugin/changelog/reish20250626-update-jitm-cache
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+JITM: Fix ineffective caching due to expired plugin sync transient

--- a/projects/plugins/protect/changelog/reish20250626-update-jitm-cache
+++ b/projects/plugins/protect/changelog/reish20250626-update-jitm-cache
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+JITM: Fix ineffective caching due to expired plugin sync transient

--- a/projects/plugins/search/changelog/reish20250626-update-jitm-cache
+++ b/projects/plugins/search/changelog/reish20250626-update-jitm-cache
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+JITM: Fix ineffective caching due to expired plugin sync transient

--- a/projects/plugins/social/changelog/reish20250626-update-jitm-cache
+++ b/projects/plugins/social/changelog/reish20250626-update-jitm-cache
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+JITM: Fix ineffective caching due to expired plugin sync transient

--- a/projects/plugins/starter-plugin/changelog/reish20250626-update-jitm-cache
+++ b/projects/plugins/starter-plugin/changelog/reish20250626-update-jitm-cache
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+JITM: Fix ineffective caching due to expired plugin sync transient

--- a/projects/plugins/videopress/changelog/reish20250626-update-jitm-cache
+++ b/projects/plugins/videopress/changelog/reish20250626-update-jitm-cache
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+JITM: Fix ineffective caching due to expired plugin sync transient

--- a/projects/plugins/wpcomsh/changelog/reish20250626-update-jitm-cache
+++ b/projects/plugins/wpcomsh/changelog/reish20250626-update-jitm-cache
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+JITM: Fix ineffective caching due to expired plugin sync transient


### PR DESCRIPTION
## Proposed changes:

* When determining if `Post_Connection_JITM` is allowed to use cache, make `(int) get_transient( 'jetpack_last_plugin_sync' ) === 0` be an allowed condition instead of a disallowed condition.

Basically, what the code is attempting to do is something like: "If I have a JITM cached from 4:00pm, but the user updated their plugins at 4:10pm, then I should no longer use the JITM."  However, there seems to be a flaw in the way this is working in practice.

The function `jetpack_track_last_sync_callback()` in `class-jitm.php` is setting the `jetpack_last_plugin_sync`, which represents the last time plugins were changed:

https://github.com/Automattic/jetpack/blob/ec7074d87b36492f277f7d6e7a992e4ac23eb66a/projects/packages/jitm/src/class-jitm.php#L392

However, it's only set for an hour. If you haven't changed any plugins recently, this goes away, which means that `(int) get_transient( 'jetpack_last_plugin_sync' ) === 0`, which also means that `$from_cache` will be assigned false, because one of the conditions its checking is `$last_sync > 0`.

Effectively, this means JITM caching only works if you changed plugin status in the last hour.

The change in this PR is to allow JITM caching when the jetpack_last_plugin_sync is missing, and to only disallow it when we have a jetpack_last_plugin_sync value, but it is newer than the last cached JITM message.

The JITM messages themselves have TTLs on them.  In my testing they are typically around 5 minutes. So even if we are effectively turning caching off from on, this is another level that should prevent us from showing out of date messages.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?

## Testing instructions:

* Make a WoA dev site
* Change to classic style (wp-admin mode)

<img width="1073" alt="Screenshot 2025-06-26 at 4 37 20 PM" src="https://github.com/user-attachments/assets/eef9c5f6-4cd9-4ba0-aca3-71ebd5dc035a" />

* Don't put this code on the site yet
* Install Query Monitor
* Change `set_transient( 'jetpack_last_plugin_sync', time(), HOUR_IN_SECONDS );` in `class-jitm.php` to 60 instead of one hour
* Flush cache on the site
* Notice that every page load on wp-admin, like listing posts, requests JITM one or twice
* Notice that activating or deactivating a plugin allows JITM caching to work (but only for one minute)
* After that one minute expires, jetpack_last_plugin_sync becomes 0 and JITM caching stops working. There will be JITM request(s) on every page load
* Install the code in this PR
* Now notice you have JITM caching even if it's been more than one minute since you activated or deactivated a plugin 