### PR TITLE
add empty spam button and endpoint

### DIFF
--- a/projects/packages/forms/changelog/add-jetpack-forms-empty-spam-endpoint
+++ b/projects/packages/forms/changelog/add-jetpack-forms-empty-spam-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: add empty spam to delete all responses marked as spam

--- a/projects/packages/forms/src/dashboard/components/empty-spam-button/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/empty-spam-button/index.tsx
@@ -110,7 +110,7 @@ const EmptySpamButton = (): JSX.Element => {
 				showTooltip={ isEmpty }
 				variant="primary"
 			>
-				{ __( 'Empty spam', 'jetpack-forms' ) }
+				{ __( 'Delete spam', 'jetpack-forms' ) }
 			</Button>
 			<ConfirmDialog
 				onCancel={ closeConfirmDialog }

--- a/projects/packages/forms/src/dashboard/components/empty-spam-button/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/empty-spam-button/index.tsx
@@ -22,9 +22,9 @@ type CoreStore = typeof coreStore & {
 /**
  * Renders a button to empty form responses.
  *
- * @return {JSX.Element} The empty trash button.
+ * @return {JSX.Element} The empty spam button.
  */
-const EmptyTrashButton = (): JSX.Element => {
+const EmptySpamButton = (): JSX.Element => {
 	const [ isConfirmDialogOpen, setConfirmDialogOpen ] = useState( false );
 	const [ isEmptying, setIsEmptying ] = useState( false );
 
@@ -141,4 +141,4 @@ const EmptyTrashButton = (): JSX.Element => {
 	);
 };
 
-export default EmptyTrashButton;
+export default EmptySpamButton;

--- a/projects/packages/forms/src/dashboard/components/empty-spam-button/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/empty-spam-button/index.tsx
@@ -1,0 +1,144 @@
+/**
+ * External dependencies
+ */
+import jetpackAnalytics from '@automattic/jetpack-analytics';
+import apiFetch from '@wordpress/api-fetch';
+import { Button, __experimentalConfirmDialog as ConfirmDialog } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
+import { store as coreStore } from '@wordpress/core-data';
+import { useDispatch } from '@wordpress/data';
+import { useState, useCallback } from '@wordpress/element';
+import { __, _n, sprintf } from '@wordpress/i18n';
+import { trash } from '@wordpress/icons';
+import { store as noticesStore } from '@wordpress/notices';
+/**
+ * Internal dependencies
+ */
+import useInboxData from '../../hooks/use-inbox-data';
+
+type CoreStore = typeof coreStore & {
+	invalidateResolution: ( selector: string, args: unknown[] ) => void;
+};
+
+/**
+ * Renders a button to empty form responses.
+ *
+ * @return {JSX.Element} The empty trash button.
+ */
+const EmptyTrashButton = (): JSX.Element => {
+	const [ isConfirmDialogOpen, setConfirmDialogOpen ] = useState( false );
+	const [ isEmptying, setIsEmptying ] = useState( false );
+
+	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+	const { invalidateResolution } = useDispatch( coreStore ) as unknown as CoreStore;
+
+	const { selectedResponsesCount, currentQuery, totalItemsSpam, isLoadingData } = useInboxData();
+
+	const isEmpty = ! isLoadingData && totalItemsSpam === 0;
+
+	const openConfirmDialog = useCallback( () => setConfirmDialogOpen( true ), [] );
+	const closeConfirmDialog = useCallback( () => setConfirmDialogOpen( false ), [] );
+
+	const onConfirmEmptying = useCallback( async () => {
+		if ( isEmptying || isEmpty ) {
+			return;
+		}
+
+		closeConfirmDialog();
+		setIsEmptying( true );
+
+		jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_empty_spam_click' );
+
+		apiFetch( {
+			method: 'DELETE',
+			path: `/wp/v2/feedback/trash?status=spam`,
+		} )
+			.then( ( response: { deleted?: number } ) => {
+				const deleted = response?.deleted ?? 0;
+				const successMessage =
+					deleted === 1
+						? __( 'Response deleted permanently.', 'jetpack-forms' )
+						: sprintf(
+								/* translators: The number of responses. */
+								_n(
+									'%d response deleted permanently.',
+									'%d responses deleted permanently.',
+									deleted,
+									'jetpack-forms'
+								),
+								deleted
+						  );
+				createSuccessNotice( successMessage, { type: 'snackbar', id: 'empty-spam' } );
+			} )
+			.catch( () => {
+				createErrorNotice( __( 'Could not empty spam.', 'jetpack-forms' ), {
+					type: 'snackbar',
+					id: 'empty-spam-error',
+				} );
+			} )
+			.finally( () => {
+				setIsEmptying( false );
+				// invalidate items list
+				invalidateResolution( 'getEntityRecords', [ 'postType', 'feedback', currentQuery ] );
+				// invalidate total items value
+				invalidateResolution( 'getEntityRecords', [
+					'postType',
+					'feedback',
+					{ ...currentQuery, per_page: 1, _fields: 'id' },
+				] );
+			} );
+	}, [
+		closeConfirmDialog,
+		createErrorNotice,
+		createSuccessNotice,
+		invalidateResolution,
+		isEmpty,
+		isEmptying,
+		currentQuery,
+	] );
+
+	return (
+		<>
+			<Button
+				__next40pxDefaultSize
+				accessibleWhenDisabled
+				className="jp-forms__button--large-green"
+				disabled={ isEmpty || isEmptying }
+				icon={ trash }
+				isBusy={ isEmptying }
+				label={ isEmpty ? __( 'Spam is already empty.', 'jetpack-forms' ) : '' }
+				onClick={ openConfirmDialog }
+				showTooltip={ isEmpty }
+				variant="primary"
+			>
+				{ __( 'Empty spam', 'jetpack-forms' ) }
+			</Button>
+			<ConfirmDialog
+				onCancel={ closeConfirmDialog }
+				onConfirm={ onConfirmEmptying }
+				isOpen={ isConfirmDialogOpen }
+				confirmButtonText={ __( 'Delete', 'jetpack-forms' ) }
+			>
+				<h3>{ __( 'Delete forever', 'jetpack-forms' ) }</h3>
+				<p>
+					{ selectedResponsesCount > 0
+						? sprintf(
+								// translators: placeholder is a number of trash total
+								_n(
+									'%d response in spam will be deleted forever. This action cannot be undone.',
+									'All %d responses in spam will be deleted forever. This action cannot be undone.',
+									totalItemsSpam || 0,
+									'jetpack-forms'
+								),
+								totalItemsSpam
+						  )
+						: __(
+								'All responses in spam will be deleted forever. This action cannot be undone.',
+								'jetpack-forms'
+						  ) }
+				</p>
+			</ConfirmDialog>
+		</>
+	);
+};
+
+export default EmptyTrashButton;

--- a/projects/packages/forms/src/dashboard/components/layout/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/layout/index.tsx
@@ -11,6 +11,7 @@ import { Outlet, useLocation, useNavigate } from 'react-router';
 /**
  * Internal dependencies
  */
+import EmptySpamButton from '../../components/empty-spam-button';
 import EmptyTrashButton from '../../components/empty-trash-button';
 import ExportResponsesButton from '../../inbox/export-responses';
 import { config } from '../../index';
@@ -36,6 +37,7 @@ const Layout = () => {
 	);
 
 	const isResponsesTrashView = currentStatus.includes( 'trash' );
+	const isResponsesSpamView = currentStatus.includes( 'spam' );
 
 	useEffect( () => {
 		jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_dashboard_page_view', {
@@ -106,13 +108,15 @@ const Layout = () => {
 				{ isSm ? (
 					<>
 						{ isResponsesTab && isResponsesTrashView && <EmptyTrashButton /> }
+						{ isResponsesTab && isResponsesSpamView && <EmptySpamButton /> }
 						<ActionsDropdownMenu exportData={ { show: isResponsesTab } } />
 					</>
 				) : (
 					<div className="jp-forms__layout-header-actions">
 						{ isResponsesTab && <ExportResponsesButton /> }
 						{ isResponsesTab && isResponsesTrashView && <EmptyTrashButton /> }
-						{ ! isResponsesTrashView && (
+						{ isResponsesTab && isResponsesSpamView && <EmptySpamButton /> }
+						{ ! isResponsesTrashView && ! isResponsesSpamView && (
 							<CreateFormButton label={ __( 'Create form', 'jetpack-forms' ) } />
 						) }
 					</div>

--- a/projects/packages/forms/tests/js/dashboard/components/empty-spam-button/index.test.jsx
+++ b/projects/packages/forms/tests/js/dashboard/components/empty-spam-button/index.test.jsx
@@ -1,0 +1,179 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+/**
+ * Internal dependencies
+ */
+import EmptySpamButton from '../../../../../src/dashboard/components/empty-spam-button';
+
+// Mock React Router
+jest.mock( 'react-router', () => ( {
+	useSearchParams: () => [ new URLSearchParams(), jest.fn() ],
+} ) );
+
+// Mock WordPress dependencies
+jest.mock( '@wordpress/components', () => ( {
+	Button: props => {
+		const { __next40pxDefaultSize, accessibleWhenDisabled, isBusy, showTooltip, ...buttonProps } =
+			props;
+		return (
+			<button type="button" aria-label={ props.label } { ...buttonProps }>
+				{ props.children }
+			</button>
+		);
+	},
+	__experimentalConfirmDialog: ( { children, onCancel, onConfirm, isOpen, confirmButtonText } ) =>
+		isOpen ? (
+			<div data-testid="confirm-dialog">
+				{ children }
+				<button onClick={ onCancel }>Cancel</button>
+				<button onClick={ onConfirm }>{ confirmButtonText }</button>
+			</div>
+		) : null,
+} ) );
+
+jest.mock( '@wordpress/icons', () => ( {
+	trash: 'trash-icon-mock',
+} ) );
+
+jest.mock( '@wordpress/core-data', () => ( {
+	useEntityRecords: jest.fn(),
+	store: 'core',
+} ) );
+
+jest.mock( '@wordpress/notices', () => ( {
+	store: 'notices',
+} ) );
+
+jest.mock( '@wordpress/api-fetch', () => jest.fn( () => Promise.resolve( { deleted: 1 } ) ) );
+
+jest.mock( '@automattic/jetpack-analytics', () => ( {
+	tracks: {
+		recordEvent: jest.fn(),
+	},
+} ) );
+
+// Mock the dashboard store
+jest.mock( '../../../../../src/dashboard/store', () => ( {
+	store: 'dashboard',
+} ) );
+
+// Mock WordPress data
+jest.mock( '@wordpress/data', () => {
+	const mockDispatch = {
+		createSuccessNotice: jest.fn(),
+		createErrorNotice: jest.fn(),
+		invalidateResolution: jest.fn(),
+	};
+
+	const mockSelect = {
+		getSelectedResponsesCount: jest.fn().mockReturnValue( 0 ),
+		getCurrentStatus: jest.fn().mockReturnValue( 'trash' ),
+		getCurrentQuery: jest.fn().mockReturnValue( {} ),
+		getFilters: jest.fn().mockReturnValue( {} ),
+	};
+
+	return {
+		useDispatch: jest.fn( store => {
+			if ( store === 'notices' ) {
+				return mockDispatch;
+			}
+			if ( store === 'core' ) {
+				return { invalidateResolution: mockDispatch.invalidateResolution };
+			}
+			return {};
+		} ),
+		useSelect: jest.fn( callback => callback( () => mockSelect ) ),
+		store: {
+			noticesStore: 'notices',
+		},
+	};
+} );
+
+// Disable console.error for specific known warnings
+/* eslint-disable no-console */
+const originalError = console.error;
+beforeAll( () => {
+	console.error = ( ...args ) => {
+		if (
+			typeof args[ 0 ] === 'string' &&
+			( args[ 0 ].includes( 'React does not recognize the' ) ||
+				args[ 0 ].includes( 'inside a test was not wrapped in act' ) )
+		) {
+			return;
+		}
+		originalError.call( console, ...args );
+	};
+} );
+
+afterAll( () => {
+	console.error = originalError;
+} );
+/* eslint-enable no-console */
+
+describe( 'EmptySpamButton', () => {
+	beforeEach( () => {
+		// Reset all mocks before each test
+		jest.clearAllMocks();
+		require( '@wordpress/core-data' ).useEntityRecords.mockReturnValue( { totalItems: 1 } );
+	} );
+
+	it( 'renders correctly', () => {
+		render( <EmptySpamButton /> );
+
+		const button = screen.getByText( 'Empty spam' );
+		expect( button ).toBeInTheDocument();
+		expect( button ).toHaveAttribute( 'type', 'button' );
+		expect( button ).toBeEnabled();
+	} );
+
+	it( 'shows disabled state when trash is empty', () => {
+		require( '@wordpress/core-data' ).useEntityRecords.mockReturnValue( { totalItems: 0 } );
+		render( <EmptySpamButton /> );
+
+		const button = screen.getByText( 'Empty spam' );
+		expect( button ).toBeDisabled();
+		expect( button ).toHaveAttribute( 'aria-label', 'Spam is already empty.' );
+	} );
+
+	it( 'shows confirmation dialog when clicked', async () => {
+		render( <EmptySpamButton /> );
+
+		const button = screen.getByText( 'Empty spam' );
+		await userEvent.click( button );
+
+		const dialog = screen.getByTestId( 'confirm-dialog' );
+		expect( dialog ).toBeInTheDocument();
+		expect( screen.getByText( 'Delete forever' ) ).toBeInTheDocument();
+	} );
+
+	it( 'empties trash when confirmed', async () => {
+		const apiFetch = require( '@wordpress/api-fetch' );
+		const { useDispatch } = require( '@wordpress/data' );
+		const mockDispatch = useDispatch( 'notices' );
+
+		render( <EmptySpamButton /> );
+
+		// Click empty trash button
+		const button = screen.getByText( 'Empty spam' );
+		await userEvent.click( button );
+
+		// Click confirm button
+		const confirmButton = screen.getByText( 'Delete' );
+		await userEvent.click( confirmButton );
+
+		// Verify API call
+		expect( apiFetch ).toHaveBeenCalledWith( {
+			method: 'DELETE',
+			path: '/wp/v2/feedback/trash?status=spam',
+		} );
+
+		// Verify success notice
+		expect( mockDispatch.createSuccessNotice ).toHaveBeenCalledWith(
+			'Response deleted permanently.',
+			{ type: 'snackbar', id: 'empty-spam' }
+		);
+	} );
+} );

--- a/projects/packages/forms/tests/js/dashboard/components/empty-spam-button/index.test.jsx
+++ b/projects/packages/forms/tests/js/dashboard/components/empty-spam-button/index.test.jsx
@@ -123,7 +123,7 @@ describe( 'EmptySpamButton', () => {
 	it( 'renders correctly', () => {
 		render( <EmptySpamButton /> );
 
-		const button = screen.getByText( 'Empty spam' );
+		const button = screen.getByText( 'Delete spam' );
 		expect( button ).toBeInTheDocument();
 		expect( button ).toHaveAttribute( 'type', 'button' );
 		expect( button ).toBeEnabled();
@@ -133,7 +133,7 @@ describe( 'EmptySpamButton', () => {
 		require( '@wordpress/core-data' ).useEntityRecords.mockReturnValue( { totalItems: 0 } );
 		render( <EmptySpamButton /> );
 
-		const button = screen.getByText( 'Empty spam' );
+		const button = screen.getByText( 'Delete spam' );
 		expect( button ).toBeDisabled();
 		expect( button ).toHaveAttribute( 'aria-label', 'Spam is already empty.' );
 	} );
@@ -141,7 +141,7 @@ describe( 'EmptySpamButton', () => {
 	it( 'shows confirmation dialog when clicked', async () => {
 		render( <EmptySpamButton /> );
 
-		const button = screen.getByText( 'Empty spam' );
+		const button = screen.getByText( 'Delete spam' );
 		await userEvent.click( button );
 
 		const dialog = screen.getByTestId( 'confirm-dialog' );
@@ -157,7 +157,7 @@ describe( 'EmptySpamButton', () => {
 		render( <EmptySpamButton /> );
 
 		// Click empty trash button
-		const button = screen.getByText( 'Empty spam' );
+		const button = screen.getByText( 'Delete spam' );
 		await userEvent.click( button );
 
 		// Click confirm button

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Endpoint_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Endpoint_Test.php
@@ -283,4 +283,52 @@ class Contact_Form_Endpoint_Test extends TestCase {
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 401, $response->get_status() );
 	}
+
+	/**
+	 * Test DELETE feedback/trash endpoint with default status
+	 */
+	public function test_delete_feedback_trash_default_status() {
+		$request = new WP_REST_Request( 'DELETE', '/wp/v2/feedback/trash' );
+
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		// Verify response code
+		$this->assertEquals( 200, $response->get_status() );
+
+		// Verify response structure
+		$this->assertIsArray( $data );
+		$this->assertArrayHasKey( 'deleted', $data );
+		$this->assertIsInt( $data['deleted'] );
+	}
+
+	/**
+	 * Test DELETE feedback/trash endpoint with spam status
+	 */
+	public function test_delete_feedback_trash_spam_status() {
+		$request = new WP_REST_Request( 'DELETE', '/wp/v2/feedback/trash' );
+		$request->set_param( 'status', 'spam' );
+
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		// Verify response code
+		$this->assertEquals( 200, $response->get_status() );
+
+		// Verify response structure
+		$this->assertIsArray( $data );
+		$this->assertArrayHasKey( 'deleted', $data );
+		$this->assertIsInt( $data['deleted'] );
+	}
+
+	/**
+	 * Test DELETE feedback/trash endpoint unauthorized access
+	 */
+	public function test_delete_feedback_trash_unauthorized() {
+		wp_set_current_user( 0 );
+		$request = new WP_REST_Request( 'DELETE', '/wp/v2/feedback/trash' );
+
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 401, $response->get_status() );
+	}
 }


### PR DESCRIPTION

Fixes FORMS-214

## Proposed changes:
This PR adds a "Empty spam" button to delete ALL responses marked as spam, regardless of selection. It works like (it's a copy of) Empty Trash button.

At this point I didn't see the need to overengineer the component into a reusable one, if we find a 3rd or 4th usage for the same request strategy, then we can revisit. Same goes for the endpoint, we're reusing the `/trash` endpoint as the verb and action are the same, seems to me it's fine to share the endpoint based on the status param.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
FORMS-214

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Visit Jetpack > Forms dashboard on the Spam view. There should be a "Empty spam" button on the top-right corner:

<img width="886" height="423" alt="image" src="https://github.com/user-attachments/assets/698e83d3-6582-4893-8911-838570816aed" />

The button will be disabled if there are no responses listed as spam. Clicking the button will open a confirmation dialog:
<img width="889" height="480" alt="image" src="https://github.com/user-attachments/assets/bcc58ae3-f9e9-4361-9ad3-1d51a9674d63" />

Cancel should work as expected. Confirming will DELETE all responses marked as spam and the view should refresh to update both the list and the number of responses (on the Inbox status toggle tab)

