### PR TITLE
My Jetpack: Fixing padding for Products tab

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/content.tsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/content.tsx
@@ -1,4 +1,5 @@
 import { __ } from '@wordpress/i18n';
+import clsx from 'clsx';
 import { Products } from './products';
 import styles from './styles.module.scss';
 
@@ -9,7 +10,7 @@ import styles from './styles.module.scss';
  */
 const ProductsContent = () => {
 	return (
-		<section className={ styles.content }>
+		<section className={ clsx( styles.content, 'my-jetpack-products-tab__content' ) }>
 			<h2>{ __( 'Products', 'jetpack-my-jetpack' ) }</h2>
 			<p className={ styles.description }>
 				{ __(

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/styles.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/styles.module.scss
@@ -5,6 +5,7 @@
 	.description {
 
 		@include gb.body-medium;
+
 		margin: 0;
 		color: #{gb.$gray-700};
 	}

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/styles.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/styles.module.scss
@@ -53,3 +53,7 @@
 	inset-inline-start: 50%;
 	margin-inline-start: -50vw;
 }
+
+.my-jetpack-tab-panel__products {
+	padding-block-end: 2.5rem;
+}

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/tab-content.tsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/tab-content.tsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx';
 import { FullWidthSeparator } from './full-width-separator';
 import { HelpContent } from './help/content';
 import { OverviewContent } from './overview/content';
@@ -30,10 +31,12 @@ export function TabContent( { name }: TabContentProps ) {
 		return null;
 	}
 
+	const tabClassName = `my-jetpack-tab-panel__${ name }`; // some tabs need other styling than others
+
 	return (
 		<>
 			<FullWidthSeparator />
-			<div className={ styles[ 'tab-content-wrapper' ] }>
+			<div className={ clsx( styles[ 'tab-content-wrapper' ], styles[ tabClassName ] ) }>
 				<ContentComponent />
 			</div>
 		</>

--- a/projects/packages/my-jetpack/changelog/update-myjetpack-myjp-192-fix-mj-products-padding
+++ b/projects/packages/my-jetpack/changelog/update-myjetpack-myjp-192-fix-mj-products-padding
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: My Jetpack: Fixing missing padding for the Products tab
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes MYJP-192

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* adding padding at the bottom of the page because the current state doesn't look good after applying https://github.com/Automattic/jetpack/pull/44146
* I also added a CSS class that doesn't use CSS modules for easier debugging

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Start a JN site for the branch
* Verify that the bottom of the Products tab has `2.5rem` padding bottom

