### PR TITLE
Forms: Remove non jwt forms instance creation

### DIFF
--- a/projects/packages/forms/changelog/update-forms-remove-non-jwt
+++ b/projects/packages/forms/changelog/update-forms-remove-non-jwt
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: Remove form instance creation via other methods on submit

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -1546,224 +1546,44 @@ class Contact_Form_Plugin {
 			return Form_Submission_Error::system_error( 'invalid_form_id_or_hash', __( 'Invalid form ID or hash.', 'jetpack-forms' ) );
 		}
 
+		if ( ! isset( $_POST['jetpack_contact_form_jwt'] ) ) {
+			/** This action is documented already in this file. */
+			do_action( 'jetpack_forms_log', 'submission_missing_jwt' );
+			// If we don't have a JWT, we can't process the form.
+			return Form_Submission_Error::system_error( 'invalid_form', __( 'Invalid form.', 'jetpack-forms' ) );
+		}
+
 		if ( is_user_logged_in() ) {
 			check_admin_referer( "contact-form_{$id}" );
 		}
 
-		$is_widget              = str_starts_with( $id, 'widget-' );
-		$is_block_template      = str_starts_with( $id, 'block-template-' );
-		$is_block_template_part = str_starts_with( $id, 'block-template-part-' );
+		$jwt = sanitize_text_field( wp_unslash( $_POST['jetpack_contact_form_jwt'] ) );
 
-		if ( isset( $_POST['jetpack_contact_form_jwt'] ) ) {
-			$jwt = sanitize_text_field( wp_unslash( $_POST['jetpack_contact_form_jwt'] ) );
-
-			try {
-				$form = Contact_Form::get_instance_from_jwt( $jwt, true );
-			} catch ( \Exception $e ) {
-				// Fail early if the JWT is invalid with detailed error information.
-				return Form_Submission_Error::system_error(
-					'invalid_jwt',
-					$e->getMessage()
-				);
-			}
-
-			// Validate that the parent post/page where the form lives still exists and is not trashed/deleted
-			$validation_error = $this->validate_parent_post( $form );
-			if ( $validation_error ) {
-				return $validation_error;
-			}
-
-			$form->validate();
-
-			if ( $form->has_errors() ) {
-				return $form->errors;
-			}
-
-			if ( ! empty( $form->attributes['salesforceData'] ) ) {
-				Post_To_Url::init();
-			}
-
-			// Deprecate postToUrl, migrate to webhooks in case someone put it to work.
-			if ( ! empty( $form->attributes['postToUrl'] ) ) {
-				// webhooks should be a collection.
-				// Turn postToUrl into a collection and merge with existing webhooks.
-				$form->attributes['webhooks'] = array_merge(
-					$form->attributes['webhooks'] ?? array(),
-					array( $form->attributes['postToUrl'] )
-				);
-			}
-
-			if ( Jetpack_Forms::is_webhooks_enabled() && ! empty( $form->attributes['webhooks'] ) ) {
-				Form_Webhooks::init();
-			}
-			// Process the form
-			return $form->process_submission();
-		}
-		/** This action is documented already in this file. */
-		do_action( 'jetpack_forms_log', 'submission_missing_jwt' );
-
-		if ( $is_widget ) {
-			// It's a form embedded in a text widget
-			$this->current_widget_id = substr( $id, 7 ); // remove "widget-"
-			$widget_type             = implode( '-', array_slice( explode( '-', $this->current_widget_id ), 0, -1 ) ); // Remove trailing -#
-
-			// Is the widget active?
-			$sidebar = is_active_widget( false, $this->current_widget_id, $widget_type );
-
-			// This is lame - no core API for getting a widget by ID
-			$widget = isset( $GLOBALS['wp_registered_widgets'][ $this->current_widget_id ] ) ? $GLOBALS['wp_registered_widgets'][ $this->current_widget_id ] : false;
-
-			if ( $sidebar && $widget && isset( $widget['callback'] ) ) {
-				// prevent PHP notices by populating widget args
-				$widget_args = array(
-					'before_widget' => '',
-					'after_widget'  => '',
-					'before_title'  => '',
-					'after_title'   => '',
-				);
-				// This is lamer - no API for outputting a given widget by ID
-				ob_start();
-				// Process the widget to populate Contact_Form::$last
-				call_user_func( $widget['callback'], $widget_args, $widget['params'][0] );
-				ob_end_clean();
-			}
-		} elseif ( $is_block_template ) {
-			/*
-			 * Recreate the logic in wp-includes/template-loader.php
-			 * that happens *after* 'template_redirect'.
-			 *
-			 * This logic populates the $_wp_current_template_content
-			 * global, which we need in order to render the contact
-			 * form for this block template.
-			 */
-			// start of copy-pasta from wp-includes/template-loader.php.
-			$tag_templates = array(
-				'is_embed'             => 'get_embed_template',
-				'is_404'               => 'get_404_template',
-				'is_search'            => 'get_search_template',
-				'is_front_page'        => 'get_front_page_template',
-				'is_home'              => 'get_home_template',
-				'is_privacy_policy'    => 'get_privacy_policy_template',
-				'is_post_type_archive' => 'get_post_type_archive_template',
-				'is_tax'               => 'get_taxonomy_template',
-				'is_attachment'        => 'get_attachment_template',
-				'is_single'            => 'get_single_template',
-				'is_page'              => 'get_page_template',
-				'is_singular'          => 'get_singular_template',
-				'is_category'          => 'get_category_template',
-				'is_tag'               => 'get_tag_template',
-				'is_author'            => 'get_author_template',
-				'is_date'              => 'get_date_template',
-				'is_archive'           => 'get_archive_template',
+		$form = null;
+		try {
+			$form = Contact_Form::get_instance_from_jwt( $jwt, true );
+		} catch ( \Exception $e ) {
+			// Fail early if the JWT is invalid with detailed error information.
+			return Form_Submission_Error::system_error(
+				'invalid_jwt',
+				$e->getMessage()
 			);
-			$template      = false;
-			// Loop through each of the template conditionals, and find the appropriate template file.
-			// This is what calls locate_block_template() to hydrate $_wp_current_template_content.
-			foreach ( $tag_templates as $tag => $template_getter ) {
-				if ( call_user_func( $tag ) ) {
-					$template = call_user_func( $template_getter );
-				}
-				if ( $template ) {
-					if ( 'is_attachment' === $tag ) {
-						remove_filter( 'the_content', 'prepend_attachment' );
-					}
-					break;
-				}
-			}
-			if ( ! $template ) {
-				$template = get_index_template();
-			}
-			// end of copy-pasta from wp-includes/template-loader.php.
-
-			// Ensure 'block_template' attribute is added to any shortcodes in the template.
-			$template = Util::grunion_contact_form_set_block_template_attribute( $template );
-
-			// Process the block template to populate Contact_Form::$last
-			get_the_block_template_html();
-		} elseif ( $is_block_template_part ) {
-			$block_template_part_id   = str_replace( 'block-template-part-', '', $id );
-			$bits                     = explode( '//', $block_template_part_id );
-			$block_template_part_slug = array_pop( $bits );
-			// Process the block part template to populate Contact_Form::$last
-			$attributes = array(
-				'theme'   => wp_get_theme()->get_stylesheet(),
-				'slug'    => $block_template_part_slug,
-				'tagName' => 'div',
-			);
-			do_blocks( '<!-- wp:template-part ' . wp_json_encode( $attributes ) . ' /-->' );
-		} else {
-			// It's a form embedded in a post
-
-			if ( ! is_post_publicly_viewable( $id ) && ! current_user_can( 'read_post', $id ) ) {
-				// The user can't see the post.
-				return Form_Submission_Error::system_error( 'post_not_viewable', __( 'You do not have permission to view this form.', 'jetpack-forms' ) );
-			}
-
-			if ( post_password_required( $id ) ) {
-				// The post is password-protected and the password is not provided.
-				return Form_Submission_Error::system_error( 'post_password_required', __( 'This form requires a password.', 'jetpack-forms' ) );
-			}
-
-			$post = get_post( $id );
-
-			// Process the content to populate Contact_Form::$last
-			if ( $post ) {
-				if ( str_contains( $post->post_content, '<!--nextpage-->' ) ) {
-					$postdata = generate_postdata( $post );
-					$page     = isset( $_POST['page'] ) ? absint( wp_unslash( $_POST['page'] ) ) : null; // phpcs:Ignore WordPress.Security.NonceVerification.Missing
-					$paged    = isset( $page ) ? $page : 1;
-					$content  = isset( $postdata['pages'][ $paged - 1 ] ) ? $postdata['pages'][ $paged - 1 ] : $post->post_content;
-				} else {
-					$content = $post->post_content;
-				}
-				/** This filter is already documented in core. wp-includes/post-template.php */
-				apply_filters( 'the_content', $content );
-			}
 		}
 
-		// In future version we will be able to skip this step.
-		$form = isset( Contact_Form::$forms[ $hash ] ) ? Contact_Form::$forms[ $hash ] : null;
-
-		// No form may mean user is using do_shortcode, grab the form using the stored post meta
-		if ( ! $form && is_numeric( $id ) && $hash ) {
-
-			// Get shortcode from post meta
-			$shortcode = get_post_meta( $id, "_g_feedback_shortcode_{$hash}", true );
-
-			// Format it
-			if ( $shortcode !== '' && $shortcode !== false ) {
-
-				// Get attributes from post meta.
-				$parameters = '';
-				$attributes = get_post_meta( $id, "_g_feedback_shortcode_atts_{$hash}", true );
-				if ( ! empty( $attributes ) && is_array( $attributes ) ) {
-					foreach ( array_filter( $attributes ) as $param => $value ) {
-						if ( is_scalar( $value ) ) {
-							$parameters .= " $param=\"$value\"";
-						}
-					}
-				}
-
-				$shortcode = '[contact-form' . $parameters . ']' . $shortcode . '[/contact-form]';
-				do_shortcode( $shortcode );
-
-				// Recreate form
-				$form = Contact_Form::$last;
-			}
-		}
-
-		if ( ! $form ) {
-			return Form_Submission_Error::system_error( 'form_not_found', __( 'Form not found.', 'jetpack-forms' ) );
-		}
-
-		if ( $form->has_errors() ) {
-			return $form->errors;
-		}
-
-		// Validate that the parent post/page where the form lives still exists and is not trashed/deleted (legacy submission path where we don't have a JWT)
+		// Validate that the parent post/page where the form lives still exists and is not trashed/deleted
 		$validation_error = $this->validate_parent_post( $form );
 		if ( $validation_error ) {
 			return $validation_error;
+		}
+
+		if ( ! $form instanceof Contact_Form ) {
+			return Form_Submission_Error::system_error( 'invalid_form_instance', __( 'Invalid form instance.', 'jetpack-forms' ) );
+		}
+
+		$form->validate();
+
+		if ( $form->has_errors() ) {
+			return $form->errors;
 		}
 
 		if ( ! empty( $form->attributes['salesforceData'] ) ) {
@@ -1780,10 +1600,9 @@ class Contact_Form_Plugin {
 			);
 		}
 
-		if ( ! empty( $form->attributes['webhooks'] ) ) {
+		if ( Jetpack_Forms::is_webhooks_enabled() && ! empty( $form->attributes['webhooks'] ) ) {
 			Form_Webhooks::init();
 		}
-
 		// Process the form
 		return $form->process_submission();
 	}

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -122,7 +122,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 	 *
 	 * @var bool
 	 */
-	public $has_verified_jwt = false;
+	public $has_verified_jwt = false; // This value is not used any more, but we keep it for backward compatibility.
 
 	/**
 	 * The source of the feedback entry.

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1784,19 +1784,6 @@ class Contact_Form extends Contact_Form_Shortcode {
 			$form->fields[] = $field;
 		}
 
-		if ( // phpcs:disable WordPress.Security.NonceVerification.Missing
-			! isset( $_POST['jetpack_contact_form_jwt'] )
-			&&
-			isset( $_POST['action'] ) && 'grunion-contact-form' === $_POST['action']
-			&&
-			isset( $_POST['contact-form-id'] ) && (string) $form->get_attribute( 'id' ) === $_POST['contact-form-id']
-			&&
-			isset( $_POST['contact-form-hash'] ) && is_string( $_POST['contact-form-hash'] ) && hash_equals( $form->hash, wp_unslash( $_POST['contact-form-hash'] ) )
-		) { // phpcs:enable
-			// If we're processing a POST submission for this contact form, validate the field value so we can show errors as necessary.
-			$field->validate();
-		}
-
 		// Output HTML
 		return $field->render();
 	}

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -2032,25 +2032,6 @@ class Contact_Form extends Contact_Form_Shortcode {
 			$to = get_option( 'admin_email' );
 		}
 
-		if ( ! $this->has_verified_jwt ) {
-			// Make sure we're processing the form we think we're processing... probably a redundant check.
-			if ( $widget ) {
-				if ( isset( $_POST['contact-form-id'] ) && 'widget-' . $widget !== $_POST['contact-form-id'] ) { // phpcs:Ignore WordPress.Security.NonceVerification.Missing -- check done by caller process_form_submission()
-					return Form_Submission_Error::system_error( 'form_id_mismatch_widget', __( 'Form ID mismatch.', 'jetpack-forms' ) );
-				}
-			} elseif ( $block_template ) {
-				if ( isset( $_POST['contact-form-id'] ) && 'block-template-' . $block_template !== $_POST['contact-form-id'] ) { // phpcs:Ignore WordPress.Security.NonceVerification.Missing -- check done by caller process_form_submission()
-					return Form_Submission_Error::system_error( 'form_id_mismatch_block_template', __( 'Form ID mismatch.', 'jetpack-forms' ) );
-				}
-			} elseif ( $block_template_part ) {
-				if ( isset( $_POST['contact-form-id'] ) && 'block-template-part-' . $block_template_part !== $_POST['contact-form-id'] ) { // phpcs:Ignore WordPress.Security.NonceVerification.Missing -- check done by caller process_form_submission()
-						return Form_Submission_Error::system_error( 'form_id_mismatch_block_template_part', __( 'Form ID mismatch.', 'jetpack-forms' ) );
-				}
-			} elseif ( isset( $_POST['contact-form-id'] ) && ( empty( $this->current_post ) || self::get_post_property( $this->current_post, 'ID' ) !== (int) sanitize_text_field( wp_unslash( $_POST['contact-form-id'] ) ) ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing -- check done by caller process_form_submission()
-				return Form_Submission_Error::system_error( 'form_id_mismatch_post', __( 'Form ID mismatch.', 'jetpack-forms' ) );
-			}
-		}
-
 		// Initialize all these "standard" fields to null
 		$comment_author_email = $response->get_author_email();
 		$comment_author       = $response->get_author();

--- a/projects/plugins/jetpack/changelog/update-forms-remove-non-jwt
+++ b/projects/plugins/jetpack/changelog/update-forms-remove-non-jwt
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: remove non jwt instance creation


### PR DESCRIPTION
In https://github.com/Automattic/jetpack/pull/44399 we merged JWT form instance creation on submit. 

This make it possible to use a JWT token to recreate the form instance when the user submits the form. 

This also means that we don't have to try to find the form and use other means of recreating the instance. Such as the post content. 

We didn't remove it right away because we wanted to be able to revert the PR in case something went wrong. And also not break any mid deploy form submissions. (Folks that open the page with the form, we deploy the new check, and they submit the form) with the submission failing. 



## Proposed changes:
* Remove the old way of submitting the form. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?


## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Submit the form. Notice that everything still work as before. 

