### PR TITLE
Workflows: update stalebot to only operate on pull requests

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,56 +1,36 @@
-
-name: 'Mark stale issues'
+name: 'Mark stale pull requests'
 on:
   schedule:
-    - cron: '30 0 * * *'
+    # Run every 6 hours at xx:30.
+    - cron: '30 */6 * * *'
   workflow_dispatch:
 
 jobs:
   stale:
     runs-on: ubuntu-latest
-    timeout-minutes: 10  # 2024-01-30: v9 takes longer, and it's not like it matters a whole lot since this only runs once per day anyway.
+    timeout-minutes: 10
     steps:
       - uses: actions/stale@v9
         with:
-          # Get issues in descending (newest first) order.
-          ascending: false
-          # Operations (roughly API calls) per run. Adjust to avoid using up the rate limit (1000/hr shared across all jobs in the repo for the token used here).
+          # Get PRs in ascending (oldest first) order.
+          ascending: true
           operations-per-run: 50
-          # After 6 months, mark issue as stale.
-          days-before-issue-stale: 180
-          # Do not auto-close issues marked as stale.
-          days-before-issue-close: -1
-          # After 3 months, mark PR as stale.
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          # PRs: Mark as stale after 3 months, close after 1 month more
           days-before-pr-stale: 90
-          # Auto-close PRs marked as stale a month later.
           days-before-pr-close: 31
-          # Delete the branch when closing PRs. GitHub's "restore branch" function works indefinitely, so no reason not to.
           delete-branch: true
-          # Issues and PRs with these labels will never be considered stale.
-          exempt-issue-labels: '[Pri] High,[Pri] BLOCKER,[Type] Feature Request,[Type] Enhancement,[Type] Janitorial,Good For Community,[Type] Good First Bug,FixTheFlows'
-          exempt-pr-labels: '[Pri] High,[Pri] BLOCKER,FixTheFlows'
-          # Label to use when marking an issue / PR as stale
+          # Label to use when marking a PR as stale
           stale-pr-label: '[Status] Stale'
-          stale-issue-label: '[Status] Stale'
-          # Messages to display.
-          stale-issue-message: |
-            <p>This issue has been marked as stale. This happened because:</p>
-
-            <ul>
-              <li>It has been inactive for the past 6 months.</li>
-              <li>It hasn’t been labeled `[Pri] BLOCKER`, `[Pri] High`, `[Type] Feature Request`, `[Type] Enhancement`, `[Type] Janitorial`, `Good For Community`, `[Type] Good First Bug`, etc.</li>
-            </ul>
-
-            <p>No further action is needed. But it's worth checking if this ticket has clear
-            reproduction steps and it is still reproducible. Feel free to close this issue
-            if you think it's not valid anymore — if you do, please add a brief
-            explanation.</p>
+          # PRs with these labels will never be considered stale.
+          exempt-pr-labels: '[Pri] High,[Pri] BLOCKER,FixTheFlows,[Status] Keep Open'
+          # Message to be added to stale PRs.
           stale-pr-message: |
             <p>This PR has been marked as stale. This happened because:</p>
 
             <ul>
               <li>It has been inactive for the past 3 months.</li>
-              <li>It hasn’t been labeled `[Pri] BLOCKER`, `[Pri] High`, etc.</li>
+              <li>It hasn't been labeled `[Pri] BLOCKER`, `[Pri] High`, `[Status] Keep Open`, etc.</li>
             </ul>
 
             <p>If this PR is still useful, please do a [trunk merge or rebase](https://github.com/Automattic/jetpack/blob/trunk/docs/git-workflow.md#keeping-your-branch-up-to-date)
@@ -63,3 +43,6 @@ jobs:
           close-pr-message: |
             <p>This PR has been automatically closed as it has not been updated in some time.
             If you want to resume work on the PR, feel free to restore the branch and reopen the PR.</p>
+          # Ignore issues, only operating on pull requests.
+          days-before-issue-stale: -1
+          days-before-issue-close: -1

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,9 +15,8 @@ jobs:
           # Get PRs in ascending (oldest first) order.
           ascending: true
           operations-per-run: 50
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          # PRs: Mark as stale after 3 months, close after 1 month more
-          days-before-pr-stale: 90
+          # PRs: Mark as stale after 2 months, close after 1 month more
+          days-before-pr-stale: 60
           days-before-pr-close: 31
           delete-branch: true
           # Label to use when marking a PR as stale


### PR DESCRIPTION
See https://linear.app/a8c/issue/QAO-62/retire-github-stalebot-in-favor-of-linear-stale-issues-automation

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Update stale.yml file to only operate on pull requests
* Change a few settings to match the Calypso action file for consistency (e.g., cron runs every 6 hours)
* Issues are now handled in Linear

### Other information:

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
1. Review YAML per docs: https://github.com/actions/stale
2. If desired, run a manual test (might require merge first, though)