### PR TITLE
Like block: do not register block when not connected to wpcom

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-like-block-not-connected
+++ b/projects/plugins/jetpack/changelog/fix-like-block-not-connected
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Likes: do not register the Like block when a site is not connected to WordPress.com.

--- a/projects/plugins/jetpack/extensions/blocks/like/like.php
+++ b/projects/plugins/jetpack/extensions/blocks/like/like.php
@@ -20,16 +20,19 @@ use Jetpack_Gutenberg;
  * registration if we need to.
  */
 function register_block() {
-	$is_wpcom = defined( 'IS_WPCOM' ) && IS_WPCOM;
+	$is_wpcom     = defined( 'IS_WPCOM' ) && IS_WPCOM;
+	$is_connected = \Jetpack::is_connection_ready();
 
-	Blocks::jetpack_register_block(
-		__DIR__,
-		array(
-			'api_version'     => 3,
-			'render_callback' => __NAMESPACE__ . '\render_block',
-			'description'     => $is_wpcom ? __( 'Give your readers the ability to show appreciation for your posts and easily share them with others.', 'jetpack' ) : __( 'Give your readers the ability to show appreciation for your posts.', 'jetpack' ),
-		)
-	);
+	if ( $is_wpcom || $is_connected ) {
+		Blocks::jetpack_register_block(
+			__DIR__,
+			array(
+				'api_version'     => 3,
+				'render_callback' => __NAMESPACE__ . '\render_block',
+				'description'     => $is_wpcom ? __( 'Give your readers the ability to show appreciation for your posts and easily share them with others.', 'jetpack' ) : __( 'Give your readers the ability to show appreciation for your posts.', 'jetpack' ),
+			)
+		);
+	}
 }
 add_action( 'init', __NAMESPACE__ . '\register_block' );
 


### PR DESCRIPTION
Fixes CML-620

## Proposed changes:

When a site is not connected to WordPress.com, the Like block should not be available, since it relies on communication between the site and WordPress.com.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Start a new JN site
* Go to Settings > Jetpack Constants
* Switch your site to offline mode.
* Go to Jetpack > Settings > Writing
* Enable the blocks module
* Go to Posts > Add New
* Type in `/like`
    * The Like block should not be available.
* Go back to Settings > Jetpack Constants
* Turn off offline mode.
* Go to Jetpack > My Jetpack
* Connect your site to your WordPress.com account
* Go to Posts > Add New
* Type in `/like`
    * The Like block is now available.
