### PR TITLE
Social: Fix image validation when images sizes are customised.

### DIFF
--- a/projects/js-packages/publicize-components/changelog/fix-social-media-validation-for-custom-image-sizes
+++ b/projects/js-packages/publicize-components/changelog/fix-social-media-validation-for-custom-image-sizes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Social: Fix image validation when images sizes are customised.

--- a/projects/js-packages/publicize-components/src/hooks/use-media-details/index.js
+++ b/projects/js-packages/publicize-components/src/hooks/use-media-details/index.js
@@ -65,7 +65,8 @@ const getMediaDetails = async media => {
 	}
 
 	// We use medium image size for previews to decrease the load time.
-	const previewSize = sizes.medium || sizes.large;
+	// But fallback to full size, if the medium size is not available.
+	const previewSize = sizes.medium || sizes.large || sizes.full;
 	const previewData = {
 		width: previewSize.width,
 		height: previewSize.height,

--- a/projects/plugins/jetpack/changelog/fix-social-media-validation-for-custom-image-sizes
+++ b/projects/plugins/jetpack/changelog/fix-social-media-validation-for-custom-image-sizes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Social: Fix image validation when images sizes are customised.

--- a/projects/plugins/social/changelog/fix-social-media-validation-for-custom-image-sizes
+++ b/projects/plugins/social/changelog/fix-social-media-validation-for-custom-image-sizes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixd image validation when images sizes are customised.


### PR DESCRIPTION
Fixes SOCIAL-116

We have a user who sees the missing image warning (p1751467577717779-slack-C08PN0LHCCT) for their Instagram connection despite the post having a featured image.

<img width="546" height="302" alt="image" src="https://github.com/user-attachments/assets/8e83e42c-c69b-430b-8203-a0c76bdd0b20" />

Upon debugging, I found out that their site uses some custom image sizes

<img width="626" height="414" alt="image" src="https://github.com/user-attachments/assets/3a63e67f-094d-43f8-87b8-5f4b6ea9cde6" />

In that media, [we expect the `medium` and `large` sizes to be present](https://github.com/Automattic/jetpack/blob/1a82f483e6175400cf79afbfd1e7d31e8d821080/projects/js-packages/publicize-components/src/hooks/use-media-details/index.js#L68), which you can see is not the case.

So, below that, we try to read `previewSize.width` when `previewSize` is `undefined`, which results in an error, but we catch it [here](https://github.com/Automattic/jetpack/blob/1a82f483e6175400cf79afbfd1e7d31e8d821080/projects/js-packages/publicize-components/src/hooks/use-media-details/index.js#L101-L106) silently. Thus, it makes the media to be non-existent for validation logic.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add a fallback to for image sizes when getting the media details for validation. The fallback is to use the `full` size, if other sizes are not available.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On trunk or in production, add an Instagram connection to the site
* Add the below snippet somewhere, e.g. to `tools/docker/mu-plugins/0-snippets.php` for your local JT site.
```php
add_filter(
	'intermediate_image_sizes',
	function ( $sizes ) {
		// Remove the 'medium' and 'large' image sizes.
		return array_diff( $sizes, array( 'medium', 'large' ) );
	}
);
```
* Go to the block editor for a post
* Add a featured image
* Open Jetpack sidebar
* Confirm that you see the notice about an image being required
* Now checkout this branch
* Confirm that you don't see the warning.