### PR TITLE
 Forms: Add error message on network request failure for ajax submission

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2532,6 +2532,9 @@ importers:
       copy-webpack-plugin:
         specifier: 13.0.0
         version: 13.0.0(webpack@5.94.0)
+      debug:
+        specifier: 4.4.1
+        version: 4.4.1
       email-validator:
         specifier: 2.0.4
         version: 2.0.4

--- a/projects/packages/forms/changelog/update-forms-submit-ajax-frontend-errors
+++ b/projects/packages/forms/changelog/update-forms-submit-ajax-frontend-errors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Forms: Add error message on network request failure for ajax submission

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -61,6 +61,7 @@
 		"@wordpress/url": "4.26.0",
 		"clsx": "2.1.1",
 		"copy-webpack-plugin": "13.0.0",
+		"debug": "4.4.1",
 		"email-validator": "2.0.4",
 		"gridicons": "3.4.2",
 		"js-sha256": "0.11.1",

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -298,7 +298,7 @@ class Contact_Form_Plugin {
 				'is_required'        => __( 'This field is required.', 'jetpack-forms' ),
 				'invalid_form_empty' => __( 'The form you are trying to submit is empty.', 'jetpack-forms' ),
 				'invalid_form'       => __( 'Please fill out the form correctly.', 'jetpack-forms' ),
-				'network_error'      => __( 'There was an error submitting the form. Please try again.', 'jetpack-forms' ),
+				'network_error'      => __( 'Connection issue while submitting the form. Check that you are connected to the Internet and try again.', 'jetpack-forms' ),
 			),
 			'admin_ajax_url' => admin_url( 'admin-ajax.php' ),
 		);

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -298,6 +298,7 @@ class Contact_Form_Plugin {
 				'is_required'        => __( 'This field is required.', 'jetpack-forms' ),
 				'invalid_form_empty' => __( 'The form you are trying to submit is empty.', 'jetpack-forms' ),
 				'invalid_form'       => __( 'Please fill out the form correctly.', 'jetpack-forms' ),
+				'network_error'      => __( 'There was an error submitting the form. Please try again.', 'jetpack-forms' ),
 			),
 			'admin_ajax_url' => admin_url( 'admin-ajax.php' ),
 		);

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -675,7 +675,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 	 * @return string HTML string for the error wrapper.
 	 */
 	private static function render_error_wrapper() {
-		$html  = '<div class="contact-form__error" data-wp-class--show-errors="state.showFromErrors">';
+		$html  = '<div class="contact-form__error" data-wp-class--show-errors="state.showFormErrors">';
 		$html .= '<span class="contact-form__warning-icon"><span class="visually-hidden">' . __( 'Warning.', 'jetpack-forms' ) . '</span><i aria-hidden="true"></i></span>
 				<span data-wp-text="state.getFormErrorMessage"></span>
 				<ul>

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -684,6 +684,8 @@ class Contact_Form extends Contact_Form_Shortcode {
 				</template>
 				</ul>';
 		$html .= '</div>';
+
+		$html .= '<div class="contact-form__error" data-wp-class--show-errors="state.showSubmissionError" data-wp-text="context.submissionError"></div>';
 		return $html;
 	}
 

--- a/projects/packages/forms/src/modules/form/shared.js
+++ b/projects/packages/forms/src/modules/form/shared.js
@@ -2,6 +2,9 @@
  * External dependencies
  */
 import { getConfig } from '@wordpress/interactivity';
+import debugFactory from 'debug';
+
+const debug = debugFactory( 'jetpack-forms:interactivity' );
 
 const NAMESPACE = 'jetpack/form';
 const config = getConfig( NAMESPACE );
@@ -61,13 +64,15 @@ export const submitForm = async formHash => {
 		} );
 
 		if ( ! response.ok ) {
-			return { success: false, error: response.status };
+			debug( 'Form submission failed', response );
+			return { success: false, error: config?.error_types?.network_error };
 		}
 
 		const result = await response.json();
 
 		return result;
 	} catch ( error ) {
-		return { success: false, error: error.message };
+		debug( 'Form submission failed', error );
+		return { success: false, error: config?.error_types?.network_error };
 	}
 };

--- a/projects/packages/forms/src/modules/form/view.js
+++ b/projects/packages/forms/src/modules/form/view.js
@@ -189,6 +189,12 @@ const { state } = store( NAMESPACE, {
 			return ! state.isFormValid && context.showErrors;
 		},
 
+		get showSubmissionError() {
+			const context = getContext();
+
+			return !! context.submissionError;
+		},
+
 		get getFormErrorMessage() {
 			if ( state.isFormEmpty ) {
 				const context = getContext();
@@ -228,11 +234,6 @@ const { state } = store( NAMESPACE, {
 			const fieldId = context.fieldId;
 			const field = context.fields[ fieldId ];
 			return field?.value || '';
-		},
-
-		get getSubmissionError() {
-			const context = getContext();
-			return context.submissionError || '';
 		},
 	},
 
@@ -339,12 +340,12 @@ const { state } = store( NAMESPACE, {
 			if ( context.isResponseWithoutReloadEnabled ) {
 				event.preventDefault();
 				event.stopPropagation();
+				context.submissionError = null;
 
 				const { success, error, data, refreshArgs } = yield submitForm( context.formHash );
 
 				if ( success ) {
 					setSubmissionData( data );
-					context.submissionError = null;
 					context.submissionSuccess = true;
 
 					if ( refreshArgs ) {

--- a/projects/packages/forms/src/modules/form/view.js
+++ b/projects/packages/forms/src/modules/form/view.js
@@ -183,7 +183,7 @@ const { state } = store( NAMESPACE, {
 			return ! Object.values( context.fields ).some( field => field.error !== 'yes' );
 		},
 
-		get showFromErrors() {
+		get showFormErrors() {
 			const context = getContext();
 
 			return ! state.isFormValid && context.showErrors;

--- a/projects/packages/forms/src/modules/form/view.js
+++ b/projects/packages/forms/src/modules/form/view.js
@@ -21,6 +21,7 @@ const withSyncEvent =
 
 const NAMESPACE = 'jetpack/form';
 const config = getConfig( NAMESPACE );
+let errorTimeout = null;
 
 const updateField = ( fieldId, value, showFieldError = false ) => {
 	const context = getContext();
@@ -192,7 +193,7 @@ const { state } = store( NAMESPACE, {
 		get showSubmissionError() {
 			const context = getContext();
 
-			return !! context.submissionError;
+			return !! context.submissionError && ! state.showFormErrors;
 		},
 
 		get getFormErrorMessage() {
@@ -358,6 +359,15 @@ const { state } = store( NAMESPACE, {
 					}
 				} else {
 					context.submissionError = error;
+
+					if ( errorTimeout ) {
+						clearTimeout( errorTimeout );
+					}
+
+					errorTimeout = setTimeout( () => {
+						context.submissionError = null;
+					}, 5000 );
+
 					setSubmissionData( [] );
 				}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Follow-up to #44204

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds an error message when form submission fails for any reason other than validation

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* With the feature flag enabled, go to a form
* Make sure the page is fully loaded and disable the network on the browser network monitor
* Submit the form
* Check that a message is displayed for 5 seconds

<img width="850" height="315" alt="Screenshot from 2025-07-18 16-39-05" src="https://github.com/user-attachments/assets/9ed8e5f6-edeb-4cb1-8a8c-d398e3ef47f2" />

