### PR TITLE
My Jetpack: Fix the alignment and responsiveness of product cards.

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/product-section.tsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/product-section.tsx
@@ -32,7 +32,7 @@ export function ProductSection( { section }: ProductSectionProps ) {
 		>
 			<h2 className={ styles[ 'section-heading' ] }>{ section.title }</h2>
 			{ section.cards?.length ? (
-				<Grid as="ul" gap={ 6 } columns={ [ 1, 1, 1, 2 ] } className={ styles[ 'product-cards' ] }>
+				<Grid as="ul" gap={ 6 } className={ styles[ 'product-cards' ] }>
 					{ section.cards.map( card => (
 						<li key={ card.product.slug }>
 							<ProductCard product={ card.product } module={ card.module } />

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/styles.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/styles.module.scss
@@ -32,7 +32,7 @@
 
 .filters-wrapper {
 
-	@include gb.break-small{
+	@include gb.break-small {
 		max-width: 12rem;
 	}
 
@@ -113,7 +113,7 @@
 		border: 1px solid rgba(0, 0, 0, 0.1);
 	}
 
-	div[data-wp-component="CardHeader"]{
+	div[data-wp-component="CardHeader"] {
 		border-bottom: 0;
 		padding-bottom: 0;
 		padding-top: 1.5rem;
@@ -123,7 +123,7 @@
 		padding-bottom: 1.5rem;
 	}
 
-	.icon-wrapper{
+	.icon-wrapper {
 		width: 3rem;
 		height: 3rem;
 		flex-shrink: 0;

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/styles.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/styles.module.scss
@@ -79,7 +79,7 @@
 		margin-block: 0;
 		grid-template-columns: repeat(1, 1fr);
 
-		@include gb.break-xlarge {
+		@include gb.break-wide {
 			// Use 2 columns for large screens
 			grid-template-columns: repeat(2, minmax(0, 1fr));
 		}

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/styles.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/styles.module.scss
@@ -77,6 +77,13 @@
 
 	.product-cards {
 		margin-block: 0;
+		grid-template-columns: repeat(1, 1fr);
+
+		@include gb.break-xlarge {
+			// Use 2 columns for large screens
+			grid-template-columns: repeat(2, 1fr);
+		}
+
 
 		div[data-wp-component="Card"] {
 			height: 100%;
@@ -119,7 +126,7 @@
 	.icon-wrapper{
 		width: 3rem;
 		height: 3rem;
-		flex-shrink: 0
+		flex-shrink: 0;
 	}
 
 	.card-title {

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/styles.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/styles.module.scss
@@ -81,7 +81,7 @@
 
 		@include gb.break-xlarge {
 			// Use 2 columns for large screens
-			grid-template-columns: repeat(2, 1fr);
+			grid-template-columns: repeat(2, minmax(0, 1fr));
 		}
 
 

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/styles.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/styles.module.scss
@@ -125,6 +125,7 @@
 	.card-title {
 
 		@include gb.heading-large;
+		margin-block: 0;
 	}
 
 	.card-description {

--- a/projects/packages/my-jetpack/changelog/fix-my-jetpack-product-card-alignment
+++ b/projects/packages/my-jetpack/changelog/fix-my-jetpack-product-card-alignment
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Products: Fix the alignment and responsiveness of product cards.


### PR DESCRIPTION


Currently, if the card title wraps into two lines, the icon and the title misalign.
<img width="777" alt="Screenshot 2025-07-01 at 11 28 22 AM" src="https://github.com/user-attachments/assets/23078641-915c-426b-99bb-2f4f006f73d8" />

Also, the cards are not very responsive at certain breakpoints, like 1050px

Fixes MYJP-207

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Remove the block margins for the card title to avoid unintentional spacing in cards.
* Fix the responsiveness of the cards grid to make them visible 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to My Jetpack > Products
* Confirm that when the card title breaks into two lines, the icons are still aligned.
* Confirm that the cards break into single line below `1080px`

<table>
    <tbody>
        <tr>
            <th>BEFORE</th>
            <th>AFTER</th>
        </tr>
        <tr>
            <th colspan="2">Card elements' alignment</th>
        </tr>
        <tr>
            <td>
<img width="820" alt="Screenshot 2025-07-01 at 11 21 03 AM" src="https://github.com/user-attachments/assets/0e5230c3-b0a5-4ffa-9d74-cbde5316f769" />
</td>
            <td>
<img width="835" alt="Screenshot 2025-07-01 at 11 22 12 AM" src="https://github.com/user-attachments/assets/e7f98bde-cf3e-4fa3-9cdf-fdd8b26efa5f" />
</td>
        </tr>
        <tr>
            <th colspan="2">Responsiveness around 1050px</th>
        </tr>
        <tr>
            <td>
<img width="656" alt="Screenshot 2025-07-01 at 11 30 37 AM" src="https://github.com/user-attachments/assets/e7d4f46e-70ac-47d1-a0f6-e51f8c998891" />
</td>
            <td>
<img width="608" alt="Screenshot 2025-07-01 at 11 33 17 AM" src="https://github.com/user-attachments/assets/2611ba4e-aa95-4383-90be-21f038519cf8" />
</td>
        </tr>
    </tbody>
</table>
