### PR TITLE
CRM: Fix daterangepicker regression in dash

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-dash_regression
+++ b/projects/plugins/crm/changelog/fix-crm-dash_regression
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix daterangepicker in dash.
+
+

--- a/projects/plugins/crm/js/ZeroBSCRM.admin.global.js
+++ b/projects/plugins/crm/js/ZeroBSCRM.admin.global.js
@@ -435,9 +435,6 @@ function zbscrm_JS_bindDateRangePicker( options ) {
 	// Bind .jpcrm-date.jpcrm-empty-start, .jpcrm-date.jpcrm-custom-field
 	jpcrm_js_bind_datepicker( options );
 
-	// Bind .jpcrm-date-range = date rangepicker
-	jpcrm_js_bind_daterangepicker( options );
-
 	// bind .jpcrm-datetime-range
 	jpcrm_js_bind_datetimerangepicker( options );
 
@@ -568,7 +565,7 @@ function jpcrm_js_bind_daterangepicker( options, callback ) {
 		}
 
 		// Initiate Date Range Picker
-		jQuery( '.jpcrm-date-range, .zbs-date-range' ).each( function ( ind, ele ) {
+		jQuery( '.jpcrm-date-range' ).each( function ( ind, ele ) {
 			const elementOptions = zbscrm_JS_clone( dateRangePickerOpts );
 
 			// and per-date-picker we can also override the format with data-daterangepicker-format attribute:

--- a/projects/plugins/crm/js/ZeroBSCRM.admin.segmentedit.js
+++ b/projects/plugins/crm/js/ZeroBSCRM.admin.segmentedit.js
@@ -7,7 +7,7 @@
 /* eslint-disable jsdoc/require-param-type */
 /* eslint-disable jsdoc/require-param-description */
 /* eslint-disable eqeqeq */
-/* global jpcrm, swal, ajaxurl, zbscrm_JS_bindDateRangePicker, zbscrm_JS_bindFieldValidators */
+/* global jpcrm, swal, ajaxurl, zbscrm_JS_bindDateRangePicker, jpcrm_js_bind_daterangepicker, zbscrm_JS_bindFieldValidators */
 
 jQuery( function () {
 	// build out initial
@@ -750,6 +750,8 @@ function zeroBSCRMJS_segment_buildConditionCascades2() {
 			setTimeout( function () {
 				// bind datetime ranges
 				zbscrm_JS_bindDateRangePicker();
+
+				jpcrm_js_bind_daterangepicker();
 
 				// this makes sure we're rebuilding post operator change
 				zeroBSCRMJS_segment_bindPostRender();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

We were binding daterangepicker to the same element twice: once as a generic bind and once with a specific callback. At some point the scripts loaded in a different order (perhaps #44109), and the generic bind happened after the specific one.

One solution would be to ensure the global JS loads before the dash JS, but that wouldn't solve the double bind. Instead, we now ensure the `jpcrm_js_bind_daterangepicker()` function is called only when needed rather than from within the globally called `zbscrm_JS_bindDateRangePicker()` function.

I've confirmed that `.zbs-date-range` is no longer used anywhere (including extensions), and `.jpcrm-date-range` is only used in the dash and for segments.

This also fixes the "maxDate" in the dash daterangepicker.

Really this whole area could use a refactor, but that's out of scope for this PR.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Verify the dash daterangepicker works as expected.
2. Verify the segment daterangepicker works (specifically "Date added" → "In date range", not "In datetime range").