### PR TITLE
Status: Remove host guess based on DNS

### DIFF
--- a/projects/packages/status/changelog/remove-status-host_guess_from_dns
+++ b/projects/packages/status/changelog/remove-status-host_guess_from_dns
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Remove host guess based on DNS.

--- a/projects/packages/status/src/class-host.php
+++ b/projects/packages/status/src/class-host.php
@@ -136,122 +136,14 @@ class Host {
 	}
 
 	/**
-	 * Returns an array of nameservers for the current site.
-	 *
-	 * @param string $domain The domain of the site to check.
-	 * @return array
-	 */
-	public function get_nameserver_dns_records( $domain ) {
-		if ( ! function_exists( 'dns_get_record' ) ) {
-			return array();
-		}
-
-		$dns_records = dns_get_record( $domain, DNS_NS ); // Fetches the DNS records of type NS (Name Server)
-		if ( false === $dns_records ) {
-			return array();
-		}
-
-		$nameservers = array();
-		foreach ( $dns_records as $record ) {
-			if ( isset( $record['target'] ) ) {
-				$nameservers[] = $record['target']; // Adds the nameserver to the array
-			}
-		}
-
-		return $nameservers; // Returns an array of nameserver names
-	}
-
-	/**
-	 * Given a DNS entry, will return a hosting provider if one can be determined. Otherwise, will return 'unknown'.
-	 * Sourced from: fbhepr%2Skers%2Sjcpbz%2Sjc%2Qpbagrag%2Syvo%2Subfgvat%2Qcebivqre%2Sanzrfreiref.cuc-og
-	 *
-	 * @param string $domain The domain of the site to check.
-	 * @return string The hosting provider of 'unknown'.
-	 */
-	public function get_hosting_provider_by_nameserver( $domain ) {
-		$known_nameservers = array(
-			'bluehost'     => array(
-				'.bluehost.com',
-			),
-			'dreamhost'    => array(
-				'.dreamhost.com',
-			),
-			'mediatemple'  => array(
-				'.mediatemple.net',
-			),
-			'xserver'      => array(
-				'.xserver.jp',
-			),
-			'namecheap'    => array(
-				'.namecheaphosting.com',
-			),
-			'hostmonster'  => array(
-				'.hostmonster.com',
-			),
-			'justhost'     => array(
-				'.justhost.com',
-			),
-			'digitalocean' => array(
-				'.digitalocean.com',
-			),
-			'one'          => array(
-				'.one.com',
-			),
-			'hostpapa'     => array(
-				'.hostpapa.com',
-			),
-			'siteground'   => array(
-				'.sgcloud.net',
-				'.sgedu.site',
-				'.sgsrv1.com',
-				'.sgvps.net',
-				'.siteground.biz',
-				'.siteground.net',
-				'.siteground.eu',
-			),
-			'inmotion'     => array(
-				'.inmotionhosting.com',
-			),
-			'ionos'        => array(
-				'.ui-dns.org',
-				'.ui-dns.de',
-				'.ui-dns.biz',
-				'.ui-dns.com',
-			),
-		);
-
-		$dns_records = $this->get_nameserver_dns_records( $domain );
-		$dns_records = array_map( 'strtolower', $dns_records );
-
-		foreach ( $known_nameservers as $host => $ns_patterns ) {
-			foreach ( $ns_patterns as $ns_pattern ) {
-				foreach ( $dns_records as $record ) {
-					if ( false !== strpos( $record, $ns_pattern ) ) {
-						return $host;
-					}
-				}
-			}
-		}
-
-		return 'unknown';
-	}
-
-	/**
 	 * Returns a guess of the hosting provider for the current site based on various checks.
 	 *
 	 * @since 5.0.4 Added $guess parameter.
-	 *
-	 * @param bool $guess Whether to guess the hosting provider.
+	 * @since $$next-version$$ Removed $guess parameter.
 	 *
 	 * @return string
 	 */
-	public function get_known_host_guess( $guess = true ) {
-		$host = Cache::get( 'host_guess' );
-
-		if ( null !== $host ) {
-			return $host;
-		}
-
+	public function get_known_host_guess() {
 		// First, let's check if we can recognize provider manually:
 		switch ( true ) {
 			case $this->is_woa_site():
@@ -275,14 +167,6 @@ class Host {
 				break;
 		}
 
-		// Second, let's check if we can recognize provider by nameservers.
-		// Only do this if we're asked to guess.
-		$domain = isset( $_SERVER['SERVER_NAME'] ) ? sanitize_text_field( wp_unslash( $_SERVER['SERVER_NAME'] ) ) : '';
-		if ( $provider === 'unknown' && ! empty( $domain ) && $guess ) {
-			$provider = $this->get_hosting_provider_by_nameserver( $domain );
-		}
-
-		Cache::set( 'host_guess', $provider );
 		return $provider;
 	}
 

--- a/projects/packages/status/tests/php/Host_Test.php
+++ b/projects/packages/status/tests/php/Host_Test.php
@@ -164,66 +164,6 @@ class Host_Test extends TestCase {
 	}
 
 	/**
-	 * Test getting the known host guess.
-	 */
-	public function test_get_nameserver_dns_records() {
-		Functions\when( 'dns_get_record' )->justReturn(
-			array(
-				array( 'target' => 'ns1.wordpress.com' ),
-				array( 'target' => 'ns2.wordpress.com' ),
-			)
-		);
-
-		$domain  = 'example.com';
-		$records = $this->host_obj->get_nameserver_dns_records( $domain );
-		$this->assertEquals( array( 'ns1.wordpress.com', 'ns2.wordpress.com' ), $records );
-	}
-
-	/**
-	 * Test getting the known host guess.
-	 */
-	public function test_get_hosting_provider_by_nameserver() {
-		$mock = $this->createPartialMock( Host::class, array( 'get_nameserver_dns_records' ) );
-
-		$mock->method( 'get_nameserver_dns_records' )
-			->willReturn( array( 'ns1.bluehost.com', 'ns2.bluehost.com' ) );
-
-		$provider = $mock->get_hosting_provider_by_nameserver( 'example.com' );
-		$this->assertEquals( 'bluehost', $provider );
-	}
-
-	/**
-	 * Test getting the known host guess.
-	 */
-	public function test_get_known_host_guess() {
-		Functions\when( 'sanitize_text_field' )->alias(
-			function ( $value ) {
-				return $value;
-			}
-		);
-		$_SERVER['SERVER_NAME'] = 'mocked.example.com';
-
-		$mock1 = $this->createPartialMock( Host::class, array( 'get_hosting_provider_by_nameserver' ) );
-
-		$mock1->method( 'get_hosting_provider_by_nameserver' )
-			->willReturn( 'bluehost' );
-
-		$this->assertEquals( 'bluehost', $mock1->get_known_host_guess() );
-		Cache::clear();
-
-		$mock2 = $this->createPartialMock( Host::class, array( 'is_atomic_platform' ) );
-
-		$mock2->method( 'is_atomic_platform' )
-			->willReturn( true );
-
-		$this->assertEquals( 'atomic', $mock2->get_known_host_guess() );
-		Cache::clear();
-
-		$this->assertEquals( 'unknown', $this->host_obj->get_known_host_guess() );
-		Cache::clear();
-	}
-
-	/**
 	 * Data provider for `test_get_source_query()` test method.
 	 *
 	 * @return array

--- a/projects/packages/status/tests/php/patchwork.json
+++ b/projects/packages/status/tests/php/patchwork.json
@@ -1,10 +1,3 @@
 {
-	"redefinable-internals": [
-		"defined",
-		"constant",
-		"dns_get_record",
-		"headers_sent",
-		"headers_list",
-		"header"
-	]
+	"redefinable-internals": [ "defined", "constant", "headers_sent", "headers_list", "header" ]
 }


### PR DESCRIPTION
Closes MONOREP-20

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This removes a problematic host guess feature based on DNS added in #34864 that is no longer needed.

Note that I removed the `$guess` param altogether rather than listing it as deprecated. We don't explicitly use the param in our code, and even if it's used externally PHP doesn't care if there are extra params.

Reported here: https://wordpress.org/support/topic/error-in-local-mode/
See also: p1752518264599949-slack-C08PN0LHCCT

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Compare to the original PR and verify the proper things were removed.