### PR TITLE
Forms: Add MailPoet to integrations modal

### DIFF
--- a/projects/packages/forms/changelog/add-form-level-mailpoet-integration
+++ b/projects/packages/forms/changelog/add-form-level-mailpoet-integration
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: Add MailPoet to integration modal.

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -531,6 +531,7 @@ class Contact_Form_Block {
 				'akismetUrl'           => $akismet_key_url,
 				'assetsUrl'            => Jetpack_Forms::assets_url(),
 				'preferredView'        => $preferred_view,
+				'isMailPoetEnabled'    => Jetpack_Forms::is_mailpoet_enabled(),
 			),
 		);
 

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/index.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/index.tsx
@@ -12,6 +12,7 @@ import AkismetCard from './akismet-card';
 import CreativeMailCard from './creative-mail-card';
 import GoogleSheetsCard from './google-sheets-card';
 import JetpackCRMCard from './jetpack-crm-card';
+import MailPoetCard from './mailpoet-card';
 import SalesforceCard from './salesforce-card';
 import './style.scss';
 /**
@@ -33,6 +34,7 @@ const IntegrationsModal = ( {
 		crm: false,
 		creativemail: false,
 		salesforce: false,
+		mailpoet: false,
 	} );
 
 	if ( ! isOpen ) {
@@ -59,6 +61,8 @@ const IntegrationsModal = ( {
 
 	const findIntegrationById = ( id: string ) =>
 		integrationsData?.find( ( integration: Integration ) => integration.id === id );
+
+	const isMailPoetEnabled: boolean = !! window?.jpFormsBlocks?.defaults?.isMailPoetEnabled;
 
 	return (
 		<Modal
@@ -88,6 +92,14 @@ const IntegrationsModal = ( {
 					data={ findIntegrationById( 'zero-bs-crm' ) }
 					refreshStatus={ refreshIntegrations }
 				/>
+				{ isMailPoetEnabled && (
+					<MailPoetCard
+						isExpanded={ expandedCards.mailpoet }
+						onToggle={ () => toggleCard( 'mailpoet' ) }
+						data={ findIntegrationById( 'mailpoet' ) }
+						refreshStatus={ refreshIntegrations }
+					/>
+				) }
 				<SalesforceCard
 					isExpanded={ expandedCards.salesforce }
 					onToggle={ () => toggleCard( 'salesforce' ) }

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/index.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/index.tsx
@@ -20,6 +20,8 @@ import './style.scss';
  */
 import type { Integration } from '../../../../types';
 
+const isMailPoetEnabled: boolean = !! window?.jpFormsBlocks?.defaults?.isMailPoetEnabled;
+
 const IntegrationsModal = ( {
 	isOpen,
 	onClose,
@@ -61,8 +63,6 @@ const IntegrationsModal = ( {
 
 	const findIntegrationById = ( id: string ) =>
 		integrationsData?.find( ( integration: Integration ) => integration.id === id );
-
-	const isMailPoetEnabled: boolean = !! window?.jpFormsBlocks?.defaults?.isMailPoetEnabled;
 
 	return (
 		<Modal

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/mailpoet-card.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/mailpoet-card.tsx
@@ -1,0 +1,96 @@
+import { Button, ExternalLink, __experimentalHStack as HStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
+import { createInterpolateElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import MailPoetIcon from '../../../../icons/mailpoet';
+import IntegrationCard from './integration-card';
+import type { SingleIntegrationCardProps, IntegrationCardData } from '../../../../types';
+
+const MailPoetCard = ( {
+	isExpanded,
+	onToggle,
+	data,
+	refreshStatus,
+}: SingleIntegrationCardProps ) => {
+	const {
+		isConnected: mailpoetActiveWithKey = false,
+		settingsUrl = '',
+		marketingUrl = '',
+	} = data || {};
+
+	const cardData: IntegrationCardData = {
+		...data,
+		showHeaderToggle: false,
+		isLoading: ! data || typeof data.isInstalled === 'undefined',
+		refreshStatus,
+		trackEventName: 'jetpack_forms_upsell_mailpoet_click',
+		notInstalledMessage: createInterpolateElement(
+			__(
+				'Add powerful email marketing to your forms with <a>MailPoet</a>. Simply install the plugin to start sending emails.',
+				'jetpack-forms'
+			),
+			{
+				a: <ExternalLink href={ marketingUrl } />,
+			}
+		),
+		notActivatedMessage: __(
+			'MailPoet is installed. Just activate the plugin to start sending emails.',
+			'jetpack-forms'
+		),
+	};
+
+	return (
+		<IntegrationCard
+			title={ __( 'MailPoet Email Marketing', 'jetpack-forms' ) }
+			description={ __(
+				'Send newsletters and marketing emails directly from your site.',
+				'jetpack-forms'
+			) }
+			icon={ <MailPoetIcon width={ 28 } height={ 28 } /> }
+			isExpanded={ isExpanded }
+			onToggle={ onToggle }
+			cardData={ cardData }
+			toggleTooltip={ __( 'Grow your audience with MailPoet', 'jetpack-forms' ) }
+		>
+			{ ! mailpoetActiveWithKey ? (
+				<div>
+					<p className="integration-card__description">
+						{ createInterpolateElement(
+							__(
+								'MailPoet is active. There is one step left. Please add your <a>MailPoet key</a>.',
+								'jetpack-forms'
+							),
+							{
+								a: <ExternalLink href={ settingsUrl } />,
+							}
+						) }
+					</p>
+					<HStack spacing="3" justify="start">
+						<Button
+							variant="secondary"
+							href={ settingsUrl }
+							target="_blank"
+							rel="noopener noreferrer"
+							__next40pxDefaultSize={ true }
+						>
+							{ __( 'Add MailPoet key', 'jetpack-forms' ) }
+						</Button>
+						<Button variant="tertiary" onClick={ refreshStatus } __next40pxDefaultSize={ true }>
+							{ __( 'Refresh status', 'jetpack-forms' ) }
+						</Button>
+					</HStack>
+				</div>
+			) : (
+				<div>
+					<p className="integration-card__description">
+						{ __( 'You can now send marketing emails with MailPoet.', 'jetpack-forms' ) }
+					</p>
+					<Button variant="link" href={ settingsUrl } target="_blank" rel="noopener noreferrer">
+						{ __( 'View MailPoet dashboard', 'jetpack-forms' ) }
+					</Button>
+				</div>
+			) }
+		</IntegrationCard>
+	);
+};
+
+export default MailPoetCard;

--- a/projects/packages/forms/src/types/index.ts
+++ b/projects/packages/forms/src/types/index.ts
@@ -101,6 +101,8 @@ export interface JPFormsBlocksDefaults {
 	formsResponsesUrl?: string;
 	/** The URL for spam form responses. */
 	formsResponsesSpamUrl?: string;
+	/** Whether MailPoet integration is enabled. */
+	isMailPoetEnabled?: boolean;
 }
 
 /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes [FORMS-206](https://linear.app/a8c/issue/FORMS-206/forms-add-mailpoet-card-to-integrations-modal)

## Proposed changes:

Notes: MailPoet integration is behind a feature flag. See test instructions. 

Adds a MailPoet card to the form integrations modal in the block editor. We already added a MailPoet card to the central dashboard here. This adds the card to the block editor as a first step toward allowing real form-level MailPoet integration.

This PR does not include the ability to have contact details actually added to MailPoet lists, which will come in a follow up. This PR simply adds the card so that it prompts a user to install / activate / connect MailPoet so it is ready to use.   

**Collapsed**
<img width="713" height="545" alt="mailpoet-collapsed" src="https://github.com/user-attachments/assets/62227e70-5231-4905-b225-64b90d5d9ca4" />

**Not installed**
<img width="642" height="167" alt="mailpoet-install" src="https://github.com/user-attachments/assets/998f5341-50ef-4e91-8640-36c06dedc5e0" />

**Not active**
<img width="697" height="143" alt="mailpoet-activate" src="https://github.com/user-attachments/assets/b210876b-5108-4434-aaad-c0ed4ba67ab7" />

**Active but needs key**
<img width="695" height="198" alt="mailpoet-needs-key" src="https://github.com/user-attachments/assets/25800691-9a4f-47ac-8988-5a20e75f0481" />


**Active with key**
<img width="695" height="176" alt="mailpoet-active-2" src="https://github.com/user-attachments/assets/c87bc1a8-b3bd-4146-a26e-e4b21fa6fe02" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None. 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No. 

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Before enabling the feature flag, confirm that MailPoet card does not show by default. Add a form to a page, open the integrations modal, and confirm no MailPoet card shows. 
* Enable the feature flag with: `add_filter( 'jetpack_forms_mailpoet_enable', '__return_true' );`
* Reload the editor, open the integrations modal and confirm the MailPoet card now shows. 
* Test different states
   - If MailPoet is not installed, you should see the "Plugin needs install" badge, a nudge in the card, and an Install button. 
   - If MailPoet is not active, you should see the "Plugin needs activation" badge, a nudge in the card, and an Activate button.
   - If MailPoet is active without a key, you should see the "Needs connect" badge, and a link to add your key.
   - If MailPoet is active with a key, you will see a link to the Mailchimp dashboard. 
