### PR TITLE
Help Center: Change "Block Guide" to "Learn more"

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/tmpfrg-439-support-change-block-guide-to-learn-more
+++ b/projects/packages/jetpack-mu-wpcom/changelog/tmpfrg-439-support-change-block-guide-to-learn-more
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+WPCOM: Block guide label in Learn more

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-description-links/src/description-support-link.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-description-links/src/description-support-link.tsx
@@ -54,7 +54,7 @@ export default function DescriptionSupportLink( {
 				style={ { display: 'block', marginTop: 10, maxWidth: 'fit-content' } }
 				ref={ reference => ref !== reference && setRef( reference ) }
 			>
-				{ __( 'Block guide', 'jetpack-mu-wpcom' ) }
+				{ __( 'Learn more', 'jetpack-mu-wpcom' ) }
 			</WpcomSupportLink>
 		</>
 	);


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/TMPFRG-439/support-change-block-guide-to-learn-more
## Proposed changes:
Changes label of block help link from "Block guide" to "Learn more"

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
1. Sync
2. Add a Table block
3. Select the block
4. The help link should say "Learn more"