### PR TITLE
tools: Better error in check-intra-monorepo-deps composer.lock update

### DIFF
--- a/tools/check-intra-monorepo-deps.sh
+++ b/tools/check-intra-monorepo-deps.sh
@@ -246,7 +246,7 @@ for SLUG in "${SLUGS[@]}"; do
 			{
 				debug "Updating $SLUG composer.lock (async)"
 				OLD="$(<composer.lock)"
-				"$BASE/tools/composer-update-monorepo.sh" --quiet --no-install --no-scripts --no-audit "$PROJECTFOLDER"
+				"$BASE/tools/composer-update-monorepo.sh" --quiet --no-install --no-scripts --no-audit "$PROJECTFOLDER" || die "Failed to update $SLUG composer.lock"
 				if [[ "$OLD" != "$(<composer.lock)" ]] && $DOCL; then
 					info "Creating changelog entry for $SLUG composer.lock update"
 					do_changelogger "$SLUG" '' 'Update composer.lock.'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
After the async updating added in #38069, the output is hard to interpret if something goes wrong. If the composer update fails, output a message indicating which project it failed in.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1751044223157759/1751035767.207239-slack-C01U2KGS2PQ

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Edit a plugin's composer.json to have a broken dependency, e.g. change the `"php": ">=7.4"` to `"php": ">=9000"` in CRM.
* Run `tools/check-intra-monorepo-deps.sh -U -P`.