### PR TITLE
wpcomsh: remove custom-fonts-typekit dependency

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/remove-wpcomsh-custom-fonts-typekit_dependency
+++ b/projects/packages/jetpack-mu-wpcom/changelog/remove-wpcomsh-custom-fonts-typekit_dependency
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Add Jetpack_Fonts_Typekit class check.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
@@ -386,7 +386,9 @@ function wpcom_hide_customizer_submenu_on_block_theme() {
 			remove_action( 'customize_register', array( $jetpack_fonts_instance, 'maybe_prepopulate_option' ), 0 );
 		}
 
-		remove_action( 'customize_register', array( 'Jetpack_Fonts_Typekit', 'maybe_override_for_advanced_mode' ), 20 );
+		if ( class_exists( '\Jetpack_Fonts_Typekit' ) ) {
+			remove_action( 'customize_register', array( 'Jetpack_Fonts_Typekit', 'maybe_override_for_advanced_mode' ), 20 );
+		}
 
 		remove_action( 'customize_register', 'Automattic\Jetpack\Masterbar\register_css_nudge_control' );
 

--- a/projects/plugins/wpcomsh/README.md
+++ b/projects/plugins/wpcomsh/README.md
@@ -222,9 +222,9 @@ If a site has the `a8c-fse-is-eligible` site option, the site is eligible for Fu
 
 Because WordPress.com supports private sites by default, customizer label copy was updated to reduce confusion on what would launch a site or what will save changes on a site.
 
-### Custom colors and fonts (+ Typekit fonts)
+### Custom colors and fonts
 
-On WP.com, we provide custom colors and fonts in a site's Customizer. In order to get them supported on an AT site, wpcomsh imports the `colors`, `custom-fonts` and `custom-fonts-typekit` codebases.
+On WP.com, we provide custom colors and fonts in a site's Customizer. In order to get them supported on an AT site, wpcomsh imports the `colors` and `custom-fonts` codebases.
 
 ### Media Library used space
 

--- a/projects/plugins/wpcomsh/changelog/remove-wpcomsh-custom-fonts-typekit_dependency
+++ b/projects/plugins/wpcomsh/changelog/remove-wpcomsh-custom-fonts-typekit_dependency
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Remove custom-fonts-typekit dependency.

--- a/projects/plugins/wpcomsh/composer.json
+++ b/projects/plugins/wpcomsh/composer.json
@@ -7,7 +7,6 @@
 		"php": ">=8.1",
 		"automattic/at-pressable-podcasting": "^2.0",
 		"automattic/custom-fonts": "^3.0",
-		"automattic/custom-fonts-typekit": "^2.0",
 		"automattic/text-media-widget-styles": "^2.0",
 		"automattic/wc-calypso-bridge": "2.11.1",
 		"wordpress/classic-editor-plugin": "1.6.7",
@@ -74,12 +73,6 @@
 			"type": "vcs",
 			"no-api": true,
 			"url": "https://github.com/Automattic/custom-fonts.git"
-		},
-		{
-			"name": "automattic/custom-fonts-typekit",
-			"type": "vcs",
-			"no-api": true,
-			"url": "https://github.com/Automattic/custom-fonts-typekit.git"
 		},
 		{
 			"name": "automattic/at-pressable-podcasting",

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a1b1c521eb5b2a265b632f721bea75ae",
+    "content-hash": "57de562590693a13d6adeadd7b887677",
     "packages": [
         {
             "name": "automattic/at-pressable-podcasting",
@@ -50,29 +50,6 @@
             ],
             "description": "A provider-agnostic WordPress plugin for changing theme fonts.",
             "time": "2024-11-19T20:05:23+00:00"
-        },
-        {
-            "name": "automattic/custom-fonts-typekit",
-            "version": "v2.0.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Automattic/custom-fonts-typekit.git",
-                "reference": "d576a78495b78d0d6acc465beecaf4079463d24c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/custom-fonts-typekit/zipball/d576a78495b78d0d6acc465beecaf4079463d24c",
-                "reference": "d576a78495b78d0d6acc465beecaf4079463d24c",
-                "shasum": ""
-            },
-            "require-dev": {
-                "10up/wp_mock": "dev-master"
-            },
-            "type": "wordpress-plugin",
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "time": "2025-04-02T12:48:49+00:00"
         },
         {
             "name": "automattic/jetpack-a8c-mc-stats",

--- a/projects/plugins/wpcomsh/tests/WpcomshLoadedTest.php
+++ b/projects/plugins/wpcomsh/tests/WpcomshLoadedTest.php
@@ -24,7 +24,6 @@ class WpcomshLoadedTest extends WP_UnitTestCase {
 	public function test_composer_dependencies_loaded() {
 		$this->assertTrue( function_exists( 'automattic_podcasting_init' ), 'vendor/automattic/at-pressable-podcasting not loaded' );
 		$this->assertTrue( class_exists( 'Jetpack_Fonts' ), 'vendor/automattic/custom-fonts not loaded' );
-		$this->assertTrue( class_exists( 'Jetpack_Fonts_Typekit' ), 'vendor/automattic/custom-fonts-typekit not loaded' );
 		$this->assertTrue( function_exists( 'wpcom_media_video_styles' ), 'vendor/automattic/text-media-widget-styles not loaded' );
 	}
 }

--- a/projects/plugins/wpcomsh/wpcomsh.php
+++ b/projects/plugins/wpcomsh/wpcomsh.php
@@ -75,7 +75,6 @@ require_once __DIR__ . '/widgets/class-jetpack-widget-twitter.php';
 require_once __DIR__ . '/vendor/autoload_packages.php';
 require_once __DIR__ . '/vendor/automattic/at-pressable-podcasting/podcasting.php';
 require_once __DIR__ . '/vendor/automattic/custom-fonts/custom-fonts.php';
-require_once __DIR__ . '/vendor/automattic/custom-fonts-typekit/custom-fonts-typekit.php';
 require_once __DIR__ . '/vendor/automattic/text-media-widget-styles/text-media-widget-styles.php';
 
 // REST API


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

As best I can tell, this dependency is unused. It was manually loaded, but none if its classes are referenced in `wpcomsh` (or the monorepo, other than one).

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

In theory this feature has long been deprecated/removed.
