### PR TITLE
Catch PHP warnings when theme JSON doesn't have fontFamily property defined

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-google_font_face_warnings
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-google_font_face_warnings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Catch PHP warnings if theme font definitions are in non-standard format.

--- a/projects/plugins/jetpack/modules/google-fonts/current/class-jetpack-google-font-face.php
+++ b/projects/plugins/jetpack/modules/google-fonts/current/class-jetpack-google-font-face.php
@@ -186,7 +186,12 @@ class Jetpack_Google_Font_Face {
 	 * @param array $font The font definition object.
 	 */
 	public static function get_font_family_name( $font ) {
-		$font_family = $font['fontFamily'];
+		$font_family = $font['fontFamily'] ?? $font['name'] ?? '';
+
+		if ( empty( $font_family ) ) {
+			return '';
+		}
+
 		if ( str_contains( $font_family, ',' ) ) {
 			$font_family = explode( ',', $font_family )[0];
 		}

--- a/projects/plugins/jetpack/modules/google-fonts/current/class-jetpack-google-font-face.php
+++ b/projects/plugins/jetpack/modules/google-fonts/current/class-jetpack-google-font-face.php
@@ -169,6 +169,9 @@ class Jetpack_Google_Font_Face {
 		$raw_data   = $theme_json->get_data();
 		if ( ! empty( $raw_data['settings']['typography']['fontFamilies'] ) ) {
 			foreach ( $raw_data['settings']['typography']['fontFamilies'] as $font ) {
+				if ( ! isset( $font['fontFamily'] ) ) {
+					continue;
+				}
 				$font_family_name = $this->format_font( $this->get_font_family_name( $font ) );
 				$font_slug        = $font['slug'] ?? '';
 				if ( $font_slug && $font_slug !== $font_family_name && ! array_key_exists( $font_slug, $font_slug_aliases ) ) {
@@ -186,12 +189,7 @@ class Jetpack_Google_Font_Face {
 	 * @param array $font The font definition object.
 	 */
 	public static function get_font_family_name( $font ) {
-		$font_family = $font['fontFamily'] ?? $font['name'] ?? '';
-
-		if ( empty( $font_family ) ) {
-			return '';
-		}
-
+		$font_family = $font['fontFamily'];
 		if ( str_contains( $font_family, ',' ) ) {
 			$font_family = explode( ',', $font_family )[0];
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This prevents a PHP warning when objects in `theme.json`'s `settings.typography.fontFamilies` do not have a `fontFamily` property.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

Per WP.org block documentation one would expect the `theme.json` to have the value of `settings.typography.fontFamilies` to be an array of objects like this:

```
{ name, slug, fontFamily, fontFace }
```

https://developer.wordpress.org/block-editor/reference-guides/theme-json-reference/theme-json-living/

While it's unclear if all the properties are "required" (Twenty Twenty-Four omits `fontFace` [in some entries](https://github.com/WordPress/twentytwentyfour/blob/df92472089ede6fae5924c124a93c843b84e8cbd/theme.json#L247-L251)) the code on our end in `Jetpack_Google_Font_Face::get_font_family_name()` was expecting `fontFamily` to be set. However, in at least one case in the wild, that was missing:

```
{
	"name": "Roboto",
	"slug": "roboto"
}
```

As such, it'd generate a warning, carry on, run trim on `null`, and return an empty string. We now no longer try to process the property if it doesn't exist

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

I suppose you could modify the theme.json of a theme to match the problem condition. 🤷