### PR TITLE
Forms: improve empty buttons state

### DIFF
--- a/projects/packages/forms/changelog/fix-jetpack-forms-empty-buttons-state
+++ b/projects/packages/forms/changelog/fix-jetpack-forms-empty-buttons-state
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Forms: invert default disabled state on empty buttons for a cleaner transition to being available, they will only become enabled when it makes sense (not loading data, total items be a truthy value)

--- a/projects/packages/forms/src/dashboard/components/empty-spam-button/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/empty-spam-button/index.tsx
@@ -6,7 +6,7 @@ import apiFetch from '@wordpress/api-fetch';
 import { Button, __experimentalConfirmDialog as ConfirmDialog } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
 import { store as coreStore } from '@wordpress/core-data';
 import { useDispatch } from '@wordpress/data';
-import { useState, useCallback } from '@wordpress/element';
+import { useState, useCallback, useEffect } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { trash } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
@@ -27,13 +27,15 @@ type CoreStore = typeof coreStore & {
 const EmptySpamButton = (): JSX.Element => {
 	const [ isConfirmDialogOpen, setConfirmDialogOpen ] = useState( false );
 	const [ isEmptying, setIsEmptying ] = useState( false );
-
+	const [ isEmpty, setIsEmpty ] = useState( true );
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const { invalidateResolution } = useDispatch( coreStore ) as unknown as CoreStore;
 
 	const { selectedResponsesCount, currentQuery, totalItemsSpam, isLoadingData } = useInboxData();
 
-	const isEmpty = ! isLoadingData && totalItemsSpam === 0;
+	useEffect( () => {
+		setIsEmpty( isLoadingData || ! totalItemsSpam );
+	}, [ totalItemsSpam, isLoadingData ] );
 
 	const openConfirmDialog = useCallback( () => setConfirmDialogOpen( true ), [] );
 	const closeConfirmDialog = useCallback( () => setConfirmDialogOpen( false ), [] );

--- a/projects/packages/forms/src/dashboard/components/empty-trash-button/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/empty-trash-button/index.tsx
@@ -6,7 +6,7 @@ import apiFetch from '@wordpress/api-fetch';
 import { Button, __experimentalConfirmDialog as ConfirmDialog } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
 import { store as coreStore } from '@wordpress/core-data';
 import { useDispatch } from '@wordpress/data';
-import { useState, useCallback } from '@wordpress/element';
+import { useState, useCallback, useEffect } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { trash } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
@@ -27,13 +27,15 @@ type CoreStore = typeof coreStore & {
 const EmptyTrashButton = (): JSX.Element => {
 	const [ isConfirmDialogOpen, setConfirmDialogOpen ] = useState( false );
 	const [ isEmptying, setIsEmptying ] = useState( false );
-
+	const [ isEmpty, setIsEmpty ] = useState( true );
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const { invalidateResolution } = useDispatch( coreStore ) as unknown as CoreStore;
 
 	const { selectedResponsesCount, currentQuery, totalItemsTrash, isLoadingData } = useInboxData();
 
-	const isEmpty = ! isLoadingData && totalItemsTrash === 0;
+	useEffect( () => {
+		setIsEmpty( isLoadingData || ! totalItemsTrash );
+	}, [ totalItemsTrash, isLoadingData ] );
 
 	const openConfirmDialog = useCallback( () => setConfirmDialogOpen( true ), [] );
 	const closeConfirmDialog = useCallback( () => setConfirmDialogOpen( false ), [] );

--- a/projects/packages/forms/src/dashboard/hooks/use-inbox-data.ts
+++ b/projects/packages/forms/src/dashboard/hooks/use-inbox-data.ts
@@ -70,46 +70,59 @@ export default function useInboxData(): UseInboxDataReturn {
 
 	const {
 		records: rawRecords,
-		isResolving: isLoadingData,
+		isResolving: isLoadingRecordsData,
 		totalItems,
 		totalPages,
 	} = useEntityRecords( 'postType', 'feedback', currentQuery );
 
 	const records = ( rawRecords || [] ) as FormResponse[];
 
-	const { totalItems: totalItemsInbox } = useEntityRecords( 'postType', 'feedback', {
-		page: 1,
-		search: '',
-		...currentQuery,
-		status: 'publish,draft',
-		per_page: 1,
-		_fields: 'id',
-	} );
+	const { isResolving: isLoadingInboxData, totalItems: totalItemsInbox = 0 } = useEntityRecords(
+		'postType',
+		'feedback',
+		{
+			page: 1,
+			search: '',
+			...currentQuery,
+			status: 'publish,draft',
+			per_page: 1,
+			_fields: 'id',
+		}
+	);
 
-	const { totalItems: totalItemsSpam } = useEntityRecords( 'postType', 'feedback', {
-		page: 1,
-		search: '',
-		...currentQuery,
-		status: 'spam',
-		per_page: 1,
-		_fields: 'id',
-	} );
+	const { isResolving: isLoadingSpamData, totalItems: totalItemsSpam = 0 } = useEntityRecords(
+		'postType',
+		'feedback',
+		{
+			page: 1,
+			search: '',
+			...currentQuery,
+			status: 'spam',
+			per_page: 1,
+			_fields: 'id',
+		}
+	);
 
-	const { totalItems: totalItemsTrash } = useEntityRecords( 'postType', 'feedback', {
-		page: 1,
-		search: '',
-		...currentQuery,
-		status: 'trash',
-		per_page: 1,
-		_fields: 'id',
-	} );
+	const { isResolving: isLoadingTrashData, totalItems: totalItemsTrash = 0 } = useEntityRecords(
+		'postType',
+		'feedback',
+		{
+			page: 1,
+			search: '',
+			...currentQuery,
+			status: 'trash',
+			per_page: 1,
+			_fields: 'id',
+		}
+	);
 
 	return {
 		totalItemsInbox,
 		totalItemsSpam,
 		totalItemsTrash,
 		records,
-		isLoadingData,
+		isLoadingData:
+			isLoadingRecordsData || isLoadingInboxData || isLoadingSpamData || isLoadingTrashData,
 		totalItems,
 		totalPages,
 		selectedResponsesCount,


### PR DESCRIPTION


## Proposed changes:
This PR inverts the default disabled state on empty buttons for a cleaner transition to being available. Those now will only become enabled when it makes sense (not loading data, total items be a truthy value).

It also addresses an issue seen on sites with no responses, where the totalItems value would be `NaN`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Go to forms dashboard. Switch to either Spam or Trash (where these buttons are rendered). If those views are empty the "Delete spam" and "Empty trash" buttons should remain disabled throughout the loading process and stay disabled.

Try opening the console and either disable cache or throttle network speed to see the buttons will only become available when all the loading process is done (granted that there's at least one response on the views).

Before this change, buttons would remain available until loading was done and only disabled if the view was empty. This could call for unsuspected trigger of these destructive actions without the entire data being loaded.

On sites with no responses at all, the value returned can sometimes be `NaN` which was also not interpreted correctly and the button would remain enabled (no harm, just nonsense)