### PR TITLE
Forms: Move integration status badge on mobile

### DIFF
--- a/projects/packages/forms/changelog/update-forms-integrations-badge-move
+++ b/projects/packages/forms/changelog/update-forms-integrations-badge-move
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: Move integration badge on mobile.

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/integration-card-header.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/integration-card-header.tsx
@@ -104,25 +104,23 @@ const IntegrationCardHeader = ( {
 						/>
 					</div>
 					<div className="integration-card__title-section">
-						<div className="integration-card__title-row">
-							<h3 className="integration-card__title">{ title }</h3>
-							{ showPluginAction && (
-								<span className="integration-card__plugin-badge">
-									{ ! isInstalled && installPluginActionLabel }
-									{ isInstalled && ! isActive && activatePluginActionLabel }
-								</span>
-							) }
-							{ showConnectedBadge && (
-								<span className="integration-card__connected-badge">
-									<Icon icon="yes-alt" size={ 12 } />
-									{ __( 'Enabled', 'jetpack-forms' ) }
-								</span>
-							) }
-							{ showPendingBadge && <>{ pendingBadge }</> }
-						</div>
+						<h3 className="integration-card__title">{ title }</h3>
 						{ description && (
 							<span className="integration-card__description">{ description }</span>
 						) }
+						{ showPluginAction && (
+							<span className="integration-card__plugin-badge">
+								{ ! isInstalled && installPluginActionLabel }
+								{ isInstalled && ! isActive && activatePluginActionLabel }
+							</span>
+						) }
+						{ showConnectedBadge && (
+							<span className="integration-card__connected-badge">
+								<Icon icon="yes-alt" size={ 12 } />
+								{ __( 'Enabled', 'jetpack-forms' ) }
+							</span>
+						) }
+						{ showPendingBadge && <>{ pendingBadge }</> }
 					</div>
 				</div>
 				<HStack

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/style.scss
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/style.scss
@@ -43,6 +43,10 @@
 		gap: 4px 12px;
 		flex-wrap: wrap;
 		align-items: center;
+
+		@media (max-width: 782px) {
+			gap: 2px 12px;
+		}
 	}
 
 	&__service-icon-container {
@@ -138,7 +142,7 @@
 		@media (max-width: 782px) {
 			text-wrap: balance;
 			order: 2;
-			padding-bottom: 4px;
+			padding-bottom: 3px;
 		}
 	}
 

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/style.scss
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/style.scss
@@ -39,20 +39,10 @@
 
 	&__title-section {
 		display: flex;
-		flex-direction: column;
-		gap: 4px;
-	}
-
-	&__title-row {
-		display: flex;
+		flex-direction: row;
+		gap: 4px 12px;
+		flex-wrap: wrap;
 		align-items: center;
-		gap: 10px;
-
-		@media (max-width: 782px) {
-			gap: 6px;
-			flex-direction: column-reverse;
-			align-items: flex-start;
-		}
 	}
 
 	&__service-icon-container {
@@ -79,6 +69,7 @@
 		font-size: 15px;
 		font-weight: 400;
 		line-height: 1.4;
+		order: 1;
 	}
 
 	&__plugin-badge,
@@ -89,6 +80,11 @@
 		border-radius: 3px;
 		font-weight: 400;
 		line-height: 16px;
+		order: 2;
+
+		@media (max-width: 782px) {
+			order: 3;
+		}
 	}
 
 	&__plugin-badge {
@@ -102,9 +98,14 @@
 		display: flex;
 		align-items: center;
 		gap: 4px;
+		order: 2;
 
 		.components-icon {
 			color: #93c692;
+		}
+
+		@media (max-width: 782px) {
+			order: 3;
 		}
 	}
 
@@ -115,11 +116,15 @@
 		display: flex;
 		align-items: center;
 		gap: 4px;
+		order: 2;
 
 		.components-icon {
 			color: #93c692;
 		}
 
+		@media (max-width: 782px) {
+			order: 3;
+		}
 	}
 
 	&__description {
@@ -127,9 +132,13 @@
 		font-size: 13px;
 		line-height: 1.5;
 		margin-top: 0;
+		width: 100%;
+		order: 3;
 
 		@media (max-width: 782px) {
 			text-wrap: balance;
+			order: 2;
+			padding-bottom: 4px;
 		}
 	}
 


### PR DESCRIPTION
## Proposed changes:

This is a follow to #44286 (see [comment](https://github.com/Automattic/jetpack/pull/44286#pullrequestreview-3016167805)). It adjusts the markup and styling so that we push the integration status badge below the title and description on mobile. To do so, we update the markup so that title, description, and badge are all in one div, and use the flex order property to change the order of the items on desktop vs mobile. 

**Before on mobile**
<img width="519" height="715" alt="forms-badge-move-before" src="https://github.com/user-attachments/assets/15e59e06-6e2b-4cac-a3f1-e3cbb634bac7" />

**After on mobile**
<img width="499" height="692" alt="forms-badge-move-after-2" src="https://github.com/user-attachments/assets/eda5898c-b41f-4658-9fde-abca95e73000" />

**After on desktop - largely unchanged**
<img width="736" height="442" alt="forms-badge-move-after-3" src="https://github.com/user-attachments/assets/870af8e9-83e3-457d-a5ac-50730065d89d" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None. 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Jetpack > Forms > Integrations. On desktop size screens, it should render as before (title + badge on first line, description below). Resize your browser window to a small size, and confirm that the status badge moves below the description like in the screenshot above (title, then description, then badge, each on own line). 
* Add a form to a page, open the integrations modal, and confirm same styling changes there. 

