### PR TITLE
Forms: add name and uuid attributes for form block

### DIFF
--- a/projects/packages/forms/changelog/add-jetpack-forms-uuid-name-attributes
+++ b/projects/packages/forms/changelog/add-jetpack-forms-uuid-name-attributes
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: add name and uuid attributes for form block

--- a/projects/packages/forms/src/blocks/contact-form/attributes.js
+++ b/projects/packages/forms/src/blocks/contact-form/attributes.js
@@ -44,4 +44,12 @@ export default {
 			sendToSalesforce: false,
 		},
 	},
+	uuid: {
+		type: 'string',
+		default: '',
+	},
+	name: {
+		type: 'string',
+		default: '',
+	},
 };

--- a/projects/packages/forms/src/blocks/contact-form/edit.js
+++ b/projects/packages/forms/src/blocks/contact-form/edit.js
@@ -102,6 +102,22 @@ const ALLOWED_FORM_BLOCKS = ALLOWED_BLOCKS.concat( ALLOWED_CORE_BLOCKS ).filter(
 
 const PRIORITIZED_INSERTER_BLOCKS = [ ...validFields.map( block => `jetpack/${ block.name }` ) ];
 
+const generateUUID = () => {
+	if ( typeof crypto !== 'undefined' && crypto.randomUUID ) {
+		return crypto.randomUUID();
+	}
+
+	// on non https environments, crypto.randomUUID is not available, so we use a fallback
+	return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace( /[xy]/g, function ( c ) {
+		const r = Math.floor( Math.random() * 16 );
+		const v = c === 'x' ? r : Math.floor( r / 4 ) + 8;
+		return v.toString( 16 );
+	} );
+};
+
+const generateRandomName = () =>
+	Math.random().toString( 36 ).substring( 2, 10 ) + Math.random().toString( 36 ).substring( 2, 10 );
+
 function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, className } ) {
 	const {
 		to,
@@ -112,8 +128,24 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 		customThankyouRedirect,
 		formTitle,
 		variationName,
+		name: formName,
+		uuid,
 	} = attributes;
 	const instanceId = useInstanceId( JetpackContactFormEdit );
+
+	// Effect for UUID generation
+	useEffect( () => {
+		if ( ! uuid ) {
+			setAttributes( { uuid: generateUUID() } );
+		}
+	}, [ uuid, setAttributes ] );
+
+	// Effect for name generation
+	useEffect( () => {
+		if ( ! formName ) {
+			setAttributes( { name: generateRandomName() } );
+		}
+	}, [ formName, setAttributes ] );
 
 	const steps = useFormSteps( clientId );
 

--- a/projects/packages/forms/src/blocks/contact-form/variation-picker.js
+++ b/projects/packages/forms/src/blocks/contact-form/variation-picker.js
@@ -55,7 +55,7 @@ export default function VariationPicker( { blockName, setAttributes, clientId, c
 					'Start by selecting one of these templates, or browse patterns.',
 					'jetpack-forms'
 				) }
-				variations={ variations.filter( v => ! v.hiddenFromPicker ) }
+				variations={ ( variations || [] ).filter( v => ! v.hiddenFromPicker ) }
 				onSelect={ ( nextVariation = defaultVariation ) => {
 					registry.batch( () => {
 						if ( nextVariation.attributes ) {

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -171,6 +171,8 @@ class Contact_Form extends Contact_Form_Shortcode {
 			'salesforceData'         => null,
 			'hiddenFields'           => null,
 			'stepTransition'         => 'fade-slide', // The transition style for multi-step forms. Options: none, fade, slide, fade-slide
+			'uuid'                   => '', // Unique UUIDv4 identifier for the form
+			'name'                   => '', // Name identifier for the form, not necessarily unique
 		);
 
 		$attributes = shortcode_atts( $this->defaults, $attributes, 'contact-form' );


### PR DESCRIPTION
## Proposed changes:
This PR adds 2 new attributes, `name` and `uuid`, to Jetpack contact-form block

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1753121466468139-slack-C052XEUUBL4

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Add a form to a post. Switch to code editor and verify the form has `uuid` and `name` attributes. Save and reload. Verify those attributes haven't changed.