### PR TITLE
Forms: configure Multistep on Jetpack and WPCOM plans

### DIFF
--- a/projects/packages/forms/changelog/update-forms-multistep-to-production
+++ b/projects/packages/forms/changelog/update-forms-multistep-to-production
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: Include multistep form in Jetpack and WPCOM plans.

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -9,6 +9,7 @@ namespace Automattic\Jetpack\Extensions\Contact_Form;
 
 use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Blocks;
+use Automattic\Jetpack\Current_Plan;
 use Automattic\Jetpack\Forms\ContactForm\Contact_Form;
 use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin;
 use Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch;
@@ -56,8 +57,7 @@ class Contact_Form_Block {
 	 * @return array
 	 */
 	public static function register_feature( $features ) {
-		// Register the contact form block feature flag.
-		$features['multistep-form'] = Blocks::get_variation() === 'beta';
+		$features['multistep-form'] = Current_Plan::supports( 'multistep-form' );
 		return $features;
 	}
 

--- a/projects/packages/plans/changelog/update-forms-multistep-to-production
+++ b/projects/packages/plans/changelog/update-forms-multistep-to-production
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: Include multistep form in Jetpack and WPCOM plans.

--- a/projects/packages/plans/src/class-current-plan.php
+++ b/projects/packages/plans/src/class-current-plan.php
@@ -63,6 +63,7 @@ class Current_Plan {
 				'core/video',
 				'core/cover',
 				'core/audio',
+				'multistep-form',
 			),
 		),
 		'personal' => array(
@@ -79,6 +80,7 @@ class Current_Plan {
 				'akismet',
 				'payments',
 				'videopress',
+				'multistep-form',
 			),
 		),
 		'premium'  => array(
@@ -98,6 +100,7 @@ class Current_Plan {
 				'vaultpress',
 				'videopress',
 				'republicize',
+				'multistep-form',
 			),
 		),
 		'security' => array(
@@ -137,6 +140,7 @@ class Current_Plan {
 			),
 			'supports' => array(
 				'ai-seo-enhancer',
+				'multistep-form',
 			),
 		),
 
@@ -148,6 +152,7 @@ class Current_Plan {
 			),
 			'supports' => array(
 				'field-file', // Forms
+				'multistep-form',
 			),
 		),
 	);

--- a/projects/packages/plans/src/class-current-plan.php
+++ b/projects/packages/plans/src/class-current-plan.php
@@ -80,7 +80,6 @@ class Current_Plan {
 				'akismet',
 				'payments',
 				'videopress',
-				'multistep-form',
 			),
 		),
 		'premium'  => array(
@@ -100,7 +99,6 @@ class Current_Plan {
 				'vaultpress',
 				'videopress',
 				'republicize',
-				'multistep-form',
 			),
 		),
 		'security' => array(
@@ -140,7 +138,6 @@ class Current_Plan {
 			),
 			'supports' => array(
 				'ai-seo-enhancer',
-				'multistep-form',
 			),
 		),
 
@@ -152,7 +149,6 @@ class Current_Plan {
 			),
 			'supports' => array(
 				'field-file', // Forms
-				'multistep-form',
 			),
 		),
 	);

--- a/projects/plugins/wpcomsh/changelog/update-forms-multistep-to-production
+++ b/projects/plugins/wpcomsh/changelog/update-forms-multistep-to-production
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: Include multistep form in Jetpack and WPCOM plans.

--- a/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
+++ b/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
@@ -392,6 +392,7 @@ class WPCOM_Features {
 	public const MONITOR_1_MINUTE_CHECK_INTERVAL   = 'monitor-1-minute-check-interval';
 	public const MONITOR_MULTIPLE_EMAIL_RECIPIENTS = 'monitor-multiple-email-recipients';
 	public const MONITOR_SMS_NOTIFICATIONS         = 'monitor-sms-notifications';
+	public const MULTISTEP_FORM                    = 'multistep-form';
 	public const NO_ADVERTS_NO_ADVERTS_PHP         = 'no-adverts/no-adverts.php';
 	public const NO_WPCOM_BRANDING                 = 'no-wpcom-branding';
 	public const OPENTABLE                         = 'opentable';
@@ -856,7 +857,10 @@ class WPCOM_Features {
 			self::JETPACK_MONITOR_MONTHLY,
 			self::JETPACK_MONITOR_YEARLY,
 		),
-
+		self::MULTISTEP_FORM                    => array(
+			self::WPCOM_PERSONAL_AND_HIGHER_PLANS,
+			self::JETPACK_ALL_SITES,
+		),
 		self::NO_ADVERTS_NO_ADVERTS_PHP         => array(
 			self::NO_ADS,
 			// Deliberately leaves out the Starter plan.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
* Promotes the Multi-step Form feature from Beta to Production.
* Adds `multistep-form` support to Jetpack Free, Personal, Premium, Security, and higher plans via `Current_Plan`.
* Maps `multistep-form` to WordPress.com Personal and higher plans, and to all Jetpack sites in `WPCOM_Features`.
* Updates the Contact Form block to check `Current_Plan::supports( 'multistep-form' )` instead of the Beta variation flag.
* Adds changelog entries for:
  * `projects/packages/forms`
  * `projects/packages/plans`
  * `projects/plugins/wpcomsh`

Needs 187900-ghe-Automattic/wpcom to work on simple sites.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
1. Spin up a site with the latest Jetpack build (or a WordPress.com sandbox).
2. Ensure the site is on one of the supported plans:
   * Jetpack: any plan (including Free).
   * WordPress.com: Personal or higher.
3. Create/edit a post or page and insert a “Contact Form” block.
4. In the block settings sidebar, confirm that the “Multi-step” variation is present and functional:
   * Toggling it splits the form into steps in the editor.
   * Publishing the page shows the multi-step UI on the front-end.
5. Change the site’s plan to an unsupported level (e.g., WordPress.com Free) and verify the option no longer appears.
6. Repeat on both simple and atomic WordPress.com sites to confirm plan gating works consistently.