### PR TITLE
Jetpack: Update the name for Monitor module to Downtime Monitor

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-monitor-module-name
+++ b/projects/plugins/jetpack/changelog/update-jetpack-monitor-module-name
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Update the name for Downtime Monitor module.

--- a/projects/plugins/jetpack/modules/monitor.php
+++ b/projects/plugins/jetpack/modules/monitor.php
@@ -1,6 +1,6 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 /**
- * Module Name: Monitor
+ * Module Name: Downtime Monitor
  * Module Description: Get instant alerts if your site goes down and know when it’s back online.
  * Sort Order: 28
  * Recommendation Order: 10


### PR DESCRIPTION
Fixes MYJP-206

Addresses some of the feedback from @keoshi in https://github.com/Automattic/jetpack/pull/43870#issuecomment-3018475030

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Rename "Monitor" module to "Downtime Monitor" 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to My Jetpack > Products
* Confirm that the security section has "Downtime Monitor" instead of just "Monitor"

<img width="813" alt="Screenshot 2025-07-01 at 2 37 17 PM" src="https://github.com/user-attachments/assets/59a09a4e-6680-4578-a01b-91d95a5540f1" />
