### PR TITLE
Boost: Remove ISA references from My Jetpack and post-purchase

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-interstitial-modal/stories/index.stories.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial-modal/stories/index.stories.jsx
@@ -18,7 +18,6 @@ const DefaultArgs = {
 			<ProductInterstitialFeatureList
 				features={ [
 					'Automated critical CSS',
-					'Image size analyzer',
 					'Performance history',
 					'Image quality control',
 					'Concatenate JS and CSS',

--- a/projects/packages/my-jetpack/changelog/remove-boost-isa-upgrade-text-HOG-212
+++ b/projects/packages/my-jetpack/changelog/remove-boost-isa-upgrade-text-HOG-212
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Admin: remove references to deprecated feature.

--- a/projects/packages/my-jetpack/src/products/class-boost.php
+++ b/projects/packages/my-jetpack/src/products/class-boost.php
@@ -197,19 +197,6 @@ class Boost extends Product {
 				),
 			),
 			array(
-				'name'  => __( 'Automatic image size analysis', 'jetpack-my-jetpack' ),
-				'info'  => array(
-					'content' => __(
-						'Scan your site for images that aren’t properly sized for the device they’re being viewed on.',
-						'jetpack-my-jetpack'
-					),
-				),
-				'tiers' => array(
-					self::FREE_TIER_SLUG     => array( 'included' => false ),
-					self::UPGRADED_TIER_SLUG => array( 'included' => true ),
-				),
-			),
-			array(
 				'name'  => __( 'Historical performance scores', 'jetpack-my-jetpack' ),
 				'info'  => array(
 					'content' => __(

--- a/projects/plugins/boost/app/assets/src/js/pages/purchase-success/purchase-success.tsx
+++ b/projects/plugins/boost/app/assets/src/js/pages/purchase-success/purchase-success.tsx
@@ -67,17 +67,6 @@ const PurchaseSuccess: FC = () => {
 				<li>
 					{ createInterpolateElement(
 						__(
-							'<strong>Image Size Analyzer:</strong> Scan and identify oversized images. Optimize them to boost loading speeds.',
-							'jetpack-boost'
-						),
-						{
-							strong: <strong />,
-						}
-					) }
-				</li>
-				<li>
-					{ createInterpolateElement(
-						__(
 							'<strong>Historical Performance:</strong> Review past performance scores and Core Web Vitals data. Identify which actions positively impacted site speeds over time.',
 							'jetpack-boost'
 						),

--- a/projects/plugins/boost/changelog/remove-boost-isa-upgrade-text-HOG-212
+++ b/projects/plugins/boost/changelog/remove-boost-isa-upgrade-text-HOG-212
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Admin: remove references to deprecated feature.

--- a/projects/plugins/boost/tests/php/My_Jetpack_Test.php
+++ b/projects/plugins/boost/tests/php/My_Jetpack_Test.php
@@ -28,7 +28,7 @@ class My_Jetpack_Test extends Base_TestCase {
 	}
 
 	public function test_is_correct_features_count() {
-		$total_features = 11;
+		$total_features = 10;
 		$this->assertCount( $total_features, $this->product['features_by_tier'], 'Expected ' . $total_features . ' features, got ' . count( $this->product['features_by_tier'] ) );
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes HOG-212

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Remove a reference to ISA in My Jetpack.
* Remove a reference to ISA in the Boost post-purchase screen.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
See Linear.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Purchase Boost via the app, confirm ISA is no longer referenced.

