### PR TITLE
Forms: Add Google disconnect button

### DIFF
--- a/projects/packages/forms/changelog/add-forms-google-disconnect-button
+++ b/projects/packages/forms/changelog/add-forms-google-disconnect-button
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: Add link to disconnect Google.

--- a/projects/packages/forms/src/dashboard/integrations/google-sheets-card.tsx
+++ b/projects/packages/forms/src/dashboard/integrations/google-sheets-card.tsx
@@ -89,6 +89,16 @@ const GoogleSheetsDashboardCard = ( {
 						<Button variant="link" onClick={ handleViewResponsesClick }>
 							{ __( 'View Form Responses', 'jetpack-forms' ) }
 						</Button>
+						<span>|</span>
+						<Button
+							variant="link"
+							onClick={ handleConnectClick }
+							target="_blank"
+							rel="noopener noreferrer"
+							disabled={ ! settingsUrl }
+						>
+							{ __( 'Disconnect Google Drive', 'jetpack-forms' ) }
+						</Button>
 					</div>
 				</div>
 			) }

--- a/projects/packages/forms/src/dashboard/integrations/google-sheets-card.tsx
+++ b/projects/packages/forms/src/dashboard/integrations/google-sheets-card.tsx
@@ -85,7 +85,7 @@ const GoogleSheetsDashboardCard = ( {
 							'jetpack-forms'
 						) }
 					</p>
-					<div className="integration-card__links">
+					<HStack spacing="2" justify="start" className="integration-card__links">
 						<Button variant="link" onClick={ handleViewResponsesClick }>
 							{ __( 'View Form Responses', 'jetpack-forms' ) }
 						</Button>
@@ -99,7 +99,7 @@ const GoogleSheetsDashboardCard = ( {
 						>
 							{ __( 'Disconnect Google Drive', 'jetpack-forms' ) }
 						</Button>
-					</div>
+					</HStack>
 				</div>
 			) }
 		</IntegrationCard>

--- a/projects/plugins/jetpack/changelog/add-forms-google-disconnect-button
+++ b/projects/plugins/jetpack/changelog/add-forms-google-disconnect-button
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: Add link to disconnect Google.


### PR DESCRIPTION
## Proposed changes:

This is a follow up I've been meaning to add for the Google Sheets card in the new integrations dashboard. Once you've connected, it's currently very hard to disconnect it - you'd need to manually go to your WordPress.com account and find the marketing / connections page. This PR just adds a link to that page for convenience. 

<img width="919" alt="forms-disconnect-google" src="https://github.com/user-attachments/assets/338d9a25-dd44-44d5-8796-ecb986d885dd" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None. 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Jetpack > Forms > Integrations
* If Google drive is not connected, connect it and click Refresh status to update the Google card. 
* Confirm you see a 'Disconnect Google Drive link, and that clicking it takes you to the Marketing > Connections dashboard where you can disconnect the service. 

