### PR TITLE
CRM: Moves clearing of roles to uninstall hook and returns early if a CRM role is found during role creation

### DIFF
--- a/projects/plugins/crm/ZeroBSCRM.php
+++ b/projects/plugins/crm/ZeroBSCRM.php
@@ -353,8 +353,13 @@ add_action( 'admin_init', 'jpcrm_plugin_redirect' );
 
 /**  Uninstall function to clear the roles. **/
 function jpcrm_uninstall() {
-	include_once __DIR__ . '/includes/ZeroBSCRM.Permissions.php';
-	zeroBSCRM_clearUserRoles();
+	remove_role( 'zerobs_admin' );
+	remove_role( 'zerobs_customermgr' );
+	remove_role( 'zerobs_quotemgr' );
+	remove_role( 'zerobs_invoicemgr' );
+	remove_role( 'zerobs_transactionmgr' );
+	remove_role( 'zerobs_customer' );
+	remove_role( 'zerobs_mailmgr' );
 }
 register_uninstall_hook( __FILE__, 'jpcrm_uninstall' );
 

--- a/projects/plugins/crm/ZeroBSCRM.php
+++ b/projects/plugins/crm/ZeroBSCRM.php
@@ -353,6 +353,7 @@ add_action( 'admin_init', 'jpcrm_plugin_redirect' );
 
 /**  Uninstall function to clear the roles. **/
 function jpcrm_uninstall() {
+	include_once __DIR__ . '/includes/ZeroBSCRM.Permissions.php';
 	zeroBSCRM_clearUserRoles();
 }
 register_uninstall_hook( __FILE__, 'jpcrm_uninstall' );

--- a/projects/plugins/crm/ZeroBSCRM.php
+++ b/projects/plugins/crm/ZeroBSCRM.php
@@ -351,6 +351,12 @@ function jpcrm_plugin_redirect() {
 }
 add_action( 'admin_init', 'jpcrm_plugin_redirect' );
 
+/**  Uninstall function to clear the roles. **/
+function jpcrm_uninstall() {
+	zeroBSCRM_clearUserRoles();
+}
+register_uninstall_hook( __FILE__, 'jpcrm_uninstall' );
+
 // =================== / General Perf Testing =========================
 // ====================================================================
 

--- a/projects/plugins/crm/changelog/improve-crm-user-roles
+++ b/projects/plugins/crm/changelog/improve-crm-user-roles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+moved removal of roles to the uninstall hook

--- a/projects/plugins/crm/includes/ZeroBSCRM.Core.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Core.php
@@ -2073,10 +2073,6 @@ final class ZeroBSCRM {
 
 		// Additional DB tables hook on activation (such as api keys table) - requires ZeroBSCRM.Database.php
 		zeroBSCRM_database_check();
-
-		// roles
-		zeroBSCRM_clearUserRoles();
-
 		// roles +
 		zeroBSCRM_addUserRoles();
 	}

--- a/projects/plugins/crm/includes/ZeroBSCRM.Permissions.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Permissions.php
@@ -29,7 +29,12 @@ function zeroBSCRM_clearUserRoles() { // phpcs:ignore WordPress.NamingConvention
 /**
  * Build User Roles
  */
-function zeroBSCRM_addUserRoles() { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.FunctionNameInvalid
+function zeroBSCRM_addUserRoles() {
+
+	// return early if a CRM role exists
+	if ( get_role( 'zerobs_admin' ) ) {
+		return;
+	}
 
 	// Jetpack CRM Admin
 	add_role(


### PR DESCRIPTION

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Returns early if a CRM user role is found
* Moves the removal of CRM roles to the uninstall hook

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion


## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
- This change should only destroy CRM user roles when the plugin is deleted, not each time it is activated. In addition the creation of roles will return early if a role is found. 

In a future enhancement, we should consider delaying the creation of additional CRM roles until the CRM operate decides they need them.

