### PR TITLE
Forms: Update integration marketing links

### DIFF
--- a/projects/packages/forms/changelog/update-form-integrations-marketing-links
+++ b/projects/packages/forms/changelog/update-form-integrations-marketing-links
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: Update integration links.

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -24,46 +24,66 @@ use WP_REST_Response;
 class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 
 	/**
-	 * Supported integrations configuration
+	 * Supported integrations configuration.
+	 *
+	 * Each integration array supports the following keys:
+	 * - type (string)                  : 'plugin' or 'service'
+	 * - file (string|null)             : Plugin file path (for plugins), or null for services
+	 * - settings_url (string|null)     : Relative admin URL for settings, or null if none
+	 * - jetpack_redirect_slug (string|null) : Slug for Redirect::get_url(), or null if none
+	 *
+	 * For jetpack_redirect_slug, you'll need to add those here first:
+	 * https://mc.a8c.com/jetpack-crew/redirects/
+	 *
+	 * Example:
+	 * [
+	 *   'akismet' => [
+	 *     'type' => 'plugin',
+	 *     'file' => 'akismet/akismet.php',
+	 *     'settings_url' => 'admin.php?page=akismet-key-config',
+	 *     'jetpack_redirect_slug' => 'org-spam',
+	 *   ],
+	 *   ...
+	 * ]
 	 *
 	 * @var array
 	 */
 	private $supported_integrations = array(
 		'akismet'                           => array(
-			'type'          => 'plugin',
-			'file'          => 'akismet/akismet.php',
-			'settings_url'  => 'admin.php?page=akismet-key-config',
-			'marketing_url' => null,
+			'type'                  => 'plugin',
+			'file'                  => 'akismet/akismet.php',
+			'settings_url'          => 'admin.php?page=akismet-key-config',
+			'jetpack_redirect_slug' => 'org-spam',
 		),
 		'creative-mail-by-constant-contact' => array(
-			'type'          => 'plugin',
-			'file'          => 'creative-mail-by-constant-contact/creative-mail-plugin.php',
-			'settings_url'  => 'admin.php?page=creativemail',
-			'marketing_url' => null,
+			'type'                  => 'plugin',
+			'file'                  => 'creative-mail-by-constant-contact/creative-mail-plugin.php',
+			'settings_url'          => 'admin.php?page=creativemail',
+			'jetpack_redirect_slug' => 'creative-mail',
 		),
 		'zero-bs-crm'                       => array(
-			'type'          => 'plugin',
-			'file'          => 'zero-bs-crm/ZeroBSCRM.php',
-			'settings_url'  => 'admin.php?page=zerobscrm-plugin-settings',
-			'marketing_url' => null,
+			'type'                  => 'plugin',
+			'file'                  => 'zero-bs-crm/ZeroBSCRM.php',
+			'settings_url'          => 'admin.php?page=zerobscrm-plugin-settings',
+			'jetpack_redirect_slug' => 'org-crm',
 		),
 		'salesforce'                        => array(
-			'type'          => 'service',
-			'file'          => null,
-			'settings_url'  => null,
-			'marketing_url' => null,
+			'type'                  => 'service',
+			'file'                  => null,
+			'settings_url'          => null,
+			'jetpack_redirect_slug' => null,
 		),
 		'google-drive'                      => array(
-			'type'          => 'service',
-			'file'          => null,
-			'settings_url'  => null,
-			'marketing_url' => null,
+			'type'                  => 'service',
+			'file'                  => null,
+			'settings_url'          => null,
+			'jetpack_redirect_slug' => null,
 		),
 		'mailpoet'                          => array(
-			'type'          => 'plugin',
-			'file'          => 'mailpoet/mailpoet.php',
-			'settings_url'  => 'admin.php?page=mailpoet-homepage',
-			'marketing_url' => null,
+			'type'                  => 'plugin',
+			'file'                  => 'mailpoet/mailpoet.php',
+			'settings_url'          => 'admin.php?page=mailpoet-homepage',
+			'jetpack_redirect_slug' => 'org-mailpoet',
 		),
 	);
 
@@ -795,7 +815,8 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 	 * @return array Service status data.
 	 */
 	private function get_service_status( $slug ) {
-		$config = $this->get_supported_integrations()[ $slug ];
+		$config        = $this->get_supported_integrations()[ $slug ];
+		$redirect_slug = $config['jetpack_redirect_slug'] ?? null;
 
 		// Default response for all integrations
 		$response = array(
@@ -804,7 +825,7 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 			'needsConnection' => true,
 			'isConnected'     => false,
 			'settingsUrl'     => $config['settings_url'] ?? null,
-			'marketingUrl'    => $config['marketing_url'] ?? null,
+			'marketingUrl'    => $redirect_slug ? Redirect::get_url( $redirect_slug ) : null,
 			'pluginFile'      => null,
 			'isInstalled'     => false,
 			'isActive'        => false,
@@ -847,6 +868,7 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 
 		$integrations  = $this->get_supported_integrations();
 		$plugin_config = $integrations[ $plugin_slug ];
+		$redirect_slug = $plugin_config['jetpack_redirect_slug'] ?? null;
 
 		$installed_plugins = get_plugins();
 		$is_installed      = isset( $installed_plugins[ $plugin_config['file'] ] );
@@ -862,7 +884,7 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 			'isConnected'     => false,
 			'version'         => $is_installed ? $installed_plugins[ $plugin_config['file'] ]['Version'] : null,
 			'settingsUrl'     => $is_active ? admin_url( $plugin_config['settings_url'] ) : null,
-			'marketingUrl'    => $plugin_config['marketing_url'] ?? null,
+			'marketingUrl'    => $redirect_slug ? Redirect::get_url( $redirect_slug ) : null,
 			'details'         => array(),
 		);
 
@@ -873,10 +895,8 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 				$response['isConnected']                       = class_exists( 'Jetpack' ) && \Jetpack::is_akismet_active();
 				$response['details']['formSubmissionsSpamUrl'] = $dashboard_view_switch->get_forms_admin_url( 'spam' );
 				$response['needsConnection']                   = true;
-				$response['marketingUrl']                      = Redirect::get_url( 'org-spam' );
 				break;
 			case 'zero-bs-crm':
-				$response['marketingUrl'] = Redirect::get_url( 'org-crm' );
 				if ( $is_active ) {
 					$has_extension       = function_exists( 'zeroBSCRM_isExtensionInstalled' ) && zeroBSCRM_isExtensionInstalled( 'jetpackforms' ); // @phan-suppress-current-line PhanUndeclaredFunction -- We're checking the function exists first
 					$response['details'] = array(
@@ -887,7 +907,6 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 				break;
 			case 'mailpoet':
 				$response['needsConnection'] = true;
-				$response['marketingUrl']    = Redirect::get_url( 'org-mailpoet' );
 				if ( class_exists( '\MailPoet\Config\ServicesChecker' ) ) {
 					$checker = new \MailPoet\Config\ServicesChecker(); // @phan-suppress-current-line PhanUndeclaredClassMethod -- we're checking the class exists first
 					if ( method_exists( $checker, 'isMailPoetAPIKeyValid' ) ) {
@@ -896,7 +915,6 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 				}
 				break;
 			case 'creative-mail-by-constant-contact':
-				$response['marketingUrl'] = Redirect::get_url( 'creative-mail' );
 				break;
 		}
 

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -30,34 +30,40 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 	 */
 	private $supported_integrations = array(
 		'akismet'                           => array(
-			'type'         => 'plugin',
-			'file'         => 'akismet/akismet.php',
-			'settings_url' => 'admin.php?page=akismet-key-config',
+			'type'          => 'plugin',
+			'file'          => 'akismet/akismet.php',
+			'settings_url'  => 'admin.php?page=akismet-key-config',
+			'marketing_url' => null,
 		),
 		'creative-mail-by-constant-contact' => array(
-			'type'         => 'plugin',
-			'file'         => 'creative-mail-by-constant-contact/creative-mail-plugin.php',
-			'settings_url' => 'admin.php?page=creativemail',
+			'type'          => 'plugin',
+			'file'          => 'creative-mail-by-constant-contact/creative-mail-plugin.php',
+			'settings_url'  => 'admin.php?page=creativemail',
+			'marketing_url' => null,
 		),
 		'zero-bs-crm'                       => array(
-			'type'         => 'plugin',
-			'file'         => 'zero-bs-crm/ZeroBSCRM.php',
-			'settings_url' => 'admin.php?page=zerobscrm-plugin-settings',
+			'type'          => 'plugin',
+			'file'          => 'zero-bs-crm/ZeroBSCRM.php',
+			'settings_url'  => 'admin.php?page=zerobscrm-plugin-settings',
+			'marketing_url' => null,
 		),
 		'salesforce'                        => array(
-			'type'         => 'service',
-			'file'         => null,
-			'settings_url' => null,
+			'type'          => 'service',
+			'file'          => null,
+			'settings_url'  => null,
+			'marketing_url' => null,
 		),
 		'google-drive'                      => array(
-			'type'         => 'service',
-			'file'         => null,
-			'settings_url' => null,
+			'type'          => 'service',
+			'file'          => null,
+			'settings_url'  => null,
+			'marketing_url' => null,
 		),
 		'mailpoet'                          => array(
-			'type'         => 'plugin',
-			'file'         => 'mailpoet/mailpoet.php',
-			'settings_url' => 'admin.php?page=mailpoet-homepage',
+			'type'          => 'plugin',
+			'file'          => 'mailpoet/mailpoet.php',
+			'settings_url'  => 'admin.php?page=mailpoet-homepage',
+			'marketing_url' => null,
 		),
 	);
 
@@ -798,6 +804,7 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 			'needsConnection' => true,
 			'isConnected'     => false,
 			'settingsUrl'     => $config['settings_url'] ?? null,
+			'marketingUrl'    => $config['marketing_url'] ?? null,
 			'pluginFile'      => null,
 			'isInstalled'     => false,
 			'isActive'        => false,
@@ -855,6 +862,7 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 			'isConnected'     => false,
 			'version'         => $is_installed ? $installed_plugins[ $plugin_config['file'] ]['Version'] : null,
 			'settingsUrl'     => $is_active ? admin_url( $plugin_config['settings_url'] ) : null,
+			'marketingUrl'    => $plugin_config['marketing_url'] ?? null,
 			'details'         => array(),
 		);
 
@@ -865,8 +873,10 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 				$response['isConnected']                       = class_exists( 'Jetpack' ) && \Jetpack::is_akismet_active();
 				$response['details']['formSubmissionsSpamUrl'] = $dashboard_view_switch->get_forms_admin_url( 'spam' );
 				$response['needsConnection']                   = true;
+				$response['marketingUrl']                      = Redirect::get_url( 'org-spam' );
 				break;
 			case 'zero-bs-crm':
+				$response['marketingUrl'] = Redirect::get_url( 'org-crm' );
 				if ( $is_active ) {
 					$has_extension       = function_exists( 'zeroBSCRM_isExtensionInstalled' ) && zeroBSCRM_isExtensionInstalled( 'jetpackforms' ); // @phan-suppress-current-line PhanUndeclaredFunction -- We're checking the function exists first
 					$response['details'] = array(
@@ -877,12 +887,16 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 				break;
 			case 'mailpoet':
 				$response['needsConnection'] = true;
+				$response['marketingUrl']    = Redirect::get_url( 'org-mailpoet' );
 				if ( class_exists( '\MailPoet\Config\ServicesChecker' ) ) {
 					$checker = new \MailPoet\Config\ServicesChecker(); // @phan-suppress-current-line PhanUndeclaredClassMethod -- we're checking the class exists first
 					if ( method_exists( $checker, 'isMailPoetAPIKeyValid' ) ) {
 						$response['isConnected'] = (bool) $checker->isMailPoetAPIKeyValid( false ); // @phan-suppress-current-line PhanUndeclaredClassMethod -- we're checking the method exists first
 					}
 				}
+				break;
+			case 'creative-mail-by-constant-contact':
+				$response['marketingUrl'] = Redirect::get_url( 'creative-mail' );
 				break;
 		}
 

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -903,8 +903,6 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 					}
 				}
 				break;
-			case 'creative-mail-by-constant-contact':
-				break;
 		}
 
 		return $response;

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -30,60 +30,49 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 	 * - type (string)                  : 'plugin' or 'service'
 	 * - file (string|null)             : Plugin file path (for plugins), or null for services
 	 * - settings_url (string|null)     : Relative admin URL for settings, or null if none
-	 * - jetpack_redirect_slug (string|null) : Slug for Redirect::get_url(), or null if none
+	 * - marketing_redirect_slug (string|null) : Slug for Redirect::get_url() for marketing links, or null if none
 	 *
-	 * For jetpack_redirect_slug, you'll need to add those here first:
+	 * For marketing_redirect_slug, you'll need to add those here first:
 	 * https://mc.a8c.com/jetpack-crew/redirects/
-	 *
-	 * Example:
-	 * [
-	 *   'akismet' => [
-	 *     'type' => 'plugin',
-	 *     'file' => 'akismet/akismet.php',
-	 *     'settings_url' => 'admin.php?page=akismet-key-config',
-	 *     'jetpack_redirect_slug' => 'org-spam',
-	 *   ],
-	 *   ...
-	 * ]
 	 *
 	 * @var array
 	 */
 	private $supported_integrations = array(
 		'akismet'                           => array(
-			'type'                  => 'plugin',
-			'file'                  => 'akismet/akismet.php',
-			'settings_url'          => 'admin.php?page=akismet-key-config',
-			'jetpack_redirect_slug' => 'org-spam',
+			'type'                    => 'plugin',
+			'file'                    => 'akismet/akismet.php',
+			'settings_url'            => 'admin.php?page=akismet-key-config',
+			'marketing_redirect_slug' => 'org-spam',
 		),
 		'creative-mail-by-constant-contact' => array(
-			'type'                  => 'plugin',
-			'file'                  => 'creative-mail-by-constant-contact/creative-mail-plugin.php',
-			'settings_url'          => 'admin.php?page=creativemail',
-			'jetpack_redirect_slug' => 'creative-mail',
+			'type'                    => 'plugin',
+			'file'                    => 'creative-mail-by-constant-contact/creative-mail-plugin.php',
+			'settings_url'            => 'admin.php?page=creativemail',
+			'marketing_redirect_slug' => 'creative-mail',
 		),
 		'zero-bs-crm'                       => array(
-			'type'                  => 'plugin',
-			'file'                  => 'zero-bs-crm/ZeroBSCRM.php',
-			'settings_url'          => 'admin.php?page=zerobscrm-plugin-settings',
-			'jetpack_redirect_slug' => 'org-crm',
+			'type'                    => 'plugin',
+			'file'                    => 'zero-bs-crm/ZeroBSCRM.php',
+			'settings_url'            => 'admin.php?page=zerobscrm-plugin-settings',
+			'marketing_redirect_slug' => 'org-crm',
 		),
 		'salesforce'                        => array(
-			'type'                  => 'service',
-			'file'                  => null,
-			'settings_url'          => null,
-			'jetpack_redirect_slug' => null,
+			'type'                    => 'service',
+			'file'                    => null,
+			'settings_url'            => null,
+			'marketing_redirect_slug' => null,
 		),
 		'google-drive'                      => array(
-			'type'                  => 'service',
-			'file'                  => null,
-			'settings_url'          => null,
-			'jetpack_redirect_slug' => null,
+			'type'                    => 'service',
+			'file'                    => null,
+			'settings_url'            => null,
+			'marketing_redirect_slug' => null,
 		),
 		'mailpoet'                          => array(
-			'type'                  => 'plugin',
-			'file'                  => 'mailpoet/mailpoet.php',
-			'settings_url'          => 'admin.php?page=mailpoet-homepage',
-			'jetpack_redirect_slug' => 'org-mailpoet',
+			'type'                    => 'plugin',
+			'file'                    => 'mailpoet/mailpoet.php',
+			'settings_url'            => 'admin.php?page=mailpoet-homepage',
+			'marketing_redirect_slug' => 'org-mailpoet',
 		),
 	);
 
@@ -816,7 +805,7 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 	 */
 	private function get_service_status( $slug ) {
 		$config        = $this->get_supported_integrations()[ $slug ];
-		$redirect_slug = $config['jetpack_redirect_slug'] ?? null;
+		$redirect_slug = $config['marketing_redirect_slug'] ?? null;
 
 		// Default response for all integrations
 		$response = array(
@@ -866,9 +855,9 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 			require_once ABSPATH . 'wp-admin/includes/plugin.php';
 		}
 
-		$integrations  = $this->get_supported_integrations();
-		$plugin_config = $integrations[ $plugin_slug ];
-		$redirect_slug = $plugin_config['jetpack_redirect_slug'] ?? null;
+		$integrations            = $this->get_supported_integrations();
+		$plugin_config           = $integrations[ $plugin_slug ];
+		$marketing_redirect_slug = $plugin_config['marketing_redirect_slug'] ?? null;
 
 		$installed_plugins = get_plugins();
 		$is_installed      = isset( $installed_plugins[ $plugin_config['file'] ] );
@@ -884,7 +873,7 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 			'isConnected'     => false,
 			'version'         => $is_installed ? $installed_plugins[ $plugin_config['file'] ]['Version'] : null,
 			'settingsUrl'     => $is_active ? admin_url( $plugin_config['settings_url'] ) : null,
-			'marketingUrl'    => $redirect_slug ? Redirect::get_url( $redirect_slug ) : null,
+			'marketingUrl'    => $marketing_redirect_slug ? Redirect::get_url( $marketing_redirect_slug ) : null,
 			'details'         => array(),
 		);
 

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -804,8 +804,8 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 	 * @return array Service status data.
 	 */
 	private function get_service_status( $slug ) {
-		$config        = $this->get_supported_integrations()[ $slug ];
-		$redirect_slug = $config['marketing_redirect_slug'] ?? null;
+		$config                  = $this->get_supported_integrations()[ $slug ];
+		$marketing_redirect_slug = $config['marketing_redirect_slug'] ?? null;
 
 		// Default response for all integrations
 		$response = array(
@@ -814,7 +814,7 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 			'needsConnection' => true,
 			'isConnected'     => false,
 			'settingsUrl'     => $config['settings_url'] ?? null,
-			'marketingUrl'    => $redirect_slug ? Redirect::get_url( $redirect_slug ) : null,
+			'marketingUrl'    => $marketing_redirect_slug ? Redirect::get_url( $marketing_redirect_slug ) : null,
 			'pluginFile'      => null,
 			'isInstalled'     => false,
 			'isActive'        => false,

--- a/projects/packages/forms/src/dashboard/integrations/akismet-card.tsx
+++ b/projects/packages/forms/src/dashboard/integrations/akismet-card.tsx
@@ -22,7 +22,11 @@ const AkismetDashboardCard = ( {
 	data,
 	refreshStatus,
 }: SingleIntegrationCardProps ) => {
-	const { isConnected: akismetActiveWithKey = false, settingsUrl = '' } = data || {};
+	const {
+		isConnected: akismetActiveWithKey = false,
+		settingsUrl = '',
+		marketingUrl = '',
+	} = data || {};
 	const navigate = useNavigate();
 
 	const cardData: IntegrationCardData = {
@@ -37,7 +41,7 @@ const AkismetDashboardCard = ( {
 				'jetpack-forms'
 			),
 			{
-				a: <ExternalLink href={ getRedirectUrl( 'akismet-wordpress-org' ) } />,
+				a: <ExternalLink href={ marketingUrl } />,
 			}
 		),
 		notActivatedMessage: __(

--- a/projects/packages/forms/src/dashboard/integrations/jetpack-crm-card.tsx
+++ b/projects/packages/forms/src/dashboard/integrations/jetpack-crm-card.tsx
@@ -3,7 +3,7 @@
  */
 import colorStudio from '@automattic/color-studio';
 import { JetpackIcon } from '@automattic/jetpack-components';
-import { Button } from '@wordpress/components';
+import { Button, ExternalLink } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import semver from 'semver';
@@ -24,7 +24,7 @@ const JetpackCRMDashboardCard = ( {
 	data,
 	refreshStatus,
 }: SingleIntegrationCardProps ) => {
-	const { settingsUrl = '', version = '', details = {} } = data || {};
+	const { settingsUrl = '', marketingUrl = '', version = '', details = {} } = data || {};
 	const { hasExtension = false, canActivateExtension = false } = details;
 
 	const crmVersion = semver.coerce( version );
@@ -36,9 +36,14 @@ const JetpackCRMDashboardCard = ( {
 		isLoading: ! data || typeof data.isInstalled === 'undefined',
 		refreshStatus,
 		trackEventName: 'jetpack_forms_upsell_crm_click',
-		notInstalledMessage: __(
-			'You can save your form contacts in Jetpack CRM. To get started, please install the plugin.',
-			'jetpack-forms'
+		notInstalledMessage: createInterpolateElement(
+			__(
+				'You can save your form contacts in Jetpack CRM. <a>Learn more</a> or to get started, please install the plugin.',
+				'jetpack-forms'
+			),
+			{
+				a: <ExternalLink href={ marketingUrl } />,
+			}
 		),
 		notActivatedMessage: __(
 			'Jetpack CRM is installed. To start saving contacts, simply activate the plugin.',

--- a/projects/packages/forms/src/dashboard/integrations/jetpack-crm-card.tsx
+++ b/projects/packages/forms/src/dashboard/integrations/jetpack-crm-card.tsx
@@ -38,7 +38,7 @@ const JetpackCRMDashboardCard = ( {
 		trackEventName: 'jetpack_forms_upsell_crm_click',
 		notInstalledMessage: createInterpolateElement(
 			__(
-				'You can save your form contacts in Jetpack CRM. <a>Learn more</a> or to get started, please install the plugin.',
+				'You can save your form contacts in <a>Jetpack CRM</a>. To get started, please install the plugin.',
 				'jetpack-forms'
 			),
 			{

--- a/projects/packages/forms/src/dashboard/integrations/mailpoet-card.tsx
+++ b/projects/packages/forms/src/dashboard/integrations/mailpoet-card.tsx
@@ -11,7 +11,11 @@ const MailPoetDashboardCard = ( {
 	data,
 	refreshStatus,
 }: SingleIntegrationCardProps ) => {
-	const { isConnected: mailpoetActiveWithKey = false, settingsUrl = '' } = data || {};
+	const {
+		isConnected: mailpoetActiveWithKey = false,
+		settingsUrl = '',
+		marketingUrl = '',
+	} = data || {};
 
 	const cardData: IntegrationCardData = {
 		...data,
@@ -25,7 +29,7 @@ const MailPoetDashboardCard = ( {
 				'jetpack-forms'
 			),
 			{
-				a: <ExternalLink href={ 'https://wordpress.org/plugins/mailpoet/' } />,
+				a: <ExternalLink href={ marketingUrl } />,
 			}
 		),
 		notActivatedMessage: __(

--- a/projects/packages/forms/src/types/index.ts
+++ b/projects/packages/forms/src/types/index.ts
@@ -24,6 +24,8 @@ export interface Integration {
 	version?: string | null;
 	/** The URL to the integration's settings page, if available. */
 	settingsUrl?: string | null;
+	/** A URL to learn about the integration, if available. */
+	marketingUrl?: string | null;
 	/** Additional details about the integration. */
 	details: Record< string, unknown >;
 }

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Endpoint_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Endpoint_Test.php
@@ -195,6 +195,7 @@ class Contact_Form_Endpoint_Test extends TestCase {
 			$this->assertArrayHasKey( 'version', $integration );
 			$this->assertArrayHasKey( 'details', $integration );
 			$this->assertArrayHasKey( 'needsConnection', $integration );
+			$this->assertArrayHasKey( 'marketingUrl', $integration );
 
 			// Verify expected data types
 			$this->assertIsString( $integration['id'] );
@@ -208,6 +209,7 @@ class Contact_Form_Endpoint_Test extends TestCase {
 			$this->assertTrue( $integration['pluginFile'] === null || is_string( $integration['pluginFile'] ) );
 			$this->assertTrue( $integration['version'] === null || is_string( $integration['version'] ) );
 			$this->assertIsArray( $integration['details'] );
+			$this->assertTrue( $integration['marketingUrl'] === null || is_string( $integration['marketingUrl'] ) );
 		}
 	}
 

--- a/projects/plugins/jetpack/changelog/update-form-integrations-marketing-links
+++ b/projects/plugins/jetpack/changelog/update-form-integrations-marketing-links
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: Update integration links.


### PR DESCRIPTION
**Note for reviewers:** The diff for this PR is a bit cleaner if you toggle the option to hide whitespace changes. There are spacing changes in several places, such as align => values in PHP.

## Proposed changes:

This PR makes a few improvements to the marketing links for integrations in the central integrations panel. 
- Endpoint: Return a marketingUrl to ensure a single source of truth + ensure we're using Jetpack Redirects
- Akismet: Update to use marketingUrl and akimset.com (rather than WordPress.org Akismet page)
- MailPoet: Update to use marketingUrl (was using a hard coded url)
- Jetpack CRM: Add new link using marketingUrl (follow up to past comment from @lezama)
- TypeScript: Adds marketingUrl to the IntegrationCard type
- Tests: Update our endpoint tests

**See Akismet, Jetpack CRM, and MailPoet links here:**
<img width="924" alt="forms-marketing-urls" src="https://github.com/user-attachments/assets/855b2b57-ff96-4bdb-ba43-4de9f078cdfe" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Slack: p1750299457762249-slack-C052XEUUBL4

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On your test site, start by deactivating and uninstalling Akismet, Jetpack CRM, and MailPoet if needed
* Go to Jetpack > Forms > Integration
* Confirm that links to learn more or see more information for Akismet, Jetpack CRM, and MailPoet all go to their respective sites. 
* Confirm that endpiont tests pass by navigating to projects/packages/form and running: `composer test-php tests/php/contact-form/Contact_Form_Endpoint_Test.php`