### PR TITLE
fix: Private site returns valid access cookie expiration

### DIFF
--- a/projects/plugins/wpcomsh/changelog/fix-private-site-returns-valid-access-cookie-expiration
+++ b/projects/plugins/wpcomsh/changelog/fix-private-site-returns-valid-access-cookie-expiration
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Private site: ensure private sites return a valid cookie expiration value

--- a/projects/plugins/wpcomsh/private-site/private-site.php
+++ b/projects/plugins/wpcomsh/private-site/private-site.php
@@ -368,9 +368,9 @@ function get_read_access_cookies( $args ) {
 
 	add_action(
 		'set_logged_in_cookie',
-		function ( $_cookie, $args ) use ( &$logged_in_cookie, &$logged_in_cookie_expiration ) {
+		function ( $_cookie, $_expires ) use ( &$logged_in_cookie, &$logged_in_cookie_expiration ) {
 			$logged_in_cookie            = $_cookie;
-			$logged_in_cookie_expiration = $args[1];
+			$logged_in_cookie_expiration = $_expires;
 		},
 		10,
 		2

--- a/projects/plugins/wpcomsh/private-site/private-site.php
+++ b/projects/plugins/wpcomsh/private-site/private-site.php
@@ -368,12 +368,12 @@ function get_read_access_cookies( $args ) {
 
 	add_action(
 		'set_logged_in_cookie',
-		function ( $_cookie, $_expires ) use ( &$logged_in_cookie, &$logged_in_cookie_expiration ) {
+		function ( $_cookie, $_expires, $_expiration ) use ( &$logged_in_cookie, &$logged_in_cookie_expiration ) {
 			$logged_in_cookie            = $_cookie;
-			$logged_in_cookie_expiration = $_expires;
+			$logged_in_cookie_expiration = $_expiration;
 		},
 		10,
-		2
+		3
 	);
 	wp_set_auth_cookie( $user->ID, true );
 	if ( ! $logged_in_cookie ) {

--- a/projects/plugins/wpcomsh/tests/PrivateSiteTest.php
+++ b/projects/plugins/wpcomsh/tests/PrivateSiteTest.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * Private Site Test file.
+ *
+ * @package wpcomsh
+ */
+
+/**
+ * Class PrivateSiteTest.
+ */
+class PrivateSiteTest extends WP_UnitTestCase {
+	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
+
+	/**
+	 * Set up test environment before each test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		// Mock the AT_PRIVACY_MODEL constant to simulate private site
+		if ( ! defined( 'AT_PRIVACY_MODEL' ) ) {
+			define( 'AT_PRIVACY_MODEL', 'wp_uploads' );
+		}
+
+		// Define constants if not already defined
+		if ( ! defined( 'DAY_IN_SECONDS' ) ) {
+			define( 'DAY_IN_SECONDS', 86400 );
+		}
+		if ( ! defined( 'COOKIEHASH' ) ) {
+			define( 'COOKIEHASH', 'test_hash' );
+		}
+		if ( ! defined( 'LOGGED_IN_COOKIE' ) ) {
+			define( 'LOGGED_IN_COOKIE', 'wordpress_logged_in_' . COOKIEHASH );
+		}
+	}
+
+	/**
+	 * Test that site_is_private() returns true when AT_PRIVACY_MODEL is set correctly.
+	 */
+	public function test_site_is_private_returns_true_when_constant_set() {
+		$this->assertTrue( \Private_Site\site_is_private() );
+	}
+
+	/**
+	 * Test get_read_access_cookies with non-existent user.
+	 */
+	public function test_get_read_access_cookies_with_nonexistent_user() {
+		$non_existent_user_id = 99999;
+
+		$result = \Private_Site\get_read_access_cookies( array( $non_existent_user_id, time() + DAY_IN_SECONDS ) );
+
+		$this->assertWPError( $result );
+		$this->assertEquals( 'account_not_found', $result->get_error_code() );
+	}
+
+	/**
+	 * Test that the XML-RPC method is registered correctly.
+	 */
+	public function test_xmlrpc_method_registration() {
+		$methods = array( 'existing.method' => 'some_callback' );
+
+		$result = \Private_Site\register_additional_jetpack_xmlrpc_methods( $methods );
+
+		$this->assertArrayHasKey( 'existing.method', $result );
+		$this->assertArrayHasKey( 'jetpack.getClosestThumbnailSizeUrl', $result );
+		$this->assertArrayHasKey( 'jetpack.getReadAccessCookies', $result );
+		$this->assertEquals( '\Private_Site\get_closest_thumbnail_size_url', $result['jetpack.getClosestThumbnailSizeUrl'] );
+		$this->assertEquals( '\Private_Site\get_read_access_cookies', $result['jetpack.getReadAccessCookies'] );
+	}
+
+	/**
+	 * Test get_closest_thumbnail_size_url with invalid URL.
+	 */
+	public function test_get_closest_thumbnail_size_url_with_invalid_url() {
+		$args = array(
+			'url'    => 'https://example.com/nonexistent-image.jpg',
+			'width'  => 150,
+			'height' => 150,
+		);
+
+		$result = \Private_Site\get_closest_thumbnail_size_url( $args );
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test that should_prevent_site_access returns true for unauthenticated users.
+	 */
+	public function test_should_prevent_site_access_returns_true_for_unauthenticated_users() {
+		wp_set_current_user( 0 );
+
+		$this->assertTrue( \Private_Site\should_prevent_site_access() );
+	}
+
+	/**
+	 * Test that blog_user_can returns false for non-logged-in users.
+	 */
+	public function test_blog_user_can_returns_false_for_non_logged_in_users() {
+		wp_set_current_user( 0 );
+
+		$this->assertFalse( \Private_Site\blog_user_can( 'read' ) );
+	}
+
+	/**
+	 * Test that is_private_blog_user returns false for non-authenticated users.
+	 */
+	public function test_is_private_blog_user_returns_false_for_non_authenticated_users() {
+		wp_set_current_user( 0 );
+
+		$this->assertFalse( \Private_Site\is_private_blog_user() );
+	}
+}

--- a/projects/plugins/wpcomsh/tests/PrivateSiteXmlrpcTest.php
+++ b/projects/plugins/wpcomsh/tests/PrivateSiteXmlrpcTest.php
@@ -11,9 +11,9 @@
 class PrivateSiteXmlrpcTest extends WP_UnitTestCase {
 	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
 
-		/**
-		 * Set up test environment before each test.
-		 */
+	/**
+	 * Set up test environment before each test.
+	 */
 	public function setUp(): void {
 		parent::setUp();
 

--- a/projects/plugins/wpcomsh/tests/PrivateSiteXmlrpcTest.php
+++ b/projects/plugins/wpcomsh/tests/PrivateSiteXmlrpcTest.php
@@ -126,7 +126,7 @@ class PrivateSiteXmlrpcTest extends WP_UnitTestCase {
 		$this->assertCount( 1, $result );
 		// The expiration should be a valid timestamp
 		$this->assertIsInt( $result[0][2] );
-		$this->assertEquals( time() + $custom_expiration + 12 * HOUR_IN_SECONDS, $result[0][2] );
+		$this->assertEquals( time() + $custom_expiration, $result[0][2] );
 	}
 
 	/**

--- a/projects/plugins/wpcomsh/tests/PrivateSiteXmlrpcTest.php
+++ b/projects/plugins/wpcomsh/tests/PrivateSiteXmlrpcTest.php
@@ -126,7 +126,9 @@ class PrivateSiteXmlrpcTest extends WP_UnitTestCase {
 		$this->assertCount( 1, $result );
 		// The expiration should be a valid timestamp
 		$this->assertIsInt( $result[0][2] );
-		$this->assertEquals( time() + $custom_expiration, $result[0][2] );
+		// Assert that the expiration is within 1 second of the expected value to
+		// account for timing differences that may occur in the test environment.
+		$this->assertLessThanOrEqual( 1, abs( ( time() + $custom_expiration ) - $result[0][2] ) );
 	}
 
 	/**

--- a/projects/plugins/wpcomsh/tests/PrivateSiteXmlrpcTest.php
+++ b/projects/plugins/wpcomsh/tests/PrivateSiteXmlrpcTest.php
@@ -1,0 +1,153 @@
+<?php
+/**
+ * Private Site XML-RPC Test file.
+ *
+ * @package wpcomsh
+ */
+
+/**
+ * Class PrivateSiteXmlrpcTest.
+ */
+class PrivateSiteXmlrpcTest extends WP_UnitTestCase {
+	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
+
+		/**
+		 * Set up test environment before each test.
+		 */
+	public function setUp(): void {
+		parent::setUp();
+
+		// Mock the AT_PRIVACY_MODEL constant to simulate private site
+		if ( ! defined( 'AT_PRIVACY_MODEL' ) ) {
+			define( 'AT_PRIVACY_MODEL', 'wp_uploads' );
+		}
+
+		// Define constants if not already defined
+		if ( ! defined( 'DAY_IN_SECONDS' ) ) {
+			define( 'DAY_IN_SECONDS', 86400 );
+		}
+		if ( ! defined( 'COOKIEHASH' ) ) {
+			define( 'COOKIEHASH', 'test_hash' );
+		}
+		if ( ! defined( 'LOGGED_IN_COOKIE' ) ) {
+			define( 'LOGGED_IN_COOKIE', 'wordpress_logged_in_' . COOKIEHASH );
+		}
+	}
+
+	/**
+	 * Test that get_read_access_cookies returns proper error for invalid user.
+	 */
+	public function test_get_read_access_cookies_invalid_user() {
+		$result = \Private_Site\get_read_access_cookies( array( 99999, time() + DAY_IN_SECONDS ) );
+
+		$this->assertWPError( $result );
+		$this->assertEquals( 'account_not_found', $result->get_error_code() );
+	}
+
+	/**
+	 * Test that get_read_access_cookies returns proper error for user without read capability.
+	 */
+	public function test_get_read_access_cookies_user_without_read_capability() {
+		// Create a user without read capabilities
+		$user_id = $this->factory()->user->create( array( 'role' => '' ) );
+
+		$result = \Private_Site\get_read_access_cookies( array( $user_id, time() + DAY_IN_SECONDS ) );
+
+		$this->assertWPError( $result );
+		$this->assertEquals( 'access error', $result->get_error_code() );
+	}
+
+	/**
+	 * Test that get_read_access_cookies works with valid user.
+	 */
+	public function test_get_read_access_cookies_valid_user() {
+		// Create a user with read capabilities
+		$user_id = $this->factory()->user->create( array( 'role' => 'subscriber' ) );
+
+		$expected_expiration = time() + ( 2 * DAY_IN_SECONDS );
+
+		$result = \Private_Site\get_read_access_cookies( array( $user_id, $expected_expiration ) );
+
+		$this->assertIsArray( $result );
+		$this->assertCount( 1, $result );
+		$this->assertIsArray( $result[0] );
+		$this->assertCount( 3, $result[0] );
+
+		// Check cookie structure
+		$this->assertEquals( LOGGED_IN_COOKIE, $result[0][0] );
+		$this->assertNotEmpty( $result[0][1] ); // Cookie value should not be empty
+		// The expiration should be a valid timestamp
+		$this->assertIsInt( $result[0][2] );
+		$this->assertGreaterThan( time(), $result[0][2] );
+	}
+
+	/**
+	 * Test that get_read_access_cookies handles missing user ID.
+	 */
+	public function test_get_read_access_cookies_missing_user_id() {
+		// Pass array with only expiration time, missing user ID
+		$result = \Private_Site\get_read_access_cookies( array( null, time() + DAY_IN_SECONDS ) );
+
+		$this->assertWPError( $result );
+		$this->assertEquals( 'account_not_found', $result->get_error_code() );
+	}
+
+	/**
+	 * Test that get_read_access_cookies handles invalid user ID type.
+	 */
+	public function test_get_read_access_cookies_invalid_user_id_type() {
+		$result = \Private_Site\get_read_access_cookies( array( 'invalid', time() + DAY_IN_SECONDS ) );
+
+		$this->assertWPError( $result );
+		$this->assertEquals( 'account_not_found', $result->get_error_code() );
+	}
+
+	/**
+	 * Test that get_read_access_cookies handles negative user ID.
+	 */
+	public function test_get_read_access_cookies_negative_user_id() {
+		$result = \Private_Site\get_read_access_cookies( array( -1, time() + DAY_IN_SECONDS ) );
+
+		$this->assertWPError( $result );
+		$this->assertEquals( 'account_not_found', $result->get_error_code() );
+	}
+
+	/**
+	 * Test that the auth cookie expiration is properly set.
+	 */
+	public function test_get_read_access_cookies_auth_cookie_expiration() {
+		$user_id = $this->factory()->user->create( array( 'role' => 'subscriber' ) );
+
+		$custom_expiration = time() + ( 5 * DAY_IN_SECONDS );
+
+		$result = \Private_Site\get_read_access_cookies( array( $user_id, $custom_expiration ) );
+
+		$this->assertIsArray( $result );
+		$this->assertCount( 1, $result );
+		// The expiration should be a valid timestamp
+		$this->assertIsInt( $result[0][2] );
+		$this->assertEquals( time() + $custom_expiration + 12 * HOUR_IN_SECONDS, $result[0][2] );
+	}
+
+	/**
+	 * Test that the send_auth_cookies filter is properly disabled.
+	 */
+	public function test_get_read_access_cookies_disables_send_auth_cookies() {
+		$user_id = $this->factory()->user->create( array( 'role' => 'subscriber' ) );
+
+		// Set up a filter to track if send_auth_cookies is disabled
+		$filter_called = false;
+		add_filter(
+			'send_auth_cookies',
+			function ( $send ) use ( &$filter_called ) {
+				$filter_called = true;
+				return $send;
+			}
+		);
+
+		\Private_Site\get_read_access_cookies( array( $user_id, time() + DAY_IN_SECONDS ) );
+
+		// The filter should have been called and disabled
+		$this->assertTrue( $filter_called );
+	}
+}

--- a/projects/plugins/wpcomsh/tests/PrivateSiteXmlrpcTest.php
+++ b/projects/plugins/wpcomsh/tests/PrivateSiteXmlrpcTest.php
@@ -38,7 +38,7 @@ class PrivateSiteXmlrpcTest extends WP_UnitTestCase {
 	 * Test that get_read_access_cookies returns proper error for invalid user.
 	 */
 	public function test_get_read_access_cookies_invalid_user() {
-		$result = \Private_Site\get_read_access_cookies( array( 99999, time() + DAY_IN_SECONDS ) );
+		$result = \Private_Site\get_read_access_cookies( array( 99999, DAY_IN_SECONDS ) );
 
 		$this->assertWPError( $result );
 		$this->assertEquals( 'account_not_found', $result->get_error_code() );
@@ -51,7 +51,7 @@ class PrivateSiteXmlrpcTest extends WP_UnitTestCase {
 		// Create a user without read capabilities
 		$user_id = $this->factory()->user->create( array( 'role' => '' ) );
 
-		$result = \Private_Site\get_read_access_cookies( array( $user_id, time() + DAY_IN_SECONDS ) );
+		$result = \Private_Site\get_read_access_cookies( array( $user_id, DAY_IN_SECONDS ) );
 
 		$this->assertWPError( $result );
 		$this->assertEquals( 'access error', $result->get_error_code() );
@@ -64,7 +64,7 @@ class PrivateSiteXmlrpcTest extends WP_UnitTestCase {
 		// Create a user with read capabilities
 		$user_id = $this->factory()->user->create( array( 'role' => 'subscriber' ) );
 
-		$expected_expiration = time() + ( 2 * DAY_IN_SECONDS );
+		$expected_expiration = 2 * DAY_IN_SECONDS;
 
 		$result = \Private_Site\get_read_access_cookies( array( $user_id, $expected_expiration ) );
 
@@ -86,7 +86,7 @@ class PrivateSiteXmlrpcTest extends WP_UnitTestCase {
 	 */
 	public function test_get_read_access_cookies_missing_user_id() {
 		// Pass array with only expiration time, missing user ID
-		$result = \Private_Site\get_read_access_cookies( array( null, time() + DAY_IN_SECONDS ) );
+		$result = \Private_Site\get_read_access_cookies( array( null, DAY_IN_SECONDS ) );
 
 		$this->assertWPError( $result );
 		$this->assertEquals( 'account_not_found', $result->get_error_code() );
@@ -96,7 +96,7 @@ class PrivateSiteXmlrpcTest extends WP_UnitTestCase {
 	 * Test that get_read_access_cookies handles invalid user ID type.
 	 */
 	public function test_get_read_access_cookies_invalid_user_id_type() {
-		$result = \Private_Site\get_read_access_cookies( array( 'invalid', time() + DAY_IN_SECONDS ) );
+		$result = \Private_Site\get_read_access_cookies( array( 'invalid', DAY_IN_SECONDS ) );
 
 		$this->assertWPError( $result );
 		$this->assertEquals( 'account_not_found', $result->get_error_code() );
@@ -106,7 +106,7 @@ class PrivateSiteXmlrpcTest extends WP_UnitTestCase {
 	 * Test that get_read_access_cookies handles negative user ID.
 	 */
 	public function test_get_read_access_cookies_negative_user_id() {
-		$result = \Private_Site\get_read_access_cookies( array( -1, time() + DAY_IN_SECONDS ) );
+		$result = \Private_Site\get_read_access_cookies( array( -1, DAY_IN_SECONDS ) );
 
 		$this->assertWPError( $result );
 		$this->assertEquals( 'account_not_found', $result->get_error_code() );
@@ -118,7 +118,7 @@ class PrivateSiteXmlrpcTest extends WP_UnitTestCase {
 	public function test_get_read_access_cookies_auth_cookie_expiration() {
 		$user_id = $this->factory()->user->create( array( 'role' => 'subscriber' ) );
 
-		$custom_expiration = time() + ( 5 * DAY_IN_SECONDS );
+		$custom_expiration = 5 * DAY_IN_SECONDS;
 
 		$result = \Private_Site\get_read_access_cookies( array( $user_id, $custom_expiration ) );
 
@@ -145,7 +145,7 @@ class PrivateSiteXmlrpcTest extends WP_UnitTestCase {
 			}
 		);
 
-		\Private_Site\get_read_access_cookies( array( $user_id, time() + DAY_IN_SECONDS ) );
+		\Private_Site\get_read_access_cookies( array( $user_id, DAY_IN_SECONDS ) );
 
 		// The filter should have been called and disabled
 		$this->assertTrue( $filter_called );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fix invalid `false` values returned for cookie expirations that originate from [previous erroneous changes](https://github.com/Automattic/wpcomsh/commit/cabdb38b1474db7381d80a7ac1c3357960635331#diff-c26ac91049f9950230fd95e1577719794c983a4ae493e2875eadc853378a200aR429-R431), where we attempt to treat the `expires` integer [parameter](https://developer.wordpress.org/reference/hooks/set_logged_in_cookie/) as an array. 

The invalid expiration values result in broken client functionality in the Jetpack mobile apps (and likely elsewhere), where cookies were erroneously expired due to incorrect dates. 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Use correct `set_logged_in_cookie` integer parameter rather than attempting access of an non-existing array value.
* Add automated tests for private site logic.
* Replace usage of `set_logged_in_cookie` `expires` value with `expiration` to allow usage of the former's grace period, if desired.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1752608193585939-slack-CDLH4C1UZ

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### 1: Private Atomic site post previews load in the Jetpack iOS app

1. Apply these changes to a private WoA dev site (see [comment](https://github.com/Automattic/jetpack/pull/44328#issuecomment-3079098596)). 
1. Log into WordPress.com in the Jetpack iOS mobile app.
1. Switch to the private Atomic site in the app. 
1. Open a post containing media in the editor. 
1. Tap the more menu (three dots) in top-right corner. 
1. Tap _Preview_. 
1. Verify the post and its media successfully load within the in-app browser. 

### 2: Private Atomic site Media Library loads images

> [!note]
> My understanding is [this case](https://github.com/Automattic/wp-calypso/issues/91136) is now irrelevant after "untangling" Calypso, as Calypso's Media Library was removed and the WP Admin Media Library is now used for Atomic sites. I include it for posterity and more robust testing. 

1. Apply these changes to a private WoA dev site (see [comment](https://github.com/Automattic/jetpack/pull/44328#issuecomment-3079098596)). 
2. Open the _Media_ page for the private Atomic site. 
3. Verify images load within the Media Library. 