### PR TITLE
Forms: Allow extenders register actions and fields for the 'feedback' post type

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2551,6 +2551,9 @@ importers:
       '@wordpress/primitives':
         specifier: 4.28.0
         version: 4.28.0(react@18.3.1)
+      '@wordpress/private-apis':
+        specifier: 1.29.0
+        version: 1.29.0
       '@wordpress/url':
         specifier: 4.28.0
         version: 4.28.0
@@ -9751,6 +9754,10 @@ packages:
 
   '@wordpress/private-apis@1.28.0':
     resolution: {integrity: sha512-NOO2bcbzzR07K7T6nqi5/VJaqkv9KgxLgkWvElKRHaekUNVyePFNXLPf0iO01vqltJHljxN9nk//edmsFTmFuQ==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
+  '@wordpress/private-apis@1.29.0':
+    resolution: {integrity: sha512-bumBqC/Fgkdu9luooBdymjXjNAd1MyoGkjxCQOVh7HSNRui77+nHaBEwTUwNeg6IgGlojGErZWlQni6BHHrbuQ==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/react-i18n@4.28.0':
@@ -21795,7 +21802,7 @@ snapshots:
       '@wordpress/i18n': 6.1.0
       '@wordpress/icons': 10.28.0(react@18.3.1)
       '@wordpress/keyboard-shortcuts': 5.28.0(react@18.3.1)
-      '@wordpress/private-apis': 1.28.0
+      '@wordpress/private-apis': 1.29.0
       clsx: 2.1.1
       cmdk: 1.1.1(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
@@ -21815,7 +21822,7 @@ snapshots:
       '@wordpress/i18n': 6.1.0
       '@wordpress/icons': 10.28.0(react@18.3.1)
       '@wordpress/keyboard-shortcuts': 5.28.0(react@18.3.1)
-      '@wordpress/private-apis': 1.28.0
+      '@wordpress/private-apis': 1.29.0
       clsx: 2.1.1
       cmdk: 1.1.1(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
@@ -21835,7 +21842,7 @@ snapshots:
       '@wordpress/i18n': 6.1.0
       '@wordpress/icons': 10.28.0(react@18.3.1)
       '@wordpress/keyboard-shortcuts': 5.28.0(react@18.3.1)
-      '@wordpress/private-apis': 1.28.0
+      '@wordpress/private-apis': 1.29.0
       clsx: 2.1.1
       cmdk: 1.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
@@ -22003,7 +22010,7 @@ snapshots:
       '@wordpress/i18n': 6.1.0
       '@wordpress/icons': 10.28.0(react@18.3.1)
       '@wordpress/notices': 5.28.0(react@18.3.1)
-      '@wordpress/private-apis': 1.28.0
+      '@wordpress/private-apis': 1.29.0
       '@wordpress/router': 1.28.0(react@18.3.1)
       '@wordpress/url': 4.28.0
       react: 18.3.1
@@ -22029,7 +22036,7 @@ snapshots:
       '@wordpress/i18n': 6.1.0
       '@wordpress/icons': 10.28.0(react@18.3.1)
       '@wordpress/notices': 5.28.0(react@18.3.1)
-      '@wordpress/private-apis': 1.28.0
+      '@wordpress/private-apis': 1.29.0
       '@wordpress/router': 1.28.0(react@18.3.1)
       '@wordpress/url': 4.28.0
       react: 18.3.1
@@ -22055,7 +22062,7 @@ snapshots:
       '@wordpress/i18n': 6.1.0
       '@wordpress/icons': 10.28.0(react@18.3.1)
       '@wordpress/notices': 5.28.0(react@18.3.1)
-      '@wordpress/private-apis': 1.28.0
+      '@wordpress/private-apis': 1.29.0
       '@wordpress/router': 1.28.0(react@18.3.1)
       '@wordpress/url': 4.28.0
       react: 18.3.1
@@ -22256,7 +22263,7 @@ snapshots:
       '@wordpress/icons': 10.28.0(react@18.3.1)
       '@wordpress/keycodes': 4.28.0
       '@wordpress/primitives': 4.28.0(react@18.3.1)
-      '@wordpress/private-apis': 1.28.0
+      '@wordpress/private-apis': 1.29.0
       '@wordpress/url': 4.28.0
       '@wordpress/warning': 3.28.0
       clsx: 2.1.1
@@ -22303,7 +22310,7 @@ snapshots:
       '@wordpress/icons': 10.28.0(react@18.3.1)
       '@wordpress/keycodes': 4.28.0
       '@wordpress/primitives': 4.28.0(react@18.3.1)
-      '@wordpress/private-apis': 1.28.0
+      '@wordpress/private-apis': 1.29.0
       '@wordpress/url': 4.28.0
       '@wordpress/warning': 3.28.0
       clsx: 2.1.1
@@ -22749,7 +22756,7 @@ snapshots:
       '@wordpress/notices': 5.28.0(react@18.3.1)
       '@wordpress/patterns': 2.28.0(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/primitives': 4.28.0(react@18.3.1)
-      '@wordpress/private-apis': 1.28.0
+      '@wordpress/private-apis': 1.29.0
       '@wordpress/router': 1.28.0(react@18.3.1)
       '@wordpress/url': 4.28.0
       '@wordpress/warning': 3.28.0
@@ -22789,7 +22796,7 @@ snapshots:
       '@wordpress/notices': 5.28.0(react@18.3.1)
       '@wordpress/patterns': 2.28.0(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/primitives': 4.28.0(react@18.3.1)
-      '@wordpress/private-apis': 1.28.0
+      '@wordpress/private-apis': 1.29.0
       '@wordpress/router': 1.28.0(react@18.3.1)
       '@wordpress/url': 4.28.0
       '@wordpress/warning': 3.28.0
@@ -22829,7 +22836,7 @@ snapshots:
       '@wordpress/notices': 5.28.0(react@18.3.1)
       '@wordpress/patterns': 2.28.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/primitives': 4.28.0(react@18.3.1)
-      '@wordpress/private-apis': 1.28.0
+      '@wordpress/private-apis': 1.29.0
       '@wordpress/router': 1.28.0(react@18.3.1)
       '@wordpress/url': 4.28.0
       '@wordpress/warning': 3.28.0
@@ -23012,7 +23019,7 @@ snapshots:
       '@wordpress/i18n': 6.1.0
       '@wordpress/icons': 10.28.0(react@18.3.1)
       '@wordpress/notices': 5.28.0(react@18.3.1)
-      '@wordpress/private-apis': 1.28.0
+      '@wordpress/private-apis': 1.29.0
       '@wordpress/url': 4.28.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -23039,7 +23046,7 @@ snapshots:
       '@wordpress/i18n': 6.1.0
       '@wordpress/icons': 10.28.0(react@18.3.1)
       '@wordpress/notices': 5.28.0(react@18.3.1)
-      '@wordpress/private-apis': 1.28.0
+      '@wordpress/private-apis': 1.29.0
       '@wordpress/url': 4.28.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -23066,7 +23073,7 @@ snapshots:
       '@wordpress/i18n': 6.1.0
       '@wordpress/icons': 10.28.0(react@18.3.1)
       '@wordpress/notices': 5.28.0(react@18.3.1)
-      '@wordpress/private-apis': 1.28.0
+      '@wordpress/private-apis': 1.29.0
       '@wordpress/url': 4.28.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -23131,7 +23138,7 @@ snapshots:
       '@wordpress/element': 6.28.0
       '@wordpress/i18n': 6.1.0
       '@wordpress/icons': 10.28.0(react@18.3.1)
-      '@wordpress/private-apis': 1.28.0
+      '@wordpress/private-apis': 1.29.0
       clsx: 2.1.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -23151,7 +23158,7 @@ snapshots:
       '@wordpress/element': 6.28.0
       '@wordpress/i18n': 6.1.0
       '@wordpress/icons': 10.28.0(react@18.3.1)
-      '@wordpress/private-apis': 1.28.0
+      '@wordpress/private-apis': 1.29.0
       clsx: 2.1.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -23177,6 +23184,10 @@ snapshots:
       requestidlecallback: 0.3.0
 
   '@wordpress/private-apis@1.28.0':
+    dependencies:
+      '@babel/runtime': 7.27.6
+
+  '@wordpress/private-apis@1.29.0':
     dependencies:
       '@babel/runtime': 7.27.6
 
@@ -23207,7 +23218,7 @@ snapshots:
       '@wordpress/i18n': 6.1.0
       '@wordpress/icons': 10.28.0(react@18.3.1)
       '@wordpress/notices': 5.28.0(react@18.3.1)
-      '@wordpress/private-apis': 1.28.0
+      '@wordpress/private-apis': 1.29.0
       '@wordpress/url': 4.28.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -23231,7 +23242,7 @@ snapshots:
       '@wordpress/i18n': 6.1.0
       '@wordpress/icons': 10.28.0(react@18.3.1)
       '@wordpress/notices': 5.28.0(react@18.3.1)
-      '@wordpress/private-apis': 1.28.0
+      '@wordpress/private-apis': 1.29.0
       '@wordpress/url': 4.28.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -23255,7 +23266,7 @@ snapshots:
       '@wordpress/i18n': 6.1.0
       '@wordpress/icons': 10.28.0(react@18.3.1)
       '@wordpress/notices': 5.28.0(react@18.3.1)
-      '@wordpress/private-apis': 1.28.0
+      '@wordpress/private-apis': 1.29.0
       '@wordpress/url': 4.28.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -23287,7 +23298,7 @@ snapshots:
       '@babel/runtime': 7.27.6
       '@wordpress/compose': 7.28.0(react@18.3.1)
       '@wordpress/element': 6.28.0
-      '@wordpress/private-apis': 1.28.0
+      '@wordpress/private-apis': 1.29.0
       '@wordpress/url': 4.28.0
       history: 5.3.0
       react: 18.3.1
@@ -23387,7 +23398,7 @@ snapshots:
       '@wordpress/element': 6.28.0
       '@wordpress/i18n': 6.1.0
       '@wordpress/preferences': 4.28.0(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/private-apis': 1.28.0
+      '@wordpress/private-apis': 1.29.0
       '@wordpress/url': 4.28.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -23407,7 +23418,7 @@ snapshots:
       '@wordpress/element': 6.28.0
       '@wordpress/i18n': 6.1.0
       '@wordpress/preferences': 4.28.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/private-apis': 1.28.0
+      '@wordpress/private-apis': 1.29.0
       '@wordpress/url': 4.28.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)

--- a/projects/packages/forms/changelog/update-forms-allow-extend-inbox-actions
+++ b/projects/packages/forms/changelog/update-forms-allow-extend-inbox-actions
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: Allow extenders register actions and fields for the 'feedback' post type.

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -59,6 +59,7 @@
 		"@wordpress/interactivity": "6.28.0",
 		"@wordpress/notices": "5.28.0",
 		"@wordpress/primitives": "4.28.0",
+		"@wordpress/private-apis": "1.29.0",
 		"@wordpress/url": "4.28.0",
 		"clsx": "2.1.1",
 		"copy-webpack-plugin": "13.0.0",

--- a/projects/packages/forms/src/dashboard/hooks/get-unlock.js
+++ b/projects/packages/forms/src/dashboard/hooks/get-unlock.js
@@ -1,0 +1,14 @@
+import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
+
+export const getUnlock = () => {
+	try {
+		// See https://github.com/WordPress/gutenberg/issues/66197
+		const { unlock } = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
+			'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
+			'@wordpress/edit-site'
+		);
+		return unlock;
+	} catch {
+		return undefined;
+	}
+};

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
@@ -8,8 +8,10 @@ import {
 	__experimentalHStack as HStack,
 } from '@wordpress/components';
 import { useResizeObserver } from '@wordpress/compose';
+import { useSelect } from '@wordpress/data';
 import { DataViews } from '@wordpress/dataviews/wp';
 import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
+import { store as editorStore } from '@wordpress/editor';
 import { useCallback, useMemo, useState } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __ } from '@wordpress/i18n';
@@ -66,6 +68,20 @@ export default function InboxView() {
 	const [ searchParams, setSearchParams ] = useSearchParams();
 	const [ containerWidth, setContainerWidth ] = useState( 0 );
 	const [ queryArgs, setQueryArgs ] = useState( EMPTY_OBJECT );
+
+	// Allow extenders register actions and fields for the 'feedback' post type.
+	// Users can use `registerEntityAction` and `registerEntityField` to register them.
+	// https://github.com/WordPress/gutenberg/blob/trunk/packages/editor/README.md#registerentityaction
+	// https://github.com/WordPress/gutenberg/blob/trunk/packages/editor/README.md#registerentityfield
+	const { feedbackEntityActions, feedbackEntityFields } = useSelect( select => {
+		const { getEntityActions, getEntityFields } = select( editorStore );
+		return {
+			feedbackEntityActions:
+				typeof getEntityActions === 'function' ? getEntityActions( 'postType', 'feedback' ) : [],
+			feedbackEntityFields:
+				typeof getEntityFields === 'function' ? getEntityFields( 'postType', 'feedback' ) : [],
+		};
+	} );
 
 	const dateSettings = getDateSettings();
 	const containerRef = useResizeObserver(
@@ -249,8 +265,9 @@ export default function InboxView() {
 				enableSorting: false,
 			},
 			{ id: 'ip', label: __( 'IP Address', 'jetpack-forms' ), enableSorting: false },
+			...feedbackEntityFields,
 		],
-		[ filterOptions, dateSettings.formats.date ]
+		[ filterOptions, dateSettings.formats.date, feedbackEntityFields ]
 	);
 
 	const actions = useMemo( () => {
@@ -260,6 +277,7 @@ export default function InboxView() {
 			moveToTrashAction,
 			restoreAction,
 			deleteAction,
+			...feedbackEntityActions,
 		];
 		if ( isMobile ) {
 			_actions.unshift( viewActionModal );
@@ -275,7 +293,7 @@ export default function InboxView() {
 			} );
 		}
 		return _actions;
-	}, [ isMobile, onChangeSelection, selection ] );
+	}, [ isMobile, onChangeSelection, selection, feedbackEntityActions ] );
 
 	return (
 		<HStack

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
@@ -15,17 +15,13 @@ import { store as editorStore } from '@wordpress/editor';
 import { useCallback, useMemo, useState, useEffect } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __ } from '@wordpress/i18n';
-import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
 import { isEmpty } from 'lodash';
 import { useSearchParams } from 'react-router';
-export const { unlock } = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
-	'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
-	'@wordpress/editor'
-);
 /**
  * Internal dependencies
  */
 import InboxStatusToggle from '../../components/inbox-status-toggle';
+import { getUnlock } from '../../hooks/get-unlock';
 import useInboxData from '../../hooks/use-inbox-data';
 import InboxResponse from '../response';
 import { getPath } from '../utils.js';
@@ -78,7 +74,16 @@ export default function InboxView() {
 	// Users can use `registerEntityAction` and `registerEntityField` to register them.
 	// https://github.com/WordPress/gutenberg/blob/trunk/packages/editor/README.md#registerentityaction
 	// https://github.com/WordPress/gutenberg/blob/trunk/packages/editor/README.md#registerentityfield
+	const unlock = getUnlock();
 	const { feedbackEntityActions, feedbackEntityFields } = useSelect( select => {
+		// Bail out, we couldn't unlock private APIs
+		if ( ! unlock ) {
+			return {
+				feedbackEntityActions: [],
+				feedbackEntityFields: [],
+			};
+		}
+
 		const { getEntityActions, getEntityFields } = unlock( select( editorStore ) );
 		return {
 			feedbackEntityActions:

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
@@ -12,12 +12,16 @@ import { useSelect } from '@wordpress/data';
 import { DataViews } from '@wordpress/dataviews/wp';
 import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
 import { store as editorStore } from '@wordpress/editor';
-import { useCallback, useMemo, useState } from '@wordpress/element';
+import { useCallback, useMemo, useState, useEffect } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __ } from '@wordpress/i18n';
+import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
 import { isEmpty } from 'lodash';
-import { useEffect } from 'react';
 import { useSearchParams } from 'react-router';
+export const { unlock } = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
+	'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
+	'@wordpress/editor'
+);
 /**
  * Internal dependencies
  */
@@ -70,14 +74,15 @@ export default function InboxView() {
 	const [ queryArgs, setQueryArgs ] = useState( EMPTY_OBJECT );
 
 	// Allow extenders register actions and fields for the 'feedback' post type.
+	// Note: this is experimental and as of 07/2025 only available with Gutenberg plugin.
 	// Users can use `registerEntityAction` and `registerEntityField` to register them.
 	// https://github.com/WordPress/gutenberg/blob/trunk/packages/editor/README.md#registerentityaction
 	// https://github.com/WordPress/gutenberg/blob/trunk/packages/editor/README.md#registerentityfield
 	const { feedbackEntityActions, feedbackEntityFields } = useSelect( select => {
-		const { getEntityActions, getEntityFields } = select( editorStore );
+		const { getEntityActions, getEntityFields } = unlock( select( editorStore ) );
 		return {
 			feedbackEntityActions:
-				typeof getEntityActions === 'function' ? getEntityActions( 'postType', 'feedback' ) : [],
+				typeof getEntityFields === 'function' ? getEntityActions( 'postType', 'feedback' ) : [],
 			feedbackEntityFields:
 				typeof getEntityFields === 'function' ? getEntityFields( 'postType', 'feedback' ) : [],
 		};

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
@@ -74,22 +74,16 @@ export default function InboxView() {
 	// Users can use `registerEntityAction` and `registerEntityField` to register them.
 	// https://github.com/WordPress/gutenberg/blob/trunk/packages/editor/README.md#registerentityaction
 	// https://github.com/WordPress/gutenberg/blob/trunk/packages/editor/README.md#registerentityfield
-	const unlock = getUnlock();
 	const { feedbackEntityActions, feedbackEntityFields } = useSelect( select => {
-		// Bail out, we couldn't unlock private APIs
-		if ( ! unlock ) {
-			return {
-				feedbackEntityActions: [],
-				feedbackEntityFields: [],
-			};
+		const unlock = getUnlock();
+		const { getEntityActions, getEntityFields } = unlock ? unlock( select( editorStore ) ) : {};
+		if ( typeof getEntityFields !== 'function' && typeof getEntityFields !== 'function' ) {
+			return { feedbackEntityActions: [], feedbackEntityFields: [] };
 		}
 
-		const { getEntityActions, getEntityFields } = unlock( select( editorStore ) );
 		return {
-			feedbackEntityActions:
-				typeof getEntityFields === 'function' ? getEntityActions( 'postType', 'feedback' ) : [],
-			feedbackEntityFields:
-				typeof getEntityFields === 'function' ? getEntityFields( 'postType', 'feedback' ) : [],
+			feedbackEntityActions: getEntityActions( 'postType', 'feedback' ),
+			feedbackEntityFields: getEntityFields( 'postType', 'feedback' ),
 		};
 	} );
 

--- a/projects/plugins/jetpack/changelog/update-forms-allow-extend-inbox-actions
+++ b/projects/plugins/jetpack/changelog/update-forms-allow-extend-inbox-actions
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: Allow extenders register actions and fields for the 'feedback' post type.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->



## Proposed changes:
<!--- Explain what functional changes your PR includes -->

Allow extenders register actions and fields for the 'feedback' post type, and expose them at the Forms inbox.

This is experimental and as of 07/2025 only available with Gutenberg plugin active!

Users can use [`registerEntityAction`](https://github.com/WordPress/gutenberg/blob/trunk/packages/editor/README.md#registerentityaction) and [`registerEntityField`](https://github.com/WordPress/gutenberg/blob/trunk/packages/editor/README.md#registerentityfield) like so:

```js
import { Icon, wordpress } from "@wordpress/icons";
import { store as noticesStore } from "@wordpress/notices";
import {
	registerEntityAction,
	registerEntityField,
} from "@wordpress/editor";
import { useEffect } from "@wordpress/element";

useEffect(() => {
	registerEntityAction("postType", "feedback", {
		id: "my-action",
		icon: <Icon icon={wordpress} />,
		isPrimary: true,
		label: "My action",
		callback: (item, { registry }) => {
			console.log("Actioned item:", item);
			const { createSuccessNotice } = registry.dispatch(noticesStore);
			createSuccessNotice("My action success!", {
				type: "snackbar",
				id: "my-action-notice",
			});
		},
	});

	registerEntityField("postType", "feedback", {
		id: "my-field-file",
		label: "File",
		render: ({ item }) => {
			console.log("Field item:", item);
			return item.has_file ? "yes" : "—";
		},
		enableSorting: false,
		enableHiding: true,
	});
}, [registerEntityAction, registerEntityField]);
```

Easiest way for you to try to is add above to same file at `projects/packages/forms/src/dashboard/inbox/dataviews/index.js`

Outcome should be new field which you can enable via the cog, and new single row primary action:

<img width="1358" height="400" alt="Screenshot 2025-07-24 at 17 34 15" src="https://github.com/user-attachments/assets/36d49aed-d2ab-40d8-9814-ca1fd6f5dc3f" />



### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add above code somewhere
* Enable Gutenberg plugin
* See field and action in the forms inbox
* With Gutenberg plugin disabled, things continue to work as we fallback to just `[]` for the arrays when functions are missing