### PR TITLE
Boost: Mock Unrelated E2E Boost Prerequisites

### DIFF
--- a/projects/plugins/boost/changelog/update-boost-e2e-mock-unrelated-testing-hog-200
+++ b/projects/plugins/boost/changelog/update-boost-e2e-mock-unrelated-testing-hog-200
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: E2E Tests: Ensure resource heavy functionality is mocked where appropriate
+
+

--- a/projects/plugins/boost/tests/e2e/lib/env/prerequisites.js
+++ b/projects/plugins/boost/tests/e2e/lib/env/prerequisites.js
@@ -16,6 +16,7 @@ export function boostPrerequisitesBuilder( page ) {
 		loggedIn: undefined,
 		modules: { active: undefined, inactive: undefined },
 		connected: undefined,
+		mockConnection: undefined,
 		jetpackDeactivated: undefined,
 		mockSpeedScore: undefined,
 		enqueuedAssets: undefined,
@@ -37,6 +38,10 @@ export function boostPrerequisitesBuilder( page ) {
 		},
 		withConnection( shouldBeConnected ) {
 			state.connected = shouldBeConnected;
+			return this;
+		},
+		withMockConnection( shouldBeMocked ) {
+			state.mockConnection = shouldBeMocked;
 			return this;
 		},
 		withTestContent( testPostTitles = [] ) {
@@ -84,6 +89,7 @@ async function buildPrerequisites( state, page ) {
 		modules: () => ensureModulesState( state.modules ),
 		loggedIn: () => ensureUserIsLoggedIn( page ),
 		connected: () => ensureConnectedState( state.connected, page ),
+		mockConnection: () => ensureMockConnectionState( state.mockConnection ),
 		testPostTitles: () => ensureTestPosts( state.testPostTitles ),
 		clean: () => ensureCleanState( state.clean ),
 		mockSpeedScore: () => ensureMockSpeedScoreState( state.mockSpeedScore ),
@@ -198,6 +204,9 @@ export async function deactivateModules( modules ) {
  * @param {page}    page              - Playwright page instance.
  */
 export async function ensureConnectedState( requiredConnected, page ) {
+	// Ensure the mock connection plugin is deactivated.
+	await execWpCommand( 'plugin deactivate e2e-mock-boost-connection' );
+
 	const isConnected = await checkIfConnected();
 
 	if ( requiredConnected && isConnected ) {
@@ -210,6 +219,24 @@ export async function ensureConnectedState( requiredConnected, page ) {
 		await disconnect();
 	} else {
 		logger.prerequisites( 'Jetpack Boost is already disconnected, moving on' );
+	}
+}
+
+/**
+ * Ensure mock connection state.
+ * @param {boolean} mockConnection - Whether the site should be connected.
+ */
+export async function ensureMockConnectionState( mockConnection ) {
+	if ( mockConnection ) {
+		logger.prerequisites( 'Mocking connection' );
+		await execWpCommand( 'plugin activate e2e-mock-boost-connection' );
+		// Update the WP option jb_get_started to false.
+		await execWpCommand( 'option update jb_get_started 0' );
+	} else {
+		logger.prerequisites( 'Unmocking connection' );
+		await execWpCommand( 'plugin deactivate e2e-mock-boost-connection' );
+		// Update the WP option jb_get_started to true.
+		await execWpCommand( 'option update jb_get_started 1' );
 	}
 }
 

--- a/projects/plugins/boost/tests/e2e/plugins/e2e-mock-boost-connection.php
+++ b/projects/plugins/boost/tests/e2e/plugins/e2e-mock-boost-connection.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Plugin Name: Boost E2E Mock Connection
+ * Plugin URI: https://github.com/automattic/jetpack
+ * Author: Heart of Gold
+ * Version: 1.0.0
+ * Text Domain: jetpack
+ *
+ * @package automattic/jetpack
+ */
+
+add_filter(
+	'jetpack_boost_connection_bypass',
+	function () {
+		return true;
+	}
+);

--- a/projects/plugins/boost/tests/e2e/specs/base/common.test.js
+++ b/projects/plugins/boost/tests/e2e/specs/base/common.test.js
@@ -10,7 +10,11 @@ test.describe( 'Common tests', () => {
 
 	test.beforeAll( async ( { browser } ) => {
 		page = await browser.newPage( playwrightConfig.use );
-		await boostPrerequisitesBuilder( page ).withCleanEnv().withConnection( true ).build();
+		await boostPrerequisitesBuilder( page )
+			.withCleanEnv()
+			.withMockConnection( true )
+			.withSpeedScoreMocked( true )
+			.build();
 	} );
 
 	test.afterAll( async () => {

--- a/projects/plugins/boost/tests/e2e/specs/base/get-started.test.ts
+++ b/projects/plugins/boost/tests/e2e/specs/base/get-started.test.ts
@@ -9,7 +9,11 @@ test.describe( 'Getting started page', () => {
 
 	test.beforeEach( async ( { browser } ) => {
 		page = await browser.newPage( playwrightConfig.use );
-		await boostPrerequisitesBuilder( page ).withCleanEnv().withConnection( false ).build();
+		await boostPrerequisitesBuilder( page )
+			.withCleanEnv()
+			.withConnection( false )
+			.withSpeedScoreMocked( true )
+			.build();
 
 		jetpackBoostPage = await JetpackBoostPage.visit( page );
 	} );

--- a/projects/plugins/boost/tests/e2e/specs/concatenate/concatenate.test.js
+++ b/projects/plugins/boost/tests/e2e/specs/concatenate/concatenate.test.js
@@ -9,10 +9,16 @@ test.describe( 'Concatenate JS and CSS', () => {
 
 	test.beforeAll( async ( { browser } ) => {
 		page = await browser.newPage( playwrightConfig.use );
-		await boostPrerequisitesBuilder( page ).withCleanEnv( true ).withConnection( true ).build();
+		await boostPrerequisitesBuilder( page )
+			.withCleanEnv()
+			.withMockConnection( true )
+			.withSpeedScoreMocked( true )
+			.build();
 	} );
 
-	test.afterAll( async () => {} );
+	test.afterAll( async () => {
+		await page.close();
+	} );
 
 	test( 'No Concatenate meta information should show on the admin when the modules are inactive', async () => {
 		await boostPrerequisitesBuilder( page )

--- a/projects/plugins/boost/tests/e2e/specs/critical-css/critical-css.test.js
+++ b/projects/plugins/boost/tests/e2e/specs/critical-css/critical-css.test.js
@@ -1,7 +1,7 @@
-import { test, expect } from '_jetpack-e2e-commons/fixtures/base-test.js';
+import { expect, test } from '_jetpack-e2e-commons/fixtures/base-test.js';
 import { execWpCommand } from '_jetpack-e2e-commons/helpers/utils-helper.js';
 import { PostFrontendPage } from '_jetpack-e2e-commons/pages/index.js';
-import { DashboardPage, ThemesPage, Sidebar } from '_jetpack-e2e-commons/pages/wp-admin/index.js';
+import { DashboardPage, Sidebar, ThemesPage } from '_jetpack-e2e-commons/pages/wp-admin/index.js';
 import playwrightConfig from '_jetpack-e2e-commons/playwright.config.mjs';
 import { boostPrerequisitesBuilder } from '../../lib/env/prerequisites.js';
 import { JetpackBoostPage } from '../../lib/pages/index.js';
@@ -12,12 +12,18 @@ test.describe( 'Critical CSS module', () => {
 
 	test.beforeAll( async ( { browser } ) => {
 		page = await browser.newPage( playwrightConfig.use );
-		await boostPrerequisitesBuilder( page ).withCleanEnv( true ).withConnection( true ).build();
+		await boostPrerequisitesBuilder( page )
+			.withCleanEnv()
+			.withMockConnection( true )
+			.withSpeedScoreMocked( true )
+			.build();
+
 		await execWpCommand( 'plugin activate e2e-critical-css-force-errors' );
 	} );
 
 	test.afterAll( async () => {
 		await execWpCommand( 'plugin deactivate e2e-critical-css-force-errors' );
+
 		if ( previousTheme !== null ) {
 			await execWpCommand( `theme activate ${ previousTheme }` );
 		}

--- a/tools/docker/jetpack-docker-config-default.yml
+++ b/tools/docker/jetpack-docker-config-default.yml
@@ -68,6 +68,7 @@ e2e:
     projects/plugins/boost/tests/e2e/plugins/e2e-concatenate-enqueue/: /var/www/html/wp-content/plugins/e2e-concatenate-enqueue/
     projects/plugins/boost/tests/e2e/plugins/e2e-appended-image/: /var/www/html/wp-content/plugins/e2e-appended-image/
     projects/plugins/boost/tests/e2e/plugins/e2e-mock-speed-score-api.php: /var/www/html/wp-content/plugins/e2e-mock-speed-score-api.php
+    projects/plugins/boost/tests/e2e/plugins/e2e-mock-boost-connection.php: /var/www/html/wp-content/plugins/e2e-mock-boost-connection.php
     projects/plugins/boost/tests/e2e/plugins/e2e-critical-css-force-errors.php: /var/www/html/wp-content/plugins/e2e-critical-css-force-errors.php
     tools/e2e-commons/plugins/e2e-search-test-helper.php: /var/www/html/wp-content/plugins/e2e-search-test-helper.php
     tools/e2e-commons/plugins/e2e-wpcom-request-interceptor.php: /var/www/html/wp-content/plugins/e2e-wpcom-request-interceptor.php


### PR DESCRIPTION
Fixes [HOG-200: Mock Unrelated Boost Prerequisites](https://linear.app/a8c/issue/HOG-200/mock-unrelated-boost-prerequisites)

## Proposed changes:
Because E2E tests use localtunnel, it's suspected that Boost functionality such as Critical CSS Regen, and Page Speed scores, which are ran multiple times during the testing, is causing the localtunnel to be extremely slow to the point that Page Speed times out, and Critical CSS Regen may never complete. These changes ensure that that functionality is only ran where expected for the enabled E2E tests.

* Mocks the Jetpack Boost Connection for E2E tests that were already enabled.
* Ensure Mock speed scores is enabled for E2E tests that were already enabled.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
Verify from the GitHub build that all tests passed.

If you want to test locally however:
From the `projects/plugins/boost/tests/e2e` directory:

### Via ngrok (Recommended, but requires a subscription)
Replace `$tunnel_url` with your actual ngrok URL

1. **Install E2E test dependencies:**
   ```bash
   pnpm install
   ```

2. **Start the Docker environment and tunnel:**
   ```bash
   pnpm run env:up && TUNNEL_URL=$tunnel_url pnpm run tunnel:up
   ```

3. **Start your ngrok tunnel**
   ```bash
   ngrok http --url=$tunnel_url http://localhost:8889/
   ```

4. **Run the specific re-enabled test suites:**
   ```bash
    TUNNEL_URL=$tunnel_url pnpm run test: run specs/critical-css
   ```

### Via localtunnel (Not recommended as it may be slow)

1. **Install E2E test dependencies:**
   ```bash
   pnpm install
   ```

2. **Start the Docker environment and tunnel:**
   ```bash
   pnpm run env:up && pnpm run tunnel:up
   ```

3. **Run the specific re-enabled test suites:**
   ```bash
   pnpm run test:run specs/critical-css
   ```

### Expected behavior:
- All Enabled Boost E2E tests under GitHub actions should pass without skipping or timeout errors
- Tests should pass consistently when run multiple times

### Verification steps:
1. **Check that tests are running in CI:**
   - The re-enabled test suites should appear in the E2E test matrix
   - CI should execute "Jetpack Boost - Modules"

2. **Test stability:**
   - Run each test suite 3-5 times to ensure consistency
   - No intermittent failures or timing-related issues should occur
