### PR TITLE
[e2e tests] Use Allure description instead of parameter to log wpcom api request count

### DIFF
--- a/tools/e2e-commons/fixtures/base-test.ts
+++ b/tools/e2e-commons/fixtures/base-test.ts
@@ -24,7 +24,9 @@ test.beforeEach( async () => {
 
 test.afterEach( async () => {
 	const wpcomRequestCount = await execWpCommand( 'transient get wpcom_request_counter' );
-	allure.label( 'Requests to WPCOM API', String( parseInt( wpcomRequestCount ) || 0 ) );
+	allure.description(
+		`'Requests to WPCOM API: ${ String( parseInt( wpcomRequestCount ) || 0 ) }'`
+	);
 } );
 
 export { test, expect };

--- a/tools/e2e-commons/fixtures/base-test.ts
+++ b/tools/e2e-commons/fixtures/base-test.ts
@@ -24,7 +24,7 @@ test.beforeEach( async () => {
 
 test.afterEach( async () => {
 	const wpcomRequestCount = await execWpCommand( 'transient get wpcom_request_counter' );
-	allure.addParameter( 'Requests to WPCOM API', String( parseInt( wpcomRequestCount ) || 0 ) );
+	allure.label( 'Requests to WPCOM API', String( parseInt( wpcomRequestCount ) || 0 ) );
 } );
 
 export { test, expect };


### PR DESCRIPTION

## Proposed changes:

Log the `wpcom_request_counter` transient value in Allure's description instead of a parameter.

<img width="497" height="97" alt="capture 2025-07-21 at 18 22 38" src="https://github.com/user-attachments/assets/2cbd8965-5490-47c1-8b1a-75757d4768a5" />


#30709 added logging of the number of wpcom api requests made during a test as an Allure parameter. While this displays nicely in Allure, it breaks the reporting in some cases. If a test is retried and the retry a different parameter value (common), Allure is reporting it as a different test and not as a retry of the same test.

<img width="1035" height="110" alt="capture 2025-07-21 at 16 59 34" src="https://github.com/user-attachments/assets/12f98adc-1fcb-493c-8167-ee3d7f1abdc4" />


### Other information:

- [x] N/A Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] N/A Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

e2e tests should pass in CI

