### PR TITLE
Coming soon banner: Fix site visibility settings link

### DIFF
--- a/projects/plugins/wpcomsh/changelog/fix-coming-soon-site-visibility-link
+++ b/projects/plugins/wpcomsh/changelog/fix-coming-soon-site-visibility-link
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix site visibility settings link in Coming Soon banner.
+
+

--- a/projects/plugins/wpcomsh/feature-plugins/full-site-editing.php
+++ b/projects/plugins/wpcomsh/feature-plugins/full-site-editing.php
@@ -117,7 +117,7 @@ function wpcom_public_coming_soon_replace_yoast_seo_notice() {
 		$blog_id      = get_current_blog_id();
 		$site_url     = get_home_url( $blog_id );
 		$site_slug    = wp_parse_url( $site_url, PHP_URL_HOST );
-		$settings_url = 'https://wordpress.com/settings/general/' . $site_slug . '#site-privacy-settings';
+		$settings_url = 'https://wordpress.com/sites/settings/v2/' . $site_slug . '/site-visibility';
 
 		if ( $is_wpcom_public_coming_soon_enabled ) {
 			/* translators: 1: opening anchor tag; 2: closing anchor tag. */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://linear.app/a8c/issue/DOTCOM-13967/coming-soon-banner-links-to-incorrect-url-for-privacy-settings

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Link to site visibility settings instead of general settings, to prevent redirect to wp-admin general settings -- which doesn't have site visibility settings.
* We could potentially also: update the copy, define a constant for this URL. But this fixes the immediate issue.

<img width="1332" height="107" alt="Screenshot 2025-07-18 at 2 28 25 PM" src="https://github.com/user-attachments/assets/f8fcd617-af8e-439c-b1be-7a3d90d59d50" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

N/A

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Create a WoA dev site and leave it in Coming Soon mode.
2. Install the Yoast SEO plugin.
3. Activate the Yoast plugin.
4. You'll see a "Heads up! Your site is currently in Coming Soon mode. If you want search engines to show this site in their search results you have to launch your site. Click here to change your site's privacy settings." banner.
5. Click the link. It first goes to `https://wordpress.com/settings/general/{site url}#site-privacy-settings`, then redirects to `{site url}/wp-admin/options-general.php`, which doesn't have privacy settings.
6. Apply this branch to WordPress.com Site Helper using the Jetpack Beta plugin.
7. Click the link again. It should go to `https://wordpress.com/sites/settings/v2/{site_slug}/site-visibility`.

