### PR TITLE
Forms: keep content centered on big screens

### DIFF
--- a/projects/packages/forms/changelog/fix-jetpack-forms-about-page-width
+++ b/projects/packages/forms/changelog/fix-jetpack-forms-about-page-width
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: allow About page to grow width so content remains centered even on oversized screens

--- a/projects/packages/forms/src/dashboard/about/style.scss
+++ b/projects/packages/forms/src/dashboard/about/style.scss
@@ -9,6 +9,7 @@
 	--section-spacing-horizontal: calc(var(--spacing-base) * 9); // 72px
 	--content-max-width: 1280px;
 	background-color: var(--jp-white);
+	flex-grow: 1;
 
 	@include mobile {
 		--section-spacing-horizontal: calc(var(--spacing-base) * 4); // 32px


### PR DESCRIPTION
## Proposed changes:
This PR allows About page to grow width to keep content center aligned even on big screens

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1753460973870349-slack-C052XEUUBL4

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Go to Jetpack Forms dashboard, visit the About page. Resize the screen to confirm even on big screens the content remains centered (use `CMD -` to shrink content size if bigger screen is not available). Test that other tabs haven't changed. Test normal and mobile views.