### PR TITLE
jetpack-mu-wpcom:  Limit comment like requests to edit-comment and gate by module

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-jetpack-mu-wpcom-improve-comments-performance
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-jetpack-mu-wpcom-improve-comments-performance
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Improves performance of wpcom comments liking by caching and minimizing API requests.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-comments/class-wp-rest-comment-like.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-comments/class-wp-rest-comment-like.php
@@ -73,9 +73,6 @@ class WP_REST_Comment_Like extends WP_REST_Controller {
 		$comment_id = $request->get_param( 'comment_id' );
 		$blog_id    = \Jetpack_Options::get_option( 'id' );
 
-		$cache_key = WPCom_Comments_Likes::get_cache_key( $comment_id, get_current_user_id() );
-		delete_transient( $cache_key );
-
 		// Call WPCom remote API to record a new like.
 		$response = \Automattic\Jetpack\Connection\Client::wpcom_json_api_request_as_user(
 			"/sites/$blog_id/comments/$comment_id/likes/new",
@@ -98,9 +95,6 @@ class WP_REST_Comment_Like extends WP_REST_Controller {
 	public function delete_like( WP_REST_Request $request ) {
 		$comment_id = $request->get_param( 'comment_id' );
 		$blog_id    = \Jetpack_Options::get_option( 'id' );
-
-		$cache_key = WPCom_Comments_Likes::get_cache_key( $comment_id, get_current_user_id() );
-		delete_transient( $cache_key );
 
 		// Call WPCom remote API to delete the current user's like.
 		$response = \Automattic\Jetpack\Connection\Client::wpcom_json_api_request_as_user(

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-comments/class-wp-rest-comment-like.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-comments/class-wp-rest-comment-like.php
@@ -73,6 +73,9 @@ class WP_REST_Comment_Like extends WP_REST_Controller {
 		$comment_id = $request->get_param( 'comment_id' );
 		$blog_id    = \Jetpack_Options::get_option( 'id' );
 
+		$cache_key = WPCom_Comments_Likes::get_cache_key( $comment_id, get_current_user_id() );
+		delete_transient( $cache_key );
+
 		// Call WPCom remote API to record a new like.
 		$response = \Automattic\Jetpack\Connection\Client::wpcom_json_api_request_as_user(
 			"/sites/$blog_id/comments/$comment_id/likes/new",
@@ -95,6 +98,9 @@ class WP_REST_Comment_Like extends WP_REST_Controller {
 	public function delete_like( WP_REST_Request $request ) {
 		$comment_id = $request->get_param( 'comment_id' );
 		$blog_id    = \Jetpack_Options::get_option( 'id' );
+
+		$cache_key = WPCom_Comments_Likes::get_cache_key( $comment_id, get_current_user_id() );
+		delete_transient( $cache_key );
 
 		// Call WPCom remote API to delete the current user's like.
 		$response = \Automattic\Jetpack\Connection\Client::wpcom_json_api_request_as_user(

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-comments/wpcom-comments.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-comments/wpcom-comments.php
@@ -94,7 +94,7 @@ class WPCom_Comments_Likes {
 	 * @param int $user_id    The user ID.
 	 * @return string The cache key.
 	 */
-	private function get_cache_key( $comment_id, $user_id ) {
+	public static function get_cache_key( $comment_id, $user_id ) {
 		return "comment_like_{$comment_id}_{$user_id}";
 	}
 
@@ -107,7 +107,7 @@ class WPCom_Comments_Likes {
 	 * @return bool|WP_Error True if the comment is liked, false otherwise, or a WP_Error if the request fails.
 	 */
 	private function do_comment_like_api_request( $blog_id, $user_id, $comment_id ) {
-		$cache_key = $this->get_cache_key( $comment_id, $user_id );
+		$cache_key = self::get_cache_key( $comment_id, $user_id );
 
 		$cached_result = get_transient( $cache_key );
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-comments/wpcom-comments.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-comments/wpcom-comments.php
@@ -39,7 +39,7 @@ class WPCom_Comments_Likes {
 			add_action( 'rest_api_init', array( $this, 'register_like_api' ) );
 		}
 
-		add_action( 'admin_init', array( $this, 'init' ) );
+		add_action( 'current_screen', array( $this, 'init' ) );
 	}
 
 	/**
@@ -63,11 +63,18 @@ class WPCom_Comments_Likes {
 			return;
 		}
 
-		if ( is_admin() ) {
-			add_filter( 'comment_class', array( $this, 'add_like_class' ), 10, 3 );
-			add_filter( 'comment_row_actions', array( $this, 'enable_likes' ), 10, 2 );
-			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ), 10, 2 );
+		if ( ! is_admin() ) {
+			return;
 		}
+
+		$screen = get_current_screen();
+		if ( ! $screen || 'edit-comments' !== $screen->id ) {
+			return;
+		}
+
+		add_filter( 'comment_class', array( $this, 'add_like_class' ), 10, 3 );
+		add_filter( 'comment_row_actions', array( $this, 'enable_likes' ), 10, 2 );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ), 10, 2 );
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-comments/wpcom-comments.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-comments/wpcom-comments.php
@@ -14,7 +14,7 @@ if ( ( ! defined( 'IS_WPCOM' ) || ! IS_WPCOM ) && ( ! defined( 'IS_ATOMIC' ) || 
  * WPCom Comments Likes functionality in a singleton pattern.
  */
 class WPCom_Comments_Likes {
-	const CACHE_EXPIRATION = HOUR_IN_SECONDS;
+	const CACHE_EXPIRATION = 900; // 15 minutes in seconds.
 
 	/**
 	 * Singleton instance.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-comments/wpcom-comments.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-comments/wpcom-comments.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:ignore
 /**
  * Plugin Name: Jetpack MU WPCom Comment Likes
  * Description: Adds a "Like" action to comment rows and enqueues the necessary assets in the admin area.
@@ -11,112 +11,227 @@ if ( ( ! defined( 'IS_WPCOM' ) || ! IS_WPCOM ) && ( ! defined( 'IS_ATOMIC' ) || 
 }
 
 /**
- * Adds a "liked" class to comments that the current user has liked.
- *
- * @param array  $classes    Array of comment classes.
- * @param string $css_class  Unused.
- * @param int    $comment_id The comment ID.
- * @return array Modified array of comment classes.
+ * WPCom Comments Likes functionality in a singleton pattern.
  */
-function wpcom_comments_add_like_class( $classes, $css_class, $comment_id ) {
-	if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-		$blog_id = get_current_blog_id();
-		$liked   = Likes::comment_like_current_user_likes( $blog_id, $comment_id );
-	} else {
-		$blog_id  = Jetpack_Options::get_option( 'id' );
-		$response = Automattic\Jetpack\Connection\Client::wpcom_json_api_request_as_user(
-			"/sites/$blog_id/comments/$comment_id/likes",
-			'v1.1',
-			array( 'method' => 'GET' ),
-			null,
-			'rest'
+class WPCom_Comments_Likes {
+	const CACHE_EXPIRATION = HOUR_IN_SECONDS;
+
+	/**
+	 * Singleton instance.
+	 *
+	 * @var WPCom_Comments_Likes
+	 */
+	private static $instance = null;
+
+	/**
+	 * Flag to track if hooks have been initialized.
+	 *
+	 * @var bool
+	 */
+	private $initialized = false;
+
+	/**
+	 * Private constructor to prevent direct instantiation.
+	 */
+	private function __construct() {
+		// Register REST API for Atomic sites.
+		if ( defined( 'IS_ATOMIC' ) && IS_ATOMIC ) {
+			add_action( 'rest_api_init', array( $this, 'register_like_api' ) );
+		}
+
+		add_action( 'admin_init', array( $this, 'init' ) );
+	}
+
+	/**
+	 * Get the singleton instance.
+	 *
+	 * @return WPCom_Comments_Likes
+	 */
+	public static function get_instance() {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Initialize the comment likes functionality if enabled.
+	 */
+	public function init() {
+		// Only initialize if comment likes are enabled.
+		if ( ! $this->is_comment_likes_enabled() ) {
+			return;
+		}
+
+		if ( is_admin() ) {
+			add_filter( 'comment_class', array( $this, 'add_like_class' ), 10, 3 );
+			add_filter( 'comment_row_actions', array( $this, 'enable_likes' ), 10, 2 );
+			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ), 10, 2 );
+		}
+	}
+
+	/**
+	 * Check if comment likes are enabled.
+	 *
+	 * This is currently only expected to work for WoW sites.
+	 *
+	 * @return bool True if comment likes are enabled, false otherwise.
+	 */
+	private function is_comment_likes_enabled() {
+		// @phan-suppress-next-line PhanUndeclaredClassReference
+		if ( class_exists( 'Jetpack' ) && method_exists( 'Jetpack', 'is_module_active' ) ) {
+			// @phan-suppress-next-line PhanUndeclaredClassMethod
+			return Jetpack::is_module_active( 'comment-likes' );
+		}
+
+		return false;
+	}
+
+	/**
+	 * Get cache key for comment like status.
+	 *
+	 * @param int $comment_id The comment ID.
+	 * @param int $user_id    The user ID.
+	 * @return string The cache key.
+	 */
+	private function get_cache_key( $comment_id, $user_id ) {
+		return "comment_like_{$comment_id}_{$user_id}";
+	}
+
+	/**
+	 * Do a comment like API request.
+	 *
+	 * @param int $blog_id    The blog ID.
+	 * @param int $user_id    The user ID.
+	 * @param int $comment_id The comment ID.
+	 * @return bool|WP_Error True if the comment is liked, false otherwise, or a WP_Error if the request fails.
+	 */
+	private function do_comment_like_api_request( $blog_id, $user_id, $comment_id ) {
+		$cache_key = $this->get_cache_key( $comment_id, $user_id );
+
+		$cached_result = get_transient( $cache_key );
+
+		if ( false !== $cached_result ) {
+			$liked = $cached_result;
+		} else {
+			$response = Automattic\Jetpack\Connection\Client::wpcom_json_api_request_as_user(
+				"/sites/$blog_id/comments/$comment_id/likes",
+				'v1.1',
+				array( 'method' => 'GET' ),
+				null,
+				'rest'
+			);
+
+			// If the request fails, simply return the unmodified classes.
+			if ( is_wp_error( $response ) ) {
+				return $response;
+			}
+
+			$response_data = json_decode( wp_remote_retrieve_body( $response ), true );
+
+			$liked = empty( $response_data['i_like'] ) ? 'no' : 'yes';
+
+			// Cache the result.
+			set_transient( $cache_key, $liked, self::CACHE_EXPIRATION );
+		}
+
+		return $liked;
+	}
+
+	/**
+	 * Adds a "liked" class to comments that the current user has liked.
+	 *
+	 * @param array  $classes    Array of comment classes.
+	 * @param string $css_class  Unused.
+	 * @param int    $comment_id The comment ID.
+	 * @return array Modified array of comment classes.
+	 */
+	public function add_like_class( $classes, $css_class, $comment_id ) {
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+			$blog_id = get_current_blog_id();
+			$liked   = Likes::comment_like_current_user_likes( $blog_id, $comment_id );
+		} else {
+			$blog_id = Jetpack_Options::get_option( 'id' );
+			$user_id = get_current_user_id();
+
+			$liked = $this->do_comment_like_api_request( $blog_id, $user_id, $comment_id );
+
+			if ( is_wp_error( $liked ) ) {
+				return $classes;
+			}
+
+			// We use 'yes' and 'no' when we store the transient to minimize unexpected casting.
+			// So, we cast to boolean here.
+			$liked = 'yes' === $liked;
+		}
+
+		// Append the 'liked' class if the comment is liked.
+		if ( $liked ) {
+			$classes[] = 'liked';
+		}
+
+		return $classes;
+	}
+
+	/**
+	 * Adds "Like" and "Unlike" action buttons to comment rows.
+	 *
+	 * @param array      $actions Array of actions for the comment.
+	 * @param WP_Comment $comment The comment object.
+	 * @return array Modified actions array.
+	 */
+	public function enable_likes( $actions, $comment ) {
+		$actions['like'] = sprintf(
+			'<button class="button-link comment-like-button" data-comment-id="%d" aria-label="%s">%s</button>',
+			$comment->comment_ID,
+			esc_attr__( 'Like this comment', 'jetpack-mu-wpcom' ),
+			esc_html__( 'Like', 'jetpack-mu-wpcom' )
 		);
 
-		// If the request fails, simply return the unmodified classes.
-		if ( is_wp_error( $response ) ) {
-			return $classes;
+		$actions['unlike'] = sprintf(
+			'<button class="button-link comment-unlike-button" data-comment-id="%d" aria-label="%s">%s</button>',
+			$comment->comment_ID,
+			esc_attr__( 'Unlike this comment', 'jetpack-mu-wpcom' ),
+			esc_html__( 'Liked by you', 'jetpack-mu-wpcom' )
+		);
+
+		return $actions;
+	}
+
+	/**
+	 * Enqueues the comment like assets (JavaScript and CSS) on the Edit Comments screen.
+	 *
+	 * @param string $hook The current admin page hook.
+	 */
+	public function enqueue_scripts( $hook ) {
+		// Only enqueue assets on the edit-comments screen.
+		if ( 'edit-comments.php' !== $hook ) {
+			return;
 		}
 
-		$response_data = json_decode( wp_remote_retrieve_body( $response ), true );
+		// Enqueue the assets using the Jetpack MU WPCom helper function.
+		jetpack_mu_wpcom_enqueue_assets( 'wpcom-comment-like', array( 'js', 'css' ) );
 
-		// If the response doesn't include 'i_like', don't add the class.
-		if ( empty( $response_data['i_like'] ) ) {
-			return $classes;
-		}
-
-		$liked = $response_data['i_like'];
+		// Localize the script with error messages.
+		wp_localize_script(
+			'jetpack-mu-wpcom-wpcom-comment-like',
+			'wpcomCommentLikesData',
+			array(
+				'post_like_error'     => __( 'Something went wrong when attempting to like that comment. Please try again.', 'jetpack-mu-wpcom' ),
+				'post_unlike_error'   => __( 'Something went wrong when attempting to unlike that comment. Please try again.', 'jetpack-mu-wpcom' ),
+				'dismiss_notice_text' => __( 'Dismiss this notice', 'jetpack-mu-wpcom' ),
+			)
+		);
 	}
 
-	// Append the 'liked' class if the comment is liked.
-	if ( $liked ) {
-		$classes[] = 'liked';
+	/**
+	 * Register an API to handle Likes on Atomic sites.
+	 */
+	public function register_like_api() {
+		require_once __DIR__ . '/class-wp-rest-comment-like.php';
+		$controller = new WP_REST_Comment_Like();
+		$controller->register_routes();
 	}
-
-	return $classes;
 }
-add_filter( 'comment_class', 'wpcom_comments_add_like_class', 10, 3 );
 
-/**
- * Adds "Like" and "Unlike" action buttons to comment rows.
- *
- * @param array      $actions Array of actions for the comment.
- * @param WP_Comment $comment The comment object.
- * @return array Modified actions array.
- */
-function wpcom_comments_enable_likes( $actions, $comment ) {
-	$actions['like'] = sprintf(
-		'<button class="button-link comment-like-button" data-comment-id="%d" aria-label="%s">%s</button>',
-		$comment->comment_ID,
-		esc_attr__( 'Like this comment', 'jetpack-mu-wpcom' ),
-		esc_html__( 'Like', 'jetpack-mu-wpcom' )
-	);
-
-	$actions['unlike'] = sprintf(
-		'<button class="button-link comment-unlike-button" data-comment-id="%d" aria-label="%s">%s</button>',
-		$comment->comment_ID,
-		esc_attr__( 'Unlike this comment', 'jetpack-mu-wpcom' ),
-		esc_html__( 'Liked by you', 'jetpack-mu-wpcom' )
-	);
-
-	return $actions;
-}
-add_filter( 'comment_row_actions', 'wpcom_comments_enable_likes', 10, 2 );
-
-/**
- * Enqueues the comment like assets (JavaScript and CSS) on the Edit Comments screen.
- *
- * @param string $hook The current admin page hook.
- */
-function wpcom_enqueue_comment_like_script( $hook ) {
-	// Only enqueue assets on the edit-comments screen.
-	if ( 'edit-comments.php' !== $hook ) {
-		return;
-	}
-
-	// Enqueue the assets using the Jetpack MU WPCom helper function.
-	jetpack_mu_wpcom_enqueue_assets( 'wpcom-comment-like', array( 'js', 'css' ) );
-
-	// Localize the script with error messages.
-	wp_localize_script(
-		'jetpack-mu-wpcom-wpcom-comment-like',
-		'wpcomCommentLikesData',
-		array(
-			'post_like_error'     => __( 'Something went wrong when attempting to like that comment. Please try again.', 'jetpack-mu-wpcom' ),
-			'post_unlike_error'   => __( 'Something went wrong when attempting to unlike that comment. Please try again.', 'jetpack-mu-wpcom' ),
-			'dismiss_notice_text' => __( 'Dismiss this notice', 'jetpack-mu-wpcom' ),
-		)
-	);
-}
-add_action( 'admin_enqueue_scripts', 'wpcom_enqueue_comment_like_script', 10, 2 );
-
-/**
- * Register an API to handle Likes on Atomic sites.
- */
-function wpcom_comments_register_like_api() {
-	require_once __DIR__ . '/class-wp-rest-comment-like.php';
-	$controller = new WP_REST_Comment_Like();
-	$controller->register_routes();
-}
-if ( defined( 'IS_ATOMIC' ) && IS_ATOMIC ) {
-	add_action( 'rest_api_init', 'wpcom_comments_register_like_api' );
-}
+WPCom_Comments_Likes::get_instance();

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-comments/wpcom-comments.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-comments/wpcom-comments.php
@@ -14,8 +14,6 @@ if ( ( ! defined( 'IS_WPCOM' ) || ! IS_WPCOM ) && ( ! defined( 'IS_ATOMIC' ) || 
  * WPCom Comments Likes functionality in a singleton pattern.
  */
 class WPCom_Comments_Likes {
-	const CACHE_EXPIRATION = 900; // 15 minutes in seconds.
-
 	/**
 	 * Singleton instance.
 	 *
@@ -95,54 +93,29 @@ class WPCom_Comments_Likes {
 	}
 
 	/**
-	 * Get cache key for comment like status.
-	 *
-	 * @param int $comment_id The comment ID.
-	 * @param int $user_id    The user ID.
-	 * @return string The cache key.
-	 */
-	public static function get_cache_key( $comment_id, $user_id ) {
-		return "comment_like_{$comment_id}_{$user_id}";
-	}
-
-	/**
 	 * Do a comment like API request.
 	 *
 	 * @param int $blog_id    The blog ID.
-	 * @param int $user_id    The user ID.
 	 * @param int $comment_id The comment ID.
 	 * @return bool|WP_Error True if the comment is liked, false otherwise, or a WP_Error if the request fails.
 	 */
-	private function do_comment_like_api_request( $blog_id, $user_id, $comment_id ) {
-		$cache_key = self::get_cache_key( $comment_id, $user_id );
+	private function do_comment_like_api_request( $blog_id, $comment_id ) {
+		$response = Automattic\Jetpack\Connection\Client::wpcom_json_api_request_as_user(
+			"/sites/$blog_id/comments/$comment_id/likes",
+			'v1.1',
+			array( 'method' => 'GET' ),
+			null,
+			'rest'
+		);
 
-		$cached_result = get_transient( $cache_key );
-
-		if ( false !== $cached_result ) {
-			$liked = $cached_result;
-		} else {
-			$response = Automattic\Jetpack\Connection\Client::wpcom_json_api_request_as_user(
-				"/sites/$blog_id/comments/$comment_id/likes",
-				'v1.1',
-				array( 'method' => 'GET' ),
-				null,
-				'rest'
-			);
-
-			// If the request fails, simply return the unmodified classes.
-			if ( is_wp_error( $response ) ) {
-				return $response;
-			}
-
-			$response_data = json_decode( wp_remote_retrieve_body( $response ), true );
-
-			$liked = empty( $response_data['i_like'] ) ? 'no' : 'yes';
-
-			// Cache the result.
-			set_transient( $cache_key, $liked, self::CACHE_EXPIRATION );
+		// If the request fails, simply return the unmodified classes.
+		if ( is_wp_error( $response ) ) {
+			return $response;
 		}
 
-		return $liked;
+		$response_data = json_decode( wp_remote_retrieve_body( $response ), true );
+
+		return ! empty( $response_data['i_like'] ?? false );
 	}
 
 	/**
@@ -159,17 +132,12 @@ class WPCom_Comments_Likes {
 			$liked   = Likes::comment_like_current_user_likes( $blog_id, $comment_id );
 		} else {
 			$blog_id = Jetpack_Options::get_option( 'id' );
-			$user_id = get_current_user_id();
 
-			$liked = $this->do_comment_like_api_request( $blog_id, $user_id, $comment_id );
+			$liked = $this->do_comment_like_api_request( $blog_id, $comment_id );
 
 			if ( is_wp_error( $liked ) ) {
 				return $classes;
 			}
-
-			// We use 'yes' and 'no' when we store the transient to minimize unexpected casting.
-			// So, we cast to boolean here.
-			$liked = 'yes' === $liked;
 		}
 
 		// Append the 'liked' class if the comment is liked.

--- a/projects/plugins/boost/changelog/update-jetpack-mu-wpcom-improve-comments-performance
+++ b/projects/plugins/boost/changelog/update-jetpack-mu-wpcom-improve-comments-performance
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Improves performance of wpcom comments liking by caching and minimizing API requests.

--- a/projects/plugins/protect/changelog/update-jetpack-mu-wpcom-improve-comments-performance
+++ b/projects/plugins/protect/changelog/update-jetpack-mu-wpcom-improve-comments-performance
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Improves performance of wpcom comments liking by caching and minimizing API requests.

--- a/projects/plugins/search/changelog/update-jetpack-mu-wpcom-improve-comments-performance
+++ b/projects/plugins/search/changelog/update-jetpack-mu-wpcom-improve-comments-performance
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Improves performance of wpcom comments liking by caching and minimizing API requests.

--- a/projects/plugins/social/changelog/update-jetpack-mu-wpcom-improve-comments-performance
+++ b/projects/plugins/social/changelog/update-jetpack-mu-wpcom-improve-comments-performance
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Improves performance of wpcom comments liking by caching and minimizing API requests.

--- a/projects/plugins/starter-plugin/changelog/update-jetpack-mu-wpcom-improve-comments-performance
+++ b/projects/plugins/starter-plugin/changelog/update-jetpack-mu-wpcom-improve-comments-performance
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Improves performance of wpcom comments liking by caching and minimizing API requests.

--- a/projects/plugins/videopress/changelog/update-jetpack-mu-wpcom-improve-comments-performance
+++ b/projects/plugins/videopress/changelog/update-jetpack-mu-wpcom-improve-comments-performance
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Improves performance of wpcom comments liking by caching and minimizing API requests.

--- a/projects/plugins/wpcomsh/changelog/update-jetpack-mu-wpcom-improve-comments-performance
+++ b/projects/plugins/wpcomsh/changelog/update-jetpack-mu-wpcom-improve-comments-performance
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Improves performance of wpcom comments liking by caching and minimizing API requests.


### PR DESCRIPTION
## Problem statement

This functionality was initially added for simple sites in #41475 and later for WoW sites in #42300. When the functionality was added for WoW sites it resulted in many API calls that occurred on each page load that includes comments.  I initially noticed this on the `wp-admin` of my site. 

![CleanShot 2025-07-04 at 23 22 30@2x](https://github.com/user-attachments/assets/f4b31a84-ef37-4997-a798-8e0f0c04c1f9)

But, after investigating the code, the API calls were also present on the frontend of the site. 

![CleanShot 2025-07-04 at 23 24 33@2x](https://github.com/user-attachments/assets/82fb6a3d-fa04-48f8-bf02-cbb24e842f17)

## Proposed changes:

The solution that I am proposing is:

- Move existing functions into a singleton pattern class. 
- On WoW sites, only load the functionality if the `comment-likes` module is enabled.
- Only hook on `comment_class` if we're in the admin to minimize frontend requests. 
- Cache the API requests via transient.

## Potential future changes

I'm not a fan of making $x number of requests, one for each comment. I think the way that we'll solve this in the future is probably by hooking in when the comments table is being rendered and making a [batch](https://developer.wordpress.com/docs/api/1.1/get/batch/) API request. If we take this approach, we'd request early, store in an array in the singleton class, and then pull from that array as we render.

Further, we could consider expanding the `is_comment_likes_enabled` method to include WPCOM simple sites. Deferring for now because of the minimal performance implications.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Ensure that you have a simple and WoW site with comments.
- On a simple site, ensure that comment like rendering at `/wp-admin` and `/wp-admin/edit-comments.php` continues to function.
- On a WoW site, while proxied so that you have the debug bar, test `/wp-admin` and `/wp-admin/edit-comments.php` as well.
- Before this change, you'll notice on these pages that you have multiple http calls for the comment likes endpoint. You can attempt to disable the comment likes module in Jetpack settings and the http calls will persist.
- After this change, check the same URLs and you should notice that after a refresh, the cache will be primed and the http calls go away. You can then test the network requests don't show when comment likes are disabled by running `wp transient delete --all && wp jetpack module deactivate comment-likes` over SSH and then loading the same URLs above.

