### PR TITLE
 Forms: Fix field order on success message and hide form on success if js is disabled

### DIFF
--- a/projects/packages/forms/changelog/update-forms-submit-ajax-sort
+++ b/projects/packages/forms/changelog/update-forms-submit-ajax-sort
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Fix field order on success message

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -909,6 +909,9 @@ class Contact_Form extends Contact_Form_Shortcode {
 		$raw_data  = self::get_raw_compiled_form_data( $feedback_id, $form );
 		$json_data = array();
 
+		// Sort by field index to maintain the correct order
+		ksort( $raw_data );
+
 		// Handle file upload field (new structure with field_id and files array)
 		foreach ( $raw_data as $field_data ) {
 			$value = $field_data['value'];

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -543,33 +543,15 @@ class Contact_Form extends Contact_Form_Shortcode {
 			$r .= "</ul>\n</div>\n\n";
 		}
 
+		if ( $is_reload_after_success && $form->is_response_without_reload_enabled ) {
+			$r .= '<noscript>';
+			$r .= self::render_noscript_success_message( $is_reload_nonce_valid, $feedback_id, $form );
+			$r .= '</noscript>';
+		}
+
 		if ( $is_reload_after_success && ! $form->is_response_without_reload_enabled ) {
 			// The contact form was submitted.  Show the success message/results.
-			$back_url = remove_query_arg( array( 'contact-form-id', 'contact-form-sent', '_wpnonce' ) );
-			$r       .= '<div class="contact-form-submission">';
-
-			$r_success_message = '<p class="go-back-message"> <a class="link" href="' . esc_url( $back_url ) . '">' . esc_html__( 'Go back', 'jetpack-forms' ) . '</a> </p>';
-
-			$r_success_message .=
-				'<h4 id="contact-form-success-header">' . esc_html( $form->get_attribute( 'customThankyouHeading' ) ) .
-				"</h4>\n\n";
-
-			// Don't show the feedback details unless the nonce matches
-			if ( $is_reload_nonce_valid ) {
-				$r_success_message .= self::success_message( $feedback_id, $form );
-			}
-
-			/**
-			 * Filter the message returned after a successful contact form submission.
-			 *
-			 * @module contact-form
-			 *
-			 * @since 1.3.1
-			 *
-			 * @param string $r_success_message Success message.
-			 */
-			$r .= apply_filters( 'grunion_contact_form_success_message', $r_success_message );
-			$r .= '</div>';
+			$r .= self::render_noscript_success_message( $is_reload_nonce_valid, $feedback_id, $form );
 		} else {
 			// Nothing special - show the normal contact form
 			if ( $form->get_attribute( 'widget' )
@@ -720,6 +702,55 @@ class Contact_Form extends Contact_Form_Shortcode {
 		 * @param string $r The contact form HTML.
 		 */
 		return apply_filters( 'jetpack_contact_form_html', $r );
+	}
+
+	/**
+	 * Renders the success message for the contact form when js is disabled or not desired.
+	 *
+	 * @param bool         $is_reload_nonce_valid - whether the nonce is valid.
+	 * @param int          $feedback_id - the feedback ID.
+	 * @param Contact_Form $form - the contact form.
+	 *
+	 * @return string HTML string for the success message.
+	 */
+	private static function render_noscript_success_message( $is_reload_nonce_valid, $feedback_id, $form ) {
+		$back_url        = remove_query_arg( array( 'contact-form-id', 'contact-form-sent', '_wpnonce', 'contact-form-hash' ) );
+		$contact_form_id = sanitize_text_field( wp_unslash( $_GET['contact-form-id'] ?? '' ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+		$message = '';
+
+		$message .= '<style>
+			.contact-form-ajax-submission {
+				display: none;
+			}
+
+			#contact-form-' . $contact_form_id . ' form.contact-form {
+				display: none;
+			}
+		</style>';
+
+		$message         .= '<div class="contact-form-submission">';
+		$success_message  = '<p class="go-back-message"> <a class="link" href="' . esc_url( $back_url ) . '">' . esc_html__( 'Go back', 'jetpack-forms' ) . '</a> </p>';
+		$success_message .= '<h4 id="contact-form-success-header">' . esc_html( $form->get_attribute( 'customThankyouHeading' ) ) . "</h4>\n\n";
+
+		// Don't show the feedback details unless the nonce matches
+		if ( $is_reload_nonce_valid ) {
+			$success_message .= self::success_message( $feedback_id, $form );
+		}
+
+		/**
+		 * Filter the message returned after a successful contact form submission.
+		 *
+		 * @module contact-form
+		 *
+		 * @since 1.3.1
+		 *
+		 * @param string $message Success message.
+		 */
+		$message .= apply_filters( 'grunion_contact_form_success_message', $success_message );
+		$message .= '</div>';
+
+		return $message;
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes a presentational issue found on the call for testing of the AJAX submission feature

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Sorts the response fields by form order

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1753458579597179/1753228326.212169-slack-C052XEUUBL4

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Submit a form via AJAX
* Check that the success message lists the responses in the order they are seen in the form