### PR TITLE
AI Client: Fix Jetpack AI upgrade links on block editor

### DIFF
--- a/projects/js-packages/ai-client/changelog/fix-jetpack-ai-upgrade-link
+++ b/projects/js-packages/ai-client/changelog/fix-jetpack-ai-upgrade-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+AI Client: Fix Jetpack AI upgrade links on block editor

--- a/projects/js-packages/ai-client/src/components/message/index.tsx
+++ b/projects/js-packages/ai-client/src/components/message/index.tsx
@@ -209,7 +209,7 @@ export function UpgradeMessage( {
 				href={ upgradeUrl }
 				target={ upgradeUrl ? '_blank' : null }
 			>
-				{ __( 'Upgrade now', 'jetpack-ai-client' ) }
+				<span>{ __( 'Upgrade now', 'jetpack-ai-client' ) }</span>
 			</Button>
 		</Message>
 	);
@@ -246,11 +246,11 @@ export function ErrorMessage( {
 					href={ upgradeUrl }
 					target={ upgradeUrl ? '_blank' : null }
 				>
-					{ __( 'Upgrade now', 'jetpack-ai-client' ) }
+					<span>{ __( 'Upgrade now', 'jetpack-ai-client' ) }</span>
 				</Button>
 			) : (
 				<Button variant="link" onClick={ onTryAgainClick }>
-					{ __( 'Try again', 'jetpack-ai-client' ) }
+					<span>{ __( 'Try again', 'jetpack-ai-client' ) }</span>
 				</Button>
 			) }
 		</Message>

--- a/projects/js-packages/ai-client/src/components/quota-exceeded-message/index.tsx
+++ b/projects/js-packages/ai-client/src/components/quota-exceeded-message/index.tsx
@@ -47,7 +47,7 @@ const useFairUsageNoticeMessage = () => {
 
 	const getFairUsageNoticeMessage = resetDateString => {
 		const fairUsageMessage = __(
-			"You've reached this month's request limit, per our <link>fair usage policy</link>.",
+			"You've reached this month's request limit, per our <link><span>fair usage policy</span></link>.",
 			'jetpack-ai-client'
 		);
 
@@ -75,6 +75,7 @@ const useFairUsageNoticeMessage = () => {
 				rel="noreferrer"
 			/>
 		),
+		span: <span />,
 	} );
 
 	return fairUsageNoticeMessageElement;

--- a/projects/js-packages/ai-client/src/components/quota-exceeded-message/light-nudge.tsx
+++ b/projects/js-packages/ai-client/src/components/quota-exceeded-message/light-nudge.tsx
@@ -28,7 +28,7 @@ export const LightNudge = ( {
 							variant="link"
 							target={ target }
 						>
-							{ isRedirecting ? redirectingText : buttonText }
+							<span>{ isRedirecting ? redirectingText : buttonText }</span>
 						</Button>
 					) }
 				</p>

--- a/projects/js-packages/ai-client/src/logo-generator/components/prompt.tsx
+++ b/projects/js-packages/ai-client/src/logo-generator/components/prompt.tsx
@@ -307,7 +307,7 @@ export const Prompt = ( { initialPrompt = '' }: PromptProps ) => {
 									target="_blank"
 									onClick={ onUpgradeClick }
 								>
-									{ __( 'Upgrade', 'jetpack-ai-client' ) }
+									<span>{ __( 'Upgrade', 'jetpack-ai-client' ) }</span>
 								</Button>
 							</>
 						) }

--- a/projects/js-packages/ai-client/src/logo-generator/components/upgrade-nudge.tsx
+++ b/projects/js-packages/ai-client/src/logo-generator/components/upgrade-nudge.tsx
@@ -50,7 +50,7 @@ export const UpgradeNudge = () => {
 					className="is-primary"
 					onClick={ handleUpgradeClick }
 				>
-					{ buttonText }
+					<span>{ buttonText }</span>
 				</Button>
 			</div>
 		</div>

--- a/projects/js-packages/ai-client/src/logo-generator/components/upgrade-screen.tsx
+++ b/projects/js-packages/ai-client/src/logo-generator/components/upgrade-screen.tsx
@@ -52,12 +52,12 @@ export const UpgradeScreen: FC< {
 				</span>
 				&nbsp;
 				<Button variant="link" href={ upgradeInfoUrl } target="_blank">
-					{ __( 'Learn more about Jetpack AI.', 'jetpack-ai-client' ) }
+					<span>{ __( 'Learn more about Jetpack AI.', 'jetpack-ai-client' ) }</span>
 				</Button>
 			</div>
 			<div className="jetpack-ai-logo-generator-modal__notice-actions">
 				<Button variant="tertiary" onClick={ onCancel }>
-					{ __( 'Cancel', 'jetpack-ai-client' ) }
+					<span>{ __( 'Cancel', 'jetpack-ai-client' ) }</span>
 				</Button>
 				<Button
 					variant="primary"
@@ -65,7 +65,7 @@ export const UpgradeScreen: FC< {
 					target="_blank"
 					onClick={ handleUpgradeClick }
 				>
-					{ __( 'Upgrade', 'jetpack-ai-client' ) }
+					<span>{ __( 'Upgrade', 'jetpack-ai-client' ) }</span>
 				</Button>
 			</div>
 		</div>

--- a/projects/js-packages/ai-client/src/logo-generator/components/visit-site-banner.tsx
+++ b/projects/js-packages/ai-client/src/logo-generator/components/visit-site-banner.tsx
@@ -44,7 +44,7 @@ export const VisitSiteBanner: FC< {
 						target="_blank"
 						onClick={ onVisitBlankTarget ? onVisitBlankTarget : null }
 					>
-						{ __( 'Learn more about Jetpack AI', 'jetpack-ai-client' ) }
+						<span>{ __( 'Learn more about Jetpack AI', 'jetpack-ai-client' ) }</span>
 						<Icon icon={ external } size={ 20 } />
 					</Button>
 				</div>

--- a/projects/js-packages/ai-client/src/logo-generator/hooks/use-fair-usage-notice-message.tsx
+++ b/projects/js-packages/ai-client/src/logo-generator/hooks/use-fair-usage-notice-message.tsx
@@ -33,7 +33,7 @@ const useFairUsageNoticeMessage = (): Element => {
 
 	const getFairUsageNoticeMessage = resetDateString => {
 		const fairUsageMessage = __(
-			"You've reached this month's request limit, per our <link>fair usage policy</link>.",
+			"You've reached this month's request limit, per our <link><span>fair usage policy</span></link>.",
 			'jetpack-ai-client'
 		);
 
@@ -59,6 +59,7 @@ const useFairUsageNoticeMessage = (): Element => {
 
 	const fairUsageNoticeMessageElement = createInterpolateElement( fairUsageNoticeMessage, {
 		link: <a href={ upgradeInfoUrl } target="_blank" rel="noreferrer" />,
+		span: <span />,
 	} );
 
 	return fairUsageNoticeMessageElement;

--- a/projects/plugins/jetpack/changelog/fix-jetpack-ai-upgrade-link
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-ai-upgrade-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+AI Assistant: Fix Jetpack AI links on block editor

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/upgrade.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/upgrade.tsx
@@ -34,13 +34,13 @@ export default function Upgrade( {
 	const requestLimit = currentTier?.value && currentTier?.value !== 1 ? currentTier.limit : 20;
 
 	const freeLimitUpgradePrompt = __(
-		'You have reached the limit of <strong>20 free</strong> requests. <button>Upgrade to continue generating feedback.</button>',
+		'You have reached the limit of <strong>20 free</strong> requests. <button><span>Upgrade to continue generating feedback.</span></button>',
 		'jetpack'
 	);
 	const tierLimitUpgradePrompt = sprintf(
 		/* translators: number is the request limit for the current tier/plan */
 		__(
-			'You have reached the limit of <strong>%d requests</strong>. <button>Upgrade to continue generating feedback.</button>',
+			'You have reached the limit of <strong>%d requests</strong>. <button><span>Upgrade to continue generating feedback.</span></button>',
 			'jetpack'
 		),
 		requestLimit
@@ -61,6 +61,7 @@ export default function Upgrade( {
 		{
 			strong: <strong />,
 			button: <Button variant="link" onClick={ handleClick } href={ upgradeUrl } target="_blank" />,
+			span: <span />,
 		}
 	);
 

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-panel/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-panel/index.tsx
@@ -129,7 +129,7 @@ export function UsagePanel( {
 										href={ contactUsURL }
 										onClick={ handleContactUsClick }
 									>
-										{ __( 'Contact Us', 'jetpack' ) }
+										<span>{ __( 'Contact Us', 'jetpack' ) }</span>
 									</Button>
 								</>
 							) }
@@ -141,7 +141,7 @@ export function UsagePanel( {
 									href={ checkoutUrl }
 									onClick={ handleUpgradeClick }
 								>
-									{ upgradeButtonText }
+									<span>{ upgradeButtonText }</span>
 								</Button>
 							) }
 						</div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes JPAI-64

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
The links on the block editor are not working unless the link text is wrapped in, e.g., a span tag.
This fixes the upgrade links for Jetpack AI by adding the wrapper. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1753132767396529-slack-CDLH4C1UZ

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Either use a new site and make 1 Jetpack AI request or simulate a new site by sandboxing the public API and use the following snippets:
```
add_filter( 'jetpack_ai_current_period_requests_count', function() { return 1; } );
add_filter( 'jetpack_ai_all_time_requests_count', function() { return 1; } );
add_filter( 'jetpack_ai_tier_licensed_quantity', function() { return 0; } );
```
* Now go to a paragraph an open the AI Assistant:
<img width="487" height="423" alt="2025-07-21_18-39" src="https://github.com/user-attachments/assets/c8d42745-dd50-4341-a03f-aed1aba547aa" />
* Now click on "Upgrade now":
<img width="895" height="156" alt="2025-07-21_18-40" src="https://github.com/user-attachments/assets/429d0261-24b6-4509-b219-6cd30d0709d7" />
* Check that you are sent to the Jetpack AI upgrade page in another tab