### PR TITLE
Add Jetpack > Scan admin menu on Simple Sites

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-jetpack-scan-admin-menu
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-jetpack-scan-admin-menu
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Make Jetpack > Scan available for Simple Sites
+
+

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
@@ -208,13 +208,13 @@ add_action( 'admin_menu', 'wpcom_add_hosting_menu' );
  * @return void
  */
 function wpcom_add_untangled_jetpack_menu() {
-	$domain                  = wp_parse_url( home_url(), PHP_URL_HOST );
+	$domain = wp_parse_url( home_url(), PHP_URL_HOST );
 
 	wpcom_hide_submenu_page( 'jetpack', esc_url( Redirect::get_url( 'calypso-scanner' ) ) );
 
 	Jetpack_Admin_UI_Admin::add_menu(
-		esc_attr__( 'Scan', 'jetpack-masterbar' ),
-		__( 'Scan', 'jetpack-masterbar' ),
+		esc_attr__( 'Scan', 'jetpack-mu-wpcom' ),
+		__( 'Scan', 'jetpack-mu-wpcom' ),
 		'manage_options',
 		'https://wordpress.com/scan/' . $domain,
 		/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
@@ -263,16 +263,14 @@ function wpcom_add_jetpack_submenu() {
 		null // @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
 	);
 
-	if ( $is_atomic_site ) {
-		add_submenu_page(
-			'jetpack',
-			__( 'Scan', 'jetpack-mu-wpcom' ),
-			__( 'Scan', 'jetpack-mu-wpcom' ),
-			'manage_options',
-			$scan_url,
-			null // @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
-		);
-	}
+	add_submenu_page(
+		'jetpack',
+		__( 'Scan', 'jetpack-mu-wpcom' ),
+		__( 'Scan', 'jetpack-mu-wpcom' ),
+		'manage_options',
+		$scan_url,
+		null // @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
+	);
 
 	if ( ! apply_filters( 'jetpack_wp_admin_subscriber_management_enabled', false ) ) {
 		add_submenu_page(

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
@@ -7,6 +7,7 @@
  * @package automattic/jetpack-mu-wpcom
  */
 
+use Automattic\Jetpack\Admin_UI\Admin_Menu as Jetpack_Admin_UI_Admin;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Redirect;
 use Automattic\Jetpack\Status;
@@ -200,6 +201,33 @@ function wpcom_add_hosting_menu() {
 add_action( 'admin_menu', 'wpcom_add_hosting_menu' );
 
 /**
+ * Register the submenu items for Jetpack menu.
+ *
+ * We require a separate function for this because the priority needs to be 999.
+ *
+ * @return void
+ */
+function wpcom_add_untangled_jetpack_menu() {
+	$domain                  = wp_parse_url( home_url(), PHP_URL_HOST );
+
+	wpcom_hide_submenu_page( 'jetpack', esc_url( Redirect::get_url( 'calypso-scanner' ) ) );
+
+	Jetpack_Admin_UI_Admin::add_menu(
+		esc_attr__( 'Scan', 'jetpack-masterbar' ),
+		__( 'Scan', 'jetpack-masterbar' ),
+		'manage_options',
+		'https://wordpress.com/scan/' . $domain,
+		/**
+		 * Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
+		 */
+		null,
+		5
+	);
+}
+
+add_action( 'admin_menu', 'wpcom_add_untangled_jetpack_menu', 999 );
+
+/**
  * Adds WordPress.com submenu items related to Jetpack under the Jetpack admin menu.
  */
 function wpcom_add_jetpack_submenu() {
@@ -232,7 +260,6 @@ function wpcom_add_jetpack_submenu() {
 	$monetize_url     = 'https://wordpress.com/earn/' . $domain;
 	$subscribers_url  = 'https://wordpress.com/subscribers/' . $domain;
 	$newsletter_url   = 'https://wordpress.com/settings/newsletter/' . $domain;
-	$scan_url         = 'https://wordpress.com/scan/' . $domain;
 	$podcasting_url   = 'https://wordpress.com/settings/podcasting/' . $domain;
 
 	// Add submenu items that link to WordPress.com.
@@ -260,15 +287,6 @@ function wpcom_add_jetpack_submenu() {
 		__( 'Monetize', 'jetpack-mu-wpcom' ),
 		'manage_options',
 		$monetize_url,
-		null // @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
-	);
-
-	add_submenu_page(
-		'jetpack',
-		__( 'Scan', 'jetpack-mu-wpcom' ),
-		__( 'Scan', 'jetpack-mu-wpcom' ),
-		'manage_options',
-		$scan_url,
 		null // @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
 	);
 
@@ -320,7 +338,6 @@ function wpcom_add_jetpack_submenu() {
 		$vaultpress_url,
 		'akismet-key-config',
 		'jetpack-search',
-		$scan_url,
 		$monetize_url,
 		$subscribers_url,
 	);

--- a/projects/packages/masterbar/changelog/update-jetpack-scan-admin-menu
+++ b/projects/packages/masterbar/changelog/update-jetpack-scan-admin-menu
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Remove the Scan from nav-unification
+
+

--- a/projects/packages/masterbar/src/admin-menu/class-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-admin-menu.php
@@ -449,7 +449,6 @@ class Admin_Menu extends Base_Admin_Menu {
 		if ( self::DEFAULT_VIEW === $this->get_preferred_view( 'jetpack' ) ) {
 			$this->hide_submenu_page( 'jetpack', 'jetpack#/settings' );
 			$this->hide_submenu_page( 'jetpack', esc_url( Redirect::get_url( 'calypso-backups' ) ) );
-			$this->hide_submenu_page( 'jetpack', esc_url( Redirect::get_url( 'calypso-scanner' ) ) );
 		}
 
 		if ( ! $is_menu_updated ) {

--- a/projects/packages/masterbar/src/admin-menu/class-atomic-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-atomic-admin-menu.php
@@ -269,19 +269,6 @@ class Atomic_Admin_Menu extends Admin_Menu {
 			parent::add_jetpack_menu();
 		}
 
-		$scan_position = $this->get_submenu_item_count( 'jetpack' ) - 1;
-
-		global $submenu;
-		if ( isset( $submenu['jetpack'] ) ) {
-			$backup_submenu_label = __( 'Backup', 'jetpack-masterbar' );
-			$submenu_labels       = array_column( $submenu['jetpack'], 3 );
-			$backup_position      = array_search( $backup_submenu_label, $submenu_labels, true );
-			$scan_position        = $backup_position !== false ? $backup_position + 1 : $this->get_submenu_item_count( 'jetpack' ) - 1;
-		}
-
-		// @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
-		add_submenu_page( 'jetpack', esc_attr__( 'Scan', 'jetpack-masterbar' ), __( 'Scan', 'jetpack-masterbar' ), 'manage_options', 'https://wordpress.com/scan/' . $this->domain, null, $scan_position );
-
 		/**
 		 * Prevent duplicate menu items that link to Jetpack Backup.
 		 * Hide the one that's shown when the standalone backup plugin is not installed, since Jetpack Backup is already included in Atomic sites.

--- a/projects/packages/masterbar/tests/php/Atomic_Admin_Menu_Test.php
+++ b/projects/packages/masterbar/tests/php/Atomic_Admin_Menu_Test.php
@@ -236,16 +236,4 @@ class Atomic_Admin_Menu_Test extends TestCase {
 
 		$this->assertContains( 'https://wordpress.com/github-deployments/' . static::$domain, $links );
 	}
-
-	/**
-	 * Tests add_jetpack_scan_menu
-	 */
-	public function test_add_jetpack_scan_submenu() {
-		global $submenu;
-
-		static::$admin_menu->add_jetpack_menu();
-		$links = wp_list_pluck( array_values( $submenu['jetpack'] ), 2 );
-
-		$this->assertContains( 'https://wordpress.com/scan/' . static::$domain, $links );
-	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Add the Jetpack > Scan Admin menu for Simple Sites.

Fixes DOTCOM-13640

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Remove the is_atomic_site check for Jetpack > Scan admin menu

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this PR on your sandbox
* Go to wp-admin and notice that "Jetpack > Scan" appears in the admin menu
* Apply this PR on your Atomic site
* Make sure we didn't introduce any regressions (the menu is the same, there's no duplicate, etc).

