### PR TITLE
Boost: Add Boost to docker phpunit command

### DIFF
--- a/tools/cli/commands/docker.js
+++ b/tools/cli/commands/docker.js
@@ -400,8 +400,12 @@ const buildExecCmd = argv => {
 			case 'boost':
 				unitTestArgs.plugin = 'jetpack-boost';
 
-				// Default to running only unit tests (excluding critical-css tests that require WorDBless)
-				argv._.push( '--testsuite', 'unit' );
+				if ( argv?.testsuite !== 'critical-css' ) {
+					argv._.push( '--testsuite', 'unit' );
+				} else {
+					argv._.push( '--testsuite', 'critical-css' );
+					argv._.push( '--bootstrap', 'tests/bootstrap-wordbless.php' );
+				}
 				break;
 			case 'crm':
 				unitTestArgs.plugin = 'zero-bs-crm';

--- a/tools/cli/commands/docker.js
+++ b/tools/cli/commands/docker.js
@@ -397,6 +397,12 @@ const buildExecCmd = argv => {
 				unitTestArgs.plugin = 'jetpack';
 				unitTestArgs.envVars = [ 'JETPACK_TEST_WPCOMSH=1' ];
 				break;
+			case 'boost':
+				unitTestArgs.plugin = 'jetpack-boost';
+
+				// Default to running only unit tests (excluding critical-css tests that require WorDBless)
+				argv._.push( '--testsuite', 'unit' );
+				break;
 			case 'crm':
 				unitTestArgs.plugin = 'zero-bs-crm';
 				break;


### PR DESCRIPTION
## Proposed changes:
* Allows Boost to use the `jetpack docker phpunit` command.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
N/A

## Testing instructions:
* Checkout branch locally
* Verify that the appropriate composer libraries are installed within Boost via going to the Boost directory (`projects/jetpack/projects/plugins/boost`) and running `composer install`
* Run `jetpack docker phpunit boost` to verify that the command works as expected, and all tests pass
* Run `jetpack docker phpunit boost --testsuite critical-css --php 8.3` in order to test Critical CSS.
  * Note: WorDBless requires PHP 8.3 to run, so adding the php argument for 8.3 is required.
 * Note: If you run `jetpack docker phpunit boost` again after, you may receive errors, you may have to run `composer install` install to install the appropriate vendor files for 8.3 again.

