### PR TITLE
 Forms: Add JSON response to form submission and ajax request under feature flag

### DIFF
--- a/projects/packages/forms/changelog/update-forms-submit-ajax-json
+++ b/projects/packages/forms/changelog/update-forms-submit-ajax-json
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Forms: Add JSON response to form submission and ajax request under feature flag

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -428,12 +428,13 @@ class Contact_Form extends Contact_Form_Shortcode {
 			$is_multistep = $max_steps > 0;
 
 			$default_context = array(
-				'formId'      => $id,
-				'formHash'    => $form->hash,
-				'showErrors'  => false, // We toggle this to true when we want to show the user errors right away.
-				'errors'      => array(), // This should be a associative array.
-				'fields'      => array(),
-				'isMultiStep' => $is_multistep, // Whether the form is a multistep form.
+				'formId'                  => $id,
+				'formHash'                => $form->hash,
+				'showErrors'              => false, // We toggle this to true when we want to show the user errors right away.
+				'errors'                  => array(), // This should be a associative array.
+				'fields'                  => array(),
+				'isMultiStep'             => $is_multistep, // Whether the form is a multistep form.
+				'isAjaxSubmissionEnabled' => apply_filters( 'jetpack_forms_enable_ajax_submission', false ),
 			);
 
 			if ( $is_multistep ) {
@@ -650,6 +651,51 @@ class Contact_Form extends Contact_Form_Shortcode {
 		ksort( $compiled_form );
 
 		return $compiled_form;
+	}
+
+	/**
+	 * Returns the JSON data for the form submission.
+	 *
+	 * @param int          $feedback_id - the feedback ID.
+	 * @param Contact_Form $form - the form.
+	 *
+	 * @return array $json_data
+	 */
+	public static function get_json_data( $feedback_id, $form ) {
+		$raw_data  = self::get_raw_compiled_form_data( $feedback_id, $form );
+		$json_data = array();
+
+		// Handle file upload field (new structure with field_id and files array)
+		foreach ( $raw_data as $field_index => $field_data ) {
+			$value = $field_data['value'];
+			$label = $field_data['label'];
+
+			if ( self::is_file_upload_field( $value ) ) {
+				$files = $value['files'];
+
+				if ( empty( $files ) ) {
+					continue;
+				}
+
+				foreach ( $files as $file ) {
+					if ( ! empty( $file['file_id'] ) ) {
+						$file_name = isset( $file['name'] ) ? $file['name'] : __( 'Attached file', 'jetpack-forms' );
+						$file_size = isset( $file['size'] ) ? size_format( $file['size'] ) : '';
+
+						$json_data[ $field_index ]['label'] = $label;
+						$json_data[ $field_index ]['value'] = array(
+							'name' => $file_name,
+							'size' => $file_size,
+						);
+					}
+				}
+			} else {
+				$json_data[ $field_index ]['label'] = $label;
+				$json_data[ $field_index ]['value'] = $value;
+			}
+		}
+
+		return $json_data;
 	}
 
 	/**
@@ -1834,6 +1880,24 @@ class Contact_Form extends Contact_Form_Shortcode {
 		 * @param array $extra_values Contact form fields not included in $all_values
 		 */
 		do_action( 'grunion_after_message_sent', $post_id, $to, $subject, $message, $headers, $all_values, $extra_values );
+
+		// If the request accepts JSON, return a JSON response instead of redirecting
+		$is_ajax_submission_enabled = apply_filters( 'jetpack_forms_enable_ajax_submission', false );
+		$accepts_json               = isset( $_SERVER['HTTP_ACCEPT'] ) && false !== strpos( strtolower( sanitize_text_field( wp_unslash( $_SERVER['HTTP_ACCEPT'] ) ) ), 'application/json' );
+
+		if ( $is_ajax_submission_enabled && $accepts_json ) {
+			header( 'Content-Type: application/json' );
+
+			echo wp_json_encode(
+				array(
+					'success' => true,
+					'message' => __( 'Your message has been sent', 'jetpack-forms' ),
+					'data'    => self::get_json_data( $post_id, $this ),
+				)
+			);
+
+			exit( 0 );
+		}
 
 		if ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
 			return self::success_message( $post_id, $this );

--- a/projects/packages/forms/src/modules/form/shared.js
+++ b/projects/packages/forms/src/modules/form/shared.js
@@ -4,9 +4,11 @@ const getForm = formHash => {
 
 export const focusNextInput = formHash => {
 	const form = getForm( formHash );
+
 	if ( ! form ) {
 		return;
 	}
+
 	const currentStep = form.querySelector( '.is-current-step' );
 	const focusableElements = currentStep.querySelectorAll(
 		'input, select, textarea, .jetpack-form-file-field__dropzone-inner, [tabindex]:not([disabled])'
@@ -14,15 +16,48 @@ export const focusNextInput = formHash => {
 	focusableElements[ 0 ]?.focus();
 };
 
-export const submitForm = formHash => {
+export const dispatchSubmitEvent = formHash => {
 	const form = getForm( formHash );
+
 	if ( ! form ) {
 		return;
 	}
+
 	form.dispatchEvent(
 		new Event( 'submit', {
 			bubbles: true,
 			cancelable: true,
 		} )
 	);
+};
+
+export const submitForm = async formHash => {
+	const form = getForm( formHash );
+
+	if ( ! form ) {
+		return { success: false, error: 'Form not found' };
+	}
+
+	try {
+		const formData = new FormData( form );
+		const url = form.getAttribute( 'action' );
+
+		const response = await fetch( url, {
+			method: 'POST',
+			body: formData,
+			headers: {
+				Accept: 'application/json',
+			},
+		} );
+
+		if ( ! response.ok ) {
+			return { success: false, error: response.status };
+		}
+
+		const result = await response.json();
+
+		return result;
+	} catch ( error ) {
+		return { success: false, error: error.message };
+	}
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of FORMS-69

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds a feature flag, `jetpack_forms_enable_ajax_submission`, without which nothing happens
* If the flag is there and a form submission has a request header accepting JSON, responds with JSON instead of redirecting

This is the first step only. Presenting the submitted data will be done at a follow-up.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Publish a form
* Submit it and check that there is no regression
* Enable the flag with `add_filter( 'jetpack_forms_enable_ajax_submission', '__return_true' );`
* Reload the form and submit again
* Check that there is no redirection or page reload
* On the developer console, check that the submission response is a JSON object with the submitted data

