### PR TITLE
Slideshow block: Ensure image shows in editor when there is only one slide

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-slideshow-regression_in_editor_with_single_slide
+++ b/projects/plugins/jetpack/changelog/fix-slideshow-regression_in_editor_with_single_slide
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Slideshow block: Ensure image shows in editor when only one image is present.

--- a/projects/plugins/jetpack/extensions/blocks/slideshow/swiper-callbacks.js
+++ b/projects/plugins/jetpack/extensions/blocks/slideshow/swiper-callbacks.js
@@ -41,7 +41,9 @@ function swiperResize( swiper ) {
 	if ( ! swiper || ! swiper.el ) {
 		return;
 	}
-	const img = swiper.el.querySelector( '.swiper-slide[data-swiper-slide-index="0"] img' );
+	const img = swiper.params.loop
+		? swiper.el.querySelector( '.swiper-slide[data-swiper-slide-index="0"] img' )
+		: swiper.el.querySelector( '.swiper-slide img' );
 	if ( ! img ) {
 		return;
 	}


### PR DESCRIPTION
Closes MONOREP-37

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes VULCAN-270 - Ensure image shows in editor when there is only one slide

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
In #44099 the Swiper dependency changed, requiring the loop param to be set dynamically to prevent JS warnings.

Unfortunately, that resulted in a different regression. Slideshows are set to `0` opacity until we give the Swiper div a `.wp-swiper-initialized` class during the init processes. When looping is set to `false` (a requirement when there are less than 2 slides), the data attribute is no longer set on the slide:

https://github.com/nolimits4web/swiper/discussions/5072

This means the selector we used doesn't find the image, and we return early before setting the class.

The fix was simple enough: adjust the selector to account for both scenarios.

As an aside: the block logic in general is a bit of a mess and someday it'd be nice to do a full rewrite, but that's out of scope here. I'll dump some random thoughts here:
* There's no clear reason why the `opacity: 0` existed in the first place. That logic dates back to here: Automattic/wp-calypso#30895
* It seems the Slideshow init triggers multiple times.
* The selector could probably be the more general version for both scenarios (it worked for me in basic testing), but I'm leaving it for now just in case.
* It seems deprecated block version CSS isn't namespaced in any way, so removing something in the default block CSS means the deprecated block CSS gains precedence, which seems odd.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Add a slideshow block with only one image.
2. Publish.
3. Ensure the Slideshow block shows the image both in the editor and on the frontend.