### PR TITLE
Forms: remove dependency injection webpack plugin

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2484,9 +2484,6 @@ importers:
       '@wordpress/dataviews':
         specifier: 4.17.0
         version: 4.17.0(patch_hash=9971bdb899e2fb0a4421ab8b7f0a54a41f03b10ef1b51d72946e94f4279e05c1)(@types/react@18.3.23)(react@18.3.1)
-      '@wordpress/dependency-extraction-webpack-plugin':
-        specifier: 6.26.0
-        version: 6.26.0(webpack@5.94.0)
       '@wordpress/dom-ready':
         specifier: 4.25.0
         version: 4.25.0

--- a/projects/packages/forms/changelog/fix-forms-dependency-injection
+++ b/projects/packages/forms/changelog/fix-forms-dependency-injection
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Remove the dependency-injection inclusion

--- a/projects/packages/forms/changelog/fix-forms-dependency-injection
+++ b/projects/packages/forms/changelog/fix-forms-dependency-injection
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Forms: Remove the dependency-injection inclusion
+Forms: Remove manual DependencyExtractionWebpackPlugin instantiation.

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -47,7 +47,6 @@
 		"@wordpress/core-data": "7.26.0",
 		"@wordpress/data": "10.26.0",
 		"@wordpress/dataviews": "4.17.0",
-		"@wordpress/dependency-extraction-webpack-plugin": "6.26.0",
 		"@wordpress/dom-ready": "4.25.0",
 		"@wordpress/editor": "14.26.0",
 		"@wordpress/element": "6.26.0",

--- a/projects/packages/forms/tools/webpack.config.modules.js
+++ b/projects/packages/forms/tools/webpack.config.modules.js
@@ -4,7 +4,6 @@
 const fs = require( 'fs' );
 const path = require( 'path' );
 const jetpackWebpackConfig = require( '@automattic/jetpack-webpack-config/webpack' );
-const DependencyExtractionWebpackPlugin = require( '@wordpress/dependency-extraction-webpack-plugin' );
 const { glob } = require( 'glob' );
 
 const moduleSrcDir = path.join( __dirname, '../src/modules' );
@@ -106,11 +105,10 @@ if ( ! fs.existsSync( moduleSrcDir ) ) {
 			},
 			plugins: [
 				...jetpackWebpackConfig.StandardPlugins( {
-					DependencyExtractionPlugin: false,
+					DependencyExtractionPlugin: true,
 					I18nLoaderPlugin: false,
 					I18nCheckPlugin: false,
 				} ),
-				new DependencyExtractionWebpackPlugin(),
 			],
 		};
 


### PR DESCRIPTION
This PR removed the inclusion of the DependencyInjection plugin since this is something that is already handled by the 
jetpackWebpackConfig.StandardPlugins code. 


## Proposed changes:
* Remove the `DependencyInjection` in favour of the `jetpackWebpackConfig.StandardPlugins` inclusion. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1752504347300399-slack-C052XEUUBL4

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
1. Make sure that the build still happends as expected. 
2. Note that the modules do not include the already existing code. Code size should not increase. 