### PR TITLE
Forms: Preserve multistep variation in AI assistant

### DIFF
--- a/projects/plugins/jetpack/changelog/update-forms-jetpack-ai-handle-multistep
+++ b/projects/plugins/jetpack/changelog/update-forms-jetpack-ai-handle-multistep
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Forms: Enable Jetpack AI to generate multistep forms.

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/text-blocks/jetpack-form/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/text-blocks/jetpack-form/index.tsx
@@ -17,6 +17,7 @@ import type { BlockEditorDispatch } from '../types';
 
 export class JetpackFormHandler extends BlockHandler {
 	currentListOfValidBlocks = [];
+	originalVariationName: string | null = null;
 
 	constructor( clientId: string ) {
 		super( clientId, [] );
@@ -30,7 +31,17 @@ export class JetpackFormHandler extends BlockHandler {
 	}
 
 	private setContent( newContent: string, isRequestDone = false ): void {
-		const { replaceInnerBlocks } = dispatch( 'core/block-editor' ) as BlockEditorDispatch;
+		const { replaceInnerBlocks, updateBlockAttributes } = dispatch(
+			'core/block-editor'
+		) as BlockEditorDispatch;
+
+		// Extract variation name from the original content if present
+		const variationMatch = newContent.match(
+			/<!-- wp:jetpack\/contact-form ({[^}]*"variationName":"([^"]+)"[^}]*}) -->/
+		);
+		if ( variationMatch && variationMatch[ 2 ] ) {
+			this.originalVariationName = variationMatch[ 2 ];
+		}
 
 		// Remove the Jetpack Form block from the content.
 		const processedContent = newContent.replace(
@@ -81,13 +92,28 @@ export class JetpackFormHandler extends BlockHandler {
 
 		// Final form adjustments (only when the request is done)
 		if ( isRequestDone ) {
+			// Restore the variation name if it was present in the original content
+			if ( this.originalVariationName ) {
+				const currentBlock = this.getBlock();
+				if (
+					currentBlock &&
+					currentBlock.attributes.variationName !== this.originalVariationName
+				) {
+					updateBlockAttributes( this.clientId, { variationName: this.originalVariationName } );
+				}
+			}
+
 			/*
 			 * Inspect generated blocks list,
 			 * checking if the jetpack/button block:
 			 * - if it exists twice or more, remove the first one.
-			 * - if it does not exist, create one.
+			 * - if it does not exist, create one (unless there's a navigation block).
 			 */
 			const allButtonBlocks = validBlocks.filter( block => block.name === 'jetpack/button' );
+			const hasNavigationBlock = validBlocks.some(
+				block => block.name === 'jetpack/form-step-navigation'
+			);
+
 			this.currentListOfValidBlocks = this.currentListOfValidBlocks || [];
 			if ( allButtonBlocks.length > 1 ) {
 				// Remove all button blocks, less the last one.
@@ -105,8 +131,8 @@ export class JetpackFormHandler extends BlockHandler {
 				} );
 
 				replaceInnerBlocks( this.clientId, this.currentListOfValidBlocks );
-			} else if ( allButtonBlocks.length === 0 ) {
-				// One button block is required.
+			} else if ( allButtonBlocks.length === 0 && ! hasNavigationBlock ) {
+				// One button block is required for non-multistep forms.
 				replaceInnerBlocks( this.clientId, [
 					...this.currentListOfValidBlocks,
 					createBlock( 'jetpack/button', {

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/text-blocks/jetpack-form/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/text-blocks/jetpack-form/index.tsx
@@ -35,12 +35,13 @@ export class JetpackFormHandler extends BlockHandler {
 			'core/block-editor'
 		) as BlockEditorDispatch;
 
-		// Extract variation name from the original content if present
-		const variationMatch = newContent.match(
-			/<!-- wp:jetpack\/contact-form ({[^}]*"variationName":"([^"]+)"[^}]*}) -->/
-		);
-		if ( variationMatch && variationMatch[ 2 ] ) {
-			this.originalVariationName = variationMatch[ 2 ];
+		// Parse the content first to extract variation name properly
+		const parsedBlocks = parse( newContent );
+
+		// Extract variation name from the parsed contact-form block if present
+		const contactFormBlock = parsedBlocks.find( block => block.name === 'jetpack/contact-form' );
+		if ( contactFormBlock && contactFormBlock.attributes?.variationName ) {
+			this.originalVariationName = contactFormBlock.attributes.variationName;
 		}
 
 		// Remove the Jetpack Form block from the content.


### PR DESCRIPTION
Fixes #

Needs: 188689-ghe-Automattic/wpcom

## Proposed changes:
* Preserve `variationName` attribute (like "multistep") when AI assistant processes Jetpack forms
* Skip adding submit button when form has navigation block to support multistep forms properly

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?
No, this PR only modifies how the AI assistant preserves existing form attributes.

## Testing instructions:

* Use the AI assistant to create Multistep forms