### PR TITLE
Forms: Removes the “Manage responses” panel from individual fields

### DIFF
--- a/projects/packages/forms/changelog/remove-manage-responses-panels
+++ b/projects/packages/forms/changelog/remove-manage-responses-panels
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Forms: remove the redundant "Manage responses" inspector panel from individual field blocks so it now only appears on the main Contact Form block. 

--- a/projects/packages/forms/src/blocks/field-checkbox/edit.js
+++ b/projects/packages/forms/src/blocks/field-checkbox/edit.js
@@ -8,7 +8,6 @@ import { PanelBody, ToggleControl } from '@wordpress/components';
 import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import JetpackFieldWidth from '../shared/components/jetpack-field-width';
-import JetpackManageResponsesSettings from '../shared/components/jetpack-manage-responses-settings';
 import ToolbarRequiredGroup from '../shared/components/toolbar-required-group';
 import useFormWrapper from '../shared/hooks/use-form-wrapper';
 import useJetpackFieldStyles from '../shared/hooks/use-jetpack-field-styles';
@@ -76,9 +75,6 @@ export default function CheckboxFieldEdit( props ) {
 				</PanelBody>
 			</InspectorControls>
 			<InspectorControls>
-				<PanelBody title={ __( 'Manage responses', 'jetpack-forms' ) }>
-					<JetpackManageResponsesSettings isChildBlock />
-				</PanelBody>
 				<PanelBody title={ __( 'Field settings', 'jetpack-forms' ) }>
 					<ToggleControl
 						label={ __( 'Field is required', 'jetpack-forms' ) }

--- a/projects/packages/forms/src/blocks/field-consent/edit.js
+++ b/projects/packages/forms/src/blocks/field-consent/edit.js
@@ -11,7 +11,6 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { useCallback, useEffect, useMemo } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import JetpackFieldWidth from '../shared/components/jetpack-field-width';
-import JetpackManageResponsesSettings from '../shared/components/jetpack-manage-responses-settings';
 import useFormWrapper from '../shared/hooks/use-form-wrapper';
 
 export default function ConsentFieldEdit( props ) {
@@ -149,9 +148,6 @@ export default function ConsentFieldEdit( props ) {
 		<>
 			<div { ...innerBlocksProps } />
 			<InspectorControls>
-				<PanelBody title={ __( 'Manage responses', 'jetpack-forms' ) }>
-					<JetpackManageResponsesSettings isChildBlock />
-				</PanelBody>
 				<PanelBody title={ __( 'Field settings', 'jetpack-forms' ) }>
 					<JetpackFieldWidth setAttributes={ setAttributes } width={ width } />
 					<ToggleControl

--- a/projects/packages/forms/src/blocks/shared/components/jetpack-field-controls.js
+++ b/projects/packages/forms/src/blocks/shared/components/jetpack-field-controls.js
@@ -7,7 +7,6 @@ import { PanelBody, TextControl, ToggleControl } from '@wordpress/components';
 import { isValidElement, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import JetpackFieldWidth from './jetpack-field-width';
-import JetpackManageResponsesSettings from './jetpack-manage-responses-settings';
 import ToolbarRequiredGroup from './toolbar-required-group';
 
 // List of reserved HTML form element attribute names
@@ -113,9 +112,6 @@ const JetpackFieldControls = ( {
 			</BlockControls>
 
 			<InspectorControls>
-				<PanelBody title={ __( 'Manage responses', 'jetpack-forms' ) }>
-					<JetpackManageResponsesSettings isChildBlock />
-				</PanelBody>
 				<PanelBody title={ __( 'Field settings', 'jetpack-forms' ) }>
 					<>{ fieldSettings }</>
 				</PanelBody>


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Removes the “Manage responses” inspector-panel from individual form-field blocks (`field-checkbox`, `field-consent`, and the shared `jetpack-field-controls` component).  
* The panel now appears only on the main **Contact Form** block, eliminating duplicate UI and simplifying the field-block settings.  

**Before:**

<img width="1059" alt="Screenshot 2025-07-07 at 10 31 17 AM" src="https://github.com/user-attachments/assets/0997e8e5-4729-4c9e-8ae0-e18ca11cac8f" />

**After:**

<img width="1061" alt="Screenshot 2025-07-07 at 10 10 17 AM" src="https://github.com/user-attachments/assets/b97f0f20-3422-4204-9ccc-e1975237f5ff" />



### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone. -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Add a **Contact Form** block to a post or page.  
2. Select the parent Contact Form block and confirm that the “Manage responses” panel appears in the sidebar settings.  
3. Select each individual field (e.g., Checkbox, Consent) and confirm that the “Manage responses” panel **no longer** appears for those field blocks.  
4. Verify that all other field settings (width, required toggle, etc.) still work as expected.