### PR TITLE
Fix flickering happening on My Jetpack tab switch

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/index.tsx
@@ -1,5 +1,5 @@
 import { TabPanel } from '@wordpress/components';
-import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate, useParams } from 'react-router';
 import useAnalytics from '../../hooks/use-analytics';
 import useIsJetpackUserNew from '../../hooks/use-is-jetpack-user-new';
@@ -20,15 +20,20 @@ export function MyJetpackTabPanel() {
 	const { recordEvent } = useAnalytics();
 	const isNewUser = useIsJetpackUserNew();
 	const tabStartTimeRef = useRef< number >( Date.now() );
+	const [ tabKey, setTabKey ] = useState( 0 );
+	const lastNavigationSourceRef = useRef< 'internal' | 'external' >( 'external' );
 
 	// If the tab is not valid, use the default one.
-	const initialTab = useMemo( () => {
+	const currentTab = useMemo( () => {
 		const validTab = isValidMyJetpackSection( params.section );
 		return validTab ? params.section : MY_JETPACK_SECTION_OVERVIEW;
 	}, [ params.section ] );
 	const onTabSelect = useCallback(
 		( tabName: string ) => {
 			if ( tabName !== params.section ) {
+				// Mark this as an internal navigation (user clicked a tab)
+				lastNavigationSourceRef.current = 'internal';
+
 				// Calculate session duration on previous tab
 				const sessionDuration = Math.floor( ( Date.now() - tabStartTimeRef.current ) / 1000 );
 
@@ -53,18 +58,27 @@ export function MyJetpackTabPanel() {
 		return <TabContent name={ tab.name as MyJetpackSection } />;
 	}, [] );
 
-	// Reset timer when component mounts or tab changes from external navigation
+	// Handle external navigation (URL changes not from tab clicks)
 	useEffect( () => {
+		// If this was an external navigation (browser back/forward, direct URL access)
+		if ( lastNavigationSourceRef.current === 'external' ) {
+			// Force remount to sync with URL
+			setTabKey( prev => prev + 1 );
+		}
+		// Reset navigation source for next change
+		lastNavigationSourceRef.current = 'external';
+
+		// Reset timer when tab changes
 		tabStartTimeRef.current = Date.now();
-	}, [ initialTab ] );
+	}, [ currentTab ] );
 
 	const tabs = useMemo( () => getMyJetpackSections(), [] );
 
 	return (
 		<TabPanel
-			key={ initialTab }
+			key={ tabKey }
 			className={ styles[ 'tab-panel' ] }
-			initialTabName={ initialTab }
+			initialTabName={ currentTab }
 			onSelect={ onTabSelect }
 			children={ tabRenderer }
 			tabs={ tabs }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes MYJP-200

## Proposed changes:
* It fixes key property for Tab Navigation component, so it doesn't trigger multiple rerenders on every tab switch

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
* Go to My Jetpack on JN and see that the flickering is reduced (and doesn't happen on tab content)

Bad:

https://github.com/user-attachments/assets/a165127d-8581-45c8-9c04-777344e2d268



Good: 


https://github.com/user-attachments/assets/ea1128b3-6050-40d2-a948-44b7f786ac72

