### PR TITLE
jetpack-mu-wpcom: JITM: Improve JITM caching for wpcom sidebar notice

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-calypso-sidebar-jitm-caching
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-calypso-sidebar-jitm-caching
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Improves JITM caching and minimizes multiple wpcom sidebar jitm requests.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-sidebar-notice/wpcom-sidebar-notice.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-sidebar-notice/wpcom-sidebar-notice.php
@@ -58,6 +58,13 @@ add_action( 'admin_enqueue_scripts', 'wpcom_enqueue_sidebar_notice_assets' );
  * @return array | null
  */
 function wpcom_get_sidebar_notice() {
+	static $cached_notice = null;
+	static $cache_loaded  = false;
+
+	if ( $cache_loaded ) {
+		return $cached_notice;
+	}
+
 	$message_path = 'calypso:sites:sidebar_notice';
 
 	if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
@@ -75,14 +82,17 @@ function wpcom_get_sidebar_notice() {
 		$message = $jitm->get_messages( $message_path, wp_json_encode( array( 'message_path' => $message_path ) ), false );
 	}
 
+	$cache_loaded = true;
+
 	if ( ! isset( $message[0] ) ) {
+		$cached_notice = null;
 		return null;
 	}
 
 	// Serialize message as object (on Simple sites we have an array, on Atomic sites we have an object).
 	$message = json_decode( wp_json_encode( $message[0] ) );
 
-	return array(
+	$cached_notice = array(
 		'content'       => $message->content->message,
 		'cta'           => $message->CTA->message, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 		'link'          => $message->CTA->link, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
@@ -91,6 +101,8 @@ function wpcom_get_sidebar_notice() {
 		'id'            => $message->id,
 		'tracks'        => $message->tracks ?? null,
 	);
+
+	return $cached_notice;
 }
 
 /**

--- a/projects/packages/jitm/changelog/update-calypso-sidebar-jitm-caching
+++ b/projects/packages/jitm/changelog/update-calypso-sidebar-jitm-caching
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Improves JITM caching and minimizes multiple wpcom sidebar jitm requests.

--- a/projects/packages/jitm/src/class-post-connection-jitm.php
+++ b/projects/packages/jitm/src/class-post-connection-jitm.php
@@ -277,8 +277,10 @@ class Post_Connection_JITM extends JITM {
 			sprintf( '/sites/%d/jitm/%s', $site_id, $message_path )
 		);
 
+		$cache_key = 'jetpack_jitm_' . substr( md5( $path ), 0, 31 );
+
 		// Attempt to get from cache.
-		$envelopes = get_transient( 'jetpack_jitm_' . substr( md5( $path ), 0, 31 ) );
+		$envelopes = get_transient( $cache_key );
 
 		// If something is in the cache and it was put in the cache after the last sync we care about, use it.
 		$use_cache = false;
@@ -339,8 +341,7 @@ class Post_Connection_JITM extends JITM {
 			// Do not cache if expiration is 0 or we're not using the cache.
 			if ( 0 !== $expiration && $use_cache ) {
 				$envelopes['last_response_time'] = time();
-
-				set_transient( 'jetpack_jitm_' . substr( md5( $path ), 0, 31 ), $envelopes, $expiration );
+				set_transient( $cache_key, $envelopes, $expiration );
 			}
 		}
 


### PR DESCRIPTION
Fixes DOTSITE-33

## Proposed changes:

There are two high level issues that this PR addresses:

First, in the case where the `jetpack_last_plugin_sync` transient was falsey, JITMs wouldn't be served from cache. This resulted in firing off a JITM request on every dashboard page load of my site. We fix that by changing the logic to serve from cache if the last sync is empty as well.

Second, when we were then querying for the the wpcom sidebar notice JITM, we were making TWO JITM requests in the same dashboard page load. This is because we were hooking on `adminmenu` and also `admin_enqueue_scripts`. To address this, this pull requests adds static caching.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<\!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<\!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
 No, this PR only fixes caching behavior and does not change what data is tracked or collected

## Testing instructions:

- In an atomic site, delete the `jetpack_last_plugin_sync` transient
- While proxied, load the dashboard at `/wp-admin`. Check HTTP requests and see multiple sidebar notice requests.
- Reload the page. You should likely see the requests again.
- Checkout this branch.
- Reload the dashboard page.
- You should see no more requests.