### PR TITLE
Latest Instagram Posts: Fix fatal error from null Instagram response

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-instagram-gallery-block-null-response-error
+++ b/projects/plugins/jetpack/changelog/fix-instagram-gallery-block-null-response-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Instagram Gallery Block: fixed fatal error when Instagram sends an unexpected "null" response.

--- a/projects/plugins/jetpack/extensions/blocks/instagram-gallery/instagram-gallery.php
+++ b/projects/plugins/jetpack/extensions/blocks/instagram-gallery/instagram-gallery.php
@@ -68,7 +68,7 @@ function render_block( $attributes, $content ) { // phpcs:ignore VariableAnalysi
 	}
 	$gallery = Jetpack_Instagram_Gallery_Helper::get_instagram_gallery( $access_token, $count );
 
-	if ( is_wp_error( $gallery ) || ! property_exists( $gallery, 'images' ) || 'ERROR' === $gallery->images ) {
+	if ( ! is_object( $gallery ) || is_wp_error( $gallery ) || ! property_exists( $gallery, 'images' ) || 'ERROR' === $gallery->images ) {
 		if ( ! current_user_can( 'edit_post', get_the_ID() ) ) {
 			return '';
 		}


### PR DESCRIPTION
Fixes VULCAN-246

I received a report of the following fatal errors appearing in error logs:
```
PHP Fatal error: Uncaught TypeError: property_exists(): Argument #1 ($object_or_class) must be of type object|string, null given in /wordpress/plugins/jetpack/14.9-a.1/extensions/blocks/instagram-gallery/instagram-gallery.php:71
```

Doing some testing, this is caused by an unhandled edge-case where Instagram's API responds with a "null" response, potentially due to periodic issues in Instagram's infrastructure.

This PR fixes the fatal error that happens when receiving this response from Instagram's API.

## Proposed changes:
* Add a test for a non-object response from `Jetpack_Instagram_Gallery_Helper::get_instagram_gallery()` in the block's `render_block()` function. This treats such a response as an error in the same way that other errors are handled.

## Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:
Since the bug only happens when Instagram responds with a response of just "null", the best way to test is to force that response. This can be done by editing the `Jetpack_Instagram_Gallery_Helper::get_instagram_gallery()` function in `projects/plugins/jetpack/_inc/lib/class-jetpack-instagram-gallery-helper.php` to return `null`, such as:

```
public static function get_instagram_gallery( $access_token_id, $count ) { 
    return null;
```

1. Ensure that you are running the latest trunk without any modifications.
2. Create a post that includes a configured Latest Instagram Posts block, connecting it to an account with images.
3. View the post and ensure that the block with the appropriate images is displayed.
4. Add the `class-jetpack-instagram-gallery-helper.php` modification described above.
5. Refresh the view of the post, and confirm that the page breaks due to a fatal error.
6. Stash or remove the `class-jetpack-instagram-gallery-helper.php` modification.
7. Check out this branch.
8. Restore the `class-jetpack-instagram-gallery-helper.php` modification.
9. Refresh the view of the post, and confirm that the page no longer breaks. If you are logged in, you should see the following error in the post content:
![image](https://github.com/user-attachments/assets/95dadbe7-f360-4a47-a67a-a83cfebe5ca1)