### PR TITLE
Backport jetpack 14.9-a.5 Changes

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -611,16 +611,16 @@
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
-            "version": "v1.1.2",
+            "version": "v1.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/composer-installer.git",
-                "reference": "e9cf5e4bbf7eeaf9ef5db34938942602838fc2b1"
+                "reference": "6e0fa428497bf560152ee73ffbb8af5c6a56b0dd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/e9cf5e4bbf7eeaf9ef5db34938942602838fc2b1",
-                "reference": "e9cf5e4bbf7eeaf9ef5db34938942602838fc2b1",
+                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/6e0fa428497bf560152ee73ffbb8af5c6a56b0dd",
+                "reference": "6e0fa428497bf560152ee73ffbb8af5c6a56b0dd",
                 "shasum": ""
             },
             "require": {
@@ -703,7 +703,7 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-07-17T20:45:56+00:00"
+            "time": "2025-06-27T17:24:01+00:00"
         },
         {
             "name": "doctrine/deprecations",
@@ -1091,16 +1091,16 @@
         },
         {
             "name": "php-stubs/woocommerce-stubs",
-            "version": "v10.0.2",
+            "version": "v9.9.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-stubs/woocommerce-stubs.git",
-                "reference": "54123e2fa2a07b11d03fe15f27fb7a64d970a9df"
+                "reference": "2efd06960ebb0ea853c906d979298fc176eec8a9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-stubs/woocommerce-stubs/zipball/54123e2fa2a07b11d03fe15f27fb7a64d970a9df",
-                "reference": "54123e2fa2a07b11d03fe15f27fb7a64d970a9df",
+                "url": "https://api.github.com/repos/php-stubs/woocommerce-stubs/zipball/2efd06960ebb0ea853c906d979298fc176eec8a9",
+                "reference": "2efd06960ebb0ea853c906d979298fc176eec8a9",
                 "shasum": ""
             },
             "require": {
@@ -1129,22 +1129,22 @@
             ],
             "support": {
                 "issues": "https://github.com/php-stubs/woocommerce-stubs/issues",
-                "source": "https://github.com/php-stubs/woocommerce-stubs/tree/v10.0.2"
+                "source": "https://github.com/php-stubs/woocommerce-stubs/tree/v9.9.4"
             },
-            "time": "2025-07-14T17:13:11+00:00"
+            "time": "2025-06-16T19:18:36+00:00"
         },
         {
             "name": "php-stubs/wordpress-stubs",
-            "version": "v6.8.2",
+            "version": "v6.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-stubs/wordpress-stubs.git",
-                "reference": "9c8e22e437463197c1ec0d5eaa9ddd4a0eb6d7f8"
+                "reference": "92e444847d94f7c30f88c60004648f507688acd5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/9c8e22e437463197c1ec0d5eaa9ddd4a0eb6d7f8",
-                "reference": "9c8e22e437463197c1ec0d5eaa9ddd4a0eb6d7f8",
+                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/92e444847d94f7c30f88c60004648f507688acd5",
+                "reference": "92e444847d94f7c30f88c60004648f507688acd5",
                 "shasum": ""
             },
             "conflict": {
@@ -1152,7 +1152,7 @@
             },
             "require-dev": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
-                "nikic/php-parser": "^5.5",
+                "nikic/php-parser": "^5.4",
                 "php": "^7.4 || ^8.0",
                 "php-stubs/generator": "^0.8.3",
                 "phpdocumentor/reflection-docblock": "^5.4.1",
@@ -1180,9 +1180,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-stubs/wordpress-stubs/issues",
-                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v6.8.2"
+                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v6.8.1"
             },
-            "time": "2025-07-16T06:41:00+00:00"
+            "time": "2025-05-02T12:33:34+00:00"
         },
         {
             "name": "php-stubs/wordpress-tests-stubs",
@@ -1820,16 +1820,16 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "2.2.0",
+            "version": "2.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "b9e61a61e39e02dd90944e9115241c7f7e76bfd8"
+                "reference": "9b30d6fd026b2c132b3985ce6b23bec09ab3aa68"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/b9e61a61e39e02dd90944e9115241c7f7e76bfd8",
-                "reference": "b9e61a61e39e02dd90944e9115241c7f7e76bfd8",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/9b30d6fd026b2c132b3985ce6b23bec09ab3aa68",
+                "reference": "9b30d6fd026b2c132b3985ce6b23bec09ab3aa68",
                 "shasum": ""
             },
             "require": {
@@ -1861,9 +1861,9 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.2.0"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.1.0"
             },
-            "time": "2025-07-13T07:04:09+00:00"
+            "time": "2025-02-19T13:28:12+00:00"
         },
         {
             "name": "psr/container",

--- a/projects/js-packages/ai-client/CHANGELOG.md
+++ b/projects/js-packages/ai-client/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.33.3] - 2025-07-21
+### Changed
+- Internal updates.
+
 ## [0.33.2] - 2025-07-14
 ### Changed
 - Update package dependencies. [#44217] [#44219]
@@ -663,6 +667,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - AI Client: stop using smart document visibility handling on the fetchEventSource library, so it does not restart the completion when changing tabs. [#32004]
 - Updated package dependencies. [#31468] [#31659] [#31785]
 
+[0.33.3]: https://github.com/Automattic/jetpack-ai-client/compare/v0.33.2...v0.33.3
 [0.33.2]: https://github.com/Automattic/jetpack-ai-client/compare/v0.33.1...v0.33.2
 [0.33.1]: https://github.com/Automattic/jetpack-ai-client/compare/v0.33.0...v0.33.1
 [0.33.0]: https://github.com/Automattic/jetpack-ai-client/compare/v0.32.1...v0.33.0

--- a/projects/js-packages/ai-client/changelog/update-stylelint-enable_spacing_rules
+++ b/projects/js-packages/ai-client/changelog/update-stylelint-enable_spacing_rules
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Stylelint: Fix spacing rules.
-
-

--- a/projects/js-packages/ai-client/changelog/update-stylelint-fix_newline_rules
+++ b/projects/js-packages/ai-client/changelog/update-stylelint-fix_newline_rules
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Stylelint: Enable newline rules.
-
-

--- a/projects/js-packages/ai-client/changelog/update-stylint-enable_indentation
+++ b/projects/js-packages/ai-client/changelog/update-stylint-enable_indentation
@@ -1,5 +1,0 @@
-Significance: patch
-Type: deprecated
-Comment: Stylelint: Enable indentation rules.
-
-

--- a/projects/js-packages/ai-client/package.json
+++ b/projects/js-packages/ai-client/package.json
@@ -1,7 +1,7 @@
 {
 	"private": false,
 	"name": "@automattic/jetpack-ai-client",
-	"version": "0.33.2",
+	"version": "0.33.3",
 	"description": "A JS client for consuming Jetpack AI services",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/ai-client/#readme",
 	"bugs": {

--- a/projects/js-packages/babel-plugin-replace-textdomain/CHANGELOG.md
+++ b/projects/js-packages/babel-plugin-replace-textdomain/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.50] - 2025-07-21
+### Changed
+- Update package dependencies. [#44356]
+
 ## [1.0.49] - 2025-07-08
 ### Changed
 - Update package dependencies. [#44217]
@@ -217,6 +221,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial release.
 - Replace missing domains too.
 
+[1.0.50]: https://github.com/Automattic/babel-plugin-replace-textdomain/compare/v1.0.49...v1.0.50
 [1.0.49]: https://github.com/Automattic/babel-plugin-replace-textdomain/compare/v1.0.48...v1.0.49
 [1.0.48]: https://github.com/Automattic/babel-plugin-replace-textdomain/compare/v1.0.47...v1.0.48
 [1.0.47]: https://github.com/Automattic/babel-plugin-replace-textdomain/compare/v1.0.46...v1.0.47

--- a/projects/js-packages/babel-plugin-replace-textdomain/changelog/renovate-babel-monorepo
+++ b/projects/js-packages/babel-plugin-replace-textdomain/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/js-packages/babel-plugin-replace-textdomain/package.json
+++ b/projects/js-packages/babel-plugin-replace-textdomain/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/babel-plugin-replace-textdomain",
-	"version": "1.0.49",
+	"version": "1.0.50",
 	"description": "A Babel plugin to replace the textdomain in gettext-style function calls.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/babel-plugin-replace-textdomain/#readme",
 	"bugs": {

--- a/projects/js-packages/base-styles/CHANGELOG.md
+++ b/projects/js-packages/base-styles/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.5] - 2025-07-21
+### Changed
+- Internal updates.
+
 ## [1.0.4] - 2025-07-10
 ### Changed
 - Internal updates.
@@ -420,6 +424,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Use Node 16.7.0 in tooling. This shouldn't change the behavior of the code itself.
 
+[1.0.5]: https://github.com/Automattic/jetpack-base-styles/compare/1.0.4...1.0.5
 [1.0.4]: https://github.com/Automattic/jetpack-base-styles/compare/1.0.3...1.0.4
 [1.0.3]: https://github.com/Automattic/jetpack-base-styles/compare/1.0.2...1.0.3
 [1.0.2]: https://github.com/Automattic/jetpack-base-styles/compare/1.0.1...1.0.2

--- a/projects/js-packages/base-styles/changelog/update-stylelint-enable_spacing_rules
+++ b/projects/js-packages/base-styles/changelog/update-stylelint-enable_spacing_rules
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Stylelint: Fix spacing rules.
-
-

--- a/projects/js-packages/base-styles/changelog/update-stylelint-fix_newline_rules
+++ b/projects/js-packages/base-styles/changelog/update-stylelint-fix_newline_rules
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Stylelint: Enable newline rules.
-
-

--- a/projects/js-packages/base-styles/changelog/update-stylint-enable_indentation
+++ b/projects/js-packages/base-styles/changelog/update-stylint-enable_indentation
@@ -1,5 +1,0 @@
-Significance: patch
-Type: deprecated
-Comment: Stylelint: Enable indentation rules.
-
-

--- a/projects/js-packages/base-styles/package.json
+++ b/projects/js-packages/base-styles/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-base-styles",
-	"version": "1.0.4",
+	"version": "1.0.5",
 	"description": "Jetpack components base styles",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/base-styles/#readme",
 	"bugs": {

--- a/projects/js-packages/boost-score-api/CHANGELOG.md
+++ b/projects/js-packages/boost-score-api/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.7] - 2025-07-21
+### Changed
+- Update dependencies. [#43068]
+
 ## [1.0.6] - 2025-07-08
 ### Changed
 - Update package dependencies. [#44217]
@@ -311,6 +315,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Create package for the boost score bar API [#30781]
 
+[1.0.7]: https://github.com/Automattic/jetpack-boost-score-api/compare/v1.0.6...v1.0.7
 [1.0.6]: https://github.com/Automattic/jetpack-boost-score-api/compare/v1.0.5...v1.0.6
 [1.0.5]: https://github.com/Automattic/jetpack-boost-score-api/compare/v1.0.4...v1.0.5
 [1.0.4]: https://github.com/Automattic/jetpack-boost-score-api/compare/v1.0.3...v1.0.4

--- a/projects/js-packages/boost-score-api/package.json
+++ b/projects/js-packages/boost-score-api/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-boost-score-api",
-	"version": "1.0.6",
+	"version": "1.0.7",
 	"description": "A package to get the Jetpack Boost score of a site",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/boost-score-api/#readme",
 	"bugs": {

--- a/projects/js-packages/charts/CHANGELOG.md
+++ b/projects/js-packages/charts/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.18.0] - 2025-07-21
+### Added
+- Add keyboard navigation support for bar and line charts. [#44036]
+- Add Woo Analytics Leaderboard chart component. [#44299]
+- Line chart: Add documentation for annotations. [#44361]
+- Line chart: Add support for custom interactive annotations. Includes a breaking change to the annotations API, from an `annotations` prop to a compound component pattern. [#44131]
+
+### Changed
+- Replace `lodash` with `deepmerge`. [#44316]
+- Update package dependencies. [#44356]
+
 ## [0.17.0] - 2025-07-14
 ### Added
 - Add foundation for ChartContext system. [#44189]
@@ -285,6 +296,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed lints following ESLint rule changes for TS [#40584]
 - Fixing a bug in Chart storybook data. [#40640]
 
+[0.18.0]: https://github.com/Automattic/charts/compare/v0.17.0...v0.18.0
 [0.17.0]: https://github.com/Automattic/charts/compare/v0.16.2...v0.17.0
 [0.16.2]: https://github.com/Automattic/charts/compare/v0.16.1...v0.16.2
 [0.16.1]: https://github.com/Automattic/charts/compare/v0.16.0...v0.16.1

--- a/projects/js-packages/charts/changelog/charts-17-line-chart-keyboard-navigation
+++ b/projects/js-packages/charts/changelog/charts-17-line-chart-keyboard-navigation
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add keyboard navigation support for the line charts

--- a/projects/js-packages/charts/changelog/charts-18-bar-chart-keyboard-navigation
+++ b/projects/js-packages/charts/changelog/charts-18-bar-chart-keyboard-navigation
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add keyboard navigation support for the bar charts

--- a/projects/js-packages/charts/changelog/line-chart-annotation-documentation
+++ b/projects/js-packages/charts/changelog/line-chart-annotation-documentation
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Line chart: Add documentation for annotations

--- a/projects/js-packages/charts/changelog/line-chart-custom-annotations
+++ b/projects/js-packages/charts/changelog/line-chart-custom-annotations
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Line chart: Add support for custom interactive annotations. Includes a breaking change to the annotations API, from an `annotations` prop to a compound component pattern.

--- a/projects/js-packages/charts/changelog/renovate-babel-monorepo
+++ b/projects/js-packages/charts/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/js-packages/charts/changelog/update-add_woo_leaderboard_chart_component
+++ b/projects/js-packages/charts/changelog/update-add_woo_leaderboard_chart_component
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add Woo Analytics Leaderboard chart component.

--- a/projects/js-packages/charts/changelog/update-replace-lodash-in-charts
+++ b/projects/js-packages/charts/changelog/update-replace-lodash-in-charts
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Replace `lodash` with `deepmerge`.

--- a/projects/js-packages/charts/changelog/update-stylelint-fix_newline_rules
+++ b/projects/js-packages/charts/changelog/update-stylelint-fix_newline_rules
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Stylelint: Enable newline rules.
-
-

--- a/projects/js-packages/charts/changelog/update-stylint-enable_indentation
+++ b/projects/js-packages/charts/changelog/update-stylint-enable_indentation
@@ -1,5 +1,0 @@
-Significance: patch
-Type: deprecated
-Comment: Stylelint: Enable indentation rules.
-
-

--- a/projects/js-packages/charts/package.json
+++ b/projects/js-packages/charts/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/charts",
-	"version": "0.17.0",
+	"version": "0.18.0",
 	"description": "Display charts within Automattic products.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/charts/#readme",
 	"bugs": {

--- a/projects/js-packages/components/CHANGELOG.md
+++ b/projects/js-packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### This is a list detailing changes for the Jetpack RNA Components package releases.
 
+## [1.1.14] - 2025-07-21
+### Changed
+- Update package dependencies. [#44356]
+
 ## [1.1.13] - 2025-07-10
 ### Changed
 - Update package dependencies. [#44219]
@@ -1477,6 +1481,7 @@
 ### Changed
 - Update node version requirement to 14.16.1
 
+[1.1.14]: https://github.com/Automattic/jetpack-components/compare/1.1.13...1.1.14
 [1.1.13]: https://github.com/Automattic/jetpack-components/compare/1.1.12...1.1.13
 [1.1.12]: https://github.com/Automattic/jetpack-components/compare/1.1.11...1.1.12
 [1.1.11]: https://github.com/Automattic/jetpack-components/compare/1.1.10...1.1.11

--- a/projects/js-packages/components/changelog/renovate-babel-monorepo
+++ b/projects/js-packages/components/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/js-packages/components/changelog/update-stylelint-enable_spacing_rules
+++ b/projects/js-packages/components/changelog/update-stylelint-enable_spacing_rules
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Stylelint: Fix spacing rules.
-
-

--- a/projects/js-packages/components/changelog/update-stylelint-fix_newline_rules
+++ b/projects/js-packages/components/changelog/update-stylelint-fix_newline_rules
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Stylelint: Enable newline rules.
-
-

--- a/projects/js-packages/components/changelog/update-stylint-enable_indentation
+++ b/projects/js-packages/components/changelog/update-stylint-enable_indentation
@@ -1,5 +1,0 @@
-Significance: patch
-Type: deprecated
-Comment: Stylelint: Enable indentation rules.
-
-

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-components",
-	"version": "1.1.13",
+	"version": "1.1.14",
 	"description": "Jetpack Components Package",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/js-packages/connection/CHANGELOG.md
+++ b/projects/js-packages/connection/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### This is a list detailing changes for the Jetpack RNA Connection Component releases.
 
+## [1.2.14] - 2025-07-21
+### Changed
+- Update package dependencies. [#44356]
+
 ## [1.2.13] - 2025-07-10
 ### Changed
 - Update package dependencies. [#44219]
@@ -1104,6 +1108,7 @@
 - `Main` and `ConnectUser` components added.
 - `JetpackRestApiClient` API client added.
 
+[1.2.14]: https://github.com/Automattic/jetpack-connection-js/compare/v1.2.13...v1.2.14
 [1.2.13]: https://github.com/Automattic/jetpack-connection-js/compare/v1.2.12...v1.2.13
 [1.2.12]: https://github.com/Automattic/jetpack-connection-js/compare/v1.2.11...v1.2.12
 [1.2.11]: https://github.com/Automattic/jetpack-connection-js/compare/v1.2.10...v1.2.11

--- a/projects/js-packages/connection/changelog/renovate-babel-monorepo
+++ b/projects/js-packages/connection/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/js-packages/connection/changelog/update-stylelint-enable_spacing_rules
+++ b/projects/js-packages/connection/changelog/update-stylelint-enable_spacing_rules
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Stylelint: Fix spacing rules.
-
-

--- a/projects/js-packages/connection/changelog/update-stylelint-fix_newline_rules
+++ b/projects/js-packages/connection/changelog/update-stylelint-fix_newline_rules
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Stylelint: Enable newline rules.
-
-

--- a/projects/js-packages/connection/changelog/update-stylint-enable_indentation
+++ b/projects/js-packages/connection/changelog/update-stylint-enable_indentation
@@ -1,5 +1,0 @@
-Significance: patch
-Type: deprecated
-Comment: Stylelint: Enable indentation rules.
-
-

--- a/projects/js-packages/connection/package.json
+++ b/projects/js-packages/connection/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-connection",
-	"version": "1.2.13",
+	"version": "1.2.14",
 	"description": "Jetpack Connection Component",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/connection/#readme",
 	"bugs": {

--- a/projects/js-packages/i18n-check-webpack-plugin/CHANGELOG.md
+++ b/projects/js-packages/i18n-check-webpack-plugin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.25] - 2025-07-21
+### Changed
+- Update package dependencies. [#44356]
+
 ## [1.1.24] - 2025-07-08
 ### Changed
 - Update package dependencies. [#44217]
@@ -273,6 +277,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release.
 
+[1.1.25]: https://github.com/Automattic/i18n-check-webpack-plugin/compare/v1.1.24...v1.1.25
 [1.1.24]: https://github.com/Automattic/i18n-check-webpack-plugin/compare/v1.1.23...v1.1.24
 [1.1.23]: https://github.com/Automattic/i18n-check-webpack-plugin/compare/v1.1.22...v1.1.23
 [1.1.22]: https://github.com/Automattic/i18n-check-webpack-plugin/compare/v1.1.21...v1.1.22

--- a/projects/js-packages/i18n-check-webpack-plugin/changelog/renovate-babel-monorepo
+++ b/projects/js-packages/i18n-check-webpack-plugin/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/js-packages/i18n-check-webpack-plugin/changelog/update-stylelint-fix_newline_rules
+++ b/projects/js-packages/i18n-check-webpack-plugin/changelog/update-stylelint-fix_newline_rules
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Stylelint: Enable newline rules.
-
-

--- a/projects/js-packages/i18n-check-webpack-plugin/package.json
+++ b/projects/js-packages/i18n-check-webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/i18n-check-webpack-plugin",
-	"version": "1.1.24",
+	"version": "1.1.25",
 	"description": "A Webpack plugin to check that WordPress i18n hasn't been mangled by Webpack optimizations.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/i18n-check-webpack-plugin/#readme",
 	"bugs": {

--- a/projects/js-packages/idc/CHANGELOG.md
+++ b/projects/js-packages/idc/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### This is a list detailing changes for the Jetpack RNA IDC package releases.
 
+## 1.0.14 - 2025-07-21
+### Changed
+- Update package dependencies. [#44356]
+
 ## 1.0.13 - 2025-07-14
 ### Changed
 - Update dependencies. [#44271]

--- a/projects/js-packages/idc/changelog/renovate-babel-monorepo
+++ b/projects/js-packages/idc/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/js-packages/idc/changelog/update-stylelint-fix_newline_rules
+++ b/projects/js-packages/idc/changelog/update-stylelint-fix_newline_rules
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Stylelint: Enable newline rules.
-
-

--- a/projects/js-packages/idc/changelog/update-stylint-enable_indentation
+++ b/projects/js-packages/idc/changelog/update-stylint-enable_indentation
@@ -1,5 +1,0 @@
-Significance: patch
-Type: deprecated
-Comment: Stylelint: Enable indentation rules.
-
-

--- a/projects/js-packages/idc/package.json
+++ b/projects/js-packages/idc/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-idc",
-	"version": "1.0.13",
+	"version": "1.0.14",
 	"description": "Jetpack Connection Component",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/js-packages/licensing/CHANGELOG.md
+++ b/projects/js-packages/licensing/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.0.13 - 2025-07-21
+### Changed
+- Update package dependencies. [#44356]
+
 ## 1.0.12 - 2025-07-14
 ### Changed
 - Update dependencies. [#44271]

--- a/projects/js-packages/licensing/changelog/renovate-babel-monorepo
+++ b/projects/js-packages/licensing/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/js-packages/licensing/changelog/update-stylelint-enable_spacing_rules
+++ b/projects/js-packages/licensing/changelog/update-stylelint-enable_spacing_rules
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Stylelint: Fix spacing rules.
-
-

--- a/projects/js-packages/licensing/changelog/update-stylelint-fix_newline_rules
+++ b/projects/js-packages/licensing/changelog/update-stylelint-fix_newline_rules
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Stylelint: Enable newline rules.
-
-

--- a/projects/js-packages/licensing/changelog/update-stylint-enable_indentation
+++ b/projects/js-packages/licensing/changelog/update-stylint-enable_indentation
@@ -1,5 +1,0 @@
-Significance: patch
-Type: deprecated
-Comment: Stylelint: Enable indentation rules.
-
-

--- a/projects/js-packages/licensing/package.json
+++ b/projects/js-packages/licensing/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-licensing",
-	"version": "1.0.12",
+	"version": "1.0.13",
 	"description": "Jetpack licensing flow",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/licensing/#readme",
 	"bugs": {

--- a/projects/js-packages/number-formatters/CHANGELOG.md
+++ b/projects/js-packages/number-formatters/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [1.0.9] - 2025-07-21
+### Changed
+- Update package dependencies. [#44356]
+
 ## [1.0.8] - 2025-07-08
 ### Changed
 - Update package dependencies. [#44217]
@@ -65,6 +69,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Initial release
 - Basic number formatting functionality
 
+[1.0.9]: https://github.com/Automattic/number-formatters/compare/1.0.8...1.0.9
 [1.0.8]: https://github.com/Automattic/number-formatters/compare/1.0.7...1.0.8
 [1.0.7]: https://github.com/Automattic/number-formatters/compare/1.0.6...1.0.7
 [1.0.6]: https://github.com/Automattic/number-formatters/compare/1.0.5...1.0.6

--- a/projects/js-packages/number-formatters/changelog/renovate-babel-monorepo
+++ b/projects/js-packages/number-formatters/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/js-packages/number-formatters/package.json
+++ b/projects/js-packages/number-formatters/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/number-formatters",
-	"version": "1.0.8",
+	"version": "1.0.9",
 	"description": "Number formatting utilities",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/js-packages/partner-coupon/CHANGELOG.md
+++ b/projects/js-packages/partner-coupon/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.0.8 - 2025-07-21
+### Changed
+- Update package dependencies. [#44356]
+
 ## 1.0.7 - 2025-07-14
 ### Changed
 - Update package dependencies. [#44217]

--- a/projects/js-packages/partner-coupon/changelog/renovate-babel-monorepo
+++ b/projects/js-packages/partner-coupon/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/js-packages/partner-coupon/changelog/update-stylelint-enable_spacing_rules
+++ b/projects/js-packages/partner-coupon/changelog/update-stylelint-enable_spacing_rules
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Stylelint: Fix spacing rules.
-
-

--- a/projects/js-packages/partner-coupon/changelog/update-stylelint-fix_newline_rules
+++ b/projects/js-packages/partner-coupon/changelog/update-stylelint-fix_newline_rules
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Stylelint: Enable newline rules.
-
-

--- a/projects/js-packages/partner-coupon/changelog/update-stylint-enable_indentation
+++ b/projects/js-packages/partner-coupon/changelog/update-stylint-enable_indentation
@@ -1,5 +1,0 @@
-Significance: patch
-Type: deprecated
-Comment: Stylelint: Enable indentation rules.
-
-

--- a/projects/js-packages/partner-coupon/package.json
+++ b/projects/js-packages/partner-coupon/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-partner-coupon",
-	"version": "1.0.7",
+	"version": "1.0.8",
 	"description": "This package aims to add components to make it easier to redeem partner coupons",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/partner-coupon/#readme",
 	"bugs": {

--- a/projects/js-packages/publicize-components/CHANGELOG.md
+++ b/projects/js-packages/publicize-components/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.5] - 2025-07-21
+### Changed
+- Change the new badge color to match WordPress colors in the connection management. [#44310]
+- Update package dependencies. [#44356]
+
+### Fixed
+- SIG: Ensure the modal loads the featured image. [#44227]
+- Social: Fix image validation when images sizes are customised. [#44368]
+
 ## [1.1.4] - 2025-07-14
 ### Changed
 - Update package dependencies. [#44217] [#44219]
@@ -1304,6 +1313,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated package dependencies. [#24470]
 
+[1.1.5]: https://github.com/Automattic/jetpack-publicize-components/compare/v1.1.4...v1.1.5
 [1.1.4]: https://github.com/Automattic/jetpack-publicize-components/compare/v1.1.3...v1.1.4
 [1.1.3]: https://github.com/Automattic/jetpack-publicize-components/compare/v1.1.2...v1.1.3
 [1.1.2]: https://github.com/Automattic/jetpack-publicize-components/compare/v1.1.1...v1.1.2

--- a/projects/js-packages/publicize-components/changelog/fix-sig-image-picking-logic
+++ b/projects/js-packages/publicize-components/changelog/fix-sig-image-picking-logic
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fixed a bug with the SIG modal not loading featured image.

--- a/projects/js-packages/publicize-components/changelog/fix-social-media-validation-for-custom-image-sizes
+++ b/projects/js-packages/publicize-components/changelog/fix-social-media-validation-for-custom-image-sizes
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Social: Fix image validation when images sizes are customised.

--- a/projects/js-packages/publicize-components/changelog/fix-social-new-badge-color
+++ b/projects/js-packages/publicize-components/changelog/fix-social-new-badge-color
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Changed the new badge color to match WordPress colors in the connection management.

--- a/projects/js-packages/publicize-components/changelog/renovate-babel-monorepo
+++ b/projects/js-packages/publicize-components/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/js-packages/publicize-components/changelog/renovate-eslint-packages
+++ b/projects/js-packages/publicize-components/changelog/renovate-eslint-packages
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: eslint: Suppress a bunch of testing-library/no-node-access false positives.
-
-

--- a/projects/js-packages/publicize-components/changelog/update-stylelint-enable_spacing_rules
+++ b/projects/js-packages/publicize-components/changelog/update-stylelint-enable_spacing_rules
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Stylelint: Fix spacing rules.
-
-

--- a/projects/js-packages/publicize-components/changelog/update-stylelint-fix_newline_rules
+++ b/projects/js-packages/publicize-components/changelog/update-stylelint-fix_newline_rules
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Stylelint: Enable newline rules.
-
-

--- a/projects/js-packages/publicize-components/changelog/update-stylint-enable_indentation
+++ b/projects/js-packages/publicize-components/changelog/update-stylint-enable_indentation
@@ -1,5 +1,0 @@
-Significance: patch
-Type: deprecated
-Comment: Stylelint: Enable indentation rules.
-
-

--- a/projects/js-packages/publicize-components/package.json
+++ b/projects/js-packages/publicize-components/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize-components",
-	"version": "1.1.4",
+	"version": "1.1.5",
 	"description": "A library of JS components required by the Publicize editor plugin",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/publicize-components/#readme",
 	"bugs": {

--- a/projects/js-packages/react-data-sync-client/changelog/force-a-release
+++ b/projects/js-packages/react-data-sync-client/changelog/force-a-release
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update dependencies.

--- a/projects/js-packages/shared-extension-utils/CHANGELOG.md
+++ b/projects/js-packages/shared-extension-utils/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.5] - 2025-07-21
+### Changed
+- Update package dependencies. [#44356]
+
 ## [1.3.4] - 2025-07-14
 ### Removed
 - Remove no-longer-needed dependency on `lodash`. [#44269]
@@ -719,6 +723,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Core: prepare utility for release
 
+[1.3.5]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/1.3.4...1.3.5
 [1.3.4]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/1.3.3...1.3.4
 [1.3.3]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/1.3.2...1.3.3
 [1.3.2]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/1.3.1...1.3.2

--- a/projects/js-packages/shared-extension-utils/changelog/renovate-babel-monorepo
+++ b/projects/js-packages/shared-extension-utils/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/js-packages/shared-extension-utils/changelog/update-stylelint-enable_spacing_rules
+++ b/projects/js-packages/shared-extension-utils/changelog/update-stylelint-enable_spacing_rules
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Stylelint: Fix spacing rules.
-
-

--- a/projects/js-packages/shared-extension-utils/changelog/update-stylelint-fix_newline_rules
+++ b/projects/js-packages/shared-extension-utils/changelog/update-stylelint-fix_newline_rules
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Stylelint: Enable newline rules.
-
-

--- a/projects/js-packages/shared-extension-utils/changelog/update-stylint-enable_indentation
+++ b/projects/js-packages/shared-extension-utils/changelog/update-stylint-enable_indentation
@@ -1,5 +1,0 @@
-Significance: patch
-Type: deprecated
-Comment: Stylelint: Enable indentation rules.
-
-

--- a/projects/js-packages/shared-extension-utils/package.json
+++ b/projects/js-packages/shared-extension-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-shared-extension-utils",
-	"version": "1.3.4",
+	"version": "1.3.5",
 	"description": "Utility functions used by the block editor extensions",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/shared-extension-utils/#readme",
 	"bugs": {

--- a/projects/js-packages/social-logos/CHANGELOG.md
+++ b/projects/js-packages/social-logos/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [3.2.6] - 2025-07-21
+### Changed
+- Internal updates.
+
 ## [3.2.5] - 2025-07-01
 ### Changed
 - Internal updates.
@@ -240,6 +244,7 @@
 
 - Build: Refactored (aligned build system with Gridicons).
 
+[3.2.6]: https://github.com/Automattic/social-logos/compare/v3.2.5...v3.2.6
 [3.2.5]: https://github.com/Automattic/social-logos/compare/v3.2.4...v3.2.5
 [3.2.4]: https://github.com/Automattic/social-logos/compare/v3.2.3...v3.2.4
 [3.2.3]: https://github.com/Automattic/social-logos/compare/v3.2.2...v3.2.3

--- a/projects/js-packages/social-logos/changelog/update-stylelint-fix_newline_rules
+++ b/projects/js-packages/social-logos/changelog/update-stylelint-fix_newline_rules
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Stylelint: Enable newline rules.
-
-

--- a/projects/js-packages/social-logos/package.json
+++ b/projects/js-packages/social-logos/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "social-logos",
-	"version": "3.2.5",
+	"version": "3.2.6",
 	"description": "A repository of all the social logos used on WordPress.com.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/social-logos/",
 	"bugs": {

--- a/projects/js-packages/webpack-config/CHANGELOG.md
+++ b/projects/js-packages/webpack-config/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 3.7.3 - 2025-07-21
+### Changed
+- Update package dependencies. [#44356]
+
 ## 3.7.2 - 2025-07-08
 ### Changed
 - Update dependencies.

--- a/projects/js-packages/webpack-config/changelog/renovate-babel-monorepo
+++ b/projects/js-packages/webpack-config/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/js-packages/webpack-config/package.json
+++ b/projects/js-packages/webpack-config/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-webpack-config",
-	"version": "3.7.2",
+	"version": "3.7.3",
 	"description": "Library of pieces for webpack config in Jetpack projects.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/webpack-config/#readme",
 	"bugs": {

--- a/projects/packages/account-protection/CHANGELOG.md
+++ b/projects/packages/account-protection/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.5] - 2025-07-21
+### Changed
+- Internal updates.
+
 ## [0.2.4] - 2025-05-05
 ### Fixed
 - Linting: Do additional stylesheet cleanup. [#43247]
@@ -37,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use jetpack-config package for Account Protection initialization. [#40925]
 - Use jetpack-logo package for Account Protection logos. [#40925]
 
+[0.2.5]: https://github.com/Automattic/jetpack-account-protection/compare/v0.2.4...v0.2.5
 [0.2.4]: https://github.com/Automattic/jetpack-account-protection/compare/v0.2.3...v0.2.4
 [0.2.3]: https://github.com/Automattic/jetpack-account-protection/compare/v0.2.2...v0.2.3
 [0.2.2]: https://github.com/Automattic/jetpack-account-protection/compare/v0.2.1...v0.2.2

--- a/projects/packages/account-protection/changelog/update-stylint-enable_indentation
+++ b/projects/packages/account-protection/changelog/update-stylint-enable_indentation
@@ -1,5 +1,0 @@
-Significance: patch
-Type: deprecated
-Comment: Stylelint: Enable indentation rules.
-
-

--- a/projects/packages/account-protection/package.json
+++ b/projects/packages/account-protection/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-account-protection",
-	"version": "0.2.4",
+	"version": "0.2.5",
 	"description": "Account protection",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/account-protection/#readme",
 	"bugs": {

--- a/projects/packages/account-protection/src/class-account-protection.php
+++ b/projects/packages/account-protection/src/class-account-protection.php
@@ -15,7 +15,7 @@ use Automattic\Jetpack\Status\Host;
  * Class Account_Protection
  */
 class Account_Protection {
-	const PACKAGE_VERSION                = '0.2.4';
+	const PACKAGE_VERSION                = '0.2.5';
 	const ACCOUNT_PROTECTION_MODULE_NAME = 'account-protection';
 
 	/**

--- a/projects/packages/assets/CHANGELOG.md
+++ b/projects/packages/assets/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.2.0] - 2025-07-21
+### Changed
+- Script Data: Ensure we only add host information on the front-end for P2 and sites using Verbum Comments. [#44241]
+
 ## [4.1.2] - 2025-07-08
 ### Changed
 - Update dependencies. [#42554]
@@ -676,6 +680,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Statically access asset tools
 
+[4.2.0]: https://github.com/Automattic/jetpack-assets/compare/v4.1.2...v4.2.0
 [4.1.2]: https://github.com/Automattic/jetpack-assets/compare/v4.1.1...v4.1.2
 [4.1.1]: https://github.com/Automattic/jetpack-assets/compare/v4.1.0...v4.1.1
 [4.1.0]: https://github.com/Automattic/jetpack-assets/compare/v4.0.32...v4.1.0

--- a/projects/packages/assets/changelog/update-limit-jetpack-script-data-public-host-availability
+++ b/projects/packages/assets/changelog/update-limit-jetpack-script-data-public-host-availability
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Script Data: Ensure we only add host information on the front-end for P2 and sites using Verbum Comments.

--- a/projects/packages/assets/composer.json
+++ b/projects/packages/assets/composer.json
@@ -63,7 +63,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-assets/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "4.1.x-dev"
+			"dev-trunk": "4.2.x-dev"
 		}
 	}
 }

--- a/projects/packages/backup/CHANGELOG.md
+++ b/projects/packages/backup/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.2.12] - 2025-07-21
+### Changed
+- Update package dependencies. [#44356]
+
 ## [4.2.11] - 2025-07-14
 ### Changed
 - Update package dependencies. [#44217] [#44219]
@@ -900,6 +904,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add API endpoints and Jetpack Backup package for managing Help…
 
+[4.2.12]: https://github.com/Automattic/jetpack-backup/compare/v4.2.11...v4.2.12
 [4.2.11]: https://github.com/Automattic/jetpack-backup/compare/v4.2.10...v4.2.11
 [4.2.10]: https://github.com/Automattic/jetpack-backup/compare/v4.2.9...v4.2.10
 [4.2.9]: https://github.com/Automattic/jetpack-backup/compare/v4.2.8...v4.2.9

--- a/projects/packages/backup/changelog/renovate-babel-monorepo
+++ b/projects/packages/backup/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/backup/changelog/update-stylelint-enable_spacing_rules
+++ b/projects/packages/backup/changelog/update-stylelint-enable_spacing_rules
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Stylelint: Fix spacing rules.
-
-

--- a/projects/packages/backup/changelog/update-stylelint-fix_newline_rules
+++ b/projects/packages/backup/changelog/update-stylelint-fix_newline_rules
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Stylelint: Enable newline rules.
-
-

--- a/projects/packages/backup/changelog/update-stylint-enable_indentation
+++ b/projects/packages/backup/changelog/update-stylint-enable_indentation
@@ -1,5 +1,0 @@
-Significance: patch
-Type: deprecated
-Comment: Stylelint: Enable indentation rules.
-
-

--- a/projects/packages/backup/src/class-package-version.php
+++ b/projects/packages/backup/src/class-package-version.php
@@ -16,7 +16,7 @@ namespace Automattic\Jetpack\Backup;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '4.2.11';
+	const PACKAGE_VERSION = '4.2.12';
 
 	const PACKAGE_SLUG = 'backup';
 

--- a/projects/packages/blaze/CHANGELOG.md
+++ b/projects/packages/blaze/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.25.37] - 2025-07-21
+### Changed
+- Update package dependencies. [#44356]
+
 ## [0.25.36] - 2025-07-14
 ### Changed
 - Update dependencies. [#44229]
@@ -642,6 +646,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated package dependencies. [#27906]
 
+[0.25.37]: https://github.com/automattic/jetpack-blaze/compare/v0.25.36...v0.25.37
 [0.25.36]: https://github.com/automattic/jetpack-blaze/compare/v0.25.35...v0.25.36
 [0.25.35]: https://github.com/automattic/jetpack-blaze/compare/v0.25.34...v0.25.35
 [0.25.34]: https://github.com/automattic/jetpack-blaze/compare/v0.25.33...v0.25.34

--- a/projects/packages/blaze/changelog/renovate-babel-monorepo
+++ b/projects/packages/blaze/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/blaze/package.json
+++ b/projects/packages/blaze/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-blaze",
-	"version": "0.25.36",
+	"version": "0.25.37",
 	"description": "Attract high-quality traffic to your site using Blaze. Using this service, you can advertise a post or page on some of the millions of pages across WordPress.com and Tumblr from just $5 per day.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/blaze/#readme",
 	"bugs": {

--- a/projects/packages/blaze/src/class-dashboard.php
+++ b/projects/packages/blaze/src/class-dashboard.php
@@ -21,7 +21,7 @@ class Dashboard {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.25.36';
+	const PACKAGE_VERSION = '0.25.37';
 
 	/**
 	 * List of dependencies needed to render the dashboard in wp-admin.

--- a/projects/packages/block-delimiter/CHANGELOG.md
+++ b/projects/packages/block-delimiter/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] - 2025-07-21
+### Changed
+- Scanner: Revert changes to returned parsed attributes. [#44365]
+
 ## [0.3.0] - 2025-07-14
 ### Added
 - Add Block_Scanner class as a replacement to Block_Delimiter. [#44158]
@@ -21,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release.
 
+[0.3.1]: https://github.com/Automattic/block-delimiter/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/Automattic/block-delimiter/compare/v0.2.1...v0.3.0
 [0.2.1]: https://github.com/Automattic/block-delimiter/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/Automattic/block-delimiter/compare/v0.1.0...v0.2.0

--- a/projects/packages/block-delimiter/changelog/update-block-delimiter-scanner-review
+++ b/projects/packages/block-delimiter/changelog/update-block-delimiter-scanner-review
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Scanner: revert changes to returned parsed attributes.

--- a/projects/packages/block-delimiter/package.json
+++ b/projects/packages/block-delimiter/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/block-delimiter",
-	"version": "0.3.0",
+	"version": "0.3.1",
 	"description": "Efficiently work with block structure",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/block-delimiter/#readme",
 	"bugs": {

--- a/projects/packages/boost-speed-score/CHANGELOG.md
+++ b/projects/packages/boost-speed-score/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.10] - 2025-07-21
+### Changed
+- Internal updates.
+
 ## [0.4.9] - 2025-05-15
 ### Changed
 - Switch from deprecated `jetpack_boost_critical_css_environment_changed` action to `jetpack_boost_environment_changed`. [#43446]
@@ -136,6 +140,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add a new package for Boost Speed Score [#30914]
 - Add a new argument to `Speed_Score` to identify where the request was made from (e.g. 'boost-plugin', 'jetpack-dashboard', etc). [#31012]
 
+[0.4.10]: https://github.com/Automattic/jetpack-boost-speed-score/compare/v0.4.9...v0.4.10
 [0.4.9]: https://github.com/Automattic/jetpack-boost-speed-score/compare/v0.4.8...v0.4.9
 [0.4.8]: https://github.com/Automattic/jetpack-boost-speed-score/compare/v0.4.7...v0.4.8
 [0.4.7]: https://github.com/Automattic/jetpack-boost-speed-score/compare/v0.4.6...v0.4.7

--- a/projects/packages/boost-speed-score/changelog/fix-phan-noopnew
+++ b/projects/packages/boost-speed-score/changelog/fix-phan-noopnew
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Phan: Clean up PhanNoopNew instances.
-

--- a/projects/packages/boost-speed-score/src/class-speed-score.php
+++ b/projects/packages/boost-speed-score/src/class-speed-score.php
@@ -25,7 +25,7 @@ if ( ! defined( 'JETPACK_BOOST_REST_PREFIX' ) ) {
  */
 class Speed_Score {
 
-	const PACKAGE_VERSION = '0.4.9';
+	const PACKAGE_VERSION = '0.4.10';
 
 	/**
 	 * Array of module slugs that are currently active and can impact speed score.

--- a/projects/packages/classic-theme-helper/CHANGELOG.md
+++ b/projects/packages/classic-theme-helper/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.11] - 2025-07-21
+### Changed
+- Update package dependencies. [#44356]
+
 ## [0.13.10] - 2025-07-14
 ### Changed
 - Update dependencies. [#44229]
@@ -337,6 +341,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Add wordpress folder on gitignore. [#37177]
 
+[0.13.11]: https://github.com/Automattic/jetpack-classic-theme-helper/compare/v0.13.10...v0.13.11
 [0.13.10]: https://github.com/Automattic/jetpack-classic-theme-helper/compare/v0.13.9...v0.13.10
 [0.13.9]: https://github.com/Automattic/jetpack-classic-theme-helper/compare/v0.13.8...v0.13.9
 [0.13.8]: https://github.com/Automattic/jetpack-classic-theme-helper/compare/v0.13.7...v0.13.8

--- a/projects/packages/classic-theme-helper/changelog/fix-phan-noopnew
+++ b/projects/packages/classic-theme-helper/changelog/fix-phan-noopnew
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Phan: Clean up PhanNoopNew instances.
-

--- a/projects/packages/classic-theme-helper/changelog/renovate-babel-monorepo
+++ b/projects/packages/classic-theme-helper/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/classic-theme-helper/changelog/update-stylelint-enable_spacing_rules
+++ b/projects/packages/classic-theme-helper/changelog/update-stylelint-enable_spacing_rules
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Stylelint: Fix spacing rules.
-
-

--- a/projects/packages/classic-theme-helper/changelog/update-stylelint-fix_newline_rules
+++ b/projects/packages/classic-theme-helper/changelog/update-stylelint-fix_newline_rules
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Stylelint: Enable newline rules.
-
-

--- a/projects/packages/classic-theme-helper/package.json
+++ b/projects/packages/classic-theme-helper/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-classic-theme-helper",
-	"version": "0.13.10",
+	"version": "0.13.11",
 	"description": "Features used with classic themes",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/classic-theme-helper/#readme",
 	"bugs": {

--- a/projects/packages/classic-theme-helper/src/class-main.php
+++ b/projects/packages/classic-theme-helper/src/class-main.php
@@ -14,7 +14,7 @@ use WP_Error;
  */
 class Main {
 
-	const PACKAGE_VERSION = '0.13.10';
+	const PACKAGE_VERSION = '0.13.11';
 
 	/**
 	 * Modules to include.

--- a/projects/packages/connection/CHANGELOG.md
+++ b/projects/packages/connection/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.15.0] - 2025-07-21
+### Added
+- Add memoization for connection owner ID to prevent excessive database calls. [#44282]
+
+### Changed
+- Update package dependencies. [#44356]
+
 ## [6.14.2] - 2025-07-14
 ### Changed
 - Update dependencies. [#44271]
@@ -1520,6 +1527,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Separate the connection library into its own package.
 
+[6.15.0]: https://github.com/Automattic/jetpack-connection/compare/v6.14.2...v6.15.0
 [6.14.2]: https://github.com/Automattic/jetpack-connection/compare/v6.14.1...v6.14.2
 [6.14.1]: https://github.com/Automattic/jetpack-connection/compare/v6.14.0...v6.14.1
 [6.14.0]: https://github.com/Automattic/jetpack-connection/compare/v6.13.13...v6.14.0

--- a/projects/packages/connection/changelog/add-connection-owner-id-memoization
+++ b/projects/packages/connection/changelog/add-connection-owner-id-memoization
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add memoization for connection owner ID to prevent excessive database calls.

--- a/projects/packages/connection/changelog/fix-phan-noopnew
+++ b/projects/packages/connection/changelog/fix-phan-noopnew
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Phan: Clean up PhanNoopNew instances.
-

--- a/projects/packages/connection/changelog/renovate-babel-monorepo
+++ b/projects/packages/connection/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/connection/changelog/update-stylelint-enable_spacing_rules
+++ b/projects/packages/connection/changelog/update-stylelint-enable_spacing_rules
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Stylelint: Fix spacing rules.
-
-

--- a/projects/packages/connection/composer.json
+++ b/projects/packages/connection/composer.json
@@ -75,7 +75,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "6.14.x-dev"
+			"dev-trunk": "6.15.x-dev"
 		},
 		"dependencies": {
 			"test-only": [

--- a/projects/packages/connection/src/class-package-version.php
+++ b/projects/packages/connection/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Connection;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '6.14.2';
+	const PACKAGE_VERSION = '6.15.0';
 
 	const PACKAGE_SLUG = 'connection';
 

--- a/projects/packages/explat/CHANGELOG.md
+++ b/projects/packages/explat/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.4] - 2025-07-21
+### Changed
+- Update package dependencies. [#44356]
+
 ## [0.3.3] - 2025-07-08
 ### Changed
 - Update package dependencies. [#44217]
@@ -199,6 +203,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ExPlat: add condition to prevent fetching the experiment assignment if there's not anon id (meaning that Tracks is likely disabled) [#38327]
 - Updated package dependencies. [#38132]
 
+[0.3.4]: https://github.com/Automattic/jetpack-explat/compare/v0.3.3...v0.3.4
 [0.3.3]: https://github.com/Automattic/jetpack-explat/compare/v0.3.2...v0.3.3
 [0.3.2]: https://github.com/Automattic/jetpack-explat/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/Automattic/jetpack-explat/compare/v0.3.0...v0.3.1

--- a/projects/packages/explat/changelog/renovate-babel-monorepo
+++ b/projects/packages/explat/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/explat/package.json
+++ b/projects/packages/explat/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-explat",
-	"version": "0.3.3",
+	"version": "0.3.4",
 	"description": "A package for running A/B tests on the Experimentation Platform (ExPlat) in the plugin.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/explat/#readme",
 	"bugs": {

--- a/projects/packages/explat/src/class-explat.php
+++ b/projects/packages/explat/src/class-explat.php
@@ -20,7 +20,7 @@ class ExPlat {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.3.3';
+	const PACKAGE_VERSION = '0.3.4';
 
 	/**
 	 * Initializer.

--- a/projects/packages/external-media/CHANGELOG.md
+++ b/projects/packages/external-media/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.5] - 2025-07-21
+### Changed
+- Update package dependencies. [#44356]
+
 ## [0.4.4] - 2025-07-14
 ### Changed
 - Update dependencies. [#44229]
@@ -142,6 +146,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix the button size in the editor for Gutenberg 18 or below. [#41619]
 - Media Library: Fix the Import Media button color in some color schemes. [#41664]
 
+[0.4.5]: https://github.com/Automattic/jetpack-external-media/compare/v0.4.4...v0.4.5
 [0.4.4]: https://github.com/Automattic/jetpack-external-media/compare/v0.4.3...v0.4.4
 [0.4.3]: https://github.com/Automattic/jetpack-external-media/compare/v0.4.2...v0.4.3
 [0.4.2]: https://github.com/Automattic/jetpack-external-media/compare/v0.4.1...v0.4.2

--- a/projects/packages/external-media/changelog/renovate-babel-monorepo
+++ b/projects/packages/external-media/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/external-media/changelog/update-cleanup-lodash-omit-function
+++ b/projects/packages/external-media/changelog/update-cleanup-lodash-omit-function
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Replace use of lodash `omit`. Should be no change to functionality.
-
-

--- a/projects/packages/external-media/changelog/update-stylelint-enable_spacing_rules
+++ b/projects/packages/external-media/changelog/update-stylelint-enable_spacing_rules
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Stylelint: Fix spacing rules.
-
-

--- a/projects/packages/external-media/changelog/update-stylint-enable_indentation
+++ b/projects/packages/external-media/changelog/update-stylint-enable_indentation
@@ -1,5 +1,0 @@
-Significance: patch
-Type: deprecated
-Comment: Stylelint: Enable indentation rules.
-
-

--- a/projects/packages/external-media/package.json
+++ b/projects/packages/external-media/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-external-media",
-	"version": "0.4.4",
+	"version": "0.4.5",
 	"description": "The external media feature allows users to select and import photos from external media",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/external-media/#readme",
 	"bugs": {

--- a/projects/packages/external-media/src/class-external-media.php
+++ b/projects/packages/external-media/src/class-external-media.php
@@ -17,7 +17,7 @@ use Jetpack_Options;
  * Class External_Media
  */
 class External_Media {
-	const PACKAGE_VERSION = '0.4.4';
+	const PACKAGE_VERSION = '0.4.5';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;
 

--- a/projects/packages/forms/.phan/baseline.php
+++ b/projects/packages/forms/.phan/baseline.php
@@ -9,15 +9,15 @@
  */
 return [
     // # Issue statistics:
-    // PhanTypeMismatchArgument : 40+ occurrences
+    // PhanTypeMismatchArgument : 35+ occurrences
     // PhanPluginDuplicateConditionalNullCoalescing : 15+ occurrences
     // PhanTypeMismatchReturnProbablyReal : 10+ occurrences
     // PhanTypeMismatchArgumentInternal : 6 occurrences
     // PhanTypeMismatchArgumentProbablyReal : 6 occurrences
-    // PhanPluginDuplicateAdjacentStatement : 2 occurrences
     // PhanPluginRedundantAssignment : 2 occurrences
     // PhanTypeConversionFromArray : 2 occurrences
     // PhanTypeMismatchReturn : 2 occurrences
+    // PhanPluginDuplicateAdjacentStatement : 1 occurrence
     // PhanPluginMixedKeyNoKey : 1 occurrence
     // PhanPossiblyNullTypeMismatchProperty : 1 occurrence
     // PhanTypeArraySuspiciousNullable : 1 occurrence

--- a/projects/packages/forms/CHANGELOG.md
+++ b/projects/packages/forms/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.0.0] - 2025-07-21
+### Added
+- Add "Empty spam" button to delete all responses marked as spam. [#44308]
+- Add Gravatars in form responses. [#44270]
+- Add tests for feedback endpoint. [#44318]
+- Display success info after form submission without reload. [#44204]
+- Include multistep form in Jetpack and WordPress.com plans. [#44309]
+
+### Changed
+- Add feature flag for MailPoet integration. [#44339]
+- Consolidate a single hook for all inbox data, making it easier to share the store props and dispatches and removing the need to invalidate the entire store to get fresh listings after emptying trash. [#44293]
+- Invert default disabled state on empty buttons for a cleaner transition to being available. [#44321]
+- Make phone fields clickable [#44291]
+- Update package dependencies. [#44338] [#44356]
+- Use sentence case in default consent text. [#44078]
+
+### Removed
+- Prevent rendering of old menu entry once the migration page is shown and the user clicks on the new dashboard URL. [#43714]
+- Remove unused editor CSS. [#44346]
+
+### Fixed
+- Add a JWT token when submitting the form so that we are able to instantiate on submit. [#44360]
+- Fix export hooks error on mobile. [#44357]
+- Fix integration card headers on mobile. [#44286]
+- Fix excess padding next to Gravatar on mobile. [#44394]
+- Prevent post_meta from being created. [#44332]
+- Remove manual `DependencyExtractionWebpackPlugin` instantiation. [#44307]
+- Show submission information after reload with AJAX submission. [#44342]
+
 ## [3.1.0] - 2025-07-14
 ### Added
 - Add "Empty trash" button. [#44225]
@@ -1293,6 +1322,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a new jetpack/forms package [#28409]
 - Added a public load_contact_form method for initializing the contact form module. [#28416]
 
+[4.0.0]: https://github.com/automattic/jetpack-forms/compare/v3.1.0...v4.0.0
 [3.1.0]: https://github.com/automattic/jetpack-forms/compare/v3.0.0...v3.1.0
 [3.0.0]: https://github.com/automattic/jetpack-forms/compare/v2.1.0...v3.0.0
 [2.1.0]: https://github.com/automattic/jetpack-forms/compare/v2.0.1...v2.1.0

--- a/projects/packages/forms/CHANGELOG.md
+++ b/projects/packages/forms/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.0.1] - 2025-07-21
+### Changed
+- Revert forms JWT usage for forms reconstruction from responses. [#44397]
+
 ## [4.0.0] - 2025-07-21
 ### Added
 - Add "Empty spam" button to delete all responses marked as spam. [#44308]
@@ -1322,6 +1326,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a new jetpack/forms package [#28409]
 - Added a public load_contact_form method for initializing the contact form module. [#28416]
 
+[4.0.1]: https://github.com/automattic/jetpack-forms/compare/v4.0.0...v4.0.1
 [4.0.0]: https://github.com/automattic/jetpack-forms/compare/v3.1.0...v4.0.0
 [3.1.0]: https://github.com/automattic/jetpack-forms/compare/v3.0.0...v3.1.0
 [3.0.0]: https://github.com/automattic/jetpack-forms/compare/v2.1.0...v3.0.0

--- a/projects/packages/forms/changelog/add-forms-mailpoet-feature-flag
+++ b/projects/packages/forms/changelog/add-forms-mailpoet-feature-flag
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Forms: Add feature flag for MailPoet integration.

--- a/projects/packages/forms/changelog/add-jetpack-forms-announce-migration-only-once
+++ b/projects/packages/forms/changelog/add-jetpack-forms-announce-migration-only-once
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Forms: once the migration page is shown and the user clicks on the new dashboard URL, update user option and not render the old menu entry anymore

--- a/projects/packages/forms/changelog/add-jetpack-forms-empty-spam-endpoint
+++ b/projects/packages/forms/changelog/add-jetpack-forms-empty-spam-endpoint
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Forms: add empty spam to delete all responses marked as spam

--- a/projects/packages/forms/changelog/add-jetpack-forms-endpoint-coverage
+++ b/projects/packages/forms/changelog/add-jetpack-forms-endpoint-coverage
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Forms: add tests for feedback endpoint

--- a/projects/packages/forms/changelog/change-jetpack-forms-inbox-store
+++ b/projects/packages/forms/changelog/change-jetpack-forms-inbox-store
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Forms: consolidate a single hook for all inbox data, making it easier to share the store props and dispatches and removing the need to invalidate the entire store to get fresh listings after emptying trash

--- a/projects/packages/forms/changelog/fix-create-post-meta-on-every-admin-load
+++ b/projects/packages/forms/changelog/fix-create-post-meta-on-every-admin-load
@@ -1,4 +1,0 @@
-Significance: minor
-Type: fixed
-
-Forms: prevent post_meta from being created

--- a/projects/packages/forms/changelog/fix-form-integrations-mobile
+++ b/projects/packages/forms/changelog/fix-form-integrations-mobile
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Forms: Fix integration card headers on mobile.

--- a/projects/packages/forms/changelog/fix-forms-action-dropdown-hooks-error
+++ b/projects/packages/forms/changelog/fix-forms-action-dropdown-hooks-error
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Forms: Fix export hooks error on mobile.

--- a/projects/packages/forms/changelog/fix-forms-dependency-injection
+++ b/projects/packages/forms/changelog/fix-forms-dependency-injection
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Forms: Remove manual DependencyExtractionWebpackPlugin instantiation.

--- a/projects/packages/forms/changelog/fix-forms-mobile-response-padding
+++ b/projects/packages/forms/changelog/fix-forms-mobile-response-padding
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Forms: fix no padding next to Gravatar on mobile

--- a/projects/packages/forms/changelog/fix-forms-whitespace
+++ b/projects/packages/forms/changelog/fix-forms-whitespace
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Just linter whitepsace fix.
-
-

--- a/projects/packages/forms/changelog/fix-jetpack-forms-empty-buttons-state
+++ b/projects/packages/forms/changelog/fix-jetpack-forms-empty-buttons-state
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Forms: invert default disabled state on empty buttons for a cleaner transition to being available, they will only become enabled when it makes sense (not loading data, total items be a truthy value)

--- a/projects/packages/forms/changelog/renovate-babel-monorepo
+++ b/projects/packages/forms/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/forms/changelog/renovate-eslint-packages
+++ b/projects/packages/forms/changelog/renovate-eslint-packages
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: eslint: Suppress a bunch of testing-library/no-node-access false positives.
-
-

--- a/projects/packages/forms/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/forms/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/forms/changelog/update-add-jwt-form-encode-decode
+++ b/projects/packages/forms/changelog/update-add-jwt-form-encode-decode
@@ -1,4 +1,0 @@
-Significance: major
-Type: fixed
-
-Forms: add a JWT token when submitting the form so that we are able to instantiate on submit

--- a/projects/packages/forms/changelog/update-cleanup-lodash-omit-function
+++ b/projects/packages/forms/changelog/update-cleanup-lodash-omit-function
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Replace use of lodash `omit`. Should be no change to functionality.
-
-

--- a/projects/packages/forms/changelog/update-form-consent-block-font
+++ b/projects/packages/forms/changelog/update-form-consent-block-font
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Forms: Make default consent test sentence case.

--- a/projects/packages/forms/changelog/update-forms-clean-out-unused-css
+++ b/projects/packages/forms/changelog/update-forms-clean-out-unused-css
@@ -1,4 +1,0 @@
-Significance: minor
-Type: removed
-
-Forms: remove unused editor CSS

--- a/projects/packages/forms/changelog/update-forms-gravatar
+++ b/projects/packages/forms/changelog/update-forms-gravatar
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Forms: add Gravatars in form responses

--- a/projects/packages/forms/changelog/update-forms-multistep-to-production
+++ b/projects/packages/forms/changelog/update-forms-multistep-to-production
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Forms: Include multistep form in Jetpack and WPCOM plans.

--- a/projects/packages/forms/changelog/update-forms-phone
+++ b/projects/packages/forms/changelog/update-forms-phone
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Forms: make phone fields clickable

--- a/projects/packages/forms/changelog/update-forms-submit-ajax-frontend-reload
+++ b/projects/packages/forms/changelog/update-forms-submit-ajax-frontend-reload
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Forms: Show submission information after reload with ajax submission

--- a/projects/packages/forms/changelog/update-forms-submit-ajax-json-frontend
+++ b/projects/packages/forms/changelog/update-forms-submit-ajax-json-frontend
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Forms: Display success info after form submission without reload

--- a/projects/packages/forms/changelog/update-stylelint-enable_spacing_rules
+++ b/projects/packages/forms/changelog/update-stylelint-enable_spacing_rules
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Stylelint: Fix spacing rules.
-
-

--- a/projects/packages/forms/changelog/update-stylelint-fix_newline_rules
+++ b/projects/packages/forms/changelog/update-stylelint-fix_newline_rules
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Stylelint: Enable newline rules.
-
-

--- a/projects/packages/forms/changelog/update-stylint-enable_indentation
+++ b/projects/packages/forms/changelog/update-stylint-enable_indentation
@@ -1,5 +1,0 @@
-Significance: patch
-Type: deprecated
-Comment: Stylelint: Enable indentation rules.
-
-

--- a/projects/packages/forms/composer.json
+++ b/projects/packages/forms/composer.json
@@ -70,7 +70,7 @@
 			"link-template": "https://github.com/automattic/jetpack-forms/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "3.1.x-dev"
+			"dev-trunk": "4.0.x-dev"
 		},
 		"textdomain": "jetpack-forms",
 		"version-constants": {

--- a/projects/packages/forms/composer.json
+++ b/projects/packages/forms/composer.json
@@ -8,7 +8,6 @@
 		"automattic/jetpack-blocks": "@dev",
 		"automattic/jetpack-assets": "@dev",
 		"automattic/jetpack-connection": "@dev",
-		"automattic/jetpack-jwt": "@dev",
 		"automattic/jetpack-logo": "@dev",
 		"automattic/jetpack-plans": "@dev",
 		"automattic/jetpack-status": "@dev",

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-forms",
-	"version": "4.0.0",
+	"version": "4.0.1",
 	"description": "Jetpack Forms",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/forms/#readme",
 	"bugs": {

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-forms",
-	"version": "3.1.0",
+	"version": "4.0.0",
 	"description": "Jetpack Forms",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/forms/#readme",
 	"bugs": {

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -14,7 +14,7 @@ use Automattic\Jetpack\Forms\Dashboard\Dashboard;
  */
 class Jetpack_Forms {
 
-	const PACKAGE_VERSION = '3.1.0';
+	const PACKAGE_VERSION = '4.0.0';
 
 	/**
 	 * Load the contact form module.

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -14,7 +14,7 @@ use Automattic\Jetpack\Forms\Dashboard\Dashboard;
  */
 class Jetpack_Forms {
 
-	const PACKAGE_VERSION = '4.0.0';
+	const PACKAGE_VERSION = '4.0.1';
 
 	/**
 	 * Load the contact form module.

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -1231,13 +1231,6 @@ class Contact_Form_Plugin {
 		$is_block_template_part = str_starts_with( $id, 'block-template-part-' );
 
 		$form = false;
-		if ( isset( $_POST['jetpack_contact_form_jwt'] ) ) {
-			$form = Contact_Form::get_instance_from_jwt( sanitize_text_field( wp_unslash( $_POST['jetpack_contact_form_jwt'] ) ) );
-			if ( ! $form ) { // fail early if the JWT is invalid.
-				// If the JWT is invalid, we can't process the form.
-				return false;
-			}
-		}
 
 		if ( $is_widget ) {
 			// It's a form embedded in a text widget
@@ -1357,10 +1350,8 @@ class Contact_Form_Plugin {
 				apply_filters( 'the_content', $content );
 			}
 		}
-		if ( ! $form ) {
-			// In future version we will be able to skip this step.
-			$form = isset( Contact_Form::$forms[ $hash ] ) ? Contact_Form::$forms[ $hash ] : null;
-		}
+
+		$form = isset( Contact_Form::$forms[ $hash ] ) ? Contact_Form::$forms[ $hash ] : null;
 
 		// No form may mean user is using do_shortcode, grab the form using the stored post meta
 		if ( ! $form && is_numeric( $id ) && $hash ) {

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -7,9 +7,7 @@
 
 namespace Automattic\Jetpack\Forms\ContactForm;
 
-use Automattic\Jetpack\Connection\Tokens;
 use Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch;
-use Automattic\Jetpack\JWT;
 use Automattic\Jetpack\Sync\Settings;
 use Jetpack_Tracks_Event;
 use PHPMailer\PHPMailer\PHPMailer;
@@ -96,20 +94,12 @@ class Contact_Form extends Contact_Form_Shortcode {
 	public $current_post;
 
 	/**
-	 * Whether the form has a verified JWT token.
-	 *
-	 * @var bool
-	 */
-	public $has_verified_jwt = false;
-
-	/**
 	 * Construction function.
 	 *
 	 * @param array  $attributes - the attributes.
 	 * @param string $content - the content.
-	 * @param bool   $set_id - whether to set the ID for the form.
 	 */
-	public function __construct( $attributes, $content = null, $set_id = true ) {
+	public function __construct( $attributes, $content = null ) {
 		global $post, $page;
 
 		// AJAX requests don't have a post object, so we need to get the post object from the $_POST['contact-form-id']
@@ -132,30 +122,29 @@ class Contact_Form extends Contact_Form_Shortcode {
 			$attributes = array();
 		}
 
-		if ( $set_id ) {
-			if ( ! empty( $attributes['widget'] ) && $attributes['widget'] ) {
-				$attributes['id'] = 'widget-' . $attributes['widget'];
-			} elseif ( ! empty( $attributes['block_template'] ) && $attributes['block_template'] ) {
-				$attributes['id'] = 'block-template-' . $attributes['block_template'];
-			} elseif ( ! empty( $attributes['block_template_part'] ) && $attributes['block_template_part'] ) {
-				$attributes['id'] = 'block-template-part-' . $attributes['block_template_part'];
-			} elseif ( $this->current_post ) {
-				$attributes['id'] = $this->current_post->ID;
-			}
-
-			// When using admin-ajax.php, we don't need to add a page number to the id
-			if ( ! empty( self::$forms ) && ! $this->is_response_without_reload_enabled ) {
-				// Ensure 'id' exists in $attributes before trying to modify it
-				if ( ! isset( $attributes['id'] ) ) {
-					$attributes['id'] = '';
-				}
-
-				// When submitting the page number is not always set, so we need to handle that: TODO: This is a hack, we need to find a better way to handle form identification
-				$page_num = max( 1, intval( $page ) );
-
-				$attributes['id'] = $attributes['id'] . '-' . ( count( self::$forms ) + 1 ) . '-' . $page_num;
-			}
+		if ( ! empty( $attributes['widget'] ) && $attributes['widget'] ) {
+			$attributes['id'] = 'widget-' . $attributes['widget'];
+		} elseif ( ! empty( $attributes['block_template'] ) && $attributes['block_template'] ) {
+			$attributes['id'] = 'block-template-' . $attributes['block_template'];
+		} elseif ( ! empty( $attributes['block_template_part'] ) && $attributes['block_template_part'] ) {
+			$attributes['id'] = 'block-template-part-' . $attributes['block_template_part'];
+		} elseif ( $this->current_post ) {
+			$attributes['id'] = $this->current_post->ID;
 		}
+
+		// When using admin-ajax.php, we don't need to add a page number to the id
+		if ( ! empty( self::$forms ) && ! $this->is_response_without_reload_enabled ) {
+			// Ensure 'id' exists in $attributes before trying to modify it
+			if ( ! isset( $attributes['id'] ) ) {
+				$attributes['id'] = '';
+			}
+
+			// When submitting the page number is not always set, so we need to handle that: TODO: This is a hack, we need to find a better way to handle form identification
+			$page_num = max( 1, intval( $page ) );
+
+			$attributes['id'] = $attributes['id'] . '-' . ( count( self::$forms ) + 1 ) . '-' . $page_num;
+		}
+
 		$this->hash                 = sha1( wp_json_encode( $attributes ) );
 		self::$forms[ $this->hash ] = $this;
 
@@ -208,76 +197,16 @@ class Contact_Form extends Contact_Form_Shortcode {
 				[contact-field label="' . __( 'Message', 'jetpack-forms' ) . '" type="textarea" /]';
 
 			$this->parse_content( $default_form );
+
+			// Store the shortcode.
+			$this->store_shortcode( $default_form, $attributes, $this->hash );
+		} else {
+			// Store the shortcode.
+			$this->store_shortcode( $content, $attributes, $this->hash );
 		}
 
 		// $this->body and $this->fields have been setup.  We no longer need the contact-field shortcode.
 		Contact_Form_Plugin::$using_contact_form_field = false;
-	}
-	/**
-	 * Get the instance of the contact form from a JWT token.
-	 *
-	 * @param string $jwt_token The JWT token.
-	 *
-	 * @return Contact_Form|null The contact form instance or null if not found.
-	 */
-	public static function get_instance_from_jwt( $jwt_token ) {
-		$secret = self::get_secret();
-		if ( empty( $secret ) ) {
-			return null;
-		}
-
-		try {
-			$data = JWT::decode( $jwt_token, $secret, array( 'HS256' ) );
-		} catch ( \Exception $e ) {
-			return null;
-		}
-
-		$attributes             = (array) $data->attributes;
-		$form                   = new self( $attributes, $data->content, empty( $attributes['id'] ) );
-		$form->hash             = $data->hash;
-		$form->has_verified_jwt = true;
-		return $form;
-	}
-	/**
-	 * Helper function to get the secret from the Tokens class.
-	 *
-	 * @return string|null The secret from the Tokens class or null if not available.
-	 */
-	private static function get_secret() {
-		$token          = ( new Tokens() )->get_access_token();
-		$default_secret = hash_hmac( 'md5', get_option( 'admin_email' ), JETPACK__VERSION );
-		if ( ! isset( $token->secret ) ) {
-			return $default_secret;
-		}
-
-		// Get the secret from the Tokens class.
-		return $token->secret;
-	}
-
-	/**
-	 * Helper function to get the attributes of the contact form.
-	 *
-	 * @return array The attributes of the contact form.
-	 */
-	public function get_attributes() {
-		return $this->attributes;
-	}
-
-	/**
-	 * Get the JWT token for the contact form instance.
-	 *
-	 * @return string The JWT token.
-	 */
-	public function get_jwt() {
-		$attributes = $this->attributes;
-		return JWT::encode(
-			array(
-				'attributes' => $attributes,
-				'content'    => $this->content,
-				'hash'       => $this->hash,
-			),
-			self::get_secret()
-		);
 	}
 
 	/**
@@ -334,10 +263,27 @@ class Contact_Form extends Contact_Form_Shortcode {
 	 * Store shortcode content for recall later
 	 *  - used to receate shortcode when user uses do_shortcode
 	 *
-	 * @deprecated 4.0.0
+	 * @param string $content - the content.
+	 * @param array  $attributes - the attributes.
+	 * @param string $hash - the hash.
 	 */
-	public static function store_shortcode() {
-		_deprecated_function( __METHOD__, '4.0.0', 'Contact_Form_Plugin::store_shortcode()' );
+	public static function store_shortcode( $content = null, $attributes = null, $hash = null ) {
+
+		if ( $content && isset( $attributes['id'] ) ) {
+
+			if ( empty( $hash ) ) {
+				$hash = sha1( wp_json_encode( $attributes ) . $content );
+			}
+
+			$shortcode_meta = (string) get_post_meta( $attributes['id'], "_g_feedback_shortcode_{$hash}", true );
+
+			if ( $shortcode_meta !== '' || $shortcode_meta !== $content ) {
+				update_post_meta( $attributes['id'], "_g_feedback_shortcode_{$hash}", $content );
+
+				// Save attributes to post_meta for later use. They're not available later in do_shortcode situations.
+				update_post_meta( $attributes['id'], "_g_feedback_shortcode_atts_{$hash}", $attributes );
+			}
+		}
 	}
 
 	/**
@@ -610,7 +556,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 			if ( $is_multistep ) { // This makes the "enter" key work in multi-step forms as expected.
 				$r .= '<input type="submit" style="display: none;" />';
 			}
-			$r .= "<input type='hidden' name='jetpack_contact_form_jwt' value='" . esc_attr( $form->get_jwt() ) . "' />\n";
+
 			$r .= $form->body;
 
 			if ( $is_multistep ) {
@@ -1507,23 +1453,21 @@ class Contact_Form extends Contact_Form_Shortcode {
 			$to = get_option( 'admin_email' );
 		}
 
-		if ( ! $this->has_verified_jwt ) {
-			// Make sure we're processing the form we think we're processing... probably a redundant check.
-			if ( $widget ) {
-				if ( isset( $_POST['contact-form-id'] ) && 'widget-' . $widget !== $_POST['contact-form-id'] ) { // phpcs:Ignore WordPress.Security.NonceVerification.Missing -- check done by caller process_form_submission()
-					return false;
-				}
-			} elseif ( $block_template ) {
-				if ( isset( $_POST['contact-form-id'] ) && 'block-template-' . $block_template !== $_POST['contact-form-id'] ) { // phpcs:Ignore WordPress.Security.NonceVerification.Missing -- check done by caller process_form_submission()
-					return false;
-				}
-			} elseif ( $block_template_part ) {
-				if ( isset( $_POST['contact-form-id'] ) && 'block-template-part-' . $block_template_part !== $_POST['contact-form-id'] ) { // phpcs:Ignore WordPress.Security.NonceVerification.Missing -- check done by caller process_form_submission()
-					return false;
-				}
-			} elseif ( isset( $_POST['contact-form-id'] ) && ( empty( $this->current_post ) || $this->current_post->ID !== (int) sanitize_text_field( wp_unslash( $_POST['contact-form-id'] ) ) ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing -- check done by caller process_form_submission()
+		// Make sure we're processing the form we think we're processing... probably a redundant check.
+		if ( $widget ) {
+			if ( isset( $_POST['contact-form-id'] ) && 'widget-' . $widget !== $_POST['contact-form-id'] ) { // phpcs:Ignore WordPress.Security.NonceVerification.Missing -- check done by caller process_form_submission()
 				return false;
 			}
+		} elseif ( $block_template ) {
+			if ( isset( $_POST['contact-form-id'] ) && 'block-template-' . $block_template !== $_POST['contact-form-id'] ) { // phpcs:Ignore WordPress.Security.NonceVerification.Missing -- check done by caller process_form_submission()
+				return false;
+			}
+		} elseif ( $block_template_part ) {
+			if ( isset( $_POST['contact-form-id'] ) && 'block-template-part-' . $block_template_part !== $_POST['contact-form-id'] ) { // phpcs:Ignore WordPress.Security.NonceVerification.Missing -- check done by caller process_form_submission()
+				return false;
+			}
+		} elseif ( isset( $_POST['contact-form-id'] ) && ( empty( $this->current_post ) || $this->current_post->ID !== (int) sanitize_text_field( wp_unslash( $_POST['contact-form-id'] ) ) ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing -- check done by caller process_form_submission()
+			return false;
 		}
 
 		$field_ids = $this->get_field_ids();

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -334,10 +334,10 @@ class Contact_Form extends Contact_Form_Shortcode {
 	 * Store shortcode content for recall later
 	 *  - used to receate shortcode when user uses do_shortcode
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 4.0.0
 	 */
 	public static function store_shortcode() {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Contact_Form_Plugin::store_shortcode()' );
+		_deprecated_function( __METHOD__, '4.0.0', 'Contact_Form_Plugin::store_shortcode()' );
 	}
 
 	/**

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
@@ -11,7 +11,6 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use WorDBless\BaseTestCase;
 use WP_Block;
-use WP_Error;
 
 /**
  * Test class for Contact_Form_Plugin
@@ -534,64 +533,5 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 				'type'         => 'checkbox-multiple',
 			),
 		);
-	}
-
-	public function test_process_from_with_jwt() {
-		$previous_post = $this->setup_token_test();
-
-		$plugin = Contact_Form_Plugin::init();
-		$result = $plugin->process_form_submission();
-
-		$this->assertInstanceOf( WP_Error::class, $result, 'Expected a WP_Error when processing the form submission.' );
-		$this->assertEquals( 'check_spam', $result->get_error_code(), 'Expected the error code to be "check_spam".' );
-
-		$this->teardown_post_for_test( $previous_post );
-	}
-
-	public function test_process_from_with_fake_jwt() {
-		$previous_post = $this->setup_token_test( 'fake.jwt.token' );
-
-		$plugin = Contact_Form_Plugin::init();
-		$result = $plugin->process_form_submission();
-
-		$this->assertFalse( $result, 'Expected a WP_Error when processing the form submission.' );
-
-		$this->teardown_post_for_test( $previous_post );
-	}
-
-	private function setup_token_test( $token = null ) {
-		global $post;
-		$post_id = wp_insert_post(
-			array(
-				'post_title'   => 'Test Contact Form',
-				'post_content' => '<!-- wp:jetpack/contact-form {"id":"test-contact-form"} /-->',
-				'post_status'  => 'publish',
-				'post_type'    => 'post',
-			)
-		);
-
-		$previous_post = $post;
-		$post          = get_post( $post_id );
-		// We do this because we don't currenly have a way to prevent the redirect to happen.
-		add_filter( 'jetpack_contact_form_is_spam', array( $this, 'return_error_for_test' ) );
-		$form                              = new Contact_Form( array( 'to' => 'test@example.com' ), "[contact-field label='Name' type='name' required='1'/]" );
-		$_POST['jetpack_contact_form_jwt'] = $token ?? $form->get_jwt();
-		$_POST['contact-form-hash']        = $form->hash;
-		$_POST['contact-form-id']          = $post_id;
-		return $previous_post;
-	}
-
-	private function teardown_post_for_test( $previous_post ) {
-		global $post;
-		wp_delete_post( $post->ID, true ); // Clean up the test post.
-		$post = $previous_post; // Restore the previous post.
-		remove_filter( 'jetpack_contact_form_is_spam', array( $this, 'return_error_for_test' ) );
-		unset( $_POST['contact-form-hash'] );
-		unset( $_POST['jetpack_contact_form_jwt'] );
-		unset( $_POST['contact-form-id'] );
-	}
-
-	public function return_error_for_test() {
-		return new WP_Error( 'check_spam', 'check_spam form submission.' );
 	}
 }

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -9,7 +9,6 @@
 
 namespace Automattic\Jetpack\Forms\ContactForm;
 
-use Automattic\Jetpack\Constants;
 use DOMDocument;
 use DOMElement;
 use PHPUnit\Framework\Attributes\Before;
@@ -2873,72 +2872,5 @@ EOT;
 
 		// Restore original post
 		$post = $original_post;
-	}
-
-	public function test_encode_form_to_jwt() {
-		Constants::set_constant( 'JETPACK_BLOG_TOKEN', 'test.token' );
-		$form = new Contact_Form(
-			array(
-				'to'      => 'hello@email.com',
-				'subject' => 'test subject',
-			),
-			"[contact-field label='Name' type='name' required='1'/]"
-			. "[contact-field label='Message' type='textarea' required='1'/]"
-		);
-
-		$jwt = $form->get_jwt();
-
-		$this->assertNotEmpty( $jwt, 'JWT should not be empty' );
-		$this->assertIsString( $jwt, 'JWT should be a string' );
-
-		$form_copy = Contact_Form::get_instance_from_jwt( $jwt );
-
-		// Decode the JWT to verify its structure
-		$to_attribute = $form_copy->get_attribute( 'to' );
-		$this->assertEquals( 'hello@email.com', $to_attribute );
-		$this->assertEquals( $form_copy->get_attributes(), $form->get_attributes(), 'Form attributes should match' );
-		$this->assertEquals( $form->get_attribute( 'to' ), $form_copy->get_attribute( 'to' ), 'Form IDs should match' );
-		$this->assertEquals( $form->get_attribute( 'id' ), $form_copy->get_attribute( 'id' ), 'Form IDs should match' );
-
-		$this->assertTrue( $form_copy->has_verified_jwt, 'Form copy should have verified JWT' );
-		$this->assertFalse( $form->has_verified_jwt, 'Original form should not have verified JWT' );
-
-		$this->assertEquals( $form->hash, $form_copy->hash, 'Form hashes should match' );
-		$this->assertNotEmpty( $form_copy->hash, 'Form hash should not be empty' );
-
-		$this->assertEquals( $form->get_field_ids(), $form_copy->get_field_ids(), 'Field IDs should match' );
-		$this->assertNotEmpty( $form_copy->get_field_ids(), 'Fields should not be empty' );
-		Constants::clear_single_constant( 'JETPACK_BLOG_TOKEN' );
-	}
-
-	public function test_get_instance_from_jwt_returns_null_when_no_secret() {
-		// Ensure JETPACK_BLOG_TOKEN is not defined
-		Constants::clear_single_constant( 'JETPACK_BLOG_TOKEN' );
-
-		$form = new Contact_Form(
-			array(
-				'to'      => 'test@email.com',
-				'subject' => 'Test Form',
-			),
-			"[contact-field label='Name' type='name' required='1'/]"
-		);
-
-		$jwt = $form->get_jwt();
-		$this->assertNotEmpty( $jwt, 'JWT should not be empty as it uses default secret' );
-		$this->assertIsString( $jwt, 'JWT should be a string' );
-
-		// The form should still be recoverable using the default secret
-		$form_copy = Contact_Form::get_instance_from_jwt( $jwt );
-		$this->assertNotNull( $form_copy, 'Should recover form using default secret' );
-		$this->assertTrue( $form_copy->has_verified_jwt, 'Form should have verified JWT with default secret' );
-	}
-
-	public function test_get_instance_from_jwt_returns_null_for_invalid_jwt() {
-		Constants::set_constant( 'JETPACK_BLOG_TOKEN', 'test.token' );
-
-		$form_copy = Contact_Form::get_instance_from_jwt( 'invalid_jwt_token' );
-		$this->assertNull( $form_copy, 'Should return null for invalid JWT token' );
-
-		Constants::clear_single_constant( 'JETPACK_BLOG_TOKEN' );
 	}
 } // end class

--- a/projects/packages/image-cdn/CHANGELOG.md
+++ b/projects/packages/image-cdn/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.14] - 2025-07-21
+### Changed
+- Internal updates. [#39303]
+
 ## [0.7.13] - 2025-06-02
 ### Changed
 - Internal updates.
@@ -206,6 +210,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add image CDN package. [#29561]
 
+[0.7.14]: https://github.com/Automattic/jetpack-image-cdn/compare/v0.7.13...v0.7.14
 [0.7.13]: https://github.com/Automattic/jetpack-image-cdn/compare/v0.7.12...v0.7.13
 [0.7.12]: https://github.com/Automattic/jetpack-image-cdn/compare/v0.7.11...v0.7.12
 [0.7.11]: https://github.com/Automattic/jetpack-image-cdn/compare/v0.7.10...v0.7.11

--- a/projects/packages/image-cdn/src/class-image-cdn.php
+++ b/projects/packages/image-cdn/src/class-image-cdn.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Image_CDN;
  */
 final class Image_CDN {
 
-	const PACKAGE_VERSION = '0.7.13';
+	const PACKAGE_VERSION = '0.7.14';
 
 	/**
 	 * Singleton.

--- a/projects/packages/jitm/CHANGELOG.md
+++ b/projects/packages/jitm/CHANGELOG.md
@@ -5,13 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.2.29] - 2025-07-21
+### Changed
+- Internal updates.
+
 ## [4.2.28] - 2025-07-08
 ### Changed
 - Update dependencies. [#44229]
 
 ## [4.2.27] - 2025-07-03
 ### Changed
-- Improve JITM caching and minimize multiple wpcom sidebar jitm requests. [#44130]
+- Improve JITM caching and minimize multiple WordPress.com sidebar JITM requests. [#44130]
 - Update package dependencies. [#44148]
 
 ## [4.2.26] - 2025-06-30
@@ -958,6 +962,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update Jetpack to use new JITM package
 
+[4.2.29]: https://github.com/Automattic/jetpack-jitm/compare/v4.2.28...v4.2.29
 [4.2.28]: https://github.com/Automattic/jetpack-jitm/compare/v4.2.27...v4.2.28
 [4.2.27]: https://github.com/Automattic/jetpack-jitm/compare/v4.2.26...v4.2.27
 [4.2.26]: https://github.com/Automattic/jetpack-jitm/compare/v4.2.25...v4.2.26

--- a/projects/packages/jitm/changelog/update-stylelint-enable_spacing_rules
+++ b/projects/packages/jitm/changelog/update-stylelint-enable_spacing_rules
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Stylelint: Fix spacing rules.
-
-

--- a/projects/packages/jitm/changelog/update-stylint-enable_indentation
+++ b/projects/packages/jitm/changelog/update-stylint-enable_indentation
@@ -1,5 +1,0 @@
-Significance: patch
-Type: deprecated
-Comment: Stylelint: Enable indentation rules.
-
-

--- a/projects/packages/jitm/src/class-jitm.php
+++ b/projects/packages/jitm/src/class-jitm.php
@@ -21,7 +21,7 @@ use Automattic\Jetpack\Status\Host;
  */
 class JITM {
 
-	const PACKAGE_VERSION = '4.2.28';
+	const PACKAGE_VERSION = '4.2.29';
 
 	/**
 	 * List of screen IDs where JITMs are allowed to display.

--- a/projects/packages/jwt/CHANGELOG.md
+++ b/projects/packages/jwt/CHANGELOG.md
@@ -5,3 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.0 - 2025-07-21
+### Added
+- Initial version. [#43692]

--- a/projects/packages/jwt/changelog/initial-version
+++ b/projects/packages/jwt/changelog/initial-version
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Initial version.

--- a/projects/packages/jwt/package.json
+++ b/projects/packages/jwt/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-jwt",
-	"version": "0.1.0-alpha",
+	"version": "0.1.0",
 	"description": "A JSON Web Token implementation for Jetpack.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jwt/#readme",
 	"bugs": {

--- a/projects/packages/jwt/src/class-jwt.php
+++ b/projects/packages/jwt/src/class-jwt.php
@@ -27,7 +27,7 @@ use UnexpectedValueException;
  */
 class JWT {
 
-	const PACKAGE_VERSION = '0.1.0-alpha';
+	const PACKAGE_VERSION = '0.1.0';
 	/**
 	 * When checking nbf, iat or expiration times,
 	 * we want to provide some extra leeway time to

--- a/projects/packages/masterbar/CHANGELOG.md
+++ b/projects/packages/masterbar/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.19.0] - 2025-07-21
+### Changed
+- Update package dependencies. [#44356]
+
+### Deprecated
+- Admin Menu: Deprecate "Settings > Podcasting" menu. [#44367]
+- Admin Menu: Deprecate "Tools > Monetize" menu. [#44216]
+- Admin Menu: Deprecate "Users > Subscribers" menu. [#44302]
+
 ## [0.18.2] - 2025-07-14
 ### Changed
 - Update dependencies. [#44229]
@@ -381,6 +390,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Notifications: Change Icon [#37676]
 - Updated package dependencies. [#37669] [#37706]
 
+[0.19.0]: https://github.com/Automattic/jetpack-masterbar/compare/v0.18.2...v0.19.0
 [0.18.2]: https://github.com/Automattic/jetpack-masterbar/compare/v0.18.1...v0.18.2
 [0.18.1]: https://github.com/Automattic/jetpack-masterbar/compare/v0.18.0...v0.18.1
 [0.18.0]: https://github.com/Automattic/jetpack-masterbar/compare/v0.17.11...v0.18.0

--- a/projects/packages/masterbar/changelog/dotcom-13810-untangling-ia-show-jetpack-monetize-menu
+++ b/projects/packages/masterbar/changelog/dotcom-13810-untangling-ia-show-jetpack-monetize-menu
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Admin Menu: Deprecate "Tools > Monetize" menu

--- a/projects/packages/masterbar/changelog/dotcom-13884-untangling-ia-show-jetpack-subscribers-menu
+++ b/projects/packages/masterbar/changelog/dotcom-13884-untangling-ia-show-jetpack-subscribers-menu
@@ -1,4 +1,0 @@
-Significance: minor
-Type: deprecated
-
-Admin Menu: Deprecate "Users > Subscribers" menu

--- a/projects/packages/masterbar/changelog/dotcom-13936-untangling-ia-show-jetpack-podcasting-menu
+++ b/projects/packages/masterbar/changelog/dotcom-13936-untangling-ia-show-jetpack-podcasting-menu
@@ -1,4 +1,0 @@
-Significance: minor
-Type: deprecated
-
-Admin Menu: Deprecate "Settings > Podcasting" menu

--- a/projects/packages/masterbar/changelog/renovate-babel-monorepo
+++ b/projects/packages/masterbar/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/masterbar/changelog/update-add-available-tools
+++ b/projects/packages/masterbar/changelog/update-add-available-tools
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Add Tools > Available tools on WPCOM sites and remove Site monitoring and GitHub deployments menus.
-
-

--- a/projects/packages/masterbar/changelog/update-remove-server-settings
+++ b/projects/packages/masterbar/changelog/update-remove-server-settings
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Remove Settings > Server Settings for AT sites
-
-

--- a/projects/packages/masterbar/changelog/update-stylelint-enable_spacing_rules
+++ b/projects/packages/masterbar/changelog/update-stylelint-enable_spacing_rules
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Stylelint: Fix spacing rules.
-
-

--- a/projects/packages/masterbar/changelog/update-stylelint-fix_newline_rules
+++ b/projects/packages/masterbar/changelog/update-stylelint-fix_newline_rules
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Stylelint: Enable newline rules.
-
-

--- a/projects/packages/masterbar/changelog/update-stylint-enable_indentation
+++ b/projects/packages/masterbar/changelog/update-stylint-enable_indentation
@@ -1,5 +1,0 @@
-Significance: patch
-Type: deprecated
-Comment: Stylelint: Enable indentation rules.
-
-

--- a/projects/packages/masterbar/composer.json
+++ b/projects/packages/masterbar/composer.json
@@ -71,7 +71,7 @@
 	"extra": {
 		"autotagger": true,
 		"branch-alias": {
-			"dev-trunk": "0.18.x-dev"
+			"dev-trunk": "0.19.x-dev"
 		},
 		"changelogger": {
 			"link-template": "https://github.com/Automattic/jetpack-masterbar/compare/v${old}...v${new}"

--- a/projects/packages/masterbar/package.json
+++ b/projects/packages/masterbar/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-masterbar",
-	"version": "0.18.2",
+	"version": "0.19.0",
 	"description": "The WordPress.com Toolbar feature replaces the default admin bar and offers quick links to the Reader, all your sites, your WordPress.com profile, and notifications.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/masterbar/#readme",
 	"bugs": {

--- a/projects/packages/masterbar/src/class-main.php
+++ b/projects/packages/masterbar/src/class-main.php
@@ -14,7 +14,7 @@ use Automattic\Jetpack\Status\Host;
  */
 class Main {
 
-	const PACKAGE_VERSION = '0.18.2';
+	const PACKAGE_VERSION = '0.19.0';
 
 	/**
 	 * Initializer.

--- a/projects/packages/my-jetpack/CHANGELOG.md
+++ b/projects/packages/my-jetpack/CHANGELOG.md
@@ -5,9 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.19.0] - 2025-07-21
+### Changed
+- Enable My Jetpack access on WP Multisite. [#44260]
+- Show warning for products and modules not available for multisite. [#44260]
+- Update package dependencies. [#44356]
+
 ## [5.18.0] - 2025-07-14
 ### Added
-- Added project-level `CLAUDE.md`. [#44191]
+- Add project-level `CLAUDE.md`. [#44191]
 
 ### Changed
 - Fix some issues with site disconnections. [#44196]
@@ -2243,6 +2249,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created package
 
+[5.19.0]: https://github.com/Automattic/jetpack-my-jetpack/compare/5.18.0...5.19.0
 [5.18.0]: https://github.com/Automattic/jetpack-my-jetpack/compare/5.17.4...5.18.0
 [5.17.4]: https://github.com/Automattic/jetpack-my-jetpack/compare/5.17.3...5.17.4
 [5.17.3]: https://github.com/Automattic/jetpack-my-jetpack/compare/5.17.2...5.17.3

--- a/projects/packages/my-jetpack/changelog/fix-my-jetpack-multisite-access
+++ b/projects/packages/my-jetpack/changelog/fix-my-jetpack-multisite-access
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Enabled My Jetpack access on WP Multisite.

--- a/projects/packages/my-jetpack/changelog/fix-myjp-213-gradient-width
+++ b/projects/packages/my-jetpack/changelog/fix-myjp-213-gradient-width
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: My Jetpack: Fixing gradient width for onboarding.
-
-

--- a/projects/packages/my-jetpack/changelog/fix-phan-noopnew
+++ b/projects/packages/my-jetpack/changelog/fix-phan-noopnew
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Phan: Clean up PhanNoopNew instances.
-

--- a/projects/packages/my-jetpack/changelog/renovate-babel-monorepo
+++ b/projects/packages/my-jetpack/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/my-jetpack/changelog/show-warning-for-products-unavailable-for-multisite
+++ b/projects/packages/my-jetpack/changelog/show-warning-for-products-unavailable-for-multisite
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Show warning for products and modules not available for multisite.

--- a/projects/packages/my-jetpack/changelog/update-stylelint-enable_spacing_rules
+++ b/projects/packages/my-jetpack/changelog/update-stylelint-enable_spacing_rules
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Stylelint: Fix spacing rules.
-
-

--- a/projects/packages/my-jetpack/changelog/update-stylelint-fix_newline_rules
+++ b/projects/packages/my-jetpack/changelog/update-stylelint-fix_newline_rules
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Stylelint: Enable newline rules.
-
-

--- a/projects/packages/my-jetpack/changelog/update-stylint-enable_indentation
+++ b/projects/packages/my-jetpack/changelog/update-stylint-enable_indentation
@@ -1,5 +1,0 @@
-Significance: patch
-Type: deprecated
-Comment: Stylelint: Enable indentation rules.
-
-

--- a/projects/packages/my-jetpack/composer.json
+++ b/projects/packages/my-jetpack/composer.json
@@ -82,7 +82,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "5.18.x-dev"
+			"dev-trunk": "5.19.x-dev"
 		},
 		"version-constants": {
 			"::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "5.18.0",
+	"version": "5.19.0",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -39,7 +39,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '5.18.0';
+	const PACKAGE_VERSION = '5.19.0';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.

--- a/projects/packages/paypal-payments/CHANGELOG.md
+++ b/projects/packages/paypal-payments/CHANGELOG.md
@@ -5,9 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2025-07-21
+### Added
+- Add new PayPal Payment block. [#43932]
+
+### Changed
+- Tests: Generate block test files with tab indents. [#44099]
+- Update package dependencies. [#44337] [#44338] [#44356]
+- Update PayPal Payment Buttons block to support rendering previews. [#44359]
+
 ## 0.1.0 - 2025-07-14
 ### Added
 - Initial version. [#43315]
 
 ### Changed
 - Simple Payments: Move Simple Payments block to PayPal Payments package. [#43413]
+
+[0.2.0]: https://github.com/Automattic/jetpack-paypal-payments/compare/v0.1.0...v0.2.0

--- a/projects/packages/paypal-payments/changelog/add-eslint-plugin-you-dont-need-lodash-underscore
+++ b/projects/packages/paypal-payments/changelog/add-eslint-plugin-you-dont-need-lodash-underscore
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Fix a use of lodash `uniq` that snuck in after #44201.
-
-

--- a/projects/packages/paypal-payments/changelog/add-paypal-ncps-block-to-paypal-payments-pkg
+++ b/projects/packages/paypal-payments/changelog/add-paypal-ncps-block-to-paypal-payments-pkg
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add new PayPal payment block.

--- a/projects/packages/paypal-payments/changelog/fix-phan-noopnew
+++ b/projects/packages/paypal-payments/changelog/fix-phan-noopnew
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Phan: Clean up PhanUndeclaredFunction instances.
-

--- a/projects/packages/paypal-payments/changelog/paypal-20-extract-attribution-code-for-payments-buttons-into-constant
+++ b/projects/packages/paypal-payments/changelog/paypal-20-extract-attribution-code-for-payments-buttons-into-constant
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: No functional change
-
-

--- a/projects/packages/paypal-payments/changelog/paypal-27-ensure-that-block-renders-a-preview
+++ b/projects/packages/paypal-payments/changelog/paypal-27-ensure-that-block-renders-a-preview
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update PayPal Payment Buttons block to support rendering previews

--- a/projects/packages/paypal-payments/changelog/renovate-babel-monorepo
+++ b/projects/packages/paypal-payments/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/paypal-payments/changelog/renovate-js-unit-testing-packages
+++ b/projects/packages/paypal-payments/changelog/renovate-js-unit-testing-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/paypal-payments/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/paypal-payments/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/paypal-payments/changelog/update-cleanup-lodash-omit-function
+++ b/projects/packages/paypal-payments/changelog/update-cleanup-lodash-omit-function
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Replace use of lodash `omit`. Should be no change to functionality.
-
-

--- a/projects/packages/paypal-payments/changelog/update-stylelint-enable_spacing_rules
+++ b/projects/packages/paypal-payments/changelog/update-stylelint-enable_spacing_rules
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Stylelint: Fix spacing rules.
-
-

--- a/projects/packages/paypal-payments/changelog/update-stylint-enable_indentation
+++ b/projects/packages/paypal-payments/changelog/update-stylint-enable_indentation
@@ -1,5 +1,0 @@
-Significance: patch
-Type: deprecated
-Comment: Stylelint: Enable indentation rules.
-
-

--- a/projects/packages/paypal-payments/changelog/update-swiper_11.2.8
+++ b/projects/packages/paypal-payments/changelog/update-swiper_11.2.8
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Tests: Generate block test files with tab indents.

--- a/projects/packages/paypal-payments/composer.json
+++ b/projects/packages/paypal-payments/composer.json
@@ -60,7 +60,7 @@
 	"extra": {
 		"autotagger": true,
 		"branch-alias": {
-			"dev-trunk": "0.1.x-dev"
+			"dev-trunk": "0.2.x-dev"
 		},
 		"changelogger": {
 			"link-template": "https://github.com/Automattic/jetpack-paypal-payments/compare/v${old}...v${new}"

--- a/projects/packages/paypal-payments/package.json
+++ b/projects/packages/paypal-payments/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-paypal-payments",
-	"version": "0.1.0",
+	"version": "0.2.0",
 	"description": "Add PayPal, credit, and debit card payment buttons with minimal setup. Good for collecting donations or payments for products and services.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/paypal-payments/#readme",
 	"bugs": {

--- a/projects/packages/paypal-payments/src/class-paypal-payments.php
+++ b/projects/packages/paypal-payments/src/class-paypal-payments.php
@@ -12,5 +12,5 @@ namespace Automattic\Jetpack;
  */
 class PayPal_Payments {
 
-	const PACKAGE_VERSION = '0.1.0';
+	const PACKAGE_VERSION = '0.2.0';
 }

--- a/projects/packages/plans/CHANGELOG.md
+++ b/projects/packages/plans/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0] - 2025-07-21
+### Added
+- Forms: Include multistep form in Jetpack and WordPress.com plans. [#44309]
+
 ## [0.8.0] - 2025-05-05
 ### Added
 - Forms: Add feature/block field-file support to Personal and Complete plans. [#43177]
@@ -210,6 +214,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 - Moved the options class into Connection. [#24095]
 
+[0.9.0]: https://github.com/Automattic/jetpack-plans/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/Automattic/jetpack-plans/compare/v0.7.1...v0.8.0
 [0.7.1]: https://github.com/Automattic/jetpack-plans/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/Automattic/jetpack-plans/compare/v0.6.1...v0.7.0

--- a/projects/packages/plans/changelog/update-forms-multistep-to-production
+++ b/projects/packages/plans/changelog/update-forms-multistep-to-production
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Forms: Include multistep form in Jetpack and WPCOM plans.

--- a/projects/packages/plans/composer.json
+++ b/projects/packages/plans/composer.json
@@ -53,7 +53,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-plans/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "0.8.x-dev"
+			"dev-trunk": "0.9.x-dev"
 		}
 	},
 	"config": {

--- a/projects/packages/plans/package.json
+++ b/projects/packages/plans/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-plans",
-	"version": "0.8.0",
+	"version": "0.9.0",
 	"description": "Fetch information about Jetpack Plans from wpcom",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/plans/#readme",
 	"bugs": {

--- a/projects/packages/plugins-installer/CHANGELOG.md
+++ b/projects/packages/plugins-installer/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.6] - 2025-07-21
+### Changed
+- Internal updates.
+
 ## [0.5.5] - 2025-04-28
 ### Changed
 - Internal updates.
@@ -126,6 +130,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fix method logic
 
+[0.5.6]: https://github.com/Automattic/jetpack-plugins-installer/compare/v0.5.5...v0.5.6
 [0.5.5]: https://github.com/Automattic/jetpack-plugins-installer/compare/v0.5.4...v0.5.5
 [0.5.4]: https://github.com/Automattic/jetpack-plugins-installer/compare/v0.5.3...v0.5.4
 [0.5.3]: https://github.com/Automattic/jetpack-plugins-installer/compare/v0.5.2...v0.5.3

--- a/projects/packages/post-list/CHANGELOG.md
+++ b/projects/packages/post-list/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.23] - 2025-07-21
+### Changed
+- Tests: Update class used in Slideshow block. [#44099]
+
 ## [0.8.22] - 2025-07-14
 ### Changed
 - Update dependencies. [#44229]
@@ -229,6 +233,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated the default columns displayed on the post and page list screens
 - Refactored thumbnail preview to function server side. All javascript removed.
 
+[0.8.23]: https://github.com/automattic/jetpack-post-list/compare/v0.8.22...v0.8.23
 [0.8.22]: https://github.com/automattic/jetpack-post-list/compare/v0.8.21...v0.8.22
 [0.8.21]: https://github.com/automattic/jetpack-post-list/compare/v0.8.20...v0.8.21
 [0.8.20]: https://github.com/automattic/jetpack-post-list/compare/v0.8.19...v0.8.20

--- a/projects/packages/post-list/changelog/update-stylelint-enable_spacing_rules
+++ b/projects/packages/post-list/changelog/update-stylelint-enable_spacing_rules
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Stylelint: Fix spacing rules.
-
-

--- a/projects/packages/post-list/changelog/update-swiper_11.2.8
+++ b/projects/packages/post-list/changelog/update-swiper_11.2.8
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Tests: Update class used in Slideshow block.

--- a/projects/packages/post-list/src/class-post-list.php
+++ b/projects/packages/post-list/src/class-post-list.php
@@ -16,7 +16,7 @@ use WP_Screen;
  */
 class Post_List {
 
-	const PACKAGE_VERSION = '0.8.22';
+	const PACKAGE_VERSION = '0.8.23';
 	const FEATURE         = 'enhanced_post_list';
 
 	/**

--- a/projects/packages/protect-status/CHANGELOG.md
+++ b/projects/packages/protect-status/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.1] - 2025-07-21
+### Changed
+- Update dependencies.
+
 ## [0.6.0] - 2025-06-05
 ### Added
 - Add functionality to correctly display database threats in the Protect UI. [#43663]
@@ -124,6 +128,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated package dependencies. [#37894]
 
+[0.6.1]: https://github.com/Automattic/jetpack-protect-status/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/Automattic/jetpack-protect-status/compare/v0.5.11...v0.6.0
 [0.5.11]: https://github.com/Automattic/jetpack-protect-status/compare/v0.5.10...v0.5.11
 [0.5.10]: https://github.com/Automattic/jetpack-protect-status/compare/v0.5.9...v0.5.10

--- a/projects/packages/protect-status/package.json
+++ b/projects/packages/protect-status/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-protect-status",
-	"version": "0.6.0",
+	"version": "0.6.1",
 	"description": "This package contains the Protect Status API functionality to retrieve a site's scan status (WordPress, Themes, and Plugins threats).",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/protect-status/#readme",
 	"bugs": {

--- a/projects/packages/protect-status/src/class-status.php
+++ b/projects/packages/protect-status/src/class-status.php
@@ -14,7 +14,7 @@ use Automattic\Jetpack\Protect_Models\Status_Model;
  */
 class Status {
 
-	const PACKAGE_VERSION = '0.6.0';
+	const PACKAGE_VERSION = '0.6.1';
 	/**
 	 * Name of the option where status is stored
 	 *

--- a/projects/packages/publicize/CHANGELOG.md
+++ b/projects/packages/publicize/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.66.2] - 2025-07-21
+### Changed
+- Update package dependencies. [#44356]
+
 ## [0.66.1] - 2025-07-14
 ### Changed
 - Update dependencies. [#44229]
@@ -1051,6 +1055,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Update package.json metadata.
 
+[0.66.2]: https://github.com/Automattic/jetpack-publicize/compare/v0.66.1...v0.66.2
 [0.66.1]: https://github.com/Automattic/jetpack-publicize/compare/v0.66.0...v0.66.1
 [0.66.0]: https://github.com/Automattic/jetpack-publicize/compare/v0.65.7...v0.66.0
 [0.65.7]: https://github.com/Automattic/jetpack-publicize/compare/v0.65.6...v0.65.7

--- a/projects/packages/publicize/changelog/fix-phan-noopnew
+++ b/projects/packages/publicize/changelog/fix-phan-noopnew
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Phan: Clean up PhanNoopNew instances.
-

--- a/projects/packages/publicize/changelog/renovate-babel-monorepo
+++ b/projects/packages/publicize/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/publicize/package.json
+++ b/projects/packages/publicize/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize",
-	"version": "0.66.1",
+	"version": "0.66.2",
 	"description": "Publicize makes it easy to share your site’s posts on several social media networks automatically when you publish a new post.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/publicize/#readme",
 	"bugs": {

--- a/projects/packages/redirect/CHANGELOG.md
+++ b/projects/packages/redirect/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.8] - 2025-07-21
+### Changed
+- Internal updates.
+
 ## [3.0.7] - 2025-04-28
 ### Changed
 - Internal updates.
@@ -245,6 +249,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Create Jetpack Redirect package
 
+[3.0.8]: https://github.com/Automattic/jetpack-redirect/compare/v3.0.7...v3.0.8
 [3.0.7]: https://github.com/Automattic/jetpack-redirect/compare/v3.0.6...v3.0.7
 [3.0.6]: https://github.com/Automattic/jetpack-redirect/compare/v3.0.5...v3.0.6
 [3.0.5]: https://github.com/Automattic/jetpack-redirect/compare/v3.0.4...v3.0.5

--- a/projects/packages/search/CHANGELOG.md
+++ b/projects/packages/search/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.52.8] - 2025-07-21
+### Changed
+- Update package dependencies. [#44356]
+
 ## [0.52.7] - 2025-07-14
 ### Changed
 - Update package dependencies. [#44217]
@@ -1283,6 +1287,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Update PHPUnit configs to include just what needs coverage rather than include everything then try to exclude stuff that doesn't.
 
+[0.52.8]: https://github.com/Automattic/jetpack-search/compare/v0.52.7...v0.52.8
 [0.52.7]: https://github.com/Automattic/jetpack-search/compare/v0.52.6...v0.52.7
 [0.52.6]: https://github.com/Automattic/jetpack-search/compare/v0.52.5...v0.52.6
 [0.52.5]: https://github.com/Automattic/jetpack-search/compare/v0.52.4...v0.52.5

--- a/projects/packages/search/changelog/fix-phan-noopnew
+++ b/projects/packages/search/changelog/fix-phan-noopnew
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Phan: Clean up PhanNoopNew instances.
-

--- a/projects/packages/search/changelog/renovate-babel-monorepo
+++ b/projects/packages/search/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/search/changelog/update-cleanup-lodash-omit-function
+++ b/projects/packages/search/changelog/update-cleanup-lodash-omit-function
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Replace use of lodash `omit`. Should be no change to functionality.
-
-

--- a/projects/packages/search/changelog/update-replace-lodash-in-search
+++ b/projects/packages/search/changelog/update-replace-lodash-in-search
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Replace remaining uses of lodash. Should be no change to functionality.
-
-

--- a/projects/packages/search/changelog/update-stylelint-enable_spacing_rules
+++ b/projects/packages/search/changelog/update-stylelint-enable_spacing_rules
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Stylelint: Fix spacing rules.
-
-

--- a/projects/packages/search/changelog/update-stylelint-fix_newline_rules
+++ b/projects/packages/search/changelog/update-stylelint-fix_newline_rules
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Stylelint: Enable newline rules.
-
-

--- a/projects/packages/search/changelog/update-stylint-enable_indentation
+++ b/projects/packages/search/changelog/update-stylint-enable_indentation
@@ -1,5 +1,0 @@
-Significance: patch
-Type: deprecated
-Comment: Stylelint: Enable indentation rules.
-
-

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\Search;
  * Search package general information
  */
 class Package {
-	const VERSION = '0.52.7';
+	const VERSION = '0.52.8';
 	const SLUG    = 'search';
 
 	/**

--- a/projects/packages/stats-admin/CHANGELOG.md
+++ b/projects/packages/stats-admin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.28.1 - 2025-07-21
+### Changed
+- Update dependencies. [#39303]
+
 ## 0.28.0 - 2025-07-14
 ### Changed
 - Use the `view_stats` capability for the Jetpack Stats menu item instead of `manage_options`. [#44194]

--- a/projects/packages/stats-admin/package.json
+++ b/projects/packages/stats-admin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-stats-admin",
-	"version": "0.28.0",
+	"version": "0.28.1",
 	"description": "Stats Dashboard",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/stats-admin/#readme",
 	"bugs": {

--- a/projects/packages/stats-admin/src/class-main.php
+++ b/projects/packages/stats-admin/src/class-main.php
@@ -22,7 +22,7 @@ class Main {
 	/**
 	 * Stats version.
 	 */
-	const VERSION = '0.28.0';
+	const VERSION = '0.28.1';
 
 	/**
 	 * Singleton Main instance.

--- a/projects/packages/stats/CHANGELOG.md
+++ b/projects/packages/stats/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.2] - 2025-07-21
+### Changed
+- Internal updates. [#39260]
+
 ## [0.17.1] - 2025-06-23
 ### Fixed
 - Autoloader: Prevent double slash in autoloader path. [#44030]
@@ -270,6 +274,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixing static method which was called without self reference. [#26640]
 
+[0.17.2]: https://github.com/Automattic/jetpack-stats/compare/v0.17.1...v0.17.2
 [0.17.1]: https://github.com/Automattic/jetpack-stats/compare/v0.17.0...v0.17.1
 [0.17.0]: https://github.com/Automattic/jetpack-stats/compare/v0.16.3...v0.17.0
 [0.16.3]: https://github.com/Automattic/jetpack-stats/compare/v0.16.2...v0.16.3

--- a/projects/packages/stats/src/class-package-version.php
+++ b/projects/packages/stats/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Stats;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '0.17.1';
+	const PACKAGE_VERSION = '0.17.2';
 
 	const PACKAGE_SLUG = 'stats';
 

--- a/projects/packages/status/CHANGELOG.md
+++ b/projects/packages/status/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.0.0] - 2025-07-21
+### Removed
+- Remove host guess based on DNS. [#44325]
+
 ## [5.4.0] - 2025-07-08
 ### Changed
 - VIP: Change hosting check method back now that constant is reliable. [#44223]
@@ -489,6 +493,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Packages: Introduce a status package
 
+[6.0.0]: https://github.com/Automattic/jetpack-status/compare/v5.4.0...v6.0.0
 [5.4.0]: https://github.com/Automattic/jetpack-status/compare/v5.3.1...v5.4.0
 [5.3.1]: https://github.com/Automattic/jetpack-status/compare/v5.3.0...v5.3.1
 [5.3.0]: https://github.com/Automattic/jetpack-status/compare/v5.2.1...v5.3.0

--- a/projects/packages/status/changelog/remove-status-host_guess_from_dns
+++ b/projects/packages/status/changelog/remove-status-host_guess_from_dns
@@ -1,4 +1,0 @@
-Significance: patch
-Type: removed
-
-Remove host guess based on DNS.

--- a/projects/packages/status/composer.json
+++ b/projects/packages/status/composer.json
@@ -53,7 +53,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-status/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "5.4.x-dev"
+			"dev-trunk": "6.0.x-dev"
 		},
 		"dependencies": {
 			"test-only": [

--- a/projects/packages/status/src/class-host.php
+++ b/projects/packages/status/src/class-host.php
@@ -139,7 +139,7 @@ class Host {
 	 * Returns a guess of the hosting provider for the current site based on various checks.
 	 *
 	 * @since 5.0.4 Added $guess parameter.
-	 * @since $$next-version$$ Removed $guess parameter.
+	 * @since 6.0.0 Removed $guess parameter.
 	 *
 	 * @return string
 	 */

--- a/projects/packages/subscribers-dashboard/CHANGELOG.md
+++ b/projects/packages/subscribers-dashboard/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.23 - 2025-07-21
+### Changed
+- Update package dependencies. [#44356]
+
 ## 0.1.22 - 2025-07-14
 ### Changed
 - Update package dependencies. [#44217] [#44219]

--- a/projects/packages/subscribers-dashboard/changelog/renovate-babel-monorepo
+++ b/projects/packages/subscribers-dashboard/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/subscribers-dashboard/package.json
+++ b/projects/packages/subscribers-dashboard/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-subscribers-dashboard",
-	"version": "0.1.22",
+	"version": "0.1.23",
 	"description": "WP Admin page to manage subscribers",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/subscribers-dashboard/#readme",
 	"bugs": {

--- a/projects/packages/subscribers-dashboard/src/class-dashboard.php
+++ b/projects/packages/subscribers-dashboard/src/class-dashboard.php
@@ -17,7 +17,7 @@ use Automattic\Jetpack\Status\Host;
  * @package jetpack-subscribers
  */
 class Dashboard {
-	const VERSION = '0.1.22';
+	const VERSION = '0.1.23';
 	/**
 	 * Whether the class has been initialized
 	 *

--- a/projects/packages/sync/CHANGELOG.md
+++ b/projects/packages/sync/CHANGELOG.md
@@ -5,9 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.15.2] - 2025-07-21
+### Changed
+- Internal updates.
+
 ## [4.15.1] - 2025-07-08
 ### Added
-- Sync: do not sync the ActivityPub outbox CPT [#44222]
+- Sync: Do not sync the ActivityPub outbox CPT. [#44222]
 
 ## [4.15.0] - 2025-07-07
 ### Added
@@ -1494,6 +1498,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Packages: Move sync to a classmapped package
 
+[4.15.2]: https://github.com/Automattic/jetpack-sync/compare/v4.15.1...v4.15.2
 [4.15.1]: https://github.com/Automattic/jetpack-sync/compare/v4.15.0...v4.15.1
 [4.15.0]: https://github.com/Automattic/jetpack-sync/compare/v4.14.2...v4.15.0
 [4.14.2]: https://github.com/Automattic/jetpack-sync/compare/v4.14.1...v4.14.2

--- a/projects/packages/sync/changelog/fix-phan-noopnew
+++ b/projects/packages/sync/changelog/fix-phan-noopnew
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Phan: Clean up PhanNoopNew instances.
-

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '4.15.1';
+	const PACKAGE_VERSION = '4.15.2';
 
 	const PACKAGE_SLUG = 'sync';
 

--- a/projects/packages/videopress/CHANGELOG.md
+++ b/projects/packages/videopress/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.30.5] - 2025-07-21
+### Changed
+- Update package dependencies. [#44356]
+
 ## [0.30.4] - 2025-07-14
 ### Changed
 - Update package dependencies. [#44217] [#44219]
@@ -1690,6 +1694,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created empty package [#24952]
 
+[0.30.5]: https://github.com/Automattic/jetpack-videopress/compare/v0.30.4...v0.30.5
 [0.30.4]: https://github.com/Automattic/jetpack-videopress/compare/v0.30.3...v0.30.4
 [0.30.3]: https://github.com/Automattic/jetpack-videopress/compare/v0.30.2...v0.30.3
 [0.30.2]: https://github.com/Automattic/jetpack-videopress/compare/v0.30.1...v0.30.2

--- a/projects/packages/videopress/changelog/fix-phan-noopnew
+++ b/projects/packages/videopress/changelog/fix-phan-noopnew
@@ -1,3 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Phan: Clean up PhanNoopNew instances.

--- a/projects/packages/videopress/changelog/renovate-babel-monorepo
+++ b/projects/packages/videopress/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/videopress/changelog/update-stylelint-enable_spacing_rules
+++ b/projects/packages/videopress/changelog/update-stylelint-enable_spacing_rules
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Stylelint: Fix spacing rules.
-
-

--- a/projects/packages/videopress/changelog/update-stylelint-fix_newline_rules
+++ b/projects/packages/videopress/changelog/update-stylelint-fix_newline_rules
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Stylelint: Enable newline rules.
-
-

--- a/projects/packages/videopress/changelog/update-stylint-enable_indentation
+++ b/projects/packages/videopress/changelog/update-stylint-enable_indentation
@@ -1,5 +1,0 @@
-Significance: patch
-Type: deprecated
-Comment: Stylelint: Enable indentation rules.
-
-

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.30.4",
+	"version": "0.30.5",
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",
 	"bugs": {

--- a/projects/packages/videopress/src/class-package-version.php
+++ b/projects/packages/videopress/src/class-package-version.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * The Package_Version class.
  */
 class Package_Version {
-	const PACKAGE_VERSION = '0.30.4';
+	const PACKAGE_VERSION = '0.30.5';
 
 	const PACKAGE_SLUG = 'videopress';
 

--- a/projects/packages/waf/CHANGELOG.md
+++ b/projects/packages/waf/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.27.1] - 2025-07-21
+### Changed
+- Internal updates.
+
 ## [0.27.0] - 2025-07-14
 ### Changed
 - VIP: Change hosting check method. [#44223]
@@ -473,6 +477,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Core: do not ship .phpcs.dir.xml in production builds.
 
+[0.27.1]: https://github.com/Automattic/jetpack-waf/compare/v0.27.0...v0.27.1
 [0.27.0]: https://github.com/Automattic/jetpack-waf/compare/v0.26.0...v0.27.0
 [0.26.0]: https://github.com/Automattic/jetpack-waf/compare/v0.25.0...v0.26.0
 [0.25.0]: https://github.com/Automattic/jetpack-waf/compare/v0.24.4...v0.25.0

--- a/projects/packages/waf/changelog/fix-phan-noopnew
+++ b/projects/packages/waf/changelog/fix-phan-noopnew
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Phan: Clean up PhanNoopNew instances.
-

--- a/projects/plugins/automattic-for-agencies-client/changelog/prerelease#5
+++ b/projects/plugins/automattic-for-agencies-client/changelog/prerelease#5
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/automattic-for-agencies-client/composer.lock
+++ b/projects/plugins/automattic-for-agencies-client/composer.lock
@@ -126,7 +126,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/assets",
-                "reference": "de727d5b798d543ded18322d80812988facccfcf"
+                "reference": "0a42fa643d1ae105ac1398fd8eeff46d6dce7004"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -152,7 +152,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-assets/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.1.x-dev"
+                    "dev-trunk": "4.2.x-dev"
                 }
             },
             "autoload": {
@@ -399,7 +399,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "3ada7720732bef274f53a977f81b23617106224b"
+                "reference": "aa43a422bbb20d041365e2d52e8ab6f7561cbf29"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -435,7 +435,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "6.14.x-dev"
+                    "dev-trunk": "6.15.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/automattic-for-agencies-client/composer.lock
+++ b/projects/plugins/automattic-for-agencies-client/composer.lock
@@ -836,7 +836,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "73f34bf0ee21bb232d4245f3ef68c7bd911cb689"
+                "reference": "2de93770f98b4c662051bac5461445f9eb3a5c9e"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -862,7 +862,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-status/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "5.4.x-dev"
+                    "dev-trunk": "6.0.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/backup/changelog/prerelease#4
+++ b/projects/plugins/backup/changelog/prerelease#4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -1700,7 +1700,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "73f34bf0ee21bb232d4245f3ef68c7bd911cb689"
+                "reference": "2de93770f98b4c662051bac5461445f9eb3a5c9e"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -1726,7 +1726,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-status/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "5.4.x-dev"
+                    "dev-trunk": "6.0.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -126,7 +126,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/assets",
-                "reference": "de727d5b798d543ded18322d80812988facccfcf"
+                "reference": "0a42fa643d1ae105ac1398fd8eeff46d6dce7004"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -152,7 +152,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-assets/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.1.x-dev"
+                    "dev-trunk": "4.2.x-dev"
                 }
             },
             "autoload": {
@@ -660,7 +660,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "3ada7720732bef274f53a977f81b23617106224b"
+                "reference": "aa43a422bbb20d041365e2d52e8ab6f7561cbf29"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -696,7 +696,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "6.14.x-dev"
+                    "dev-trunk": "6.15.x-dev"
                 },
                 "dependencies": {
                     "test-only": [
@@ -1178,7 +1178,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "254c9942d3aa9df70c4dae2632d7ea13b6c55f84"
+                "reference": "154b0cb39e1dd3c951b2c53a0bd50edbca2f3b81"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1217,7 +1217,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "5.18.x-dev"
+                    "dev-trunk": "5.19.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"
@@ -1333,7 +1333,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/plans",
-                "reference": "8336af6815cea248ed38cd238c181a606c19b3fe"
+                "reference": "781f78eb3303aab7be574e82a0da7d0b22ab6b66"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1357,7 +1357,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-plans/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.8.x-dev"
+                    "dev-trunk": "0.9.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/boost/changelog/prerelease#2
+++ b/projects/plugins/boost/changelog/prerelease#2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -126,7 +126,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/assets",
-                "reference": "de727d5b798d543ded18322d80812988facccfcf"
+                "reference": "0a42fa643d1ae105ac1398fd8eeff46d6dce7004"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -152,7 +152,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-assets/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.1.x-dev"
+                    "dev-trunk": "4.2.x-dev"
                 }
             },
             "autoload": {
@@ -520,7 +520,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "3ada7720732bef274f53a977f81b23617106224b"
+                "reference": "aa43a422bbb20d041365e2d52e8ab6f7561cbf29"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -556,7 +556,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "6.14.x-dev"
+                    "dev-trunk": "6.15.x-dev"
                 },
                 "dependencies": {
                     "test-only": [
@@ -1099,7 +1099,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "254c9942d3aa9df70c4dae2632d7ea13b6c55f84"
+                "reference": "154b0cb39e1dd3c951b2c53a0bd50edbca2f3b81"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1138,7 +1138,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "5.18.x-dev"
+                    "dev-trunk": "5.19.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"
@@ -1254,7 +1254,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/plans",
-                "reference": "8336af6815cea248ed38cd238c181a606c19b3fe"
+                "reference": "781f78eb3303aab7be574e82a0da7d0b22ab6b66"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1278,7 +1278,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-plans/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.8.x-dev"
+                    "dev-trunk": "0.9.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -1755,7 +1755,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "73f34bf0ee21bb232d4245f3ef68c7bd911cb689"
+                "reference": "2de93770f98b4c662051bac5461445f9eb3a5c9e"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -1781,7 +1781,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-status/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "5.4.x-dev"
+                    "dev-trunk": "6.0.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/classic-theme-helper-plugin/changelog/prerelease#23
+++ b/projects/plugins/classic-theme-helper-plugin/changelog/prerelease#23
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/classic-theme-helper-plugin/composer.lock
+++ b/projects/plugins/classic-theme-helper-plugin/composer.lock
@@ -66,7 +66,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/assets",
-                "reference": "de727d5b798d543ded18322d80812988facccfcf"
+                "reference": "0a42fa643d1ae105ac1398fd8eeff46d6dce7004"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -92,7 +92,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-assets/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.1.x-dev"
+                    "dev-trunk": "4.2.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/classic-theme-helper-plugin/composer.lock
+++ b/projects/plugins/classic-theme-helper-plugin/composer.lock
@@ -516,7 +516,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "73f34bf0ee21bb232d4245f3ef68c7bd911cb689"
+                "reference": "2de93770f98b4c662051bac5461445f9eb3a5c9e"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -542,7 +542,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-status/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "5.4.x-dev"
+                    "dev-trunk": "6.0.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/crm/changelog/prerelease
+++ b/projects/plugins/crm/changelog/prerelease
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/crm/composer.lock
+++ b/projects/plugins/crm/composer.lock
@@ -12,7 +12,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/assets",
-                "reference": "de727d5b798d543ded18322d80812988facccfcf"
+                "reference": "0a42fa643d1ae105ac1398fd8eeff46d6dce7004"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -38,7 +38,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-assets/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.1.x-dev"
+                    "dev-trunk": "4.2.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/crm/composer.lock
+++ b/projects/plugins/crm/composer.lock
@@ -268,7 +268,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "73f34bf0ee21bb232d4245f3ef68c7bd911cb689"
+                "reference": "2de93770f98b4c662051bac5461445f9eb3a5c9e"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -294,7 +294,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-status/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "5.4.x-dev"
+                    "dev-trunk": "6.0.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/inspect/changelog/prerelease#4
+++ b/projects/plugins/inspect/changelog/prerelease#4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/inspect/composer.lock
+++ b/projects/plugins/inspect/composer.lock
@@ -652,7 +652,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "73f34bf0ee21bb232d4245f3ef68c7bd911cb689"
+                "reference": "2de93770f98b4c662051bac5461445f9eb3a5c9e"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -678,7 +678,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-status/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "5.4.x-dev"
+                    "dev-trunk": "6.0.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/inspect/composer.lock
+++ b/projects/plugins/inspect/composer.lock
@@ -126,7 +126,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/assets",
-                "reference": "de727d5b798d543ded18322d80812988facccfcf"
+                "reference": "0a42fa643d1ae105ac1398fd8eeff46d6dce7004"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -152,7 +152,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-assets/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.1.x-dev"
+                    "dev-trunk": "4.2.x-dev"
                 }
             },
             "autoload": {
@@ -399,7 +399,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "3ada7720732bef274f53a977f81b23617106224b"
+                "reference": "aa43a422bbb20d041365e2d52e8ab6f7561cbf29"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -435,7 +435,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "6.14.x-dev"
+                    "dev-trunk": "6.15.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/jetpack/CHANGELOG.md
+++ b/projects/plugins/jetpack/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 ### This is a list detailing changes for all Jetpack releases.
 
+## 14.9-a.5 - 2025-07-21
+### Enhancements
+- Add new PayPal Payment block (beta). [#43932]
+- Forms: Add Gravatars in form responses. [#44270]
+- Forms: Make phone fields clickable [#44291]
+- Forms: Use sentence case in default consent text. [#44078]
+- My Jetpack: Enable access to My Jetpack on WP Multisite. [#44260]
+- Podcast player block: Improve page load performance by removing use of `lodash`. [#44319]
+- Story block: Improve page load performance by removing use of `lodash`. [#44319]
+- Update PayPal Payment Buttons block to support rendering previews. [#44359]
+
+### Bug fixes
+- Dashboard: Use UTC for Jetpack Stats chart. [#44380]
+- Forms: Fix the way forms are submitted. [#44360]
+- Social: Fix image validation when images sizes are customised. [#44368]
+
+### Other changes <!-- Non-user-facing changes go here. This section will not be copied to readme.txt. -->
+- Code Modernization: Replace usage of certain `preg_match()` checks with `str_contains()`. [#44324]
+- E2E tests: Remove redundant logic in test fixture and converted the fixture to Typscript. [#44327]
+- Editor assets endpoint: Reinstate missing Jetpack assets via handle-based exclusion logic. [#44274]
+- Subscriptions Widget: Add fallback values. [#44265]
+- Update dependencies. [#44099]
+- Update package dependencies. [#44356]
+- Widgets: Prevent PHP warning on legacy Twitter Timeline widget. [#44317]
+
 ## 14.9-a.3 - 2025-07-14
 ### Enhancements
 - Forms: Add "Empty trash" button. [#44225]

--- a/projects/plugins/jetpack/changelog/add-paypal-ncps-block-to-paypal-payments-pkg
+++ b/projects/plugins/jetpack/changelog/add-paypal-ncps-block-to-paypal-payments-pkg
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Add new PayPal payment block.

--- a/projects/plugins/jetpack/changelog/e2e-remove-redundant-test-fixture
+++ b/projects/plugins/jetpack/changelog/e2e-remove-redundant-test-fixture
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-E2E tests: remove redundant logic in test fixture and converted the fixture to Typscript

--- a/projects/plugins/jetpack/changelog/e2e-simplify-resolve-site-url
+++ b/projects/plugins/jetpack/changelog/e2e-simplify-resolve-site-url
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: E2E tests improvements
-
-

--- a/projects/plugins/jetpack/changelog/fix-create-post-meta-on-every-admin-load
+++ b/projects/plugins/jetpack/changelog/fix-create-post-meta-on-every-admin-load
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-

--- a/projects/plugins/jetpack/changelog/fix-my-jetpack-multisite-access
+++ b/projects/plugins/jetpack/changelog/fix-my-jetpack-multisite-access
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-My Jetpack: Enabled access to My Jetpack on WP Multisite.

--- a/projects/plugins/jetpack/changelog/fix-myjp-213-gradient-width
+++ b/projects/plugins/jetpack/changelog/fix-myjp-213-gradient-width
@@ -1,5 +1,0 @@
-Significance: patch
-Type: bugfix
-Comment: My Jetpack: Fixing gradient width for onboarding.
-
-

--- a/projects/plugins/jetpack/changelog/fix-phan-noopnew
+++ b/projects/plugins/jetpack/changelog/fix-phan-noopnew
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-Comment: Phan: Clean up PhanNoopNew instances.
-

--- a/projects/plugins/jetpack/changelog/fix-reinstate-jetpack-assets-to-editor-assets-endpoint
+++ b/projects/plugins/jetpack/changelog/fix-reinstate-jetpack-assets-to-editor-assets-endpoint
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Editor assets endpoint: reinstate missing Jetpack assets via handle-based exclusion logic

--- a/projects/plugins/jetpack/changelog/fix-replace-lodash-underscore-in-modules
+++ b/projects/plugins/jetpack/changelog/fix-replace-lodash-underscore-in-modules
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Replace lodash/underscore in modules. Should be no change to functionality.
-
-

--- a/projects/plugins/jetpack/changelog/fix-social-media-validation-for-custom-image-sizes
+++ b/projects/plugins/jetpack/changelog/fix-social-media-validation-for-custom-image-sizes
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Social: Fix image validation when images sizes are customised.

--- a/projects/plugins/jetpack/changelog/fix-story-block-flowRight
+++ b/projects/plugins/jetpack/changelog/fix-story-block-flowRight
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Fix story block after #44319
-
-

--- a/projects/plugins/jetpack/changelog/fix-twitter-timeline-php_warning
+++ b/projects/plugins/jetpack/changelog/fix-twitter-timeline-php_warning
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Widgets: Prevent PHP warning on legacy Twitter Timeline widget. 

--- a/projects/plugins/jetpack/changelog/paypal-27-ensure-that-block-renders-a-preview
+++ b/projects/plugins/jetpack/changelog/paypal-27-ensure-that-block-renders-a-preview
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Update PayPal Payment Buttons block to support rendering previews

--- a/projects/plugins/jetpack/changelog/renovate-babel-monorepo
+++ b/projects/plugins/jetpack/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Update package dependencies.

--- a/projects/plugins/jetpack/changelog/update-add-jwt-form-encode-decode
+++ b/projects/plugins/jetpack/changelog/update-add-jwt-form-encode-decode
@@ -1,4 +1,0 @@
-Significance: minor
-Type: bugfix
-
-Forms: fix the way forms are submitted 

--- a/projects/plugins/jetpack/changelog/update-cleanup-lodash-omit-function
+++ b/projects/plugins/jetpack/changelog/update-cleanup-lodash-omit-function
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Replace use of lodash `omit`. Should be no change to functionality.
-
-

--- a/projects/plugins/jetpack/changelog/update-form-consent-block-font
+++ b/projects/plugins/jetpack/changelog/update-form-consent-block-font
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Forms: Make default consent test sentence case.

--- a/projects/plugins/jetpack/changelog/update-forms-gravatar
+++ b/projects/plugins/jetpack/changelog/update-forms-gravatar
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Forms: add Gravatars in form responses

--- a/projects/plugins/jetpack/changelog/update-forms-phone
+++ b/projects/plugins/jetpack/changelog/update-forms-phone
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Forms: make phone fields clickable

--- a/projects/plugins/jetpack/changelog/update-jetpack-modules-string-compare-operations
+++ b/projects/plugins/jetpack/changelog/update-jetpack-modules-string-compare-operations
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Code Modernization: Replace usage of certain preg_match() checks with str_contains().

--- a/projects/plugins/jetpack/changelog/update-replace-lodash-in-jetpack-block-viewjs
+++ b/projects/plugins/jetpack/changelog/update-replace-lodash-in-jetpack-block-viewjs
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-Story block: improve page load performance by removing use of `lodash`.

--- a/projects/plugins/jetpack/changelog/update-replace-lodash-in-jetpack-block-viewjs#2
+++ b/projects/plugins/jetpack/changelog/update-replace-lodash-in-jetpack-block-viewjs#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-Podcast player block: improve page load performance by removing use of `lodash`.

--- a/projects/plugins/jetpack/changelog/update-replace-lodash-in-mailchimp-block-viewjs
+++ b/projects/plugins/jetpack/changelog/update-replace-lodash-in-mailchimp-block-viewjs
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Replace use of `lodash` in Mailchimp block view.js
-
-

--- a/projects/plugins/jetpack/changelog/update-settings-sharing-wpcom
+++ b/projects/plugins/jetpack/changelog/update-settings-sharing-wpcom
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Use Settings > Sharing page for WPCOM (Simple and Atomic) sites
-
-

--- a/projects/plugins/jetpack/changelog/update-stylelint-enable_spacing_rules
+++ b/projects/plugins/jetpack/changelog/update-stylelint-enable_spacing_rules
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Stylelint: Fix spacing rules.
-
-

--- a/projects/plugins/jetpack/changelog/update-stylelint-fix_newline_rules
+++ b/projects/plugins/jetpack/changelog/update-stylelint-fix_newline_rules
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Stylelint: Enable newline rules.
-
-

--- a/projects/plugins/jetpack/changelog/update-stylint-enable_indentation
+++ b/projects/plugins/jetpack/changelog/update-stylint-enable_indentation
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Stylelint: Enable indentation rules.
-
-

--- a/projects/plugins/jetpack/changelog/update-subscriptions-widget-update-function-defaults
+++ b/projects/plugins/jetpack/changelog/update-subscriptions-widget-update-function-defaults
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Subscriptions Widget: Adding fallback values.

--- a/projects/plugins/jetpack/changelog/update-swiper_11.2.8
+++ b/projects/plugins/jetpack/changelog/update-swiper_11.2.8
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Update dependencies.

--- a/projects/plugins/jetpack/changelog/update-use_utc_on_jetpack_dashboard_stats_chart
+++ b/projects/plugins/jetpack/changelog/update-use_utc_on_jetpack_dashboard_stats_chart
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Use UTC for Jetpack Stats chart on Dashboard.

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -110,7 +110,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ14_9_a_3",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ14_9_a_5",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -1413,14 +1413,13 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/forms",
-                "reference": "690af0bed3b8874b34ab6a079a1eb2f946334eab"
+                "reference": "e575465d91341af76df4d6fccc469823520dd957"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
                 "automattic/jetpack-assets": "@dev",
                 "automattic/jetpack-blocks": "@dev",
                 "automattic/jetpack-connection": "@dev",
-                "automattic/jetpack-jwt": "@dev",
                 "automattic/jetpack-logo": "@dev",
                 "automattic/jetpack-plans": "@dev",
                 "automattic/jetpack-status": "@dev",
@@ -1741,70 +1740,6 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Just in time messages for Jetpack",
-            "transport-options": {
-                "relative": true
-            }
-        },
-        {
-            "name": "automattic/jetpack-jwt",
-            "version": "dev-trunk",
-            "dist": {
-                "type": "path",
-                "url": "../../packages/jwt",
-                "reference": "d0fbea9bb3f1d4c1e8e66af2780d8cdabe357319"
-            },
-            "require": {
-                "php": ">=7.2"
-            },
-            "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
-                "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^4.0.0"
-            },
-            "suggest": {
-                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
-            },
-            "type": "jetpack-library",
-            "extra": {
-                "autotagger": true,
-                "mirror-repo": "Automattic/jetpack-jwt",
-                "changelogger": {
-                    "link-template": "https://github.com/automattic/jetpack-jwt/compare/v${old}...v${new}"
-                },
-                "branch-alias": {
-                    "dev-trunk": "0.1.x-dev"
-                },
-                "textdomain": "jetpack-jwt",
-                "version-constants": {
-                    "::PACKAGE_VERSION": "src/class-jwt.php"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "scripts": {
-                "build-development": [
-                    "echo 'Add your build step to composer.json, please!'"
-                ],
-                "build-production": [
-                    "echo 'Add your build step to composer.json, please!'"
-                ],
-                "phpunit": [
-                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
-                ],
-                "test-coverage": [
-                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
-                ],
-                "test-php": [
-                    "@composer phpunit"
-                ]
-            },
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "description": "A JSON Web Token (JWT) implementation for Jetpack.",
             "transport-options": {
                 "relative": true
             }

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -250,7 +250,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/assets",
-                "reference": "de727d5b798d543ded18322d80812988facccfcf"
+                "reference": "0a42fa643d1ae105ac1398fd8eeff46d6dce7004"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -276,7 +276,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-assets/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.1.x-dev"
+                    "dev-trunk": "4.2.x-dev"
                 }
             },
             "autoload": {
@@ -1019,7 +1019,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "3ada7720732bef274f53a977f81b23617106224b"
+                "reference": "aa43a422bbb20d041365e2d52e8ab6f7561cbf29"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -1055,7 +1055,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "6.14.x-dev"
+                    "dev-trunk": "6.15.x-dev"
                 },
                 "dependencies": {
                     "test-only": [
@@ -1413,7 +1413,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/forms",
-                "reference": "3c2be9c5348ce7de224ebe854b99bcdb87e931e1"
+                "reference": "690af0bed3b8874b34ab6a079a1eb2f946334eab"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1445,7 +1445,7 @@
                     "link-template": "https://github.com/automattic/jetpack-forms/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.1.x-dev"
+                    "dev-trunk": "4.0.x-dev"
                 },
                 "textdomain": "jetpack-forms",
                 "version-constants": {
@@ -1926,7 +1926,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/masterbar",
-                "reference": "3fecd1e7106a4f3efb85c188d1717d6eae5a93a4"
+                "reference": "35da68eb47a67e6711af53de5829a86f9b2b358b"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -1956,7 +1956,7 @@
             "extra": {
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "0.18.x-dev"
+                    "dev-trunk": "0.19.x-dev"
                 },
                 "changelogger": {
                     "link-template": "https://github.com/Automattic/jetpack-masterbar/compare/v${old}...v${new}"
@@ -2009,7 +2009,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "254c9942d3aa9df70c4dae2632d7ea13b6c55f84"
+                "reference": "154b0cb39e1dd3c951b2c53a0bd50edbca2f3b81"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -2048,7 +2048,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "5.18.x-dev"
+                    "dev-trunk": "5.19.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"
@@ -2164,7 +2164,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/paypal-payments",
-                "reference": "212a7b22dff2a31244d1bd0898143f35eec59667"
+                "reference": "9a3a07927fb852524773126ddbdb1b799e28b648"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -2187,7 +2187,7 @@
             "extra": {
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "0.1.x-dev"
+                    "dev-trunk": "0.2.x-dev"
                 },
                 "changelogger": {
                     "link-template": "https://github.com/Automattic/jetpack-paypal-payments/compare/v${old}...v${new}"
@@ -2241,7 +2241,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/plans",
-                "reference": "8336af6815cea248ed38cd238c181a606c19b3fe"
+                "reference": "781f78eb3303aab7be574e82a0da7d0b22ab6b66"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -2265,7 +2265,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-plans/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.8.x-dev"
+                    "dev-trunk": "0.9.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -2906,7 +2906,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "73f34bf0ee21bb232d4245f3ef68c7bd911cb689"
+                "reference": "2de93770f98b4c662051bac5461445f9eb3a5c9e"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -2932,7 +2932,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-status/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "5.4.x-dev"
+                    "dev-trunk": "6.0.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/jetpack/extensions/blocks/paypal-payment-buttons/paypal-payment-buttons.php
+++ b/projects/plugins/jetpack/extensions/blocks/paypal-payment-buttons/paypal-payment-buttons.php
@@ -2,7 +2,7 @@
 /**
  * PayPal Payment Buttons block.
  *
- * @since $$next-version$$
+ * @since 14.9
  *
  * @package automattic/jetpack
  */

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 14.9-a.3
+ * Version: 14.9-a.5
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.7' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '7.2' );
-define( 'JETPACK__VERSION', '14.9-a.3' );
+define( 'JETPACK__VERSION', '14.9-a.5' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/readme.txt
+++ b/projects/plugins/jetpack/readme.txt
@@ -326,18 +326,21 @@ Jetpack Backup can do a full website migration to a new host, migrate theme file
 
 
 == Changelog ==
-### 14.9-a.3 - 2025-07-14
+### 14.9-a.5 - 2025-07-21
 #### Enhancements
-- Forms: Add "Empty trash" button.
-- Forms: Add link to disconnect Google.
-- Forms: Add tip that spam will automatically be deleted after 15 days.
-- Forms: Improve email copy-to-clipboard visually and make it less hidden.
-- Forms: Refresh look of responses in dashboard.
-- Forms: Update integration links.
-- Use the `view_stats` cap for the Jetpack Stats menu item instead of `manage_options`.
+- Add new PayPal Payment block (beta).
+- Forms: Add Gravatars in form responses.
+- Forms: Make phone fields clickable
+- Forms: Use sentence case in default consent text.
+- My Jetpack: Enable access to My Jetpack on WP Multisite.
+- Podcast player block: Improve page load performance by removing use of `lodash`.
+- Story block: Improve page load performance by removing use of `lodash`.
+- Update PayPal Payment Buttons block to support rendering previews.
 
-#### Improved compatibility
-- Sync: Ignore the ActivityPub Outbox CPT.
+#### Bug fixes
+- Dashboard: Use UTC for Jetpack Stats chart.
+- Forms: Fix the way forms are submitted.
+- Social: Fix image validation when images sizes are customised.
 
 --------
 

--- a/projects/plugins/mu-wpcom-plugin/changelog/prerelease#8
+++ b/projects/plugins/mu-wpcom-plugin/changelog/prerelease#8
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -126,7 +126,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/assets",
-                "reference": "de727d5b798d543ded18322d80812988facccfcf"
+                "reference": "0a42fa643d1ae105ac1398fd8eeff46d6dce7004"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -152,7 +152,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-assets/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.1.x-dev"
+                    "dev-trunk": "4.2.x-dev"
                 }
             },
             "autoload": {
@@ -559,7 +559,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "3ada7720732bef274f53a977f81b23617106224b"
+                "reference": "aa43a422bbb20d041365e2d52e8ab6f7561cbf29"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -595,7 +595,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "6.14.x-dev"
+                    "dev-trunk": "6.15.x-dev"
                 },
                 "dependencies": {
                     "test-only": [
@@ -1010,7 +1010,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/masterbar",
-                "reference": "3fecd1e7106a4f3efb85c188d1717d6eae5a93a4"
+                "reference": "35da68eb47a67e6711af53de5829a86f9b2b358b"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -1040,7 +1040,7 @@
             "extra": {
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "0.18.x-dev"
+                    "dev-trunk": "0.19.x-dev"
                 },
                 "changelogger": {
                     "link-template": "https://github.com/Automattic/jetpack-masterbar/compare/v${old}...v${new}"
@@ -1233,7 +1233,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/plans",
-                "reference": "8336af6815cea248ed38cd238c181a606c19b3fe"
+                "reference": "781f78eb3303aab7be574e82a0da7d0b22ab6b66"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1257,7 +1257,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-plans/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.8.x-dev"
+                    "dev-trunk": "0.9.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -1543,7 +1543,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "73f34bf0ee21bb232d4245f3ef68c7bd911cb689"
+                "reference": "2de93770f98b4c662051bac5461445f9eb3a5c9e"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -1569,7 +1569,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-status/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "5.4.x-dev"
+                    "dev-trunk": "6.0.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/protect/changelog/prerelease#3
+++ b/projects/plugins/protect/changelog/prerelease#3
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -195,7 +195,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/assets",
-                "reference": "de727d5b798d543ded18322d80812988facccfcf"
+                "reference": "0a42fa643d1ae105ac1398fd8eeff46d6dce7004"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -221,7 +221,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-assets/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.1.x-dev"
+                    "dev-trunk": "4.2.x-dev"
                 }
             },
             "autoload": {
@@ -644,7 +644,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "3ada7720732bef274f53a977f81b23617106224b"
+                "reference": "aa43a422bbb20d041365e2d52e8ab6f7561cbf29"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -680,7 +680,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "6.14.x-dev"
+                    "dev-trunk": "6.15.x-dev"
                 },
                 "dependencies": {
                     "test-only": [
@@ -1162,7 +1162,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "254c9942d3aa9df70c4dae2632d7ea13b6c55f84"
+                "reference": "154b0cb39e1dd3c951b2c53a0bd50edbca2f3b81"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1201,7 +1201,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "5.18.x-dev"
+                    "dev-trunk": "5.19.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"
@@ -1317,7 +1317,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/plans",
-                "reference": "8336af6815cea248ed38cd238c181a606c19b3fe"
+                "reference": "781f78eb3303aab7be574e82a0da7d0b22ab6b66"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1341,7 +1341,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-plans/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.8.x-dev"
+                    "dev-trunk": "0.9.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -1684,7 +1684,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "73f34bf0ee21bb232d4245f3ef68c7bd911cb689"
+                "reference": "2de93770f98b4c662051bac5461445f9eb3a5c9e"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -1710,7 +1710,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-status/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "5.4.x-dev"
+                    "dev-trunk": "6.0.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/search/changelog/prerelease#7
+++ b/projects/plugins/search/changelog/prerelease#7
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -126,7 +126,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/assets",
-                "reference": "de727d5b798d543ded18322d80812988facccfcf"
+                "reference": "0a42fa643d1ae105ac1398fd8eeff46d6dce7004"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -152,7 +152,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-assets/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.1.x-dev"
+                    "dev-trunk": "4.2.x-dev"
                 }
             },
             "autoload": {
@@ -520,7 +520,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "3ada7720732bef274f53a977f81b23617106224b"
+                "reference": "aa43a422bbb20d041365e2d52e8ab6f7561cbf29"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -556,7 +556,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "6.14.x-dev"
+                    "dev-trunk": "6.15.x-dev"
                 },
                 "dependencies": {
                     "test-only": [
@@ -1038,7 +1038,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "254c9942d3aa9df70c4dae2632d7ea13b6c55f84"
+                "reference": "154b0cb39e1dd3c951b2c53a0bd50edbca2f3b81"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1077,7 +1077,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "5.18.x-dev"
+                    "dev-trunk": "5.19.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"
@@ -1193,7 +1193,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/plans",
-                "reference": "8336af6815cea248ed38cd238c181a606c19b3fe"
+                "reference": "781f78eb3303aab7be574e82a0da7d0b22ab6b66"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1217,7 +1217,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-plans/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.8.x-dev"
+                    "dev-trunk": "0.9.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -1710,7 +1710,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "73f34bf0ee21bb232d4245f3ef68c7bd911cb689"
+                "reference": "2de93770f98b4c662051bac5461445f9eb3a5c9e"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -1736,7 +1736,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-status/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "5.4.x-dev"
+                    "dev-trunk": "6.0.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/social/changelog/prerelease#10
+++ b/projects/plugins/social/changelog/prerelease#10
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -126,7 +126,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/assets",
-				"reference": "de727d5b798d543ded18322d80812988facccfcf"
+				"reference": "0a42fa643d1ae105ac1398fd8eeff46d6dce7004"
 			},
 			"require": {
 				"automattic/jetpack-constants": "@dev",
@@ -152,7 +152,7 @@
 					"link-template": "https://github.com/Automattic/jetpack-assets/compare/v${old}...v${new}"
 				},
 				"branch-alias": {
-					"dev-trunk": "4.1.x-dev"
+					"dev-trunk": "4.2.x-dev"
 				}
 			},
 			"autoload": {
@@ -520,7 +520,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/connection",
-				"reference": "3ada7720732bef274f53a977f81b23617106224b"
+				"reference": "aa43a422bbb20d041365e2d52e8ab6f7561cbf29"
 			},
 			"require": {
 				"automattic/jetpack-a8c-mc-stats": "@dev",
@@ -556,7 +556,7 @@
 					"link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
 				},
 				"branch-alias": {
-					"dev-trunk": "6.14.x-dev"
+					"dev-trunk": "6.15.x-dev"
 				},
 				"dependencies": {
 					"test-only": [
@@ -1038,7 +1038,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/my-jetpack",
-				"reference": "254c9942d3aa9df70c4dae2632d7ea13b6c55f84"
+				"reference": "154b0cb39e1dd3c951b2c53a0bd50edbca2f3b81"
 			},
 			"require": {
 				"automattic/jetpack-admin-ui": "@dev",
@@ -1077,7 +1077,7 @@
 					"link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
 				},
 				"branch-alias": {
-					"dev-trunk": "5.18.x-dev"
+					"dev-trunk": "5.19.x-dev"
 				},
 				"version-constants": {
 					"::PACKAGE_VERSION": "src/class-initializer.php"
@@ -1193,7 +1193,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/plans",
-				"reference": "8336af6815cea248ed38cd238c181a606c19b3fe"
+				"reference": "781f78eb3303aab7be574e82a0da7d0b22ab6b66"
 			},
 			"require": {
 				"automattic/jetpack-connection": "@dev",
@@ -1217,7 +1217,7 @@
 					"link-template": "https://github.com/Automattic/jetpack-plans/compare/v${old}...v${new}"
 				},
 				"branch-alias": {
-					"dev-trunk": "0.8.x-dev"
+					"dev-trunk": "0.9.x-dev"
 				}
 			},
 			"autoload": {

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -1704,7 +1704,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/status",
-				"reference": "73f34bf0ee21bb232d4245f3ef68c7bd911cb689"
+				"reference": "2de93770f98b4c662051bac5461445f9eb3a5c9e"
 			},
 			"require": {
 				"automattic/jetpack-constants": "@dev",
@@ -1730,7 +1730,7 @@
 					"link-template": "https://github.com/Automattic/jetpack-status/compare/v${old}...v${new}"
 				},
 				"branch-alias": {
-					"dev-trunk": "5.4.x-dev"
+					"dev-trunk": "6.0.x-dev"
 				},
 				"dependencies": {
 					"test-only": [

--- a/projects/plugins/starter-plugin/changelog/prerelease#6
+++ b/projects/plugins/starter-plugin/changelog/prerelease#6
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -1560,7 +1560,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "73f34bf0ee21bb232d4245f3ef68c7bd911cb689"
+                "reference": "2de93770f98b4c662051bac5461445f9eb3a5c9e"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -1586,7 +1586,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-status/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "5.4.x-dev"
+                    "dev-trunk": "6.0.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -126,7 +126,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/assets",
-                "reference": "de727d5b798d543ded18322d80812988facccfcf"
+                "reference": "0a42fa643d1ae105ac1398fd8eeff46d6dce7004"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -152,7 +152,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-assets/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.1.x-dev"
+                    "dev-trunk": "4.2.x-dev"
                 }
             },
             "autoload": {
@@ -520,7 +520,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "3ada7720732bef274f53a977f81b23617106224b"
+                "reference": "aa43a422bbb20d041365e2d52e8ab6f7561cbf29"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -556,7 +556,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "6.14.x-dev"
+                    "dev-trunk": "6.15.x-dev"
                 },
                 "dependencies": {
                     "test-only": [
@@ -1038,7 +1038,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "254c9942d3aa9df70c4dae2632d7ea13b6c55f84"
+                "reference": "154b0cb39e1dd3c951b2c53a0bd50edbca2f3b81"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1077,7 +1077,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "5.18.x-dev"
+                    "dev-trunk": "5.19.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"
@@ -1193,7 +1193,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/plans",
-                "reference": "8336af6815cea248ed38cd238c181a606c19b3fe"
+                "reference": "781f78eb3303aab7be574e82a0da7d0b22ab6b66"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1217,7 +1217,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-plans/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.8.x-dev"
+                    "dev-trunk": "0.9.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/videopress/changelog/prerelease#6
+++ b/projects/plugins/videopress/changelog/prerelease#6
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -1560,7 +1560,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "73f34bf0ee21bb232d4245f3ef68c7bd911cb689"
+                "reference": "2de93770f98b4c662051bac5461445f9eb3a5c9e"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -1586,7 +1586,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-status/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "5.4.x-dev"
+                    "dev-trunk": "6.0.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -126,7 +126,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/assets",
-                "reference": "de727d5b798d543ded18322d80812988facccfcf"
+                "reference": "0a42fa643d1ae105ac1398fd8eeff46d6dce7004"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -152,7 +152,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-assets/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.1.x-dev"
+                    "dev-trunk": "4.2.x-dev"
                 }
             },
             "autoload": {
@@ -520,7 +520,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "3ada7720732bef274f53a977f81b23617106224b"
+                "reference": "aa43a422bbb20d041365e2d52e8ab6f7561cbf29"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -556,7 +556,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "6.14.x-dev"
+                    "dev-trunk": "6.15.x-dev"
                 },
                 "dependencies": {
                     "test-only": [
@@ -1038,7 +1038,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "254c9942d3aa9df70c4dae2632d7ea13b6c55f84"
+                "reference": "154b0cb39e1dd3c951b2c53a0bd50edbca2f3b81"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1077,7 +1077,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "5.18.x-dev"
+                    "dev-trunk": "5.19.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"
@@ -1193,7 +1193,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/plans",
-                "reference": "8336af6815cea248ed38cd238c181a606c19b3fe"
+                "reference": "781f78eb3303aab7be574e82a0da7d0b22ab6b66"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1217,7 +1217,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-plans/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.8.x-dev"
+                    "dev-trunk": "0.9.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/wpcomsh/changelog/prerelease#7
+++ b/projects/plugins/wpcomsh/changelog/prerelease#7
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -1818,7 +1818,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "73f34bf0ee21bb232d4245f3ef68c7bd911cb689"
+                "reference": "2de93770f98b4c662051bac5461445f9eb3a5c9e"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -1844,7 +1844,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-status/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "5.4.x-dev"
+                    "dev-trunk": "6.0.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -194,7 +194,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/assets",
-                "reference": "de727d5b798d543ded18322d80812988facccfcf"
+                "reference": "0a42fa643d1ae105ac1398fd8eeff46d6dce7004"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -220,7 +220,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-assets/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.1.x-dev"
+                    "dev-trunk": "4.2.x-dev"
                 }
             },
             "autoload": {
@@ -768,7 +768,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "3ada7720732bef274f53a977f81b23617106224b"
+                "reference": "aa43a422bbb20d041365e2d52e8ab6f7561cbf29"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -804,7 +804,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "6.14.x-dev"
+                    "dev-trunk": "6.15.x-dev"
                 },
                 "dependencies": {
                     "test-only": [
@@ -1219,7 +1219,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/masterbar",
-                "reference": "3fecd1e7106a4f3efb85c188d1717d6eae5a93a4"
+                "reference": "35da68eb47a67e6711af53de5829a86f9b2b358b"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -1249,7 +1249,7 @@
             "extra": {
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "0.18.x-dev"
+                    "dev-trunk": "0.19.x-dev"
                 },
                 "changelogger": {
                     "link-template": "https://github.com/Automattic/jetpack-masterbar/compare/v${old}...v${new}"
@@ -1442,7 +1442,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/plans",
-                "reference": "8336af6815cea248ed38cd238c181a606c19b3fe"
+                "reference": "781f78eb3303aab7be574e82a0da7d0b22ab6b66"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1466,7 +1466,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-plans/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.8.x-dev"
+                    "dev-trunk": "0.9.x-dev"
                 }
             },
             "autoload": {


### PR DESCRIPTION
Closes MONOREP-31

 <!--- This template is used for backporting changes made during a plugin release back to trunk. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Backports changes for jetpack 14.9-a.5

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/a
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Proofread changes.