### PR TITLE
Forms: Show submission information after reload with ajax submission

### DIFF
--- a/projects/packages/forms/changelog/update-forms-submit-ajax-frontend-reload
+++ b/projects/packages/forms/changelog/update-forms-submit-ajax-frontend-reload
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Show submission information after reload with ajax submission

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -386,6 +386,19 @@ class Contact_Form extends Contact_Form_Shortcode {
 		$container_classes[]      = self::get_block_alignment_class( $attributes );
 		$container_classes_string = implode( ' ', $container_classes );
 
+		$is_reload_after_success = isset( $_GET['contact-form-id'] )
+		&& (int) $_GET['contact-form-id'] === (int) self::$last->get_attribute( 'id' )
+		&& isset( $_GET['contact-form-sent'] )
+		&& isset( $_GET['contact-form-hash'] )
+		&& is_string( $_GET['contact-form-hash'] )
+		&& hash_equals( $form->hash, wp_unslash( $_GET['contact-form-hash'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+		if ( $is_reload_after_success ) {
+			$feedback_id           = (int) $_GET['contact-form-sent'];
+			$is_reload_nonce_valid = isset( $_GET['_wpnonce'] )
+				&& wp_verify_nonce( sanitize_key( wp_unslash( $_GET['_wpnonce'] ) ), "contact-form-sent-{$feedback_id}" );
+		}
+
 		$max_steps = 0;
 		if ( preg_match_all( '/data-wp-context=[\'"]?{"step":(\d+)}[\'"]?/', $content, $matches ) ) {
 			if ( ! empty( $matches[1] ) ) {
@@ -404,7 +417,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 			'fields'                         => array(),
 			'isMultiStep'                    => $is_multistep, // Whether the form is a multistep form.
 			'isResponseWithoutReloadEnabled' => $form->is_response_without_reload_enabled,
-			'submissionData'                 => null,
+			'submissionData'                 => $is_reload_after_success && $is_reload_nonce_valid ? self::get_json_data( (int) $_GET['contact-form-sent'], $form ) : null,
 			'submissionError'                => null,
 			'elementId'                      => $element_id,
 		);
@@ -431,6 +444,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 			class='{$container_classes_string}'
 			data-wp-interactive='jetpack/form' " . wp_interactivity_data_wp_context( $context ) . "
 			data-wp-watch--scroll-to-wrapper=\"callbacks.scrollToWrapper\"
+			data-wp-class--has-loaded=\"state.hasLoaded\"
 		>\n";
 
 		if ( $form->is_response_without_reload_enabled ) {
@@ -446,14 +460,8 @@ class Contact_Form extends Contact_Form_Shortcode {
 			$r .= "</ul>\n</div>\n\n";
 		}
 
-		if ( isset( $_GET['contact-form-id'] )
-			&& (int) $_GET['contact-form-id'] === (int) self::$last->get_attribute( 'id' )
-			&& isset( $_GET['contact-form-sent'] ) && isset( $_GET['contact-form-hash'] )
-			&& is_string( $_GET['contact-form-hash'] )
-			&& hash_equals( $form->hash, wp_unslash( $_GET['contact-form-hash'] ) ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( $is_reload_after_success && ! $form->is_response_without_reload_enabled ) {
 			// The contact form was submitted.  Show the success message/results.
-			$feedback_id = (int) $_GET['contact-form-sent'];
-
 			$back_url = remove_query_arg( array( 'contact-form-id', 'contact-form-sent', '_wpnonce' ) );
 			$r       .= '<div class="contact-form-submission">';
 
@@ -464,11 +472,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 				"</h4>\n\n";
 
 			// Don't show the feedback details unless the nonce matches
-			if (
-				$feedback_id
-				&& isset( $_GET['_wpnonce'] )
-				&& wp_verify_nonce( sanitize_key( wp_unslash( $_GET['_wpnonce'] ) ), "contact-form-sent-{$feedback_id}" )
-			) {
+			if ( $is_reload_nonce_valid ) {
 				$r_success_message .= self::success_message( $feedback_id, $form );
 			}
 
@@ -659,7 +663,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 	 */
 	private static function render_ajax_success_wrapper( $form ) {
 		$html  = '<div class="contact-form-submission contact-form-ajax-submission" data-wp-class--is-submitted="state.hasSubmitted">';
-		$html .= '<p class="go-back-message"> <a class="link" href="#" data-wp-on--click="actions.goBack">' . esc_html__( 'Go back', 'jetpack-forms' ) . '</a> </p>';
+		$html .= '<p class="go-back-message"> <a class="link" role="button" tabindex="0" data-wp-on--click="actions.goBack">' . esc_html__( 'Go back', 'jetpack-forms' ) . '</a> </p>';
 		$html .=
 			'<h4 id="contact-form-success-header">' . esc_html( $form->get_attribute( 'customThankyouHeading' ) ) .
 			"</h4>\n\n";
@@ -2017,6 +2021,13 @@ class Contact_Form extends Contact_Form_Shortcode {
 		 */
 		do_action( 'grunion_after_message_sent', $post_id, $to, $subject, $message, $headers, $all_values, $extra_values );
 
+		$refresh_args = array(
+			'contact-form-id'   => $id,
+			'contact-form-sent' => $post_id,
+			'contact-form-hash' => $this->hash,
+			'_wpnonce'          => wp_create_nonce( "contact-form-sent-{$post_id}" ), // wp_nonce_url HTMLencodes :( .
+		);
+
 		// If the request accepts JSON, return a JSON response instead of redirecting
 		$accepts_json = isset( $_SERVER['HTTP_ACCEPT'] ) && false !== strpos( strtolower( sanitize_text_field( wp_unslash( $_SERVER['HTTP_ACCEPT'] ) ) ), 'application/json' );
 
@@ -2025,8 +2036,9 @@ class Contact_Form extends Contact_Form_Shortcode {
 
 			echo wp_json_encode(
 				array(
-					'success' => true,
-					'data'    => self::get_json_data( $post_id, $this ),
+					'success'     => true,
+					'data'        => self::get_json_data( $post_id, $this ),
+					'refreshArgs' => $refresh_args,
 				)
 			);
 
@@ -2056,14 +2068,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 
 		if ( ! $custom_redirect ) {
 			$redirect = add_query_arg(
-				urlencode_deep(
-					array(
-						'contact-form-id'   => $id,
-						'contact-form-sent' => $post_id,
-						'contact-form-hash' => $this->hash,
-						'_wpnonce'          => wp_create_nonce( "contact-form-sent-{$post_id}" ), // wp_nonce_url HTMLencodes :( .
-					)
-				),
+				urlencode_deep( $refresh_args ),
 				$redirect
 			);
 		}

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -415,7 +415,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 		// Initial data used to render the success message when the page is reloaded after a successful submission
 		// Don't show the feedback details unless the nonce matches
 		$submission_data           = $is_reload_after_success && $is_reload_nonce_valid ? self::get_json_data( (int) $_GET['contact-form-sent'], $form ) : null;
-		$formatted_submission_data = $submission_data ? self::format_submission_data( $submission_data ) : null;
+		$formatted_submission_data = $submission_data ? self::format_submission_data( $submission_data ) : array();
 		$submission_success        = $form->is_response_without_reload_enabled && $is_reload_after_success;
 
 		$default_context = array(
@@ -657,16 +657,16 @@ class Contact_Form extends Contact_Form_Shortcode {
 	 * @return array The formatted submission data.
 	 */
 	private static function format_submission_data( $data ) {
-		$submission_data = array();
+		$formatted_submission_data = array();
 
 		foreach ( $data as $field_data ) {
-			$submission_data[] = array(
+			$formatted_submission_data[] = array(
 				'label' => self::maybe_add_colon_to_label( $field_data['label'] ),
 				'value' => self::maybe_transform_value( $field_data['value'] ),
 			);
 		}
 
-		return $submission_data;
+		return $formatted_submission_data;
 	}
 
 	/**

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -393,6 +393,9 @@ class Contact_Form extends Contact_Form_Shortcode {
 		&& is_string( $_GET['contact-form-hash'] )
 		&& hash_equals( $form->hash, wp_unslash( $_GET['contact-form-hash'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
+		$feedback_id           = 0;
+		$is_reload_nonce_valid = false;
+
 		if ( $is_reload_after_success ) {
 			$feedback_id           = (int) $_GET['contact-form-sent'];
 			$is_reload_nonce_valid = isset( $_GET['_wpnonce'] )
@@ -409,6 +412,12 @@ class Contact_Form extends Contact_Form_Shortcode {
 		$is_multistep = $max_steps > 0;
 		$element_id   = 'jp-form-' . esc_attr( $form->hash );
 
+		// Initial data used to render the success message when the page is reloaded after a successful submission
+		// Don't show the feedback details unless the nonce matches
+		$submission_data           = $is_reload_after_success && $is_reload_nonce_valid ? self::get_json_data( (int) $_GET['contact-form-sent'], $form ) : null;
+		$formatted_submission_data = $submission_data ? self::format_submission_data( $submission_data ) : null;
+		$submission_success        = $form->is_response_without_reload_enabled && $is_reload_after_success;
+
 		$default_context = array(
 			'formId'                         => $id,
 			'formHash'                       => $form->hash,
@@ -417,7 +426,9 @@ class Contact_Form extends Contact_Form_Shortcode {
 			'fields'                         => array(),
 			'isMultiStep'                    => $is_multistep, // Whether the form is a multistep form.
 			'isResponseWithoutReloadEnabled' => $form->is_response_without_reload_enabled,
-			'submissionData'                 => $is_reload_after_success && $is_reload_nonce_valid ? self::get_json_data( (int) $_GET['contact-form-sent'], $form ) : null,
+			'submissionData'                 => $submission_data,
+			'formattedSubmissionData'        => $formatted_submission_data,
+			'submissionSuccess'              => $submission_success,
 			'submissionError'                => null,
 			'elementId'                      => $element_id,
 		);
@@ -444,11 +455,10 @@ class Contact_Form extends Contact_Form_Shortcode {
 			class='{$container_classes_string}'
 			data-wp-interactive='jetpack/form' " . wp_interactivity_data_wp_context( $context ) . "
 			data-wp-watch--scroll-to-wrapper=\"callbacks.scrollToWrapper\"
-			data-wp-class--has-loaded=\"state.hasLoaded\"
 		>\n";
 
 		if ( $form->is_response_without_reload_enabled ) {
-			$r .= self::render_ajax_success_wrapper( $form );
+			$r .= self::render_ajax_success_wrapper( $form, $submission_success, $formatted_submission_data );
 		}
 
 		if ( is_wp_error( $form->errors ) && $form->errors->get_error_codes() ) {
@@ -520,9 +530,12 @@ class Contact_Form extends Contact_Form_Shortcode {
 			$url                     = apply_filters( 'grunion_contact_form_form_action', "{$url}#contact-form-{$id}", $GLOBALS['post'], $id, $page );
 			$has_submit_button_block = str_contains( $content, 'wp-block-jetpack-button' );
 			$form_classes            = 'contact-form commentsblock';
-			$post_title              = $post->post_title ?? '';
-			$form_accessible_name    = ! empty( $attributes['formTitle'] ) ? $attributes['formTitle'] : $post_title;
-			$form_aria_label         = isset( $form_accessible_name ) && ! empty( $form_accessible_name ) ? 'aria-label="' . esc_attr( $form_accessible_name ) . '"' : '';
+			if ( $submission_success ) {
+				$form_classes .= ' submission-success';
+			}
+			$post_title           = $post->post_title ?? '';
+			$form_accessible_name = ! empty( $attributes['formTitle'] ) ? $attributes['formTitle'] : $post_title;
+			$form_aria_label      = isset( $form_accessible_name ) && ! empty( $form_accessible_name ) ? 'aria-label="' . esc_attr( $form_accessible_name ) . '"' : '';
 
 			if ( $has_submit_button_block ) {
 				$form_classes .= ' wp-block-jetpack-contact-form';
@@ -534,7 +547,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 				class='" . esc_attr( $form_classes ) . "' $form_aria_label
 				data-wp-on--submit=\"actions.onFormSubmit\"
 				data-wp-on--reset=\"actions.onFormReset\"
-				data-wp-class--is-submitted=\"state.hasSubmitted\"
+				data-wp-class--submission-success=\"context.submissionSuccess\"
 				data-wp-class--is-first-step=\"state.isFirstStep\"
 				data-wp-class--is-last-step=\"state.isLastStep\"
 				data-wp-class--is-ajax-form=\"context.isResponseWithoutReloadEnabled\"
@@ -637,6 +650,26 @@ class Contact_Form extends Contact_Form_Shortcode {
 	}
 
 	/**
+	 * Helper function to format the submission data for the success message.
+	 *
+	 * @param array $data The submission data.
+	 *
+	 * @return array The formatted submission data.
+	 */
+	private static function format_submission_data( $data ) {
+		$submission_data = array();
+
+		foreach ( $data as $field_data ) {
+			$submission_data[] = array(
+				'label' => self::maybe_add_colon_to_label( $field_data['label'] ),
+				'value' => self::maybe_transform_value( $field_data['value'] ),
+			);
+		}
+
+		return $submission_data;
+	}
+
+	/**
 	 * Helper function that display the error wrapper.
 	 *
 	 * @return string HTML string for the error wrapper.
@@ -658,11 +691,17 @@ class Contact_Form extends Contact_Form_Shortcode {
 	 * Renders the success wrapper after a form is submitted without reloading the page.
 	 *
 	 * @param Contact_Form $form - the contact form.
+	 * @param bool         $submission_success - whether the form has already been submitted.
+	 * @param array        $formatted_submission_data - the formatted submission data.
 	 *
 	 * @return string HTML string for the success wrapper.
 	 */
-	private static function render_ajax_success_wrapper( $form ) {
-		$html  = '<div class="contact-form-submission contact-form-ajax-submission" data-wp-class--is-submitted="state.hasSubmitted">';
+	private static function render_ajax_success_wrapper( $form, $submission_success = false, $formatted_submission_data = array() ) {
+		$classes = 'contact-form-submission contact-form-ajax-submission';
+		if ( $submission_success ) {
+			$classes .= ' submission-success';
+		}
+		$html  = '<div class="' . esc_attr( $classes ) . '" data-wp-class--submission-success="context.submissionSuccess">';
 		$html .= '<p class="go-back-message"> <a class="link" role="button" tabindex="0" data-wp-on--click="actions.goBack">' . esc_html__( 'Go back', 'jetpack-forms' ) . '</a> </p>';
 		$html .=
 			'<h4 id="contact-form-success-header">' . esc_html( $form->get_attribute( 'customThankyouHeading' ) ) .
@@ -687,10 +726,20 @@ class Contact_Form extends Contact_Form_Shortcode {
 
 			$html .= wp_kses( $raw_message, $allowed_html );
 		} else {
-			$html .= '<template data-wp-each--submission="state.getSubmissionData">
-				<div class="field-name" data-wp-text="context.submission.label" data-wp-bind--hidden="!context.submission.label"></div>
-				<div class="field-value" data-wp-text="context.submission.value"></div>
+			$html .= '<template data-wp-each--submission="context.formattedSubmissionData">
+				<div>
+					<div class="field-name" data-wp-text="context.submission.label" data-wp-bind--hidden="!context.submission.label"></div>
+					<div class="field-value" data-wp-text="context.submission.value"></div>
+				</div>
 			</template>';
+
+			// For each entry in the submission data array, render a div with the label and value.
+			foreach ( $formatted_submission_data as $submission ) {
+				$html .= '<div data-wp-each-child>
+					<div class="field-name" data-wp-text="context.submission.label" data-wp-bind--hidden="!context.submission.label">' . $submission['label'] . '</div>
+					<div class="field-value" data-wp-text="context.submission.value">' . $submission['value'] . '</div>
+				</div>';
+			}
 		}
 
 		$html .= '</div>';
@@ -786,7 +835,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 		$json_data = array();
 
 		// Handle file upload field (new structure with field_id and files array)
-		foreach ( $raw_data as $field_index => $field_data ) {
+		foreach ( $raw_data as $field_data ) {
 			$value = $field_data['value'];
 			$label = $field_data['label'];
 
@@ -802,16 +851,20 @@ class Contact_Form extends Contact_Form_Shortcode {
 						$file_name = isset( $file['name'] ) ? $file['name'] : __( 'Attached file', 'jetpack-forms' );
 						$file_size = isset( $file['size'] ) ? size_format( $file['size'] ) : '';
 
-						$json_data[ $field_index ]['label'] = $label;
-						$json_data[ $field_index ]['value'] = array(
-							'name' => $file_name,
-							'size' => $file_size,
+						$json_data[] = array(
+							'label' => $label,
+							'value' => array(
+								'name' => $file_name,
+								'size' => $file_size,
+							),
 						);
 					}
 				}
 			} else {
-				$json_data[ $field_index ]['label'] = $label;
-				$json_data[ $field_index ]['value'] = $value;
+				$json_data[] = array(
+					'label' => $label,
+					'value' => $value,
+				);
 			}
 		}
 
@@ -2359,6 +2412,23 @@ class Contact_Form extends Contact_Form_Shortcode {
 		$formatted_label = str_ends_with( $formatted_label, '?' ) ? $formatted_label : rtrim( $formatted_label, ':' ) . ':';
 
 		return $formatted_label;
+	}
+
+	/**
+	 * Ensures a value is formatted as a string, taking into account file upload fields.
+	 *
+	 * @param mixed $value The value to transform.
+	 * @return mixed The transformed value.
+	 */
+	private static function maybe_transform_value( $value ) {
+		// For file upload fields, we want to show the file name and size
+		if ( is_array( $value ) && isset( $value['name'] ) && isset( $value['size'] ) ) {
+			$file_name = $value['name'];
+			$file_size = $value['size'];
+			return empty( $file_size ) ? $file_name : $file_name . ' (' . $file_size . ')';
+		}
+
+		return $value;
 	}
 
 	/**

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -1175,19 +1175,10 @@ on production builds, the attributes are being reordered, causing side-effects
   width: 1px;
 }
 
-.contact-form.is-ajax-form.is-submitted {
+.contact-form.is-ajax-form.submission-success {
 	display: none;
 }
 
-.contact-form-ajax-submission:not(.is-submitted) {
+.contact-form-ajax-submission:not(.submission-success) {
 	display: none;
-}
-
-.wp-block-jetpack-contact-form-container:not(.has-loaded) {
-	opacity: 0;
-}
-
-.wp-block-jetpack-contact-form-container {
-	opacity: 1;
-	transition: opacity 0.3s ease-in-out;
 }

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -226,6 +226,7 @@
 .contact-form-submission .go-back-message .link {
 	font-weight: 200;
 	color: inherit;
+	cursor: pointer;
 }
 
 .contact-form-submission .field-name {
@@ -1180,4 +1181,13 @@ on production builds, the attributes are being reordered, causing side-effects
 
 .contact-form-ajax-submission:not(.is-submitted) {
 	display: none;
+}
+
+.wp-block-jetpack-contact-form-container:not(.has-loaded) {
+	opacity: 0;
+}
+
+.wp-block-jetpack-contact-form-container {
+	opacity: 1;
+	transition: opacity 0.3s ease-in-out;
 }

--- a/projects/packages/forms/src/modules/form/view.js
+++ b/projects/packages/forms/src/modules/form/view.js
@@ -39,6 +39,18 @@ const updateField = ( fieldId, value, showFieldError = false ) => {
 	}
 };
 
+const setSubmissionData = ( data = [] ) => {
+	const context = getContext();
+
+	context.submissionData = data;
+
+	// This cannot be a derived state because it needs to be defined on the backend for first render to avoid hydration errors.
+	context.formattedSubmissionData = data.map( item => ( {
+		label: maybeAddColonToLabel( item.label ),
+		value: maybeTransformValue( item.value ),
+	} ) );
+};
+
 const registerField = (
 	fieldId,
 	type,
@@ -222,26 +234,6 @@ const { state } = store( NAMESPACE, {
 			const context = getContext();
 			return context.submissionError || '';
 		},
-
-		get getSubmissionData() {
-			const context = getContext();
-
-			const data = context.submissionData ? Object.values( context.submissionData ) : [];
-
-			return data.map( item => ( {
-				label: maybeAddColonToLabel( item.label ),
-				value: maybeTransformValue( item.value ),
-			} ) );
-		},
-
-		get hasSubmitted() {
-			const context = getContext();
-			return !! context.submissionData && context.isResponseWithoutReloadEnabled;
-		},
-
-		get hasLoaded() {
-			return true;
-		},
 	},
 
 	actions: {
@@ -351,8 +343,9 @@ const { state } = store( NAMESPACE, {
 				const { success, error, data, refreshArgs } = yield submitForm( context.formHash );
 
 				if ( success ) {
-					context.submissionData = data;
+					setSubmissionData( data );
 					context.submissionError = null;
+					context.submissionSuccess = true;
 
 					if ( refreshArgs ) {
 						const url = new URL( window.location.href );
@@ -364,7 +357,7 @@ const { state } = store( NAMESPACE, {
 					}
 				} else {
 					context.submissionError = error;
-					context.submissionData = null;
+					setSubmissionData( [] );
 				}
 
 				context.isSubmitting = false;
@@ -416,11 +409,15 @@ const { state } = store( NAMESPACE, {
 
 		goBack: () => {
 			const context = getContext();
+
 			const form = document.getElementById( context.elementId );
+
 			form?.reset?.();
-			context.submissionData = null;
+			setSubmissionData( [] );
 			context.submissionError = null;
 			context.hasClickedBack = true;
+			context.submissionSuccess = false;
+
 			// Remove the refresh args from the URL.
 			const url = new URL( window.location.href );
 			url.searchParams.delete( 'contact-form-id' );
@@ -441,7 +438,7 @@ const { state } = store( NAMESPACE, {
 		scrollToWrapper() {
 			const context = getContext();
 
-			if ( state.hasSubmitted || context.hasClickedBack ) {
+			if ( context.submissionSuccess || context.hasClickedBack ) {
 				const wrapperElement = document.getElementById( `contact-form-${ context.formId }` );
 				wrapperElement?.scrollIntoView( { behavior: 'smooth' } );
 				context.hasClickedBack = false;

--- a/projects/packages/forms/src/modules/form/view.js
+++ b/projects/packages/forms/src/modules/form/view.js
@@ -238,6 +238,10 @@ const { state } = store( NAMESPACE, {
 			const context = getContext();
 			return !! context.submissionData && context.isResponseWithoutReloadEnabled;
 		},
+
+		get hasLoaded() {
+			return true;
+		},
 	},
 
 	actions: {
@@ -344,11 +348,20 @@ const { state } = store( NAMESPACE, {
 				event.preventDefault();
 				event.stopPropagation();
 
-				const { success, error, data } = yield submitForm( context.formHash );
+				const { success, error, data, refreshArgs } = yield submitForm( context.formHash );
 
 				if ( success ) {
 					context.submissionData = data;
 					context.submissionError = null;
+
+					if ( refreshArgs ) {
+						const url = new URL( window.location.href );
+						url.searchParams.set( 'contact-form-id', refreshArgs[ 'contact-form-id' ] );
+						url.searchParams.set( 'contact-form-sent', refreshArgs[ 'contact-form-sent' ] );
+						url.searchParams.set( 'contact-form-hash', refreshArgs[ 'contact-form-hash' ] );
+						url.searchParams.set( '_wpnonce', refreshArgs._wpnonce );
+						window.history.replaceState( null, '', url.toString() );
+					}
 				} else {
 					context.submissionError = error;
 					context.submissionData = null;
@@ -408,6 +421,13 @@ const { state } = store( NAMESPACE, {
 			context.submissionData = null;
 			context.submissionError = null;
 			context.hasClickedBack = true;
+			// Remove the refresh args from the URL.
+			const url = new URL( window.location.href );
+			url.searchParams.delete( 'contact-form-id' );
+			url.searchParams.delete( 'contact-form-sent' );
+			url.searchParams.delete( 'contact-form-hash' );
+			url.searchParams.delete( '_wpnonce' );
+			window.history.replaceState( null, '', url.toString() );
 		},
 	},
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Follow-up to #44204 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Keeps the default behavior of displaying the submission information after reload

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply the feature flag
* Submit a form
* Reload the page after the submission confirmation is visible
* Check that the information is displayed again

