### PR TITLE
Forms: remove unused editor CSS

### DIFF
--- a/projects/packages/forms/changelog/update-forms-clean-out-unused-css
+++ b/projects/packages/forms/changelog/update-forms-clean-out-unused-css
@@ -1,0 +1,4 @@
+Significance: minor
+Type: removed
+
+Forms: remove unused editor CSS

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -74,10 +74,6 @@
 			&.jetpack-field__width-25 {
 				flex: 1 1 calc( 25% - calc(var(--wp--style--block-gap, 1.5rem) * 1) );
 				max-width: 25%;
-
-				.jetpack-option__input.jetpack-option__input.jetpack-option__input {
-					width: 70px;
-				}
 			}
 
 			&.jetpack-field__width-33 {

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -510,28 +510,6 @@
 	}
 }
 
-// TODO - See if we can find usage of this class. It's possibly a dead style.
-.jetpack-field-multiple .jetpack-field-multiple__add-option {
-	margin: 0;
-	padding: 0;
-
-	.dashicon {
-		width: 1rem;
-		height: 1rem;
-		display: flex;
-		margin-left: 0;
-		margin-right: 0.75rem;
-
-		&::before {
-			font-size: 1rem;
-		}
-	}
-
-	svg {
-		margin-right: 12px;
-	}
-}
-
 // Duplicated to elevate specificity in order to overwrite core styles
 .jetpack-field-multiple__list.jetpack-field-multiple__list {
 	list-style-type: none;
@@ -555,14 +533,6 @@
 	&:empty {
 		display: none;
 	}
-
-	// TODO - This looks like dead code, it looks like field select can't contain a multiple list.
-	// TODO: make this a class, @enej
-	[data-type='jetpack/field-select'] & {
-		border: 1px solid rgba( 0, 0, 0, 0.4 );
-		border-radius: 4px;
-		padding: 4px;
-	}
 }
 
 // Ensure global styles can ovewrite the default border color.
@@ -576,36 +546,8 @@
 	margin: 0;
 }
 
-// TODO - This looks like dead code, along with the `JetpackOption` component.
-// Duplicated to elevate specificity in order to overwrite core styles
-.jetpack-option__input.jetpack-option__input.jetpack-option__input {
-	color: inherit;
-	background: transparent;
-	border: none;
-	border-radius: 0;
-	flex-grow: 1;
-	line-height: 1.5;
-	font-size: inherit;
-	padding: 0;
-
-	&:hover {
-		border-color: #357cb5;
-	}
-
-	&:focus {
-		box-shadow: none;
-	}
-}
-
 .jetpack-field-multiple.components-base-control {
 	font-size: inherit;
-}
-
-// TODO - This is possibly dead CSS.
-// Duplicated to elevate specificity in order to overwrite calypso styles
-.jetpack-option__remove.jetpack-option__remove {
-	padding: 6px;
-	vertical-align: bottom;
 }
 
 .jetpack-field .components-base-control__label {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Tested especially select field and seems unaffected. Looked also around in code if I can find selectors:

<img width="671" height="279" alt="Screenshot 2025-07-17 at 12 08 21" src="https://github.com/user-attachments/assets/fb3a70e4-92ba-4786-9989-26e6ce67bb52" />


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

