### PR TITLE
Forms: Update integration links to HStack

### DIFF
--- a/projects/packages/forms/changelog/update-form-integration-links-hstack
+++ b/projects/packages/forms/changelog/update-form-integration-links-hstack
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Forms: Update integration links to HStack.

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/akismet-card.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/akismet-card.tsx
@@ -1,5 +1,5 @@
 import { getRedirectUrl } from '@automattic/jetpack-components';
-import { Button, ExternalLink } from '@wordpress/components';
+import { Button, ExternalLink, __experimentalHStack as HStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import AkismetIcon from '../../../../icons/akismet';
@@ -77,7 +77,7 @@ const AkismetCard = ( {
 					<p className="integration-card__description">
 						{ __( 'Your forms are automatically protected with Akismet.', 'jetpack-forms' ) }
 					</p>
-					<div className="integration-card__links">
+					<HStack spacing="2" justify="start">
 						<Button
 							variant="link"
 							href={ formSubmissionsUrl }
@@ -94,7 +94,7 @@ const AkismetCard = ( {
 						<ExternalLink href={ getRedirectUrl( 'akismet-jetpack-forms-docs' ) }>
 							{ __( 'Learn about Akismet', 'jetpack-forms' ) }
 						</ExternalLink>
-					</div>
+					</HStack>
 				</div>
 			) }
 		</IntegrationCard>

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/akismet-card.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/akismet-card.tsx
@@ -77,7 +77,7 @@ const AkismetCard = ( {
 					<p className="integration-card__description">
 						{ __( 'Your forms are automatically protected with Akismet.', 'jetpack-forms' ) }
 					</p>
-					<HStack spacing="2" justify="start">
+					<HStack spacing="2" justify="start" className="integration-card__links">
 						<Button
 							variant="link"
 							href={ formSubmissionsUrl }

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/google-sheets-card.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/google-sheets-card.tsx
@@ -96,7 +96,7 @@ const GoogleSheetsCard = ( {
 							'jetpack-forms'
 						) }
 					</p>
-					<HStack spacing="2" justify="start">
+					<HStack spacing="2" justify="start" className="integration-card__links">
 						<Button
 							variant="link"
 							href={ FORM_RESPONSES_URL }

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/google-sheets-card.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/google-sheets-card.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@wordpress/components';
+import { Button, __experimentalHStack as HStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
 import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import GoogleSheetsIcon from '../../../../icons/google-sheets';
@@ -96,7 +96,7 @@ const GoogleSheetsCard = ( {
 							'jetpack-forms'
 						) }
 					</p>
-					<div className="integration-card__links">
+					<HStack spacing="2" justify="start">
 						<Button
 							variant="link"
 							href={ FORM_RESPONSES_URL }
@@ -105,7 +105,17 @@ const GoogleSheetsCard = ( {
 						>
 							{ __( 'View Form Responses', 'jetpack-forms' ) }
 						</Button>
-					</div>
+						<span>|</span>
+						<Button
+							variant="link"
+							onClick={ handleConnectClick }
+							target="_blank"
+							rel="noopener noreferrer"
+							disabled={ ! settingsUrl }
+						>
+							{ __( 'Disconnect Google Drive', 'jetpack-forms' ) }
+						</Button>
+					</HStack>
 				</div>
 			) }
 		</IntegrationCard>

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/style.scss
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/style.scss
@@ -154,4 +154,16 @@
 	&__service-icon--google-sheets {
 		border-radius: 0 !important;
 	}
+
+	.integration-card__links {
+
+		@media (max-width: 480px) {
+			flex-direction: column !important;
+			align-items: flex-start !important;
+
+			span {
+				display: none;
+			}
+		}
+	}
 }

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/style.scss
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/style.scss
@@ -120,6 +120,18 @@
 		}
 	}
 
+	&__links {
+
+		@media (max-width: 480px) {
+			flex-direction: column;
+			align-items: flex-start;
+
+			span {
+				display: none;
+			}
+		}
+	}
+
 	.components-button .components-spinner {
 		margin: 0 8px;
 		width: 16px;
@@ -153,17 +165,5 @@
 
 	&__service-icon--google-sheets {
 		border-radius: 0 !important;
-	}
-
-	.integration-card__links {
-
-		@media (max-width: 480px) {
-			flex-direction: column !important;
-			align-items: flex-start !important;
-
-			span {
-				display: none;
-			}
-		}
 	}
 }

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/style.scss
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/style.scss
@@ -120,7 +120,7 @@
 		}
 	}
 
-	&__links {
+	&__links.components-h-stack {
 
 		@media (max-width: 480px) {
 			flex-direction: column;

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/style.scss
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/style.scss
@@ -120,12 +120,6 @@
 		}
 	}
 
-	&__links {
-		display: flex;
-		align-items: center;
-		gap: 8px;
-	}
-
 	.components-button .components-spinner {
 		margin: 0 8px;
 		width: 16px;

--- a/projects/packages/forms/src/dashboard/integrations/akismet-card.tsx
+++ b/projects/packages/forms/src/dashboard/integrations/akismet-card.tsx
@@ -93,7 +93,7 @@ const AkismetDashboardCard = ( {
 					<p className="integration-card__description">
 						{ __( 'Your forms are automatically protected with Akismet.', 'jetpack-forms' ) }
 					</p>
-					<HStack spacing="2" justify="start">
+					<HStack spacing="2" justify="start" className="integration-card__links">
 						<Button variant="link" onClick={ handleViewSpamClick }>
 							{ __( 'View spam', 'jetpack-forms' ) }
 						</Button>

--- a/projects/packages/forms/src/dashboard/integrations/akismet-card.tsx
+++ b/projects/packages/forms/src/dashboard/integrations/akismet-card.tsx
@@ -93,7 +93,7 @@ const AkismetDashboardCard = ( {
 					<p className="integration-card__description">
 						{ __( 'Your forms are automatically protected with Akismet.', 'jetpack-forms' ) }
 					</p>
-					<div className="integration-card__links">
+					<HStack spacing="2" justify="start">
 						<Button variant="link" onClick={ handleViewSpamClick }>
 							{ __( 'View spam', 'jetpack-forms' ) }
 						</Button>
@@ -105,7 +105,7 @@ const AkismetDashboardCard = ( {
 						<ExternalLink href={ getRedirectUrl( 'akismet-jetpack-forms-docs' ) }>
 							{ __( 'Learn about Akismet', 'jetpack-forms' ) }
 						</ExternalLink>
-					</div>
+					</HStack>
 				</div>
 			) }
 		</IntegrationCard>

--- a/projects/packages/forms/src/dashboard/integrations/google-sheets-card.tsx
+++ b/projects/packages/forms/src/dashboard/integrations/google-sheets-card.tsx
@@ -85,7 +85,7 @@ const GoogleSheetsDashboardCard = ( {
 							'jetpack-forms'
 						) }
 					</p>
-					<HStack spacing="2" justify="start" className="integration-card__links">
+					<HStack spacing="2" justify="start">
 						<Button variant="link" onClick={ handleViewResponsesClick }>
 							{ __( 'View Form Responses', 'jetpack-forms' ) }
 						</Button>

--- a/projects/packages/forms/src/dashboard/integrations/google-sheets-card.tsx
+++ b/projects/packages/forms/src/dashboard/integrations/google-sheets-card.tsx
@@ -85,7 +85,7 @@ const GoogleSheetsDashboardCard = ( {
 							'jetpack-forms'
 						) }
 					</p>
-					<HStack spacing="2" justify="start">
+					<HStack spacing="2" justify="start" className="integration-card__links">
 						<Button variant="link" onClick={ handleViewResponsesClick }>
 							{ __( 'View Form Responses', 'jetpack-forms' ) }
 						</Button>

--- a/projects/packages/forms/src/dashboard/integrations/mailpoet-card.tsx
+++ b/projects/packages/forms/src/dashboard/integrations/mailpoet-card.tsx
@@ -80,11 +80,9 @@ const MailPoetDashboardCard = ( {
 					<p className="integration-card__description">
 						{ __( 'You can now send marketing emails with MailPoet.', 'jetpack-forms' ) }
 					</p>
-					<div className="integration-card__links">
-						<Button variant="link" href={ settingsUrl } target="_blank" rel="noopener noreferrer">
-							{ __( 'View MailPoet dashboard', 'jetpack-forms' ) }
-						</Button>
-					</div>
+					<Button variant="link" href={ settingsUrl } target="_blank" rel="noopener noreferrer">
+						{ __( 'View MailPoet dashboard', 'jetpack-forms' ) }
+					</Button>
 				</div>
 			) }
 		</IntegrationCard>


### PR DESCRIPTION
## Proposed changes:

This updates our integration card to use HStack for links. And it adds the 'Disconnect Google Drive' link to the Google card in the integrations modal. This work is a follow up to #44253 (see this [comment](https://github.com/Automattic/jetpack/pull/44253#discussion_r2195696346)).

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No. 

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

This is a refactor, so everything should work the same as before. 

* Go to Jetpack > Forms > Integrations
* Connect/install Akismet, Google Sheets, and MailChimp if needed. 
* Confirm that the links to view settings, etc, look and work as before. 
* Add a form block to a post, open the integrations modal, and confirm links for those cards look and work as expected.