### PR TITLE
My Jetpack: Hide notifications when disconnected + change disconnection URL

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/connection-status-card/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/connection-status-card/index.tsx
@@ -27,6 +27,7 @@ const ConnectionStatusCard: ConnectionStatusCardType = ( {
 	redirectUri = null,
 	title = __( 'Connection', 'jetpack-my-jetpack' ),
 	onDisconnected,
+	onUnlinked,
 	connectedPlugins,
 	connectedSiteId,
 	context,
@@ -102,9 +103,9 @@ const ConnectionStatusCard: ConnectionStatusCardType = ( {
 		( e: MouseEvent< HTMLButtonElement > ) => {
 			e && e.preventDefault();
 			setConnectionStatus( { isUserConnected: false } );
-			onDisconnected?.();
+			onUnlinked?.();
 		},
-		[ onDisconnected, setConnectionStatus ]
+		[ onUnlinked, setConnectionStatus ]
 	);
 
 	const handleConnectUser = useCallback(

--- a/projects/packages/my-jetpack/_inc/components/connection-status-card/types.ts
+++ b/projects/packages/my-jetpack/_inc/components/connection-status-card/types.ts
@@ -50,6 +50,7 @@ interface ConnectionStatusCardProps {
 	redirectUri?: string;
 	title?: string;
 	onDisconnected?: () => void;
+	onUnlinked?: () => void;
 	connectedPlugins?: {
 		name: string;
 		slug: string;

--- a/projects/packages/my-jetpack/_inc/components/connections-section/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/connections-section/index.jsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 import { MyJetpackRoutes } from '../../constants';
 import { useAllProducts } from '../../data/products/use-all-products';
+import { getMyJetpackWindowInitialState } from '../../data/utils/get-my-jetpack-window-state';
 import getProductSlugsThatRequireUserConnection from '../../data/utils/get-product-slugs-that-require-user-connection';
 import useMyJetpackConnection from '../../hooks/use-my-jetpack-connection';
 import useMyJetpackNavigate from '../../hooks/use-my-jetpack-navigate';
@@ -15,7 +16,22 @@ export default function ConnectionsSection() {
 	const { apiRoot, apiNonce, topJetpackMenuItemUrl, connectedPlugins } = useMyJetpackConnection();
 	const navigate = useMyJetpackNavigate( MyJetpackRoutes.ConnectionSkipPricing );
 	const { data: products, isLoading, isError } = useAllProducts();
-	const onDisconnected = () => document?.location?.reload( true ); // TODO: replace with a better experience.
+	const { adminUrl } = getMyJetpackWindowInitialState();
+
+	// Handle full site disconnection - redirect to admin
+	const onFullyDisconnected = () => {
+		if ( adminUrl ) {
+			window.location.href = adminUrl;
+		} else {
+			document?.location?.reload( true );
+		}
+	};
+
+	// Handle user unlink only - stay in admin, just reload
+	const onUserUnlinked = () => {
+		document?.location?.reload( true );
+	};
+
 	const productsThatRequireUserConnection = useMemo( () => {
 		if ( isLoading || isError ) {
 			return [];
@@ -33,7 +49,9 @@ export default function ConnectionsSection() {
 			connectedPlugins={ connectedPlugins }
 			requiresUserConnection={ productsThatRequireUserConnection.length > 0 }
 			// eslint-disable-next-line react/jsx-no-bind
-			onDisconnected={ onDisconnected }
+			onDisconnected={ onFullyDisconnected }
+			// eslint-disable-next-line react/jsx-no-bind
+			onUnlinked={ onUserUnlinked }
 		/>
 	);
 }

--- a/projects/packages/my-jetpack/changelog/fix-my-jetpack-disconnection-issues
+++ b/projects/packages/my-jetpack/changelog/fix-my-jetpack-disconnection-issues
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Fixed some issues with site disconnections

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -705,6 +705,14 @@ class Initializer {
 		if ( ! current_user_can( 'manage_options' ) ) {
 			return;
 		}
+
+		// Don't show any red bubbles when Jetpack is disconnected
+		// Users can't act on most alerts without a connection
+		$connection = new Connection_Manager();
+		if ( ! $connection->is_connected() ) {
+			return;
+		}
+
 		$rbn = new Red_Bubble_Notifications();
 
 		// filters for the items in this file


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes MYJP-193

 ## Proposed changes:
  This PR resolves two issues that occur after disconnecting Jetpack:

  1. **Red bubble persistence**: The red notification bubble in the admin menu persisted even after Jetpack was fully disconnected, showing misleading alerts that users couldn't act upon.

![image](https://github.com/user-attachments/assets/7d1c2bf7-309e-45cb-9533-6a5c4c5efd73)


  2. **Navigation after disconnection**: The "Back to my website" button in the disconnect dialog redirected users to the onboarding page instead of returning them to the WordPress admin dashboard.

  **Key Changes:**
  - Added global connection check in `maybe_show_red_bubble()` to prevent ALL red bubble notifications when Jetpack is disconnected
  - Updated disconnect callbacks to distinguish between full site disconnection vs user-only disconnection
  - Modified navigation to redirect to admin dashboard (`/wp-admin/`) instead of site homepage after full disconnection
  - Simplified red bubble logic by removing redundant individual connection checks

  ### Other information:

  - [ ] Have you written new tests for your changes, if applicable?
  - [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
  - [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

  ## Jetpack product discussion
  <!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
  Related to MYJP-193 - improves user experience after Jetpack disconnection

  ## Does this pull request change what data or activity we track or use?
  No.


  ## Testing instructions:

  ### Testing Red Bubble Fix:
  1. **Setup**: Ensure you have a Jetpack site with some notifications (backup issues, protect alerts, etc.)
  2. **Before**: Note the red bubble with number appears next to "Jetpack" in the admin menu
  3. **Disconnect**: Go to My Jetpack → Manage connection → Disconnect Jetpack completely
  4. **Verify**: After disconnection, refresh any admin page - the red bubble should be completely gone
  5. **Reconnect**: Reconnect Jetpack and verify red bubbles appear again when appropriate

  ### Testing Navigation Fix:
  1. **Setup**: Have a connected Jetpack site
  2. **Disconnect**: Go to My Jetpack → Manage connection → Disconnect Jetpack
  3. **Click "Back to my website"**: After disconnection is complete, click the "Back to my website" button
  4. **Verify**: Should redirect to `/wp-admin/`

  ### Testing User Unlink (separate from full disconnect):
  1. **Setup**: Have a connected Jetpack site
  2. **Unlink user**: Go to My Jetpack → Manage connection → Disconnect my user account (not full site disconnect)
  3. **Verify**: Should stay in current admin page with reload, not redirect elsewhere


https://github.com/user-attachments/assets/fded2717-d48c-4091-92ca-3754f46c1359

