### PR TITLE
Stylelint: Do not enforce unitless zero value in custom properties

### DIFF
--- a/projects/packages/forms/changelog/fix-stylelint-do_not_enforce_unitless_0_value_in_custom_properties
+++ b/projects/packages/forms/changelog/fix-stylelint-do_not_enforce_unitless_0_value_in_custom_properties
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix padding on input and textarea fields.

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -3,7 +3,7 @@
 	--jetpack--contact-form--border-color: #8c8f94;
 	--jetpack--contact-form--border-size: 1px;
 	--jetpack--contact-form--border-style: solid;
-	--jetpack--contact-form--border-radius: 0;
+	--jetpack--contact-form--border-radius: 0px;
 	--jetpack--contact-form--input-padding: 16px;
 	--jetpack--contact-form--font-size: 16px;
 	--jetpack--contact-form--error-color: #b32d2e;

--- a/projects/plugins/boost/app/assets/src/js/pages/image-size-analysis/image-size-analysis.module.scss
+++ b/projects/plugins/boost/app/assets/src/js/pages/image-size-analysis/image-size-analysis.module.scss
@@ -36,8 +36,8 @@
 	 * Narrow screen overrides.
 	 */
 	@media ( max-width: 782px ) {
-		--expanded-gap: 0;
-		--border-radius: 0;
+		--expanded-gap: 0px;
+		--border-radius: 0px;
 		--table-column-expand: 32px;
 	}
 }

--- a/projects/plugins/boost/changelog/fix-stylelint-do_not_enforce_unitless_0_value_in_custom_properties
+++ b/projects/plugins/boost/changelog/fix-stylelint-do_not_enforce_unitless_0_value_in_custom_properties
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+Comment: Use units in CSS vars to avoid issues with CSS math functions.
+

--- a/projects/plugins/jetpack/changelog/fix-stylelint-do_not_enforce_unitless_0_value_in_custom_properties
+++ b/projects/plugins/jetpack/changelog/fix-stylelint-do_not_enforce_unitless_0_value_in_custom_properties
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: Fix padding on input and textarea fields.

--- a/tools/js-tools/stylelint.config.base.mjs
+++ b/tools/js-tools/stylelint.config.base.mjs
@@ -19,6 +19,15 @@ const baseConfig = {
 			},
 		],
 
+		// Stylelint allows `0px` in math-type functions, but sometimes those math-type functions are
+		// passed vars instead of hard-coded values, and we need to prevent those from being unitless.
+		'length-zero-no-unit': [
+			true,
+			{
+				ignore: [ 'custom-properties' ],
+			},
+		],
+
 		// In theory this is a good rule, but in practice it's a massive lift to resolve existing violations.
 		// Here's an example that has no good answers:
 		// https://github.com/Automattic/jetpack/blob/86e27497d4b8e0736cae61c325f017dedad16dbb/projects/js-packages/components/components/button/style.module.scss#L73-L94


### PR DESCRIPTION
Closes MONOREP-32

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

In #43213 we enabled the `length-zero-no-unit` Stylelint rule. This ignores calc-type functions, but when the value is in a custom property (CSS var) we need to allow zero-value units. This adds [the ignore option](https://stylelint.io/user-guide/rules/length-zero-no-unit/#ignore) for custom properties.

In particular this impacted form field padding due to the use of `max()`. There were also two similar instances in Boost but there was no math-type function used there, so there should have been no impact.

Slack discussion here: p1753119226161839-slack-C05Q5HSS013
Issue reported in 10019043-zen.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
