### PR TITLE
VideoPress: Prevent videopress blocks autoplaying inside iframe previews

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class.jetpack-iframe-embed.php
+++ b/projects/plugins/jetpack/_inc/lib/class.jetpack-iframe-embed.php
@@ -35,6 +35,8 @@ class Jetpack_Iframe_Embed {
 		add_filter( 'shortcode_atts_video', array( 'Jetpack_Iframe_Embed', 'disable_autoplay' ) );
 		add_filter( 'shortcode_atts_audio', array( 'Jetpack_Iframe_Embed', 'disable_autoplay' ) );
 
+		add_filter( 'render_block_data', array( 'Jetpack_Iframe_Embed', 'disable_videopress_autoplay' ) );
+
 		$ver = sprintf( '%s-%s', gmdate( 'oW' ), defined( 'JETPACK__VERSION' ) ? JETPACK__VERSION : '' );
 		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
 			wp_enqueue_script(
@@ -83,6 +85,25 @@ class Jetpack_Iframe_Embed {
 	 */
 	public static function disable_autoplay( $atts ) {
 		return array_merge( $atts, array( 'autoplay' => false ) );
+	}
+
+	/**
+	 * Disable `autoplay` and add `muted` to all videopress blocks in
+	 * context of an iframe.
+	 *
+	 * @param array $parsed_block An associative array of the block being rendered.
+	 * @return array The modified block data.
+	 */
+	public static function disable_videopress_autoplay( $parsed_block ) {
+		if (
+			isset( $parsed_block['blockName'] ) &&
+			isset( $parsed_block['attrs'] ) &&
+			'videopress/video' === $parsed_block['blockName']
+		) {
+			$parsed_block['attrs']['autoplay'] = false;
+			$parsed_block['attrs']['muted']    = true;
+		}
+		return $parsed_block;
 	}
 
 	/**

--- a/projects/plugins/jetpack/_inc/lib/class.jetpack-iframe-embed.php
+++ b/projects/plugins/jetpack/_inc/lib/class.jetpack-iframe-embed.php
@@ -35,7 +35,8 @@ class Jetpack_Iframe_Embed {
 		add_filter( 'shortcode_atts_video', array( 'Jetpack_Iframe_Embed', 'disable_autoplay' ) );
 		add_filter( 'shortcode_atts_audio', array( 'Jetpack_Iframe_Embed', 'disable_autoplay' ) );
 
-		add_filter( 'render_block_data', array( 'Jetpack_Iframe_Embed', 'disable_video_block_autoplay' ) );
+		add_filter( 'render_block_data', array( 'Jetpack_Iframe_Embed', 'disable_video_block_attr' ) );
+		add_filter( 'render_block', array( 'Jetpack_Iframe_Embed', 'disable_video_rendered_html' ), 10, 2 );
 
 		$ver = sprintf( '%s-%s', gmdate( 'oW' ), defined( 'JETPACK__VERSION' ) ? JETPACK__VERSION : '' );
 		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
@@ -94,67 +95,124 @@ class Jetpack_Iframe_Embed {
 	 * @param array $parsed_block An associative array of the block being rendered.
 	 * @return array The modified block data.
 	 */
-	public static function disable_video_block_autoplay( $parsed_block ) {
+	public static function disable_video_block_attr( $parsed_block ) {
 		if ( ! isset( $parsed_block['blockName'] ) || ! isset( $parsed_block['attrs'] ) ) {
 			return $parsed_block;
 		}
 
-		if ( 'videopress/video' === $parsed_block['blockName'] || 'core/video' === $parsed_block['blockName'] ) {
+		if ( $parsed_block['blockName'] === 'videopress/video' || $parsed_block['blockName'] === 'core/video' ) {
 			$parsed_block['attrs']['autoplay'] = false;
 			$parsed_block['attrs']['muted']    = true;
 		}
 
-		if ( 'core/video' === $parsed_block['blockName'] && isset( $parsed_block['innerHTML'] ) ) {
-			$processor = WP_HTML_Processor::create_fragment( $parsed_block['innerHTML'] );
-			while ( $processor->next_tag( 'iframe' ) ) {
-				$iframe_src = $processor->get_attribute( 'src' );
-				if ( $iframe_src ) {
-					$parsed_url = wp_parse_url( $iframe_src );
-					if ( isset( $parsed_url['query'] ) ) {
-						parse_str( $parsed_url['query'], $query_params );
-						$query_params['autoPlay'] = '0';
-						$parsed_url['query']      = http_build_query( $query_params );
-					} else {
-						$parsed_url['query'] = 'autoPlay=0';
-					}
-					$new_src = ( isset( $parsed_url['scheme'] ) ? $parsed_url['scheme'] . '://' : '' ) .
-						( isset( $parsed_url['host'] ) ? $parsed_url['host'] : '' ) .
-						( isset( $parsed_url['port'] ) ? ':' . $parsed_url['port'] : '' ) .
-						( isset( $parsed_url['path'] ) ? $parsed_url['path'] : '' ) .
-						( isset( $parsed_url['query'] ) ? '?' . $parsed_url['query'] : '' ) .
-						( isset( $parsed_url['fragment'] ) ? '#' . $parsed_url['fragment'] : '' );
-					$processor->set_attribute( 'src', $new_src );
-				}
-			}
-			$parsed_block['innerHTML'] = $processor->get_updated_html();
-		}
-
-		if ( 'core/video' === $parsed_block['blockName'] && isset( $parsed_block['innerContent'] ) && isset( $parsed_block['innerContent'][0] ) ) {
-			$processor = WP_HTML_Processor::create_fragment( $parsed_block['innerContent'][0] );
-			while ( $processor->next_tag( 'iframe' ) ) {
-				$iframe_src = $processor->get_attribute( 'src' );
-				if ( $iframe_src ) {
-					$parsed_url = wp_parse_url( $iframe_src );
-					if ( isset( $parsed_url['query'] ) ) {
-						parse_str( $parsed_url['query'], $query_params );
-						$query_params['autoPlay'] = '0';
-						$parsed_url['query']      = http_build_query( $query_params );
-					} else {
-						$parsed_url['query'] = 'autoPlay=0';
-					}
-					$new_src = ( isset( $parsed_url['scheme'] ) ? $parsed_url['scheme'] . '://' : '' ) .
-						( isset( $parsed_url['host'] ) ? $parsed_url['host'] : '' ) .
-						( isset( $parsed_url['port'] ) ? ':' . $parsed_url['port'] : '' ) .
-						( isset( $parsed_url['path'] ) ? $parsed_url['path'] : '' ) .
-						( isset( $parsed_url['query'] ) ? '?' . $parsed_url['query'] : '' ) .
-						( isset( $parsed_url['fragment'] ) ? '#' . $parsed_url['fragment'] : '' );
-					$processor->set_attribute( 'src', $new_src );
-				}
-			}
-			$parsed_block['innerContent'][0] = $processor->get_updated_html();
-		}
-
 		return $parsed_block;
+	}
+
+	/**
+	 * Disable `autoplay` and add `muted` to all blocks which embed videopress iframes.
+	 *
+	 * @param string $block_content The block content about to be appended.
+	 * @param array  $block         The full block, including name and attributes.
+	 * @return string Rendered HTML for the embed block.
+	 */
+	public static function disable_video_rendered_html( $block_content, $block ) {
+		if ( $block['blockName'] === 'core/embed' && $block['attrs']['providerNameSlug'] === 'videopress' ) {
+			$block_content = self::change_element_src_query_param( $block_content, array( 'tag_name' => 'iframe' ), 'autoPlay', '0' );
+			return self::change_element_src_query_param( $block_content, array( 'tag_name' => 'iframe' ), 'muted', '1' );
+		}
+
+		if ( $block['blockName'] === 'core/video' ) {
+			$block_content = self::change_element_src_query_param( $block_content, array( 'tag_name' => 'iframe' ), 'autoPlay', '0' );
+			return self::change_element_src_query_param( $block_content, array( 'tag_name' => 'iframe' ), 'muted', '1' );
+		}
+
+		if ( $block['blockName'] === 'jetpack/videopress' ) {
+			$block_content = self::change_element_src_query_param( $block_content, array( 'tag_name' => 'iframe' ), 'autoPlay', '0' );
+			return self::change_element_src_query_param( $block_content, array( 'tag_name' => 'iframe' ), 'muted', '1' );
+		}
+
+		if ( $block['blockName'] === 'core/cover' && $block['attrs']['backgroundType'] === 'video' ) {
+			$block_content = self::change_element_src_query_param( $block_content, array( 'class_name' => 'wp-block-cover__video-background' ), 'autoPlay', '0' );
+			$block_content = self::change_element_src_query_param( $block_content, array( 'class_name' => 'wp-block-cover__video-background' ), 'muted', '1' );
+			return self::change_element_remove_attribute( $block_content, array( 'class_name' => 'wp-block-cover__video-background' ), 'autoplay' );
+		}
+
+		return $block_content;
+	}
+
+	/**
+	 * Finds the first tag that matches the query and updates the `src` attribute by
+	 * changing one of its query parameters.
+	 *
+	 * @param string $block_content         The HTML to process.
+	 * @param array  $tag_query             The query to find the tag (e.g., ['tag_name'=>'h1']).
+	 * @param string $query_param_name      The name of the attribute to remove.
+	 * @param string $new_query_param_value The name of the attribute to remove.
+	 * @return string The updated HTML.
+	 */
+	private static function change_element_src_query_param( $block_content, $tag_query, $query_param_name, $new_query_param_value ) {
+		$tags = new WP_HTML_Tag_Processor( $block_content );
+		if ( ! $tags->next_tag( $tag_query ) ) {
+			return $block_content;
+		}
+
+		$src = $tags->get_attribute( 'src' );
+		if ( ! $src ) {
+			return $block_content;
+		}
+
+		$parsed_url = wp_parse_url( $src );
+		if ( ! $parsed_url ) {
+			return $block_content;
+		} elseif ( isset( $parsed_url['query'] ) ) {
+			$src_query = $parsed_url['query'];
+			parse_str( $src_query, $query_params );
+			$query_params[ $query_param_name ] = $new_query_param_value;
+		} else {
+			$parsed_url['query'] = sprintf( '%s=%s', $query_param_name, $new_query_param_value );
+		}
+
+		parse_str( $src_query, $query_params );
+		$query_params[ $query_param_name ] = $new_query_param_value;
+
+		if ( isset( $parsed_url['query'] ) ) {
+			parse_str( $parsed_url['query'], $query_params );
+			$query_params[ $query_param_name ] = $new_query_param_value;
+			$parsed_url['query']               = http_build_query( $query_params );
+		} else {
+			$parsed_url['query'] = rawurlencode( $query_param_name ) . '=' . rawurlencode( $new_query_param_value );
+		}
+
+		$new_src = ( isset( $parsed_url['scheme'] ) ? $parsed_url['scheme'] . '://' : '' ) .
+			( isset( $parsed_url['host'] ) ? $parsed_url['host'] : '' ) .
+			( isset( $parsed_url['port'] ) ? ':' . $parsed_url['port'] : '' ) .
+			( isset( $parsed_url['path'] ) ? $parsed_url['path'] : '' ) .
+			( isset( $parsed_url['query'] ) ? '?' . $parsed_url['query'] : '' ) .
+			( isset( $parsed_url['fragment'] ) ? '#' . $parsed_url['fragment'] : '' );
+		$tags->set_attribute( 'src', $new_src );
+
+		return $tags->get_updated_html();
+	}
+
+	/**
+	 * Removes the specified attribute from the first tag that matches the query.
+	 *
+	 * @param string $block_content The HTML to process.
+	 * @param array  $tag_query     The query to find the tag (e.g., ['tag_name'=>'h1']).
+	 * @param string $attr_name     The name of the attribute to remove.
+	 * @return string The updated HTML.
+	 */
+	private static function change_element_remove_attribute( $block_content, $tag_query, $attr_name ) {
+		$tags = new WP_HTML_Tag_Processor( $block_content );
+		if ( ! $tags->next_tag( $tag_query ) ) {
+			return $block_content;
+		}
+
+		if ( ! $tags->remove_attribute( $attr_name ) ) {
+			return $block_content;
+		}
+
+		return $tags->get_updated_html();
 	}
 
 	/**

--- a/projects/plugins/jetpack/_inc/lib/class.jetpack-iframe-embed.php
+++ b/projects/plugins/jetpack/_inc/lib/class.jetpack-iframe-embed.php
@@ -35,7 +35,7 @@ class Jetpack_Iframe_Embed {
 		add_filter( 'shortcode_atts_video', array( 'Jetpack_Iframe_Embed', 'disable_autoplay' ) );
 		add_filter( 'shortcode_atts_audio', array( 'Jetpack_Iframe_Embed', 'disable_autoplay' ) );
 
-		add_filter( 'render_block_data', array( 'Jetpack_Iframe_Embed', 'disable_videopress_autoplay' ) );
+		add_filter( 'render_block_data', array( 'Jetpack_Iframe_Embed', 'disable_video_block_autoplay' ) );
 
 		$ver = sprintf( '%s-%s', gmdate( 'oW' ), defined( 'JETPACK__VERSION' ) ? JETPACK__VERSION : '' );
 		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
@@ -88,21 +88,22 @@ class Jetpack_Iframe_Embed {
 	}
 
 	/**
-	 * Disable `autoplay` and add `muted` to all videopress blocks in
+	 * Disable `autoplay` and add `muted` to all videopress and core/video blocks in
 	 * context of an iframe.
 	 *
 	 * @param array $parsed_block An associative array of the block being rendered.
 	 * @return array The modified block data.
 	 */
-	public static function disable_videopress_autoplay( $parsed_block ) {
-		if (
-			isset( $parsed_block['blockName'] ) &&
-			isset( $parsed_block['attrs'] ) &&
-			'videopress/video' === $parsed_block['blockName']
-		) {
+	public static function disable_video_block_autoplay( $parsed_block ) {
+		if ( ! isset( $parsed_block['blockName'] ) || ! isset( $parsed_block['attrs'] ) ) {
+			return $parsed_block;
+		}
+
+		if ( 'videopress/video' === $parsed_block['blockName'] || 'core/video' === $parsed_block['blockName'] ) {
 			$parsed_block['attrs']['autoplay'] = false;
 			$parsed_block['attrs']['muted']    = true;
 		}
+
 		return $parsed_block;
 	}
 

--- a/projects/plugins/jetpack/_inc/lib/class.jetpack-iframe-embed.php
+++ b/projects/plugins/jetpack/_inc/lib/class.jetpack-iframe-embed.php
@@ -104,6 +104,56 @@ class Jetpack_Iframe_Embed {
 			$parsed_block['attrs']['muted']    = true;
 		}
 
+		if ( 'core/video' === $parsed_block['blockName'] && isset( $parsed_block['innerHTML'] ) ) {
+			$processor = WP_HTML_Processor::create_fragment( $parsed_block['innerHTML'] );
+			while ( $processor->next_tag( 'iframe' ) ) {
+				$iframe_src = $processor->get_attribute( 'src' );
+				if ( $iframe_src ) {
+					$parsed_url = wp_parse_url( $iframe_src );
+					if ( isset( $parsed_url['query'] ) ) {
+						parse_str( $parsed_url['query'], $query_params );
+						$query_params['autoPlay'] = '0';
+						$parsed_url['query']      = http_build_query( $query_params );
+					} else {
+						$parsed_url['query'] = 'autoPlay=0';
+					}
+					$new_src = ( isset( $parsed_url['scheme'] ) ? $parsed_url['scheme'] . '://' : '' ) .
+						( isset( $parsed_url['host'] ) ? $parsed_url['host'] : '' ) .
+						( isset( $parsed_url['port'] ) ? ':' . $parsed_url['port'] : '' ) .
+						( isset( $parsed_url['path'] ) ? $parsed_url['path'] : '' ) .
+						( isset( $parsed_url['query'] ) ? '?' . $parsed_url['query'] : '' ) .
+						( isset( $parsed_url['fragment'] ) ? '#' . $parsed_url['fragment'] : '' );
+					$processor->set_attribute( 'src', $new_src );
+				}
+			}
+			$parsed_block['innerHTML'] = $processor->get_updated_html();
+		}
+
+		if ( 'core/video' === $parsed_block['blockName'] && isset( $parsed_block['innerContent'] ) && isset( $parsed_block['innerContent'][0] ) ) {
+			$processor = WP_HTML_Processor::create_fragment( $parsed_block['innerContent'][0] );
+			while ( $processor->next_tag( 'iframe' ) ) {
+				$iframe_src = $processor->get_attribute( 'src' );
+				if ( $iframe_src ) {
+					$parsed_url = wp_parse_url( $iframe_src );
+					if ( isset( $parsed_url['query'] ) ) {
+						parse_str( $parsed_url['query'], $query_params );
+						$query_params['autoPlay'] = '0';
+						$parsed_url['query']      = http_build_query( $query_params );
+					} else {
+						$parsed_url['query'] = 'autoPlay=0';
+					}
+					$new_src = ( isset( $parsed_url['scheme'] ) ? $parsed_url['scheme'] . '://' : '' ) .
+						( isset( $parsed_url['host'] ) ? $parsed_url['host'] : '' ) .
+						( isset( $parsed_url['port'] ) ? ':' . $parsed_url['port'] : '' ) .
+						( isset( $parsed_url['path'] ) ? $parsed_url['path'] : '' ) .
+						( isset( $parsed_url['query'] ) ? '?' . $parsed_url['query'] : '' ) .
+						( isset( $parsed_url['fragment'] ) ? '#' . $parsed_url['fragment'] : '' );
+					$processor->set_attribute( 'src', $new_src );
+				}
+			}
+			$parsed_block['innerContent'][0] = $processor->get_updated_html();
+		}
+
 		return $parsed_block;
 	}
 

--- a/projects/plugins/jetpack/changelog/DOTDASH-137-disable-videopress-in-preview
+++ b/projects/plugins/jetpack/changelog/DOTDASH-137-disable-videopress-in-preview
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Prevent videopress blocks autoplaying when previewed inside Calypso iframes

--- a/projects/plugins/jetpack/changelog/DOTDASH-137-disable-videopress-in-preview
+++ b/projects/plugins/jetpack/changelog/DOTDASH-137-disable-videopress-in-preview
@@ -1,4 +1,4 @@
 Significance: minor
 Type: other
 
-Prevent videopress blocks autoplaying when previewed inside Calypso iframes
+Prevent video blocks autoplaying when previewed inside Calypso iframes


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of DOTDASH-137

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Prevent videopress blocks from autoplaying in Calypso iframe previews
* It does this by changing the `muted` and `autoplay` attributes during render

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

The video shortcodes are already being prevented from autoplaying in an iframe preview. So by the same logic the videopress block should also 

The `?iframe=true&preview=true` logic isn't bullet proof. _Theoretically_ a used could choose to use these query params too on their front end. But it is safe to change behaviour based on these flags because
- We're already relying on these flags
- The change is only minor, it does not for example, break video playback

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

**Testing Simple and VideoPress**

* On your test site, add a videopress video (ideally one with audio) to the front page. Set it to autoplay.
* Sandbox your test site
* Load your site's front end with `?iframe=true&preview=true` query params
  * The video does not auto play
* Load your site's front end without the query params
  * The video auto plays
* `https://wpcalypso.wordpress.com/v2` and find your site in grid view
  * The video in the preview should not play
* `https://wordpress.com/home/{{ your test site }}`
  * Once https://github.com/Automattic/wp-calypso/pull/104713 is merged, the preview on My Home will not auto play.

**Testing Atomic and VideoPress**

Use The Jetpack beta plugin do the same tests on an atomic site

**Testing Atomic and core/video**

* Disable the VideoPress feature from the JP dashboard `/wp-admin/admin.php?page=jetpack#/dashboard`
* Upload a fresh video
  * You can reupload the same video if you want but you have to delete the old copy from your media library first
  * Any video file left over from when VideoPress was enabled will still have a videopress URL
* In a new page add a `core/video` block, using your fresh video file
* Load your site's front end with `?iframe=true&preview=true` query params
  * The video does not auto play
* Load your site's front end without the query params
  * The video auto plays

**Other blocks to test**

* A `core/video` block that is pointing at a video press file
* A `core/cover` block which is using a video background
* A `[wpvideo asdfksda]` shortcode
* An embed block, where a videopress url has been pasted