### PR TITLE
Subscription: Use expected comment return values

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-comment-default
+++ b/projects/plugins/jetpack/changelog/fix-comment-default
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Subscription: Return expected type when modifying get_comment return value.

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -1005,11 +1005,11 @@ function maybe_close_comments( $default_comments_open, $post_id ) {
 }
 
 /**
- * Gate access to existing comments
+ * Gate access to existing comments.
  *
- * @param string $comment The comment.
+ * @param \WP_Comment $comment The comment.
  *
- * @return string
+ * @return \WP_Comment|null
  */
 function maybe_gate_existing_comments( $comment ) {
 	if ( empty( $comment ) ) {
@@ -1020,7 +1020,8 @@ function maybe_gate_existing_comments( $comment ) {
 	if ( Jetpack_Memberships::user_can_view_post() ) {
 		return $comment;
 	}
-	return '';
+
+	return null;
 }
 
 /**


### PR DESCRIPTION
Introduced in #28170.

`maybe_gate_existing_comments()` runs on the `get_comment` filter within `get_comment()`.
[The documented return values for this function](https://developer.wordpress.org/reference/functions/get_comment/) are `WP_Comment|array|null`, however the callback returns an empty string in the case where a comment can't be viewed.

This empty string causes Fatal Errors downstream, when Activitypub tries to generate a json representation for the comment, and now [attempts to transform a string](https://github.com/Automattic/wordpress-activitypub/blob/trunk/includes/transformer/class-factory.php#L38) instead of [bailing on `null`](https://github.com/Automattic/wordpress-activitypub/blob/trunk/includes/transformer/class-factory.php#L43).

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Updates return value of `maybe_gate_existing_comments()` to `null` when comment can't be viewed.
* Updates function docs to reflect the types the function accepts and returns.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

I assume this is how it can be tested? Not sure yet.

* Apply this PR to a WoA site with ActivityPub active.
* Create post and and select Paid Subscribers only before publishing
* Comment on that post.
* Navigate to yoursite.com/?activitypub&c=COMMENT_ID

