### PR TITLE
Admin Bar: Make the plan sub-item clickable

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/dotcom-13657-make-the-plan-label-in-the-actionbar-clickable
+++ b/projects/packages/jetpack-mu-wpcom/changelog/dotcom-13657-make-the-plan-label-in-the-actionbar-clickable
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Make the Plans sub-item of the WordPress.com admin bar clickable.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.js
@@ -1,0 +1,13 @@
+import { wpcomTrackEvent } from '../../common/tracks';
+
+import './wpcom-admin-bar.scss';
+
+document.addEventListener( 'DOMContentLoaded', () => {
+	const launchButton = document.querySelector( '#wp-admin-bar-site-plan-badge a' );
+	if ( ! launchButton ) {
+		return;
+	}
+	launchButton.addEventListener( 'click', () => {
+		wpcomTrackEvent( 'wpcom_adminbar_plan_clicked' );
+	} );
+} );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
@@ -416,7 +416,7 @@ function wpcom_add_site_badges_and_plan( $wp_admin_bar ) {
 	if ( $badge_text ) {
 		$status_text = '<div class="wp-admin-bar__site-info">
 							<span class="wp-admin-bar__site-info-label">' . __( 'Status', 'jetpack-mu-wpcom' ) . '</span>
-							<div class="wp-admin-bar__info-badges">' . esc_html( $badge_text ) . '</div>
+							<span class="wp-admin-bar__info-badges">' . esc_html( $badge_text ) . '</span>
 						</div>';
 	}
 
@@ -430,42 +430,59 @@ function wpcom_add_site_badges_and_plan( $wp_admin_bar ) {
 			$current_plan = Current_Plan::get();
 		}
 		$plan_name = $current_plan['product_name_short'] ?? '';
+
 		if ( $plan_name ) {
-			$plan_text = '<div class="wp-admin-bar__site-info">
-							<span class="wp-admin-bar__site-info-label">' . __( 'Plan', 'jetpack-mu-wpcom' ) . '</span>
-							<div class="wp-admin-bar__info-badges">' . esc_html( $plan_name ) . '</div>
-						</div>';
+			$site_slug = method_exists( '\WPCOM_Masterbar', 'get_calypso_site_slug' )
+				? WPCOM_Masterbar::get_calypso_site_slug( get_current_blog_id() )
+				: '';
+
+			if ( $site_slug ) {
+				$plan_text = '<a class="wp-admin-bar__site-info" href="https://wordpress.com/plans/' . esc_attr( $site_slug ) . '">
+								<span class="wp-admin-bar__site-info-label">' . __( 'Plan', 'jetpack-mu-wpcom' ) . '</span>
+								<span class="wp-admin-bar__info-badges">' . esc_html( $plan_name ) . '</span>
+							</a>';
+			} else {
+				$plan_text = '<div class="wp-admin-bar__site-info">
+								<span class="wp-admin-bar__site-info-label">' . __( 'Plan', 'jetpack-mu-wpcom' ) . '</span>
+								<span class="wp-admin-bar__info-badges">' . esc_html( $plan_name ) . '</span>
+							</div>';
+			}
 		}
 	}
 
-	if ( $status_text || $plan_text ) {
+	if ( $plan_text ) {
 		$wp_admin_bar->add_group(
 			array(
 				'parent' => 'site-name',
-				'id'     => 'site-badge',
+				'id'     => 'site-plan',
+			)
+		);
+		$wp_admin_bar->add_node(
+			array(
+				'parent' => 'site-plan',
+				'id'     => 'site-plan-badge',
+				'title'  => $plan_text,
+			)
+		);
+	}
+
+	if ( $status_text ) {
+		$wp_admin_bar->add_group(
+			array(
+				'parent' => 'site-name',
+				'id'     => 'site-status',
 				'meta'   => array(
 					'class' => 'ab-sub-secondary',
 				),
 			)
 		);
-		if ( $status_text ) {
-			$wp_admin_bar->add_node(
-				array(
-					'parent' => 'site-badge',
-					'id'     => 'site-badge-status',
-					'title'  => $status_text,
-				)
-			);
-		}
-		if ( $plan_text ) {
-			$wp_admin_bar->add_node(
-				array(
-					'parent' => 'site-badge',
-					'id'     => 'site-badge-plan',
-					'title'  => $plan_text,
-				)
-			);
-		}
+		$wp_admin_bar->add_node(
+			array(
+				'parent' => 'site-status',
+				'id'     => 'site-status-badge',
+				'title'  => $status_text,
+			)
+		);
 	}
 }
 add_action( 'admin_bar_menu', 'wpcom_add_site_badges_and_plan', 35 );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
@@ -51,11 +51,24 @@ function maybe_add_origin_site_id_to_url( $url ) {
  * Enqueue assets needed by the WordPress.com admin bar.
  */
 function wpcom_enqueue_admin_bar_assets() {
+	$asset_file = include Jetpack_Mu_Wpcom::BASE_DIR . 'build/wpcom-admin-bar/wpcom-admin-bar.asset.php';
+
+	wp_enqueue_script(
+		'wpcom-admin-bar',
+		plugins_url( 'build/wpcom-admin-bar/wpcom-admin-bar.js', Jetpack_Mu_Wpcom::BASE_FILE ),
+		$asset_file['dependencies'] ?? array(),
+		$asset_file['version'] ?? filemtime( Jetpack_Mu_Wpcom::BASE_DIR . 'build/wpcom-admin-bar/wpcom-admin-bar.js' ),
+		array(
+			'strategy'  => 'defer',
+			'in_footer' => true,
+		)
+	);
+
 	wp_enqueue_style(
 		'wpcom-admin-bar',
 		plugins_url( 'build/wpcom-admin-bar/wpcom-admin-bar.css', Jetpack_Mu_Wpcom::BASE_FILE ),
 		array(),
-		Jetpack_Mu_Wpcom::PACKAGE_VERSION
+		$asset_file['version'] ?? filemtime( Jetpack_Mu_Wpcom::BASE_DIR . 'build/wpcom-admin-bar/wpcom-admin-bar.css' )
 	);
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.scss
@@ -125,19 +125,21 @@
 /**
  * Site badge and plan info in the dropdown
  */
-#wp-admin-bar-site-badge {
+#wp-admin-bar-site-plan,
+#wp-admin-bar-site-status {
 	display: flex;
 	flex-direction: column;
 	gap: 4px;
 	min-width: 260px;
 }
 
-#wp-admin-bar-site-badge-status .ab-item,
-#wp-admin-bar-site-badge-plan .ab-item {
+#wp-admin-bar-site-plan-badge .ab-item,
+#wp-admin-bar-site-status-badge .ab-item {
 	height: auto !important;
 }
 
-#wpadminbar .wp-admin-bar__site-info {
+#wpadminbar .wp-admin-bar__site-info,
+#wpadminbar a.wp-admin-bar__site-info {
 	display: flex;
 	flex-direction: row;
 	justify-content: space-between;
@@ -161,6 +163,15 @@
 	line-height: 20px;
 	display: flex;
 	align-items: center;
+}
+
+#wpadminbar a.wp-admin-bar__site-info {
+	display: flex;
+	padding: 0;
+
+	.wp-admin-bar__info-badges {
+		color: rgba(240, 246, 252, .7);
+	}
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/webpack.config.js
+++ b/projects/packages/jetpack-mu-wpcom/webpack.config.js
@@ -29,7 +29,7 @@ module.exports = async () => {
 				'paragraph-block-placeholder':
 					'./src/features/paragraph-block-placeholder/paragraph-block-placeholder.js',
 				'tags-education': './src/features/tags-education/tags-education.js',
-				'wpcom-admin-bar': './src/features/wpcom-admin-bar/wpcom-admin-bar.scss',
+				'wpcom-admin-bar': './src/features/wpcom-admin-bar/wpcom-admin-bar.js',
 				'wpcom-blocks-event-countdown-editor':
 					'./src/features/wpcom-blocks/event-countdown/editor.js',
 				'wpcom-blocks-event-countdown-view': './src/features/wpcom-blocks/event-countdown/view.js',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of DOTCOM-13657

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* On the Dotcom admin bar, make the Plan sub-item clickable, sending to `wordpress.com/plans/{SITE}`.
* Clicking the item records a `wpcom_adminbar_plan_clicked` event.
* Also reorder the menu so that the clickable Plan item is adjacent the other clickable items, instead of being separated by the Status item.

| Before | After |
|--------|--------|
| ![Screenshot 2025-07-01 at 17 07 33](https://github.com/user-attachments/assets/da0f856c-5920-476a-a91e-90d7c54e4695) | ![Screenshot 2025-07-01 at 17 07 06](https://github.com/user-attachments/assets/e6affb63-5d71-4e72-bfa2-437f2ac654fe) | 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

DOTCOM-13657

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

These instructions can only be executed by Automatticians.

* Apply these changes to your sandbox (PCYsg-Osp-p2), and sandbox a test site.
* Check the site's front-end or wp-admin (but not Calypso — that requires a separate change).
* Look at the primary menu of the admin bar, the one displaying the site title. Hover on it to open it.
* Confirm the Plan item is clickable, looks as expected, and opens `wordpress.com/plans/{SITE}`.