### PR TITLE
fix: Reinstate Jetpack assets to editor assets endpoint

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-block-editor-assets.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-block-editor-assets.php
@@ -312,7 +312,8 @@ class WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets extends WP_REST_Controller 
 			$src[0] === '/' ||
 			strpos( $src, 'wp-includes/' ) !== false ||
 			strpos( $src, 'wp-admin/' ) !== false ||
-			strpos( $src, 'plugins/gutenberg/' ) !== false;
+			strpos( $src, 'plugins/gutenberg/' ) !== false ||
+			strpos( $src, 'plugins/gutenberg-core/' ) !== false; // WPCOM-specific path
 	}
 
 	/**

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-block-editor-assets.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-block-editor-assets.php
@@ -20,10 +20,10 @@ class WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets extends WP_REST_Controller 
 	 * @var array
 	 */
 	const ALLOWED_PLUGIN_HANDLE_PREFIXES = array(
-		'wp-',
-		'jetpack-',
-		'jp-',
-		'videopress-',
+		'jetpack-', // E.g., jetpack-blocks-editor, jetpack-connection
+		'jp-', // E.g., jp-forms-blocks
+		'videopress-', // E.g., videopress-add-resumable-upload-support
+		'wp-', // E.g., wp-block-styles, wp-jp-i18n-loader
 	);
 
 	/**

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-block-editor-assets.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-block-editor-assets.php
@@ -14,18 +14,16 @@ class WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets extends WP_REST_Controller 
 	const CACHE_BUSTER = '2025-02-28';
 
 	/**
-	 * List of allowed plugins whose assets should be preserved.
-	 * Each entry should be a unique identifier that appears in the asset URL.
+	 * List of allowed plugin handle prefixes whose assets should be preserved.
+	 * Each entry should be a handle prefix that identifies assets from allowed plugins.
 	 *
 	 * @var array
 	 */
-	const ALLOWED_PLUGINS = array(
-		'/plugins/gutenberg/', // Default plugin location
-		'/plugins/gutenberg-core/', // WPCOM Simple site location
-		'/plugins/jetpack/', // Default plugin location
-		'/plugins/jetpack-dev/', // Used for loading in-progress work
-		'/mu-plugins/jetpack-mu-wpcom-plugin/', // WPCOM Simple site location
-		'/mu-plugins/wpcomsh/', // WoA helpers, including Jetpack assets in vendor directories
+	const ALLOWED_PLUGIN_HANDLE_PREFIXES = array(
+		'wp-',
+		'jetpack-',
+		'jp-',
+		'videopress-',
 	);
 
 	/**
@@ -277,11 +275,11 @@ class WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets extends WP_REST_Controller 
 		// Unregister disallowed plugin scripts
 		foreach ( $wp_scripts->registered as $handle => $script ) {
 			// Skip core scripts and protected handles
-			if ( $this->is_core_asset( $script->src ) || $this->is_protected_handle( $handle ) ) {
+			if ( $this->is_core_or_gutenberg_asset( $script->src ) || $this->is_protected_handle( $handle ) ) {
 				continue;
 			}
 
-			if ( ! $this->is_allowed_plugin_asset( $script->src ) ) {
+			if ( ! $this->is_allowed_plugin_handle( $handle ) ) {
 				unset( $wp_scripts->registered[ $handle ] );
 			}
 		}
@@ -289,23 +287,23 @@ class WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets extends WP_REST_Controller 
 		// Unregister disallowed plugin styles
 		foreach ( $wp_styles->registered as $handle => $style ) {
 			// Skip core styles and protected handles
-			if ( $this->is_core_asset( $style->src ) || $this->is_protected_handle( $handle ) ) {
+			if ( $this->is_core_or_gutenberg_asset( $style->src ) || $this->is_protected_handle( $handle ) ) {
 				continue;
 			}
 
-			if ( ! $this->is_allowed_plugin_asset( $style->src ) ) {
+			if ( ! $this->is_allowed_plugin_handle( $handle ) ) {
 				unset( $wp_styles->registered[ $handle ] );
 			}
 		}
 	}
 
 	/**
-	 * Check if an asset is a core asset.
+	 * Check if an asset is a core or Gutenberg asset.
 	 *
 	 * @param string $src The asset source URL.
-	 * @return bool True if the asset is a core asset, false otherwise.
+	 * @return bool True if the asset is a core or Gutenberg asset, false otherwise.
 	 */
-	private function is_core_asset( $src ) {
+	private function is_core_or_gutenberg_asset( $src ) {
 		if ( ! is_string( $src ) ) {
 			return false;
 		}
@@ -313,7 +311,8 @@ class WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets extends WP_REST_Controller 
 		return empty( $src ) ||
 			$src[0] === '/' ||
 			strpos( $src, 'wp-includes/' ) !== false ||
-			strpos( $src, 'wp-admin/' ) !== false;
+			strpos( $src, 'wp-admin/' ) !== false ||
+			strpos( $src, 'plugins/gutenberg/' ) !== false;
 	}
 
 	/**
@@ -327,18 +326,18 @@ class WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets extends WP_REST_Controller 
 	}
 
 	/**
-	 * Check if an asset is from an allowed plugin.
+	 * Check if a handle is from an allowed plugin.
 	 *
-	 * @param string $src The asset source URL.
-	 * @return bool True if the asset is from an allowed plugin, false otherwise.
+	 * @param string $handle The asset handle.
+	 * @return bool True if the handle is from an allowed plugin, false otherwise.
 	 */
-	private function is_allowed_plugin_asset( $src ) {
-		if ( ! is_string( $src ) || empty( $src ) ) {
+	private function is_allowed_plugin_handle( $handle ) {
+		if ( ! is_string( $handle ) || empty( $handle ) ) {
 			return false;
 		}
 
-		foreach ( self::ALLOWED_PLUGINS as $allowed_plugin ) {
-			if ( strpos( $src, $allowed_plugin ) !== false ) {
+		foreach ( self::ALLOWED_PLUGIN_HANDLE_PREFIXES as $allowed_prefix ) {
+			if ( strpos( $handle, $allowed_prefix ) === 0 ) {
 				return true;
 			}
 		}

--- a/projects/plugins/jetpack/changelog/fix-reinstate-jetpack-assets-to-editor-assets-endpoint
+++ b/projects/plugins/jetpack/changelog/fix-reinstate-jetpack-assets-to-editor-assets-endpoint
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Editor assets endpoint: reinstate missing Jetpack assets via handle-based exclusion logic

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test.php
@@ -53,12 +53,16 @@ class WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test extends Jetpack_REST_T
 		wp_register_style( 'jetpack-mock-style', 'http://example.org/mock-editor.css', array(), '1.0' );
 		wp_register_script( 'disallowed-plugin-script', 'http://example.org/script.js', array(), '1.0', true );
 		wp_register_style( 'disallowed-plugin-style', 'http://example.org/style.css', array(), '1.0' );
+		wp_register_script( 'wpcom-gutenberg-script', 'http://example.org/plugins/gutenberg-core/script.js', array(), '1.0', true );
+		wp_register_style( 'wpcom-gutenberg-style', 'http://example.org/plugins/gutenberg-core/style.css', array(), '1.0' );
 
 		// Enqueue our mock assets
 		wp_enqueue_script( 'jetpack-mock-script' );
 		wp_enqueue_style( 'jetpack-mock-style' );
 		wp_enqueue_script( 'disallowed-plugin-script' );
 		wp_enqueue_style( 'disallowed-plugin-style' );
+		wp_enqueue_script( 'wpcom-gutenberg-script' );
+		wp_enqueue_style( 'wpcom-gutenberg-style' );
 	}
 
 	/**
@@ -287,5 +291,22 @@ class WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test extends Jetpack_REST_T
 		// Cleanup.
 		unregister_post_type( 'custom_type' );
 		remove_role( 'custom_editor' );
+	}
+
+	/**
+	 * Test that WPCOM-specific Gutenberg assets are preserved.
+	 */
+	public function test_wpcom_gutenberg_assets_are_preserved() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
+
+		$request  = new WP_REST_Request( Requests::GET, '/wpcom/v2/editor-assets' );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		// Verify the WPCOM Gutenberg assets are preserved in the output
+		$this->assertStringContainsString( 'wpcom-gutenberg-script', $data['scripts'] );
+		$this->assertStringContainsString( 'wpcom-gutenberg-style', $data['styles'] );
+		$this->assertStringContainsString( 'plugins/gutenberg-core/script.js', $data['scripts'] );
+		$this->assertStringContainsString( 'plugins/gutenberg-core/style.css', $data['styles'] );
 	}
 }

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test.php
@@ -245,7 +245,7 @@ class WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test extends Jetpack_REST_T
 	/**
 	 * Enqueue assets using WPCOM's specific Gutenberg paths.
 	 */
-	public static function mock_wpcom_gutenberg_assets() {
+	public function mock_wpcom_gutenberg_assets() {
 		wp_register_script( 'wpcom-gutenberg-script', 'http://example.org/plugins/gutenberg-core/script.js', array(), '1.0', true );
 		wp_register_style( 'wpcom-gutenberg-style', 'http://example.org/plugins/gutenberg-core/style.css', array(), '1.0' );
 

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test.php
@@ -29,40 +29,9 @@ class WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test extends Jetpack_REST_T
 		parent::set_up();
 		$this->instance = new WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets();
 
-		// Mock the enqueue_block_editor_assets action to prevent loading non-existent files
+		// Remove existing actions to prevent failed loading of files that may or
+		// may not exist depending on the build output.
 		remove_all_actions( 'enqueue_block_editor_assets' );
-		add_action( 'enqueue_block_editor_assets', array( $this, 'mock_block_editor_assets' ) );
-	}
-
-	/**
-	 * Clean up after each test.
-	 */
-	public function tear_down() {
-		// Remove our mock action
-		remove_action( 'enqueue_block_editor_assets', array( $this, 'mock_block_editor_assets' ) );
-		parent::tear_down();
-	}
-
-	/**
-	 * Mock function for block editor assets.
-	 * This provides minimal required assets without loading actual files.
-	 */
-	public function mock_block_editor_assets() {
-		// Register minimal mock assets that don't require actual files
-		wp_register_script( 'jetpack-mock-script', 'http://example.org/mock-editor.js', array(), '1.0', true );
-		wp_register_style( 'jetpack-mock-style', 'http://example.org/mock-editor.css', array(), '1.0' );
-		wp_register_script( 'disallowed-plugin-script', 'http://example.org/script.js', array(), '1.0', true );
-		wp_register_style( 'disallowed-plugin-style', 'http://example.org/style.css', array(), '1.0' );
-		wp_register_script( 'wpcom-gutenberg-script', 'http://example.org/plugins/gutenberg-core/script.js', array(), '1.0', true );
-		wp_register_style( 'wpcom-gutenberg-style', 'http://example.org/plugins/gutenberg-core/style.css', array(), '1.0' );
-
-		// Enqueue our mock assets
-		wp_enqueue_script( 'jetpack-mock-script' );
-		wp_enqueue_style( 'jetpack-mock-style' );
-		wp_enqueue_script( 'disallowed-plugin-script' );
-		wp_enqueue_style( 'disallowed-plugin-style' );
-		wp_enqueue_script( 'wpcom-gutenberg-script' );
-		wp_enqueue_style( 'wpcom-gutenberg-style' );
 	}
 
 	/**
@@ -182,6 +151,8 @@ class WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test extends Jetpack_REST_T
 	public function test_get_items_returns_allowed_plugin_assets() {
 		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
 
+		add_action( 'enqueue_block_editor_assets', array( $this, 'mock_allowed_plugin_assets' ) );
+
 		$request  = new WP_REST_Request( Requests::GET, '/wpcom/v2/editor-assets' );
 		$response = $this->server->dispatch( $request );
 		$data     = $response->get_data();
@@ -189,6 +160,21 @@ class WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test extends Jetpack_REST_T
 		// Verify the allowed plugin script and style are in the output
 		$this->assertStringContainsString( 'jetpack-mock-script', $data['scripts'] );
 		$this->assertStringContainsString( 'jetpack-mock-style', $data['styles'] );
+
+		remove_action( 'enqueue_block_editor_assets', array( $this, 'mock_allowed_plugin_assets' ) );
+	}
+
+	/**
+	 * Enqueue allowed plugin assets.
+	 */
+	public function mock_allowed_plugin_assets() {
+		// Register minimal mock assets that don't require actual files
+		wp_register_script( 'jetpack-mock-script', 'http://example.org/mock-editor.js', array(), '1.0', true );
+		wp_register_style( 'jetpack-mock-style', 'http://example.org/mock-editor.css', array(), '1.0' );
+
+		// Enqueue our mock assets
+		wp_enqueue_script( 'jetpack-mock-script' );
+		wp_enqueue_style( 'jetpack-mock-style' );
 	}
 
 	/**
@@ -197,6 +183,8 @@ class WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test extends Jetpack_REST_T
 	public function test_disallowed_plugin_assets_are_filtered() {
 		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
 
+		add_action( 'enqueue_block_editor_assets', array( $this, 'mock_disallowed_plugin_assets' ) );
+
 		$request  = new WP_REST_Request( Requests::GET, '/wpcom/v2/editor-assets' );
 		$response = $this->server->dispatch( $request );
 		$data     = $response->get_data();
@@ -204,6 +192,19 @@ class WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test extends Jetpack_REST_T
 		// Verify the disallowed plugin script and style are not in the output
 		$this->assertStringNotContainsString( 'disallowed-plugin-script', $data['scripts'] );
 		$this->assertStringNotContainsString( 'disallowed-plugin-style', $data['styles'] );
+
+		remove_action( 'enqueue_block_editor_assets', array( $this, 'mock_disallowed_plugin_assets' ) );
+	}
+
+	/**
+	 * Enqueue disallowed plugin assets.
+	 */
+	public function mock_disallowed_plugin_assets() {
+		wp_register_script( 'disallowed-plugin-script', 'http://example.org/script.js', array(), '1.0', true );
+		wp_register_style( 'disallowed-plugin-style', 'http://example.org/style.css', array(), '1.0' );
+
+		wp_enqueue_script( 'disallowed-plugin-script' );
+		wp_enqueue_style( 'disallowed-plugin-style' );
 	}
 
 	/**
@@ -218,6 +219,38 @@ class WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test extends Jetpack_REST_T
 
 		// Verify jQuery is in the output
 		$this->assertStringContainsString( 'jquery', $data['scripts'] );
+	}
+
+	/**
+	 * Test that WPCOM-specific Gutenberg assets are preserved.
+	 */
+	public function test_wpcom_gutenberg_assets_are_preserved() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
+
+		add_action( 'enqueue_block_editor_assets', array( $this, 'mock_wpcom_gutenberg_assets' ) );
+
+		$request  = new WP_REST_Request( Requests::GET, '/wpcom/v2/editor-assets' );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		// Verify the WPCOM Gutenberg assets are preserved in the output
+		$this->assertStringContainsString( 'wpcom-gutenberg-script', $data['scripts'] );
+		$this->assertStringContainsString( 'wpcom-gutenberg-style', $data['styles'] );
+		$this->assertStringContainsString( 'plugins/gutenberg-core/script.js', $data['scripts'] );
+		$this->assertStringContainsString( 'plugins/gutenberg-core/style.css', $data['styles'] );
+
+		remove_action( 'enqueue_block_editor_assets', array( $this, 'mock_wpcom_gutenberg_assets' ) );
+	}
+
+	/**
+	 * Enqueue assets using WPCOM's specific Gutenberg paths.
+	 */
+	public static function mock_wpcom_gutenberg_assets() {
+		wp_register_script( 'wpcom-gutenberg-script', 'http://example.org/plugins/gutenberg-core/script.js', array(), '1.0', true );
+		wp_register_style( 'wpcom-gutenberg-style', 'http://example.org/plugins/gutenberg-core/style.css', array(), '1.0' );
+
+		wp_enqueue_script( 'wpcom-gutenberg-script' );
+		wp_enqueue_style( 'wpcom-gutenberg-style' );
 	}
 
 	/**
@@ -291,22 +324,5 @@ class WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test extends Jetpack_REST_T
 		// Cleanup.
 		unregister_post_type( 'custom_type' );
 		remove_role( 'custom_editor' );
-	}
-
-	/**
-	 * Test that WPCOM-specific Gutenberg assets are preserved.
-	 */
-	public function test_wpcom_gutenberg_assets_are_preserved() {
-		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
-
-		$request  = new WP_REST_Request( Requests::GET, '/wpcom/v2/editor-assets' );
-		$response = $this->server->dispatch( $request );
-		$data     = $response->get_data();
-
-		// Verify the WPCOM Gutenberg assets are preserved in the output
-		$this->assertStringContainsString( 'wpcom-gutenberg-script', $data['scripts'] );
-		$this->assertStringContainsString( 'wpcom-gutenberg-style', $data['styles'] );
-		$this->assertStringContainsString( 'plugins/gutenberg-core/script.js', $data['scripts'] );
-		$this->assertStringContainsString( 'plugins/gutenberg-core/style.css', $data['styles'] );
 	}
 }

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test.php
@@ -49,14 +49,14 @@ class WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test extends Jetpack_REST_T
 	 */
 	public function mock_block_editor_assets() {
 		// Register minimal mock assets that don't require actual files
-		wp_register_script( 'mock-editor-script', 'http://example.org/plugins/jetpack/mock-editor.js', array(), '1.0', true );
-		wp_register_style( 'mock-editor-style', 'http://example.org/plugins/jetpack/mock-editor.css', array(), '1.0' );
-		wp_register_script( 'disallowed-plugin-script', 'http://example.org/plugins/disallowed-plugin/script.js', array(), '1.0', true );
-		wp_register_script( 'disallowed-plugin-style', 'http://example.org/plugins/disallowed-plugin/style.css', array(), '1.0', true );
+		wp_register_script( 'jetpack-mock-script', 'http://example.org/mock-editor.js', array(), '1.0', true );
+		wp_register_style( 'jetpack-mock-style', 'http://example.org/mock-editor.css', array(), '1.0' );
+		wp_register_script( 'disallowed-plugin-script', 'http://example.org/script.js', array(), '1.0', true );
+		wp_register_style( 'disallowed-plugin-style', 'http://example.org/style.css', array(), '1.0' );
 
 		// Enqueue our mock assets
-		wp_enqueue_script( 'mock-editor-script' );
-		wp_enqueue_style( 'mock-editor-style' );
+		wp_enqueue_script( 'jetpack-mock-script' );
+		wp_enqueue_style( 'jetpack-mock-style' );
 		wp_enqueue_script( 'disallowed-plugin-script' );
 		wp_enqueue_style( 'disallowed-plugin-style' );
 	}
@@ -183,8 +183,8 @@ class WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test extends Jetpack_REST_T
 		$data     = $response->get_data();
 
 		// Verify the allowed plugin script and style are in the output
-		$this->assertStringContainsString( 'mock-editor-script', $data['scripts'] );
-		$this->assertStringContainsString( 'mock-editor-style', $data['styles'] );
+		$this->assertStringContainsString( 'jetpack-mock-script', $data['scripts'] );
+		$this->assertStringContainsString( 'jetpack-mock-style', $data['styles'] );
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

https://github.com/Automattic/jetpack/pull/44093 fixed de-registering of assets not present on the allow list. However, it was overlooked that certain Jetpack assets were then erroneously excluded.

Namely, the `jetpack-blocks-editor` assets were excluded as their `jetpack-blocks-assets-base-url` dependency was also excluded. The latter was excluded as it is an "inline" script without a `src` attribute. The lack of a `src` meant the path-based exclusion erroneously de-registered the script.

Using a handle-based exclusion means that both inline and external scripts are correct assessed by the plugin filtering logic.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Replace asset path-based exclusion logic with asset handle-based exclusion logic. 

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
0b1591ec5132-linear-project

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Create a WPCOM site. 
1. Apply these Jetpack changes to your site (see [comment](https://github.com/Automattic/jetpack/pull/44274#issuecomment-3058182547)).  
1. Make a request to the `/wpcom/v2/sites/<site_id>/editor-assets` endpoint for the WPCOM site—via [API Console](https://developer.wordpress.com/docs/api/console/), `curl`, etc. 
1. Verify the 200 response contains the `jetpack-blocks-editor-js` script.