### PR TITLE
PayPal Payments: Update copy and links for PayPal Payment Buttons block

### DIFF
--- a/projects/packages/paypal-payments/changelog/paypal-22-ensure-that-link-out-to-paypal-payment-button-goes-to
+++ b/projects/packages/paypal-payments/changelog/paypal-22-ensure-that-link-out-to-paypal-payment-button-goes-to
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Changed copy and links for PayPal Payments Buttons block.

--- a/projects/packages/paypal-payments/src/paypal-payment-buttons/edit.js
+++ b/projects/packages/paypal-payments/src/paypal-payment-buttons/edit.js
@@ -324,16 +324,6 @@ export default function Edit( { attributes, setAttributes, isSelected } ) {
 				instructions={ buttonType === 'stacked' ? stackedInstructions : singleInstructions }
 				notices={ notice }
 			>
-				<Text>
-					<ExternalLink href={ getPayPalSignupUrl() }>
-						<strong>{ __( 'Sign up', 'jetpack-paypal-payments' ) }</strong>
-					</ExternalLink>{ ' ' }
-					{ __( 'or', 'jetpack-paypal-payments' ) }{ ' ' }
-					<ExternalLink href={ getPayPalLoginUrl() }>
-						<strong>{ __( 'log in', 'jetpack-paypal-payments' ) }</strong>
-					</ExternalLink>{ ' ' }
-					{ __( 'to PayPal to get your Payment Button code.', 'jetpack-paypal-payments' ) }
-				</Text>
 				<ToggleGroupControl
 					label={ __( 'Button type', 'jetpack-paypal-payments' ) }
 					value={ buttonType }
@@ -367,6 +357,16 @@ export default function Edit( { attributes, setAttributes, isSelected } ) {
 						label={ __( 'Single Button', 'jetpack-paypal-payments' ) }
 					/>
 				</ToggleGroupControl>
+				<Text>
+					<ExternalLink href={ getPayPalSignupUrl() }>
+						<strong>{ __( 'Sign up', 'jetpack-paypal-payments' ) }</strong>
+					</ExternalLink>{ ' ' }
+					{ __( 'or', 'jetpack-paypal-payments' ) }{ ' ' }
+					<ExternalLink href={ getPayPalLoginUrl() }>
+						<strong>{ __( 'log in', 'jetpack-paypal-payments' ) }</strong>
+					</ExternalLink>{ ' ' }
+					{ __( 'to PayPal to get your Payment Button code.', 'jetpack-paypal-payments' ) }
+				</Text>
 				{ 'stacked' === buttonType && (
 					<PlainText
 						value={ rawHeadCode }

--- a/projects/packages/paypal-payments/src/paypal-payment-buttons/edit.js
+++ b/projects/packages/paypal-payments/src/paypal-payment-buttons/edit.js
@@ -324,6 +324,16 @@ export default function Edit( { attributes, setAttributes, isSelected } ) {
 				instructions={ buttonType === 'stacked' ? stackedInstructions : singleInstructions }
 				notices={ notice }
 			>
+				<Text>
+					<ExternalLink href={ getPayPalSignupUrl() }>
+						<strong>{ __( 'Sign up', 'jetpack-paypal-payments' ) }</strong>
+					</ExternalLink>{ ' ' }
+					{ __( 'or', 'jetpack-paypal-payments' ) }{ ' ' }
+					<ExternalLink href={ getPayPalLoginUrl() }>
+						<strong>{ __( 'log in', 'jetpack-paypal-payments' ) }</strong>
+					</ExternalLink>{ ' ' }
+					{ __( 'to PayPal to get your Payment Button code.', 'jetpack-paypal-payments' ) }
+				</Text>
 				<ToggleGroupControl
 					label={ __( 'Button type', 'jetpack-paypal-payments' ) }
 					value={ buttonType }
@@ -389,16 +399,6 @@ export default function Edit( { attributes, setAttributes, isSelected } ) {
 					aria-label={ 'stacked' === buttonType ? stackedButtonCodeLabel : singleButtonCodeLabel }
 					name="paypal-payment-buttons-code-body"
 				/>
-				<Text>
-					<ExternalLink href={ getPayPalSignupUrl() }>
-						<strong>{ __( 'Sign up', 'jetpack-paypal-payments' ) }</strong>
-					</ExternalLink>{ ' ' }
-					{ __( 'or', 'jetpack-paypal-payments' ) }{ ' ' }
-					<ExternalLink href={ getPayPalLoginUrl() }>
-						<strong>{ __( 'log in', 'jetpack-paypal-payments' ) }</strong>
-					</ExternalLink>{ ' ' }
-					{ __( 'to PayPal to get your Payment Button code.', 'jetpack-paypal-payments' ) }
-				</Text>
 			</Placeholder>
 		</div>
 	);

--- a/projects/packages/paypal-payments/src/paypal-payment-buttons/edit.js
+++ b/projects/packages/paypal-payments/src/paypal-payment-buttons/edit.js
@@ -1,3 +1,4 @@
+import { isWpcomPlatformSite } from '@automattic/jetpack-script-data';
 import { PlainText, useBlockProps } from '@wordpress/block-editor';
 import {
 	ExternalLink,
@@ -94,6 +95,30 @@ const validHostedButtonId = hostedButtonId => /^[A-Z0-9]+$/.test( hostedButtonId
 
 const validButtonText = buttonText =>
 	buttonText && buttonText.trim().length > 0 && buttonText.length <= 50;
+
+/**
+ * Get PayPal signup URL with platform-specific tracking parameters
+ *
+ * @return {string} The PayPal signup URL
+ */
+const getPayPalSignupUrl = () => {
+	const isWpcom = isWpcomPlatformSite();
+	const utmSource = isWpcom ? 'wp_com' : 'wp_org';
+	const atCode = isWpcom ? 'wp_com' : 'wp_org';
+	return `https://www.paypal.com/bizsignup/entry?product=payment_button&utm_source=${ utmSource }&at_code=${ atCode }`;
+};
+
+/**
+ * Get PayPal login URL with platform-specific tracking parameters
+ *
+ * @return {string} The PayPal login URL
+ */
+const getPayPalLoginUrl = () => {
+	const isWpcom = isWpcomPlatformSite();
+	const utmSource = isWpcom ? 'wp_com' : 'wp_org';
+	const atCode = isWpcom ? 'wp_com' : 'wp_org';
+	return `https://www.paypal.com/ncp/buttons/create?utm_source=${ utmSource }&at_code=${ atCode }`;
+};
 
 /**
  * PayPal Single Button Preview component (rendered directly)
@@ -332,15 +357,6 @@ export default function Edit( { attributes, setAttributes, isSelected } ) {
 						label={ __( 'Single Button', 'jetpack-paypal-payments' ) }
 					/>
 				</ToggleGroupControl>
-				<Text>
-					<ExternalLink href={ __( 'https://www.paypal.com/buttons/', 'jetpack-paypal-payments' ) }>
-						<strong>{ __( 'Go to PayPal', 'jetpack-paypal-payments' ) }</strong>
-					</ExternalLink>{ ' ' }
-					{ __(
-						'to get your Payment Button code and choose Payment Buttons. Enter your product and service details, and build the buttons. Copy the HTML button code for Stacked Buttons or Single Button and paste below.',
-						'jetpack-paypal-payments'
-					) }
-				</Text>
 				{ 'stacked' === buttonType && (
 					<PlainText
 						value={ rawHeadCode }
@@ -373,6 +389,16 @@ export default function Edit( { attributes, setAttributes, isSelected } ) {
 					aria-label={ 'stacked' === buttonType ? stackedButtonCodeLabel : singleButtonCodeLabel }
 					name="paypal-payment-buttons-code-body"
 				/>
+				<Text>
+					<ExternalLink href={ getPayPalSignupUrl() }>
+						<strong>{ __( 'Sign up', 'jetpack-paypal-payments' ) }</strong>
+					</ExternalLink>{ ' ' }
+					{ __( 'or', 'jetpack-paypal-payments' ) }{ ' ' }
+					<ExternalLink href={ getPayPalLoginUrl() }>
+						<strong>{ __( 'log in', 'jetpack-paypal-payments' ) }</strong>
+					</ExternalLink>{ ' ' }
+					{ __( 'to PayPal to get your Payment Button code.', 'jetpack-paypal-payments' ) }
+				</Text>
 			</Placeholder>
 		</div>
 	);

--- a/projects/packages/paypal-payments/tests/js/paypal-payment-buttons-block-tests/edit.test.js
+++ b/projects/packages/paypal-payments/tests/js/paypal-payment-buttons-block-tests/edit.test.js
@@ -1,6 +1,11 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import Edit from '../../../src/paypal-payment-buttons/edit';
 
+// Mock Jetpack script data
+jest.mock( '@automattic/jetpack-script-data', () => ( {
+	isWpcomPlatformSite: jest.fn( () => false ), // Default to WordPress.org for tests
+} ) );
+
 // Mock WordPress dependencies
 jest.mock( '@wordpress/block-editor', () => ( {
 	useBlockProps: () => ( { className: 'wp-block-paypal-payment-buttons' } ),
@@ -324,12 +329,51 @@ describe( 'Edit', () => {
 		} );
 	} );
 
-	it( 'renders external link to PayPal buttons page', () => {
+	it( 'renders external links to PayPal signup and login pages for WordPress.org', () => {
 		render( <Edit { ...defaultProps } /> );
-		const link = screen.getByTestId( 'external-link' );
-		expect( link ).toBeInTheDocument();
-		expect( link ).toHaveAttribute( 'href', 'https://www.paypal.com/buttons/' );
-		expect( link ).toHaveTextContent( 'Go to PayPal' );
+		const links = screen.getAllByTestId( 'external-link' );
+		expect( links ).toHaveLength( 2 );
+
+		// Check signup link
+		expect( links[ 0 ] ).toHaveAttribute(
+			'href',
+			'https://www.paypal.com/bizsignup/entry?product=payment_button&utm_source=wp_org&at_code=wp_org'
+		);
+		expect( links[ 0 ] ).toHaveTextContent( 'Sign up' );
+
+		// Check login link
+		expect( links[ 1 ] ).toHaveAttribute(
+			'href',
+			'https://www.paypal.com/ncp/buttons/create?utm_source=wp_org&at_code=wp_org'
+		);
+		expect( links[ 1 ] ).toHaveTextContent( 'log in' );
+	} );
+
+	it( 'renders external links to PayPal signup and login pages for WordPress.com', () => {
+		// Mock WordPress.com platform
+		const { isWpcomPlatformSite } = require( '@automattic/jetpack-script-data' );
+		isWpcomPlatformSite.mockReturnValue( true );
+
+		render( <Edit { ...defaultProps } /> );
+		const links = screen.getAllByTestId( 'external-link' );
+		expect( links ).toHaveLength( 2 );
+
+		// Check signup link
+		expect( links[ 0 ] ).toHaveAttribute(
+			'href',
+			'https://www.paypal.com/bizsignup/entry?product=payment_button&utm_source=wp_com&at_code=wp_com'
+		);
+		expect( links[ 0 ] ).toHaveTextContent( 'Sign up' );
+
+		// Check login link
+		expect( links[ 1 ] ).toHaveAttribute(
+			'href',
+			'https://www.paypal.com/ncp/buttons/create?utm_source=wp_com&at_code=wp_com'
+		);
+		expect( links[ 1 ] ).toHaveTextContent( 'log in' );
+
+		// Reset mock
+		isWpcomPlatformSite.mockReturnValue( false );
 	} );
 
 	describe( 'Instruction Elements', () => {
@@ -337,10 +381,10 @@ describe( 'Edit', () => {
 			render( <Edit { ...defaultProps } /> );
 			const instructionText = screen.getByTestId( 'experimental-text' );
 			expect( instructionText ).toBeInTheDocument();
-			expect( instructionText ).toHaveTextContent( 'Go to PayPal' );
-			expect( instructionText ).toHaveTextContent(
-				'to get your Payment Button code and choose Payment Buttons'
-			);
+			expect( instructionText ).toHaveTextContent( 'Sign up' );
+			expect( instructionText ).toHaveTextContent( 'or' );
+			expect( instructionText ).toHaveTextContent( 'log in' );
+			expect( instructionText ).toHaveTextContent( 'to PayPal to get your Payment Button code.' );
 		} );
 	} );
 


### PR DESCRIPTION
Fixes PAYPAL-22

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Updates the copy and link URLs to be more explicit.

<img width="1332" height="690" alt="CleanShot 2025-07-22 at 20 52 44@2x" src="https://github.com/user-attachments/assets/3747c880-b55b-475f-acbb-4a079b0cf4c4" />

<img width="1346" height="584" alt="CleanShot 2025-07-22 at 20 53 13@2x" src="https://github.com/user-attachments/assets/21fb2a68-971a-495a-86f2-1f6e8e69228c" />

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

See PAYPAL-22

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

On a connected Jetpack site:

- Checkout branch
- Ensure extra widgets setting is toggled on
- Ensure beta blocks are enabled with the following constant: `define( 'JETPACK_BLOCKS_VARIATION', 'beta' );`
- Create a new page
- Add the PayPal Payments Block
- Check the copy matches the screenshot
- Check that the links mention wporg

On a simple site:
- Copy the `sh` command below and run in your sandbox
- Insert the block on a simple site
- Ensure that the attribution mentions wpcom
