### PR TITLE
Forms: add inbox hook

### DIFF
--- a/projects/packages/forms/changelog/change-jetpack-forms-inbox-store
+++ b/projects/packages/forms/changelog/change-jetpack-forms-inbox-store
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Forms: consolidate a single hook for all inbox data, making it easier to share the store props and dispatches and removing the need to invalidate the entire store to get fresh listings after emptying trash

--- a/projects/packages/forms/src/dashboard/components/empty-trash-button/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/empty-trash-button/index.tsx
@@ -4,8 +4,8 @@
 import jetpackAnalytics from '@automattic/jetpack-analytics';
 import apiFetch from '@wordpress/api-fetch';
 import { Button, __experimentalConfirmDialog as ConfirmDialog } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
-import { useEntityRecords, store as coreStore } from '@wordpress/core-data';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import { useDispatch } from '@wordpress/data';
 import { useState, useCallback } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { trash } from '@wordpress/icons';
@@ -13,10 +13,10 @@ import { store as noticesStore } from '@wordpress/notices';
 /**
  * Internal dependencies
  */
-import { store as dashboardStore } from '../../store';
+import useInboxData from '../../hooks/use-inbox-data';
 
 type CoreStore = typeof coreStore & {
-	invalidateResolutionForStore: ( store: typeof dashboardStore ) => void;
+	invalidateResolution: ( selector: string, args: unknown[] ) => void;
 };
 
 /**
@@ -29,22 +29,11 @@ const EmptyTrashButton = (): JSX.Element => {
 	const [ isEmptying, setIsEmptying ] = useState( false );
 
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
-	const { invalidateResolutionForStore } = useDispatch( coreStore ) as unknown as CoreStore;
+	const { invalidateResolution } = useDispatch( coreStore ) as unknown as CoreStore;
 
-	const selectedResponsesCount = useSelect(
-		select => select( dashboardStore ).getSelectedResponsesCount(),
-		[]
-	);
+	const { selectedResponsesCount, currentQuery, totalItemsTrash, isLoadingData } = useInboxData();
 
-	const { isResolving: isTotalItemsResolving, totalItems } = useEntityRecords(
-		'postType',
-		'feedback',
-		{
-			status: 'trash',
-		}
-	);
-
-	const isEmpty = ! isTotalItemsResolving && totalItems === 0;
+	const isEmpty = ! isLoadingData && totalItemsTrash === 0;
 
 	const openConfirmDialog = useCallback( () => setConfirmDialogOpen( true ), [] );
 	const closeConfirmDialog = useCallback( () => setConfirmDialogOpen( false ), [] );
@@ -88,15 +77,23 @@ const EmptyTrashButton = (): JSX.Element => {
 			} )
 			.finally( () => {
 				setIsEmptying( false );
-				invalidateResolutionForStore( dashboardStore );
+				// invalidate items list
+				invalidateResolution( 'getEntityRecords', [ 'postType', 'feedback', currentQuery ] );
+				// invalidate total items value
+				invalidateResolution( 'getEntityRecords', [
+					'postType',
+					'feedback',
+					{ ...currentQuery, per_page: 1, _fields: 'id' },
+				] );
 			} );
 	}, [
 		closeConfirmDialog,
 		createErrorNotice,
 		createSuccessNotice,
-		invalidateResolutionForStore,
+		invalidateResolution,
 		isEmpty,
 		isEmptying,
+		currentQuery,
 	] );
 
 	return (
@@ -129,10 +126,10 @@ const EmptyTrashButton = (): JSX.Element => {
 								_n(
 									'%d response in trash will be deleted forever. This action cannot be undone.',
 									'All %d responses in trash will be deleted forever. This action cannot be undone.',
-									totalItems || 0,
+									totalItemsTrash || 0,
 									'jetpack-forms'
 								),
-								totalItems
+								totalItemsTrash
 						  )
 						: __(
 								'All responses in trash will be deleted forever. This action cannot be undone.',

--- a/projects/packages/forms/src/dashboard/components/inbox-status-toggle/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/inbox-status-toggle/index.tsx
@@ -9,10 +9,13 @@ import {
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 } from '@wordpress/components';
-import { useEntityRecords } from '@wordpress/core-data';
 import { __, _x, sprintf } from '@wordpress/i18n';
 import { useCallback } from 'react';
 import { useSearchParams } from 'react-router';
+/**
+ * Internal dependencies
+ */
+import useInboxData from '../../hooks/use-inbox-data';
 
 /**
  * Returns a formatted tab label with count.
@@ -26,35 +29,17 @@ function getTabLabel( label: string, count: number ): string {
 	return sprintf( __( '%1$s (%2$s)', 'jetpack-forms' ), label, count || 0 );
 }
 
-type InboxStatusToggleProps = {
-	currentQuery: Record< string, unknown >;
-};
-
 /**
  * Renders the status toggle for the inbox view.
  *
- * @param {InboxStatusToggleProps} props - The component props.
  * @return {JSX.Element} The status toggle component.
  */
-export default function InboxStatusToggle( { currentQuery }: InboxStatusToggleProps ): JSX.Element {
+export default function InboxStatusToggle(): JSX.Element {
 	const [ searchParams, setSearchParams ] = useSearchParams();
 	const status = searchParams.get( 'status' ) || 'inbox';
-	const queryBase = { search: '', page: 1, ...currentQuery, per_page: 1, _fields: 'id' };
 	const [ isSm ] = useBreakpointMatch( 'sm' );
-	const { totalItems: totalItemsInbox } = useEntityRecords( 'postType', 'feedback', {
-		...queryBase,
-		status: 'publish,draft',
-	} );
 
-	const { totalItems: totalItemsSpam } = useEntityRecords( 'postType', 'feedback', {
-		...queryBase,
-		status: 'spam',
-	} );
-
-	const { totalItems: totalItemsTrash } = useEntityRecords( 'postType', 'feedback', {
-		...queryBase,
-		status: 'trash',
-	} );
+	const { totalItemsInbox, totalItemsSpam, totalItemsTrash } = useInboxData();
 
 	const statusTabs = [
 		{ label: getTabLabel( __( 'Inbox', 'jetpack-forms' ), totalItemsInbox ), value: 'inbox' },

--- a/projects/packages/forms/src/dashboard/hooks/use-inbox-data.ts
+++ b/projects/packages/forms/src/dashboard/hooks/use-inbox-data.ts
@@ -1,0 +1,91 @@
+import { useEntityRecords } from '@wordpress/core-data';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { useSearchParams } from 'react-router';
+import { store as dashboardStore } from '../store';
+
+/**
+ * Helper function to get the status filter to apply from the URL.
+ * This is the only way to filter the data by `status` as intentionally
+ * we don't want to have a `status` filter in the UI.
+ *
+ * @param {string} urlStatus - The current status from the URL.
+ * @return {string} The status filter to apply.
+ */
+function getStatusFilter( urlStatus ) {
+	// Only allow specific status values.
+	const statusFilter = [ 'inbox', 'spam', 'trash' ].includes( urlStatus ) ? urlStatus : 'inbox';
+	return statusFilter === 'inbox' ? 'draft,publish' : statusFilter;
+}
+
+/**
+ * Hook to get the total number of form responses for each status.
+ *
+ * @return {object} The total number of form responses for each status.
+ */
+export default function useInboxData() {
+	const [ searchParams ] = useSearchParams();
+	const { setCurrentQuery, setSelectedResponses } = useDispatch( dashboardStore );
+	const urlStatus = searchParams.get( 'status' );
+	const statusFilter = getStatusFilter( urlStatus );
+
+	const { selectedResponsesCount, currentStatus, currentQuery, filterOptions } = useSelect(
+		select => ( {
+			selectedResponsesCount: select( dashboardStore ).getSelectedResponsesCount(),
+			currentStatus: select( dashboardStore ).getCurrentStatus(),
+			currentQuery: select( dashboardStore ).getCurrentQuery(),
+			filterOptions: select( dashboardStore ).getFilters(),
+		} ),
+		[]
+	);
+
+	const {
+		records,
+		isResolving: isLoadingData,
+		totalItems,
+		totalPages,
+	} = useEntityRecords( 'postType', 'feedback', currentQuery );
+
+	const { totalItems: totalItemsInbox } = useEntityRecords( 'postType', 'feedback', {
+		page: 1,
+		search: '',
+		...currentQuery,
+		status: 'publish,draft',
+		per_page: 1,
+		_fields: 'id',
+	} );
+
+	const { totalItems: totalItemsSpam } = useEntityRecords( 'postType', 'feedback', {
+		page: 1,
+		search: '',
+		...currentQuery,
+		status: 'spam',
+		per_page: 1,
+		_fields: 'id',
+	} );
+
+	const { totalItems: totalItemsTrash } = useEntityRecords( 'postType', 'feedback', {
+		page: 1,
+		search: '',
+		...currentQuery,
+		status: 'trash',
+		per_page: 1,
+		_fields: 'id',
+	} );
+
+	return {
+		totalItemsInbox,
+		totalItemsSpam,
+		totalItemsTrash,
+		records,
+		isLoadingData,
+		totalItems,
+		totalPages,
+		selectedResponsesCount,
+		setSelectedResponses,
+		statusFilter,
+		currentStatus,
+		currentQuery,
+		setCurrentQuery,
+		filterOptions,
+	};
+}

--- a/projects/packages/forms/src/dashboard/hooks/use-inbox-data.ts
+++ b/projects/packages/forms/src/dashboard/hooks/use-inbox-data.ts
@@ -2,6 +2,7 @@ import { useEntityRecords } from '@wordpress/core-data';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useSearchParams } from 'react-router';
 import { store as dashboardStore } from '../store';
+import type { FormResponse } from '../../types';
 
 /**
  * Helper function to get the status filter to apply from the URL.
@@ -18,11 +19,31 @@ function getStatusFilter( urlStatus ) {
 }
 
 /**
- * Hook to get the total number of form responses for each status.
- *
- * @return {object} The total number of form responses for each status.
+ * Interface for the return value of the useInboxData hook.
  */
-export default function useInboxData() {
+interface UseInboxDataReturn {
+	totalItemsInbox: number;
+	totalItemsSpam: number;
+	totalItemsTrash: number;
+	records: FormResponse[];
+	isLoadingData: boolean;
+	totalItems: number;
+	totalPages: number;
+	selectedResponsesCount: number;
+	setSelectedResponses: ( responses: string[] ) => void;
+	statusFilter: string;
+	currentStatus: string;
+	currentQuery: Record< string, unknown >;
+	setCurrentQuery: ( query: Record< string, unknown > ) => void;
+	filterOptions: Record< string, unknown >;
+}
+
+/**
+ * Hook to get all inbox related data.
+ *
+ * @return {UseInboxDataReturn} The inbox related data.
+ */
+export default function useInboxData(): UseInboxDataReturn {
 	const [ searchParams ] = useSearchParams();
 	const { setCurrentQuery, setSelectedResponses } = useDispatch( dashboardStore );
 	const urlStatus = searchParams.get( 'status' );
@@ -39,11 +60,13 @@ export default function useInboxData() {
 	);
 
 	const {
-		records,
+		records: rawRecords,
 		isResolving: isLoadingData,
 		totalItems,
 		totalPages,
 	} = useEntityRecords( 'postType', 'feedback', currentQuery );
+
+	const records = ( rawRecords || [] ) as FormResponse[];
 
 	const { totalItems: totalItemsInbox } = useEntityRecords( 'postType', 'feedback', {
 		page: 1,

--- a/projects/packages/forms/src/dashboard/hooks/use-inbox-data.ts
+++ b/projects/packages/forms/src/dashboard/hooks/use-inbox-data.ts
@@ -1,7 +1,16 @@
+/**
+ * External dependencies
+ */
 import { useEntityRecords } from '@wordpress/core-data';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useSearchParams } from 'react-router';
+/**
+ * Internal dependencies
+ */
 import { store as dashboardStore } from '../store';
+/**
+ * Types
+ */
 import type { FormResponse } from '../../types';
 
 /**

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
@@ -8,8 +8,6 @@ import {
 	__experimentalHStack as HStack,
 } from '@wordpress/components';
 import { useResizeObserver } from '@wordpress/compose';
-import { useEntityRecords } from '@wordpress/core-data';
-import { useSelect, useDispatch } from '@wordpress/data';
 import { DataViews } from '@wordpress/dataviews/wp';
 import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
 import { useCallback, useMemo, useState } from '@wordpress/element';
@@ -22,7 +20,7 @@ import { useSearchParams } from 'react-router';
  * Internal dependencies
  */
 import InboxStatusToggle from '../../components/inbox-status-toggle';
-import { store as dashboardStore } from '../../store';
+import useInboxData from '../../hooks/use-inbox-data';
 import InboxResponse from '../response';
 import { getPath } from '../utils.js';
 import {
@@ -59,20 +57,6 @@ const formatFieldValue = fieldValue => {
 };
 
 /**
- * Helper function to get the status filter to apply from the URL.
- * This is the only way to filter the data by `status` as intentionally
- * we don't want to have a `status` filter in the UI.
- *
- * @param {string} urlStatus - The current status from the URL.
- * @return {string} The status filter to apply.
- */
-function getStatusFilter( urlStatus ) {
-	// Only allow specific status values.
-	const statusFilter = [ 'inbox', 'spam', 'trash' ].includes( urlStatus ) ? urlStatus : 'inbox';
-	return statusFilter === 'inbox' ? 'draft,publish' : statusFilter;
-}
-
-/**
  * The DataViews implementation.
  *
  * @return {import('react').JSX.Element} The DataViews component.
@@ -91,11 +75,19 @@ export default function InboxView() {
 		{ box: 'border-box' }
 	);
 	const isMobile = containerWidth <= MOBILE_BREAKPOINT;
-	const { setCurrentQuery, setSelectedResponses } = useDispatch( dashboardStore );
 	const selectedResponses = searchParams.get( 'r' );
-	const urlStatus = searchParams.get( 'status' );
-	const statusFilter = getStatusFilter( urlStatus );
-	const filterOptions = useSelect( select => select( dashboardStore ).getFilters(), [] );
+
+	const {
+		setCurrentQuery,
+		setSelectedResponses,
+		statusFilter,
+		filterOptions,
+		records,
+		isLoadingData,
+		totalItems,
+		totalPages,
+	} = useInboxData();
+
 	useEffect( () => {
 		const _filters = view.filters?.reduce( ( accumulator, { field, value } ) => {
 			if ( ! value ) {
@@ -128,12 +120,6 @@ export default function InboxView() {
 		// rendering different ones.
 		setQueryArgs( _queryArgs );
 	}, [ view, statusFilter, setCurrentQuery ] );
-	const {
-		records,
-		isResolving: isLoadingData,
-		totalItems,
-		totalPages,
-	} = useEntityRecords( 'postType', 'feedback', queryArgs );
 	const data = useMemo(
 		() =>
 			records?.map( record => ( {

--- a/projects/packages/forms/tests/js/dashboard/components/empty-trash-button/index.test.jsx
+++ b/projects/packages/forms/tests/js/dashboard/components/empty-trash-button/index.test.jsx
@@ -8,6 +8,11 @@ import userEvent from '@testing-library/user-event';
  */
 import EmptyTrashButton from '../../../../../src/dashboard/components/empty-trash-button';
 
+// Mock React Router
+jest.mock( 'react-router', () => ( {
+	useSearchParams: () => [ new URLSearchParams(), jest.fn() ],
+} ) );
+
 // Mock WordPress dependencies
 jest.mock( '@wordpress/components', () => ( {
 	Button: props => {
@@ -60,11 +65,14 @@ jest.mock( '@wordpress/data', () => {
 	const mockDispatch = {
 		createSuccessNotice: jest.fn(),
 		createErrorNotice: jest.fn(),
-		invalidateResolutionForStore: jest.fn(),
+		invalidateResolution: jest.fn(),
 	};
 
 	const mockSelect = {
 		getSelectedResponsesCount: jest.fn().mockReturnValue( 0 ),
+		getCurrentStatus: jest.fn().mockReturnValue( 'trash' ),
+		getCurrentQuery: jest.fn().mockReturnValue( {} ),
+		getFilters: jest.fn().mockReturnValue( {} ),
 	};
 
 	return {
@@ -73,7 +81,7 @@ jest.mock( '@wordpress/data', () => {
 				return mockDispatch;
 			}
 			if ( store === 'core' ) {
-				return { invalidateResolutionForStore: mockDispatch.invalidateResolutionForStore };
+				return { invalidateResolution: mockDispatch.invalidateResolution };
 			}
 			return {};
 		} ),


### PR DESCRIPTION
Part of FORMS-214

## Proposed changes:
Consolidate a single hook for all inbox data, making it easier to share the store props and dispatches and removing the need to invalidate the entire store to get fresh listings after emptying trash.

The change will also help creating a new "empty spam" button/action/request

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
https://github.com/Automattic/jetpack/pull/44225#discussion_r2200524246

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
The only noticeable change this should bring is optimized backend requests. Check that the dashboard works as usual, selections, export and moving responses around (mark as spam, mark as not spam, trash, restore) work as expected. Once with something in the trash, test the empty trash button while monitoring network requests. After emptying trash, the view should refresh but a single request should be seen (as opposed to 3 or 7 when invalidating the entire store). 