### PR TITLE
Jetpack AI: change chrome experiment v2

### DIFF
--- a/projects/js-packages/ai-client/changelog/change-jetpack-forms-chrome-experiment-v2
+++ b/projects/js-packages/ai-client/changelog/change-jetpack-forms-chrome-experiment-v2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Jetpack AI: change Chrome AI experiment namme to v2

--- a/projects/js-packages/ai-client/src/chrome-ai/get-availability.ts
+++ b/projects/js-packages/ai-client/src/chrome-ai/get-availability.ts
@@ -94,7 +94,7 @@ export async function isChromeAIAvailable() {
 	} );
 
 	const { variationName } = await loadExperimentAssignmentWithAuth(
-		'calypso_jetpack_ai_gemini_api_202503_v1'
+		'calypso_jetpack_ai_gemini_api_202503_v2'
 	);
 
 	debug( 'variationName', variationName );


### PR DESCRIPTION
Part of JETPACK-28

## Proposed changes:
This PR changes the name of the experiment to start using v2

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1750865976932469-slack-C7HH3V5AS

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
TBD