### PR TITLE
Jetpack Debug: fix JS and CSS in Broken Token tool

### DIFF
--- a/projects/plugins/debug-helper/changelog/fix-broken-token-js
+++ b/projects/plugins/debug-helper/changelog/fix-broken-token-js
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix JS in Broken Token tool.

--- a/projects/plugins/debug-helper/modules/class-wpcom-api-request-tracker-module.php
+++ b/projects/plugins/debug-helper/modules/class-wpcom-api-request-tracker-module.php
@@ -41,8 +41,8 @@ class WPCOM_API_Request_Tracker_Module {
 	 * Enqueue scripts.
 	 */
 	public function enqueue_scripts() {
-		wp_enqueue_style( 'broken_token_style', plugin_dir_url( __FILE__ ) . 'inc/css/wpcom-api-request-tracker.css', array(), JETPACK_DEBUG_HELPER_VERSION );
-		wp_enqueue_script( 'broken_token_script', plugin_dir_url( __FILE__ ) . 'inc/js/wpcom-api-request-tracker.js', array( 'jquery' ), JETPACK_DEBUG_HELPER_VERSION, true );
+		wp_enqueue_style( 'broken_token_request_tracker_style', plugin_dir_url( __FILE__ ) . 'inc/css/wpcom-api-request-tracker.css', array(), JETPACK_DEBUG_HELPER_VERSION );
+		wp_enqueue_script( 'broken_token_request_tracker_script', plugin_dir_url( __FILE__ ) . 'inc/js/wpcom-api-request-tracker.js', array( 'jquery' ), JETPACK_DEBUG_HELPER_VERSION, true );
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes:
When "WPCOM API Request Tracker" is enabled, its JS and CSS files overwrite Broken Token ones, so the latter do not load.
That results in JS-based functionality not working on the Broken Token page.

This PR fixes the issue by providing API Request Tracker with its own handles for JS and CSS files.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
1. Enable Jetpack Debug plugin.
2. Activate "Broken token Utilities" and "WPCOM API Request Tracker".
3. Go to "Jetpack Debug -> Broken Token", confirm the "Break some stuff:" buttons are red.
4. Click "Set custom blog token", confirm the input fields show up.