### PR TITLE
Forms: Fix form id collision check

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-ajax-submission-id
+++ b/projects/packages/forms/changelog/fix-forms-ajax-submission-id
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Fix form id collision check

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -133,8 +133,11 @@ class Contact_Form extends Contact_Form_Shortcode {
 		}
 
 		if ( $set_id ) {
+			$is_widget = false;
+
 			if ( ! empty( $attributes['widget'] ) && $attributes['widget'] ) {
 				$attributes['id'] = 'widget-' . $attributes['widget'];
+				$is_widget        = true;
 			} elseif ( ! empty( $attributes['block_template'] ) && $attributes['block_template'] ) {
 				$attributes['id'] = 'block-template-' . $attributes['block_template'];
 			} elseif ( ! empty( $attributes['block_template_part'] ) && $attributes['block_template_part'] ) {
@@ -143,8 +146,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 				$attributes['id'] = $this->current_post->ID;
 			}
 
-			// When using admin-ajax.php, we don't need to add a page number to the id
-			if ( ! empty( self::$forms ) && ! $this->is_response_without_reload_enabled ) {
+			if ( ! empty( self::$forms ) && ! $is_widget ) {
 				// Ensure 'id' exists in $attributes before trying to modify it
 				if ( ! isset( $attributes['id'] ) ) {
 					$attributes['id'] = '';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Follow-up to https://github.com/Automattic/jetpack/pull/44204

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Disables the id changing logic for widgets only
* Depends on https://github.com/Automattic/jetpack/pull/44399 to work properly
* Will be rebased and updated after https://github.com/Automattic/jetpack/pull/44399 is merged

This id changing logic is intended to identify forms when there is more than one in the same post. I previously tested with a single post in a form and thought it would not be necessary for AJAX requests, but it is still necessary.
Widgets are removed from this because they are not subject to this problem and should have the same id everywhere as they have fixed places.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Enable the feature flag (check the PR linked above)
* Go to a post with more than one form
* Submit it
* Check that submission works as expected
* Reload the page
* Check that the submission data is displayed as expected
* Go to the home page and find a post in the second page with forms in it, preferrably more than one
* Test submitting from the second page
* Check that it works as expected
* Add some forms as widgets. Try adding two form widgets in the same slot
* Submit them
* Check that the submission works as expected
