### PR TITLE
PayPal Payments: Update and simplify copy for retrieving code

### DIFF
--- a/projects/packages/paypal-payments/changelog/paypal-24-improve-payment-buttons-block-instructions-to-be-more
+++ b/projects/packages/paypal-payments/changelog/paypal-24-improve-payment-buttons-block-instructions-to-be-more
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Updates PayPal Payment Buttons block copy to be simpler.

--- a/projects/packages/paypal-payments/src/paypal-payment-buttons/edit.js
+++ b/projects/packages/paypal-payments/src/paypal-payment-buttons/edit.js
@@ -9,10 +9,6 @@ import {
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalText as Text,
-	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
-	__experimentalItemGroup as ItemGroup,
-	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
-	__experimentalItem as Item,
 } from '@wordpress/components';
 import { useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -316,25 +312,14 @@ export default function Edit( { attributes, setAttributes, isSelected } ) {
 					/>
 				</ToggleGroupControl>
 				<Text>
-					<strong>{ __( 'Instructions:', 'jetpack-paypal-payments' ) }</strong>
+					<ExternalLink href={ __( 'https://www.paypal.com/buttons/', 'jetpack-paypal-payments' ) }>
+						<strong>{ __( 'Go to PayPal', 'jetpack-paypal-payments' ) }</strong>
+					</ExternalLink>{ ' ' }
+					{ __(
+						'to get your Payment Button code and choose Payment Buttons. Enter your product and service details, and build the buttons. Copy the HTML button code for Stacked Buttons or Single Button and paste below.',
+						'jetpack-paypal-payments'
+					) }
 				</Text>
-				<ItemGroup>
-					<Item>
-						1.{ ' ' }
-						<ExternalLink
-							href={ __( 'https://www.paypal.com/buttons/', 'jetpack-paypal-payments' ) }
-						>
-							{ __( 'Go to PayPal to get your button code', 'jetpack-paypal-payments' ) }
-						</ExternalLink>
-					</Item>
-					<Item>
-						{ __(
-							'2. After login, choose Payment Buttons. Enter your product or service details, and build the buttons. Copy the button code for Stacked Buttons (copy html code) or Single Button.',
-							'jetpack-paypal-payments'
-						) }
-					</Item>
-					<Item>{ __( '3. Paste the code below.', 'jetpack-paypal-payments' ) }</Item>
-				</ItemGroup>
 				{ 'stacked' === buttonType && (
 					<PlainText
 						value={ rawHeadCode }

--- a/projects/packages/paypal-payments/tests/js/paypal-payment-buttons-block-tests/edit.test.js
+++ b/projects/packages/paypal-payments/tests/js/paypal-payment-buttons-block-tests/edit.test.js
@@ -62,8 +62,6 @@ jest.mock( '@wordpress/components', () => ( {
 	},
 	__experimentalToggleGroupControlOption: () => null, // We're not using the actual implementation
 	__experimentalText: ( { children } ) => <span data-testid="experimental-text">{ children }</span>,
-	__experimentalItemGroup: ( { children } ) => <div data-testid="item-group">{ children }</div>,
-	__experimentalItem: ( { children } ) => <div data-testid="item">{ children }</div>,
 	SVG: props => <svg { ...props } />,
 	Path: props => <path { ...props } />,
 } ) );
@@ -328,55 +326,18 @@ describe( 'Edit', () => {
 		const link = screen.getByTestId( 'external-link' );
 		expect( link ).toBeInTheDocument();
 		expect( link ).toHaveAttribute( 'href', 'https://www.paypal.com/buttons/' );
-		expect( link ).toHaveTextContent( 'Go to PayPal to get your button code' );
+		expect( link ).toHaveTextContent( 'Go to PayPal' );
 	} );
 
 	describe( 'Instruction Elements', () => {
-		it( 'renders instruction text with strong tag', () => {
+		it( 'renders simplified instruction text', () => {
 			render( <Edit { ...defaultProps } /> );
 			const instructionText = screen.getByTestId( 'experimental-text' );
 			expect( instructionText ).toBeInTheDocument();
-			expect( instructionText ).toHaveTextContent( 'Instructions:' );
-		} );
-
-		it( 'renders item group with three instruction items', () => {
-			render( <Edit { ...defaultProps } /> );
-			const itemGroup = screen.getByTestId( 'item-group' );
-			expect( itemGroup ).toBeInTheDocument();
-
-			const items = screen.getAllByTestId( 'item' );
-			expect( items ).toHaveLength( 3 );
-		} );
-
-		it( 'renders correct instruction items for stacked buttons', () => {
-			render( <Edit { ...defaultProps } /> );
-			const items = screen.getAllByTestId( 'item' );
-
-			expect( items[ 0 ] ).toHaveTextContent( '1. Go to PayPal to get your button code' );
-			expect( items[ 1 ] ).toHaveTextContent(
-				'2. After login, choose Payment Buttons. Enter your product or service details, and build the buttons. Copy the button code for Stacked Buttons (copy html code) or Single Button.'
+			expect( instructionText ).toHaveTextContent( 'Go to PayPal' );
+			expect( instructionText ).toHaveTextContent(
+				'to get your Payment Button code and choose Payment Buttons'
 			);
-			expect( items[ 2 ] ).toHaveTextContent( '3. Paste the code below.' );
-		} );
-
-		it( 'renders correct instruction items for single button type', () => {
-			render(
-				<Edit
-					attributes={ {
-						...defaultProps.attributes,
-						buttonType: 'single',
-					} }
-					setAttributes={ defaultProps.setAttributes }
-					isSelected={ true }
-				/>
-			);
-			const items = screen.getAllByTestId( 'item' );
-
-			expect( items[ 0 ] ).toHaveTextContent( '1. Go to PayPal to get your button code' );
-			expect( items[ 1 ] ).toHaveTextContent(
-				'2. After login, choose Payment Buttons. Enter your product or service details, and build the buttons. Copy the button code for Stacked Buttons (copy html code) or Single Button.'
-			);
-			expect( items[ 2 ] ).toHaveTextContent( '3. Paste the code below.' );
 		} );
 	} );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes PAYPAL-24

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Simplified the copy on the PayPal Payment Buttons block that prompts the user where/how to get the code to enter into the block.
<img width="1380" height="694" alt="CleanShot 2025-07-18 at 20 30 43@2x" src="https://github.com/user-attachments/assets/da357bd6-fed2-4c9f-bf8c-38e46bbd04a4" />


### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
See PAYPAL-24

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

On a connected Jetpack site:
- Checkout branch
- Ensure extra widgets is toggled on in Jetpack settings
- Ensure that beta blocks enabled with this constant: `define( 'JETPACK_BLOCKS_VARIATION', 'beta' );`
- Create a new page
- Insert the PayPal Payment Buttons block
- See new copy

