### PR TITLE
[e2e tests] Remove redundant or unnecessary test setup steps 

### DIFF
--- a/.github/files/e2e-tests/e2e-matrix.js
+++ b/.github/files/e2e-tests/e2e-matrix.js
@@ -101,7 +101,7 @@ const projects = [
 	{
 		project: 'Search',
 		path: 'projects/plugins/search/tests/e2e',
-		testArgs: [],
+		testArgs: [ '**' ],
 		targets: [ 'plugins/search' ],
 		suite: '',
 		buildGroup: 'jetpack-search',
@@ -109,7 +109,7 @@ const projects = [
 	{
 		project: 'VideoPress',
 		path: 'projects/plugins/videopress/tests/e2e',
-		testArgs: [],
+		testArgs: [ '**' ],
 		targets: [ 'plugins/videopress' ],
 		suite: '',
 		buildGroup: 'jetpack-videopress',
@@ -117,7 +117,7 @@ const projects = [
 	{
 		project: 'Social',
 		path: 'projects/plugins/social/tests/e2e',
-		testArgs: [],
+		testArgs: [ '**' ],
 		targets: [ 'plugins/social' ],
 		suite: '',
 		buildGroup: 'jetpack-social',
@@ -125,7 +125,7 @@ const projects = [
 	{
 		project: 'Protect',
 		path: 'projects/plugins/protect/tests/e2e',
-		testArgs: [],
+		testArgs: [ '**' ],
 		targets: [ 'plugins/protect' ],
 		suite: '',
 		buildGroup: 'jetpack-protect',

--- a/.github/files/e2e-tests/e2e-matrix.js
+++ b/.github/files/e2e-tests/e2e-matrix.js
@@ -101,7 +101,7 @@ const projects = [
 	{
 		project: 'Search',
 		path: 'projects/plugins/search/tests/e2e',
-		testArgs: [ '**' ],
+		testArgs: [ 'specs' ],
 		targets: [ 'plugins/search' ],
 		suite: '',
 		buildGroup: 'jetpack-search',
@@ -109,7 +109,7 @@ const projects = [
 	{
 		project: 'VideoPress',
 		path: 'projects/plugins/videopress/tests/e2e',
-		testArgs: [ '**' ],
+		testArgs: [ 'specs' ],
 		targets: [ 'plugins/videopress' ],
 		suite: '',
 		buildGroup: 'jetpack-videopress',
@@ -117,7 +117,7 @@ const projects = [
 	{
 		project: 'Social',
 		path: 'projects/plugins/social/tests/e2e',
-		testArgs: [ '**' ],
+		testArgs: [ 'specs' ],
 		targets: [ 'plugins/social' ],
 		suite: '',
 		buildGroup: 'jetpack-social',
@@ -125,7 +125,7 @@ const projects = [
 	{
 		project: 'Protect',
 		path: 'projects/plugins/protect/tests/e2e',
-		testArgs: [ '**' ],
+		testArgs: [ 'specs' ],
 		targets: [ 'plugins/protect' ],
 		suite: '',
 		buildGroup: 'jetpack-protect',

--- a/projects/plugins/automattic-for-agencies-client/changelog/e2e-test-setup-tweaks
+++ b/projects/plugins/automattic-for-agencies-client/changelog/e2e-test-setup-tweaks
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: E2E tests tweaks: removed redundant setup steps
+
+

--- a/projects/plugins/automattic-for-agencies-client/tests/e2e/package.json
+++ b/projects/plugins/automattic-for-agencies-client/tests/e2e/package.json
@@ -25,7 +25,7 @@
 		"tunnel:reset": "tunnel reset",
 		"tunnel:down": "tunnel down",
 		"pretest:run": "pnpm run clean",
-		"test:run": ". ./node_modules/_jetpack-e2e-commons/bin/app-password.sh && playwright install --with-deps chromium && NODE_CONFIG_DIR='./config' ALLURE_RESULTS_DIR=./output/allure-results NODE_PATH=\"$PWD/node_modules\" playwright test --config=./playwright.config.mjs"
+		"test:run": ". ./node_modules/_jetpack-e2e-commons/bin/app-password.sh && playwright install chromium && NODE_CONFIG_DIR='./config' ALLURE_RESULTS_DIR=./output/allure-results NODE_PATH=\"$PWD/node_modules\" playwright test --config=./playwright.config.mjs"
 	},
 	"devDependencies": {
 		"@playwright/test": "1.51.1",

--- a/projects/plugins/automattic-for-agencies-client/tests/e2e/specs/start.test.js
+++ b/projects/plugins/automattic-for-agencies-client/tests/e2e/specs/start.test.js
@@ -1,15 +1,7 @@
 import { test } from '@playwright/test';
-import { prerequisitesBuilder } from '_jetpack-e2e-commons/env/prerequisites.js';
 import { Sidebar, DashboardPage } from '_jetpack-e2e-commons/pages/wp-admin/index.js';
-import playwrightConfig from '../playwright.config.mjs';
 
 test.describe( 'Automattic for Agencies plugin!', () => {
-	test.beforeEach( async ( { browser } ) => {
-		const page = await browser.newPage( playwrightConfig.use );
-		await prerequisitesBuilder( page ).withCleanEnv().withLoggedIn( true ).build();
-		await page.close();
-	} );
-
 	// eslint-disable-next-line playwright/expect-expect -- TODO: Fix/justify this.
 	test( 'Visit Jetpack page', async ( { page } ) => {
 		await DashboardPage.visit( page );

--- a/projects/plugins/boost/changelog/e2e-test-setup-tweaks
+++ b/projects/plugins/boost/changelog/e2e-test-setup-tweaks
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: e2e tests: update the Playwright install command
+
+

--- a/projects/plugins/boost/tests/e2e/package.json
+++ b/projects/plugins/boost/tests/e2e/package.json
@@ -24,7 +24,7 @@
 		"tunnel:reset": "tunnel reset",
 		"tunnel:down": "tunnel down",
 		"pretest:run": "pnpm run clean",
-		"test:run": ". ./node_modules/_jetpack-e2e-commons/bin/app-password.sh && playwright install --with-deps chromium && NODE_CONFIG_DIR='./config' ALLURE_RESULTS_DIR=./output/allure-results NODE_PATH=\"$PWD/node_modules\" playwright test --config=./playwright.config.mjs",
+		"test:run": ". ./node_modules/_jetpack-e2e-commons/bin/app-password.sh && playwright install chromium && NODE_CONFIG_DIR='./config' ALLURE_RESULTS_DIR=./output/allure-results NODE_PATH=\"$PWD/node_modules\" playwright test --config=./playwright.config.mjs",
 		"prepare:e2e": "pnpm jetpack docker --type e2e --name t1 exec-silent -- chown -R www-data .htaccess wp-config.php wp-content"
 	},
 	"devDependencies": {

--- a/projects/plugins/classic-theme-helper-plugin/changelog/e2e-test-setup-tweaks
+++ b/projects/plugins/classic-theme-helper-plugin/changelog/e2e-test-setup-tweaks
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: E2E tests tweaks: removed redundant setup steps
+
+

--- a/projects/plugins/classic-theme-helper-plugin/tests/e2e/package.json
+++ b/projects/plugins/classic-theme-helper-plugin/tests/e2e/package.json
@@ -25,7 +25,7 @@
 		"tunnel:reset": "tunnel reset",
 		"tunnel:down": "tunnel down",
 		"pretest:run": "pnpm run clean",
-		"test:run": ". ./node_modules/_jetpack-e2e-commons/bin/app-password.sh && playwright install --with-deps chromium && NODE_CONFIG_DIR='./config' ALLURE_RESULTS_DIR=./output/allure-results NODE_PATH=\"$PWD/node_modules\" playwright test --config=./playwright.config.mjs"
+		"test:run": ". ./node_modules/_jetpack-e2e-commons/bin/app-password.sh && playwright install chromium && NODE_CONFIG_DIR='./config' ALLURE_RESULTS_DIR=./output/allure-results NODE_PATH=\"$PWD/node_modules\" playwright test --config=./playwright.config.mjs"
 	},
 	"devDependencies": {
 		"@playwright/test": "1.51.1",

--- a/projects/plugins/classic-theme-helper-plugin/tests/e2e/specs/start.test.js
+++ b/projects/plugins/classic-theme-helper-plugin/tests/e2e/specs/start.test.js
@@ -1,15 +1,7 @@
 import { test } from '@playwright/test';
-import { prerequisitesBuilder } from '_jetpack-e2e-commons/env/prerequisites.js';
 import { Sidebar, DashboardPage } from '_jetpack-e2e-commons/pages/wp-admin/index.js';
-import playwrightConfig from '../playwright.config.mjs';
 
 test.describe( 'Classic Theme Helper plugin!', () => {
-	test.beforeEach( async ( { browser } ) => {
-		const page = await browser.newPage( playwrightConfig.use );
-		await prerequisitesBuilder( page ).withCleanEnv().withLoggedIn( true ).build();
-		await page.close();
-	} );
-
 	// eslint-disable-next-line playwright/expect-expect -- TODO: Fix/justify this.
 	test( 'Visit Jetpack page', async ( { page } ) => {
 		await DashboardPage.visit( page );

--- a/projects/plugins/jetpack/changelog/e2e-test-setup-tweaks
+++ b/projects/plugins/jetpack/changelog/e2e-test-setup-tweaks
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: E2E tests tweaks: removed redundant setup steps
+
+

--- a/projects/plugins/jetpack/tests/e2e/specs/onboarding/full-connection.test.ts
+++ b/projects/plugins/jetpack/tests/e2e/specs/onboarding/full-connection.test.ts
@@ -1,17 +1,13 @@
 import { test, expect } from '_jetpack-e2e-commons/fixtures/base-test.ts';
 import { Onboarding } from '_jetpack-e2e-commons/flows/onboarding.ts';
-import { authenticateUser } from '_jetpack-e2e-commons/helpers/login-utils.ts';
-import { getSiteCredentials } from '_jetpack-e2e-commons/helpers/utils-helper.js';
 import logger from '_jetpack-e2e-commons/logger.js';
 import { disconnect, isSiteConnected, isUserConnected } from '_jetpack-e2e-commons/utils/index.ts';
 
-test.beforeEach( async ( { request, requestUtils } ) => {
+test.beforeEach( async ( { requestUtils } ) => {
 	await disconnect( requestUtils );
 
 	expect( await isUserConnected( requestUtils ) ).toBe( false );
 	expect( await isSiteConnected( requestUtils ) ).toBe( false );
-
-	await authenticateUser( request, getSiteCredentials() );
 } );
 
 test( 'Full connection - Site and User', async ( { page, requestUtils, admin } ) => {

--- a/projects/plugins/jetpack/tests/e2e/specs/onboarding/landing-page.test.ts
+++ b/projects/plugins/jetpack/tests/e2e/specs/onboarding/landing-page.test.ts
@@ -1,16 +1,12 @@
 import { expect, test } from '_jetpack-e2e-commons/fixtures/base-test.ts';
 import { Onboarding } from '_jetpack-e2e-commons/flows/onboarding.ts';
-import { authenticateUser } from '_jetpack-e2e-commons/helpers/login-utils.ts';
-import { getSiteCredentials } from '_jetpack-e2e-commons/helpers/utils-helper.js';
 import { disconnect, isSiteConnected, isUserConnected } from '_jetpack-e2e-commons/utils/index.ts';
 
-test.beforeEach( async ( { request, requestUtils } ) => {
+test.beforeEach( async ( { requestUtils } ) => {
 	await disconnect( requestUtils );
 
 	expect( await isUserConnected( requestUtils ) ).toBe( false );
 	expect( await isSiteConnected( requestUtils ) ).toBe( false );
-
-	await authenticateUser( request, getSiteCredentials() );
 } );
 
 test( 'Onboarding landing page', async ( { page, admin } ) => {

--- a/projects/plugins/jetpack/tests/e2e/specs/onboarding/site-connection.test.ts
+++ b/projects/plugins/jetpack/tests/e2e/specs/onboarding/site-connection.test.ts
@@ -1,16 +1,12 @@
 import { test, expect } from '_jetpack-e2e-commons/fixtures/base-test.ts';
 import { Onboarding } from '_jetpack-e2e-commons/flows/onboarding.ts';
-import { authenticateUser } from '_jetpack-e2e-commons/helpers/login-utils.ts';
-import { getSiteCredentials } from '_jetpack-e2e-commons/helpers/utils-helper.js';
 import { disconnect, isSiteConnected, isUserConnected } from '_jetpack-e2e-commons/utils/index.ts';
 
-test.beforeEach( async ( { requestUtils, request } ) => {
+test.beforeEach( async ( { requestUtils } ) => {
 	await disconnect( requestUtils );
 
 	expect( await isUserConnected( requestUtils ) ).toBe( false );
 	expect( await isSiteConnected( requestUtils ) ).toBe( false );
-
-	await authenticateUser( request, getSiteCredentials() );
 } );
 
 test( 'Site only connection', async ( { page, admin } ) => {

--- a/projects/plugins/jetpack/tests/e2e/specs/sync/sync.test.js
+++ b/projects/plugins/jetpack/tests/e2e/specs/sync/sync.test.js
@@ -1,4 +1,3 @@
-import { prerequisitesBuilder } from '_jetpack-e2e-commons/env/index.js';
 import { test, expect } from '_jetpack-e2e-commons/fixtures/base-test.ts';
 import { execWpCommand } from '_jetpack-e2e-commons/helpers/utils-helper.js';
 import logger from '_jetpack-e2e-commons/logger.js';
@@ -10,7 +9,6 @@ import {
 	disableDedicatedSync,
 	isSyncQueueEmpty,
 } from '../../helpers/sync-helper.js';
-import playwrightConfig from '../../playwright.config.mjs';
 
 test.describe( 'Sync', () => {
 	const wpcomRestAPIBase = 'https://public-api.wordpress.com/rest/';
@@ -19,11 +17,7 @@ test.describe( 'Sync', () => {
 	let wpcomPostsResponse;
 	let wpcomPosts;
 
-	test.beforeAll( async ( { browser } ) => {
-		const page = await browser.newPage( playwrightConfig.use );
-		await prerequisitesBuilder( page ).withLoggedIn( true ).build();
-		await page.close();
-
+	test.beforeAll( async ( {} ) => {
 		const jetpackOptions = await execWpCommand( 'option get jetpack_options --format=json' );
 		wpcomBlogId = JSON.parse( jetpackOptions ).id;
 		wpcomForcedPostsUrl =

--- a/projects/plugins/protect/changelog/e2e-test-setup-tweaks
+++ b/projects/plugins/protect/changelog/e2e-test-setup-tweaks
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: E2E tests tweaks: removed redundant setup steps
+
+

--- a/projects/plugins/protect/tests/e2e/package.json
+++ b/projects/plugins/protect/tests/e2e/package.json
@@ -25,7 +25,7 @@
 		"tunnel:reset": "tunnel reset",
 		"tunnel:down": "tunnel down",
 		"pretest:run": "pnpm run clean",
-		"test:run": ". ./node_modules/_jetpack-e2e-commons/bin/app-password.sh && playwright install --with-deps chromium && NODE_CONFIG_DIR='./config' ALLURE_RESULTS_DIR=./output/allure-results NODE_PATH=\"$PWD/node_modules\" playwright test --config=./playwright.config.mjs"
+		"test:run": ". ./node_modules/_jetpack-e2e-commons/bin/app-password.sh && playwright install chromium && NODE_CONFIG_DIR='./config' ALLURE_RESULTS_DIR=./output/allure-results NODE_PATH=\"$PWD/node_modules\" playwright test --config=./playwright.config.mjs"
 	},
 	"devDependencies": {
 		"@playwright/test": "1.51.1",

--- a/projects/plugins/protect/tests/e2e/specs/start.test.js
+++ b/projects/plugins/protect/tests/e2e/specs/start.test.js
@@ -5,15 +5,16 @@ import {
 	execSyncShellCommand,
 	execWpCommand,
 } from '_jetpack-e2e-commons/helpers/utils-helper.js';
+import { disconnect } from '_jetpack-e2e-commons/utils/index.ts';
 import { connect } from '../flows/connection';
 
 test.describe( 'Jetpack Protect Plugin', () => {
-	test.beforeEach( async ( { page, admin } ) => {
+	test.beforeEach( async ( { page, admin, requestUtils } ) => {
+		await disconnect( requestUtils );
+
 		await prerequisitesBuilder( page )
-			.withCleanEnv()
 			.withActivePlugins( [ 'jetpack-protect' ] )
 			.withInactivePlugins( [ 'e2e-waf-data-interceptor' ] )
-			.withLoggedIn( true )
 			.build();
 
 		/**

--- a/projects/plugins/search/changelog/e2e-test-setup-tweaks
+++ b/projects/plugins/search/changelog/e2e-test-setup-tweaks
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: E2E tests tweaks: removed redundant setup steps
+
+

--- a/projects/plugins/search/tests/e2e/package.json
+++ b/projects/plugins/search/tests/e2e/package.json
@@ -23,7 +23,7 @@
 		"tunnel:reset": "tunnel reset",
 		"tunnel:down": "tunnel down",
 		"pretest:run": "pnpm run clean",
-		"test:run": ". ./node_modules/_jetpack-e2e-commons/bin/app-password.sh && playwright install --with-deps chromium && NODE_CONFIG_DIR='./config' ALLURE_RESULTS_DIR=./output/allure-results NODE_PATH=\"$PWD/node_modules\" playwright test --config=playwright.config.mjs"
+		"test:run": ". ./node_modules/_jetpack-e2e-commons/bin/app-password.sh && playwright install chromium && NODE_CONFIG_DIR='./config' ALLURE_RESULTS_DIR=./output/allure-results NODE_PATH=\"$PWD/node_modules\" playwright test --config=playwright.config.mjs"
 	},
 	"devDependencies": {
 		"@playwright/test": "1.51.1",

--- a/projects/plugins/search/tests/e2e/playwright.config.mjs
+++ b/projects/plugins/search/tests/e2e/playwright.config.mjs
@@ -9,7 +9,7 @@ export default {
 		{
 			name: 'jetpack search e2e',
 			testMatch: '**/specs/**',
-			dependencies: [ 'global authentication' ],
+			dependencies: [ 'connection setup' ],
 		},
 	],
 };

--- a/projects/plugins/search/tests/e2e/specs/search-configure.test.js
+++ b/projects/plugins/search/tests/e2e/specs/search-configure.test.js
@@ -20,8 +20,6 @@ test.describe( 'Search Configure', () => {
 		const page = await browser.newPage( playwrightConfig.use );
 		await clearSearchPlanInfo();
 		await prerequisitesBuilder( page )
-			.withLoggedIn( true )
-			.withConnection( true )
 			.withPlan( Plans.Complete )
 			.withActiveModules( [ 'search' ] )
 			.build();

--- a/projects/plugins/search/tests/e2e/specs/search-dashboard.test.js
+++ b/projects/plugins/search/tests/e2e/specs/search-dashboard.test.js
@@ -15,8 +15,6 @@ test.describe( 'Search Dashboard', () => {
 		const page = await browser.newPage( playwrightConfig.use );
 		await clearSearchPlanInfo();
 		await prerequisitesBuilder( page )
-			.withLoggedIn( true )
-			.withConnection( true )
 			.withPlan( Plans.Complete )
 			.withActiveModules( [ 'search' ] )
 			.build();

--- a/projects/plugins/search/tests/e2e/specs/search.test.js
+++ b/projects/plugins/search/tests/e2e/specs/search.test.js
@@ -17,8 +17,6 @@ test.describe( 'Instant Search', () => {
 		const page = await browser.newPage( playwrightConfig.use );
 		await clearSearchPlanInfo();
 		await prerequisitesBuilder( page )
-			.withLoggedIn( true )
-			.withConnection( true )
 			.withPlan( Plans.Complete )
 			.withActiveModules( [ 'search' ] )
 			.build();

--- a/projects/plugins/social/changelog/e2e-test-setup-tweaks
+++ b/projects/plugins/social/changelog/e2e-test-setup-tweaks
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: E2E tests tweaks: removed redundant setup steps
+
+

--- a/projects/plugins/social/tests/e2e/package.json
+++ b/projects/plugins/social/tests/e2e/package.json
@@ -27,7 +27,7 @@
 		"tunnel:reset": "tunnel reset",
 		"tunnel:down": "tunnel down",
 		"pretest:run": "pnpm run clean",
-		"test:run": ". ./node_modules/_jetpack-e2e-commons/bin/app-password.sh && playwright install --with-deps chromium && NODE_CONFIG_DIR='./config' ALLURE_RESULTS_DIR=./output/allure-results NODE_PATH=\"$PWD/node_modules\" playwright test --config=./playwright.config.mjs"
+		"test:run": ". ./node_modules/_jetpack-e2e-commons/bin/app-password.sh && playwright install chromium && NODE_CONFIG_DIR='./config' ALLURE_RESULTS_DIR=./output/allure-results NODE_PATH=\"$PWD/node_modules\" playwright test --config=./playwright.config.mjs"
 	},
 	"devDependencies": {
 		"@playwright/test": "1.51.1",

--- a/projects/plugins/social/tests/e2e/package.json
+++ b/projects/plugins/social/tests/e2e/package.json
@@ -14,6 +14,7 @@
 	"license": "GPL-2.0-or-later",
 	"author": "Automattic",
 	"scripts": {
+		"allure-report": "allure generate --clean --output ./output/allure-report ./output/allure-results && allure open ./output/allure-report",
 		"build": "pnpm jetpack build packages/assets packages/connection packages/publicize plugins/social plugins/jetpack -v --no-pnpm-install --production",
 		"clean": "rm -rf output",
 		"config:decrypt": "openssl enc -md sha1 -aes-256-cbc -pbkdf2 -iter 100000 -d -pass env:CONFIG_KEY -in ./node_modules/_jetpack-e2e-commons/config/encrypted.enc -out ./config/local.cjs",

--- a/projects/plugins/social/tests/e2e/specs/admin-page.test.js
+++ b/projects/plugins/social/tests/e2e/specs/admin-page.test.js
@@ -1,12 +1,14 @@
 import { prerequisitesBuilder } from '_jetpack-e2e-commons/env/prerequisites.js';
 import { expect, test } from '_jetpack-e2e-commons/fixtures/base-test.ts';
 import logger from '_jetpack-e2e-commons/logger.js';
+import { disconnect } from '_jetpack-e2e-commons/utils/index.ts';
 
-test.beforeEach( async ( { page } ) => {
+test.beforeEach( async ( { page, requestUtils } ) => {
+	await disconnect( requestUtils );
+
 	await prerequisitesBuilder( page )
 		.withCleanEnv()
 		.withActivePlugins( [ 'jetpack-social' ] )
-		.withLoggedIn( true )
 		.build();
 } );
 

--- a/projects/plugins/social/tests/e2e/specs/admin-page.test.js
+++ b/projects/plugins/social/tests/e2e/specs/admin-page.test.js
@@ -6,10 +6,7 @@ import { disconnect } from '_jetpack-e2e-commons/utils/index.ts';
 test.beforeEach( async ( { page, requestUtils } ) => {
 	await disconnect( requestUtils );
 
-	await prerequisitesBuilder( page )
-		.withCleanEnv()
-		.withActivePlugins( [ 'jetpack-social' ] )
-		.build();
+	await prerequisitesBuilder( page ).withActivePlugins( [ 'jetpack-social' ] ).build();
 } );
 
 test( 'Jetpack Social admin page', async ( { page, admin } ) => {

--- a/projects/plugins/social/tests/e2e/specs/admin-page.test.js
+++ b/projects/plugins/social/tests/e2e/specs/admin-page.test.js
@@ -5,7 +5,6 @@ import { disconnect } from '_jetpack-e2e-commons/utils/index.ts';
 
 test.beforeEach( async ( { page, requestUtils } ) => {
 	await disconnect( requestUtils );
-
 	await prerequisitesBuilder( page ).withActivePlugins( [ 'jetpack-social' ] ).build();
 } );
 

--- a/projects/plugins/social/tests/e2e/specs/connection.test.js
+++ b/projects/plugins/social/tests/e2e/specs/connection.test.js
@@ -1,13 +1,21 @@
 import { prerequisitesBuilder } from '_jetpack-e2e-commons/env/prerequisites.js';
 import { test, expect } from '_jetpack-e2e-commons/fixtures/base-test.ts';
+import { execWpCommand } from '_jetpack-e2e-commons/helpers/utils-helper.js';
 import { disconnect } from '_jetpack-e2e-commons/utils/index.ts';
 import { connect } from '../flows/index.js';
 import { JetpackSocialPage } from '../pages/index.js';
+import playwrightConfig from '../playwright.config.mjs';
 
-test.beforeEach( async ( { page, requestUtils } ) => {
+test.beforeAll( async ( { browser, requestUtils } ) => {
 	await disconnect( requestUtils );
+	await execWpCommand( 'option delete jetpack-social_show_pricing_page' );
 
-	await prerequisitesBuilder( page ).withActivePlugins( [ 'jetpack-social' ] ).build();
+	const page = await browser.newPage( playwrightConfig.use );
+	await prerequisitesBuilder( page )
+		.withInactivePlugins( [ 'jetpack' ] )
+		.withActivePlugins( [ 'jetpack-social' ] )
+		.build();
+	await page.close();
 } );
 
 test( 'Jetpack Social connection', async ( { page } ) => {

--- a/projects/plugins/social/tests/e2e/specs/connection.test.js
+++ b/projects/plugins/social/tests/e2e/specs/connection.test.js
@@ -1,14 +1,15 @@
 import { prerequisitesBuilder } from '_jetpack-e2e-commons/env/prerequisites.js';
 import { test, expect } from '_jetpack-e2e-commons/fixtures/base-test.ts';
+import { disconnect } from '_jetpack-e2e-commons/utils/index.ts';
 import { connect } from '../flows/index.js';
 import { JetpackSocialPage } from '../pages/index.js';
 
-test.beforeEach( async ( { page } ) => {
+test.beforeEach( async ( { page, requestUtils } ) => {
+	await disconnect( requestUtils );
+
 	await prerequisitesBuilder( page )
 		.withCleanEnv()
 		.withActivePlugins( [ 'jetpack-social' ] )
-		.withLoggedIn( true )
-		.withWpComLoggedIn( true )
 		.build();
 } );
 

--- a/projects/plugins/social/tests/e2e/specs/connection.test.js
+++ b/projects/plugins/social/tests/e2e/specs/connection.test.js
@@ -7,10 +7,7 @@ import { JetpackSocialPage } from '../pages/index.js';
 test.beforeEach( async ( { page, requestUtils } ) => {
 	await disconnect( requestUtils );
 
-	await prerequisitesBuilder( page )
-		.withCleanEnv()
-		.withActivePlugins( [ 'jetpack-social' ] )
-		.build();
+	await prerequisitesBuilder( page ).withActivePlugins( [ 'jetpack-social' ] ).build();
 } );
 
 test( 'Jetpack Social connection', async ( { page } ) => {

--- a/projects/plugins/social/tests/e2e/specs/social-sidebar.test.js
+++ b/projects/plugins/social/tests/e2e/specs/social-sidebar.test.js
@@ -9,7 +9,6 @@ test.beforeEach( async ( { page, requestUtils } ) => {
 	await disconnect( requestUtils );
 
 	await prerequisitesBuilder( page )
-		.withCleanEnv()
 		.withActivePlugins( [ 'jetpack-social' ] )
 		.withInactivePlugins( [ 'jetpack' ] )
 		.build();

--- a/projects/plugins/social/tests/e2e/specs/social-sidebar.test.js
+++ b/projects/plugins/social/tests/e2e/specs/social-sidebar.test.js
@@ -1,17 +1,22 @@
 import { prerequisitesBuilder } from '_jetpack-e2e-commons/env/prerequisites.js';
 import { expect, test } from '_jetpack-e2e-commons/fixtures/base-test.ts';
+import { execWpCommand } from '_jetpack-e2e-commons/helpers/utils-helper.js';
 import logger from '_jetpack-e2e-commons/logger.js';
 import BlockEditorPage from '_jetpack-e2e-commons/pages/wp-admin/block-editor.js';
-import { disconnect } from '_jetpack-e2e-commons/utils/index.ts';
+import { disconnect } from '_jetpack-e2e-commons/utils/connection-utils.ts';
 import { connect } from '../flows/index.js';
+import playwrightConfig from '../playwright.config.mjs';
 
-test.beforeEach( async ( { page, requestUtils } ) => {
+test.beforeAll( async ( { browser, requestUtils } ) => {
 	await disconnect( requestUtils );
+	await execWpCommand( 'option delete jetpack-social_show_pricing_page' );
 
+	const page = await browser.newPage( playwrightConfig.use );
 	await prerequisitesBuilder( page )
-		.withActivePlugins( [ 'jetpack-social' ] )
 		.withInactivePlugins( [ 'jetpack' ] )
+		.withActivePlugins( [ 'jetpack-social' ] )
 		.build();
+	await page.close();
 } );
 
 test( 'Jetpack Social sidebar', async ( { page, admin } ) => {

--- a/projects/plugins/social/tests/e2e/specs/social-sidebar.test.js
+++ b/projects/plugins/social/tests/e2e/specs/social-sidebar.test.js
@@ -2,15 +2,16 @@ import { prerequisitesBuilder } from '_jetpack-e2e-commons/env/prerequisites.js'
 import { expect, test } from '_jetpack-e2e-commons/fixtures/base-test.ts';
 import logger from '_jetpack-e2e-commons/logger.js';
 import BlockEditorPage from '_jetpack-e2e-commons/pages/wp-admin/block-editor.js';
+import { disconnect } from '_jetpack-e2e-commons/utils/index.ts';
 import { connect } from '../flows/index.js';
 
-test.beforeEach( async ( { page } ) => {
+test.beforeEach( async ( { page, requestUtils } ) => {
+	await disconnect( requestUtils );
+
 	await prerequisitesBuilder( page )
 		.withCleanEnv()
 		.withActivePlugins( [ 'jetpack-social' ] )
 		.withInactivePlugins( [ 'jetpack' ] )
-		.withLoggedIn( true )
-		.withWpComLoggedIn( true )
 		.build();
 } );
 

--- a/projects/plugins/starter-plugin/changelog/e2e-test-setup-tweaks
+++ b/projects/plugins/starter-plugin/changelog/e2e-test-setup-tweaks
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: E2E tests tweaks: removed redundant setup steps
+
+

--- a/projects/plugins/starter-plugin/tests/e2e/package.json
+++ b/projects/plugins/starter-plugin/tests/e2e/package.json
@@ -25,7 +25,7 @@
 		"tunnel:reset": "tunnel reset",
 		"tunnel:down": "tunnel down",
 		"pretest:run": "pnpm run clean",
-		"test:run": ". ./node_modules/_jetpack-e2e-commons/bin/app-password.sh && playwright install --with-deps chromium && NODE_CONFIG_DIR='./config' ALLURE_RESULTS_DIR=./output/allure-results NODE_PATH=\"$PWD/node_modules\" playwright test --config=./playwright.config.mjs"
+		"test:run": ". ./node_modules/_jetpack-e2e-commons/bin/app-password.sh && playwright install chromium && NODE_CONFIG_DIR='./config' ALLURE_RESULTS_DIR=./output/allure-results NODE_PATH=\"$PWD/node_modules\" playwright test --config=./playwright.config.mjs"
 	},
 	"devDependencies": {
 		"@playwright/test": "1.51.1",

--- a/projects/plugins/starter-plugin/tests/e2e/specs/start.test.js
+++ b/projects/plugins/starter-plugin/tests/e2e/specs/start.test.js
@@ -1,15 +1,7 @@
 import { test } from '@playwright/test';
-import { prerequisitesBuilder } from '_jetpack-e2e-commons/env/prerequisites.js';
 import { Sidebar, DashboardPage } from '_jetpack-e2e-commons/pages/wp-admin/index.js';
-import playwrightConfig from '../playwright.config.mjs';
 
 test.describe( 'Starter Plugin!', () => {
-	test.beforeEach( async ( { browser } ) => {
-		const page = await browser.newPage( playwrightConfig.use );
-		await prerequisitesBuilder( page ).withCleanEnv().withLoggedIn( true ).build();
-		await page.close();
-	} );
-
 	// eslint-disable-next-line playwright/expect-expect -- TODO: Fix/justify this.
 	test( 'Visit Jetpack page', async ( { page } ) => {
 		await DashboardPage.visit( page );

--- a/projects/plugins/videopress/changelog/e2e-test-setup-tweaks
+++ b/projects/plugins/videopress/changelog/e2e-test-setup-tweaks
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: E2E tests tweaks: removed redundant setup steps
+
+

--- a/projects/plugins/videopress/tests/e2e/package.json
+++ b/projects/plugins/videopress/tests/e2e/package.json
@@ -25,7 +25,7 @@
 		"tunnel:reset": "tunnel reset",
 		"tunnel:down": "tunnel down",
 		"pretest:run": "pnpm run clean",
-		"test:run": ". ./node_modules/_jetpack-e2e-commons/bin/app-password.sh && playwright install --with-deps chromium && NODE_CONFIG_DIR='./config' ALLURE_RESULTS_DIR=./output/allure-results NODE_PATH=\"$PWD/node_modules\" playwright test --config=./playwright.config.mjs"
+		"test:run": ". ./node_modules/_jetpack-e2e-commons/bin/app-password.sh && playwright install chromium && NODE_CONFIG_DIR='./config' ALLURE_RESULTS_DIR=./output/allure-results NODE_PATH=\"$PWD/node_modules\" playwright test --config=./playwright.config.mjs"
 	},
 	"devDependencies": {
 		"@playwright/test": "1.51.1",

--- a/projects/plugins/videopress/tests/e2e/specs/start.test.js
+++ b/projects/plugins/videopress/tests/e2e/specs/start.test.js
@@ -1,15 +1,7 @@
 import { test } from '@playwright/test';
-import { prerequisitesBuilder } from '_jetpack-e2e-commons/env/prerequisites.js';
 import { Sidebar, DashboardPage } from '_jetpack-e2e-commons/pages/wp-admin/index.js';
-import playwrightConfig from '../playwright.config.mjs';
 
 test.describe( 'VideoPress plugin!', () => {
-	test.beforeEach( async ( { browser } ) => {
-		const page = await browser.newPage( playwrightConfig.use );
-		await prerequisitesBuilder( page ).withCleanEnv().withLoggedIn( true ).build();
-		await page.close();
-	} );
-
 	// eslint-disable-next-line playwright/expect-expect -- TODO: Fix/justify this.
 	test( 'Visit Jetpack page', async ( { page } ) => {
 		await DashboardPage.visit( page );


### PR DESCRIPTION
## Proposed changes:

Follow-up of #44353, remove some e2e setup steps that are redundant or unnecessary.

### Other information:

- [x] N/A Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] N/A Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

e2e tests should pass in CI