### PR TITLE
Script-utils: Remove unused isAtomicSite function

### DIFF
--- a/projects/js-packages/script-data/changelog/remove-is-atomic-site-function
+++ b/projects/js-packages/script-data/changelog/remove-is-atomic-site-function
@@ -1,0 +1,4 @@
+Significance: minor
+Type: removed
+
+Utils: Remove unused isAtomicSite function.

--- a/projects/js-packages/script-data/src/utils.ts
+++ b/projects/js-packages/script-data/src/utils.ts
@@ -81,18 +81,8 @@ export function isSimpleSite() {
 }
 
 /**
- * Check if the is an Atomic site.
- * This does not include WoA, but does include the likes of Jurassic Ninja, Pressable, Bluehost on Atomic.
- *
- * @return {boolean} Whether the site is an Atomic site.
- */
-export function isAtomicSite() {
-	return getScriptData()?.site?.host === 'atomic';
-}
-
-/**
  * Check if the site is a WoA site.
- * For WoA only - not general Atomic (see isAtomicSite()).
+ * For WoA only - not general Atomic (eg. not Jurassic Ninja, Pressable, Bluehost on Atomic).
  *
  * @return Whether the site is woa.
  */


### PR DESCRIPTION
## Proposed changes:

* To prevent future confusion, for now we're removing the unused `isAtomicSite` function from the `script-data` utils.
* Ref: pdWQjU-1ku-p2#comment-1325

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

pdWQjU-1ku-p2#comment-1325

## Does this pull request change what data or activity we track or use?

No.
## Testing instructions:

* Proof-read.
* You can confirm no function calls to `isAtomicSite` with a search in the monorepo as well.