### PR TITLE
Boost: Exclude scripts of type module from concatenation

### DIFF
--- a/projects/plugins/boost/app/lib/minify/class-concatenate-js.php
+++ b/projects/plugins/boost/app/lib/minify/class-concatenate-js.php
@@ -342,14 +342,16 @@ class Concatenate_JS extends WP_Scripts {
 
 	/**
 	 * Returns the type of the script.
-	 * module, text/javascript, etc.
+	 * module, text/javascript, etc. False if the script tag is invalid,
+	 * or the type is not set.
 	 *
 	 * @since $$next-version$$
 	 *
 	 * @param string $handle The script's registered handle.
 	 * @param string $src The script's source URL.
 	 *
-	 * @return string The type of the script.
+	 * @return string|false The type of the script. False if the script tag is invalid,
+	 * or the type is not set.
 	 */
 	private function get_script_type( $handle, $src ) {
 		$script_tag_attr = array(
@@ -363,13 +365,13 @@ class Concatenate_JS extends WP_Scripts {
 		// This is a workaround to get the type of the script without outputting it.
 		$script_tag = apply_filters( 'script_loader_tag', $script_tag, $handle, $src );
 		$processor  = new \WP_HTML_Tag_Processor( $script_tag );
-		$processor->next_tag();
-		$script_type = $processor->get_attribute( 'type' );
-		if ( ! $script_type ) {
-			$script_type = 'text/javascript';
+
+		// If for some reason the script tag isn't valid, bail.
+		if ( false === $processor->next_tag() ) {
+			return false;
 		}
 
-		return $script_type;
+		return $processor->get_attribute( 'type' );
 	}
 
 	public function __isset( $key ) {

--- a/projects/plugins/boost/app/lib/minify/class-concatenate-js.php
+++ b/projects/plugins/boost/app/lib/minify/class-concatenate-js.php
@@ -361,8 +361,13 @@ class Concatenate_JS extends WP_Scripts {
 		$script_tag = wp_get_script_tag( $script_tag_attr );
 
 		// This is a workaround to get the type of the script without outputting it.
-		$script_tag  = apply_filters( 'script_loader_tag', $script_tag, $handle, $src );
-		$script_type = preg_match( '/type=(["\'])([^"\']+)\1/', $script_tag, $matches ) ? $matches[2] : 'text/javascript';
+		$script_tag = apply_filters( 'script_loader_tag', $script_tag, $handle, $src );
+		$processor  = new \WP_HTML_Tag_Processor( $script_tag );
+		$processor->next_tag();
+		$script_type = $processor->get_attribute( 'type' );
+		if ( ! $script_type ) {
+			$script_type = 'text/javascript';
+		}
 
 		return $script_type;
 	}

--- a/projects/plugins/boost/app/lib/minify/class-concatenate-js.php
+++ b/projects/plugins/boost/app/lib/minify/class-concatenate-js.php
@@ -188,6 +188,20 @@ class Concatenate_JS extends WP_Scripts {
 				}
 			}
 
+			// This is a workaround to get the type of the script without outputting it.
+			// Build the final version of the script tag (by running it through apply_filters)
+			// and then checking the type. If it's a module script,
+			// skip it, as modules can't be concatenated with other scripts.
+			$script_tag  = '<script type="text/javascript" src="' . esc_url( $js_url ) . '"></script>';
+			$script_tag  = apply_filters( 'script_loader_tag', $script_tag, $handle, $js_url );
+			$script_type = preg_match( '/<script type=(["\'])([^"\']+)\1/', $script_tag, $matches ) ? $matches[2] : 'text/javascript';
+			if ( 'module' === $script_type ) {
+				$do_concat = false;
+				if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+					printf( "\n<!-- No Concat JS %s => Module Script -->\n", esc_html( $handle ) );
+				}
+			}
+
 			/**
 			 * Filter that allows plugins to disable concatenation of certain scripts.
 			 *

--- a/projects/plugins/boost/app/lib/minify/class-concatenate-js.php
+++ b/projects/plugins/boost/app/lib/minify/class-concatenate-js.php
@@ -195,13 +195,10 @@ class Concatenate_JS extends WP_Scripts {
 				if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 					printf( "\n<!-- No Concat JS %s => No URL -->\n", esc_html( $handle ) );
 				}
-			} else {
-				$script_type = $this->get_script_type( $handle, $js_url );
-				if ( 'module' === $script_type ) {
-					$do_concat = false;
-					if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-						printf( "\n<!-- No Concat JS %s => Module Script -->\n", esc_html( $handle ) );
-					}
+			} elseif ( 'module' === $this->get_script_type( $handle, $js_url ) ) {
+				$do_concat = false;
+				if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+					printf( "\n<!-- No Concat JS %s => Module Script -->\n", esc_html( $handle ) );
 				}
 			}
 

--- a/projects/plugins/boost/app/lib/minify/class-concatenate-js.php
+++ b/projects/plugins/boost/app/lib/minify/class-concatenate-js.php
@@ -367,7 +367,7 @@ class Concatenate_JS extends WP_Scripts {
 		$processor  = new \WP_HTML_Tag_Processor( $script_tag );
 
 		// If for some reason the script tag isn't valid, bail.
-		if ( false === $processor->next_tag() ) {
+		if ( ! $processor->next_tag() ) {
 			return false;
 		}
 

--- a/projects/plugins/boost/app/lib/minify/class-concatenate-js.php
+++ b/projects/plugins/boost/app/lib/minify/class-concatenate-js.php
@@ -188,17 +188,20 @@ class Concatenate_JS extends WP_Scripts {
 				}
 			}
 
-			// This is a workaround to get the type of the script without outputting it.
-			// Build the final version of the script tag (by running it through apply_filters)
-			// and then checking the type. If it's a module script,
-			// skip it, as modules can't be concatenated with other scripts.
-			$script_tag  = '<script type="text/javascript" src="' . esc_url( $js_url ) . '"></script>';
-			$script_tag  = apply_filters( 'script_loader_tag', $script_tag, $handle, $js_url );
-			$script_type = preg_match( '/<script type=(["\'])([^"\']+)\1/', $script_tag, $matches ) ? $matches[2] : 'text/javascript';
-			if ( 'module' === $script_type ) {
+			/** This filter is documented in wp-includes/class-wp-scripts.php */
+			$js_url = esc_url_raw( apply_filters( 'script_loader_src', $js_url, $handle ) );
+			if ( ! $js_url ) {
 				$do_concat = false;
 				if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-					printf( "\n<!-- No Concat JS %s => Module Script -->\n", esc_html( $handle ) );
+					printf( "\n<!-- No Concat JS %s => No URL -->\n", esc_html( $handle ) );
+				}
+			} else {
+				$script_type = $this->get_script_type( $handle, $js_url );
+				if ( 'module' === $script_type ) {
+					$do_concat = false;
+					if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+						printf( "\n<!-- No Concat JS %s => Module Script -->\n", esc_html( $handle ) );
+					}
 				}
 			}
 
@@ -338,6 +341,33 @@ class Concatenate_JS extends WP_Scripts {
 		do_action( 'js_concat_did_items', $javascripts );
 
 		return $this->done;
+	}
+
+	/**
+	 * Returns the type of the script.
+	 * module, text/javascript, etc.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param string $handle The script's registered handle.
+	 * @param string $src The script's source URL.
+	 *
+	 * @return string The type of the script.
+	 */
+	private function get_script_type( $handle, $src ) {
+		$script_tag_attr = array(
+			'src' => $src,
+			'id'  => "$handle-js",
+		);
+
+		// Get the script tag and allow plugins to filter it.
+		$script_tag = wp_get_script_tag( $script_tag_attr );
+
+		// This is a workaround to get the type of the script without outputting it.
+		$script_tag  = apply_filters( 'script_loader_tag', $script_tag, $handle, $src );
+		$script_type = preg_match( '/type=(["\'])([^"\']+)\1/', $script_tag, $matches ) ? $matches[2] : 'text/javascript';
+
+		return $script_type;
 	}
 
 	public function __isset( $key ) {

--- a/projects/plugins/boost/changelog/fix-boost-concat-js-skip-modules-HOG-153
+++ b/projects/plugins/boost/changelog/fix-boost-concat-js-skip-modules-HOG-153
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Concatenate JS: Exclude scripts of type module from concatenation.


### PR DESCRIPTION
Fixes HOG-153

Concatenate JS by default doesn't concatenate scripts that are of `type="module"` if they have been correctly enqueued using `wp_enqueue_script_module`. However, some plugins like AIOSEO add the `type="module"` part [after the script](https://github.com/awesomemotive/all-in-one-seo-pack/blob/master/app/Common/Traits/Assets.php#L113-L125) has been [output](https://github.com/Automattic/jetpack/blob/8b4d259a02563ecb73b30b5fda3d8ca7ccd1fd82/projects/plugins/boost/app/lib/minify/class-concatenate-js.php#L322) (by that time, it's been concatenated).

This PR fixes that by creating a script tag and checking its type before it's output.

## Proposed changes:

* Exclude scripts that have `type="module` assigned to them after enqueue;
* Fix Concatenate JS not respecting `script_loader_src` filter, allowing scripts that shouldn't be shown on the page to be shown.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

HOG-153

## Does this pull request change what data or activity we track or use?

no

## Testing instructions:

### Test that script modules are excluded from concatenation

- Setup Boost (free);
- Setup [AIOSEO](https://wordpress.org/plugins/all-in-one-seo-pack/). You'll know it's set up because there are two `type="module"` scripts on the page:
  - aioseo/js/src/vue/standalone/seo-preview/main.js
  - aioseo/js/src/vue/standalone/app/main.js
- Open the home page and make sure there are no errors in the console;
- Enable Concatenate JS and visit the home page again - there should be no errors in the console;
- Search the source of the page for `type="module"` - there should be 2. If you have WP_DEBUG enabled, you should see this:

<img width="745" alt="CleanShot 2025-07-04 at 14 28 20@2x" src="https://github.com/user-attachments/assets/34b16eca-f5fa-4b43-a0ee-07d52ef32167" />

### Test that scripts are properly skipped when using filters

- You can do this test right after the above one;
- Add this script to your website. It causes the frontend.min.js script that comes from the `google-analytics-for-wordpress` plugin, to be skipped.
```php
add_filter( 'script_loader_src', function ( $src, $handle ) {
	if ( 'monsterinsights-vue-frontend' === $handle ) {
		return false;
	}

	return $src;
}, 10, 2 );
```

- Open the page and make sure that there's no reference to `frontend.min.js`;
- Remove the PHP snippet and make sure the script is on the page.