### PR TITLE
CRM: Improve/crm install routine and load order

### DIFF
--- a/projects/plugins/crm/ZeroBSCRM.php
+++ b/projects/plugins/crm/ZeroBSCRM.php
@@ -302,6 +302,12 @@ function zeroBSCRM_init_perfTest() {
  * @return void
  */
 function jpcrm_plugin_activate() {
+
+	// run the install functions.
+	include_once __DIR__ . '/includes/ZeroBSCRM.Core.php';
+	$zbs = ZeroBSCRM::instance();
+	$zbs->install();
+
 	// Skip redirect if it's a bulk activation with more than one plugin.
 	if (
 		// phpcs:disable WordPress.Security.NonceVerification.Recommended,WordPress.Security.NonceVerification.Missing -- This is safe.

--- a/projects/plugins/crm/changelog/improve-crm-install-routine-and-load-order
+++ b/projects/plugins/crm/changelog/improve-crm-install-routine-and-load-order
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+install functions running every pageload.

--- a/projects/plugins/crm/includes/ZeroBSCRM.Core.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Core.php
@@ -573,9 +573,6 @@ final class ZeroBSCRM {
 			// urls, slugs, (post inc.)
 			$this->setupUrlsSlugsEtc();
 
-			// Install stuff
-			$this->install();
-
 			// } Initialisation
 			$this->init_hooks();
 


### PR DESCRIPTION
This is a patch to fix the consistent removal and re-creation of CRM user roles via zeroBSCRM_clearUserRoles(); and then zeroBSCRM_addUserRoles(); due to the install function firing in the class construct on `init` 

## Testing instructions
In trunk you'll notice lots of duplicate queries caused by repeated role creation and destruction.

In this branch, they'll only fire on the install hook. 

Further changes will be made to make the two role functions more efficient (returning early if a CRM role already exists) and only clearing them on CRM uninsitall. 

## Does this pull request change what data or activity we track or use?

No