### PR TITLE
Boost: Fix sprintf function call compatibility with Gutenberg 21.2

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/features/cornerstone-pages/cornerstone-pages.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/cornerstone-pages/cornerstone-pages.tsx
@@ -58,20 +58,24 @@ const CornerstoneTitleSummary = () => {
 		return null;
 	}
 
+	const pages =
+		cornerstonePages.length === 0
+			? __( 'Homepage', 'jetpack-boost' )
+			: sprintf(
+					/* translators: %d is the number of pages in the custom cornerstone pages list. */
+					_n(
+						'Homepage + %d page',
+						'Homepage + %d pages',
+						cornerstonePages.length,
+						'jetpack-boost'
+					),
+					cornerstonePages.length
+			  );
+
 	return sprintf(
 		/* translators: %s is the number of pages in the custom cornerstone pages list. */
 		__( 'Added: %s', 'jetpack-boost' ),
-		() => {
-			if ( cornerstonePages.length === 0 ) {
-				return __( 'Homepage', 'jetpack-boost' );
-			}
-
-			return sprintf(
-				/* translators: %d is the number of pages in the custom cornerstone pages list. */
-				_n( 'Homepage + %d page', 'Homepage + %d pages', cornerstonePages.length, 'jetpack-boost' ),
-				cornerstonePages.length
-			);
-		}
+		pages
 	);
 };
 

--- a/projects/plugins/boost/changelog/fix-boost-gutenberg-plugin-conflict-HOG-219
+++ b/projects/plugins/boost/changelog/fix-boost-gutenberg-plugin-conflict-HOG-219
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+General: Fix minor incompatibility with certain Boost labels and Gutenberg 21.2


### PR DESCRIPTION
Fixes [HOG-219: Cornerstone pages UI broken when Gutenberg plugin is active](https://linear.app/a8c/issue/HOG-219/cornerstone-pages-ui-broken-when-gutenberg-plugin-is-active)

## Proposed changes:
* Fixed incorrect usage of sprintf() in CornerstoneTitleSummary component where an anonymous function was passed as the second argument instead of calling the function to get its return value

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
1. Go to Jetpack Boost settings
2. Navigate to Cornerstone Pages section
3. Verify the title summary displays correctly formatted text instead of raw function code
4. Add/remove cornerstone pages and verify the summary updates correctly
5. Test with different numbers of cornerstone pages (0, 1, multiple)

### Compatibility Testing:
- Test with Gutenberg 21.2+ (should work correctly)
- Test with Gutenberg 21.1.1 and earlier (should continue working)
- Test without Gutenberg plugin (should continue working with WordPress core)

### Background

**Root Cause:** The issue was caused by incorrect usage of `sprintf()` where we passed an anonymous function as the second argument instead of calling the function first.

**Why it worked before:** WordPress core and Gutenberg ≤21.1.1 used the [sprintf-js library](https://www.npmjs.com/package/sprintf-js) that would automatically execute function arguments via its [computed values functionality](https://www.npmjs.com/package/sprintf-js#computed-values).

**What changed:** Gutenberg 21.2 updated their `@wordpress/i18n` implementation to use a standards-compliant `sprintf` that doesn't execute function arguments, causing the function code to be displayed as text. (https://github.com/WordPress/gutenberg/pull/70434)

**The fix:** Changed from `sprintf(template, functionRef)` to `sprintf(template, functionRef())` to ensure we pass the actual value instead of the function reference.

