### PR TITLE
Untangling: Bring Settings > Sharing to WPCOM Sites

### DIFF
--- a/projects/plugins/jetpack/_inc/client/sharing/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/sharing/index.jsx
@@ -19,7 +19,7 @@ import {
 import { getModule } from 'state/modules';
 import { isModuleFound as _isModuleFound } from 'state/search';
 import { getSettings } from 'state/settings';
-import { getActiveFeatures, siteUsesWpAdminInterface } from 'state/site';
+import { getActiveFeatures } from 'state/site';
 import { Likes } from './likes';
 import { Publicize } from './publicize';
 import { ShareButtons } from './share-buttons';
@@ -30,7 +30,6 @@ class Sharing extends Component {
 			settings: this.props.settings,
 			getModule: this.props.module,
 			isOfflineMode: this.props.isOfflineMode,
-			siteUsesWpAdminInterface: this.props.siteUsesWpAdminInterface,
 			isUnavailableInOfflineMode: this.props.isUnavailableInOfflineMode,
 			isLinked: this.props.isLinked,
 			connectUrl: this.props.connectUrl,
@@ -80,7 +79,6 @@ export default connect( state => {
 		module: module_name => getModule( state, module_name ),
 		settings: getSettings( state ),
 		isOfflineMode: isOfflineMode( state ),
-		siteUsesWpAdminInterface: siteUsesWpAdminInterface( state ),
 		isUnavailableInOfflineMode: module_name => isUnavailableInOfflineMode( state, module_name ),
 		isModuleFound: module_name => _isModuleFound( state, module_name ),
 		isLinked: isCurrentUserLinked( state ),

--- a/projects/plugins/jetpack/_inc/client/sharing/share-buttons.jsx
+++ b/projects/plugins/jetpack/_inc/client/sharing/share-buttons.jsx
@@ -1,4 +1,5 @@
 import { getRedirectUrl } from '@automattic/jetpack-components';
+import { isWpcomPlatformSite } from '@automattic/jetpack-script-data';
 import { ExternalLink } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
@@ -26,7 +27,6 @@ export const ShareButtons = withModuleSettingsFormHelpers(
 				blogID = this.props.blogID,
 				siteAdminUrl = this.props.siteAdminUrl,
 				isOfflineMode = this.props.isOfflineMode,
-				siteUsesWpAdminInterface = this.props.siteUsesWpAdminInterface,
 				hasSharingBlock = this.props.hasSharingBlock,
 				isBlockTheme = this.props.isBlockTheme,
 				isActive = this.props.getOptionValue( 'sharedaddy' );
@@ -56,7 +56,7 @@ export const ShareButtons = withModuleSettingsFormHelpers(
 
 				if ( shouldShowSharingBlock ) {
 					cardProps.href = `${ siteAdminUrl }site-editor.php?path=%2Fwp_template`;
-				} else if ( isLinked && ! isOfflineMode && ! siteUsesWpAdminInterface ) {
+				} else if ( isLinked && ! isOfflineMode && ! isWpcomPlatformSite() ) {
 					cardProps.href = getRedirectUrl( 'calypso-marketing-sharing-buttons', {
 						site: blogID ?? siteRawUrl,
 					} );

--- a/projects/plugins/jetpack/changelog/update-settings-sharing-wpcom
+++ b/projects/plugins/jetpack/changelog/update-settings-sharing-wpcom
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Use Settings > Sharing page for WPCOM (Simple and Atomic) sites
+
+

--- a/projects/plugins/jetpack/modules/sharedaddy/sharing.php
+++ b/projects/plugins/jetpack/modules/sharedaddy/sharing.php
@@ -11,6 +11,7 @@ use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Redirect;
 use Automattic\Jetpack\Status;
+use Automattic\Jetpack\Status\Host;
 
 if ( ! defined( 'WP_SHARING_PLUGIN_URL' ) ) {
 	define( 'WP_SHARING_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
@@ -128,12 +129,12 @@ class Sharing_Admin {
 	 * Register Sharing settings menu page in offline mode or when wp-admin interface is enabled.
 	 */
 	public function subscription_menu() {
-		$wpcom_is_wp_admin_interface = get_option( 'wpcom_admin_interface' ) === 'wp-admin';
-		$is_user_connected           = ( new Connection_Manager() )->is_user_connected();
+		$is_user_connected = ( new Connection_Manager() )->is_user_connected();
 
 		if (
 			( new Status() )->is_offline_mode()
-			|| $wpcom_is_wp_admin_interface
+			// Always enable Settings > Sharing on Atomic and Simple.
+			|| ( new Host() )->is_wpcom_platform()
 			|| ! $is_user_connected
 		) {
 			add_submenu_page(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes DOTCOM-13875

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Enable Settings > Sharing on all WPCOM sites (Atomic and Simple)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this branch on your sandbox and on an Atomic site
* Notice you have a "Settings > Sharing" menu item
* Enable a classic theme
* Go to Jetpack > Settings > Sharing and click on the link to configure the buttons
* Notice that you're sent to Settings > Sharing

<img width="1258" height="284" alt="Screenshot 2025-07-17 at 18 42 22" src="https://github.com/user-attachments/assets/eb43bbf8-1e69-4620-af7c-dc45920fa805" />


