### PR TITLE
Forms: Fix export hooks error on mobile

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-action-dropdown-hooks-error
+++ b/projects/packages/forms/changelog/fix-forms-action-dropdown-hooks-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Fix export hooks error on mobile.

--- a/projects/packages/forms/src/dashboard/components/actions-dropdown-menu/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/actions-dropdown-menu/index.tsx
@@ -17,8 +17,10 @@ type ActionsDropdownMenuProps = {
 	exportData: { show: boolean };
 };
 
-const CreateFormDropdownItem = () => {
+const ActionsDropdownMenu = ( { exportData }: ActionsDropdownMenuProps ) => {
 	const { openNewForm } = useCreateForm();
+	const { showExportModal, openModal, closeModal, onExport, autoConnectGdrive, exportLabel } =
+		useExportResponses();
 
 	const analyticsEvent = useCallback( () => {
 		jetpackAnalytics.tracks.recordEvent( 'jetpack_wpa_forms_landing_page_cta_click', {
@@ -26,43 +28,32 @@ const CreateFormDropdownItem = () => {
 		} );
 	}, [] );
 
-	const onClick = useCallback( () => {
+	const onCreateFormClick = useCallback( () => {
 		openNewForm( {
 			analyticsEvent,
 		} );
 	}, [ openNewForm, analyticsEvent ] );
 
-	return {
-		icon: plus,
-		onClick,
-		title: __( 'Create form', 'jetpack-forms' ),
-	};
-};
-
-const ExportDropdownItem = ( { onClick }: { onClick: () => void } ) => {
-	const { exportLabel } = useExportResponses();
-
-	return {
-		icon: download,
-		onClick,
-		title: exportLabel,
-	};
-};
-
-const ActionsDropdownMenu = ( { exportData }: ActionsDropdownMenuProps ) => {
-	const { showExportModal, openModal, closeModal, onExport, autoConnectGdrive } =
-		useExportResponses();
+	const controls = [
+		...( exportData.show
+			? [
+					{
+						icon: download,
+						onClick: openModal,
+						title: exportLabel,
+					},
+			  ]
+			: [] ),
+		{
+			icon: plus,
+			onClick: onCreateFormClick,
+			title: __( 'Create form', 'jetpack-forms' ),
+		},
+	];
 
 	return (
 		<>
-			<DropdownMenu
-				controls={ [
-					...( exportData.show ? [ ExportDropdownItem( { onClick: openModal } ) ] : [] ),
-					CreateFormDropdownItem(),
-				] }
-				icon={ menu }
-			/>
-
+			<DropdownMenu controls={ controls } icon={ menu } />
 			{ showExportModal && (
 				<ExportResponsesModal
 					onRequestClose={ closeModal }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes [FORMS-230](https://linear.app/a8c/issue/FORMS-230/forms-dashboard-tabs-not-rendering-properly-on-mobile)

## Proposed changes:

**Original issue.** On mobile only, clicking a tab on the forms dashboard was causing an error. The visible error was "Cannot read properties of undefined" message. But in the console, the error was actually related to a violation of React's [rules of hooks](https://legacy.reactjs.org/docs/hooks-rules.html). 

**Diagnosis.** In the dashboard's Layout component, we conditionally load `ActionsDropdownMenu` on small screens [here](https://github.com/Automattic/jetpack/blob/23ef0ebf36df6853222e12ab8eab9245fc63e93c/projects/packages/forms/src/dashboard/components/layout/index.tsx#L108). That in turn renders `DropdownMenu`, and we were constructing the 'controls' prop [here](https://github.com/Automattic/jetpack/blob/23ef0ebf36df6853222e12ab8eab9245fc63e93c/projects/packages/forms/src/dashboard/components/actions-dropdown-menu/index.tsx#L59) by calling two functions, `ExportDropdownItem()` and `CreateFormDropdownItem()`. These functions finally invoke a number of React hooks. But we can't call React hooks inside normal functions. It violates the 'Only call hooks at the top level' rule.

**Fix.** I've addressed the issue by refactoring to ensure the hooks are called at the root of the ActionsDropdownMenu component rather than inside of functions. We still construct the 'controls' array conditionally, the same way, using on the output from those hooks, so the end result is the same. 

**Screenshot: original error.**
<img width="250" height="300" alt="original-hooks-error" src="https://github.com/user-attachments/assets/2ad8681d-c937-4b0b-9cf1-97ea2eca8995" />

**Console errors:** The original issue was associated with a sequence of console errors. 

```
Warning: React has detected a change in the order of Hooks called by ActionsDropdownMenu. This will lead to bugs and errors if not fixed. For more information, read the Rules of Hooks: https://reactjs.org/link/rules-of-hooks
...
Warning: The final argument passed to useCallback changed size between renders. The order and size of this array must remain constant.
...
Uncaught TypeError: Cannot read properties of undefined (reading 'length')
...
The above error occurred in the <ActionsDropdownMenu> component:
```

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
See Linear issue above. 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No. 

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On a small screen (you can just resize your browser window), go to Jetpack > Forms. Click the Integrations or About tab, and confirm you do not see the error. 
* Confirm the dropdown menu on small screens loads the same before and after. 