### PR TITLE
Remove sending is_singular_post parameter

### DIFF
--- a/projects/plugins/jetpack/changelog/remove-sending-is-singular-post
+++ b/projects/plugins/jetpack/changelog/remove-sending-is-singular-post
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Previously we started using is_singular_post to highlight that current page is available for inline ads. Since we have solved the issue with JavaScript, we don't need this query param any more.

--- a/projects/plugins/jetpack/modules/wordads/php/class-wordads-smart.php
+++ b/projects/plugins/jetpack/modules/wordads/php/class-wordads-smart.php
@@ -150,7 +150,7 @@ class WordAds_Smart {
 
 		wp_enqueue_script(
 			'adflow_config',
-			$this->get_config_url(), // The URL is not escaped because we need two parameters to pass.
+			esc_url( $this->get_config_url() ),
 			array( 'adflow_script_loader' ),
 			JETPACK__VERSION,
 			false
@@ -248,9 +248,8 @@ class WordAds_Smart {
 	 */
 	private function get_config_url(): string {
 		return sprintf(
-			'https://public-api.wordpress.com/wpcom/v2/sites/%1$d/adflow/conf/?_jsonp=a8c_adflow_callback&is_singular_post=%2$d&',
-			$this->params->blog_id,
-			(int) is_singular( 'post' )
+			'https://public-api.wordpress.com/wpcom/v2/sites/%1$d/adflow/conf/?_jsonp=a8c_adflow_callback',
+			$this->params->blog_id
 		);
 	}
 


### PR DESCRIPTION
Related to ADS-295 and `187107-ghe-Automattic/wpcom`

## Proposed changes:

- Remove sending `is_singular_post` to highlight the current URL is suitable for inline ads (because 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Testing instructions:

If you need to know more about how to get Jetpack tests site up and running, please take a look at `184618-ghe-Automattic/wpcom`. Also, please don't forget to make your site launched and be public (use WP Admin > General > Reading section).

- Sandbox your WPCOM with the branch for accompanying PR (`187107-ghe-Automattic/wpcom`)
- Open Jetpack Beta Tester (e.g. https://timurjetpacktest.wpcomstaging.com/wp-admin/admin.php?page=jetpack-beta for my test Jetpack site);
- Activate `remove/sending-is-singular-post` branch for Jetpack;
- Prepare a tab for testing, open Dev Tools > Network;
- Filter all Network requests by "adflow";
- Open your test post or a page (in my case it's https://timurjetpacktest.wpcomstaging.com/2025/06/16/discover-northern-cardinal/?wordads-logging=true&ad_dev=true);
- Make sure that the request does not contain `is_singular_post` query parameter, in my case the request is
```https://public-api.wordpress.com/wpcom/v2/sites/245586497/adflow/conf/?_jsonp=a8c_adflow_callback&ver=14.9-a.0
```

- Make sure that you can see development ads (with the use of `?ad_dev=true`)

<img width="963" alt="image" src="https://github.com/user-attachments/assets/50dd3bbf-aed1-47d8-97f4-3d7fa37052f0" />

- And, the most important, inline ads:

<img width="1380" alt="Screenshot 2025-07-04 at 12 19 29" src="https://github.com/user-attachments/assets/f519bdc0-d88c-467a-9094-3648807e95d0" />

### Troubleshooting

In the case you don't see ads due to `af.pubmine.com/?api_version=2` returns 204 (the ad slot considered as Brand Unsafe), just switch to local AdFlow in WATL and run AdFlow locally.