### PR TITLE
Forms: Fix css admin issues

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-about-page-alignment
+++ b/projects/packages/forms/changelog/fix-forms-about-page-alignment
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: minor css fixes for the admin side

--- a/projects/packages/forms/src/dashboard/about/style.scss
+++ b/projects/packages/forms/src/dashboard/about/style.scss
@@ -6,6 +6,7 @@
 }
 
 .jp-forms__about {
+	width: 100%;
 	--section-spacing-horizontal: calc(var(--spacing-base) * 9); // 72px
 	--content-max-width: 1280px;
 	background-color: var(--jp-white);

--- a/projects/packages/forms/src/dashboard/about/style.scss
+++ b/projects/packages/forms/src/dashboard/about/style.scss
@@ -6,7 +6,6 @@
 }
 
 .jp-forms__about {
-	width: 100%;
 	--section-spacing-horizontal: calc(var(--spacing-base) * 9); // 72px
 	--content-max-width: 1280px;
 	background-color: var(--jp-white);

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -339,6 +339,13 @@
 	@media (min-width: 782px) {
 		margin-bottom: 57px;
 	}
+
+	.components-tip {
+		background-color: rgba(var(--wp-admin-theme-color--rgb), 0.04);
+		margin: 0 24px 16px;
+		padding: 8px 16px;
+		border-radius: 4px;
+	}
 }
 
 

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -188,14 +188,24 @@
 	}
 
 	.file-field__icon {
-		width: 40px;
-		height: 40px;
+		width: 32px;
+		min-width: 32px;
+		height: 32px;
+		margin-top: 8px;
+		background-size: 18px;
 		border-radius: 50%;
 		background-color: #f6f6f7;
 		background-image: url(../../contact-form/images/file-icons/txt.svg);
 		background-repeat: no-repeat;
 		background-position: center;
-		background-size: 24px;
+
+		@media (min-width: 782px) {
+			width: 40px;
+			min-width: 40px;
+			height: 40px;
+			background-size: 24px;
+			margin-top: 0;
+		}
 	}
 
 	.file-field__icon.icon-cal {


### PR DESCRIPTION
This PR fixes. 
1. Mobile File Upload field. 
Before:
<img width="976" height="362" alt="Screenshot 2025-07-25 at 10 12 56 AM" src="https://github.com/user-attachments/assets/c292cf80-d48c-421e-b04f-249c1d2ec230" />



After:
<img width="998" height="268" alt="Screenshot 2025-07-25 at 10 11 31 AM" src="https://github.com/user-attachments/assets/cb149312-524d-4414-be9c-35c73e8ce43c" />

2. the tip style. 
Before:
<img width="820" height="190" alt="Screenshot 2025-07-25 at 10 13 14 AM" src="https://github.com/user-attachments/assets/5a7cd64c-7baa-4454-b3a6-1e554bcf5835" />

After:
<img width="1274" height="206" alt="Screenshot 2025-07-25 at 10 10 54 AM" src="https://github.com/user-attachments/assets/9ef4b78c-3619-421f-b67d-1d1370e59889" />


## Proposed changes:
* Reduce the size of the icon on mobile and make sure it is round. 
* Make the tip different style then regular form field. 


### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?


## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Add a file upload filed. Submit a file upload. 
On the admin / response view on mobile notice that the field looks more like you would expect. 

Make a response as spam. Visit the  single view and notice that the tip looks a bit less broken. 