### PR TITLE
wpcomsh: Add wpcomsh diagnostic CLI command for debugging

### DIFF
--- a/projects/plugins/wpcomsh/changelog/dotcom-13947-internal-tool-request-cli-diagnostic-command-for-hes
+++ b/projects/plugins/wpcomsh/changelog/dotcom-13947-internal-tool-request-cli-diagnostic-command-for-hes
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added a new wp wpcomsh diagnostic command

--- a/projects/plugins/wpcomsh/class-wpcomsh-cli-commands.php
+++ b/projects/plugins/wpcomsh/class-wpcomsh-cli-commands.php
@@ -1179,7 +1179,7 @@ if ( class_exists( 'WP_CLI_Command' ) ) {
 			// 1. Jetpack Status
 			WP_CLI::log( WP_CLI::colorize( '%Y--- Jetpack Status ---%n' ) );
 			$jetpack_result = WP_CLI::runcommand(
-				'jetpack status',
+				'jetpack status full',
 				array(
 					'launch'     => false,
 					'return'     => 'all',

--- a/projects/plugins/wpcomsh/class-wpcomsh-cli-commands.php
+++ b/projects/plugins/wpcomsh/class-wpcomsh-cli-commands.php
@@ -1159,6 +1159,201 @@ if ( class_exists( 'WP_CLI_Command' ) ) {
 		public function plugin_dance_health_check( $args, $assoc_args ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 			WP_CLI::success( 'Healthy' );
 		}
+
+		/**
+		 * Runs comprehensive site diagnostics including Jetpack status, admin users, plugins, purchases, and PHP errors
+		 *
+		 * ## OPTIONS
+		 *
+		 * [--interactive]
+		 * : Run through the diagnostics interactively, pausing between each section
+		 *
+		 * @subcommand diagnostic
+		 */
+		public function diagnostic( $args, $assoc_args ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter
+			$interactive = WP_CLI\Utils\get_flag_value( $assoc_args, 'interactive', false );
+
+			WP_CLI::log( WP_CLI::colorize( '%B=== SITE DIAGNOSTICS ===%n' ) );
+			WP_CLI::log( '' );
+
+			// 1. Jetpack Status
+			WP_CLI::log( WP_CLI::colorize( '%Y--- Jetpack Status ---%n' ) );
+			$jetpack_result = WP_CLI::runcommand(
+				'jetpack status',
+				array(
+					'launch'     => false,
+					'return'     => 'all',
+					'exit_error' => false,
+				)
+			);
+
+			if ( 0 === $jetpack_result->return_code ) {
+				WP_CLI::log( $jetpack_result->stdout );
+			} else {
+				WP_CLI::log( WP_CLI::colorize( '%RJetpack status command failed:%n' ) );
+				WP_CLI::log( $jetpack_result->stderr );
+			}
+
+			if ( $interactive ) {
+				WP_CLI::log( '' );
+				WP_CLI::log( 'Press Enter to continue...' );
+				fgets( STDIN );
+			}
+
+			WP_CLI::log( '' );
+
+			// 2. Admin Users
+			WP_CLI::log( WP_CLI::colorize( '%Y--- Administrator Users ---%n' ) );
+			$admin_users_result = WP_CLI::runcommand(
+				'user list --role=administrator',
+				array(
+					'launch'     => false,
+					'return'     => 'all',
+					'exit_error' => false,
+				)
+			);
+
+			if ( 0 === $admin_users_result->return_code ) {
+				WP_CLI::log( $admin_users_result->stdout );
+			} else {
+				WP_CLI::log( WP_CLI::colorize( '%RAdmin users command failed:%n' ) );
+				WP_CLI::log( $admin_users_result->stderr );
+			}
+
+			if ( $interactive ) {
+				WP_CLI::log( '' );
+				WP_CLI::log( 'Press Enter to continue...' );
+				fgets( STDIN );
+			}
+
+			WP_CLI::log( '' );
+
+			// 3. Plugin Status
+			WP_CLI::log( WP_CLI::colorize( '%Y--- Plugin Status ---%n' ) );
+			$plugin_status_result = WP_CLI::runcommand(
+				'plugin status',
+				array(
+					'launch'     => false,
+					'return'     => 'all',
+					'exit_error' => false,
+				)
+			);
+
+			if ( 0 === $plugin_status_result->return_code ) {
+				WP_CLI::log( $plugin_status_result->stdout );
+			} else {
+				WP_CLI::log( WP_CLI::colorize( '%RPlugin status command failed:%n' ) );
+				WP_CLI::log( $plugin_status_result->stderr );
+			}
+
+			if ( $interactive ) {
+				WP_CLI::log( '' );
+				WP_CLI::log( 'Press Enter to continue...' );
+				fgets( STDIN );
+			}
+
+			WP_CLI::log( '' );
+
+			// 4. WPCOMSH Purchases (formatted as table)
+			WP_CLI::log( WP_CLI::colorize( '%Y--- Site Purchases ---%n' ) );
+			$purchases_result = WP_CLI::runcommand(
+				'wpcomsh purchases --format=json',
+				array(
+					'launch'     => false,
+					'return'     => 'all',
+					'exit_error' => false,
+				)
+			);
+
+			if ( 0 === $purchases_result->return_code ) {
+				$purchases_data = json_decode( $purchases_result->stdout, true );
+				if ( is_array( $purchases_data ) && ! empty( $purchases_data ) ) {
+					$formatted_purchases = array();
+					foreach ( $purchases_data as $purchase ) {
+						$formatted_purchases[] = array(
+							'product'    => $purchase['product_slug'] ?? 'N/A',
+							'type'       => $purchase['product_type'] ?? 'N/A',
+							'subscribed' => isset( $purchase['subscribed_date'] ) ? gmdate( 'Y-m-d', strtotime( $purchase['subscribed_date'] ) ) : 'N/A',
+							'expires'    => isset( $purchase['expiry_date'] ) ? gmdate( 'Y-m-d', strtotime( $purchase['expiry_date'] ) ) : 'N/A',
+							'auto_renew' => isset( $purchase['auto_renew'] ) ? ( $purchase['auto_renew'] ? 'Yes' : 'No' ) : 'N/A',
+						);
+					}
+
+					$table_args = array( 'format' => 'table' );
+					$formatter  = new \WP_CLI\Formatter(
+						$table_args,
+						array( 'product', 'type', 'subscribed', 'expires', 'auto_renew' )
+					);
+					$formatter->display_items( $formatted_purchases );
+				} else {
+					WP_CLI::log( 'No purchases found.' );
+				}
+			} else {
+				WP_CLI::log( WP_CLI::colorize( '%RPurchases command failed:%n' ) );
+				WP_CLI::log( $purchases_result->stderr );
+			}
+
+			if ( $interactive ) {
+				WP_CLI::log( '' );
+				WP_CLI::log( 'Press Enter to continue...' );
+				fgets( STDIN );
+			}
+
+			WP_CLI::log( '' );
+
+			// 5. PHP Errors (filtered to recent fatals and errors)
+			WP_CLI::log( WP_CLI::colorize( '%Y--- Recent PHP Errors ---%n' ) );
+			$php_errors_result = WP_CLI::runcommand(
+				'php-errors',
+				array(
+					'launch'     => false,
+					'return'     => 'all',
+					'exit_error' => false,
+				)
+			);
+
+			if ( 0 === $php_errors_result->return_code ) {
+				$error_lines     = explode( "\n", trim( $php_errors_result->stdout ) );
+				$filtered_errors = array();
+				$today           = gmdate( 'Y-m-d' );
+				$yesterday       = gmdate( 'Y-m-d', strtotime( '-1 day' ) );
+
+				foreach ( $error_lines as $line ) {
+					if ( empty( trim( $line ) ) ) {
+						continue;
+					}
+
+					// Filter for recent errors (today and yesterday) and fatals
+					if ( strpos( $line, $today ) !== false || strpos( $line, $yesterday ) !== false ) {
+						if ( strpos( $line, 'Fatal error' ) !== false || strpos( $line, 'PHP Fatal error' ) !== false ) {
+							$filtered_errors[] = $line;
+						}
+					}
+				}
+
+				if ( ! empty( $filtered_errors ) ) {
+					WP_CLI::log( WP_CLI::colorize( '%RRecent Fatal PHP Errors:%n' ) );
+					foreach ( $filtered_errors as $error ) {
+						WP_CLI::log( $error );
+					}
+				} else {
+					// Show last 10 errors of any type if no recent fatals
+					WP_CLI::log( WP_CLI::colorize( '%GNo recent fatal errors found. Last 10 PHP errors:%n' ) );
+					$recent_errors = array_slice( $error_lines, -10 );
+					foreach ( $recent_errors as $error ) {
+						if ( ! empty( trim( $error ) ) ) {
+							WP_CLI::log( $error );
+						}
+					}
+				}
+			} else {
+				WP_CLI::log( WP_CLI::colorize( '%RPHP errors command failed:%n' ) );
+				WP_CLI::log( $php_errors_result->stderr );
+			}
+
+			WP_CLI::log( '' );
+			WP_CLI::log( WP_CLI::colorize( '%B=== DIAGNOSTICS COMPLETE ===%n' ) );
+		}
 	}
 }
 

--- a/projects/plugins/wpcomsh/class-wpcomsh-cli-commands.php
+++ b/projects/plugins/wpcomsh/class-wpcomsh-cli-commands.php
@@ -1163,16 +1163,9 @@ if ( class_exists( 'WP_CLI_Command' ) ) {
 		/**
 		 * Runs comprehensive site diagnostics including Jetpack status, admin users, plugins, purchases, and PHP errors
 		 *
-		 * ## OPTIONS
-		 *
-		 * [--interactive]
-		 * : Run through the diagnostics interactively, pausing between each section
-		 *
 		 * @subcommand diagnostic
 		 */
-		public function diagnostic( $args, $assoc_args ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter
-			$interactive = WP_CLI\Utils\get_flag_value( $assoc_args, 'interactive', false );
-
+		public function diagnostic( $args, $assoc_args ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter, VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 			WP_CLI::log( WP_CLI::colorize( '%B=== SITE DIAGNOSTICS ===%n' ) );
 			WP_CLI::log( '' );
 
@@ -1192,12 +1185,6 @@ if ( class_exists( 'WP_CLI_Command' ) ) {
 			} else {
 				WP_CLI::log( WP_CLI::colorize( '%RJetpack status command failed:%n' ) );
 				WP_CLI::log( $jetpack_result->stderr );
-			}
-
-			if ( $interactive ) {
-				WP_CLI::log( '' );
-				WP_CLI::log( 'Press Enter to continue...' );
-				fgets( STDIN );
 			}
 
 			WP_CLI::log( '' );
@@ -1220,12 +1207,6 @@ if ( class_exists( 'WP_CLI_Command' ) ) {
 				WP_CLI::log( $admin_users_result->stderr );
 			}
 
-			if ( $interactive ) {
-				WP_CLI::log( '' );
-				WP_CLI::log( 'Press Enter to continue...' );
-				fgets( STDIN );
-			}
-
 			WP_CLI::log( '' );
 
 			// 3. Plugin Status
@@ -1244,12 +1225,6 @@ if ( class_exists( 'WP_CLI_Command' ) ) {
 			} else {
 				WP_CLI::log( WP_CLI::colorize( '%RPlugin status command failed:%n' ) );
 				WP_CLI::log( $plugin_status_result->stderr );
-			}
-
-			if ( $interactive ) {
-				WP_CLI::log( '' );
-				WP_CLI::log( 'Press Enter to continue...' );
-				fgets( STDIN );
 			}
 
 			WP_CLI::log( '' );
@@ -1293,12 +1268,6 @@ if ( class_exists( 'WP_CLI_Command' ) ) {
 				WP_CLI::log( $purchases_result->stderr );
 			}
 
-			if ( $interactive ) {
-				WP_CLI::log( '' );
-				WP_CLI::log( 'Press Enter to continue...' );
-				fgets( STDIN );
-			}
-
 			WP_CLI::log( '' );
 
 			// 5. PHP Errors (filtered to recent fatals and errors)
@@ -1315,30 +1284,56 @@ if ( class_exists( 'WP_CLI_Command' ) ) {
 			if ( 0 === $php_errors_result->return_code ) {
 				$error_lines     = explode( "\n", trim( $php_errors_result->stdout ) );
 				$filtered_errors = array();
-				$today           = gmdate( 'Y-m-d' );
-				$yesterday       = gmdate( 'Y-m-d', strtotime( '-1 day' ) );
+
+				$recent_dates = array(
+					gmdate( 'd-M-Y' ),
+					gmdate( 'd-M-Y', strtotime( '-1 day' ) ),
+					gmdate( 'd-M-Y', strtotime( '-2 days' ) ),
+				);
 
 				foreach ( $error_lines as $line ) {
 					if ( empty( trim( $line ) ) ) {
 						continue;
 					}
 
-					// Filter for recent errors (today and yesterday) and fatals
-					if ( strpos( $line, $today ) !== false || strpos( $line, $yesterday ) !== false ) {
-						if ( strpos( $line, 'Fatal error' ) !== false || strpos( $line, 'PHP Fatal error' ) !== false ) {
-							$filtered_errors[] = $line;
+					$is_recent = false;
+					foreach ( $recent_dates as $date ) {
+						if ( strpos( $line, $date ) !== false ) {
+							$is_recent = true;
+							break;
+						}
+					}
+
+					if ( $is_recent ) {
+						// Check for various types of critical/fatal errors
+						$critical_patterns = array(
+							'Fatal error',
+							'PHP Fatal error',
+							'Parse error',
+							'Uncaught Error',
+							'Uncaught Exception',
+							'TypeError',
+							'ArgumentCountError',
+							'Compile error',
+						);
+
+						foreach ( $critical_patterns as $pattern ) {
+							if ( strpos( $line, $pattern ) !== false ) {
+								$filtered_errors[] = $line;
+								break;
+							}
 						}
 					}
 				}
 
 				if ( ! empty( $filtered_errors ) ) {
-					WP_CLI::log( WP_CLI::colorize( '%RRecent Fatal PHP Errors:%n' ) );
+					WP_CLI::log( WP_CLI::colorize( '%RRecent Critical PHP Errors:%n' ) );
 					foreach ( $filtered_errors as $error ) {
 						WP_CLI::log( $error );
 					}
 				} else {
-					// Show last 10 errors of any type if no recent fatals
-					WP_CLI::log( WP_CLI::colorize( '%GNo recent fatal errors found. Last 10 PHP errors:%n' ) );
+					// Show last 10 errors of any type if no recent critical errors
+					WP_CLI::log( WP_CLI::colorize( '%GNo recent critical errors found. Last 10 PHP errors:%n' ) );
 					$recent_errors = array_slice( $error_lines, -10 );
 					foreach ( $recent_errors as $error ) {
 						if ( ! empty( trim( $error ) ) ) {


### PR DESCRIPTION
Fixes DOTCOM-13947

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds a new `wp wpcomsh diagnostic` CLI command that groups other useful commands for ease of HEs.

<img width="4792" height="3428" alt="CleanShot 2025-07-17 at 18 46 10@2x" src="https://github.com/user-attachments/assets/3b032373-d2d6-487e-9dc9-5cbf13cc3beb" />

Note: This is a slightly outdated screenshot as the newer command outputs `wp jetpack status full`. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- On WoW dev site...
- Checkout branch
- SSH to site or use CLI URL
- Run `wp wpcomsh diagnostic`

