### PR TITLE
[e2e tests] Always use baseURL from Playwright config

### DIFF
--- a/projects/plugins/boost/changelog/e2e-simplify-resolve-site-url
+++ b/projects/plugins/boost/changelog/e2e-simplify-resolve-site-url
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: E2E tests improvements
+
+

--- a/projects/plugins/boost/tests/e2e/lib/pages/frontend/FirstPostPage.js
+++ b/projects/plugins/boost/tests/e2e/lib/pages/frontend/FirstPostPage.js
@@ -3,7 +3,7 @@ import pwConfig from '../../../playwright.config.mjs';
 
 export default class FirstPostPage extends WpPage {
 	constructor( page ) {
-		const url = `${ pwConfig.use[ 0 ].baseURL }/?p=1`;
+		const url = `${ pwConfig.use.baseURL }/?p=1`;
 		super( page, { url } );
 	}
 

--- a/projects/plugins/boost/tests/e2e/lib/pages/frontend/FirstPostPage.js
+++ b/projects/plugins/boost/tests/e2e/lib/pages/frontend/FirstPostPage.js
@@ -1,9 +1,9 @@
-import { resolveSiteUrl } from '_jetpack-e2e-commons/helpers/utils-helper.js';
 import WpPage from '_jetpack-e2e-commons/pages/wp-page.js';
+import pwConfig from '../../../playwright.config.mjs';
 
 export default class FirstPostPage extends WpPage {
 	constructor( page ) {
-		const url = `${ resolveSiteUrl() }/?p=1`;
+		const url = `${ pwConfig.use[ 0 ].baseURL }/?p=1`;
 		super( page, { url } );
 	}
 

--- a/projects/plugins/boost/tests/e2e/lib/pages/wp-admin/JetpackBoostPage.js
+++ b/projects/plugins/boost/tests/e2e/lib/pages/wp-admin/JetpackBoostPage.js
@@ -7,7 +7,7 @@ const apiEndpointsRegex = {
 
 export default class JetpackBoostPage extends WpPage {
 	constructor( page ) {
-		const url = pwConfig.use[ 0 ].baseURL + '/wp-admin/admin.php?page=jetpack-boost';
+		const url = pwConfig.use.baseURL + '/wp-admin/admin.php?page=jetpack-boost';
 		super( page, { expectedSelectors: [ '#jb-dashboard' ], url } );
 	}
 

--- a/projects/plugins/boost/tests/e2e/lib/pages/wp-admin/JetpackBoostPage.js
+++ b/projects/plugins/boost/tests/e2e/lib/pages/wp-admin/JetpackBoostPage.js
@@ -1,5 +1,5 @@
-import { resolveSiteUrl } from '_jetpack-e2e-commons/helpers/utils-helper.js';
 import WpPage from '_jetpack-e2e-commons/pages/wp-page.js';
+import pwConfig from '../../../playwright.config.mjs';
 
 const apiEndpointsRegex = {
 	'modules-state': /jetpack-boost-ds\/modules-state\/set/,
@@ -7,7 +7,7 @@ const apiEndpointsRegex = {
 
 export default class JetpackBoostPage extends WpPage {
 	constructor( page ) {
-		const url = resolveSiteUrl() + '/wp-admin/admin.php?page=jetpack-boost';
+		const url = pwConfig.use[ 0 ].baseURL + '/wp-admin/admin.php?page=jetpack-boost';
 		super( page, { expectedSelectors: [ '#jb-dashboard' ], url } );
 	}
 

--- a/projects/plugins/boost/tests/e2e/lib/pages/wp-admin/PermalinksPage.js
+++ b/projects/plugins/boost/tests/e2e/lib/pages/wp-admin/PermalinksPage.js
@@ -1,9 +1,9 @@
-import { resolveSiteUrl } from '_jetpack-e2e-commons/helpers/utils-helper.js';
 import WpPage from '_jetpack-e2e-commons/pages/wp-page.js';
+import pwConfig from '../../../playwright.config.mjs';
 
 export default class PermalinksPage extends WpPage {
 	constructor( page ) {
-		const url = `${ resolveSiteUrl() }/wp-admin/options-permalink.php`;
+		const url = `${ pwConfig.use[ 0 ].baseURL }/wp-admin/options-permalink.php`;
 		super( page, { expectedSelectors: [ '.permalink-structure' ], url } );
 	}
 

--- a/projects/plugins/boost/tests/e2e/lib/pages/wp-admin/PermalinksPage.js
+++ b/projects/plugins/boost/tests/e2e/lib/pages/wp-admin/PermalinksPage.js
@@ -3,7 +3,7 @@ import pwConfig from '../../../playwright.config.mjs';
 
 export default class PermalinksPage extends WpPage {
 	constructor( page ) {
-		const url = `${ pwConfig.use[ 0 ].baseURL }/wp-admin/options-permalink.php`;
+		const url = `${ pwConfig.use.baseURL }/wp-admin/options-permalink.php`;
 		super( page, { expectedSelectors: [ '.permalink-structure' ], url } );
 	}
 

--- a/projects/plugins/boost/tests/e2e/specs/page-cache/page-cache.test.js
+++ b/projects/plugins/boost/tests/e2e/specs/page-cache/page-cache.test.js
@@ -1,5 +1,4 @@
 import { test, expect } from '_jetpack-e2e-commons/fixtures/base-test.ts';
-import { resolveSiteUrl } from '_jetpack-e2e-commons/helpers/utils-helper.js';
 import { PostFrontendPage } from '_jetpack-e2e-commons/pages/index.js';
 import playwrightConfig from '_jetpack-e2e-commons/playwright.config.mjs';
 import { boostPrerequisitesBuilder } from '../../lib/env/prerequisites.js';
@@ -46,13 +45,14 @@ test.describe( 'Cache module', () => {
 	// Make sure there's no cache header when module is disabled.
 	test( 'Page Cache header should not be present when module is inactive', async ( {
 		browser,
+		baseURL,
 	} ) => {
 		// Ensure default storageState is empty.
 		const newContext = await browser.newContext( { storageState: {} } );
 		const newPage = await newContext.newPage();
 
 		newPage.on( 'response', response => {
-			if ( response.url().replace( /\/$/, '' ) !== resolveSiteUrl().replace( /\/$/, '' ) ) {
+			if ( response.url().replace( /\/$/, '' ) !== baseURL.replace( /\/$/, '' ) ) {
 				return;
 			}
 
@@ -97,7 +97,10 @@ test.describe( 'Cache module', () => {
 	} );
 
 	// Make sure there's a cache header when module is enabled.
-	test( 'Page Cache header should be present when module is active', async ( { browser } ) => {
+	test( 'Page Cache header should be present when module is active', async ( {
+		browser,
+		baseURL,
+	} ) => {
 		await boostPrerequisitesBuilder( page ).withActiveModules( [ 'page_cache' ] ).build();
 
 		// Ensure default storageState is empty.
@@ -107,7 +110,7 @@ test.describe( 'Cache module', () => {
 		let totalVisits = 0;
 
 		newPage.on( 'response', response => {
-			if ( response.url().replace( /\/$/, '' ) !== resolveSiteUrl().replace( /\/$/, '' ) ) {
+			if ( response.url().replace( /\/$/, '' ) !== baseURL.replace( /\/$/, '' ) ) {
 				return;
 			}
 

--- a/projects/plugins/jetpack/changelog/e2e-simplify-resolve-site-url
+++ b/projects/plugins/jetpack/changelog/e2e-simplify-resolve-site-url
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: E2E tests improvements
+
+

--- a/projects/plugins/jetpack/tests/e2e/specs/post-connection/waf-blocking.test.js
+++ b/projects/plugins/jetpack/tests/e2e/specs/post-connection/waf-blocking.test.js
@@ -1,6 +1,5 @@
 import { Plans, prerequisitesBuilder } from '_jetpack-e2e-commons/env/index.js';
 import { test, expect } from '_jetpack-e2e-commons/fixtures/base-test.ts';
-import { resolveSiteUrl } from '_jetpack-e2e-commons/helpers/utils-helper.js';
 import { WpPage } from '_jetpack-e2e-commons/pages/index.js';
 import { enableAutomaticRules, generateRules } from '../../helpers/waf-helper.js';
 import playwrightConfig from '../../playwright.config.mjs';
@@ -24,11 +23,11 @@ test.describe.parallel( 'WAF Blocking', () => {
 		await page.close();
 	} );
 
-	test( 'Block a simple request', async ( { page } ) => {
+	test( 'Block a simple request', async ( { page, baseURL } ) => {
 		await test.step( 'Block it', async () => {
 			const blockedPage = new WpPage( page, { pageName: 'Blocked request' } );
 
-			const response = await blockedPage.goto( `${ resolveSiteUrl() }/?blubb=<script>` );
+			const response = await blockedPage.goto( `${ baseURL }/?blubb=<script>` );
 			expect( response.status() ).toStrictEqual( 403 );
 
 			/*

--- a/projects/plugins/jetpack/tests/e2e/specs/update/plugin-update.test.js
+++ b/projects/plugins/jetpack/tests/e2e/specs/update/plugin-update.test.js
@@ -2,17 +2,16 @@ import { prerequisitesBuilder } from '_jetpack-e2e-commons/env/index.js';
 import { test, expect } from '_jetpack-e2e-commons/fixtures/base-test.ts';
 import {
 	execShellCommand,
-	resolveSiteUrl,
 	execContainerShellCommand,
 } from '_jetpack-e2e-commons/helpers/utils-helper.js';
 import { PluginsPage, JetpackDashboardPage } from '_jetpack-e2e-commons/pages/wp-admin/index.js';
 
-test.skip( 'Update Jetpack plugin', async ( { page } ) => {
+test.skip( 'Update Jetpack plugin', async ( { page, baseURL } ) => {
 	const binPath = '/usr/local/src/jetpack-monorepo/projects/plugins/jetpack/tests/e2e/bin/update/';
 
 	// Prepare for update
 	await execShellCommand( `./bin/update/prepare-zip.sh` );
-	await execContainerShellCommand( `${ binPath }prepare-update.sh ${ resolveSiteUrl() }` );
+	await execContainerShellCommand( `${ binPath }prepare-update.sh ${ baseURL }` );
 
 	// Update
 	await prerequisitesBuilder( page ).withLoggedIn( true ).withConnection( true ).build();
@@ -24,7 +23,7 @@ test.skip( 'Update Jetpack plugin', async ( { page } ) => {
 	} );
 
 	// Capture Jetpack status before update
-	await execContainerShellCommand( `${ binPath }pre-update.sh ${ resolveSiteUrl() }` );
+	await execContainerShellCommand( `${ binPath }pre-update.sh ${ baseURL }` );
 
 	await test.step( 'Can update Jetpack', async () => {
 		await pluginsPage.updateJetpack();

--- a/projects/plugins/search/changelog/e2e-simplify-resolve-site-url
+++ b/projects/plugins/search/changelog/e2e-simplify-resolve-site-url
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: E2E tests improvements
+
+

--- a/projects/plugins/search/tests/e2e/pages/search-homepage.js
+++ b/projects/plugins/search/tests/e2e/pages/search-homepage.js
@@ -1,12 +1,12 @@
-import { resolveSiteUrl } from '_jetpack-e2e-commons/helpers/utils-helper.js';
 import WpPage from '_jetpack-e2e-commons/pages/wp-page.js';
+import pwConfig from '../playwright.config.mjs';
 
 export default class SearchHomepage extends WpPage {
 	static SEARCH_API_PATTERN =
 		/^https:\/\/public-api\.wordpress.com\/rest\/v1.3\/sites\/\d+\/search.*/;
 
 	constructor( page ) {
-		const url = `${ resolveSiteUrl() }/?result_format=expanded`;
+		const url = `${ pwConfig.use[ 0 ].baseURL }/?result_format=expanded`;
 		super( page, {
 			expectedSelectors: [ '.wp-block-search__input, .search-field' ],
 			url,

--- a/projects/plugins/search/tests/e2e/pages/search-homepage.js
+++ b/projects/plugins/search/tests/e2e/pages/search-homepage.js
@@ -6,7 +6,7 @@ export default class SearchHomepage extends WpPage {
 		/^https:\/\/public-api\.wordpress.com\/rest\/v1.3\/sites\/\d+\/search.*/;
 
 	constructor( page ) {
-		const url = `${ pwConfig.use[ 0 ].baseURL }/?result_format=expanded`;
+		const url = `${ pwConfig.use.baseURL }/?result_format=expanded`;
 		super( page, {
 			expectedSelectors: [ '.wp-block-search__input, .search-field' ],
 			url,

--- a/projects/plugins/search/tests/e2e/pages/wp-admin/search-configure.js
+++ b/projects/plugins/search/tests/e2e/pages/wp-admin/search-configure.js
@@ -5,7 +5,7 @@ export default class SearchConfigure extends WpPage {
 	static SEARCH_SETTING_API_PATTERN = /^https?:\/\/.*%2Fwp%2Fv2%2Fsettings/;
 
 	constructor( page ) {
-		const url = `${ pwConfig.use[ 0 ].baseURL }/wp-admin/admin.php?page=jetpack-search-configure`;
+		const url = `${ pwConfig.use.baseURL }/wp-admin/admin.php?page=jetpack-search-configure`;
 		super( page, {
 			expectedSelectors: [ '.jp-search-configure-header__title' ],
 			url,

--- a/projects/plugins/search/tests/e2e/pages/wp-admin/search-configure.js
+++ b/projects/plugins/search/tests/e2e/pages/wp-admin/search-configure.js
@@ -1,11 +1,11 @@
-import { resolveSiteUrl } from '_jetpack-e2e-commons/helpers/utils-helper.js';
 import WpPage from '_jetpack-e2e-commons/pages/wp-page.js';
+import pwConfig from '../../playwright.config.mjs';
 
 export default class SearchConfigure extends WpPage {
 	static SEARCH_SETTING_API_PATTERN = /^https?:\/\/.*%2Fwp%2Fv2%2Fsettings/;
 
 	constructor( page ) {
-		const url = `${ resolveSiteUrl() }/wp-admin/admin.php?page=jetpack-search-configure`;
+		const url = `${ pwConfig.use[ 0 ].baseURL }/wp-admin/admin.php?page=jetpack-search-configure`;
 		super( page, {
 			expectedSelectors: [ '.jp-search-configure-header__title' ],
 			url,

--- a/projects/plugins/search/tests/e2e/pages/wp-admin/search-dashboard.js
+++ b/projects/plugins/search/tests/e2e/pages/wp-admin/search-dashboard.js
@@ -5,7 +5,7 @@ export default class SearchDashboard extends WpPage {
 	static SEARCH_SETTING_API_PATTERN = /^https?:\/\/.*jetpack\/v4\/search\/settings/;
 
 	constructor( page ) {
-		const url = `${ pwConfig.use[ 0 ].baseURL }/wp-admin/admin.php?page=jetpack-search`;
+		const url = `${ pwConfig.use.baseURL }/wp-admin/admin.php?page=jetpack-search`;
 		super( page, {
 			expectedSelectors: [ '.jp-search-dashboard-top__title' ],
 			url,

--- a/projects/plugins/search/tests/e2e/pages/wp-admin/search-dashboard.js
+++ b/projects/plugins/search/tests/e2e/pages/wp-admin/search-dashboard.js
@@ -1,11 +1,11 @@
-import { resolveSiteUrl } from '_jetpack-e2e-commons/helpers/utils-helper.js';
 import WpPage from '_jetpack-e2e-commons/pages/wp-page.js';
+import pwConfig from '../../playwright.config.mjs';
 
 export default class SearchDashboard extends WpPage {
 	static SEARCH_SETTING_API_PATTERN = /^https?:\/\/.*jetpack\/v4\/search\/settings/;
 
 	constructor( page ) {
-		const url = `${ resolveSiteUrl() }/wp-admin/admin.php?page=jetpack-search`;
+		const url = `${ pwConfig.use[ 0 ].baseURL }/wp-admin/admin.php?page=jetpack-search`;
 		super( page, {
 			expectedSelectors: [ '.jp-search-dashboard-top__title' ],
 			url,

--- a/projects/plugins/search/tests/e2e/specs/search.test.js
+++ b/projects/plugins/search/tests/e2e/specs/search.test.js
@@ -1,6 +1,5 @@
 import { prerequisitesBuilder, Plans } from '_jetpack-e2e-commons/env/index.js';
 import { test, expect } from '_jetpack-e2e-commons/fixtures/base-test.ts';
-import { resolveSiteUrl } from '_jetpack-e2e-commons/helpers/utils-helper.js';
 import {
 	enableInstantSearch,
 	disableInstantSearch,
@@ -13,7 +12,6 @@ import playwrightConfig from '../playwright.config.mjs';
 
 test.describe( 'Instant Search', () => {
 	let homepage;
-	const siteUrl = resolveSiteUrl();
 
 	test.beforeAll( async ( { browser } ) => {
 		const page = await browser.newPage( playwrightConfig.use );
@@ -150,9 +148,9 @@ test.describe( 'Instant Search', () => {
 		} );
 	} );
 
-	test( 'Can display different result formats', async () => {
+	test( 'Can display different result formats', async ( { baseURL } ) => {
 		await test.step( 'Can use minimal format', async () => {
-			await homepage.goto( `${ siteUrl }?result_format=minimal` );
+			await homepage.goto( `${ baseURL }?result_format=minimal` );
 			await homepage.waitForInstantSearchReady();
 			await homepage.focusSearchInput();
 			await homepage.enterQuery( 'random-string-1' );
@@ -167,7 +165,7 @@ test.describe( 'Instant Search', () => {
 		} );
 
 		await test.step( 'Can use product format', async () => {
-			await homepage.goto( `${ siteUrl }?result_format=product` );
+			await homepage.goto( `${ baseURL }?result_format=product` );
 			await homepage.waitForInstantSearchReady();
 			await homepage.focusSearchInput();
 			await homepage.enterQuery( 'random-string-2' );
@@ -190,7 +188,7 @@ test.describe( 'Instant Search', () => {
 		} );
 
 		await test.step( 'Can use expanded format', async () => {
-			await homepage.goto( `${ siteUrl }?result_format=expanded&s=random-string-3` );
+			await homepage.goto( `${ baseURL }?result_format=expanded&s=random-string-3` );
 			await homepage.waitForInstantSearchReady();
 
 			expect( await homepage.isOverlayVisible(), 'Overlay should be visible' ).toBeTruthy();
@@ -205,8 +203,8 @@ test.describe( 'Instant Search', () => {
 		} );
 	} );
 
-	test( 'Can open overlay by clicking a link', async () => {
-		await homepage.goto( `${ siteUrl }?jetpack_search_link_in_footer=1` );
+	test( 'Can open overlay by clicking a link', async ( { baseURL } ) => {
+		await homepage.goto( `${ baseURL }?jetpack_search_link_in_footer=1` );
 		await homepage.waitForInstantSearchReady();
 
 		expect( await homepage.isOverlayVisible(), 'Overlay should not be visible' ).toBeFalsy();

--- a/projects/plugins/social/changelog/e2e-simplify-resolve-site-url
+++ b/projects/plugins/social/changelog/e2e-simplify-resolve-site-url
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: E2E tests improvements
+
+

--- a/projects/plugins/social/tests/e2e/pages/wp-admin/jetpack-social.js
+++ b/projects/plugins/social/tests/e2e/pages/wp-admin/jetpack-social.js
@@ -4,7 +4,7 @@ import pwConfig from '../../playwright.config.mjs';
 
 export default class JetpackSocialPage extends WpPage {
 	constructor( page ) {
-		const url = pwConfig.use[ 0 ].baseURL + '/wp-admin/admin.php?page=jetpack-social';
+		const url = pwConfig.use.baseURL + '/wp-admin/admin.php?page=jetpack-social';
 		super( page, { expectedSelectors: [], url } );
 	}
 

--- a/projects/plugins/social/tests/e2e/pages/wp-admin/jetpack-social.js
+++ b/projects/plugins/social/tests/e2e/pages/wp-admin/jetpack-social.js
@@ -1,10 +1,10 @@
-import { resolveSiteUrl } from '_jetpack-e2e-commons/helpers/utils-helper.js';
 import logger from '_jetpack-e2e-commons/logger.js';
 import WpPage from '_jetpack-e2e-commons/pages/wp-page.js';
+import pwConfig from '../../playwright.config.mjs';
 
 export default class JetpackSocialPage extends WpPage {
 	constructor( page ) {
-		const url = resolveSiteUrl() + '/wp-admin/admin.php?page=jetpack-social';
+		const url = pwConfig.use[ 0 ].baseURL + '/wp-admin/admin.php?page=jetpack-social';
 		super( page, { expectedSelectors: [], url } );
 	}
 

--- a/tools/e2e-commons/bin/performance.js
+++ b/tools/e2e-commons/bin/performance.js
@@ -4,7 +4,8 @@ import path from 'path';
 import { URL } from 'url';
 import { mergeWith } from 'lodash-es';
 import { prerequisitesBuilder } from '../env/prerequisites.js';
-import { execSyncShellCommand, execWpCommand, resolveSiteUrl } from '../helpers/utils-helper.js';
+import { execSyncShellCommand, execWpCommand } from '../helpers/utils-helper.js';
+import pwConfig from '../playwright.config.mjs';
 
 const __dirname = new URL( '.', import.meta.url ).pathname;
 
@@ -55,7 +56,7 @@ async function runTests( type, round ) {
 		cwd: gutenbergPath,
 		env: {
 			...process.env,
-			WP_BASE_URL: resolveSiteUrl(),
+			WP_BASE_URL: pwConfig.use[ 0 ].baseURL,
 			WP_ARTIFACTS_PATH: resultsPath,
 			RESULTS_ID: `${ type }.${ round }`,
 		},

--- a/tools/e2e-commons/bin/performance.js
+++ b/tools/e2e-commons/bin/performance.js
@@ -56,7 +56,7 @@ async function runTests( type, round ) {
 		cwd: gutenbergPath,
 		env: {
 			...process.env,
-			WP_BASE_URL: pwConfig.use[ 0 ].baseURL,
+			WP_BASE_URL: pwConfig.use.baseURL,
 			WP_ARTIFACTS_PATH: resultsPath,
 			RESULTS_ID: `${ type }.${ round }`,
 		},

--- a/tools/e2e-commons/bin/update-beta-version.js
+++ b/tools/e2e-commons/bin/update-beta-version.js
@@ -24,7 +24,7 @@ function getAuthHeader() {
 async function getJetpackVersionFromSite() {
 	let response;
 	try {
-		response = await fetch( pwConfig.use[ 0 ].baseURL + '/index.php?rest_route=/wp/v2/plugins', {
+		response = await fetch( pwConfig.use.baseURL + '/index.php?rest_route=/wp/v2/plugins', {
 			headers: { Authorization: getAuthHeader() },
 		} );
 
@@ -52,7 +52,7 @@ async function getJetpackVersionFromSite() {
  */
 async function forcePluginUpdates() {
 	const response = await fetch(
-		pwConfig.use[ 0 ].baseURL + '/index.php?rest_route=/jp-e2e/v1/beta-autoupdate',
+		pwConfig.use.baseURL + '/index.php?rest_route=/jp-e2e/v1/beta-autoupdate',
 		{
 			method: 'POST',
 			headers: { Authorization: getAuthHeader() },

--- a/tools/e2e-commons/bin/update-beta-version.js
+++ b/tools/e2e-commons/bin/update-beta-version.js
@@ -1,8 +1,9 @@
 import { fileURLToPath } from 'url';
+import pwConfig from '../playwright.config.mjs';
 
 // Below call should be BEFORE requiring config, so library wil pick it up.
 process.env.NODE_CONFIG_DIR = fileURLToPath( new URL( '../config', import.meta.url ) );
-const { resolveSiteUrl, getSiteCredentials } = await import( '../helpers/utils-helper.js' );
+const { getSiteCredentials } = await import( '../helpers/utils-helper.js' );
 
 /**
  * Get HTTP Authentication header value
@@ -23,7 +24,7 @@ function getAuthHeader() {
 async function getJetpackVersionFromSite() {
 	let response;
 	try {
-		response = await fetch( resolveSiteUrl() + '/index.php?rest_route=/wp/v2/plugins', {
+		response = await fetch( pwConfig.use[ 0 ].baseURL + '/index.php?rest_route=/wp/v2/plugins', {
 			headers: { Authorization: getAuthHeader() },
 		} );
 
@@ -51,7 +52,7 @@ async function getJetpackVersionFromSite() {
  */
 async function forcePluginUpdates() {
 	const response = await fetch(
-		resolveSiteUrl() + '/index.php?rest_route=/jp-e2e/v1/beta-autoupdate',
+		pwConfig.use[ 0 ].baseURL + '/index.php?rest_route=/jp-e2e/v1/beta-autoupdate',
 		{
 			method: 'POST',
 			headers: { Authorization: getAuthHeader() },

--- a/tools/e2e-commons/flows/log-in.js
+++ b/tools/e2e-commons/flows/log-in.js
@@ -33,7 +33,7 @@ export async function loginToWpSite( page, mockPlanData ) {
 	if ( ! mockPlanData ) {
 		await (
 			await DashboardPage.init( page )
-		).setSandboxModeForPayments( cookie, new URL( pwConfig.use[ 0 ].baseURL ).host );
+		).setSandboxModeForPayments( cookie, new URL( pwConfig.use.baseURL ).host );
 	}
 }
 

--- a/tools/e2e-commons/flows/log-in.js
+++ b/tools/e2e-commons/flows/log-in.js
@@ -1,8 +1,8 @@
 import config from 'config';
-import { resolveSiteUrl } from '../helpers/utils-helper.js';
 import logger from '../logger.js';
 import { DashboardPage, WPLoginPage } from '../pages/wp-admin/index.js';
 import { LoginPage } from '../pages/wpcom/index.js';
+import pwConfig from '../playwright.config.mjs';
 
 const cookie = config.get( 'storeSandboxCookieValue' );
 
@@ -33,7 +33,7 @@ export async function loginToWpSite( page, mockPlanData ) {
 	if ( ! mockPlanData ) {
 		await (
 			await DashboardPage.init( page )
-		).setSandboxModeForPayments( cookie, new URL( resolveSiteUrl() ).host );
+		).setSandboxModeForPayments( cookie, new URL( pwConfig.use[ 0 ].baseURL ).host );
 	}
 }
 

--- a/tools/e2e-commons/helpers/partner-provisioning.js
+++ b/tools/e2e-commons/helpers/partner-provisioning.js
@@ -3,7 +3,8 @@ import * as url from 'url';
 import config from 'config';
 import shellescape from 'shell-escape';
 import logger from '../logger.js';
-import { execSyncShellCommand, execWpCommand, resolveSiteUrl } from './utils-helper.js';
+import pwConfig from '../playwright.config.mjs';
+import { execSyncShellCommand, execWpCommand } from './utils-helper.js';
 
 /**
  * Provisions Jetpack plan and connects the site through Jetpack Start flow
@@ -20,7 +21,9 @@ export async function provisionJetpackStartConnection( userId, plan = 'free', us
 	const cmd = `sh ${ path.resolve(
 		__dirname,
 		'../../partner-provision.sh'
-	) } --partner_id=${ clientID } --partner_secret=${ clientSecret } --user=${ user } --plan=${ plan } --url=${ resolveSiteUrl() } --wpcom_user_id=${ userId }`;
+	) } --partner_id=${ clientID } --partner_secret=${ clientSecret } --user=${ user } --plan=${ plan } --url=${
+		pwConfig.use[ 0 ].baseURL
+	} --wpcom_user_id=${ userId }`;
 
 	let response;
 	// catch a command failed error so that secrets are not logged

--- a/tools/e2e-commons/helpers/partner-provisioning.js
+++ b/tools/e2e-commons/helpers/partner-provisioning.js
@@ -22,7 +22,7 @@ export async function provisionJetpackStartConnection( userId, plan = 'free', us
 		__dirname,
 		'../../partner-provision.sh'
 	) } --partner_id=${ clientID } --partner_secret=${ clientSecret } --user=${ user } --plan=${ plan } --url=${
-		pwConfig.use[ 0 ].baseURL
+		pwConfig.use.baseURL
 	} --wpcom_user_id=${ userId }`;
 
 	let response;

--- a/tools/e2e-commons/helpers/plan-helper.js
+++ b/tools/e2e-commons/helpers/plan-helper.js
@@ -2,7 +2,8 @@ import fs from 'fs';
 import path from 'path';
 import config from 'config';
 import logger from '../logger.js';
-import { execWpCommand, resolveSiteUrl } from './utils-helper.js';
+import pwConfig from '../playwright.config.mjs';
+import { execWpCommand } from './utils-helper.js';
 
 /**
  * Persist plan data.
@@ -11,7 +12,7 @@ import { execWpCommand, resolveSiteUrl } from './utils-helper.js';
 export async function persistPlanData( planType = 'jetpack_complete' ) {
 	const planDataOption = 'e2e_jetpack_plan_data';
 	const siteId = await getSiteId();
-	const planData = getPlanData( siteId, resolveSiteUrl(), planType );
+	const planData = getPlanData( siteId, pwConfig.use[ 0 ].baseURL, planType );
 	const planDatafilePath = path.resolve( config.get( 'temp.planData' ) );
 
 	fs.writeFileSync( planDatafilePath, JSON.stringify( planData ) );

--- a/tools/e2e-commons/helpers/plan-helper.js
+++ b/tools/e2e-commons/helpers/plan-helper.js
@@ -12,7 +12,7 @@ import { execWpCommand } from './utils-helper.js';
 export async function persistPlanData( planType = 'jetpack_complete' ) {
 	const planDataOption = 'e2e_jetpack_plan_data';
 	const siteId = await getSiteId();
-	const planData = getPlanData( siteId, pwConfig.use[ 0 ].baseURL, planType );
+	const planData = getPlanData( siteId, pwConfig.use.baseURL, planType );
 	const planDatafilePath = path.resolve( config.get( 'temp.planData' ) );
 
 	fs.writeFileSync( planDatafilePath, JSON.stringify( planData ) );

--- a/tools/e2e-commons/helpers/utils-helper.js
+++ b/tools/e2e-commons/helpers/utils-helper.js
@@ -3,7 +3,6 @@ import fs from 'fs';
 import path from 'path';
 import config from 'config';
 import logger from '../logger.js';
-import pwConfig from '../playwright.config.mjs';
 const { E2E_DEBUG } = process.env;
 export const BASE_DOCKER_CMD = 'pnpm jetpack docker --type e2e --name t1';
 
@@ -93,7 +92,7 @@ export async function activateModule( page, module ) {
  * @return {Promise<string>} output
  */
 export async function execWpCommand( wpCmd, sendUrl = true ) {
-	const urlArgument = sendUrl ? `--url="${ pwConfig.use.baseURL }"` : '';
+	const urlArgument = sendUrl ? `--url="${ resolveSiteUrl() }"` : '';
 	const cmd = `${ BASE_DOCKER_CMD } wp -- ${ wpCmd } ${ urlArgument }`;
 	let result = await execShellCommand( cmd );
 
@@ -333,7 +332,7 @@ export async function logEnvironment() {
 		}
 
 		const credentials = getSiteCredentials();
-		const plugins = await fetch( pwConfig.use.baseURL + '/index.php?rest_route=/wp/v2/plugins', {
+		const plugins = await fetch( resolveSiteUrl() + '/index.php?rest_route=/wp/v2/plugins', {
 			headers: {
 				Authorization:
 					'Basic ' +

--- a/tools/e2e-commons/helpers/utils-helper.js
+++ b/tools/e2e-commons/helpers/utils-helper.js
@@ -93,7 +93,7 @@ export async function activateModule( page, module ) {
  * @return {Promise<string>} output
  */
 export async function execWpCommand( wpCmd, sendUrl = true ) {
-	const urlArgument = sendUrl ? `--url="${ pwConfig.use[ 0 ].baseURL }"` : '';
+	const urlArgument = sendUrl ? `--url="${ pwConfig.use.baseURL }"` : '';
 	const cmd = `${ BASE_DOCKER_CMD } wp -- ${ wpCmd } ${ urlArgument }`;
 	let result = await execShellCommand( cmd );
 
@@ -215,7 +215,7 @@ export function setWpEnvVars() {
 	const site = getConfigTestSite();
 	const storage = config.get( 'temp.storage' );
 
-	process.env.WP_BASE_URL = pwConfig.use[ 0 ].baseURL;
+	process.env.WP_BASE_URL = resolveSiteUrl();
 	process.env.WP_USERNAME = site.username;
 	process.env.WP_PASSWORD = site.password;
 	if ( storage ) {
@@ -333,18 +333,13 @@ export async function logEnvironment() {
 		}
 
 		const credentials = getSiteCredentials();
-		const plugins = await fetch(
-			pwConfig.use[ 0 ].baseURL + '/index.php?rest_route=/wp/v2/plugins',
-			{
-				headers: {
-					Authorization:
-						'Basic ' +
-						Buffer.from( credentials.username + ':' + credentials.apiPassword ).toString(
-							'base64'
-						),
-				},
-			}
-		).then( res => res.json() );
+		const plugins = await fetch( pwConfig.use.baseURL + '/index.php?rest_route=/wp/v2/plugins', {
+			headers: {
+				Authorization:
+					'Basic ' +
+					Buffer.from( credentials.username + ':' + credentials.apiPassword ).toString( 'base64' ),
+			},
+		} ).then( res => res.json() );
 
 		for ( const p of plugins ) {
 			env.plugins.push( {

--- a/tools/e2e-commons/helpers/utils-helper.js
+++ b/tools/e2e-commons/helpers/utils-helper.js
@@ -3,6 +3,7 @@ import fs from 'fs';
 import path from 'path';
 import config from 'config';
 import logger from '../logger.js';
+import pwConfig from '../playwright.config.mjs';
 const { E2E_DEBUG } = process.env;
 export const BASE_DOCKER_CMD = 'pnpm jetpack docker --type e2e --name t1';
 
@@ -92,7 +93,7 @@ export async function activateModule( page, module ) {
  * @return {Promise<string>} output
  */
 export async function execWpCommand( wpCmd, sendUrl = true ) {
-	const urlArgument = sendUrl ? `--url="${ resolveSiteUrl() }"` : '';
+	const urlArgument = sendUrl ? `--url="${ pwConfig.use[ 0 ].baseURL }"` : '';
 	const cmd = `${ BASE_DOCKER_CMD } wp -- ${ wpCmd } ${ urlArgument }`;
 	let result = await execShellCommand( cmd );
 
@@ -214,7 +215,7 @@ export function setWpEnvVars() {
 	const site = getConfigTestSite();
 	const storage = config.get( 'temp.storage' );
 
-	process.env.WP_BASE_URL = resolveSiteUrl();
+	process.env.WP_BASE_URL = pwConfig.use[ 0 ].baseURL;
 	process.env.WP_USERNAME = site.username;
 	process.env.WP_PASSWORD = site.password;
 	if ( storage ) {
@@ -332,13 +333,18 @@ export async function logEnvironment() {
 		}
 
 		const credentials = getSiteCredentials();
-		const plugins = await fetch( resolveSiteUrl() + '/index.php?rest_route=/wp/v2/plugins', {
-			headers: {
-				Authorization:
-					'Basic ' +
-					Buffer.from( credentials.username + ':' + credentials.apiPassword ).toString( 'base64' ),
-			},
-		} ).then( res => res.json() );
+		const plugins = await fetch(
+			pwConfig.use[ 0 ].baseURL + '/index.php?rest_route=/wp/v2/plugins',
+			{
+				headers: {
+					Authorization:
+						'Basic ' +
+						Buffer.from( credentials.username + ':' + credentials.apiPassword ).toString(
+							'base64'
+						),
+				},
+			}
+		).then( res => res.json() );
 
 		for ( const p of plugins ) {
 			env.plugins.push( {

--- a/tools/e2e-commons/pages/frontend/postFrontend.js
+++ b/tools/e2e-commons/pages/frontend/postFrontend.js
@@ -1,9 +1,9 @@
-import { resolveSiteUrl } from '../../helpers/utils-helper.js';
+import pwConfig from '../../playwright.config.mjs';
 import WpPage from '../wp-page.js';
 
 export default class PostFrontendPage extends WpPage {
 	constructor( page ) {
-		const url = resolveSiteUrl();
+		const url = pwConfig.use[ 0 ].baseURL;
 		super( page, { url } );
 	}
 

--- a/tools/e2e-commons/pages/frontend/postFrontend.js
+++ b/tools/e2e-commons/pages/frontend/postFrontend.js
@@ -3,7 +3,7 @@ import WpPage from '../wp-page.js';
 
 export default class PostFrontendPage extends WpPage {
 	constructor( page ) {
-		const url = pwConfig.use[ 0 ].baseURL;
+		const url = pwConfig.use.baseURL;
 		super( page, { url } );
 	}
 

--- a/tools/e2e-commons/pages/frontend/site-page.js
+++ b/tools/e2e-commons/pages/frontend/site-page.js
@@ -3,7 +3,7 @@ import WpPage from '../wp-page.js';
 
 export default class SitePage extends WpPage {
 	constructor( page ) {
-		const url = pwConfig.use[ 0 ].baseURL;
+		const url = pwConfig.use.baseURL;
 		super( page, { url } );
 	}
 }

--- a/tools/e2e-commons/pages/frontend/site-page.js
+++ b/tools/e2e-commons/pages/frontend/site-page.js
@@ -1,9 +1,9 @@
-import { resolveSiteUrl } from '../../helpers/utils-helper.js';
+import pwConfig from '../../playwright.config.mjs';
 import WpPage from '../wp-page.js';
 
 export default class SitePage extends WpPage {
 	constructor( page ) {
-		const url = resolveSiteUrl();
+		const url = pwConfig.use[ 0 ].baseURL;
 		super( page, { url } );
 	}
 }

--- a/tools/e2e-commons/pages/wp-admin/block-editor.js
+++ b/tools/e2e-commons/pages/wp-admin/block-editor.js
@@ -1,9 +1,9 @@
-import { resolveSiteUrl } from '../../helpers/utils-helper.js';
+import pwConfig from '../../playwright.config.mjs';
 import WpPage from '../wp-page.js';
 
 export default class BlockEditorPage extends WpPage {
 	constructor( page ) {
-		const url = resolveSiteUrl() + '/wp-admin/post-new.php';
+		const url = pwConfig.use[ 0 ].baseURL + '/wp-admin/post-new.php';
 		super( page, { expectedSelectors: [ '#editor' ], url } );
 	}
 

--- a/tools/e2e-commons/pages/wp-admin/block-editor.js
+++ b/tools/e2e-commons/pages/wp-admin/block-editor.js
@@ -3,7 +3,7 @@ import WpPage from '../wp-page.js';
 
 export default class BlockEditorPage extends WpPage {
 	constructor( page ) {
-		const url = pwConfig.use[ 0 ].baseURL + '/wp-admin/post-new.php';
+		const url = pwConfig.use.baseURL + '/wp-admin/post-new.php';
 		super( page, { expectedSelectors: [ '#editor' ], url } );
 	}
 

--- a/tools/e2e-commons/pages/wp-admin/blocks/mailchimp.js
+++ b/tools/e2e-commons/pages/wp-admin/blocks/mailchimp.js
@@ -67,7 +67,7 @@ export default class MailchimpBlock extends EditorCanvas {
 			// Quick fix for redirect URL not working with site ID
 			const workingUrl = connectionsUrl.replace(
 				/\d+/,
-				pwConfig.use[ 0 ].baseURL.replace( 'https://', '' )
+				pwConfig.use.baseURL.replace( 'https://', '' )
 			);
 			await wpComTab.goto( workingUrl );
 
@@ -118,7 +118,7 @@ export default class MailchimpBlock extends EditorCanvas {
 	async isMailchimpConnected() {
 		let connectionStatus = '';
 		try {
-			const url = `${ pwConfig.use[ 0 ].baseURL }/index.php?rest_route=/wpcom/v2/mailchimp&_locale=user`;
+			const url = `${ pwConfig.use.baseURL }/index.php?rest_route=/wpcom/v2/mailchimp&_locale=user`;
 			const res = await axios.get( url );
 			logger.debug( JSON.stringify( res.data ) );
 			connectionStatus = res.data.code;

--- a/tools/e2e-commons/pages/wp-admin/blocks/mailchimp.js
+++ b/tools/e2e-commons/pages/wp-admin/blocks/mailchimp.js
@@ -1,6 +1,6 @@
 import axios from 'axios';
-import { resolveSiteUrl } from '../../../helpers/utils-helper.js';
 import logger from '../../../logger.js';
+import pwConfig from '../../../playwright.config.mjs';
 import { LoginPage, ConnectionsPage } from '../../wpcom/index.js';
 import EditorCanvas from './editor-canvas.js';
 
@@ -67,7 +67,7 @@ export default class MailchimpBlock extends EditorCanvas {
 			// Quick fix for redirect URL not working with site ID
 			const workingUrl = connectionsUrl.replace(
 				/\d+/,
-				resolveSiteUrl().replace( 'https://', '' )
+				pwConfig.use[ 0 ].baseURL.replace( 'https://', '' )
 			);
 			await wpComTab.goto( workingUrl );
 
@@ -118,7 +118,7 @@ export default class MailchimpBlock extends EditorCanvas {
 	async isMailchimpConnected() {
 		let connectionStatus = '';
 		try {
-			const url = `${ resolveSiteUrl() }/index.php?rest_route=/wpcom/v2/mailchimp&_locale=user`;
+			const url = `${ pwConfig.use[ 0 ].baseURL }/index.php?rest_route=/wpcom/v2/mailchimp&_locale=user`;
 			const res = await axios.get( url );
 			logger.debug( JSON.stringify( res.data ) );
 			connectionStatus = res.data.code;

--- a/tools/e2e-commons/pages/wp-admin/dashboard.js
+++ b/tools/e2e-commons/pages/wp-admin/dashboard.js
@@ -4,7 +4,7 @@ import WpPage from '../wp-page.js';
 
 export default class DashboardPage extends WpPage {
 	constructor( page ) {
-		const url = `${ pwConfig.use[ 0 ].baseURL }/wp-admin`;
+		const url = `${ pwConfig.use.baseURL }/wp-admin`;
 		super( page, { expectedSelectors: [ '#dashboard-widgets-wrap' ], url } );
 	}
 

--- a/tools/e2e-commons/pages/wp-admin/dashboard.js
+++ b/tools/e2e-commons/pages/wp-admin/dashboard.js
@@ -1,10 +1,10 @@
-import { resolveSiteUrl } from '../../helpers/utils-helper.js';
+import pwConfig from '../../playwright.config.mjs';
 import PageActions from '../page-actions.js';
 import WpPage from '../wp-page.js';
 
 export default class DashboardPage extends WpPage {
 	constructor( page ) {
-		const url = `${ resolveSiteUrl() }/wp-admin`;
+		const url = `${ pwConfig.use[ 0 ].baseURL }/wp-admin`;
 		super( page, { expectedSelectors: [ '#dashboard-widgets-wrap' ], url } );
 	}
 

--- a/tools/e2e-commons/pages/wp-admin/jetpack-dashboard.js
+++ b/tools/e2e-commons/pages/wp-admin/jetpack-dashboard.js
@@ -4,7 +4,7 @@ import WpPage from '../wp-page.js';
 
 export default class JetpackDashboardPage extends WpPage {
 	constructor( page ) {
-		const url = pwConfig.use[ 0 ].baseURL + '/wp-admin/admin.php?page=jetpack#/dashboard';
+		const url = pwConfig.use.baseURL + '/wp-admin/admin.php?page=jetpack#/dashboard';
 		super( page, { expectedSelectors: [ '#jp-plugin-container', '.jp-at-a-glance' ], url } );
 	}
 

--- a/tools/e2e-commons/pages/wp-admin/jetpack-dashboard.js
+++ b/tools/e2e-commons/pages/wp-admin/jetpack-dashboard.js
@@ -1,10 +1,10 @@
-import { resolveSiteUrl } from '../../helpers/utils-helper.js';
 import logger from '../../logger.js';
+import pwConfig from '../../playwright.config.mjs';
 import WpPage from '../wp-page.js';
 
 export default class JetpackDashboardPage extends WpPage {
 	constructor( page ) {
-		const url = resolveSiteUrl() + '/wp-admin/admin.php?page=jetpack#/dashboard';
+		const url = pwConfig.use[ 0 ].baseURL + '/wp-admin/admin.php?page=jetpack#/dashboard';
 		super( page, { expectedSelectors: [ '#jp-plugin-container', '.jp-at-a-glance' ], url } );
 	}
 

--- a/tools/e2e-commons/pages/wp-admin/jetpack-my-plan.js
+++ b/tools/e2e-commons/pages/wp-admin/jetpack-my-plan.js
@@ -4,7 +4,7 @@ import WpPage from '../wp-page.js';
 
 export default class JetpackMyPlanPage extends WpPage {
 	constructor( page ) {
-		const url = pwConfig.use[ 0 ].baseURL + '/wp-admin/admin.php?page=jetpack#/my-plan';
+		const url = pwConfig.use.baseURL + '/wp-admin/admin.php?page=jetpack#/my-plan';
 		super( page, { expectedSelectors: [ '#jp-plugin-container', '.jp-landing__plans' ], url } );
 	}
 

--- a/tools/e2e-commons/pages/wp-admin/jetpack-my-plan.js
+++ b/tools/e2e-commons/pages/wp-admin/jetpack-my-plan.js
@@ -1,10 +1,10 @@
-import { resolveSiteUrl } from '../../helpers/utils-helper.js';
 import logger from '../../logger.js';
+import pwConfig from '../../playwright.config.mjs';
 import WpPage from '../wp-page.js';
 
 export default class JetpackMyPlanPage extends WpPage {
 	constructor( page ) {
-		const url = resolveSiteUrl() + '/wp-admin/admin.php?page=jetpack#/my-plan';
+		const url = pwConfig.use[ 0 ].baseURL + '/wp-admin/admin.php?page=jetpack#/my-plan';
 		super( page, { expectedSelectors: [ '#jp-plugin-container', '.jp-landing__plans' ], url } );
 	}
 

--- a/tools/e2e-commons/pages/wp-admin/jetpack.js
+++ b/tools/e2e-commons/pages/wp-admin/jetpack.js
@@ -4,7 +4,7 @@ import WpPage from '../wp-page.js';
 
 export default class JetpackPage extends WpPage {
 	constructor( page ) {
-		const url = pwConfig.use[ 0 ].baseURL + '/wp-admin/admin.php?page=jetpack#/';
+		const url = pwConfig.use.baseURL + '/wp-admin/admin.php?page=jetpack#/';
 		super( page, { expectedSelectors: [ '#jp-plugin-container' ], url } );
 	}
 

--- a/tools/e2e-commons/pages/wp-admin/jetpack.js
+++ b/tools/e2e-commons/pages/wp-admin/jetpack.js
@@ -1,10 +1,10 @@
-import { resolveSiteUrl } from '../../helpers/utils-helper.js';
 import logger from '../../logger.js';
+import pwConfig from '../../playwright.config.mjs';
 import WpPage from '../wp-page.js';
 
 export default class JetpackPage extends WpPage {
 	constructor( page ) {
-		const url = resolveSiteUrl() + '/wp-admin/admin.php?page=jetpack#/';
+		const url = pwConfig.use[ 0 ].baseURL + '/wp-admin/admin.php?page=jetpack#/';
 		super( page, { expectedSelectors: [ '#jp-plugin-container' ], url } );
 	}
 

--- a/tools/e2e-commons/pages/wp-admin/login.js
+++ b/tools/e2e-commons/pages/wp-admin/login.js
@@ -1,11 +1,12 @@
-import { getSiteCredentials, resolveSiteUrl } from '../../helpers/utils-helper.js';
+import { getSiteCredentials } from '../../helpers/utils-helper.js';
 import logger from '../../logger.js';
+import pwConfig from '../../playwright.config.mjs';
 import { takeScreenshot } from '../../reporters/index.js';
 import WpPage from '../wp-page.js';
 
 export default class WPLoginPage extends WpPage {
 	constructor( page ) {
-		const url = `${ resolveSiteUrl() }/wp-login.php`;
+		const url = `${ pwConfig.use[ 0 ].baseURL }/wp-login.php`;
 		super( page, { expectedSelectors: [ '#loginform' ], url } );
 	}
 

--- a/tools/e2e-commons/pages/wp-admin/login.js
+++ b/tools/e2e-commons/pages/wp-admin/login.js
@@ -6,7 +6,7 @@ import WpPage from '../wp-page.js';
 
 export default class WPLoginPage extends WpPage {
 	constructor( page ) {
-		const url = `${ pwConfig.use[ 0 ].baseURL }/wp-login.php`;
+		const url = `${ pwConfig.use.baseURL }/wp-login.php`;
 		super( page, { expectedSelectors: [ '#loginform' ], url } );
 	}
 

--- a/tools/e2e-commons/pages/wp-admin/plugins.js
+++ b/tools/e2e-commons/pages/wp-admin/plugins.js
@@ -3,7 +3,7 @@ import WpPage from '../wp-page.js';
 
 export default class PluginsPage extends WpPage {
 	constructor( page ) {
-		const url = `${ pwConfig.use[ 0 ].baseURL }/wp-admin/plugins.php`;
+		const url = `${ pwConfig.use.baseURL }/wp-admin/plugins.php`;
 		super( page, { expectedSelectors: [ '.search-box' ], url } );
 	}
 

--- a/tools/e2e-commons/pages/wp-admin/plugins.js
+++ b/tools/e2e-commons/pages/wp-admin/plugins.js
@@ -1,9 +1,9 @@
-import { resolveSiteUrl } from '../../helpers/utils-helper.js';
+import pwConfig from '../../playwright.config.mjs';
 import WpPage from '../wp-page.js';
 
 export default class PluginsPage extends WpPage {
 	constructor( page ) {
-		const url = `${ resolveSiteUrl() }/wp-admin/plugins.php`;
+		const url = `${ pwConfig.use[ 0 ].baseURL }/wp-admin/plugins.php`;
 		super( page, { expectedSelectors: [ '.search-box' ], url } );
 	}
 

--- a/tools/e2e-commons/pages/wp-admin/profile.js
+++ b/tools/e2e-commons/pages/wp-admin/profile.js
@@ -3,7 +3,7 @@ import WpPage from '../wp-page.js';
 
 export default class ProfilePage extends WpPage {
 	constructor( page ) {
-		const url = `${ pwConfig.use[ 0 ].baseURL }/wp-admin/profile.php`;
+		const url = `${ pwConfig.use.baseURL }/wp-admin/profile.php`;
 		super( page, { expectedSelectors: [ '#profile-page' ], url } );
 	}
 }

--- a/tools/e2e-commons/pages/wp-admin/profile.js
+++ b/tools/e2e-commons/pages/wp-admin/profile.js
@@ -1,9 +1,9 @@
-import { resolveSiteUrl } from '../../helpers/utils-helper.js';
+import pwConfig from '../../playwright.config.mjs';
 import WpPage from '../wp-page.js';
 
 export default class ProfilePage extends WpPage {
 	constructor( page ) {
-		const url = `${ resolveSiteUrl() }/wp-admin/profile.php`;
+		const url = `${ pwConfig.use[ 0 ].baseURL }/wp-admin/profile.php`;
 		super( page, { expectedSelectors: [ '#profile-page' ], url } );
 	}
 }

--- a/tools/e2e-commons/pages/wp-admin/recommendations.js
+++ b/tools/e2e-commons/pages/wp-admin/recommendations.js
@@ -1,9 +1,9 @@
-import { resolveSiteUrl } from '../../helpers/utils-helper.js';
+import pwConfig from '../../playwright.config.mjs';
 import WpPage from '../wp-page.js';
 
 export default class RecommendationsPage extends WpPage {
 	constructor( page ) {
-		const url = `${ resolveSiteUrl() }/wp-admin/admin.php?page=jetpack#/recommendations`;
+		const url = `${ pwConfig.use[ 0 ].baseURL }/wp-admin/admin.php?page=jetpack#/recommendations`;
 		super( page, { expectedSelectors: [ '[class^=jp-recommendations-]' ], url } );
 	}
 

--- a/tools/e2e-commons/pages/wp-admin/recommendations.js
+++ b/tools/e2e-commons/pages/wp-admin/recommendations.js
@@ -3,7 +3,7 @@ import WpPage from '../wp-page.js';
 
 export default class RecommendationsPage extends WpPage {
 	constructor( page ) {
-		const url = `${ pwConfig.use[ 0 ].baseURL }/wp-admin/admin.php?page=jetpack#/recommendations`;
+		const url = `${ pwConfig.use.baseURL }/wp-admin/admin.php?page=jetpack#/recommendations`;
 		super( page, { expectedSelectors: [ '[class^=jp-recommendations-]' ], url } );
 	}
 

--- a/tools/e2e-commons/pages/wp-admin/site-editor.js
+++ b/tools/e2e-commons/pages/wp-admin/site-editor.js
@@ -8,7 +8,7 @@ import { EditorCanvas } from './index.js';
 
 export default class SiteEditorPage extends WpPage {
 	constructor( page ) {
-		const url = pwConfig.use[ 0 ].baseURL + '/wp-admin/site-editor.php';
+		const url = pwConfig.use.baseURL + '/wp-admin/site-editor.php';
 		super( page, { expectedSelectors: [ '#site-editor' ], url } );
 
 		this.canvasPage = new EditorCanvas( page );

--- a/tools/e2e-commons/pages/wp-admin/site-editor.js
+++ b/tools/e2e-commons/pages/wp-admin/site-editor.js
@@ -1,14 +1,14 @@
 import { expect } from '@playwright/test';
 import { waitForBlock } from '../../helpers/blocks-helper.js';
-import { resolveSiteUrl } from '../../helpers/utils-helper.js';
 import logger from '../../logger.js';
+import pwConfig from '../../playwright.config.mjs';
 import { SitePage } from '../index.js';
 import WpPage from '../wp-page.js';
 import { EditorCanvas } from './index.js';
 
 export default class SiteEditorPage extends WpPage {
 	constructor( page ) {
-		const url = resolveSiteUrl() + '/wp-admin/site-editor.php';
+		const url = pwConfig.use[ 0 ].baseURL + '/wp-admin/site-editor.php';
 		super( page, { expectedSelectors: [ '#site-editor' ], url } );
 
 		this.canvasPage = new EditorCanvas( page );


### PR DESCRIPTION
## Proposed changes:

Simplifies E2E tests URL resolution by using baseURL directly from Playwright configuration instead of always resolving site URLs by reading the tunnels file.

### Other information:

- [x] N/A Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] N/A Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

E2E tests should pass in CI.
