### PR TITLE
Subscriptions: stop hiding floating button on mobile

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-hidden-floating-subscribe-button
+++ b/projects/plugins/jetpack/changelog/fix-hidden-floating-subscribe-button
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Floating subscription button: display on mobile devices as well when enabled.

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-floating-button/subscribe-floating-button.css
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-floating-button/subscribe-floating-button.css
@@ -4,10 +4,3 @@
 	bottom: 0;
 	right: 0;
 }
-
-@media screen and (max-width: 640px) {
-
-	.jetpack-subscribe-floating-button {
-		display: none;
-	}
-}


### PR DESCRIPTION
Fixes CML-660

## Proposed changes:

The button was originally hidden on mobile when it was first released in #37722. It doesn't need to be.

> [!NOTE]
> I played with different layout settings (less margin on mobile), but it does look quite good as it is in my tests.

![Screenshot_20250722-125750](https://github.com/user-attachments/assets/ce262076-d1ba-4541-bf31-f04009a967d5)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Go to Jetpack > Settings > Newsletter
* Enable newsletters
* Enable the "Floating subscribe button on site's bottom corner" option
* Access your site on mobile
    * Ensure the subscribe button looks good.
