### PR TITLE
WAF: Fix Brute_Force_Protection class warnings

### DIFF
--- a/projects/packages/waf/changelog/fix-bruteforce-protect-warnings
+++ b/projects/packages/waf/changelog/fix-bruteforce-protect-warnings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix PHP warnings for Brute_Force_Protection->get_local_host()

--- a/projects/packages/waf/composer.json
+++ b/projects/packages/waf/composer.json
@@ -39,7 +39,14 @@
 			"php -dpcov.directory=. ./vendor/bin/phpunit-select-config tests/php/unit/phpunit.#.xml.dist --coverage-html ./coverage"
 		],
 		"test-php": [
-			"@composer phpunit"
+			"@test-php-integration",
+			"@test-php-unit"
+		],
+		"test-php-unit": [
+			"phpunit-select-config tests/php/unit/phpunit.#.xml.dist --colors=always"
+		],
+		"test-php-integration": [
+			"phpunit-select-config tests/php/integration/phpunit.#.xml.dist --colors=always"
 		]
 	},
 	"repositories": [

--- a/projects/packages/waf/src/class-brute-force-protection.php
+++ b/projects/packages/waf/src/class-brute-force-protection.php
@@ -1165,9 +1165,11 @@ class Brute_Force_Protection {
 			$uri = network_home_url();
 		}
 
+		$domain  = '';
 		$uridata = wp_parse_url( $uri );
-
-		$domain = $uridata['host'];
+		if ( false !== $uridata ) {
+			$domain = $uridata['host'];
+		}
 
 		// If we still don't have the site_url, get it.
 		if ( ! $domain ) {

--- a/projects/packages/waf/tests/php/integration/BruteForceProtectionTest.php
+++ b/projects/packages/waf/tests/php/integration/BruteForceProtectionTest.php
@@ -6,6 +6,7 @@
  */
 
 use Automattic\Jetpack\Waf\Brute_Force_Protection\Brute_Force_Protection;
+use PHPUnit\Framework\Attributes\BackupGlobals;
 
 /**
  * Brute Force Protection test case.
@@ -88,18 +89,14 @@ class BruteForceProtectionTest extends WorDBless\BaseTestCase {
 
 	/**
 	 * Test that get_local_host handles wp_parse_url returning false.
+	 *
+	 * @backupGlobals enabled
 	 */
+	#[BackupGlobals( true )]
 	public function test_get_local_host_handles_wp_parse_url_false() {
-		$original_http_host   = $_SERVER['HTTP_HOST'] ?? null;
 		$_SERVER['HTTP_HOST'] = '';
 
 		$result = $this->instance->get_local_host();
-
-		if ( null !== $original_http_host ) {
-			$_SERVER['HTTP_HOST'] = $original_http_host;
-		} else {
-			unset( $_SERVER['HTTP_HOST'] );
-		}
 
 		$this->assertIsString( $result );
 		$this->assertNotEmpty( $result );

--- a/projects/packages/waf/tests/php/integration/BruteForceProtectionTest.php
+++ b/projects/packages/waf/tests/php/integration/BruteForceProtectionTest.php
@@ -85,4 +85,23 @@ class BruteForceProtectionTest extends WorDBless\BaseTestCase {
 
 		$this->instance->log_failed_attempt( 'username', $error );
 	}
+
+	/**
+	 * Test that get_local_host handles wp_parse_url returning false.
+	 */
+	public function test_get_local_host_handles_wp_parse_url_false() {
+		$original_http_host   = $_SERVER['HTTP_HOST'] ?? null;
+		$_SERVER['HTTP_HOST'] = '';
+
+		$result = $this->instance->get_local_host();
+
+		if ( null !== $original_http_host ) {
+			$_SERVER['HTTP_HOST'] = $original_http_host;
+		} else {
+			unset( $_SERVER['HTTP_HOST'] );
+		}
+
+		$this->assertIsString( $result );
+		$this->assertNotEmpty( $result );
+	}
 }

--- a/projects/plugins/jetpack/changelog/update-composer-lock
+++ b/projects/plugins/jetpack/changelog/update-composer-lock
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Update composer.lock

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -3125,7 +3125,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/waf",
-				"reference": "c09184172f454b654a2ae4f7056b95c7c388dad0"
+				"reference": "6c1f8b69d0e51a1ba39f1f5c0008f00e5f432a3c"
 			},
 			"require": {
 				"automattic/jetpack-connection": "@dev",
@@ -3177,7 +3177,14 @@
 					"php -dpcov.directory=. ./vendor/bin/phpunit-select-config tests/php/unit/phpunit.#.xml.dist --coverage-html ./coverage"
 				],
 				"test-php": [
-					"@composer phpunit"
+					"@test-php-integration",
+					"@test-php-unit"
+				],
+				"test-php-unit": [
+					"phpunit-select-config tests/php/unit/phpunit.#.xml.dist --colors=always"
+				],
+				"test-php-integration": [
+					"phpunit-select-config tests/php/integration/phpunit.#.xml.dist --colors=always"
 				]
 			},
 			"license": [

--- a/projects/plugins/protect/changelog/update-composer-lock
+++ b/projects/plugins/protect/changelog/update-composer-lock
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update composer.lock

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -1892,7 +1892,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/waf",
-                "reference": "c09184172f454b654a2ae4f7056b95c7c388dad0"
+                "reference": "6c1f8b69d0e51a1ba39f1f5c0008f00e5f432a3c"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1944,7 +1944,14 @@
                     "php -dpcov.directory=. ./vendor/bin/phpunit-select-config tests/php/unit/phpunit.#.xml.dist --coverage-html ./coverage"
                 ],
                 "test-php": [
-                    "@composer phpunit"
+                    "@test-php-integration",
+                    "@test-php-unit"
+                ],
+                "test-php-unit": [
+                    "phpunit-select-config tests/php/unit/phpunit.#.xml.dist --colors=always"
+                ],
+                "test-php-integration": [
+                    "phpunit-select-config tests/php/integration/phpunit.#.xml.dist --colors=always"
                 ]
             },
             "license": [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes [PROTECT-53][1].

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

Add a check for `wp_parse_url()` return value, ensuring we won't treat `false` as an array. This avoids:

```
PHP Warning: Trying to access array offset on value of type bool
```

Also split `composer test-php` into two subcommands, `test-php-integration` and `test-php-unit`, ensuring the appropriate environment is loaded when running individual test files.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Run the automated tests:

```
$ cd projects/packages/waf/
$ composer test-php-integration tests/php/integration/BruteForceProtectionTest.php
> phpunit-select-config tests/php/integration/phpunit.#.xml.dist --colors=always 'tests/php/integration/BruteForceProtectionTest.php'
PHPUnit 11.5.25 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.2.28
Configuration: /home/myhro/Documents/github.com/Automattic/jetpack/projects/packages/waf/tests/php/integration/phpunit.11.xml.dist

.....                                                               5 / 5 (100%)

Time: 00:00.007, Memory: 44.50 MB

OK (5 tests, 9 assertions)
```

[1]: https://linear.app/a8c/issue/PROTECT-53/