### PR TITLE
Forms: use inner blocks for dropdown field

### DIFF
--- a/projects/packages/forms/changelog/update-forms-select-inner-blocks
+++ b/projects/packages/forms/changelog/update-forms-select-inner-blocks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: improve adding, editing and removing options for dropdown field

--- a/projects/packages/forms/src/blocks/contact-form/child-blocks.js
+++ b/projects/packages/forms/src/blocks/contact-form/child-blocks.js
@@ -4,6 +4,7 @@ import {
 } from '@automattic/jetpack-shared-extension-utils';
 import DeprecatedOptionCheckbox from '../deprecated/field-option-checkbox';
 import DeprecatedOptionRadio from '../deprecated/field-option-radio';
+import JetpackDropdown from '../dropdown';
 import JetpackDropzone from '../dropzone';
 import JetpackCheckboxField from '../field-checkbox';
 import JetpackConsentField from '../field-consent/';
@@ -42,6 +43,7 @@ import JetpackOptions from '../options';
 export const childBlocks = [
 	JetpackLabel,
 	JetpackDropzone,
+	JetpackDropdown,
 	JetpackInput,
 	JetpackOption,
 	JetpackOptions,

--- a/projects/packages/forms/src/blocks/contact-form/child-blocks.js
+++ b/projects/packages/forms/src/blocks/contact-form/child-blocks.js
@@ -5,6 +5,7 @@ import {
 import DeprecatedOptionCheckbox from '../deprecated/field-option-checkbox';
 import DeprecatedOptionRadio from '../deprecated/field-option-radio';
 import JetpackDropdown from '../dropdown';
+import JetpackDropdownOption from '../dropdown-option';
 import JetpackDropzone from '../dropzone';
 import JetpackCheckboxField from '../field-checkbox';
 import JetpackConsentField from '../field-consent/';
@@ -44,6 +45,7 @@ export const childBlocks = [
 	JetpackLabel,
 	JetpackDropzone,
 	JetpackDropdown,
+	JetpackDropdownOption,
 	JetpackInput,
 	JetpackOption,
 	JetpackOptions,

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -445,6 +445,20 @@ class Contact_Form_Block {
 			)
 		);
 
+		Blocks::jetpack_register_block(
+			'jetpack/dropdown',
+			array(
+				'render_callback' => array( Contact_Form_Plugin::class, 'gutenblock_render_dropdown' ),
+			)
+		);
+
+		Blocks::jetpack_register_block(
+			'jetpack/dropdown-option',
+			array(
+				'render_callback' => array( Contact_Form_Plugin::class, 'gutenblock_render_dropdown_option' ),
+			)
+		);
+
 		if ( Blocks::get_variation() === 'beta' ) {
 			Blocks::jetpack_register_block(
 				'jetpack/field-hidden',

--- a/projects/packages/forms/src/blocks/dropdown-option/edit.js
+++ b/projects/packages/forms/src/blocks/dropdown-option/edit.js
@@ -12,12 +12,30 @@ export default function DropdownOptionEdit( props ) {
 	const blockProps = useBlockProps( {
 		className,
 	} );
-	const { removeBlocks, insertBlocks } = useDispatch( blockEditorStore );
-	const { getBlockIndex, getBlockRootClientId, getNextBlockClientId, getPreviousBlockClientId } =
-		useSelect( blockEditorStore );
+	const { removeBlocks, replaceBlocks, insertBlocks } = useDispatch( blockEditorStore );
+	const {
+		getBlockIndex,
+		getBlockRootClientId,
+		getMultiSelectedBlockClientIds,
+		getNextBlockClientId,
+		getPreviousBlockClientId,
+	} = useSelect( blockEditorStore );
 
 	const onPaste = event => {
 		const pastedText = event.clipboardData.getData( 'text/plain' );
+
+		// While pasting, multiple blocks were selected
+		const multiSelectedBlockClientIds = getMultiSelectedBlockClientIds();
+		if ( multiSelectedBlockClientIds.length ) {
+			const lines = pastedText.split( '\n' );
+			const newOptions = lines.map( line =>
+				createBlock( 'jetpack/dropdown-option', { option: line } )
+			);
+			replaceBlocks( multiSelectedBlockClientIds, newOptions );
+			return;
+		}
+
+		// Otherwise pasting in a single block…
 
 		// Check if the pasted text contains multiple lines
 		if ( pastedText.includes( '\n' ) ) {

--- a/projects/packages/forms/src/blocks/dropdown-option/edit.js
+++ b/projects/packages/forms/src/blocks/dropdown-option/edit.js
@@ -62,7 +62,7 @@ export default function DropdownOptionEdit( props ) {
 		const nextBlockClientId = getNextBlockClientId( clientId );
 		const previousBlockClientId = getPreviousBlockClientId( clientId );
 
-		if ( ! nextBlockClientId || ! previousBlockClientId ) {
+		if ( ! nextBlockClientId && ! previousBlockClientId ) {
 			// If this is the the only option, remove by emptying value
 			setAttributes( { option: '' } );
 			return;

--- a/projects/packages/forms/src/blocks/dropdown-option/edit.js
+++ b/projects/packages/forms/src/blocks/dropdown-option/edit.js
@@ -6,19 +6,15 @@ import { __ } from '@wordpress/i18n';
 import { close } from '@wordpress/icons';
 
 export default function DropdownOptionEdit( props ) {
-	const { attributes, clientId, setAttributes } = props;
+	const { attributes, clientId, mergeBlocks, setAttributes } = props;
 	const { option } = attributes;
 	const className = 'jetpack-field-dropdown__option';
 	const blockProps = useBlockProps( {
 		className,
 	} );
-
 	const { removeBlocks, insertBlocks } = useDispatch( blockEditorStore );
-	const { getBlockRootClientId, getBlockIndex } = useSelect( blockEditorStore );
-
-	const onRemove = () => {
-		return removeBlocks( clientId );
-	};
+	const { getBlockIndex, getBlockRootClientId, getNextBlockClientId, getPreviousBlockClientId } =
+		useSelect( blockEditorStore );
 
 	const onPaste = event => {
 		const pastedText = event.clipboardData.getData( 'text/plain' );
@@ -44,6 +40,19 @@ export default function DropdownOptionEdit( props ) {
 		}
 	};
 
+	const onRemove = () => {
+		const nextBlockClientId = getNextBlockClientId( clientId );
+		const previousBlockClientId = getPreviousBlockClientId( clientId );
+
+		if ( ! nextBlockClientId || ! previousBlockClientId ) {
+			// If this is the the only option, remove by emptying value
+			setAttributes( { option: '' } );
+			return;
+		}
+
+		return removeBlocks( clientId );
+	};
+
 	return (
 		<div { ...blockProps }>
 			<Flex>
@@ -53,6 +62,7 @@ export default function DropdownOptionEdit( props ) {
 						aria-label={ __( 'Dropdown option value', 'jetpack-forms' ) }
 						identifier="option"
 						onChange={ value => setAttributes( { option: value } ) }
+						onMerge={ mergeBlocks }
 						onPaste={ onPaste }
 						onRemove={ onRemove }
 						placeholder={ __( 'Add option…', 'jetpack-forms' ) }

--- a/projects/packages/forms/src/blocks/dropdown-option/edit.js
+++ b/projects/packages/forms/src/blocks/dropdown-option/edit.js
@@ -59,6 +59,7 @@ export default function DropdownOptionEdit( props ) {
 				<FlexItem isBlock>
 					<RichText
 						__unstablePastePlainText
+						allowedFormats={ [] }
 						aria-label={ __( 'Dropdown option value', 'jetpack-forms' ) }
 						identifier="option"
 						onChange={ value => setAttributes( { option: value } ) }

--- a/projects/packages/forms/src/blocks/dropdown-option/edit.js
+++ b/projects/packages/forms/src/blocks/dropdown-option/edit.js
@@ -1,0 +1,52 @@
+import { RichText, useBlockProps, store as blockEditorStore } from '@wordpress/block-editor';
+import { Button, Flex, FlexItem } from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import { close } from '@wordpress/icons';
+import useInsertAfterOnEnterKeyDown from '../shared/hooks/use-insert-after-on-enter-key-down';
+
+const noop = () => undefined;
+
+export default function DropdownOptionEdit( props ) {
+	// eslint-disable-next-line no-console
+	console.log( props );
+	const { attributes, clientId, setAttributes, name } = props;
+	const { option } = attributes;
+	const className = 'jetpack-field-dropdown__option';
+	const blockProps = useBlockProps( { className } );
+	const onKeyDown = useInsertAfterOnEnterKeyDown( clientId, name );
+
+	const { removeBlocks } = useDispatch( blockEditorStore ); // insertAfterBlock
+
+	const onRemove = () => {
+		return removeBlocks( clientId );
+	};
+
+	return (
+		<div { ...blockProps }>
+			<Flex>
+				<FlexItem isBlock>
+					<RichText
+						allowedFormats={ [] }
+						onChange={ value => setAttributes( { option: value } ) }
+						onKeyDown={ onKeyDown }
+						onRemove={ onRemove }
+						onReplace={ noop }
+						placeholder={ __( 'Add option…', 'jetpack-forms' ) }
+						value={ option || '' }
+						withoutInteractiveFormatting
+					/>
+				</FlexItem>
+				<FlexItem>
+					<Button
+						className="jetpack-field-dropdown__option-remove"
+						label={ __( 'Remove', 'jetpack-forms' ) }
+						variant="tertiary"
+						onClick={ onRemove }
+						icon={ close }
+					></Button>
+				</FlexItem>
+			</Flex>
+		</div>
+	);
+}

--- a/projects/packages/forms/src/blocks/dropdown-option/edit.js
+++ b/projects/packages/forms/src/blocks/dropdown-option/edit.js
@@ -85,6 +85,7 @@ export default function DropdownOptionEdit( props ) {
 						onPaste={ onPaste }
 						onRemove={ onRemove }
 						placeholder={ __( 'Add option…', 'jetpack-forms' ) }
+						tagName="div"
 						value={ option || '' }
 						withoutInteractiveFormatting
 					/>

--- a/projects/packages/forms/src/blocks/dropdown-option/edit.js
+++ b/projects/packages/forms/src/blocks/dropdown-option/edit.js
@@ -1,22 +1,29 @@
 import { RichText, useBlockProps, store as blockEditorStore } from '@wordpress/block-editor';
 import { Button, Flex, FlexItem } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
+import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { close } from '@wordpress/icons';
-import useInsertAfterOnEnterKeyDown from '../shared/hooks/use-insert-after-on-enter-key-down';
 
 const noop = () => undefined;
 
 export default function DropdownOptionEdit( props ) {
-	// eslint-disable-next-line no-console
-	console.log( props );
-	const { attributes, clientId, setAttributes, name } = props;
+	const { attributes, clientId, setAttributes } = props;
 	const { option } = attributes;
 	const className = 'jetpack-field-dropdown__option';
 	const blockProps = useBlockProps( { className } );
-	const onKeyDown = useInsertAfterOnEnterKeyDown( clientId, name );
 
-	const { removeBlocks } = useDispatch( blockEditorStore ); // insertAfterBlock
+	const { removeBlocks, insertAfterBlock } = useDispatch( blockEditorStore );
+
+	const onKeyDown = useCallback(
+		event => {
+			if ( event.key === 'Enter' && ! event.shiftKey ) {
+				event.preventDefault();
+				insertAfterBlock( clientId );
+			}
+		},
+		[ insertAfterBlock, clientId ]
+	);
 
 	const onRemove = () => {
 		return removeBlocks( clientId );
@@ -30,7 +37,6 @@ export default function DropdownOptionEdit( props ) {
 						allowedFormats={ [] }
 						onChange={ value => setAttributes( { option: value } ) }
 						onKeyDown={ onKeyDown }
-						onRemove={ onRemove }
 						onReplace={ noop }
 						placeholder={ __( 'Add option…', 'jetpack-forms' ) }
 						value={ option || '' }

--- a/projects/packages/forms/src/blocks/dropdown-option/edit.js
+++ b/projects/packages/forms/src/blocks/dropdown-option/edit.js
@@ -1,32 +1,47 @@
 import { RichText, useBlockProps, store as blockEditorStore } from '@wordpress/block-editor';
+import { createBlock } from '@wordpress/blocks';
 import { Button, Flex, FlexItem } from '@wordpress/components';
-import { useDispatch } from '@wordpress/data';
-import { useCallback } from '@wordpress/element';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { close } from '@wordpress/icons';
-
-const noop = () => undefined;
 
 export default function DropdownOptionEdit( props ) {
 	const { attributes, clientId, setAttributes } = props;
 	const { option } = attributes;
 	const className = 'jetpack-field-dropdown__option';
-	const blockProps = useBlockProps( { className } );
+	const blockProps = useBlockProps( {
+		className,
+	} );
 
-	const { removeBlocks, insertAfterBlock } = useDispatch( blockEditorStore );
-
-	const onKeyDown = useCallback(
-		event => {
-			if ( event.key === 'Enter' && ! event.shiftKey ) {
-				event.preventDefault();
-				insertAfterBlock( clientId );
-			}
-		},
-		[ insertAfterBlock, clientId ]
-	);
+	const { removeBlocks, insertBlocks } = useDispatch( blockEditorStore );
+	const { getBlockRootClientId, getBlockIndex } = useSelect( blockEditorStore );
 
 	const onRemove = () => {
 		return removeBlocks( clientId );
+	};
+
+	const onPaste = event => {
+		const pastedText = event.clipboardData.getData( 'text/plain' );
+
+		// Check if the pasted text contains multiple lines
+		if ( pastedText.includes( '\n' ) ) {
+			event.preventDefault();
+
+			const lines = pastedText.split( '\n' );
+
+			// Grab first element of the pasted list as a value for current option block
+			const firstLine = lines.shift();
+			setAttributes( { option: `${ option || '' }${ firstLine }` } );
+
+			// Append rest of the lines as new option blocks
+			const newOptions = lines.map( line =>
+				createBlock( 'jetpack/dropdown-option', { option: line } )
+			);
+			const rootClientId = getBlockRootClientId( clientId );
+			const index = getBlockIndex( clientId );
+
+			insertBlocks( newOptions, index + 1, rootClientId );
+		}
 	};
 
 	return (
@@ -34,10 +49,12 @@ export default function DropdownOptionEdit( props ) {
 			<Flex>
 				<FlexItem isBlock>
 					<RichText
-						allowedFormats={ [] }
+						__unstablePastePlainText
+						aria-label={ __( 'Dropdown option value', 'jetpack-forms' ) }
+						identifier="option"
 						onChange={ value => setAttributes( { option: value } ) }
-						onKeyDown={ onKeyDown }
-						onReplace={ noop }
+						onPaste={ onPaste }
+						onRemove={ onRemove }
 						placeholder={ __( 'Add option…', 'jetpack-forms' ) }
 						value={ option || '' }
 						withoutInteractiveFormatting

--- a/projects/packages/forms/src/blocks/dropdown-option/index.js
+++ b/projects/packages/forms/src/blocks/dropdown-option/index.js
@@ -23,6 +23,10 @@ const settings = {
 		reusable: false,
 		splitting: true,
 	},
+	merge: ( attributes, { option = '' } ) => ( {
+		...attributes,
+		option: ( attributes.option || '' ) + option,
+	} ),
 	edit,
 	save,
 };

--- a/projects/packages/forms/src/blocks/dropdown-option/index.js
+++ b/projects/packages/forms/src/blocks/dropdown-option/index.js
@@ -29,6 +29,7 @@ const settings = {
 	} ),
 	edit,
 	save,
+	__experimentalLabel: ( { option } ) => option,
 };
 
 export default {

--- a/projects/packages/forms/src/blocks/dropdown-option/index.js
+++ b/projects/packages/forms/src/blocks/dropdown-option/index.js
@@ -1,0 +1,32 @@
+import { __ } from '@wordpress/i18n';
+import { lineSolid } from '@wordpress/icons';
+import { getIconColor } from '../shared/util/block-icons';
+import edit from './edit';
+import save from './save';
+
+const name = 'dropdown-option';
+const settings = {
+	apiVersion: 3,
+	title: __( 'Option', 'jetpack-forms' ),
+	description: __( 'Option for dropdown fields.', 'jetpack-forms' ),
+	parent: [ 'jetpack/dropdown' ],
+	category: 'contact-form',
+	icon: {
+		foreground: getIconColor(),
+		src: lineSolid,
+	},
+	attributes: { option: { type: 'string', default: '' } },
+	supports: {
+		anchor: false,
+		customClassName: false,
+		html: false,
+		reusable: false,
+	},
+	edit,
+	save,
+};
+
+export default {
+	name,
+	settings,
+};

--- a/projects/packages/forms/src/blocks/dropdown-option/index.js
+++ b/projects/packages/forms/src/blocks/dropdown-option/index.js
@@ -21,6 +21,7 @@ const settings = {
 		customClassName: false,
 		html: false,
 		reusable: false,
+		splitting: true,
 	},
 	edit,
 	save,

--- a/projects/packages/forms/src/blocks/dropdown-option/save.js
+++ b/projects/packages/forms/src/blocks/dropdown-option/save.js
@@ -1,0 +1,7 @@
+import { useBlockProps, RichText } from '@wordpress/block-editor';
+
+export default ( { attributes } ) => {
+	const blockProps = useBlockProps.save();
+
+	return <RichText.Content { ...blockProps } tagName="p" value={ attributes.content } />;
+};

--- a/projects/packages/forms/src/blocks/dropdown-option/save.js
+++ b/projects/packages/forms/src/blocks/dropdown-option/save.js
@@ -1,7 +1,1 @@
-import { useBlockProps, RichText } from '@wordpress/block-editor';
-
-export default ( { attributes } ) => {
-	const blockProps = useBlockProps.save();
-
-	return <RichText.Content { ...blockProps } tagName="p" value={ attributes.content } />;
-};
+export default () => null;

--- a/projects/packages/forms/src/blocks/dropdown/edit.js
+++ b/projects/packages/forms/src/blocks/dropdown/edit.js
@@ -1,0 +1,35 @@
+import { InnerBlocks, useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
+import { __ } from '@wordpress/i18n';
+
+import './editor.scss';
+
+const DEFAULT_BLOCK = {
+	name: 'core/paragraph',
+	attributes: { placeholder: __( 'Add option…', 'jetpack-forms' ) },
+};
+
+const BLOCKS_TEMPLATE = [
+	[
+		DEFAULT_BLOCK.name,
+		{
+			...DEFAULT_BLOCK.attributes,
+		},
+	],
+];
+
+export default function DropdownEdit() {
+	const blockProps = useBlockProps( { className: 'jetpack-field-dropdown__popover' } );
+	const innerBlocksProps = useInnerBlocksProps( blockProps );
+
+	return (
+		<div { ...innerBlocksProps }>
+			<InnerBlocks
+				template={ BLOCKS_TEMPLATE }
+				defaultBlock={ DEFAULT_BLOCK }
+				directInsert={ true }
+				templateLock={ false }
+				renderAppender={ InnerBlocks.DefaultBlockAppender }
+			/>
+		</div>
+	);
+}

--- a/projects/packages/forms/src/blocks/dropdown/edit.js
+++ b/projects/packages/forms/src/blocks/dropdown/edit.js
@@ -19,17 +19,14 @@ const BLOCKS_TEMPLATE = [
 
 export default function DropdownEdit() {
 	const blockProps = useBlockProps( { className: 'jetpack-field-dropdown__popover' } );
-	const innerBlocksProps = useInnerBlocksProps( blockProps );
+	const innerBlocksProps = useInnerBlocksProps( blockProps, {
+		__experimentalCaptureToolbars: true,
+		defaultBlock: DEFAULT_BLOCK,
+		directInsert: true,
+		renderAppender: InnerBlocks.DefaultBlockAppender,
+		template: BLOCKS_TEMPLATE,
+		templateLock: false,
+	} );
 
-	return (
-		<div { ...innerBlocksProps }>
-			<InnerBlocks
-				template={ BLOCKS_TEMPLATE }
-				defaultBlock={ DEFAULT_BLOCK }
-				directInsert={ true }
-				templateLock={ false }
-				renderAppender={ InnerBlocks.DefaultBlockAppender }
-			/>
-		</div>
-	);
+	return <div { ...innerBlocksProps }>{ innerBlocksProps.children }</div>;
 }

--- a/projects/packages/forms/src/blocks/dropdown/edit.js
+++ b/projects/packages/forms/src/blocks/dropdown/edit.js
@@ -18,7 +18,6 @@ export default function DropdownEdit() {
 				__experimentalCaptureToolbars={ true }
 				defaultBlock={ DEFAULT_BLOCK }
 				directInsert={ true }
-				renderAppender={ false }
 				template={ TEMPLATE }
 				templateLock={ false }
 				templateInsertUpdatesSelection={ true }

--- a/projects/packages/forms/src/blocks/dropdown/edit.js
+++ b/projects/packages/forms/src/blocks/dropdown/edit.js
@@ -1,11 +1,10 @@
 import { InnerBlocks, useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
-import { __ } from '@wordpress/i18n';
 
 import './editor.scss';
 
 const DEFAULT_BLOCK = {
-	name: 'core/paragraph',
-	attributes: { placeholder: __( 'Add option…', 'jetpack-forms' ) },
+	name: 'jetpack/dropdown-option',
+	attributes: {},
 };
 
 const BLOCKS_TEMPLATE = [
@@ -19,14 +18,18 @@ const BLOCKS_TEMPLATE = [
 
 export default function DropdownEdit() {
 	const blockProps = useBlockProps( { className: 'jetpack-field-dropdown__popover' } );
-	const innerBlocksProps = useInnerBlocksProps( blockProps, {
-		__experimentalCaptureToolbars: true,
-		defaultBlock: DEFAULT_BLOCK,
-		directInsert: true,
-		renderAppender: InnerBlocks.DefaultBlockAppender,
-		template: BLOCKS_TEMPLATE,
-		templateLock: false,
-	} );
+	const innerBlocksProps = useInnerBlocksProps( blockProps );
 
-	return <div { ...innerBlocksProps }>{ innerBlocksProps.children }</div>;
+	return (
+		<div { ...innerBlocksProps }>
+			<InnerBlocks
+				template={ BLOCKS_TEMPLATE }
+				defaultBlock={ DEFAULT_BLOCK }
+				directInsert={ true }
+				templateLock={ false }
+				renderAppender={ InnerBlocks.DefaultBlockAppender }
+				__experimentalCaptureToolbars={ true }
+			/>
+		</div>
+	);
 }

--- a/projects/packages/forms/src/blocks/dropdown/edit.js
+++ b/projects/packages/forms/src/blocks/dropdown/edit.js
@@ -4,17 +4,9 @@ import './editor.scss';
 
 const DEFAULT_BLOCK = {
 	name: 'jetpack/dropdown-option',
-	attributes: {},
 };
 
-const BLOCKS_TEMPLATE = [
-	[
-		DEFAULT_BLOCK.name,
-		{
-			...DEFAULT_BLOCK.attributes,
-		},
-	],
-];
+const TEMPLATE = [ [ DEFAULT_BLOCK.name ] ];
 
 export default function DropdownEdit() {
 	const blockProps = useBlockProps( { className: 'jetpack-field-dropdown__popover' } );
@@ -23,12 +15,13 @@ export default function DropdownEdit() {
 	return (
 		<div { ...innerBlocksProps }>
 			<InnerBlocks
-				template={ BLOCKS_TEMPLATE }
+				__experimentalCaptureToolbars={ true }
 				defaultBlock={ DEFAULT_BLOCK }
 				directInsert={ true }
+				renderAppender={ false }
+				template={ TEMPLATE }
 				templateLock={ false }
-				renderAppender={ InnerBlocks.DefaultBlockAppender }
-				__experimentalCaptureToolbars={ true }
+				templateInsertUpdatesSelection={ true }
 			/>
 		</div>
 	);

--- a/projects/packages/forms/src/blocks/dropdown/editor.scss
+++ b/projects/packages/forms/src/blocks/dropdown/editor.scss
@@ -1,0 +1,6 @@
+.wp-block-jetpack-dropdown {
+
+	p {
+		margin-bottom: 10px
+	}
+}

--- a/projects/packages/forms/src/blocks/dropdown/editor.scss
+++ b/projects/packages/forms/src/blocks/dropdown/editor.scss
@@ -1,6 +1,15 @@
 .wp-block-jetpack-dropdown {
+	display: none;
 
 	p {
-		margin-bottom: 10px
+		margin-bottom: 10px;
+	}
+}
+
+.is-selected,
+.has-child-selected {
+
+	.wp-block-jetpack-dropdown {
+		display: block;
 	}
 }

--- a/projects/packages/forms/src/blocks/dropdown/index.js
+++ b/projects/packages/forms/src/blocks/dropdown/index.js
@@ -1,0 +1,70 @@
+import { __ } from '@wordpress/i18n';
+import { menu } from '@wordpress/icons';
+import { getIconColor } from '../shared/util/block-icons';
+import edit from './edit';
+import save from './save';
+
+const name = 'dropdown';
+const settings = {
+	apiVersion: 3,
+	title: __( 'Dropdown', 'jetpack-forms' ),
+	description: __( 'Options for dropdown fields.', 'jetpack-forms' ),
+	parent: [ 'jetpack/field-select' ],
+	allowedBlocks: [ 'core/paragraph' ],
+	category: 'contact-form',
+	icon: {
+		foreground: getIconColor(),
+		src: menu,
+	},
+	attributes: {
+		style: {
+			type: 'object',
+			default: {
+				dimensions: {
+					maxHeight: '350px',
+				},
+			},
+		},
+	},
+	supports: {
+		reusable: false,
+		html: false,
+		color: {
+			gradients: true,
+			heading: true,
+			button: true,
+			link: true,
+			__experimentalDefaultControls: {
+				background: true,
+				text: true,
+			},
+		},
+		spacing: {
+			margin: [ 'top' ],
+			padding: true,
+		},
+		dimensions: {
+			minHeight: true,
+			maxHeight: true, // Doesn't work :-(
+		},
+		__experimentalBorder: {
+			color: true,
+			radius: true,
+			style: true,
+			width: true,
+			__experimentalDefaultControls: {
+				color: true,
+				radius: true,
+				style: true,
+				width: true,
+			},
+		},
+	},
+	edit,
+	save,
+};
+
+export default {
+	name,
+	settings,
+};

--- a/projects/packages/forms/src/blocks/dropdown/index.js
+++ b/projects/packages/forms/src/blocks/dropdown/index.js
@@ -16,54 +16,10 @@ const settings = {
 		foreground: getIconColor(),
 		src: menu,
 	},
-	attributes: {
-		/*
-		style: {
-			type: 'object',
-			default: {
-				spacing: {
-					margin: { top: '10px' },
-				},
-			},
-		},
-		*/
-	},
 	supports: {
 		anchor: false,
 		reusable: false,
 		html: false,
-		/*
-		color: {
-			gradients: true,
-			heading: true,
-			button: true,
-			link: true,
-			__experimentalDefaultControls: {
-				background: true,
-				text: true,
-			},
-		},
-		spacing: {
-			margin: [ 'top' ],
-			padding: true,
-		},
-		dimensions: {
-			minHeight: true,
-			maxHeight: true, // Doesn't work :-(
-		},
-		__experimentalBorder: {
-			color: true,
-			radius: true,
-			style: true,
-			width: true,
-			__experimentalDefaultControls: {
-				color: true,
-				radius: true,
-				style: true,
-				width: true,
-			},
-		},
-		*/
 	},
 	edit,
 	save,

--- a/projects/packages/forms/src/blocks/dropdown/index.js
+++ b/projects/packages/forms/src/blocks/dropdown/index.js
@@ -10,7 +10,7 @@ const settings = {
 	title: __( 'Dropdown', 'jetpack-forms' ),
 	description: __( 'Options for dropdown fields.', 'jetpack-forms' ),
 	parent: [ 'jetpack/field-select' ],
-	allowedBlocks: [ 'core/paragraph' ],
+	allowedBlocks: [ 'jetpack/dropdown-option' ],
 	category: 'contact-form',
 	icon: {
 		foreground: getIconColor(),
@@ -20,8 +20,8 @@ const settings = {
 		style: {
 			type: 'object',
 			default: {
-				dimensions: {
-					maxHeight: '350px',
+				spacing: {
+					margin: { top: '10px' },
 				},
 			},
 		},

--- a/projects/packages/forms/src/blocks/dropdown/index.js
+++ b/projects/packages/forms/src/blocks/dropdown/index.js
@@ -17,6 +17,7 @@ const settings = {
 		src: menu,
 	},
 	attributes: {
+		/*
 		style: {
 			type: 'object',
 			default: {
@@ -25,10 +26,13 @@ const settings = {
 				},
 			},
 		},
+		*/
 	},
 	supports: {
+		anchor: false,
 		reusable: false,
 		html: false,
+		/*
 		color: {
 			gradients: true,
 			heading: true,
@@ -59,6 +63,7 @@ const settings = {
 				width: true,
 			},
 		},
+		*/
 	},
 	edit,
 	save,

--- a/projects/packages/forms/src/blocks/dropdown/save.js
+++ b/projects/packages/forms/src/blocks/dropdown/save.js
@@ -1,0 +1,7 @@
+import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
+
+export default () => {
+	const blockProps = useBlockProps.save();
+	const innerBlocksProps = useInnerBlocksProps.save( blockProps );
+	return <div { ...innerBlocksProps } />;
+};

--- a/projects/packages/forms/src/blocks/field-select/edit.js
+++ b/projects/packages/forms/src/blocks/field-select/edit.js
@@ -1,23 +1,18 @@
 import {
-	RichText,
+	InspectorControls,
 	store as blockEditorStore,
 	useBlockProps,
 	useInnerBlocksProps,
 } from '@wordpress/block-editor';
-import { Icon, Button, Flex, FlexItem } from '@wordpress/components';
+import { PanelBody } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { useMemo, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { close } from '@wordpress/icons';
 import clsx from 'clsx';
 import JetpackFieldControls from '../shared/components/jetpack-field-controls';
 import useFormWrapper from '../shared/hooks/use-form-wrapper';
 import useJetpackFieldStyles from '../shared/hooks/use-jetpack-field-styles';
-import { getCaretPosition } from '../shared/util/caret';
 import { ALLOWED_INNER_BLOCKS } from '../shared/util/constants';
-import setFocus from '../shared/util/set-focus';
-
-const noop = () => undefined;
 
 export default function DropdownFieldEdit( props ) {
 	const { attributes, clientId, isSelected, name, setAttributes } = props;
@@ -64,132 +59,36 @@ export default function DropdownFieldEdit( props ) {
 			templateLock: 'all',
 		}
 	);
-
+	/*
 	const optionWrapperStyles = {
 		className: 'jetpack-field-dropdown__popover',
 	};
 
 	const changeFocus = ( index, cursorToEnd ) =>
 		setFocus( optionsWrapper.current, '[role=textbox]', index, cursorToEnd );
-
-	const handleSingleValue = ( index, value ) => {
-		const _options = [ ...options ];
-
-		_options[ index ] = value;
-
-		setAttributes( { options: _options } );
-		changeFocus( index );
-	};
-
-	const handleMultiValues = ( index, array ) => {
-		const _options = [ ...attributes.options ];
-		const cursorToEnd = array[ array.length - 1 ] !== '';
-
-		if ( _options[ index ] ) {
-			_options[ index ] = array.shift();
-			index++;
-		}
-
-		_options.splice( index, 0, ...array );
-
-		setAttributes( { options: _options } );
-		changeFocus( index + array.length - 1, cursorToEnd );
-	};
-
-	const handleChangeOption = index => value => {
-		const values = ( value || '' ).split( '\n' ).filter( op => op && op.trim() !== '' );
-
-		if ( ! values.length ) {
-			return;
-		}
-
-		if ( values.length > 1 ) {
-			handleMultiValues( index, values );
-		} else {
-			handleSingleValue( index, values.pop() );
-		}
-	};
-
-	const handleKeyDown = index => e => {
-		// Create a new dropdown option when the user hits Enter.
-		// Previously handled with the onSplit prop, which was removed in https://github.com/WordPress/gutenberg/pull/54543
-		if ( 'Enter' !== e.key ) {
-			return;
-		}
-
-		e.preventDefault();
-
-		const value = attributes.options[ index ];
-
-		if ( ! value ) {
-			return;
-		}
-
-		const caretPos = getCaretPosition( e.target );
-		// splitValue is the value after the caret position when a user hits Enter
-		const splitValue = caretPos ? value.slice( caretPos ) : '';
-
-		handleMultiValues(
-			index,
-			splitValue ? [ value.slice( 0, caretPos ), splitValue ] : [ value, '' ]
-		);
-	};
-
-	const handleDeleteOption = index => () => {
-		if ( attributes.options.length === 1 ) {
-			return;
-		}
-
-		const _options = [ ...attributes.options ];
-		_options.splice( index, 1 );
-		if ( _options.length === 0 || _options.filter( option => option ).length === 0 ) {
-			return;
-		}
-		setAttributes( { options: _options } );
-		changeFocus( Math.max( index - 1, 0 ), true );
-	};
-
+*/
 	return (
-		<div { ...blockProps }>
-			<div { ...innerBlocksProps } />
-			{ ( isSelected || isInnerBlockSelected ) && (
-				<div ref={ optionsWrapper } { ...optionWrapperStyles }>
-					{ options.map( ( option, index ) => (
-						<Flex key={ index } className="jetpack-field-dropdown__option">
-							<FlexItem isBlock>
-								<RichText
-									value={ option }
-									onChange={ handleChangeOption( index ) }
-									onKeyDown={ handleKeyDown( index ) }
-									onRemove={ handleDeleteOption( index ) }
-									onReplace={ noop }
-									placeholder={ __( 'Add option…', 'jetpack-forms' ) }
-									__unstableDisableFormats
-								/>
-							</FlexItem>
-							<FlexItem>
-								{ ( options.filter( opt => opt ).length > 1 || option === '' ) && (
-									<Button
-										className="jetpack-field-dropdown__option-remove"
-										label={ __( 'Remove', 'jetpack-forms' ) }
-										onClick={ handleDeleteOption( index ) }
-									>
-										<Icon icon={ close } />
-									</Button>
-								) }
-							</FlexItem>
-						</Flex>
-					) ) }
-				</div>
-			) }
-			<JetpackFieldControls
-				id={ id }
-				required={ required }
-				attributes={ attributes }
-				setAttributes={ setAttributes }
-				width={ width }
-				type="dropdown"
-			/>
-		</div>
+		<>
+			<div { ...blockProps }>
+				<div { ...innerBlocksProps } />
+				<JetpackFieldControls
+					id={ id }
+					required={ required }
+					attributes={ attributes }
+					setAttributes={ setAttributes }
+					width={ width }
+					type="dropdown"
+				/>
+				<InspectorControls>
+					<PanelBody title={ __( 'Options', 'jetpack-forms' ) }>
+						{ options.filter( opt => opt ).length && (
+							<ul>
+								{ options.map( ( option, index ) => ( option ? <li>{ option }</li> : null ) ) }
+							</ul>
+						) }
+					</PanelBody>
+				</InspectorControls>
+			</div>
+		</>
 	);
 }

--- a/projects/packages/forms/src/blocks/field-select/edit.js
+++ b/projects/packages/forms/src/blocks/field-select/edit.js
@@ -52,13 +52,14 @@ export default function DropdownFieldEdit( props ) {
 				'jetpack/input',
 				{ type: 'dropdown', placeholder: __( 'Select one option', 'jetpack-forms' ) },
 			],
+			[ 'jetpack/dropdown', { options, lock: { move: true, remove: true } } ],
 		];
-	}, [ required ] );
+	}, [ required, options ] );
 
 	const innerBlocksProps = useInnerBlocksProps(
 		{ className: 'jetpack-field-dropdown__wrapper' },
 		{
-			allowedBlocks: ALLOWED_INNER_BLOCKS,
+			allowedBlocks: [ ...ALLOWED_INNER_BLOCKS, 'jetpack/dropdown' ],
 			template,
 			templateLock: 'all',
 		}

--- a/projects/packages/forms/src/blocks/field-select/edit.js
+++ b/projects/packages/forms/src/blocks/field-select/edit.js
@@ -1,12 +1,10 @@
 import {
-	InspectorControls,
 	store as blockEditorStore,
 	useBlockProps,
 	useInnerBlocksProps,
 } from '@wordpress/block-editor';
-import { PanelBody } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
-import { useMemo, useRef } from '@wordpress/element';
+import { useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import JetpackFieldControls from '../shared/components/jetpack-field-controls';
@@ -37,7 +35,6 @@ export default function DropdownFieldEdit( props ) {
 		style: blockStyle,
 	} );
 
-	const optionsWrapper = useRef( undefined );
 	useFormWrapper( { attributes, clientId, name } );
 
 	const template = useMemo( () => {
@@ -59,14 +56,7 @@ export default function DropdownFieldEdit( props ) {
 			templateLock: 'all',
 		}
 	);
-	/*
-	const optionWrapperStyles = {
-		className: 'jetpack-field-dropdown__popover',
-	};
 
-	const changeFocus = ( index, cursorToEnd ) =>
-		setFocus( optionsWrapper.current, '[role=textbox]', index, cursorToEnd );
-*/
 	return (
 		<>
 			<div { ...blockProps }>
@@ -79,15 +69,6 @@ export default function DropdownFieldEdit( props ) {
 					width={ width }
 					type="dropdown"
 				/>
-				<InspectorControls>
-					<PanelBody title={ __( 'Options', 'jetpack-forms' ) }>
-						{ options.filter( opt => opt ).length && (
-							<ul>
-								{ options.map( ( option, index ) => ( option ? <li>{ option }</li> : null ) ) }
-							</ul>
-						) }
-					</PanelBody>
-				</InspectorControls>
 			</div>
 		</>
 	);

--- a/projects/packages/forms/src/blocks/field-select/index.js
+++ b/projects/packages/forms/src/blocks/field-select/index.js
@@ -10,11 +10,13 @@ import save from './save';
 const name = 'field-select';
 const settings = {
 	...defaultSettings,
+	allowedBlocks: [ 'jetpack/label', 'jetpack/dropdown' ],
 	title: __( 'Dropdown field', 'jetpack-forms' ),
 	keywords: [
 		__( 'Choose', 'jetpack-forms' ),
 		__( 'Dropdown', 'jetpack-forms' ),
 		__( 'Option', 'jetpack-forms' ),
+		__( 'Select', 'jetpack-forms' ),
 	],
 	description: __(
 		'Add a compact select box, that when expanded, allows visitors to choose one value from the list.',

--- a/projects/packages/forms/src/blocks/input/edit.js
+++ b/projects/packages/forms/src/blocks/input/edit.js
@@ -57,6 +57,9 @@ const InputEdit = ( { attributes, clientId, isSelected, name, setAttributes, con
 		return (
 			<div { ...blockProps }>
 				<RichText
+					aria-label={ __( 'Dropdown text', 'jetpack-forms' ) }
+					disableLineBreaks
+					identifier="placeholder"
 					allowedFormats={ ALLOWED_FORMATS }
 					onChange={ value => setAttributes( { placeholder: value } ) }
 					value={ placeholder ? placeholder : __( 'Select one option', 'jetpack-forms' ) }

--- a/projects/packages/forms/src/blocks/shared/hooks/use-insert-after-on-enter-key-down.js
+++ b/projects/packages/forms/src/blocks/shared/hooks/use-insert-after-on-enter-key-down.js
@@ -3,7 +3,7 @@ import { createBlock, getDefaultBlockName } from '@wordpress/blocks';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useCallback } from '@wordpress/element';
 
-export default function ( clientId, isParent = false, defaultBlockName ) {
+export default function ( clientId, isParent = false ) {
 	const { fieldParentId, parentIndex, formParentId } = useSelect(
 		select => {
 			const blockEditor = select( blockEditorStore );
@@ -40,12 +40,12 @@ export default function ( clientId, isParent = false, defaultBlockName ) {
 			) {
 				event.preventDefault();
 				insertBlock(
-					createBlock( defaultBlockName || getDefaultBlockName() ),
+					createBlock( getDefaultBlockName() ),
 					parentIndex + 1,
 					formParentId // Insert in the same context as the field block.
 				);
 			}
 		},
-		[ insertBlock, fieldParentId, formParentId, parentIndex, defaultBlockName ]
+		[ insertBlock, fieldParentId, formParentId, parentIndex ]
 	);
 }

--- a/projects/packages/forms/src/blocks/shared/hooks/use-insert-after-on-enter-key-down.js
+++ b/projects/packages/forms/src/blocks/shared/hooks/use-insert-after-on-enter-key-down.js
@@ -3,7 +3,7 @@ import { createBlock, getDefaultBlockName } from '@wordpress/blocks';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useCallback } from '@wordpress/element';
 
-export default function ( clientId, isParent = false ) {
+export default function ( clientId, isParent = false, defaultBlockName ) {
 	const { fieldParentId, parentIndex, formParentId } = useSelect(
 		select => {
 			const blockEditor = select( blockEditorStore );
@@ -40,12 +40,12 @@ export default function ( clientId, isParent = false ) {
 			) {
 				event.preventDefault();
 				insertBlock(
-					createBlock( getDefaultBlockName() ),
+					createBlock( defaultBlockName || getDefaultBlockName() ),
 					parentIndex + 1,
 					formParentId // Insert in the same context as the field block.
 				);
 			}
 		},
-		[ insertBlock, fieldParentId, formParentId, parentIndex ]
+		[ insertBlock, fieldParentId, formParentId, parentIndex, defaultBlockName ]
 	);
 }

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -1244,7 +1244,7 @@ class Contact_Form_Plugin {
 	}
 
 	/**
-	 * Render the dropdown field.
+	 * Render the dropdown.
 	 *
 	 * @param array  $atts - the block attributes.
 	 * @param string $content - html content.
@@ -1252,7 +1252,18 @@ class Contact_Form_Plugin {
 	 * @return string HTML for the dropdown in select field.
 	 */
 	public static function gutenblock_render_dropdown( $atts, $content ) {
+		return $content;
+	}
 
+	/**
+	 * Render the dropdown option.
+	 *
+	 * @param array  $atts - the block attributes.
+	 * @param string $content - html content.
+	 *
+	 * @return string HTML for the dropdown option in select field.
+	 */
+	public static function gutenblock_render_dropdown_option( $atts, $content ) {
 		return $content;
 	}
 

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -1242,6 +1242,20 @@ class Contact_Form_Plugin {
 
 		return $output;
 	}
+
+	/**
+	 * Render the dropdown field.
+	 *
+	 * @param array  $atts - the block attributes.
+	 * @param string $content - html content.
+	 *
+	 * @return string HTML for the dropdown in select field.
+	 */
+	public static function gutenblock_render_dropdown( $atts, $content ) {
+
+		return $content;
+	}
+
 	/**
 	 * Render the dropzone field.
 	 *

--- a/projects/plugins/jetpack/changelog/update-forms-select-inner-blocks
+++ b/projects/plugins/jetpack/changelog/update-forms-select-inner-blocks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: improve adding, editing and removing options for dropdown field


### PR DESCRIPTION
Resolves FORMS-126
Resolves FORMS-194

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to autocomplete feature which would benefit from customization options for dropdown and easier management of longer lists:
- https://github.com/Automattic/jetpack/pull/44334
- FORMS-65


https://github.com/user-attachments/assets/85442296-6d4e-483d-9ae3-4422a8f1b27c



## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

