### PR TITLE
Open support links on the upsell wrapper inside the Help Center, only in WPAdmin

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-DOTSUP-36
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-DOTSUP-36
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+Load UpsellSupportLinkHandler only on wpadmin

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
@@ -214,13 +214,15 @@ class Help_Center {
 			);
 		}
 
-		wp_enqueue_script(
-			'wpcom-upsell-support-link-handler',
-			plugins_url( 'build/wpcom-upsell-support-link-handler/wpcom-upsell-support-link-handler.js', Jetpack_Mu_Wpcom::BASE_FILE ),
-			array(),
-			filemtime( Jetpack_Mu_Wpcom::BASE_DIR . 'build/wpcom-upsell-support-link-handler/wpcom-upsell-support-link-handler.js' ),
-			true
-		);
+		if ( $variant === 'wp-admin' || $variant === 'wp-admin-disconnected' ) {
+			wp_enqueue_script(
+				'wpcom-upsell-support-link-handler',
+				plugins_url( 'build/wpcom-upsell-support-link-handler/wpcom-upsell-support-link-handler.js', Jetpack_Mu_Wpcom::BASE_FILE ),
+				array(),
+				filemtime( Jetpack_Mu_Wpcom::BASE_DIR . 'build/wpcom-upsell-support-link-handler/wpcom-upsell-support-link-handler.js' ),
+				true
+			);
+		}
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes DOTSUP-36

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Enqueue the `wpcom-upsell-support-link-handler` script only in wp-admin. The [previous PR](https://github.com/Automattic/jetpack/pull/44199) might have caused a [weird bug](p1752067545602399-slack-C04DZ8M0GHW) that made prices disappear under certain circumstances.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Run the command mentioned on the github-actions [comment](https://github.com/Automattic/jetpack/pull/44248#issuecomment-3052921585) to enable this branch on your sandbox
* On a simple site, go to `/wp-admin/tools.php?page=theme-editor`
* Click on `Learn more`
* Check that the Help Center app is opened:

![image](https://github.com/user-attachments/assets/d44798f2-b867-449c-b523-6ce7cdb003c1)
