### PR TITLE
Untangling: Rename Vaultpress to Backup admin menu on WPCOM

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-rename-vaultpress-on-wpcom
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-rename-vaultpress-on-wpcom
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Rename Jetpack > Vaultpress to Jetpack > Backup admin menu for WPCOM sites
+
+

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
@@ -211,6 +211,7 @@ function wpcom_add_untangled_jetpack_menu() {
 	$domain = wp_parse_url( home_url(), PHP_URL_HOST );
 
 	wpcom_hide_submenu_page( 'jetpack', esc_url( Redirect::get_url( 'calypso-scanner' ) ) );
+	wpcom_hide_submenu_page( 'jetpack', esc_url( Redirect::get_url( 'calypso-backups' ) ) );
 
 	Jetpack_Admin_UI_Admin::add_menu(
 		esc_attr__( 'Scan', 'jetpack-mu-wpcom' ),
@@ -222,6 +223,18 @@ function wpcom_add_untangled_jetpack_menu() {
 		 */
 		null,
 		5
+	);
+
+	Jetpack_Admin_UI_Admin::add_menu(
+		esc_attr__( 'Backup', 'jetpack-mu-wpcom' ),
+		__( 'Backup', 'jetpack-mu-wpcom' ),
+		'manage_options',
+		'https://wordpress.com/backup/' . $domain,
+		/**
+		 * Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
+		 */
+		null,
+		3
 	);
 }
 
@@ -251,12 +264,10 @@ function wpcom_add_jetpack_submenu() {
 	// Hide submenu items that link to Jetpack Cloud.
 	wpcom_hide_submenu_page( 'jetpack', esc_url( Redirect::get_url( 'cloud-activity-log-wp-menu', array( 'site' => $blog_id ) ) ) );
 	wpcom_hide_submenu_page( 'jetpack', esc_url( Redirect::get_url( 'cloud-scan-history-wp-menu' ) ) );
-	wpcom_hide_submenu_page( 'jetpack', esc_url( Redirect::get_url( 'calypso-backups' ) ) );
 	wpcom_hide_submenu_page( 'jetpack', esc_url( Redirect::get_url( 'jetpack-menu-jetpack-manage-subscribers', array( 'site' => $blog_id ) ) ) );
 
 	$domain           = wp_parse_url( home_url(), PHP_URL_HOST );
 	$activity_log_url = 'https://wordpress.com/activity-log/' . $domain;
-	$vaultpress_url   = 'https://wordpress.com/backup/' . $domain;
 	$monetize_url     = 'https://wordpress.com/earn/' . $domain;
 	$subscribers_url  = 'https://wordpress.com/subscribers/' . $domain;
 	$newsletter_url   = 'https://wordpress.com/settings/newsletter/' . $domain;
@@ -269,15 +280,6 @@ function wpcom_add_jetpack_submenu() {
 		__( 'Activity Log', 'jetpack-mu-wpcom' ),
 		'manage_options',
 		$activity_log_url,
-		null // @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
-	);
-
-	add_submenu_page(
-		'jetpack',
-		__( 'VaultPress', 'jetpack-mu-wpcom' ),
-		__( 'VaultPress', 'jetpack-mu-wpcom' ),
-		'manage_options',
-		$vaultpress_url,
 		null // @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
 	);
 
@@ -335,7 +337,6 @@ function wpcom_add_jetpack_submenu() {
 		'my-jetpack',
 		'stats',
 		$activity_log_url,
-		$vaultpress_url,
 		'akismet-key-config',
 		'jetpack-search',
 		$monetize_url,

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
@@ -234,7 +234,7 @@ function wpcom_add_untangled_jetpack_menu() {
 		 * Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
 		 */
 		null,
-		3
+		4
 	);
 }
 

--- a/projects/packages/masterbar/changelog/update-rename-vaultpress-on-wpcom
+++ b/projects/packages/masterbar/changelog/update-rename-vaultpress-on-wpcom
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Rename Jetpack > Vaultpress to Jetpack > Backup admin menu for WPCOM sites
+
+

--- a/projects/packages/masterbar/src/admin-menu/class-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-admin-menu.php
@@ -10,7 +10,6 @@ namespace Automattic\Jetpack\Masterbar;
 use Automattic\Jetpack\Admin_UI\Admin_Menu as Jetpack_Admin_UI_Admin;
 use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Assets\Logo;
-use Automattic\Jetpack\Redirect;
 
 require_once __DIR__ . '/class-base-admin-menu.php';
 

--- a/projects/packages/masterbar/src/admin-menu/class-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-admin-menu.php
@@ -413,18 +413,6 @@ class Admin_Menu extends Base_Admin_Menu {
 			null,
 			2
 		);
-
-		Jetpack_Admin_UI_Admin::add_menu(
-			esc_attr__( 'Backup', 'jetpack-masterbar' ),
-			__( 'Backup', 'jetpack-masterbar' ),
-			'manage_options',
-			'https://wordpress.com/backup/' . $this->domain,
-			/**
-			 * Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
-			 */
-			null,
-			3
-		);
 	}
 
 	/**
@@ -448,7 +436,6 @@ class Admin_Menu extends Base_Admin_Menu {
 
 		if ( self::DEFAULT_VIEW === $this->get_preferred_view( 'jetpack' ) ) {
 			$this->hide_submenu_page( 'jetpack', 'jetpack#/settings' );
-			$this->hide_submenu_page( 'jetpack', esc_url( Redirect::get_url( 'calypso-backups' ) ) );
 		}
 
 		if ( ! $is_menu_updated ) {

--- a/projects/packages/masterbar/src/admin-menu/class-atomic-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-atomic-admin-menu.php
@@ -268,14 +268,6 @@ class Atomic_Admin_Menu extends Admin_Menu {
 		} else {
 			parent::add_jetpack_menu();
 		}
-
-		/**
-		 * Prevent duplicate menu items that link to Jetpack Backup.
-		 * Hide the one that's shown when the standalone backup plugin is not installed, since Jetpack Backup is already included in Atomic sites.
-		 *
-		 * @see https://github.com/Automattic/jetpack/pull/33955
-		 */
-		$this->hide_submenu_page( 'jetpack', esc_url( Redirect::get_url( 'calypso-backups' ) ) );
 	}
 
 	/**

--- a/projects/packages/masterbar/src/admin-menu/class-atomic-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-atomic-admin-menu.php
@@ -11,7 +11,6 @@ use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Current_Plan as Jetpack_Plan;
 use Automattic\Jetpack\JITMS\JITM;
 use Automattic\Jetpack\Modules;
-use Automattic\Jetpack\Redirect;
 use Automattic\Jetpack\Subscribers_Dashboard\Dashboard as Subscribers_Dashboard;
 
 require_once __DIR__ . '/class-admin-menu.php';

--- a/projects/packages/masterbar/tests/php/Admin_Menu_Test.php
+++ b/projects/packages/masterbar/tests/php/Admin_Menu_Test.php
@@ -344,7 +344,6 @@ class Admin_Menu_Test extends TestCase {
 		static::$admin_menu->add_jetpack_menu();
 
 		$this->assertSame( 'https://wordpress.com/activity-log/' . static::$domain, $submenu['jetpack'][3][2] );
-		$this->assertSame( 'https://wordpress.com/backup/' . static::$domain, $submenu['jetpack'][4][2] );
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes DOTCOM-13641

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Rename Jetpack > Vaultpress to Jetpack > Backup
* Remove the nav-unification code

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this PR on Atomic and on your Sandbox
* Make sure that the Jetpack menu contains "Backup" instead of Vaultpress

