### PR TITLE
jetpack: Replace use of lodash in Mailchimp block view.js

### DIFF
--- a/projects/plugins/jetpack/changelog/update-replace-lodash-in-mailchimp-block-viewjs
+++ b/projects/plugins/jetpack/changelog/update-replace-lodash-in-mailchimp-block-viewjs
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Replace use of `lodash` in Mailchimp block view.js
+
+

--- a/projects/plugins/jetpack/extensions/blocks/mailchimp/view.js
+++ b/projects/plugins/jetpack/extensions/blocks/mailchimp/view.js
@@ -1,9 +1,6 @@
 import domReady from '@wordpress/dom-ready';
+import debounce from 'debounce';
 import { validate as emailValidatorValidate } from 'email-validator';
-// NOTE: We only import the debounce package here for to reduced bundle size.
-//       Do not import the entire lodash library!
-// eslint-disable-next-line lodash/import-scope
-import debounce from 'lodash/debounce';
 import { BLOCK_CLASS } from './constants';
 
 import './view.scss';
@@ -73,7 +70,6 @@ function activateSubscription( block, blogId ) {
 			.call( form.querySelectorAll( 'input[type="hidden"].mc-submit-param' ) )
 			.reduce( ( accumulator, node ) => ( { ...accumulator, [ node.name ]: node.value } ), {} );
 		block.classList.add( 'is-processing' );
-		emailField.removeEventListener( 'input', handleEmailValidation( form, emailField ) );
 		processingEl.classList.add( 'is-visible' );
 		fetchSubscription( blogId, email, params ).then(
 			response => {


### PR DESCRIPTION
Closes MONOREP-25

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This block, instead of using the full lodash, was importing `lodash/debounce` directly (and therefore embedding it). Since we're already bringing in the `debounce` package, use it here too.

Also, remove a useless `removeEventListener()` call. It never worked because it's not passing the same function.

The savings of 1841 bytes (uncompressed) isn't much, but it's something and it sets a better example.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pdWQjU-1jP-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check that email validation in the block on the frontend still works.