### PR TITLE
Forms: show only 'from' column on mobile

### DIFF
--- a/projects/packages/forms/changelog/change-jetpack-forms-dashboard-mobile-dataviews-columns
+++ b/projects/packages/forms/changelog/change-jetpack-forms-dashboard-mobile-dataviews-columns
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Forms: show only "from" column on mobile dataviews

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
@@ -197,8 +197,8 @@ export default function InboxView() {
 		() => ( { totalItems, totalPages } ),
 		[ totalItems, totalPages ]
 	);
-	const fields = useMemo(
-		() => [
+	const fields = useMemo( () => {
+		const allFields = [
 			{
 				id: 'from',
 				label: __( 'From', 'jetpack-forms' ),
@@ -210,48 +210,53 @@ export default function InboxView() {
 				enableSorting: false,
 				enableHiding: false,
 			},
-			{
-				id: 'date',
-				label: __( 'Date', 'jetpack-forms' ),
-				render: ( { item } ) => dateI18n( dateSettings.formats.date, item.date ),
-				elements: ( filterOptions?.date || [] ).map( _filter => {
-					const date = new Date();
-					date.setDate( 1 );
-					date.setMonth( _filter.month - 1 ); // Months are zero-based in JS Date objects.
-					date.setFullYear( _filter.year );
-					return {
-						label: dateI18n(
-							// translators: Date format for date filters' labels. See https://www.php.net/manual/en/datetime.format.php
-							__( 'F Y', 'jetpack-forms' ),
-							date
-						),
-						value: `${ _filter.year }/${ _filter.month }`,
-					};
-				} ),
-				filterBy: { operators: [ 'is' ] },
-				enableSorting: false,
-			},
-			{
-				id: 'source',
-				label: __( 'Source', 'jetpack-forms' ),
-				render: ( { item } ) => {
-					return (
-						<ExternalLink href={ item.entry_permalink }>
-							{ decodeEntities( item.entry_title ) || getPath( item ) }
-						</ExternalLink>
-					);
-				},
-				elements: ( filterOptions?.source || [] ).map( source => ( {
-					value: source.id,
-					label: decodeEntities( source.title ) || getPath( { entry_permalink: source.url } ),
-				} ) ),
-				filterBy: { operators: [ 'is' ] },
-				enableSorting: false,
-			},
+			isMobile
+				? null
+				: {
+						id: 'date',
+						label: __( 'Date', 'jetpack-forms' ),
+						render: ( { item } ) => dateI18n( dateSettings.formats.date, item.date ),
+						elements: ( filterOptions?.date || [] ).map( _filter => {
+							const date = new Date();
+							date.setDate( 1 );
+							date.setMonth( _filter.month - 1 ); // Months are zero-based in JS Date objects.
+							date.setFullYear( _filter.year );
+							return {
+								label: dateI18n(
+									// translators: Date format for date filters' labels. See https://www.php.net/manual/en/datetime.format.php
+									__( 'F Y', 'jetpack-forms' ),
+									date
+								),
+								value: `${ _filter.year }/${ _filter.month }`,
+							};
+						} ),
+						filterBy: { operators: [ 'is' ] },
+						enableSorting: false,
+				  },
+			isMobile
+				? null
+				: {
+						id: 'source',
+						label: __( 'Source', 'jetpack-forms' ),
+						render: ( { item } ) => {
+							return (
+								<ExternalLink href={ item.entry_permalink }>
+									{ decodeEntities( item.entry_title ) || getPath( item ) }
+								</ExternalLink>
+							);
+						},
+						elements: ( filterOptions?.source || [] ).map( source => ( {
+							value: source.id,
+							label: decodeEntities( source.title ) || getPath( { entry_permalink: source.url } ),
+						} ) ),
+						filterBy: { operators: [ 'is' ] },
+						enableSorting: false,
+				  },
 			{ id: 'ip', label: __( 'IP Address', 'jetpack-forms' ), enableSorting: false },
-		],
-		[ filterOptions, dateSettings.formats.date ]
-	);
+		];
+
+		return allFields.filter( Boolean );
+	}, [ filterOptions, dateSettings.formats.date, isMobile ] );
 
 	const actions = useMemo( () => {
 		const _actions = [


### PR DESCRIPTION
## Proposed changes:
This PR conditionally crafts the fields for dataviews for mobile views. This way, mobile renders only the basic columns/fields:

<img width="399" height="582" alt="image" src="https://github.com/user-attachments/assets/fe25a7e6-6329-4dc3-8265-8fba0e9a5073" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1753193486494909/1753190897.867759-slack-C052XEUUBL4

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Go to forms dashboard. See that desktop view hasn't change and everything works as usual.
Switch to mobile view, notice that only "from" and "actions" columns are rendered, see that things work as usual.