### PR TITLE
MYJP: Fix onboarding tour mobile app link

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/onboarding-tour/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/onboarding-tour/index.tsx
@@ -1,4 +1,4 @@
-import { Guide } from '@wordpress/components';
+import { ExternalLink, Guide } from '@wordpress/components';
 import { createInterpolateElement, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { FC, useCallback } from 'react';
@@ -100,11 +100,11 @@ const OnboardingTour: FC< { open?: boolean } > = ( { open = true } ) => {
 									<p className="myjetpack-onboarding-welcome-tour__text">
 										{ createInterpolateElement(
 											__(
-												'Install the Jetpack app for iOS or Android and stay connected to your site from anywhere!<br /><br />We sent you an email with the download link.',
+												'Install the <mobileLink>Jetpack app</mobileLink> for iOS or Android and stay connected to your site from anywhere!',
 												'jetpack-my-jetpack'
 											),
 											{
-												br: <br />,
+												mobileLink: <ExternalLink href="https://jetpack.com/mobile/" />,
 											}
 										) }
 									</p>

--- a/projects/packages/my-jetpack/changelog/fix-myjp-onboarding-modal-mobile-link
+++ b/projects/packages/my-jetpack/changelog/fix-myjp-onboarding-modal-mobile-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Replace static mobile app text with direct link to download page


### PR DESCRIPTION
Fixes MYJP-234

## Summary

Updates the My Jetpack onboarding tour to replace static text about sending an email with a direct link to the Jetpack mobile app download page.

## Changes

- Import `ExternalLink` component from `@wordpress/components`
- - Replace static text "We sent you an email with the download link" with a clickable link to https://jetpack.com/mobile/
- - Update the `createInterpolateElement` configuration to use `mobileLink` instead of `br` tags

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions

1. Go to My Jetpack dashboard
2. Navigate to the onboarding tour (may need to reset onboarding state)
3. Look for the mobile app step
4. Verify the text now shows "Install the Jetpack app for iOS or Android..." with "Jetpack app" as a clickable link
5. Click the link to confirm it opens https://jetpack.com/mobile/ in a new tab

<img width="415" height="501" alt="CleanShot 2025-07-18 at 11 36 01 png" src="https://github.com/user-attachments/assets/61b21e88-1e57-4a12-9634-924d62234c39" />
