### PR TITLE
push-to-mirrors: Try working around a git bug

### DIFF
--- a/projects/github-actions/push-to-mirrors/changelog/fix-push-to-mirrors-workaround-git-bug
+++ b/projects/github-actions/push-to-mirrors/changelog/fix-push-to-mirrors-workaround-git-bug
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Add a workaround for [a git bug](https://lore.kernel.org/git/20250428192320.3595509-1-jonathantanmy@google.com/).

--- a/projects/github-actions/push-to-mirrors/push-to-mirrors.sh
+++ b/projects/github-actions/push-to-mirrors/push-to-mirrors.sh
@@ -204,7 +204,10 @@ while read -r GIT_SLUG; do
 				echo "::endgroup::"
 			fi
 			echo "::group::Fetching treeless commits for source repo $LAST_COMMIT and $SHA"
-			git -c protocol.version=2 fetch --filter=tree:0 --no-tags --progress --no-recurse-submodules origin "$LAST_COMMIT" "$SHA"
+			# We hit a git bug here. https://lore.kernel.org/git/20250428192320.3595509-1-jonathantanmy@google.com/
+			# Running the command twice seems to work around it.
+			git -c protocol.version=2 fetch --filter=tree:0 --no-tags --progress --no-recurse-submodules origin "$LAST_COMMIT" "$SHA" ||
+				git -c protocol.version=2 fetch --filter=tree:0 --no-tags --progress --no-recurse-submodules origin "$LAST_COMMIT" "$SHA"
 			echo "::endgroup::"
 			MB=$( git merge-base "$LAST_COMMIT" "$SHA" || true )
 			if [[ -z "$MB" ]]; then


### PR DESCRIPTION
Closes MONOREP-12

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Seems we're running into a git bug, [reported][1] a few months back but seemingly no progress since due to lack of a simple reproduction.

It seems that the failure is in some sort of optional post-fetch processing, as running the command a second time seems to work. 🤷

[1]: https://lore.kernel.org/git/20250428192320.3595509-1-jonathantanmy@google.com/

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1752510247106009/1752508831.876649-slack-C01U2KGS2PQ

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

I can reproduce by doing something like this in a fresh temporary directory:
```
# Setup, like action/checkout
git init .
git remote add origin https://github.com/Automattic/jetpack
git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +93c01a3ac82d21ebc35f53d10b3fcaa9e6e840c3:refs/remotes/origin/prerelease
git checkout --progress --force -B prerelease refs/remotes/origin/prerelease

# From push-to-mirrors
git -c protocol.version=2 fetch --unshallow --filter=tree:0 --no-tags --progress --no-recurse-submodules origin HEAD

# This is the failing command
git -c protocol.version=2 fetch --filter=tree:0 --no-tags --progress --no-recurse-submodules origin 93c01a3ac82d21ebc35f53d10b3fcaa9e6e840c3 7162d0b6a1ff8eb8e01a88ce074a1eb7a5900b21
echo $?

# Running a second time works 🤷
git -c protocol.version=2 fetch --filter=tree:0 --no-tags --progress --no-recurse-submodules origin 93c01a3ac82d21ebc35f53d10b3fcaa9e6e840c3 7162d0b6a1ff8eb8e01a88ce074a1eb7a5900b21
echo $?
git log -1 7162d0b6a1ff8eb8e01a88ce074a1eb7a5900b21
```