### PR TITLE
SAL_Site: Prevent warnings due to reading properties on null

### DIFF
--- a/projects/plugins/jetpack/changelog/update-class-json-api-site-base-prevent-prop-warnings
+++ b/projects/plugins/jetpack/changelog/update-class-json-api-site-base-prevent-prop-warnings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+SAL: Ensurethat we don't check for properties on null.

--- a/projects/plugins/jetpack/sal/class.json-api-site-base.php
+++ b/projects/plugins/jetpack/sal/class.json-api-site-base.php
@@ -785,15 +785,10 @@ abstract class SAL_Site {
 				) );
 		}
 
-		if (
-		! $authorized &&
-		(
-		( 'trash' === $post->post_status && current_user_can( 'edit_post', $post->ID ) )
-		|| 'auto-draft' === $post->post_status
-		)
-		) {
-			$authorized = true;
-		}
+		$authorized = $authorized || (
+			( 'trash' === $post->post_status && current_user_can( 'edit_post', $post->ID ) )
+			|| 'auto-draft' === $post->post_status
+		);
 
 		if ( ! $authorized ) {
 			return new WP_Error( 'unauthorized', 'User cannot view post', 403 );

--- a/projects/plugins/jetpack/sal/class.json-api-site-base.php
+++ b/projects/plugins/jetpack/sal/class.json-api-site-base.php
@@ -770,22 +770,27 @@ abstract class SAL_Site {
 		// If the post is of status inherit, check if the parent exists ( different to 0 ) to check for the parent status object.
 		if ( 'inherit' === $post->post_status && 0 !== (int) $post->post_parent ) {
 			$parent_post     = get_post( $post->post_parent );
-			$post_status_obj = get_post_status_object( $parent_post->post_status );
+			$post_status_obj = $parent_post ? get_post_status_object( $parent_post->post_status ) : null;
 		} else {
 			$post_status_obj = get_post_status_object( $post->post_status );
 		}
 
-		$authorized = (
-			$post_status_obj->public ||
-			( is_user_logged_in() &&
-				(
-					( $post_status_obj->protected && current_user_can( 'edit_post', $post->ID ) ) ||
-					( $post_status_obj->private && current_user_can( 'read_post', $post->ID ) ) ||
-					( 'trash' === $post->post_status && current_user_can( 'edit_post', $post->ID ) ) ||
-					'auto-draft' === $post->post_status
-				)
-			)
-		);
+		$authorized = false;
+
+		if ( $post_status_obj ) {
+			$authorized = $post_status_obj->public
+				|| ( is_user_logged_in() && (
+				( $post_status_obj->protected && current_user_can( 'edit_post', $post->ID ) )
+				|| ( $post_status_obj->private && current_user_can( 'read_post', $post->ID ) )
+				) );
+		}
+
+		if (
+		( 'trash' === $post->post_status && current_user_can( 'edit_post', $post->ID ) )
+		|| 'auto-draft' === $post->post_status
+		) {
+			$authorized = true;
+		}
 
 		if ( ! $authorized ) {
 			return new WP_Error( 'unauthorized', 'User cannot view post', 403 );

--- a/projects/plugins/jetpack/sal/class.json-api-site-base.php
+++ b/projects/plugins/jetpack/sal/class.json-api-site-base.php
@@ -786,8 +786,11 @@ abstract class SAL_Site {
 		}
 
 		if (
+		! $authorized &&
+		(
 		( 'trash' === $post->post_status && current_user_can( 'edit_post', $post->ID ) )
 		|| 'auto-draft' === $post->post_status
+		)
 		) {
 			$authorized = true;
 		}


### PR DESCRIPTION
Fixes VULCAN-228

## Proposed changes:

* This PR adds property checks within the `user_can_view_post` function, specifically with regard to  checking the `$parent_post`, and therefore the `$post_status_obj` value. Both `get_post` and `get_post_status_object` can return null so we should allow for that, and ensure the rest of the code continues processing as before if these values are null.
* What we are preventing are warnings that were being output in logs.


Logs: e1891edb5a21bf2c639db4455ebc23cc-logstash

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

pdWQjU-1g0-p2 

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* Code-review

* You can also test this by visiting the URL mentioned in the Linear issue, and then on trunk observing a new entry in the above linked Logstash logs.
* If you are have sandboxed `https://public-api. wordpress.com/`, you should also see an error while tailing for errors: `tail -f /tmp/php-errors`
* You can confirm the change prevents the warning and doesn't impact the output by using the commands in the generated comment below and sandboxing `https://public-api. wordpress.com/`, while tailing for errors. No errors should be generated.