### PR TITLE
Tests: Don't run WP Cloud tests on forked PRs

### DIFF
--- a/.github/workflows/wpcloud.yml
+++ b/.github/workflows/wpcloud.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     name: Install the Monorepo and build wpcomsh
     runs-on: ubuntu-latest
-    if: github.repository == 'Automattic/jetpack'
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
     outputs:
       wpcomsh: ${{ steps.changed.outputs.wpcomsh }}
     steps:

--- a/.github/workflows/wpcloud.yml
+++ b/.github/workflows/wpcloud.yml
@@ -13,6 +13,7 @@ jobs:
   build:
     name: Install the Monorepo and build wpcomsh
     runs-on: ubuntu-latest
+    if: github.repository == 'Automattic/jetpack'
     outputs:
       wpcomsh: ${{ steps.changed.outputs.wpcomsh }}
     steps:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

We shouldn't try to run the WP Cloud workflow on forked PRs; it'll always fail since there's no access to the secrets.

Context: p1751651725530069/1751622682.406089-slack-CDLH4C1UZ

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Create a PR that targets this branch that affects wpcomsh in some way.