### PR TITLE
Connection: fix a fatal triggered by disconnecting too early

### DIFF
--- a/projects/packages/connection/changelog/fix-connected-plugins-too-early-fatal
+++ b/projects/packages/connection/changelog/fix-connected-plugins-too-early-fatal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix a fatal triggered by trying to disconnect Jetpack too early.

--- a/projects/packages/connection/src/class-plugin.php
+++ b/projects/packages/connection/src/class-plugin.php
@@ -100,7 +100,7 @@ class Plugin {
 				_doing_it_wrong(
 					__METHOD__,
 					esc_html( $plugins->get_error_message() ),
-					'$$next-version$$'
+					'{plugin/package}-$$next-version$$'
 				);
 			} else {
 				wp_trigger_error( __METHOD__, $plugins->get_error_message() );

--- a/projects/packages/connection/src/class-plugin.php
+++ b/projects/packages/connection/src/class-plugin.php
@@ -95,6 +95,19 @@ class Plugin {
 	public function is_only() {
 		$plugins = Plugin_Storage::get_all();
 
+		if ( is_wp_error( $plugins ) ) {
+			if ( 'too_early' === $plugins->get_error_code() ) {
+				_doing_it_wrong(
+					__METHOD__,
+					esc_html( $plugins->get_error_message() ),
+					'$$next-version$$'
+				);
+			} else {
+				wp_trigger_error( __METHOD__, $plugins->get_error_message() );
+			}
+			return false;
+		}
+
 		return ! $plugins || ( array_key_exists( $this->slug, $plugins ) && 1 === count( $plugins ) );
 	}
 }

--- a/projects/packages/connection/src/class-plugin.php
+++ b/projects/packages/connection/src/class-plugin.php
@@ -97,11 +97,7 @@ class Plugin {
 
 		if ( is_wp_error( $plugins ) ) {
 			if ( 'too_early' === $plugins->get_error_code() ) {
-				_doing_it_wrong(
-					__METHOD__,
-					esc_html( $plugins->get_error_message() ),
-					'{plugin/package}-$$next-version$$'
-				);
+				_doing_it_wrong( __METHOD__, esc_html( $plugins->get_error_message() ), '$$next-version$$' );
 			} else {
 				wp_trigger_error( __METHOD__, $plugins->get_error_message() );
 			}

--- a/projects/packages/connection/src/class-plugin.php
+++ b/projects/packages/connection/src/class-plugin.php
@@ -97,9 +97,9 @@ class Plugin {
 
 		if ( is_wp_error( $plugins ) ) {
 			if ( 'too_early' === $plugins->get_error_code() ) {
-				_doing_it_wrong( __METHOD__, esc_html( $plugins->get_error_message() ), '$$next-version$$' );
+				_doing_it_wrong( __METHOD__, esc_html( $plugins->get_error_code() . ': ' . $plugins->get_error_message() ), '$$next-version$$' );
 			} else {
-				wp_trigger_error( __METHOD__, $plugins->get_error_message() );
+				wp_trigger_error( __METHOD__, $plugins->get_error_code() . ': ' . $plugins->get_error_message() );
 			}
 			return false;
 		}

--- a/projects/packages/connection/tests/php/Plugin_Test.php
+++ b/projects/packages/connection/tests/php/Plugin_Test.php
@@ -46,10 +46,10 @@ class Plugin_Test extends TestCase {
 	protected function tearDown(): void {
 		parent::tearDown();
 
-		$reflection          = new \ReflectionClass( Plugin_Storage::class );
-		$configured_property = $reflection->getProperty( 'plugins' );
-		$configured_property->setAccessible( true );
-		$configured_property->setValue( null, array() );
+		$reflection       = new \ReflectionClass( Plugin_Storage::class );
+		$plugins_property = $reflection->getProperty( 'plugins' );
+		$plugins_property->setAccessible( true );
+		$plugins_property->setValue( null, array() );
 	}
 
 	/**
@@ -81,10 +81,6 @@ class Plugin_Test extends TestCase {
 	 */
 	public function test_is_only_no_plugins() {
 		$plugin = new Plugin( self::PLUGIN_SLUG );
-
-		// Mock Plugin_Storage::get_all() to return empty array
-		$mock = $this->createMock( Plugin_Storage::class );
-		$mock->method( 'get_all' )->willReturn( array() );
 
 		$this->assertTrue( $plugin->is_only() );
 	}
@@ -135,8 +131,6 @@ class Plugin_Test extends TestCase {
 		$this->expectException( Exception::class );
 		$this->expectExceptionMessage( 'You cannot call this method until Jetpack Config is configured' );
 
-		$this->assertFalse( $plugin->is_only() );
-
-		$configured_property->setValue( null, true );
+		$plugin->is_only();
 	}
 }

--- a/projects/packages/connection/tests/php/Plugin_Test.php
+++ b/projects/packages/connection/tests/php/Plugin_Test.php
@@ -121,7 +121,8 @@ class Plugin_Test extends TestCase {
 		$configured_property->setValue( null, false );
 
 		set_error_handler(
-			static function ( $errno, $errstr ) {
+			// @phan-suppress-next-line PhanPluginNeverReturnFunction,PhanTypeMismatchArgumentInternal The complaints aren't compatible with PHP <8.0
+			static function ( int $errno, string $errstr ): void {
 				restore_error_handler();
 				throw new Exception( $errstr, $errno );
 			},

--- a/projects/packages/connection/tests/php/Plugin_Test.php
+++ b/projects/packages/connection/tests/php/Plugin_Test.php
@@ -8,6 +8,7 @@
 
 namespace Automattic\Jetpack\Connection;
 
+use Exception;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\TestCase;
@@ -42,6 +43,15 @@ class Plugin_Test extends TestCase {
 		Plugin_Storage::configure();
 	}
 
+	protected function tearDown(): void {
+		parent::tearDown();
+
+		$reflection          = new \ReflectionClass( Plugin_Storage::class );
+		$configured_property = $reflection->getProperty( 'plugins' );
+		$configured_property->setAccessible( true );
+		$configured_property->setValue( null, array() );
+	}
+
 	/**
 	 * Unit test for the `Plugin::add()` method.
 	 */
@@ -64,5 +74,69 @@ class Plugin_Test extends TestCase {
 		$plugin->remove();
 
 		$this->assertArrayNotHasKey( self::PLUGIN_SLUG, Plugin_Storage::get_all() );
+	}
+
+	/**
+	 * Unit test for the `Plugin::is_only()` method when no plugins exist.
+	 */
+	public function test_is_only_no_plugins() {
+		$plugin = new Plugin( self::PLUGIN_SLUG );
+
+		// Mock Plugin_Storage::get_all() to return empty array
+		$mock = $this->createMock( Plugin_Storage::class );
+		$mock->method( 'get_all' )->willReturn( array() );
+
+		$this->assertTrue( $plugin->is_only() );
+	}
+
+	/**
+	 * Unit test for the `Plugin::is_only()` method when current plugin is the only one.
+	 */
+	public function test_is_only_single_plugin() {
+		$plugin = new Plugin( self::PLUGIN_SLUG );
+		$plugin->add( self::PLUGIN_NAME, $this->plugin_args );
+
+		$this->assertTrue( $plugin->is_only() );
+	}
+
+	/**
+	 * Unit test for the `Plugin::is_only()` method when multiple plugins exist.
+	 */
+	public function test_is_only_multiple_plugins() {
+		$plugin1 = new Plugin( self::PLUGIN_SLUG );
+		$plugin1->add( self::PLUGIN_NAME, $this->plugin_args );
+
+		$plugin2 = new Plugin( 'another-plugin' );
+		$plugin2->add( 'Another Plugin', array() );
+
+		$this->assertFalse( $plugin1->is_only() );
+	}
+
+	/**
+	 * Unit test for the `Plugin::is_only()` method when Plugin_Storage::get_all() returns WP_Error with 'too_early' code.
+	 */
+	public function test_is_only_too_early() {
+		$plugin = new Plugin( self::PLUGIN_SLUG );
+
+		// De-configuring the `Plugin_Storage` to trigger the error.
+		$reflection          = new \ReflectionClass( Plugin_Storage::class );
+		$configured_property = $reflection->getProperty( 'configured' );
+		$configured_property->setAccessible( true );
+		$configured_property->setValue( null, false );
+
+		set_error_handler(
+			static function ( $errno, $errstr ) {
+				restore_error_handler();
+				throw new Exception( $errstr, $errno );
+			},
+			E_ALL
+		);
+
+		$this->expectException( Exception::class );
+		$this->expectExceptionMessage( 'You cannot call this method until Jetpack Config is configured' );
+
+		$this->assertFalse( $plugin->is_only() );
+
+		$configured_property->setValue( null, true );
 	}
 }

--- a/projects/packages/connection/tests/php/Plugin_Test.php
+++ b/projects/packages/connection/tests/php/Plugin_Test.php
@@ -130,7 +130,7 @@ class Plugin_Test extends TestCase {
 		);
 
 		$this->expectException( Exception::class );
-		$this->expectExceptionMessage( 'You cannot call this method until Jetpack Config is configured' );
+		$this->expectExceptionMessage( 'too_early' );
 
 		$plugin->is_only();
 	}


### PR DESCRIPTION
## Proposed changes:
* Fix a fatal triggered by trying to disconnect Jetpack too early.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1753210135129039-slack-C05PV073SG3

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
1. Connect Jetpack.
2. Edit the file `projects/plugins/jetpack/load-jetpack.php` by adding `Jetpack::disconnect();` in the end of the file.
3. Load your site, confirm it loads well and no fatal is triggered.
4. Check the error log, confirm that the error notice was triggered:
```
PHP Notice:  Function Automattic\Jetpack\Connection\Plugin::is_only was called <strong>incorrectly</strong>. You cannot call this method until Jetpack Config is configured Please see <a href="https://developer.wordpress.org/advanced-administration/debug/debug-wordpress/">Debugging in WordPress</a> for more information. (This message was added in version $$next-version$$.) in /var/www/html/wp-includes/functions.php on line 6121
```
5. Remove the changes from the `load-jetpack.php` file.
6. Make sure Jetpack is the only jetpack-connected plugin, then deactivate it.
7. Check `jetpack_private_options`, confirm the tokens were deleted.
8. Activate another jetpack-connected plugin, then deactivate Jetpack.
9. Check `jetpack_private_options` and "My Jetpack", confirm you are still connected.