### PR TITLE
Full sync adjust chunk size if the full sync is stuck

### DIFF
--- a/projects/packages/sync/changelog/update-full-sync-adjust-chunk-size-if-stuck
+++ b/projects/packages/sync/changelog/update-full-sync-adjust-chunk-size-if-stuck
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Full Sync: Adjust chunk size in case full sync gets stuck.

--- a/projects/packages/sync/src/modules/class-module.php
+++ b/projects/packages/sync/src/modules/class-module.php
@@ -478,7 +478,7 @@ abstract class Module {
 		// We will adjust if it is stuck after 10 minutes.
 		if (
 			$is_stuck &&
-			( time() - $stuck_data['timestamp'] ) >= 1 * MINUTE_IN_SECONDS
+			( time() - $stuck_data['timestamp'] ) >= 10 * MINUTE_IN_SECONDS
 		) {
 			$stuck_count         = ++$stuck_data['stuck_count'];
 			$adjusted_chunk_size = max( 1, (int) ( $default_chunk_size / ( 2 ** $stuck_count ) ) ); // Halve the chunk size for each stuck iteration.

--- a/projects/packages/sync/src/modules/class-module.php
+++ b/projects/packages/sync/src/modules/class-module.php
@@ -411,12 +411,13 @@ abstract class Module {
 			$status['last_sent'] = $this->get_initial_last_sent();
 		}
 
-		$limits = Settings::get_setting( 'full_sync_limits' )[ $this->name() ] ??
+		$limits               = Settings::get_setting( 'full_sync_limits' )[ $this->name() ] ??
 			Defaults::get_default_setting( 'full_sync_limits' )[ $this->name() ] ??
 			array(
 				'max_chunks' => 10,
 				'chunk_size' => 100,
 			);
+		$limits['chunk_size'] = $this->adjust_chunk_size_if_stuck( $status['last_sent'], $limits['chunk_size'] );
 
 		$chunks_sent = 0;
 
@@ -455,6 +456,58 @@ abstract class Module {
 		}
 
 		return $status;
+	}
+
+	/**
+	 * Adjust chunk size using adaptive logic and update transient for tracking stuck state.
+	 *
+	 * @param string $last_sent The current last_sent marker.
+	 * @param int    $default_chunk_size The default chunk size.
+	 * @return int Adjusted chunk size.
+	 */
+	private function adjust_chunk_size_if_stuck( $last_sent, $default_chunk_size ) {
+		$transient_key       = 'jetpack_sync_last_sent_' . $this->name();
+		$stuck_data          = get_transient( $transient_key );
+		$stuck_count         = 0;
+		$adjusted_chunk_size = $default_chunk_size;
+		$is_stuck            = isset( $stuck_data['last_sent'] ) && $stuck_data['last_sent'] === $last_sent;
+		if ( $is_stuck && $stuck_data['adjusted_chunk_size'] === 1 ) {
+			return 1; // If we are already at the minimum chunk size, do not adjust further.
+		}
+
+		// We will adjust if it is stuck after 10 minutes.
+		if (
+			$is_stuck &&
+			( time() - $stuck_data['timestamp'] ) >= 1 * MINUTE_IN_SECONDS
+		) {
+			$stuck_count         = ++$stuck_data['stuck_count'];
+			$adjusted_chunk_size = max( 1, (int) ( $default_chunk_size / ( 2 ** $stuck_count ) ) ); // Halve the chunk size for each stuck iteration.
+			// If we are stuck, we will send an action to notify about the adjustment.
+			$this->send_action(
+				'jetpack_full_sync_stuck_adjustment',
+				array(
+					'module'              => $this->name(),
+					'last_sent'           => $last_sent,
+					'stuck_count'         => $stuck_count,
+					'adjusted_chunk_size' => $adjusted_chunk_size,
+				)
+			);
+		}
+
+		// Set or update the transient with the new last_sent, timestamp, and stuck_count.
+		// If we are not stuck, reset the timestamp and stuck_count.
+		set_transient(
+			$transient_key,
+			array(
+				'last_sent'           => $last_sent,
+				'timestamp'           => $is_stuck ? $stuck_data['timestamp'] : time(),
+				'stuck_count'         => $stuck_count,
+				'adjusted_chunk_size' => $adjusted_chunk_size,
+			),
+			HOUR_IN_SECONDS
+		);
+
+		return $adjusted_chunk_size;
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes [VULCAN-256](https://linear.app/a8c/issue/VULCAN-256/investigate-oom-during-full-sync-rollout-to-500-posts-in-the-package)

There have been efforts in the past to reduce the OOMs (mostly in WPCOM end) when doing Full Syncs.
https://github.com/Automattic/jetpack/pull/34390
https://github.com/Automattic/jetpack/pull/41350
https://github.com/Automattic/jetpack/pull/41433

After the above, we are trying to be more aggressive in terms of the Chunk size limits ( The idea is to move to a default of 500 posts ). But there are a small number of remote sites that struggle when querying the information (even with lower limits) and OOM on the remote site end. Since Full Sync runs are not very frequent and it is happening for a few sites, this PR tries to mitigate the issues by adjusting the chunk_size for Full Syncs by reducing it if a stuck Full Sync is found.
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Use a transient to adjust chunk sizes in full sync in case we detect the module is stuck.
* An action will be sent to wpcom to monitor such cases.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Needs 188757-ghe-Automattic/wpcom
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
#### Check BAU works as expected
The first thing would be to run a Full Sync for a Jetpack site and see that things work as expected.
No `jetpack_full_sync_stuck_adjustment` actions should be sent to wpcom. 

#### Testing the stuck adjustment
After that and since this is for sites that have their full sync stuck. We will need to tweak a bit the test site for doing so.
- The first thing I'd recommend is to lower the 10 minute to consider the full sync is stuck to something like 30 seconds. 
Then there are two options.
##### Option 1 Don't update last sent status after sending.
- Comment Line 451 `$status = $this->set_send_full_sync_actions_status( $status, $objects );` 
- This will send the actions, but since `last_sent` won't be updated we will keep sending the same action again and again.
- Run a Full Sync for everything for a test site.
- You will see that Full Sync doesn't advance and `jetpack_full_sync_stuck_adjustment` actions will be sent to wpcom in the jetpack-audit-* index.
- Uncomment the line and full sync will start working.
##### Option 2 Simulate an OOM by dying before sending anything
- We need a site with several hundred posts to Sync.
- Before the while loop in `send_full_sync_actions` add the following
```
if ( $this->name() === 'posts' && $limits['chunk_size'] > 70 ) {
	wp_die();
}
```
- Unless you want to wait for three minutes for every action to happen you will need to lower `LOCK_TRANSIENT_EXPIRY` to something like 10 seconds. Since we are dying before sending, the lock stays.
- Run a Full Sync for everything for a test site.
- You will see that Full Sync doesn't advance initially and `jetpack_full_sync_stuck_adjustment` actions will be sent to wpcom in the jetpack-audit-* index.
- When the adjustment reaches a size lower than 70  a `jetpack_full_sync_post` action will be sent with that many items.