### PR TITLE
Block delimiter: revert changes to parsed attributes, and update documentation

### DIFF
--- a/projects/packages/block-delimiter/README.md
+++ b/projects/packages/block-delimiter/README.md
@@ -74,16 +74,14 @@ $scanner = Block_Scanner::create( $post_content );
 
 // Find the first image block
 while ( $scanner->next_delimiter() ) {
-    if ( ! $scanner->is_block_type( 'image' ) ) {
+    if ( ! $scanner->opens_block( 'image' ) ) {
         continue;
     }
     
-    if ( $scanner->opens_block() ) {
-        $attributes = $scanner->allocate_and_return_parsed_attributes();
-        if ( isset( $attributes['id'] ) ) {
-            echo "Found image with ID: " . $attributes['id'];
-            break;
-        }
+    $attributes = $scanner->allocate_and_return_parsed_attributes();
+    if ( isset( $attributes['id'] ) ) {
+        echo "Found image with ID: " . $attributes['id'];
+        break;
     }
 }
 ```

--- a/projects/packages/block-delimiter/README.md
+++ b/projects/packages/block-delimiter/README.md
@@ -128,7 +128,7 @@ Paragraph with font size: small
 
 ### Counting Block Types
 
-Get a summary of all block types in a document:
+Get a count of all block types in a document:
 
 ```php
 use Automattic\Block_Scanner;
@@ -149,33 +149,33 @@ $post_content = '<!-- wp:heading {"level":2} -->
 <ul><li>Item 1</li><li>Item 2</li></ul>
 <!-- /wp:list -->';
 
-function get_block_types_in( string $html ): array {
-    $block_types = [];
+function count_block_types_in( string $html ): array {
+    $block_counts = [];
     $scanner = Block_Scanner::create( $html );
     
     while ( $scanner->next_delimiter() ) {
         if ( $scanner->opens_block() ) {
-            $block_types[ $scanner->get_block_type() ] = true;
+            $block_type = $scanner->get_block_type();
+            $block_counts[ $block_type ] = ( $block_counts[ $block_type ] ?? 0 ) + 1;
         }
     }
     
-    $block_types = array_keys( $block_types );
-    sort( $block_types );
-    return $block_types;
+    ksort( $block_counts );
+    return $block_counts;
 }
 
-$block_types = get_block_types_in( $post_content );
-print_r( $block_types );
+$block_counts = count_block_types_in( $post_content );
+print_r( $block_counts );
 ```
 
 **Output:**
 ```
 Array
 (
-    [0] => core/heading
-    [1] => core/image
-    [2] => core/list
-    [3] => core/paragraph
+    [core/heading] => 1
+    [core/image] => 1
+    [core/list] => 1
+    [core/paragraph] => 2
 )
 ```
 
@@ -341,7 +341,7 @@ Paragraph with font size: small
 
 ### Counting Block Types
 
-Get a summary of all block types in a document:
+Get a count of all block types in a document:
 
 ```php
 use Automattic\Block_Delimiter;
@@ -362,32 +362,32 @@ $post_content = '<!-- wp:heading {"level":2} -->
 <ul><li>Item 1</li><li>Item 2</li></ul>
 <!-- /wp:list -->';
 
-function get_block_types_in( string $html ): array {
-    $block_types = [];
+function count_block_types_in( string $html ): array {
+    $block_counts = [];
     
     foreach ( Block_Delimiter::scan_delimiters( $html ) as $delimiter ) {
         if ( Block_Delimiter::OPENER === $delimiter->get_delimiter_type() ) {
-            $block_types[ $delimiter->allocate_and_return_block_type() ] = true;
+            $block_type = $delimiter->allocate_and_return_block_type();
+            $block_counts[ $block_type ] = ( $block_counts[ $block_type ] ?? 0 ) + 1;
         }
     }
     
-    $block_types = array_keys( $block_types );
-    sort( $block_types );
-    return $block_types;
+    ksort( $block_counts );
+    return $block_counts;
 }
 
-$block_types = get_block_types_in( $post_content );
-print_r( $block_types );
+$block_counts = count_block_types_in( $post_content );
+print_r( $block_counts );
 ```
 
 **Output:**
 ```
 Array
 (
-    [0] => core/heading
-    [1] => core/image
-    [2] => core/list
-    [3] => core/paragraph
+    [core/heading] => 1
+    [core/image] => 1
+    [core/list] => 1
+    [core/paragraph] => 2
 )
 ```
 

--- a/projects/packages/block-delimiter/changelog/update-block-delimiter-scanner-review
+++ b/projects/packages/block-delimiter/changelog/update-block-delimiter-scanner-review
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Scanner: revert changes to returned parsed attributes.

--- a/projects/packages/block-delimiter/src/class-block-scanner.php
+++ b/projects/packages/block-delimiter/src/class-block-scanner.php
@@ -808,7 +808,7 @@ class Block_Scanner {
 		}
 
 		$json_span = substr( $this->source_text, $this->json_at, $this->json_length );
-		$parsed    = json_decode( $json_span, true, 512, JSON_OBJECT_AS_ARRAY | JSON_INVALID_UTF8_SUBSTITUTE );
+		$parsed    = json_decode( $json_span, null, 512, JSON_OBJECT_AS_ARRAY | JSON_INVALID_UTF8_SUBSTITUTE );
 
 		$last_error            = json_last_error();
 		$this->last_json_error = $last_error;


### PR DESCRIPTION
## Proposed changes:

This PR applies changes following @dmsnell's review in #44158.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Is CI happy?
* Are the changed readme sections still helpful?

