### PR TITLE
Forms: fix use of fixed values for layout to take core sidebar and header into account

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-inbox-variables
+++ b/projects/packages/forms/changelog/fix-forms-inbox-variables
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Forms: use a core variable to account for admin bar
+Forms: use a core variable to account for admin bar and CSS to account for folded sidebar.

--- a/projects/packages/forms/changelog/fix-forms-inbox-variables
+++ b/projects/packages/forms/changelog/fix-forms-inbox-variables
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: use a core variable to account for admin bar

--- a/projects/packages/forms/src/dashboard/components/layout/style.scss
+++ b/projects/packages/forms/src/dashboard/components/layout/style.scss
@@ -21,7 +21,7 @@ body.jetpack_page_jetpack-forms-admin {
 	margin: 0;
 	padding: 0;
 	width: 100%;
-	min-height: calc(100vh - 32px); // 32px is the height of the top admin bar
+	min-height: calc(100vh - var(--wp-admin--admin-bar--height));
 
 	.jp-forms__logo-wrapper,
 	.jp-forms__layout-header {

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -1,3 +1,5 @@
+@use "@wordpress/base-styles/breakpoints";
+@use "@wordpress/base-styles/variables";
 @import "@wordpress/dataviews/build-style/style.css";
 
 $tab-item-height: 40px;
@@ -357,13 +359,49 @@ $action-bar-height: 88px;
 	.dataviews-footer {
 		position: fixed;
 		bottom: 0;
-		width: 100%;
-		left: 0;
 
-		@media (min-width: 782px) {
-			width: calc(100% - 160px);
-			left: 160px; // 160px is compensation for the width of the sidebar
+		// Compensation for the width of the sidebar
+		// Set left position when auto-fold is not on the body element.
+		// Adapted from https://github.com/WordPress/gutenberg/blob/4ea86f891145daa12c8b59b18f02fb9fc4d83c5a/packages/base-styles/_mixins.scss#L183-L218
+		left: 0;
+		width: 100%;
+
+		@media (min-width: #{ (breakpoints.$break-medium + 1) }) {
+			left: variables.$admin-sidebar-width;
+			width: calc(100% - variables.$admin-sidebar-width);
 		}
+	}
+}
+
+/*
+ * Compensation for the width of the sidebar
+ * Auto fold is when on smaller breakpoints, nav menu auto collapses.
+ * Adapted from: https://github.com/WordPress/gutenberg/blob/4ea86f891145daa12c8b59b18f02fb9fc4d83c5a/packages/base-styles/_mixins.scss#L183-L218
+ */
+.auto-fold .jp-forms__inbox__dataviews .dataviews-footer {
+
+	@media (min-width: #{ (breakpoints.$break-medium + 1) }) {
+		left: variables.$admin-sidebar-width-collapsed;
+		width: calc(100% - variables.$admin-sidebar-width-collapsed);
+	}
+
+	@media (min-width: #{ (breakpoints.$break-large + 1) }) {
+		left: variables.$admin-sidebar-width;
+		width: calc(100% - variables.$admin-sidebar-width);
+	}
+}
+
+/*
+ * Compensation for the width of the sidebar when the Sidebar
+ * is manually collapsed.
+ * Adapted from: https://github.com/WordPress/gutenberg/blob/4ea86f891145daa12c8b59b18f02fb9fc4d83c5a/packages/base-styles/_mixins.scss#L183-L218
+ */
+.folded .jp-forms__inbox__dataviews .dataviews-footer {
+	left: 0;
+
+	@media (min-width: #{ (breakpoints.$break-medium + 1) }) {
+		left: variables.$admin-sidebar-width-collapsed;
+		width: calc(100% - variables.$admin-sidebar-width-collapsed);
 	}
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* At Forms inbox layout, use variable for core header height, and take into account folded sidebars.

Variables for header in core:
- [Desktop](https://github.com/WordPress/WordPress/blob/b72ccf266154b3729f6dbd4350c7a8b17577d299/wp-includes/css/admin-bar.css#L2)
- [Mobile](https://github.com/WordPress/WordPress/blob/b72ccf266154b3729f6dbd4350c7a8b17577d299/wp-includes/css/admin-bar.css#L740-L743)

Take into account different sidebar width (open, hidden and folded) for fixed footer positioning with CSS adapted from [a core mixin](https://github.com/WordPress/gutenberg/blob/4ea86f891145daa12c8b59b18f02fb9fc4d83c5a/packages/base-styles/_mixins.scss#L183-L218). We could use the core-mixin as-is just for `left`, but we also needed `width`.

### Before

#### Footer

<img width="872" height="152" alt="Screenshot 2025-07-25 at 14 17 07" src="https://github.com/user-attachments/assets/90e03200-3a3a-4e36-8c54-e6e605187ea6" />
<img width="1145" height="129" alt="Screenshot 2025-07-25 at 14 17 01" src="https://github.com/user-attachments/assets/56c7b074-1a7b-4a3f-becb-2b20d0c21ab9" />

#### Header

Not sure how to replicate the issue. 🤔 

### After

#### Footer

<img width="910" height="177" alt="Screenshot 2025-07-25 at 14 41 18" src="https://github.com/user-attachments/assets/1ca614af-060d-41d9-a2af-3e68259a44d3" />
<img width="1052" height="137" alt="Screenshot 2025-07-25 at 14 41 14" src="https://github.com/user-attachments/assets/c13b7b32-58fd-48eb-a527-9f9ad3683164" />

#### Header

<img width="739" height="159" alt="Screenshot 2025-07-25 at 14 41 41" src="https://github.com/user-attachments/assets/e2db2f18-b724-4bf1-9e7a-e047cb176805" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Inbox
* Test mobile, desktop and different screen widths


