### PR TITLE
PayPal Payments: Clear parameters when toggling button type

### DIFF
--- a/projects/packages/paypal-payments/changelog/paypal-25-consider-clearing-block-parameters-when-toggling-stacked-or
+++ b/projects/packages/paypal-payments/changelog/paypal-25-consider-clearing-block-parameters-when-toggling-stacked-or
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Clears PayPal Payment buttons block parameters when changing block type

--- a/projects/packages/paypal-payments/src/paypal-payment-buttons/edit.js
+++ b/projects/packages/paypal-payments/src/paypal-payment-buttons/edit.js
@@ -209,10 +209,10 @@ export default function Edit( { attributes, setAttributes, isSelected } ) {
 
 	// Initialize raw code when valid extracted values exist
 	useEffect( () => {
-		if ( ! rawHeadCode && scriptSrc ) {
+		if ( ! rawHeadCode && scriptSrc && buttonType === 'stacked' ) {
 			setRawHeadCode( generateHeadCode( scriptSrc ) );
 		}
-	}, [ scriptSrc, rawHeadCode ] );
+	}, [ scriptSrc, rawHeadCode, buttonType ] );
 
 	useEffect( () => {
 		if ( ! rawBodyCode && hostedButtonId ) {
@@ -296,7 +296,17 @@ export default function Edit( { attributes, setAttributes, isSelected } ) {
 					label={ __( 'Button type', 'jetpack-paypal-payments' ) }
 					value={ buttonType }
 					hideLabelFromVision
-					onChange={ type => setAttributes( { buttonType: type } ) }
+					onChange={ type => {
+						const newAttributes = { buttonType: type };
+						newAttributes.scriptSrc = '';
+						newAttributes.buttonText = '';
+						newAttributes.hostedButtonId = '';
+
+						setRawHeadCode( '' );
+						setRawBodyCode( '' );
+
+						setAttributes( newAttributes );
+					} }
 					isBlock
 					__nextHasNoMarginBottom={ true }
 					__next40pxDefaultSize={ true }

--- a/projects/packages/paypal-payments/tests/js/paypal-payment-buttons-block-tests/edit.test.js
+++ b/projects/packages/paypal-payments/tests/js/paypal-payment-buttons-block-tests/edit.test.js
@@ -155,6 +155,9 @@ describe( 'Edit', () => {
 		fireEvent.click( screen.getByTestId( 'toggle-option-single' ) ); // eslint-disable-line testing-library/prefer-user-event
 		expect( setAttributes ).toHaveBeenCalledWith( {
 			buttonType: 'single',
+			scriptSrc: '',
+			buttonText: '',
+			hostedButtonId: '',
 		} );
 	} );
 
@@ -377,6 +380,84 @@ describe( 'Edit', () => {
 				'2. After login, choose Payment Buttons. Enter your product or service details, and build the buttons. Copy the button code for Stacked Buttons (copy html code) or Single Button.'
 			);
 			expect( items[ 2 ] ).toHaveTextContent( '3. Paste the code below.' );
+		} );
+	} );
+
+	describe( 'Parameter Clearing on Button Type Toggle', () => {
+		it( 'clears all parameters when switching from stacked to single', () => {
+			const setAttributes = jest.fn();
+			render(
+				<Edit
+					attributes={ {
+						buttonType: 'stacked',
+						scriptSrc: 'https://www.paypal.com/sdk/js?client-id=test',
+						hostedButtonId: 'ABC123DEF',
+						buttonText: '',
+					} }
+					setAttributes={ setAttributes }
+					isSelected={ true }
+				/>
+			);
+
+			fireEvent.click( screen.getByTestId( 'toggle-option-single' ) ); // eslint-disable-line testing-library/prefer-user-event
+
+			expect( setAttributes ).toHaveBeenCalledWith( {
+				buttonType: 'single',
+				scriptSrc: '',
+				buttonText: '',
+				hostedButtonId: '',
+			} );
+		} );
+
+		it( 'clears all parameters when switching from single to stacked', () => {
+			const setAttributes = jest.fn();
+			render(
+				<Edit
+					attributes={ {
+						buttonType: 'single',
+						scriptSrc: '',
+						hostedButtonId: 'ABC123DEF',
+						buttonText: 'Pay Now',
+					} }
+					setAttributes={ setAttributes }
+					isSelected={ true }
+				/>
+			);
+
+			fireEvent.click( screen.getByTestId( 'toggle-option-stacked' ) ); // eslint-disable-line testing-library/prefer-user-event
+
+			expect( setAttributes ).toHaveBeenCalledWith( {
+				buttonType: 'stacked',
+				scriptSrc: '',
+				buttonText: '',
+				hostedButtonId: '',
+			} );
+		} );
+
+		it( 'clears all parameters when switching to the same type', () => {
+			const setAttributes = jest.fn();
+			render(
+				<Edit
+					attributes={ {
+						buttonType: 'stacked',
+						scriptSrc: 'https://www.paypal.com/sdk/js?client-id=test',
+						hostedButtonId: 'ABC123DEF',
+						buttonText: '',
+					} }
+					setAttributes={ setAttributes }
+					isSelected={ true }
+				/>
+			);
+
+			fireEvent.click( screen.getByTestId( 'toggle-option-stacked' ) ); // eslint-disable-line testing-library/prefer-user-event
+
+			// Should clear all parameters even when switching to the same type
+			expect( setAttributes ).toHaveBeenCalledWith( {
+				buttonType: 'stacked',
+				scriptSrc: '',
+				buttonText: '',
+				hostedButtonId: '',
+			} );
 		} );
 	} );
 

--- a/projects/plugins/jetpack/changelog/paypal-25-consider-clearing-block-parameters-when-toggling-stacked-or
+++ b/projects/plugins/jetpack/changelog/paypal-25-consider-clearing-block-parameters-when-toggling-stacked-or
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Clears PayPal Payment buttons block parameters when changing block type


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixed PAYPAL-25

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Previously, when switching between button types, parameters would be persisted which presented potential for issues and confusing UX. This change will clear out the script src and button ID parameters to address this issue.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
See PAYPAL-25

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

With a Jetpack connected site:

- Checkout branch
- Ensure that extra widgets are allowed in Jetpack settings
- Ensure that beta blocks allowed with the following constant: `define( 'JETPACK_BLOCKS_VARIATION', 'beta' );`
- Add new page
- Add PayPal Payment Buttons block into the block editor
- Create a button at https://paypal.com/buttons
- Get stacked buttons code
- Enter the code into the block settings
- Save page
- Ensure that button renders as expected on the frontend of the site
- Go back to edit page
- Toggle block to single button
- Ensure settings cleared
- Save page
- Load frontend of page
- Ensure no block rendered
- Go back to edit page
- Insert single button code in block editor
- Save page
- View front end of page
- Ensure no block is rendered
- Go back to edit page
- Toggle to stacked buttons
- Ensure settings are cleared
- Save page
- Ensure that no block is rendered
