### PR TITLE
Status: Change hosting checks back to original for VIP

### DIFF
--- a/projects/packages/status/changelog/update-vip-site-check-in-status-class
+++ b/projects/packages/status/changelog/update-vip-site-check-in-status-class
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+VIP: Changed hosting check method.

--- a/projects/packages/status/src/class-host.php
+++ b/projects/packages/status/src/class-host.php
@@ -55,11 +55,7 @@ class Host {
 	 * @return bool
 	 */
 	public function is_vip_site() {
-		$_blog_id = get_current_blog_id();
-		if ( function_exists( 'wpcom_is_vip' ) ) {
-			return wpcom_is_vip( $_blog_id );
-		}
-		return false;
+		return Constants::is_defined( 'WPCOM_IS_VIP_ENV' ) && true === Constants::get_constant( 'WPCOM_IS_VIP_ENV' );
 	}
 
 	/**

--- a/projects/packages/waf/changelog/update-vip-site-check-in-status-class
+++ b/projects/packages/waf/changelog/update-vip-site-check-in-status-class
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+VIP: Changed hosting check method.

--- a/projects/packages/waf/tests/php/integration/WafUnsupportedEnvironmentIntegrationTest.php
+++ b/projects/packages/waf/tests/php/integration/WafUnsupportedEnvironmentIntegrationTest.php
@@ -47,8 +47,6 @@ final class WafUnsupportedEnvironmentIntegrationTest extends WorDBless\BaseTestC
 	 * Test teardown.
 	 */
 	protected function tear_down() {
-		global $wpcom_is_vip;
-		$wpcom_is_vip = false;
 		Constants::clear_constants();
 		Cache::clear();
 	}
@@ -104,8 +102,7 @@ final class WafUnsupportedEnvironmentIntegrationTest extends WorDBless\BaseTestC
 	 * Test WAF init in a VIP environment.
 	 */
 	public function testWafInitVipEnvironment() {
-		global $wpcom_is_vip;
-		$wpcom_is_vip = true;
+		Constants::set_constant( 'WPCOM_IS_VIP_ENV', true );
 
 		$available_modules = ( new Modules() )->get_available();
 

--- a/projects/packages/waf/tests/php/integration/bootstrap.php
+++ b/projects/packages/waf/tests/php/integration/bootstrap.php
@@ -12,10 +12,3 @@ require_once __DIR__ . '/../../../vendor/autoload.php';
 
 // Initialize WordPress test environment
 \Automattic\Jetpack\Test_Environment::init();
-
-// Mock version of `wpcom_is_vip()` function for testing `Host::is_vip_site()`.
-$wpcom_is_vip = false; // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-function wpcom_is_vip( $blog_id = null ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-	global $wpcom_is_vip;
-	return $wpcom_is_vip;
-}


### PR DESCRIPTION
## Proposed changes:

* In https://github.com/Automattic/jetpack/pull/44059, hosting checks were modified due to earlier changes  resulting in failing E2E tests on deploy. The reason for that was that the Simple site used for testing was being defined as a VIP site, thus failing tests (p1750691245800779/1750681477.544699-slack-C01U2KGS2PQ).
* However, the function used is deprecated on the VIP end, and will result in deprecation notices if Jetpack is updated there (p1751906406966599-slack-CDD9LQRSN)
* A fix has been made on the WPcom side to ensure that constant that was being used previously, is more reliable: 187258-ghe-Automattic/wpcom
* As a result of that change, we can change our usage back to what it was before to help prevent issues on VIP.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

p1751906406966599-slack-CDD9LQRSN

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* This can be tested on the Simple site in question - see p1750691245800779/1750681477.544699-slack-C01U2KGS2PQ, by using the commands in the generated comment below and sandboxing that site.

(I'm unable to test this myself as I'm not a super admin on the test site in question.)