### PR TITLE
Jetpack Modules: Avoid using regexes when possible

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-modules-string-compare-operations
+++ b/projects/plugins/jetpack/changelog/update-jetpack-modules-string-compare-operations
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Code Modernization: Replace usage of certail preg_match() checks with str_contains().

--- a/projects/plugins/jetpack/changelog/update-jetpack-modules-string-compare-operations
+++ b/projects/plugins/jetpack/changelog/update-jetpack-modules-string-compare-operations
@@ -1,4 +1,4 @@
 Significance: patch
 Type: other
 
-Code Modernization: Replace usage of certail preg_match() checks with str_contains().
+Code Modernization: Replace usage of certain preg_match() checks with str_contains().

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
@@ -824,7 +824,7 @@ class Jetpack_Carousel {
 		foreach ( $matches[0] as $image_html ) {
 			if (
 				preg_match( '/(wp-image-|data-id=)\"?([0-9]+)\"?/i', $image_html, $class_id )
-				&& ! preg_match( '/wp-block-jetpack-slideshow_image/', $image_html )
+				&& ! str_contains( $image_html, 'wp-block-jetpack-slideshow_image' )
 			) {
 				/**
 				 * Allow filtering the attachment ID used to fetch and populate metadata about an image in a gallery.

--- a/projects/plugins/jetpack/modules/shortcodes/class.filter-embedded-html-objects.php
+++ b/projects/plugins/jetpack/modules/shortcodes/class.filter-embedded-html-objects.php
@@ -324,7 +324,7 @@ class Filter_Embedded_HTML_Objects {
 		foreach ( self::$failed_embeds as $entry ) {
 			$html = sprintf( '<a href="%s">%s</a>', esc_url( $entry['src'] ), esc_url( $entry['src'] ) );
 			// Check if the string doesn't contain iframe, before replace.
-			if ( ! preg_match( '/<iframe /', $string ) ) {
+			if ( ! str_contains( $string, '<iframe ' ) ) {
 				$string = str_replace( $entry['match'], $html, $string );
 			}
 		}

--- a/projects/plugins/jetpack/modules/sitemaps/sitemaps.php
+++ b/projects/plugins/jetpack/modules/sitemaps/sitemaps.php
@@ -246,28 +246,6 @@ class Jetpack_Sitemap_Manager {
 				);
 			}
 
-			// Catch sitemap xml.
-			if ( preg_match( $regex['sitemap'], $request['sitemap_name'] ) ) {
-				$this->serve_raw_and_die(
-					$xml_content_type,
-					$this->librarian->get_sitemap_text(
-						$request['sitemap_name'],
-						JP_PAGE_SITEMAP_TYPE
-					)
-				);
-			}
-
-			// Catch sitemap index xml.
-			if ( preg_match( $regex['index'], $request['sitemap_name'] ) ) {
-				$this->serve_raw_and_die(
-					$xml_content_type,
-					$this->librarian->get_sitemap_text(
-						$request['sitemap_name'],
-						JP_PAGE_SITEMAP_INDEX_TYPE
-					)
-				);
-			}
-
 			// Catch sitemap xsl.
 			if ( 'sitemap.xsl' === $request['sitemap_name'] ) {
 				$this->serve_raw_and_die(
@@ -284,55 +262,11 @@ class Jetpack_Sitemap_Manager {
 				);
 			}
 
-			// Catch image sitemap xml.
-			if ( preg_match( $regex['image'], $request['sitemap_name'] ) ) {
-				$this->serve_raw_and_die(
-					$xml_content_type,
-					$this->librarian->get_sitemap_text(
-						$request['sitemap_name'],
-						JP_IMAGE_SITEMAP_TYPE
-					)
-				);
-			}
-
-			// Catch image sitemap index xml.
-			if ( preg_match( $regex['image-index'], $request['sitemap_name'] ) ) {
-				$this->serve_raw_and_die(
-					$xml_content_type,
-					$this->librarian->get_sitemap_text(
-						$request['sitemap_name'],
-						JP_IMAGE_SITEMAP_INDEX_TYPE
-					)
-				);
-			}
-
 			// Catch image sitemap xsl.
 			if ( 'image-sitemap.xsl' === $request['sitemap_name'] ) {
 				$this->serve_raw_and_die(
 					'application/xml',
 					Jetpack_Sitemap_Stylist::image_sitemap_xsl()
-				);
-			}
-
-			// Catch video sitemap xml.
-			if ( preg_match( $regex['video'], $request['sitemap_name'] ) ) {
-				$this->serve_raw_and_die(
-					$xml_content_type,
-					$this->librarian->get_sitemap_text(
-						$request['sitemap_name'],
-						JP_VIDEO_SITEMAP_TYPE
-					)
-				);
-			}
-
-			// Catch video sitemap index xml.
-			if ( preg_match( $regex['video-index'], $request['sitemap_name'] ) ) {
-				$this->serve_raw_and_die(
-					$xml_content_type,
-					$this->librarian->get_sitemap_text(
-						$request['sitemap_name'],
-						JP_VIDEO_SITEMAP_INDEX_TYPE
-					)
 				);
 			}
 
@@ -358,6 +292,72 @@ class Jetpack_Sitemap_Manager {
 				$this->serve_raw_and_die(
 					'application/xml',
 					Jetpack_Sitemap_Stylist::news_sitemap_xsl()
+				);
+			}
+
+			// Catch sitemap xml.
+			if ( preg_match( $regex['sitemap'], $request['sitemap_name'] ) ) {
+				$this->serve_raw_and_die(
+					$xml_content_type,
+					$this->librarian->get_sitemap_text(
+						$request['sitemap_name'],
+						JP_PAGE_SITEMAP_TYPE
+					)
+				);
+			}
+
+			// Catch sitemap index xml.
+			if ( preg_match( $regex['index'], $request['sitemap_name'] ) ) {
+				$this->serve_raw_and_die(
+					$xml_content_type,
+					$this->librarian->get_sitemap_text(
+						$request['sitemap_name'],
+						JP_PAGE_SITEMAP_INDEX_TYPE
+					)
+				);
+			}
+
+			// Catch image sitemap xml.
+			if ( preg_match( $regex['image'], $request['sitemap_name'] ) ) {
+				$this->serve_raw_and_die(
+					$xml_content_type,
+					$this->librarian->get_sitemap_text(
+						$request['sitemap_name'],
+						JP_IMAGE_SITEMAP_TYPE
+					)
+				);
+			}
+
+			// Catch image sitemap index xml.
+			if ( preg_match( $regex['image-index'], $request['sitemap_name'] ) ) {
+				$this->serve_raw_and_die(
+					$xml_content_type,
+					$this->librarian->get_sitemap_text(
+						$request['sitemap_name'],
+						JP_IMAGE_SITEMAP_INDEX_TYPE
+					)
+				);
+			}
+
+			// Catch video sitemap xml.
+			if ( preg_match( $regex['video'], $request['sitemap_name'] ) ) {
+				$this->serve_raw_and_die(
+					$xml_content_type,
+					$this->librarian->get_sitemap_text(
+						$request['sitemap_name'],
+						JP_VIDEO_SITEMAP_TYPE
+					)
+				);
+			}
+
+			// Catch video sitemap index xml.
+			if ( preg_match( $regex['video-index'], $request['sitemap_name'] ) ) {
+				$this->serve_raw_and_die(
+					$xml_content_type,
+					$this->librarian->get_sitemap_text(
+						$request['sitemap_name'],
+						JP_VIDEO_SITEMAP_INDEX_TYPE
+					)
 				);
 			}
 		}

--- a/projects/plugins/jetpack/modules/sitemaps/sitemaps.php
+++ b/projects/plugins/jetpack/modules/sitemaps/sitemaps.php
@@ -277,7 +277,7 @@ class Jetpack_Sitemap_Manager {
 			}
 
 			// Catch sitemap index xsl.
-			if ( preg_match( $regex['index-style'], $request['sitemap_name'] ) ) {
+			if ( 'sitemap-index.xsl' === $request['sitemap_name'] ) {
 				$this->serve_raw_and_die(
 					'application/xml',
 					Jetpack_Sitemap_Stylist::sitemap_index_xsl()

--- a/projects/plugins/jetpack/modules/sitemaps/sitemaps.php
+++ b/projects/plugins/jetpack/modules/sitemaps/sitemaps.php
@@ -195,19 +195,12 @@ class Jetpack_Sitemap_Manager {
 	public function callback_action_catch_sitemap_urls() {
 		// Regular expressions for sitemap URL routing.
 		$regex = array(
-			'master'        => '/^sitemap\.xml$/',
-			'sitemap'       => '/^sitemap-[1-9][0-9]*\.xml$/',
-			'index'         => '/^sitemap-index-[1-9][0-9]*\.xml$/',
-			'sitemap-style' => '/^sitemap\.xsl$/',
-			'index-style'   => '/^sitemap-index\.xsl$/',
-			'image'         => '/^image-sitemap-[1-9][0-9]*\.xml$/',
-			'image-index'   => '/^image-sitemap-index-[1-9][0-9]*\.xml$/',
-			'image-style'   => '/^image-sitemap\.xsl$/',
-			'video'         => '/^video-sitemap-[1-9][0-9]*\.xml$/',
-			'video-index'   => '/^video-sitemap-index-[1-9][0-9]*\.xml$/',
-			'video-style'   => '/^video-sitemap\.xsl$/',
-			'news'          => '/^news-sitemap\.xml$/',
-			'news-style'    => '/^news-sitemap\.xsl$/',
+			'sitemap'     => '/^sitemap-[1-9][0-9]*\.xml$/',
+			'index'       => '/^sitemap-index-[1-9][0-9]*\.xml$/',
+			'image'       => '/^image-sitemap-[1-9][0-9]*\.xml$/',
+			'image-index' => '/^image-sitemap-index-[1-9][0-9]*\.xml$/',
+			'video'       => '/^video-sitemap-[1-9][0-9]*\.xml$/',
+			'video-index' => '/^video-sitemap-index-[1-9][0-9]*\.xml$/',
 		);
 
 		// The raw path(+query) of the requested URI.
@@ -235,7 +228,7 @@ class Jetpack_Sitemap_Manager {
 			$xml_content_type = apply_filters( 'jetpack_sitemap_content_type', 'text/xml' );
 
 			// Catch master sitemap xml.
-			if ( preg_match( $regex['master'], $request['sitemap_name'] ) ) {
+			if ( 'sitemap.xml' === $request['sitemap_name'] ) {
 				$sitemap_content = $this->librarian->get_sitemap_text(
 					jp_sitemap_filename( JP_MASTER_SITEMAP_TYPE, 0 ),
 					JP_MASTER_SITEMAP_TYPE
@@ -276,7 +269,7 @@ class Jetpack_Sitemap_Manager {
 			}
 
 			// Catch sitemap xsl.
-			if ( preg_match( $regex['sitemap-style'], $request['sitemap_name'] ) ) {
+			if ( 'sitemap.xsl' === $request['sitemap_name'] ) {
 				$this->serve_raw_and_die(
 					'application/xml',
 					Jetpack_Sitemap_Stylist::sitemap_xsl()
@@ -314,7 +307,7 @@ class Jetpack_Sitemap_Manager {
 			}
 
 			// Catch image sitemap xsl.
-			if ( preg_match( $regex['image-style'], $request['sitemap_name'] ) ) {
+			if ( 'image-sitemap.xsl' === $request['sitemap_name'] ) {
 				$this->serve_raw_and_die(
 					'application/xml',
 					Jetpack_Sitemap_Stylist::image_sitemap_xsl()
@@ -344,7 +337,7 @@ class Jetpack_Sitemap_Manager {
 			}
 
 			// Catch video sitemap xsl.
-			if ( preg_match( $regex['video-style'], $request['sitemap_name'] ) ) {
+			if ( 'video-sitemap.xsl' === $request['sitemap_name'] ) {
 				$this->serve_raw_and_die(
 					'application/xml',
 					Jetpack_Sitemap_Stylist::video_sitemap_xsl()
@@ -352,7 +345,7 @@ class Jetpack_Sitemap_Manager {
 			}
 
 			// Catch news sitemap xml.
-			if ( preg_match( $regex['news'], $request['sitemap_name'] ) ) {
+			if ( 'news-sitemap.xml' === $request['sitemap_name'] ) {
 				$sitemap_builder = new Jetpack_Sitemap_Builder();
 				$this->serve_raw_and_die(
 					$xml_content_type,
@@ -361,7 +354,7 @@ class Jetpack_Sitemap_Manager {
 			}
 
 			// Catch news sitemap xsl.
-			if ( preg_match( $regex['news-style'], $request['sitemap_name'] ) ) {
+			if ( 'news-sitemap.xsl' === $request['sitemap_name'] ) {
 				$this->serve_raw_and_die(
 					'application/xml',
 					Jetpack_Sitemap_Stylist::news_sitemap_xsl()

--- a/projects/plugins/jetpack/modules/theme-tools/content-options/author-bio.php
+++ b/projects/plugins/jetpack/modules/theme-tools/content-options/author-bio.php
@@ -105,7 +105,7 @@ if ( ! function_exists( 'jetpack_has_gravatar' ) ) {
 		$headers = get_headers( $url );
 
 		// If 200 is found, the user has a Gravatar; otherwise, they don't.
-		return preg_match( '|200|', $headers[0] ) ? true : false;
+		return str_contains( $headers[0], '200' );
 	}
 
 }


### PR DESCRIPTION
While looking into OOM errors in the modules, I noticed that some checks can benefit from using simple string comparison or str_contains checks.

## Proposed changes:

* Use str_contains instead of preg_match;
* Use direct string comparison instead of regexes when possible;
* Reorder string comparisons to be before preg_match checks as they are faster.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

n/a

## Does this pull request change what data or activity we track or use?

no

## Testing instructions:

- Make sure the code changes make sense.