### PR TITLE
Prevent PHP warnings in autoupdate hooks

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-autoupdate_warnings
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-autoupdate_warnings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Autoupdate: Prevent warnings when data is malformed.

--- a/projects/plugins/jetpack/class.jetpack-autoupdate.php
+++ b/projects/plugins/jetpack/class.jetpack-autoupdate.php
@@ -92,6 +92,10 @@ class Jetpack_Autoupdate {
 			return true;
 		}
 
+		if ( ! isset( $item->slug ) || ! isset( $item->type ) ) {
+			return $update;
+		}
+
 		// Themes.
 		$autoupdate_themes_translations = Jetpack_Options::get_option( 'autoupdate_themes_translations', array() );
 		$autoupdate_theme_list          = Jetpack_Options::get_option( 'autoupdate_themes', array() );
@@ -128,6 +132,9 @@ class Jetpack_Autoupdate {
 	 * @return bool|null Whether to update.
 	 */
 	public function autoupdate_theme( $update, $item ) {
+		if ( ! isset( $item->theme ) ) {
+			return $update;
+		}
 		$autoupdate_theme_list = Jetpack_Options::get_option( 'autoupdate_themes', array() );
 		if ( in_array( $item->theme, $autoupdate_theme_list, true ) ) {
 			$this->expect( $item->theme, 'theme' );


### PR DESCRIPTION
Closes MONOREP-35

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR avoids various PHP warnings in the autoupdate hooks by returning early if the provided data is not as expected.

Since they're called by filters (`auto_update_theme` and `auto_update_translation`), we can't control the input.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Currently there are tens of thousands of instances of this error in the WP Cloud logs over the last month:
```
PHP Warning: Undefined property: stdClass::$theme in /wordpress/plugins/jetpack/14.9-a.5/class.jetpack-autoupdate.php on line 132
```

There are also some of these:
```
PHP Warning: Undefined property: stdClass::$slug in /wordpress/plugins/jetpack/14.9-a.3/class.jetpack-autoupdate.php on line 99
```

```
PHP Warning: Attempt to read property "slug" on array in /wordpress/plugins/jetpack/14.8-a.9/class.jetpack-autoupdate.php on line 113
```


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Do my changes look safe? Does the return value make sense?
