### PR TITLE
Clean up lodash array functions

### DIFF
--- a/projects/js-packages/shared-extension-utils/changelog/update-cleanup-lodash-array-funcs
+++ b/projects/js-packages/shared-extension-utils/changelog/update-cleanup-lodash-array-funcs
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Replace some uses of lodash array functions with native JS equivalents. Should be no change in functionality.
+
+

--- a/projects/js-packages/shared-extension-utils/src/plan-utils.js
+++ b/projects/js-packages/shared-extension-utils/src/plan-utils.js
@@ -1,7 +1,7 @@
 import { isWoASite, isSimpleSite } from '@automattic/jetpack-script-data';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
-import { compact, get, map, filter } from 'lodash';
+import { get } from 'lodash';
 import getJetpackData from './get-jetpack-data';
 import getJetpackExtensionAvailability from './get-jetpack-extension-availability';
 import getSiteFragment from './get-site-fragment';
@@ -45,12 +45,9 @@ export function getUpgradeUrl( { planSlug, plan, postId, postType } ) {
 					return isSimpleSite()
 						? addQueryArgs(
 								'/' +
-									compact( [
-										postTypeEditorRoutePrefix,
-										postType,
-										getSiteFragment(),
-										postId,
-									] ).join( '/' ),
+									[ postTypeEditorRoutePrefix, postType, getSiteFragment(), postId ]
+										.filter( Boolean )
+										.join( '/' ),
 								{
 									plan_upgraded: 1,
 								}
@@ -174,7 +171,7 @@ export function isUpgradeNudgeEnabled() {
  * @returns {boolean} True is the block is usable with a Free plan. Otherwise, False.
  */
 export const isStillUsableWithFreePlan = name =>
-	map( usableBlockWithFreePlan, 'name' ).includes( name );
+	usableBlockWithFreePlan.some( v => v.name === name );
 
 export const getUsableBlockProps = blockName =>
-	filter( usableBlockWithFreePlan, ( { name } ) => name === blockName )[ 0 ];
+	usableBlockWithFreePlan.filter( ( { name } ) => name === blockName )[ 0 ];

--- a/projects/packages/external-media/changelog/update-cleanup-lodash-array-funcs
+++ b/projects/packages/external-media/changelog/update-cleanup-lodash-array-funcs
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Replace some uses of lodash array functions with native JS equivalents. Should be no change in functionality.
+
+

--- a/projects/packages/external-media/src/shared/constants.js
+++ b/projects/packages/external-media/src/shared/constants.js
@@ -1,6 +1,5 @@
 import { dateI18n } from '@wordpress/date';
 import { __ } from '@wordpress/i18n';
-import { map, range } from 'lodash';
 
 export const SOURCE_WORDPRESS = 'wordpress';
 export const SOURCE_GOOGLE_PHOTOS = 'google_photos';
@@ -179,7 +178,7 @@ export const CURRENT_YEAR = new Date().getFullYear();
 
 export const MONTH_SELECT_OPTIONS = [
 	{ label: __( 'Any Month', 'jetpack-external-media' ), value: -1 },
-	...map( range( 0, 12 ), value => ( {
+	...Array.from( Array( 12 ), ( _, value ) => ( {
 		// Following call generates a new date object for the particular month and gets its name.
 		label: dateI18n( 'F', new Date( 0, value ) ),
 		value,

--- a/projects/packages/forms/changelog/update-cleanup-lodash-array-funcs
+++ b/projects/packages/forms/changelog/update-cleanup-lodash-array-funcs
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Replace some uses of lodash array functions with native JS equivalents. Should be no change in functionality.
+
+

--- a/projects/packages/forms/src/blocks/contact-form/edit.js
+++ b/projects/packages/forms/src/blocks/contact-form/edit.js
@@ -25,7 +25,6 @@ import { store as editorStore } from '@wordpress/editor';
 import { useRef, useEffect, useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
-import { filter, map } from 'lodash';
 import { store as singleStepStore } from '../../store/form-step-preview';
 import {
 	PREVIOUS_BUTTON_TEMPLATE,
@@ -54,7 +53,7 @@ const FormTransitionState = {
 	IS_FORM: 'is-form',
 };
 
-const validFields = filter( childBlocks, ( { settings } ) => {
+const validFields = childBlocks.filter( ( { settings } ) => {
 	return (
 		! settings.parent ||
 		settings.parent === 'jetpack/contact-form' ||
@@ -62,7 +61,7 @@ const validFields = filter( childBlocks, ( { settings } ) => {
 	);
 } );
 
-const ALLOWED_BLOCKS = [ ...map( validFields, block => `jetpack/${ block.name }` ) ];
+const ALLOWED_BLOCKS = [ ...validFields.map( block => `jetpack/${ block.name }` ) ];
 
 const ALLOWED_CORE_BLOCKS = [
 	'core/audio',
@@ -101,7 +100,7 @@ const ALLOWED_FORM_BLOCKS = ALLOWED_BLOCKS.concat( ALLOWED_CORE_BLOCKS ).filter(
 	block => ! REMOVE_FIELDS_FROM_FORM.includes( block )
 );
 
-const PRIORITIZED_INSERTER_BLOCKS = [ ...map( validFields, block => `jetpack/${ block.name }` ) ];
+const PRIORITIZED_INSERTER_BLOCKS = [ ...validFields.map( block => `jetpack/${ block.name }` ) ];
 
 function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, className } ) {
 	const {

--- a/projects/packages/forms/src/blocks/contact-form/variation-picker.js
+++ b/projects/packages/forms/src/blocks/contact-form/variation-picker.js
@@ -9,11 +9,11 @@ import { useDispatch, useRegistry, useSelect } from '@wordpress/data';
 import { useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
-import { filter, get, map } from 'lodash';
+import { get } from 'lodash';
 import './util/form-styles.js';
 
 const createBlocksFromInnerBlocksTemplate = innerBlocksTemplate => {
-	const blocks = map( innerBlocksTemplate, ( [ blockName, attr, innerBlocks = [] ] ) =>
+	const blocks = innerBlocksTemplate.map( ( [ blockName, attr, innerBlocks = [] ] ) =>
 		createBlock( blockName, attr, createBlocksFromInnerBlocksTemplate( innerBlocks ) )
 	);
 
@@ -56,7 +56,7 @@ export default function VariationPicker( { blockName, setAttributes, clientId, c
 					'Start by selecting one of these templates, or browse patterns.',
 					'jetpack-forms'
 				) }
-				variations={ filter( variations, v => ! v.hiddenFromPicker ) }
+				variations={ variations.filter( v => ! v.hiddenFromPicker ) }
 				onSelect={ ( nextVariation = defaultVariation ) => {
 					registry.batch( () => {
 						if ( nextVariation.attributes ) {

--- a/projects/packages/forms/src/blocks/contact-form/variations.js
+++ b/projects/packages/forms/src/blocks/contact-form/variations.js
@@ -3,11 +3,10 @@ import { hasFeatureFlag } from '@automattic/jetpack-shared-extension-utils';
 import { Path } from '@wordpress/components';
 import { __, _x } from '@wordpress/i18n';
 import { people } from '@wordpress/icons';
-import { compact } from 'lodash';
 import renderMaterialIcon from '../shared/components/render-material-icon';
 import { getIconColor } from '../shared/util/block-icons';
 
-const variations = compact( [
+const variations = [
 	{
 		name: 'regular-form',
 		title: __( 'Form', 'jetpack-forms' ),
@@ -1090,6 +1089,6 @@ const variations = compact( [
 			],
 		},
 	},
-] );
+].filter( Boolean );
 
 export default variations;

--- a/projects/packages/forms/src/blocks/input-rating/stars.js
+++ b/projects/packages/forms/src/blocks/input-rating/stars.js
@@ -1,5 +1,4 @@
 import { useCallback } from '@wordpress/element';
-import { range } from 'lodash';
 
 /**
  * Interactive star-rating row.
@@ -21,7 +20,7 @@ export default function Stars( { max, value = 0, onChange = () => {} } ) {
 
 	return (
 		<div className="jetpack-field-rating__wrapper">
-			{ range( 1, max + 1 ).map( position => (
+			{ Array.from( Array( max ), ( _, i ) => i + 1 ).map( position => (
 				<span
 					key={ position }
 					className="jetpack-field-rating__button"

--- a/projects/packages/forms/src/dashboard/inbox/response.js
+++ b/projects/packages/forms/src/dashboard/inbox/response.js
@@ -17,7 +17,6 @@ import { decodeEntities } from '@wordpress/html-entities';
 import { __, sprintf } from '@wordpress/i18n';
 import { download } from '@wordpress/icons';
 import clsx from 'clsx';
-import { map } from 'lodash';
 /**
  * Internal dependencies
  */
@@ -290,7 +289,7 @@ const InboxResponse = ( { response, loading, onModalStateChange } ) => {
 				<div className="jp-forms__inbox-response-separator" />
 
 				<div className="jp-forms__inbox-response-data">
-					{ map( response.fields, ( value, key ) => (
+					{ Object.entries( response.fields ).map( ( [ key, value ] ) => (
 						<div key={ key } className="jp-forms__inbox-response-item">
 							<div className="jp-forms__inbox-response-data-label">
 								{ key.endsWith( '?' ) ? key : `${ key }:` }

--- a/projects/packages/jetpack-mu-wpcom/changelog/update-cleanup-lodash-array-funcs
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-cleanup-lodash-array-funcs
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Replace some uses of lodash array functions with native JS equivalents. Should be no change in functionality.
+
+

--- a/projects/packages/jetpack-mu-wpcom/src/features/block-inserter-modifications/src/contextual-tip.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/block-inserter-modifications/src/contextual-tip.js
@@ -1,7 +1,7 @@
 import { Tip } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
-import { get, filter, deburr, lowerCase, includes } from 'lodash';
+import { get, deburr, lowerCase } from 'lodash';
 import tipsList from './list';
 
 /**
@@ -24,12 +24,10 @@ function ContextualTip( { searchTerm, random = false, canUserCreate } ) {
 
 	const normalizedSearchTerm = deburr( lowerCase( searchTerm ) ).replace( /^\//, '' );
 
-	const foundTips = filter(
-		tipsList,
+	const foundTips = tipsList.filter(
 		( { keywords, permission } ) =>
 			canUserCreate( permission ) &&
-			filter( [ ...new Set( keywords ) ], keyword => includes( normalizedSearchTerm, keyword ) )
-				.length
+			[ ...new Set( keywords ) ].some( keyword => normalizedSearchTerm.includes( keyword ) )
 	);
 
 	if ( ! foundTips.length ) {

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/stats/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/stats/index.jsx
@@ -4,7 +4,7 @@ import { ExternalLink, Spinner } from '@wordpress/components';
 import { dateI18n } from '@wordpress/date';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import { forEach, get, isEmpty } from 'lodash';
+import { get, isEmpty } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -71,7 +71,7 @@ export class DashStats extends Component {
 			/* translators: long month/year format, such as: January, 2021. */
 			longMonthYearFormat = __( 'F Y', 'jetpack' );
 
-		forEach( statsData[ unit ].data, v => {
+		for ( const v of statsData[ unit ].data ) {
 			const views = v[ 1 ];
 			let date = v[ 0 ],
 				chartLabel = '',
@@ -126,7 +126,7 @@ export class DashStats extends Component {
 					},
 				],
 			} );
-		} );
+		}
 
 		return { chartData: s, totalViews: totalViews };
 	}

--- a/projects/plugins/jetpack/_inc/client/components/banner/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/banner/index.jsx
@@ -1,6 +1,5 @@
 import { Icon } from '@wordpress/icons';
 import clsx from 'clsx';
-import { size } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect as reduxConnect } from 'react-redux';
@@ -143,7 +142,7 @@ export class Banner extends Component {
 				<div className="dops-banner__info">
 					<div className="dops-banner__title">{ title }</div>
 					{ description && <div className="dops-banner__description">{ description }</div> }
-					{ size( list ) > 0 && (
+					{ list?.length > 0 && (
 						<ul className="dops-banner__list">
 							{ list.map( ( item, key ) => (
 								<li key={ key }>

--- a/projects/plugins/jetpack/_inc/client/components/dash-item/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/dash-item/index.jsx
@@ -1,7 +1,6 @@
 import { getRedirectUrl } from '@automattic/jetpack-components';
 import { __, _x } from '@wordpress/i18n';
 import clsx from 'clsx';
-import { includes } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -68,20 +67,17 @@ export class DashItem extends Component {
 
 		if ( '' !== this.props.module ) {
 			toggle =
-				( includes(
-					[
-						'monitor',
-						'protect',
-						'photon',
-						'vaultpress',
-						'scan',
-						'backups',
-						'akismet',
-						'search',
-						'videopress',
-					],
-					this.props.module
-				) &&
+				( [
+					'monitor',
+					'protect',
+					'photon',
+					'vaultpress',
+					'scan',
+					'backups',
+					'akismet',
+					'search',
+					'videopress',
+				].includes( this.props.module ) &&
 					this.props.isOfflineMode ) ||
 				this.props.noToggle ||
 				// Avoid toggle for manage as it's no longer a module

--- a/projects/plugins/jetpack/_inc/client/components/module-settings/with-module-settings-form-helpers.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/module-settings/with-module-settings-form-helpers.jsx
@@ -1,4 +1,4 @@
-import { each, get, omit } from 'lodash';
+import { get, omit } from 'lodash';
 import { Component } from 'react';
 import { connectModuleOptions } from 'components/module-settings/connect-module-options';
 import analytics from 'lib/analytics';
@@ -121,12 +121,9 @@ export function withModuleSettingsFormHelpers( InnerComponent ) {
 				.then( () => {
 					// Track it
 
-					const saneOptions = {};
-
-					each( this.state.options, ( value, key ) => {
-						key = key.replace( /-/, '_' );
-						saneOptions[ key ] = value;
-					} );
+					const saneOptions = Object.fromEntries(
+						Object.entries( this.state.options ).map( ( [ k, v ] ) => [ k.replace( /-/, '_' ), v ] )
+					);
 
 					this.trackFormSubmission( saneOptions );
 

--- a/projects/plugins/jetpack/_inc/client/components/section-nav/docs/example.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/section-nav/docs/example.jsx
@@ -1,4 +1,3 @@
-import { forEach } from 'lodash';
 import { PureComponent } from 'react';
 import Search from 'components/search';
 import SectionNav from 'components/section-nav';
@@ -63,7 +62,7 @@ class SectionNavigation extends PureComponent {
 	render() {
 		const demoSections = {};
 
-		forEach( this.props, ( prop, key ) => {
+		for ( const [ key, prop ] of Object.entries( this.props ) ) {
 			demoSections[ key ] = [];
 
 			prop.forEach( function ( item, index ) {
@@ -78,7 +77,7 @@ class SectionNavigation extends PureComponent {
 					</NavItem>
 				);
 			}, this );
-		} );
+		}
 
 		return (
 			<div className="design-assets__group">

--- a/projects/plugins/jetpack/_inc/client/components/select-dropdown/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/select-dropdown/index.jsx
@@ -1,7 +1,7 @@
 /** @ssr-ready **/
 
 import clsx from 'clsx';
-import { filter, find, findIndex, map, result } from 'lodash';
+import { result } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component, Children, cloneElement, createRef } from 'react';
 import Count from 'components/count';
@@ -92,7 +92,7 @@ class SelectDropdown extends Component {
 			return;
 		}
 
-		const selectedItem = find( props.options, value => ! value.isLabel );
+		const selectedItem = props.options.find( value => ! value.isLabel );
 		return selectedItem && selectedItem.value;
 	}
 
@@ -184,7 +184,10 @@ class SelectDropdown extends Component {
 		const dropdownClassName = clsx( dropdownClasses );
 		const selectedText = this.props.selectedText
 			? this.props.selectedText
-			: result( find( this.props.options, { value: this.state.selected } ), 'label' );
+			: result(
+					this.props.options.find( v => v.value === this.state.selected ),
+					'label'
+			  );
 
 		return (
 			<div style={ this.props.style } className={ dropdownClassName }>
@@ -323,26 +326,17 @@ class SelectDropdown extends Component {
 		}
 
 		if ( this.props.options.length ) {
-			items = map(
-				filter( this.props.options, item => {
-					return item && ! item.isLabel;
-				} ),
-				'value'
-			);
+			items = this.props.options.filter( item => item && ! item.isLabel ).map( v => v.value );
 
 			focusedIndex =
 				typeof this.focused === 'number' ? this.focused : items.indexOf( this.state.selected );
 		} else {
-			items = filter( this.props.children, function ( item ) {
-				return item.type === DropdownItem;
-			} );
+			items = Children.toArray( this.props.children ).filter( item => item.type === DropdownItem );
 
 			focusedIndex =
 				typeof this.focused === 'number'
 					? this.focused
-					: findIndex( items, function ( item ) {
-							return item.props.selected;
-					  } );
+					: items.findIndex( item => item.props.selected );
 		}
 
 		const increment = direction === 'previous' ? -1 : 1;

--- a/projects/plugins/jetpack/_inc/client/components/settings-card/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/settings-card/index.jsx
@@ -1,5 +1,5 @@
 import { __, _x } from '@wordpress/i18n';
-import { get, includes } from 'lodash';
+import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import Button from 'components/button';
@@ -90,7 +90,7 @@ export const SettingsCard = inprops => {
 	// Non admin users only get Publicize and Post by Email settings.
 	if (
 		! props.userCanManageModules &&
-		! includes( [ 'post-by-email', 'publicize' ], props.module )
+		! [ 'post-by-email', 'publicize' ].includes( props.module )
 	) {
 		return <span />;
 	}

--- a/projects/plugins/jetpack/_inc/client/components/settings-group/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/settings-group/index.jsx
@@ -1,5 +1,4 @@
 import clsx from 'clsx';
-import { includes } from 'lodash';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import Card from 'components/card';
@@ -37,7 +36,7 @@ export const SettingsGroup = inprops => {
 	if (
 		module.module &&
 		! props.userCanManageModules &&
-		! includes( [ 'post-by-email', 'publicize' ], module.module )
+		! [ 'post-by-email', 'publicize' ].includes( module.module )
 	) {
 		return <span />;
 	}

--- a/projects/plugins/jetpack/_inc/client/lib/plans/constants.js
+++ b/projects/plugins/jetpack/_inc/client/lib/plans/constants.js
@@ -1,5 +1,3 @@
-import { includes } from 'lodash';
-
 // plans constants
 export const PLAN_BUSINESS = 'business-bundle';
 export const PLAN_BUSINESS_2_YEARS = 'business-bundle-2y';
@@ -450,7 +448,7 @@ export const JETPACK_FEATURE_PRODUCT_UPSELL_MAP = {
  * @return {boolean} True if it's monthly plan
  */
 export function isMonthly( plan ) {
-	return includes( JETPACK_MONTHLY_PLANS, plan );
+	return JETPACK_MONTHLY_PLANS.includes( plan );
 }
 /**
  * Checks if a plan slug is in the group of popular plans.
@@ -459,7 +457,7 @@ export function isMonthly( plan ) {
  * @return {boolean} True if it's popular plan
  */
 export function isPopular( plan ) {
-	return includes( POPULAR_PLANS, plan );
+	return POPULAR_PLANS.includes( plan );
 }
 /**
  * Checks if a plan slug is a new plan.
@@ -468,7 +466,7 @@ export function isPopular( plan ) {
  * @return {boolean} True if it's new plan
  */
 export function isNew( plan ) {
-	return includes( NEW_PLANS, plan );
+	return NEW_PLANS.includes( plan );
 }
 
 /**
@@ -478,7 +476,7 @@ export function isNew( plan ) {
  * @return {boolean} True if the plan includes Jetpack Anti-Spam
  */
 export function isJetpackPlanWithAntiSpam( plan ) {
-	return includes( JETPACK_PLANS_WITH_ANTI_SPAM, plan );
+	return JETPACK_PLANS_WITH_ANTI_SPAM.includes( plan );
 }
 
 /**
@@ -488,7 +486,7 @@ export function isJetpackPlanWithAntiSpam( plan ) {
  * @return {boolean} True if the plan contains backup features
  */
 export function isJetpackPlanWithBackup( plan ) {
-	return includes( JETPACK_PLANS_WITH_BACKUP, plan );
+	return JETPACK_PLANS_WITH_BACKUP.includes( plan );
 }
 
 /**
@@ -498,7 +496,7 @@ export function isJetpackPlanWithBackup( plan ) {
  * @return {boolean} True if the product is Jetpack Backup
  */
 export function isJetpackBackup( product ) {
-	return includes( JETPACK_BACKUP_PRODUCTS, product );
+	return JETPACK_BACKUP_PRODUCTS.includes( product );
 }
 
 /**
@@ -508,7 +506,7 @@ export function isJetpackBackup( product ) {
  * @return {boolean} True if the product is Jetpack Search
  */
 export function isJetpackSearch( product ) {
-	return includes( JETPACK_SEARCH_PRODUCTS, product );
+	return JETPACK_SEARCH_PRODUCTS.includes( product );
 }
 
 /**

--- a/projects/plugins/jetpack/_inc/client/my-plan/my-plan-body.jsx
+++ b/projects/plugins/jetpack/_inc/client/my-plan/my-plan-body.jsx
@@ -2,7 +2,7 @@ import { getRedirectUrl } from '@automattic/jetpack-components';
 import { isWoASite } from '@automattic/jetpack-script-data';
 import { ExternalLink } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { get, includes } from 'lodash';
+import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -72,21 +72,18 @@ class MyPlanBody extends Component {
 	render() {
 		let planCard = '';
 		const planClass = 'offline' !== this.props.plan ? getPlanClass( this.props.plan ) : 'offline';
-		const isPlanPremiumOrBetter = includes(
-			[
-				'is-premium-plan',
-				'is-business-plan',
-				'is-security-t1-plan',
-				'is-security-t2-plan',
-				'is-complete-plan',
+		const isPlanPremiumOrBetter = [
+			'is-premium-plan',
+			'is-business-plan',
+			'is-security-t1-plan',
+			'is-security-t2-plan',
+			'is-complete-plan',
 
-				// DEPRECATED: Daily and Real-time variations will soon be retired.
-				// Remove after all customers are migrated to new products.
-				'is-daily-security-plan',
-				'is-realtime-security-plan',
-			],
-			planClass
-		);
+			// DEPRECATED: Daily and Real-time variations will soon be retired.
+			// Remove after all customers are migrated to new products.
+			'is-daily-security-plan',
+			'is-realtime-security-plan',
+		].includes( planClass );
 		const rewindActive = 'active' === get( this.props.rewindStatus, [ 'state' ], false ),
 			hideVaultPressCard =
 				! this.props.showBackups ||

--- a/projects/plugins/jetpack/_inc/client/my-plan/my-plan-header/index.js
+++ b/projects/plugins/jetpack/_inc/client/my-plan/my-plan-header/index.js
@@ -3,7 +3,7 @@ import { ExternalLink } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, _n, _x, sprintf } from '@wordpress/i18n';
 import clsx from 'clsx';
-import { find, isEmpty } from 'lodash';
+import { isEmpty } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -50,7 +50,7 @@ class MyPlanHeader extends Component {
 			};
 		}
 
-		const purchase = find( purchases, purchaseObj => purchaseObj.product_slug === productSlug );
+		const purchase = purchases?.find( purchaseObj => purchaseObj.product_slug === productSlug );
 
 		let expiration;
 		let activation;

--- a/projects/plugins/jetpack/_inc/client/notices/validation-error-list.jsx
+++ b/projects/plugins/jetpack/_inc/client/notices/validation-error-list.jsx
@@ -1,5 +1,4 @@
 import { _n } from '@wordpress/i18n';
-import { map } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 
@@ -22,7 +21,7 @@ export default class ValidationErrorList extends Component {
 					) }
 				</p>
 				<ul>
-					{ map( this.props.messages, function ( message, index ) {
+					{ this.props.messages.map( function ( message, index ) {
 						return <li key={ index }>{ message }</li>;
 					} ) }
 				</ul>

--- a/projects/plugins/jetpack/_inc/client/searchable-modules/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/searchable-modules/index.jsx
@@ -1,5 +1,4 @@
 import { __ } from '@wordpress/i18n';
-import { includes, forEach } from 'lodash';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import Banner from 'components/banner';
@@ -55,8 +54,8 @@ export const SearchableModules = withModuleSettingsFormHelpers(
 
 			const allModules = this.props.modules,
 				results = [];
-			forEach( allModules, ( moduleData, slug ) => {
-				if ( this.props.isModuleFound( slug ) && includes( safelist, slug ) ) {
+			for ( const [ slug, moduleData ] of Object.entries( allModules ) ) {
+				if ( this.props.isModuleFound( slug ) && safelist.includes( slug ) ) {
 					const isModuleUnavailableInOfflineMode =
 						this.props.isOfflineMode && this.props.isUnavailableInOfflineMode( moduleData.module );
 					const isModuleUnavailableInSiteConnectionMode =
@@ -65,7 +64,7 @@ export const SearchableModules = withModuleSettingsFormHelpers(
 
 					// Not available in offline or SiteConnection mode.
 					if ( isModuleUnavailableInOfflineMode || isModuleUnavailableInSiteConnectionMode ) {
-						return results.push(
+						results.push(
 							<ActiveCard
 								key={ slug }
 								moduleData={ moduleData }
@@ -73,6 +72,7 @@ export const SearchableModules = withModuleSettingsFormHelpers(
 								siteConnectionMode={ isModuleUnavailableInSiteConnectionMode }
 							/>
 						);
+						continue;
 					}
 
 					if ( this.props.getOptionValue( moduleData.module ) ) {
@@ -92,7 +92,7 @@ export const SearchableModules = withModuleSettingsFormHelpers(
 						);
 					}
 				}
-			} );
+			}
 
 			return <div>{ results }</div>;
 		}

--- a/projects/plugins/jetpack/_inc/client/security/allowList.jsx
+++ b/projects/plugins/jetpack/_inc/client/security/allowList.jsx
@@ -1,6 +1,5 @@
 import { ToggleControl } from '@automattic/jetpack-components';
 import { __, _x, sprintf } from '@wordpress/i18n';
-import { includes } from 'lodash';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import Button from 'components/button';
@@ -99,7 +98,7 @@ const AllowList = class extends Component {
 
 	currentIpIsSafelisted = () => {
 		// get current IP allow list in textarea from this.state.ipAllowList;
-		return !! includes( this.state.ipAllowList, this.props.currentIp );
+		return !! this.state.ipAllowList?.includes( this.props.currentIp );
 	};
 
 	addToSafelist = () => {

--- a/projects/plugins/jetpack/_inc/client/security/backups-scan.jsx
+++ b/projects/plugins/jetpack/_inc/client/security/backups-scan.jsx
@@ -3,7 +3,7 @@ import { formatNumber } from '@automattic/number-formatters';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, _x, _n, sprintf } from '@wordpress/i18n';
 import { info } from '@wordpress/icons';
-import { get, includes } from 'lodash';
+import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -227,7 +227,7 @@ export const BackupsScan = withModuleSettingsFormHelpers(
 			}
 
 			// Backup & Scan is working in this site.
-			if ( includes( [ 'provisioning', 'awaiting_credentials', 'active' ], rewindState ) ) {
+			if ( [ 'provisioning', 'awaiting_credentials', 'active' ].includes( rewindState ) ) {
 				return <BackupsScanRewind { ...this.props } rewindState={ rewindState } />;
 			}
 

--- a/projects/plugins/jetpack/_inc/client/state/connection/reducer.js
+++ b/projects/plugins/jetpack/_inc/client/state/connection/reducer.js
@@ -1,4 +1,4 @@
-import { get, includes, merge } from 'lodash';
+import { get, merge } from 'lodash';
 import { combineReducers } from 'redux';
 import {
 	JETPACK_CONNECTION_STATUS_FETCH,
@@ -396,7 +396,7 @@ export function isInIdentityCrisis( state ) {
  * @return {boolean} True if module requires connection.
  */
 export function requiresConnection( state, slug ) {
-	return includes( getModulesThatRequireConnection( state ).concat( [ 'backups', 'scan' ] ), slug );
+	return getModulesThatRequireConnection( state ).concat( [ 'backups', 'scan' ] ).includes( slug );
 }
 
 /**
@@ -418,7 +418,7 @@ export function isUnavailableInOfflineMode( state, module ) {
  * @return {boolean} True if module requires connection.
  */
 export function requiresUserConnection( state, slug ) {
-	return includes( getModulesThatRequireUserConnection( state ), slug );
+	return getModulesThatRequireUserConnection( state ).includes( slug );
 }
 
 /**

--- a/projects/plugins/jetpack/_inc/client/state/modules/actions.js
+++ b/projects/plugins/jetpack/_inc/client/state/modules/actions.js
@@ -1,6 +1,5 @@
 import restApi from '@automattic/jetpack-api';
 import { __, sprintf } from '@wordpress/i18n';
-import { some } from 'lodash';
 import { createNotice, removeNotice } from 'components/global-notices/state/notices/actions';
 import {
 	JETPACK_MODULES_LIST_FETCH,
@@ -348,7 +347,7 @@ export const regeneratePostByEmailAddress = () => {
 export function maybeReloadAfterAction( newOptionValue ) {
 	const reloadForOptionValues = [ 'jetpack_testimonial', 'jetpack_portfolio' ];
 
-	if ( some( reloadForOptionValues, optionValue => optionValue in newOptionValue ) ) {
+	if ( reloadForOptionValues.some( optionValue => optionValue in newOptionValue ) ) {
 		window.location.reload();
 	}
 }

--- a/projects/plugins/jetpack/_inc/client/state/modules/reducer.js
+++ b/projects/plugins/jetpack/_inc/client/state/modules/reducer.js
@@ -1,4 +1,4 @@
-import { get, includes, intersection } from 'lodash';
+import { get, intersection } from 'lodash';
 import { combineReducers } from 'redux';
 import {
 	JETPACK_SET_INITIAL_STATE,
@@ -324,7 +324,7 @@ export function isModuleActivated( state, name ) {
  * @return {boolean}            Whether a module is available to be displayed in the dashboard.
  */
 export function isModuleAvailable( state, moduleSlug ) {
-	return includes( Object.keys( state.jetpack.modules.items ), moduleSlug );
+	return Object.keys( state.jetpack.modules.items ).includes( moduleSlug );
 }
 
 /**

--- a/projects/plugins/jetpack/_inc/client/state/search/reducer.js
+++ b/projects/plugins/jetpack/_inc/client/state/search/reducer.js
@@ -1,4 +1,4 @@
-import { find, get } from 'lodash';
+import { get } from 'lodash';
 import { combineReducers } from 'redux';
 import { JETPACK_SEARCH_TERM } from 'state/action-types';
 
@@ -34,7 +34,9 @@ export function getSearchTerm( state ) {
  * @return {boolean}       Whether the module should be in the search results
  */
 export function isModuleFound( state, module ) {
-	const result = find( get( state.jetpack, [ 'modules', 'items' ], {} ), [ 'module', module ] );
+	const result = Object.values( get( state.jetpack, [ 'modules', 'items' ], {} ) ).find(
+		v => v?.module === module
+	);
 
 	if ( 'undefined' === typeof result ) {
 		return false;

--- a/projects/plugins/jetpack/_inc/client/state/settings/actions.js
+++ b/projects/plugins/jetpack/_inc/client/state/settings/actions.js
@@ -1,6 +1,6 @@
 import restApi from '@automattic/jetpack-api';
 import { __, sprintf } from '@wordpress/i18n';
-import { get, some } from 'lodash';
+import { get } from 'lodash';
 import { createNotice, removeNotice } from 'components/global-notices/state/notices/actions';
 import {
 	JETPACK_SETTINGS_FETCH,
@@ -101,7 +101,7 @@ export const updateSettings = ( newOptionValues, noticeMessages = {} ) => {
 		// Adapt message for above options, since it needs to reload.
 		if (
 			'object' === typeof newOptionValues &&
-			some( reloadForOptionValues, optionValue => optionValue in newOptionValues )
+			reloadForOptionValues.some( optionValue => optionValue in newOptionValues )
 		) {
 			messages.success = __( 'Updated settings. Refreshing page…', 'jetpack' );
 		}
@@ -116,7 +116,7 @@ export const updateSettings = ( newOptionValues, noticeMessages = {} ) => {
 		];
 		if (
 			'object' === typeof newOptionValues &&
-			! some( suppressNoticeFor, optionValue => optionValue in newOptionValues )
+			! suppressNoticeFor.some( optionValue => optionValue in newOptionValues )
 		) {
 			dispatch( createNotice( 'is-info', messages.progress, { id: 'module-setting-update' } ) );
 		}
@@ -140,7 +140,7 @@ export const updateSettings = ( newOptionValues, noticeMessages = {} ) => {
 				dispatch( removeNotice( 'module-setting-update-success' ) );
 				if (
 					'object' === typeof newOptionValues &&
-					! some( suppressNoticeFor, optionValue => optionValue in newOptionValues )
+					! suppressNoticeFor.some( optionValue => optionValue in newOptionValues )
 				) {
 					dispatch(
 						createNotice( 'is-success', messages.success, {

--- a/projects/plugins/jetpack/_inc/client/state/settings/reducer.js
+++ b/projects/plugins/jetpack/_inc/client/state/settings/reducer.js
@@ -1,4 +1,4 @@
-import { filter, get, includes, mapValues, merge, some } from 'lodash';
+import { get, mapValues, merge } from 'lodash';
 import { combineReducers } from 'redux';
 import {
 	JETPACK_SET_INITIAL_STATE,
@@ -134,12 +134,9 @@ export function isFetchingSettingsList( state ) {
  * @return {boolean}                Whether option is being updated on the setting
  */
 export function isUpdatingSetting( state, settings = '' ) {
-	if ( 'object' === typeof settings ) {
-		return some(
-			filter( state.jetpack.settings.requests.settingsSent, ( item, key ) =>
-				includes( settings, key )
-			),
-			item => item
+	if ( Array.isArray( settings ) ) {
+		return Object.entries( state.jetpack.settings.requests.settingsSent ).some(
+			( [ key, item ] ) => item && settings.includes( key )
 		);
 	}
 	return state.jetpack.settings.requests.settingsSent[ settings ];

--- a/projects/plugins/jetpack/_inc/client/state/site/reducer.js
+++ b/projects/plugins/jetpack/_inc/client/state/site/reducer.js
@@ -1,5 +1,5 @@
 import { __ } from '@wordpress/i18n';
-import { find, get, merge } from 'lodash';
+import { get, merge } from 'lodash';
 import { combineReducers } from 'redux';
 import {
 	getPlanClass,
@@ -407,7 +407,7 @@ export function hasActiveProductPurchase( state ) {
  * @return {object}       A active security bundle on the site, undefined otherwise
  */
 export function getActiveSecurityPurchase( state ) {
-	return find( getActiveSitePurchases( state ), purchase =>
+	return getActiveSitePurchases( state ).find( purchase =>
 		isJetpackSecurityBundle( purchase.product_slug )
 	);
 }
@@ -439,7 +439,7 @@ export function hasActiveCompletePurchase( state ) {
  * @return {object}       An active Search product if one was found, undefined otherwise.
  */
 export function getActiveSearchPurchase( state ) {
-	return find( getActiveProductPurchases( state ), product =>
+	return getActiveProductPurchases( state ).find( product =>
 		isJetpackSearch( product.product_slug )
 	);
 }
@@ -461,7 +461,7 @@ export function hasActiveSearchPurchase( state ) {
  * @return {object}       An active Creator product if one was found, undefined otherwise.
  */
 export function getActiveCreatorPurchase( state ) {
-	return find( getActiveProductPurchases( state ), product =>
+	return getActiveProductPurchases( state ).find( product =>
 		isJetpackCreator( product.product_slug )
 	);
 }
@@ -473,7 +473,7 @@ export function getActiveCreatorPurchase( state ) {
  * @return {object}       An active Growth product if one was found, undefined otherwise.
  */
 export function getActiveGrowthPurchase( state ) {
-	return find( getActiveProductPurchases( state ), product =>
+	return getActiveProductPurchases( state ).find( product =>
 		isJetpackGrowth( product.product_slug )
 	);
 }
@@ -505,7 +505,7 @@ export function hasActiveGrowthPurchase( state ) {
  * @return {object}       An active Anti-Spam product if one was found, undefined otherwise.
  */
 export function getActiveAntiSpamPurchase( state ) {
-	return find( getActiveProductPurchases( state ), product =>
+	return getActiveProductPurchases( state ).find( product =>
 		isJetpackAntiSpam( product.product_slug )
 	);
 }
@@ -527,7 +527,7 @@ export function hasActiveAntiSpamPurchase( state ) {
  * @return {object}       An active Boost product if one was found, undefined otherwise.
  */
 export function getActiveBoostPurchase( state ) {
-	return find( getActiveProductPurchases( state ), product =>
+	return getActiveProductPurchases( state ).find( product =>
 		isJetpackBoost( product.product_slug )
 	);
 }
@@ -549,7 +549,7 @@ export function hasActiveBoostPurchase( state ) {
  * @return {object}       An active backup product if one was found, undefined otherwise.
  */
 export function getActiveBackupPurchase( state ) {
-	return find( getActiveProductPurchases( state ), product =>
+	return getActiveProductPurchases( state ).find( product =>
 		isJetpackBackup( product.product_slug )
 	);
 }
@@ -561,7 +561,7 @@ export function getActiveBackupPurchase( state ) {
  * @return {boolean}      True if the site has an active backup product purchase, false otherwise.
  */
 export function getActiveSocialPurchase( state ) {
-	return find( getActiveProductPurchases( state ), product =>
+	return getActiveProductPurchases( state ).find( product =>
 		isJetpackSocial( product.product_slug )
 	);
 }
@@ -593,7 +593,7 @@ export function hasActiveSocialPurchase( state ) {
  * @return {object}       An active legacy plan with security features if one was found, undefined otherwise.
  */
 export function getSecurityComparableLegacyPlan( state ) {
-	return find( getActiveProductPurchases( state ), product =>
+	return getActiveProductPurchases( state ).find( product =>
 		isSecurityComparableJetpackLegacyPlan( product.product_slug )
 	);
 }

--- a/projects/plugins/jetpack/_inc/client/traffic/site-stats.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/site-stats.jsx
@@ -2,7 +2,6 @@ import { getRedirectUrl, ToggleControl } from '@automattic/jetpack-components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
 import clsx from 'clsx';
-import { filter, includes } from 'lodash';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import Button from 'components/button';
@@ -26,17 +25,17 @@ class SiteStatsComponent extends Component {
 			count_roles: countRoles,
 			roles: roles,
 
-			count_roles_administrator: includes( countRoles, 'administrator', false ),
-			count_roles_editor: includes( countRoles, 'editor', false ),
-			count_roles_author: includes( countRoles, 'author', false ),
-			count_roles_contributor: includes( countRoles, 'contributor', false ),
-			count_roles_subscriber: includes( countRoles, 'subscriber', false ),
+			count_roles_administrator: !! countRoles?.includes( 'administrator' ),
+			count_roles_editor: !! countRoles?.includes( 'editor' ),
+			count_roles_author: !! countRoles?.includes( 'author' ),
+			count_roles_contributor: !! countRoles?.includes( 'contributor' ),
+			count_roles_subscriber: !! countRoles?.includes( 'subscriber' ),
 
 			roles_administrator: true,
-			roles_editor: includes( roles, 'editor', false ),
-			roles_author: includes( roles, 'author', false ),
-			roles_contributor: includes( roles, 'contributor', false ),
-			roles_subscriber: includes( roles, 'subscriber', false ),
+			roles_editor: !! roles?.includes( 'editor' ),
+			roles_author: !! roles?.includes( 'author' ),
+			roles_contributor: !! roles?.includes( 'contributor' ),
+			roles_subscriber: !! roles?.includes( 'subscriber' ),
 
 			wpcom_reader_views_enabled: props.getOptionValue( 'wpcom_reader_views_enabled' ),
 		};
@@ -70,14 +69,12 @@ class SiteStatsComponent extends Component {
 		let value = this.props.getOptionValue( optionSet, 'stats' ),
 			toggled = false;
 		if ( ! this.state[ `${ optionSet }_${ optionName }` ] ) {
-			if ( ! includes( value, optionName ) ) {
+			if ( ! value.includes( optionName ) ) {
 				value.push( optionName );
 				toggled = true;
 			}
-		} else if ( includes( value, optionName ) ) {
-			value = filter( value, item => {
-				return item !== optionName;
-			} );
+		} else if ( value.includes( optionName ) ) {
+			value = value.filter( item => item !== optionName );
 		}
 
 		this.setState(

--- a/projects/plugins/jetpack/_inc/client/traffic/verification-services.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/verification-services.jsx
@@ -2,7 +2,7 @@ import { getRedirectUrl } from '@automattic/jetpack-components';
 import { ExternalLink } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import { get, includes } from 'lodash';
+import { get } from 'lodash';
 import { Component } from 'react';
 import { FormFieldset, FormLabel } from 'components/forms';
 import JetpackBanner from 'components/jetpack-banner';
@@ -32,7 +32,7 @@ class VerificationServicesComponent extends Component {
 			return content;
 		}
 
-		if ( includes( content, '<meta' ) ) {
+		if ( content.includes( '<meta' ) ) {
 			// We were passed a meta tag already!
 			return content;
 		}

--- a/projects/plugins/jetpack/changelog/update-cleanup-lodash-array-funcs
+++ b/projects/plugins/jetpack/changelog/update-cleanup-lodash-array-funcs
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Replace some uses of lodash array functions with native JS equivalents. Should be no change in functionality.
+
+

--- a/projects/plugins/jetpack/extensions/blocks/eventbrite/deprecated/v1/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/eventbrite/deprecated/v1/index.js
@@ -2,7 +2,7 @@ import { RichText, getColorClassName } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
 import { _x } from '@wordpress/i18n';
 import clsx from 'clsx';
-import { isEmpty, omit, pick, some } from 'lodash';
+import { isEmpty, omit, pick } from 'lodash';
 
 /**
  * Deprecation reasons:
@@ -186,7 +186,10 @@ export default {
 		const isModal = 'modal' === attributes.style || attributes.useModal;
 		return (
 			isModal &&
-			( isEmpty( innerBlocks ) || some( pick( attributes, deprecatedButtonAttributes ), Boolean ) )
+			( isEmpty( innerBlocks ) ||
+				Object.entries( attributes ).some(
+					( [ k, v ] ) => v && deprecatedButtonAttributes.includes( k )
+				) )
 		);
 	},
 };

--- a/projects/plugins/jetpack/extensions/blocks/instagram-gallery/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/instagram-gallery/edit.js
@@ -4,7 +4,7 @@ import { Button, Placeholder, RadioControl, Spinner, withNotices } from '@wordpr
 import { useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
-import { find, isEmpty, isEqual, map, times } from 'lodash';
+import { isEmpty, isEqual } from 'lodash';
 import { getValidatedAttributes } from '../../shared/get-validated-attributes';
 import metadata from './block.json';
 import { NEW_INSTAGRAM_CONNECTION } from './constants';
@@ -98,7 +98,7 @@ const InstagramGalleryEdit = props => {
 		if ( selectedAccount && NEW_INSTAGRAM_CONNECTION !== selectedAccount ) {
 			setAttributes( {
 				accessToken: selectedAccount,
-				instagramUser: find( userConnections, { token: selectedAccount } ).username,
+				instagramUser: userConnections.find( v => v.token === selectedAccount ).username,
 			} );
 			return;
 		}
@@ -117,7 +117,7 @@ const InstagramGalleryEdit = props => {
 	const renderInstagramConnection = () => {
 		const hasUserConnections = userConnections.length > 0;
 		const radioOptions = [
-			...map( userConnections, connection => ( {
+			...userConnections.map( connection => ( {
 				label: `@${ connection.username }`,
 				value: connection.token,
 			} ) ),
@@ -190,7 +190,7 @@ const InstagramGalleryEdit = props => {
 
 			{ showGallery && (
 				<div className={ gridClasses } style={ gridStyle }>
-					{ times( isSelected ? count : unselectedCount, index => (
+					{ Array.from( Array( isSelected ? count : unselectedCount ), ( _, index ) => (
 						<span
 							className={ clsx( 'wp-block-jetpack-instagram-gallery__grid-post' ) }
 							key={ index }

--- a/projects/plugins/jetpack/extensions/blocks/instagram-gallery/use-connect-instagram.js
+++ b/projects/plugins/jetpack/extensions/blocks/instagram-gallery/use-connect-instagram.js
@@ -3,7 +3,6 @@ import PopupMonitor from '@automattic/popup-monitor';
 import apiFetch from '@wordpress/api-fetch';
 import { useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { find } from 'lodash';
 import { NEW_INSTAGRAM_CONNECTION } from './constants';
 
 export default function useConnectInstagram( {
@@ -39,7 +38,7 @@ export default function useConnectInstagram( {
 	useEffect( () => {
 		if (
 			NEW_INSTAGRAM_CONNECTION !== selectedAccount &&
-			! find( userConnections, { token: selectedAccount } )
+			! userConnections.find( v => v.token === selectedAccount )
 		) {
 			setSelectedAccount( undefined );
 		}

--- a/projects/plugins/jetpack/extensions/blocks/mailchimp/deprecated/v1/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/mailchimp/deprecated/v1/index.js
@@ -1,6 +1,6 @@
 import { createBlock } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
-import { isEmpty, omit, pick, some } from 'lodash';
+import { isEmpty, omit } from 'lodash';
 
 const deprecatedAttributes = [
 	'submitButtonText',
@@ -95,6 +95,7 @@ export default {
 		return [ newAttributes, newInnerBlocks ];
 	},
 	isEligible: ( attributes, innerBlocks ) =>
-		isEmpty( innerBlocks ) || some( pick( attributes, deprecatedAttributes ), Boolean ),
+		isEmpty( innerBlocks ) ||
+		Object.entries( attributes ).some( ( [ k, v ] ) => v && deprecatedAttributes.includes( k ) ),
 	save: () => null,
 };

--- a/projects/plugins/jetpack/extensions/blocks/map/lookup/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/map/lookup/index.js
@@ -4,7 +4,7 @@ import { Component } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { ENTER, ESCAPE, UP, DOWN, LEFT, RIGHT } from '@wordpress/keycodes';
 import clsx from 'clsx';
-import { debounce, map } from 'lodash';
+import { debounce } from 'lodash';
 
 function filterOptions( options = [], maxResults = 10 ) {
 	const filtered = [];
@@ -199,7 +199,7 @@ export class Lookup extends Component {
 						noArrow
 					>
 						<div id={ listBoxId } role="listbox" className="components-autocomplete__results">
-							{ map( filteredOptions, ( option, index ) => (
+							{ filteredOptions.map( ( option, index ) => (
 								<Button
 									key={ option.key }
 									id={ `components-autocomplete-item-${ instanceId }-${ option.key }` }

--- a/projects/plugins/jetpack/extensions/blocks/opentable/styles.js
+++ b/projects/plugins/jetpack/extensions/blocks/opentable/styles.js
@@ -1,5 +1,4 @@
 import { __ } from '@wordpress/i18n';
-import { compact } from 'lodash';
 
 export const buttonStyle = {
 	name: 'button',
@@ -7,11 +6,11 @@ export const buttonStyle = {
 };
 
 export const getStyleOptions = rid =>
-	compact( [
+	[
 		{ name: 'standard', label: __( 'Standard (224 x 301 pixels)', 'jetpack' ), isDefault: true },
 		{ name: 'tall', label: __( 'Tall (288 x 490 pixels)', 'jetpack' ) },
 		{ name: 'wide', label: __( 'Wide (840 x 150 pixels)', 'jetpack' ) },
 		( ! rid || rid.length === 1 ) && buttonStyle,
-	] );
+	].filter( Boolean );
 
 export const getStyleValues = rid => getStyleOptions( rid ).map( option => option.name );

--- a/projects/plugins/jetpack/extensions/blocks/rating-star/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/rating-star/edit.js
@@ -59,7 +59,7 @@ export default Symbol =>
 					/>
 				</BlockControls>
 				<div style={ { textAlign: align } }>
-					{ Array.from( Array( maxRating ), ( _, i ) => i + 1 ).map( position => (
+					{ Array.from( Array( Math.ceil( maxRating ) ), ( _, i ) => i + 1 ).map( position => (
 						<Rating key={ position } id={ position } setRating={ setNewRating }>
 							<span>
 								<Symbol

--- a/projects/plugins/jetpack/extensions/blocks/rating-star/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/rating-star/edit.js
@@ -7,7 +7,6 @@ import {
 } from '@wordpress/block-editor';
 import { PanelBody, RangeControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { range } from 'lodash';
 
 export const Rating = ( { id, setRating, children } ) => {
 	const setNewRating = newRating => () => setRating( newRating );
@@ -60,7 +59,7 @@ export default Symbol =>
 					/>
 				</BlockControls>
 				<div style={ { textAlign: align } }>
-					{ range( 1, maxRating + 1 ).map( position => (
+					{ Array.from( Array( maxRating ), ( _, i ) => i + 1 ).map( position => (
 						<Rating key={ position } id={ position } setRating={ setNewRating }>
 							<span>
 								<Symbol

--- a/projects/plugins/jetpack/extensions/blocks/rating-star/save.js
+++ b/projects/plugins/jetpack/extensions/blocks/rating-star/save.js
@@ -1,5 +1,4 @@
 import { useBlockProps } from '@wordpress/block-editor';
-import { range } from 'lodash';
 
 // This is a dynamic block, meaning that its content is created on the server.
 // This function is only to provide a fallback in case the block is deactivated
@@ -16,7 +15,7 @@ export default fallbackSymbol =>
 
 		return (
 			<figure { ...blockProps } style={ { textAlign: align } }>
-				{ range( 1, rating + 1 ).map( position => (
+				{ Array.from( Array( rating ), ( _, i ) => i + 1 ).map( position => (
 					<span key={ position } style={ { color } }>
 						{ fallbackSymbol }
 					</span>

--- a/projects/plugins/jetpack/extensions/blocks/rating-star/save.js
+++ b/projects/plugins/jetpack/extensions/blocks/rating-star/save.js
@@ -15,7 +15,7 @@ export default fallbackSymbol =>
 
 		return (
 			<figure { ...blockProps } style={ { textAlign: align } }>
-				{ Array.from( Array( rating ), ( _, i ) => i + 1 ).map( position => (
+				{ Array.from( Array( Math.ceil( rating ) ), ( _, i ) => i + 1 ).map( position => (
 					<span key={ position } style={ { color } }>
 						{ fallbackSymbol }
 					</span>

--- a/projects/plugins/jetpack/extensions/blocks/recurring-payments/deprecated/v1/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/recurring-payments/deprecated/v1/index.js
@@ -1,5 +1,5 @@
 import { createBlock } from '@wordpress/blocks';
-import { isEmpty, omit, pick, some } from 'lodash';
+import { isEmpty, omit } from 'lodash';
 
 const deprecatedAttributes = [
 	'submitButtonText',
@@ -59,6 +59,7 @@ export default {
 		return [ newAttributes, newInnerBlocks ];
 	},
 	isEligible: ( attributes, innerBlocks ) =>
-		isEmpty( innerBlocks ) || some( pick( attributes, deprecatedAttributes ), Boolean ),
+		isEmpty( innerBlocks ) ||
+		Object.entries( attributes ).some( ( [ k, v ] ) => v && deprecatedAttributes.includes( k ) ),
 	save: () => null,
 };

--- a/projects/plugins/jetpack/extensions/blocks/slideshow/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/slideshow/edit.js
@@ -13,7 +13,7 @@ import domReady from '@wordpress/dom-ready';
 import { mediaUpload } from '@wordpress/editor';
 import { useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { get, map, pick } from 'lodash';
+import { get, pick } from 'lodash';
 import metadata from './block.json';
 import { PanelControls, ToolbarControls } from './controls';
 import Slideshow from './slideshow';
@@ -96,7 +96,7 @@ export const SlideshowEdit = ( {
 	const uploadFromFiles = event => addFiles( event.target.files );
 
 	const getImageSizeOptions = () =>
-		map( imageSizes, ( { name, slug } ) => ( { value: slug, label: name } ) );
+		imageSizes?.map( ( { name, slug } ) => ( { value: slug, label: name } ) ) ?? [];
 
 	const updateImagesSize = slug => {
 		const updatedImages = images.map( image => {

--- a/projects/plugins/jetpack/extensions/blocks/slideshow/transforms.js
+++ b/projects/plugins/jetpack/extensions/blocks/slideshow/transforms.js
@@ -1,5 +1,4 @@
 import { createBlock } from '@wordpress/blocks';
-import { filter } from 'lodash';
 
 /**
  * Filter valid images
@@ -8,7 +7,7 @@ import { filter } from 'lodash';
  * @return {Array} Array of image objects which have id and url
  */
 function getValidImages( images ) {
-	return filter( images, ( { id, url } ) => id && url );
+	return images.filter( ( { id, url } ) => id && url );
 }
 
 const transforms = {

--- a/projects/plugins/jetpack/extensions/blocks/story/player/modal/aria-helper.js
+++ b/projects/plugins/jetpack/extensions/blocks/story/player/modal/aria-helper.js
@@ -1,5 +1,3 @@
-import { forEach } from 'lodash';
-
 const LIVE_REGION_ARIA_ROLES = new Set( [ 'alert', 'status', 'log', 'marquee', 'timer' ] );
 
 let hiddenElements = [],
@@ -22,15 +20,15 @@ export function hideApp( unhiddenElement ) {
 		return;
 	}
 	const elements = document.body.children;
-	forEach( elements, element => {
+	for ( const element of elements ) {
 		if ( element === unhiddenElement ) {
-			return;
+			continue;
 		}
 		if ( elementShouldBeHidden( element ) ) {
 			element.setAttribute( 'aria-hidden', 'true' );
 			hiddenElements.push( element );
 		}
-	} );
+	}
 	isHidden = true;
 }
 
@@ -58,9 +56,9 @@ export function showApp() {
 	if ( ! isHidden ) {
 		return;
 	}
-	forEach( hiddenElements, element => {
+	for ( const element of hiddenElements ) {
 		element.removeAttribute( 'aria-hidden' );
-	} );
+	}
 	hiddenElements = [];
 	isHidden = false;
 }

--- a/projects/plugins/jetpack/extensions/blocks/story/player/player-ui.js
+++ b/projects/plugins/jetpack/extensions/blocks/story/player/player-ui.js
@@ -5,7 +5,6 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { useRef, useState, useEffect, useLayoutEffect, useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
-import { some } from 'lodash';
 import blockMetadata from '../block.json';
 import { Background, Controls, Header, Overlay } from './components';
 import useLongPress from './lib/use-long-press';
@@ -54,7 +53,7 @@ export default function PlayerUI( { id, slides, metadata, disabled } ) {
 		{ box: 'border-box' }
 	);
 	const [ targetAspectRatio, setTargetAspectRatio ] = useState( settings.defaultAspectRatio );
-	const uploading = some( slides, media => isBlobURL( media.url ) );
+	const uploading = slides.some( media => isBlobURL( media.url ) );
 	const isVideo = slideIndex => {
 		const media = slideIndex < slides.length ? slides[ slideIndex ] : null;
 		if ( ! media ) {

--- a/projects/plugins/jetpack/extensions/blocks/story/player/progress-bar.js
+++ b/projects/plugins/jetpack/extensions/blocks/story/player/progress-bar.js
@@ -1,5 +1,4 @@
 import { useSelect } from '@wordpress/data';
-import { range } from 'lodash';
 import { Bullet } from './components';
 
 export const ProgressBullet = ( {
@@ -59,7 +58,7 @@ export const ProgressBar = ( { playerId, slides, disabled, onSlideSeek, maxBulle
 			{ firstReachableSlideIndex > 0 && (
 				<Bullet key="bullet-0" index={ firstReachableSlideIndex - 1 } progress={ 100 } isEllipsis />
 			) }
-			{ range( 1, bulletCount + 1 ).map( ( slide, bulletIndex ) => {
+			{ Array.from( Array( bulletCount ), ( _, i ) => i + 1 ).map( ( slide, bulletIndex ) => {
 				const slideIndex = bulletIndex + firstReachableSlideIndex;
 				let progress = null;
 				if ( slideIndex < currentSlideIndex ) {

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/deprecated/v5/save.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/deprecated/v5/save.js
@@ -5,7 +5,6 @@ import {
 } from '@wordpress/block-editor';
 import { RawHTML } from '@wordpress/element';
 import clsx from 'clsx';
-import { reduce } from 'lodash';
 import definedAttributes from '../v3/attributes';
 
 export const DEFAULT_BORDER_RADIUS_VALUE = 0;
@@ -121,9 +120,8 @@ export default function Save( { className, attributes } ) {
 		show_only_email_and_button: true,
 	};
 
-	const shortcodeAttributesStringified = reduce(
-		shortcodeAttributes,
-		( stringifiedAttributes, value, key ) => {
+	const shortcodeAttributesStringified = Object.entries( shortcodeAttributes ).reduce(
+		( stringifiedAttributes, [ key, value ] ) => {
 			if ( undefined === value ) {
 				return stringifiedAttributes;
 			}

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/deprecated/v6/save.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/deprecated/v6/save.js
@@ -5,7 +5,6 @@ import {
 } from '@wordpress/block-editor';
 import { RawHTML } from '@wordpress/element';
 import clsx from 'clsx';
-import { reduce } from 'lodash';
 import defaultAttributes from './attributes';
 
 const DEFAULT_BORDER_RADIUS_VALUE = 0;
@@ -125,9 +124,8 @@ export default function Save( { className, attributes } ) {
 		show_only_email_and_button: true,
 	};
 
-	const shortcodeAttributesStringified = reduce(
-		shortcodeAttributes,
-		( stringifiedAttributes, value, key ) => {
+	const shortcodeAttributesStringified = Object.entries( shortcodeAttributes ).reduce(
+		( stringifiedAttributes, [ key, value ] ) => {
 			if ( undefined === value ) {
 				return stringifiedAttributes;
 			}

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/deprecated/v7/save.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/deprecated/v7/save.js
@@ -5,7 +5,6 @@ import {
 } from '@wordpress/block-editor';
 import { RawHTML } from '@wordpress/element';
 import clsx from 'clsx';
-import { reduce } from 'lodash';
 import defaultAttributes from './attributes';
 
 export const DEFAULT_BORDER_RADIUS_VALUE = 0;
@@ -146,9 +145,8 @@ export default function Save( { className, attributes } ) {
 		success_message: successMessage,
 	};
 
-	const shortcodeAttributesStringified = reduce(
-		shortcodeAttributes,
-		( stringifiedAttributes, value, key ) => {
+	const shortcodeAttributesStringified = Object.entries( shortcodeAttributes ).reduce(
+		( stringifiedAttributes, [ key, value ] ) => {
 			if ( undefined === value ) {
 				return stringifiedAttributes;
 			}

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/deprecated/v1/layout/mosaic/ratios.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/deprecated/v1/layout/mosaic/ratios.js
@@ -1,18 +1,7 @@
-import {
-	every,
-	isEqual,
-	map,
-	overEvery,
-	some,
-	sum,
-	take,
-	takeRight,
-	takeWhile,
-	zipWith,
-} from 'lodash';
+import { isEqual, overEvery, sum, takeWhile, zipWith } from 'lodash';
 
 export function imagesToRatios( images ) {
-	return map( images, ratioFromImage );
+	return images.map( ratioFromImage );
 }
 
 export function ratioFromImage( { height, width } ) {
@@ -177,7 +166,7 @@ export function ratiosToMosaicRows( ratios, { isWide } = {} ) {
 			isWide &&
 			( toProcess.length === 5 || ( toProcess.length !== 10 && toProcess.length > 6 ) ) &&
 			fiveIsNotRecent( processed ) &&
-			sum( take( toProcess, 5 ) ) < 5
+			sum( toProcess.slice( 0, 5 ) ) < 5
 		) {
 			next = [ 1, 1, 1, 1, 1 ];
 		} else if (
@@ -218,7 +207,7 @@ export function ratiosToMosaicRows( ratios, { isWide } = {} ) {
 }
 
 function isThreeValidCandidate( processed, toProcess, isWide ) {
-	const ratio = sum( take( toProcess, 3 ) );
+	const ratio = sum( toProcess.slice( 0, 3 ) );
 	return (
 		toProcess.length >= 3 &&
 		toProcess.length !== 4 &&
@@ -234,7 +223,7 @@ function isThreeValidCandidate( processed, toProcess, isWide ) {
 }
 
 function isFourValidCandidate( processed, toProcess ) {
-	const ratio = sum( take( toProcess, 4 ) );
+	const ratio = sum( toProcess.slice( 0, 4 ) );
 	return (
 		( fourIsNotRecent( processed ) && ratio < 3.5 && toProcess.length > 5 ) ||
 		( ratio < 7 && toProcess.length === 4 )
@@ -243,13 +232,13 @@ function isFourValidCandidate( processed, toProcess ) {
 
 function isNotRecentShape( shape, numRecents ) {
 	return recents =>
-		! some( takeRight( recents, numRecents ), recentShape => isEqual( recentShape, shape ) );
+		! recents.slice( -numRecents ).some( recentShape => isEqual( recentShape, shape ) );
 }
 
 function checkNextRatios( shape ) {
 	return ratios =>
 		ratios.length >= shape.length &&
-		every( zipWith( shape, ratios.slice( 0, shape.length ), ( f, r ) => f( r ) ) );
+		zipWith( shape, ratios.slice( 0, shape.length ), ( f, r ) => f( r ) ).every( Boolean );
 }
 
 function isLandscape( ratio ) {

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/deprecated/v1/layout/square.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/deprecated/v1/layout/square.js
@@ -1,4 +1,4 @@
-import { chunk, take } from 'lodash';
+import { chunk } from 'lodash';
 import { MAX_COLUMNS } from '../constants';
 import Column from './column';
 import Gallery from './gallery';
@@ -12,7 +12,7 @@ export default function Square( { columns, renderedImages } ) {
 	return (
 		<Gallery>
 			{ [
-				...( remainder ? [ take( renderedImages, remainder ) ] : [] ),
+				...( remainder ? [ renderedImages.slice( 0, remainder ) ] : [] ),
 				...chunk( renderedImages.slice( remainder ), columnCount ),
 			].map( ( imagesInRow, rowIndex ) => (
 				<Row key={ rowIndex } className={ `columns-${ imagesInRow.length }` }>

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/deprecated/v2/layout/mosaic/ratios.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/deprecated/v2/layout/mosaic/ratios.js
@@ -1,18 +1,7 @@
-import {
-	every,
-	isEqual,
-	map,
-	overEvery,
-	some,
-	sum,
-	take,
-	takeRight,
-	takeWhile,
-	zipWith,
-} from 'lodash';
+import { isEqual, overEvery, sum, takeWhile, zipWith } from 'lodash';
 
 export function imagesToRatios( images ) {
-	return map( images, ratioFromImage );
+	return images.map( ratioFromImage );
 }
 
 export function ratioFromImage( { height, width } ) {
@@ -177,7 +166,7 @@ export function ratiosToMosaicRows( ratios, { isWide } = {} ) {
 			isWide &&
 			( toProcess.length === 5 || ( toProcess.length !== 10 && toProcess.length > 6 ) ) &&
 			fiveIsNotRecent( processed ) &&
-			sum( take( toProcess, 5 ) ) < 5
+			sum( toProcess.slice( 0, 5 ) ) < 5
 		) {
 			next = [ 1, 1, 1, 1, 1 ];
 		} else if (
@@ -218,7 +207,7 @@ export function ratiosToMosaicRows( ratios, { isWide } = {} ) {
 }
 
 function isThreeValidCandidate( processed, toProcess, isWide ) {
-	const ratio = sum( take( toProcess, 3 ) );
+	const ratio = sum( toProcess.slice( 0, 3 ) );
 	return (
 		toProcess.length >= 3 &&
 		toProcess.length !== 4 &&
@@ -234,7 +223,7 @@ function isThreeValidCandidate( processed, toProcess, isWide ) {
 }
 
 function isFourValidCandidate( processed, toProcess ) {
-	const ratio = sum( take( toProcess, 4 ) );
+	const ratio = sum( toProcess.slice( 0, 4 ) );
 	return (
 		( fourIsNotRecent( processed ) && ratio < 3.5 && toProcess.length > 5 ) ||
 		( ratio < 7 && toProcess.length === 4 )
@@ -243,13 +232,13 @@ function isFourValidCandidate( processed, toProcess ) {
 
 function isNotRecentShape( shape, numRecents ) {
 	return recents =>
-		! some( takeRight( recents, numRecents ), recentShape => isEqual( recentShape, shape ) );
+		! recents.slice( -numRecents ).some( recentShape => isEqual( recentShape, shape ) );
 }
 
 function checkNextRatios( shape ) {
 	return ratios =>
 		ratios.length >= shape.length &&
-		every( zipWith( shape, ratios.slice( 0, shape.length ), ( f, r ) => f( r ) ) );
+		zipWith( shape, ratios.slice( 0, shape.length ), ( f, r ) => f( r ) ).every( Boolean );
 }
 
 function isLandscape( ratio ) {

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/deprecated/v2/layout/square.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/deprecated/v2/layout/square.js
@@ -1,4 +1,4 @@
-import { chunk, take } from 'lodash';
+import { chunk } from 'lodash';
 import { MAX_COLUMNS } from '../constants';
 import Column from './column';
 import Gallery from './gallery';
@@ -12,7 +12,7 @@ export default function Square( { columns, renderedImages } ) {
 	return (
 		<Gallery>
 			{ [
-				...( remainder ? [ take( renderedImages, remainder ) ] : [] ),
+				...( remainder ? [ renderedImages.slice( 0, remainder ) ] : [] ),
 				...chunk( renderedImages.slice( remainder ), columnCount ),
 			].map( ( imagesInRow, rowIndex ) => (
 				<Row key={ rowIndex } className={ `columns-${ imagesInRow.length }` }>

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/deprecated/v2/utils/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/deprecated/v2/utils/index.js
@@ -1,5 +1,4 @@
 import { isBlobURL } from '@wordpress/blob';
-import { range } from 'lodash';
 import photon from 'photon';
 import { PHOTON_MAX_RESIZE } from '../constants';
 
@@ -66,36 +65,35 @@ export function photonizedImgProps( img, galleryAtts = {} ) {
 	const step = 300;
 	const srcsetMinWith = 600;
 
-	let srcSet;
+	let srcSet = [];
 	if ( isSquareishLayout( layoutStyle ) ) {
 		const minWidth = Math.min( srcsetMinWith, width, height );
 		const maxWidth = Math.min( PHOTON_MAX_RESIZE, width, height );
 
-		srcSet = range( minWidth, maxWidth, step )
-			.map( srcsetWidth => {
-				const srcsetSrc = photonImplementation( url, {
-					resize: `${ srcsetWidth },${ srcsetWidth }`,
-					strip: 'info',
-				} );
-				return srcsetSrc ? `${ srcsetSrc } ${ srcsetWidth }w` : null;
-			} )
-			.filter( Boolean )
-			.join( ',' );
+		for ( let srcsetWidth = minWidth; srcsetWidth < maxWidth; srcsetWidth += step ) {
+			const srcsetSrc = photonImplementation( url, {
+				resize: `${ srcsetWidth },${ srcsetWidth }`,
+				strip: 'info',
+			} );
+			if ( srcsetSrc ) {
+				srcSet.push( `${ srcsetSrc } ${ srcsetWidth }w` );
+			}
+		}
 	} else {
 		const minWidth = Math.min( srcsetMinWith, width );
 		const maxWidth = Math.min( PHOTON_MAX_RESIZE, width );
 
-		srcSet = range( minWidth, maxWidth, step )
-			.map( srcsetWidth => {
-				const srcsetSrc = photonImplementation( url, {
-					strip: 'info',
-					width: srcsetWidth,
-				} );
-				return srcsetSrc ? `${ srcsetSrc } ${ srcsetWidth }w` : null;
-			} )
-			.filter( Boolean )
-			.join( ',' );
+		for ( let srcsetWidth = minWidth; srcsetWidth < maxWidth; srcsetWidth += step ) {
+			const srcsetSrc = photonImplementation( url, {
+				strip: 'info',
+				width: srcsetWidth,
+			} );
+			if ( srcsetSrc ) {
+				srcSet.push( `${ srcsetSrc } ${ srcsetWidth }w` );
+			}
+		}
 	}
+	srcSet = srcSet.join( ',' );
 
 	return Object.assign( { src }, srcSet && { srcSet } );
 }

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/deprecated/v3/layout/mosaic/ratios.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/deprecated/v3/layout/mosaic/ratios.js
@@ -1,18 +1,7 @@
-import {
-	every,
-	isEqual,
-	map,
-	overEvery,
-	some,
-	sum,
-	take,
-	takeRight,
-	takeWhile,
-	zipWith,
-} from 'lodash';
+import { isEqual, overEvery, sum, takeWhile, zipWith } from 'lodash';
 
 export function imagesToRatios( images ) {
-	return map( images, ratioFromImage );
+	return images.map( ratioFromImage );
 }
 
 export function ratioFromImage( { height, width } ) {
@@ -177,7 +166,7 @@ export function ratiosToMosaicRows( ratios, { isWide } = {} ) {
 			isWide &&
 			( toProcess.length === 5 || ( toProcess.length !== 10 && toProcess.length > 6 ) ) &&
 			fiveIsNotRecent( processed ) &&
-			sum( take( toProcess, 5 ) ) < 5
+			sum( toProcess.slice( 0, 5 ) ) < 5
 		) {
 			next = [ 1, 1, 1, 1, 1 ];
 		} else if (
@@ -218,7 +207,7 @@ export function ratiosToMosaicRows( ratios, { isWide } = {} ) {
 }
 
 function isThreeValidCandidate( processed, toProcess, isWide ) {
-	const ratio = sum( take( toProcess, 3 ) );
+	const ratio = sum( toProcess.slice( 0, 3 ) );
 	return (
 		toProcess.length >= 3 &&
 		toProcess.length !== 4 &&
@@ -234,7 +223,7 @@ function isThreeValidCandidate( processed, toProcess, isWide ) {
 }
 
 function isFourValidCandidate( processed, toProcess ) {
-	const ratio = sum( take( toProcess, 4 ) );
+	const ratio = sum( toProcess.slice( 0, 4 ) );
 	return (
 		( fourIsNotRecent( processed ) && ratio < 3.5 && toProcess.length > 5 ) ||
 		( ratio < 7 && toProcess.length === 4 )
@@ -243,13 +232,13 @@ function isFourValidCandidate( processed, toProcess ) {
 
 function isNotRecentShape( shape, numRecents ) {
 	return recents =>
-		! some( takeRight( recents, numRecents ), recentShape => isEqual( recentShape, shape ) );
+		! recents.slice( -numRecents ).some( recentShape => isEqual( recentShape, shape ) );
 }
 
 function checkNextRatios( shape ) {
 	return ratios =>
 		ratios.length >= shape.length &&
-		every( zipWith( shape, ratios.slice( 0, shape.length ), ( f, r ) => f( r ) ) );
+		zipWith( shape, ratios.slice( 0, shape.length ), ( f, r ) => f( r ) ).every( Boolean );
 }
 
 function isLandscape( ratio ) {

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/deprecated/v3/layout/square.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/deprecated/v3/layout/square.js
@@ -1,4 +1,4 @@
-import { chunk, take } from 'lodash';
+import { chunk } from 'lodash';
 import { MAX_COLUMNS } from '../constants';
 import Column from './column';
 import Gallery from './gallery';
@@ -12,7 +12,7 @@ export default function Square( { columns, renderedImages } ) {
 	return (
 		<Gallery>
 			{ [
-				...( remainder ? [ take( renderedImages, remainder ) ] : [] ),
+				...( remainder ? [ renderedImages.slice( 0, remainder ) ] : [] ),
 				...chunk( renderedImages.slice( remainder ), columnCount ),
 			].map( ( imagesInRow, rowIndex ) => (
 				<Row key={ rowIndex } className={ `columns-${ imagesInRow.length }` }>

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/deprecated/v3/utils/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/deprecated/v3/utils/index.js
@@ -1,5 +1,4 @@
 import { isBlobURL } from '@wordpress/blob';
-import { range } from 'lodash';
 import photon from 'photon';
 import { PHOTON_MAX_RESIZE } from '../constants';
 
@@ -67,36 +66,35 @@ export function photonizedImgProps( img, galleryAtts = {} ) {
 	const step = 300;
 	const srcsetMinWith = 600;
 
-	let srcSet;
+	let srcSet = [];
 	if ( isSquareishLayout( layoutStyle ) ) {
 		const minWidth = Math.min( srcsetMinWith, width, height );
 		const maxWidth = Math.min( PHOTON_MAX_RESIZE, width, height );
 
-		srcSet = range( minWidth, maxWidth, step )
-			.map( srcsetWidth => {
-				const srcsetSrc = photonImplementation( url, {
-					resize: `${ srcsetWidth },${ srcsetWidth }`,
-					strip: 'info',
-				} );
-				return srcsetSrc ? `${ srcsetSrc } ${ srcsetWidth }w` : null;
-			} )
-			.filter( Boolean )
-			.join( ',' );
+		for ( let srcsetWidth = minWidth; srcsetWidth < maxWidth; srcsetWidth += step ) {
+			const srcsetSrc = photonImplementation( url, {
+				resize: `${ srcsetWidth },${ srcsetWidth }`,
+				strip: 'info',
+			} );
+			if ( srcsetSrc ) {
+				srcSet.push( `${ srcsetSrc } ${ srcsetWidth }w` );
+			}
+		}
 	} else {
 		const minWidth = Math.min( srcsetMinWith, width );
 		const maxWidth = Math.min( PHOTON_MAX_RESIZE, width );
 
-		srcSet = range( minWidth, maxWidth, step )
-			.map( srcsetWidth => {
-				const srcsetSrc = photonImplementation( url, {
-					strip: 'info',
-					width: srcsetWidth,
-				} );
-				return srcsetSrc ? `${ srcsetSrc } ${ srcsetWidth }w` : null;
-			} )
-			.filter( Boolean )
-			.join( ',' );
+		for ( let srcsetWidth = minWidth; srcsetWidth < maxWidth; srcsetWidth += step ) {
+			const srcsetSrc = photonImplementation( url, {
+				strip: 'info',
+				width: srcsetWidth,
+			} );
+			if ( srcsetSrc ) {
+				srcSet.push( `${ srcsetSrc } ${ srcsetWidth }w` );
+			}
+		}
 	}
+	srcSet = srcSet.join( ',' );
 
 	return Object.assign( { src }, srcSet && { srcSet } );
 }

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/deprecated/v4/layout/mosaic/ratios.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/deprecated/v4/layout/mosaic/ratios.js
@@ -1,18 +1,7 @@
-import {
-	every,
-	isEqual,
-	map,
-	overEvery,
-	some,
-	sum,
-	take,
-	takeRight,
-	takeWhile,
-	zipWith,
-} from 'lodash';
+import { isEqual, overEvery, sum, takeWhile, zipWith } from 'lodash';
 
 export function imagesToRatios( images ) {
-	return map( images, ratioFromImage );
+	return images.map( ratioFromImage );
 }
 
 export function ratioFromImage( { height, width } ) {
@@ -177,7 +166,7 @@ export function ratiosToMosaicRows( ratios, { isWide } = {} ) {
 			isWide &&
 			( toProcess.length === 5 || ( toProcess.length !== 10 && toProcess.length > 6 ) ) &&
 			fiveIsNotRecent( processed ) &&
-			sum( take( toProcess, 5 ) ) < 5
+			sum( toProcess.slice( 0, 5 ) ) < 5
 		) {
 			next = [ 1, 1, 1, 1, 1 ];
 		} else if (
@@ -218,7 +207,7 @@ export function ratiosToMosaicRows( ratios, { isWide } = {} ) {
 }
 
 function isThreeValidCandidate( processed, toProcess, isWide ) {
-	const ratio = sum( take( toProcess, 3 ) );
+	const ratio = sum( toProcess.slice( 0, 3 ) );
 	return (
 		toProcess.length >= 3 &&
 		toProcess.length !== 4 &&
@@ -234,7 +223,7 @@ function isThreeValidCandidate( processed, toProcess, isWide ) {
 }
 
 function isFourValidCandidate( processed, toProcess ) {
-	const ratio = sum( take( toProcess, 4 ) );
+	const ratio = sum( toProcess.slice( 0, 4 ) );
 	return (
 		( fourIsNotRecent( processed ) && ratio < 3.5 && toProcess.length > 5 ) ||
 		( ratio < 7 && toProcess.length === 4 )
@@ -243,13 +232,13 @@ function isFourValidCandidate( processed, toProcess ) {
 
 function isNotRecentShape( shape, numRecents ) {
 	return recents =>
-		! some( takeRight( recents, numRecents ), recentShape => isEqual( recentShape, shape ) );
+		! recents.slice( -numRecents ).some( recentShape => isEqual( recentShape, shape ) );
 }
 
 function checkNextRatios( shape ) {
 	return ratios =>
 		ratios.length >= shape.length &&
-		every( zipWith( shape, ratios.slice( 0, shape.length ), ( f, r ) => f( r ) ) );
+		zipWith( shape, ratios.slice( 0, shape.length ), ( f, r ) => f( r ) ).every( Boolean );
 }
 
 function isLandscape( ratio ) {

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/deprecated/v4/layout/square.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/deprecated/v4/layout/square.js
@@ -1,4 +1,4 @@
-import { chunk, take } from 'lodash';
+import { chunk } from 'lodash';
 import { MAX_COLUMNS } from '../constants';
 import Column from './column';
 import Gallery from './gallery';
@@ -12,7 +12,7 @@ export default function Square( { columns, renderedImages } ) {
 	return (
 		<Gallery>
 			{ [
-				...( remainder ? [ take( renderedImages, remainder ) ] : [] ),
+				...( remainder ? [ renderedImages.slice( 0, remainder ) ] : [] ),
 				...chunk( renderedImages.slice( remainder ), columnCount ),
 			].map( ( imagesInRow, rowIndex ) => (
 				<Row key={ rowIndex } className={ `columns-${ imagesInRow.length }` }>

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/deprecated/v4/utils/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/deprecated/v4/utils/index.js
@@ -1,7 +1,6 @@
 import { isWoASite } from '@automattic/jetpack-script-data';
 import { isPrivateSite } from '@automattic/jetpack-shared-extension-utils';
 import { isBlobURL } from '@wordpress/blob';
-import { range } from 'lodash';
 import photon from 'photon';
 import isOfflineMode from '../../../../../shared/is-offline-mode';
 import { PHOTON_MAX_RESIZE } from '../constants';
@@ -75,36 +74,35 @@ export function photonizedImgProps( img, galleryAtts = {} ) {
 	const step = 300;
 	const srcsetMinWith = 600;
 
-	let srcSet;
+	let srcSet = [];
 	if ( isSquareishLayout( layoutStyle ) ) {
 		const minWidth = Math.min( srcsetMinWith, width, height );
 		const maxWidth = Math.min( PHOTON_MAX_RESIZE, width, height );
 
-		srcSet = range( minWidth, maxWidth, step )
-			.map( srcsetWidth => {
-				const srcsetSrc = photonImplementation( url, {
-					resize: `${ srcsetWidth },${ srcsetWidth }`,
-					strip: 'info',
-				} );
-				return srcsetSrc ? `${ srcsetSrc } ${ srcsetWidth }w` : null;
-			} )
-			.filter( Boolean )
-			.join( ',' );
+		for ( let srcsetWidth = minWidth; srcsetWidth < maxWidth; srcsetWidth += step ) {
+			const srcsetSrc = photonImplementation( url, {
+				resize: `${ srcsetWidth },${ srcsetWidth }`,
+				strip: 'info',
+			} );
+			if ( srcsetSrc ) {
+				srcSet.push( `${ srcsetSrc } ${ srcsetWidth }w` );
+			}
+		}
 	} else {
 		const minWidth = Math.min( srcsetMinWith, width );
 		const maxWidth = Math.min( PHOTON_MAX_RESIZE, width );
 
-		srcSet = range( minWidth, maxWidth, step )
-			.map( srcsetWidth => {
-				const srcsetSrc = photonImplementation( url, {
-					strip: 'info',
-					width: srcsetWidth,
-				} );
-				return srcsetSrc ? `${ srcsetSrc } ${ srcsetWidth }w` : null;
-			} )
-			.filter( Boolean )
-			.join( ',' );
+		for ( let srcsetWidth = minWidth; srcsetWidth < maxWidth; srcsetWidth += step ) {
+			const srcsetSrc = photonImplementation( url, {
+				strip: 'info',
+				width: srcsetWidth,
+			} );
+			if ( srcsetSrc ) {
+				srcSet.push( `${ srcsetSrc } ${ srcsetWidth }w` );
+			}
+		}
 	}
+	srcSet = srcSet.join( ',' );
 
 	return Object.assign( { src }, srcSet && { srcSet } );
 }

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/deprecated/v6/layout/mosaic/ratios.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/deprecated/v6/layout/mosaic/ratios.js
@@ -1,18 +1,7 @@
-import {
-	every,
-	isEqual,
-	map,
-	overEvery,
-	some,
-	sum,
-	take,
-	takeRight,
-	takeWhile,
-	zipWith,
-} from 'lodash';
+import { isEqual, overEvery, sum, takeWhile, zipWith } from 'lodash';
 
 export function imagesToRatios( images ) {
-	return map( images, ratioFromImage );
+	return images.map( ratioFromImage );
 }
 
 export function ratioFromImage( { height, width } ) {
@@ -177,7 +166,7 @@ export function ratiosToMosaicRows( ratios, { isWide } = {} ) {
 			isWide &&
 			( toProcess.length === 5 || ( toProcess.length !== 10 && toProcess.length > 6 ) ) &&
 			fiveIsNotRecent( processed ) &&
-			sum( take( toProcess, 5 ) ) < 5
+			sum( toProcess.slice( 0, 5 ) ) < 5
 		) {
 			next = [ 1, 1, 1, 1, 1 ];
 		} else if (
@@ -218,7 +207,7 @@ export function ratiosToMosaicRows( ratios, { isWide } = {} ) {
 }
 
 function isThreeValidCandidate( processed, toProcess, isWide ) {
-	const ratio = sum( take( toProcess, 3 ) );
+	const ratio = sum( toProcess.slice( 0, 3 ) );
 	return (
 		toProcess.length >= 3 &&
 		toProcess.length !== 4 &&
@@ -234,7 +223,7 @@ function isThreeValidCandidate( processed, toProcess, isWide ) {
 }
 
 function isFourValidCandidate( processed, toProcess ) {
-	const ratio = sum( take( toProcess, 4 ) );
+	const ratio = sum( toProcess.slice( 0, 4 ) );
 	return (
 		( fourIsNotRecent( processed ) && ratio < 3.5 && toProcess.length > 5 ) ||
 		( ratio < 7 && toProcess.length === 4 )
@@ -243,13 +232,13 @@ function isFourValidCandidate( processed, toProcess ) {
 
 function isNotRecentShape( shape, numRecents ) {
 	return recents =>
-		! some( takeRight( recents, numRecents ), recentShape => isEqual( recentShape, shape ) );
+		! recents.slice( -numRecents ).some( recentShape => isEqual( recentShape, shape ) );
 }
 
 function checkNextRatios( shape ) {
 	return ratios =>
 		ratios.length >= shape.length &&
-		every( zipWith( shape, ratios.slice( 0, shape.length ), ( f, r ) => f( r ) ) );
+		zipWith( shape, ratios.slice( 0, shape.length ), ( f, r ) => f( r ) ).every( Boolean );
 }
 
 function isLandscape( ratio ) {

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/deprecated/v6/layout/square.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/deprecated/v6/layout/square.js
@@ -1,4 +1,4 @@
-import { chunk, take } from 'lodash';
+import { chunk } from 'lodash';
 import { MAX_COLUMNS } from '../constants';
 import Column from './column';
 import Gallery from './gallery';
@@ -12,7 +12,7 @@ export default function Square( { columns, renderedImages } ) {
 	return (
 		<Gallery>
 			{ [
-				...( remainder ? [ take( renderedImages, remainder ) ] : [] ),
+				...( remainder ? [ renderedImages.slice( 0, remainder ) ] : [] ),
 				...chunk( renderedImages.slice( remainder ), columnCount ),
 			].map( ( imagesInRow, rowIndex ) => (
 				<Row key={ rowIndex } className={ `columns-${ imagesInRow.length }` }>

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/deprecated/v6/utils/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/deprecated/v6/utils/index.js
@@ -1,7 +1,6 @@
 import { isWoASite } from '@automattic/jetpack-script-data';
 import { isPrivateSite } from '@automattic/jetpack-shared-extension-utils';
 import { isBlobURL } from '@wordpress/blob';
-import { range } from 'lodash';
 import photon from 'photon';
 import isOfflineMode from '../../../../../shared/is-offline-mode';
 import { PHOTON_MAX_RESIZE } from '../constants';
@@ -75,36 +74,35 @@ export function photonizedImgProps( img, galleryAtts = {} ) {
 	const step = 300;
 	const srcsetMinWith = 600;
 
-	let srcSet;
+	let srcSet = [];
 	if ( isSquareishLayout( layoutStyle ) ) {
 		const minWidth = Math.min( srcsetMinWith, width, height );
 		const maxWidth = Math.min( PHOTON_MAX_RESIZE, width, height );
 
-		srcSet = range( minWidth, maxWidth, step )
-			.map( srcsetWidth => {
-				const srcsetSrc = photonImplementation( url, {
-					resize: `${ srcsetWidth },${ srcsetWidth }`,
-					strip: 'info',
-				} );
-				return srcsetSrc ? `${ srcsetSrc } ${ srcsetWidth }w` : null;
-			} )
-			.filter( Boolean )
-			.join( ',' );
+		for ( let srcsetWidth = minWidth; srcsetWidth < maxWidth; srcsetWidth += step ) {
+			const srcsetSrc = photonImplementation( url, {
+				resize: `${ srcsetWidth },${ srcsetWidth }`,
+				strip: 'info',
+			} );
+			if ( srcsetSrc ) {
+				srcSet.push( `${ srcsetSrc } ${ srcsetWidth }w` );
+			}
+		}
 	} else {
 		const minWidth = Math.min( srcsetMinWith, width );
 		const maxWidth = Math.min( PHOTON_MAX_RESIZE, width );
 
-		srcSet = range( minWidth, maxWidth, step )
-			.map( srcsetWidth => {
-				const srcsetSrc = photonImplementation( url, {
-					strip: 'info',
-					width: srcsetWidth,
-				} );
-				return srcsetSrc ? `${ srcsetSrc } ${ srcsetWidth }w` : null;
-			} )
-			.filter( Boolean )
-			.join( ',' );
+		for ( let srcsetWidth = minWidth; srcsetWidth < maxWidth; srcsetWidth += step ) {
+			const srcsetSrc = photonImplementation( url, {
+				strip: 'info',
+				width: srcsetWidth,
+			} );
+			if ( srcsetSrc ) {
+				srcSet.push( `${ srcsetSrc } ${ srcsetWidth }w` );
+			}
+		}
 	}
+	srcSet = srcSet.join( ',' );
 
 	return Object.assign( { src }, srcSet && { srcSet } );
 }

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/edit.js
@@ -4,7 +4,7 @@ import { DropZone, FormFileUpload, withNotices } from '@wordpress/components';
 import { mediaUpload } from '@wordpress/editor';
 import { useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { filter, get, pick } from 'lodash';
+import { get, pick } from 'lodash';
 import { getActiveStyleName } from '../../shared/block-styles';
 import metadata from './block.json';
 import { ALLOWED_MEDIA_TYPES, LAYOUT_STYLES } from './constants';
@@ -72,7 +72,7 @@ const TiledGalleryEdit = ( {
 	};
 
 	const onRemoveImage = index => () => {
-		const filteredImages = filter( images, ( img, i ) => index !== i );
+		const filteredImages = images.filter( ( img, i ) => index !== i );
 
 		setSelectedImage( null );
 		setChanged( true );

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/editor.js
@@ -1,5 +1,4 @@
 import { createBlock } from '@wordpress/blocks';
-import { filter } from 'lodash';
 import { registerJetpackBlockFromMetadata } from '../../shared/register-jetpack-block';
 import metadata from './block.json';
 import { default as deprecated } from './deprecated';
@@ -71,7 +70,7 @@ const exampleAttributes = {
  * @return {Array} Array of image objects which have id and url
  */
 function getValidImages( images ) {
-	return filter( images, ( { id, url } ) => id && url );
+	return images.filter( ( { id, url } ) => id && url );
 }
 registerJetpackBlockFromMetadata( metadata, {
 	edit,

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/layout/mosaic/ratios.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/layout/mosaic/ratios.js
@@ -1,18 +1,7 @@
-import {
-	every,
-	isEqual,
-	map,
-	overEvery,
-	some,
-	sum,
-	take,
-	takeRight,
-	takeWhile,
-	zipWith,
-} from 'lodash';
+import { isEqual, overEvery, sum, takeWhile, zipWith } from 'lodash';
 
 export function imagesToRatios( images ) {
-	return map( images, ratioFromImage );
+	return images.map( ratioFromImage );
 }
 
 export function ratioFromImage( { height, width } ) {
@@ -177,7 +166,7 @@ export function ratiosToMosaicRows( ratios, { isWide } = {} ) {
 			isWide &&
 			( toProcess.length === 5 || ( toProcess.length !== 10 && toProcess.length > 6 ) ) &&
 			fiveIsNotRecent( processed ) &&
-			sum( take( toProcess, 5 ) ) < 5
+			sum( toProcess.slice( 0, 5 ) ) < 5
 		) {
 			next = [ 1, 1, 1, 1, 1 ];
 		} else if (
@@ -218,7 +207,7 @@ export function ratiosToMosaicRows( ratios, { isWide } = {} ) {
 }
 
 function isThreeValidCandidate( processed, toProcess, isWide ) {
-	const ratio = sum( take( toProcess, 3 ) );
+	const ratio = sum( toProcess.slice( 0, 3 ) );
 	return (
 		toProcess.length >= 3 &&
 		toProcess.length !== 4 &&
@@ -234,7 +223,7 @@ function isThreeValidCandidate( processed, toProcess, isWide ) {
 }
 
 function isFourValidCandidate( processed, toProcess ) {
-	const ratio = sum( take( toProcess, 4 ) );
+	const ratio = sum( toProcess.slice( 0, 4 ) );
 	return (
 		( fourIsNotRecent( processed ) && ratio < 3.5 && toProcess.length > 5 ) ||
 		( ratio < 7 && toProcess.length === 4 )
@@ -243,13 +232,13 @@ function isFourValidCandidate( processed, toProcess ) {
 
 function isNotRecentShape( shape, numRecents ) {
 	return recents =>
-		! some( takeRight( recents, numRecents ), recentShape => isEqual( recentShape, shape ) );
+		! recents.slice( -numRecents ).some( recentShape => isEqual( recentShape, shape ) );
 }
 
 function checkNextRatios( shape ) {
 	return ratios =>
 		ratios.length >= shape.length &&
-		every( zipWith( shape, ratios.slice( 0, shape.length ), ( f, r ) => f( r ) ) );
+		zipWith( shape, ratios.slice( 0, shape.length ), ( f, r ) => f( r ) ).every( Boolean );
 }
 
 function isLandscape( ratio ) {

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/layout/mosaic/test/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/layout/mosaic/test/index.js
@@ -1,11 +1,10 @@
 import { render } from '@testing-library/react';
-import { range } from 'lodash';
 import Mosaic from '..';
 import * as imageSets from '../../test/fixtures/image-sets';
 
 test.each( Object.entries( imageSets ) )( 'renders as expected (set %s)', ( k, images ) => {
 	const { container } = render(
-		<Mosaic images={ images } renderedImages={ range( images.length ) } />
+		<Mosaic images={ images } renderedImages={ [ ...Array( images.length ).keys() ] } />
 	);
 	expect( container ).toMatchSnapshot( 'images' );
 } );

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/layout/square.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/layout/square.js
@@ -1,4 +1,4 @@
-import { chunk, take } from 'lodash';
+import { chunk } from 'lodash';
 import { MAX_COLUMNS } from '../constants';
 import Column from './column';
 import Gallery from './gallery';
@@ -12,7 +12,7 @@ export default function Square( { columns, renderedImages } ) {
 	return (
 		<Gallery>
 			{ [
-				...( remainder ? [ take( renderedImages, remainder ) ] : [] ),
+				...( remainder ? [ renderedImages.slice( 0, remainder ) ] : [] ),
 				...chunk( renderedImages.slice( remainder ), columnCount ),
 			].map( ( imagesInRow, rowIndex ) => (
 				<Row key={ rowIndex } className={ `columns-${ imagesInRow.length }` }>

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/utils/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/utils/index.js
@@ -2,7 +2,6 @@ import { isWoASite, isSimpleSite } from '@automattic/jetpack-script-data';
 import { isPrivateSite } from '@automattic/jetpack-shared-extension-utils';
 import { isBlobURL } from '@wordpress/blob';
 import { select } from '@wordpress/data';
-import { range } from 'lodash';
 import photon from 'photon';
 import isOfflineMode from '../../../shared/is-offline-mode';
 import { PHOTON_MAX_RESIZE } from '../constants';
@@ -86,36 +85,35 @@ export function photonizedImgProps( img, galleryAtts = {} ) {
 	const step = 300;
 	const srcsetMinWith = 600;
 
-	let srcSet;
+	let srcSet = [];
 	if ( isSquareishLayout( layoutStyle ) ) {
 		const minWidth = Math.min( srcsetMinWith, width, height );
 		const maxWidth = Math.min( PHOTON_MAX_RESIZE, width, height );
 
-		srcSet = range( minWidth, maxWidth, step )
-			.map( srcsetWidth => {
-				const srcsetSrc = photonImplementation( url, {
-					resize: `${ srcsetWidth },${ srcsetWidth }`,
-					strip: 'info',
-				} );
-				return srcsetSrc ? `${ srcsetSrc } ${ srcsetWidth }w` : null;
-			} )
-			.filter( Boolean )
-			.join( ',' );
+		for ( let srcsetWidth = minWidth; srcsetWidth < maxWidth; srcsetWidth += step ) {
+			const srcsetSrc = photonImplementation( url, {
+				resize: `${ srcsetWidth },${ srcsetWidth }`,
+				strip: 'info',
+			} );
+			if ( srcsetSrc ) {
+				srcSet.push( `${ srcsetSrc } ${ srcsetWidth }w` );
+			}
+		}
 	} else {
 		const minWidth = Math.min( srcsetMinWith, width );
 		const maxWidth = Math.min( PHOTON_MAX_RESIZE, width );
 
-		srcSet = range( minWidth, maxWidth, step )
-			.map( srcsetWidth => {
-				const srcsetSrc = photonImplementation( url, {
-					strip: 'info',
-					width: srcsetWidth,
-				} );
-				return srcsetSrc ? `${ srcsetSrc } ${ srcsetWidth }w` : null;
-			} )
-			.filter( Boolean )
-			.join( ',' );
+		for ( let srcsetWidth = minWidth; srcsetWidth < maxWidth; srcsetWidth += step ) {
+			const srcsetSrc = photonImplementation( url, {
+				strip: 'info',
+				width: srcsetWidth,
+			} );
+			if ( srcsetSrc ) {
+				srcSet.push( `${ srcsetSrc } ${ srcsetWidth }w` );
+			}
+		}
 	}
+	srcSet = srcSet.join( ',' );
 
 	return Object.assign( { src }, srcSet && { srcSet } );
 }

--- a/projects/plugins/jetpack/extensions/blocks/videopress/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/editor.js
@@ -18,7 +18,6 @@ import { mediaUpload, store as editorStore } from '@wordpress/editor';
 import { useContext, useEffect } from '@wordpress/element';
 import { addFilter } from '@wordpress/hooks';
 import { __ } from '@wordpress/i18n';
-import { every } from 'lodash';
 /**
  * Internal dependencies
  */
@@ -314,7 +313,7 @@ const addVideoPressSupport = ( settings, name ) => {
 				from: [
 					{
 						type: 'files',
-						isMatch: files => every( files, file => file.type.indexOf( 'video/' ) === 0 ),
+						isMatch: files => files.every( file => file.type.indexOf( 'video/' ) === 0 ),
 						// We define a higher priority (lower number) than the default of 10. This ensures that this
 						// transformation prevails over the core video block default transformations.
 						priority: 9,

--- a/projects/plugins/jetpack/extensions/shared/block-styles.js
+++ b/projects/plugins/jetpack/extensions/shared/block-styles.js
@@ -1,5 +1,4 @@
 import TokenList from '@wordpress/token-list';
-import { find } from 'lodash';
 
 /**
  * Returns the active style from the given className.
@@ -18,13 +17,13 @@ function getActiveStyle( styles, className ) {
 		}
 
 		const potentialStyleName = style.substring( 9 );
-		const activeStyle = find( styles, { name: potentialStyleName } );
+		const activeStyle = styles.find( v => v.name === potentialStyleName );
 		if ( activeStyle ) {
 			return activeStyle;
 		}
 	}
 
-	return find( styles, 'isDefault' );
+	return styles.find( v => v.isDefault );
 }
 
 export function getActiveStyleName( styles, className ) {

--- a/projects/plugins/jetpack/extensions/shared/get-validated-attributes.js
+++ b/projects/plugins/jetpack/extensions/shared/get-validated-attributes.js
@@ -1,5 +1,3 @@
-import { reduce } from 'lodash';
-
 /**
  * Take user set attributes and validate them against the attribute definition.
  *
@@ -8,28 +6,19 @@ import { reduce } from 'lodash';
  * @return {object} Block attributes that have been validated.
  */
 export const getValidatedAttributes = ( attributeDetails, attributesToValidate ) =>
-	reduce(
-		attributesToValidate,
-		( ret, attribute, attributeKey ) => {
-			if ( undefined === attributeDetails[ attributeKey ] ) {
-				return ret;
-			}
-			const {
-				type,
-				validator,
-				validValues,
-				default: defaultVal,
-			} = attributeDetails[ attributeKey ];
-			if ( 'boolean' === type ) {
-				ret[ attributeKey ] = attribute === 'false' ? false : !! attribute;
-			} else if ( validator ) {
-				ret[ attributeKey ] = validator( attribute ) ? attribute : defaultVal;
-			} else if ( validValues ) {
-				ret[ attributeKey ] = validValues.includes( attribute ) ? attribute : defaultVal;
-			} else {
-				ret[ attributeKey ] = attribute;
-			}
+	Object.entries( attributesToValidate ).reduce( ( ret, [ attributeKey, attribute ] ) => {
+		if ( undefined === attributeDetails[ attributeKey ] ) {
 			return ret;
-		},
-		{}
-	);
+		}
+		const { type, validator, validValues, default: defaultVal } = attributeDetails[ attributeKey ];
+		if ( 'boolean' === type ) {
+			ret[ attributeKey ] = attribute === 'false' ? false : !! attribute;
+		} else if ( validator ) {
+			ret[ attributeKey ] = validator( attribute ) ? attribute : defaultVal;
+		} else if ( validValues ) {
+			ret[ attributeKey ] = validValues.includes( attribute ) ? attribute : defaultVal;
+		} else {
+			ret[ attributeKey ] = attribute;
+		}
+		return ret;
+	}, {} );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
These functions are generally the same as functions now available on arrays. In the abstract, these are

* `every( array, predicate )` => `array.every( predicate )`
* `some( array, predicate )` => `array.some( predicate )`
* `filter( array, predicate )` => `array.filter( predicate )`
* `find( array, predicate )` => `array.find( predicate )`
* `findIndex( array, predicate )` => `array.findIndex( predicate )`
* `includes( array, value )` => `array.includes( value )`
* `includes( string, substr )` => `string.includes( substr )`
* `map( array, predicate )` => `array.map( predicate )`
* `reduce( array, func, initial )` => `array.reduce( func, initial )`
* `forEach( array, v => ... )` => `for ( const v of array ) { ... }`

Plus a few more array-related functions that have simple replacements:

* `compact( array )` => `array.filter( Boolean )`
* `map( range( n ), cb )` => `Array.from( Array( n ), cb )`
* `range( min, max )` => `Array.from( Array( max - min ), ( _, i ) => i + min )`
* `range( min, max, step ).map()` => rewrote as a for loop
* `times( n, cb )` => `Array.from( Array( n ), p )`
* `take( array, n )` => `array.slice( 0, n )`
* `takeRight( array, n )` => `array.slice( -n )` (which would break if n is 0, but it never is in our code)
* `size( array )` => `array.length`

But lodash has a lot of DWIM that the standard functions don't.

For one thing, many of these accept any object, not just an array. Those generally get rewritten to use `Object.entries( obj )` to get an array to iterate over.

Similarly, many treat `undefined` as an empty array. Checks need to be added or optional chaining needs to be used if getting undefined is a possibility.

Also, many of the functions accepting a predicate take other things too:
* A string, meaning `v => v.string`.
* An object, meaning `v => v.key1 === value1 && v.key2 === value2 && ...`
* A two-element array, meaning `v => get( v, arr[0] ) === arr[1]`. These had to be rewritten too.

A few things got cleaned up a bit more extensively, e.g. chains like `.filter( p1 ).some( p2 )` can be `.some( p1 && p2 )`.
### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pdWQjU-1jP-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

The following things are touched in possibly non-trivial ways:
* Forms blocks
* Forms dashboard
* jetpack-mu-wpcom block inserter modifications - contextual tips
* Jetpack dashboard
  * At-a-glance stats
  * Select dropdown component
  * Searchable modules component (Settings → search bar → "notes")
* Jetpack blocks in the editor
  * Instagram gallery
  * Rating star
  * Slideshow
  * Story
  * Tiled Gallery
* Jetpack story block on the frontend