### PR TITLE
Jetpack_Media: Ensure we check for the directory name before creating a file for deletion

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class.media.php
+++ b/projects/plugins/jetpack/_inc/lib/class.media.php
@@ -262,8 +262,11 @@ class Jetpack_Media {
 	 */
 	public static function delete_file( $pathname ) {
 		if ( ! file_exists( $pathname ) || ! is_file( $pathname ) ) {
-			// let's touch a fake file to try to `really` remove the media file.
-			touch( $pathname ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_touch
+			$dir = dirname( $pathname );
+			if ( is_dir( $dir ) ) {
+				// let's touch a fake file to try to `really` remove the media file.
+				touch( $pathname ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_touch
+			}
 		}
 
 		return wp_delete_file( $pathname );

--- a/projects/plugins/jetpack/changelog/update-class-media-delete-file-add-dir-check
+++ b/projects/plugins/jetpack/changelog/update-class-media-delete-file-add-dir-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Media: Prevent warnings in logs by checking for a directory before attempting to create a newfile.


### PR DESCRIPTION
Fixes VULCAN-231

## Proposed changes:

* This PR adds a directory check just before we attempt to create a file using `touch` in `delete_file` (which is then deleted if so), within the Jetpack_Media class.
* The reason for this is to prevent numerous warnings in error logs, such as: `touch(): Unable to create file /home/wpcom/public_html/wp-content/blogs.dir/487/123456789/files/2024/07/example.jpg because No such file or directory`
* The actions that are being taken to result in those warnings, are when cleaning revision history when a media item is deleted, given a media id. In these cases, this is happening when WPcom sites are being purged, starting with the `wpj_wpcom_empty_blog` action.
* The warning is happening because the parent directory of the file does not exist (most likely already deleted when attempting to create the file).

Additional notes:
* As an alternative to using `touch`, we could use `WP_Filesystem`. However there is a slight difference in behaviour, eg touch will update an existing file if it exists, `WP_Filesystem` will create a new one, so to keep expectations similar I've left the `touch` call.
* Additionally, it's not clear why we want to even create a fake file in order to delete it anyway. I'm not sure if this is documented anywhere (the addition was 8 years ago). It's possible there are hooks or filters attached to file deletion - or that we want to ensure that file deletion process is always followed.


Logs: f8067b1bf0597d58405d91441358a723-logstash

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

pdWQjU-1g0-p2

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

This can be tested without going through the WPcom site purging process (the function itself can be tested).
On a self-hosted test site, on Jetpack trunk:
* Add a new Tiled Gallery within a post. Upload some images from your computer.
* Confirm they are visible via the media library.
* Select and copy the file path linked as the 'original image' (when opening the image details).
* For the next step, you could use a code snippet or wp shell as two options.
* Code snippet approach:
* Add the below snippet of code to a code snippets plugin, substituting the example image file path with your image file path:
```
add_action( 'init', function() {
    if ( isset( $_GET['test_jetpack_media_delete'] ) ) {
        $path = WP_CONTENT_DIR . '/uploads/2025/07/example.jpg';
        Jetpack_Media::delete_file( $path );
        echo 'Tested Jetpack_Media::delete_file(). Check debug.log for errors.';
        exit;
    }
});
```
* Visit `https://yoursite.com/?test_jetpack_media_delete=1`
* `wp shell` approach:
* You could also use `wp shell` for a Jurassic Ninja site (`wp shell`, when SSH'd in):
```
require_once WP_CONTENT_DIR . '/plugins/jetpack/_inc/lib/class.media.php';
Jetpack_Media::delete_file( 'https://yoursite.com/wp-content/uploads/2025/07/yourimage.jpg' );
```
* Opening up your error logs, you should not see any warnings (the image will be deleted, but it's variants remain so you will likely still see it in the media library)
* Repeat the above steps again, but this time after adding the image, delete the folder it is in via SSH:
`rm -r /htdocs/wp-content/uploads/2025/07/` (most likely path, if using a Jurassic Ninja site)
* When running the `delete_file` function, this time you should see the warning mentioned above in your logs.

To test the fix:
* Using the Jetpack Beta tester plugin apply this PR (if testing on Jurassic Ninja).
* Follow the same steps as above - with the directory existing the image should still be properly deleted (you may need to clear the browser or site cache if you still see it, but you can confirm the file is deleted via SSH as well). With the directory removed, no warnings should occur.