### PR TITLE
Docker: Symlink plugins using WP.org slugs

### DIFF
--- a/tools/cli/commands/docker.js
+++ b/tools/cli/commands/docker.js
@@ -398,7 +398,7 @@ const buildExecCmd = argv => {
 				unitTestArgs.envVars = [ 'JETPACK_TEST_WPCOMSH=1' ];
 				break;
 			case 'crm':
-				unitTestArgs.plugin = 'crm';
+				unitTestArgs.plugin = 'zero-bs-crm';
 				break;
 			case 'wpcomsh':
 				unitTestArgs.plugin = 'wpcomsh';

--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -388,11 +388,11 @@ Since everything under `mu-plugins` and `wordpress/wp-content` is git-ignored, y
 Note that any folder within the `projects/plugins` directory will be automatically linked.
 If you're starting a new monorepo plugin, you may need to `jetpack docker stop` and `jetpack docker up` to re-run the initial linking step so it can be added.
 
-You can add your plugin to the list of plugins not allowed to be deleted or updated by adding this to a new file at `tools/docker/mu-plugins`:
+Deleting and updating plugins that are symlinked is disabled. You can block this for additional plugins using the `jetpack_docker_avoided_plugins` filter, adding something like this to a new file at `tools/docker/mu-plugins`:
 
 ```php
 function jetpack_docker_disable_gutenberg_deletion( $plugins ) {
-	array_push( $plugins, 'gutenberg' );
+	array_push( $plugins, 'gutenberg/gutenberg.php' );
 	return $plugins;
 }
 add_filter( 'jetpack_docker_avoided_plugins', 'jetpack_docker_disable_gutenberg_deletion' );

--- a/tools/docker/bin/run.sh
+++ b/tools/docker/bin/run.sh
@@ -111,7 +111,13 @@ fi
 
 for DIR in /usr/local/src/jetpack-monorepo/projects/plugins/*; do
 	[ -d "$DIR" ] || continue # We are only interested in directories, e.g. different plugins.
-	PLUGIN="$(basename $DIR)"
+	PLUGIN="$(basename "$DIR")"
+
+	# Handle special case: symlink crm as zero-bs-crm
+	if [[ "$PLUGIN" = 'crm' ]]; then
+		PLUGIN='zero-bs-crm'
+	fi
+
 	# Symlink plugins into the wp-content dir.
 	if [ ! -e /var/www/html/wp-content/plugins/"$PLUGIN" ]; then
 		echo "Linking the $PLUGIN plugin."

--- a/tools/docker/bin/run.sh
+++ b/tools/docker/bin/run.sh
@@ -113,15 +113,13 @@ for DIR in /usr/local/src/jetpack-monorepo/projects/plugins/*; do
 	[ -d "$DIR" ] || continue # We are only interested in directories, e.g. different plugins.
 	PLUGIN="$(basename "$DIR")"
 
-	# Handle special case: symlink crm as zero-bs-crm
-	if [[ "$PLUGIN" = 'crm' ]]; then
-		PLUGIN='zero-bs-crm'
-	fi
+	# Read plugin slug from composer.json, with fallback to beta-plugin-slug
+	PLUGIN_SLUG=$(jq -r '.extra["wp-plugin-slug"] // .extra["beta-plugin-slug"]' "$DIR/composer.json")
 
 	# Symlink plugins into the wp-content dir.
-	if [ ! -e /var/www/html/wp-content/plugins/"$PLUGIN" ]; then
-		echo "Linking the $PLUGIN plugin."
-		ln -s "$DIR" /var/www/html/wp-content/plugins/"$PLUGIN"
+	if [ ! -e /var/www/html/wp-content/plugins/"$PLUGIN_SLUG" ]; then
+		echo "Linking the $PLUGIN plugin as $PLUGIN_SLUG."
+		ln -s "$DIR" /var/www/html/wp-content/plugins/"$PLUGIN_SLUG"
 	fi
 done
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Plugins are currently symlinked with their project name. CRM's project is `crm` and its plugin slug is actually `zero-bs-crm`, and sometimes this causes issues with translation and debugging, e.g.:

* p1749762500545129/1749761359.331669-slack-CDLH4C1UZ
* pbhBOz-3uv-p2#comment-4294
* p1751484929730289-slack-C08LH6UQQ6S

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
The plugin is now symlinked as `zero-bs-crm`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Tests should continue to work as before.