### PR TITLE
Open Graph: support Core's site logo in fallback images

### DIFF
--- a/projects/plugins/jetpack/changelog/update-opengraph-site-logo-fallback
+++ b/projects/plugins/jetpack/changelog/update-opengraph-site-logo-fallback
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Open Graph meta tags: support site logos when generating fallback Image Meta tags.

--- a/projects/plugins/jetpack/functions.opengraph.php
+++ b/projects/plugins/jetpack/functions.opengraph.php
@@ -484,7 +484,7 @@ function jetpack_og_get_site_image( $width, $height ) {
 	}
 
 	// Third fall back, Core's site logo.
-	if ( empty( $image ) && has_custom_logo() ) {
+	if ( has_custom_logo() ) {
 		$custom_logo_id = get_theme_mod( 'custom_logo' );
 		$sl_details     = wp_get_attachment_image_src(
 			$custom_logo_id,

--- a/projects/plugins/jetpack/functions.opengraph.php
+++ b/projects/plugins/jetpack/functions.opengraph.php
@@ -483,7 +483,27 @@ function jetpack_og_get_site_image( $width, $height ) {
 		}
 	}
 
-	// Third fall back, Core Site Icon, if valid in size.
+	// Third fall back, Core's site logo.
+	if ( empty( $image ) && has_custom_logo() ) {
+		$custom_logo_id = get_theme_mod( 'custom_logo' );
+		$sl_details     = wp_get_attachment_image_src(
+			$custom_logo_id,
+			'full'
+		);
+		if (
+			isset( $sl_details[0] ) && isset( $sl_details[1] ) && isset( $sl_details[2] )
+			&& ( _jetpack_og_get_image_validate_size( $sl_details[1], $sl_details[2], $width, $height ) )
+		) {
+			return array(
+				'src'      => $sl_details[0],
+				'width'    => $sl_details[1],
+				'height'   => $sl_details[2],
+				'alt_text' => Jetpack_PostImages::get_alt_text( $custom_logo_id ),
+			);
+		}
+	}
+
+	// Fourth fall back, Core Site Icon, if valid in size.
 	if ( has_site_icon() ) {
 		$image_id = get_option( 'site_icon' );
 		$icon     = wp_get_attachment_image_src( $image_id, 'full' );

--- a/projects/plugins/jetpack/tests/php/Functions_OpenGraph_Test.php
+++ b/projects/plugins/jetpack/tests/php/Functions_OpenGraph_Test.php
@@ -97,6 +97,37 @@ class Functions_OpenGraph_Test extends Jetpack_Attachment_TestCase {
 	}
 
 	/**
+	 * Test Core's custom logo fallback in jetpack_og_get_image.
+	 *
+	 * @since $$next-version$$
+	 */
+	public function test_jetpack_og_get_image_core_custom_logo() {
+		$default_url = jetpack_og_get_image();
+
+		// Set up Core's custom logo
+		set_theme_mod( 'custom_logo', $this->icon_id );
+
+		// Test valid-sized Core's custom logo
+		$image_url      = jetpack_og_get_image( 200, 200 );
+		$custom_logo_id = get_theme_mod( 'custom_logo' );
+		$logo_details   = wp_get_attachment_image_src( $custom_logo_id, 'full' );
+		$this->assertEquals( $logo_details[0], $image_url['src'] );
+		$this->assertEquals( $logo_details[1], $image_url['width'] );
+		$this->assertEquals( $logo_details[2], $image_url['height'] );
+
+		// Test that alt text is included
+		$this->assertArrayHasKey( 'alt_text', $image_url );
+
+		// Test smaller/invalid Core's custom logo (should fall back to default)
+		$image_url = jetpack_og_get_image( 512, 512 );
+		$this->assertNotEquals( $logo_details[0], $image_url['src'] );
+		$this->assertEquals( $default_url['src'], $image_url['src'] );
+
+		// Clean up
+		remove_theme_mod( 'custom_logo' );
+	}
+
+	/**
 	 * Test potential descriptions given to OG description.
 	 *
 	 * @dataProvider jetpack_og_get_description_data_provider


### PR DESCRIPTION
Follow-up to #44336

Fixes CML-711

## Proposed changes:

Until now, we looked for site's representative images by checking blavatars, Jetpack's site logo, and core's site icon. Let's check core's site logo too.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Do the tests pass?
* Go to Jetpack > Settings > Sharing
* Enable the Sharing module
* Load your site's home page
* View source
* Check the `og:image` tag
   * It should use a default blank image tag.
* Go to Appearance > Editor
* Edit the header template
* Add a site logo block
* Upload an image to that block
* Save your changes
* Load your site's home page
* View source
* Check the `og:image` tag
    * It should use the image you just uploaded
