### PR TITLE
docker: Improve handling of wordpress-develop

### DIFF
--- a/docs/examples/bootstrap.php
+++ b/docs/examples/bootstrap.php
@@ -36,10 +36,30 @@ if ( false !== getenv( 'WORDPRESS_DEVELOP_DIR' ) ) {
 }
 
 if ( ! isset( $_tests_dir ) || ! file_exists( $_tests_dir . '/includes/bootstrap.php' ) ) {
-	echo 'Failed to automatically locate WordPress or wordpress-develop to run tests.' . PHP_EOL;
-	echo PHP_EOL;
-	echo 'Set the WORDPRESS_DEVELOP_DIR environment variable to point to a copy of WordPress' . PHP_EOL;
-	echo 'or wordpress-develop.' . PHP_EOL;
+	if ( is_dir( '/tmp/wordpress-develop' ) && file_exists( '/var/scripts/ensure-php-version.sh' ) ) {
+		fprintf(
+			STDERR,
+			<<<'EOF'
+Looks like you're using the Jetpack Docker dev env, but the wordpress-develop checkout is incomplete.
+Try running `jetpack docker stop && jetpack docker up` to repopulate it.
+
+If that doesn't fix it, try (on the host) deleting `tools/docker/wordpress-develop/tests/` and then
+running `jetpack docker stop && jetpack docker up` again to repopulate it.
+
+EOF
+		);
+	} else {
+		fprintf(
+			STDERR,
+			<<<'EOF'
+Failed to automatically locate WordPress or wordpress-develop to run tests.
+
+Set the WORDPRESS_DEVELOP_DIR environment variable to point to a copy of WordPress
+or wordpress-develop.
+
+EOF
+		);
+	}
 	exit( 1 );
 }
 

--- a/projects/plugins/crm/changelog/fix-jetpack-docker-phpunit-error-recovery
+++ b/projects/plugins/crm/changelog/fix-jetpack-docker-phpunit-error-recovery
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Improve phpunit bootstrap for running from `jetpack docker phpunit`.
+
+

--- a/projects/plugins/crm/tests/php/bootstrap.php
+++ b/projects/plugins/crm/tests/php/bootstrap.php
@@ -47,16 +47,30 @@ if ( defined( 'WP_DEV_LOCATION' ) ) {
 }
 
 if ( ! isset( $test_root ) || ! file_exists( $test_root . '/includes/bootstrap.php' ) ) {
-	fprintf(
-		STDERR,
-		<<<'EOF'
+	if ( is_dir( '/tmp/wordpress-develop' ) && file_exists( '/var/scripts/ensure-php-version.sh' ) ) {
+		fprintf(
+			STDERR,
+			<<<'EOF'
+Looks like you're using the Jetpack Docker dev env, but the wordpress-develop checkout is incomplete.
+Try running `jetpack docker stop && jetpack docker up` to repopulate it.
+
+If that doesn't fix it, try (on the host) deleting `tools/docker/wordpress-develop/tests/` and then
+running `jetpack docker stop && jetpack docker up` again to repopulate it.
+
+EOF
+		);
+	} else {
+		fprintf(
+			STDERR,
+			<<<'EOF'
 Failed to automatically locate WordPress or wordpress-develop to run tests.
 
 Set the WORDPRESS_DEVELOP_DIR environment variable to point to a copy of WordPress
 or wordpress-develop.
 
 EOF
-	);
+		);
+	}
 	exit( 1 );
 }
 

--- a/projects/plugins/jetpack/changelog/fix-jetpack-docker-phpunit-error-recovery
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-docker-phpunit-error-recovery
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Improve phpunit bootstrap for running from `jetpack docker phpunit`.
+
+

--- a/projects/plugins/jetpack/tests/php/bootstrap.php
+++ b/projects/plugins/jetpack/tests/php/bootstrap.php
@@ -51,15 +51,30 @@ if ( false !== getenv( 'WORDPRESS_DEVELOP_DIR' ) ) {
 }
 
 if ( ! isset( $test_root ) || ! file_exists( $test_root . '/includes/bootstrap.php' ) ) {
-	fprintf(
-		STDERR,
-		<<<'EOF'
+	if ( is_dir( '/tmp/wordpress-develop' ) && file_exists( '/var/scripts/ensure-php-version.sh' ) ) {
+		fprintf(
+			STDERR,
+			<<<'EOF'
+Looks like you're using the Jetpack Docker dev env, but the wordpress-develop checkout is incomplete.
+Try running `jetpack docker stop && jetpack docker up` to repopulate it.
+
+If that doesn't fix it, try (on the host) deleting `tools/docker/wordpress-develop/tests/` and then
+running `jetpack docker stop && jetpack docker up` again to repopulate it.
+
+EOF
+		);
+	} else {
+		fprintf(
+			STDERR,
+			<<<'EOF'
 Failed to automatically locate WordPress or wordpress-develop to run tests.
 
 Set the WORDPRESS_DEVELOP_DIR environment variable to point to a copy of WordPress
 or wordpress-develop.
+
 EOF
-	);
+		);
+	}
 	exit( 1 );
 }
 

--- a/tools/docker/bin/run.sh
+++ b/tools/docker/bin/run.sh
@@ -78,7 +78,7 @@ fi
 
 if [ "$COMPOSE_PROJECT_NAME" == "jetpack_dev" ] ; then
 	# If we don't have the wordpress test helpers, download them
-	if [ ! -d /tmp/wordpress-develop/tests ]; then
+	if [ ! -d /tmp/wordpress-develop/tests/phpunit/data -o ! -d /tmp/wordpress-develop/tests/phpunit/includes ]; then
 		CUR_WP_VERSION=$(wp core version);
 		# Get latest WordPress unit-test helper files
 		svn co \


### PR DESCRIPTION
Closes MONOREP-28

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
In `tools/docker/bin/run.sh`, look for the two checkouts individually instead of assuming both exist when `/tmp/wordpress-develop/tests` exists.

In the plugin bootstraps, detect the Docker environment and provide a more helpful error message for that case.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1752844536979559-slack-CDLH4C1UZ

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Bring up the container (`jetpack docker up -d`).
* On the host, delete `tools/docker/wordpress-develop/tests/phpunit/includes/` but leave `tools/docker/wordpress-develop/tests/phpunit/data/` intact.
* Run `jetpack docker phpunit jetpack` or `jetpack docker phpunit crm`. Verify the error message is useful.
* Run `jetpack test -v plugins/jetpack plugins/crm`. Verify the error message is correct there too (i.e. does not mention docker).
* Run `jetpack docker stop && jetpack docker up -d`. This should recreate `tools/docker/wordpress-develop/tests/phpunit/includes/`.
* Verify `jetpack docker phpunit jetpack` and `jetpack docker phpunit crm` proceed to run tests now.
