### PR TITLE
Admin Menu: Show "Jetpack > Podcasting" menu on all sites

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/dotcom-13936-untangling-ia-show-jetpack-podcasting-menu
+++ b/projects/packages/jetpack-mu-wpcom/changelog/dotcom-13936-untangling-ia-show-jetpack-podcasting-menu
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Admin Menu: Show "Jetpack > Podcasting" menu on all sites

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
@@ -261,6 +261,16 @@ function wpcom_add_jetpack_submenu() {
 		$subscribers_dashboard->add_wp_admin_submenu();
 	}
 
+	// Jetpack > Podcasting
+	add_submenu_page(
+		'jetpack',
+		__( 'Podcasting', 'jetpack-mu-wpcom' ),
+		__( 'Podcasting', 'jetpack-mu-wpcom' ),
+		'manage_options',
+		'https://wordpress.com/settings/podcasting/' . $domain,
+		null // @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
+	);
+
 	if ( $uses_wp_admin_interface ) {
 		// Jetpack > Activity Log.
 		wpcom_hide_submenu_page( 'jetpack', esc_url( Redirect::get_url( 'cloud-activity-log-wp-menu', array( 'site' => $blog_id ) ) ) );
@@ -284,16 +294,6 @@ function wpcom_add_jetpack_submenu() {
 				null // @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
 			);
 		}
-
-		// Jetpack > Podcasting
-		add_submenu_page(
-			'jetpack',
-			__( 'Podcasting', 'jetpack-mu-wpcom' ),
-			__( 'Podcasting', 'jetpack-mu-wpcom' ),
-			'manage_options',
-			'https://wordpress.com/settings/podcasting/' . $domain,
-			null // @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
-		);
 	}
 
 	// Re-order menu.

--- a/projects/packages/masterbar/changelog/dotcom-13936-untangling-ia-show-jetpack-podcasting-menu
+++ b/projects/packages/masterbar/changelog/dotcom-13936-untangling-ia-show-jetpack-podcasting-menu
@@ -1,0 +1,4 @@
+Significance: minor
+Type: deprecated
+
+Admin Menu: Deprecate "Settings > Podcasting" menu

--- a/projects/packages/masterbar/src/admin-menu/class-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-admin-menu.php
@@ -388,8 +388,11 @@ class Admin_Menu extends Base_Admin_Menu {
 
 		// @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
 		add_submenu_page( 'options-general.php', esc_attr__( 'Newsletter', 'jetpack-masterbar' ), __( 'Newsletter', 'jetpack-masterbar' ), 'manage_options', 'https://wordpress.com/settings/newsletter/' . $this->domain, null, 7 );
-		// @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
-		add_submenu_page( 'options-general.php', esc_attr__( 'Podcasting', 'jetpack-masterbar' ), __( 'Podcasting', 'jetpack-masterbar' ), 'manage_options', 'https://wordpress.com/settings/podcasting/' . $this->domain, null, 8 );
+		// Temporary "Settings > Podcasting" menu for existing users that shows a callout informing that the screen has moved to "Jetpack > Podcasting".
+		if ( get_current_user_id() < 268901000 ) {
+			// @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
+			add_submenu_page( 'options-general.php', esc_attr__( 'Podcasting', 'jetpack-masterbar' ), __( 'Podcasting', 'jetpack-masterbar' ), 'manage_options', 'https://wordpress.com/settings/jetpack-podcasting/' . $this->domain, null, 8 );
+		}
 	}
 
 	/**


### PR DESCRIPTION
Fixes DOTCOM-13936

## Proposed changes:

- Display the Jetpack > Podcasting menu on all sites (previously only visible with the classic interface).
- Deprecate the Settings > Podcasting menu for existing users with a callout informing that the menu has been moved (see https://github.com/Automattic/wp-calypso/pull/104805).

Site / Interface | Before | After
--- | --- | ---
Simple / Default | <img width="559" height="283" alt="Screenshot 2025-07-18 at 11 37 58" src="https://github.com/user-attachments/assets/65ccdcc2-ec97-48be-9205-ad8d0ca37a72" /><ul><li>Jetpack > Podcasting does not exist.</li></ul> | <img width="559" height="314" alt="Screenshot 2025-07-18 at 11 46 15" src="https://github.com/user-attachments/assets/b13115c3-267c-499e-9bbb-b559938694e1" /><ul><li>Jetpack > Podcasting is now visible.</li></ul>
Simple / Classic | <img width="332" height="363" alt="Screenshot 2025-07-18 at 11 38 11" src="https://github.com/user-attachments/assets/3cd86ed0-5d7c-4b21-968e-bf9f0025abb1" /><ul><li>Jetpack > Podcasting already exists.</li></ul> | <img width="332" height="363" alt="Screenshot 2025-07-18 at 11 38 11" src="https://github.com/user-attachments/assets/3cd86ed0-5d7c-4b21-968e-bf9f0025abb1" /><ul><li>No changes.</li></ul>
Atomic / Simple | <img width="559" height="392" alt="Screenshot 2025-07-18 at 11 38 40" src="https://github.com/user-attachments/assets/de80f1bf-1cb2-411d-886c-90a79ecd71bc" /><ul><li>Jetpack > Podcasting does not exist.</li></ul> | <img width="559" height="418" alt="Screenshot 2025-07-18 at 11 56 27" src="https://github.com/user-attachments/assets/d556c8ed-5a94-4a51-8607-86f904ac203a" /><ul><li>Jetpack > Podcasting is now visible.</li></ul>
Atomic / Classic | <img width="334" height="447" alt="Screenshot 2025-07-18 at 11 39 17" src="https://github.com/user-attachments/assets/edd36374-7444-42b7-ab71-d0b4515e75ae" /><ul><li>Jetpack > Podcasting already exists.</li></ul> | <img width="334" height="447" alt="Screenshot 2025-07-18 at 11 39 17" src="https://github.com/user-attachments/assets/edd36374-7444-42b7-ab71-d0b4515e75ae" /><ul><li>No changes.</li></ul>

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
- Apply these changes to your WP.com site
- Make sure that "Jetpack > Podcasting" is visible on the default admin interface
- Make sure it points to `/Podcasting/:site`
- Make sure that "Settings > Podcasting" is only visible on the default admin interface and only for existing users.
- Make sure it points to `/settings/jetpack-podcasting/:site` (check https://github.com/Automattic/wp-calypso/pull/104805 to test the callout).

