### PR TITLE
CRM: Fix quote templates code editor button glitch

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-quote_template_code_editor_button_glitch
+++ b/projects/plugins/crm/changelog/fix-crm-quote_template_code_editor_button_glitch
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Quote Templates: Fix code editor display.

--- a/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.QuoteTemplates.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.QuoteTemplates.php
@@ -129,7 +129,9 @@ defined( 'ZEROBSCRM_PATH' ) || exit( 0 );
 				// template placeholder helper
 				echo '<div class="jpcrm-form-group jpcrm-form-group-span-2" style="text-align:end;"><span class="ui basic black label">' . esc_html__( 'Did you know: You can now use Quote Placeholders?', 'zero-bs-crm' ) . ' <a href="' . esc_url( $zbs->urls['kbquoteplaceholders'] ) . '" target="_blank">' . esc_html__( 'Read More', 'zero-bs-crm' ) . '</a></span></div>';
 				##/WLREMOVE
-
+				?>
+			</div>
+			<?php
 				$content = wp_kses( $quote_template_content, $zbs->acceptable_html );
 
 				echo '<div class="jpcrm-form-group jpcrm-form-group-span-2">';
@@ -141,8 +143,7 @@ defined( 'ZEROBSCRM_PATH' ) || exit( 0 );
 					array( 'editor_height' => 580 )
 				);
 				echo '</div>';
-				?>
-			</div>
+			?>
 		</div>
 		<?php
 	}

--- a/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.QuoteTemplates.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.QuoteTemplates.php
@@ -70,82 +70,82 @@ defined( 'ZEROBSCRM_PATH' ) || exit( 0 );
 
         }
 
-        public function html( $quoteTemplate, $metabox ) {
+	/**
+	 * Outputs the HTML for the Quote Template metabox.
+	 *
+	 * @param array $quote_template The quote template data.
+	 * @param array $metabox Unused.
+	 */
+	public function html( $quote_template, $metabox ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 
-                global $zbs;
+		global $zbs;
 
-                // localise ID
-                $quoteTemplateID = -1; if (is_array($quoteTemplate) && isset($quoteTemplate['id'])) $quoteTemplateID = (int)$quoteTemplate['id'];
-                $quoteTemplateContent = ''; if (is_array($quoteTemplate) && isset($quoteTemplate['content'])) $quoteTemplateContent = $quoteTemplate['content'];
-                
-                ?>
-                <script type="text/javascript">var zbscrmjs_secToken = '<?php echo esc_js( wp_create_nonce( 'zbscrmjs-ajax-nonce' ) ); ?>';</script>
-                <?php
+		$quote_template_content = '';
+		if ( is_array( $quote_template ) && isset( $quote_template['content'] ) ) {
+			$quote_template_content = $quote_template['content'];
+		}
+		?>
+		<script type="text/javascript">var zbscrmjs_secToken = '<?php echo esc_js( wp_create_nonce( 'zbscrmjs-ajax-nonce' ) ); ?>';</script>
+		<?php
 
-                // pass specific placeholder list for WYSIWYG inserter
-                // <TBC> is there a better place to pass this? 
-                $placeholder_templating = $zbs->get_templating();
-                $placeholder_list = $placeholder_templating->get_placeholders_for_tooling( array( 'quote', 'contact', 'global' ), false, false );
-                echo '<script>var jpcrm_placeholder_list = ' . json_encode( $placeholder_templating->simplify_placeholders_for_wysiwyg( $placeholder_list ) ) . ';</script>';
+		// pass specific placeholder list for WYSIWYG inserter
+		$placeholder_templating = $zbs->get_templating();
+		$placeholder_list       = $placeholder_templating->get_placeholders_for_tooling( array( 'quote', 'contact', 'global' ), false, false );
+		echo '<script>var jpcrm_placeholder_list = ' . wp_json_encode( $placeholder_templating->simplify_placeholders_for_wysiwyg( $placeholder_list ) ) . ';</script>';
 
-                // for mvp v3.0 we now just hard-type these, as there a lesser obj rarely used.
-                $fields = array(
+		// for mvp v3.0 we now just hard-type these, as there a lesser obj rarely used.
+		$fields = array(
 
-                        'title' => array(
+			'title' => array(
+				0           => 'text',
+				1           => __( 'Template Title', 'zero-bs-crm' ),
+				2           => '', // placeholder
+				'essential' => 1,
+			),
 
-                            0 => 'text',
-                            1 => __('Template Title','zero-bs-crm'),
-                            2 => '', // placeholder
-                            'essential' => 1
+			'value' => array(
+				0           => 'price',
+				1           => __( 'Starting Value', 'zero-bs-crm' ),
+				2           => '', // placeholder
+				'essential' => 1,
+			),
 
-                        ),
+			'notes' => array(
+				0           => 'textarea',
+				1           => __( 'Notes', 'zero-bs-crm' ),
+				2           => '', // placeholder
+				'essential' => 1,
+			),
+		);
 
-                        'value' => array(
+		?>
+		<div>
+			<div class="jpcrm-form-grid" id="wptbpMetaBoxMainItem">
+				<?php
+				// output fields
+				$skip_fields = array( 'content' ); // dealt with below
+				zeroBSCRM_html_editFields( $quote_template, $fields, 'zbsqt_', $skip_fields );
+				##WLREMOVE
+				// template placeholder helper
+				echo '<div class="jpcrm-form-group jpcrm-form-group-span-2" style="text-align:end;"><span class="ui basic black label">' . esc_html__( 'Did you know: You can now use Quote Placeholders?', 'zero-bs-crm' ) . ' <a href="' . esc_url( $zbs->urls['kbquoteplaceholders'] ) . '" target="_blank">' . esc_html__( 'Read More', 'zero-bs-crm' ) . '</a></span></div>';
+				##/WLREMOVE
 
-                            0 => 'price',
-                            1 => __('Starting Value','zero-bs-crm'),
-                            2 => '', // placeholder
-                            'essential' => 1
+				$content = wp_kses( $quote_template_content, $zbs->acceptable_html );
 
-                        ),
-
-                        'notes' => array(
-
-                            0 => 'textarea',
-                            1 => __('Notes','zero-bs-crm'),
-                            2 => '', // placeholder
-                            'essential' => 1
-
-                        )
-                );
-
+				echo '<div class="jpcrm-form-group jpcrm-form-group-span-2">';
+				// remove "Add contact form" button from Jetpack
+				remove_action( 'media_buttons', 'grunion_media_button', 999 );
+				wp_editor(
+					$content,
+					'zbs_quotetemplate_content',
+					array( 'editor_height' => 580 )
+				);
+				echo '</div>';
 				?>
-					<div>
-						<div class="jpcrm-form-grid" id="wptbpMetaBoxMainItem">
-					<?php
-
-                    // output fields
-                    $skipFields = array('content'); // dealt with below
-                    zeroBSCRM_html_editFields($quoteTemplate,$fields,'zbsqt_',$skipFields);
-                        ##WLREMOVE
-                        // template placeholder helper
-								echo '<div class="jpcrm-form-group jpcrm-form-group-span-2" style="text-align:end;"><span class="ui basic black label">' . esc_html__( 'Did you know: You can now use Quote Placeholders?', 'zero-bs-crm' ) . ' <a href="' . esc_url( $zbs->urls['kbquoteplaceholders'] ) . '" target="_blank">' . esc_html__( 'Read More', 'zero-bs-crm' ) . '</a></span></div>';
-                        ##/WLREMOVE
-
-						$content = wp_kses( $quoteTemplateContent, $zbs->acceptable_html ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
-
-								echo '<div class="jpcrm-form-group jpcrm-form-group-span-2">';
-                        // remove "Add contact form" button from Jetpack
-                        remove_action( 'media_buttons', 'grunion_media_button', 999 );
-                        wp_editor( $content, 'zbs_quotetemplate_content', array(
-                            'editor_height' => 580
-                        ));
-								echo '</div>';
-					?>
-					</div></div>
-					<?php
-              
-        }
+			</div>
+		</div>
+		<?php
+	}
 
         public function save_data( $quoteTemplateID, $quoteTemplate ) {
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes this:
![image](https://github.com/user-attachments/assets/f8598d7a-4bbe-44e9-9a2e-1f6f5a363a51)

It now looks like this:
![image](https://github.com/user-attachments/assets/b3d1d943-799f-416b-8e2f-03de2c7d2291)


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

