### PR TITLE
Untangling: Show "Jetpack -> Subscribers" menu on all sites

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/dotcom-13884-untangling-ia-show-jetpack-subscribers-menu
+++ b/projects/packages/jetpack-mu-wpcom/changelog/dotcom-13884-untangling-ia-show-jetpack-subscribers-menu
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Admin Menu: Register "Jetpack > Subscribers" menu on all sites

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
@@ -245,6 +245,22 @@ function wpcom_add_jetpack_submenu() {
 		null // @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
 	);
 
+	// Jetpack > Subscribers.
+	if ( ! apply_filters( 'jetpack_wp_admin_subscriber_management_enabled', false ) ) {
+		wpcom_hide_submenu_page( 'jetpack', esc_url( Redirect::get_url( 'jetpack-menu-jetpack-manage-subscribers', array( 'site' => $blog_id ) ) ) );
+		add_submenu_page(
+			'jetpack',
+			__( 'Subscribers', 'jetpack-mu-wpcom' ),
+			__( 'Subscribers', 'jetpack-mu-wpcom' ),
+			'manage_options',
+			'https://wordpress.com/subscribers/' . $domain,
+			null // @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
+		);
+	} else {
+		$subscribers_dashboard = new Subscribers_Dashboard();
+		$subscribers_dashboard->add_wp_admin_submenu();
+	}
+
 	if ( $uses_wp_admin_interface ) {
 		// Jetpack > Activity Log.
 		wpcom_hide_submenu_page( 'jetpack', esc_url( Redirect::get_url( 'cloud-activity-log-wp-menu', array( 'site' => $blog_id ) ) ) );
@@ -256,22 +272,6 @@ function wpcom_add_jetpack_submenu() {
 			'https://wordpress.com/activity-log/' . $domain,
 			null // @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
 		);
-
-		// Jetpack > Subscribers.
-		if ( ! apply_filters( 'jetpack_wp_admin_subscriber_management_enabled', false ) ) {
-			wpcom_hide_submenu_page( 'jetpack', esc_url( Redirect::get_url( 'jetpack-menu-jetpack-manage-subscribers', array( 'site' => $blog_id ) ) ) );
-			add_submenu_page(
-				'jetpack',
-				__( 'Subscribers', 'jetpack-mu-wpcom' ),
-				__( 'Subscribers', 'jetpack-mu-wpcom' ),
-				'manage_options',
-				'https://wordpress.com/subscribers/' . $domain,
-				null // @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
-			);
-		} else {
-			$subscribers_dashboard = new Subscribers_Dashboard();
-			$subscribers_dashboard->add_wp_admin_submenu();
-		}
 
 		// Jetpack > Newsletter.
 		if ( $is_simple_site ) {

--- a/projects/packages/masterbar/changelog/dotcom-13884-untangling-ia-show-jetpack-subscribers-menu
+++ b/projects/packages/masterbar/changelog/dotcom-13884-untangling-ia-show-jetpack-subscribers-menu
@@ -1,0 +1,4 @@
+Significance: minor
+Type: deprecated
+
+Admin Menu: Deprecate "Users > Subscribers" menu

--- a/projects/packages/masterbar/src/admin-menu/class-atomic-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-atomic-admin-menu.php
@@ -11,7 +11,6 @@ use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Current_Plan as Jetpack_Plan;
 use Automattic\Jetpack\JITMS\JITM;
 use Automattic\Jetpack\Modules;
-use Automattic\Jetpack\Subscribers_Dashboard\Dashboard as Subscribers_Dashboard;
 
 require_once __DIR__ . '/class-admin-menu.php';
 
@@ -138,13 +137,10 @@ class Atomic_Admin_Menu extends Admin_Menu {
 			$this->update_submenus( $slug, $submenus_to_update );
 		}
 
+		// Temporary "Users > Subscribers" menu for existing users that shows a callout informing that the screen has moved to "Jetpack > Subscribers".
 		if ( ! $this->use_wp_admin_interface() && ! apply_filters( 'jetpack_wp_admin_subscriber_management_enabled', false ) ) {
-			// The 'Subscribers' menu exists in the Jetpack menu for Classic wp-admin interface, so only add it for non-wp-admin interfaces.
 			// // @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
 			add_submenu_page( 'users.php', esc_attr__( 'Subscribers', 'jetpack-masterbar' ), __( 'Subscribers', 'jetpack-masterbar' ), 'list_users', 'https://wordpress.com/subscribers/' . $this->domain, null );
-		} elseif ( apply_filters( 'jetpack_wp_admin_subscriber_management_enabled', false ) ) {
-			$subscribers_dashboard = new Subscribers_Dashboard();
-			$subscribers_dashboard->add_wp_admin_submenu();
 		}
 
 		// Users who can't 'list_users' will see "Profile" menu & "Profile > Account Settings" as submenu.

--- a/projects/packages/masterbar/src/admin-menu/class-atomic-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-atomic-admin-menu.php
@@ -138,7 +138,7 @@ class Atomic_Admin_Menu extends Admin_Menu {
 		}
 
 		// Temporary "Users > Subscribers" menu for existing users that shows a callout informing that the screen has moved to "Jetpack > Subscribers".
-		if ( ! $this->use_wp_admin_interface() && ! apply_filters( 'jetpack_wp_admin_subscriber_management_enabled', false ) ) {
+		if ( ! $this->use_wp_admin_interface() && ! apply_filters( 'jetpack_wp_admin_subscriber_management_enabled', false ) && get_current_user_id() < 268854000 ) {
 			// // @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
 			add_submenu_page( 'users.php', esc_attr__( 'Subscribers', 'jetpack-masterbar' ), __( 'Subscribers', 'jetpack-masterbar' ), 'list_users', 'https://wordpress.com/subscribers/jetpack-subscribers/' . $this->domain, null );
 		}

--- a/projects/packages/masterbar/src/admin-menu/class-atomic-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-atomic-admin-menu.php
@@ -140,7 +140,7 @@ class Atomic_Admin_Menu extends Admin_Menu {
 		// Temporary "Users > Subscribers" menu for existing users that shows a callout informing that the screen has moved to "Jetpack > Subscribers".
 		if ( ! $this->use_wp_admin_interface() && ! apply_filters( 'jetpack_wp_admin_subscriber_management_enabled', false ) ) {
 			// // @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
-			add_submenu_page( 'users.php', esc_attr__( 'Subscribers', 'jetpack-masterbar' ), __( 'Subscribers', 'jetpack-masterbar' ), 'list_users', 'https://wordpress.com/subscribers/' . $this->domain, null );
+			add_submenu_page( 'users.php', esc_attr__( 'Subscribers', 'jetpack-masterbar' ), __( 'Subscribers', 'jetpack-masterbar' ), 'list_users', 'https://wordpress.com/subscribers/jetpack-subscribers/' . $this->domain, null );
 		}
 
 		// Users who can't 'list_users' will see "Profile" menu & "Profile > Account Settings" as submenu.

--- a/projects/packages/masterbar/src/admin-menu/class-wpcom-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-wpcom-admin-menu.php
@@ -7,7 +7,6 @@
 
 namespace Automattic\Jetpack\Masterbar;
 
-use Automattic\Jetpack\Subscribers_Dashboard\Dashboard as Subscribers_Dashboard;
 use Jetpack_Custom_CSS;
 use JITM;
 
@@ -271,12 +270,11 @@ class WPcom_Admin_Menu extends Admin_Menu {
 		$this->update_submenus( $slug, $submenus_to_update );
 		// @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
 		add_submenu_page( 'users.php', esc_attr__( 'Add New User', 'jetpack-masterbar' ), __( 'Add New User', 'jetpack-masterbar' ), 'promote_users', 'https://wordpress.com/people/new/' . $this->domain, null, 1 );
+
+		// Temporary "Users > Subscribers" menu for existing users that shows a callout informing that the screen has moved to "Jetpack > Subscribers".
 		if ( ! apply_filters( 'jetpack_wp_admin_subscriber_management_enabled', false ) ) {
 			// @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
-			add_submenu_page( 'users.php', esc_attr__( 'Subscribers', 'jetpack-masterbar' ), __( 'Subscribers', 'jetpack-masterbar' ), 'list_users', 'https://wordpress.com/subscribers/' . $this->domain, null, 3 );
-		} else {
-			$subscribers_dashboard = new Subscribers_Dashboard();
-			$subscribers_dashboard->add_wp_admin_submenu();
+			add_submenu_page( 'users.php', esc_attr__( 'Subscribers', 'jetpack-masterbar' ), __( 'Subscribers', 'jetpack-masterbar' ), 'list_users', 'https://wordpress.com/subscribers/jetpack-subscribers/' . $this->domain, null, 3 );
 		}
 	}
 

--- a/projects/packages/masterbar/src/admin-menu/class-wpcom-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-wpcom-admin-menu.php
@@ -272,7 +272,7 @@ class WPcom_Admin_Menu extends Admin_Menu {
 		add_submenu_page( 'users.php', esc_attr__( 'Add New User', 'jetpack-masterbar' ), __( 'Add New User', 'jetpack-masterbar' ), 'promote_users', 'https://wordpress.com/people/new/' . $this->domain, null, 1 );
 
 		// Temporary "Users > Subscribers" menu for existing users that shows a callout informing that the screen has moved to "Jetpack > Subscribers".
-		if ( ! apply_filters( 'jetpack_wp_admin_subscriber_management_enabled', false ) ) {
+		if ( ! apply_filters( 'jetpack_wp_admin_subscriber_management_enabled', false ) && get_current_user_id() < 268854000 ) {
 			// @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
 			add_submenu_page( 'users.php', esc_attr__( 'Subscribers', 'jetpack-masterbar' ), __( 'Subscribers', 'jetpack-masterbar' ), 'list_users', 'https://wordpress.com/subscribers/jetpack-subscribers/' . $this->domain, null, 3 );
 		}

--- a/projects/packages/masterbar/tests/php/Atomic_Admin_Menu_Test.php
+++ b/projects/packages/masterbar/tests/php/Atomic_Admin_Menu_Test.php
@@ -178,7 +178,6 @@ class Atomic_Admin_Menu_Test extends TestCase {
 		$this->assertSame( 'https://wordpress.com/people/team/' . static::$domain, $submenu['users.php'][0][2] );
 		$this->assertSame( 'user-new.php', $submenu['users.php'][2][2] );
 		$this->assertSame( 'profile.php', $submenu['users.php'][3][2] );
-		$this->assertSame( 'https://wordpress.com/subscribers/' . static::$domain, $submenu['users.php'][4][2] );
 		$this->assertSame( 'https://wordpress.com/me/account', $submenu['users.php'][5][2] );
 	}
 

--- a/projects/packages/masterbar/tests/php/WPcom_Admin_Menu_Test.php
+++ b/projects/packages/masterbar/tests/php/WPcom_Admin_Menu_Test.php
@@ -173,7 +173,6 @@ class WPcom_Admin_Menu_Test extends TestCase {
 		static::$admin_menu->set_preferred_view( 'users.php', 'unknown' );
 		static::$admin_menu->add_users_menu();
 		$this->assertSame( 'https://wordpress.com/people/team/' . static::$domain, array_shift( $submenu['users.php'] )[2] );
-		$this->assertSame( 'https://wordpress.com/subscribers/' . static::$domain, $submenu['users.php'][2][2] );
 	}
 
 	/**


### PR DESCRIPTION
Fixes DOTCOM-13884

## Proposed changes:

- Move the `/subscribers/:site` path to the Jetpack > Subscribers menu for all sites (that menu was previously only visible with the classic interface).
- The existing Users > Subscribers menu (only visible with the default interface) will now point to `/subscribers/jetpack-subscribers/:site` so we can inform users with a callout that the menu has been moved (see DOTCOM-13883). This menu will be removed after a month, and it's only visible to existing users.

Site / Interface | Before | After
--- | --- | ---
Simple / Default | <img width="555" height="259" alt="Screenshot 2025-07-14 at 08 07 43" src="https://github.com/user-attachments/assets/433a4b8c-de45-469d-858a-7853de0b437c" /><ul><li>Jetpack > Subscribers does not exist.</li></ul> | <img width="556" height="284" alt="Screenshot 2025-07-14 at 17 17 12" src="https://github.com/user-attachments/assets/2761d236-e6dc-4826-bc33-48429b40f3ed" /><ul><li>Jetpack > Subscribers is now visible.</li></ul>
Simple / Classic | <img width="333" height="370" alt="Screenshot 2025-07-14 at 08 10 34" src="https://github.com/user-attachments/assets/7ca69480-53b2-4c55-8c24-829b9c6000b9" /><ul><li>Jetpack > Subscribers already exists.</li></ul> | <img width="333" height="370" alt="Screenshot 2025-07-14 at 08 10 34" src="https://github.com/user-attachments/assets/7ca69480-53b2-4c55-8c24-829b9c6000b9" /><ul><li>No changes.</li></ul>
Atomic / Simple | <img width="555" height="366" alt="Screenshot 2025-07-14 at 08 59 09" src="https://github.com/user-attachments/assets/d662b831-f1ad-458f-9406-27e886090797" /><ul><li>Jetpack > Subscribers does not exist.</li></ul> |<img width="557" height="398" alt="Screenshot 2025-07-14 at 17 20 51" src="https://github.com/user-attachments/assets/0798f861-49bb-4f6e-9a6d-c5e815b6ae81" /><ul><li>Jetpack > Subscribers is now visible.</li></ul>
Atomic / Classic | <img width="334" height="457" alt="Screenshot 2025-07-14 at 08 59 49" src="https://github.com/user-attachments/assets/9fbbab8a-9eb1-4644-949d-d9e38ec4e8ee" /><ul><li>Jetpack > Subscribers already exists.</li></ul> | <img width="334" height="457" alt="Screenshot 2025-07-14 at 08 59 49" src="https://github.com/user-attachments/assets/9fbbab8a-9eb1-4644-949d-d9e38ec4e8ee" /><ul><li>No changes.</li></ul>

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
- Apply these changes to your WP.com site
- Make sure that "Jetpack > Subscribers" is visible on the default admin interface
- Make sure it points to `/subscribers/:site`
- Make sure that "Tools > Monetize" is only visible on the default admin interface and only for existing users.
- Make sure it points to `/subscibers/jetpack-subscribers/:site` (on a follow-up, this route will display a callout, see see DOTCOM-13883).

