### PR TITLE
Stats: Update capabilities

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/dotcom-13798-update-jetpack-stats-required-capabilities-on-simple-sites
+++ b/projects/packages/jetpack-mu-wpcom/changelog/dotcom-13798-update-jetpack-stats-required-capabilities-on-simple-sites
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+On Dotcom, extend Stats access to administrator, editor, author, contributor roles.

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -314,6 +314,7 @@ class Jetpack_Mu_Wpcom {
 		}
 		require_once __DIR__ . '/features/pages/pages.php';
 		require_once __DIR__ . '/features/replace-site-visibility/replace-site-visibility.php';
+		require_once __DIR__ . '/features/stats/stats.php';
 		require_once __DIR__ . '/features/wpcom-admin-bar/wpcom-admin-bar.php';
 		require_once __DIR__ . '/features/wpcom-admin-interface/wpcom-admin-interface.php';
 		require_once __DIR__ . '/features/wpcom-admin-menu/wpcom-admin-menu.php';

--- a/projects/packages/jetpack-mu-wpcom/src/features/stats/stats.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/stats/stats.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Jetpack Stats on WordPress.com
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+/**
+ * Extends the default value for which roles can access the Stats menu item.
+ *
+ * This enables the `view_stats` capability to work with all roles that are available on Simple sites.
+ *
+ * @see https://wordpress.com/support/invite-people/user-roles/#access-to-stats
+ * @see projects/plugins/wpcomsh/feature-plugins/stats.php
+ *
+ * @param mixed $caps Caps.
+ * @param mixed $cap Cap.
+ * @param mixed $user_id User ID.
+ * @return array Possibly mapped capabilities for meta capability.
+ */
+function wpcom_map_jetpack_stats_caps( $caps, $cap, $user_id ) {
+	// Map view_stats to exists.
+	if ( 'view_stats' === $cap ) {
+		$user        = new WP_User( $user_id );
+		$user_role   = array_shift( $user->roles );
+		$stats_roles = array( 'administrator', 'editor', 'author', 'contributor' );
+
+		// Is the users role in the available stats roles?
+		if ( is_array( $stats_roles ) && in_array( $user_role, $stats_roles, true ) ) {
+			$caps = array( 'read' );
+		}
+	}
+
+	return $caps;
+}
+
+add_filter( 'map_meta_cap', 'wpcom_map_jetpack_stats_caps', 10, 3 );

--- a/projects/packages/jetpack-mu-wpcom/src/features/stats/stats.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/stats/stats.php
@@ -34,4 +34,7 @@ function wpcom_map_jetpack_stats_caps( $caps, $cap, $user_id ) {
 	return $caps;
 }
 
-add_filter( 'map_meta_cap', 'wpcom_map_jetpack_stats_caps', 10, 3 );
+// Let Atomic sites handle this through the Jetpack settings.
+if ( ( defined( 'IS_WPCOM' ) && IS_WPCOM ) && ( ! defined( 'IS_ATOMIC' ) || ! IS_ATOMIC ) ) {
+	add_filter( 'map_meta_cap', 'wpcom_map_jetpack_stats_caps', 10, 3 );
+}

--- a/projects/packages/jetpack-mu-wpcom/src/features/stats/stats.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/stats/stats.php
@@ -26,7 +26,7 @@ function wpcom_map_jetpack_stats_caps( $caps, $cap, $user_id ) {
 		$stats_roles = array( 'administrator', 'editor', 'author', 'contributor' );
 
 		// Is the users role in the available stats roles?
-		if ( is_array( $stats_roles ) && in_array( $user_role, $stats_roles, true ) ) {
+		if ( in_array( $user_role, $stats_roles, true ) ) {
 			$caps = array( 'read' );
 		}
 	}

--- a/projects/packages/stats-admin/changelog/dotcom-13798-update-jetpack-stats-required-capabilities-on-simple-sites
+++ b/projects/packages/stats-admin/changelog/dotcom-13798-update-jetpack-stats-required-capabilities-on-simple-sites
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Use the view_stats cap for the Jetpack Stats menu item instead of manage_options.

--- a/projects/packages/stats-admin/src/class-dashboard.php
+++ b/projects/packages/stats-admin/src/class-dashboard.php
@@ -58,7 +58,7 @@ class Dashboard {
 		$page_suffix = Admin_Menu::add_menu(
 			__( 'Stats', 'jetpack-stats-admin' ),
 			_x( 'Stats', 'product name shown in menu', 'jetpack-stats-admin' ),
-			'manage_options',
+			'view_stats',
 			'stats',
 			array( $this, 'render' )
 		);

--- a/projects/plugins/jetpack/changelog/dotcom-13798-update-jetpack-stats-required-capabilities-on-simple-sites
+++ b/projects/plugins/jetpack/changelog/dotcom-13798-update-jetpack-stats-required-capabilities-on-simple-sites
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Use the view_stats cap for the Jetpack Stats menu item instead of manage_options.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes DOTCOM-13798

## Proposed changes:

* Use the `view_stats` capability for the Stats menu item instead of `manage_options`.
* Only on Dotcom, extend the `view_stats` capability to administrator, editor, author, contributor roles (as per [docs](https://wordpress.com/support/invite-people/user-roles/#access-to-stats)).

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On your Jetpack site, open Jetpack -> Settings -> Traffic.
* Expand the Jetpack Stats section and take note of the roles that have access to Stats.
* Testing with users with various roles, confirm that:
  * The Jetpack -> Stats menu item is only visible to roles that can view Stats.
  * The Stats page can only be accessed by roles that can view Stats.

**The following instructions can only be executed by Automatticians on WordPress.com.**

* Before applying the changes, pick a test Simple site.
* Use a non-admin user (editor, author, or contributor).
  * Confirm that you cannot see the Jetpack -> Stats menu item, nor access it.
* Apply these changes to your sandbox (PCYsg-Osp-p2), sandbox the API and a test site.
* Use a non-admin user (editor, author, or contributor).
  * Confirm that you can see the Jetpack -> Stats menu item, and access it.
* Use a lower role user (viewer, subscriber).
  * Confirm that you cannot see the Jetpack -> Stats menu item, nor access it.