### PR TITLE
CI: Update test-report and slack-notification conditions to ensure execution only if e2e tests are not cancelled

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -306,7 +306,7 @@ jobs:
   test-report:
     name: "Test report"
     runs-on: ubuntu-latest
-    if: ${{ success() || failure() }}
+    if: ${{ always() && needs.e2e-tests.result != 'cancelled' }}
     needs: [e2e-tests]
 
     steps:
@@ -357,7 +357,7 @@ jobs:
   slack-notification:
     name: "Slack notification"
     runs-on: ubuntu-latest
-    if: ${{ success() || failure() }}
+    if: ${{ always() && needs.e2e-tests.result != 'cancelled' }}
     needs: [e2e-tests]
 
     steps:


### PR DESCRIPTION
## Proposed changes:

Fix E2E test reporting jobs not running when tests pass or are skipped

- Updated test-report job condition from `success() || failure()` to `always() && needs.e2e-tests.result != 'cancelled'`
- Updated slack-notification job condition to use the same logic

The test-report and slack-notification jobs were not running when E2E tests passed for push to trunk, most probably because the e2e build job was skipped and that affected the matrix result.

- Job skipped when tests passed (trunk): https://github.com/Automattic/jetpack/actions/runs/16292028543
- Job ran when tests failed (trunk): https://github.com/Automattic/jetpack/actions/runs/16226889489
- Job ran when tests passed but build job ran (PR): https://github.com/Automattic/jetpack/actions/runs/16292591717?pr=44310

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

To be checked after merge. If the tests pass, the test report job should run.