### PR TITLE
Autoloader: remove unneeded dev files from production package

### DIFF
--- a/projects/packages/autoloader/.gitattributes
+++ b/projects/packages/autoloader/.gitattributes
@@ -3,5 +3,9 @@
 .github/         export-ignore
 
 # Files not needed in the production build.
-/changelog/**    production-exclude
-/tests/**        production-exclude
+/changelog/**                   production-exclude
+/tests/**                       production-exclude
+.gitignore                      production-exclude
+.phpcs.dir.phpcompatibility.xml production-exclude
+.phpcs.dir.xml                  production-exclude
+

--- a/projects/packages/autoloader/changelog/update-autoloader-exclude-stable
+++ b/projects/packages/autoloader/changelog/update-autoloader-exclude-stable
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Production release: remove development files from production version of the package.


### PR DESCRIPTION
## Proposed changes:

This PR ensures that some of the development files currently shipping with the stable version of `automattic/jetpack-autoloader` are not included in the final release.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

Not much to test here ; just make sure the files I've added to the config are indeed not needed in the stable version of the package.
