### PR TITLE
Forms: move number field min/max settings to the field from input

### DIFF
--- a/projects/packages/forms/changelog/update-forms-number-settings-move
+++ b/projects/packages/forms/changelog/update-forms-number-settings-move
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: move number field min/max settings to the field from input

--- a/projects/packages/forms/src/blocks/field-number/edit.js
+++ b/projects/packages/forms/src/blocks/field-number/edit.js
@@ -1,25 +1,61 @@
+import { InspectorControls } from '@wordpress/block-editor';
+import { PanelBody, __experimentalNumberControl as NumberControl } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
 import { __ } from '@wordpress/i18n';
 import JetpackField from '../shared/components/jetpack-field';
 import useFormWrapper from '../shared/hooks/use-form-wrapper';
 
 export default function NumberFieldEdit( props ) {
 	useFormWrapper( props );
+	const { attributes, clientId, insertBlocksAfter, isSelected, setAttributes } = props;
 
 	return (
-		<JetpackField
-			clientId={ props.clientId }
-			type="number"
-			label={ __( 'Number', 'jetpack-forms' ) }
-			required={ props.attributes.required }
-			requiredText={ props.attributes.requiredText }
-			setAttributes={ props.setAttributes }
-			isSelected={ props.isSelected }
-			defaultValue={ props.attributes.defaultValue }
-			placeholder={ props.attributes.placeholder }
-			id={ props.attributes.id }
-			width={ props.attributes.width }
-			attributes={ props.attributes }
-			insertBlocksAfter={ props.insertBlocksAfter }
-		/>
+		<>
+			<JetpackField
+				clientId={ clientId }
+				type="number"
+				label={ __( 'Number', 'jetpack-forms' ) }
+				required={ attributes.required }
+				requiredText={ attributes.requiredText }
+				setAttributes={ setAttributes }
+				isSelected={ isSelected }
+				defaultValue={ attributes.defaultValue }
+				placeholder={ attributes.placeholder }
+				id={ attributes.id }
+				width={ attributes.width }
+				attributes={ attributes }
+				insertBlocksAfter={ insertBlocksAfter }
+			/>
+			<InspectorControls>
+				<PanelBody title={ __( 'Settings', 'jetpack-forms' ) }>
+					<NumberControl
+						key="min"
+						label={ __( 'Minimum value', 'jetpack-forms' ) }
+						value={ attributes.min }
+						onChange={ value => setAttributes( { min: value } ) }
+						max={ attributes.max }
+						__nextHasNoMarginBottom={ true }
+						__next40pxDefaultSize={ true }
+						help={ __(
+							'The minimum value to accept in the input. Leaving empty allows any negative and positive values.',
+							'jetpack-forms'
+						) }
+					/>
+					<NumberControl
+						key="max"
+						label={ __( 'Maximum value', 'jetpack-forms' ) }
+						value={ attributes.max }
+						onChange={ value =>
+							setAttributes( {
+								max: value,
+							} )
+						}
+						min={ attributes.min }
+						__nextHasNoMarginBottom={ true }
+						__next40pxDefaultSize={ true }
+						help={ __( 'The maximum value to accept in the input.', 'jetpack-forms' ) }
+					/>
+				</PanelBody>
+			</InspectorControls>
+		</>
 	);
 }

--- a/projects/packages/forms/src/blocks/input/edit.js
+++ b/projects/packages/forms/src/blocks/input/edit.js
@@ -1,5 +1,4 @@
-import { InspectorControls, RichText, useBlockProps } from '@wordpress/block-editor';
-import { PanelBody, __experimentalNumberControl as NumberControl } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
+import { RichText, useBlockProps } from '@wordpress/block-editor';
 import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { clsx } from 'clsx';
@@ -32,7 +31,7 @@ const getInputClass = type => {
 const InputEdit = ( { attributes, clientId, isSelected, name, setAttributes, context } ) => {
 	const { 'jetpack/field-share-attributes': isSynced } = context;
 	useSyncedAttributes( name, isSynced, SYNCED_ATTRIBUTE_KEYS, attributes, setAttributes );
-	const { max, min, placeholder, type } = attributes;
+	const { placeholder, type } = attributes;
 	const variationProps = useVariationStyleProperties( {
 		clientId,
 		inputBlockName: name,
@@ -79,39 +78,6 @@ const InputEdit = ( { attributes, clientId, isSelected, name, setAttributes, con
 				value={ isSelected ? placeholder : '' }
 				placeholder={ placeholder }
 			/>
-			{ type === 'number' && (
-				<InspectorControls>
-					<PanelBody title={ __( 'Settings', 'jetpack-forms' ) }>
-						<NumberControl
-							key="min"
-							label={ __( 'Minimum value', 'jetpack-forms' ) }
-							value={ min }
-							onChange={ value => setAttributes( { min: value } ) }
-							max={ max }
-							__nextHasNoMarginBottom={ true }
-							__next40pxDefaultSize={ true }
-							help={ __(
-								'The minimum value to accept in the input. Leaving empty allows any negative and positive values.',
-								'jetpack-forms'
-							) }
-						/>
-						<NumberControl
-							key="max"
-							label={ __( 'Maximum value', 'jetpack-forms' ) }
-							value={ attributes.max }
-							onChange={ value =>
-								setAttributes( {
-									max: value,
-								} )
-							}
-							min={ min }
-							__nextHasNoMarginBottom={ true }
-							__next40pxDefaultSize={ true }
-							help={ __( 'The maximum value to accept in the input.', 'jetpack-forms' ) }
-						/>
-					</PanelBody>
-				</InspectorControls>
-			) }
 		</>
 	);
 };

--- a/projects/plugins/jetpack/changelog/update-forms-number-settings-move
+++ b/projects/plugins/jetpack/changelog/update-forms-number-settings-move
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: move number field min/max settings to the field from input


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

WIP

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

### Before

https://github.com/user-attachments/assets/4f9ac93f-23ae-42aa-81d7-2f9bd0f5e7c2

### After

https://github.com/user-attachments/assets/985d00a6-03af-4e6c-8384-36b99096e212



### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

