### PR TITLE
Forms: Display success info after form submission without reload

### DIFF
--- a/projects/packages/forms/changelog/update-forms-submit-ajax-json-frontend
+++ b/projects/packages/forms/changelog/update-forms-submit-ajax-json-frontend
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Forms: Display success info after form submission without reload

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -1888,7 +1888,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 			$interactivity_attrs = ''; // Reset interactivity attributes for the field wrapper.
 		}
 
-		$field .= "\n<div {$block_style} {$interactivity_attrs} {$shell_field_class} data-wp-init='callbacks.initializeField' >\n"; // new in Jetpack 6.8.0
+		$field .= "\n<div {$block_style} {$interactivity_attrs} {$shell_field_class} data-wp-init='callbacks.initializeField' data-wp-on--jetpack-form-reset='callbacks.initializeField' >\n"; // new in Jetpack 6.8.0
 
 		switch ( $type ) {
 			case 'email':

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -1184,6 +1184,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 			data-wp-on--dragleave="actions.dragLeave"
 			data-wp-on--mouseleave="actions.dragLeave"
 			data-wp-on--drop="actions.fileDropped"
+			data-wp-on--jetpack-form-reset="actions.resetFiles"
 			data-is-required="<?php echo esc_attr( $required ); ?>"
 		>
 			<div class="jetpack-form-file-field__dropzone" data-wp-class--is-dropping="context.isDropping" data-wp-class--is-hidden="state.hasMaxFiles">

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -294,11 +294,12 @@ class Contact_Form_Plugin {
 		wp_style_add_data( 'grunion.css', 'rtl', 'replace' );
 
 		$config = array(
-			'error_types' => array(
+			'error_types'    => array(
 				'is_required'        => __( 'This field is required.', 'jetpack-forms' ),
 				'invalid_form_empty' => __( 'The form you are trying to submit is empty.', 'jetpack-forms' ),
 				'invalid_form'       => __( 'Please fill out the form correctly.', 'jetpack-forms' ),
 			),
+			'admin_ajax_url' => admin_url( 'admin-ajax.php' ),
 		);
 		wp_interactivity_config( 'jetpack/form', $config );
 		\wp_enqueue_script_module(

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -86,6 +86,13 @@ class Contact_Form extends Contact_Form_Shortcode {
 	public $is_response_without_reload_enabled = false;
 
 	/**
+	 * The current post object for this form.
+	 *
+	 * @var WP_Post|null
+	 */
+	public $current_post;
+
+	/**
 	 * Construction function.
 	 *
 	 * @param array  $attributes - the attributes.
@@ -93,6 +100,16 @@ class Contact_Form extends Contact_Form_Shortcode {
 	 */
 	public function __construct( $attributes, $content = null ) {
 		global $post, $page;
+
+		// AJAX requests don't have a post object, so we need to get the post object from the $_POST['contact-form-id']
+		$this->current_post = $post;
+
+		// phpcs:disable WordPress.Security.NonceVerification.Missing -- Nonce verification happens in process_form_submission() for logged-in users
+		if ( ! $this->current_post && isset( $_POST['contact-form-id'] ) ) {
+			$contact_form_id    = sanitize_text_field( wp_unslash( $_POST['contact-form-id'] ) );
+			$this->current_post = get_post( $contact_form_id );
+		}
+		// phpcs:enable
 
 		$this->is_response_without_reload_enabled = apply_filters( 'jetpack_forms_enable_ajax_submission', false );
 
@@ -104,12 +121,12 @@ class Contact_Form extends Contact_Form_Shortcode {
 			$attributes = array();
 		}
 
-		if ( $post ) {
+		if ( $this->current_post ) {
 			$default_subject = sprintf(
 				// translators: the blog name and post title.
 				_x( '%1$s %2$s', '%1$s = blog name, %2$s = post title', 'jetpack-forms' ),
 				$default_subject,
-				Contact_Form_Plugin::strip_tags( $post->post_title )
+				Contact_Form_Plugin::strip_tags( $this->current_post->post_title )
 			);
 		}
 
@@ -124,9 +141,9 @@ class Contact_Form extends Contact_Form_Shortcode {
 		} elseif ( ! empty( $attributes['block_template_part'] ) && $attributes['block_template_part'] ) {
 			$default_to      .= get_option( 'admin_email' );
 			$attributes['id'] = 'block-template-part-' . $attributes['block_template_part'];
-		} elseif ( $post ) {
-			$attributes['id'] = $post->ID;
-			$post_author      = get_userdata( $post->post_author );
+		} elseif ( $this->current_post ) {
+			$attributes['id'] = $this->current_post->ID;
+			$post_author      = get_userdata( $this->current_post->post_author );
 			if ( is_a( $post_author, '\WP_User' ) ) {
 				$default_to .= $post_author->user_email;
 			} else {
@@ -140,10 +157,13 @@ class Contact_Form extends Contact_Form_Shortcode {
 				$attributes['id'] = '';
 			}
 
-			// When submitting the page number is not always set, so we need to handle that: TODO: This is a hack, we need to find a better way to handle form identification
-			$page_num = max( 1, intval( $page ) );
+			// Widgets do not require a page number, so we don't need to add it to the id
+			if ( empty( $attributes['widget'] ) ) {
+				// When submitting the page number is not always set, so we need to handle that: TODO: This is a hack, we need to find a better way to handle form identification
+				$page_num = max( 1, intval( $page ) );
 
-			$attributes['id'] = $attributes['id'] . '-' . ( count( self::$forms ) + 1 ) . '-' . $page_num;
+				$attributes['id'] = $attributes['id'] . '-' . ( count( self::$forms ) + 1 ) . '-' . $page_num;
+			}
 		}
 
 		$this->hash                 = sha1( wp_json_encode( $attributes ) );
@@ -1301,8 +1321,6 @@ class Contact_Form extends Contact_Form_Shortcode {
 	 * Stores feedback.  Sends email.
 	 */
 	public function process_submission() {
-		global $post;
-
 		$plugin = Contact_Form_Plugin::init();
 
 		$id                  = $this->get_attribute( 'id' );
@@ -1356,7 +1374,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 			if ( isset( $_POST['contact-form-id'] ) && 'block-template-part-' . $block_template_part !== $_POST['contact-form-id'] ) { // phpcs:Ignore WordPress.Security.NonceVerification.Missing -- check done by caller process_form_submission()
 				return false;
 			}
-		} elseif ( isset( $_POST['contact-form-id'] ) && ( empty( $post ) || $post->ID !== (int) $_POST['contact-form-id'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing -- check done by caller process_form_submission()
+		} elseif ( isset( $_POST['contact-form-id'] ) && ( empty( $this->current_post ) || $this->current_post->ID !== (int) sanitize_text_field( wp_unslash( $_POST['contact-form-id'] ) ) ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing -- check done by caller process_form_submission()
 			return false;
 		}
 
@@ -1637,8 +1655,8 @@ class Contact_Form extends Contact_Form_Shortcode {
 		$feedback_id    = md5( $feedback_title );
 
 		$entry_values = array(
-			'entry_title'     => the_title_attribute( 'echo=0' ),
-			'entry_permalink' => esc_url( self::get_permalink( get_the_ID() ) ),
+			'entry_title'     => $this->current_post ? $this->current_post->post_title : the_title_attribute( 'echo=0' ),
+			'entry_permalink' => esc_url( self::get_permalink( $this->current_post ? $this->current_post->ID : get_the_ID() ) ),
 			'feedback_id'     => $feedback_id,
 		);
 
@@ -1657,7 +1675,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 		if ( $block_template || $block_template_part || $widget ) {
 			$url = home_url( '/' );
 		} else {
-			$url = self::get_permalink( $post->ID );
+			$url = self::get_permalink( $this->current_post ? $this->current_post->ID : 0 );
 		}
 
 		// translators: the time of the form submission.
@@ -1722,7 +1740,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 				'post_date'    => addslashes( $feedback_time ),
 				'post_type'    => 'feedback',
 				'post_status'  => addslashes( $feedback_status ),
-				'post_parent'  => $post ? (int) $post->ID : 0,
+				'post_parent'  => $this->current_post ? (int) $this->current_post->ID : 0,
 				'post_title'   => addslashes( wp_kses( $feedback_title, array() ) ),
 				// phpcs:ignore WordPress.NamingConventions.ValidVariableName.InterpolatedVariableNotSnakeCase, WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.PHP.DevelopmentFunctions.error_log_print_r
 				'post_content' => addslashes( wp_kses( "$comment_content\n<!--more-->\nAUTHOR: {$comment_author}\nAUTHOR EMAIL: {$comment_author_email}\nAUTHOR URL: {$comment_author_url}\nSUBJECT: {$subject}\n{$comment_ip_text}JSON_DATA\n" . @wp_json_encode( $all_values, true ), array() ) ), // so that search will pick up this data

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -345,6 +345,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 		}
 
 		$is_multistep = $max_steps > 0;
+		$element_id   = 'jp-form-' . esc_attr( $form->hash );
 
 		$default_context = array(
 			'formId'                         => $id,
@@ -354,6 +355,9 @@ class Contact_Form extends Contact_Form_Shortcode {
 			'fields'                         => array(),
 			'isMultiStep'                    => $is_multistep, // Whether the form is a multistep form.
 			'isResponseWithoutReloadEnabled' => $form->is_response_without_reload_enabled,
+			'submissionData'                 => null,
+			'submissionError'                => null,
+			'elementId'                      => $element_id,
 		);
 
 		if ( $is_multistep ) {
@@ -374,6 +378,10 @@ class Contact_Form extends Contact_Form_Shortcode {
 
 		$r  = '';
 		$r .= "<div data-test='contact-form' id='contact-form-$id' class='{$container_classes_string}' data-wp-interactive='jetpack/form' " . wp_interactivity_data_wp_context( $context ) . ">\n";
+
+		if ( $form->is_response_without_reload_enabled ) {
+			$r .= self::render_ajax_success_wrapper( $form );
+		}
 
 		if ( is_wp_error( $form->errors ) && $form->errors->get_error_codes() ) {
 			// There are errors.  Display them
@@ -463,10 +471,11 @@ class Contact_Form extends Contact_Form_Shortcode {
 			}
 
 			$r .= "<form action='" . esc_url( $url ) . "'
-				id='jp-form-" . esc_attr( $form->hash ) . "'
+				id='" . $element_id . "'
 				method='post'
 				class='" . esc_attr( $form_classes ) . "' $form_aria_label
 				data-wp-on--submit=\"actions.onFormSubmit\"
+				data-wp-class--is-submitted=\"state.hasSubmitted\"
 				data-wp-class--is-first-step=\"state.isFirstStep\"
 				data-wp-class--is-last-step=\"state.isLastStep\"
 				novalidate >\n";
@@ -581,6 +590,49 @@ class Contact_Form extends Contact_Form_Shortcode {
 					<li><a data-wp-bind--href="context.item.anchor" data-wp-on--click="actions.scrollIntoView" data-wp-text="context.item.label"></a></li>
 				</template>
 				</ul>';
+		$html .= '</div>';
+		return $html;
+	}
+
+	/**
+	 * Renders the success wrapper after a form is submitted without reloading the page.
+	 *
+	 * @param Contact_Form $form - the contact form.
+	 *
+	 * @return string HTML string for the success wrapper.
+	 */
+	private static function render_ajax_success_wrapper( $form ) {
+		$html  = '<div class="contact-form-submission" data-wp-class--is-submitted="state.hasSubmitted"';
+		$html .= '<p class="go-back-message"> <a class="link" href="#" data-wp-on--click="actions.goBack">' . esc_html__( 'Go back', 'jetpack-forms' ) . '</a> </p>';
+		$html .=
+			'<h4 id="contact-form-success-header">' . esc_html( $form->get_attribute( 'customThankyouHeading' ) ) .
+			"</h4>\n\n";
+
+		if ( 'message' === $form->get_attribute( 'customThankyou' ) ) {
+			$raw_message = wpautop( $form->get_attribute( 'customThankyouMessage' ) );
+			// Add more allowed HTML elements for file download links
+			$allowed_html = array(
+				'br'         => array(),
+				'blockquote' => array( 'class' => array() ),
+				'p'          => array(),
+				'div'        => array(
+					'class' => array(),
+					'style' => array(),
+				),
+				'span'       => array(
+					'class' => array(),
+					'style' => array(),
+				),
+			);
+
+			$html .= wp_kses( $raw_message, $allowed_html );
+		} else {
+			$html .= '<template data-wp-each--submission="state.getSubmissionData">
+				<div class="field-name" data-wp-text="context.submission.label" data-wp-bind--hidden="!context.submission.label"></div>
+				<div class="field-value" data-wp-text="context.submission.value"></div>
+			</template>';
+		}
+
 		$html .= '</div>';
 		return $html;
 	}

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1654,9 +1654,29 @@ class Contact_Form extends Contact_Form_Shortcode {
 		$feedback_title = "{$comment_author} - {$feedback_time}";
 		$feedback_id    = md5( $feedback_title );
 
+		$entry_title     = '';
+		$entry_permalink = '';
+
+		if ( $this->current_post ) {
+			$entry_title     = $this->current_post->post_title;
+			$entry_permalink = esc_url( self::get_permalink( $this->current_post->ID ) );
+		} elseif ( $widget ) {
+			$entry_title     = __( 'Sidebar Widget', 'jetpack-forms' );
+			$entry_permalink = esc_url( home_url( '/' ) );
+		} elseif ( $block_template ) {
+			$entry_title     = __( 'Block Template', 'jetpack-forms' );
+			$entry_permalink = esc_url( home_url( '/' ) );
+		} elseif ( $block_template_part ) {
+			$entry_title     = __( 'Block Template Part', 'jetpack-forms' );
+			$entry_permalink = esc_url( home_url( '/' ) );
+		} else {
+			$entry_title     = the_title_attribute( 'echo=0' );
+			$entry_permalink = esc_url( self::get_permalink( get_the_ID() ) );
+		}
+
 		$entry_values = array(
-			'entry_title'     => $this->current_post ? $this->current_post->post_title : the_title_attribute( 'echo=0' ),
-			'entry_permalink' => esc_url( self::get_permalink( $this->current_post ? $this->current_post->ID : get_the_ID() ) ),
+			'entry_title'     => $entry_title,
+			'entry_permalink' => $entry_permalink,
 			'feedback_id'     => $feedback_id,
 		);
 

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -398,7 +398,12 @@ class Contact_Form extends Contact_Form_Shortcode {
 		$context = is_array( $context ) ? array_merge( $default_context, $context ) : $default_context;
 
 		$r  = '';
-		$r .= "<div data-test='contact-form' id='contact-form-$id' class='{$container_classes_string}' data-wp-interactive='jetpack/form' " . wp_interactivity_data_wp_context( $context ) . ">\n";
+		$r .= "<div data-test='contact-form'
+			id='contact-form-$id'
+			class='{$container_classes_string}'
+			data-wp-interactive='jetpack/form' " . wp_interactivity_data_wp_context( $context ) . "
+			data-wp-watch--scroll-to-wrapper=\"callbacks.scrollToWrapper\"
+		>\n";
 
 		if ( $form->is_response_without_reload_enabled ) {
 			$r .= self::render_ajax_success_wrapper( $form );
@@ -625,7 +630,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 	 * @return string HTML string for the success wrapper.
 	 */
 	private static function render_ajax_success_wrapper( $form ) {
-		$html  = '<div class="contact-form-submission contact-form-ajax-submission" data-wp-class--is-submitted="state.hasSubmitted"';
+		$html  = '<div class="contact-form-submission contact-form-ajax-submission" data-wp-class--is-submitted="state.hasSubmitted">';
 		$html .= '<p class="go-back-message"> <a class="link" href="#" data-wp-on--click="actions.goBack">' . esc_html__( 'Go back', 'jetpack-forms' ) . '</a> </p>';
 		$html .=
 			'<h4 id="contact-form-success-header">' . esc_html( $form->get_attribute( 'customThankyouHeading' ) ) .

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -496,6 +496,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 				method='post'
 				class='" . esc_attr( $form_classes ) . "' $form_aria_label
 				data-wp-on--submit=\"actions.onFormSubmit\"
+				data-wp-on--reset=\"actions.onFormReset\"
 				data-wp-class--is-submitted=\"state.hasSubmitted\"
 				data-wp-class--is-first-step=\"state.isFirstStep\"
 				data-wp-class--is-last-step=\"state.isLastStep\"

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -79,6 +79,13 @@ class Contact_Form extends Contact_Form_Shortcode {
 	public static $allowed_html_tags_for_submit_button = array( 'br' => array() );
 
 	/**
+	 * Whether to enable response without reloading the page.
+	 *
+	 * @var bool
+	 */
+	public $is_response_without_reload_enabled = false;
+
+	/**
 	 * Construction function.
 	 *
 	 * @param array  $attributes - the attributes.
@@ -86,6 +93,8 @@ class Contact_Form extends Contact_Form_Shortcode {
 	 */
 	public function __construct( $attributes, $content = null ) {
 		global $post, $page;
+
+		$this->is_response_without_reload_enabled = apply_filters( 'jetpack_forms_enable_ajax_submission', false );
 
 		// Set up the default subject and recipient for this form.
 		$default_to      = '';
@@ -428,13 +437,13 @@ class Contact_Form extends Contact_Form_Shortcode {
 			$is_multistep = $max_steps > 0;
 
 			$default_context = array(
-				'formId'                  => $id,
-				'formHash'                => $form->hash,
-				'showErrors'              => false, // We toggle this to true when we want to show the user errors right away.
-				'errors'                  => array(), // This should be a associative array.
-				'fields'                  => array(),
-				'isMultiStep'             => $is_multistep, // Whether the form is a multistep form.
-				'isAjaxSubmissionEnabled' => apply_filters( 'jetpack_forms_enable_ajax_submission', false ),
+				'formId'                         => $id,
+				'formHash'                       => $form->hash,
+				'showErrors'                     => false, // We toggle this to true when we want to show the user errors right away.
+				'errors'                         => array(), // This should be a associative array.
+				'fields'                         => array(),
+				'isMultiStep'                    => $is_multistep, // Whether the form is a multistep form.
+				'isResponseWithoutReloadEnabled' => $form->is_response_without_reload_enabled,
 			);
 
 			if ( $is_multistep ) {
@@ -1884,10 +1893,9 @@ class Contact_Form extends Contact_Form_Shortcode {
 		do_action( 'grunion_after_message_sent', $post_id, $to, $subject, $message, $headers, $all_values, $extra_values );
 
 		// If the request accepts JSON, return a JSON response instead of redirecting
-		$is_ajax_submission_enabled = apply_filters( 'jetpack_forms_enable_ajax_submission', false );
-		$accepts_json               = isset( $_SERVER['HTTP_ACCEPT'] ) && false !== strpos( strtolower( sanitize_text_field( wp_unslash( $_SERVER['HTTP_ACCEPT'] ) ) ), 'application/json' );
+		$accepts_json = isset( $_SERVER['HTTP_ACCEPT'] ) && false !== strpos( strtolower( sanitize_text_field( wp_unslash( $_SERVER['HTTP_ACCEPT'] ) ) ), 'application/json' );
 
-		if ( $is_ajax_submission_enabled && $accepts_json ) {
+		if ( $this->is_response_without_reload_enabled && $accepts_json ) {
 			header( 'Content-Type: application/json' );
 
 			echo wp_json_encode(

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -152,19 +152,17 @@ class Contact_Form extends Contact_Form_Shortcode {
 			}
 		}
 
-		if ( ! empty( self::$forms ) ) {
+		// When using admin-ajax.php, we don't need to add a page number to the id
+		if ( ! empty( self::$forms ) && ! $this->is_response_without_reload_enabled ) {
 			// Ensure 'id' exists in $attributes before trying to modify it
 			if ( ! isset( $attributes['id'] ) ) {
 				$attributes['id'] = '';
 			}
 
-			// Widgets do not require a page number, so we don't need to add it to the id
-			if ( empty( $attributes['widget'] ) ) {
-				// When submitting the page number is not always set, so we need to handle that: TODO: This is a hack, we need to find a better way to handle form identification
-				$page_num = max( 1, intval( $page ) );
+			// When submitting the page number is not always set, so we need to handle that: TODO: This is a hack, we need to find a better way to handle form identification
+			$page_num = max( 1, intval( $page ) );
 
-				$attributes['id'] = $attributes['id'] . '-' . ( count( self::$forms ) + 1 ) . '-' . $page_num;
-			}
+			$attributes['id'] = $attributes['id'] . '-' . ( count( self::$forms ) + 1 ) . '-' . $page_num;
 		}
 
 		$this->hash                 = sha1( wp_json_encode( $attributes ) );

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -337,8 +337,43 @@ class Contact_Form extends Contact_Form_Shortcode {
 		$container_classes[]      = self::get_block_alignment_class( $attributes );
 		$container_classes_string = implode( ' ', $container_classes );
 
+		$max_steps = 0;
+		if ( preg_match_all( '/data-wp-context=[\'"]?{"step":(\d+)}[\'"]?/', $content, $matches ) ) {
+			if ( ! empty( $matches[1] ) ) {
+				$max_steps = max( array_map( 'intval', $matches[1] ) );
+			}
+		}
+
+		$is_multistep = $max_steps > 0;
+
+		$default_context = array(
+			'formId'                         => $id,
+			'formHash'                       => $form->hash,
+			'showErrors'                     => false, // We toggle this to true when we want to show the user errors right away.
+			'errors'                         => array(), // This should be a associative array.
+			'fields'                         => array(),
+			'isMultiStep'                    => $is_multistep, // Whether the form is a multistep form.
+			'isResponseWithoutReloadEnabled' => $form->is_response_without_reload_enabled,
+		);
+
+		if ( $is_multistep ) {
+			$multistep_context = array(
+				'currentStep' => isset( $_GET[ $id . '-step' ] ) ? absint( $_GET[ $id . '-step' ] ) : 1, // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+				'maxSteps'    => $max_steps,
+				'direction'   => 'forward', // Default direction for animations
+				'transition'  => $form->get_attribute( 'stepTransition' ) ? $form->get_attribute( 'stepTransition' ) : 'fade-slide', // Transition style for step animations
+			);
+
+			if ( ! is_array( $context ) ) {
+				$context = array();
+			}
+			$context = array_merge( $context, $multistep_context );
+		}
+
+		$context = is_array( $context ) ? array_merge( $default_context, $context ) : $default_context;
+
 		$r  = '';
-		$r .= "<div data-test='contact-form' id='contact-form-$id' class='{$container_classes_string}'>\n";
+		$r .= "<div data-test='contact-form' id='contact-form-$id' class='{$container_classes_string}' data-wp-interactive='jetpack/form' " . wp_interactivity_data_wp_context( $context ) . ">\n";
 
 		if ( is_wp_error( $form->errors ) && $form->errors->get_error_codes() ) {
 			// There are errors.  Display them
@@ -427,46 +462,10 @@ class Contact_Form extends Contact_Form_Shortcode {
 				$form_classes .= ' wp-block-jetpack-contact-form';
 			}
 
-			$max_steps = 0;
-			if ( preg_match_all( '/data-wp-context=[\'"]?{"step":(\d+)}[\'"]?/', $content, $matches ) ) {
-				if ( ! empty( $matches[1] ) ) {
-					$max_steps = max( array_map( 'intval', $matches[1] ) );
-				}
-			}
-
-			$is_multistep = $max_steps > 0;
-
-			$default_context = array(
-				'formId'                         => $id,
-				'formHash'                       => $form->hash,
-				'showErrors'                     => false, // We toggle this to true when we want to show the user errors right away.
-				'errors'                         => array(), // This should be a associative array.
-				'fields'                         => array(),
-				'isMultiStep'                    => $is_multistep, // Whether the form is a multistep form.
-				'isResponseWithoutReloadEnabled' => $form->is_response_without_reload_enabled,
-			);
-
-			if ( $is_multistep ) {
-				$multistep_context = array(
-					'currentStep' => isset( $_GET[ $id . '-step' ] ) ? absint( $_GET[ $id . '-step' ] ) : 1,
-					'maxSteps'    => $max_steps,
-					'direction'   => 'forward', // Default direction for animations
-					'transition'  => $form->get_attribute( 'stepTransition' ) ? $form->get_attribute( 'stepTransition' ) : 'fade-slide', // Transition style for step animations
-				);
-
-				if ( ! is_array( $context ) ) {
-					$context = array();
-				}
-				$context = array_merge( $context, $multistep_context );
-			}
-
-			$context = is_array( $context ) ? array_merge( $default_context, $context ) : $default_context;
-
 			$r .= "<form action='" . esc_url( $url ) . "'
 				id='jp-form-" . esc_attr( $form->hash ) . "'
 				method='post'
 				class='" . esc_attr( $form_classes ) . "' $form_aria_label
-				data-wp-interactive=\"jetpack/form\"  " . wp_interactivity_data_wp_context( $context ) . "
 				data-wp-on--submit=\"actions.onFormSubmit\"
 				data-wp-class--is-first-step=\"state.isFirstStep\"
 				data-wp-class--is-last-step=\"state.isLastStep\"
@@ -1901,7 +1900,6 @@ class Contact_Form extends Contact_Form_Shortcode {
 			echo wp_json_encode(
 				array(
 					'success' => true,
-					'message' => __( 'Your message has been sent', 'jetpack-forms' ),
 					'data'    => self::get_json_data( $post_id, $this ),
 				)
 			);

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -13,6 +13,7 @@ use Jetpack_Tracks_Event;
 use PHPMailer\PHPMailer\PHPMailer;
 use WP_Block;
 use WP_Error;
+use WP_Post;
 
 /**
  * Class for the contact-form shortcode.

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -478,6 +478,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 				data-wp-class--is-submitted=\"state.hasSubmitted\"
 				data-wp-class--is-first-step=\"state.isFirstStep\"
 				data-wp-class--is-last-step=\"state.isLastStep\"
+				data-wp-class--is-ajax-form=\"context.isResponseWithoutReloadEnabled\"
 				novalidate >\n";
 
 			if ( $is_multistep ) { // This makes the "enter" key work in multi-step forms as expected.
@@ -602,7 +603,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 	 * @return string HTML string for the success wrapper.
 	 */
 	private static function render_ajax_success_wrapper( $form ) {
-		$html  = '<div class="contact-form-submission" data-wp-class--is-submitted="state.hasSubmitted"';
+		$html  = '<div class="contact-form-submission contact-form-ajax-submission" data-wp-class--is-submitted="state.hasSubmitted"';
 		$html .= '<p class="go-back-message"> <a class="link" href="#" data-wp-on--click="actions.goBack">' . esc_html__( 'Go back', 'jetpack-forms' ) . '</a> </p>';
 		$html .=
 			'<h4 id="contact-form-success-header">' . esc_html( $form->get_attribute( 'customThankyouHeading' ) ) .

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -1175,10 +1175,10 @@ on production builds, the attributes are being reordered, causing side-effects
   width: 1px;
 }
 
-.wp-block-jetpack-contact-form.is-submitted {
+.wp-block-jetpack-contact-form.is-ajax-form.is-submitted {
 	display: none;
 }
 
-.contact-form-submission:not(.is-submitted) {
+.contact-form-ajax-submission:not(.is-submitted) {
 	display: none;
 }

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -1174,3 +1174,11 @@ on production builds, the attributes are being reordered, causing side-effects
   white-space: nowrap;
   width: 1px;
 }
+
+.wp-block-jetpack-contact-form.is-submitted {
+	display: none;
+}
+
+.contact-form-submission:not(.is-submitted) {
+	display: none;
+}

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -1175,7 +1175,7 @@ on production builds, the attributes are being reordered, causing side-effects
   width: 1px;
 }
 
-.wp-block-jetpack-contact-form.is-ajax-form.is-submitted {
+.contact-form.is-ajax-form.is-submitted {
 	display: none;
 }
 

--- a/projects/packages/forms/src/modules/file-field/view.js
+++ b/projects/packages/forms/src/modules/file-field/view.js
@@ -379,6 +379,14 @@ const { state, actions } = store( NAMESPACE, {
 		},
 
 		/**
+		 * Reset the files in the context.
+		 */
+		resetFiles: () => {
+			const context = getContext();
+			context.files = [];
+		},
+
+		/**
 		 * Remove a file from the context and cancel its upload if in progress.
 		 *
 		 * @param {Event} event - The event object.

--- a/projects/packages/forms/src/modules/form/shared.js
+++ b/projects/packages/forms/src/modules/form/shared.js
@@ -1,3 +1,11 @@
+/*
+ * External dependencies
+ */
+import { getConfig } from '@wordpress/interactivity';
+
+const NAMESPACE = 'jetpack/form';
+const config = getConfig( NAMESPACE );
+
 const getForm = formHash => {
 	return document.getElementById( 'jp-form-' + formHash );
 };
@@ -40,7 +48,9 @@ export const submitForm = async formHash => {
 
 	try {
 		const formData = new FormData( form );
-		const url = form.getAttribute( 'action' );
+
+		const adminAjaxUrl = config?.admin_ajax_url || '/wp-admin/admin-ajax.php';
+		const url = `${ adminAjaxUrl }?action=grunion-contact-form`;
 
 		const response = await fetch( url, {
 			method: 'POST',

--- a/projects/packages/forms/src/modules/form/view.js
+++ b/projects/packages/forms/src/modules/form/view.js
@@ -283,10 +283,9 @@ const { state } = store( NAMESPACE, {
 				return;
 			}
 
-			// Set submitting state
 			context.isSubmitting = true;
 
-			if ( context.isAjaxSubmissionEnabled ) {
+			if ( context.isResponseWithoutReloadEnabled ) {
 				event.preventDefault();
 				event.stopPropagation();
 

--- a/projects/packages/forms/src/modules/form/view.js
+++ b/projects/packages/forms/src/modules/form/view.js
@@ -77,6 +77,16 @@ const getError = field => {
 	return config.error_types && config.error_types[ field.error ];
 };
 
+const maybeAddColonToLabel = label => {
+	const formattedLabel = label ? label : null;
+
+	if ( ! formattedLabel ) {
+		return null;
+	}
+
+	return formattedLabel.endsWith( '?' ) ? formattedLabel : formattedLabel.replace( /:$/, '' ) + ':';
+};
+
 const { state } = store( NAMESPACE, {
 	state: {
 		get fieldHasErrors() {
@@ -199,9 +209,25 @@ const { state } = store( NAMESPACE, {
 			return field.value;
 		},
 
-		get submissionError() {
+		get getSubmissionError() {
 			const context = getContext();
 			return context.submissionError || '';
+		},
+
+		get getSubmissionData() {
+			const context = getContext();
+
+			const data = context.submissionData ? Object.values( context.submissionData ) : [];
+
+			return data.map( item => ( {
+				label: maybeAddColonToLabel( item.label ),
+				value: item.value,
+			} ) );
+		},
+
+		get hasSubmitted() {
+			const context = getContext();
+			return !! context.submissionData && context.isResponseWithoutReloadEnabled;
 		},
 	},
 
@@ -289,8 +315,15 @@ const { state } = store( NAMESPACE, {
 				event.preventDefault();
 				event.stopPropagation();
 
-				// TODO: Get the data and update the page
-				yield submitForm( context.formHash );
+				const { success, error, data } = yield submitForm( context.formHash );
+
+				if ( success ) {
+					context.submissionData = data;
+					context.submissionError = null;
+				} else {
+					context.submissionError = error;
+					context.submissionData = null;
+				}
 
 				context.isSubmitting = false;
 			}
@@ -338,6 +371,14 @@ const { state } = store( NAMESPACE, {
 				event.preventDefault();
 			}
 		} ),
+
+		goBack: () => {
+			const context = getContext();
+			const form = document.getElementById( context.elementId );
+			form?.reset?.();
+			context.submissionData = null;
+			context.submissionError = null;
+		},
 	},
 
 	callbacks: {

--- a/projects/packages/forms/src/modules/form/view.js
+++ b/projects/packages/forms/src/modules/form/view.js
@@ -295,6 +295,10 @@ const { state } = store( NAMESPACE, {
 					wrapper.dispatchEvent( new CustomEvent( 'jetpack-form-reset', { bubbles: false } ) );
 				} );
 			}
+
+			if ( context.isMultiStep ) {
+				context.currentStep = 1;
+			}
 		},
 
 		onFormSubmit: withSyncEvent( function* ( event ) {

--- a/projects/packages/forms/src/modules/form/view.js
+++ b/projects/packages/forms/src/modules/form/view.js
@@ -206,7 +206,7 @@ const { state } = store( NAMESPACE, {
 			const context = getContext();
 			const fieldId = context.fieldId;
 			const field = context.fields[ fieldId ];
-			return field.value;
+			return field?.value || '';
 		},
 
 		get getSubmissionError() {
@@ -279,6 +279,22 @@ const { state } = store( NAMESPACE, {
 		onFieldBlur: event => {
 			const context = getContext();
 			updateField( context.fieldId, event.target.value, true );
+		},
+
+		onFormReset: () => {
+			const context = getContext();
+			context.fields = [];
+
+			// Dispatch custom events to reset all fields
+			const formElement = document.getElementById( context.elementId );
+
+			if ( formElement ) {
+				const fieldWrappers = formElement.querySelectorAll( '[data-wp-on--jetpack-form-reset]' );
+
+				fieldWrappers.forEach( wrapper => {
+					wrapper.dispatchEvent( new CustomEvent( 'jetpack-form-reset', { bubbles: false } ) );
+				} );
+			}
 		},
 
 		onFormSubmit: withSyncEvent( function* ( event ) {

--- a/projects/packages/forms/src/modules/form/view.js
+++ b/projects/packages/forms/src/modules/form/view.js
@@ -87,6 +87,15 @@ const maybeAddColonToLabel = label => {
 	return formattedLabel.endsWith( '?' ) ? formattedLabel : formattedLabel.replace( /:$/, '' ) + ':';
 };
 
+const maybeTransformValue = value => {
+	// For file upload fields, we want to show the file name and size
+	if ( value?.name && value?.size ) {
+		return value.name + ' (' + value.size + ')';
+	}
+
+	return value;
+};
+
 const { state } = store( NAMESPACE, {
 	state: {
 		get fieldHasErrors() {
@@ -221,7 +230,7 @@ const { state } = store( NAMESPACE, {
 
 			return data.map( item => ( {
 				label: maybeAddColonToLabel( item.label ),
-				value: item.value,
+				value: maybeTransformValue( item.value ),
 			} ) );
 		},
 

--- a/projects/packages/forms/src/modules/form/view.js
+++ b/projects/packages/forms/src/modules/form/view.js
@@ -394,6 +394,7 @@ const { state } = store( NAMESPACE, {
 			form?.reset?.();
 			context.submissionData = null;
 			context.submissionError = null;
+			context.hasClickedBack = true;
 		},
 	},
 
@@ -402,6 +403,16 @@ const { state } = store( NAMESPACE, {
 			const context = getContext();
 			const { fieldId, fieldType, fieldLabel, fieldValue, fieldIsRequired, fieldExtra } = context;
 			registerField( fieldId, fieldType, fieldLabel, fieldValue, fieldIsRequired, fieldExtra );
+		},
+
+		scrollToWrapper() {
+			const context = getContext();
+
+			if ( state.hasSubmitted || context.hasClickedBack ) {
+				const wrapperElement = document.getElementById( `contact-form-${ context.formId }` );
+				wrapperElement?.scrollIntoView( { behavior: 'smooth' } );
+				context.hasClickedBack = false;
+			}
 		},
 	},
 } );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of FORMS-69

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Displays the submitted data without reload if the feature flag is on
* Fixes forms on widgets and on paginated content (when the feature flag is on)
* Does not deal with submission errors (network, mostly)
* Does not deal with transitions 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Make sure the feature flag is *disabled*
* Submit some forms. Test post forms, pages with more than one form, widgets...
* Check that it works exactly the same as in trunk, with no regressions. Forms on widgets do not work on trunk, and forms on paginated posts (your Home, add some posts with forms in them) also do not work. This is expected, same as trunk.
* Enable the flag with `add_filter( 'jetpack_forms_enable_ajax_submission', '__return_true' );`
* Reload the pages and submit again. Test the same cases.
* Check that the information is displayed without a reload on all cases
* Check that you can go back and the form is displayed without a reload, in a reset state
* Check that you can fill it and submit again
* Check that emails are sent as expected
* Check that the forms are displayed in the dashboard as expected
