### PR TITLE
Forms: progress indicator: display steps names settings

### DIFF
--- a/projects/packages/forms/changelog/update-form-progress-indicator-show-steps-names
+++ b/projects/packages/forms/changelog/update-form-progress-indicator-show-steps-names
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: Progress Indicator: Add show step names setting.

--- a/projects/packages/forms/src/blocks/form-progress-indicator/edit.js
+++ b/projects/packages/forms/src/blocks/form-progress-indicator/edit.js
@@ -19,6 +19,16 @@ const FormProgressIndicatorEdit = ( { clientId, attributes, setAttributes } ) =>
 
 	const blockProps = useBlockProps();
 
+	// Accessibility attributes for the progress bar wrapper.
+	const roundedProgress = Math.round( progress );
+	const progressBarWrapperProps = {
+		...blockProps,
+		role: 'progressbar',
+		'aria-valuemin': 0,
+		'aria-valuemax': 100,
+		'aria-valuenow': roundedProgress,
+	};
+
 	// Only need to set width – colours come from core style engine variables.
 	const progressBarStyle = {
 		width: `${ progress }%`,
@@ -36,7 +46,11 @@ const FormProgressIndicatorEdit = ( { clientId, attributes, setAttributes } ) =>
 				}
 				const isCurrent = index === currentStepInfo.index;
 				return (
-					<li key={ step.clientId } className={ isCurrent ? 'is-current-step' : '' }>
+					<li
+						key={ step.clientId }
+						className={ isCurrent ? 'is-current-step' : '' }
+						aria-current={ isCurrent ? 'step' : undefined }
+					>
 						{ label }
 					</li>
 				);
@@ -57,7 +71,7 @@ const FormProgressIndicatorEdit = ( { clientId, attributes, setAttributes } ) =>
 			</InspectorControls>
 			<div className="jetpack-form-progress-indicator--wrapper">
 				{ namesList }
-				<div { ...blockProps }>
+				<div { ...progressBarWrapperProps }>
 					<div className="jetpack-form-progress-indicator-bar" style={ progressBarStyle }></div>
 				</div>
 			</div>

--- a/projects/packages/forms/src/blocks/form-progress-indicator/edit.js
+++ b/projects/packages/forms/src/blocks/form-progress-indicator/edit.js
@@ -1,11 +1,14 @@
-import { useBlockProps } from '@wordpress/block-editor';
+import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
+import { PanelBody, ToggleControl } from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
 import StepControls from '../shared/components/form-step-controls';
 import useParentFormClientId from '../shared/hooks/use-parent-form-client-id';
 import useStepNavigation from '../shared/hooks/use-step-navigation';
 
 import './editor.scss';
 
-const FormProgressIndicatorEdit = ( { clientId } ) => {
+const FormProgressIndicatorEdit = ( { clientId, attributes, setAttributes } ) => {
+	const { displayStepNames = false } = attributes;
 	const parentFormId = useParentFormClientId( clientId );
 	const { currentStepInfo, steps } = useStepNavigation( parentFormId );
 
@@ -21,9 +24,39 @@ const FormProgressIndicatorEdit = ( { clientId } ) => {
 		width: `${ progress }%`,
 	};
 
+	const namesList = displayStepNames ? (
+		<ol className="jetpack-form-progress-indicator-names">
+			{ steps.map( ( step, index ) => {
+				let label;
+				if ( step?.attributes?.stepLabel ) {
+					label = step.attributes.stepLabel;
+				} else {
+					/* translators: %d: step number */
+					label = sprintf( __( 'Step %d', 'jetpack-forms' ), index + 1 );
+				}
+				const isCurrent = index === currentStepInfo.index;
+				return (
+					<li key={ step.clientId } className={ isCurrent ? 'is-current-step' : '' }>
+						{ label }
+					</li>
+				);
+			} ) }
+		</ol>
+	) : null;
+
 	return (
 		<>
+			<InspectorControls>
+				<PanelBody title={ __( 'Progress Indicator', 'jetpack-forms' ) } initialOpen={ true }>
+					<ToggleControl
+						label={ __( 'Display step names', 'jetpack-forms' ) }
+						checked={ displayStepNames }
+						onChange={ value => setAttributes( { displayStepNames: value } ) }
+					/>
+				</PanelBody>
+			</InspectorControls>
 			<div className="jetpack-form-progress-indicator--wrapper">
+				{ namesList }
 				<div { ...blockProps }>
 					<div className="jetpack-form-progress-indicator-bar" style={ progressBarStyle }></div>
 				</div>

--- a/projects/packages/forms/src/blocks/form-progress-indicator/editor.scss
+++ b/projects/packages/forms/src/blocks/form-progress-indicator/editor.scss
@@ -27,3 +27,23 @@
 		border-radius: calc( var( --jp-form-progress-height ) / 2 );
 	}
 }
+
+.jetpack-form-progress-indicator--wrapper .jetpack-form-progress-indicator-names {
+	list-style: none;
+	margin-bottom: 0.5rem;
+	padding: 0;
+	display: flex;
+	justify-content: space-between;
+	font-size: 0.8rem;
+
+	li {
+	    opacity: 0.4;
+	    transition: color 0.2s ease, opacity 0.2s ease;
+	}
+
+	li.is-current-step {
+	    font-weight: 700;
+	    opacity: 1;
+	    color: var(--jp-form-progress-active-color, currentColor);
+	}
+}

--- a/projects/packages/forms/src/blocks/form-progress-indicator/index.js
+++ b/projects/packages/forms/src/blocks/form-progress-indicator/index.js
@@ -56,7 +56,12 @@ export const settings = {
 	},
 	edit: edit,
 	save: save,
-	attributes: {},
+	attributes: {
+		displayStepNames: {
+			type: 'boolean',
+			default: false,
+		},
+	},
 	transforms: {},
 	example: {},
 };

--- a/projects/packages/forms/src/blocks/form-progress-indicator/save.js
+++ b/projects/packages/forms/src/blocks/form-progress-indicator/save.js
@@ -1,10 +1,12 @@
 import { useBlockProps } from '@wordpress/block-editor';
 
-const FormProgressIndicatorSave = () => {
+const FormProgressIndicatorSave = ( { attributes } ) => {
+	const { displayStepNames = false } = attributes;
 	const blockProps = useBlockProps.save();
 
 	return (
 		<div className="jetpack-form-progress-indicator--wrapper">
+			{ displayStepNames && <ol className="jetpack-form-progress-indicator-names"></ol> }
 			<div { ...blockProps }>
 				<div className="jetpack-form-progress-indicator-bar"></div>
 			</div>

--- a/projects/packages/forms/src/blocks/form-progress-indicator/save.js
+++ b/projects/packages/forms/src/blocks/form-progress-indicator/save.js
@@ -2,7 +2,13 @@ import { useBlockProps } from '@wordpress/block-editor';
 
 const FormProgressIndicatorSave = ( { attributes } ) => {
 	const { displayStepNames = false } = attributes;
-	const blockProps = useBlockProps.save();
+	const blockProps = useBlockProps.save( {
+		role: 'progressbar',
+		'aria-valuemin': 0,
+		'aria-valuemax': 100,
+		// Bind numeric progress value from interactivity store.
+		'data-wp-bind--aria-valuenow': 'state.getStepProgressValue',
+	} );
 
 	return (
 		<div className="jetpack-form-progress-indicator--wrapper">

--- a/projects/packages/forms/src/blocks/form-progress-indicator/style.scss
+++ b/projects/packages/forms/src/blocks/form-progress-indicator/style.scss
@@ -27,3 +27,23 @@
 		border-radius: calc( var( --jp-form-progress-height ) / 2 );
 	}
 }
+
+.jetpack-form-progress-indicator--wrapper .jetpack-form-progress-indicator-names {
+	list-style: none;
+	margin-bottom: 0.5rem;
+	padding: 0;
+	display: flex;
+	justify-content: space-between;
+	font-size: 0.8rem;
+
+	li {
+		opacity: 0.4; /* Make inactive steps lighter */
+		transition: color 0.2s ease, opacity 0.2s ease;
+	}
+
+	li.is-current-step {
+		font-weight: 700;
+		opacity: 1;
+		color: var(--jp-form-progress-active-color, currentColor); /* Allow theme override */
+	}
+}

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -779,7 +779,7 @@ class Contact_Form_Plugin {
 		$processor->next_tag();
 		$processor->set_attribute( 'data-wp-interactive', 'jetpack/form' );
 		$processor->set_attribute( 'data-wp-init--initializeProgress', 'callbacks.initializeProgress' );
-		$processor->set_attribute( 'data-wp-watch--highlight', 'callbacks.updateHighlight' );
+		$processor->set_attribute( 'data-wp-watch--currentStep', 'callbacks.updateProgressHighlight' );
 		// Accessibility attributes for the progress bar.
 		$processor->set_attribute( 'role', 'progressbar' );
 		$processor->set_attribute( 'aria-valuemin', '0' );

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -656,7 +656,7 @@ class Contact_Form_Plugin {
 			$processed_content = do_blocks( $content );
 		}
 		$is_current_step_class = ( self::$step_count === 1 ? 'is-current-step' : '' );
-		return '<div data-wp-interactive="jetpack/form" class="jetpack-form-step ' . $is_current_step_class . ' " data-wp-class--is-before-current="state.isBeforeCurrent" data-wp-class--is-after-current="state.isAfterCurrent" data-wp-class--is-current-step="state.isCurrentStep" ' . wp_interactivity_data_wp_context( array( 'step' => self::$step_count ) ) . ' >'
+		return '<div data-wp-interactive="jetpack/form" class="jetpack-form-step ' . $is_current_step_class . ' " data-wp-class--is-before-current="state.isBeforeCurrent" data-wp-class--is-after-current="state.isAfterCurrent" data-wp-class--is-current-step="state.isCurrentStep" data-step-label="' . esc_attr( isset( $atts['stepLabel'] ) ? $atts['stepLabel'] : '' ) . '" ' . wp_interactivity_data_wp_context( array( 'step' => self::$step_count ) ) . ' >'
 				. $processed_content
 			. '</div>';
 	}
@@ -778,6 +778,8 @@ class Contact_Form_Plugin {
 		$processor = new \WP_HTML_Tag_Processor( $content );
 		$processor->next_tag();
 		$processor->set_attribute( 'data-wp-interactive', 'jetpack/form' );
+		$processor->set_attribute( 'data-wp-init--initializeProgress', 'callbacks.initializeProgress' );
+		$processor->set_attribute( 'data-wp-watch--highlight', 'callbacks.updateHighlight' );
 
 		while ( $processor->next_tag() ) {
 			$class = $processor->get_attribute( 'class' );

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -780,6 +780,11 @@ class Contact_Form_Plugin {
 		$processor->set_attribute( 'data-wp-interactive', 'jetpack/form' );
 		$processor->set_attribute( 'data-wp-init--initializeProgress', 'callbacks.initializeProgress' );
 		$processor->set_attribute( 'data-wp-watch--highlight', 'callbacks.updateHighlight' );
+		// Accessibility attributes for the progress bar.
+		$processor->set_attribute( 'role', 'progressbar' );
+		$processor->set_attribute( 'aria-valuemin', '0' );
+		$processor->set_attribute( 'aria-valuemax', '100' );
+		$processor->set_attribute( 'data-wp-bind--aria-valuenow', 'state.getStepProgressValue' );
 
 		while ( $processor->next_tag() ) {
 			$class = $processor->get_attribute( 'class' );

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -451,13 +451,33 @@ class Contact_Form extends Contact_Form_Shortcode {
 				$context = array_merge( $context, $multistep_context );
 			}
 
+			$step_labels_json = '[]';
+			if ( $is_multistep ) {
+				$step_labels      = array();
+				$step_index       = 1;
+				$processor_labels = new \WP_HTML_Tag_Processor( $content );
+				while ( $processor_labels->next_tag() ) {
+					$class = $processor_labels->get_attribute( 'class' );
+					if ( $class && str_contains( $class, 'jetpack-form-step' ) ) {
+						$label = $processor_labels->get_attribute( 'data-step-label' );
+						/* translators: %d is the step index shown to the user when no custom label is provided. */
+						$step_labels[] = $label ? $label : sprintf( __( 'Step %d', 'jetpack-forms' ), $step_index );
+						++$step_index;
+					}
+				}
+				$step_labels_json = wp_json_encode( $step_labels );
+			}
+
 			$context = is_array( $context ) ? array_merge( $default_context, $context ) : $default_context;
 
 			$r .= "<form action='" . esc_url( $url ) . "'
 				id='jp-form-" . esc_attr( $form->hash ) . "'
 				method='post'
 				class='" . esc_attr( $form_classes ) . "' $form_aria_label
-				data-wp-interactive=\"jetpack/form\"  " . wp_interactivity_data_wp_context( $context ) . "
+				data-step-labels='" . esc_attr( $step_labels_json ) . "'
+				data-wp-interactive=\"jetpack/form\"
+				data-wp-init--initializeForm=\"callbacks.initializeForm\"
+				" . wp_interactivity_data_wp_context( $context ) . "
 				data-wp-on--submit=\"actions.onFormSubmit\"
 				data-wp-class--is-first-step=\"state.isFirstStep\"
 				data-wp-class--is-last-step=\"state.isLastStep\"

--- a/projects/packages/forms/src/modules/form-progress-indicator/view.js
+++ b/projects/packages/forms/src/modules/form-progress-indicator/view.js
@@ -6,6 +6,11 @@ store( 'jetpack/form', {
 			const context = getContext();
 			return ( Math.max( 1, context.currentStep ) / context.maxSteps ) * 100 + '%';
 		},
+		// Provide numeric progress value (0-100) for aria-valuenow bindings.
+		get getStepProgressValue() {
+			const context = getContext();
+			return Math.round( ( Math.max( 1, context.currentStep ) / context.maxSteps ) * 100 );
+		},
 	},
 	callbacks: {
 		initializeProgress: () => {
@@ -34,7 +39,13 @@ store( 'jetpack/form', {
 				Array.from( namesList.children ).forEach( child => {
 					const li = child;
 					const stepIdx = Number( li.dataset.stepIndex );
-					li.classList.toggle( 'is-current-step', stepIdx === currentStep );
+					const isCurrent = stepIdx === currentStep;
+					li.classList.toggle( 'is-current-step', isCurrent );
+					if ( isCurrent ) {
+						li.setAttribute( 'aria-current', 'step' );
+					} else {
+						li.removeAttribute( 'aria-current' );
+					}
 				} );
 			};
 
@@ -71,6 +82,9 @@ store( 'jetpack/form', {
 					// Store step index for easy lookup when highlighting.
 					li.dataset.stepIndex = String( idx + 1 );
 					li.classList.toggle( 'is-current-step', idx + 1 === context.currentStep );
+					if ( idx + 1 === context.currentStep ) {
+						li.setAttribute( 'aria-current', 'step' );
+					}
 					namesList.appendChild( li );
 				} );
 

--- a/projects/packages/forms/src/modules/form-progress-indicator/view.js
+++ b/projects/packages/forms/src/modules/form-progress-indicator/view.js
@@ -1,43 +1,23 @@
 import { getContext, store, getElement } from '@wordpress/interactivity';
 
 store( 'jetpack/form', {
-	state: {
-		get getStepProgress() {
-			const context = getContext();
-			return ( Math.max( 1, context.currentStep ) / context.maxSteps ) * 100 + '%';
-		},
-		// Provide numeric progress value (0-100) for aria-valuenow bindings.
-		get getStepProgressValue() {
-			const context = getContext();
-			return Math.round( ( Math.max( 1, context.currentStep ) / context.maxSteps ) * 100 );
-		},
-		// Expose the current step so we can watch it from markup (data-wp-watch--highlight).
-		// Whenever `currentStep` changes, this derived getter will emit a new value and
-		// trigger the watcher.
-		get highlight() {
-			const context = getContext();
-			return context.currentStep;
-		},
-	},
+	// progress-indicator module only needs callbacks; progress-related state
+	// has been moved to the shared form store.
 	callbacks: {
 		initializeProgress: () => {
-			const context = getContext();
-
-			// Ensure a valid transition value.
-			if (
-				! context.transition ||
-				! [ 'none', 'fade', 'slide', 'fade-slide' ].includes( context.transition )
-			) {
-				context.transition = 'fade-slide';
-			}
-
 			const elementInfo = getElement();
 			if ( ! elementInfo?.ref ) {
 				return; // Element not yet available
 			}
+
+			const context = getContext();
+
+			// Previously ensured a valid transition value, but multiple transitions
+			// are not yet implemented. Removing for now to simplify logic.
+
 			const wrapper = elementInfo.ref;
 
-			const updateHighlight = () => {
+			const updateProgressHighlight = () => {
 				const namesList = wrapper.querySelector( '.jetpack-form-progress-indicator-names' );
 				if ( ! namesList ) {
 					return;
@@ -82,11 +62,19 @@ store( 'jetpack/form', {
 					return;
 				}
 
-				stepNodes.forEach( ( stepNode, idx ) => {
-					const label = stepNode.getAttribute( 'data-step-label' ) || `Step ${ idx + 1 }`;
+				let labels = store( 'jetpack/form' ).state.stepLabels;
+				if ( ! Array.isArray( labels ) || labels.length === 0 ) {
+					// Fallback: derive labels from DOM if not provided.
+					labels = [];
+					stepNodes.forEach( ( stepNode, idx ) => {
+						const l = stepNode.getAttribute( 'data-step-label' ) || `Step ${ idx + 1 }`;
+						labels.push( l );
+					} );
+				}
+
+				labels.forEach( ( label, idx ) => {
 					const li = document.createElement( 'li' );
 					li.textContent = label;
-					// Store step index for easy lookup when highlighting.
 					li.dataset.stepIndex = String( idx + 1 );
 					li.classList.toggle( 'is-current-step', idx + 1 === context.currentStep );
 					if ( idx + 1 === context.currentStep ) {
@@ -96,19 +84,19 @@ store( 'jetpack/form', {
 				} );
 
 				// Initial highlight.
-				updateHighlight();
+				updateProgressHighlight();
 			};
 
 			// Build the names list once on initialization.
 			buildNamesList();
 			// Expose highlight updater so it can be referenced by data-wp-watch.
-			context.updateProgressNamesHighlight = updateHighlight;
+			context.updateProgressHighlight = updateProgressHighlight;
 		},
-		updateHighlight: () => {
+		updateProgressHighlight: () => {
 			// Exposed for data-wp-watch in markup.
 			const context = getContext();
-			if ( typeof context.updateProgressNamesHighlight === 'function' ) {
-				context.updateProgressNamesHighlight();
+			if ( typeof context.updateProgressHighlight === 'function' ) {
+				context.updateProgressHighlight();
 			}
 		},
 	},

--- a/projects/packages/forms/src/modules/form-progress-indicator/view.js
+++ b/projects/packages/forms/src/modules/form-progress-indicator/view.js
@@ -1,4 +1,4 @@
-import { getContext, store } from '@wordpress/interactivity';
+import { getContext, store, getElement } from '@wordpress/interactivity';
 
 store( 'jetpack/form', {
 	state: {
@@ -7,16 +7,93 @@ store( 'jetpack/form', {
 			return ( Math.max( 1, context.currentStep ) / context.maxSteps ) * 100 + '%';
 		},
 	},
-	actions: {
-		initializeProgress() {
-			// Initialize progress indicator when the form loads
+	callbacks: {
+		initializeProgress: () => {
 			const context = getContext();
-			// Ensure we have a valid transition value
+
+			// Ensure a valid transition value.
 			if (
 				! context.transition ||
 				! [ 'none', 'fade', 'slide', 'fade-slide' ].includes( context.transition )
 			) {
-				context.transition = 'fade-slide'; // Default transition if not set or invalid
+				context.transition = 'fade-slide';
+			}
+
+			const elementInfo = getElement();
+			if ( ! elementInfo?.ref ) {
+				return; // Element not yet available
+			}
+			const wrapper = elementInfo.ref;
+
+			const updateHighlight = () => {
+				const namesList = wrapper.querySelector( '.jetpack-form-progress-indicator-names' );
+				if ( ! namesList ) {
+					return;
+				}
+				const { currentStep } = getContext();
+				Array.from( namesList.children ).forEach( child => {
+					const li = child;
+					const stepIdx = Number( li.dataset.stepIndex );
+					li.classList.toggle( 'is-current-step', stepIdx === currentStep );
+				} );
+			};
+
+			const buildNamesList = () => {
+				const namesList = wrapper.querySelector( '.jetpack-form-progress-indicator-names' );
+				if ( ! namesList ) {
+					return;
+				}
+
+				// Avoid rebuilding if already populated with expected number of steps.
+				if ( namesList.childElementCount >= context.maxSteps ) {
+					return;
+				}
+
+				// Clear any existing items before (re)building.
+				while ( namesList.firstChild ) {
+					namesList.removeChild( namesList.firstChild );
+				}
+
+				const formEl = wrapper.closest( 'form' );
+				if ( ! formEl ) {
+					return;
+				}
+
+				const stepNodes = Array.from( formEl.querySelectorAll( '.jetpack-form-step' ) );
+				if ( stepNodes.length === 0 ) {
+					return;
+				}
+
+				stepNodes.forEach( ( stepNode, idx ) => {
+					const label = stepNode.getAttribute( 'data-step-label' ) || `Step ${ idx + 1 }`;
+					const li = document.createElement( 'li' );
+					li.textContent = label;
+					// Store step index for easy lookup when highlighting.
+					li.dataset.stepIndex = String( idx + 1 );
+					li.classList.toggle( 'is-current-step', idx + 1 === context.currentStep );
+					namesList.appendChild( li );
+				} );
+
+				// Initial highlight.
+				updateHighlight();
+
+				// If after building we still have fewer items than expected, try again on next tick.
+				if ( namesList.childElementCount < context.maxSteps ) {
+					setTimeout( buildNamesList, 50 );
+				}
+			};
+
+			// Defer building list creation then attach a global watch to keep highlight in sync.
+			setTimeout( buildNamesList, 0 );
+
+			// Expose highlight updater so it can be referenced by data-wp-watch.
+			context.updateProgressNamesHighlight = updateHighlight;
+		},
+		updateHighlight: () => {
+			// Exposed for data-wp-watch in markup.
+			const context = getContext();
+			if ( typeof context.updateProgressNamesHighlight === 'function' ) {
+				context.updateProgressNamesHighlight();
 			}
 		},
 	},

--- a/projects/packages/forms/src/modules/form-progress-indicator/view.js
+++ b/projects/packages/forms/src/modules/form-progress-indicator/view.js
@@ -11,6 +11,13 @@ store( 'jetpack/form', {
 			const context = getContext();
 			return Math.round( ( Math.max( 1, context.currentStep ) / context.maxSteps ) * 100 );
 		},
+		// Expose the current step so we can watch it from markup (data-wp-watch--highlight).
+		// Whenever `currentStep` changes, this derived getter will emit a new value and
+		// trigger the watcher.
+		get highlight() {
+			const context = getContext();
+			return context.currentStep;
+		},
 	},
 	callbacks: {
 		initializeProgress: () => {
@@ -90,16 +97,10 @@ store( 'jetpack/form', {
 
 				// Initial highlight.
 				updateHighlight();
-
-				// If after building we still have fewer items than expected, try again on next tick.
-				if ( namesList.childElementCount < context.maxSteps ) {
-					setTimeout( buildNamesList, 50 );
-				}
 			};
 
-			// Defer building list creation then attach a global watch to keep highlight in sync.
-			setTimeout( buildNamesList, 0 );
-
+			// Build the names list once on initialization.
+			buildNamesList();
 			// Expose highlight updater so it can be referenced by data-wp-watch.
 			context.updateProgressNamesHighlight = updateHighlight;
 		},

--- a/projects/packages/forms/src/modules/form/view.js
+++ b/projects/packages/forms/src/modules/form/view.js
@@ -6,6 +6,7 @@ import {
 	store,
 	getConfig,
 	withSyncEvent as originalWithSyncEvent,
+	getElement,
 } from '@wordpress/interactivity';
 /*
  * Internal dependencies
@@ -203,9 +204,39 @@ const { state } = store( NAMESPACE, {
 			const context = getContext();
 			return context.submissionError || '';
 		},
+
+		// Returns an array of step labels for multi-step forms. Populated during initialization.
+		get stepLabels() {
+			const context = getContext();
+			return context.stepLabels || [];
+		},
+
+		// Progress indicator helpers
+		get getStepProgress() {
+			const context = getContext();
+			return ( Math.max( 1, context.currentStep ) / context.maxSteps ) * 100 + '%';
+		},
+
+		// Provide numeric progress value (0-100) for aria-valuenow bindings.
+		get getStepProgressValue() {
+			const context = getContext();
+			return Math.round( ( Math.max( 1, context.currentStep ) / context.maxSteps ) * 100 );
+		},
+
+		// Expose the current step so markup can watch it via data-wp-watch.
+		get currentStep() {
+			const context = getContext();
+			return context.currentStep;
+		},
 	},
 
 	actions: {
+		// Stores the ordered list of step labels so other components (progress indicator,
+		// navigation, etc.) can reuse them without querying the DOM again.
+		setStepLabels: labels => {
+			const context = getContext();
+			context.stepLabels = labels;
+		},
 		updateFieldValue: ( fieldId, value ) => {
 			updateField( fieldId, value );
 		},
@@ -342,6 +373,26 @@ const { state } = store( NAMESPACE, {
 	},
 
 	callbacks: {
+		// Runs once for the <form> element. Reads step labels injected by PHP and
+		// stores them in the shared form store so all components can reuse them.
+		initializeForm() {
+			const elementInfo = getElement();
+			if ( ! elementInfo?.ref ) {
+				return;
+			}
+
+			const labelsAttr = elementInfo.ref.dataset.stepLabels || '[]';
+			let labels = [];
+			try {
+				labels = JSON.parse( labelsAttr );
+			} catch {
+				// If parsing fails, leave labels empty.
+			}
+
+			if ( Array.isArray( labels ) && labels.length ) {
+				store( NAMESPACE ).actions.setStepLabels( labels );
+			}
+		},
 		initializeField() {
 			const context = getContext();
 			const { fieldId, fieldType, fieldLabel, fieldValue, fieldIsRequired, fieldExtra } = context;


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
* Forms → Progress Indicator block: introduce a “Display step names” option (new `displayStepNames` attribute).
* Add a ToggleControl in block settings to enable/disable showing step names.
* Render an ordered list of step-labels both in the editor and on the frontend.
* Current step is highlighted and announced via `aria-current="step"`; highlight updates automatically as the user progresses.
* Extend view script to build and maintain the names list, ensuring accessibility and smooth transitions.
* Add supporting styles for the names list and highlight state.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
1. In the block editor, insert or select a “Form → Progress indicator” inside a multi-step Jetpack Form.
2. Open the block’s settings sidebar → “Progress Indicator”.
3. Toggle “Display step names”.
   * Expect an ordered list of each step’s label to appear above the progress bar.
4. Switch between steps using the editor navigation or the Step Controls:
   * The list item for the current step should receive the `is-current-step` class.
5. Save the post and view it on the frontend:
   * Verify that the names list appears (when enabled) and the highlight moves as you progress through the form.
6. Disable “Display step names” and confirm the list disappears both in the editor and on the frontend.

