### PR TITLE
Widgets: Prevent PHP warning in legacy Twitter Timeline widget

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-twitter-timeline-php_warning
+++ b/projects/plugins/jetpack/changelog/fix-twitter-timeline-php_warning
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Widgets: Prevent PHP warning on legacy Twitter Timeline widget. 

--- a/projects/plugins/jetpack/modules/widgets/twitter-timeline.php
+++ b/projects/plugins/jetpack/modules/widgets/twitter-timeline.php
@@ -253,7 +253,7 @@ class Jetpack_Twitter_Timeline_Widget extends WP_Widget {
 			$instance['width'] = 220;
 		}
 
-		$tweet_display             = sanitize_text_field( $new_instance['tweet-display'] );
+		$tweet_display             = sanitize_text_field( $new_instance['tweet-display'] ?? 'dynamic' );
 		$instance['tweet-display'] = $tweet_display;
 		/**
 		 * A timeline with a specified limit is expanded to the height of those Tweets.


### PR DESCRIPTION
Closes MONOREP-16

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This catches and provides a fallback for the following PHP warning:

```
PHP Warning: Undefined array key "tweet-display" in /wordpress/plugins/jetpack/14.9-a.1/modules/widgets/twitter-timeline.php on line 256
```

95% of the warnings come from one site. With this PR, if the `tweet-display` key isn't set it'll use `'dynamic'` (just because).

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

I wasn't able to get this widget to even show; it seems to be a legacy widget that isn't particularly supported. The important thing is that the warning no longer occurs and the fallback in the code makes sense.