### PR TITLE
Forms: Use JWT for passing the Contact_Form object around - Try 2

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -611,16 +611,16 @@
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
-            "version": "v1.1.1",
+            "version": "v1.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/composer-installer.git",
-                "reference": "6e0fa428497bf560152ee73ffbb8af5c6a56b0dd"
+                "reference": "e9cf5e4bbf7eeaf9ef5db34938942602838fc2b1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/6e0fa428497bf560152ee73ffbb8af5c6a56b0dd",
-                "reference": "6e0fa428497bf560152ee73ffbb8af5c6a56b0dd",
+                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/e9cf5e4bbf7eeaf9ef5db34938942602838fc2b1",
+                "reference": "e9cf5e4bbf7eeaf9ef5db34938942602838fc2b1",
                 "shasum": ""
             },
             "require": {
@@ -703,7 +703,7 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-06-27T17:24:01+00:00"
+            "time": "2025-07-17T20:45:56+00:00"
         },
         {
             "name": "doctrine/deprecations",
@@ -1091,16 +1091,16 @@
         },
         {
             "name": "php-stubs/woocommerce-stubs",
-            "version": "v9.9.4",
+            "version": "v10.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-stubs/woocommerce-stubs.git",
-                "reference": "2efd06960ebb0ea853c906d979298fc176eec8a9"
+                "reference": "54123e2fa2a07b11d03fe15f27fb7a64d970a9df"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-stubs/woocommerce-stubs/zipball/2efd06960ebb0ea853c906d979298fc176eec8a9",
-                "reference": "2efd06960ebb0ea853c906d979298fc176eec8a9",
+                "url": "https://api.github.com/repos/php-stubs/woocommerce-stubs/zipball/54123e2fa2a07b11d03fe15f27fb7a64d970a9df",
+                "reference": "54123e2fa2a07b11d03fe15f27fb7a64d970a9df",
                 "shasum": ""
             },
             "require": {
@@ -1129,22 +1129,22 @@
             ],
             "support": {
                 "issues": "https://github.com/php-stubs/woocommerce-stubs/issues",
-                "source": "https://github.com/php-stubs/woocommerce-stubs/tree/v9.9.4"
+                "source": "https://github.com/php-stubs/woocommerce-stubs/tree/v10.0.2"
             },
-            "time": "2025-06-16T19:18:36+00:00"
+            "time": "2025-07-14T17:13:11+00:00"
         },
         {
             "name": "php-stubs/wordpress-stubs",
-            "version": "v6.8.1",
+            "version": "v6.8.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-stubs/wordpress-stubs.git",
-                "reference": "92e444847d94f7c30f88c60004648f507688acd5"
+                "reference": "9c8e22e437463197c1ec0d5eaa9ddd4a0eb6d7f8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/92e444847d94f7c30f88c60004648f507688acd5",
-                "reference": "92e444847d94f7c30f88c60004648f507688acd5",
+                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/9c8e22e437463197c1ec0d5eaa9ddd4a0eb6d7f8",
+                "reference": "9c8e22e437463197c1ec0d5eaa9ddd4a0eb6d7f8",
                 "shasum": ""
             },
             "conflict": {
@@ -1152,7 +1152,7 @@
             },
             "require-dev": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
-                "nikic/php-parser": "^5.4",
+                "nikic/php-parser": "^5.5",
                 "php": "^7.4 || ^8.0",
                 "php-stubs/generator": "^0.8.3",
                 "phpdocumentor/reflection-docblock": "^5.4.1",
@@ -1180,9 +1180,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-stubs/wordpress-stubs/issues",
-                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v6.8.1"
+                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v6.8.2"
             },
-            "time": "2025-05-02T12:33:34+00:00"
+            "time": "2025-07-16T06:41:00+00:00"
         },
         {
             "name": "php-stubs/wordpress-tests-stubs",
@@ -1820,16 +1820,16 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "2.1.0",
+            "version": "2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "9b30d6fd026b2c132b3985ce6b23bec09ab3aa68"
+                "reference": "b9e61a61e39e02dd90944e9115241c7f7e76bfd8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/9b30d6fd026b2c132b3985ce6b23bec09ab3aa68",
-                "reference": "9b30d6fd026b2c132b3985ce6b23bec09ab3aa68",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/b9e61a61e39e02dd90944e9115241c7f7e76bfd8",
+                "reference": "b9e61a61e39e02dd90944e9115241c7f7e76bfd8",
                 "shasum": ""
             },
             "require": {
@@ -1861,9 +1861,9 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.1.0"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.2.0"
             },
-            "time": "2025-02-19T13:28:12+00:00"
+            "time": "2025-07-13T07:04:09+00:00"
         },
         {
             "name": "psr/container",

--- a/projects/packages/forms/.phan/baseline.php
+++ b/projects/packages/forms/.phan/baseline.php
@@ -9,15 +9,15 @@
  */
 return [
     // # Issue statistics:
-    // PhanTypeMismatchArgument : 35+ occurrences
+    // PhanTypeMismatchArgument : 40+ occurrences
     // PhanPluginDuplicateConditionalNullCoalescing : 15+ occurrences
     // PhanTypeMismatchReturnProbablyReal : 10+ occurrences
     // PhanTypeMismatchArgumentInternal : 6 occurrences
     // PhanTypeMismatchArgumentProbablyReal : 6 occurrences
+    // PhanPluginDuplicateAdjacentStatement : 2 occurrences
     // PhanPluginRedundantAssignment : 2 occurrences
     // PhanTypeConversionFromArray : 2 occurrences
     // PhanTypeMismatchReturn : 2 occurrences
-    // PhanPluginDuplicateAdjacentStatement : 1 occurrence
     // PhanPluginMixedKeyNoKey : 1 occurrence
     // PhanPossiblyNullTypeMismatchProperty : 1 occurrence
     // PhanTypeArraySuspiciousNullable : 1 occurrence

--- a/projects/packages/forms/changelog/update-add-jwt-form-encode-decode
+++ b/projects/packages/forms/changelog/update-add-jwt-form-encode-decode
@@ -1,0 +1,4 @@
+Significance: major
+Type: fixed
+
+Forms: add a JWT token when submitting the form so that we are able to instantiate on submit

--- a/projects/packages/forms/composer.json
+++ b/projects/packages/forms/composer.json
@@ -8,6 +8,7 @@
 		"automattic/jetpack-blocks": "@dev",
 		"automattic/jetpack-assets": "@dev",
 		"automattic/jetpack-connection": "@dev",
+		"automattic/jetpack-jwt": "@dev",
 		"automattic/jetpack-logo": "@dev",
 		"automattic/jetpack-plans": "@dev",
 		"automattic/jetpack-status": "@dev",

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -1232,6 +1232,13 @@ class Contact_Form_Plugin {
 		$is_block_template_part = str_starts_with( $id, 'block-template-part-' );
 
 		$form = false;
+		if ( isset( $_POST['jetpack_contact_form_jwt'] ) ) {
+			$form = Contact_Form::get_instance_from_jwt( sanitize_text_field( wp_unslash( $_POST['jetpack_contact_form_jwt'] ) ) );
+			if ( ! $form ) { // fail early if the JWT is invalid.
+				// If the JWT is invalid, we can't process the form.
+				return false;
+			}
+		}
 
 		if ( $is_widget ) {
 			// It's a form embedded in a text widget
@@ -1351,8 +1358,10 @@ class Contact_Form_Plugin {
 				apply_filters( 'the_content', $content );
 			}
 		}
-
-		$form = isset( Contact_Form::$forms[ $hash ] ) ? Contact_Form::$forms[ $hash ] : null;
+		if ( ! $form ) {
+			// In future version we will be able to skip this step.
+			$form = isset( Contact_Form::$forms[ $hash ] ) ? Contact_Form::$forms[ $hash ] : null;
+		}
 
 		// No form may mean user is using do_shortcode, grab the form using the stored post meta
 		if ( ! $form && is_numeric( $id ) && $hash ) {

--- a/projects/packages/forms/src/contact-form/class-contact-form-shortcode.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-shortcode.php
@@ -147,6 +147,11 @@ class Contact_Form_Shortcode {
 			return array_map( array( $this, 'unesc_attr' ), $value );
 		}
 
+		if ( is_object( $value ) ) {
+			$value = (array) $value;
+			return array_map( array( $this, 'unesc_attr' ), $value );
+		}
+
 		// For back-compat with old Grunion encoding
 		// Also, unencode commas
 		$value = strtr(

--- a/projects/packages/forms/src/contact-form/class-contact-form-shortcode.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-shortcode.php
@@ -147,6 +147,7 @@ class Contact_Form_Shortcode {
 			return array_map( array( $this, 'unesc_attr' ), $value );
 		}
 
+		// Due to the JWT conversion we may have an object here instead of an array. Let's handle that.
 		if ( is_object( $value ) ) {
 			$value = (array) $value;
 			return array_map( array( $this, 'unesc_attr' ), $value );

--- a/projects/packages/forms/src/contact-form/class-contact-form-shortcode.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-shortcode.php
@@ -147,12 +147,6 @@ class Contact_Form_Shortcode {
 			return array_map( array( $this, 'unesc_attr' ), $value );
 		}
 
-		// Due to the JWT conversion we may have an object here instead of an array. Let's handle that.
-		if ( is_object( $value ) ) {
-			$value = (array) $value;
-			return array_map( array( $this, 'unesc_attr' ), $value );
-		}
-
 		// For back-compat with old Grunion encoding
 		// Also, unencode commas
 		$value = strtr(

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -232,14 +232,13 @@ class Contact_Form extends Contact_Form_Shortcode {
 		}
 
 		try {
-			$data = JWT::decode( $jwt_token, $secret, array( 'HS256' ) );
+			$data = JWT::decode( $jwt_token, $secret, array( 'HS256' ), true );
 		} catch ( \Exception $e ) {
 			return null;
 		}
 
-		$attributes             = (array) $data->attributes;
-		$form                   = new self( $attributes, $data->content, empty( $attributes['id'] ) );
-		$form->hash             = $data->hash;
+		$form                   = new self( $data['attributes'], $data['content'], empty( $data['attributes']['id'] ) );
+		$form->hash             = $data['hash'];
 		$form->has_verified_jwt = true;
 		return $form;
 	}

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -191,11 +191,6 @@ class Contact_Form extends Contact_Form_Shortcode {
 
 		parent::__construct( $attributes, $content );
 
-		// Convert it boolean.
-		if ( isset( $this->attributes['jetpackCRM'] ) && is_string( $this->attributes['jetpackCRM'] ) ) {
-			$this->attributes['jetpackCRM'] = ! empty( $this->attributes['jetpackCRM'] );
-		}
-
 		// There were no fields in the contact form. The form was probably just [contact-form /]. Build a default form.
 		if ( empty( $this->fields ) ) {
 			// same as the original Grunion v1 form.

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -7,7 +7,9 @@
 
 namespace Automattic\Jetpack\Forms\ContactForm;
 
+use Automattic\Jetpack\Connection\Tokens;
 use Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch;
+use Automattic\Jetpack\JWT;
 use Automattic\Jetpack\Sync\Settings;
 use Jetpack_Tracks_Event;
 use PHPMailer\PHPMailer\PHPMailer;
@@ -94,12 +96,20 @@ class Contact_Form extends Contact_Form_Shortcode {
 	public $current_post;
 
 	/**
+	 * Whether the form has a verified JWT token.
+	 *
+	 * @var bool
+	 */
+	public $has_verified_jwt = false;
+
+	/**
 	 * Construction function.
 	 *
 	 * @param array  $attributes - the attributes.
 	 * @param string $content - the content.
+	 * @param bool   $set_id - whether to set the ID for the form.
 	 */
-	public function __construct( $attributes, $content = null ) {
+	public function __construct( $attributes, $content = null, $set_id = true ) {
 		global $post, $page;
 
 		// AJAX requests don't have a post object, so we need to get the post object from the $_POST['contact-form-id']
@@ -122,29 +132,30 @@ class Contact_Form extends Contact_Form_Shortcode {
 			$attributes = array();
 		}
 
-		if ( ! empty( $attributes['widget'] ) && $attributes['widget'] ) {
-			$attributes['id'] = 'widget-' . $attributes['widget'];
-		} elseif ( ! empty( $attributes['block_template'] ) && $attributes['block_template'] ) {
-			$attributes['id'] = 'block-template-' . $attributes['block_template'];
-		} elseif ( ! empty( $attributes['block_template_part'] ) && $attributes['block_template_part'] ) {
-			$attributes['id'] = 'block-template-part-' . $attributes['block_template_part'];
-		} elseif ( $this->current_post ) {
-			$attributes['id'] = $this->current_post->ID;
-		}
-
-		// When using admin-ajax.php, we don't need to add a page number to the id
-		if ( ! empty( self::$forms ) && ! $this->is_response_without_reload_enabled ) {
-			// Ensure 'id' exists in $attributes before trying to modify it
-			if ( ! isset( $attributes['id'] ) ) {
-				$attributes['id'] = '';
+		if ( $set_id ) {
+			if ( ! empty( $attributes['widget'] ) && $attributes['widget'] ) {
+				$attributes['id'] = 'widget-' . $attributes['widget'];
+			} elseif ( ! empty( $attributes['block_template'] ) && $attributes['block_template'] ) {
+				$attributes['id'] = 'block-template-' . $attributes['block_template'];
+			} elseif ( ! empty( $attributes['block_template_part'] ) && $attributes['block_template_part'] ) {
+				$attributes['id'] = 'block-template-part-' . $attributes['block_template_part'];
+			} elseif ( $this->current_post ) {
+				$attributes['id'] = $this->current_post->ID;
 			}
 
-			// When submitting the page number is not always set, so we need to handle that: TODO: This is a hack, we need to find a better way to handle form identification
-			$page_num = max( 1, intval( $page ) );
+			// When using admin-ajax.php, we don't need to add a page number to the id
+			if ( ! empty( self::$forms ) && ! $this->is_response_without_reload_enabled ) {
+				// Ensure 'id' exists in $attributes before trying to modify it
+				if ( ! isset( $attributes['id'] ) ) {
+					$attributes['id'] = '';
+				}
 
-			$attributes['id'] = $attributes['id'] . '-' . ( count( self::$forms ) + 1 ) . '-' . $page_num;
+				// When submitting the page number is not always set, so we need to handle that: TODO: This is a hack, we need to find a better way to handle form identification
+				$page_num = max( 1, intval( $page ) );
+
+				$attributes['id'] = $attributes['id'] . '-' . ( count( self::$forms ) + 1 ) . '-' . $page_num;
+			}
 		}
-
 		$this->hash                 = sha1( wp_json_encode( $attributes ) );
 		self::$forms[ $this->hash ] = $this;
 
@@ -197,16 +208,76 @@ class Contact_Form extends Contact_Form_Shortcode {
 				[contact-field label="' . __( 'Message', 'jetpack-forms' ) . '" type="textarea" /]';
 
 			$this->parse_content( $default_form );
-
-			// Store the shortcode.
-			$this->store_shortcode( $default_form, $attributes, $this->hash );
-		} else {
-			// Store the shortcode.
-			$this->store_shortcode( $content, $attributes, $this->hash );
 		}
 
 		// $this->body and $this->fields have been setup.  We no longer need the contact-field shortcode.
 		Contact_Form_Plugin::$using_contact_form_field = false;
+	}
+	/**
+	 * Get the instance of the contact form from a JWT token.
+	 *
+	 * @param string $jwt_token The JWT token.
+	 *
+	 * @return Contact_Form|null The contact form instance or null if not found.
+	 */
+	public static function get_instance_from_jwt( $jwt_token ) {
+		$secret = self::get_secret();
+		if ( empty( $secret ) ) {
+			return null;
+		}
+
+		try {
+			$data = JWT::decode( $jwt_token, $secret, array( 'HS256' ) );
+		} catch ( \Exception $e ) {
+			return null;
+		}
+
+		$attributes             = (array) $data->attributes;
+		$form                   = new self( $attributes, $data->content, empty( $attributes['id'] ) );
+		$form->hash             = $data->hash;
+		$form->has_verified_jwt = true;
+		return $form;
+	}
+	/**
+	 * Helper function to get the secret from the Tokens class.
+	 *
+	 * @return string|null The secret from the Tokens class or null if not available.
+	 */
+	private static function get_secret() {
+		$token          = ( new Tokens() )->get_access_token();
+		$default_secret = hash_hmac( 'md5', get_option( 'admin_email' ), JETPACK__VERSION );
+		if ( ! isset( $token->secret ) ) {
+			return $default_secret;
+		}
+
+		// Get the secret from the Tokens class.
+		return $token->secret;
+	}
+
+	/**
+	 * Helper function to get the attributes of the contact form.
+	 *
+	 * @return array The attributes of the contact form.
+	 */
+	public function get_attributes() {
+		return $this->attributes;
+	}
+
+	/**
+	 * Get the JWT token for the contact form instance.
+	 *
+	 * @return string The JWT token.
+	 */
+	public function get_jwt() {
+		$attributes = $this->attributes;
+		return JWT::encode(
+			array(
+				'attributes' => $attributes,
+				'content'    => $this->content,
+				'hash'       => $this->hash,
+			),
+			self::get_secret()
+		);
 	}
 
 	/**
@@ -263,27 +334,10 @@ class Contact_Form extends Contact_Form_Shortcode {
 	 * Store shortcode content for recall later
 	 *  - used to receate shortcode when user uses do_shortcode
 	 *
-	 * @param string $content - the content.
-	 * @param array  $attributes - the attributes.
-	 * @param string $hash - the hash.
+	 * @deprecated $$next-version$$
 	 */
-	public static function store_shortcode( $content = null, $attributes = null, $hash = null ) {
-
-		if ( $content && isset( $attributes['id'] ) ) {
-
-			if ( empty( $hash ) ) {
-				$hash = sha1( wp_json_encode( $attributes ) . $content );
-			}
-
-			$shortcode_meta = (string) get_post_meta( $attributes['id'], "_g_feedback_shortcode_{$hash}", true );
-
-			if ( $shortcode_meta !== '' || $shortcode_meta !== $content ) {
-				update_post_meta( $attributes['id'], "_g_feedback_shortcode_{$hash}", $content );
-
-				// Save attributes to post_meta for later use. They're not available later in do_shortcode situations.
-				update_post_meta( $attributes['id'], "_g_feedback_shortcode_atts_{$hash}", $attributes );
-			}
-		}
+	public static function store_shortcode() {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Contact_Form_Plugin::store_shortcode()' );
 	}
 
 	/**
@@ -556,7 +610,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 			if ( $is_multistep ) { // This makes the "enter" key work in multi-step forms as expected.
 				$r .= '<input type="submit" style="display: none;" />';
 			}
-
+			$r .= "<input type='hidden' name='jetpack_contact_form_jwt' value='" . esc_attr( $form->get_jwt() ) . "' />\n";
 			$r .= $form->body;
 
 			if ( $is_multistep ) {
@@ -1455,21 +1509,23 @@ class Contact_Form extends Contact_Form_Shortcode {
 			$to = get_option( 'admin_email' );
 		}
 
-		// Make sure we're processing the form we think we're processing... probably a redundant check.
-		if ( $widget ) {
-			if ( isset( $_POST['contact-form-id'] ) && 'widget-' . $widget !== $_POST['contact-form-id'] ) { // phpcs:Ignore WordPress.Security.NonceVerification.Missing -- check done by caller process_form_submission()
+		if ( ! $this->has_verified_jwt ) {
+			// Make sure we're processing the form we think we're processing... probably a redundant check.
+			if ( $widget ) {
+				if ( isset( $_POST['contact-form-id'] ) && 'widget-' . $widget !== $_POST['contact-form-id'] ) { // phpcs:Ignore WordPress.Security.NonceVerification.Missing -- check done by caller process_form_submission()
+					return false;
+				}
+			} elseif ( $block_template ) {
+				if ( isset( $_POST['contact-form-id'] ) && 'block-template-' . $block_template !== $_POST['contact-form-id'] ) { // phpcs:Ignore WordPress.Security.NonceVerification.Missing -- check done by caller process_form_submission()
+					return false;
+				}
+			} elseif ( $block_template_part ) {
+				if ( isset( $_POST['contact-form-id'] ) && 'block-template-part-' . $block_template_part !== $_POST['contact-form-id'] ) { // phpcs:Ignore WordPress.Security.NonceVerification.Missing -- check done by caller process_form_submission()
+					return false;
+				}
+			} elseif ( isset( $_POST['contact-form-id'] ) && ( empty( $this->current_post ) || $this->current_post->ID !== (int) sanitize_text_field( wp_unslash( $_POST['contact-form-id'] ) ) ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing -- check done by caller process_form_submission()
 				return false;
 			}
-		} elseif ( $block_template ) {
-			if ( isset( $_POST['contact-form-id'] ) && 'block-template-' . $block_template !== $_POST['contact-form-id'] ) { // phpcs:Ignore WordPress.Security.NonceVerification.Missing -- check done by caller process_form_submission()
-				return false;
-			}
-		} elseif ( $block_template_part ) {
-			if ( isset( $_POST['contact-form-id'] ) && 'block-template-part-' . $block_template_part !== $_POST['contact-form-id'] ) { // phpcs:Ignore WordPress.Security.NonceVerification.Missing -- check done by caller process_form_submission()
-				return false;
-			}
-		} elseif ( isset( $_POST['contact-form-id'] ) && ( empty( $this->current_post ) || $this->current_post->ID !== (int) sanitize_text_field( wp_unslash( $_POST['contact-form-id'] ) ) ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing -- check done by caller process_form_submission()
-			return false;
 		}
 
 		$field_ids = $this->get_field_ids();

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -191,6 +191,11 @@ class Contact_Form extends Contact_Form_Shortcode {
 
 		parent::__construct( $attributes, $content );
 
+		// Convert it boolean.
+		if ( isset( $this->attributes['jetpackCRM'] ) && is_string( $this->attributes['jetpackCRM'] ) ) {
+			$this->attributes['jetpackCRM'] = ! empty( $this->attributes['jetpackCRM'] );
+		}
+
 		// There were no fields in the contact form. The form was probably just [contact-form /]. Build a default form.
 		if ( empty( $this->fields ) ) {
 			// same as the original Grunion v1 form.

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
@@ -11,6 +11,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use WorDBless\BaseTestCase;
 use WP_Block;
+use WP_Error;
 
 /**
  * Test class for Contact_Form_Plugin
@@ -533,5 +534,64 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 				'type'         => 'checkbox-multiple',
 			),
 		);
+	}
+
+	public function test_process_from_with_jwt() {
+		$previous_post = $this->setup_token_test();
+
+		$plugin = Contact_Form_Plugin::init();
+		$result = $plugin->process_form_submission();
+
+		$this->assertInstanceOf( WP_Error::class, $result, 'Expected a WP_Error when processing the form submission.' );
+		$this->assertEquals( 'check_spam', $result->get_error_code(), 'Expected the error code to be "check_spam".' );
+
+		$this->teardown_post_for_test( $previous_post );
+	}
+
+	public function test_process_from_with_fake_jwt() {
+		$previous_post = $this->setup_token_test( 'fake.jwt.token' );
+
+		$plugin = Contact_Form_Plugin::init();
+		$result = $plugin->process_form_submission();
+
+		$this->assertFalse( $result, 'Expected a WP_Error when processing the form submission.' );
+
+		$this->teardown_post_for_test( $previous_post );
+	}
+
+	private function setup_token_test( $token = null ) {
+		global $post;
+		$post_id = wp_insert_post(
+			array(
+				'post_title'   => 'Test Contact Form',
+				'post_content' => '<!-- wp:jetpack/contact-form {"id":"test-contact-form"} /-->',
+				'post_status'  => 'publish',
+				'post_type'    => 'post',
+			)
+		);
+
+		$previous_post = $post;
+		$post          = get_post( $post_id );
+		// We do this because we don't currenly have a way to prevent the redirect to happen.
+		add_filter( 'jetpack_contact_form_is_spam', array( $this, 'return_error_for_test' ) );
+		$form                              = new Contact_Form( array( 'to' => 'test@example.com' ), "[contact-field label='Name' type='name' required='1'/]" );
+		$_POST['jetpack_contact_form_jwt'] = $token ?? $form->get_jwt();
+		$_POST['contact-form-hash']        = $form->hash;
+		$_POST['contact-form-id']          = $post_id;
+		return $previous_post;
+	}
+
+	private function teardown_post_for_test( $previous_post ) {
+		global $post;
+		wp_delete_post( $post->ID, true ); // Clean up the test post.
+		$post = $previous_post; // Restore the previous post.
+		remove_filter( 'jetpack_contact_form_is_spam', array( $this, 'return_error_for_test' ) );
+		unset( $_POST['contact-form-hash'] );
+		unset( $_POST['jetpack_contact_form_jwt'] );
+		unset( $_POST['contact-form-id'] );
+	}
+
+	public function return_error_for_test() {
+		return new WP_Error( 'check_spam', 'check_spam form submission.' );
 	}
 }

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -2954,6 +2954,8 @@ EOT;
 		$form_copy = Contact_Form::get_instance_from_jwt( $jwt );
 		$this->assertNotNull( $form_copy, 'Should recover form using default secret' );
 		$this->assertTrue( $form_copy->has_verified_jwt, 'Form should have verified JWT with default secret' );
+
+		$this->assertEquals( $form->get_attributes( 'salesforceData' ), $form_copy->get_attributes( 'salesforceData' ), 'Form attributes should match' );
 	}
 
 	public function test_get_instance_from_jwt_returns_null_for_invalid_jwt() {

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -2933,6 +2933,29 @@ EOT;
 		$this->assertTrue( $form_copy->has_verified_jwt, 'Form should have verified JWT with default secret' );
 	}
 
+	public function test_get_instance_from_jwt_returns_with_salesforce_data() {
+		// Ensure JETPACK_BLOG_TOKEN is not defined
+		Constants::clear_single_constant( 'JETPACK_BLOG_TOKEN' );
+
+		$form = new Contact_Form(
+			array(
+				'to'             => 'test@email.com',
+				'subject'        => 'Test Form',
+				'salesforceData' => array( 'organizationId' => '12345' ),
+			),
+			"[contact-field label='Name' type='name' required='1'/]"
+		);
+
+		$jwt = $form->get_jwt();
+		$this->assertNotEmpty( $jwt, 'JWT should not be empty as it uses default secret' );
+		$this->assertIsString( $jwt, 'JWT should be a string' );
+
+		// The form should still be recoverable using the default secret
+		$form_copy = Contact_Form::get_instance_from_jwt( $jwt );
+		$this->assertNotNull( $form_copy, 'Should recover form using default secret' );
+		$this->assertTrue( $form_copy->has_verified_jwt, 'Form should have verified JWT with default secret' );
+	}
+
 	public function test_get_instance_from_jwt_returns_null_for_invalid_jwt() {
 		Constants::set_constant( 'JETPACK_BLOG_TOKEN', 'test.token' );
 

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -9,6 +9,7 @@
 
 namespace Automattic\Jetpack\Forms\ContactForm;
 
+use Automattic\Jetpack\Constants;
 use DOMDocument;
 use DOMElement;
 use PHPUnit\Framework\Attributes\Before;
@@ -2872,5 +2873,72 @@ EOT;
 
 		// Restore original post
 		$post = $original_post;
+	}
+
+	public function test_encode_form_to_jwt() {
+		Constants::set_constant( 'JETPACK_BLOG_TOKEN', 'test.token' );
+		$form = new Contact_Form(
+			array(
+				'to'      => 'hello@email.com',
+				'subject' => 'test subject',
+			),
+			"[contact-field label='Name' type='name' required='1'/]"
+			. "[contact-field label='Message' type='textarea' required='1'/]"
+		);
+
+		$jwt = $form->get_jwt();
+
+		$this->assertNotEmpty( $jwt, 'JWT should not be empty' );
+		$this->assertIsString( $jwt, 'JWT should be a string' );
+
+		$form_copy = Contact_Form::get_instance_from_jwt( $jwt );
+
+		// Decode the JWT to verify its structure
+		$to_attribute = $form_copy->get_attribute( 'to' );
+		$this->assertEquals( 'hello@email.com', $to_attribute );
+		$this->assertEquals( $form_copy->get_attributes(), $form->get_attributes(), 'Form attributes should match' );
+		$this->assertEquals( $form->get_attribute( 'to' ), $form_copy->get_attribute( 'to' ), 'Form IDs should match' );
+		$this->assertEquals( $form->get_attribute( 'id' ), $form_copy->get_attribute( 'id' ), 'Form IDs should match' );
+
+		$this->assertTrue( $form_copy->has_verified_jwt, 'Form copy should have verified JWT' );
+		$this->assertFalse( $form->has_verified_jwt, 'Original form should not have verified JWT' );
+
+		$this->assertEquals( $form->hash, $form_copy->hash, 'Form hashes should match' );
+		$this->assertNotEmpty( $form_copy->hash, 'Form hash should not be empty' );
+
+		$this->assertEquals( $form->get_field_ids(), $form_copy->get_field_ids(), 'Field IDs should match' );
+		$this->assertNotEmpty( $form_copy->get_field_ids(), 'Fields should not be empty' );
+		Constants::clear_single_constant( 'JETPACK_BLOG_TOKEN' );
+	}
+
+	public function test_get_instance_from_jwt_returns_null_when_no_secret() {
+		// Ensure JETPACK_BLOG_TOKEN is not defined
+		Constants::clear_single_constant( 'JETPACK_BLOG_TOKEN' );
+
+		$form = new Contact_Form(
+			array(
+				'to'      => 'test@email.com',
+				'subject' => 'Test Form',
+			),
+			"[contact-field label='Name' type='name' required='1'/]"
+		);
+
+		$jwt = $form->get_jwt();
+		$this->assertNotEmpty( $jwt, 'JWT should not be empty as it uses default secret' );
+		$this->assertIsString( $jwt, 'JWT should be a string' );
+
+		// The form should still be recoverable using the default secret
+		$form_copy = Contact_Form::get_instance_from_jwt( $jwt );
+		$this->assertNotNull( $form_copy, 'Should recover form using default secret' );
+		$this->assertTrue( $form_copy->has_verified_jwt, 'Form should have verified JWT with default secret' );
+	}
+
+	public function test_get_instance_from_jwt_returns_null_for_invalid_jwt() {
+		Constants::set_constant( 'JETPACK_BLOG_TOKEN', 'test.token' );
+
+		$form_copy = Contact_Form::get_instance_from_jwt( 'invalid_jwt_token' );
+		$this->assertNull( $form_copy, 'Should return null for invalid JWT token' );
+
+		Constants::clear_single_constant( 'JETPACK_BLOG_TOKEN' );
 	}
 } // end class

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -2933,33 +2933,55 @@ EOT;
 		$this->assertTrue( $form_copy->has_verified_jwt, 'Form should have verified JWT with default secret' );
 	}
 
-	public function test_get_instance_from_jwt_returns_with_salesforce_data() {
+	public function test_get_instance_from_jwt_returns_with_all_attribute_data() {
 		// Ensure JETPACK_BLOG_TOKEN is not defined
 		Constants::clear_single_constant( 'JETPACK_BLOG_TOKEN' );
 
+		$attributes = array(
+			'to'                     => 'test@email.com',
+			'subject'                => 'Test Form',
+			'show_subject'           => 'no', // only used in back-compat mode
+			'widget'                 => 'string',    // Not exposed to the user. Works with Contact_Form_Plugin::widget_atts()
+			'block_template'         => null, // Not exposed to the user. Works with template_loader
+			'block_template_part'    => null, // Not exposed to the user. Works with Contact_Form::parse()
+			'id'                     => null, // Not exposed to the user. Set above.
+			'submit_button_text'     => __( 'Submit', 'jetpack-forms' ),
+			// These attributes come from the block editor, so use camel case instead of snake case.
+			'customThankyou'         => 'message', // Whether to show a custom thankyou response after submitting a form. '' for no, 'message' for a custom message, 'redirect' to redirect to a new URL.
+			'customThankyouHeading'  => __( 'Your message has been sent', 'jetpack-forms' ), // The text to show above customThankyouMessage.
+			'customThankyouMessage'  => __( 'Thank you for your submission!', 'jetpack-forms' ), // The message to show when customThankyou is set to 'message'.
+			'customThankyouRedirect' => '', // The URL to redirect to when customThankyou is set to 'redirect'.
+			'jetpackCRM'             => true, // Whether Jetpack CRM should store the form submission.
+			'className'              => 'string-class-name', // The class name to apply to the form.
+			'postToUrl'              => 'https://example.com/submit', // The URL to post the form data to.
+			'salesforceData'         => array( 'organizationId' => '12345' ),
+			'hiddenFields'           => array(
+				'hiddenField1' => 'value1',
+				'hiddenField2' => 'value2',
+			), // Hidden fields to include in the form.
+			'stepTransition'         => 'fade-slide',
+
+		);
+
 		$form = new Contact_Form(
-			array(
-				'to'             => 'test@email.com',
-				'subject'        => 'Test Form',
-				'salesforceData' => array( 'organizationId' => '12345' ),
-			),
+			$attributes,
 			"[contact-field label='Name' type='name' required='1'/]"
 		);
 
 		$jwt = $form->get_jwt();
 		$this->assertNotEmpty( $jwt, 'JWT should not be empty as it uses default secret' );
 		$this->assertIsString( $jwt, 'JWT should be a string' );
-
-		// The form should still be recoverable using the default secret
 		$form_copy = Contact_Form::get_instance_from_jwt( $jwt );
+
+		$this->assertEquals( $form->get_attributes(), $form_copy->get_attributes(), 'Form attributes should match' );
 		$this->assertNotNull( $form_copy, 'Should recover form using default secret' );
 		$this->assertTrue( $form_copy->has_verified_jwt, 'Form should have verified JWT with default secret' );
-
 		$this->assertEquals( $form->get_attribute( 'salesforceData' ), $form_copy->get_attribute( 'salesforceData' ), 'Form attributes should match' );
 		$this->assertIsArray( $form_copy->get_attribute( 'salesforceData' ), 'salesforceData should be an array' );
-
 		$this->assertArrayHasKey( 'organizationId', $form_copy->get_attribute( 'salesforceData' ), 'salesforceData should contain organizationId' );
 		$this->assertSame( '12345', $form_copy->get_attribute( 'salesforceData' )['organizationId'], 'organizationId should match' );
+
+		$this->assertTrue( $form_copy->get_attribute( 'jetpackCRM' ), 'jetpackCRM should be true' );
 	}
 
 	public function test_get_instance_from_jwt_returns_null_for_invalid_jwt() {

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -2944,7 +2944,6 @@ EOT;
 			'widget'                 => 'string',    // Not exposed to the user. Works with Contact_Form_Plugin::widget_atts()
 			'block_template'         => null, // Not exposed to the user. Works with template_loader
 			'block_template_part'    => null, // Not exposed to the user. Works with Contact_Form::parse()
-			'id'                     => null, // Not exposed to the user. Set above.
 			'submit_button_text'     => __( 'Submit', 'jetpack-forms' ),
 			// These attributes come from the block editor, so use camel case instead of snake case.
 			'customThankyou'         => 'message', // Whether to show a custom thankyou response after submitting a form. '' for no, 'message' for a custom message, 'redirect' to redirect to a new URL.
@@ -2960,8 +2959,13 @@ EOT;
 				'hiddenField2' => 'value2',
 			), // Hidden fields to include in the form.
 			'stepTransition'         => 'fade-slide',
-
 		);
+		// Add a widget ID to the attributes for testing.
+		$expected_attributes                        = $attributes;
+		$expected_attributes['jetpackCRM']          = '1';
+		$expected_attributes['block_template']      = '';
+		$expected_attributes['block_template_part'] = '';
+		$expected_attributes['id']                  = 'widget-string';
 
 		$form = new Contact_Form(
 			$attributes,
@@ -2981,7 +2985,7 @@ EOT;
 		$this->assertArrayHasKey( 'organizationId', $form_copy->get_attribute( 'salesforceData' ), 'salesforceData should contain organizationId' );
 		$this->assertSame( '12345', $form_copy->get_attribute( 'salesforceData' )['organizationId'], 'organizationId should match' );
 
-		$this->assertTrue( $form_copy->get_attribute( 'jetpackCRM' ), 'jetpackCRM should be true' );
+		$this->assertEquals( $expected_attributes, $form_copy->get_attributes(), 'jetpackCRM should be true' );
 	}
 
 	public function test_get_instance_from_jwt_returns_null_for_invalid_jwt() {

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -2955,7 +2955,11 @@ EOT;
 		$this->assertNotNull( $form_copy, 'Should recover form using default secret' );
 		$this->assertTrue( $form_copy->has_verified_jwt, 'Form should have verified JWT with default secret' );
 
-		$this->assertEquals( $form->get_attributes( 'salesforceData' ), $form_copy->get_attributes( 'salesforceData' ), 'Form attributes should match' );
+		$this->assertEquals( $form->get_attribute( 'salesforceData' ), $form_copy->get_attribute( 'salesforceData' ), 'Form attributes should match' );
+		$this->assertIsArray( $form_copy->get_attribute( 'salesforceData' ), 'salesforceData should be an array' );
+
+		$this->assertArrayHasKey( 'organizationId', $form_copy->get_attribute( 'salesforceData' ), 'salesforceData should contain organizationId' );
+		$this->assertSame( '12345', $form_copy->get_attribute( 'salesforceData' )['organizationId'], 'organizationId should match' );
 	}
 
 	public function test_get_instance_from_jwt_returns_null_for_invalid_jwt() {

--- a/projects/packages/jwt/changelog/revert-44397-revert-44360-update-add-jwt-form-encode-decode
+++ b/projects/packages/jwt/changelog/revert-44397-revert-44360-update-add-jwt-form-encode-decode
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Make it possible to decode as array

--- a/projects/packages/jwt/src/class-jwt.php
+++ b/projects/packages/jwt/src/class-jwt.php
@@ -69,6 +69,7 @@ class JWT {
 	 *                                     If the algorithm used is asymmetric, this is the public key.
 	 * @param array        $allowed_algs   List of supported verification algorithms.
 	 *                                     Supported algorithms are 'HS256', 'HS384', 'HS512' and 'RS256'.
+	 * @param bool         $as_array Whether to return the result as an associative array.
 	 *
 	 * @return object The JWT's payload as a PHP object
 	 *
@@ -81,7 +82,7 @@ class JWT {
 	 * @uses json_decode
 	 * @uses urlsafe_b64_decode
 	 */
-	public static function decode( $jwt, $key, array $allowed_algs = array() ) {
+	public static function decode( $jwt, $key, array $allowed_algs = array(), $as_array = false ) {
 		$timestamp = static::$timestamp === null ? time() : static::$timestamp;
 
 		if ( empty( $key ) ) {
@@ -100,7 +101,7 @@ class JWT {
 			throw new UnexpectedValueException( 'Invalid header encoding' );
 		}
 
-		$payload = static::json_decode( static::urlsafe_b64_decode( $bodyb64 ) );
+		$payload = static::json_decode( static::urlsafe_b64_decode( $bodyb64 ), $as_array );
 		if ( null === $payload ) {
 			throw new UnexpectedValueException( 'Invalid claims encoding' );
 		}
@@ -138,25 +139,38 @@ class JWT {
 			throw new SignatureInvalidException( 'Signature verification failed' );
 		}
 
+		$nbf = ! $as_array && isset( $payload->nbf ) ? $payload->nbf : null;
+		if ( $as_array && isset( $payload['nbf'] ) ) {
+			$nbf = $payload['nbf'];
+		}
 		// Check if the nbf if it is defined. This is the time that the
 		// token can actually be used. If it's not yet that time, abort.
-		if ( isset( $payload->nbf ) && $payload->nbf > ( $timestamp + static::$leeway ) ) {
+		if ( $nbf > ( $timestamp + static::$leeway ) ) {
 			throw new BeforeValidException(
-				'Cannot handle token prior to ' . gmdate( 'Y-m-d\\TH:i:sO', $payload->nbf )
+				'Cannot handle token prior to ' . gmdate( 'Y-m-d\\TH:i:sO', $nbf )
 			);
 		}
 
+		$iat = ! $as_array && isset( $payload->iat ) ? $payload->iat : null;
+		if ( $as_array && isset( $payload['iat'] ) ) {
+			$iat = $payload['iat'];
+		}
 		// Check that this token has been created before 'now'. This prevents
 		// using tokens that have been created for later use (and haven't
 		// correctly used the nbf claim).
-		if ( isset( $payload->iat ) && $payload->iat > ( $timestamp + static::$leeway ) ) {
+		if ( $iat > ( $timestamp + static::$leeway ) ) {
 			throw new BeforeValidException(
-				'Cannot handle token prior to ' . gmdate( 'Y-m-d\\TH:i:sO', $payload->iat )
+				'Cannot handle token prior to ' . gmdate( 'Y-m-d\\TH:i:sO', $iat )
 			);
 		}
 
+		$exp = ! $as_array && isset( $payload->exp ) ? $payload->exp : null;
+		if ( $as_array && isset( $payload['exp'] ) ) {
+			$exp = $payload['exp'];
+		}
+
 		// Check if this token has expired.
-		if ( isset( $payload->exp ) && ( $timestamp - static::$leeway ) >= $payload->exp ) {
+		if ( $exp && ( $timestamp - static::$leeway ) >= $exp ) {
 			throw new ExpiredException( 'Expired token' );
 		}
 
@@ -294,13 +308,14 @@ class JWT {
 	 * Decode a JSON string into a PHP object.
 	 *
 	 * @param string $input JSON string.
+	 * @param bool   $as_array Whether to return the result as an associative array.
 	 *
 	 * @return object Object representation of JSON string
 	 *
 	 * @throws DomainException Provided string was invalid JSON.
 	 */
-	public static function json_decode( $input ) {
-		$obj   = json_decode( $input, false, 512, JSON_BIGINT_AS_STRING );
+	public static function json_decode( $input, $as_array = false ) {
+		$obj   = json_decode( $input, $as_array, 512, JSON_BIGINT_AS_STRING );
 		$errno = json_last_error();
 
 		if ( $errno ) {

--- a/projects/packages/jwt/src/class-jwt.php
+++ b/projects/packages/jwt/src/class-jwt.php
@@ -71,7 +71,7 @@ class JWT {
 	 *                                     Supported algorithms are 'HS256', 'HS384', 'HS512' and 'RS256'.
 	 * @param bool         $as_array Whether to return the result as an associative array.
 	 *
-	 * @return object The JWT's payload as a PHP object
+	 * @return object|array The JWT's payload as a PHP object or array.
 	 *
 	 * @throws UnexpectedValueException     Provided JWT was invalid.
 	 * @throws SignatureInvalidException    Provided JWT was invalid because the signature verification failed.
@@ -310,7 +310,7 @@ class JWT {
 	 * @param string $input JSON string.
 	 * @param bool   $as_array Whether to return the result as an associative array.
 	 *
-	 * @return object Object representation of JSON string
+	 * @return object|array Object or Array representation of JSON string
 	 *
 	 * @throws DomainException Provided string was invalid JSON.
 	 */

--- a/projects/packages/jwt/tests/php/Jwt_Test.php
+++ b/projects/packages/jwt/tests/php/Jwt_Test.php
@@ -43,6 +43,26 @@ class Jwt_Test extends TestCase {
 		$this->assertEquals( $payload['iss'], $decoded->iss );
 		$this->assertEquals( $payload['sub'], $decoded->sub );
 	}
+	/**
+	 * Test that the JWT class has a method to encode a token.
+	 */
+	public function test_jwt_encode_decode_array() {
+		$secret  = '1234567890abcdef1234567890abcdef'; // Example secret key
+		$payload = array(
+			'howdy' => 'world',
+			'iss'   => 'https://example.com',
+			'sub'   => '1234567890',
+		);
+		$jwt     = JWT::encode( $payload, $secret, 'HS256' );
+		$decoded = JWT::decode( $jwt, $secret, array( 'HS256' ), true );
+
+		$this->assertNotEmpty( $jwt );
+		$this->assertIsString( $jwt );
+		$this->assertIsArray( $decoded );
+		$this->assertEquals( $payload['howdy'], $decoded['howdy'] );
+		$this->assertEquals( $payload['iss'], $decoded['iss'] );
+		$this->assertEquals( $payload['sub'], $decoded['sub'] );
+	}
 
 	/**
 	 * Test that the JWT class has a method to encode a token.

--- a/projects/plugins/jetpack/changelog/update-add-jwt-form-encode-decode
+++ b/projects/plugins/jetpack/changelog/update-add-jwt-form-encode-decode
@@ -1,0 +1,4 @@
+Significance: minor
+Type: bugfix
+
+Forms: fix the way forms are submitted 

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -1413,7 +1413,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/forms",
-                "reference": "e575465d91341af76df4d6fccc469823520dd957"
+                "reference": "690af0bed3b8874b34ab6a079a1eb2f946334eab"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -1420,6 +1420,7 @@
                 "automattic/jetpack-assets": "@dev",
                 "automattic/jetpack-blocks": "@dev",
                 "automattic/jetpack-connection": "@dev",
+                "automattic/jetpack-jwt": "@dev",
                 "automattic/jetpack-logo": "@dev",
                 "automattic/jetpack-plans": "@dev",
                 "automattic/jetpack-status": "@dev",
@@ -1740,6 +1741,70 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Just in time messages for Jetpack",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-jwt",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/jwt",
+                "reference": "d0fbea9bb3f1d4c1e8e66af2780d8cdabe357319"
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
+                "automattic/phpunit-select-config": "@dev",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-jwt",
+                "changelogger": {
+                    "link-template": "https://github.com/automattic/jetpack-jwt/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "0.1.x-dev"
+                },
+                "textdomain": "jetpack-jwt",
+                "version-constants": {
+                    "::PACKAGE_VERSION": "src/class-jwt.php"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "build-development": [
+                    "echo 'Add your build step to composer.json, please!'"
+                ],
+                "build-production": [
+                    "echo 'Add your build step to composer.json, please!'"
+                ],
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "A JSON Web Token (JWT) implementation for Jetpack.",
             "transport-options": {
                 "relative": true
             }


### PR DESCRIPTION
This PR implements https://github.com/Automattic/jetpack/pull/44360 but with fixes that caused us to revert it. Please see the [original PR ](https://github.com/Automattic/jetpack/pull/44360 )- 

The revert can be found here. https://github.com/Automattic/jetpack/pull/44397 

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Add a form. Does it submit as expected?
Add a form in a widget. Does it submit as expected? 
