### PR TITLE
Replace lodash/underscore in some modules

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-replace-lodash-underscore-in-modules
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-replace-lodash-underscore-in-modules
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Replace lodash/underscore in modules. Should be no change to functionality.
+
+

--- a/projects/packages/jetpack-mu-wpcom/src/features/custom-css/custom-css.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/custom-css/custom-css.php
@@ -463,7 +463,6 @@ if ( ! class_exists( 'Jetpack_Custom_CSS_Enhancements' ) ) {
 					'dependencies' => array(
 						'jquery',
 						'customize-controls',
-						'underscore',
 					),
 					'in-footer'    => true,
 					'css_path'     => '../../build/customizer-control/customizer-control.css',

--- a/projects/packages/jetpack-mu-wpcom/src/features/custom-css/custom-css/js/core-customizer-css-preview.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/custom-css/custom-css/js/core-customizer-css-preview.js
@@ -1,5 +1,5 @@
 // Originally based on https://raw.githubusercontent.com/xwp/wp-custom-scss-demo/master/custom-scss-demo-preview.js
-/* globals jpCustomizerCssPreview _ wp */
+/* globals jpCustomizerCssPreview wp */
 ( function ( api, $ ) {
 	if ( api.settingPreviewHandlers ) {
 		// No-op the custom_css preview handler since now handled by partial.
@@ -27,9 +27,9 @@
 			// No special providers, just write what we got.
 			const deferred = new $.Deferred();
 			const setting = api( 'custom_css[' + api.settings.theme.stylesheet + ']' );
-			_.each( partial.placements(), function ( placement ) {
+			for ( const placement of partial.placements() ) {
 				placement.container.text( setting.get() );
-			} );
+			}
 
 			deferred.resolve();
 			return deferred.promise();

--- a/projects/plugins/jetpack/_inc/jetpack-modules.models.js
+++ b/projects/plugins/jetpack/_inc/jetpack-modules.models.js
@@ -1,6 +1,6 @@
 window.jetpackModules = window.jetpackModules || {};
 
-window.jetpackModules.models = ( function ( window, $, _, Backbone ) {
+window.jetpackModules.models = ( function ( window, $, Backbone ) {
 	'use strict';
 
 	var models = {};
@@ -14,7 +14,7 @@ window.jetpackModules.models = ( function ( window, $, _, Backbone ) {
 		 */
 		filter_and_sort: function () {
 			var subsubsub = $( '.subsubsub .current a' ),
-				items = this.get( 'raw' ),
+				items = Object.values( this.get( 'raw' ) ),
 				m_filter = $( '.button-group.filter-active .active' ),
 				m_sort = $( '.button-group.sort .active' ),
 				m_search = $( '#srch-term-search-input' ).val().toLowerCase(),
@@ -22,19 +22,17 @@ window.jetpackModules.models = ( function ( window, $, _, Backbone ) {
 
 			// If a module filter has been selected, filter it!
 			if ( ! subsubsub.closest( 'li' ).hasClass( 'all' ) ) {
-				items = _.filter( items, function ( item ) {
-					return _.contains( item.module_tags, subsubsub.data( 'title' ) );
-				} );
+				items = items.filter( item => item.module_tags.includes( subsubsub.data( 'title' ) ) );
 			}
 
 			if ( m_filter.data( 'filter-by' ) ) {
-				items = _.filter( items, function ( item ) {
-					return item[ m_filter.data( 'filter-by' ) ] === m_filter.data( 'filter-value' );
-				} );
+				items = items.filter(
+					item => item[ m_filter.data( 'filter-by' ) ] === m_filter.data( 'filter-value' )
+				);
 			}
 
 			if ( m_search.length ) {
-				items = _.filter( items, function ( item ) {
+				items = items.filter( function ( item ) {
 					var search_text =
 						item.name +
 						' ' +
@@ -50,15 +48,18 @@ window.jetpackModules.models = ( function ( window, $, _, Backbone ) {
 			}
 
 			if ( m_sort.data( 'sort-by' ) ) {
-				items = _.sortBy( items, m_sort.data( 'sort-by' ) );
-				if ( 'reverse' === m_sort.data( 'sort-order' ) ) {
-					items.reverse();
-				}
+				const key = m_sort.data( 'sort-by' );
+				const cmpret = 'reverse' === m_sort.data( 'sort-order' ) ? -1 : 1;
+
+				items.sort( ( a, b ) =>
+					// eslint-disable-next-line no-nested-ternary
+					a[ key ] > b[ key ] ? cmpret : a[ key ] < b[ key ] ? -cmpret : 0
+				);
 			}
 
 			// Sort unavailable modules to the end if the user is running in local mode.
-			groups = _.groupBy( items, 'available' );
-			if ( _.has( groups, 'false' ) ) {
+			groups = Object.groupBy( items, item => item.available );
+			if ( Object.hasOwn( groups, 'false' ) ) {
 				items = [].concat( groups.true, groups.false );
 			}
 
@@ -75,4 +76,4 @@ window.jetpackModules.models = ( function ( window, $, _, Backbone ) {
 	} );
 
 	return models;
-} )( window, jQuery, _, Backbone );
+} )( window, jQuery, Backbone );

--- a/projects/plugins/jetpack/_inc/jetpack-modules.models.js
+++ b/projects/plugins/jetpack/_inc/jetpack-modules.models.js
@@ -17,8 +17,7 @@ window.jetpackModules.models = ( function ( window, $, Backbone ) {
 				items = Object.values( this.get( 'raw' ) ),
 				m_filter = $( '.button-group.filter-active .active' ),
 				m_sort = $( '.button-group.sort .active' ),
-				m_search = $( '#srch-term-search-input' ).val().toLowerCase(),
-				groups;
+				m_search = $( '#srch-term-search-input' ).val().toLowerCase();
 
 			// If a module filter has been selected, filter it!
 			if ( ! subsubsub.closest( 'li' ).hasClass( 'all' ) ) {
@@ -58,10 +57,8 @@ window.jetpackModules.models = ( function ( window, $, Backbone ) {
 			}
 
 			// Sort unavailable modules to the end if the user is running in local mode.
-			groups = Object.groupBy( items, item => item.available );
-			if ( Object.hasOwn( groups, 'false' ) ) {
-				items = [].concat( groups.true, groups.false );
-			}
+			// JS sort is supposed to be stable since 2019, and is in browsers we care about, so this is safe.
+			items.sort( ( a, b ) => b.available - a.available );
 
 			// Now shove it back in.
 			this.set( 'items', items );

--- a/projects/plugins/jetpack/_inc/jetpack-modules.views.js
+++ b/projects/plugins/jetpack/_inc/jetpack-modules.views.js
@@ -1,6 +1,6 @@
 window.jetpackModules = window.jetpackModules || {};
 
-window.jetpackModules.views = ( function ( window, $, _, Backbone, wp ) {
+window.jetpackModules.views = ( function ( window, $, Backbone, wp ) {
 	'use strict';
 
 	var views = {};
@@ -59,4 +59,4 @@ window.jetpackModules.views = ( function ( window, $, _, Backbone, wp ) {
 	} );
 
 	return views;
-} )( window, jQuery, _, Backbone, wp );
+} )( window, jQuery, Backbone, wp );

--- a/projects/plugins/jetpack/changelog/fix-replace-lodash-underscore-in-modules
+++ b/projects/plugins/jetpack/changelog/fix-replace-lodash-underscore-in-modules
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Replace lodash/underscore in modules. Should be no change to functionality.
+
+

--- a/projects/plugins/jetpack/class.jetpack-modules-list-table.php
+++ b/projects/plugins/jetpack/class.jetpack-modules-list-table.php
@@ -51,7 +51,7 @@ class Jetpack_Modules_List_Table extends WP_List_Table {
 				'_inc/build/jetpack-modules.models.min.js',
 				'_inc/jetpack-modules.models.js'
 			),
-			array( 'jquery', 'backbone', 'underscore' ),
+			array( 'jquery', 'backbone' ),
 			JETPACK__VERSION,
 			false // @todo Can this be put in the footer?
 		);
@@ -61,7 +61,7 @@ class Jetpack_Modules_List_Table extends WP_List_Table {
 				'_inc/build/jetpack-modules.views.min.js',
 				'_inc/jetpack-modules.views.js'
 			),
-			array( 'jquery', 'backbone', 'underscore', 'wp-util' ),
+			array( 'jquery', 'backbone', 'wp-util' ),
 			JETPACK__VERSION,
 			false // @todo Can this be put in the footer?
 		);

--- a/projects/plugins/jetpack/modules/videopress/js/editor-view.js
+++ b/projects/plugins/jetpack/modules/videopress/js/editor-view.js
@@ -130,28 +130,21 @@
 			};
 
 			tinyMCE.ui.FormItem.prototype.renderHtml = function () {
-				_.each(
-					vpEditorView.modal_labels,
-					function ( value, key ) {
-						if ( value === this.settings.items.text ) {
-							this.classes.add( 'videopress-field-' + key );
-						}
-					},
-					this
-				);
+				for ( const [ key, value ] of Object.entries( vpEditorView.modal_labels ) ) {
+					if ( value === this.settings.items.text ) {
+						this.classes.add( 'videopress-field-' + key );
+					}
+				}
 
 				if (
-					_.contains(
-						[
-							vpEditorView.modal_labels.hd,
-							vpEditorView.modal_labels.permalink,
-							vpEditorView.modal_labels.autoplay,
-							vpEditorView.modal_labels.loop,
-							vpEditorView.modal_labels.freedom,
-							vpEditorView.modal_labels.flashonly,
-						],
-						this.settings.items.text
-					)
+					[
+						vpEditorView.modal_labels.hd,
+						vpEditorView.modal_labels.permalink,
+						vpEditorView.modal_labels.autoplay,
+						vpEditorView.modal_labels.loop,
+						vpEditorView.modal_labels.freedom,
+						vpEditorView.modal_labels.flashonly,
+					].includes( this.settings.items.text )
 				) {
 					this.classes.add( 'videopress-checkbox' );
 				}
@@ -161,13 +154,9 @@
 			/**
 			 * Populate the defaults.
 			 */
-			_.each(
-				this.defaults,
-				function ( value, key ) {
-					named[ key ] = this.coerce( named, key );
-				},
-				this
-			);
+			for ( const [ key ] of Object.entries( this.defaults ) ) {
+				named[ key ] = this.coerce( named, key );
+			}
 
 			/**
 			 * Declare the fields that will show in the popup when editing the shortcode.
@@ -243,7 +232,9 @@
 						tag: renderer.shortcode_string,
 						type: 'single',
 						attrs: {
-							named: _.pick( e.data, _.keys( renderer.defaults ) ),
+							named: Object.fromEntries(
+								Object.entries( e.data ).filter( ( [ k ] ) => k in renderer.defaults )
+							),
 							numeric: [ e.data.guid ],
 						},
 					};
@@ -252,23 +243,19 @@
 						args.attrs.named.at = '';
 					}
 
-					_.each(
-						renderer.defaults,
-						function ( value, key ) {
-							args.attrs.named[ key ] = this.coerce( args.attrs.named, key );
+					for ( const [ key, value ] of Object.entries( renderer.defaults ) ) {
+						args.attrs.named[ key ] = renderer.coerce( args.attrs.named, key );
 
-							if ( value === args.attrs.named[ key ] ) {
-								delete args.attrs.named[ key ];
-							}
-						},
-						renderer
-					);
+						if ( value === args.attrs.named[ key ] ) {
+							delete args.attrs.named[ key ];
+						}
+					}
 
 					editor.insertContent( wp.shortcode.string( args ) );
 				},
 				onopen: function ( e ) {
 					var prefix = 'mce-videopress-field-';
-					_.each( [ 'w', 'at' ], function ( value ) {
+					for ( const value of [ 'w', 'at' ] ) {
 						e.target.$el
 							.find( '.' + prefix + value + ' .mce-container-body' )
 							.append(
@@ -281,7 +268,7 @@
 									'">' +
 									vpEditorView.modal_labels[ value + '_unit' ]
 							);
-					} );
+					}
 					$( 'body' ).addClass( 'modal-open' );
 				},
 				onclose: function () {
@@ -293,11 +280,12 @@
 			tinyMCE.ui.FormItem.prototype.renderHtml = oldRenderFormItem;
 		},
 	};
-	wp.mce.views.register( 'videopress', wp.mce.videopress_wp_view_renderer );
 
 	// Extend the videopress one to also handle `wpvideo` instances.
-	wp.mce.wpvideo_wp_view_renderer = _.extend( {}, wp.mce.videopress_wp_view_renderer, {
+	wp.mce.wpvideo_wp_view_renderer = Object.assign( {}, wp.mce.videopress_wp_view_renderer, {
 		shortcode_string: 'wpvideo',
 	} );
+
+	wp.mce.views.register( 'videopress', wp.mce.videopress_wp_view_renderer );
 	wp.mce.views.register( 'wpvideo', wp.mce.wpvideo_wp_view_renderer );
 } )( jQuery, wp, vpEditorView );

--- a/projects/plugins/jetpack/modules/videopress/js/videopress-plupload.js
+++ b/projects/plugins/jetpack/modules/videopress/js/videopress-plupload.js
@@ -222,7 +222,7 @@ window.wp = window.wp || {};
 		 * @param {Array}             files    Array of file objects that were added to queue by the user.
 		 */
 		this.uploader.bind( 'FilesAdded', function ( up, files ) {
-			_.each( files, function ( file ) {
+			for ( const file of files ) {
 				var attributes, image;
 
 				// Ignore failed uploads.
@@ -231,17 +231,19 @@ window.wp = window.wp || {};
 				}
 
 				// Generate attributes for a new `Attachment` model.
-				attributes = _.extend(
-					{
-						file: file,
-						uploading: true,
-						date: new Date(),
-						filename: file.name,
-						menuOrder: 0,
-						uploadedTo: wp.media.model.settings.post.id,
-					},
-					_.pick( file, 'loaded', 'size', 'percent' )
-				);
+				attributes = {
+					file: file,
+					uploading: true,
+					date: new Date(),
+					filename: file.name,
+					menuOrder: 0,
+					uploadedTo: wp.media.model.settings.post.id,
+					...Object.fromEntries(
+						Object.entries( file ).filter(
+							( [ k ] ) => k === 'loaded' || k === 'size' || k === 'percent'
+						)
+					),
+				};
 
 				// Handle early mime type scanning for images.
 				image = /(?:jpe?g|png|gif|webp)$/i.exec( file.name );
@@ -261,14 +263,18 @@ window.wp = window.wp || {};
 				Uploader.queue.add( file.attachment );
 
 				self.added( file.attachment );
-			} );
+			}
 
 			up.refresh();
 			up.start();
 		} );
 
 		this.uploader.bind( 'UploadProgress', function ( up, file ) {
-			file.attachment.set( _.pick( file, 'loaded', 'percent' ) );
+			file.attachment.set(
+				Object.fromEntries(
+					Object.entries( file ).filter( ( [ k ] ) => k === 'loaded' || k === 'percent' )
+				)
+			);
 			self.progress( file.attachment );
 		} );
 
@@ -295,11 +301,11 @@ window.wp = window.wp || {};
 				response = vp.handleStandardResponse( response, file );
 			}
 
-			_.each( [ 'file', 'loaded', 'size', 'percent' ], function ( k ) {
+			for ( const k of [ 'file', 'loaded', 'size', 'percent' ] ) {
 				file.attachment.unset( k );
-			} );
+			}
 
-			file.attachment.set( _.extend( response.data, { uploading: false } ) );
+			file.attachment.set( { ...response.data, uploading: false } );
 			var att = wp.media.model.Attachment.get( response.data.id, file.attachment );
 
 			/* Once the new "empty" attachment is added to the collection above, check if it exists on the server, then set the new data.
@@ -340,7 +346,7 @@ window.wp = window.wp || {};
 				if ( pluploadError.code === plupload[ k ] ) {
 					message = Uploader.errorMap[ k ];
 
-					if ( _.isFunction( message ) ) {
+					if ( typeof message === 'function' ) {
 						message = message( pluploadError.file, pluploadError );
 					}
 

--- a/projects/plugins/jetpack/modules/videopress/js/videopress-uploader.js
+++ b/projects/plugins/jetpack/modules/videopress/js/videopress-uploader.js
@@ -9,7 +9,7 @@ window.wp = window.wp || {};
 		 * This is the standard uploader response handler.
 		 */
 		handleStandardResponse: function ( response, file ) {
-			if ( ! _.isObject( response ) || _.isUndefined( response.success ) ) {
+			if ( typeof response !== 'object' || typeof response.success === 'undefined' ) {
 				return error( pluploadL10n.default_error, null, file );
 			} else if ( ! response.success ) {
 				return error( response.data && response.data.message, response.data, file );

--- a/projects/plugins/jetpack/modules/videopress/js/videopress-uploader.js
+++ b/projects/plugins/jetpack/modules/videopress/js/videopress-uploader.js
@@ -9,7 +9,11 @@ window.wp = window.wp || {};
 		 * This is the standard uploader response handler.
 		 */
 		handleStandardResponse: function ( response, file ) {
-			if ( typeof response !== 'object' || typeof response.success === 'undefined' ) {
+			if (
+				response === null ||
+				typeof response !== 'object' ||
+				typeof response.success === 'undefined'
+			) {
 				return error( pluploadL10n.default_error, null, file );
 			} else if ( ! response.success ) {
 				return error( response.data && response.data.message, response.data, file );

--- a/projects/plugins/wpcomsh/changelog/fix-replace-lodash-underscore-in-modules
+++ b/projects/plugins/wpcomsh/changelog/fix-replace-lodash-underscore-in-modules
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Replace lodash/underscore in modules. Should be no change to functionality.
+
+

--- a/projects/plugins/wpcomsh/custom-colors/js/colors-control-beta.js
+++ b/projects/plugins/wpcomsh/custom-colors/js/colors-control-beta.js
@@ -1,5 +1,5 @@
-/* global wp, _, ColorsTool, _wpCustomizeSettings, Backbone */
-( function ( wp, $, _ ) {
+/* global wp, ColorsTool, _wpCustomizeSettings, Backbone */
+( function ( wp, $ ) {
 	// Open closure
 
 	wp = wp || {};
@@ -151,7 +151,7 @@
 					}
 				};
 
-			_.defer( function () {
+			setTimeout( function () {
 				// Grab core's control
 				$( '[data-id-from="accordion-section-colors"]' )
 					.addClass( 'customize-control' )
@@ -387,7 +387,7 @@
 				generatePalette = $( '#generate-palette' ),
 				checkValidImage = function ( value ) {
 					const badValues = [ 'remove-header', 'random-uploaded-image', 'random-default-image' ];
-					if ( value && ! _.contains( badValues, value ) ) {
+					if ( value && ! badValues.includes( value ) ) {
 						ct.opts.headerImage = value;
 						generatePalette.show();
 						return true;
@@ -1052,14 +1052,15 @@
 			'click .button.background-options': 'toggleOptions',
 		},
 		initialize: function () {
-			_.bindAll(
-				this,
+			for ( const func of [
 				'updateImage',
 				'updateBgSize',
 				'updateRectangleStyle',
 				'showPickerBorder',
-				'hidePickerBorder'
-			);
+				'hidePickerBorder',
+			] ) {
+				this[ func ] = this[ func ].bind( this );
+			}
 			this.controller = this.options.controller;
 			api.bind( 'change', this.updateImage );
 			this.render();
@@ -1215,24 +1216,16 @@
 			repeat: 'repeat',
 		},
 		states: function () {
-			return _.reduce(
-				this._defaults,
-				function ( acc, val, key ) {
-					acc[ key ] = api( 'background_' + key ).get() || val;
-					return acc;
-				},
-				{}
-			);
+			return Object.entries( this._defaults ).reduce( ( acc, [ key, val ] ) => {
+				acc[ key ] = api( 'background_' + key ).get() || val;
+				return acc;
+			}, {} );
 		},
 		render: function () {
 			this.$el.html( this.template() );
-			_.each(
-				this.states(),
-				function ( value, key ) {
-					this.$el.find( 'input[name=' + key + '][value=' + value + ']' ).prop( 'checked', true );
-				},
-				this
-			);
+			for ( const [ key, value ] of Object.entries( this.states() ) ) {
+				this.$el.find( 'input[name=' + key + '][value=' + value + ']' ).prop( 'checked', true );
+			}
 			this.setupIris();
 			return this;
 		},
@@ -1301,4 +1294,4 @@
 
 	// let's use it.
 	api.controlConstructor.colorsTool = api.ColorsTool;
-} )( wp, jQuery, _ ); // Close closure. She sells sea shells.
+} )( wp, jQuery ); // Close closure. She sells sea shells.

--- a/projects/plugins/wpcomsh/custom-colors/js/colors-control.js
+++ b/projects/plugins/wpcomsh/custom-colors/js/colors-control.js
@@ -1,5 +1,5 @@
-/* global wp, _, _wpCustomizeSettings, Backbone */
-( function ( wp, $, _ ) {
+/* global wp, _wpCustomizeSettings, Backbone */
+( function ( wp, $ ) {
 	// Open closure
 
 	wp = wp || {};
@@ -373,7 +373,7 @@
 				generatePalette = $( '#generate-palette' ),
 				checkValidImage = function ( value ) {
 					const badValues = [ 'remove-header', 'random-uploaded-image', 'random-default-image' ];
-					if ( value && ! _.contains( badValues, value ) ) {
+					if ( value && ! badValues.includes( value ) ) {
 						ct.opts.headerImage = value;
 						generatePalette.show();
 						return true;
@@ -924,14 +924,15 @@
 			'click .button.background-options': 'toggleOptions',
 		},
 		initialize: function () {
-			_.bindAll(
-				this,
+			for ( const func of [
 				'updateImage',
 				'updateBgSize',
 				'updateRectangleStyle',
 				'showPickerBorder',
-				'hidePickerBorder'
-			);
+				'hidePickerBorder',
+			] ) {
+				this[ func ] = this[ func ].bind( this );
+			}
 			this.controller = this.options.controller;
 			api.bind( 'change', this.updateImage );
 			this.render();
@@ -1087,24 +1088,16 @@
 			repeat: 'repeat',
 		},
 		states: function () {
-			return _.reduce(
-				this._defaults,
-				function ( acc, val, key ) {
-					acc[ key ] = api( 'background_' + key ).get() || val;
-					return acc;
-				},
-				{}
-			);
+			return Object.entries( this._defaults ).reduce( ( acc, [ key, val ] ) => {
+				acc[ key ] = api( 'background_' + key ).get() || val;
+				return acc;
+			}, {} );
 		},
 		render: function () {
 			this.$el.html( this.template() );
-			_.each(
-				this.states(),
-				function ( value, key ) {
-					this.$el.find( 'input[name=' + key + '][value=' + value + ']' ).prop( 'checked', true );
-				},
-				this
-			);
+			for ( const [ key, value ] of Object.entries( this.states() ) ) {
+				this.$el.find( 'input[name=' + key + '][value=' + value + ']' ).prop( 'checked', true );
+			}
 			this.setupIris();
 			return this;
 		},
@@ -1173,4 +1166,4 @@
 
 	// let's use it.
 	api.controlConstructor.colorsTool = api.ColorsTool;
-} )( wp, jQuery, _ ); // Close closure. She sells sea shells.
+} )( wp, jQuery ); // Close closure. She sells sea shells.


### PR DESCRIPTION
Closes MONOREP-13

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
The eslint plugin caught a few more things using a `_` global rather than referring to lodash directly. Some are actually underscore, apparently.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pdWQjU-1jP-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Build happy?
* Make sure the affected features work right.
  * [ ] jetpack-mu-wpcom custom-css js/core-customizer-css-preview.js (I don't know how to activate this?)
  * [x] Table sorting and filtering in Jetpack's modules page
  * [x] Jetpack's videopress module in the classic editor.
  * [x] Custom colors on a WoA site (in the customizer, using a theme like TwentyFourteen that supports it).