### PR TITLE
My Jetpack: Fix issue with tab tracking

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/index.tsx
@@ -79,8 +79,7 @@ export function MyJetpackTabPanel() {
 			user_type: isNewUser ? 'new' : 'returning',
 			navigation_source: lastNavigationSourceRef.current,
 		} );
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [] ); // track this only on page load
+	}, [ currentTab, isNewUser, recordEvent ] ); // track this whenever tab changes
 
 	const tabs = useMemo( () => getMyJetpackSections(), [] );
 

--- a/projects/packages/my-jetpack/changelog/fix-mjp-tab-tracking-issue
+++ b/projects/packages/my-jetpack/changelog/fix-mjp-tab-tracking-issue
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed a bug with tracking with MJP.


### PR DESCRIPTION
Fixes MYJP-226

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fixes an issue with the `useEffect` for `jetpack_myjetpack_tab_view`.
* The problem is that it ran only once on page load, not when the actual tab changes

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check that the tracking is working well using tracks.
* You can also check this superset query to see the bug https://superset-wyeast.a8c.com/sqllab/?savedQueryId=3335
* The view event is pretty much only registered for overview, unless the page was opened/refreshed on another tab

