### PR TITLE
Forms: Add step names and dots style to progress indicator

### DIFF
--- a/projects/packages/forms/changelog/add-form-progress-indicator-improvements
+++ b/projects/packages/forms/changelog/add-form-progress-indicator-improvements
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: Add step names and dots style options to progress indicator block.

--- a/projects/packages/forms/src/blocks/contact-form/attributes.js
+++ b/projects/packages/forms/src/blocks/contact-form/attributes.js
@@ -48,4 +48,8 @@ export default {
 		type: 'boolean',
 		default: false,
 	},
+	formSteps: {
+		type: 'array',
+		default: [],
+	},
 };

--- a/projects/packages/forms/src/blocks/contact-form/edit.js
+++ b/projects/packages/forms/src/blocks/contact-form/edit.js
@@ -121,7 +121,6 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 	useEffect( () => {
 		const stepData = steps.map( ( step, index ) => ( {
 			clientId: step.clientId,
-			name: step.attributes?.stepLabel || `Step ${ index + 1 }`,
 			label: step.attributes?.stepLabel || `Step ${ index + 1 }`,
 		} ) );
 		setAttributes( { formSteps: stepData } );

--- a/projects/packages/forms/src/blocks/contact-form/edit.js
+++ b/projects/packages/forms/src/blocks/contact-form/edit.js
@@ -117,6 +117,16 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 
 	const steps = useFormSteps( clientId );
 
+	// Update formSteps attribute when steps change
+	useEffect( () => {
+		const stepData = steps.map( ( step, index ) => ( {
+			clientId: step.clientId,
+			name: step.attributes?.stepLabel || `Step ${ index + 1 }`,
+			label: step.attributes?.stepLabel || `Step ${ index + 1 }`,
+		} ) );
+		setAttributes( { formSteps: stepData } );
+	}, [ steps, setAttributes ] );
+
 	const submitButton = useFindBlockRecursively(
 		clientId,
 		block => block.name === 'jetpack/button'

--- a/projects/packages/forms/src/blocks/contact-form/index.js
+++ b/projects/packages/forms/src/blocks/contact-form/index.js
@@ -62,6 +62,7 @@ export const settings = {
 	attributes: defaultAttributes,
 	providesContext: {
 		'jetpack/form-class-name': 'className',
+		'jetpack/form-steps': 'formSteps',
 	},
 	edit,
 	save: () => {

--- a/projects/packages/forms/src/blocks/form-progress-indicator/edit.js
+++ b/projects/packages/forms/src/blocks/form-progress-indicator/edit.js
@@ -74,9 +74,9 @@ const FormProgressIndicatorEdit = ( {
 			<div className="jetpack-form-progress-indicator--wrapper">
 				<div { ...blockProps }>
 					<div className="jetpack-form-progress-indicator-bar" style={ progressBarStyle }></div>
-					{ ( showStepNames || isDotStyle ) && finalSteps.length > 0 && (
-						<div className="jetpack-form-progress-indicator-steps">
-							{ finalSteps.map( ( step, index ) => {
+					<div className="jetpack-form-progress-indicator-steps">
+						{ finalSteps.length > 0 &&
+							finalSteps.map( ( step, index ) => {
 								const isActive = index === currentStepInfo.index;
 								const isCompleted = index < currentStepInfo.index;
 
@@ -101,8 +101,7 @@ const FormProgressIndicatorEdit = ( {
 									</div>
 								);
 							} ) }
-						</div>
-					) }
+					</div>
 				</div>
 			</div>
 			<StepControls formClientId={ parentFormId } showToggle={ false } showNavigation={ true } />

--- a/projects/packages/forms/src/blocks/form-progress-indicator/edit.js
+++ b/projects/packages/forms/src/blocks/form-progress-indicator/edit.js
@@ -64,7 +64,7 @@ const FormProgressIndicatorEdit = ( {
 										data-step-index={ index }
 									>
 										<span className="jetpack-form-progress-indicator-step-label">
-											{ step.name || step.label || `Step ${ index + 1 }` }
+											{ step.label }
 										</span>
 									</div>
 								) ) }

--- a/projects/packages/forms/src/blocks/form-progress-indicator/edit.js
+++ b/projects/packages/forms/src/blocks/form-progress-indicator/edit.js
@@ -75,15 +75,18 @@ const FormProgressIndicatorEdit = ( {
 										}${ isCompleted ? ' is-completed' : '' }` }
 										data-step-index={ index }
 									>
+										<div className="jetpack-form-progress-indicator-line"></div>
 										{ isDotStyle && (
-											<span className="jetpack-form-progress-indicator-step-number">
-												{ isCompleted ? '✓' : index + 1 }
-											</span>
+											<div className="jetpack-form-progress-indicator-dot">
+												<span className="jetpack-form-progress-indicator-step-number">
+													{ isCompleted ? '✓' : index + 1 }
+												</span>
+											</div>
 										) }
 										{ showStepNames && (
-											<span className="jetpack-form-progress-indicator-step-label">
+											<div className="jetpack-form-progress-indicator-step-label">
 												{ step.label }
-											</span>
+											</div>
 										) }
 									</div>
 								);

--- a/projects/packages/forms/src/blocks/form-progress-indicator/edit.js
+++ b/projects/packages/forms/src/blocks/form-progress-indicator/edit.js
@@ -1,20 +1,37 @@
-import { useBlockProps } from '@wordpress/block-editor';
+import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
+import { PanelBody, ToggleControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 import StepControls from '../shared/components/form-step-controls';
 import useParentFormClientId from '../shared/hooks/use-parent-form-client-id';
 import useStepNavigation from '../shared/hooks/use-step-navigation';
 
 import './editor.scss';
 
-const FormProgressIndicatorEdit = ( { clientId } ) => {
+const FormProgressIndicatorEdit = ( {
+	attributes,
+	setAttributes,
+	clientId,
+	className,
+	context,
+} ) => {
+	const { showStepNames } = attributes;
 	const parentFormId = useParentFormClientId( clientId );
 	const { currentStepInfo, steps } = useStepNavigation( parentFormId );
 
-	let progress = steps.length ? ( ( currentStepInfo.index + 1 ) / steps.length ) * 100 : 10;
-	if ( currentStepInfo.index === -1 && steps.length > 0 ) {
-		progress = ( 1 / steps.length ) * 100; // Assume the first step is active
+	// Use steps from context if available, fallback to useStepNavigation
+	const contextSteps = context?.[ 'jetpack/form-steps' ] || [];
+	const finalSteps = contextSteps.length > 0 ? contextSteps : steps;
+
+	let progress = finalSteps.length
+		? ( ( currentStepInfo.index + 1 ) / finalSteps.length ) * 100
+		: 10;
+	if ( currentStepInfo.index === -1 && finalSteps.length > 0 ) {
+		progress = ( 1 / finalSteps.length ) * 100; // Assume the first step is active
 	}
 
-	const blockProps = useBlockProps();
+	const blockProps = useBlockProps( {
+		className: `${ className || '' }${ showStepNames ? ' show-step-names' : '' }`,
+	} );
 
 	// Only need to set width – colours come from core style engine variables.
 	const progressBarStyle = {
@@ -23,9 +40,36 @@ const FormProgressIndicatorEdit = ( { clientId } ) => {
 
 	return (
 		<>
+			<InspectorControls>
+				<PanelBody title={ __( 'Settings', 'jetpack-forms' ) }>
+					<ToggleControl
+						label={ __( 'Show step names', 'jetpack-forms' ) }
+						checked={ showStepNames }
+						onChange={ value => setAttributes( { showStepNames: value } ) }
+					/>
+				</PanelBody>
+			</InspectorControls>
 			<div className="jetpack-form-progress-indicator--wrapper">
 				<div { ...blockProps }>
 					<div className="jetpack-form-progress-indicator-bar" style={ progressBarStyle }></div>
+					{ ( showStepNames || className?.includes( 'is-style-dots' ) ) &&
+						finalSteps.length > 0 && (
+							<div className="jetpack-form-progress-indicator-steps">
+								{ finalSteps.map( ( step, index ) => (
+									<div
+										key={ index }
+										className={ `jetpack-form-progress-indicator-step${
+											index <= currentStepInfo.index ? ' is-active' : ''
+										}` }
+										data-step-index={ index }
+									>
+										<span className="jetpack-form-progress-indicator-step-label">
+											{ step.name || step.label || `Step ${ index + 1 }` }
+										</span>
+									</div>
+								) ) }
+							</div>
+						) }
 				</div>
 			</div>
 			<StepControls formClientId={ parentFormId } showToggle={ false } showNavigation={ true } />

--- a/projects/packages/forms/src/blocks/form-progress-indicator/edit.js
+++ b/projects/packages/forms/src/blocks/form-progress-indicator/edit.js
@@ -33,6 +33,9 @@ const FormProgressIndicatorEdit = ( {
 		className: `${ className || '' }${ showStepNames ? ' show-step-names' : '' }`,
 	} );
 
+	const isDotStyle =
+		className?.includes( 'is-style-dots' ) || blockProps.className?.includes( 'is-style-dots' );
+
 	// Only need to set width – colours come from core style engine variables.
 	const progressBarStyle = {
 		width: `${ progress }%`,
@@ -52,24 +55,25 @@ const FormProgressIndicatorEdit = ( {
 			<div className="jetpack-form-progress-indicator--wrapper">
 				<div { ...blockProps }>
 					<div className="jetpack-form-progress-indicator-bar" style={ progressBarStyle }></div>
-					{ ( showStepNames || className?.includes( 'is-style-dots' ) ) &&
-						finalSteps.length > 0 && (
-							<div className="jetpack-form-progress-indicator-steps">
-								{ finalSteps.map( ( step, index ) => (
-									<div
-										key={ index }
-										className={ `jetpack-form-progress-indicator-step${
-											index <= currentStepInfo.index ? ' is-active' : ''
-										}` }
-										data-step-index={ index }
-									>
+					{ ( showStepNames || isDotStyle ) && finalSteps.length > 0 && (
+						<div className="jetpack-form-progress-indicator-steps">
+							{ finalSteps.map( ( step, index ) => (
+								<div
+									key={ index }
+									className={ `jetpack-form-progress-indicator-step${
+										index <= currentStepInfo.index ? ' is-active' : ''
+									}` }
+									data-step-index={ index }
+								>
+									{ showStepNames && (
 										<span className="jetpack-form-progress-indicator-step-label">
 											{ step.label }
 										</span>
-									</div>
-								) ) }
-							</div>
-						) }
+									) }
+								</div>
+							) ) }
+						</div>
+					) }
 				</div>
 			</div>
 			<StepControls formClientId={ parentFormId } showToggle={ false } showNavigation={ true } />

--- a/projects/packages/forms/src/blocks/form-progress-indicator/edit.js
+++ b/projects/packages/forms/src/blocks/form-progress-indicator/edit.js
@@ -22,13 +22,6 @@ const FormProgressIndicatorEdit = ( {
 	const contextSteps = context?.[ 'jetpack/form-steps' ] || [];
 	const finalSteps = contextSteps.length > 0 ? contextSteps : steps;
 
-	let progress = finalSteps.length
-		? ( ( currentStepInfo.index + 1 ) / finalSteps.length ) * 100
-		: 10;
-	if ( currentStepInfo.index === -1 && finalSteps.length > 0 ) {
-		progress = ( 1 / finalSteps.length ) * 100; // Assume the first step is active
-	}
-
 	const blockProps = useBlockProps( {
 		className: `${ className || '' }${ showStepNames ? ' show-step-names' : '' }`,
 		style: {
@@ -39,11 +32,6 @@ const FormProgressIndicatorEdit = ( {
 
 	const isDotStyle =
 		className?.includes( 'is-style-dots' ) || blockProps.className?.includes( 'is-style-dots' );
-
-	// Only need to set width – colours come from core style engine variables.
-	const progressBarStyle = {
-		width: `${ progress }%`,
-	};
 
 	return (
 		<>
@@ -73,7 +61,6 @@ const FormProgressIndicatorEdit = ( {
 			</InspectorControls>
 			<div className="jetpack-form-progress-indicator--wrapper">
 				<div { ...blockProps }>
-					<div className="jetpack-form-progress-indicator-bar" style={ progressBarStyle }></div>
 					<div className="jetpack-form-progress-indicator-steps">
 						{ finalSteps.length > 0 &&
 							finalSteps.map( ( step, index ) => {

--- a/projects/packages/forms/src/blocks/form-progress-indicator/edit.js
+++ b/projects/packages/forms/src/blocks/form-progress-indicator/edit.js
@@ -1,4 +1,4 @@
-import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
+import { InspectorControls, useBlockProps, PanelColorSettings } from '@wordpress/block-editor';
 import { PanelBody, ToggleControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import StepControls from '../shared/components/form-step-controls';
@@ -14,7 +14,7 @@ const FormProgressIndicatorEdit = ( {
 	className,
 	context,
 } ) => {
-	const { showStepNames } = attributes;
+	const { showStepNames, progressColor, backgroundColor } = attributes;
 	const parentFormId = useParentFormClientId( clientId );
 	const { currentStepInfo, steps } = useStepNavigation( parentFormId );
 
@@ -31,6 +31,10 @@ const FormProgressIndicatorEdit = ( {
 
 	const blockProps = useBlockProps( {
 		className: `${ className || '' }${ showStepNames ? ' show-step-names' : '' }`,
+		style: {
+			'--jetpack-progress-color': progressColor || undefined,
+			'--jetpack-progress-bg-color': backgroundColor || undefined,
+		},
 	} );
 
 	const isDotStyle =
@@ -51,27 +55,52 @@ const FormProgressIndicatorEdit = ( {
 						onChange={ value => setAttributes( { showStepNames: value } ) }
 					/>
 				</PanelBody>
+				<PanelColorSettings
+					title={ __( 'Color settings', 'jetpack-forms' ) }
+					colorSettings={ [
+						{
+							value: progressColor,
+							onChange: value => setAttributes( { progressColor: value } ),
+							label: __( 'Progress color', 'jetpack-forms' ),
+						},
+						{
+							value: backgroundColor,
+							onChange: value => setAttributes( { backgroundColor: value } ),
+							label: __( 'Background color', 'jetpack-forms' ),
+						},
+					] }
+				/>
 			</InspectorControls>
 			<div className="jetpack-form-progress-indicator--wrapper">
 				<div { ...blockProps }>
 					<div className="jetpack-form-progress-indicator-bar" style={ progressBarStyle }></div>
 					{ ( showStepNames || isDotStyle ) && finalSteps.length > 0 && (
 						<div className="jetpack-form-progress-indicator-steps">
-							{ finalSteps.map( ( step, index ) => (
-								<div
-									key={ index }
-									className={ `jetpack-form-progress-indicator-step${
-										index <= currentStepInfo.index ? ' is-active' : ''
-									}` }
-									data-step-index={ index }
-								>
-									{ showStepNames && (
-										<span className="jetpack-form-progress-indicator-step-label">
-											{ step.label }
-										</span>
-									) }
-								</div>
-							) ) }
+							{ finalSteps.map( ( step, index ) => {
+								const isActive = index === currentStepInfo.index;
+								const isCompleted = index < currentStepInfo.index;
+
+								return (
+									<div
+										key={ index }
+										className={ `jetpack-form-progress-indicator-step${
+											isActive ? ' is-active' : ''
+										}${ isCompleted ? ' is-completed' : '' }` }
+										data-step-index={ index }
+									>
+										{ isDotStyle && (
+											<span className="jetpack-form-progress-indicator-step-number">
+												{ isCompleted ? '✓' : index + 1 }
+											</span>
+										) }
+										{ showStepNames && (
+											<span className="jetpack-form-progress-indicator-step-label">
+												{ step.label }
+											</span>
+										) }
+									</div>
+								);
+							} ) }
 						</div>
 					) }
 				</div>

--- a/projects/packages/forms/src/blocks/form-progress-indicator/editor.scss
+++ b/projects/packages/forms/src/blocks/form-progress-indicator/editor.scss
@@ -1,5 +1,5 @@
 // Import the main styles
-@import "./style";
+@use "./style";
 
 // Editor-specific overrides
 .wp-block-jetpack-form-progress-indicator {

--- a/projects/packages/forms/src/blocks/form-progress-indicator/editor.scss
+++ b/projects/packages/forms/src/blocks/form-progress-indicator/editor.scss
@@ -3,28 +3,18 @@
 
 // Editor-specific overrides
 .wp-block-jetpack-form-progress-indicator {
-	// In editor, show steps when enabled (class-based approach)
-	&.show-step-names .jetpack-form-progress-indicator-steps {
-		display: flex;
-	}
-
-	// In editor, always show steps for dots style (even without showStepNames)
-	&.is-style-dots .jetpack-form-progress-indicator-steps {
+	// In editor, always show the steps container
+	.jetpack-form-progress-indicator-steps {
 		display: grid !important;
 	}
 
-	// Step names need to be shown when enabled in editor
-	.jetpack-form-progress-indicator-steps:empty {
-		display: none;
-	}
-
-	// Editor-specific: Show step numbers in dots style
-	&.is-style-dots .jetpack-form-progress-indicator-step-number {
-		display: flex !important; // Override the display: none from line style
-	}
-
-	// Show labels when showStepNames is true (works for both line and dots style)
+	// Show labels when showStepNames is true (class-based approach for editor)
 	&.show-step-names .jetpack-form-progress-indicator-step-label {
 		display: block !important;
+	}
+
+	// Ensure step numbers are visible in dots style in editor
+	&.is-style-dots .jetpack-form-progress-indicator-step-number {
+		display: flex !important;
 	}
 }

--- a/projects/packages/forms/src/blocks/form-progress-indicator/editor.scss
+++ b/projects/packages/forms/src/blocks/form-progress-indicator/editor.scss
@@ -1,17 +1,15 @@
 .wp-block-jetpack-form-progress-indicator {
 	--jp-form-progress-height: 0.75rem;
-
-	// Use theme colors with fallbacks
 	--jp-form-progress-bg-color: #e0e0e0;
 
-	// Essential structure
+	// Default line style
 	height: var(--jp-form-progress-height);
 	position: relative;
-	overflow: hidden;
+	overflow: visible;
 	border-radius: calc(var(--jp-form-progress-height) / 2);
 	background-color: var(--wp--style--color--background, var(--wp--preset--color--secondary, var(--jp-form-progress-bg-color)));
 
-	// Progress bar element - rendered as a child element to match the frontend
+	// Progress bar element for line style
 	.jetpack-form-progress-indicator-bar {
 		content: "";
 		display: block;
@@ -25,5 +23,86 @@
 		z-index: 1;
 		background-color: currentColor;
 		border-radius: calc(var(--jp-form-progress-height) / 2);
+	}
+
+	// Step labels container
+	.jetpack-form-progress-indicator-steps {
+		display: flex;
+		justify-content: space-between;
+		position: absolute;
+		top: calc(100% + 0.5rem);
+		left: 0;
+		right: 0;
+		width: 100%;
+	}
+
+	.jetpack-form-progress-indicator-step {
+		position: relative;
+		text-align: center;
+
+		&.is-active .jetpack-form-progress-indicator-step-label {
+			font-weight: 600;
+			color: currentColor;
+		}
+	}
+
+	.jetpack-form-progress-indicator-step-label {
+		font-size: 0.875rem;
+		color: var(--wp--preset--color--contrast-2, #666);
+		white-space: nowrap;
+	}
+
+	// Step names need to be shown when enabled
+	.jetpack-form-progress-indicator-steps:empty {
+		display: none;
+	}
+
+	// Dots style variation
+	&.is-style-dots {
+		height: auto;
+		background: none;
+		overflow: visible;
+
+		.jetpack-form-progress-indicator-bar {
+			display: none;
+		}
+
+		.jetpack-form-progress-indicator-steps {
+			position: static;
+			display: flex !important;
+			justify-content: center;
+			align-items: center;
+			gap: 1rem;
+		}
+
+		.jetpack-form-progress-indicator-step {
+			display: flex;
+			flex-direction: column;
+			align-items: center;
+			gap: 0.5rem;
+
+			&::before {
+				content: "";
+				display: block;
+				width: 1rem;
+				height: 1rem;
+				border-radius: 50%;
+				background-color: var(--wp--style--color--background, var(--wp--preset--color--secondary, var(--jp-form-progress-bg-color)));
+				transition: background-color 0.3s ease;
+			}
+
+			&.is-active::before {
+				background-color: currentColor;
+			}
+		}
+
+		.jetpack-form-progress-indicator-step-label {
+			position: static;
+		}
+
+		// Hide labels when showStepNames is false
+		&:not(.show-step-names) .jetpack-form-progress-indicator-step-label {
+			display: none;
+		}
 	}
 }

--- a/projects/packages/forms/src/blocks/form-progress-indicator/editor.scss
+++ b/projects/packages/forms/src/blocks/form-progress-indicator/editor.scss
@@ -9,6 +9,7 @@
 	border-radius: calc(var(--jp-form-progress-height) / 2);
 	background-color: var(--wp--style--color--background, var(--wp--preset--color--secondary, var(--jp-form-progress-bg-color)));
 
+
 	// Progress bar element for line style
 	.jetpack-form-progress-indicator-bar {
 		content: "";
@@ -21,7 +22,7 @@
 		min-width: var(--jp-form-progress-height);
 		transition: width 0.3s ease-in-out;
 		z-index: 1;
-		background-color: currentColor;
+		background-color: var(--jetpack-progress-color, var(--wp--preset--color--primary, var(--wp--preset--color--contrast, currentColor)));
 		border-radius: calc(var(--jp-form-progress-height) / 2);
 	}
 
@@ -42,14 +43,18 @@
 
 		&.is-active .jetpack-form-progress-indicator-step-label {
 			font-weight: 600;
-			color: currentColor;
 		}
 	}
 
 	.jetpack-form-progress-indicator-step-label {
 		font-size: 0.875rem;
-		color: var(--wp--preset--color--contrast-2, #666);
+		color: currentColor;
 		white-space: nowrap;
+	}
+
+	// Hide step numbers in line style (only show in dots style)
+	&:not(.is-style-dots) .jetpack-form-progress-indicator-step-number {
+		display: none;
 	}
 
 	// Step names need to be shown when enabled
@@ -62,17 +67,21 @@
 		height: auto;
 		background: none;
 		overflow: visible;
+		position: relative;
+		padding: 0 1rem; // Add padding to ensure dots aren't cut off
 
 		.jetpack-form-progress-indicator-bar {
 			display: none;
 		}
 
 		.jetpack-form-progress-indicator-steps {
-			position: static;
-			display: flex !important;
-			justify-content: center;
-			align-items: center;
-			gap: 1rem;
+			position: relative;
+			display: grid !important;
+			grid-auto-flow: column;
+			grid-auto-columns: 1fr;
+			align-items: flex-start;
+			width: 100%;
+			padding: 0;
 		}
 
 		.jetpack-form-progress-indicator-step {
@@ -80,20 +89,78 @@
 			flex-direction: column;
 			align-items: center;
 			gap: 0.5rem;
+			position: relative;
+			z-index: 1;
 
+			// Connecting line between dots (only for steps that aren't last)
+			&:not(:last-child) {
+
+				&::after {
+					content: "";
+					position: absolute;
+					top: 1rem; // Half of dot height (2rem / 2)
+					left: 50%; // Start from center of current dot // Full width of grid cell
+					height: 2px;
+					background-color: var(--jetpack-progress-bg-color, var(--wp--preset--color--secondary, var(--jp-form-progress-bg-color)));
+					z-index: 0;
+					// Adjust to connect dots properly
+					transform: translateX(1rem); // Move line to start from right edge of dot
+					// Calculate width to reach the next dot
+					width: calc(100% - 2rem); // Subtract the dot width
+				}
+			}
+
+			// Dot background
 			&::before {
 				content: "";
 				display: block;
-				width: 1rem;
-				height: 1rem;
+				width: 2rem;
+				height: 2rem;
 				border-radius: 50%;
-				background-color: var(--wp--style--color--background, var(--wp--preset--color--secondary, var(--jp-form-progress-bg-color)));
+				background-color: var(--jetpack-progress-bg-color, var(--wp--preset--color--secondary, var(--jp-form-progress-bg-color)));
 				transition: background-color 0.3s ease;
+				position: relative;
+				z-index: 2;
 			}
 
-			&.is-active::before {
-				background-color: currentColor;
+			&.is-active::before,
+			&.is-completed::before {
+				// Use progress color first, then theme contrast (usually dark)
+				background-color:
+ var(--jetpack-progress-color, var(--wp--preset--color--contrast, currentColor));
 			}
+		}
+
+		// Step number/checkmark inside the dot - only show in dots style
+		.jetpack-form-progress-indicator-step-number {
+			position: absolute;
+			top: 0;
+			left: 50%;
+			transform: translateX(-50%);
+			width: 2rem;
+			height: 2rem;
+			display: flex !important; // Override the display: none from line style
+			align-items: center;
+			justify-content: center;
+			font-size: 0.875rem;
+			font-weight: 600;
+			z-index: 3;
+			line-height: 1;
+			// Default color for inactive steps
+			color: var(--wp--preset--color--contrast, currentColor);
+		}
+
+		// Active step numbers - higher specificity
+		.jetpack-form-progress-indicator-step.is-active .jetpack-form-progress-indicator-step-number {
+			color: var(--wp--preset--color--base, #fff);
+			text-shadow: 0 0 1px rgba(0, 0, 0, 0.5);
+		}
+
+		// Completed step numbers - higher specificity
+		.jetpack-form-progress-indicator-step.is-completed .jetpack-form-progress-indicator-step-number {
+			color: var(--wp--preset--color--base, #fff);
+			text-shadow: 0 0 1px rgba(0, 0, 0, 0.5);
+			font-size: 1.125rem;
 		}
 
 		.jetpack-form-progress-indicator-step-label {

--- a/projects/packages/forms/src/blocks/form-progress-indicator/editor.scss
+++ b/projects/packages/forms/src/blocks/form-progress-indicator/editor.scss
@@ -1,175 +1,30 @@
+// Import the main styles
+@import "./style";
+
+// Editor-specific overrides
 .wp-block-jetpack-form-progress-indicator {
-	--jp-form-progress-height: 0.75rem;
-	--jp-form-progress-bg-color: #e0e0e0;
-
-	// Default line style
-	height: var(--jp-form-progress-height);
-	position: relative;
-	overflow: visible;
-	border-radius: calc(var(--jp-form-progress-height) / 2);
-	background-color: var(--wp--style--color--background, var(--wp--preset--color--secondary, var(--jp-form-progress-bg-color)));
-
-
-	// Progress bar element for line style
-	.jetpack-form-progress-indicator-bar {
-		content: "";
-		display: block;
-		position: absolute;
-		top: 0;
-		left: 0;
-		height: 100%;
-		width: 1%;
-		min-width: var(--jp-form-progress-height);
-		transition: width 0.3s ease-in-out;
-		z-index: 1;
-		background-color: var(--jetpack-progress-color, var(--wp--preset--color--primary, var(--wp--preset--color--contrast, currentColor)));
-		border-radius: calc(var(--jp-form-progress-height) / 2);
-	}
-
-	// Step labels container
-	.jetpack-form-progress-indicator-steps {
+	// In editor, show steps when enabled (class-based approach)
+	&.show-step-names .jetpack-form-progress-indicator-steps {
 		display: flex;
-		justify-content: space-between;
-		position: absolute;
-		top: calc(100% + 0.5rem);
-		left: 0;
-		right: 0;
-		width: 100%;
 	}
 
-	.jetpack-form-progress-indicator-step {
-		position: relative;
-		text-align: center;
-
-		&.is-active .jetpack-form-progress-indicator-step-label {
-			font-weight: 600;
-		}
+	// In editor, always show steps for dots style (even without showStepNames)
+	&.is-style-dots .jetpack-form-progress-indicator-steps {
+		display: grid !important;
 	}
 
-	.jetpack-form-progress-indicator-step-label {
-		font-size: 0.875rem;
-		color: currentColor;
-		white-space: nowrap;
-	}
-
-	// Hide step numbers in line style (only show in dots style)
-	&:not(.is-style-dots) .jetpack-form-progress-indicator-step-number {
-		display: none;
-	}
-
-	// Step names need to be shown when enabled
+	// Step names need to be shown when enabled in editor
 	.jetpack-form-progress-indicator-steps:empty {
 		display: none;
 	}
 
-	// Dots style variation
-	&.is-style-dots {
-		height: auto;
-		background: none;
-		overflow: visible;
-		position: relative;
-		padding: 0 1rem; // Add padding to ensure dots aren't cut off
+	// Editor-specific: Show step numbers in dots style
+	&.is-style-dots .jetpack-form-progress-indicator-step-number {
+		display: flex !important; // Override the display: none from line style
+	}
 
-		.jetpack-form-progress-indicator-bar {
-			display: none;
-		}
-
-		.jetpack-form-progress-indicator-steps {
-			position: relative;
-			display: grid !important;
-			grid-auto-flow: column;
-			grid-auto-columns: 1fr;
-			align-items: flex-start;
-			width: 100%;
-			padding: 0;
-		}
-
-		.jetpack-form-progress-indicator-step {
-			display: flex;
-			flex-direction: column;
-			align-items: center;
-			gap: 0.5rem;
-			position: relative;
-			z-index: 1;
-
-			// Connecting line between dots (only for steps that aren't last)
-			&:not(:last-child) {
-
-				&::after {
-					content: "";
-					position: absolute;
-					top: 1rem; // Half of dot height (2rem / 2)
-					left: 50%; // Start from center of current dot // Full width of grid cell
-					height: 2px;
-					background-color: var(--jetpack-progress-bg-color, var(--wp--preset--color--secondary, var(--jp-form-progress-bg-color)));
-					z-index: 0;
-					// Adjust to connect dots properly
-					transform: translateX(1rem); // Move line to start from right edge of dot
-					// Calculate width to reach the next dot
-					width: calc(100% - 2rem); // Subtract the dot width
-				}
-			}
-
-			// Dot background
-			&::before {
-				content: "";
-				display: block;
-				width: 2rem;
-				height: 2rem;
-				border-radius: 50%;
-				background-color: var(--jetpack-progress-bg-color, var(--wp--preset--color--secondary, var(--jp-form-progress-bg-color)));
-				transition: background-color 0.3s ease;
-				position: relative;
-				z-index: 2;
-			}
-
-			&.is-active::before,
-			&.is-completed::before {
-				// Use progress color first, then theme contrast (usually dark)
-				background-color:
- var(--jetpack-progress-color, var(--wp--preset--color--contrast, currentColor));
-			}
-		}
-
-		// Step number/checkmark inside the dot - only show in dots style
-		.jetpack-form-progress-indicator-step-number {
-			position: absolute;
-			top: 0;
-			left: 50%;
-			transform: translateX(-50%);
-			width: 2rem;
-			height: 2rem;
-			display: flex !important; // Override the display: none from line style
-			align-items: center;
-			justify-content: center;
-			font-size: 0.875rem;
-			font-weight: 600;
-			z-index: 3;
-			line-height: 1;
-			// Default color for inactive steps
-			color: var(--wp--preset--color--contrast, currentColor);
-		}
-
-		// Active step numbers - higher specificity
-		.jetpack-form-progress-indicator-step.is-active .jetpack-form-progress-indicator-step-number {
-			color: var(--wp--preset--color--base, #fff);
-			text-shadow: 0 0 1px rgba(0, 0, 0, 0.5);
-		}
-
-		// Completed step numbers - higher specificity
-		.jetpack-form-progress-indicator-step.is-completed .jetpack-form-progress-indicator-step-number {
-			color: var(--wp--preset--color--base, #fff);
-			text-shadow: 0 0 1px rgba(0, 0, 0, 0.5);
-			font-size: 1.125rem;
-		}
-
-		.jetpack-form-progress-indicator-step-label {
-			position: static;
-		}
-
-		// Hide labels when showStepNames is false
-		&:not(.show-step-names) .jetpack-form-progress-indicator-step-label {
-			display: none;
-		}
+	// Show labels when showStepNames is true (works for both line and dots style)
+	&.show-step-names .jetpack-form-progress-indicator-step-label {
+		display: block !important;
 	}
 }

--- a/projects/packages/forms/src/blocks/form-progress-indicator/editor.scss
+++ b/projects/packages/forms/src/blocks/form-progress-indicator/editor.scss
@@ -5,7 +5,7 @@
 .wp-block-jetpack-form-progress-indicator {
 	// In editor, always show the steps container
 	.jetpack-form-progress-indicator-steps {
-		display: grid !important;
+		display: flex !important;
 	}
 
 	// Show labels when showStepNames is true (class-based approach for editor)

--- a/projects/packages/forms/src/blocks/form-progress-indicator/index.js
+++ b/projects/packages/forms/src/blocks/form-progress-indicator/index.js
@@ -31,6 +31,7 @@ export const settings = {
 			},
 		},
 	},
+	usesContext: [ 'jetpack/form-steps' ],
 	title: __( 'Progress indicator', 'jetpack-forms' ),
 	description: __(
 		'Show a visual indicator of progress through multi-step forms.',
@@ -56,7 +57,23 @@ export const settings = {
 	},
 	edit: edit,
 	save: save,
-	attributes: {},
+	attributes: {
+		showStepNames: {
+			type: 'boolean',
+			default: false,
+		},
+	},
+	styles: [
+		{
+			name: 'line',
+			label: __( 'Line', 'jetpack-forms' ),
+			isDefault: true,
+		},
+		{
+			name: 'dots',
+			label: __( 'Dots', 'jetpack-forms' ),
+		},
+	],
 	transforms: {},
 	example: {},
 };

--- a/projects/packages/forms/src/blocks/form-progress-indicator/index.js
+++ b/projects/packages/forms/src/blocks/form-progress-indicator/index.js
@@ -21,14 +21,16 @@ export const settings = {
 			margin: true,
 		},
 		color: {
-			background: true,
 			text: true,
-			gradients: true,
+			background: false, // Disable default background to avoid wrapper styling
 			__experimentalDefaultControls: {
-				background: true,
 				text: true,
-				gradient: true,
 			},
+		},
+		__experimentalBorder: {
+			color: true,
+			radius: true,
+			width: true,
 		},
 	},
 	usesContext: [ 'jetpack/form-steps' ],
@@ -61,6 +63,12 @@ export const settings = {
 		showStepNames: {
 			type: 'boolean',
 			default: false,
+		},
+		progressColor: {
+			type: 'string',
+		},
+		backgroundColor: {
+			type: 'string',
 		},
 	},
 	styles: [

--- a/projects/packages/forms/src/blocks/form-progress-indicator/index.js
+++ b/projects/packages/forms/src/blocks/form-progress-indicator/index.js
@@ -1,3 +1,4 @@
+import { useBlockProps } from '@wordpress/block-editor';
 import { Rect } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import renderMaterialIcon from '../shared/components/render-material-icon';
@@ -84,6 +85,43 @@ export const settings = {
 	],
 	transforms: {},
 	example: {},
+	deprecated: [
+		{
+			attributes: {
+				showStepNames: {
+					type: 'boolean',
+					default: false,
+				},
+				progressColor: {
+					type: 'string',
+				},
+				backgroundColor: {
+					type: 'string',
+				},
+			},
+			save: ( { attributes } ) => {
+				const { showStepNames, progressColor, backgroundColor } = attributes;
+				const blockProps = useBlockProps.save( {
+					style: {
+						'--jetpack-progress-color': progressColor || undefined,
+						'--jetpack-progress-bg-color': backgroundColor || undefined,
+					},
+				} );
+
+				return (
+					<div
+						className="jetpack-form-progress-indicator--wrapper"
+						data-show-step-names={ showStepNames }
+					>
+						<div { ...blockProps }>
+							<div className="jetpack-form-progress-indicator-bar"></div>
+							<div className="jetpack-form-progress-indicator-steps"></div>
+						</div>
+					</div>
+				);
+			},
+		},
+	],
 };
 
 export default {

--- a/projects/packages/forms/src/blocks/form-progress-indicator/index.js
+++ b/projects/packages/forms/src/blocks/form-progress-indicator/index.js
@@ -123,6 +123,13 @@ export const settings = {
 			isEligible: ( attributes, innerBlocks, { innerHTML } ) => {
 				return innerHTML && innerHTML.includes( 'jetpack-form-progress-indicator-bar' );
 			},
+			migrate: attributes => {
+				// Ensure showStepNames defaults to false if not set
+				return {
+					...attributes,
+					showStepNames: attributes.showStepNames !== undefined ? attributes.showStepNames : false,
+				};
+			},
 		},
 	],
 };

--- a/projects/packages/forms/src/blocks/form-progress-indicator/index.js
+++ b/projects/packages/forms/src/blocks/form-progress-indicator/index.js
@@ -120,6 +120,9 @@ export const settings = {
 					</div>
 				);
 			},
+			isEligible: ( attributes, innerBlocks, { innerHTML } ) => {
+				return innerHTML && innerHTML.includes( 'jetpack-form-progress-indicator-bar' );
+			},
 		},
 	],
 };

--- a/projects/packages/forms/src/blocks/form-progress-indicator/index.js
+++ b/projects/packages/forms/src/blocks/form-progress-indicator/index.js
@@ -23,9 +23,12 @@ export const settings = {
 		},
 		color: {
 			text: true,
-			background: false, // Disable default background to avoid wrapper styling
+			background: true, // Keep background support for backward compatibility
+			gradients: true,
 			__experimentalDefaultControls: {
+				background: true,
 				text: true,
+				gradient: true,
 			},
 		},
 		__experimentalBorder: {
@@ -85,7 +88,39 @@ export const settings = {
 	],
 	transforms: {},
 	example: {},
+	// Accept legacy markup (single progress bar div) as still valid to avoid validation errors.
+	isValid: ( attrs, innerBlocks, { innerHTML } ) => {
+		return (
+			innerHTML &&
+			innerHTML.includes( 'jetpack-form-progress-indicator-bar' ) &&
+			! innerHTML.includes( 'jetpack-form-progress-indicator-steps' )
+		);
+	},
 	deprecated: [
+		// v1 – original implementation with only progress bar (no steps container)
+		{
+			// When block was saved before attributes like showStepNames existed.
+			attributes: {
+				showStepNames: { type: 'boolean' },
+				progressColor: { type: 'string' },
+				backgroundColor: { type: 'string' },
+			},
+			isEligible: attrs => attrs.showStepNames === undefined,
+			save: () => {
+				const blockProps = useBlockProps.save();
+				return (
+					<div className="jetpack-form-progress-indicator--wrapper">
+						<div { ...blockProps }>
+							<div className="jetpack-form-progress-indicator-bar"></div>
+						</div>
+					</div>
+				);
+			},
+			migrate: attributes => ( {
+				...attributes,
+				showStepNames: false,
+			} ),
+		},
 		{
 			attributes: {
 				showStepNames: {
@@ -112,7 +147,12 @@ export const settings = {
 				);
 			},
 			isEligible: ( attributes, innerBlocks, { innerHTML } ) => {
-				return innerHTML && innerHTML.includes( 'jetpack-form-progress-indicator-bar' );
+				// Eligible when markup contains the legacy bar element but NOT the new steps container.
+				return (
+					innerHTML &&
+					innerHTML.includes( 'jetpack-form-progress-indicator-bar' ) &&
+					! innerHTML.includes( 'jetpack-form-progress-indicator-steps' )
+				);
 			},
 			migrate: attributes => {
 				// Ensure showStepNames defaults to false if not set

--- a/projects/packages/forms/src/blocks/form-progress-indicator/index.js
+++ b/projects/packages/forms/src/blocks/form-progress-indicator/index.js
@@ -99,23 +99,14 @@ export const settings = {
 					type: 'string',
 				},
 			},
-			save: ( { attributes } ) => {
-				const { showStepNames, progressColor, backgroundColor } = attributes;
-				const blockProps = useBlockProps.save( {
-					style: {
-						'--jetpack-progress-color': progressColor || undefined,
-						'--jetpack-progress-bg-color': backgroundColor || undefined,
-					},
-				} );
+			save: () => {
+				// Legacy output only included the progress bar element.
+				const blockProps = useBlockProps.save();
 
 				return (
-					<div
-						className="jetpack-form-progress-indicator--wrapper"
-						data-show-step-names={ showStepNames }
-					>
+					<div className="jetpack-form-progress-indicator--wrapper">
 						<div { ...blockProps }>
 							<div className="jetpack-form-progress-indicator-bar"></div>
-							<div className="jetpack-form-progress-indicator-steps"></div>
 						</div>
 					</div>
 				);

--- a/projects/packages/forms/src/blocks/form-progress-indicator/save.js
+++ b/projects/packages/forms/src/blocks/form-progress-indicator/save.js
@@ -1,12 +1,17 @@
 import { useBlockProps } from '@wordpress/block-editor';
 
-const FormProgressIndicatorSave = () => {
+const FormProgressIndicatorSave = ( { attributes } ) => {
+	const { showStepNames } = attributes;
 	const blockProps = useBlockProps.save();
 
 	return (
-		<div className="jetpack-form-progress-indicator--wrapper">
+		<div
+			className="jetpack-form-progress-indicator--wrapper"
+			data-show-step-names={ showStepNames }
+		>
 			<div { ...blockProps }>
 				<div className="jetpack-form-progress-indicator-bar"></div>
+				<div className="jetpack-form-progress-indicator-steps"></div>
 			</div>
 		</div>
 	);

--- a/projects/packages/forms/src/blocks/form-progress-indicator/save.js
+++ b/projects/packages/forms/src/blocks/form-progress-indicator/save.js
@@ -15,7 +15,6 @@ const FormProgressIndicatorSave = ( { attributes } ) => {
 			data-show-step-names={ showStepNames }
 		>
 			<div { ...blockProps }>
-				<div className="jetpack-form-progress-indicator-bar"></div>
 				<div className="jetpack-form-progress-indicator-steps"></div>
 			</div>
 		</div>

--- a/projects/packages/forms/src/blocks/form-progress-indicator/save.js
+++ b/projects/packages/forms/src/blocks/form-progress-indicator/save.js
@@ -1,8 +1,13 @@
 import { useBlockProps } from '@wordpress/block-editor';
 
 const FormProgressIndicatorSave = ( { attributes } ) => {
-	const { showStepNames } = attributes;
-	const blockProps = useBlockProps.save();
+	const { showStepNames, progressColor, backgroundColor } = attributes;
+	const blockProps = useBlockProps.save( {
+		style: {
+			'--jetpack-progress-color': progressColor || undefined,
+			'--jetpack-progress-bg-color': backgroundColor || undefined,
+		},
+	} );
 
 	return (
 		<div

--- a/projects/packages/forms/src/blocks/form-progress-indicator/save.js
+++ b/projects/packages/forms/src/blocks/form-progress-indicator/save.js
@@ -2,20 +2,26 @@ import { useBlockProps } from '@wordpress/block-editor';
 
 const FormProgressIndicatorSave = ( { attributes } ) => {
 	const { showStepNames, progressColor, backgroundColor } = attributes;
+
+	// Only set CSS vars when values are defined to avoid empty style="".
+	const styleVars = {
+		...( progressColor ? { '--jetpack-progress-color': progressColor } : {} ),
+		...( backgroundColor ? { '--jetpack-progress-bg-color': backgroundColor } : {} ),
+	};
+
 	const blockProps = useBlockProps.save( {
-		style: {
-			'--jetpack-progress-color': progressColor || undefined,
-			'--jetpack-progress-bg-color': backgroundColor || undefined,
-		},
+		style: Object.keys( styleVars ).length ? styleVars : undefined,
 	} );
 
+	const wrapperProps = {
+		className: 'jetpack-form-progress-indicator--wrapper',
+		...( showStepNames ? { 'data-show-step-names': true } : {} ),
+	};
+
 	return (
-		<div
-			className="jetpack-form-progress-indicator--wrapper"
-			data-show-step-names={ showStepNames }
-		>
+		<div { ...wrapperProps }>
 			<div { ...blockProps }>
-				<div className="jetpack-form-progress-indicator-steps"></div>
+				<div className="jetpack-form-progress-indicator-steps" />
 			</div>
 		</div>
 	);

--- a/projects/packages/forms/src/blocks/form-progress-indicator/style.scss
+++ b/projects/packages/forms/src/blocks/form-progress-indicator/style.scss
@@ -9,6 +9,7 @@
 	border-radius: calc(var(--jp-form-progress-height) / 2);
 	background-color: var(--wp--style--color--background, var(--wp--preset--color--secondary, var(--jp-form-progress-bg-color)));
 
+
 	// Progress bar element for line style
 	.jetpack-form-progress-indicator-bar {
 		content: "";
@@ -21,7 +22,7 @@
 		min-width: var(--jp-form-progress-height);
 		transition: width 0.3s ease-in-out;
 		z-index: 1;
-		background-color: currentColor;
+		background-color: var(--jetpack-progress-color, var(--wp--preset--color--primary, var(--wp--preset--color--contrast, currentColor)));
 		border-radius: calc(var(--jp-form-progress-height) / 2);
 	}
 
@@ -42,14 +43,18 @@
 
 		&.is-active .jetpack-form-progress-indicator-step-label {
 			font-weight: 600;
-			color: currentColor;
 		}
 	}
 
 	.jetpack-form-progress-indicator-step-label {
 		font-size: 0.875rem;
-		color: var(--wp--preset--color--contrast-2, #666);
+		color: currentColor;
 		white-space: nowrap;
+	}
+
+	// Hide step numbers in line style (only show in dots style)
+	&:not(.is-style-dots) .jetpack-form-progress-indicator-step-number {
+		display: none;
 	}
 
 	// Show steps when enabled
@@ -65,17 +70,21 @@
 		height: auto;
 		background: none;
 		overflow: visible;
+		position: relative;
+		padding: 0 1rem; // Add padding to ensure dots aren't cut off
 
 		.jetpack-form-progress-indicator-bar {
 			display: none;
 		}
 
 		.jetpack-form-progress-indicator-steps {
-			position: static;
-			display: flex !important;
-			justify-content: center;
-			align-items: center;
-			gap: 1rem;
+			position: relative;
+			display: grid !important;
+			grid-auto-flow: column;
+			grid-auto-columns: 1fr;
+			align-items: flex-start;
+			width: 100%;
+			padding: 0;
 		}
 
 		.jetpack-form-progress-indicator-step {
@@ -83,20 +92,78 @@
 			flex-direction: column;
 			align-items: center;
 			gap: 0.5rem;
+			position: relative;
+			z-index: 1;
 
+			// Connecting line between dots (only for steps that aren't last)
+			&:not(:last-child) {
+
+				&::after {
+					content: "";
+					position: absolute;
+					top: 1rem; // Half of dot height (2rem / 2)
+					left: 50%; // Start from center of current dot // Full width of grid cell
+					height: 2px;
+					background-color: var(--jetpack-progress-bg-color, var(--wp--preset--color--secondary, var(--jp-form-progress-bg-color)));
+					z-index: 0;
+					// Adjust to connect dots properly
+					transform: translateX(1rem); // Move line to start from right edge of dot
+					// Calculate width to reach the next dot
+					width: calc(100% - 2rem); // Subtract the dot width
+				}
+			}
+
+			// Dot background
 			&::before {
 				content: "";
 				display: block;
-				width: 1rem;
-				height: 1rem;
+				width: 2rem;
+				height: 2rem;
 				border-radius: 50%;
-				background-color: var(--wp--style--color--background, var(--wp--preset--color--secondary, var(--jp-form-progress-bg-color)));
+				background-color: var(--jetpack-progress-bg-color, var(--wp--preset--color--secondary, var(--jp-form-progress-bg-color)));
 				transition: background-color 0.3s ease;
+				position: relative;
+				z-index: 2;
 			}
 
-			&.is-active::before {
-				background-color: currentColor;
+			&.is-active::before,
+			&.is-completed::before {
+				// Use progress color first, then theme contrast (usually dark)
+				background-color:
+ var(--jetpack-progress-color, var(--wp--preset--color--contrast, currentColor));
 			}
+		}
+
+		// Step number/checkmark inside the dot - show in dots style
+		.jetpack-form-progress-indicator-step-number {
+			position: absolute;
+			top: 0;
+			left: 50%;
+			transform: translateX(-50%);
+			width: 2rem;
+			height: 2rem;
+			display: flex;
+			align-items: center;
+			justify-content: center;
+			font-size: 0.875rem;
+			font-weight: 600;
+			z-index: 3;
+			line-height: 1;
+			// Default color for inactive steps
+			color: var(--wp--preset--color--contrast, currentColor);
+		}
+
+		// Active step numbers - higher specificity
+		.jetpack-form-progress-indicator-step.is-active .jetpack-form-progress-indicator-step-number {
+			color: var(--wp--preset--color--base, #fff);
+			text-shadow: 0 0 1px rgba(0, 0, 0, 0.5);
+		}
+
+		// Completed step numbers - higher specificity
+		.jetpack-form-progress-indicator-step.is-completed .jetpack-form-progress-indicator-step-number {
+			color: var(--wp--preset--color--base, #fff);
+			text-shadow: 0 0 1px rgba(0, 0, 0, 0.5);
+			font-size: 1.125rem;
 		}
 
 		.jetpack-form-progress-indicator-step-label {

--- a/projects/packages/forms/src/blocks/form-progress-indicator/style.scss
+++ b/projects/packages/forms/src/blocks/form-progress-indicator/style.scss
@@ -2,44 +2,28 @@
 	--jp-form-progress-height: 0.75rem;
 	--jp-form-progress-bg-color: #e0e0e0;
 
-	// Default line style
-	height: var(--jp-form-progress-height);
+	// Default styles - unified for both line and dots
 	position: relative;
 	overflow: visible;
-	border-radius: calc(var(--jp-form-progress-height) / 2);
-	background-color: var(--jetpack-progress-bg-color, var(--wp--style--color--background, var(--wp--preset--color--secondary, var(--jp-form-progress-bg-color))));
 
-
-	// Progress bar element for line style
-	.jetpack-form-progress-indicator-bar {
-		content: "";
-		display: block;
-		position: absolute;
-		top: 0;
-		left: 0;
-		height: 100%;
-		width: 1%;
-		min-width: var(--jp-form-progress-height);
-		transition: width 0.3s ease-in-out;
-		z-index: 1;
-		background-color: var(--jetpack-progress-color, var(--wp--preset--color--primary, var(--wp--preset--color--contrast, currentColor)));
-		border-radius: calc(var(--jp-form-progress-height) / 2);
-	}
-
-	// Step labels container
+	// Step container - used for both dots and line styles
 	.jetpack-form-progress-indicator-steps {
-		display: none;
-		justify-content: space-between;
-		position: absolute;
-		top: calc(100% + 0.5rem);
-		left: 0;
-		right: 0;
+		display: grid;
+		grid-auto-flow: column;
+		grid-auto-columns: 1fr;
+		align-items: center;
 		width: 100%;
+		padding: 0;
+		position: relative;
 	}
 
 	.jetpack-form-progress-indicator-step {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 0.5rem;
 		position: relative;
-		text-align: center;
+		z-index: 1;
 
 		&.is-active .jetpack-form-progress-indicator-step-label {
 			font-weight: 600;
@@ -50,67 +34,85 @@
 		font-size: 0.875rem;
 		color: currentColor;
 		white-space: nowrap;
+		display: none; // Hidden by default, shown when step names enabled
 	}
 
-	// Hide step numbers in line style (only show in dots style)
-	&:not(.is-style-dots) .jetpack-form-progress-indicator-step-number {
-		display: none;
-	}
-
-	// Show steps when enabled
+	// Show step labels when enabled
 	.jetpack-form-progress-indicator--wrapper[data-show-step-names="true"] & {
 
-		.jetpack-form-progress-indicator-steps {
-			display: flex;
+		.jetpack-form-progress-indicator-step-label {
+			display: block;
 		}
+
+		// Add the same spacing as other form blocks when step names are shown
+		margin-bottom: var(--wp--style--block-gap, 1.5rem);
 	}
 
-	// Dots style variation
-	&.is-style-dots {
-		height: auto;
-		background: none;
-		overflow: visible;
-		position: relative;
-		padding: 0 1rem; // Add padding to ensure dots aren't cut off
-
-		.jetpack-form-progress-indicator-bar {
-			display: none;
-		}
+	// Line style (default) - make steps look like a progress line
+	&:not(.is-style-dots) {
+		height: var(--jp-form-progress-height);
+		background-color: var(--jetpack-progress-bg-color, var(--wp--preset--color--secondary, var(--jp-form-progress-bg-color)));
+		border-radius: calc(var(--jp-form-progress-height) / 2);
 
 		.jetpack-form-progress-indicator-steps {
-			position: relative;
-			display: grid !important;
-			grid-auto-flow: column;
-			grid-auto-columns: 1fr;
-			align-items: flex-start;
-			width: 100%;
-			padding: 0;
+			height: 100%;
+			align-items: center;
 		}
 
 		.jetpack-form-progress-indicator-step {
-			display: flex;
-			flex-direction: column;
-			align-items: center;
-			gap: 0.5rem;
-			position: relative;
-			z-index: 1;
+			flex-direction: row;
+			gap: 0;
+			height: 100%;
 
+			// Active and completed steps get the progress color
+			&.is-active,
+			&.is-completed {
+				background-color: var(--jetpack-progress-color, var(--wp--preset--color--primary, currentColor));
+			}
+
+			// First step gets left rounded corners
+			&:first-child {
+				border-top-left-radius: calc(var(--jp-form-progress-height) / 2);
+				border-bottom-left-radius: calc(var(--jp-form-progress-height) / 2);
+			}
+
+			// Last step gets right rounded corners
+			&:last-child {
+				border-top-right-radius: calc(var(--jp-form-progress-height) / 2);
+				border-bottom-right-radius: calc(var(--jp-form-progress-height) / 2);
+			}
+		}
+
+		// Hide step numbers in line style
+		.jetpack-form-progress-indicator-step-number {
+			display: none;
+		}
+
+		// Position step labels below the line
+		.jetpack-form-progress-indicator-step-label {
+			position: absolute;
+			top: calc(100% + 0.5rem);
+			left: 50%;
+			transform: translateX(-50%);
+		}
+	}
+
+	// Dots style - larger dots with numbers/checkmarks
+	&.is-style-dots {
+		padding: 0 1rem; // Add padding to ensure dots aren't cut off
+
+		.jetpack-form-progress-indicator-step {
 			// Connecting line between dots (only for steps that aren't last)
-			&:not(:last-child) {
-
-				&::after {
-					content: "";
-					position: absolute;
-					top: 1rem; // Half of dot height (2rem / 2)
-					left: 50%; // Start from center of current dot // Full width of grid cell
-					height: 2px;
-					background-color: var(--jetpack-progress-bg-color, var(--wp--preset--color--secondary, var(--jp-form-progress-bg-color)));
-					z-index: 0;
-					// Adjust to connect dots properly
-					transform: translateX(1rem); // Move line to start from right edge of dot
-					// Calculate width to reach the next dot
-					width: calc(100% - 2rem); // Subtract the dot width
-				}
+			&:not(:last-child)::after {
+				content: "";
+				position: absolute;
+				top: 1rem; // Half of dot height (2rem / 2)
+				left: 50%;
+				height: 2px;
+				background-color: var(--jetpack-progress-bg-color, var(--wp--preset--color--secondary, var(--jp-form-progress-bg-color)));
+				z-index: 0;
+				transform: translateX(1rem); // Move line to start from right edge of dot
+				width: calc(100% - 2rem); // Subtract the dot width
 			}
 
 			// Dot background
@@ -128,12 +130,11 @@
 
 			&.is-active::before,
 			&.is-completed::before {
-				// Use progress color first, then theme contrast (usually dark)
 				background-color: var(--jetpack-progress-color, var(--wp--preset--color--contrast, currentColor));
 			}
 		}
 
-		// Step number/checkmark inside the dot - show in dots style
+		// Step number/checkmark inside the dot
 		.jetpack-form-progress-indicator-step-number {
 			position: absolute;
 			top: 0;
@@ -148,33 +149,20 @@
 			font-weight: 600;
 			z-index: 3;
 			line-height: 1;
-			// Default color for inactive steps
 			color: var(--wp--preset--color--contrast, currentColor);
 		}
 
-		// Active step numbers - higher specificity
+		// Active step numbers
 		.jetpack-form-progress-indicator-step.is-active .jetpack-form-progress-indicator-step-number {
 			color: var(--wp--preset--color--base, #fff);
 			text-shadow: 0 0 1px rgba(0, 0, 0, 0.5);
 		}
 
-		// Completed step numbers - higher specificity
+		// Completed step numbers
 		.jetpack-form-progress-indicator-step.is-completed .jetpack-form-progress-indicator-step-number {
 			color: var(--wp--preset--color--base, #fff);
 			text-shadow: 0 0 1px rgba(0, 0, 0, 0.5);
 			font-size: 1.125rem;
-		}
-
-		.jetpack-form-progress-indicator-step-label {
-			position: static;
-		}
-	}
-
-	// Hide labels in dots style when showStepNames is false
-	.jetpack-form-progress-indicator--wrapper:not([data-show-step-names="true"]) &.is-style-dots {
-
-		.jetpack-form-progress-indicator-step-label {
-			display: none;
 		}
 	}
 }

--- a/projects/packages/forms/src/blocks/form-progress-indicator/style.scss
+++ b/projects/packages/forms/src/blocks/form-progress-indicator/style.scss
@@ -1,17 +1,15 @@
 .wp-block-jetpack-form-progress-indicator {
 	--jp-form-progress-height: 0.75rem;
-
-	// Use theme colors with fallbacks
 	--jp-form-progress-bg-color: #e0e0e0;
 
-	// Essential structure
+	// Default line style
 	height: var(--jp-form-progress-height);
 	position: relative;
-	overflow: hidden;
+	overflow: visible;
 	border-radius: calc(var(--jp-form-progress-height) / 2);
 	background-color: var(--wp--style--color--background, var(--wp--preset--color--secondary, var(--jp-form-progress-bg-color)));
 
-	// Progress bar element - rendered as a child element to match the frontend
+	// Progress bar element for line style
 	.jetpack-form-progress-indicator-bar {
 		content: "";
 		display: block;
@@ -25,5 +23,92 @@
 		z-index: 1;
 		background-color: currentColor;
 		border-radius: calc(var(--jp-form-progress-height) / 2);
+	}
+
+	// Step labels container
+	.jetpack-form-progress-indicator-steps {
+		display: none;
+		justify-content: space-between;
+		position: absolute;
+		top: calc(100% + 0.5rem);
+		left: 0;
+		right: 0;
+		width: 100%;
+	}
+
+	.jetpack-form-progress-indicator-step {
+		position: relative;
+		text-align: center;
+
+		&.is-active .jetpack-form-progress-indicator-step-label {
+			font-weight: 600;
+			color: currentColor;
+		}
+	}
+
+	.jetpack-form-progress-indicator-step-label {
+		font-size: 0.875rem;
+		color: var(--wp--preset--color--contrast-2, #666);
+		white-space: nowrap;
+	}
+
+	// Show steps when enabled
+	.jetpack-form-progress-indicator--wrapper[data-show-step-names="true"] & {
+
+		.jetpack-form-progress-indicator-steps {
+			display: flex;
+		}
+	}
+
+	// Dots style variation
+	&.is-style-dots {
+		height: auto;
+		background: none;
+		overflow: visible;
+
+		.jetpack-form-progress-indicator-bar {
+			display: none;
+		}
+
+		.jetpack-form-progress-indicator-steps {
+			position: static;
+			display: flex !important;
+			justify-content: center;
+			align-items: center;
+			gap: 1rem;
+		}
+
+		.jetpack-form-progress-indicator-step {
+			display: flex;
+			flex-direction: column;
+			align-items: center;
+			gap: 0.5rem;
+
+			&::before {
+				content: "";
+				display: block;
+				width: 1rem;
+				height: 1rem;
+				border-radius: 50%;
+				background-color: var(--wp--style--color--background, var(--wp--preset--color--secondary, var(--jp-form-progress-bg-color)));
+				transition: background-color 0.3s ease;
+			}
+
+			&.is-active::before {
+				background-color: currentColor;
+			}
+		}
+
+		.jetpack-form-progress-indicator-step-label {
+			position: static;
+		}
+	}
+
+	// Hide labels in dots style when showStepNames is false
+	.jetpack-form-progress-indicator--wrapper:not([data-show-step-names="true"]) &.is-style-dots {
+
+		.jetpack-form-progress-indicator-step-label {
+			display: none;
+		}
 	}
 }

--- a/projects/packages/forms/src/blocks/form-progress-indicator/style.scss
+++ b/projects/packages/forms/src/blocks/form-progress-indicator/style.scss
@@ -1,6 +1,9 @@
 .wp-block-jetpack-form-progress-indicator {
 	--jp-form-progress-height: 0.75rem;
 	--jp-form-progress-bg-color: #e0e0e0;
+	// Derived colour vars for easier reuse
+	--jp-progress-bg: var(--jetpack-progress-bg-color, var(--wp--preset--color--secondary, var(--jp-form-progress-bg-color)));
+	--jp-progress-color: var(--jetpack-progress-color, var(--wp--preset--color--primary, currentColor));
 
 	// Default styles - unified for both line and dots
 	position: relative;
@@ -70,7 +73,7 @@
 		left: 0;
 		width: 100%;
 		height: var(--jp-form-progress-height);
-		background-color: var(--jetpack-progress-bg-color, var(--wp--preset--color--secondary, var(--jp-form-progress-bg-color)));
+		background-color: var(--jp-progress-bg);
 		z-index: 0;
 		display: none; // Hidden by default
 	}
@@ -83,7 +86,7 @@
 	// Active and completed steps get the progress color on their line
 	.jetpack-form-progress-indicator-step.is-active .jetpack-form-progress-indicator-line,
 	.jetpack-form-progress-indicator-step.is-completed .jetpack-form-progress-indicator-line {
-		background-color: var(--jetpack-progress-color, var(--wp--preset--color--primary, currentColor));
+		background-color: var(--jp-progress-color);
 	}
 
 	// Rounded corners for first and last line elements
@@ -107,14 +110,7 @@
 		// Add the same spacing as other form blocks when step names are shown
 		margin-bottom: var(--wp--style--block-gap, 1.5rem);
 
-		// First and last step labels align with form edges
-		.jetpack-form-progress-indicator-step:first-child .jetpack-form-progress-indicator-step-label {
-			text-align: left;
-		}
-
-		.jetpack-form-progress-indicator-step:last-child .jetpack-form-progress-indicator-step-label {
-			text-align: right;
-		}
+		// Alignment handled globally above – no extra rules needed here.
 
 	}
 
@@ -144,7 +140,7 @@
 			width: 2rem;
 			height: 2rem;
 			border-radius: 50%;
-			background-color: var(--jetpack-progress-bg-color, var(--wp--preset--color--secondary, var(--jp-form-progress-bg-color)));
+			background-color: var(--jp-progress-bg);
 			transition: background-color 0.3s ease;
 			position: relative;
 			z-index: 2;
@@ -163,7 +159,7 @@
 		// Active and completed dots
 		.jetpack-form-progress-indicator-step.is-active .jetpack-form-progress-indicator-dot,
 		.jetpack-form-progress-indicator-step.is-completed .jetpack-form-progress-indicator-dot {
-			background-color: var(--jetpack-progress-color, var(--wp--preset--color--contrast, currentColor));
+			background-color: var(--jp-progress-color);
 		}
 
 		.jetpack-form-progress-indicator-step.is-active .jetpack-form-progress-indicator-step-number,

--- a/projects/packages/forms/src/blocks/form-progress-indicator/style.scss
+++ b/projects/packages/forms/src/blocks/form-progress-indicator/style.scss
@@ -21,7 +21,6 @@
 		display: flex;
 		flex-direction: column;
 		align-items: center;
-		gap: 0.5rem;
 		position: relative;
 		z-index: 1;
 
@@ -35,6 +34,10 @@
 		color: currentColor;
 		white-space: nowrap;
 		display: none; // Hidden by default, shown when step names enabled
+		position: absolute;
+		top: calc(100% + 0.5rem);
+		left: 50%;
+		transform: translateX(-50%);
 	}
 
 	// Show step labels when enabled
@@ -88,13 +91,6 @@
 			display: none;
 		}
 
-		// Position step labels below the line
-		.jetpack-form-progress-indicator-step-label {
-			position: absolute;
-			top: calc(100% + 0.5rem);
-			left: 50%;
-			transform: translateX(-50%);
-		}
 	}
 
 	// Dots style - larger dots with numbers/checkmarks

--- a/projects/packages/forms/src/blocks/form-progress-indicator/style.scss
+++ b/projects/packages/forms/src/blocks/form-progress-indicator/style.scss
@@ -5,16 +5,26 @@
 	// Default styles - unified for both line and dots
 	position: relative;
 	overflow: visible;
+	width: 100%;
+	box-sizing: border-box;
 
 	// Step container - used for both dots and line styles
 	.jetpack-form-progress-indicator-steps {
-		display: grid;
-		grid-auto-flow: column;
-		grid-auto-columns: 1fr;
-		align-items: center;
+		display: flex;
+		justify-content: space-between;
+		align-items: flex-start;
 		width: 100%;
 		padding: 0;
 		position: relative;
+		overflow: hidden;
+
+		.jetpack-form-progress-indicator-step:first-child {
+			align-items: flex-start;
+		}
+
+		.jetpack-form-progress-indicator-step:last-child {
+			align-items: flex-end;
+		}
 	}
 
 	.jetpack-form-progress-indicator-step {
@@ -23,6 +33,8 @@
 		align-items: center;
 		position: relative;
 		z-index: 1;
+		min-width: 6rem;
+		max-width: 100%;
 
 		&.is-active .jetpack-form-progress-indicator-step-label {
 			font-weight: 600;
@@ -34,10 +46,55 @@
 		color: currentColor;
 		white-space: nowrap;
 		display: none; // Hidden by default, shown when step names enabled
+		margin-top: 0.5rem;
+		width: 100%;
+		text-align: center;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+	// Ensure first and last step labels align with the form edges, regardless of
+	// whether the step names wrapper attribute is present. This fixes alignment
+	// in the editor when the block is using the default "line" style.
+	.jetpack-form-progress-indicator-step:first-child .jetpack-form-progress-indicator-step-label {
+		text-align: left;
+	}
+
+	.jetpack-form-progress-indicator-step:last-child .jetpack-form-progress-indicator-step-label {
+		text-align: right;
+	}
+
+	// Line element - shared between both styles
+	.jetpack-form-progress-indicator-line {
 		position: absolute;
-		top: calc(100% + 0.5rem);
-		left: 50%;
-		transform: translateX(-50%);
+		top: 0;
+		left: 0;
+		width: 100%;
+		height: var(--jp-form-progress-height);
+		background-color: var(--jetpack-progress-bg-color, var(--wp--preset--color--secondary, var(--jp-form-progress-bg-color)));
+		z-index: 0;
+		display: none; // Hidden by default
+	}
+
+	// Dot element - hidden by default, shown in dots style
+	.jetpack-form-progress-indicator-dot {
+		display: none;
+	}
+
+	// Active and completed steps get the progress color on their line
+	.jetpack-form-progress-indicator-step.is-active .jetpack-form-progress-indicator-line,
+	.jetpack-form-progress-indicator-step.is-completed .jetpack-form-progress-indicator-line {
+		background-color: var(--jetpack-progress-color, var(--wp--preset--color--primary, currentColor));
+	}
+
+	// Rounded corners for first and last line elements
+	.jetpack-form-progress-indicator-step:first-child .jetpack-form-progress-indicator-line {
+		border-top-left-radius: calc(var(--jp-form-progress-height) / 2);
+		border-bottom-left-radius: calc(var(--jp-form-progress-height) / 2);
+	}
+
+	.jetpack-form-progress-indicator-step:last-child .jetpack-form-progress-indicator-line {
+		border-top-right-radius: calc(var(--jp-form-progress-height) / 2);
+		border-bottom-right-radius: calc(var(--jp-form-progress-height) / 2);
 	}
 
 	// Show step labels when enabled
@@ -49,116 +106,84 @@
 
 		// Add the same spacing as other form blocks when step names are shown
 		margin-bottom: var(--wp--style--block-gap, 1.5rem);
+
+		// First and last step labels align with form edges
+		.jetpack-form-progress-indicator-step:first-child .jetpack-form-progress-indicator-step-label {
+			text-align: left;
+		}
+
+		.jetpack-form-progress-indicator-step:last-child .jetpack-form-progress-indicator-step-label {
+			text-align: right;
+		}
+
 	}
 
-	// Line style (default) - make steps look like a progress line
-	&:not(.is-style-dots) {
-		height: var(--jp-form-progress-height);
-		background-color: var(--jetpack-progress-bg-color, var(--wp--preset--color--secondary, var(--jp-form-progress-bg-color)));
-		border-radius: calc(var(--jp-form-progress-height) / 2);
-
+	// Line style - show line elements as progress bar
+	&.is-style-line {
+		// Remove gaps between steps to create continuous bar
 		.jetpack-form-progress-indicator-steps {
-			height: 100%;
-			align-items: center;
+			gap: 0;
 		}
 
 		.jetpack-form-progress-indicator-step {
-			flex-direction: row;
-			gap: 0;
-			height: 100%;
-
-			// Active and completed steps get the progress color
-			&.is-active,
-			&.is-completed {
-				background-color: var(--jetpack-progress-color, var(--wp--preset--color--primary, currentColor));
-			}
-
-			// First step gets left rounded corners
-			&:first-child {
-				border-top-left-radius: calc(var(--jp-form-progress-height) / 2);
-				border-bottom-left-radius: calc(var(--jp-form-progress-height) / 2);
-			}
-
-			// Last step gets right rounded corners
-			&:last-child {
-				border-top-right-radius: calc(var(--jp-form-progress-height) / 2);
-				border-bottom-right-radius: calc(var(--jp-form-progress-height) / 2);
-			}
+			flex: 1; // Equal width segments
 		}
 
-		// Hide step numbers in line style
-		.jetpack-form-progress-indicator-step-number {
-			display: none;
+		.jetpack-form-progress-indicator-line {
+			display: block;
+			position: relative;
+			margin: 0; // Remove any margins
 		}
-
 	}
 
 	// Dots style - larger dots with numbers/checkmarks
 	&.is-style-dots {
-		padding: 0 1rem; // Add padding to ensure dots aren't cut off
-
-		.jetpack-form-progress-indicator-step {
-			// Connecting line between dots (only for steps that aren't last)
-			&:not(:last-child)::after {
-				content: "";
-				position: absolute;
-				top: 1rem; // Half of dot height (2rem / 2)
-				left: 50%;
-				height: 2px;
-				background-color: var(--jetpack-progress-bg-color, var(--wp--preset--color--secondary, var(--jp-form-progress-bg-color)));
-				z-index: 0;
-				transform: translateX(1rem); // Move line to start from right edge of dot
-				width: calc(100% - 2rem); // Subtract the dot width
-			}
-
-			// Dot background
-			&::before {
-				content: "";
-				display: block;
-				width: 2rem;
-				height: 2rem;
-				border-radius: 50%;
-				background-color: var(--jetpack-progress-bg-color, var(--wp--preset--color--secondary, var(--jp-form-progress-bg-color)));
-				transition: background-color 0.3s ease;
-				position: relative;
-				z-index: 2;
-			}
-
-			&.is-active::before,
-			&.is-completed::before {
-				background-color: var(--jetpack-progress-color, var(--wp--preset--color--contrast, currentColor));
-			}
+		// Show dot container
+		.jetpack-form-progress-indicator-dot {
+			display: flex;
+			width: 2rem;
+			height: 2rem;
+			border-radius: 50%;
+			background-color: var(--jetpack-progress-bg-color, var(--wp--preset--color--secondary, var(--jp-form-progress-bg-color)));
+			transition: background-color 0.3s ease;
+			position: relative;
+			z-index: 2;
+			align-items: center;
+			justify-content: center;
 		}
 
 		// Step number/checkmark inside the dot
 		.jetpack-form-progress-indicator-step-number {
-			position: absolute;
-			top: 0;
-			left: 50%;
-			transform: translateX(-50%);
-			width: 2rem;
-			height: 2rem;
-			display: flex;
-			align-items: center;
-			justify-content: center;
 			font-size: 0.875rem;
 			font-weight: 600;
-			z-index: 3;
 			line-height: 1;
 			color: var(--wp--preset--color--contrast, currentColor);
 		}
 
-		// Active step numbers
-		.jetpack-form-progress-indicator-step.is-active .jetpack-form-progress-indicator-step-number {
+		// Active and completed dots
+		.jetpack-form-progress-indicator-step.is-active .jetpack-form-progress-indicator-dot,
+		.jetpack-form-progress-indicator-step.is-completed .jetpack-form-progress-indicator-dot {
+			background-color: var(--jetpack-progress-color, var(--wp--preset--color--contrast, currentColor));
+		}
+
+		.jetpack-form-progress-indicator-step.is-active .jetpack-form-progress-indicator-step-number,
+		.jetpack-form-progress-indicator-step.is-completed .jetpack-form-progress-indicator-step-number {
 			color: var(--wp--preset--color--base, #fff);
 			text-shadow: 0 0 1px rgba(0, 0, 0, 0.5);
 		}
 
 		// Completed step numbers
 		.jetpack-form-progress-indicator-step.is-completed .jetpack-form-progress-indicator-step-number {
-			color: var(--wp--preset--color--base, #fff);
-			text-shadow: 0 0 1px rgba(0, 0, 0, 0.5);
 			font-size: 1.125rem;
+		}
+
+		// Show connecting lines between dots
+		.jetpack-form-progress-indicator-step:not(:last-child) .jetpack-form-progress-indicator-line {
+			display: block;
+			top: 1rem;
+			height: 2px;
+			left: 2rem; // Start from right edge of current dot
+			width: 100vw; // Extend across screen
 		}
 	}
 }

--- a/projects/packages/forms/src/blocks/form-progress-indicator/style.scss
+++ b/projects/packages/forms/src/blocks/form-progress-indicator/style.scss
@@ -7,7 +7,7 @@
 	position: relative;
 	overflow: visible;
 	border-radius: calc(var(--jp-form-progress-height) / 2);
-	background-color: var(--wp--style--color--background, var(--wp--preset--color--secondary, var(--jp-form-progress-bg-color)));
+	background-color: var(--jetpack-progress-bg-color, var(--wp--style--color--background, var(--wp--preset--color--secondary, var(--jp-form-progress-bg-color))));
 
 
 	// Progress bar element for line style
@@ -129,8 +129,7 @@
 			&.is-active::before,
 			&.is-completed::before {
 				// Use progress color first, then theme contrast (usually dark)
-				background-color:
- var(--jetpack-progress-color, var(--wp--preset--color--contrast, currentColor));
+				background-color: var(--jetpack-progress-color, var(--wp--preset--color--contrast, currentColor));
 			}
 		}
 

--- a/projects/packages/forms/src/blocks/form-step/index.js
+++ b/projects/packages/forms/src/blocks/form-step/index.js
@@ -1,3 +1,4 @@
+import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 import { getIconColor } from '../shared/util/block-icons';
 import edit from './edit';
@@ -53,6 +54,31 @@ export const settings = {
 	edit: edit,
 	save: save,
 	example: {},
+	deprecated: [
+		{
+			// Legacy markup did not include the data-step-label attribute that is now written by the block.
+			attributes: {
+				align: { type: 'string' },
+				backgroundColor: { type: 'string' },
+				gradient: { type: 'string' },
+				textColor: { type: 'string' },
+				style: { type: 'object' },
+				stepLabel: { type: 'string' },
+			},
+			isEligible: ( attributes, innerBlocks, { innerHTML } ) => {
+				// Eligible when markup does NOT contain the new data attribute.
+				return innerHTML && ! innerHTML.includes( 'data-step-label' );
+			},
+			save: () => {
+				// Replicate legacy output – simply render inner blocks without extra dataset.
+				const blockProps = useBlockProps.save();
+				const innerBlocksProps = useInnerBlocksProps.save( blockProps );
+
+				return <div { ...innerBlocksProps } />;
+			},
+			migrate: attributes => attributes, // No attribute changes required.
+		},
+	],
 };
 
 export default {

--- a/projects/packages/forms/src/blocks/form-step/save.js
+++ b/projects/packages/forms/src/blocks/form-step/save.js
@@ -1,7 +1,10 @@
 import { useInnerBlocksProps, useBlockProps } from '@wordpress/block-editor';
 
-export default function save() {
-	const blockProps = useBlockProps.save();
+export default function save( { attributes } ) {
+	const { stepLabel } = attributes;
+	const blockProps = useBlockProps.save( {
+		'data-step-label': stepLabel,
+	} );
 	const innerBlocksProps = useInnerBlocksProps.save( blockProps );
 
 	return <div { ...innerBlocksProps } />;

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -812,10 +812,11 @@ class Contact_Form_Plugin {
 				// Build steps HTML from context data
 				foreach ( $form_steps as $index => $step ) {
 					$step_label  = $step['label'] ?? 'Step ' . ( $index + 1 );
+					$label_html  = $show_step_names ? sprintf( '<span class="jetpack-form-progress-indicator-step-label">%s</span>', esc_html( $step_label ) ) : '';
 					$steps_html .= sprintf(
-						'<div class="jetpack-form-progress-indicator-step" data-step-index="%d"><span class="jetpack-form-progress-indicator-step-label">%s</span></div>',
+						'<div class="jetpack-form-progress-indicator-step" data-step-index="%d">%s</div>',
 						$index,
-						esc_html( $step_label )
+						$label_html
 					);
 				}
 			} else {
@@ -828,20 +829,22 @@ class Contact_Form_Plugin {
 					if ( ! empty( $step_blocks ) ) {
 						foreach ( $step_blocks as $index => $step_block ) {
 							$step_label  = $step_block['attrs']['stepLabel'] ?? 'Step ' . ( $index + 1 );
+							$label_html  = $show_step_names ? sprintf( '<span class="jetpack-form-progress-indicator-step-label">%s</span>', esc_html( $step_label ) ) : '';
 							$steps_html .= sprintf(
-								'<div class="jetpack-form-progress-indicator-step" data-step-index="%d"><span class="jetpack-form-progress-indicator-step-label">%s</span></div>',
+								'<div class="jetpack-form-progress-indicator-step" data-step-index="%d">%s</div>',
 								$index,
-								esc_html( $step_label )
+								$label_html
 							);
 						}
 					} else {
 						// Ultimate fallback: Create generic steps
 						$step_count = 3;
 						for ( $i = 0; $i < $step_count; $i++ ) {
+							$label_html  = $show_step_names ? sprintf( '<span class="jetpack-form-progress-indicator-step-label">Step %d</span>', $i + 1 ) : '';
 							$steps_html .= sprintf(
-								'<div class="jetpack-form-progress-indicator-step" data-step-index="%d"><span class="jetpack-form-progress-indicator-step-label">Step %d</span></div>',
+								'<div class="jetpack-form-progress-indicator-step" data-step-index="%d">%s</div>',
 								$i,
-								$i + 1
+								$label_html
 							);
 						}
 					}

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -811,11 +811,11 @@ class Contact_Form_Plugin {
 			if ( ! empty( $form_steps ) ) {
 				// Build steps HTML from context data
 				foreach ( $form_steps as $index => $step ) {
-					$step_name   = $step['name'] ?? 'Step ' . ( $index + 1 );
+					$step_label  = $step['label'] ?? 'Step ' . ( $index + 1 );
 					$steps_html .= sprintf(
 						'<div class="jetpack-form-progress-indicator-step" data-step-index="%d"><span class="jetpack-form-progress-indicator-step-label">%s</span></div>',
 						$index,
-						esc_html( $step_name )
+						esc_html( $step_label )
 					);
 				}
 			} else {
@@ -827,11 +827,11 @@ class Contact_Form_Plugin {
 
 					if ( ! empty( $step_blocks ) ) {
 						foreach ( $step_blocks as $index => $step_block ) {
-							$step_name   = $step_block['attrs']['stepLabel'] ?? 'Step ' . ( $index + 1 );
+							$step_label  = $step_block['attrs']['stepLabel'] ?? 'Step ' . ( $index + 1 );
 							$steps_html .= sprintf(
 								'<div class="jetpack-form-progress-indicator-step" data-step-index="%d"><span class="jetpack-form-progress-indicator-step-label">%s</span></div>',
 								$index,
-								esc_html( $step_name )
+								esc_html( $step_label )
 							);
 						}
 					} else {

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -195,6 +195,9 @@ class Contact_Form_Plugin {
 
 		add_filter( 'jetpack_contact_form_is_spam', array( $this, 'is_spam_blocklist' ), 10, 2 );
 		add_filter( 'jetpack_contact_form_in_comment_disallowed_list', array( $this, 'is_in_disallowed_list' ), 10, 2 );
+
+		// Note: We previously tried using render_block_data to set form steps context,
+		// but found that parsing post content directly is more reliable for server-side rendering
 		// Akismet to the rescue
 		if ( defined( 'AKISMET_VERSION' ) || function_exists( 'akismet_http_post' ) ) {
 			add_filter( 'jetpack_contact_form_is_spam', array( $this, 'is_spam_akismet' ), 10, 2 );
@@ -778,15 +781,9 @@ class Contact_Form_Plugin {
 			$version
 		);
 
-		// Get step data from block context
+		// Get step data - try block context first, then parse from content
 		$form_steps      = $block->context['jetpack/form-steps'] ?? array();
 		$show_step_names = $attributes['showStepNames'] ?? false;
-
-		// Check if this is dots style
-		$is_dots_style = false;
-		if ( preg_match( '/\bis-style-dots\b/', $content ) ) {
-			$is_dots_style = true;
-		}
 
 		$processor = new \WP_HTML_Tag_Processor( $content );
 
@@ -803,74 +800,87 @@ class Contact_Form_Plugin {
 			break;
 		}
 
-		// If we need to render steps (dots or step names), we'll use string replacement
-		if ( $is_dots_style || $show_step_names ) {
-			$steps_html = '';
+		// Always populate the steps HTML - the container is always in the markup
+		$steps_html = '';
 
-			if ( ! empty( $form_steps ) ) {
-				// Build steps HTML from context data
-				foreach ( $form_steps as $index => $step ) {
-					$step_label = $step['label'] ?? 'Step ' . ( $index + 1 );
-					$label_html = $show_step_names ? sprintf( '<span class="jetpack-form-progress-indicator-step-label">%s</span>', esc_html( $step_label ) ) : '';
-					// For initial render, assume currentStep = 1 (first step)
-					$is_initially_active = $index === 0 ? ' is-active' : '';
-					$steps_html         .= sprintf(
-						'<div class="jetpack-form-progress-indicator-step%s" data-wp-class--is-active="state.isStepActive" %s>%s</div>',
-						$is_initially_active,
-						wp_interactivity_data_wp_context( array( 'stepIndex' => $index ) ),
-						$label_html
-					);
-				}
-			} else {
-				// Fallback: Try to find step blocks in the post content
-				global $post;
-				if ( $post && has_blocks( $post->post_content ) ) {
-					$blocks      = parse_blocks( $post->post_content );
-					$step_blocks = self::find_step_blocks_recursive( $blocks );
-
-					if ( ! empty( $step_blocks ) ) {
-						foreach ( $step_blocks as $index => $step_block ) {
-							$step_label = $step_block['attrs']['stepLabel'] ?? 'Step ' . ( $index + 1 );
-							$label_html = $show_step_names ? sprintf( '<span class="jetpack-form-progress-indicator-step-label">%s</span>', esc_html( $step_label ) ) : '';
-							// For initial render, assume currentStep = 1 (first step)
-							$is_initially_active = $index === 0 ? ' is-active' : '';
-							$steps_html         .= sprintf(
-								'<div class="jetpack-form-progress-indicator-step%s" data-wp-class--is-active="state.isStepActive" %s>%s</div>',
-								$is_initially_active,
-								wp_interactivity_data_wp_context( array( 'stepIndex' => $index ) ),
-								$label_html
-							);
-						}
-					} else {
-						// Ultimate fallback: Create generic steps
-						$step_count = 3;
-						for ( $i = 0; $i < $step_count; $i++ ) {
-							$label_html = $show_step_names ? sprintf( '<span class="jetpack-form-progress-indicator-step-label">Step %d</span>', $i + 1 ) : '';
-							// For initial render, assume currentStep = 1 (first step)
-							$is_initially_active = $i === 0 ? ' is-active' : '';
-							$steps_html         .= sprintf(
-								'<div class="jetpack-form-progress-indicator-step%s" data-wp-class--is-active="state.isStepActive" %s>%s</div>',
-								$is_initially_active,
-								wp_interactivity_data_wp_context( array( 'stepIndex' => $i ) ),
-								$label_html
-							);
-						}
-					}
-				}
+		// If no steps from context, parse from post content
+		if ( empty( $form_steps ) ) {
+			global $post;
+			if ( $post && $post->post_content ) {
+				$parsed_blocks = parse_blocks( $post->post_content );
+				$form_steps    = self::find_steps_in_blocks( $parsed_blocks );
 			}
+		}
+
+		// Build steps HTML from the data
+		foreach ( $form_steps as $index => $step ) {
+			$step_label = $step['label'] ?? 'Step ' . ( $index + 1 );
+			$label_html = $show_step_names ? sprintf( '<span class="jetpack-form-progress-indicator-step-label">%s</span>', esc_html( $step_label ) ) : '';
+			// For initial render, assume currentStep = 1 (first step)
+			$is_initially_active = $index === 0 ? ' is-active' : '';
+			$steps_html         .= sprintf(
+				'<div class="jetpack-form-progress-indicator-step%s" data-wp-class--is-active="state.isStepActive" %s>%s</div>',
+				$is_initially_active,
+				wp_interactivity_data_wp_context( array( 'stepIndex' => $index ) ),
+				$label_html
+			);
+		}
 
 			// Use string replacement to insert the steps HTML
 			$updated_content = $processor->get_updated_html();
-			$updated_content = str_replace(
-				'<div class="jetpack-form-progress-indicator-steps"></div>',
-				'<div class="jetpack-form-progress-indicator-steps" data-wp-interactive="jetpack/form">' . $steps_html . '</div>',
-				$updated_content
-			);
+		$updated_content     = str_replace(
+			'<div class="jetpack-form-progress-indicator-steps"></div>',
+			'<div class="jetpack-form-progress-indicator-steps" data-wp-interactive="jetpack/form">' . $steps_html . '</div>',
+			$updated_content
+		);
 
-			return $updated_content;
+		return $updated_content;
+	}
+
+	/**
+	 * Find form steps in parsed blocks.
+	 *
+	 * @param array $blocks The parsed blocks array.
+	 * @return array Array of step data.
+	 */
+	private static function find_steps_in_blocks( $blocks ) {
+		$form_steps = array();
+
+		foreach ( $blocks as $block ) {
+			// Look for contact form blocks
+			if ( $block['blockName'] === 'jetpack/contact-form' && ! empty( $block['innerBlocks'] ) ) {
+				foreach ( $block['innerBlocks'] as $inner_block ) {
+					// Check direct children for steps
+					if ( $inner_block['blockName'] === 'jetpack/form-step' ) {
+						$label        = $inner_block['attrs']['stepLabel'] ?? 'Step ' . ( count( $form_steps ) + 1 );
+						$form_steps[] = array(
+							'label'    => $label,
+							'clientId' => $inner_block['clientId'] ?? '',
+						);
+					} elseif ( ! empty( $inner_block['innerBlocks'] ) ) {
+						// Check nested blocks (steps might be in wrapper)
+						foreach ( $inner_block['innerBlocks'] as $nested_block ) {
+							if ( $nested_block['blockName'] === 'jetpack/form-step' ) {
+								$label        = $nested_block['attrs']['stepLabel'] ?? 'Step ' . ( count( $form_steps ) + 1 );
+								$form_steps[] = array(
+									'label'    => $label,
+									'clientId' => $nested_block['clientId'] ?? '',
+								);
+							}
+						}
+					}
+				}
+				break; // Found a form, stop looking
+			} elseif ( ! empty( $block['innerBlocks'] ) ) {
+				// Recursively search in inner blocks
+				$nested_steps = self::find_steps_in_blocks( $block['innerBlocks'] );
+				if ( ! empty( $nested_steps ) ) {
+					$form_steps = array_merge( $form_steps, $nested_steps );
+				}
+			}
 		}
 
-		return $processor->get_updated_html();
+		return $form_steps;
 	}
 
 	/**

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -749,12 +749,13 @@ class Contact_Form_Plugin {
 	/**
 	 * Render the progress indicator.
 	 *
-	 * @param array  $attributes - the block attributes.
-	 * @param string $content - html content.
+	 * @param array    $attributes - the block attributes.
+	 * @param string   $content - html content.
+	 * @param WP_Block $block - the block instance.
 	 *
 	 * @return string HTML for the progress indicator.
 	 */
-	public static function gutenblock_render_form_progress_indicator( $attributes, $content ) {
+	public static function gutenblock_render_form_progress_indicator( $attributes, $content, $block ) {
 		$version = Constants::get_constant( 'JETPACK__VERSION' );
 		if ( empty( $version ) ) {
 			$version = '0.1';
@@ -762,14 +763,14 @@ class Contact_Form_Plugin {
 
 		// Enqueue the frontend style for the progress indicator.
 		$style_handle = 'jetpack-form-progress-indicator-style';
-		$style_path   = '../../dist/blocks/form-progress-indicator/style.css'; // Path from the 404 error
+		$style_path   = '../../dist/blocks/form-progress-indicator/style.css';
 		if ( ! wp_style_is( $style_handle, 'enqueued' ) ) {
 			wp_enqueue_style( $style_handle, plugins_url( $style_path, __FILE__ ), array(), $version );
 		}
 
-		// Enqueue the interactivity script module (matching form-step pattern).
+		// Enqueue the interactivity script module.
 		$script_handle = 'jetpack-form-progress-indicator';
-		$script_path   = '../../dist/modules/form-progress-indicator/view.js'; // Path from previous 404 error
+		$script_path   = '../../dist/modules/form-progress-indicator/view.js';
 		\wp_enqueue_script_module(
 			$script_handle,
 			plugins_url( $script_path, __FILE__ ),
@@ -777,18 +778,108 @@ class Contact_Form_Plugin {
 			$version
 		);
 
-		$processor = new \WP_HTML_Tag_Processor( $content );
-		$processor->next_tag();
-		$processor->set_attribute( 'data-wp-interactive', 'jetpack/form' );
+		// Get step data from block context
+		$form_steps      = $block->context['jetpack/form-steps'] ?? array();
+		$show_step_names = $attributes['showStepNames'] ?? false;
 
-		while ( $processor->next_tag() ) {
-			$class = $processor->get_attribute( 'class' );
-			if ( 'jetpack-form-progress-indicator-bar' === $class ) {
-				$processor->set_attribute( 'data-wp-style--width', 'state.getStepProgress' );
+		// Check if this is dots style
+		$is_dots_style = false;
+		if ( preg_match( '/\bis-style-dots\b/', $content ) ) {
+			$is_dots_style = true;
+		}
+
+		$processor = new \WP_HTML_Tag_Processor( $content );
+
+		// Find the wrapper and add interactivity
+		if ( $processor->next_tag( array( 'class_name' => 'jetpack-form-progress-indicator--wrapper' ) ) ) {
+			$processor->set_attribute( 'data-wp-interactive', 'jetpack/form' );
+			$processor->set_attribute( 'data-wp-init', 'actions.initializeProgress' );
+			$processor->set_attribute( 'data-wp-watch', 'callbacks.updateStepNames' );
+		}
+
+		// Find the progress bar and add width binding
+		$processor = new \WP_HTML_Tag_Processor( $processor->get_updated_html() );
+		while ( $processor->next_tag( array( 'class_name' => 'jetpack-form-progress-indicator-bar' ) ) ) {
+			$processor->set_attribute( 'data-wp-style--width', 'state.getStepProgress' );
+			break;
+		}
+
+		// If we need to render steps (dots or step names), we'll use string replacement
+		if ( $is_dots_style || $show_step_names ) {
+			$steps_html = '';
+
+			if ( ! empty( $form_steps ) ) {
+				// Build steps HTML from context data
+				foreach ( $form_steps as $index => $step ) {
+					$step_name   = $step['name'] ?? 'Step ' . ( $index + 1 );
+					$steps_html .= sprintf(
+						'<div class="jetpack-form-progress-indicator-step" data-step-index="%d"><span class="jetpack-form-progress-indicator-step-label">%s</span></div>',
+						$index,
+						esc_html( $step_name )
+					);
+				}
+			} else {
+				// Fallback: Try to find step blocks in the post content
+				global $post;
+				if ( $post && has_blocks( $post->post_content ) ) {
+					$blocks      = parse_blocks( $post->post_content );
+					$step_blocks = self::find_step_blocks_recursive( $blocks );
+
+					if ( ! empty( $step_blocks ) ) {
+						foreach ( $step_blocks as $index => $step_block ) {
+							$step_name   = $step_block['attrs']['stepLabel'] ?? 'Step ' . ( $index + 1 );
+							$steps_html .= sprintf(
+								'<div class="jetpack-form-progress-indicator-step" data-step-index="%d"><span class="jetpack-form-progress-indicator-step-label">%s</span></div>',
+								$index,
+								esc_html( $step_name )
+							);
+						}
+					} else {
+						// Ultimate fallback: Create generic steps
+						$step_count = 3;
+						for ( $i = 0; $i < $step_count; $i++ ) {
+							$steps_html .= sprintf(
+								'<div class="jetpack-form-progress-indicator-step" data-step-index="%d"><span class="jetpack-form-progress-indicator-step-label">Step %d</span></div>',
+								$i,
+								$i + 1
+							);
+						}
+					}
+				}
 			}
+
+			// Use string replacement to insert the steps HTML
+			$updated_content = $processor->get_updated_html();
+			$updated_content = str_replace(
+				'<div class="jetpack-form-progress-indicator-steps"></div>',
+				'<div class="jetpack-form-progress-indicator-steps">' . $steps_html . '</div>',
+				$updated_content
+			);
+
+			return $updated_content;
 		}
 
 		return $processor->get_updated_html();
+	}
+
+	/**
+	 * Recursively find form step blocks in parsed blocks.
+	 *
+	 * @param array $blocks The parsed blocks array.
+	 * @return array Array of step blocks.
+	 */
+	private static function find_step_blocks_recursive( $blocks ) {
+		$step_blocks = array();
+
+		foreach ( $blocks as $block ) {
+			if ( $block['blockName'] === 'jetpack/form-step' ) {
+				$step_blocks[] = $block;
+			} elseif ( ! empty( $block['innerBlocks'] ) ) {
+				$step_blocks = array_merge( $step_blocks, self::find_step_blocks_recursive( $block['innerBlocks'] ) );
+			}
+		}
+
+		return $step_blocks;
 	}
 
 	/**

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -794,7 +794,6 @@ class Contact_Form_Plugin {
 		if ( $processor->next_tag( array( 'class_name' => 'jetpack-form-progress-indicator--wrapper' ) ) ) {
 			$processor->set_attribute( 'data-wp-interactive', 'jetpack/form' );
 			$processor->set_attribute( 'data-wp-init', 'actions.initializeProgress' );
-			$processor->set_attribute( 'data-wp-watch', 'callbacks.updateStepNames' );
 		}
 
 		// Find the progress bar and add width binding
@@ -814,7 +813,7 @@ class Contact_Form_Plugin {
 					$step_label  = $step['label'] ?? 'Step ' . ( $index + 1 );
 					$label_html  = $show_step_names ? sprintf( '<span class="jetpack-form-progress-indicator-step-label">%s</span>', esc_html( $step_label ) ) : '';
 					$steps_html .= sprintf(
-						'<div class="jetpack-form-progress-indicator-step" data-step-index="%d">%s</div>',
+						'<div class="jetpack-form-progress-indicator-step" data-wp-class--is-active="state.isStepActive" data-wp-context=\'{"stepIndex":%d}\'>%s</div>',
 						$index,
 						$label_html
 					);
@@ -831,7 +830,7 @@ class Contact_Form_Plugin {
 							$step_label  = $step_block['attrs']['stepLabel'] ?? 'Step ' . ( $index + 1 );
 							$label_html  = $show_step_names ? sprintf( '<span class="jetpack-form-progress-indicator-step-label">%s</span>', esc_html( $step_label ) ) : '';
 							$steps_html .= sprintf(
-								'<div class="jetpack-form-progress-indicator-step" data-step-index="%d">%s</div>',
+								'<div class="jetpack-form-progress-indicator-step" data-wp-class--is-active="state.isStepActive" data-wp-context=\'{"stepIndex":%d}\'>%s</div>',
 								$index,
 								$label_html
 							);
@@ -842,7 +841,7 @@ class Contact_Form_Plugin {
 						for ( $i = 0; $i < $step_count; $i++ ) {
 							$label_html  = $show_step_names ? sprintf( '<span class="jetpack-form-progress-indicator-step-label">Step %d</span>', $i + 1 ) : '';
 							$steps_html .= sprintf(
-								'<div class="jetpack-form-progress-indicator-step" data-step-index="%d">%s</div>',
+								'<div class="jetpack-form-progress-indicator-step" data-wp-class--is-active="state.isStepActive" data-wp-context=\'{"stepIndex":%d}\'>%s</div>',
 								$i,
 								$label_html
 							);

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -783,7 +783,6 @@ class Contact_Form_Plugin {
 
 		// Get step data - try block context first, then parse from content
 		$form_steps       = $block->context['jetpack/form-steps'] ?? array();
-		$show_step_names  = $attributes['showStepNames'] ?? false;
 		$progress_color   = $attributes['progressColor'] ?? '';
 		$background_color = $attributes['backgroundColor'] ?? '';
 
@@ -826,18 +825,23 @@ class Contact_Form_Plugin {
 		// Build steps HTML from the data
 		foreach ( $form_steps as $index => $step ) {
 			$step_label = $step['label'] ?? 'Step ' . ( $index + 1 );
-			$label_html = $show_step_names ? sprintf( '<span class="jetpack-form-progress-indicator-step-label">%s</span>', esc_html( $step_label ) ) : '';
+			$label_html = sprintf( '<div class="jetpack-form-progress-indicator-step-label">%s</div>', esc_html( $step_label ) );
 
 			// Add step number for dots style with dynamic content binding
 			$step_number_html = sprintf( '<span class="jetpack-form-progress-indicator-step-number" data-wp-text="state.getStepContent">%d</span>', $index + 1 );
+			$dot_html         = sprintf( '<div class="jetpack-form-progress-indicator-dot">%s</div>', $step_number_html );
+
+			// Add line element
+			$line_html = '<div class="jetpack-form-progress-indicator-line"></div>';
 
 			// For initial render, assume currentStep = 1 (first step)
 			$is_initially_active = $index === 0 ? ' is-active' : '';
 			$step_html           = sprintf(
-				'<div class="jetpack-form-progress-indicator-step%s" data-wp-class--is-active="state.isStepActive" data-wp-class--is-completed="state.isStepCompleted" %s>%s%s</div>',
+				'<div class="jetpack-form-progress-indicator-step%s" data-wp-class--is-active="state.isStepActive" data-wp-class--is-completed="state.isStepCompleted" %s>%s%s%s</div>',
 				$is_initially_active,
 				wp_interactivity_data_wp_context( array( 'stepIndex' => $index ) ),
-				$step_number_html,
+				$line_html,
+				$dot_html,
 				$label_html
 			);
 			$steps_html         .= $step_html;

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -782,8 +782,10 @@ class Contact_Form_Plugin {
 		);
 
 		// Get step data - try block context first, then parse from content
-		$form_steps      = $block->context['jetpack/form-steps'] ?? array();
-		$show_step_names = $attributes['showStepNames'] ?? false;
+		$form_steps       = $block->context['jetpack/form-steps'] ?? array();
+		$show_step_names  = $attributes['showStepNames'] ?? false;
+		$progress_color   = $attributes['progressColor'] ?? '';
+		$background_color = $attributes['backgroundColor'] ?? '';
 
 		$processor = new \WP_HTML_Tag_Processor( $content );
 
@@ -791,6 +793,22 @@ class Contact_Form_Plugin {
 		if ( $processor->next_tag( array( 'class_name' => 'jetpack-form-progress-indicator--wrapper' ) ) ) {
 			$processor->set_attribute( 'data-wp-interactive', 'jetpack/form' );
 			$processor->set_attribute( 'data-wp-init', 'actions.initializeProgress' );
+		}
+
+		// Find the main block wrapper and add custom color properties
+		$processor = new \WP_HTML_Tag_Processor( $processor->get_updated_html() );
+		if ( $processor->next_tag( array( 'class_name' => 'wp-block-jetpack-form-progress-indicator' ) ) ) {
+			$style = '';
+			if ( $progress_color ) {
+				$style .= '--jetpack-progress-color:' . esc_attr( $progress_color ) . ';';
+			}
+			if ( $background_color ) {
+				$style .= '--jetpack-progress-bg-color:' . esc_attr( $background_color ) . ';';
+			}
+			if ( $style ) {
+				$existing_style = $processor->get_attribute( 'style' ) ? $processor->get_attribute( 'style' ) : '';
+				$processor->set_attribute( 'style', $existing_style . $style );
+			}
 		}
 
 		// Find the progress bar and add width binding
@@ -816,20 +834,28 @@ class Contact_Form_Plugin {
 		foreach ( $form_steps as $index => $step ) {
 			$step_label = $step['label'] ?? 'Step ' . ( $index + 1 );
 			$label_html = $show_step_names ? sprintf( '<span class="jetpack-form-progress-indicator-step-label">%s</span>', esc_html( $step_label ) ) : '';
+
+			// Add step number for dots style with dynamic content binding
+			$step_number_html = sprintf( '<span class="jetpack-form-progress-indicator-step-number" data-wp-text="state.getStepContent">%d</span>', $index + 1 );
+
 			// For initial render, assume currentStep = 1 (first step)
 			$is_initially_active = $index === 0 ? ' is-active' : '';
-			$steps_html         .= sprintf(
-				'<div class="jetpack-form-progress-indicator-step%s" data-wp-class--is-active="state.isStepActive" %s>%s</div>',
+			$step_html           = sprintf(
+				'<div class="jetpack-form-progress-indicator-step%s" data-wp-class--is-active="state.isStepActive" data-wp-class--is-completed="state.isStepCompleted" %s>%s%s</div>',
 				$is_initially_active,
 				wp_interactivity_data_wp_context( array( 'stepIndex' => $index ) ),
+				$step_number_html,
 				$label_html
 			);
+			$steps_html         .= $step_html;
 		}
 
-			// Use string replacement to insert the steps HTML
-			$updated_content = $processor->get_updated_html();
-		$updated_content     = str_replace(
-			'<div class="jetpack-form-progress-indicator-steps"></div>',
+		// Get the updated HTML and replace the steps container with populated content
+		$updated_content = $processor->get_updated_html();
+
+		// Use regex to find and replace the steps container regardless of existing attributes
+		$updated_content = preg_replace(
+			'/<div class="jetpack-form-progress-indicator-steps"[^>]*><\/div>/',
 			'<div class="jetpack-form-progress-indicator-steps" data-wp-interactive="jetpack/form">' . $steps_html . '</div>',
 			$updated_content
 		);

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -810,11 +810,14 @@ class Contact_Form_Plugin {
 			if ( ! empty( $form_steps ) ) {
 				// Build steps HTML from context data
 				foreach ( $form_steps as $index => $step ) {
-					$step_label  = $step['label'] ?? 'Step ' . ( $index + 1 );
-					$label_html  = $show_step_names ? sprintf( '<span class="jetpack-form-progress-indicator-step-label">%s</span>', esc_html( $step_label ) ) : '';
-					$steps_html .= sprintf(
-						'<div class="jetpack-form-progress-indicator-step" data-wp-class--is-active="state.isStepActive" data-wp-context=\'{"stepIndex":%d}\'>%s</div>',
-						$index,
+					$step_label = $step['label'] ?? 'Step ' . ( $index + 1 );
+					$label_html = $show_step_names ? sprintf( '<span class="jetpack-form-progress-indicator-step-label">%s</span>', esc_html( $step_label ) ) : '';
+					// For initial render, assume currentStep = 1 (first step)
+					$is_initially_active = $index === 0 ? ' is-active' : '';
+					$steps_html         .= sprintf(
+						'<div class="jetpack-form-progress-indicator-step%s" data-wp-class--is-active="state.isStepActive" %s>%s</div>',
+						$is_initially_active,
+						wp_interactivity_data_wp_context( array( 'stepIndex' => $index ) ),
 						$label_html
 					);
 				}
@@ -827,11 +830,14 @@ class Contact_Form_Plugin {
 
 					if ( ! empty( $step_blocks ) ) {
 						foreach ( $step_blocks as $index => $step_block ) {
-							$step_label  = $step_block['attrs']['stepLabel'] ?? 'Step ' . ( $index + 1 );
-							$label_html  = $show_step_names ? sprintf( '<span class="jetpack-form-progress-indicator-step-label">%s</span>', esc_html( $step_label ) ) : '';
-							$steps_html .= sprintf(
-								'<div class="jetpack-form-progress-indicator-step" data-wp-class--is-active="state.isStepActive" data-wp-context=\'{"stepIndex":%d}\'>%s</div>',
-								$index,
+							$step_label = $step_block['attrs']['stepLabel'] ?? 'Step ' . ( $index + 1 );
+							$label_html = $show_step_names ? sprintf( '<span class="jetpack-form-progress-indicator-step-label">%s</span>', esc_html( $step_label ) ) : '';
+							// For initial render, assume currentStep = 1 (first step)
+							$is_initially_active = $index === 0 ? ' is-active' : '';
+							$steps_html         .= sprintf(
+								'<div class="jetpack-form-progress-indicator-step%s" data-wp-class--is-active="state.isStepActive" %s>%s</div>',
+								$is_initially_active,
+								wp_interactivity_data_wp_context( array( 'stepIndex' => $index ) ),
 								$label_html
 							);
 						}
@@ -839,10 +845,13 @@ class Contact_Form_Plugin {
 						// Ultimate fallback: Create generic steps
 						$step_count = 3;
 						for ( $i = 0; $i < $step_count; $i++ ) {
-							$label_html  = $show_step_names ? sprintf( '<span class="jetpack-form-progress-indicator-step-label">Step %d</span>', $i + 1 ) : '';
-							$steps_html .= sprintf(
-								'<div class="jetpack-form-progress-indicator-step" data-wp-class--is-active="state.isStepActive" data-wp-context=\'{"stepIndex":%d}\'>%s</div>',
-								$i,
+							$label_html = $show_step_names ? sprintf( '<span class="jetpack-form-progress-indicator-step-label">Step %d</span>', $i + 1 ) : '';
+							// For initial render, assume currentStep = 1 (first step)
+							$is_initially_active = $i === 0 ? ' is-active' : '';
+							$steps_html         .= sprintf(
+								'<div class="jetpack-form-progress-indicator-step%s" data-wp-class--is-active="state.isStepActive" %s>%s</div>',
+								$is_initially_active,
+								wp_interactivity_data_wp_context( array( 'stepIndex' => $i ) ),
 								$label_html
 							);
 						}
@@ -854,7 +863,7 @@ class Contact_Form_Plugin {
 			$updated_content = $processor->get_updated_html();
 			$updated_content = str_replace(
 				'<div class="jetpack-form-progress-indicator-steps"></div>',
-				'<div class="jetpack-form-progress-indicator-steps">' . $steps_html . '</div>',
+				'<div class="jetpack-form-progress-indicator-steps" data-wp-interactive="jetpack/form">' . $steps_html . '</div>',
 				$updated_content
 			);
 

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -811,13 +811,6 @@ class Contact_Form_Plugin {
 			}
 		}
 
-		// Find the progress bar and add width binding
-		$processor = new \WP_HTML_Tag_Processor( $processor->get_updated_html() );
-		while ( $processor->next_tag( array( 'class_name' => 'jetpack-form-progress-indicator-bar' ) ) ) {
-			$processor->set_attribute( 'data-wp-style--width', 'state.getStepProgress' );
-			break;
-		}
-
 		// Always populate the steps HTML - the container is always in the markup
 		$steps_html = '';
 

--- a/projects/packages/forms/src/modules/form-progress-indicator/view.js
+++ b/projects/packages/forms/src/modules/form-progress-indicator/view.js
@@ -1,4 +1,4 @@
-import { getContext, store } from '@wordpress/interactivity';
+import { getContext, store, getElement } from '@wordpress/interactivity';
 
 store( 'jetpack/form', {
 	state: {
@@ -10,13 +10,38 @@ store( 'jetpack/form', {
 	actions: {
 		initializeProgress() {
 			// Initialize progress indicator when the form loads
+			// The steps are already server-rendered, we just need to ensure they're updated
 			const context = getContext();
+
 			// Ensure we have a valid transition value
 			if (
 				! context.transition ||
 				! [ 'none', 'fade', 'slide', 'fade-slide' ].includes( context.transition )
 			) {
 				context.transition = 'fade-slide'; // Default transition if not set or invalid
+			}
+		},
+		renderStepNames() {
+			// Steps are now server-rendered, no need to create them via JavaScript
+			// This function is kept for compatibility but doesn't do anything
+		},
+	},
+	callbacks: {
+		updateStepNames() {
+			const context = getContext();
+			const element = getElement();
+			const wrapper = element.ref;
+
+			// Update active states for all steps
+			const steps = wrapper?.querySelectorAll( '.jetpack-form-progress-indicator-step' );
+			if ( steps ) {
+				steps.forEach( ( step, index ) => {
+					if ( index < context.currentStep ) {
+						step.classList.add( 'is-active' );
+					} else {
+						step.classList.remove( 'is-active' );
+					}
+				} );
 			}
 		},
 	},

--- a/projects/packages/forms/src/modules/form-progress-indicator/view.js
+++ b/projects/packages/forms/src/modules/form-progress-indicator/view.js
@@ -1,10 +1,22 @@
-import { getContext, store, getElement } from '@wordpress/interactivity';
+import { getContext, store } from '@wordpress/interactivity';
 
 store( 'jetpack/form', {
 	state: {
 		get getStepProgress() {
 			const context = getContext();
 			return ( Math.max( 1, context.currentStep ) / context.maxSteps ) * 100 + '%';
+		},
+		get isStepActive() {
+			const context = getContext();
+			// Get the parent context (form context) and the local context (step context)
+			const stepIndex = context.stepIndex;
+			const currentStep = context.currentStep;
+
+			// If we have a local stepIndex, compare it with the form's currentStep
+			if ( typeof stepIndex !== 'undefined' && typeof currentStep !== 'undefined' ) {
+				return stepIndex < currentStep;
+			}
+			return false;
 		},
 	},
 	actions: {
@@ -27,22 +39,6 @@ store( 'jetpack/form', {
 		},
 	},
 	callbacks: {
-		updateStepNames() {
-			const context = getContext();
-			const element = getElement();
-			const wrapper = element.ref;
-
-			// Update active states for all steps
-			const steps = wrapper?.querySelectorAll( '.jetpack-form-progress-indicator-step' );
-			if ( steps ) {
-				steps.forEach( ( step, index ) => {
-					if ( index < context.currentStep ) {
-						step.classList.add( 'is-active' );
-					} else {
-						step.classList.remove( 'is-active' );
-					}
-				} );
-			}
-		},
+		// No longer needed - active states are handled declaratively in PHP/JS
 	},
 } );

--- a/projects/packages/forms/src/modules/form-progress-indicator/view.js
+++ b/projects/packages/forms/src/modules/form-progress-indicator/view.js
@@ -8,9 +8,23 @@ store( 'jetpack/form', {
 		},
 		get isStepActive() {
 			const context = getContext();
-			// For progress indicator steps, we want to show as active if currentStep > stepIndex
+			// For progress indicator steps, we want to show as active if currentStep === stepIndex + 1
 			// stepIndex is 0-based, currentStep is 1-based
-			return context.currentStep > context.stepIndex;
+			return context.currentStep === context.stepIndex + 1;
+		},
+		get isStepCompleted() {
+			const context = getContext();
+			// Step is completed if currentStep > stepIndex + 1
+			// stepIndex is 0-based, currentStep is 1-based
+			return context.currentStep > context.stepIndex + 1;
+		},
+		get getStepContent() {
+			const context = getContext();
+			// Return checkmark for completed steps, number for others
+			if ( context.currentStep > context.stepIndex + 1 ) {
+				return '✓';
+			}
+			return context.stepIndex + 1;
 		},
 	},
 	actions: {

--- a/projects/packages/forms/src/modules/form-progress-indicator/view.js
+++ b/projects/packages/forms/src/modules/form-progress-indicator/view.js
@@ -8,15 +8,9 @@ store( 'jetpack/form', {
 		},
 		get isStepActive() {
 			const context = getContext();
-			// Get the parent context (form context) and the local context (step context)
-			const stepIndex = context.stepIndex;
-			const currentStep = context.currentStep;
-
-			// If we have a local stepIndex, compare it with the form's currentStep
-			if ( typeof stepIndex !== 'undefined' && typeof currentStep !== 'undefined' ) {
-				return stepIndex < currentStep;
-			}
-			return false;
+			// For progress indicator steps, we want to show as active if currentStep > stepIndex
+			// stepIndex is 0-based, currentStep is 1-based
+			return context.currentStep > context.stepIndex;
 		},
 	},
 	actions: {
@@ -38,7 +32,5 @@ store( 'jetpack/form', {
 			// This function is kept for compatibility but doesn't do anything
 		},
 	},
-	callbacks: {
-		// No longer needed - active states are handled declaratively in PHP/JS
-	},
+	callbacks: {},
 } );


### PR DESCRIPTION
## Summary

Enhances the form progress indicator block with new display options and improved functionality:

- **Block Styles**: Adds "Line" (default) and "Dots" style variations
- **Step Names Toggle**: Adds setting to show/hide custom step names for both styles  
- **Server-side Rendering**: Implements PHP rendering using block context and Tag Processor
- **Block Context Integration**: Uses WordPress block context system to share step data between form and progress indicator blocks
- **Fallback Support**: Gracefully falls back to parsing post content when context data is unavailable

## Features

### Line Style (Default)
- Shows traditional progress bar with optional step names below
- Step names appear as labels positioned along the progress line

### Dots Style  
- Shows circular dots representing each step
- Active steps are highlighted with the current color
- Step names appear below each dot when enabled

### Settings Panel
- Toggle to show/hide step names for both styles
- Works with custom step labels set in form step blocks

## Technical Implementation

- Uses `providesContext`/`usesContext` for proper data sharing between blocks
- Server-side rendering ensures SEO-friendly output and better performance  
- CSS-based styling with proper theme color integration
- JavaScript handles active state updates during step navigation

## Test plan

- [ ] Create a multi-step form with custom step labels
- [ ] Add progress indicator block
- [ ] Test line style with step names on/off
- [ ] Test dots style with step names on/off  
- [ ] Verify step names show custom labels, not generic ones
- [ ] Test on frontend with step navigation
- [ ] Verify active states update correctly
