### PR TITLE
Boost: Allow control over whether a module should run or not

### DIFF
--- a/projects/plugins/boost/app/modules/class-modules-setup.php
+++ b/projects/plugins/boost/app/modules/class-modules-setup.php
@@ -292,10 +292,23 @@ class Modules_Setup implements Has_Setup, Has_Data_Sync {
 	 */
 	public function can_module_run( $module ) {
 		$website_public = Config::is_website_public();
+		$can_module_run = true;
+
+		// If the module requires the website to be public and it's not, don't allow it to run.
 		if ( $module->feature instanceof Needs_Website_To_Be_Public && ! $website_public ) {
-			return false;
+			$can_module_run = false;
 		}
 
-		return true;
+		/**
+		 * Filter to allow modules to run even if the website is not public.
+		 * This is useful for debugging purposes.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param bool   $can_module_run Whether the module should be disabled.
+		 * @param Module $module         The module to check.
+		 * @param bool   $website_public Whether the website is public.
+		 */
+		return apply_filters( 'jetpack_boost_can_module_run', $can_module_run, $module, $website_public );
 	}
 }

--- a/projects/plugins/boost/changelog/update-boost-allow-modules-to-run-local-dev-HOG-206
+++ b/projects/plugins/boost/changelog/update-boost-allow-modules-to-run-local-dev-HOG-206
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+General: Add WP filter (jetpack_boost_can_module_run) to allow more control over which modules can run their functionality.


### PR DESCRIPTION
Fixes HOG-206

## Proposed changes:

* Add WP filter (`jetpack_boost_can_module_run`) to allow developers more control over which module should run its functionality (useful for local development).

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

HOG-206

## Does this pull request change what data or activity we track or use?

no

## Testing instructions:

### Test that everything still works

- Setup this on a jurassic ninja and make sure it works as expected. Test both free and premium and make sure that all features work;

### Test the filter

- Setup this locally and make sure it's connected to your local Boost Cloud instance;
- Add this snippet to force modules to run their functionality:

```php
add_filter( 'jetpack_boost_can_module_run', '__return_true' );
```
- Or use this boost developer PR - https://github.com/Automattic/boost-developer/pull/42;
- Make sure LCP, Cloud CSS work.
- You can also remove the snippet and features should stop working (LCP wouldn't optimize, Cloud CSS wouldn't print its CSS).