### PR TITLE
Connection: update protected owner class

### DIFF
--- a/projects/plugins/wpcomsh/changelog/update-connection-error-refactor-wpcomsh
+++ b/projects/plugins/wpcomsh/changelog/update-connection-error-refactor-wpcomsh
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updating protected owner handling to match updated main class.
+
+

--- a/projects/plugins/wpcomsh/connection/class-protected-owner-error-handler.php
+++ b/projects/plugins/wpcomsh/connection/class-protected-owner-error-handler.php
@@ -60,7 +60,7 @@ namespace Automattic\WPComSH\Connection;
  * default User_Admin class behavior to ensure the WP.com invitation checkbox is not
  * pre-checked when creating protected owner accounts.
  *
- * Enhanced Features (connection package $$next-version$$+):
+ * Enhanced Features:
  * - Enhanced error data structure with action labels and variants
  * - Analytics tracking events for user interactions
  * - Backward compatibility with older connection package versions
@@ -200,10 +200,8 @@ class Protected_Owner_Error_Handler {
 	 * Build enhanced error data using the new connection package methods
 	 *
 	 * This method leverages the new build_action_error_data method available in
-	 * connection package version $$next-version$$ and later to provide enhanced
+	 * new connection package version to provide enhanced
 	 * error handling with secondary button support.
-	 *
-	 * @since $$next-version$$
 	 *
 	 * @param array $raw_error The raw error data from the stored option.
 	 * @return array|false Enhanced error data array or false if method not available.
@@ -239,19 +237,7 @@ class Protected_Owner_Error_Handler {
 			),
 		);
 
-		/**
-		 * Filter the enhanced error data arguments for protected owner errors.
-		 *
-		 * Allows customization of error actions, labels, tracking events, and other
-		 * error data before it's processed by the connection package.
-		 *
-		 * @since $$next-version$$
-		 *
-		 * @param array $args      The error data arguments.
-		 * @param array $raw_error The raw error data from storage.
-		 */
-		$args = apply_filters( 'wpcomsh_protected_owner_error_data_args', $args, $raw_error );
-
+		// @phan-suppress-next-line PhanUndeclaredMethod -- Method exists in newer connection package versions
 		return $error_handler->build_action_error_data( $args );
 	}
 
@@ -274,18 +260,7 @@ class Protected_Owner_Error_Handler {
 			'support_url' => admin_url( 'user-new.php' ),
 		);
 
-		/**
-		 * Filter the legacy error data for protected owner errors.
-		 *
-		 * Allows customization of error data when using older connection package versions
-		 * that don't support the enhanced error handling features.
-		 *
-		 * @since $$next-version$$
-		 *
-		 * @param array $legacy_data The legacy error data array.
-		 * @param array $raw_error   The raw error data from storage.
-		 */
-		return apply_filters( 'wpcomsh_protected_owner_legacy_error_data', $legacy_data, $raw_error );
+		return $legacy_data;
 	}
 
 	/**
@@ -293,8 +268,6 @@ class Protected_Owner_Error_Handler {
 	 *
 	 * This method can be used to determine if the current connection package version
 	 * supports the enhanced error handling features.
-	 *
-	 * @since $$next-version$$
 	 *
 	 * @return bool True if enhanced features are available, false otherwise.
 	 */

--- a/projects/plugins/wpcomsh/connection/class-protected-owner-error-handler.php
+++ b/projects/plugins/wpcomsh/connection/class-protected-owner-error-handler.php
@@ -2,6 +2,45 @@
 /**
  * The Jetpack Connection Protected Owner Error Handler class file.
  *
+ * USAGE EXAMPLES:
+ *
+ * 1. Basic usage (automatic - no code required):
+ *    The class automatically handles protected owner errors when they occur.
+ *
+ * 2. Check if enhanced features are available:
+ *    $handler = Protected_Owner_Error_Handler::get_instance();
+ *    if ( $handler->has_enhanced_error_handling() ) {
+ *        // Enhanced features are available
+ *    }
+ *
+ * 3. Customize enhanced error data:
+ *    add_filter( 'wpcomsh_protected_owner_error_data_args', function( $args, $raw_error ) {
+ *        // Customize the action
+ *        $args['action_label'] = __( 'Create User Account', 'my-plugin' );
+ *        $args['tracking_event'] = 'my_custom_tracking_event';
+ *
+ *        // Add custom data
+ *        $args['extra_data']['custom_field'] = 'custom_value';
+ *
+ *        return $args;
+ *    }, 10, 2 );
+ *
+ * 4. Customize legacy error data (for older connection package versions):
+ *    add_filter( 'wpcomsh_protected_owner_legacy_error_data', function( $legacy_data, $raw_error ) {
+ *        $legacy_data['custom_field'] = 'custom_value';
+ *        return $legacy_data;
+ *    }, 10, 2 );
+ *
+ * 5. Handle both old and new versions in your code:
+ *    $handler = Protected_Owner_Error_Handler::get_instance();
+ *    if ( $handler->has_enhanced_error_handling() ) {
+ *        // Use enhanced features
+ *        add_filter( 'wpcomsh_protected_owner_error_data_args', 'my_enhanced_customization' );
+ *    } else {
+ *        // Use legacy approach
+ *        add_filter( 'wpcomsh_protected_owner_legacy_error_data', 'my_legacy_customization' );
+ *    }
+ *
  * @package wpcomsh
  */
 
@@ -20,6 +59,11 @@ namespace Automattic\WPComSH\Connection;
  * user creation form when creating missing protected owner accounts. It overrides the
  * default User_Admin class behavior to ensure the WP.com invitation checkbox is not
  * pre-checked when creating protected owner accounts.
+ *
+ * Enhanced Features (connection package $$next-version$$+):
+ * - Enhanced error data structure with action labels and variants
+ * - Analytics tracking events for user interactions
+ * - Backward compatibility with older connection package versions
  *
  * @since 7.0.0
  */
@@ -124,16 +168,20 @@ class Protected_Owner_Error_Handler {
 		$user_id   = '0';
 		$timestamp = $raw_error['timestamp'] ?? time();
 
+		// Check if we have the new Error_Handler class with build_action_error_data method
+		// This provides enhanced error data for newer connection package versions
+		$error_data = $this->build_enhanced_error_data( $raw_error );
+
+		// Fallback to legacy error data if enhanced method is not available
+		if ( false === $error_data ) {
+			$error_data = $this->build_legacy_error_data( $raw_error );
+		}
+
 		$error_details = array(
 			'error_code'    => $error_code,
 			'user_id'       => $user_id,
 			'error_message' => $this->get_error_message( $raw_error['email'] ),
-			'error_data'    => array(
-				'email'       => $raw_error['email'],
-				'error_type'  => $raw_error['error_type'],
-				'action'      => 'create_missing_account',
-				'support_url' => admin_url( 'user-new.php' ),
-			),
+			'error_data'    => $error_data,
 			'timestamp'     => $timestamp,
 			'nonce'         => wp_generate_password( 10, false ),
 			'error_type'    => 'protected_owner',
@@ -146,6 +194,117 @@ class Protected_Owner_Error_Handler {
 				$user_id => $error_details,
 			),
 		);
+	}
+
+	/**
+	 * Build enhanced error data using the new connection package methods
+	 *
+	 * This method leverages the new build_action_error_data method available in
+	 * connection package version $$next-version$$ and later to provide enhanced
+	 * error handling with secondary button support.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $raw_error The raw error data from the stored option.
+	 * @return array|false Enhanced error data array or false if method not available.
+	 */
+	private function build_enhanced_error_data( $raw_error ) {
+		// Check if the new Error_Handler class and method are available
+		if ( ! class_exists( '\Automattic\Jetpack\Connection\Error_Handler' ) ) {
+			return false;
+		}
+
+		$error_handler = \Automattic\Jetpack\Connection\Error_Handler::get_instance();
+		if ( ! method_exists( $error_handler, 'build_action_error_data' ) ) {
+			return false;
+		}
+
+		// Build enhanced error data with improved action handling
+		$args = array(
+			'action'         => 'create_missing_account',
+			'action_label'   => __( 'Create Account', 'wpcomsh' ),
+			'action_variant' => 'primary',
+			'action_url'     => add_query_arg(
+				array(
+					'jetpack_protected_owner_email'  => rawurlencode( $raw_error['email'] ),
+					'jetpack_create_missing_account' => '1',
+				),
+				admin_url( 'user-new.php' )
+			),
+			'tracking_event' => 'jetpack_protected_owner_create_account_click',
+			'extra_data'     => array(
+				'email'       => $raw_error['email'],
+				'error_type'  => $raw_error['error_type'],
+				'support_url' => admin_url( 'user-new.php' ), // Backward compatibility
+			),
+		);
+
+		/**
+		 * Filter the enhanced error data arguments for protected owner errors.
+		 *
+		 * Allows customization of error actions, labels, tracking events, and other
+		 * error data before it's processed by the connection package.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param array $args      The error data arguments.
+		 * @param array $raw_error The raw error data from storage.
+		 */
+		$args = apply_filters( 'wpcomsh_protected_owner_error_data_args', $args, $raw_error );
+
+		return $error_handler->build_action_error_data( $args );
+	}
+
+	/**
+	 * Build legacy error data for backward compatibility
+	 *
+	 * This method provides the original error data structure for older
+	 * connection package versions that don't support the enhanced features.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @param array $raw_error The raw error data from the stored option.
+	 * @return array Legacy error data array.
+	 */
+	private function build_legacy_error_data( $raw_error ) {
+		$legacy_data = array(
+			'email'       => $raw_error['email'],
+			'error_type'  => $raw_error['error_type'],
+			'action'      => 'create_missing_account',
+			'support_url' => admin_url( 'user-new.php' ),
+		);
+
+		/**
+		 * Filter the legacy error data for protected owner errors.
+		 *
+		 * Allows customization of error data when using older connection package versions
+		 * that don't support the enhanced error handling features.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param array $legacy_data The legacy error data array.
+		 * @param array $raw_error   The raw error data from storage.
+		 */
+		return apply_filters( 'wpcomsh_protected_owner_legacy_error_data', $legacy_data, $raw_error );
+	}
+
+	/**
+	 * Check if enhanced error handling is available
+	 *
+	 * This method can be used to determine if the current connection package version
+	 * supports the enhanced error handling features.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return bool True if enhanced features are available, false otherwise.
+	 */
+	public function has_enhanced_error_handling() {
+		if ( ! class_exists( '\Automattic\Jetpack\Connection\Error_Handler' ) ) {
+			return false;
+		}
+
+		$error_handler = \Automattic\Jetpack\Connection\Error_Handler::get_instance();
+		return method_exists( $error_handler, 'build_action_error_data' );
 	}
 
 	/**

--- a/projects/plugins/wpcomsh/connection/class-protected-owner-error-handler.php
+++ b/projects/plugins/wpcomsh/connection/class-protected-owner-error-handler.php
@@ -177,15 +177,12 @@ class Protected_Owner_Error_Handler {
 	 * @return array|false Enhanced error data array or false if method not available.
 	 */
 	private function build_enhanced_error_data( $raw_error ) {
-		// Check if the new Error_Handler class and method are available
-		if ( ! class_exists( '\Automattic\Jetpack\Connection\Error_Handler' ) ) {
+		// Check if enhanced error handling is available
+		if ( ! $this->has_enhanced_error_handling() ) {
 			return false;
 		}
 
 		$error_handler = \Automattic\Jetpack\Connection\Error_Handler::get_instance();
-		if ( ! method_exists( $error_handler, 'build_action_error_data' ) ) {
-			return false;
-		}
 
 		// Build enhanced error data with improved action handling
 		$args = array(

--- a/projects/plugins/wpcomsh/connection/class-protected-owner-error-handler.php
+++ b/projects/plugins/wpcomsh/connection/class-protected-owner-error-handler.php
@@ -13,34 +13,6 @@
  *        // Enhanced features are available
  *    }
  *
- * 3. Customize enhanced error data:
- *    add_filter( 'wpcomsh_protected_owner_error_data_args', function( $args, $raw_error ) {
- *        // Customize the action
- *        $args['action_label'] = __( 'Create User Account', 'my-plugin' );
- *        $args['tracking_event'] = 'my_custom_tracking_event';
- *
- *        // Add custom data
- *        $args['extra_data']['custom_field'] = 'custom_value';
- *
- *        return $args;
- *    }, 10, 2 );
- *
- * 4. Customize legacy error data (for older connection package versions):
- *    add_filter( 'wpcomsh_protected_owner_legacy_error_data', function( $legacy_data, $raw_error ) {
- *        $legacy_data['custom_field'] = 'custom_value';
- *        return $legacy_data;
- *    }, 10, 2 );
- *
- * 5. Handle both old and new versions in your code:
- *    $handler = Protected_Owner_Error_Handler::get_instance();
- *    if ( $handler->has_enhanced_error_handling() ) {
- *        // Use enhanced features
- *        add_filter( 'wpcomsh_protected_owner_error_data_args', 'my_enhanced_customization' );
- *    } else {
- *        // Use legacy approach
- *        add_filter( 'wpcomsh_protected_owner_legacy_error_data', 'my_legacy_customization' );
- *    }
- *
  * @package wpcomsh
  */
 
@@ -60,10 +32,8 @@ namespace Automattic\WPComSH\Connection;
  * default User_Admin class behavior to ensure the WP.com invitation checkbox is not
  * pre-checked when creating protected owner accounts.
  *
- * Enhanced Features:
- * - Enhanced error data structure with action labels and variants
- * - Analytics tracking events for user interactions
- * - Backward compatibility with older connection package versions
+ * Automatically uses enhanced error handling when available in newer connection package versions,
+ * with backward compatibility for older versions.
  *
  * @since 7.0.0
  */
@@ -289,7 +259,7 @@ class Protected_Owner_Error_Handler {
 	private function get_error_message( $email ) {
 		return sprintf(
 			/* translators: %s is the WordPress.com email address */
-			__( 'This site needs to be connected to WordPress.com by the plan owner account with email %s. Please create a local user account with this email address to resolve this issue.', 'wpcomsh' ),
+			__( 'The user account that owns the plan is missing from your site. To fix this, you can create an account using the email address %s.', 'wpcomsh' ),
 			esc_html( $email )
 		);
 	}

--- a/projects/plugins/wpcomsh/tests/ProtectedOwnerErrorHandlerTest.php
+++ b/projects/plugins/wpcomsh/tests/ProtectedOwnerErrorHandlerTest.php
@@ -39,10 +39,6 @@ class ProtectedOwnerErrorHandlerTest extends WP_UnitTestCase {
 		delete_option( Protected_Owner_Error_Handler::STORED_ERRORS_OPTION );
 		delete_option( 'jetpack_connection_xmlrpc_verified_errors' );
 
-		// Clean up any filters that might have been added during tests
-		remove_all_filters( 'wpcomsh_protected_owner_error_data_args' );
-		remove_all_filters( 'wpcomsh_protected_owner_legacy_error_data' );
-
 		parent::tearDown();
 	}
 

--- a/projects/plugins/wpcomsh/tests/ProtectedOwnerErrorHandlerTest.php
+++ b/projects/plugins/wpcomsh/tests/ProtectedOwnerErrorHandlerTest.php
@@ -38,113 +38,20 @@ class ProtectedOwnerErrorHandlerTest extends WP_UnitTestCase {
 	public function tearDown(): void {
 		delete_option( Protected_Owner_Error_Handler::STORED_ERRORS_OPTION );
 		delete_option( 'jetpack_connection_xmlrpc_verified_errors' );
+
+		// Clean up any filters that might have been added during tests
+		remove_all_filters( 'wpcomsh_protected_owner_error_data_args' );
+		remove_all_filters( 'wpcomsh_protected_owner_legacy_error_data' );
+
 		parent::tearDown();
 	}
 
 	/**
-	 * Test that the class implements singleton pattern correctly.
+	 * Test has_enhanced_error_handling method.
 	 */
-	public function test_singleton_pattern() {
-		$instance1 = Protected_Owner_Error_Handler::get_instance();
-		$instance2 = Protected_Owner_Error_Handler::get_instance();
-
-		$this->assertSame( $instance1, $instance2 );
-		$this->assertInstanceOf( Protected_Owner_Error_Handler::class, $instance1 );
-	}
-
-	/**
-	 * Test handle_error returns original errors when no error is stored.
-	 */
-	public function test_handle_error_returns_original_errors_when_no_error_stored() {
-		$original_errors = array( 'some_error' => array( '1' => array( 'data' => 'test' ) ) );
-		$result          = $this->handler->handle_error( $original_errors );
-		$this->assertEquals( array(), $result );
-	}
-
-	/**
-	 * Test handle_error returns original errors for invalid data.
-	 */
-	public function test_handle_error_returns_original_errors_for_invalid_data() {
-		$original_errors = array( 'some_error' => array( '1' => array( 'data' => 'test' ) ) );
-
-		// Test with non-array data
-		update_option( Protected_Owner_Error_Handler::STORED_ERRORS_OPTION, 'invalid_data' );
-		$result = $this->handler->handle_error( $original_errors );
-		$this->assertEquals( array(), $result );
-
-		// Test with missing error_type
-		update_option( Protected_Owner_Error_Handler::STORED_ERRORS_OPTION, array( 'email' => 'test@example.com' ) );
-		$result = $this->handler->handle_error( $original_errors );
-		$this->assertEquals( array(), $result );
-
-		// Test with missing email
-		update_option( Protected_Owner_Error_Handler::STORED_ERRORS_OPTION, array( 'error_type' => 'missing_owner' ) );
-		$result = $this->handler->handle_error( $original_errors );
-		$this->assertEquals( array(), $result );
-	}
-
-	/**
-	 * Test handle_error returns original errors when user exists.
-	 */
-	public function test_handle_error_returns_original_errors_when_user_exists() {
-		$test_email      = 'test@example.com';
-		$original_errors = array( 'some_error' => array( '1' => array( 'data' => 'test' ) ) );
-
-		// Create a user with the required email
-		$this->factory()->user->create( array( 'user_email' => $test_email ) );
-
-		// Set up an error
-		update_option(
-			Protected_Owner_Error_Handler::STORED_ERRORS_OPTION,
-			array(
-				'error_type' => 'missing_owner',
-				'email'      => $test_email,
-			)
-		);
-
-		$result = $this->handler->handle_error( $original_errors );
-
-		// Should return empty array and delete the stored error
-		$this->assertEquals( array(), $result );
-		$this->assertFalse( get_option( Protected_Owner_Error_Handler::STORED_ERRORS_OPTION ) );
-	}
-
-	/**
-	 * Test handle_error returns protected owner error when user doesn't exist.
-	 */
-	public function test_handle_error_returns_protected_owner_error() {
-		$test_email      = 'test@example.com';
-		$test_timestamp  = time();
-		$original_errors = array( 'some_error' => array( '1' => array( 'data' => 'test' ) ) );
-
-		update_option(
-			Protected_Owner_Error_Handler::STORED_ERRORS_OPTION,
-			array(
-				'error_type' => 'missing_owner',
-				'email'      => $test_email,
-				'timestamp'  => $test_timestamp,
-			)
-		);
-
-		$result = $this->handler->handle_error( $original_errors );
-
-		// Should return only the protected owner error (takes priority)
-		$this->assertIsArray( $result );
-		$this->assertArrayHasKey( 'protected_owner_missing', $result );
-		$this->assertArrayNotHasKey( 'some_error', $result );
-
-		$error_data = $result['protected_owner_missing']['0'];
-		$this->assertEquals( 'protected_owner_missing', $error_data['error_code'] );
-		$this->assertSame( '0', $error_data['user_id'] );
-		$this->assertEquals( 'protected_owner', $error_data['error_type'] );
-		$this->assertEquals( $test_timestamp, $error_data['timestamp'] );
-		$this->assertArrayHasKey( 'error_message', $error_data );
-		$this->assertStringContainsString( $test_email, $error_data['error_message'] );
-		$this->assertArrayHasKey( 'error_data', $error_data );
-		$this->assertEquals( $test_email, $error_data['error_data']['email'] );
-		$this->assertEquals( 'missing_owner', $error_data['error_data']['error_type'] );
-		$this->assertEquals( 'create_missing_account', $error_data['error_data']['action'] );
-		$this->assertStringContainsString( 'user-new.php', $error_data['error_data']['support_url'] );
+	public function test_has_enhanced_error_handling() {
+		$result = $this->handler->has_enhanced_error_handling();
+		$this->assertIsBool( $result );
 	}
 
 	/**

--- a/projects/plugins/wpcomsh/tests/ProtectedOwnerErrorHandlerTest.php
+++ b/projects/plugins/wpcomsh/tests/ProtectedOwnerErrorHandlerTest.php
@@ -51,6 +51,135 @@ class ProtectedOwnerErrorHandlerTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test build_enhanced_error_data method when enhanced error handling is available.
+	 */
+	public function test_build_enhanced_error_data_when_available() {
+		// Skip if enhanced error handling is not available
+		if ( ! $this->handler->has_enhanced_error_handling() ) {
+			$this->markTestSkipped( 'Enhanced error handling not available' );
+		}
+
+		$raw_error = array(
+			'error_type' => 'missing_owner',
+			'email'      => 'test@example.com',
+		);
+
+		// Use reflection to access private method
+		$reflection = new ReflectionClass( $this->handler );
+		$method     = $reflection->getMethod( 'build_enhanced_error_data' );
+		$method->setAccessible( true );
+
+		$result = $method->invoke( $this->handler, $raw_error );
+
+		$this->assertIsArray( $result );
+		$this->assertEquals( 'create_missing_account', $result['action'] );
+		$this->assertEquals( 'test@example.com', $result['extra_data']['email'] );
+	}
+
+	/**
+	 * Test build_enhanced_error_data method when enhanced error handling is not available.
+	 */
+	public function test_build_enhanced_error_data_when_not_available() {
+		// Skip if enhanced error handling is available
+		if ( $this->handler->has_enhanced_error_handling() ) {
+			$this->markTestSkipped( 'Enhanced error handling is available' );
+		}
+
+		$raw_error = array(
+			'error_type' => 'missing_owner',
+			'email'      => 'test@example.com',
+		);
+
+		// Use reflection to access private method
+		$reflection = new ReflectionClass( $this->handler );
+		$method     = $reflection->getMethod( 'build_enhanced_error_data' );
+		$method->setAccessible( true );
+
+		$result = $method->invoke( $this->handler, $raw_error );
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test build_legacy_error_data method.
+	 */
+	public function test_build_legacy_error_data() {
+		$raw_error = array(
+			'error_type' => 'missing_owner',
+			'email'      => 'test@example.com',
+		);
+
+		// Use reflection to access private method
+		$reflection = new ReflectionClass( $this->handler );
+		$method     = $reflection->getMethod( 'build_legacy_error_data' );
+		$method->setAccessible( true );
+
+		$result = $method->invoke( $this->handler, $raw_error );
+
+		$this->assertIsArray( $result );
+		$this->assertEquals( 'test@example.com', $result['email'] );
+		$this->assertEquals( 'create_missing_account', $result['action'] );
+	}
+
+	/**
+	 * Test handle_error method returns protected owner error when active error exists.
+	 */
+	public function test_handle_error_returns_protected_owner_error() {
+		$test_email = 'test@example.com';
+
+		// Set an error
+		update_option(
+			Protected_Owner_Error_Handler::STORED_ERRORS_OPTION,
+			array(
+				'error_type' => 'missing_owner',
+				'email'      => $test_email,
+			)
+		);
+
+		$result = $this->handler->handle_error( array() );
+
+		$this->assertArrayHasKey( 'protected_owner_missing', $result );
+		$error_details = $result['protected_owner_missing']['0'];
+		$this->assertEquals( 'protected_owner_missing', $error_details['error_code'] );
+		$this->assertEquals( $test_email, $error_details['error_data']['email'] );
+	}
+
+	/**
+	 * Test handle_error method returns empty array when no active error exists.
+	 */
+	public function test_handle_error_returns_empty_when_no_active_error() {
+		delete_option( Protected_Owner_Error_Handler::STORED_ERRORS_OPTION );
+
+		$result = $this->handler->handle_error( array() );
+
+		$this->assertEmpty( $result );
+	}
+
+	/**
+	 * Test handle_error method clears error when user exists.
+	 */
+	public function test_handle_error_clears_error_when_user_exists() {
+		$test_email = 'test@example.com';
+
+		// Create a user with the test email
+		$this->factory()->user->create( array( 'user_email' => $test_email ) );
+
+		// Set an error
+		update_option(
+			Protected_Owner_Error_Handler::STORED_ERRORS_OPTION,
+			array(
+				'error_type' => 'missing_owner',
+				'email'      => $test_email,
+			)
+		);
+
+		$result = $this->handler->handle_error( array() );
+
+		$this->assertEmpty( $result );
+		$this->assertFalse( get_option( Protected_Owner_Error_Handler::STORED_ERRORS_OPTION ) );
+	}
+
+	/**
 	 * Test delete_error method.
 	 */
 	public function test_delete_error() {


### PR DESCRIPTION
Related to changes in https://github.com/Automattic/jetpack/pull/44281 , this PR adds progressive enhancement code that will kick in as soon as the updated connection package is deployed on WoA. Until the other PR is merged and deployed, the protected owner errors will work in the same way as they do now.

Another minor change is the error message text as per discussion in pghT6q-6h-p2

Closes VULCAN-185


### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a WoA dev site. Create a secondary admin account and connect it. Log in as the secondary admin and delete the primary admin account.
* Run JP debugger tool and use the Restore user connection button (but don't force create a missing account!). This will trigger the error.
* The error should show up in admin dashboards for the secondary admin.
* Use beta tester to load this PR for the wpcomsh plugin. Everything should be the same.
* If https://github.com/Automattic/jetpack/pull/44281 hasn't been merged yet, load it in beta tester for Jetpack plugin. Otherwise load bleeding edge version of Jetpack. Everything should be the same. 