### PR TITLE
Forms: cleanup unused css from inbox

### DIFF
--- a/projects/packages/forms/changelog/update-forms-inbox-cleanup-unused-css
+++ b/projects/packages/forms/changelog/update-forms-inbox-cleanup-unused-css
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: clean up old unused CSS for inbox"

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -1,9 +1,5 @@
 @import "@wordpress/dataviews/build-style/style.css";
 
-$tab-item-height: 40px;
-$tabs-height: $tab-item-height + 16px;
-$action-bar-height: 88px;
-
 .jp-forms__inbox {
 	// visual aid for focus, currently only export button
 	.button-primary.export-button:focus {
@@ -16,51 +12,6 @@ $action-bar-height: 88px;
 			font-size: var(--jp-forms-font-size-regular);
 		}
 	}
-}
-
-.jp-forms__inbox-tabs {
-
-	.components-tab-panel__tabs {
-		margin: 0;
-		padding: 10px 48px 10px;
-		z-index: 1;
-		flex: 0 1 auto;
-
-		@media (max-width: 600px) {
-			top: 0;
-		}
-
-		@media (max-width: 520px) {
-			padding: 0 24px;
-		}
-	}
-}
-
-.jp-forms__inbox-tab-item {
-	font-size: var(--jp-forms-font-size-regular);
-	font-weight: 400;
-	height: $tab-item-height;
-	padding: 8px 16px;
-
-	&.active-tab {
-		font-weight: 600;
-	}
-}
-
-.jp-forms__inbox-tab-item-count {
-	align-items: center;
-	background: transparent;
-	border: 1px solid #dcdcde;
-	border-radius: 3px;
-	box-sizing: border-box;
-	color: #2c3338;
-	display: inline-flex;
-	font-size: 12px;
-	font-weight: 400;
-	height: 20px;
-	line-height: 18px;
-	margin-left: 10px;
-	padding: 0 6px;
 }
 
 @keyframes jp-forms__slide-in {
@@ -400,13 +351,6 @@ body.jetpack_page_jetpack-forms-admin {
 	display: flex;
 	flex-direction: column;
 	width: 100%;
-}
-
-.jp-forms__inbox-tabs .components-tab-panel__tab-content {
-	flex: 1;
-
-	/* Important to pair with flex-shrink */
-	min-height: 0;
 }
 
 .jp-forms__inbox-file-preview-shell {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:

Removes some un-used CSS that was used in the past for tabs area.

These day stabs uses different components. It should continue look as-is:

<img width="448" height="141" alt="image" src="https://github.com/user-attachments/assets/432e959b-082e-4226-9dad-4a4dbf9b5991" />




### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Jetpack -> Forms; nothing should change here around the tabs area

