### PR TITLE
VideoPress: Fix PHP fatals in class-initializer.php

### DIFF
--- a/projects/packages/videopress/changelog/fix-error-fatal-logs
+++ b/projects/packages/videopress/changelog/fix-error-fatal-logs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress: Fix PHP fatals in class-initializer.php

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -83,7 +83,9 @@ class Initializer {
 			require_once __DIR__ . '/utility-functions.php';
 		}
 
-		require_once __DIR__ . '/class-block-replacement.php';
+		if ( ! is_admin() ) {
+			require_once __DIR__ . '/class-block-replacement.php';
+		}
 
 		// Set up package version hook.
 		add_filter( 'jetpack_package_versions', __NAMESPACE__ . '\Package_Version::send_package_version_to_tracker' );

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -83,10 +83,6 @@ class Initializer {
 			require_once __DIR__ . '/utility-functions.php';
 		}
 
-		if ( ! is_admin() ) {
-			require_once __DIR__ . '/class-block-replacement.php';
-		}
-
 		// Set up package version hook.
 		add_filter( 'jetpack_package_versions', __NAMESPACE__ . '\Package_Version::send_package_version_to_tracker' );
 
@@ -98,9 +94,8 @@ class Initializer {
 
 		if ( is_admin() ) {
 			AJAX::init();
-		}
-
-		if ( ! is_admin() ) {
+		} else {
+			require_once __DIR__ . '/class-block-replacement.php';
 			Block_Replacement::init();
 		}
 	}

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -83,6 +83,8 @@ class Initializer {
 			require_once __DIR__ . '/utility-functions.php';
 		}
 
+		require_once __DIR__ . '/class-block-replacement.php';
+
 		// Set up package version hook.
 		add_filter( 'jetpack_package_versions', __NAMESPACE__ . '\Package_Version::send_package_version_to_tracker' );
 
@@ -168,7 +170,7 @@ class Initializer {
 	 *
 	 * @return string|false
 	 */
-	public static function video_enqueue_bridge_when_oembed_present( $cache, $url, $attr, $post_ID ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+	public static function video_enqueue_bridge_when_oembed_present( $cache, $url, $attr, $post_ID = null ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		if ( Utils::is_videopress_url( $url ) ) {
 			Jwt_Token_Bridge::enqueue_jwt_token_bridge();
 		}


### PR DESCRIPTION
Fixes: https://linear.app/a8c/issue/VIDP-25/videopress-php-fatal-error-logs

## Proposed changes:

* Add missing require_once for Block_Replacement class to fix PHP fatal: "Class 'Automattic\Jetpack\VideoPress\Block_Replacement' not found"

* Make post_ID parameter optional in video_enqueue_bridge_when_oembed_present method to fix PHP fatal: "Too few arguments to function `Automattic\Jetpack\VideoPress\Initializer::video_enqueue_bridge_when_oembed_present()`"

Both issues were observed in WP Cloud logs and these changes ensure proper class loading and maintain compatibility with WordPress's embed_oembed_html filter.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

p1751393283310399-slack-C02LT75D3

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- No need for special testing, except for the existing tests