### PR TITLE
Admin Menu: Add back JITM upsells to default admin interface

### DIFF
--- a/projects/packages/masterbar/changelog/m4r73ch-888-free-domain-credit-banner-showing-in-calypso-but-not-in-wp
+++ b/projects/packages/masterbar/changelog/m4r73ch-888-free-domain-credit-banner-showing-in-calypso-but-not-in-wp
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Admin Menu: Add back JITM upsells to default admin interface

--- a/projects/packages/masterbar/src/admin-menu/admin-menu.js
+++ b/projects/packages/masterbar/src/admin-menu/admin-menu.js
@@ -146,9 +146,7 @@ import './admin-menu.css';
 					try {
 						if ( xhr.readyState === XMLHttpRequest.DONE ) {
 							if ( xhr.status === 200 && xhr.responseText ) {
-								adminMenu
-									.querySelector( '#toplevel_page_site_card' )
-									.insertAdjacentHTML( 'afterend', xhr.responseText );
+								adminMenu.insertAdjacentHTML( 'afterbegin', xhr.responseText );
 							}
 						}
 					} catch {


### PR DESCRIPTION
Fixes M4R73CH-888

## Proposed changes:

Adds back the JITM upsells to the sidebar on sites with the default admin interface.

Before | After
--- | ---
<img width="338" alt="Screenshot 2025-06-27 at 17 32 11" src="https://github.com/user-attachments/assets/f198cf6a-e041-42b7-8123-22a34d1e90a0" /> | <img width="461" alt="Screenshot 2025-06-27 at 17 36 59" src="https://github.com/user-attachments/assets/9c0f7efd-593d-49c1-9d4a-2802c962b932" />

They were inadvertently removed in https://github.com/Automattic/jetpack/pull/42499 after removing an element from the DOM that was required to exist before injecting the JITMs. 

This PR changes that logic so we no longer depends on that DOM element, it only needs the `#adminmenu` element which is the container of the admin menu.


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
- Apply these changes to your WP.com
- Switch to a WP.com Free site with the default admin interface active
- Go to `/wp-admin`
- You should see a "Free domain with an annual plan" upsell.
