### PR TITLE
Boost: Re-enable Base/Common E2E Tests

### DIFF
--- a/projects/plugins/boost/tests/e2e/specs/base/common.test.js
+++ b/projects/plugins/boost/tests/e2e/specs/base/common.test.js
@@ -6,67 +6,75 @@ import playwrightConfig from '_jetpack-e2e-commons/playwright.config.mjs';
 import { boostPrerequisitesBuilder } from '../../lib/env/prerequisites.js';
 import { JetpackBoostPage } from '../../lib/pages/index.js';
 
-test.afterAll( async ( { browser } ) => {
-	const page = await browser.newPage( playwrightConfig.use );
+test.describe( 'Common tests', () => {
+	let page;
 
-	await prerequisitesBuilder( page ).withActivePlugins( [ 'boost' ] ).build();
-	await boostPrerequisitesBuilder( page ).withConnection( true ).build();
-	await page.close();
-} );
+	test.beforeAll( async ( { browser } ) => {
+		page = await browser.newPage( playwrightConfig.use );
+		await boostPrerequisitesBuilder( page ).withCleanEnv( true ).withConnection( true ).build();
+	} );
 
-test( 'Click on the plugins page should navigate to Boost settings page', async ( { page } ) => {
-	await DashboardPage.visit( page );
-	await ( await Sidebar.init( page ) ).selectInstalledPlugins();
-	await ( await PluginsPage.init( page ) ).clickOnJetpackBoostSettingsLink();
-	expect( page.url(), "URL should contain 'page=jetpack-boost" ).toContain( 'page=jetpack-boost' );
-} );
+	test.afterAll( async () => {
+		await prerequisitesBuilder( page ).withActivePlugins( [ 'boost' ] ).build();
+		await boostPrerequisitesBuilder( page ).withConnection( true ).build();
 
-test( 'Click on the sidebar Boost Jetpack submenu should navigate to Boost settings page', async ( {
-	page,
-} ) => {
-	await DashboardPage.visit( page );
-	await ( await Sidebar.init( page ) ).selectJetpackBoost();
-	expect( page.url(), "URL should contain 'page=jetpack-boost" ).toContain( 'page=jetpack-boost' );
-} );
+		await page.close();
+	} );
 
-test( 'Deactivating the plugin should clear Critical CSS and Dismissed Recommendation notice option', async ( {
-	page,
-} ) => {
-	// Generate Critical CSS to ensure that on plugin deactivation it is cleared.
-	// TODO: Also should make sure that a Critical CSS recommendation is dismissed to check that the options does not exist after deactivation of the plugin.
-	await boostPrerequisitesBuilder( page )
-		.withCleanEnv( true )
-		.withActiveModules( [ 'critical_css' ] )
-		.build();
-	const jetpackBoostPage = await JetpackBoostPage.visit( page );
+	test( 'Click on the plugins page should navigate to Boost settings page', async () => {
+		await DashboardPage.visit( page );
+		await ( await Sidebar.init( page ) ).selectInstalledPlugins();
+		await ( await PluginsPage.init( page ) ).clickOnJetpackBoostSettingsLink();
+		expect( page.url(), "URL should contain 'page=jetpack-boost" ).toContain(
+			'page=jetpack-boost'
+		);
+	} );
 
-	// Wait for generation progress UI first
-	expect(
-		await jetpackBoostPage.waitForCriticalCssGenerationProgressUIVisibility(),
-		'Critical CSS generation progress indicator should be visible'
-	).toBeTruthy();
+	test( 'Click on the sidebar Boost Jetpack submenu should navigate to Boost settings page', async () => {
+		await DashboardPage.visit( page );
+		await ( await Sidebar.init( page ) ).selectJetpackBoost();
+		expect( page.url(), "URL should contain 'page=jetpack-boost" ).toContain(
+			'page=jetpack-boost'
+		);
+	} );
 
-	// Then wait for meta info to be visible
-	expect(
-		await jetpackBoostPage.waitForCriticalCssMetaInfoVisibility(),
-		'Critical CSS meta info should be visible'
-	).toBeTruthy();
+	test( 'Deactivating the plugin should clear Critical CSS and Dismissed Recommendation notice option', async () => {
+		// Generate Critical CSS to ensure that on plugin deactivation it is cleared.
+		// TODO: Also should make sure that a Critical CSS recommendation is dismissed to check that the options does not exist after deactivation of the plugin.
+		await boostPrerequisitesBuilder( page )
+			.withCleanEnv( true )
+			.withActiveModules( [ 'critical_css' ] )
+			.build();
+		const jetpackBoostPage = await JetpackBoostPage.visit( page );
 
-	await DashboardPage.visit( page );
-	await ( await Sidebar.init( page ) ).selectInstalledPlugins();
+		// Wait for generation progress UI first
+		expect(
+			await jetpackBoostPage.waitForCriticalCssGenerationProgressUIVisibility(),
+			'Critical CSS generation progress indicator should be visible'
+		).toBeTruthy();
 
-	// Deactivate boost
-	const pluginsPage = await PluginsPage.init( page );
-	await pluginsPage.deactivatePlugin( 'jetpack-boost' );
-	await pluginsPage.click( 'text=Just Deactivate' );
+		// Then wait for meta info to be visible
+		expect(
+			await jetpackBoostPage.waitForCriticalCssMetaInfoVisibility(),
+			'Critical CSS meta info should be visible'
+		).toBeTruthy();
 
-	let result;
-	result = await execWpCommand(
-		'db query \'SELECT ID FROM wp_posts WHERE post_type LIKE "%jb_store_%"\' --skip-column-names'
-	);
-	expect( result.length, 'No DB records are found' ).toBe( 0 );
-	result = await execWpCommand(
-		'db query \'SELECT option_id FROM wp_options WHERE option_name = "jb-critical-css-dismissed-recommendations"\' --skip-column-names'
-	);
-	expect( result.length, 'No DB records are found' ).toBe( 0 );
+		await DashboardPage.visit( page );
+		await ( await Sidebar.init( page ) ).selectInstalledPlugins();
+
+		// Deactivate boost
+		const pluginsPage = await PluginsPage.init( page );
+		await pluginsPage.deactivatePlugin( 'jetpack-boost' );
+		await pluginsPage.click( 'text=Just Deactivate' );
+
+		let result;
+		result = await execWpCommand(
+			'db query \'SELECT ID FROM wp_posts WHERE post_type LIKE "%jb_store_%"\' --skip-column-names'
+		);
+		expect( result.length, 'No DB records are found' ).toBe( 0 );
+		result = await execWpCommand(
+			'db query \'SELECT option_id FROM wp_options WHERE option_name = "jb-critical-css-dismissed-recommendations"\' --skip-column-names'
+		);
+		expect( result.length, 'No DB records are found' ).toBe( 0 );
+	} );
 } );

--- a/tools/e2e-commons/pages/wp-admin/sidebar.js
+++ b/tools/e2e-commons/pages/wp-admin/sidebar.js
@@ -22,7 +22,7 @@ export default class Sidebar extends WpPage {
 		const jetpackMenuSelector = '#toplevel_page_jetpack';
 		const menuItemSelector = '#toplevel_page_jetpack a[href$="jetpack-boost"]';
 
-		return await this._selectMenuItem( jetpackMenuSelector, menuItemSelector );
+		return await this._selectJetpackMenuItem( jetpackMenuSelector, menuItemSelector );
 	}
 
 	async selectNewPost() {


### PR DESCRIPTION
- Updated test common.test.js structure to use `test.describe` and `test.beforeAll` for better organization and readability.
- Enhanced the deactivation test to ensure proper cleanup of Critical CSS and dismissed recommendations.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

