### PR TITLE
PayPal Payments: Render single button preview in editor

### DIFF
--- a/projects/packages/paypal-payments/changelog/paypal-27-ensure-that-block-renders-a-preview
+++ b/projects/packages/paypal-payments/changelog/paypal-27-ensure-that-block-renders-a-preview
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update PayPal Payment Buttons block to support rendering previews

--- a/projects/packages/paypal-payments/src/paypal-payment-buttons/edit.js
+++ b/projects/packages/paypal-payments/src/paypal-payment-buttons/edit.js
@@ -69,10 +69,20 @@ const generateHeadCode = scriptSrc => {
 	return `<script src="${ scriptSrc }"></script>`;
 };
 
-const generateBodyCode = hostedButtonId => {
+const generateBodyCode = ( hostedButtonId, buttonType = 'stacked', buttonText = '' ) => {
 	if ( ! hostedButtonId ) {
 		return '';
 	}
+
+	if ( buttonType === 'single' ) {
+		return `<style>.pp-${ hostedButtonId }{text-align:center;border:none;border-radius:0.25rem;min-width:11.625rem;padding:0 2rem;height:2.625rem;font-weight:bold;background-color:#FFD140;color:#000000;font-family:"Helvetica Neue",Arial,sans-serif;font-size:1rem;line-height:1.25rem;cursor:pointer;}</style>
+<form action="https://www.paypal.com/ncp/payment/${ hostedButtonId }" method="post" target="_blank" style="display:inline-grid;justify-items:center;align-content:start;gap:0.5rem;">
+  <input class="pp-${ hostedButtonId }" type="submit" value="${ buttonText || 'Pay Now' }" />
+  <img src="https://www.paypalobjects.com/images/Debit_Credit_APM.svg" alt="cards" />
+  <section style="font-size: 0.75rem;"> Powered by <img src="https://www.paypalobjects.com/paypal-ui/logos/svg/paypal-wordmark-color.svg" alt="paypal" style="height:0.875rem;vertical-align:middle;"/></section>
+</form>`;
+	}
+
 	return `<div id="paypal-container-${ hostedButtonId }"></div>
 <script>
   paypal.HostedButtons({
@@ -213,9 +223,9 @@ export default function Edit( { attributes, setAttributes, isSelected } ) {
 
 	useEffect( () => {
 		if ( ! rawBodyCode && hostedButtonId ) {
-			setRawBodyCode( generateBodyCode( hostedButtonId ) );
+			setRawBodyCode( generateBodyCode( hostedButtonId, buttonType, buttonText ) );
 		}
-	}, [ hostedButtonId, rawBodyCode ] );
+	}, [ hostedButtonId, rawBodyCode, buttonType, buttonText ] );
 
 	useEffect( () => {
 		// Check if user has pasted invalid code that couldn't be extracted

--- a/projects/packages/paypal-payments/src/paypal-payment-buttons/edit.js
+++ b/projects/packages/paypal-payments/src/paypal-payment-buttons/edit.js
@@ -150,6 +150,26 @@ const PayPalSingleButtonPreview = ( { buttonText } ) => {
 };
 
 /**
+ * Check if we have the required data for a preview (only single buttons)
+ *
+ * @param {object} attributes - The block attributes
+ * @return {boolean} Whether preview can be shown
+ */
+const canShowPreview = attributes => {
+	const { buttonType, hostedButtonId, buttonText } = attributes;
+
+	if ( ! hostedButtonId || ! validHostedButtonId( hostedButtonId ) ) {
+		return false;
+	}
+
+	if ( buttonType === 'single' ) {
+		return buttonText && validButtonText( buttonText );
+	}
+
+	return false;
+};
+
+/**
  * PayPal Preview component router
  *
  * @param {object} root0            - The component props
@@ -157,22 +177,9 @@ const PayPalSingleButtonPreview = ( { buttonText } ) => {
  * @return {Element|null} The PayPal preview component or null
  */
 const PayPalPreview = ( { attributes } ) => {
-	const { buttonType, hostedButtonId, buttonText } = attributes;
+	const { buttonType, buttonText } = attributes;
 
-	// Check if we have the required data for a preview (only single buttons)
-	const canShowPreview = () => {
-		if ( ! hostedButtonId || ! validHostedButtonId( hostedButtonId ) ) {
-			return false;
-		}
-
-		if ( buttonType === 'single' ) {
-			return buttonText && validButtonText( buttonText );
-		}
-
-		return false;
-	};
-
-	if ( ! canShowPreview() ) {
+	if ( ! canShowPreview( attributes ) ) {
 		return (
 			<div
 				style={ {
@@ -284,16 +291,7 @@ export default function Edit( { attributes, setAttributes, isSelected } ) {
 		if ( isSelected || notice ) {
 			return false;
 		}
-
-		if ( ! hostedButtonId || ! validHostedButtonId( hostedButtonId ) ) {
-			return false;
-		}
-
-		if ( buttonType === 'single' ) {
-			return buttonText && validButtonText( buttonText );
-		}
-
-		return false;
+		return canShowPreview( attributes );
 	};
 
 	return (

--- a/projects/packages/paypal-payments/src/paypal-payment-buttons/edit.js
+++ b/projects/packages/paypal-payments/src/paypal-payment-buttons/edit.js
@@ -180,21 +180,7 @@ const PayPalPreview = ( { attributes } ) => {
 	const { buttonType, buttonText } = attributes;
 
 	if ( ! canShowPreview( attributes ) ) {
-		return (
-			<div
-				style={ {
-					padding: '40px 20px',
-					textAlign: 'center',
-					color: '#666',
-					fontStyle: 'italic',
-					border: '2px dashed #ddd',
-					borderRadius: '4px',
-					backgroundColor: '#f9f9f9',
-				} }
-			>
-				{ __( 'Configure PayPal button settings to see preview', 'jetpack-paypal-payments' ) }
-			</div>
-		);
+		return null;
 	}
 
 	// Only render preview for single button type

--- a/projects/packages/paypal-payments/src/paypal-payment-buttons/edit.js
+++ b/projects/packages/paypal-payments/src/paypal-payment-buttons/edit.js
@@ -89,7 +89,106 @@ const validHostedButtonId = hostedButtonId => /^[A-Z0-9]+$/.test( hostedButtonId
 const validButtonText = buttonText =>
 	buttonText && buttonText.trim().length > 0 && buttonText.length <= 50;
 
-export default function Edit( { attributes, setAttributes } ) {
+/**
+ * PayPal Single Button Preview component (rendered directly)
+ *
+ * @param {object} root0            - The component props
+ * @param {string} root0.buttonText - The button text
+ * @return {Element} The PayPal single button preview component
+ */
+const PayPalSingleButtonPreview = ( { buttonText } ) => {
+	const paypalButtonStyles = {
+		textAlign: 'center',
+		border: 'none',
+		borderRadius: '0.25rem',
+		minWidth: '11.625rem',
+		padding: '0 2rem',
+		height: '2.625rem',
+		fontWeight: 'bold',
+		backgroundColor: '#FFD140',
+		color: '#000000',
+		fontFamily: '"Helvetica Neue", Arial, sans-serif',
+		fontSize: '1rem',
+		lineHeight: '1.25rem',
+		cursor: 'pointer',
+		pointerEvents: 'none', // Prevent clicking in editor
+	};
+
+	return (
+		<div style={ { textAlign: 'center' } }>
+			<form
+				style={ {
+					display: 'inline-grid',
+					justifyItems: 'center',
+					alignContent: 'start',
+					gap: '0.5rem',
+				} }
+			>
+				<input type="button" value={ buttonText } style={ paypalButtonStyles } />
+				<img src="https://www.paypalobjects.com/images/Debit_Credit_APM.svg" alt="cards" />
+				<section style={ { fontSize: '0.75rem' } }>
+					Powered by{ ' ' }
+					<img
+						src="https://www.paypalobjects.com/paypal-ui/logos/svg/paypal-wordmark-color.svg"
+						alt="paypal"
+						style={ { height: '0.875rem', verticalAlign: 'middle' } }
+					/>
+				</section>
+			</form>
+		</div>
+	);
+};
+
+/**
+ * PayPal Preview component router
+ *
+ * @param {object} root0            - The component props
+ * @param {object} root0.attributes - The block attributes
+ * @return {Element|null} The PayPal preview component or null
+ */
+const PayPalPreview = ( { attributes } ) => {
+	const { buttonType, hostedButtonId, buttonText } = attributes;
+
+	// Check if we have the required data for a preview (only single buttons)
+	const canShowPreview = () => {
+		if ( ! hostedButtonId || ! validHostedButtonId( hostedButtonId ) ) {
+			return false;
+		}
+
+		if ( buttonType === 'single' ) {
+			return buttonText && validButtonText( buttonText );
+		}
+
+		return false;
+	};
+
+	if ( ! canShowPreview() ) {
+		return (
+			<div
+				style={ {
+					padding: '40px 20px',
+					textAlign: 'center',
+					color: '#666',
+					fontStyle: 'italic',
+					border: '2px dashed #ddd',
+					borderRadius: '4px',
+					backgroundColor: '#f9f9f9',
+				} }
+			>
+				{ __( 'Configure PayPal button settings to see preview', 'jetpack-paypal-payments' ) }
+			</div>
+		);
+	}
+
+	// Only render preview for single button type
+	if ( buttonType === 'single' ) {
+		return <PayPalSingleButtonPreview buttonText={ buttonText } />;
+	}
+
+	return null;
+};
+
+export default function Edit( { attributes, setAttributes, isSelected } ) {
 	const { buttonType, scriptSrc, hostedButtonId, buttonText } = attributes;
 	const [ notice, setNotice ] = useState( null );
 	const [ rawHeadCode, setRawHeadCode ] = useState( '' );
@@ -170,89 +269,110 @@ export default function Edit( { attributes, setAttributes } ) {
 		setNotice( null );
 	}, [ buttonType, scriptSrc, hostedButtonId, buttonText, rawHeadCode, rawBodyCode ] );
 
+	// Determine if we should show the preview (only for single buttons)
+	const shouldShowPreview = () => {
+		if ( isSelected || notice ) {
+			return false;
+		}
+
+		if ( ! hostedButtonId || ! validHostedButtonId( hostedButtonId ) ) {
+			return false;
+		}
+
+		if ( buttonType === 'single' ) {
+			return buttonText && validButtonText( buttonText );
+		}
+
+		return false;
+	};
+
 	return (
 		<div { ...useBlockProps() }>
-			<Placeholder
-				icon={ PayPalIcon }
-				label={ __( 'PayPal Payment Buttons', 'jetpack-paypal-payments' ) }
-				isColumnLayout
-				instructions={ buttonType === 'stacked' ? stackedInstructions : singleInstructions }
-				notices={ notice }
-			>
-				<ToggleGroupControl
-					label={ __( 'Button type', 'jetpack-paypal-payments' ) }
-					value={ buttonType }
-					hideLabelFromVision
-					onChange={ type => setAttributes( { buttonType: type } ) }
-					isBlock
-					__nextHasNoMarginBottom={ true }
-					__next40pxDefaultSize={ true }
+			{ shouldShowPreview() ? (
+				<PayPalPreview attributes={ attributes } />
+			) : (
+				<Placeholder
+					icon={ PayPalIcon }
+					label={ __( 'PayPal Payment Buttons', 'jetpack-paypal-payments' ) }
+					isColumnLayout
+					instructions={ buttonType === 'stacked' ? stackedInstructions : singleInstructions }
+					notices={ notice }
 				>
-					<ToggleGroupControlOption
-						value="stacked"
-						label={ __( 'Stacked Buttons (Recommended)', 'jetpack-paypal-payments' ) }
-						aria-label={ __(
-							'Stacked Buttons are the recommended option for better conversion rates.',
-							'jetpack-paypal-payments'
-						) }
-						showTooltip={ true }
-					/>
-					<ToggleGroupControlOption
-						value="single"
-						label={ __( 'Single Button', 'jetpack-paypal-payments' ) }
-					/>
-				</ToggleGroupControl>
-				<Text>
-					<strong>{ __( 'Instructions:', 'jetpack-paypal-payments' ) }</strong>
-				</Text>
-				<ItemGroup>
-					<Item>
-						1.{ ' ' }
-						<ExternalLink
-							href={ __( 'https://www.paypal.com/buttons/', 'jetpack-paypal-payments' ) }
-						>
-							{ __( 'Go to PayPal to get your button code', 'jetpack-paypal-payments' ) }
-						</ExternalLink>
-					</Item>
-					<Item>
-						{ __(
-							'2. After login, choose Payment Buttons. Enter your product or service details, and build the buttons. Copy the button code for Stacked Buttons (copy html code) or Single Button.',
-							'jetpack-paypal-payments'
-						) }
-					</Item>
-					<Item>{ __( '3. Paste the code below.', 'jetpack-paypal-payments' ) }</Item>
-				</ItemGroup>
-				{ 'stacked' === buttonType && (
+					<ToggleGroupControl
+						label={ __( 'Button type', 'jetpack-paypal-payments' ) }
+						value={ buttonType }
+						hideLabelFromVision
+						onChange={ type => setAttributes( { buttonType: type } ) }
+						isBlock
+						__nextHasNoMarginBottom={ true }
+						__next40pxDefaultSize={ true }
+					>
+						<ToggleGroupControlOption
+							value="stacked"
+							label={ __( 'Stacked Buttons (Recommended)', 'jetpack-paypal-payments' ) }
+							aria-label={ __(
+								'Stacked Buttons are the recommended option for better conversion rates.',
+								'jetpack-paypal-payments'
+							) }
+							showTooltip={ true }
+						/>
+						<ToggleGroupControlOption
+							value="single"
+							label={ __( 'Single Button', 'jetpack-paypal-payments' ) }
+						/>
+					</ToggleGroupControl>
+					<Text>
+						<strong>{ __( 'Instructions:', 'jetpack-paypal-payments' ) }</strong>
+					</Text>
+					<ItemGroup>
+						<Item>
+							1.{ ' ' }
+							<ExternalLink
+								href={ __( 'https://www.paypal.com/buttons/', 'jetpack-paypal-payments' ) }
+							>
+								{ __( 'Go to PayPal to get your button code', 'jetpack-paypal-payments' ) }
+							</ExternalLink>
+						</Item>
+						<Item>
+							{ __(
+								'2. After login, choose Payment Buttons. Enter your product or service details, and build the buttons. Copy the button code for Stacked Buttons (copy html code) or Single Button.',
+								'jetpack-paypal-payments'
+							) }
+						</Item>
+						<Item>{ __( '3. Paste the code below.', 'jetpack-paypal-payments' ) }</Item>
+					</ItemGroup>
+					{ 'stacked' === buttonType && (
+						<PlainText
+							value={ rawHeadCode }
+							onChange={ code => {
+								setRawHeadCode( code );
+								const extractedSrc = extractScriptSrc( code );
+								setAttributes( {
+									scriptSrc: extractedSrc,
+								} );
+							} }
+							placeholder={ __( 'Paste the head code here…', 'jetpack-paypal-payments' ) }
+							aria-label={ __( 'PayPal button head code', 'jetpack-paypal-payments' ) }
+							name="paypal-payment-buttons-code-head"
+						/>
+					) }
 					<PlainText
-						value={ rawHeadCode }
+						value={ rawBodyCode }
 						onChange={ code => {
-							setRawHeadCode( code );
-							const extractedSrc = extractScriptSrc( code );
+							setRawBodyCode( code );
+							const extractedButtonId = extractHostedButtonId( code );
+							const extractedButtonText = extractButtonText( code );
 							setAttributes( {
-								scriptSrc: extractedSrc,
+								hostedButtonId: extractedButtonId,
+								buttonText: extractedButtonText,
 							} );
 						} }
-						placeholder={ __( 'Paste the head code here…', 'jetpack-paypal-payments' ) }
-						aria-label={ __( 'PayPal button head code', 'jetpack-paypal-payments' ) }
-						name="paypal-payment-buttons-code-head"
+						placeholder={ __( 'Paste the code here…', 'jetpack-paypal-payments' ) }
+						aria-label={ __( 'PayPal button code', 'jetpack-paypal-payments' ) }
+						name="paypal-payment-buttons-code-body"
 					/>
-				) }
-				<PlainText
-					value={ rawBodyCode }
-					onChange={ code => {
-						setRawBodyCode( code );
-						const extractedButtonId = extractHostedButtonId( code );
-						const extractedButtonText = extractButtonText( code );
-						setAttributes( {
-							hostedButtonId: extractedButtonId,
-							buttonText: extractedButtonText,
-						} );
-					} }
-					placeholder={ __( 'Paste the code here…', 'jetpack-paypal-payments' ) }
-					aria-label={ __( 'PayPal button code', 'jetpack-paypal-payments' ) }
-					name="paypal-payment-buttons-code-body"
-				/>
-			</Placeholder>
+				</Placeholder>
+			) }
 		</div>
 	);
 }

--- a/projects/packages/paypal-payments/src/paypal-payment-buttons/edit.js
+++ b/projects/packages/paypal-payments/src/paypal-payment-buttons/edit.js
@@ -272,101 +272,100 @@ export default function Edit( { attributes, setAttributes, isSelected } ) {
 		setNotice( null );
 	}, [ buttonType, scriptSrc, hostedButtonId, buttonText, rawHeadCode, rawBodyCode ] );
 
-	// Determine if we should show the preview (only for single buttons)
-	const shouldShowPreview = () => {
-		if ( isSelected || notice ) {
-			return false;
-		}
-		return canShowPreview( attributes );
-	};
+	const blockProps = useBlockProps();
+
+	// Early return for preview rendering
+	if ( ! isSelected && ! notice && canShowPreview( attributes ) ) {
+		return (
+			<div { ...blockProps }>
+				<PayPalPreview attributes={ attributes } />
+			</div>
+		);
+	}
 
 	return (
-		<div { ...useBlockProps() }>
-			{ shouldShowPreview() ? (
-				<PayPalPreview attributes={ attributes } />
-			) : (
-				<Placeholder
-					icon={ PayPalIcon }
-					label={ __( 'PayPal Payment Buttons', 'jetpack-paypal-payments' ) }
-					isColumnLayout
-					instructions={ buttonType === 'stacked' ? stackedInstructions : singleInstructions }
-					notices={ notice }
+		<div { ...blockProps }>
+			<Placeholder
+				icon={ PayPalIcon }
+				label={ __( 'PayPal Payment Buttons', 'jetpack-paypal-payments' ) }
+				isColumnLayout
+				instructions={ buttonType === 'stacked' ? stackedInstructions : singleInstructions }
+				notices={ notice }
+			>
+				<ToggleGroupControl
+					label={ __( 'Button type', 'jetpack-paypal-payments' ) }
+					value={ buttonType }
+					hideLabelFromVision
+					onChange={ type => setAttributes( { buttonType: type } ) }
+					isBlock
+					__nextHasNoMarginBottom={ true }
+					__next40pxDefaultSize={ true }
 				>
-					<ToggleGroupControl
-						label={ __( 'Button type', 'jetpack-paypal-payments' ) }
-						value={ buttonType }
-						hideLabelFromVision
-						onChange={ type => setAttributes( { buttonType: type } ) }
-						isBlock
-						__nextHasNoMarginBottom={ true }
-						__next40pxDefaultSize={ true }
-					>
-						<ToggleGroupControlOption
-							value="stacked"
-							label={ __( 'Stacked Buttons (Recommended)', 'jetpack-paypal-payments' ) }
-							aria-label={ __(
-								'Stacked Buttons are the recommended option for better conversion rates.',
-								'jetpack-paypal-payments'
-							) }
-							showTooltip={ true }
-						/>
-						<ToggleGroupControlOption
-							value="single"
-							label={ __( 'Single Button', 'jetpack-paypal-payments' ) }
-						/>
-					</ToggleGroupControl>
-					<Text>
-						<strong>{ __( 'Instructions:', 'jetpack-paypal-payments' ) }</strong>
-					</Text>
-					<ItemGroup>
-						<Item>
-							1.{ ' ' }
-							<ExternalLink
-								href={ __( 'https://www.paypal.com/buttons/', 'jetpack-paypal-payments' ) }
-							>
-								{ __( 'Go to PayPal to get your button code', 'jetpack-paypal-payments' ) }
-							</ExternalLink>
-						</Item>
-						<Item>
-							{ __(
-								'2. After login, choose Payment Buttons. Enter your product or service details, and build the buttons. Copy the button code for Stacked Buttons (copy html code) or Single Button.',
-								'jetpack-paypal-payments'
-							) }
-						</Item>
-						<Item>{ __( '3. Paste the code below.', 'jetpack-paypal-payments' ) }</Item>
-					</ItemGroup>
-					{ 'stacked' === buttonType && (
-						<PlainText
-							value={ rawHeadCode }
-							onChange={ code => {
-								setRawHeadCode( code );
-								const extractedSrc = extractScriptSrc( code );
-								setAttributes( {
-									scriptSrc: extractedSrc,
-								} );
-							} }
-							placeholder={ __( 'Paste the head code here…', 'jetpack-paypal-payments' ) }
-							aria-label={ __( 'PayPal button head code', 'jetpack-paypal-payments' ) }
-							name="paypal-payment-buttons-code-head"
-						/>
-					) }
+					<ToggleGroupControlOption
+						value="stacked"
+						label={ __( 'Stacked Buttons (Recommended)', 'jetpack-paypal-payments' ) }
+						aria-label={ __(
+							'Stacked Buttons are the recommended option for better conversion rates.',
+							'jetpack-paypal-payments'
+						) }
+						showTooltip={ true }
+					/>
+					<ToggleGroupControlOption
+						value="single"
+						label={ __( 'Single Button', 'jetpack-paypal-payments' ) }
+					/>
+				</ToggleGroupControl>
+				<Text>
+					<strong>{ __( 'Instructions:', 'jetpack-paypal-payments' ) }</strong>
+				</Text>
+				<ItemGroup>
+					<Item>
+						1.{ ' ' }
+						<ExternalLink
+							href={ __( 'https://www.paypal.com/buttons/', 'jetpack-paypal-payments' ) }
+						>
+							{ __( 'Go to PayPal to get your button code', 'jetpack-paypal-payments' ) }
+						</ExternalLink>
+					</Item>
+					<Item>
+						{ __(
+							'2. After login, choose Payment Buttons. Enter your product or service details, and build the buttons. Copy the button code for Stacked Buttons (copy html code) or Single Button.',
+							'jetpack-paypal-payments'
+						) }
+					</Item>
+					<Item>{ __( '3. Paste the code below.', 'jetpack-paypal-payments' ) }</Item>
+				</ItemGroup>
+				{ 'stacked' === buttonType && (
 					<PlainText
-						value={ rawBodyCode }
+						value={ rawHeadCode }
 						onChange={ code => {
-							setRawBodyCode( code );
-							const extractedButtonId = extractHostedButtonId( code );
-							const extractedButtonText = extractButtonText( code );
+							setRawHeadCode( code );
+							const extractedSrc = extractScriptSrc( code );
 							setAttributes( {
-								hostedButtonId: extractedButtonId,
-								buttonText: extractedButtonText,
+								scriptSrc: extractedSrc,
 							} );
 						} }
-						placeholder={ __( 'Paste the code here…', 'jetpack-paypal-payments' ) }
-						aria-label={ __( 'PayPal button code', 'jetpack-paypal-payments' ) }
-						name="paypal-payment-buttons-code-body"
+						placeholder={ __( 'Paste the head code here…', 'jetpack-paypal-payments' ) }
+						aria-label={ __( 'PayPal button head code', 'jetpack-paypal-payments' ) }
+						name="paypal-payment-buttons-code-head"
 					/>
-				</Placeholder>
-			) }
+				) }
+				<PlainText
+					value={ rawBodyCode }
+					onChange={ code => {
+						setRawBodyCode( code );
+						const extractedButtonId = extractHostedButtonId( code );
+						const extractedButtonText = extractButtonText( code );
+						setAttributes( {
+							hostedButtonId: extractedButtonId,
+							buttonText: extractedButtonText,
+						} );
+					} }
+					placeholder={ __( 'Paste the code here…', 'jetpack-paypal-payments' ) }
+					aria-label={ __( 'PayPal button code', 'jetpack-paypal-payments' ) }
+					name="paypal-payment-buttons-code-body"
+				/>
+			</Placeholder>
 		</div>
 	);
 }

--- a/projects/packages/paypal-payments/tests/js/paypal-payment-buttons-block-tests/edit.test.js
+++ b/projects/packages/paypal-payments/tests/js/paypal-payment-buttons-block-tests/edit.test.js
@@ -99,10 +99,14 @@ describe( 'Edit', () => {
 			buttonText: '',
 		},
 		setAttributes: jest.fn(),
+		isSelected: true,
 	};
 
 	beforeEach( () => {
 		jest.clearAllMocks();
+
+		// Mock window.ajaxurl for iframe preview
+		global.window.ajaxurl = 'https://example.com/wp-admin/admin-ajax.php';
 	} );
 
 	it( 'renders without crashing', () => {
@@ -132,6 +136,7 @@ describe( 'Edit', () => {
 					buttonType: 'single',
 				} }
 				setAttributes={ defaultProps.setAttributes }
+				isSelected={ true }
 			/>
 		);
 
@@ -142,7 +147,13 @@ describe( 'Edit', () => {
 
 	it( 'updates buttonType when toggle is clicked', () => {
 		const setAttributes = jest.fn();
-		render( <Edit attributes={ defaultProps.attributes } setAttributes={ setAttributes } /> );
+		render(
+			<Edit
+				attributes={ defaultProps.attributes }
+				setAttributes={ setAttributes }
+				isSelected={ true }
+			/>
+		);
 
 		fireEvent.click( screen.getByTestId( 'toggle-option-single' ) ); // eslint-disable-line testing-library/prefer-user-event
 		expect( setAttributes ).toHaveBeenCalledWith( {
@@ -153,7 +164,11 @@ describe( 'Edit', () => {
 	it( 'updates scriptSrc when head code is entered', () => {
 		const setAttributes = jest.fn();
 		render(
-			<Edit attributes={ { ...defaultProps.attributes } } setAttributes={ setAttributes } />
+			<Edit
+				attributes={ { ...defaultProps.attributes } }
+				setAttributes={ setAttributes }
+				isSelected={ true }
+			/>
 		);
 
 		const inputs = screen.getAllByTestId( 'plain-text' );
@@ -171,7 +186,11 @@ describe( 'Edit', () => {
 	it( 'updates hostedButtonId when body code is entered', () => {
 		const setAttributes = jest.fn();
 		render(
-			<Edit attributes={ { ...defaultProps.attributes } } setAttributes={ setAttributes } />
+			<Edit
+				attributes={ { ...defaultProps.attributes } }
+				setAttributes={ setAttributes }
+				isSelected={ true }
+			/>
 		);
 
 		const inputs = screen.getAllByTestId( 'plain-text' );
@@ -196,6 +215,7 @@ describe( 'Edit', () => {
 			<Edit
 				attributes={ { ...defaultProps.attributes, buttonType: 'single' } }
 				setAttributes={ setAttributes }
+				isSelected={ true }
 			/>
 		);
 
@@ -350,6 +370,7 @@ describe( 'Edit', () => {
 						buttonType: 'single',
 					} }
 					setAttributes={ defaultProps.setAttributes }
+					isSelected={ true }
 				/>
 			);
 			const items = screen.getAllByTestId( 'item' );
@@ -359,6 +380,100 @@ describe( 'Edit', () => {
 				'2. After login, choose Payment Buttons. Enter your product or service details, and build the buttons. Copy the button code for Stacked Buttons (copy html code) or Single Button.'
 			);
 			expect( items[ 2 ] ).toHaveTextContent( '3. Paste the code below.' );
+		} );
+	} );
+
+	describe( 'Preview Functionality', () => {
+		it( 'shows no preview for stacked buttons', () => {
+			render(
+				<Edit
+					attributes={ {
+						buttonType: 'stacked',
+						scriptSrc: 'https://www.paypal.com/sdk/js?client-id=test',
+						hostedButtonId: 'ABC123DEF',
+					} }
+					setAttributes={ jest.fn() }
+					isSelected={ false }
+				/>
+			);
+
+			// Should show the configuration form since stacked button previews are disabled
+			expect( screen.getByTestId( 'placeholder' ) ).toBeInTheDocument();
+			expect( screen.queryByTitle( 'PayPal Button Preview' ) ).not.toBeInTheDocument();
+		} );
+
+		it( 'shows direct button preview when block is not selected and has valid single button data', () => {
+			render(
+				<Edit
+					attributes={ {
+						buttonType: 'single',
+						hostedButtonId: 'ABC123DEF',
+						buttonText: 'Buy Now',
+					} }
+					setAttributes={ jest.fn() }
+					isSelected={ false }
+				/>
+			);
+
+			// Single button should render directly, not in iframe
+			const button = screen.getByDisplayValue( 'Buy Now' );
+			expect( button ).toBeInTheDocument();
+			expect( button ).toHaveAttribute( 'type', 'button' );
+			expect( screen.queryByTitle( 'PayPal Button Preview' ) ).not.toBeInTheDocument();
+		} );
+
+		it( 'shows placeholder when block is not selected but data is invalid', () => {
+			render(
+				<Edit
+					attributes={ {
+						buttonType: 'single',
+						hostedButtonId: '',
+						buttonText: '',
+					} }
+					setAttributes={ jest.fn() }
+					isSelected={ false }
+				/>
+			);
+
+			// Should show the configuration form, not the preview
+			expect( screen.getByTestId( 'placeholder' ) ).toBeInTheDocument();
+			expect( screen.queryByTitle( 'PayPal Button Preview' ) ).not.toBeInTheDocument();
+		} );
+
+		it( 'shows settings form when block is selected', () => {
+			render(
+				<Edit
+					attributes={ {
+						buttonType: 'single',
+						hostedButtonId: 'ABC123DEF',
+						buttonText: 'Buy Now',
+					} }
+					setAttributes={ jest.fn() }
+					isSelected={ true }
+				/>
+			);
+
+			expect( screen.getByTestId( 'placeholder' ) ).toBeInTheDocument();
+			expect( screen.queryByTitle( 'PayPal Button Preview' ) ).not.toBeInTheDocument();
+		} );
+
+		it( 'shows preview placeholder message when data is incomplete', () => {
+			// Mock the preview component to show up, but with incomplete data
+			render(
+				<Edit
+					attributes={ {
+						buttonType: 'single',
+						hostedButtonId: '', // Missing button ID
+						buttonText: '',
+					} }
+					setAttributes={ jest.fn() }
+					isSelected={ false }
+				/>
+			);
+
+			// Should show the configuration form since data is incomplete
+			expect( screen.getByTestId( 'placeholder' ) ).toBeInTheDocument();
+			expect( screen.queryByTitle( 'PayPal Button Preview' ) ).not.toBeInTheDocument();
 		} );
 	} );
 } );

--- a/projects/packages/paypal-payments/tests/js/paypal-payment-buttons-block-tests/edit.test.js
+++ b/projects/packages/paypal-payments/tests/js/paypal-payment-buttons-block-tests/edit.test.js
@@ -104,9 +104,6 @@ describe( 'Edit', () => {
 
 	beforeEach( () => {
 		jest.clearAllMocks();
-
-		// Mock window.ajaxurl for iframe preview
-		global.window.ajaxurl = 'https://example.com/wp-admin/admin-ajax.php';
 	} );
 
 	it( 'renders without crashing', () => {

--- a/projects/plugins/jetpack/changelog/paypal-27-ensure-that-block-renders-a-preview
+++ b/projects/plugins/jetpack/changelog/paypal-27-ensure-that-block-renders-a-preview
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Update PayPal Payment Buttons block to support rendering previews


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Partially addresses PAYPAL-27

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds a preview for the PayPal Payment Buttons block when a single button is in use.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
See PAYPAL-27

Of note, showing a preview for stacked buttons seems much more difficult because it is a dynamic block that relies on JS loading. I explored some options around loading the placeholder and JS via an iFrame, but the UX there feels off. I also mocked out the buttons with just HTML/CSS as I considered adding the mock as the preview. 

<img width="438" height="546" alt="CleanShot 2025-07-17 at 15 01 31@2x" src="https://github.com/user-attachments/assets/5e514d5e-8235-48ac-8e3a-516b4d4cbf11" />

But, since this may not match the final rendered content, it doesn't seem like a great idea to render this. We'll need to consider further how to handle stacked buttons preview.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- On a connected Jetpack site
- Checkout branch
- Ensure beta blocks enabled. `define( 'JETPACK_BLOCKS_VARIATION', 'beta' );`
- Insert PayPal Payment Buttons block
- Insert single button code
- Click outside of block
- Ensure preview shows
- Insert stacked buttons code
- Ensure no preview loads

