### PR TITLE
Connection: memoize connection owner's ID

### DIFF
--- a/projects/packages/connection/changelog/add-connection-owner-id-memoization
+++ b/projects/packages/connection/changelog/add-connection-owner-id-memoization
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add memoization for connection owner ID to prevent excessive database calls.

--- a/projects/packages/connection/src/class-manager.php
+++ b/projects/packages/connection/src/class-manager.php
@@ -1144,7 +1144,7 @@ class Manager {
 			\Jetpack_Options::update_option( 'master_user', $new_owner_id );
 
 			// Clear the memoized connection owner ID since it changed
-			self::$connection_owner_id = null;
+			static::$connection_owner_id = null;
 
 			// Track it.
 			( new Tracking() )->record_user_event( 'set_connection_owner_success' );

--- a/projects/packages/connection/src/class-manager.php
+++ b/projects/packages/connection/src/class-manager.php
@@ -676,8 +676,8 @@ class Manager {
 	 * @since 5.0.0
 	 */
 	public function reset_connection_status() {
-		self::$is_connected          = null;
-		static::$connection_owner_id = null;
+		self::$is_connected        = null;
+		self::$connection_owner_id = null;
 	}
 
 	/**
@@ -822,13 +822,13 @@ class Manager {
 	 */
 	public function get_connection_owner_id() {
 		// Check if the memoized value is available.
-		if ( null === static::$connection_owner_id ) {
-			$owner                       = $this->get_connection_owner();
-			static::$connection_owner_id = $owner instanceof \WP_User ? $owner->ID : 0;
+		if ( null === self::$connection_owner_id ) {
+			$owner                     = $this->get_connection_owner();
+			self::$connection_owner_id = $owner instanceof \WP_User ? $owner->ID : 0;
 		}
 
 		// If the ID is set to 0, there's no valid connection owner.
-		return static::$connection_owner_id > 0 ? static::$connection_owner_id : false;
+		return self::$connection_owner_id > 0 ? self::$connection_owner_id : false;
 	}
 
 	/**
@@ -1069,7 +1069,7 @@ class Manager {
 					Jetpack_Options::delete_option( 'master_user' );
 
 					// Clear the memoized connection owner ID since it changed
-					static::$connection_owner_id = null;
+					self::$connection_owner_id = null;
 				}
 			}
 		}
@@ -1144,7 +1144,7 @@ class Manager {
 			\Jetpack_Options::update_option( 'master_user', $new_owner_id );
 
 			// Clear the memoized connection owner ID since it changed
-			static::$connection_owner_id = null;
+			self::$connection_owner_id = null;
 
 			// Track it.
 			( new Tracking() )->record_user_event( 'set_connection_owner_success' );
@@ -1836,7 +1836,7 @@ class Manager {
 		);
 
 		// Clear the memoized connection owner ID since it changed
-		static::$connection_owner_id = null;
+		self::$connection_owner_id = null;
 
 		( new Secrets() )->delete_all();
 		$this->get_tokens()->delete_all();

--- a/projects/packages/connection/src/class-manager.php
+++ b/projects/packages/connection/src/class-manager.php
@@ -821,7 +821,7 @@ class Manager {
 	 * @return bool|int Returns the ID of the connection owner or False if no connection owner found.
 	 */
 	public function get_connection_owner_id() {
-		// Check if memoized value if available.
+		// Check if the memoized value is available.
 		if ( null === static::$connection_owner_id ) {
 			$owner                       = $this->get_connection_owner();
 			static::$connection_owner_id = $owner instanceof \WP_User ? $owner->ID : 0;

--- a/projects/packages/connection/src/class-manager.php
+++ b/projects/packages/connection/src/class-manager.php
@@ -88,6 +88,14 @@ class Manager {
 	private static $is_connected = null;
 
 	/**
+	 * Memoized user ID of the connection owner.
+	 * If undefined or invalid, set to 0.
+	 *
+	 * @var null|int
+	 */
+	private static $connection_owner_id = null;
+
+	/**
 	 * Tracks whether connection status invalidation hooks have been added.
 	 *
 	 * @var bool
@@ -198,6 +206,7 @@ class Manager {
 		add_action( 'pre_update_jetpack_option_blog_token', array( $this, 'reset_connection_status' ) );
 		add_action( 'pre_update_jetpack_option_user_token', array( $this, 'reset_connection_status' ) );
 		add_action( 'pre_update_jetpack_option_user_tokens', array( $this, 'reset_connection_status' ) );
+		add_action( 'pre_update_jetpack_option_master_user', array( $this, 'reset_connection_status' ) );
 		// phpcs:ignore WPCUT.SwitchBlog.SwitchBlog -- wpcom flags **every** use of switch_blog, apparently expecting valid instances to ignore or suppress the sniff.
 		add_action( 'switch_blog', array( $this, 'reset_connection_status' ) );
 
@@ -667,7 +676,8 @@ class Manager {
 	 * @since 5.0.0
 	 */
 	public function reset_connection_status() {
-		self::$is_connected = null;
+		self::$is_connected          = null;
+		static::$connection_owner_id = null;
 	}
 
 	/**
@@ -811,8 +821,14 @@ class Manager {
 	 * @return bool|int Returns the ID of the connection owner or False if no connection owner found.
 	 */
 	public function get_connection_owner_id() {
-		$owner = $this->get_connection_owner();
-		return $owner instanceof \WP_User ? $owner->ID : false;
+		// Check if memoized value if available.
+		if ( null === static::$connection_owner_id ) {
+			$owner                       = $this->get_connection_owner();
+			static::$connection_owner_id = $owner instanceof \WP_User ? $owner->ID : 0;
+		}
+
+		// If the ID is set to 0, there's no valid connection owner.
+		return static::$connection_owner_id > 0 ? static::$connection_owner_id : false;
 	}
 
 	/**
@@ -862,9 +878,7 @@ class Manager {
 	 * @return WP_User|false False if no connection owner found.
 	 */
 	public function get_connection_owner() {
-
 		$user_id = \Jetpack_Options::get_option( 'master_user' );
-
 		if ( ! $user_id ) {
 			return false;
 		}
@@ -1053,6 +1067,9 @@ class Manager {
 
 				if ( $is_primary_user ) {
 					Jetpack_Options::delete_option( 'master_user' );
+
+					// Clear the memoized connection owner ID since it changed
+					static::$connection_owner_id = null;
 				}
 			}
 		}
@@ -1125,6 +1142,9 @@ class Manager {
 			// Update the connection owner in Jetpack only if they were successfully updated on WPCOM.
 			// This will ensure consistency with WPCOM.
 			\Jetpack_Options::update_option( 'master_user', $new_owner_id );
+
+			// Clear the memoized connection owner ID since it changed
+			self::$connection_owner_id = null;
 
 			// Track it.
 			( new Tracking() )->record_user_event( 'set_connection_owner_success' );
@@ -1814,6 +1834,9 @@ class Manager {
 				'fallback_no_verify_ssl_certs',
 			)
 		);
+
+		// Clear the memoized connection owner ID since it changed
+		static::$connection_owner_id = null;
 
 		( new Secrets() )->delete_all();
 		$this->get_tokens()->delete_all();

--- a/projects/packages/connection/tests/php/Connection_Notice_Test.php
+++ b/projects/packages/connection/tests/php/Connection_Notice_Test.php
@@ -30,6 +30,18 @@ class Connection_Notice_Test extends TestCase {
 	private $fake_users = array();
 
 	/**
+	 * Initialize the hooks to reset memoized connection properties.
+	 */
+	public static function setUpBeforeClass(): void {
+		// Use reflection to call the private method that sets up cache invalidation hooks.
+		$manager    = new Manager();
+		$reflection = new \ReflectionClass( $manager );
+		$method     = $reflection->getMethod( 'add_connection_status_invalidation_hooks' );
+		$method->setAccessible( true );
+		$method->invoke( $manager );
+	}
+
+	/**
 	 * Testing the "need to connect first" notice.
 	 */
 	public function test_delete_user_connect_notice() {

--- a/projects/packages/connection/tests/php/Jetpack_XMLRPC_Server_Test.php
+++ b/projects/packages/connection/tests/php/Jetpack_XMLRPC_Server_Test.php
@@ -3,8 +3,10 @@
  * Tests the Legacy Jetpack_XMLRPC_Server class.
  */
 
+use Automattic\Jetpack\Connection\Manager;
 use Automattic\Jetpack\Connection\Tokens;
 use Automattic\Jetpack\Constants;
+use PHPUnit\Framework\Attributes\BeforeClass;
 use WorDBless\BaseTestCase;
 
 /**
@@ -18,6 +20,21 @@ class Jetpack_XMLRPC_Server_Test extends BaseTestCase {
 	 * @var integer
 	 */
 	protected $xmlrpc_admin = 0;
+
+	/**
+	 * Initialize the hooks to reset memoized connection properties.
+	 *
+	 * @beforeClass
+	 */
+	#[BeforeClass]
+	public static function set_up_before_class() {
+		// Use reflection to call the private method that sets up cache invalidation hooks.
+		$manager    = new Manager();
+		$reflection = new \ReflectionClass( $manager );
+		$method     = $reflection->getMethod( 'add_connection_status_invalidation_hooks' );
+		$method->setAccessible( true );
+		$method->invoke( $manager );
+	}
 
 	/**
 	 * Set up before each test

--- a/projects/packages/connection/tests/php/ManagerIntegrationTest.php
+++ b/projects/packages/connection/tests/php/ManagerIntegrationTest.php
@@ -8,6 +8,7 @@
 namespace Automattic\Jetpack\Connection;
 
 use Automattic\Jetpack\Constants;
+use PHPUnit\Framework\Attributes\BeforeClass;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 
@@ -27,12 +28,26 @@ class ManagerIntegrationTest extends \WorDBless\BaseTestCase {
 	private $manager;
 
 	/**
+	 * Initialize the hooks to reset memoized connection properties.
+	 *
+	 * @beforeClass
+	 */
+	#[BeforeClass]
+	public static function set_up_before_class() {
+		// Use reflection to call the private method that sets up cache invalidation hooks.
+		$manager    = new Manager();
+		$reflection = new \ReflectionClass( $manager );
+		$method     = $reflection->getMethod( 'add_connection_status_invalidation_hooks' );
+		$method->setAccessible( true );
+		$method->invoke( $manager );
+	}
+
+	/**
 	 * Initialize the object before running the test method.
 	 */
 	public function set_up() {
 		$this->manager = new Manager();
 		Constants::set_constant( 'JETPACK__API_BASE', 'https://jetpack.wordpress.com/jetpack.' );
-		$this->reset_connection_status();
 	}
 
 	/**
@@ -40,7 +55,6 @@ class ManagerIntegrationTest extends \WorDBless\BaseTestCase {
 	 */
 	public function tear_down() {
 		Constants::clear_constants();
-		$this->reset_connection_status();
 	}
 
 	/**

--- a/projects/packages/connection/tests/php/ManagerTest.php
+++ b/projects/packages/connection/tests/php/ManagerTest.php
@@ -9,6 +9,7 @@ namespace Automattic\Jetpack\Connection;
 
 use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Status\Cache as StatusCache;
+use Jetpack_Options;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use WorDBless\Options as WorDBless_Options;
@@ -597,6 +598,84 @@ class ManagerTest extends TestCase {
 		$result = $this->manager->update_connection_owner( $admin_id );
 
 		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test updating the connection owner when remote call to wpcom succeeds.
+	 */
+	public function test_update_connection_owner_with_memoization_reset() {
+		// Create a fresh mock manager without the get_connection_owner_id method mocked.
+		$this->manager = $this->getMockBuilder( 'Automattic\Jetpack\Connection\Manager' )
+			->onlyMethods( array( 'get_tokens', 'unlink_user_from_wpcom', 'update_connection_owner_wpcom', 'disconnect_site_wpcom' ) )
+			->getMock();
+
+		// Use reflection to call the private method that sets up cache invalidation hooks.
+		$reflection = new \ReflectionClass( $this->manager );
+		$method     = $reflection->getMethod( 'add_connection_status_invalidation_hooks' );
+		$method->setAccessible( true );
+		$method->invoke( $this->manager );
+
+		// Create the first admin user.
+		$admin_id = wp_insert_user(
+			array(
+				'user_login' => 'admin',
+				'user_pass'  => 'pass',
+				'user_email' => 'admin@admin.com',
+				'role'       => 'administrator',
+			)
+		);
+
+		// Mock the tokens to return a valid access token for any user.
+		$this->tokens->method( 'get_access_token' )
+			->willReturnCallback(
+				function ( $admin_id ) {
+					return (object) array(
+						'secret'           => 'abcd1234',
+						'external_user_id' => $admin_id,
+					);
+				}
+			);
+		$this->manager->method( 'get_tokens' )
+			->willReturn( $this->tokens );
+
+		// Mock the wpcom update call to succeed.
+		$this->manager->method( 'update_connection_owner_wpcom' )
+			->willReturn( true );
+
+		// Test first owner update and verify the cache is updated.
+		$result_update = $this->manager->update_connection_owner( $admin_id );
+		$this->assertTrue( $result_update );
+		$this->assertEquals( $admin_id, $this->manager->get_connection_owner_id() );
+
+		// Create a second admin user.
+		$admin2_id = wp_insert_user(
+			array(
+				'user_login' => 'admin2',
+				'user_pass'  => 'pass',
+				'user_email' => 'admin2@admin.com',
+				'role'       => 'administrator',
+			)
+		);
+
+		// Test second owner update and verify the cache is invalidated and updated.
+		$result_update = $this->manager->update_connection_owner( $admin2_id );
+		$this->assertTrue( $result_update );
+		$this->assertEquals( $admin2_id, $this->manager->get_connection_owner_id() );
+
+		// Create a third admin user.
+		$admin3_id = wp_insert_user(
+			array(
+				'user_login' => 'admin3',
+				'user_pass'  => 'pass',
+				'user_email' => 'admin3@admin.com',
+				'role'       => 'administrator',
+			)
+		);
+		// Directly set the master_user option to simulate a direct database update.
+		Jetpack_Options::update_option( 'master_user', $admin3_id );
+
+		// Verify that the cache properly reflects the updated owner.
+		$this->assertEquals( $admin3_id, $this->manager->get_connection_owner_id() );
 	}
 
 	/**

--- a/projects/packages/connection/tests/php/ManagerTest.php
+++ b/projects/packages/connection/tests/php/ManagerTest.php
@@ -52,6 +52,18 @@ class ManagerTest extends TestCase {
 	const DEFAULT_TEST_CAPS = array( 'default_test_caps' );
 
 	/**
+	 * Initialize the hooks to reset memoized connection properties.
+	 */
+	public static function setUpBeforeClass(): void {
+		// Use reflection to call the private method that sets up cache invalidation hooks.
+		$manager    = new Manager();
+		$reflection = new \ReflectionClass( $manager );
+		$method     = $reflection->getMethod( 'add_connection_status_invalidation_hooks' );
+		$method->setAccessible( true );
+		$method->invoke( $manager );
+	}
+
+	/**
 	 * Initialize the object before running the test method.
 	 */
 	public function setUp(): void {
@@ -608,12 +620,6 @@ class ManagerTest extends TestCase {
 		$this->manager = $this->getMockBuilder( 'Automattic\Jetpack\Connection\Manager' )
 			->onlyMethods( array( 'get_tokens', 'unlink_user_from_wpcom', 'update_connection_owner_wpcom', 'disconnect_site_wpcom' ) )
 			->getMock();
-
-		// Use reflection to call the private method that sets up cache invalidation hooks.
-		$reflection = new \ReflectionClass( $this->manager );
-		$method     = $reflection->getMethod( 'add_connection_status_invalidation_hooks' );
-		$method->setAccessible( true );
-		$method->invoke( $this->manager );
 
 		// Create the first admin user.
 		$admin_id = wp_insert_user(


### PR DESCRIPTION
## Proposed changes:
* Prevent excessive database queries by memoizing connection owner ID throughout the request.
* If connection owner gets changed or removed, clean the memoized value.

WordPress is efficient in caching user data, so it doesn't rerun database queries to fetch user data if it's already been fetched.
The problems appear when there's a mismatch, and connection owner ID does not match any user accounts. In that case WordPress will not be able to cache the results of the user data query, so it will be queried multiple times.

Memoizing connection ID prevents this kind of situation by storing `0` if there's no connection owner, or if its invalid (e.g. mismatch described above). Therefore, the user info query will not be repeated.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:

### Confirm the issue is fixed:
1. **First, try to reproduce the issue on `trunk`:**
2. Connect Jetpack.
3. Use "Jetpack Debug -> Broken Token" to "Randomize Primary User ID and move the user token together". Confirm that the new connection owner ID does not match any of existing user accounts.
4. Install ["Query Monitor" plugin](https://wordpress.org/plugins/query-monitor/).
5. Go to Jetpack Dashboard and check for "Database Queries -> Duplicate Queries". There should be a huge number of duplicate requests (~80) trying to fetch user data by this random ID (`SELECT * FROM wp_users WHERE ID = '12345' LIMIT 1`)
6. **Now, switch to this branch: `add/connection-owner-id-memoization`.**
7. Repeat step 5, confirm the number of duplicated queries is now pretty low (less than 10).

### Play around with the connection, confirm it continues to work as expected:
1. Connect Jetpack.
2. Disconnect user, then reconnect.
3. Disconnect Jetpack, reconnect it in site-only mode.
4. Connect the user.
5. Connect a secondary user, then disconnect them.