### PR TITLE
Boost: Add E2E Tests for Cornerstone Pages

### DIFF
--- a/.github/files/e2e-tests/e2e-matrix.js
+++ b/.github/files/e2e-tests/e2e-matrix.js
@@ -83,6 +83,14 @@ const projects = [
 		buildGroup: 'jetpack-boost',
 	},
 	{
+		project: 'Jetpack Boost - Cornerstone Pages',
+		path: 'projects/plugins/boost/tests/e2e',
+		testArgs: [ 'specs/cornerstone' ],
+		targets: [ 'plugins/boost' ],
+		suite: '',
+		buildGroup: 'jetpack-boost',
+	},
+	{
 		project: 'Jetpack Boost - Image CDN',
 		path: 'projects/plugins/boost/tests/e2e',
 		testArgs: [ 'specs/image-cdn' ],

--- a/projects/plugins/boost/app/assets/src/js/features/cornerstone-pages/prerender/prerender.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/cornerstone-pages/prerender/prerender.tsx
@@ -31,7 +31,7 @@ const Prerender = () => {
 
 	return (
 		<div className={ styles.wrapper }>
-			<div className={ styles.title }>
+			<div className={ styles.title } data-testid="prerender-cornerstone-pages-title">
 				<h4>{ __( 'Prerender Cornerstone Pages', 'jetpack-boost' ) }</h4>
 				<ToggleControl
 					className={ styles[ 'toggle-control' ] }

--- a/projects/plugins/boost/app/lib/class-cli.php
+++ b/projects/plugins/boost/app/lib/class-cli.php
@@ -28,7 +28,7 @@ class CLI {
 	 */
 	private $jetpack_boost;
 
-	const MAKE_E2E_TESTS_WORK_MODULES = array( 'critical_css', 'render_blocking_js', 'page_cache', 'lcp', 'minify_js', 'minify_css', 'image_cdn', 'image_guide' );
+	const MAKE_E2E_TESTS_WORK_MODULES = array( 'critical_css', 'speculation_rules', 'render_blocking_js', 'page_cache', 'lcp', 'minify_js', 'minify_css', 'image_cdn', 'image_guide' );
 
 	/**
 	 * CLI constructor.

--- a/projects/plugins/boost/changelog/add-boost-e2e-tests-cornerstone-pages-HOG-225
+++ b/projects/plugins/boost/changelog/add-boost-e2e-tests-cornerstone-pages-HOG-225
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Add E2E Tests for Cornerstone Pages functionality
+
+

--- a/projects/plugins/boost/tests/e2e/lib/env/prerequisites.js
+++ b/projects/plugins/boost/tests/e2e/lib/env/prerequisites.js
@@ -19,6 +19,7 @@ export function boostPrerequisitesBuilder( page ) {
 		mockConnection: undefined,
 		jetpackDeactivated: undefined,
 		mockSpeedScore: undefined,
+		mockPremiumFeatures: undefined,
 		enqueuedAssets: undefined,
 		appendImage: undefined,
 	};
@@ -52,6 +53,10 @@ export function boostPrerequisitesBuilder( page ) {
 			state.mockSpeedScore = shouldMockSpeedScore;
 			return this;
 		},
+		withPremiumFeaturesMocked( features = [] ) {
+			state.mockPremiumFeatures = features;
+			return this;
+		},
 		withEnqueuedAssets( shouldEnqueueAssets ) {
 			state.enqueuedAssets = shouldEnqueueAssets;
 			return this;
@@ -72,17 +77,18 @@ export function boostPrerequisitesBuilder( page ) {
 
 /**
  * Build prerequisites.
- * @param {object}  state                - State
- * @param {boolean} state.clean          - Whether to reset the environment.
- * @param {boolean} state.connected      - Whether the site should be connected.
- * @param {object}  state.plugins        - Plugins state, see ensurePluginsState()
- * @param {object}  state.modules        - Modules state, see ensureModulesState()
- * @param {Array}   state.loggedIn       -
- * @param {Array}   state.testPostTitles -
- * @param {boolean} state.mockSpeedScore -
- * @param {boolean} state.enqueuedAssets -
- * @param {boolean} state.appendImage    -
- * @param {page}    page                 - Playwright page instance.
+ * @param {object}  state                     - State
+ * @param {boolean} state.clean               - Whether to reset the environment.
+ * @param {boolean} state.connected           - Whether the site should be connected.
+ * @param {object}  state.plugins             - Plugins state, see ensurePluginsState()
+ * @param {object}  state.modules             - Modules state, see ensureModulesState()
+ * @param {Array}   state.loggedIn            -
+ * @param {Array}   state.testPostTitles      -
+ * @param {boolean} state.mockSpeedScore      -
+ * @param {Array}   state.mockPremiumFeatures - Premium features to mock
+ * @param {boolean} state.enqueuedAssets      -
+ * @param {boolean} state.appendImage         -
+ * @param {page}    page                      - Playwright page instance.
  */
 async function buildPrerequisites( state, page ) {
 	const functions = {
@@ -93,6 +99,7 @@ async function buildPrerequisites( state, page ) {
 		testPostTitles: () => ensureTestPosts( state.testPostTitles ),
 		clean: () => ensureCleanState( state.clean ),
 		mockSpeedScore: () => ensureMockSpeedScoreState( state.mockSpeedScore ),
+		mockPremiumFeatures: () => ensureMockPremiumFeaturesState( state.mockPremiumFeatures ),
 		enqueuedAssets: () => ensureEnqueuedAssets( state.enqueuedAssets ),
 		appendImage: () => ensureAppendedImage( state.appendImage ),
 	};
@@ -143,6 +150,27 @@ export async function ensureMockSpeedScoreState( mockSpeedScore ) {
 	} else {
 		logger.prerequisites( 'Unmocking Speed Score' );
 		await execWpCommand( 'plugin deactivate e2e-mock-speed-score-api' );
+	}
+}
+
+/**
+ * Ensure premium features mock plugin state.
+ * @param {Array} mockPremiumFeatures - Array of premium features to mock.
+ */
+export async function ensureMockPremiumFeaturesState( mockPremiumFeatures ) {
+	if ( mockPremiumFeatures && mockPremiumFeatures.length > 0 ) {
+		logger.prerequisites( `Mocking Premium Features: ${ mockPremiumFeatures.join( ', ' ) }` );
+		// Enable the premium features mock plugin.
+		await execWpCommand( 'plugin activate e2e-mock-premium-features' );
+		// Set the features to mock as a proper PHP array using WP-CLI's --format=json
+		const featuresJson = JSON.stringify( mockPremiumFeatures );
+		await execWpCommand(
+			`option update e2e_mock_premium_features '${ featuresJson }' --format=json`
+		);
+	} else {
+		logger.prerequisites( 'Unmocking Premium Features' );
+		await execWpCommand( 'plugin deactivate e2e-mock-premium-features' );
+		await execWpCommand( 'option delete e2e_mock_premium_features' );
 	}
 }
 

--- a/projects/plugins/boost/tests/e2e/lib/pages/wp-admin/JetpackBoostPage.js
+++ b/projects/plugins/boost/tests/e2e/lib/pages/wp-admin/JetpackBoostPage.js
@@ -256,4 +256,75 @@ export default class JetpackBoostPage extends WpPage {
 			( await this.currentPageTitleIs( /Overall Score: [A-Z]/i ) )
 		);
 	}
+
+	async isCornerstonePagesContentVisible() {
+		return await this.page.getByText( 'List the most important pages' ).isVisible();
+	}
+
+	async openCornerstonePagesPanel() {
+		const panelToggle = this.page.locator( 'text=Cornerstone Pages' ).first();
+		if ( ! ( await this.isCornerstonePagesContentVisible() ) ) {
+			await panelToggle.click();
+			await this.isCornerstonePagesContentVisible();
+		}
+	}
+
+	async enterCornerstonePageUrl( url ) {
+		const textarea = this.page.locator( '#jb-cornerstone-pages' );
+		await textarea.fill( url );
+	}
+
+	async clearCornerstonePageInput() {
+		const textarea = this.page.locator( '#jb-cornerstone-pages' );
+		await textarea.fill( '' );
+	}
+
+	async addCornerstonePage( url ) {
+		await this.enterCornerstonePageUrl( url );
+		const saveButton = this.page.locator( 'text=Save' ).first();
+		await saveButton.click();
+	}
+
+	async getCornerstonePageInputValue() {
+		const textarea = this.page.locator( '#jb-cornerstone-pages' );
+		return await textarea.inputValue();
+	}
+
+	async isCornerstoneSaveButtonDisabled() {
+		const saveButton = this.page.locator( 'text=Save' ).first();
+		return await saveButton.isDisabled();
+	}
+
+	async isCornerstoneUpgradeCTAVisible() {
+		const selector = 'text=Premium users can add up to 10 cornerstone pages';
+		return this.page.isVisible( selector );
+	}
+
+	async isPremiumFeatureDetected() {
+		return await this.page
+			.getByRole( 'button', { name: 'Cornerstone Pages Upgraded' } )
+			.isVisible();
+	}
+
+	async waitForNotice( message ) {
+		const notice = this.page.locator( `.components-snackbar:has-text("${ message }")` );
+		await notice.waitFor( {
+			timeout: 10000,
+		} );
+	}
+
+	// Prerender methods
+	async isPrerenderToggleVisible() {
+		const selector = 'text=Prerender Cornerstone Pages';
+		return this.page.isVisible( selector );
+	}
+
+	async togglePrerenderOption( enabled ) {
+		const toggle = this.page.locator( '[data-testid="prerender-cornerstone-pages-title"] input' );
+		const isCurrentlyChecked = await toggle.isChecked();
+
+		if ( isCurrentlyChecked !== enabled ) {
+			await toggle.click();
+		}
+	}
 }

--- a/projects/plugins/boost/tests/e2e/plugins/e2e-mock-premium-features.php
+++ b/projects/plugins/boost/tests/e2e/plugins/e2e-mock-premium-features.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Plugin Name: Boost E2E Premium Features Mocker
+ * Plugin URI: https://github.com/automattic/jetpack
+ * Author: Heart of Gold
+ * Version: 1.0.0
+ * Text Domain: jetpack
+ *
+ * @package automattic/jetpack
+ */
+
+/**
+ * Mock premium features for E2E testing.
+ * This plugin uses the proper filter hooks to override premium feature availability.
+ */
+
+/**
+ * Store the mocked features in a global option
+ *
+ * @return array The mocked premium features.
+ */
+function e2e_get_mocked_premium_features() {
+	return get_option( 'e2e_mock_premium_features', array() );
+}
+
+/**
+ * Set the mocked premium features
+ *
+ * @param array $features List of features to mock.
+ */
+function e2e_set_mocked_premium_features( $features ) {
+	if ( empty( $features ) ) {
+		delete_option( 'e2e_mock_premium_features' );
+	} else {
+		update_option( 'e2e_mock_premium_features', $features, false );
+	}
+}
+
+/**
+ * Set up premium feature filters
+ */
+function e2e_setup_premium_feature_filters() {
+	$premium_features = array(
+		'cloud-critical-css',
+		'image-size-analysis',
+		'performance-history',
+		'image-cdn-liar',
+		'image-cdn-quality',
+		'support',
+		'page-cache',
+		'cornerstone-10-pages',
+	);
+
+	foreach ( $premium_features as $feature ) {
+		add_filter( "jetpack_boost_has_feature_{$feature}", 'e2e_mock_premium_feature_check', 10, 1 );
+	}
+}
+
+/**
+ * Mock premium feature check
+ *
+ * @param bool $has_feature Original feature availability.
+ * @return bool Whether the feature should be available.
+ */
+function e2e_mock_premium_feature_check( $has_feature ) {
+	$mocked_features = e2e_get_mocked_premium_features();
+
+	// Get the current filter name to determine which feature is being checked
+	$current_filter = current_filter();
+	$feature        = str_replace( 'jetpack_boost_has_feature_', '', $current_filter );
+
+	// If this feature is in our mocked list, return true
+	if ( in_array( $feature, $mocked_features, true ) ) {
+		return true;
+	}
+
+	// Otherwise, return the original value
+	return $has_feature;
+}
+
+// Hook into the premium feature filters
+add_action( 'init', 'e2e_setup_premium_feature_filters' );
+
+/**
+ * Clean up on deactivation
+ */
+register_deactivation_hook( __FILE__, 'e2e_premium_features_cleanup' );
+
+/**
+ * Cleanup function
+ */
+function e2e_premium_features_cleanup() {
+	delete_option( 'e2e_mock_premium_features' );
+}

--- a/projects/plugins/boost/tests/e2e/specs/cornerstone/cornerstone.test.js
+++ b/projects/plugins/boost/tests/e2e/specs/cornerstone/cornerstone.test.js
@@ -1,0 +1,346 @@
+import { test, expect } from '_jetpack-e2e-commons/fixtures/base-test.ts';
+import { execWpCommand } from '_jetpack-e2e-commons/helpers/utils-helper.js';
+import playwrightConfig from '_jetpack-e2e-commons/playwright.config.mjs';
+import { boostPrerequisitesBuilder } from '../../lib/env/prerequisites.js';
+import { JetpackBoostPage } from '../../lib/pages/index.js';
+
+/* global Jetpack_Boost */
+
+test.describe( 'Cornerstone Pages', () => {
+	let page;
+
+	test.beforeAll( async ( { browser } ) => {
+		page = await browser.newPage( playwrightConfig.use );
+		await boostPrerequisitesBuilder( page )
+			.withCleanEnv()
+			.withMockConnection( true )
+			.withSpeedScoreMocked( true )
+			.build();
+	} );
+
+	test.afterAll( async () => {
+		await page.close();
+	} );
+
+	test.beforeEach( async () => {
+		// Reset cornerstone pages before each test to ensure atomicity
+		// Using option delete ensures the system properly initializes an empty array
+		await execWpCommand( 'option delete jetpack_boost_ds_cornerstone_pages_list' );
+	} );
+
+	test( 'Cornerstone Pages panel should be visible and toggleable', async () => {
+		const jetpackBoostPage = await JetpackBoostPage.visit( page );
+
+		// Test panel toggle functionality - title should be visible but content should be collapsed
+		const panelToggle = page.locator( 'text=Cornerstone Pages' ).first();
+		await expect( panelToggle, 'Panel title should be visible' ).toBeVisible();
+
+		// Panel content should NOT be visible initially (collapsed by default)
+		expect(
+			await jetpackBoostPage.isCornerstonePagesContentVisible(),
+			'Cornerstone Pages content should be collapsed by default'
+		).toBeFalsy();
+
+		// Test opening the panel
+		await panelToggle.click();
+
+		expect(
+			await jetpackBoostPage.isCornerstonePagesContentVisible(),
+			'Panel content should be visible when opened'
+		).toBeTruthy();
+	} );
+
+	test( 'Should display predefined pages (homepage) correctly', async () => {
+		const jetpackBoostPage = await JetpackBoostPage.visit( page );
+
+		// Open the panel
+		await jetpackBoostPage.openCornerstonePagesPanel();
+
+		// Check that homepage is listed in predefined pages
+		const homeUrl = await page.evaluate( () => Jetpack_Boost.site.url );
+		await expect(
+			page.locator( `text=${ homeUrl }` ).first(),
+			'Homepage should be listed in predefined pages'
+		).toBeVisible();
+
+		// Check the homepage label
+		await expect(
+			page.locator( 'text=Homepage:' ),
+			'Homepage label should be visible'
+		).toBeVisible();
+	} );
+
+	test( 'Should allow adding valid custom cornerstone pages on free plan', async () => {
+		const jetpackBoostPage = await JetpackBoostPage.visit( page );
+		await jetpackBoostPage.openCornerstonePagesPanel();
+
+		const testUrl = '/test-page';
+		await jetpackBoostPage.addCornerstonePage( testUrl );
+
+		// Wait for save success notice
+		await jetpackBoostPage.waitForNotice( 'Cornerstone pages saved' );
+
+		// Verify the page was added (should show "Homepage + 1 page" in the title summary)
+		await expect(
+			page.locator( 'text=Homepage + 1 page' ),
+			'Should display correct page count in summary'
+		).toBeVisible();
+	} );
+
+	test( 'Should validate URLs correctly and show error messages', async () => {
+		const jetpackBoostPage = await JetpackBoostPage.visit( page );
+		await jetpackBoostPage.openCornerstonePagesPanel();
+
+		// Test invalid URL (different site)
+		await jetpackBoostPage.enterCornerstonePageUrl( 'https://example.com/test' );
+		await expect(
+			page.locator( 'text=The URL seems to be a different site' ),
+			'Should show error for different site URL'
+		).toBeVisible();
+
+		// Test homepage URL (should be rejected)
+		const homeUrl = await page.evaluate( () => Jetpack_Boost.site.url );
+		await jetpackBoostPage.clearCornerstonePageInput();
+		await jetpackBoostPage.enterCornerstonePageUrl( homeUrl );
+		await expect(
+			page.locator( 'text=The homepage does not need to be added' ),
+			'Should show error for homepage URL'
+		).toBeVisible();
+
+		// Clear the input for next tests
+		await jetpackBoostPage.clearCornerstonePageInput();
+	} );
+
+	test( 'Should enforce free plan limit of 1 custom page', async () => {
+		const jetpackBoostPage = await JetpackBoostPage.visit( page );
+		await jetpackBoostPage.openCornerstonePagesPanel();
+
+		// Try to add 2 pages (should fail on free plan)
+		const testUrls = '/test-page-1\n/test-page-2';
+		await jetpackBoostPage.enterCornerstonePageUrl( testUrls );
+
+		await expect(
+			page.locator( 'text=You can add only 1 cornerstone page URL' ),
+			'Should show limit error for free plan'
+		).toBeVisible();
+
+		// Verify save button is disabled
+		expect(
+			await jetpackBoostPage.isCornerstoneSaveButtonDisabled(),
+			'Save button should be disabled with validation error'
+		).toBeTruthy();
+	} );
+
+	test( 'Should allow adding up to 10 pages on premium plan', async () => {
+		// Mock premium features using the new plugin approach
+		await boostPrerequisitesBuilder( page )
+			.withPremiumFeaturesMocked( [ 'cornerstone-10-pages' ] )
+			.build();
+
+		const jetpackBoostPage = await JetpackBoostPage.visit( page );
+		await jetpackBoostPage.openCornerstonePagesPanel();
+
+		// Verify that premium features are detected
+		expect(
+			await jetpackBoostPage.isPremiumFeatureDetected(),
+			'Premium features should be detected by the frontend'
+		).toBeTruthy();
+
+		// Add 10 pages
+		const tenPages = Array.from( { length: 10 }, ( _, i ) => `/page-${ i + 1 }` ).join( '\n' );
+		await jetpackBoostPage.addCornerstonePage( tenPages );
+
+		// Wait for save success notice
+		await jetpackBoostPage.waitForNotice( 'Cornerstone pages saved' );
+
+		// Verify the pages were added
+		await expect(
+			page.locator( 'text=Homepage + 10 pages' ),
+			'Should display correct page count in summary for 10 pages'
+		).toBeVisible();
+	} );
+
+	test( 'Should enforce premium plan limit of 10 custom pages', async () => {
+		// Mock premium features using the new plugin approach
+		await boostPrerequisitesBuilder( page )
+			.withPremiumFeaturesMocked( [ 'cornerstone-10-pages' ] )
+			.build();
+
+		const jetpackBoostPage = await JetpackBoostPage.visit( page );
+		await jetpackBoostPage.openCornerstonePagesPanel();
+
+		// Try to add 11 pages
+		const elevenPages = Array.from( { length: 11 }, ( _, i ) => `/page-${ i + 1 }` ).join( '\n' );
+		await jetpackBoostPage.enterCornerstonePageUrl( elevenPages );
+
+		await expect(
+			page.locator( 'text=You can add up to 10 cornerstone page URLs' ),
+			'Should show limit error for premium plan'
+		).toBeVisible();
+
+		// Verify save button is disabled
+		expect(
+			await jetpackBoostPage.isCornerstoneSaveButtonDisabled(),
+			'Save button should be disabled with validation error'
+		).toBeTruthy();
+	} );
+
+	test( 'Should show upgrade CTA for premium features on free plan', async () => {
+		const jetpackBoostPage = await JetpackBoostPage.visit( page );
+		await jetpackBoostPage.openCornerstonePagesPanel();
+
+		expect(
+			await jetpackBoostPage.isCornerstoneUpgradeCTAVisible(),
+			'Upgrade CTA should be visible on free plan'
+		).toBeTruthy();
+
+		await expect(
+			page.locator( 'text=Premium users can add up to 10 cornerstone pages' ),
+			'Should show premium limit in upgrade message'
+		).toBeVisible();
+	} );
+
+	test( 'Should show load default pages functionality', async () => {
+		const jetpackBoostPage = await JetpackBoostPage.visit( page );
+		await jetpackBoostPage.openCornerstonePagesPanel();
+
+		// Check that load default button exists
+		await expect(
+			page.locator( 'text=Load default pages' ),
+			'Load default pages button should be visible'
+		).toBeVisible();
+
+		// Test load default pages functionality (if there are default pages configured)
+		const loadDefaultButton = page.locator( 'text=Load default pages' );
+		if ( await loadDefaultButton.isEnabled() ) {
+			await loadDefaultButton.click();
+			// Should show some default pages loaded
+			expect(
+				await jetpackBoostPage.getCornerstonePageInputValue(),
+				'Should have some content after loading defaults'
+			).toBeTruthy();
+		}
+	} );
+
+	test( 'Prerender toggle should be visible when speculation_rules module is available', async () => {
+		// Activate speculation_rules module
+		await boostPrerequisitesBuilder( page ).withActiveModules( [ 'speculation_rules' ] ).build();
+
+		const jetpackBoostPage = await JetpackBoostPage.visit( page );
+		await jetpackBoostPage.openCornerstonePagesPanel();
+
+		expect(
+			await jetpackBoostPage.isPrerenderToggleVisible(),
+			'Prerender toggle should be visible when speculation_rules is available'
+		).toBeTruthy();
+
+		await expect(
+			page.locator( 'text=Prerender Cornerstone Pages' ),
+			'Prerender section title should be visible'
+		).toBeVisible();
+
+		// Test toggle functionality
+		await jetpackBoostPage.togglePrerenderOption( true );
+		await jetpackBoostPage.waitForNotice( 'Prerender enabled' );
+
+		await jetpackBoostPage.togglePrerenderOption( false );
+		await jetpackBoostPage.waitForNotice( 'Prerender disabled' );
+	} );
+
+	test( 'Prerender toggle should not be visible when speculation_rules module is unavailable', async () => {
+		// Deactivate speculation_rules module
+		await boostPrerequisitesBuilder( page ).withInactiveModules( [ 'speculation_rules' ] ).build();
+
+		const jetpackBoostPage = await JetpackBoostPage.visit( page );
+		await jetpackBoostPage.openCornerstonePagesPanel();
+
+		expect(
+			await jetpackBoostPage.isPrerenderToggleVisible(),
+			'Prerender toggle should not be visible when speculation_rules is unavailable'
+		).toBeFalsy();
+	} );
+
+	test( 'Should handle relative URLs correctly', async () => {
+		const jetpackBoostPage = await JetpackBoostPage.visit( page );
+		await jetpackBoostPage.openCornerstonePagesPanel();
+
+		// Test relative URL (should work)
+		const relativeUrl = '/about-us';
+		await jetpackBoostPage.clearCornerstonePageInput();
+		await jetpackBoostPage.addCornerstonePage( relativeUrl );
+
+		// Wait for save success notice
+		await jetpackBoostPage.waitForNotice( 'Cornerstone pages saved' );
+
+		// Verify it was saved properly
+		await expect(
+			page.locator( 'text=Homepage + 1 page' ),
+			'Should accept and save relative URLs'
+		).toBeVisible();
+	} );
+
+	test( 'Should trigger Critical CSS regeneration when pages are updated for premium users', async () => {
+		// Mock premium features and activate critical_css module
+		await boostPrerequisitesBuilder( page )
+			.withPremiumFeaturesMocked( [ 'cornerstone-10-pages' ] )
+			.withActiveModules( [ 'critical_css' ] )
+			.build();
+
+		const jetpackBoostPage = await JetpackBoostPage.visit( page );
+		await jetpackBoostPage.openCornerstonePagesPanel();
+
+		// Add a page (this should trigger CSS regeneration for premium users)
+		await jetpackBoostPage.addCornerstonePage( '/premium-test-page' );
+
+		// Wait for save notice
+		await jetpackBoostPage.waitForNotice( 'Cornerstone pages saved' );
+
+		// Navigate to main page to check if Critical CSS regeneration was triggered
+		// Note: The exact UI for this might vary, but we should see regeneration activity
+		expect(
+			await jetpackBoostPage.isCriticalCssMetaVisible(),
+			'Critical CSS meta should be visible after cornerstone pages update'
+		).toBeTruthy();
+	} );
+
+	test( 'Should persist cornerstone pages across page reloads', async () => {
+		const jetpackBoostPage = await JetpackBoostPage.visit( page );
+		await jetpackBoostPage.openCornerstonePagesPanel();
+
+		const testUrl = '/persistent-page';
+		await jetpackBoostPage.addCornerstonePage( testUrl );
+		await jetpackBoostPage.waitForNotice( 'Cornerstone pages saved' );
+
+		// Reload the page
+		await page.reload();
+		const jetpackBoostPageReloaded = await JetpackBoostPage.visit( page );
+		await jetpackBoostPageReloaded.openCornerstonePagesPanel();
+
+		// Check that the page is still there
+		const inputValue = await jetpackBoostPageReloaded.getCornerstonePageInputValue();
+		expect(
+			inputValue.includes( testUrl ),
+			'Cornerstone pages should persist across page reloads'
+		).toBeTruthy();
+	} );
+
+	test( 'Should show correct summary in panel title based on number of pages', async () => {
+		const jetpackBoostPage = await JetpackBoostPage.visit( page );
+
+		// Should show "Added: Homepage" when no custom pages
+		await expect(
+			page.locator( 'text=Added: Homepage' ),
+			'Should show only homepage when no custom pages'
+		).toBeVisible();
+
+		await jetpackBoostPage.openCornerstonePagesPanel();
+		await jetpackBoostPage.addCornerstonePage( '/test-summary' );
+		await jetpackBoostPage.waitForNotice( 'Cornerstone pages saved' );
+
+		// Should show "Added: Homepage + 1 page"
+		await expect(
+			page.locator( 'text=Added: Homepage + 1 page' ),
+			'Should show correct count with 1 custom page'
+		).toBeVisible();
+	} );
+} );

--- a/projects/plugins/boost/tests/e2e/specs/cornerstone/cornerstone.test.js
+++ b/projects/plugins/boost/tests/e2e/specs/cornerstone/cornerstone.test.js
@@ -23,11 +23,10 @@ test.describe( 'Cornerstone Pages', () => {
 	} );
 
 	test.afterEach( async () => {
+		await boostPrerequisitesBuilder( page ).withPremiumFeaturesMocked( [] ).build();
 		// Reset cornerstone pages before each test to ensure atomicity
 		// Using option delete ensures the system properly initializes an empty array
 		await execWpCommand( 'option delete jetpack_boost_ds_cornerstone_pages_list' );
-
-		await boostPrerequisitesBuilder( page ).withPremiumFeaturesMocked( [] ).build();
 	} );
 
 	test( 'Cornerstone Pages panel should be visible and toggleable', async () => {

--- a/projects/plugins/boost/tests/e2e/specs/cornerstone/cornerstone.test.js
+++ b/projects/plugins/boost/tests/e2e/specs/cornerstone/cornerstone.test.js
@@ -22,10 +22,12 @@ test.describe( 'Cornerstone Pages', () => {
 		await page.close();
 	} );
 
-	test.beforeEach( async () => {
+	test.afterEach( async () => {
 		// Reset cornerstone pages before each test to ensure atomicity
 		// Using option delete ensures the system properly initializes an empty array
 		await execWpCommand( 'option delete jetpack_boost_ds_cornerstone_pages_list' );
+
+		await boostPrerequisitesBuilder( page ).withPremiumFeaturesMocked( [] ).build();
 	} );
 
 	test( 'Cornerstone Pages panel should be visible and toggleable', async () => {
@@ -210,22 +212,21 @@ test.describe( 'Cornerstone Pages', () => {
 			'Load default pages button should be visible'
 		).toBeVisible();
 
+		const testUrls = '/sample-page';
+		await jetpackBoostPage.enterCornerstonePageUrl( testUrls );
+
 		// Test load default pages functionality (if there are default pages configured)
-		const loadDefaultButton = page.locator( 'text=Load default pages' );
-		if ( await loadDefaultButton.isEnabled() ) {
-			await loadDefaultButton.click();
-			// Should show some default pages loaded
-			expect(
-				await jetpackBoostPage.getCornerstonePageInputValue(),
-				'Should have some content after loading defaults'
-			).toBeTruthy();
-		}
+		const loadDefaultButton = page.getByRole( 'button', { name: 'Load default pages' } );
+		await loadDefaultButton.click();
+
+		// Should show some default pages loaded
+		expect(
+			await jetpackBoostPage.getCornerstonePageInputValue(),
+			'Should have no content after loading defaults'
+		).toBeFalsy();
 	} );
 
 	test( 'Prerender toggle should be visible when speculation_rules module is available', async () => {
-		// Activate speculation_rules module
-		await boostPrerequisitesBuilder( page ).withActiveModules( [ 'speculation_rules' ] ).build();
-
 		const jetpackBoostPage = await JetpackBoostPage.visit( page );
 		await jetpackBoostPage.openCornerstonePagesPanel();
 
@@ -234,30 +235,12 @@ test.describe( 'Cornerstone Pages', () => {
 			'Prerender toggle should be visible when speculation_rules is available'
 		).toBeTruthy();
 
-		await expect(
-			page.locator( 'text=Prerender Cornerstone Pages' ),
-			'Prerender section title should be visible'
-		).toBeVisible();
-
 		// Test toggle functionality
 		await jetpackBoostPage.togglePrerenderOption( true );
 		await jetpackBoostPage.waitForNotice( 'Prerender enabled' );
 
 		await jetpackBoostPage.togglePrerenderOption( false );
 		await jetpackBoostPage.waitForNotice( 'Prerender disabled' );
-	} );
-
-	test( 'Prerender toggle should not be visible when speculation_rules module is unavailable', async () => {
-		// Deactivate speculation_rules module
-		await boostPrerequisitesBuilder( page ).withInactiveModules( [ 'speculation_rules' ] ).build();
-
-		const jetpackBoostPage = await JetpackBoostPage.visit( page );
-		await jetpackBoostPage.openCornerstonePagesPanel();
-
-		expect(
-			await jetpackBoostPage.isPrerenderToggleVisible(),
-			'Prerender toggle should not be visible when speculation_rules is unavailable'
-		).toBeFalsy();
 	} );
 
 	test( 'Should handle relative URLs correctly', async () => {
@@ -277,30 +260,6 @@ test.describe( 'Cornerstone Pages', () => {
 			page.locator( 'text=Homepage + 1 page' ),
 			'Should accept and save relative URLs'
 		).toBeVisible();
-	} );
-
-	test( 'Should trigger Critical CSS regeneration when pages are updated for premium users', async () => {
-		// Mock premium features and activate critical_css module
-		await boostPrerequisitesBuilder( page )
-			.withPremiumFeaturesMocked( [ 'cornerstone-10-pages' ] )
-			.withActiveModules( [ 'critical_css' ] )
-			.build();
-
-		const jetpackBoostPage = await JetpackBoostPage.visit( page );
-		await jetpackBoostPage.openCornerstonePagesPanel();
-
-		// Add a page (this should trigger CSS regeneration for premium users)
-		await jetpackBoostPage.addCornerstonePage( '/premium-test-page' );
-
-		// Wait for save notice
-		await jetpackBoostPage.waitForNotice( 'Cornerstone pages saved' );
-
-		// Navigate to main page to check if Critical CSS regeneration was triggered
-		// Note: The exact UI for this might vary, but we should see regeneration activity
-		expect(
-			await jetpackBoostPage.isCriticalCssMetaVisible(),
-			'Critical CSS meta should be visible after cornerstone pages update'
-		).toBeTruthy();
 	} );
 
 	test( 'Should persist cornerstone pages across page reloads', async () => {

--- a/tools/docker/jetpack-docker-config-default.yml
+++ b/tools/docker/jetpack-docker-config-default.yml
@@ -69,6 +69,7 @@ e2e:
     projects/plugins/boost/tests/e2e/plugins/e2e-appended-image/: /var/www/html/wp-content/plugins/e2e-appended-image/
     projects/plugins/boost/tests/e2e/plugins/e2e-mock-speed-score-api.php: /var/www/html/wp-content/plugins/e2e-mock-speed-score-api.php
     projects/plugins/boost/tests/e2e/plugins/e2e-mock-boost-connection.php: /var/www/html/wp-content/plugins/e2e-mock-boost-connection.php
+    projects/plugins/boost/tests/e2e/plugins/e2e-mock-premium-features.php: /var/www/html/wp-content/plugins/e2e-mock-premium-features.php
     projects/plugins/boost/tests/e2e/plugins/e2e-critical-css-force-errors.php: /var/www/html/wp-content/plugins/e2e-critical-css-force-errors.php
     tools/e2e-commons/plugins/e2e-search-test-helper.php: /var/www/html/wp-content/plugins/e2e-search-test-helper.php
     tools/e2e-commons/plugins/e2e-wpcom-request-interceptor.php: /var/www/html/wp-content/plugins/e2e-wpcom-request-interceptor.php


### PR DESCRIPTION
Fixes [HOG-225: E2E Tests for Cornerstone Pages](https://linear.app/a8c/issue/HOG-225/e2e-tests-for-cornerstone-pages)

## Proposed changes:
Add End-to-End (E2E) test coverage for the Jetpack Boost Cornerstone Pages.

**Test Coverage:**
- Panel visibility and toggle functionality
- Adding and validating custom Cornerstone Pages
- Free plan limits (1 custom page) vs Premium plan limits (10 custom pages)  
- URL validation: relative URLs, different site rejection, homepage rejection
- Prerender toggle functionality (speculation rules)
- Upgrade CTA display for free users
- Correct page count summaries in panel titles

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A 

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

### Prerequisites:
- Ensure E2E Tests all pass within the build, especially: `E2E Tests / Jetpack Boost - Cornerstone Pages e2e tests`

