### PR TITLE
Subscriptions: disable Featured image toggle on private sites

### DIFF
--- a/projects/plugins/jetpack/_inc/client/newsletter/email-settings.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/email-settings.jsx
@@ -183,7 +183,8 @@ const EmailSettings = props => {
 		? __( 'Enable featured image on your new post emails', 'jetpack' )
 		: __(
 				'Featured images cannot be shown in emails when your site is private, because access to your images is restricted to your site only.',
-				'jetpack'
+				'jetpack',
+				/* dummy arg to avoid bad minification */ 0
 		  );
 
 	return (

--- a/projects/plugins/jetpack/_inc/client/newsletter/email-settings.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/email-settings.jsx
@@ -29,6 +29,7 @@ import {
 	getNewsletterDateExample,
 	getSiteAdminUrl,
 	getCurrenUserEmailAddress,
+	isSitePublic,
 } from 'state/initial-state';
 import { getModule } from 'state/modules';
 import BylinePreview from './byline-preview';
@@ -66,6 +67,7 @@ const EmailSettings = props => {
 		dateExample,
 		siteName,
 		siteHasConnectedUser,
+		isSitePubliclyAccessible,
 	} = props;
 
 	const disabled = ! siteHasConnectedUser || ! isSubscriptionsActive || unavailableInOfflineMode;
@@ -134,7 +136,9 @@ const EmailSettings = props => {
 	);
 
 	const featuredImageInputDisabled =
-		disabled || isSavingAnyOption( [ FEATURED_IMAGE_IN_EMAIL_OPTION ] );
+		disabled ||
+		! isSitePubliclyAccessible ||
+		isSavingAnyOption( [ FEATURED_IMAGE_IN_EMAIL_OPTION ] );
 	const excerptInputDisabled =
 		disabled || isSavingAnyOption( [ SUBSCRIPTION_EMAILS_USE_EXCERPT_OPTION ] );
 
@@ -175,6 +179,13 @@ const EmailSettings = props => {
 		}
 	};
 
+	const featuredImageInfo = isSitePubliclyAccessible
+		? __( 'Enable featured image on your new post emails', 'jetpack' )
+		: __(
+				'Featured images cannot be shown in emails when your site is private, because access to your images is restricted to your site only.',
+				'jetpack'
+		  );
+
 	return (
 		<SettingsCard
 			{ ...props }
@@ -202,11 +213,7 @@ const EmailSettings = props => {
 					disabled={ featuredImageInputDisabled }
 					checked={ isFeaturedImageInEmailEnabled && isSubscriptionsActive }
 					toogling={ isSavingAnyOption( [ FEATURED_IMAGE_IN_EMAIL_OPTION ] ) }
-					label={
-						<span className="jp-form-toggle-explanation">
-							{ __( 'Enable featured image on your new post emails', 'jetpack' ) }
-						</span>
-					}
+					label={ <span className="jp-form-toggle-explanation">{ featuredImageInfo }</span> }
 					onChange={ handleEnableFeaturedImageInEmailToggleChange }
 				/>
 			</SettingsGroup>
@@ -465,6 +472,7 @@ export default withModuleSettingsFormHelpers(
 			isFeaturedImageInEmailEnabled: ownProps.getOptionValue( FEATURED_IMAGE_IN_EMAIL_OPTION ),
 			isGravatarEnabled: ownProps.getOptionValue( GRAVATER_OPTION ),
 			isPostDateEnabled: ownProps.getOptionValue( POST_DATE_OPTION ),
+			isSitePubliclyAccessible: isSitePublic( state ),
 			isAuthorEnabled: ownProps.getOptionValue( AUTHOR_OPTION ),
 			subscriptionEmailsUseExcerpt: ownProps.getOptionValue(
 				SUBSCRIPTION_EMAILS_USE_EXCERPT_OPTION

--- a/projects/plugins/jetpack/_inc/client/newsletter/email-settings.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/email-settings.jsx
@@ -212,7 +212,9 @@ const EmailSettings = props => {
 			>
 				<ToggleControl
 					disabled={ featuredImageInputDisabled }
-					checked={ isFeaturedImageInEmailEnabled && isSubscriptionsActive }
+					checked={
+						isFeaturedImageInEmailEnabled && isSubscriptionsActive && ! featuredImageInputDisabled
+					}
 					toogling={ isSavingAnyOption( [ FEATURED_IMAGE_IN_EMAIL_OPTION ] ) }
 					label={ <span className="jp-form-toggle-explanation">{ featuredImageInfo }</span> }
 					onChange={ handleEnableFeaturedImageInEmailToggleChange }

--- a/projects/plugins/jetpack/changelog/fix-private-featured-images-newsletters
+++ b/projects/plugins/jetpack/changelog/fix-private-featured-images-newsletters
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Subscriptions: disable option to add featured image to emails on private sites.


### PR DESCRIPTION
See CML-635

## Proposed changes:

On private sites, Featured images cannot be displayed in emails. Let's disable the field and show an explanation.

**Public sites**

<img width="1109" alt="Screenshot 2025-07-03 at 16 30 53" src="https://github.com/user-attachments/assets/e8ae945d-6d78-4d57-85a8-fe52a883fd76" />

**Private sites**

<img width="1060" alt="Screenshot 2025-07-03 at 16 28 20" src="https://github.com/user-attachments/assets/1b26545f-f032-446d-9c09-63fba736d459" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

> [!NOTE]
> This can only be tested on a WoA site.

* Start with a public site
* Go to Jetpack > Settings > Newsletter
    * The featured image option should be accessible when the module is active.
* Make your site private in Settings > Reading
* Go back to Jetpack > Settings > Newsletter
   * The feature image option should now be disabled
