### PR TITLE
CRM: Resolves #44256 - Fix regression that caused excess queries

### DIFF
--- a/projects/plugins/crm/ZeroBSCRM.php
+++ b/projects/plugins/crm/ZeroBSCRM.php
@@ -302,6 +302,7 @@ function zeroBSCRM_init_perfTest() {
  * @return void
  */
 function jpcrm_plugin_activate() {
+	add_option( 'jpcrm_do_install', true );
 	// Skip redirect if it's a bulk activation with more than one plugin.
 	if (
 		// phpcs:disable WordPress.Security.NonceVerification.Recommended,WordPress.Security.NonceVerification.Missing -- This is safe.

--- a/projects/plugins/crm/changelog/fix-crm-query_regression
+++ b/projects/plugins/crm/changelog/fix-crm-query_regression
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Prevent regression that caused excess queries.

--- a/projects/plugins/crm/includes/ZeroBSCRM.Core.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Core.php
@@ -573,8 +573,11 @@ final class ZeroBSCRM {
 			// urls, slugs, (post inc.)
 			$this->setupUrlsSlugsEtc();
 
-			// Install stuff
-			$this->install();
+			// Set up database, perms, etc.
+			if ( get_option( 'jpcrm_do_install' ) ) {
+				$this->install();
+				delete_option( 'jpcrm_do_install' );
+			}
 
 			// } Initialisation
 			$this->init_hooks();

--- a/projects/plugins/crm/tests/php/bootstrap.php
+++ b/projects/plugins/crm/tests/php/bootstrap.php
@@ -81,15 +81,6 @@ require $test_root . '/includes/functions.php';
 function _jpcrm_manually_load_plugin() {
 	// Load the main plugin file
 	require_once JETPACK_CRM_TESTS_ROOT . '/../../ZeroBSCRM.php';
-
-	// For tests, we need to manually initialize the plugin
-	global $zbs;
-	$zbs = zeroBSCRM::instance();
-
-	$zbs->install();
-	if ( function_exists( 'zeroBSCRM_notifyme_createDBtable' ) ) {
-		zeroBSCRM_notifyme_createDBtable();
-	}
 }
 
 tests_add_filter( 'muplugins_loaded', '_jpcrm_manually_load_plugin' );

--- a/projects/plugins/crm/tests/php/bootstrap.php
+++ b/projects/plugins/crm/tests/php/bootstrap.php
@@ -81,6 +81,13 @@ require $test_root . '/includes/functions.php';
 function _jpcrm_manually_load_plugin() {
 	// Load the main plugin file
 	require_once JETPACK_CRM_TESTS_ROOT . '/../../ZeroBSCRM.php';
+
+	// For tests, we need to manually initialize the plugin
+	global $zbs;
+	$zbs = zeroBSCRM::instance();
+
+	$zbs->install();
+	zeroBSCRM_notifyme_createDBtable();
 }
 
 tests_add_filter( 'muplugins_loaded', '_jpcrm_manually_load_plugin' );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Resolves #44256 - Fix regression that caused excess queries

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
In #44109, the load order was shuffled and the install routine that was previously run on plugin activation was moved into the main ZeroBSCRM class constructor.

As a result, the install routine ran every time the class was initialized (e.g. every pageload, and probably more).

As a mitigation, this PR adds a `jpcrm_do_install` option on activation, and checks for that option prior to running the install routine and deleting it.

Ideally load orders would be better decoupled, but I believe this should resolve the issue in the meantime.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

