### PR TITLE
renovate: Group fullcalendar updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -65,7 +65,11 @@
 		},
 		{
 			groupName: 'Size-limit',
-			matchPackageNames: [ 'size-limit', '@size-limit/preset-app' ],
+			matchSourceUrls: [ 'https://github.com/ai/size-limit' ],
+		},
+		{
+			groupName: 'Fullcalendar monorepo',
+			matchSourceUrls: [ 'https://github.com/fullcalendar/fullcalendar' ],
 		},
 		// These aren't a monorepo, but we may as well do them all together anyway.
 		{


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Renovate will group `@fullcalendar/*` by default, but not `fullcalendar` itself. Configure it to do so.

Also reconfigure the size-limit grouping in the same manner instead of listing just the two packages we directly use.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None. Shaving a yak, #44206 is easiest fixed by updating fullcalendar, which made me notice the separation of the two packages.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Fork it an run it in the fork.
  * [x] https://github.com/anomiex/jetpack/actions/runs/16119411529
