### PR TITLE
Forms: Add backend MailPoet integration

### DIFF
--- a/projects/packages/forms/changelog/add-forms-backend-mailpoet-integration
+++ b/projects/packages/forms/changelog/add-forms-backend-mailpoet-integration
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: Add MailPoet backend integration.

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/index.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/index.tsx
@@ -64,8 +64,6 @@ const IntegrationsModal = ( {
 	const findIntegrationById = ( id: string ) =>
 		integrationsData?.find( ( integration: Integration ) => integration.id === id );
 
-	const isMailPoetEnabled: boolean = !! window?.jpFormsBlocks?.defaults?.isMailPoetEnabled;
-
 	return (
 		<Modal
 			title={ __( 'Manage integrations', 'jetpack-forms' ) }

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/index.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/index.tsx
@@ -64,6 +64,8 @@ const IntegrationsModal = ( {
 	const findIntegrationById = ( id: string ) =>
 		integrationsData?.find( ( integration: Integration ) => integration.id === id );
 
+	const isMailPoetEnabled: boolean = !! window?.jpFormsBlocks?.defaults?.isMailPoetEnabled;
+
 	return (
 		<Modal
 			title={ __( 'Manage integrations', 'jetpack-forms' ) }

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -304,12 +304,14 @@ class Contact_Form_Plugin {
 		self::register_contact_form_blocks();
 
 		// Register MailPoet integration hook after the class is loaded.
-		add_action(
-			'grunion_after_feedback_post_inserted',
-			array( MailPoet_Integration::class, 'handle_mailpoet_integration' ),
-			15,
-			3
-		);
+		if ( Jetpack_Forms::is_mailpoet_enabled() ) {
+			add_action(
+				'grunion_after_feedback_post_inserted',
+				array( MailPoet_Integration::class, 'handle_mailpoet_integration' ),
+				15,
+				4
+			);
+		}
 	}
 
 	/**

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -11,6 +11,7 @@ use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Extensions\Contact_Form\Contact_Form_Block;
 use Automattic\Jetpack\Forms\Jetpack_Forms;
+use Automattic\Jetpack\Forms\Service\MailPoet_Integration;
 use Automattic\Jetpack\Forms\Service\Post_To_Url;
 use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Terms_Of_Service;
@@ -1382,6 +1383,11 @@ class Contact_Form_Plugin {
 
 		if ( ! empty( $form->attributes['salesforceData'] ) || ! empty( $form->attributes['postToUrl'] ) ) {
 			Post_To_Url::init();
+		}
+
+		// MailPoet integration: initialize if enabled.
+		if ( ! empty( $form->attributes['connectMailPoet'] ) ) {
+			MailPoet_Integration::init();
 		}
 		// Process the form
 		return $form->process_submission();

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -302,6 +302,14 @@ class Contact_Form_Plugin {
 		}
 
 		self::register_contact_form_blocks();
+
+		// Register MailPoet integration hook after the class is loaded.
+		add_action(
+			'grunion_after_feedback_post_inserted',
+			array( MailPoet_Integration::class, 'handle_mailpoet_integration' ),
+			15,
+			3
+		);
 	}
 
 	/**
@@ -1385,10 +1393,6 @@ class Contact_Form_Plugin {
 			Post_To_Url::init();
 		}
 
-		// MailPoet integration: initialize if enabled.
-		if ( ! empty( $form->attributes['connectMailPoet'] ) ) {
-			MailPoet_Integration::init();
-		}
 		// Process the form
 		return $form->process_submission();
 	}

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -179,6 +179,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 			'customThankyouMessage'  => __( 'Thank you for your submission!', 'jetpack-forms' ), // The message to show when customThankyou is set to 'message'.
 			'customThankyouRedirect' => '', // The URL to redirect to when customThankyou is set to 'redirect'.
 			'jetpackCRM'             => true, // Whether Jetpack CRM should store the form submission.
+			'connectMailPoet'        => false, // Whether to send contact to MailPoet.
 			'className'              => null,
 			'postToUrl'              => null,
 			'salesforceData'         => null,

--- a/projects/packages/forms/src/service/class-mailpoet-integration.php
+++ b/projects/packages/forms/src/service/class-mailpoet-integration.php
@@ -23,7 +23,7 @@ class MailPoet_Integration {
 	/**
 	 * MailPoet API instance
 	 *
-	 * @var \MailPoet\API\API|null
+	 * @var mixed
 	 */
 	protected $mailpoet_api = null;
 
@@ -50,10 +50,11 @@ class MailPoet_Integration {
 	/**
 	 * Get the MailPoet API instance (v1), instantiating if necessary.
 	 *
-	 * @return \MailPoet\API\API|null
+	 * @return mixed
 	 */
 	protected function get_api() {
-		if ( null === $this->mailpoet_api && class_exists( '\\MailPoet\\API\\API' ) ) {
+		if ( null === $this->mailpoet_api && class_exists( '\MailPoet\API\API' ) ) {
+			// @phan-suppress-next-line PhanUndeclaredClassMethod -- dynamic plugin API
 			$this->mailpoet_api = \MailPoet\API\API::MP( 'v1' );
 		}
 		return $this->mailpoet_api;
@@ -62,8 +63,8 @@ class MailPoet_Integration {
 	/**
 	 * Get or create a MailPoet list for Jetpack Forms.
 	 *
-	 * @param \MailPoet\API\API $mailpoet_api The MailPoet API instance.
-	 * @param string|null       $list_name Optional. The name of the list to get or create. Defaults to 'Jetpack Form Subscribers'.
+	 * @param mixed       $mailpoet_api The MailPoet API instance.
+	 * @param string|null $list_name Optional. The name of the list to get or create. Defaults to 'Jetpack Form Subscribers'.
 	 * @return string|null List ID or null on failure.
 	 */
 	protected function get_or_create_list_id( $mailpoet_api, $list_name = null ) {
@@ -72,34 +73,23 @@ class MailPoet_Integration {
 		$list_name                = $list_name ? $list_name : $default_list_name;
 		$list_description         = $list_name === $default_list_name ? $default_list_description : $list_name;
 		try {
-			/**
-			 * Suppress undefined method warning for dynamic MailPoet API.
-			 *
-			 * @disregard P1013
-			 */
-			$lists = $mailpoet_api->getLists(); // @phan-suppress-current-line PhanUndeclaredClassMethod -- we check existence of class in  get_api() method
-
+			// @phan-suppress-next-line PhanUndeclaredClassMethod -- dynamic plugin API
+			$lists = $mailpoet_api->getLists();
 			// Look for an existing list with the given name (not deleted)
 			foreach ( $lists as $list ) {
 				if ( $list['name'] === $list_name && empty( $list['deleted_at'] ) ) {
 					return $list['id'];
 				}
 			}
-
-			/**
-			 * Suppress undefined method warning for dynamic MailPoet API.
-			 *
-			 * @disregard P1013
-			 */
-			$new_list = $mailpoet_api->addList( // @phan-suppress-current-line PhanUndeclaredClassMethod -- we check existence of class in  get_api() method
+			// Not found, create it
+			// @phan-suppress-next-line PhanUndeclaredClassMethod -- dynamic plugin API
+			$new_list = $mailpoet_api->addList(
 				array(
 					'name'        => $list_name,
 					'description' => $list_description,
 				)
 			);
 			return $new_list['id'];
-		} catch ( \MailPoet\API\MP\v1\APIException $e ) {
-			return null;
 		} catch ( \Exception $e ) {
 			return null;
 		}
@@ -108,25 +98,19 @@ class MailPoet_Integration {
 	/**
 	 * Add a subscriber to a MailPoet list.
 	 *
-	 * @param \MailPoet\API\API $mailpoet_api The MailPoet API instance.
-	 * @param string            $list_id The MailPoet list ID.
-	 * @param array             $subscriber_data Associative array with at least 'email', optionally 'first_name', 'last_name'.
+	 * @param mixed  $mailpoet_api The MailPoet API instance.
+	 * @param string $list_id The MailPoet list ID.
+	 * @param array  $subscriber_data Associative array with at least 'email', optionally 'first_name', 'last_name'.
 	 * @return array|null Subscriber data on success, or null on failure.
 	 */
 	protected function add_subscriber_to_list( $mailpoet_api, $list_id, $subscriber_data ) {
 		try {
-			/**
-			 * Suppress undefined method warning for dynamic MailPoet API.
-			 *
-			 * @disregard P1013
-			 */
-			$subscriber = $mailpoet_api->addSubscriber( // @phan-suppress-current-line PhanUndeclaredClassMethod -- we check existence of class in  get_api() method
+			// @phan-suppress-next-line PhanUndeclaredClassMethod -- dynamic plugin API
+			$subscriber = $mailpoet_api->addSubscriber(
 				$subscriber_data,
 				array( $list_id )
 			);
 			return $subscriber;
-		} catch ( \MailPoet\API\MP\v1\APIException $e ) {
-			return null;
 		} catch ( \Exception $e ) {
 			return null;
 		}

--- a/projects/packages/forms/src/service/class-mailpoet-integration.php
+++ b/projects/packages/forms/src/service/class-mailpoet-integration.php
@@ -14,50 +14,23 @@ namespace Automattic\Jetpack\Forms\Service;
  */
 class MailPoet_Integration {
 	/**
-	 * Singleton instance
-	 *
-	 * @var MailPoet_Integration
-	 */
-	private static $instance = null;
-
-	/**
 	 * MailPoet API instance
 	 *
 	 * @var mixed
 	 */
-	protected $mailpoet_api = null;
-
-	/**
-	 * Initialize and return singleton instance.
-	 *
-	 * @return MailPoet_Integration
-	 */
-	public static function init() {
-		if ( null === self::$instance ) {
-			self::$instance = new self();
-		}
-		return self::$instance;
-	}
-
-	/**
-	 * MailPoet_Integration class constructor.
-	 * Hooks on `grunion_after_feedback_post_inserted` action to handle MailPoet integration.
-	 */
-	private function __construct() {
-		add_action( 'grunion_after_feedback_post_inserted', array( $this, 'handle_mailpoet_integration' ), 15, 3 );
-	}
+	protected static $mailpoet_api = null;
 
 	/**
 	 * Get the MailPoet API instance (v1), instantiating if necessary.
 	 *
 	 * @return mixed
 	 */
-	protected function get_api() {
-		if ( null === $this->mailpoet_api && class_exists( '\MailPoet\API\API' ) ) {
+	protected static function get_api() {
+		if ( null === self::$mailpoet_api && class_exists( '\MailPoet\API\API' ) ) {
 			// @phan-suppress-next-line PhanUndeclaredClassMethod
-			$this->mailpoet_api = \MailPoet\API\API::MP( 'v1' );
+			self::$mailpoet_api = \MailPoet\API\API::MP( 'v1' );
 		}
-		return $this->mailpoet_api;
+		return self::$mailpoet_api;
 	}
 
 	/**
@@ -67,7 +40,7 @@ class MailPoet_Integration {
 	 * @param string|null $list_name Optional. The name of the list to get or create. Defaults to 'Jetpack Form Subscribers'.
 	 * @return string|null List ID or null on failure.
 	 */
-	protected function get_or_create_list_id( $mailpoet_api, $list_name = null ) {
+	protected static function get_or_create_list_id( $mailpoet_api, $list_name = null ) {
 		$default_list_name        = 'Jetpack Form Subscribers';
 		$default_list_description = 'Subscribers from Jetpack Forms';
 		$list_name                = $list_name ? $list_name : $default_list_name;
@@ -101,7 +74,7 @@ class MailPoet_Integration {
 	 * @param array  $subscriber_data Associative array with at least 'email', optionally 'first_name', 'last_name'.
 	 * @return array|null Subscriber data on success, or null on failure.
 	 */
-	protected function add_subscriber_to_list( $mailpoet_api, $list_id, $subscriber_data ) {
+	protected static function add_subscriber_to_list( $mailpoet_api, $list_id, $subscriber_data ) {
 		try {
 			$subscriber = $mailpoet_api->addSubscriber(
 				$subscriber_data,
@@ -119,7 +92,7 @@ class MailPoet_Integration {
 	 * @param array $fields Collection of Contact_Form_Field instances.
 	 * @return array Associative array with at least 'email', optionally 'first_name', 'last_name'. Empty array if no email found.
 	 */
-	protected function get_subscriber_data_from_fields( $fields ) {
+	protected static function get_subscriber_data_from_fields( $fields ) {
 		// Try and get the form from any of the fields
 		$form = null;
 		foreach ( $fields as $field ) {
@@ -132,7 +105,6 @@ class MailPoet_Integration {
 			return array();
 		}
 
-		// Extract email, first_name, last_name from form fields.
 		$subscriber_data = array();
 		foreach ( $form->fields as $field ) {
 			$id    = strtolower( str_replace( array( ' ', '_' ), '', $field->get_attribute( 'id' ) ) );
@@ -148,7 +120,6 @@ class MailPoet_Integration {
 			}
 		}
 
-		// Only return the subscriber data if we have an email.
 		if ( empty( $subscriber_data['email'] ) ) {
 			return array();
 		}
@@ -163,28 +134,45 @@ class MailPoet_Integration {
 	 * @param array $fields       Collection of Contact_Form_Field instances.
 	 * @param bool  $is_spam      Whether the submission is spam.
 	 */
-	public function handle_mailpoet_integration( $post_id, $fields, $is_spam ) {
+	public static function handle_mailpoet_integration( $post_id, $fields, $is_spam ) {
 		if ( $is_spam ) {
 			return;
 		}
-		$mailpoet_api = $this->get_api();
+
+		// Try and get the form from any of the fields
+		$form = null;
+		foreach ( $fields as $field ) {
+			if ( ! empty( $field->form ) ) {
+				$form = $field->form;
+				break;
+			}
+		}
+		if ( ! $form || ! is_a( $form, 'Automattic\Jetpack\Forms\ContactForm\Contact_Form' ) ) {
+			return;
+		}
+
+		if ( empty( $form->attributes['connectMailPoet'] ) ) {
+			return;
+		}
+
+		$mailpoet_api = self::get_api();
 		if ( ! $mailpoet_api ) {
 			// MailPoet is not active or not loaded.
 			return;
 		}
 
-		$list_id = $this->get_or_create_list_id( $mailpoet_api );
+		$list_id = self::get_or_create_list_id( $mailpoet_api );
 		if ( ! $list_id ) {
-			// Could not get or create the list.
+			// Could not get or create the list; bail out.
 			return;
 		}
 
-		$subscriber_data = $this->get_subscriber_data_from_fields( $fields );
+		$subscriber_data = self::get_subscriber_data_from_fields( $fields );
 		if ( empty( $subscriber_data ) ) {
-			// Could not get minimum required subscriber data (email).
+			// Email is required for MailPoet subscribers.
 			return;
 		}
 
-		$this->add_subscriber_to_list( $mailpoet_api, $list_id, $subscriber_data );
+		self::add_subscriber_to_list( $mailpoet_api, $list_id, $subscriber_data );
 	}
 }

--- a/projects/packages/forms/src/service/class-mailpoet-integration.php
+++ b/projects/packages/forms/src/service/class-mailpoet-integration.php
@@ -54,6 +54,7 @@ class MailPoet_Integration {
 	 */
 	protected function get_api() {
 		if ( null === $this->mailpoet_api && class_exists( '\MailPoet\API\API' ) ) {
+			// @phan-suppress-next-line PhanUndeclaredClassMethod
 			$this->mailpoet_api = \MailPoet\API\API::MP( 'v1' );
 		}
 		return $this->mailpoet_api;

--- a/projects/packages/forms/src/service/class-mailpoet-integration.php
+++ b/projects/packages/forms/src/service/class-mailpoet-integration.php
@@ -44,7 +44,7 @@ class MailPoet_Integration {
 	 * Hooks on `grunion_after_feedback_post_inserted` action to handle MailPoet integration.
 	 */
 	private function __construct() {
-		add_action( 'grunion_after_feedback_post_inserted', array( $this, 'handle_mailpoet_integration' ), 15, 4 );
+		add_action( 'grunion_after_feedback_post_inserted', array( $this, 'handle_mailpoet_integration' ), 15, 3 );
 	}
 
 	/**
@@ -162,9 +162,8 @@ class MailPoet_Integration {
 	 * @param int   $post_id      The post ID for the feedback CPT.
 	 * @param array $fields       Collection of Contact_Form_Field instances.
 	 * @param bool  $is_spam      Whether the submission is spam.
-	 * @param array $entry_values Extra fields from the contact form.
 	 */
-	public function handle_mailpoet_integration( $post_id, $fields, $is_spam, $entry_values ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+	public function handle_mailpoet_integration( $post_id, $fields, $is_spam ) {
 		if ( $is_spam ) {
 			return;
 		}

--- a/projects/packages/forms/src/service/class-mailpoet-integration.php
+++ b/projects/packages/forms/src/service/class-mailpoet-integration.php
@@ -1,0 +1,210 @@
+<?php
+/**
+ * MailPoet Integration for Jetpack Contact Forms.
+ *
+ * @package automattic/jetpack
+ */
+
+namespace Automattic\Jetpack\Forms\Service;
+
+/**
+ * Class MailPoet_Integration
+ *
+ * Handles integration with MailPoet for Jetpack Contact Forms.
+ */
+class MailPoet_Integration {
+	/**
+	 * Singleton instance
+	 *
+	 * @var MailPoet_Integration
+	 */
+	private static $instance = null;
+
+	/**
+	 * MailPoet API instance
+	 *
+	 * @var \MailPoet\API\API|null
+	 */
+	protected $mailpoet_api = null;
+
+	/**
+	 * Initialize and return singleton instance.
+	 *
+	 * @return MailPoet_Integration
+	 */
+	public static function init() {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * MailPoet_Integration class constructor.
+	 * Hooks on `grunion_after_feedback_post_inserted` action to handle MailPoet integration.
+	 */
+	private function __construct() {
+		add_action( 'grunion_after_feedback_post_inserted', array( $this, 'handle_mailpoet_integration' ), 15, 4 );
+	}
+
+	/**
+	 * Get the MailPoet API instance (v1), instantiating if necessary.
+	 *
+	 * @return \MailPoet\API\API|null
+	 */
+	protected function get_api() {
+		if ( null === $this->mailpoet_api && class_exists( '\\MailPoet\\API\\API' ) ) {
+			$this->mailpoet_api = \MailPoet\API\API::MP( 'v1' );
+		}
+		return $this->mailpoet_api;
+	}
+
+	/**
+	 * Get or create a MailPoet list for Jetpack Forms.
+	 *
+	 * @param \MailPoet\API\API $mailpoet_api The MailPoet API instance.
+	 * @param string|null       $list_name Optional. The name of the list to get or create. Defaults to 'Jetpack Form Subscribers'.
+	 * @return string|null List ID or null on failure.
+	 */
+	protected function get_or_create_list_id( $mailpoet_api, $list_name = null ) {
+		$default_list_name        = 'Jetpack Form Subscribers';
+		$default_list_description = 'Subscribers from Jetpack Forms';
+		$list_name                = $list_name ? $list_name : $default_list_name;
+		$list_description         = $list_name === $default_list_name ? $default_list_description : $list_name;
+		try {
+			/**
+			 * Suppress undefined method warning for dynamic MailPoet API.
+			 *
+			 * @disregard P1013
+			 */
+			$lists = $mailpoet_api->getLists(); // @phan-suppress-current-line PhanUndeclaredClassMethod -- we check existence of class in  get_api() method
+
+			// Look for an existing list with the given name (not deleted)
+			foreach ( $lists as $list ) {
+				if ( $list['name'] === $list_name && empty( $list['deleted_at'] ) ) {
+					return $list['id'];
+				}
+			}
+
+			/**
+			 * Suppress undefined method warning for dynamic MailPoet API.
+			 *
+			 * @disregard P1013
+			 */
+			$new_list = $mailpoet_api->addList( // @phan-suppress-current-line PhanUndeclaredClassMethod -- we check existence of class in  get_api() method
+				array(
+					'name'        => $list_name,
+					'description' => $list_description,
+				)
+			);
+			return $new_list['id'];
+		} catch ( \MailPoet\API\MP\v1\APIException $e ) {
+			return null;
+		} catch ( \Exception $e ) {
+			return null;
+		}
+	}
+
+	/**
+	 * Add a subscriber to a MailPoet list.
+	 *
+	 * @param \MailPoet\API\API $mailpoet_api The MailPoet API instance.
+	 * @param string            $list_id The MailPoet list ID.
+	 * @param array             $subscriber_data Associative array with at least 'email', optionally 'first_name', 'last_name'.
+	 * @return array|null Subscriber data on success, or null on failure.
+	 */
+	protected function add_subscriber_to_list( $mailpoet_api, $list_id, $subscriber_data ) {
+		try {
+			/**
+			 * Suppress undefined method warning for dynamic MailPoet API.
+			 *
+			 * @disregard P1013
+			 */
+			$subscriber = $mailpoet_api->addSubscriber( // @phan-suppress-current-line PhanUndeclaredClassMethod -- we check existence of class in  get_api() method
+				$subscriber_data,
+				array( $list_id )
+			);
+			return $subscriber;
+		} catch ( \MailPoet\API\MP\v1\APIException $e ) {
+			return null;
+		} catch ( \Exception $e ) {
+			return null;
+		}
+	}
+
+	/**
+	 * Extract subscriber data (email, first_name, last_name) from form fields.
+	 *
+	 * @param array $fields Collection of Contact_Form_Field instances.
+	 * @return array Associative array with at least 'email', optionally 'first_name', 'last_name'. Empty array if no email found.
+	 */
+	protected function get_subscriber_data_from_fields( $fields ) {
+		// Try and get the form from any of the fields
+		$form = null;
+		foreach ( $fields as $field ) {
+			if ( ! empty( $field->form ) ) {
+				$form = $field->form;
+				break;
+			}
+		}
+		if ( ! $form || ! is_a( $form, 'Automattic\Jetpack\Forms\ContactForm\Contact_Form' ) ) {
+			return array();
+		}
+
+		// Extract email, first_name, last_name from form fields.
+		$subscriber_data = array();
+		foreach ( $form->fields as $field ) {
+			$id    = strtolower( str_replace( array( ' ', '_' ), '', $field->get_attribute( 'id' ) ) );
+			$label = strtolower( str_replace( array( ' ', '_' ), '', $field->get_attribute( 'label' ) ) );
+			$value = trim( $field->value );
+
+			if ( ( $id === 'email' || $label === 'email' ) && ! empty( $value ) ) {
+				$subscriber_data['email'] = $value;
+			} elseif ( ( $id === 'firstname' || $label === 'firstname' ) && ! empty( $value ) ) {
+				$subscriber_data['first_name'] = $value;
+			} elseif ( ( $id === 'lastname' || $label === 'lastname' ) && ! empty( $value ) ) {
+				$subscriber_data['last_name'] = $value;
+			}
+		}
+
+		// Only return the subscriber data if we have an email.
+		if ( empty( $subscriber_data['email'] ) ) {
+			return array();
+		}
+
+		return $subscriber_data;
+	}
+
+	/**
+	 * Handle MailPoet integration after feedback post is inserted.
+	 *
+	 * @param int   $post_id      The post ID for the feedback CPT.
+	 * @param array $fields       Collection of Contact_Form_Field instances.
+	 * @param bool  $is_spam      Whether the submission is spam.
+	 * @param array $entry_values Extra fields from the contact form.
+	 */
+	public function handle_mailpoet_integration( $post_id, $fields, $is_spam, $entry_values ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		if ( $is_spam ) {
+			return;
+		}
+		$mailpoet_api = $this->get_api();
+		if ( ! $mailpoet_api ) {
+			// MailPoet is not active or not loaded.
+			return;
+		}
+
+		$list_id = $this->get_or_create_list_id( $mailpoet_api );
+		if ( ! $list_id ) {
+			// Could not get or create the list.
+			return;
+		}
+
+		$subscriber_data = $this->get_subscriber_data_from_fields( $fields );
+		if ( empty( $subscriber_data ) ) {
+			// Could not get minimum required subscriber data (email).
+			return;
+		}
+
+		$this->add_subscriber_to_list( $mailpoet_api, $list_id, $subscriber_data );
+	}
+}

--- a/projects/packages/forms/src/service/class-mailpoet-integration.php
+++ b/projects/packages/forms/src/service/class-mailpoet-integration.php
@@ -54,7 +54,6 @@ class MailPoet_Integration {
 	 */
 	protected function get_api() {
 		if ( null === $this->mailpoet_api && class_exists( '\MailPoet\API\API' ) ) {
-			// @phan-suppress-next-line PhanUndeclaredClassMethod -- dynamic plugin API
 			$this->mailpoet_api = \MailPoet\API\API::MP( 'v1' );
 		}
 		return $this->mailpoet_api;
@@ -73,7 +72,6 @@ class MailPoet_Integration {
 		$list_name                = $list_name ? $list_name : $default_list_name;
 		$list_description         = $list_name === $default_list_name ? $default_list_description : $list_name;
 		try {
-			// @phan-suppress-next-line PhanUndeclaredClassMethod -- dynamic plugin API
 			$lists = $mailpoet_api->getLists();
 			// Look for an existing list with the given name (not deleted)
 			foreach ( $lists as $list ) {
@@ -82,7 +80,6 @@ class MailPoet_Integration {
 				}
 			}
 			// Not found, create it
-			// @phan-suppress-next-line PhanUndeclaredClassMethod -- dynamic plugin API
 			$new_list = $mailpoet_api->addList(
 				array(
 					'name'        => $list_name,
@@ -105,7 +102,6 @@ class MailPoet_Integration {
 	 */
 	protected function add_subscriber_to_list( $mailpoet_api, $list_id, $subscriber_data ) {
 		try {
-			// @phan-suppress-next-line PhanUndeclaredClassMethod -- dynamic plugin API
 			$subscriber = $mailpoet_api->addSubscriber(
 				$subscriber_data,
 				array( $list_id )

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -2959,6 +2959,7 @@ EOT;
 				'hiddenField2' => 'value2',
 			), // Hidden fields to include in the form.
 			'stepTransition'         => 'fade-slide',
+			'connectMailPoet'        => false,
 		);
 		// Add a widget ID to the attributes for testing.
 		$expected_attributes                        = $attributes;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes [FORMS-232](https://linear.app/a8c/issue/FORMS-232/forms-enable-basic-form-level-mailpoet-integration)

## Proposed changes:

**Important:** 
* This is branched from and is the backend counterpart to [this PR](https://github.com/Automattic/jetpack/pull/44431), which adds MailPoet integration in the editor. By testing this, you can also test that PR in the editor. 
* All MailPoet integration remains behind a feature flag which is false by default. See testing instructions. 

**Changes:** 
* In class-contact-form-plugin.php, we hook onto the 'grunion_after_feedback_post_inserted' to fire MailPoet integration logic. 
   - This is wrapped in our MailPoet feature flag
* **Adds a new `MailPoet_Integration` class** to handle MailPoet logic.
   - The main callback is MailPoetIntegration::handle_mailpoet_integration(). This method runs some simple checks for spam and for the connectMailPoet form attribute, and if all is clear, fires MailPoet integration methods, including
   - Instantiating the MailPoet API
   - Creating a `Jetpack Form Subscribers` list if one does not already exist. The method for this allow allows us to pass in a field name. In a future PR, we should fetch all lists and allow users to select one or add a new list in the block editor in the MailPoet card. I'd like to handle that separately. 
   - Extracting subscriber data from the form. Email is the only required field for MailPoet, but we also check for first name and last name. For all fields, we try to find them using both field IDs and field Labels. 
   - Finally, adding the contact to the MailPoet list.
   
**Follow ups (not yet done):** 
* We'll want to tie this into the Consent checkbox field, or create a new one for MailPoet. We'll want to check for consent before adding users to the list, depending on conditions. 
* We'll want to fetch all MailPoet lists, and show them in the MailPoet card in the modal. Users will be able to select one, or add a new list. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
See the linear issue and project above.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
Yes.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add a form to a page. Be sure to include at least an "Email" field. You can also try adding "First Name" and "Last Name". Other fields will not be added to MailPoet. 
* If needed, install and activate MailPoet from the modal, and get and add a MailPoet key. To get a key, you can create a free account at https://account.mailpoet.com
* When everything active and connected, you'll be able to enable the toggle on the card header, which means your form is now connected to MailPoet. You'll see the MailPoet icon on the sidebar. 
* Go to the frontend and submit your form. 
* Go to MailPoet -> Lists and confirm the "Jetpack Form Subscribers" list is added. 
* Go to MailPoet -> Subscribers and confirm a contact has been added using the email you added to the form. 
* Disable MailPoet connection in the modal, resave, resubmit the form, and confirm that the email/contact is not added to MailPoet. 

