### PR TITLE
Boost: Exclude builder plugins' post types from Critical CSS

### DIFF
--- a/projects/plugins/boost/changelog/update-boost-compatibility-ignore-builder-post-types-HOG-184
+++ b/projects/plugins/boost/changelog/update-boost-compatibility-ignore-builder-post-types-HOG-184
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Critical CSS: Exclude post types of popular builder plugins from generation.

--- a/projects/plugins/boost/compatibility/beaver-builder.php
+++ b/projects/plugins/boost/compatibility/beaver-builder.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Compatibility for Beaver Builder (both lite and Pro versions).
+ *
+ * @package automattic/jetpack-boost
+ */
+
+namespace Automattic\Jetpack_Boost\Compatibility\Beaver_Builder;
+
+/**
+ * Exclude Beaver Builder custom post types from list of posts to generate critical CSS for.
+ *
+ * @param array $post_types Post types.
+ */
+function exclude_beaver_builder_custom_post_types( $post_types ) {
+	unset( $post_types['fl-builder-template'] );
+	unset( $post_types['fl-theme-layout'] );
+
+	return $post_types;
+}
+
+add_filter( 'jetpack_boost_critical_css_post_types_singular', __NAMESPACE__ . '\exclude_beaver_builder_custom_post_types' );
+add_filter( 'jetpack_boost_critical_css_post_types_archives', __NAMESPACE__ . '\exclude_beaver_builder_custom_post_types' );

--- a/projects/plugins/boost/compatibility/breakdance.php
+++ b/projects/plugins/boost/compatibility/breakdance.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Compatibility for Breakdance
+ *
+ * @package automattic/jetpack-boost
+ */
+
+namespace Automattic\Jetpack_Boost\Compatibility\Breakdance;
+
+/**
+ * Exclude Breakdance custom post types from list of posts to generate critical CSS for.
+ *
+ * @param array $post_types Post types.
+ */
+function exclude_breakdance_custom_post_types( $post_types ) {
+	if ( defined( 'BREAKDANCE_ALL_EDITABLE_POST_TYPES' ) ) {
+		foreach ( BREAKDANCE_ALL_EDITABLE_POST_TYPES as $post_type ) {
+			unset( $post_types[ $post_type ] );
+		}
+	}
+
+	return $post_types;
+}
+
+add_filter( 'jetpack_boost_critical_css_post_types_singular', __NAMESPACE__ . '\exclude_breakdance_custom_post_types' );
+add_filter( 'jetpack_boost_critical_css_post_types_archives', __NAMESPACE__ . '\exclude_breakdance_custom_post_types' );

--- a/projects/plugins/boost/compatibility/elementor.php
+++ b/projects/plugins/boost/compatibility/elementor.php
@@ -22,6 +22,10 @@ function exclude_elementor_library_custom_post_type( $post_types ) {
 		unset( $post_types[ \Elementor\Modules\LandingPages\Module::CPT ] );
 	}
 
+	if ( defined( '\Elementor\Modules\FloatingButtons\Module::CPT_FLOATING_BUTTONS' ) ) {
+		unset( $post_types[ \Elementor\Modules\FloatingButtons\Module::CPT_FLOATING_BUTTONS ] );
+	}
+
 	if ( isset( $post_types['elementor-hf'] ) ) {
 		unset( $post_types['elementor-hf'] );
 	}

--- a/projects/plugins/boost/jetpack-boost.php
+++ b/projects/plugins/boost/jetpack-boost.php
@@ -246,6 +246,11 @@ function include_compatibility_files() {
 		require_once __DIR__ . '/compatibility/beaver-builder.php';
 	}
 
+	// Exclude Breakdance custom post types.
+	if ( defined( 'BREAKDANCE_ALL_EDITABLE_POST_TYPES' ) ) {
+		require_once __DIR__ . '/compatibility/breakdance.php';
+	}
+
 	// Exclude known scripts that causes problem when concatenated.
 	require_once __DIR__ . '/compatibility/js-concatenate.php';
 

--- a/projects/plugins/boost/jetpack-boost.php
+++ b/projects/plugins/boost/jetpack-boost.php
@@ -241,6 +241,11 @@ function include_compatibility_files() {
 		require_once __DIR__ . '/compatibility/aioseo.php';
 	}
 
+	// Exclude Beaver Builder custom post types.
+	if ( class_exists( 'FLBuilderLoader' ) ) {
+		require_once __DIR__ . '/compatibility/beaver-builder.php';
+	}
+
 	// Exclude known scripts that causes problem when concatenated.
 	require_once __DIR__ . '/compatibility/js-concatenate.php';
 

--- a/projects/plugins/boost/jetpack-boost.php
+++ b/projects/plugins/boost/jetpack-boost.php
@@ -221,7 +221,7 @@ function include_compatibility_files() {
 		require_once __DIR__ . '/compatibility/web-stories.php';
 	}
 
-	if ( defined( '\Elementor\TemplateLibrary\Source_Local::CPT' ) || defined( '\Elementor\Modules\LandingPages\Module::CPT' ) ) {
+	if ( defined( '\Elementor\TemplateLibrary\Source_Local::CPT' ) || defined( '\Elementor\Modules\LandingPages\Module::CPT' ) || defined( '\Elementor\Modules\FloatingButtons\Module::CPT_FLOATING_BUTTONS' ) ) {
 		require_once __DIR__ . '/compatibility/elementor.php';
 	}
 


### PR DESCRIPTION
Fixes HOG-184

This is a collection of post types that we've received complaints for. Some are registered correctly, but I added them anyway, to avoid having to patch Boost if down the line a plugin messes up their post type registration.

Divi Builder isn't in the list, as the custom post types it registers aren't available when Source Providers are collected.

I didn't outline testing instructions as most plugins are premium and the steps to make posts from their post types show in the source providers list are quite lengthy.

## Proposed changes:

* Exclude post types of popular builder plugins from Critical CSS generation:
  - Beaver Builder;
  - Breakdance;
  - Elementor (already present, just added another post type).

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
HOG-184

## Does this pull request change what data or activity we track or use?

no

## Testing instructions:

N/A