### PR TITLE
wpcomsh_footer_rum_js: Add filter for adding data to rum_kv

### DIFF
--- a/projects/plugins/wpcomsh/changelog/customize-wpcomsh-rum
+++ b/projects/plugins/wpcomsh/changelog/customize-wpcomsh-rum
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: wpcomsh_footer_rum_js: Internal change to allow more flexibility
+
+

--- a/projects/plugins/wpcomsh/wpcomsh.php
+++ b/projects/plugins/wpcomsh/wpcomsh.php
@@ -601,6 +601,11 @@ function wpcomsh_footer_rum_js() {
 	}
 
 	$rum_kv = array();
+	$rum_kv = apply_filters( 'wpcomsh_rum_kv', $rum_kv, $service );
+	if ( ! is_array( $rum_kv ) ) {
+		$rum_kv = array();
+	}
+
 	$rum_kv = wpcomsh_get_woo_rum_data( $rum_kv );
 	// Add user login and theme info.
 	$rum_kv['logged_in']        = is_user_logged_in() ? '1' : '0';


### PR DESCRIPTION
Fixes #

## Proposed changes:
* Inside `wpcomsh_footer_rum_js()`, add a `wpcomsh_rum_kv` filter to allow other plugins to put data on $rum_kv

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?

## Testing instructions:

* Go to '..'
*

* Apply change to WoA dev site
```
function demo_add_rum_test_flag( $kv, $service ) {
        $kv['demo_filter_active'] = '1';
        return $kv;
}
add_filter( 'wpcomsh_rum_kv', 'demo_add_rum_test_flag', 10, 2 );
```
