### PR TITLE
Forms: Only enqueue forms view script when the form is renderd. 

### DIFF
--- a/projects/packages/forms/changelog/fix-do-not-enqueue-forms-interactivity
+++ b/projects/packages/forms/changelog/fix-do-not-enqueue-forms-interactivity
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Forms: only enqueue script view script when the form is rendered 
+Forms: only enqueue view script when the form is rendered

--- a/projects/packages/forms/changelog/fix-do-not-enqueue-forms-interactivity
+++ b/projects/packages/forms/changelog/fix-do-not-enqueue-forms-interactivity
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: only enqueue script view script when the form is rendered 

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -293,23 +293,6 @@ class Contact_Form_Plugin {
 		wp_register_style( 'grunion.css', Jetpack_Forms::plugin_url() . '../dist/contact-form/css/grunion.css', array(), \JETPACK__VERSION );
 		wp_style_add_data( 'grunion.css', 'rtl', 'replace' );
 
-		$config = array(
-			'error_types'    => array(
-				'is_required'        => __( 'This field is required.', 'jetpack-forms' ),
-				'invalid_form_empty' => __( 'The form you are trying to submit is empty.', 'jetpack-forms' ),
-				'invalid_form'       => __( 'Please fill out the form correctly.', 'jetpack-forms' ),
-				'network_error'      => __( 'Connection issue while submitting the form. Check that you are connected to the Internet and try again.', 'jetpack-forms' ),
-			),
-			'admin_ajax_url' => admin_url( 'admin-ajax.php' ),
-		);
-		wp_interactivity_config( 'jetpack/form', $config );
-		\wp_enqueue_script_module(
-			'jp-forms-view',
-			plugins_url( '../../dist/modules/form/view.js', __FILE__ ),
-			array( '@wordpress/interactivity' ),
-			\JETPACK__VERSION
-		);
-
 		add_filter( 'js_do_concat', array( __CLASS__, 'disable_forms_view_script_concat' ), 10, 3 );
 
 		if ( defined( 'JETPACK__PLUGIN_DIR' ) ) {

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -437,6 +437,23 @@ class Contact_Form extends Contact_Form_Shortcode {
 			wp_enqueue_script( 'accessible-form' );
 		}
 
+		$config = array(
+			'error_types'    => array(
+				'is_required'        => __( 'This field is required.', 'jetpack-forms' ),
+				'invalid_form_empty' => __( 'The form you are trying to submit is empty.', 'jetpack-forms' ),
+				'invalid_form'       => __( 'Please fill out the form correctly.', 'jetpack-forms' ),
+				'network_error'      => __( 'Connection issue while submitting the form. Check that you are connected to the Internet and try again.', 'jetpack-forms' ),
+			),
+			'admin_ajax_url' => admin_url( 'admin-ajax.php' ),
+		);
+		wp_interactivity_config( 'jetpack/form', $config );
+		\wp_enqueue_script_module(
+			'jp-forms-view',
+			plugins_url( '../../dist/modules/form/view.js', __FILE__ ),
+			array( '@wordpress/interactivity' ),
+			\JETPACK__VERSION
+		);
+
 		$container_classes        = array( 'wp-block-jetpack-contact-form-container' );
 		$container_classes[]      = self::get_block_alignment_class( $attributes );
 		$container_classes_string = implode( ' ', $container_classes );

--- a/projects/plugins/jetpack/changelog/fix-do-not-enqueue-forms-interactivity
+++ b/projects/plugins/jetpack/changelog/fix-do-not-enqueue-forms-interactivity
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: only enqueue view script when the form is rendered


### PR DESCRIPTION
Fixes FORMS-NEW

## Proposed changes:
* Instead of enqueuing the script on every page. Only enqueue it when we are rendering the form or the success message. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1753353066837609-slack-C08LGEFJMQT 

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
Add the form block. Notice that it still works as expected. 
- For example you should see error messages when then you are filling out the form. 
- Load a page without the form. Notice that the script is not included. 