### PR TITLE
Update wpcomsh to use wc-calypso-bridge 2.11.2

### DIFF
--- a/projects/plugins/wpcomsh/changelog/update-wpcomsh-to-use-wc-calypso-bridge-2.11.2
+++ b/projects/plugins/wpcomsh/changelog/update-wpcomsh-to-use-wc-calypso-bridge-2.11.2
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+Update wc-calypso-bridge from 2.11.1 to 2.11.2

--- a/projects/plugins/wpcomsh/composer.json
+++ b/projects/plugins/wpcomsh/composer.json
@@ -9,7 +9,7 @@
 		"automattic/custom-fonts": "^3.0",
 		"automattic/custom-fonts-typekit": "^2.0",
 		"automattic/text-media-widget-styles": "^2.0",
-		"automattic/wc-calypso-bridge": "2.11.1",
+		"automattic/wc-calypso-bridge": "2.11.2",
 		"wordpress/classic-editor-plugin": "1.6.7",
 		"automattic/jetpack-autoloader": "@dev",
 		"automattic/jetpack-composer-plugin": "@dev",

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a1b1c521eb5b2a265b632f721bea75ae",
+    "content-hash": "26335f6723fffa1b26ae5a942697dee3",
     "packages": [
         {
             "name": "automattic/at-pressable-podcasting",
@@ -2116,16 +2116,16 @@
         },
         {
             "name": "automattic/wc-calypso-bridge",
-            "version": "v2.11.1",
+            "version": "v2.11.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/wc-calypso-bridge.git",
-                "reference": "35e6235347b9ef6c1708dbe52b6efef8b2c6a0c1"
+                "reference": "58a48bf01ae28a4c974bdcc0449733f03b2326de"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/wc-calypso-bridge/zipball/35e6235347b9ef6c1708dbe52b6efef8b2c6a0c1",
-                "reference": "35e6235347b9ef6c1708dbe52b6efef8b2c6a0c1",
+                "url": "https://api.github.com/repos/Automattic/wc-calypso-bridge/zipball/58a48bf01ae28a4c974bdcc0449733f03b2326de",
+                "reference": "58a48bf01ae28a4c974bdcc0449733f03b2326de",
                 "shasum": ""
             },
             "require-dev": {
@@ -2164,7 +2164,10 @@
                     "phpcbf -p"
                 ]
             },
-            "time": "2025-07-03T16:00:11+00:00"
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "time": "2025-07-22T10:34:27+00:00"
         },
         {
             "name": "scssphp/scssphp",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes DOTCOM-13568

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

* This PR updates `wc-calypso-bridge` from 2.11.1 to 2.11.2 to pick up the changes documented in https://github.com/Automattic/wc-calypso-bridge/pull/1576. The changes boil down to the following general groups:
  - Multiple changes where we're removing redundant or unnecessary filters, largely because the functionality has been moved upstream (including to wpcomsh)
  - We made a change to a WooCommerce filter so we only hide the Add-Ons submenu for Commerce trials -- the menu has been replaced by the Extensions sub-menu, but it's still used for a redirect when disconnecting from WooCommerce.com

### Other information:

- [N/A] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### Various filter changes

* Set up a WordPress.com development site, and apply the code from this PR to the site
* Use a snippet tool or custom code to add the following code snippet to the site:
```php
function pr44428_test_all_filters() {

	$test_already_run = get_option( '_pr44428_test_all_filters', false );
	if ( $test_already_run ) {
		return;
	}

	$tests = [];

	if ( class_exists( 'Automattic\Jetpack\Sync\Defaults' ) ) {
		$jetpack_sync_comment_meta_list = Automattic\Jetpack\Sync\Defaults::get_comment_meta_whitelist();
		$tests['jetpack_sync_comment_meta_890'] = in_array( 'rating', $jetpack_sync_comment_meta_list, true );

		$tests['jetpack_sync_options_890'] = [];

		$jetpack_sync_options_list = Automattic\Jetpack\Sync\Defaults::get_options_whitelist();
		$options_to_test = [
			'woocommerce_currency_pos',
			'woocommerce_price_thousand_sep',
			'woocommerce_price_decimal_sep',
			'woocommerce_price_num_decimals',
		];
		foreach ( $options_to_test as $option_name ) {
			$tests['jetpack_sync_options_890'][ $option_name ] = in_array( $option_name, $jetpack_sync_options_list, true );
		}

		$jetpack_sync_post_meta_list = Automattic\Jetpack\Sync\Defaults::get_post_meta_whitelist();
		$tests['jetpack_sync_post_meta_890'] = in_array( '_created_via', $jetpack_sync_post_meta_list, true );
	} else {
		$tests['jetpack_sync_890'] = 'FAILED: Jetpack Sync code not loaded';
	}

	$tests['stripe_apple_pay_option_891'] = get_option( 'wc_stripe_show_apple_pay_notice' );
	$tests['stripe_show_request_api_option_891'] = get_option( 'wc_stripe_show_request_api_notice' );

	$tests['mailchimp_activation_option_893'] = get_option( 'mailchimp_woocommerce_plugin_do_activation_redirect' );

	$tests['woocommerce_install_admin_notice_886'] = apply_filters( 'woocommerce_show_admin_notice', true, 'install' );

	$allowed_redirect_hosts = apply_filters( 'allowed_redirect_hosts', [] );
	$tests['allowed_redirect_hosts_889'] = [
		'wordpress.com' => in_array( 'wordpress.com', $allowed_redirect_hosts, true ),
		'calypso.localhost' => in_array( 'calypso.localhost', $allowed_redirect_hosts, true ),
	];

	error_log( 'DEBUG filters PR 44428: ' . json_encode( $tests, JSON_PRETTY_PRINT ) );
	update_option( '_pr44428_test_all_filters', true );
}

add_action( 'wp_loaded', 'pr44428_test_all_filters' );
```
* Trigger the code above by navigating any post, page, or URL for your test site
* Inspect the generated PHP error log, and verify the following:
  - `jetpack_sync_comment_meta_890` should be true
  - The `woocommerce_currency_pos`, `woocommerce_price_thousand_sep`, `woocommerce_price_decimal_sep`, and `woocommerce_price_num_decimals` keys below `jetpack_sync_options_890` should all be true
  - `jetpack_sync_post_meta_890` should be true
  - `stripe_apple_pay_option_891` and `stripe_show_request_api_option_891` should both be false
  - `mailchimp_activation_option_893` should be false
  - `woocommerce_install_admin_notice_886` should be true
  - The `wordpress.com` and `calypso.localhost` keys below `allowed_redirect_hosts_889` should both be true
You end up with content something like the following (when unformatted via a browser in my case):
```
DEBUG filters PR 44428: { "jetpack_sync_comment_meta_890": true, "jetpack_sync_options_890": { "woocommerce_currency_pos": true, "woocommerce_price_thousand_sep": true, "woocommerce_price_decimal_sep": true, "woocommerce_price_num_decimals": true }, "jetpack_sync_post_meta_890": true, "stripe_apple_pay_option_891": false, "stripe_show_request_api_option_891": false, "mailchimp_activation_option_893": false, "woocommerce_install_admin_notice_886": true, "allowed_redirect_hosts_889": { "wordpress.com": true, "calypso.localhost": true } }
```

* If your site doesn't have a Commerce plan, purchase one
* After the plan purchase has been fully processed, navigate to _WooCommerce_ > _Home_
* Click on the user icon in the top right corner of the screen
* Click on the "Disconnect" option that appears in the drop-down menu
* Verify that the operation completes successfully and the UI doesn't get stuck