### PR TITLE
Dashboard: Use UTC as the standard timezone for the Jetpack Dashboard Stats chart

### DIFF
--- a/projects/plugins/jetpack/_inc/client/at-a-glance/stats/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/stats/index.jsx
@@ -1,7 +1,7 @@
 import { getRedirectUrl, JetpackLogo } from '@automattic/jetpack-components';
 import { formatNumber } from '@automattic/number-formatters';
 import { ExternalLink, Spinner } from '@wordpress/components';
-import { dateI18n } from '@wordpress/date';
+import { gmdateI18n } from '@wordpress/date';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { isEmpty } from 'lodash';
@@ -87,18 +87,18 @@ export class DashStats extends Component {
 			totalViews += views;
 
 			if ( 'day' === unit ) {
-				chartLabel = dateI18n( shortMonthFormat, date, true );
-				tooltipLabel = dateI18n( longMonthFormat, date, true );
+				chartLabel = gmdateI18n( shortMonthFormat, date );
+				tooltipLabel = gmdateI18n( longMonthFormat, date );
 			} else if ( 'week' === unit ) {
-				chartLabel = dateI18n( shortMonthFormat, date, true );
+				chartLabel = gmdateI18n( shortMonthFormat, date );
 				tooltipLabel = sprintf(
 					/* translators: placeholder is a date. */
 					__( 'Week of %s', 'jetpack' ),
-					dateI18n( longMonthFormat, date, true )
+					gmdateI18n( longMonthFormat, date )
 				);
 			} else if ( 'month' === unit ) {
-				chartLabel = dateI18n( 'M', date, true );
-				tooltipLabel = dateI18n( longMonthYearFormat, date, true );
+				chartLabel = gmdateI18n( 'M', date );
+				tooltipLabel = gmdateI18n( longMonthYearFormat, date );
 			}
 
 			s.push( {

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/stats/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/stats/index.jsx
@@ -87,18 +87,18 @@ export class DashStats extends Component {
 			totalViews += views;
 
 			if ( 'day' === unit ) {
-				chartLabel = dateI18n( shortMonthFormat, date );
-				tooltipLabel = dateI18n( longMonthFormat, date );
+				chartLabel = dateI18n( shortMonthFormat, date, true );
+				tooltipLabel = dateI18n( longMonthFormat, date, true );
 			} else if ( 'week' === unit ) {
-				chartLabel = dateI18n( shortMonthFormat, date );
+				chartLabel = dateI18n( shortMonthFormat, date, true );
 				tooltipLabel = sprintf(
 					/* translators: placeholder is a date. */
 					__( 'Week of %s', 'jetpack' ),
-					dateI18n( longMonthFormat, date )
+					dateI18n( longMonthFormat, date, true )
 				);
 			} else if ( 'month' === unit ) {
-				chartLabel = dateI18n( 'M', date );
-				tooltipLabel = dateI18n( longMonthYearFormat, date );
+				chartLabel = dateI18n( 'M', date, true );
+				tooltipLabel = dateI18n( longMonthYearFormat, date, true );
 			}
 
 			s.push( {

--- a/projects/plugins/jetpack/changelog/update-use_utc_on_jetpack_dashboard_stats_chart
+++ b/projects/plugins/jetpack/changelog/update-use_utc_on_jetpack_dashboard_stats_chart
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Use UTC for Jetpack Stats chart on Dashboard.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes STATS-132.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Use UTC as the standard timezone for the Jetpack Dashboard Stats chart to align with the Odyssey Stats chart.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Set Settings > General > Timezone to `UTC-4` for a self-hosted site.
* Ensure Jetpack > Dashboard > Jetpack Stats chart shows the exact same data with Jetpack > Stats > Traffic chart.

### Jetpack > Stats > Traffic chart
<img width="1298" height="741" alt="截圖 2025-07-18 晚上11 26 30" src="https://github.com/user-attachments/assets/186d03e4-16ca-4c9c-b4d6-11181fd846be" />

### Jetpack > Dashboard > Jetpack Stats chart
|Before|After|
|-|-|
|<img width="1084" height="524" alt="截圖 2025-07-18 晚上10 35 15" src="https://github.com/user-attachments/assets/1e006d83-a89d-4d2a-a9e6-6dedb378f5b3" />|<img width="1091" height="523" alt="截圖 2025-07-18 晚上11 14 57" src="https://github.com/user-attachments/assets/62020e1d-399c-49dc-bc79-63b823eea7c0" />|