### PR TITLE
eslint: Disable testing-library rules for playwright tests

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-eslint-for-playwright-should-exclude-testing-library
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-eslint-for-playwright-should-exclude-testing-library
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Correctly configure eslint to lint `src/features/verbum-comments/tests/` as Playwright tests, not Testing-library.
+
+

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/tests/atomic/author_must_fill_name_and_email.test.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/tests/atomic/author_must_fill_name_and_email.test.ts
@@ -30,5 +30,5 @@ test( 'Atomic: author_must_fill_name_and_email', async ( { page } ) => {
 	await page.waitForLoadState( 'domcontentloaded' );
 	await expect( page.getByText( randomComment ) ).toBeVisible();
 	await expect( page.getByText( randomName ) ).toBeVisible();
-	await expect( page.getByText( randomEmail ) ).not.toBeVisible();
+	await expect( page.getByText( randomEmail ) ).toBeHidden();
 } );

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/tests/eslint.config.mjs
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/tests/eslint.config.mjs
@@ -1,0 +1,9 @@
+// This directory contains Playwright tests, not jest tests. Configure accordingly.
+
+import { makeBaseConfig, defineConfig } from 'jetpack-js-tools/eslintrc/base.mjs';
+import playwrightConfig from 'jetpack-js-tools/eslintrc/playwright.mjs';
+
+export default defineConfig(
+	makeBaseConfig( import.meta.url, { envs: [ 'node' ] } ),
+	playwrightConfig
+);

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/tsconfig.json
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/tsconfig.json
@@ -10,5 +10,9 @@
 		"jsxImportSource": "preact"
 	},
 	"typeRoots": [ "./src/components", "./src/editor", "./node_modules/@types" ],
-	"include": [ "node_modules/vite/client.d.ts", "**/*" ]
+	"include": [ "node_modules/vite/client.d.ts", "**/*" ],
+	"exclude": [
+		// Linting this file makes tsc complain about a bunch of irrelevant stuff, including stuff deep inside node_modules. I don't know why.
+		"./tests/eslint.config.mjs"
+	]
 }

--- a/tools/e2e-commons/eslint.config.mjs
+++ b/tools/e2e-commons/eslint.config.mjs
@@ -13,7 +13,7 @@ import playwrightConfig from 'jetpack-js-tools/eslintrc/playwright.mjs';
 export function makeE2eConfig( configurl, opts = {} ) {
 	opts.envs ??= [ 'node' ];
 
-	return defineConfig( makeBaseConfig( configurl, { envs: [ 'node' ] } ), playwrightConfig, {
+	return defineConfig( makeBaseConfig( configurl, opts ), playwrightConfig, {
 		languageOptions: {
 			globals: {
 				wp: true,
@@ -24,8 +24,6 @@ export function makeE2eConfig( configurl, opts = {} ) {
 			'no-console': 'off',
 			'n/no-process-exit': 'off',
 			'playwright/no-skipped-test': 'off',
-			// False positives when using `page.getByRole()`
-			'testing-library/prefer-screen-queries': 'off',
 		},
 	} );
 }

--- a/tools/js-tools/eslintrc/playwright.mjs
+++ b/tools/js-tools/eslintrc/playwright.mjs
@@ -1,7 +1,22 @@
 import eslintPluginPlaywright from 'eslint-plugin-playwright';
+import eslintPluginTestingLibrary from 'eslint-plugin-testing-library';
 import { defineConfig, javascriptFiles } from './base.mjs';
 
-export default defineConfig( {
-	files: javascriptFiles,
-	extends: [ eslintPluginPlaywright.configs[ 'flat/recommended' ] ],
-} );
+export default defineConfig(
+	{
+		files: javascriptFiles,
+		extends: [ eslintPluginPlaywright.configs[ 'flat/recommended' ] ],
+	},
+	{
+		name: 'Disable testing-library, conflicts with playwright',
+		files: javascriptFiles,
+		rules: {
+			...Object.fromEntries(
+				Object.keys( eslintPluginTestingLibrary.rules ).map( k => [
+					`testing-library/${ k }`,
+					'off',
+				] )
+			),
+		},
+	}
+);


### PR DESCRIPTION
Closes MONOREP-22

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
While Playwright and Testing-library are very similar, there are some differences and the testing-library eslint rules have some false positives when run against Playwright test code. More such false positives will be coming in eslint-plugin-testing-library v7.5.

The appropriate thing to do is disable the eslint-plugin-testing-library rules for Playwright tests, where we're already loading eslint-plugin-playwright.

This also cleans up a bug in `tools/e2e-commons/eslint.config.mjs` where it was ignoring the `opts` parameter (which no callers currently use), since the file was being edited anyway.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Came up while reviewing #44276.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* CI happy?
