### PR TITLE
Sync: ignore the ActivityPub Outbox CPT

### DIFF
--- a/projects/packages/sync/changelog/add-sync-activity-pub-cpt
+++ b/projects/packages/sync/changelog/add-sync-activity-pub-cpt
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Sync: do not sync the ActivityPub outbox CPT

--- a/projects/packages/sync/src/class-defaults.php
+++ b/projects/packages/sync/src/class-defaults.php
@@ -467,6 +467,7 @@ class Defaults {
 		'secupress_log_err404', // SecuPress Plugin - Log 404 pages
 		'iw_omnibus_price_log', // Omnibus Plugin - Log price changes.
 		'od_url_metrics', // Optimization Detective - Log URL metrics.
+		'ap_outbox', // ActivityPub Outbox; only used for broadcasting ActivityPub activity to followers.
 	);
 
 	/**

--- a/projects/plugins/automattic-for-agencies-client/changelog/add-sync-activity-pub-cpt
+++ b/projects/plugins/automattic-for-agencies-client/changelog/add-sync-activity-pub-cpt
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Sync: Ignore the ActivityPub Outbox CPT

--- a/projects/plugins/backup/changelog/add-sync-activity-pub-cpt
+++ b/projects/plugins/backup/changelog/add-sync-activity-pub-cpt
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Sync: Ignore the ActivityPub Outbox CPT

--- a/projects/plugins/boost/changelog/add-sync-activity-pub-cpt
+++ b/projects/plugins/boost/changelog/add-sync-activity-pub-cpt
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Sync: Ignore the ActivityPub Outbox CPT

--- a/projects/plugins/jetpack/changelog/add-sync-activity-pub-cpt
+++ b/projects/plugins/jetpack/changelog/add-sync-activity-pub-cpt
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Sync: ignore the ActivityPub Outbox CPT

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-sync-activity-pub-cpt
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-sync-activity-pub-cpt
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Sync: Ignore the ActivityPub Outbox CPT

--- a/projects/plugins/protect/changelog/add-sync-activity-pub-cpt
+++ b/projects/plugins/protect/changelog/add-sync-activity-pub-cpt
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Sync: Ignore the ActivityPub Outbox CPT

--- a/projects/plugins/search/changelog/add-sync-activity-pub-cpt
+++ b/projects/plugins/search/changelog/add-sync-activity-pub-cpt
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Sync: Ignore the ActivityPub Outbox CPT

--- a/projects/plugins/social/changelog/add-sync-activity-pub-cpt
+++ b/projects/plugins/social/changelog/add-sync-activity-pub-cpt
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Sync: Ignore the ActivityPub Outbox CPT

--- a/projects/plugins/starter-plugin/changelog/add-sync-activity-pub-cpt
+++ b/projects/plugins/starter-plugin/changelog/add-sync-activity-pub-cpt
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Sync: Ignore the ActivityPub Outbox CPT

--- a/projects/plugins/videopress/changelog/add-sync-activity-pub-cpt
+++ b/projects/plugins/videopress/changelog/add-sync-activity-pub-cpt
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Sync: Ignore the ActivityPub Outbox CPT

--- a/projects/plugins/wpcomsh/changelog/add-sync-activity-pub-cpt
+++ b/projects/plugins/wpcomsh/changelog/add-sync-activity-pub-cpt
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Sync: Ignore the ActivityPub Outbox CPT


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

The ap_outbox CPT is only used as an outbox of other activity on the site for the purposes of ActivityPub. There's no use for it in the Jetpack context, so let's ignore it.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add ap_outbox to the sync disallowed CPT list.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1751600286308159-slack-C04TJ8P900J

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Post on an AP enabled website
* Confirm no ap_outbox activity in the sync queue.