### PR TITLE
VideoPress: Fix video row action button clickability by properly hiding upload date on hover

### DIFF
--- a/projects/packages/videopress/changelog/update-upload-local-video-btn
+++ b/projects/packages/videopress/changelog/update-upload-local-video-btn
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress: Fix video row action button clickability by properly hiding stats on hover

--- a/projects/packages/videopress/src/client/admin/components/video-row/style.module.scss
+++ b/projects/packages/videopress/src/client/admin/components/video-row/style.module.scss
@@ -23,9 +23,7 @@
 		background-color: var( --jp-gray-0 );
 
 		.stats:not(.mobile-stats) {
-			opacity: 0;
-			width: 0;
-			height: 0;
+			display: none;
 		}
 
 		.actions {

--- a/projects/plugins/jetpack/changelog/update-upload-local-video-btn
+++ b/projects/plugins/jetpack/changelog/update-upload-local-video-btn
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+VideoPress: Fix video row action button clickability by properly hiding stats on hover

--- a/projects/plugins/videopress/changelog/update-upload-local-video-btn
+++ b/projects/plugins/videopress/changelog/update-upload-local-video-btn
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress: Fix video row action button clickability by properly hiding stats on hover


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/VIDP-22/videopress-local-videos-upload-to-videopress-button-doesnt-trigger-the

## Proposed changes:

Fix video row action button clickability by properly hiding stats on hover. Previously, stats were hidden using opacity and dimensions which kept the element in the document flow, blocking click events. Now using `display: none` to completely remove the element when hovering, ensuring action buttons are fully interactive.

<img width="1187" alt="Screenshot 2025-07-01 at 22 33 19" src="https://github.com/user-attachments/assets/70adc060-9b18-4517-870e-0b72e3a58097" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to `Media -> Add Media File` (sidebar navigation)
* Upload a Video file
* Open `Jetpack -> VideoPress`
* Under the "Local Videos"
* Hover over the video raw, check if the `Upload to VideoPress` button is clickable

