### PR TITLE
SEO tags: do not attempt to use OG function when not available

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-fatal-function-not-available
+++ b/projects/plugins/jetpack/changelog/fix-fatal-function-not-available
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+SEO tags: do not use Open Graph util function to strip query blocks when Open Graph functions are not availabe

--- a/projects/plugins/jetpack/modules/seo-tools/class-jetpack-seo-utils.php
+++ b/projects/plugins/jetpack/modules/seo-tools/class-jetpack-seo-utils.php
@@ -139,6 +139,10 @@ class Jetpack_SEO_Utils {
 	 * @return string Post content stripped from wp:query blocks.
 	 */
 	public static function remove_query_blocks( $content ) {
+		if ( ! function_exists( 'jetpack_og_remove_query_blocks' ) ) {
+			return $content;
+		}
+
 		return jetpack_og_remove_query_blocks( $content );
 	}
 }


### PR DESCRIPTION
Follow-up to #44155

## Proposed changes:

On p2, wp_head() can be called before the Open Graph functions are loaded and available on the site, thus creating fatal errors:

```
Uncaught Error: Call to undefined function jetpack_og_remove_query_blocks(), .../jetpack-plugin/moon/modules/seo-tools/class-jetpack-seo-utils.php
```

Let's avoid that fatal.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

Internal reference: p1751533573673559-slack-C034JEXD1RD

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

> [!NOTE]
> Test on a p2 on WordPress.com

* Sandbox a p2.
* Load that p2, scroll down the page, load more posts.
    * polling for posts should eventually happen, and you'll experience the fatal error
* Apply this patch
    * The error should not happen anymore
