### PR TITLE
Memberships endpoint: Add newsletter product tier validation

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/memberships.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/memberships.php
@@ -640,10 +640,10 @@ class WPCOM_REST_API_V2_Endpoint_Memberships extends WP_REST_Controller {
 		}
 
 		foreach ( $existing_yearly_plans as $existing_plan ) {
-			if ( isset( $existing_plan['tier'] ) && $existing_plan['tier'] === $tier && '1 year' === $existing_plan['interval'] ) {
+			if ( isset( $existing_plan['tier'] ) && (string) $existing_plan['tier'] === (string) $tier && '1 year' === $existing_plan['interval'] ) {
 				// If this is an update, allow it to reference itself.
 				$product_id = $request->get_param( 'product_id' );
-				if ( ! $product_id || $existing_plan['id'] !== $product_id ) {
+				if ( ! $product_id || (string) $existing_plan['id'] !== (string) $product_id ) {
 					return new WP_Error( 'duplicate_tier_reference', __( 'Another yearly plan already references this monthly plan. Each monthly plan can only have one corresponding yearly plan.', 'jetpack' ), array( 'status' => 400 ) );
 				}
 			}

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/memberships.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/memberships.php
@@ -503,19 +503,65 @@ class WPCOM_REST_API_V2_Endpoint_Memberships extends WP_REST_Controller {
 	 *
 	 * @param WP_REST_Request $request The request for this endpoint, containing the details needed to build the payload.
 	 * @return array The built payload.
+	 * @throws \Exception When tier validation fails.
 	 */
 	private function get_payload_for_product( WP_REST_Request $request ) {
 		$is_editable             = isset( $request['is_editable'] ) ? (bool) $request['is_editable'] : null;
 		$type                    = isset( $request['type'] ) ? $request['type'] : null;
 		$tier                    = isset( $request['tier'] ) ? $request['tier'] : null;
 		$buyer_can_change_amount = isset( $request['buyer_can_change_amount'] ) && (bool) $request['buyer_can_change_amount'];
+		$interval                = $request['interval'];
+
+		// Validate tier field usage according to the tier system design.
+		// Only apply tier validation for newsletter plans with type 'tier'.
+		if ( null !== $tier && 'tier' === $type ) {
+			// Monthly plans should not have a tier field.
+			if ( '1 month' === $interval ) {
+				throw new \Exception( __( 'Monthly plans should not have a tier field. The tier field is only used to link yearly plans to their corresponding monthly plans.', 'jetpack' ) );
+			}
+
+			// Yearly plans must have a valid tier that points to a monthly plan.
+			if ( '1 year' === $interval ) {
+				if ( ! is_numeric( $tier ) || $tier <= 0 ) {
+					throw new \Exception( __( 'Yearly plans must have a valid tier ID that points to an existing monthly plan.', 'jetpack' ) );
+				}
+
+				// Check if the referenced monthly plan exists and is actually a monthly plan.
+				if ( $this->is_wpcom() ) {
+					require_lib( 'memberships' );
+					Memberships_Store_Sandbox::get_instance()->init( true );
+
+					$monthly_plan = Memberships_Product::get_from_post( get_current_blog_id(), $tier );
+					if ( is_wp_error( $monthly_plan ) || ! $monthly_plan ) {
+						throw new \Exception( __( 'The specified tier ID does not correspond to an existing monthly plan.', 'jetpack' ) );
+					}
+
+					$monthly_plan_data = $monthly_plan->to_array();
+					if ( '1 month' !== $monthly_plan_data['interval'] ) {
+						throw new \Exception( __( 'The specified tier ID must point to a monthly plan (1 month interval).', 'jetpack' ) );
+					}
+
+					// Check for duplicate tier usage - only one yearly plan should reference a specific monthly plan.
+					$existing_yearly_plans = Memberships_Product::get_product_list( get_current_blog_id(), 'tier', null, false );
+					foreach ( $existing_yearly_plans as $existing_plan ) {
+						if ( isset( $existing_plan['tier'] ) && $existing_plan['tier'] === $tier && '1 year' === $existing_plan['interval'] ) {
+							// If this is an update, allow it to reference itself.
+							$product_id = $request->get_param( 'product_id' );
+							if ( ! $product_id || $existing_plan['id'] !== $product_id ) {
+								throw new \Exception( __( 'Another yearly plan already references this monthly plan. Each monthly plan can only have one corresponding yearly plan.', 'jetpack' ) );
+							}
+						}
+					}
+				}
+			}
+		}
 
 		$payload = array(
 			'title'                        => $request['title'],
 			'price'                        => $request['price'],
 			'currency'                     => $request['currency'],
 			'buyer_can_change_amount'      => $buyer_can_change_amount,
-			'interval'                     => $request['interval'],
+			'interval'                     => $interval,
 			'type'                         => $type,
 			'welcome_email_content'        => $request['welcome_email_content'],
 			'subscribe_as_site_subscriber' => $request['subscribe_as_site_subscriber'],

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/memberships.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/memberships.php
@@ -282,6 +282,10 @@ class WPCOM_REST_API_V2_Endpoint_Memberships extends WP_REST_Controller {
 	public function create_product( WP_REST_Request $request ) {
 		$payload = $this->get_payload_for_product( $request );
 
+		if ( is_wp_error( $payload ) ) {
+			return $payload;
+		}
+
 		if ( $this->is_wpcom() ) {
 			require_lib( 'memberships' );
 			try {
@@ -304,6 +308,10 @@ class WPCOM_REST_API_V2_Endpoint_Memberships extends WP_REST_Controller {
 	public function update_product( \WP_REST_Request $request ) {
 		$product_id = $request->get_param( 'product_id' );
 		$payload    = $this->get_payload_for_product( $request );
+
+		if ( is_wp_error( $payload ) ) {
+			return $payload;
+		}
 
 		if ( $this->is_wpcom() ) {
 			require_lib( 'memberships' );
@@ -502,8 +510,7 @@ class WPCOM_REST_API_V2_Endpoint_Memberships extends WP_REST_Controller {
 	 * Get a payload for creating or updating products by parsing the request.
 	 *
 	 * @param WP_REST_Request $request The request for this endpoint, containing the details needed to build the payload.
-	 * @return array The built payload.
-	 * @throws \Exception When tier validation fails.
+	 * @return array|WP_Error The built payload or WP_Error on validation failure.
 	 */
 	private function get_payload_for_product( WP_REST_Request $request ) {
 		$is_editable             = isset( $request['is_editable'] ) ? (bool) $request['is_editable'] : null;
@@ -517,13 +524,13 @@ class WPCOM_REST_API_V2_Endpoint_Memberships extends WP_REST_Controller {
 		if ( null !== $tier && 'tier' === $type ) {
 			// Monthly plans should not have a tier field.
 			if ( '1 month' === $interval ) {
-				throw new \Exception( __( 'Monthly plans should not have a tier field. The tier field is only used to link yearly plans to their corresponding monthly plans.', 'jetpack' ) );
+				return new WP_Error( 'invalid_tier_usage', __( 'Monthly plans should not have a tier field. The tier field is only used to link yearly plans to their corresponding monthly plans.', 'jetpack' ), array( 'status' => 400 ) );
 			}
 
 			// Yearly plans must have a valid tier that points to a monthly plan.
 			if ( '1 year' === $interval ) {
 				if ( ! is_numeric( $tier ) || $tier <= 0 ) {
-					throw new \Exception( __( 'Yearly plans must have a valid tier ID that points to an existing monthly plan.', 'jetpack' ) );
+					return new WP_Error( 'invalid_tier_id', __( 'Yearly plans must have a valid tier ID that points to an existing monthly plan.', 'jetpack' ), array( 'status' => 400 ) );
 				}
 
 				// Check if the referenced monthly plan exists and is actually a monthly plan.
@@ -533,12 +540,12 @@ class WPCOM_REST_API_V2_Endpoint_Memberships extends WP_REST_Controller {
 
 					$monthly_plan = Memberships_Product::get_from_post( get_current_blog_id(), $tier );
 					if ( is_wp_error( $monthly_plan ) || ! $monthly_plan ) {
-						throw new \Exception( __( 'The specified tier ID does not correspond to an existing monthly plan.', 'jetpack' ) );
+						return new WP_Error( 'tier_not_found', __( 'The specified tier ID does not correspond to an existing monthly plan.', 'jetpack' ), array( 'status' => 400 ) );
 					}
 
 					$monthly_plan_data = $monthly_plan->to_array();
 					if ( '1 month' !== $monthly_plan_data['interval'] ) {
-						throw new \Exception( __( 'The specified tier ID must point to a monthly plan (1 month interval).', 'jetpack' ) );
+						return new WP_Error( 'invalid_tier_interval', __( 'The specified tier ID must point to a monthly plan (1 month interval).', 'jetpack' ), array( 'status' => 400 ) );
 					}
 
 					// Check for duplicate tier usage - only one yearly plan should reference a specific monthly plan.
@@ -548,7 +555,7 @@ class WPCOM_REST_API_V2_Endpoint_Memberships extends WP_REST_Controller {
 							// If this is an update, allow it to reference itself.
 							$product_id = $request->get_param( 'product_id' );
 							if ( ! $product_id || $existing_plan['id'] !== $product_id ) {
-								throw new \Exception( __( 'Another yearly plan already references this monthly plan. Each monthly plan can only have one corresponding yearly plan.', 'jetpack' ) );
+								return new WP_Error( 'duplicate_tier_reference', __( 'Another yearly plan already references this monthly plan. Each monthly plan can only have one corresponding yearly plan.', 'jetpack' ), array( 'status' => 400 ) );
 							}
 						}
 					}

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/memberships.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/memberships.php
@@ -550,6 +550,9 @@ class WPCOM_REST_API_V2_Endpoint_Memberships extends WP_REST_Controller {
 
 					// Check for duplicate tier usage - only one yearly plan should reference a specific monthly plan.
 					$existing_yearly_plans = Memberships_Product::get_product_list( get_current_blog_id(), 'tier', null, false );
+					if ( is_wp_error( $existing_yearly_plans ) ) {
+						return new WP_Error( 'product_list_error', __( 'Could not retrieve existing products to check for duplicate tier references.', 'jetpack' ), array( 'status' => 500 ) );
+					}
 					foreach ( $existing_yearly_plans as $existing_plan ) {
 						if ( isset( $existing_plan['tier'] ) && $existing_plan['tier'] === $tier && '1 year' === $existing_plan['interval'] ) {
 							// If this is an update, allow it to reference itself.

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/memberships.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/memberships.php
@@ -519,51 +519,10 @@ class WPCOM_REST_API_V2_Endpoint_Memberships extends WP_REST_Controller {
 		$buyer_can_change_amount = isset( $request['buyer_can_change_amount'] ) && (bool) $request['buyer_can_change_amount'];
 		$interval                = $request['interval'];
 
-		// Validate tier field usage according to the tier system design.
-		// Only apply tier validation for newsletter plans with type 'tier'.
-		if ( null !== $tier && 'tier' === $type ) {
-			// Monthly plans should not have a tier field.
-			if ( '1 month' === $interval ) {
-				return new WP_Error( 'invalid_tier_usage', __( 'Monthly plans should not have a tier field. The tier field is only used to link yearly plans to their corresponding monthly plans.', 'jetpack' ), array( 'status' => 400 ) );
-			}
-
-			// Yearly plans must have a valid tier that points to a monthly plan.
-			if ( '1 year' === $interval ) {
-				if ( ! is_numeric( $tier ) || $tier <= 0 ) {
-					return new WP_Error( 'invalid_tier_id', __( 'Yearly plans must have a valid tier ID that points to an existing monthly plan.', 'jetpack' ), array( 'status' => 400 ) );
-				}
-
-				// Check if the referenced monthly plan exists and is actually a monthly plan.
-				if ( $this->is_wpcom() ) {
-					require_lib( 'memberships' );
-					Memberships_Store_Sandbox::get_instance()->init( true );
-
-					$monthly_plan = Memberships_Product::get_from_post( get_current_blog_id(), $tier );
-					if ( is_wp_error( $monthly_plan ) || ! $monthly_plan ) {
-						return new WP_Error( 'tier_not_found', __( 'The specified tier ID does not correspond to an existing monthly plan.', 'jetpack' ), array( 'status' => 400 ) );
-					}
-
-					$monthly_plan_data = $monthly_plan->to_array();
-					if ( '1 month' !== $monthly_plan_data['interval'] ) {
-						return new WP_Error( 'invalid_tier_interval', __( 'The specified tier ID must point to a monthly plan (1 month interval).', 'jetpack' ), array( 'status' => 400 ) );
-					}
-
-					// Check for duplicate tier usage - only one yearly plan should reference a specific monthly plan.
-					$existing_yearly_plans = Memberships_Product::get_product_list( get_current_blog_id(), 'tier', null, false );
-					if ( is_wp_error( $existing_yearly_plans ) ) {
-						return new WP_Error( 'product_list_error', __( 'Could not retrieve existing products to check for duplicate tier references.', 'jetpack' ), array( 'status' => 500 ) );
-					}
-					foreach ( $existing_yearly_plans as $existing_plan ) {
-						if ( isset( $existing_plan['tier'] ) && $existing_plan['tier'] === $tier && '1 year' === $existing_plan['interval'] ) {
-							// If this is an update, allow it to reference itself.
-							$product_id = $request->get_param( 'product_id' );
-							if ( ! $product_id || $existing_plan['id'] !== $product_id ) {
-								return new WP_Error( 'duplicate_tier_reference', __( 'Another yearly plan already references this monthly plan. Each monthly plan can only have one corresponding yearly plan.', 'jetpack' ), array( 'status' => 400 ) );
-							}
-						}
-					}
-				}
-			}
+		// Validate tier field usage.
+		$tier_validation = $this->validate_tier_field( $request, $tier, $type, $interval );
+		if ( is_wp_error( $tier_validation ) ) {
+			return $tier_validation;
 		}
 
 		$payload = array(
@@ -586,7 +545,111 @@ class WPCOM_REST_API_V2_Endpoint_Memberships extends WP_REST_Controller {
 		if ( null !== $is_editable ) {
 			$payload['is_editable'] = $is_editable;
 		}
+
 		return $payload;
+	}
+
+	/**
+	 * Validate tier field usage for newsletter plans.
+	 *
+	 * @param WP_REST_Request $request  The request object.
+	 * @param string|null     $tier     The tier value to validate.
+	 * @param string|null     $type     The product type.
+	 * @param string          $interval The product interval.
+	 * @return WP_Error|null  Error object if validation fails, null if successful.
+	 */
+	private function validate_tier_field( WP_REST_Request $request, $tier, $type, $interval ) {
+		// Only apply tier validation for newsletter plans with type 'tier'.
+		if ( null === $tier || 'tier' !== $type ) {
+			return null;
+		}
+
+		// Monthly plans should not have a tier field.
+		if ( '1 month' === $interval ) {
+			return new WP_Error( 'invalid_tier_usage', __( 'Monthly plans should not have a tier field. The tier field is only used to link yearly plans to their corresponding monthly plans.', 'jetpack' ), array( 'status' => 400 ) );
+		}
+
+		// Yearly plans must have a valid tier that points to a monthly plan.
+		if ( '1 year' === $interval ) {
+			return $this->validate_yearly_tier( $request, $tier );
+		}
+
+		return null;
+	}
+
+	/**
+	 * Validate yearly tier requirements.
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 * @param string|int      $tier    The tier value to validate.
+	 * @return WP_Error|null  Error object if validation fails, null if successful.
+	 */
+	private function validate_yearly_tier( WP_REST_Request $request, $tier ) {
+		if ( ! is_numeric( $tier ) || $tier <= 0 ) {
+			return new WP_Error( 'invalid_tier_id', __( 'Yearly plans must have a valid tier ID that points to an existing monthly plan.', 'jetpack' ), array( 'status' => 400 ) );
+		}
+
+		if ( ! $this->is_wpcom() ) {
+			return null; // Validation will happen on WPCOM side.
+		}
+
+		return $this->validate_tier_references( $request, $tier );
+	}
+
+	/**
+	 * Validate that the tier references a valid monthly plan and check for duplicates.
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 * @param string|int      $tier    The tier value to validate.
+	 * @return WP_Error|null  Error object if validation fails, null if successful.
+	 */
+	private function validate_tier_references( WP_REST_Request $request, $tier ) {
+		require_lib( 'memberships' );
+		Memberships_Store_Sandbox::get_instance()->init( true );
+
+		// Check if the referenced monthly plan exists and is actually a monthly plan.
+		$monthly_plan = Memberships_Product::get_from_post( get_current_blog_id(), $tier );
+		if ( is_wp_error( $monthly_plan ) || ! $monthly_plan ) {
+			return new WP_Error( 'tier_not_found', __( 'The specified tier ID does not correspond to an existing monthly plan.', 'jetpack' ), array( 'status' => 400 ) );
+		}
+
+		$monthly_plan_data = $monthly_plan->to_array();
+		if ( '1 month' !== $monthly_plan_data['interval'] ) {
+			return new WP_Error( 'invalid_tier_interval', __( 'The specified tier ID must point to a monthly plan (1 month interval).', 'jetpack' ), array( 'status' => 400 ) );
+		}
+
+		return $this->check_duplicate_tier_references( $request, $tier );
+	}
+
+	/**
+	 * Check for duplicate tier references.
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 * @param string|int      $tier    The tier value to check.
+	 * @return WP_Error|null  Error object if duplicate found, null if successful.
+	 */
+	private function check_duplicate_tier_references( WP_REST_Request $request, $tier ) {
+		$existing_yearly_plans = Memberships_Product::get_product_list( get_current_blog_id(), 'tier', null, false );
+		if ( is_wp_error( $existing_yearly_plans ) ) {
+			return new WP_Error( 'product_list_error', __( 'Could not retrieve existing products to check for duplicate tier references.', 'jetpack' ), array( 'status' => 500 ) );
+		}
+
+		// Ensure the result is iterable before foreach.
+		if ( ! is_array( $existing_yearly_plans ) && ! $existing_yearly_plans instanceof Traversable ) {
+			return new WP_Error( 'invalid_product_list', __( 'Unexpected error: product list is not iterable.', 'jetpack' ), array( 'status' => 500 ) );
+		}
+
+		foreach ( $existing_yearly_plans as $existing_plan ) {
+			if ( isset( $existing_plan['tier'] ) && $existing_plan['tier'] === $tier && '1 year' === $existing_plan['interval'] ) {
+				// If this is an update, allow it to reference itself.
+				$product_id = $request->get_param( 'product_id' );
+				if ( ! $product_id || $existing_plan['id'] !== $product_id ) {
+					return new WP_Error( 'duplicate_tier_reference', __( 'Another yearly plan already references this monthly plan. Each monthly plan can only have one corresponding yearly plan.', 'jetpack' ), array( 'status' => 400 ) );
+				}
+			}
+		}
+
+		return null;
 	}
 
 	/**

--- a/projects/plugins/jetpack/changelog/add-newsletter-product-tier-validation
+++ b/projects/plugins/jetpack/changelog/add-newsletter-product-tier-validation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Memberships: Add validation for newsletter plan tiers.

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Memberships_Test.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Memberships_Test.php
@@ -418,6 +418,72 @@ class WPCOM_REST_API_V2_Endpoint_Memberships_Test extends Jetpack_REST_TestCase 
 	}
 
 	/**
+	 * Tests POST 'memberships/product' endpoint with tier ID that doesn't exist.
+	 */
+	public function test_create_product_with_nonexistent_tier() {
+		add_filter( 'pre_http_request', array( $this, 'mock_wpcom_api_response_tier_not_found' ), 10, 3 );
+
+		$request = new WP_REST_Request( Requests::POST, '/wpcom/v2/memberships/product' );
+		$request->set_header( 'content_type', 'application/json' );
+		$body = array(
+			'title'    => 'Yearly Plan',
+			'price'    => 100,
+			'currency' => 'USD',
+			'interval' => '1 year',
+			'type'     => 'tier',
+			'tier'     => 99999, // Non-existent tier ID
+		);
+		$request->set_body( wp_json_encode( $body ) );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertErrorResponse( 'tier_not_found', $response, 400 );
+	}
+
+	/**
+	 * Tests POST 'memberships/product' endpoint with tier ID that points to non-monthly plan.
+	 */
+	public function test_create_product_with_tier_pointing_to_non_monthly_plan() {
+		add_filter( 'pre_http_request', array( $this, 'mock_wpcom_api_response_invalid_tier_interval' ), 10, 3 );
+
+		$request = new WP_REST_Request( Requests::POST, '/wpcom/v2/memberships/product' );
+		$request->set_header( 'content_type', 'application/json' );
+		$body = array(
+			'title'    => 'Yearly Plan',
+			'price'    => 100,
+			'currency' => 'USD',
+			'interval' => '1 year',
+			'type'     => 'tier',
+			'tier'     => 456, // Tier ID pointing to a non-monthly plan
+		);
+		$request->set_body( wp_json_encode( $body ) );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertErrorResponse( 'invalid_tier_interval', $response, 400 );
+	}
+
+	/**
+	 * Tests POST 'memberships/product' endpoint with duplicate tier reference.
+	 */
+	public function test_create_product_with_duplicate_tier_reference() {
+		add_filter( 'pre_http_request', array( $this, 'mock_wpcom_api_response_duplicate_tier_reference' ), 10, 3 );
+
+		$request = new WP_REST_Request( Requests::POST, '/wpcom/v2/memberships/product' );
+		$request->set_header( 'content_type', 'application/json' );
+		$body = array(
+			'title'    => 'Yearly Plan',
+			'price'    => 100,
+			'currency' => 'USD',
+			'interval' => '1 year',
+			'type'     => 'tier',
+			'tier'     => 789, // Tier ID already referenced by another yearly plan
+		);
+		$request->set_body( wp_json_encode( $body ) );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertErrorResponse( 'duplicate_tier_reference', $response, 400 );
+	}
+
+	/**
 	 * Tests PUT 'memberships/product/[product_id]' endpoint without authorization.
 	 */
 	public function test_update_product_no_auth() {
@@ -830,6 +896,78 @@ class WPCOM_REST_API_V2_Endpoint_Memberships_Test extends Jetpack_REST_TestCase 
 			'status_code' => 200,
 			'response'    => array(
 				'code' => 200,
+			),
+		);
+	}
+
+	/**
+	 * Mock WPCOM API response for tier not found error.
+	 *
+	 * @param bool   $response Whether to preempt an HTTP request's return value. Default false.
+	 * @param array  $args     HTTP request arguments.
+	 * @param string $url      The request URL.
+	 * @return array
+	 */
+	public function mock_wpcom_api_response_tier_not_found( $response, $args, $url ) {
+		$this->assertEquals( Requests::POST, $args['method'] );
+		$this->assertStringStartsWith( 'https://public-api.wordpress.com/wpcom/v2/sites/' . static::$blog_id . '/memberships/product', $url );
+
+		return array(
+			'headers'     => array(
+				'Allow' => 'POST',
+			),
+			'body'        => '{"code":"tier_not_found","message":"The specified tier ID does not correspond to an existing monthly plan.","data":{"status":400}}',
+			'status_code' => 400,
+			'response'    => array(
+				'code' => 400,
+			),
+		);
+	}
+
+	/**
+	 * Mock WPCOM API response for invalid tier interval error.
+	 *
+	 * @param bool   $response Whether to preempt an HTTP request's return value. Default false.
+	 * @param array  $args     HTTP request arguments.
+	 * @param string $url      The request URL.
+	 * @return array
+	 */
+	public function mock_wpcom_api_response_invalid_tier_interval( $response, $args, $url ) {
+		$this->assertEquals( Requests::POST, $args['method'] );
+		$this->assertStringStartsWith( 'https://public-api.wordpress.com/wpcom/v2/sites/' . static::$blog_id . '/memberships/product', $url );
+
+		return array(
+			'headers'     => array(
+				'Allow' => 'POST',
+			),
+			'body'        => '{"code":"invalid_tier_interval","message":"The specified tier ID must point to a monthly plan (1 month interval).","data":{"status":400}}',
+			'status_code' => 400,
+			'response'    => array(
+				'code' => 400,
+			),
+		);
+	}
+
+	/**
+	 * Mock WPCOM API response for duplicate tier reference error.
+	 *
+	 * @param bool   $response Whether to preempt an HTTP request's return value. Default false.
+	 * @param array  $args     HTTP request arguments.
+	 * @param string $url      The request URL.
+	 * @return array
+	 */
+	public function mock_wpcom_api_response_duplicate_tier_reference( $response, $args, $url ) {
+		$this->assertEquals( Requests::POST, $args['method'] );
+		$this->assertStringStartsWith( 'https://public-api.wordpress.com/wpcom/v2/sites/' . static::$blog_id . '/memberships/product', $url );
+
+		return array(
+			'headers'     => array(
+				'Allow' => 'POST',
+			),
+			'body'        => '{"code":"duplicate_tier_reference","message":"Another yearly plan already references this monthly plan. Each monthly plan can only have one corresponding yearly plan.","data":{"status":400}}',
+			'status_code' => 400,
+			'response'    => array(
+				'code' => 400,
 			),
 		);
 	}

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Memberships_Test.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Memberships_Test.php
@@ -357,6 +357,67 @@ class WPCOM_REST_API_V2_Endpoint_Memberships_Test extends Jetpack_REST_TestCase 
 	}
 
 	/**
+	 * Tests POST 'memberships/product' endpoint with invalid tier for monthly plan.
+	 */
+	public function test_create_product_with_invalid_tier_for_monthly_plan() {
+		$request = new WP_REST_Request( Requests::POST, '/wpcom/v2/memberships/product' );
+		$request->set_header( 'content_type', 'application/json' );
+		$body = array(
+			'title'    => 'Monthly Plan',
+			'price'    => 10,
+			'currency' => 'USD',
+			'interval' => '1 month',
+			'type'     => 'tier',
+			'tier'     => 123, // Monthly plans should not have tier
+		);
+		$request->set_body( wp_json_encode( $body ) );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertErrorResponse( 'rest_invalid_param', $response, 400 );
+	}
+
+	/**
+	 * Tests POST 'memberships/product' endpoint with invalid tier value.
+	 */
+	public function test_create_product_with_invalid_tier_value() {
+		$request = new WP_REST_Request( Requests::POST, '/wpcom/v2/memberships/product' );
+		$request->set_header( 'content_type', 'application/json' );
+		$body = array(
+			'title'    => 'Yearly Plan',
+			'price'    => 100,
+			'currency' => 'USD',
+			'interval' => '1 year',
+			'type'     => 'tier',
+			'tier'     => -1, // Invalid tier value
+		);
+		$request->set_body( wp_json_encode( $body ) );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertErrorResponse( 'rest_invalid_param', $response, 400 );
+	}
+
+	/**
+	 * Tests POST 'memberships/product' endpoint with tier for donation product (should be allowed).
+	 */
+	public function test_create_donation_product_with_tier() {
+		$request = new WP_REST_Request( Requests::POST, '/wpcom/v2/memberships/product' );
+		$request->set_header( 'content_type', 'application/json' );
+		$body = array(
+			'title'    => 'Donation Plan',
+			'price'    => 10,
+			'currency' => 'USD',
+			'interval' => '1 month',
+			'type'     => 'donation',
+			'tier'     => 123, // Donation products can have tier
+		);
+		$request->set_body( wp_json_encode( $body ) );
+		$response = $this->server->dispatch( $request );
+
+		// This should not fail because donation products are not subject to tier validation
+		$this->assertNotEquals( 400, $response->get_status() );
+	}
+
+	/**
 	 * Tests PUT 'memberships/product/[product_id]' endpoint without authorization.
 	 */
 	public function test_update_product_no_auth() {
@@ -426,6 +487,42 @@ class WPCOM_REST_API_V2_Endpoint_Memberships_Test extends Jetpack_REST_TestCase 
 		$response = $this->server->dispatch( $request );
 
 		$this->assertErrorResponse( 'dummy_error', $response, 500 );
+	}
+
+	/**
+	 * Tests PUT 'memberships/product/{id}' endpoint with invalid tier for monthly plan.
+	 */
+	public function test_update_product_with_invalid_tier_for_monthly_plan() {
+		// First create a product
+		$create_request = new WP_REST_Request( Requests::POST, '/wpcom/v2/memberships/product' );
+		$create_request->set_header( 'content_type', 'application/json' );
+		$create_body = array(
+			'title'    => 'Monthly Plan',
+			'price'    => 10,
+			'currency' => 'USD',
+			'interval' => '1 month',
+			'type'     => 'tier',
+		);
+		$create_request->set_body( wp_json_encode( $create_body ) );
+		$create_response = $this->server->dispatch( $create_request );
+		$product_data    = $create_response->get_data();
+		$product_id      = $product_data['id'];
+
+		// Now try to update it with an invalid tier
+		$update_request = new WP_REST_Request( Requests::PUT, "/wpcom/v2/memberships/product/$product_id" );
+		$update_request->set_header( 'content_type', 'application/json' );
+		$update_body = array(
+			'title'    => 'Updated Monthly Plan',
+			'price'    => 15,
+			'currency' => 'USD',
+			'interval' => '1 month',
+			'type'     => 'tier',
+			'tier'     => 123, // Monthly plans should not have tier
+		);
+		$update_request->set_body( wp_json_encode( $update_body ) );
+		$update_response = $this->server->dispatch( $update_request );
+
+		$this->assertErrorResponse( 'rest_invalid_param', $update_response, 400 );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Memberships_Test.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Memberships_Test.php
@@ -1,15 +1,21 @@
 <?php
 /**
  * Tests for /wpcom/v2/external-media endpoints.
+ *
+ * @covers WPCOM_REST_API_V2_Endpoint_Memberships
  */
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use WpOrg\Requests\Requests;
 
 require_once dirname( __DIR__, 2 ) . '/lib/Jetpack_REST_TestCase.php';
 
 /**
  * Class WPCOM_REST_API_V2_Endpoint_Memberships_Test
+ *
+ * @covers \WPCOM_REST_API_V2_Endpoint_Memberships
  */
+#[CoversClass( WPCOM_REST_API_V2_Endpoint_Memberships::class )]
 class WPCOM_REST_API_V2_Endpoint_Memberships_Test extends Jetpack_REST_TestCase {
 
 	/**

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Memberships_Test.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Memberships_Test.php
@@ -373,7 +373,7 @@ class WPCOM_REST_API_V2_Endpoint_Memberships_Test extends Jetpack_REST_TestCase 
 		$request->set_body( wp_json_encode( $body ) );
 		$response = $this->server->dispatch( $request );
 
-		$this->assertErrorResponse( 'rest_invalid_param', $response, 400 );
+		$this->assertErrorResponse( 'invalid_tier_usage', $response, 400 );
 	}
 
 	/**
@@ -393,7 +393,7 @@ class WPCOM_REST_API_V2_Endpoint_Memberships_Test extends Jetpack_REST_TestCase 
 		$request->set_body( wp_json_encode( $body ) );
 		$response = $this->server->dispatch( $request );
 
-		$this->assertErrorResponse( 'rest_invalid_param', $response, 400 );
+		$this->assertErrorResponse( 'invalid_tier_id', $response, 400 );
 	}
 
 	/**
@@ -493,6 +493,9 @@ class WPCOM_REST_API_V2_Endpoint_Memberships_Test extends Jetpack_REST_TestCase 
 	 * Tests PUT 'memberships/product/{id}' endpoint with invalid tier for monthly plan.
 	 */
 	public function test_update_product_with_invalid_tier_for_monthly_plan() {
+		// Mock the WPCOM API response for product creation
+		add_filter( 'pre_http_request', array( $this, 'mock_wpcom_api_response_create_product_success' ), 10, 3 );
+
 		// First create a product
 		$create_request = new WP_REST_Request( Requests::POST, '/wpcom/v2/memberships/product' );
 		$create_request->set_header( 'content_type', 'application/json' );
@@ -508,6 +511,10 @@ class WPCOM_REST_API_V2_Endpoint_Memberships_Test extends Jetpack_REST_TestCase 
 		$product_data    = $create_response->get_data();
 		$product_id      = $product_data['id'];
 
+		// Remove the create mock and add update mock
+		remove_filter( 'pre_http_request', array( $this, 'mock_wpcom_api_response_create_product_success' ), 10 );
+		add_filter( 'pre_http_request', array( $this, 'mock_wpcom_api_response_update_product_remote_error' ), 10, 3 );
+
 		// Now try to update it with an invalid tier
 		$update_request = new WP_REST_Request( Requests::PUT, "/wpcom/v2/memberships/product/$product_id" );
 		$update_request->set_header( 'content_type', 'application/json' );
@@ -522,7 +529,7 @@ class WPCOM_REST_API_V2_Endpoint_Memberships_Test extends Jetpack_REST_TestCase 
 		$update_request->set_body( wp_json_encode( $update_body ) );
 		$update_response = $this->server->dispatch( $update_request );
 
-		$this->assertErrorResponse( 'rest_invalid_param', $update_response, 400 );
+		$this->assertErrorResponse( 'invalid_tier_usage', $update_response, 400 );
 	}
 
 	/**
@@ -799,6 +806,30 @@ class WPCOM_REST_API_V2_Endpoint_Memberships_Test extends Jetpack_REST_TestCase 
 			'status_code' => 500,
 			'response'    => array(
 				'code' => 500,
+			),
+		);
+	}
+
+	/**
+	 * Validate the Jetpack API request for creating memberships products and mock the successful response.
+	 *
+	 * @param bool   $response Whether to preempt an HTTP request's return value. Default false.
+	 * @param array  $args     HTTP request arguments.
+	 * @param string $url      The request URL.
+	 * @return array
+	 */
+	public function mock_wpcom_api_response_create_product_success( $response, $args, $url ) {
+		$this->assertEquals( Requests::POST, $args['method'] );
+		$this->assertStringStartsWith( 'https://public-api.wordpress.com/wpcom/v2/sites/' . static::$blog_id . '/memberships/product', $url );
+
+		return array(
+			'headers'     => array(
+				'Allow' => 'POST',
+			),
+			'body'        => '{"id":123,"title":"Monthly Plan","price":10,"currency":"USD","interval":"1 month","type":"tier"}',
+			'status_code' => 200,
+			'response'    => array(
+				'code' => 200,
 			),
 		);
 	}

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Memberships_Test.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Memberships_Test.php
@@ -971,4 +971,82 @@ class WPCOM_REST_API_V2_Endpoint_Memberships_Test extends Jetpack_REST_TestCase 
 			),
 		);
 	}
+
+	/**
+	 * Test validate_tier_field method with null tier (should pass).
+	 */
+	public function test_validate_tier_field_with_null_tier() {
+		$endpoint = new WPCOM_REST_API_V2_Endpoint_Memberships();
+		$request  = new WP_REST_Request();
+
+		$reflection = new ReflectionClass( $endpoint );
+		$method     = $reflection->getMethod( 'validate_tier_field' );
+		$method->setAccessible( true );
+
+		$result = $method->invoke( $endpoint, $request, null, 'tier', '1 month' );
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * Test validate_tier_field method with non-tier type (should pass).
+	 */
+	public function test_validate_tier_field_with_non_tier_type() {
+		$endpoint = new WPCOM_REST_API_V2_Endpoint_Memberships();
+		$request  = new WP_REST_Request();
+
+		$reflection = new ReflectionClass( $endpoint );
+		$method     = $reflection->getMethod( 'validate_tier_field' );
+		$method->setAccessible( true );
+
+		$result = $method->invoke( $endpoint, $request, 123, 'donation', '1 month' );
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * Test validate_tier_field method with monthly plan and tier (should fail).
+	 */
+	public function test_validate_tier_field_with_monthly_plan_and_tier() {
+		$endpoint = new WPCOM_REST_API_V2_Endpoint_Memberships();
+		$request  = new WP_REST_Request();
+
+		$reflection = new ReflectionClass( $endpoint );
+		$method     = $reflection->getMethod( 'validate_tier_field' );
+		$method->setAccessible( true );
+
+		$result = $method->invoke( $endpoint, $request, 123, 'tier', '1 month' );
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertEquals( 'invalid_tier_usage', $result->get_error_code() );
+	}
+
+	/**
+	 * Test validate_yearly_tier method with invalid tier value.
+	 */
+	public function test_validate_yearly_tier_with_invalid_value() {
+		$endpoint = new WPCOM_REST_API_V2_Endpoint_Memberships();
+		$request  = new WP_REST_Request();
+
+		$reflection = new ReflectionClass( $endpoint );
+		$method     = $reflection->getMethod( 'validate_yearly_tier' );
+		$method->setAccessible( true );
+
+		$result = $method->invoke( $endpoint, $request, -1 );
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertEquals( 'invalid_tier_id', $result->get_error_code() );
+	}
+
+	/**
+	 * Test validate_yearly_tier method with non-numeric tier.
+	 */
+	public function test_validate_yearly_tier_with_non_numeric_tier() {
+		$endpoint = new WPCOM_REST_API_V2_Endpoint_Memberships();
+		$request  = new WP_REST_Request();
+
+		$reflection = new ReflectionClass( $endpoint );
+		$method     = $reflection->getMethod( 'validate_yearly_tier' );
+		$method->setAccessible( true );
+
+		$result = $method->invoke( $endpoint, $request, 'invalid' );
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertEquals( 'invalid_tier_id', $result->get_error_code() );
+	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://linear.app/a8c/issue/CML-671/paid-newsletters-fail-to-auto-renew-converted-to-tiers

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Validate that tiers are correct when created or updated.
* Add tests for the tier validation.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

N/A

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this change to your sandbox with `bin/jetpack-downloader test jetpack add/newsletter-product-tier-validation` and sandbox the API.
* Visit https://wordpress.com/earn/payments/ and choose a site connected to Stripe to test with.
* Click to add a new payment plan. Toggle on "Paid newsletter tier" and fill in the other plan data. The plan should add successfully.
* Click to edit the created payment plan, make some adjustments to the monthly and yearly pricing and click save. The plan should save successfully without errors.

I wasn't able to test from the API console (possibly because `IS_WPCOM` is `false` there?) but I did get a "Another yearly plan already references this monthly plan..." error while testing via the UI before I fixed the product id type mismatch, so the validation is running.

<img width="682" height="735" alt="Screenshot 2025-07-25 at 2 36 19 PM" src="https://github.com/user-attachments/assets/eb2b59f6-7176-4062-a10d-6fbd824fa658" />
