### PR TITLE
Forms: prepare Forms header for Next Admin visually

### DIFF
--- a/projects/packages/forms/changelog/update-forms-dashboard-header
+++ b/projects/packages/forms/changelog/update-forms-dashboard-header
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: match dashboard header with typical WP dataviews headers

--- a/projects/packages/forms/src/dashboard/components/layout/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/layout/index.tsx
@@ -3,7 +3,13 @@
  */
 import jetpackAnalytics from '@automattic/jetpack-analytics';
 import { useBreakpointMatch } from '@automattic/jetpack-components';
-import { TabPanel } from '@wordpress/components';
+import {
+	__experimentalHeading as Heading, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+	__experimentalVStack as VStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+	FlexItem,
+	TabPanel,
+} from '@wordpress/components';
 import { useCallback, useEffect, useMemo } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
 import { Outlet, useLocation, useNavigate } from 'react-router';
@@ -14,7 +20,6 @@ import ExportResponsesButton from '../../inbox/export-responses';
 import { config } from '../../index';
 import ActionsDropdownMenu from '../actions-dropdown-menu';
 import CreateFormButton from '../create-form-button';
-import JetpackFormsLogo from '../logo';
 
 import './style.scss';
 
@@ -87,19 +92,23 @@ const Layout = () => {
 
 	return (
 		<div className="jp-forms__layout">
-			<div className="jp-forms__layout-header">
-				<div className="jp-forms__logo-wrapper">
-					<JetpackFormsLogo />
-				</div>
-				{ isSm ? (
-					<ActionsDropdownMenu exportData={ { show: isResponsesTab } } />
-				) : (
-					<div className="jp-forms__layout-header-actions">
-						{ isResponsesTab && <ExportResponsesButton /> }
-						<CreateFormButton label={ __( 'Create form', 'jetpack-forms' ) } />
-					</div>
-				) }
-			</div>
+			<VStack className="jp-forms__layout-header" as="header" spacing={ 0 }>
+				<HStack className="jp-forms__layout-header__page-title">
+					<Heading as="h2" level={ 3 } weight={ 500 }>
+						Forms
+					</Heading>
+					<FlexItem>
+						{ isSm ? (
+							<ActionsDropdownMenu exportData={ { show: isResponsesTab } } />
+						) : (
+							<HStack>
+								{ isResponsesTab && <ExportResponsesButton /> }
+								<CreateFormButton label={ __( 'Create form', 'jetpack-forms' ) } />
+							</HStack>
+						) }
+					</FlexItem>
+				</HStack>
+			</VStack>
 			<TabPanel
 				className="jp-forms__dashboard-tabs"
 				tabs={ tabs }

--- a/projects/packages/forms/src/dashboard/components/layout/style.scss
+++ b/projects/packages/forms/src/dashboard/components/layout/style.scss
@@ -1,13 +1,9 @@
-@mixin mobile {
 
-	@media (max-width: 599px) {
-		@content;
-	}
-}
+@import '@automattic/jetpack-base-styles/gutenberg-base-styles';
 
 body[class*="_page_jetpack-forms"],
 body.jetpack_page_jetpack-forms-admin {
-	background-color: #fff;
+	background-color: $white;
 
 	#wpcontent {
 		padding-left: 0;
@@ -22,94 +18,29 @@ body.jetpack_page_jetpack-forms-admin {
 	padding: 0;
 	width: 100%;
 	height: 100%;
-
-	.jp-forms__logo-wrapper,
-	.jp-forms__layout-header {
-		flex: 0 1 auto; /* Flex, but don't grow */
-	}
-
-	.jp-forms__logo-wrapper {
-
-		@include mobile {
-			width: 180px;
-		}
-	}
-
-	.jp-forms__layout-header-actions {
-		display: flex;
-		gap: 8px;
-	}
-
-	.jp-forms__logo {
-		margin: 20px 48px;
-		width: 200px;
-
-		@media (max-width: 660px) {
-			margin: 20px 24px;
-		}
-	}
-}
-
-#jp-forms-dashboard .jp-forms__layout {
-
-	.jp-forms__layout-header {
-		display: flex;
-		align-items: center;
-		justify-content: space-between;
-		padding: 30px 30px 0 0;
-
-		@media (max-width: 782px) {
-			padding: 40px 20px 0 0;
-		}
-	}
-
-	.jp-forms__dashboard-tabs {
-		display: flex;
-		flex-direction: column;
-		flex-grow: 1;
-
-		> .components-tab-panel__tabs {
-			margin: 0;
-			padding: 0 48px;
-			border-bottom: 1px solid var(--jp-gray-5);
-
-			.components-tab-panel__tabs-item {
-				border-bottom: 2px solid transparent;
-				font-size: var(--jp-forms-font-size-regular);
-				font-weight: 400;
-				height: 40px;
-				padding: 8px 16px;
-
-				&.is-active {
-					border-color: var(--jp-green-50);
-					font-weight: 500;
-
-					&::after {
-						display: none;
-					}
-				}
-			}
-
-			@media (max-width: 600px) {
-				top: 0;
-			}
-
-			@media (max-width: 660px) {
-				padding: 0 24px;
-			}
-		}
-
-		.components-tab-panel__tab-content {
-			height: 100%;
-		}
-	}
 }
 
 .jp-forms__layout-header {
-	box-sizing: border-box;
-	margin: 0;
-	padding: 16px 48px 0;
-	width: 100%;
+	padding: $grid-unit-20 $grid-unit-60;
+	top: 0;
+
+	@media not (prefers-reduced-motion) {
+		transition: padding ease-out 0.1s;
+	}
+
+	.components-heading {
+		color: $gray-900;
+	}
+
+	.jp-forms__layout__page-title {
+		min-height: $grid-unit-50;
+
+		.components-heading {
+			flex-grow: 1;
+			flex-basis: 0;
+			white-space: nowrap;
+		}
+	}
 }
 
 .jp-forms__layout-title {
@@ -119,4 +50,56 @@ body.jetpack_page_jetpack-forms-admin {
 	height: 40px;
 	line-height: 40px;
 	margin: 0;
+}
+
+@media (max-width: 430px) {
+
+	.jp-forms__layout-header {
+		padding: $grid-unit-20 $grid-unit-30;
+	}
+}
+
+.jp-forms__dashboard-tabs {
+	display: flex;
+	flex-direction: column;
+	flex-grow: 1;
+
+	> .components-tab-panel__tabs {
+		margin: 0;
+		padding: 0 48px;
+		border-bottom: 1px solid $gray-100;
+
+		.components-tab-panel__tabs-item {
+			border-bottom: 2px solid transparent;
+			font-size: var(--jp-forms-font-size-regular);
+			font-weight: 400;
+			height: 40px;
+			padding: 8px 16px;
+
+			&.is-active {
+				border-color: var(--jp-green-50);
+				font-weight: 500;
+
+				&::after {
+					display: none;
+				}
+			}
+		}
+
+		@media not (prefers-reduced-motion) {
+			transition: padding ease-out 0.1s;
+		}
+
+		@media (max-width: 600px) {
+			top: 0;
+		}
+
+		@media (max-width: 430px) {
+			padding: 0 24px;
+		}
+	}
+
+	.components-tab-panel__tab-content {
+		height: 100%;
+	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Since we've moved under "Jetpack", the Jetpack logo and "Jetpack" prefix in front of "Forms" becomes less critical for brand regognition.

To align more closely with design language of (still evolving) upcoming we can also adjust things like spacing. Here's Gutenberg's experimental "posts" page using DataViews:

<img width="1621" alt="Screenshot 2025-07-09 at 15 21 52" src="https://github.com/user-attachments/assets/c8d41b16-f29b-42e1-9bea-a234b9843415" />

The styles and component structure are taken from the above page (as of July 9, 2025), and adopted for our use:
- https://github.com/WordPress/gutenberg/blob/52fb078a0e02fd1acccd5413e58c13122b8f8514/packages/edit-site/src/components/page/style.scss#L13-L48
- https://github.com/WordPress/gutenberg/blob/52fb078a0e02fd1acccd5413e58c13122b8f8514/packages/edit-site/src/components/page/header.js#L17-L43

Result is slightly more compact than what we had before.

Later we can componentise this within Jetpack in short term, and eventually hopefully use components from Gutenberg directly as componentry evolves. 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Rewrite header area of Forms dashboard layout

### Before

<img width="1622" alt="Screenshot 2025-07-09 at 15 23 44" src="https://github.com/user-attachments/assets/cd8338ce-8b8e-430d-87df-4d83e8d44ceb" />

<img width="417" alt="Screenshot 2025-07-09 at 15 26 24" src="https://github.com/user-attachments/assets/d30bca6d-6046-4b05-9973-3c7137af61c3" />


### After

<img width="1475" alt="Screenshot 2025-07-09 at 15 14 16" src="https://github.com/user-attachments/assets/f2dad1af-41b9-4b67-ab47-86baf64b5654" />

<img width="407" alt="Screenshot 2025-07-09 at 15 27 00" src="https://github.com/user-attachments/assets/2914b4cc-05f8-4ef5-8c23-b9f9eddb6e77" />



### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to 'Jetpack -> Forms' 

