### PR TITLE
Update/wpcomsh wc calypso bridge 2 11 1

### DIFF
--- a/projects/plugins/wpcomsh/changelog/Update wc-calypso-bridge to 2.11.1 in wpcomsh.
+++ b/projects/plugins/wpcomsh/changelog/Update wc-calypso-bridge to 2.11.1 in wpcomsh.
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Version bump.
+
+

--- a/projects/plugins/wpcomsh/composer.json
+++ b/projects/plugins/wpcomsh/composer.json
@@ -9,7 +9,7 @@
 		"automattic/custom-fonts": "^3.0",
 		"automattic/custom-fonts-typekit": "^2.0",
 		"automattic/text-media-widget-styles": "^2.0",
-		"automattic/wc-calypso-bridge": "2.11.0",
+		"automattic/wc-calypso-bridge": "2.11.1",
 		"wordpress/classic-editor-plugin": "1.6.7",
 		"automattic/jetpack-autoloader": "@dev",
 		"automattic/jetpack-composer-plugin": "@dev",

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f6d1378bc7a15012c804e69534b5fe23",
+    "content-hash": "a1b1c521eb5b2a265b632f721bea75ae",
     "packages": [
         {
             "name": "automattic/at-pressable-podcasting",
@@ -2116,16 +2116,16 @@
         },
         {
             "name": "automattic/wc-calypso-bridge",
-            "version": "v2.11.0",
+            "version": "v2.11.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/wc-calypso-bridge.git",
-                "reference": "17a231774e87ccac34d6fa08f704b153151b9c74"
+                "reference": "35e6235347b9ef6c1708dbe52b6efef8b2c6a0c1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/wc-calypso-bridge/zipball/17a231774e87ccac34d6fa08f704b153151b9c74",
-                "reference": "17a231774e87ccac34d6fa08f704b153151b9c74",
+                "url": "https://api.github.com/repos/Automattic/wc-calypso-bridge/zipball/35e6235347b9ef6c1708dbe52b6efef8b2c6a0c1",
+                "reference": "35e6235347b9ef6c1708dbe52b6efef8b2c6a0c1",
                 "shasum": ""
             },
             "require-dev": {
@@ -2164,7 +2164,7 @@
                     "phpcbf -p"
                 ]
             },
-            "time": "2025-06-26T19:38:56+00:00"
+            "time": "2025-07-03T16:00:11+00:00"
         },
         {
             "name": "scssphp/scssphp",


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Bump wc-calypso-bridge to 2.11.1 to fix issue with guided setup not working for new WooCommerce installations on WoW sites. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A. See p1751462628090939-slack-dotcom-escalations.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

See https://github.com/Automattic/wc-calypso-bridge/pull/1564

