### PR TITLE
CRM: Fix errant quote template link

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-quote_template_errant_link
+++ b/projects/plugins/crm/changelog/fix-crm-quote_template_errant_link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Quote Templates: Clean up link when creating a new quote template.

--- a/projects/plugins/crm/includes/class-learn-menu.php
+++ b/projects/plugins/crm/includes/class-learn-menu.php
@@ -1026,7 +1026,7 @@ class Learn_Menu {
 				'url'           => 'https://jetpackcrm.com/feature/quotes/',
 				'img'           => 'learn-quote-template.png',
 				'content'       => '<p>' . __( 'Quote templates save you time. You can enter placeholders so that when you generate a new quote using the template, the contact fields are automatically populated.', 'zero-bs-crm' ) . '</p>',
-				'right_buttons' => ' <a href="' . jpcrm_esc_link( 'create', -1, 'zerobs_quo_template', false ) . '#free-extensions-tour" class="jpcrm-button font-14px" id="add-template">' . __( 'Add new template', 'zero-bs-crm' ) . '</a>',
+				'right_buttons' => ' <a href="' . jpcrm_esc_link( 'create', -1, 'zerobs_quo_template', false ) . '" class="jpcrm-button font-14px" id="add-template">' . __( 'Add new template', 'zero-bs-crm' ) . '</a>',
 			),
 			'quotetemplatenew'   => array(
 				'title'     => __( 'New Quote Template', 'zero-bs-crm' ),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

When clicking "Add new template" from the quote templates listview, the URL appends `#free-extensions-tour`. This has been the case for 8+ years, but has no purpose.

This PR removes that extra bit from the URL.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

