### PR TITLE
Blocks: defensive coding against jetpack_set_available_extensions

### DIFF
--- a/projects/plugins/jetpack/changelog/update-blocks-defensive-arrays
+++ b/projects/plugins/jetpack/changelog/update-blocks-defensive-arrays
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Blocks: defensive coding to prevent errors from plugins malforming extensions.

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -277,7 +277,7 @@ class Jetpack_Gutenberg {
 	 */
 	public static function get_preset( $deprecated = null ) {
 		if ( $deprecated ) {
-			_deprecated_argument( __METHOD__, '1.2.3', 'The $preset argument is no longer needed or used.' );
+			_deprecated_argument( __METHOD__, '14.3', 'The $preset argument is no longer needed or used.' );
 		}
 
 		if ( self::$preset_cache ) {

--- a/projects/plugins/jetpack/extensions/extended-blocks/core-audio/core-audio.php
+++ b/projects/plugins/jetpack/extensions/extended-blocks/core-audio/core-audio.php
@@ -10,7 +10,7 @@ add_filter(
 	'jetpack_set_available_extensions',
 	function ( $extensions ) {
 		return array_merge(
-			$extensions,
+			(array) $extensions,
 			array(
 				'core/audio',
 			)

--- a/projects/plugins/jetpack/extensions/extended-blocks/core-cover/core-cover.php
+++ b/projects/plugins/jetpack/extensions/extended-blocks/core-cover/core-cover.php
@@ -10,7 +10,7 @@ add_filter(
 	'jetpack_set_available_extensions',
 	function ( $extensions ) {
 		return array_merge(
-			$extensions,
+			(array) $extensions,
 			array(
 				'core/cover',
 			)

--- a/projects/plugins/jetpack/extensions/extended-blocks/core-video/core-video.php
+++ b/projects/plugins/jetpack/extensions/extended-blocks/core-video/core-video.php
@@ -10,7 +10,7 @@ add_filter(
 	'jetpack_set_available_extensions',
 	function ( $extensions ) {
 		return array_merge(
-			$extensions,
+			(array) $extensions,
 			array(
 				'core/video',
 			)

--- a/projects/plugins/jetpack/extensions/extended-blocks/premium-content-container/premium-content-container.php
+++ b/projects/plugins/jetpack/extensions/extended-blocks/premium-content-container/premium-content-container.php
@@ -10,7 +10,7 @@ add_filter(
 	'jetpack_set_available_extensions',
 	function ( $extensions ) {
 		return array_merge(
-			$extensions,
+			(array) $extensions,
 			array(
 				'premium-content/container',
 			)

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-assistant-plugin.php
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-assistant-plugin.php
@@ -41,7 +41,7 @@ add_filter(
 	'jetpack_set_available_extensions',
 	function ( $extensions ) {
 		return array_merge(
-			$extensions,
+			(array) $extensions,
 			array(
 				FEATURE_NAME,
 			)

--- a/projects/plugins/jetpack/extensions/plugins/ai-content-lens/ai-content-lens.php
+++ b/projects/plugins/jetpack/extensions/plugins/ai-content-lens/ai-content-lens.php
@@ -38,7 +38,7 @@ add_filter(
 	'jetpack_set_available_extensions',
 	function ( $extensions ) {
 		return array_merge(
-			$extensions,
+			(array) $extensions,
 			array(
 				FEATURE_NAME,
 			)

--- a/projects/plugins/jetpack/extensions/plugins/payments/payments.php
+++ b/projects/plugins/jetpack/extensions/plugins/payments/payments.php
@@ -18,7 +18,7 @@ add_filter(
 	'jetpack_set_available_extensions',
 	function ( $extensions ) {
 		return array_merge(
-			$extensions,
+			(array) $extensions,
 			array(
 				FEATURE_NAME,
 			)

--- a/projects/plugins/jetpack/extensions/plugins/post-publish-qr-post-panel/post-publish-qr-post-panel.php
+++ b/projects/plugins/jetpack/extensions/plugins/post-publish-qr-post-panel/post-publish-qr-post-panel.php
@@ -13,7 +13,7 @@ add_filter(
 	'jetpack_set_available_extensions',
 	function ( $extensions ) {
 		return array_merge(
-			$extensions,
+			(array) $extensions,
 			array(
 				FEATURE_NAME,
 			)

--- a/projects/plugins/jetpack/extensions/plugins/publicize/publicize.php
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/publicize.php
@@ -58,7 +58,7 @@ add_filter(
 	'jetpack_set_available_extensions',
 	function ( $extensions ) {
 		return array_merge(
-			$extensions,
+			(array) $extensions,
 			array(
 				'republicize',
 			)

--- a/projects/plugins/jetpack/extensions/plugins/seo/seo.php
+++ b/projects/plugins/jetpack/extensions/plugins/seo/seo.php
@@ -44,7 +44,7 @@ add_filter(
 	'jetpack_set_available_extensions',
 	function ( $extensions ) {
 		return array_merge(
-			$extensions,
+			(array) $extensions,
 			array( 'advanced-seo' )
 		);
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Follow-up to #44144
ref JETPACK-581

Adds additional defensive type casting to ensure arrays are being used through the `jetpack_set_available_extensions` filter within Jetpack.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Always cast an array before using an array-requiring function.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* `add_filter( 'jetpack_set_available_extensions', '__return_false', 9 );`
* Before patch, it'll fatal on first time the filter is invoked within Jetpack (core-audio.php)
* After patch, all joyful.

