### PR TITLE
Blocks: ensure a filter returns an array

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-extensions-always-array-JETPACK-581
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-extensions-always-array-JETPACK-581
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Blocks: return an error when a filter returns a non-array

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -277,7 +277,7 @@ class Jetpack_Gutenberg {
 	 */
 	public static function get_preset( $deprecated = null ) {
 		if ( $deprecated ) {
-			_deprecated_argument( __METHOD__, '$$next-version', 'The $preset argument is no longer needed or used.' );
+			_deprecated_argument( __METHOD__, '1.2.3', 'The $preset argument is no longer needed or used.' );
 		}
 
 		if ( self::$preset_cache ) {
@@ -413,11 +413,7 @@ class Jetpack_Gutenberg {
 			self::$extensions = apply_filters( 'jetpack_set_available_extensions', self::get_available_extensions() );
 
 			if ( ! is_array( self::$extensions ) ) {
-				_doing_it_wrong(
-					__METHOD__,
-					esc_html__( 'The jetpack_set_available_extensions filter must return an array.', 'jetpack' ),
-					'$$next-version$$'
-				);
+				_doing_it_wrong( __METHOD__, esc_html__( 'The jetpack_set_available_extensions filter must return an array.', 'jetpack' ), '$$next-version$$' );
 				self::$extensions = array();
 			}
 		}

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -411,6 +411,15 @@ class Jetpack_Gutenberg {
 			 * @param array
 			 */
 			self::$extensions = apply_filters( 'jetpack_set_available_extensions', self::get_available_extensions() );
+
+			if ( ! is_array( self::$extensions ) ) {
+				_doing_it_wrong(
+					__METHOD__,
+					esc_html__( 'The jetpack_set_available_extensions filter must return an array.', 'jetpack' ),
+					'$$next-version$$'
+				);
+				self::$extensions = array();
+			}
 		}
 
 		return self::$extensions;

--- a/tools/replace-next-version-tag.sh
+++ b/tools/replace-next-version-tag.sh
@@ -21,6 +21,9 @@ function usage {
 		   Other WordPress deprecation functions also work. The call must be on one
 		   line, indented with tabs, and the '$$next-version$$' token must be in a
 		   single-quoted string.
+		 - `_doing_it_wrong( ..., ..., '$$next-version$$' )`
+		   The call must be on one line, indented with tabs, and the '$$next-version$$'
+		   token must be in a single-quoted string as the third parameter.
 	EOH
 	exit 1
 }
@@ -88,6 +91,8 @@ for FILE in $(git ls-files "projects/$SLUG/"); do
 	sed -i.bak -E -e $'s!(^\t*_deprecated_(function|constructor|file|argument|hook|class)\\( .*, \'[^\']*)\\$\\$next-version\\$\\$\'!\\1'"$VE"$'\'!g' "$FILE"
 	rm "$FILE.bak" # We need a backup file because macOS requires it.
 	sed -i.bak -E -e $'s!((do_action|apply_filters)_deprecated\\( .*, \'[^\']*)\\$\\$next-version\\$\\$\'!\\1'"$VE"$'\'!g' "$FILE"
+	rm "$FILE.bak" # We need a backup file because macOS requires it.
+	sed -i.bak -E -e $'s!(^\t*_doing_it_wrong\\( .*, .*, \'[^\']*)\\$\\$next-version\\$\\$\'!\\1'"$VE"$'\'!g' "$FILE"
 	rm "$FILE.bak" # We need a backup file because macOS requires it.
 
 	if grep -F -q '$$next-version$$' "$FILE"; then


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Consumers of get_extension should be able to assume an array is returned. The upstream code will always provide an array, so let's force an empty one for a non-array and report the filter.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Ensure the extension is an array.
* doing_it_wrong for things not doing that.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
JETPACK-581

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add `add_filter( 'jetpack_set_available_extensions', '__return_false' )` to a site.
* Reproduce the situation of JETPACK-581 (e.g. look for these errors when publishing something new).

