### PR TITLE
Forms: fix create post meta on every admin load

### DIFF
--- a/projects/packages/forms/changelog/fix-create-post-meta-on-every-admin-load
+++ b/projects/packages/forms/changelog/fix-create-post-meta-on-every-admin-load
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+Forms: prevent post_meta from being created

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -494,6 +494,7 @@ class Contact_Form_Block {
 	 * Loads scripts
 	 */
 	public static function load_editor_scripts() {
+		global $post;
 		// Bail early if the user cannot manage the block.
 		if ( ! self::can_manage_block() ) {
 			return;
@@ -516,8 +517,6 @@ class Contact_Form_Block {
 
 		// Create a Contact_Form instance to get the default values
 		$dashboard_view_switch   = new Dashboard_View_Switch();
-		$contact_form            = new Contact_Form( array() );
-		$defaults                = $contact_form->defaults;
 		$form_responses_url      = $dashboard_view_switch->get_forms_admin_url();
 		$akismet_active_with_key = Jetpack::is_akismet_active();
 		$akismet_key_url         = admin_url( 'admin.php?page=akismet-key-config' );
@@ -525,8 +524,8 @@ class Contact_Form_Block {
 
 		$data = array(
 			'defaults' => array(
-				'to'                   => $defaults['to'],
-				'subject'              => $defaults['subject'],
+				'to'                   => Contact_Form::get_default_to( $post ? $post->post_author : null ),
+				'subject'              => Contact_Form::get_default_subject( array() ),
 				'formsResponsesUrl'    => $form_responses_url,
 				'akismetActiveWithKey' => $akismet_active_with_key,
 				'akismetUrl'           => $akismet_key_url,

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -115,41 +115,21 @@ class Contact_Form extends Contact_Form_Shortcode {
 		$this->is_response_without_reload_enabled = apply_filters( 'jetpack_forms_enable_ajax_submission', false );
 
 		// Set up the default subject and recipient for this form.
-		$default_to      = '';
-		$default_subject = '[' . get_option( 'blogname' ) . ']';
+		$default_to      = self::get_default_to( $this->current_post ? $this->current_post->post_author : null );
+		$default_subject = self::get_default_subject( $attributes );
 
 		if ( ! isset( $attributes ) || ! is_array( $attributes ) ) {
 			$attributes = array();
 		}
 
-		if ( $this->current_post ) {
-			$default_subject = sprintf(
-				// translators: the blog name and post title.
-				_x( '%1$s %2$s', '%1$s = blog name, %2$s = post title', 'jetpack-forms' ),
-				$default_subject,
-				Contact_Form_Plugin::strip_tags( $this->current_post->post_title )
-			);
-		}
-
 		if ( ! empty( $attributes['widget'] ) && $attributes['widget'] ) {
-			$default_to      .= get_option( 'admin_email' );
 			$attributes['id'] = 'widget-' . $attributes['widget'];
-			// translators: the blog name (and post name, if applicable).
-			$default_subject = sprintf( _x( '%1$s Sidebar', '%1$s = blog name', 'jetpack-forms' ), $default_subject );
 		} elseif ( ! empty( $attributes['block_template'] ) && $attributes['block_template'] ) {
-			$default_to      .= get_option( 'admin_email' );
 			$attributes['id'] = 'block-template-' . $attributes['block_template'];
 		} elseif ( ! empty( $attributes['block_template_part'] ) && $attributes['block_template_part'] ) {
-			$default_to      .= get_option( 'admin_email' );
 			$attributes['id'] = 'block-template-part-' . $attributes['block_template_part'];
 		} elseif ( $this->current_post ) {
 			$attributes['id'] = $this->current_post->ID;
-			$post_author      = get_userdata( $this->current_post->post_author );
-			if ( is_a( $post_author, '\WP_User' ) ) {
-				$default_to .= $post_author->user_email;
-			} else {
-				$default_to .= get_option( 'admin_email' );
-			}
 		}
 
 		// When using admin-ajax.php, we don't need to add a page number to the id

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -230,6 +230,56 @@ class Contact_Form extends Contact_Form_Shortcode {
 	}
 
 	/**
+	 * Get the default recipient email address for the contact form.
+	 *
+	 * @param int|null $post_author_id The ID of the post author. If provided, will return the author's email.
+	 *
+	 * @return string The default recipient email address.
+	 */
+	public static function get_default_to( $post_author_id = null ) {
+
+		if ( $post_author_id ) {
+			$post_author = get_userdata( $post_author_id );
+			if ( ! empty( $post_author->user_email ) ) {
+				return $post_author->user_email;
+			}
+		}
+		// Get the default recipient email address.
+		$default_to = get_option( 'admin_email' );
+
+		return $default_to;
+	}
+
+	/**
+	 * Get the default subject for the contact form.
+	 *
+	 * @param array $attributes The attributes of the contact form.
+	 *
+	 * @return string The default subject for the contact form.
+	 */
+	public static function get_default_subject( $attributes ) {
+		global $post;
+		// Get the default subject for the contact form.
+		$default_subject = '[' . get_option( 'blogname' ) . ']';
+
+		if ( $post ) {
+			$default_subject = sprintf(
+				// translators: the blog name and post title.
+				_x( '%1$s %2$s', '%1$s = blog name, %2$s = post title', 'jetpack-forms' ),
+				$default_subject,
+				Contact_Form_Plugin::strip_tags( $post->post_title )
+			);
+		}
+
+		if ( ! empty( $attributes['widget'] ) && $attributes['widget'] ) {
+			// translators: '%1$s the blog name
+			$default_subject = sprintf( _x( '%1$s Sidebar', '%1$s = blog name', 'jetpack-forms' ), $default_subject );
+		}
+
+		return $default_subject;
+	}
+
+	/**
 	 * Store shortcode content for recall later
 	 *  - used to receate shortcode when user uses do_shortcode
 	 *

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -2741,4 +2741,136 @@ EOT;
 
 		$this->assertEquals( $form1->defaults['to'], get_option( 'admin_email' ), 'The default to address should equal the admin email.' );
 	}
+
+	/**
+	 * Tests get_default_to method with valid post author.
+	 */
+	public function test_get_default_to_with_valid_post_author() {
+		$author_id = wp_insert_user(
+			array(
+				'user_email' => 'author@example.com',
+				'user_login' => 'test_author',
+				'user_pass'  => 'password123',
+			)
+		);
+
+		$result = Contact_Form::get_default_to( $author_id );
+
+		$this->assertEquals( 'author@example.com', $result );
+
+		wp_delete_user( $author_id );
+	}
+
+	/**
+	 * Tests get_default_to method with invalid post author ID.
+	 */
+	public function test_get_default_to_with_invalid_post_author() {
+		$result = Contact_Form::get_default_to( 99999 ); // Non-existent user ID
+
+		$this->assertEquals( get_option( 'admin_email' ), $result );
+	}
+
+	/**
+	 * Tests get_default_to method with null post author ID.
+	 */
+	public function test_get_default_to_with_null_post_author() {
+		$result = Contact_Form::get_default_to( null );
+
+		$this->assertEquals( get_option( 'admin_email' ), $result );
+	}
+
+	/**
+	 * Tests get_default_to method with post author that has empty email.
+	 */
+	public function test_get_default_to_with_empty_author_email() {
+		$author_id = wp_insert_user(
+			array(
+				'user_email' => '',
+				'user_login' => 'test_author_no_email',
+				'user_pass'  => 'password123',
+			)
+		);
+
+		$result = Contact_Form::get_default_to( $author_id );
+
+		$this->assertEquals( get_option( 'admin_email' ), $result );
+
+		wp_delete_user( $author_id );
+	}
+
+	/**
+	 * Tests get_default_subject method with post.
+	 */
+	public function test_get_default_subject_with_post() {
+		global $post;
+
+		$attributes = array();
+		$result     = Contact_Form::get_default_subject( $attributes );
+
+		$expected = '[' . get_option( 'blogname' ) . '] ' . Contact_Form_Plugin::strip_tags( $post->post_title );
+		$this->assertEquals( $expected, $result );
+	}
+
+	/**
+	 * Tests get_default_subject method with widget attribute.
+	 */
+	public function test_get_default_subject_with_widget() {
+		global $post;
+
+		$attributes = array( 'widget' => true );
+		$result     = Contact_Form::get_default_subject( $attributes );
+
+		$blog_name = get_option( 'blogname' );
+		$expected  = '[' . $blog_name . '] ' . Contact_Form_Plugin::strip_tags( $post->post_title ) . ' Sidebar';
+		$this->assertEquals( $expected, $result );
+	}
+
+	/**
+	 * Tests get_default_subject method with widget attribute set to false.
+	 */
+	public function test_get_default_subject_with_widget_false() {
+		global $post;
+
+		$attributes = array( 'widget' => false );
+		$result     = Contact_Form::get_default_subject( $attributes );
+
+		$expected = '[' . get_option( 'blogname' ) . '] ' . Contact_Form_Plugin::strip_tags( $post->post_title );
+		$this->assertEquals( $expected, $result );
+	}
+
+	/**
+	 * Tests get_default_subject method without post.
+	 */
+	public function test_get_default_subject_without_post() {
+		global $post;
+		$original_post = $post;
+		$post          = null;
+
+		$attributes = array();
+		$result     = Contact_Form::get_default_subject( $attributes );
+
+		$expected = '[' . get_option( 'blogname' ) . ']';
+		$this->assertEquals( $expected, $result );
+
+		// Restore original post
+		$post = $original_post;
+	}
+
+	/**
+	 * Tests get_default_subject method without post but with widget.
+	 */
+	public function test_get_default_subject_without_post_with_widget() {
+		global $post;
+		$original_post = $post;
+		$post          = null;
+
+		$attributes = array( 'widget' => true );
+		$result     = Contact_Form::get_default_subject( $attributes );
+
+		$expected = '[' . get_option( 'blogname' ) . '] Sidebar';
+		$this->assertEquals( $expected, $result );
+
+		// Restore original post
+		$post = $original_post;
+	}
 } // end class

--- a/projects/plugins/jetpack/changelog/fix-create-post-meta-on-every-admin-load
+++ b/projects/plugins/jetpack/changelog/fix-create-post-meta-on-every-admin-load
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/44296

## Proposed changes:
This PR extracts methods for default form attributes so a Contact_Form class doesn't need to be instantiated each time we need them (which was causing the metas to be created).

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1752657943918339-slack-C052XEUUBL4

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Without applying this branch, create a post in the editor and save it with no content. Take note of its ID.

Use wp cli to see the post metas:

```
wp post meta list [POST ID HERE]
```

See that it holds 2 metas:
- `_g_feedback_shortcode_[SOME HASH HERE]`
- `_g_feedback_shortcode_atts_[SOME HASH HERE]`

Apply the branch, and repeat the process creating a new post. This time when you list the metas those won't be there.