### PR TITLE
Forms: fix integrations panel max width

### DIFF
--- a/projects/packages/forms/changelog/update-forms-integrations-max-width
+++ b/projects/packages/forms/changelog/update-forms-integrations-max-width
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: set max width for integrations panel

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/style.scss
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/style.scss
@@ -9,6 +9,7 @@
 		align-items: center;
 		justify-content: space-between;
 		width: 100%;
+		gap: 16px;
 
 		@media (max-width: 782px) {
 			flex-direction: column;

--- a/projects/packages/forms/src/dashboard/integrations/style.scss
+++ b/projects/packages/forms/src/dashboard/integrations/style.scss
@@ -12,7 +12,8 @@
 		display: flex;
 		flex-direction: column;
 		gap: 8px;
-		margin-bottom: 24px;
+		margin: 0 auto 24px auto;
+		max-width: 620px;
 
 		.jp-forms__integrations-header-heading {
 			color: colors.$gray-900;

--- a/projects/packages/forms/src/dashboard/integrations/style.scss
+++ b/projects/packages/forms/src/dashboard/integrations/style.scss
@@ -2,18 +2,15 @@
 @use "@wordpress/base-styles/variables";
 
 .jp-forms__integrations {
-	padding: 32px 16.6%;
-
-	@media ( max-width: 782px ) {
-		padding: 32px 8px;
-	}
+	padding: 32px 8px;
+	margin: 0 auto 24px auto;
+	max-width: 680px;
 
 	.jp-forms__integrations-header {
 		display: flex;
 		flex-direction: column;
 		gap: 8px;
-		margin: 0 auto 24px auto;
-		max-width: 620px;
+		margin-bottom: 24px;
 
 		.jp-forms__integrations-header-heading {
 			color: colors.$gray-900;

--- a/projects/packages/forms/src/dashboard/integrations/style.scss
+++ b/projects/packages/forms/src/dashboard/integrations/style.scss
@@ -4,7 +4,7 @@
 .jp-forms__integrations {
 	padding: 32px 8px;
 	margin: 0 auto 24px auto;
-	max-width: 680px;
+	max-width: 720px;
 
 	.jp-forms__integrations-header {
 		display: flex;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes integrations panel becoming too wide, spreading description and actions quite far apart.

I set width to max 620px but could be anything else.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

Before

<img width="1402" alt="image" src="https://github.com/user-attachments/assets/2e229097-a148-4620-98ab-8e8de2ea6fce" />


After
<img width="1402" alt="image" src="https://github.com/user-attachments/assets/8b25ea5b-9752-4950-b87f-e33bb4ede613" />


(Buttons are pink becaus screenshots are from Atomic site)

Aside, we should review+improve mobile width of this screen:

<img width="469" alt="image" src="https://github.com/user-attachments/assets/11cae174-302a-45d7-99ef-92f8620e3e27" />



### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

