### PR TITLE
Dashboard: Prevent failures when stats endpoint returns an error

### DIFF
--- a/projects/plugins/jetpack/_inc/client/at-a-glance/stats/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/stats/index.jsx
@@ -71,7 +71,7 @@ export class DashStats extends Component {
 			/* translators: long month/year format, such as: January, 2021. */
 			longMonthYearFormat = __( 'F Y', 'jetpack' );
 
-		for ( const v of statsData[ unit ].data ) {
+		for ( const v of statsData[ unit ].data ?? [] ) {
 			const views = v[ 1 ];
 			let date = v[ 0 ],
 				chartLabel = '',

--- a/projects/plugins/jetpack/changelog/fix-jetpack-broken_dash_when_stats_endpoint_fails
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-broken_dash_when_stats_endpoint_fails
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Dashboard: Prevent failure if stats endpoint returns an error.


### PR DESCRIPTION
Closes MONOREP-34

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This is a regression in #44233.

Reported here: p1753199077799899-slack-C08PN0LHCCT

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Connect Jetpack.
2. Break the blog token.
3. Visit the dashboard: `/wp-admin/admin.php?page=jetpack#/dashboard`

On `trunk` or `14.9-a.5`, the page does not load.

On the `fix/jetpack/broken_dash_when_stats_endpoint_fails` branch, the page loads and has this message in the stats area: "Something happened while loading Jetpack Stats."