### PR TITLE
Update class-publicize-utils.php to check for existence of `get_current_screen()` before trying to call it

### DIFF
--- a/projects/packages/publicize/changelog/trunc-get_current_screen
+++ b/projects/packages/publicize/changelog/trunc-get_current_screen
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+get_current_screen(): Check for the existence before trying to call it

--- a/projects/packages/publicize/changelog/trunk
+++ b/projects/packages/publicize/changelog/trunk
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Removed comment... purely aesthentic
-
-

--- a/projects/packages/publicize/changelog/trunk
+++ b/projects/packages/publicize/changelog/trunk
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Removed comment... purely aesthentic
+
+

--- a/projects/packages/publicize/src/class-publicize-utils.php
+++ b/projects/packages/publicize/src/class-publicize-utils.php
@@ -1,5 +1,4 @@
 <?php
-// plugins/jetpack/jetpack_vendor/automattic/jetpack-publicize/src/class-publicize-utils.php
 /**
  * Publicize_Utils.
  *

--- a/projects/packages/publicize/src/class-publicize-utils.php
+++ b/projects/packages/publicize/src/class-publicize-utils.php
@@ -1,4 +1,5 @@
 <?php
+// plugins/jetpack/jetpack_vendor/automattic/jetpack-publicize/src/class-publicize-utils.php
 /**
  * Publicize_Utils.
  *
@@ -20,7 +21,7 @@ class Publicize_Utils {
 	 * Whether the current page is the social settings page.
 	 */
 	public static function is_social_settings_page() {
-		$screen = get_current_screen();
+		$screen = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
 
 		return ! empty( $screen ) && 'jetpack_page_jetpack-social' === $screen->base;
 	}
@@ -29,7 +30,7 @@ class Publicize_Utils {
 	 * Whether the current page is the Jetpack settings page.
 	 */
 	public static function is_jetpack_settings_page() {
-		$screen = get_current_screen();
+		$screen = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
 
 		return ! empty( $screen ) && 'toplevel_page_jetpack' === $screen->base;
 	}
@@ -44,7 +45,7 @@ class Publicize_Utils {
 			return false;
 		}
 
-		$screen = get_current_screen();
+		$screen = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
 
 		if ( empty( $screen ) || ! $screen->is_block_editor() ) {
 			return false;


### PR DESCRIPTION
Check for the existence of `get_current_screen()` before trying to call it

Calls to `get_current_screen()` were being made without ensuring that it exists. This caused a problem with an old theme, chocotheme, but looks to be bad practice, anyway, as shown by other files which _do_ check its existence first. 

The level of testing should be obvious to those who are more familiar with this code. 

## Does this pull request change what data or activity we track or use?

I do not believe this change affects data or privacy since it merely circumvents flow of control. 

## Testing instructions:

* Calls to `is_social_settings_page()`, `is_jetpack_settings_page()`, and `should_block_editor_have_social()` should all succeed without error, even when run outside the context of `get_current_screen()` being defined. 
