### PR TITLE
Forms: Add new feedback classes 

### DIFF
--- a/projects/packages/forms/changelog/add-new-feedback-classes-refactor
+++ b/projects/packages/forms/changelog/add-new-feedback-classes-refactor
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: Adding new classes for the Feedback refactor

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -281,6 +281,14 @@ class Contact_Form extends Contact_Form_Shortcode {
 			self::get_secret()
 		);
 	}
+	/**
+	 * Get the count of forms.
+	 *
+	 * @return int The count of forms.
+	 */
+	public static function get_forms_count() {
+		return count( self::$forms );
+	}
 
 	/**
 	 * Get the default recipient email address for the contact form.
@@ -1433,7 +1441,8 @@ class Contact_Form extends Contact_Form_Shortcode {
 		);
 
 		// Initialize marketing consent
-		$field_ids['email_marketing_consent'] = null;
+		$field_ids['email_marketing_consent']       = null;
+		$field_ids['email_marketing_consent_field'] = null;
 
 		foreach ( $this->fields as $id => $field ) {
 			$type = $field->get_attribute( 'type' );
@@ -1466,6 +1475,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 				case 'consent':
 					// Set email marketing consent for the first Consent type field
 					if ( null === $field_ids['email_marketing_consent'] ) {
+						$field_ids['email_marketing_consent_field'] = $id;
 						if ( $field->value ) {
 							$field_ids['email_marketing_consent'] = true;
 						} else {

--- a/projects/packages/forms/src/contact-form/class-feedback-author.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-author.php
@@ -1,0 +1,148 @@
+<?php
+/**
+ * Feedback class.
+ *
+ * @package automattic/jetpack-forms
+ */
+
+namespace Automattic\Jetpack\Forms\ContactForm;
+
+/**
+ * Class Feedback_Author
+ *
+ * Represents the author of a feedback entry, including their name, email, and URL.
+ */
+class Feedback_Author {
+
+	/**
+	 * The name of the author.
+	 *
+	 * @var string
+	 */
+	private $name;
+
+	/**
+	 * The email of the author.
+	 *
+	 * @var string
+	 */
+	private $email;
+
+	/**
+	 * The url of the author.
+	 *
+	 * @var string
+	 */
+	private $url;
+
+	/**
+	 * Constructor for Feedback_Author.
+	 *
+	 * @param string $name  The name of the author.
+	 * @param string $email The email of the author.
+	 * @param string $url   The URL of the author.
+	 */
+	public function __construct( $name = '', $email = '', $url = '' ) {
+		$this->name  = $name;
+		$this->email = $email;
+		$this->url   = $url;
+	}
+
+	/**
+	 * Create a Feedback_Author instance from the submission data.
+	 *
+	 * @param array        $post_data The post data from the form submission.
+	 * @param Contact_Form $form      The form object.
+	 * @return Feedback_Author The Feedback_Author instance.
+	 */
+	public static function from_submission( $post_data, $form ) {
+		return new self(
+			self::get_computed_author_info( $post_data, 'name', 'pre_comment_author_name', $form ),
+			self::get_computed_author_info( $post_data, 'email', 'pre_comment_author_email', $form ),
+			self::get_computed_author_info( $post_data, 'url', 'pre_comment_author_url', $form )
+		);
+	}
+
+	/**
+	 * Gets the computed author.
+	 *
+	 * @param array        $post_data The post data from the form submission.
+	 * @param string       $type The type of author information to retrieve (e.g., 'name', 'email', 'url').
+	 * @param string       $filter Optional filter to apply to the value.
+	 * @param Contact_Form $form The form object.
+	 *
+	 * @return string Filter value for the author information.
+	 */
+	private static function get_computed_author_info( $post_data, $type, $filter, $form ) {
+		$field_ids = $form->get_field_ids();
+		if ( isset( $field_ids[ $type ] ) ) {
+			$key   = $field_ids[ $type ];
+			$value = isset( $post_data[ $key ] ) ? sanitize_text_field( wp_unslash( $post_data[ $key ] ) ) : '';
+			if ( is_string( $value ) ) {
+				return Contact_Form_Plugin::strip_tags(
+					stripslashes(
+						/**
+						 *
+						 * Listed to help search find the filters.
+						 * apply_filters( ''pre_comment_author_name', $value )
+						 * apply_filters( ''pre_comment_author_email', $value )
+						 * apply_filters( ''pre_comment_author_url', $value )
+						*/
+						apply_filters( $filter, addslashes( $value ) )
+					)
+				);
+
+			}
+		}
+		return '';
+	}
+
+	/**
+	 * Get the display name of the author.
+	 *
+	 * If the name is not set, it will return the email.
+	 *
+	 * @return string The display name of the author.
+	 */
+	public function get_display_name(): string {
+		return empty( $this->name ) ? $this->email : $this->name;
+	}
+
+	/**
+	 * Get the avatar URL of the author.
+	 *
+	 * If the email is not set, it will return an empty string.
+	 *
+	 * @return string The avatar URL of the author.
+	 */
+	public function get_avatar_url(): string {
+		return ! empty( $this->email ) ? get_avatar_url( $this->email ) : '';
+	}
+
+	/**
+	 * Get the name of the author.
+	 *
+	 * @return string The name of the author.
+	 */
+	public function get_name() {
+		return $this->name;
+	}
+
+	/**
+	 * Get the email of the author.
+	 *
+	 * @return string The email of the author.
+	 */
+	public function get_email() {
+		return $this->email;
+	}
+
+	/**
+	 * Get the URL of the author.
+	 *
+	 * @return string The URL of the author.
+	 */
+	public function get_url() {
+		return $this->url;
+	}
+}

--- a/projects/packages/forms/src/contact-form/class-feedback-field.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-field.php
@@ -1,0 +1,288 @@
+<?php
+/**
+ * Feedback_Field class.
+ *
+ * @package automattic/jetpack-forms
+ */
+
+namespace Automattic\Jetpack\Forms\ContactForm;
+
+/**
+ * Feedback field class.
+ *
+ * Represents the submitted form data of an individual field.
+ */
+class Feedback_Field {
+
+	/**
+	 * The key of the field.
+	 *
+	 * @var string
+	 */
+	private $key;
+
+	/**
+	 * The label of the field.
+	 *
+	 * @var string
+	 */
+	private $label;
+
+	/**
+	 * The value of the field.
+	 *
+	 * @var mixed
+	 */
+	private $value;
+
+	/**
+	 * The type of the field.
+	 *
+	 * @var string
+	 */
+	private $type;
+
+	/**
+	 * Additional metadata for the field.
+	 *
+	 * @var array
+	 */
+	private $meta;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param string $key   The key of the field.
+	 * @param string $label The label of the field.
+	 * @param mixed  $value The value of the field.
+	 * @param string $type  The type of the field (default is 'basic').
+	 * @param array  $meta  Additional metadata for the field (default is an empty array).
+	 */
+	public function __construct( $key, $label, $value, $type = 'basic', $meta = array() ) {
+		$this->key   = $key;
+		$this->label = mb_convert_encoding( $label, 'UTF-8', 'HTML-ENTITIES' );
+		$this->value = $value;
+		$this->type  = $type;
+		$this->meta  = $meta;
+	}
+
+	/**
+	 * Get the value of the field.
+	 *
+	 * @return string
+	 */
+	public function get_key() {
+		return $this->key;
+	}
+
+	/**
+	 * Get the label of the field.
+	 *
+	 * @return string
+	 */
+	public function get_label() {
+		return $this->label;
+	}
+
+	/**
+	 * Get the value of the field.
+	 *
+	 * @return mixed
+	 */
+	public function get_value() {
+		return $this->value;
+	}
+
+	/**
+	 * Get the value of the field for rendering.
+	 *
+	 * @param string $context The context in which the value is being rendered (default is 'default').
+	 *
+	 * @return string
+	 */
+	public function get_render_value( $context = 'default' ) {
+		switch ( $context ) {
+			case 'api':
+				return $this->get_render_api_value();
+			case 'default':
+			default:
+				return $this->get_render_default_value();
+		}
+	}
+
+	/**
+	 * Get the default value of the field for rendering.
+	 *
+	 * @return string
+	 */
+	private function get_render_default_value() {
+		if ( $this->is_of_type( 'file' ) ) {
+			$files = array();
+			foreach ( $this->value['files'] as &$file ) {
+				if ( ! isset( $file['size'] ) || ! isset( $file['file_id'] ) ) {
+					// this shouldn't happen, todo: log this
+					continue;
+				}
+				$file_name = $file['name'] ?? __( 'Attached file', 'jetpack-forms' );
+				$file_size = isset( $file['size'] ) ? size_format( $file['size'] ) : '';
+				$files[]   = $file_name . ' (' . $file_size . ')';
+			}
+			return implode( ', ', $files );
+		}
+
+		if ( is_array( $this->value ) ) {
+			return implode( ', ', $this->value );
+		}
+
+		return $this->value;
+	}
+
+	/**
+	 * Get the value of the field for the API.
+	 *
+	 * @return string
+	 */
+	private function get_render_api_value() {
+
+		if ( $this->is_of_type( 'file' ) ) {
+			$files = array();
+			foreach ( $this->value['files'] as &$file ) {
+				if ( ! isset( $file['size'] ) || ! isset( $file['file_id'] ) ) {
+					// this shouldn't happen, todo: log this
+					continue;
+				}
+				$file_id                = absint( $file['file_id'] );
+				$file['file_id']        = $file_id;
+				$file['size']           = size_format( $file['size'] );
+				$file['url']            = apply_filters( 'jetpack_unauth_file_download_url', '', $file_id );
+				$file['is_previewable'] = $this->is_previewable_file( $file );
+				$files[]                = $file;
+			}
+			$this->value['files'] = $files;
+			return $this->value;
+		}
+
+		if ( is_array( $this->value ) ) {
+			// If the value is an array, we can return it as a JSON string.
+			return implode( ', ', $this->value );
+		}
+		// This method is deprecated, use render_value instead.
+		return $this->value;
+	}
+	/**
+	 * Check if the field is of a specific type.
+	 *
+	 * @param string $type The type to check against.
+	 *
+	 * @return bool True if the field is of the specified type, false otherwise.
+	 */
+	public function is_of_type( $type ) {
+		return $this->type === $type;
+	}
+
+	/**
+	 * Check if the field should be compiled.
+	 *
+	 * @return bool
+	 */
+	public function compile_field() {
+		return $this->get_meta_key_value( 'render' ) === false;
+	}
+
+	/**
+	 * Get the type of the field.
+	 *
+	 * @return string
+	 */
+	public function get_type() {
+		return $this->type;
+	}
+
+	/**
+	 * Get the meta array of the field.
+	 *
+	 * @return array
+	 */
+	public function get_meta() {
+		return $this->meta;
+	}
+
+	/**
+	 * Get a specific meta value by key.
+	 *
+	 * @param string $meta_key The key of the meta to retrieve.
+	 *
+	 * @return mixed|null Returns the value of the meta key if it exists, null otherwise.
+	 */
+	public function get_meta_key_value( $meta_key ) {
+		if ( isset( $this->meta[ $meta_key ] ) ) {
+			return $this->meta[ $meta_key ];
+		}
+		return null;
+	}
+
+	/**
+	 * Get the serialized representation of the field.
+	 *
+	 * @return array
+	 */
+	public function serialize() {
+		return array(
+			'key'   => $this->get_key(),
+			'label' => $this->get_label(),
+			'value' => $this->get_value(),
+			'type'  => $this->get_type(),
+			'meta'  => $this->get_meta(),
+		);
+	}
+	/**
+	 * Create a Feedback_Field object from serialized data.
+	 *
+	 * @param array $data The serialized data.
+	 *
+	 * @return Feedback_Field|null Returns a Feedback_Field object or null if the data is invalid.
+	 */
+	public static function from_serialized( $data ) {
+		if ( ! is_array( $data ) || ! isset( $data['key'] ) || ! isset( $data['value'] ) || ! isset( $data['label'] ) ) {
+			return null;
+		}
+
+		return new self(
+			$data['key'],
+			$data['label'],
+			$data['value'],
+			$data['type'] ?? 'basic',
+			$data['meta'] ?? array()
+		);
+	}
+
+	/**
+	 * Check if the field has a file
+	 *
+	 * @return bool
+	 */
+	public function has_file() {
+		if ( $this->is_of_type( 'file' ) ) {
+			if ( ! isset( $this->value['files'] ) || ! is_array( $this->value['files'] ) ) {
+				return false;
+			}
+			return count( $this->value['files'] ) > 0;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Checks if the file is previewable based on its type or extension.
+	 *
+	 * @param array $file File data.
+	 * @return bool True if the file is previewable, false otherwise.
+	 */
+	private function is_previewable_file( $file ) {
+		$file_type = strtolower( pathinfo( $file['name'], PATHINFO_EXTENSION ) );
+		// Check if the file is previewable based on its type or extension.
+		// Note: This is a simplified check and does not match if the file is allowed to be uploaded by the server.
+		$previewable_types = array( 'jpg', 'jpeg', 'png', 'gif', 'webp' );
+		return in_array( $file_type, $previewable_types, true );
+	}
+}

--- a/projects/packages/forms/src/contact-form/class-feedback-source.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-source.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * Feedback Entry
+ *
+ * @package automattic/jetpack-forms
+ */
+
+namespace Automattic\Jetpack\Forms\ContactForm;
+
+/**
+ * Class Feedback_Source
+ *
+ * Represents where a feedback was created from, feedback entry with an ID, title, permalink, and page number.
+ */
+class Feedback_Source {
+
+	/**
+	 * The ID of the post or page that the feedback was created on.
+	 *
+	 * @var int
+	 */
+	private $id = 0;
+
+	/**
+	 * The title of the  post or page that the feedback was created on.
+	 *
+	 * @var string
+	 */
+	private $title = '';
+
+	/**
+	 * The permalink of the feedback entry.
+	 *
+	 * @var string
+	 */
+	private $permalink = '';
+
+	/**
+	 * The page number of the feedback post or page that the feedback was created on.
+	 * This is used to determine the page number in a paginated view of page or post.
+	 *
+	 * @var int
+	 */
+	private $page_number = 1;
+
+	/**
+	 * Constructor for Feedback_Source.
+	 *
+	 * @param int    $id          The ID of the feedback entry.
+	 * @param string $title       The title of the feedback entry.
+	 * @param int    $page_number The page number of the feedback entry, default is 1.
+	 */
+	public function __construct( $id, $title, $page_number = 1 ) {
+
+		$this->id          = $id > 0 ? (int) $id : 0;
+		$this->title       = $title;
+		$this->page_number = $page_number;
+		$this->permalink   = '';
+
+		if ( $id <= 0 ) {
+			return;
+		}
+
+		$entry_post = get_post( $id );
+
+		if ( $entry_post && $entry_post->post_status === 'publish' ) {
+			$this->permalink = get_permalink( $entry_post );
+			$this->title     = get_the_title( $entry_post );
+		}
+	}
+
+	/**
+	 * Creates a Feedback_Source instance from a submission.
+	 *
+	 * @param \WP_Post|null $current_post The current post object.
+	 * @param int           $current_page_number The current page number, default is 1.
+	 * @return Feedback_Source Returns an instance of Feedback_Source.
+	 */
+	public static function from_submission( $current_post, int $current_page_number = 1 ) {
+		$id = isset( $current_post->ID ) ? (int) $current_post->ID : 0;
+
+		if ( ! $current_post instanceof \WP_Post || $id === 0 ) {
+			return new self( 0, '', $current_page_number );
+		}
+
+		$title = $current_post->post_title ?? '';
+
+		return new self( $id, $title, $current_page_number );
+	}
+
+	/**
+	 * Get the permalink of the feedback entry.
+	 *
+	 * @return string The permalink of the feedback entry.
+	 */
+	public function get_permalink() {
+		if ( $this->page_number > 1 && ! empty( $this->permalink ) ) {
+			return add_query_arg( 'page', $this->page_number, $this->permalink );
+		}
+		return $this->permalink;
+	}
+
+	/**
+	 * Get the relative permalink of the feedback entry.
+	 *
+	 * @return string The relative permalink of the feedback entry.
+	 */
+	public function get_relative_permalink() {
+		if ( ! empty( $this->permalink ) ) {
+			return wp_make_link_relative( $this->get_permalink() );
+		}
+		return '';
+	}
+
+	/**
+	 * Get the page number of the feedback entry.
+	 *
+	 * @return int The page number of the feedback entry.
+	 */
+	public function get_page_number() {
+		return $this->page_number;
+	}
+	/**
+	 * Get the title of the feedback entry.
+	 *
+	 * @return string The title of the feedback entry.
+	 */
+	public function get_title() {
+		return $this->title;
+	}
+	/**
+	 * Get the post id of the feedback entry.
+	 *
+	 * @return int The ID of the feedback entry.
+	 */
+	public function get_id() {
+		return $this->id;
+	}
+
+	/**
+	 * Get the page number of the entry title.
+	 *
+	 * @return array
+	 */
+	public function serialize() {
+		return array(
+			'entry_title' => $this->title,
+			'entry_page'  => $this->page_number,
+		);
+	}
+}

--- a/projects/packages/forms/src/contact-form/class-feedback.php
+++ b/projects/packages/forms/src/contact-form/class-feedback.php
@@ -1,0 +1,1040 @@
+<?php
+/**
+ * Feedback class.
+ *
+ * @package automattic/jetpack-forms
+ */
+
+namespace Automattic\Jetpack\Forms\ContactForm;
+
+use WP_Post;
+/**
+ * Handles the response for a contact form submission.
+ *
+ * Feedback objects are there to help us interact with the form response data.
+ */
+class Feedback {
+
+	const POST_TYPE = 'feedback';
+
+	/**
+	 * The form field values.
+	 *
+	 * @var array
+	 */
+	protected $fields = array();
+
+	/**
+	 * Does the response have files attached to it?
+	 *
+	 * @var bool
+	 */
+	protected $has_file = false;
+
+	/**
+	 * The status of the feedback entry.
+	 *
+	 * @var string
+	 */
+	protected $status = 'publish'; // Default status is 'publish' or other statuses as needed.
+
+	/**
+	 * The IP address of the user who submitted the feedback.
+	 *
+	 * This is only available on form submissions, and might not be available when retrieving existing feedback posts in case the site admin decides to not store the IP address.
+	 *
+	 * @var string|null
+	 */
+	protected $ip_address = null;
+
+	/**
+	 * The subject of the feedback entry.
+	 *
+	 * @var string
+	 */
+	protected $subject = '';
+
+	/**
+	 * Feedback ID of the feedback entry.
+	 *
+	 * Marked as legacy because it is not used in the new feedback system.
+	 *
+	 * @var string
+	 */
+	protected $legacy_feedback_id = '';
+
+	/**
+	 * The title of the feedback entry.
+	 *
+	 * Marked as legacy because it is not used in the new feedback system.
+	 *
+	 * @var string
+	 */
+	protected $legacy_feedback_title = '';
+
+	/**
+	 * The time of the feedback entry.
+	 *
+	 * This is used to store the title of the feedback entry.
+	 *
+	 * @var string
+	 */
+	protected $feedback_time = '';
+
+	/**
+	 * The Feedback_Author of the feedback entry.
+	 *
+	 * @var Feedback_Author
+	 */
+	protected $author_data;
+
+	/**
+	 * The comment content of the feedback entry.
+	 *
+	 * @var string
+	 */
+	protected $comment_content = '';
+
+	/**
+	 * Whether the user has given consent for data processing.
+	 *
+	 * @var bool
+	 */
+	protected $has_consent = false;
+
+	/**
+	 * The entry object of the post that the feedback was submitted from.
+	 *
+	 * This is used to store the entry object of the post that the feedback was submitted from.
+	 *
+	 * @var Feedback_Source
+	 */
+	protected $source;
+
+	/**
+	 * Create a response object from a feedback post ID.
+	 *
+	 * @param int $feedback_post_id The ID of the feedback post.
+	 * @return static|null
+	 */
+	public static function get( $feedback_post_id ) {
+
+		$feedback_post = get_post( $feedback_post_id );
+		if ( ! $feedback_post || self::POST_TYPE !== $feedback_post->post_type ) {
+			return null;
+		}
+
+		$instance = new self();
+		$instance->load_from_post( $feedback_post );
+		return $instance;
+	}
+
+	/**
+	 * Create a Feedback object from a feedback post.
+	 *
+	 * @param WP_Post $feedback_post The feedback post object.
+	 */
+	private function load_from_post( WP_Post $feedback_post ) {
+
+		$parsed_content = $this->parse_content( $feedback_post->post_content, $feedback_post->post_mime_type );
+
+		$this->status             = $feedback_post->post_status;
+		$this->legacy_feedback_id = $feedback_post->post_name;
+		$this->feedback_time      = $feedback_post->post_date;
+
+		$this->fields = $parsed_content['fields'] ?? array();
+
+		$this->source = new Feedback_Source(
+			$feedback_post->post_parent,
+			$parsed_content['entry_title'] ?? '',
+			$parsed_content['entry_page'] ?? 1
+		);
+
+		$this->ip_address = $parsed_content['ip'] ?? $this->get_first_field_of_type( 'ip' );
+		$this->subject    = $parsed_content['subject'] ?? $this->get_first_field_of_type( 'subject' );
+
+		$this->author_data = new Feedback_Author(
+			$this->get_first_field_of_type( 'name', 'pre_comment_author_name' ),
+			$this->get_first_field_of_type( 'email', 'pre_comment_author_email' ),
+			$this->get_first_field_of_type( 'url', 'pre_comment_author_url' )
+		);
+
+		$this->comment_content = $this->get_first_field_of_type( 'textarea' );
+		$this->has_consent     = ( strtolower( $this->get_first_field_of_type( 'consent' ) ) === 'yes' );
+
+		$this->legacy_feedback_title = $feedback_post->post_title ? $feedback_post->post_title : $this->get_author() . ' - ' . $feedback_post->post_date;
+	}
+
+	/**
+	 * Create a response object from a form submission.
+	 *
+	 * @param array        $post_data Typically $_POST.
+	 * @param Contact_Form $form      The form object.
+	 * @param WP_Post|null $current_post The current post object, if available.
+	 * @param int          $current_page_number The current page number associated with the current post object entry.
+	 *
+	 * @return static
+	 */
+	public static function from_submission( $post_data, $form, $current_post = null, $current_page_number = 1 ) {
+		$instance = new self();
+		$instance->load_from_submission( $post_data, $form, $current_post, $current_page_number );
+		return $instance;
+	}
+
+	/**
+	 * Load from Form Submission.
+	 *
+	 * @param array        $post_data The $_POST received during the form submission.
+	 * @param Contact_Form $form  The form object.
+	 * @param WP_Post|null $current_post The current post object, if available.
+	 * @param int          $current_page_number The current page number associated with the current post object entry.
+	 */
+	private function load_from_submission( $post_data, $form, $current_post = null, $current_page_number = 1 ) {
+
+		$this->source = Feedback_Source::from_submission( $current_post, $current_page_number );
+		// If post_data is provided, use it to populate fields.
+		$this->fields          = $this->get_computed_fields( $post_data, $form );
+		$this->ip_address      = Contact_Form_Plugin::get_ip_address();
+		$this->subject         = $this->get_computed_subject( $post_data, $form );
+		$this->author_data     = Feedback_Author::from_submission( $post_data, $form );
+		$this->comment_content = $this->get_computed_comment_content( $post_data, $form );
+		$this->has_consent     = $this->get_computed_consent( $post_data, $form );
+
+		$this->feedback_time         = current_time( 'mysql' );
+		$this->legacy_feedback_title = "{$this->get_author()} - {$this->feedback_time}";
+		$this->legacy_feedback_id    = md5( $this->legacy_feedback_title );
+	}
+
+	/**
+	 * Get a sanitized value from the post data.
+	 *
+	 * @param string $key The key to look for in the post data.
+	 * @param array  $post_data The post data array, typically $_POST.
+	 *
+	 * @return string|array The sanitized value, or an empty string if the key is not found.
+	 */
+	private function get_field_value( $key, $post_data ) {
+		if ( isset( $post_data[ $key ] ) ) {
+			if ( is_array( $post_data[ $key ] ) ) {
+				return array_map( 'sanitize_text_field', wp_unslash( $post_data[ $key ] ) );
+			} else {
+				return sanitize_text_field( wp_unslash( $post_data[ $key ] ) );
+			}
+		}
+		return '';
+	}
+
+	/**
+	 * Get the computed fields from the post data.
+	 *
+	 * @param string $label The label of the field to look for.
+	 * @param string $context The context in which the value is being rendered (default is 'default').
+	 *
+	 * @return string The Value of the field.
+	 */
+	public function get_field_value_by_label( $label, $context = 'default' ) {
+		// This method is used to get the value of a field by its label.
+		foreach ( $this->fields as $field ) {
+			if ( $field->get_label() === $label ) {
+				return $field->get_render_value( $context );
+			}
+		}
+		return '';
+	}
+	/**
+	 * Get the value of the field based on the first type found.
+	 *
+	 * @param string      $type The type of the field to look for.
+	 * @param string|null $filter Optional filter to apply to the value.
+	 * @param string      $context The context in which the value is being rendered (default is 'default').
+	 *
+	 * @return string The value of the first field of the specified type, or an empty string if not found.
+	 */
+	private function get_first_field_of_type( $type, $filter = null, $context = 'default' ) {
+		// This method is used to get the first field of a specific type.
+		foreach ( $this->fields as $field ) {
+			if ( $field->get_type() === $type ) {
+				if ( $filter ) {
+					return Contact_Form_Plugin::strip_tags(
+						stripslashes(
+							/** This filter is already documented in core/wp-includes/comment-functions.php */
+							\apply_filters( $filter, addslashes( $field->get_render_value( $context ) ) )
+						)
+					);
+				}
+				return $field->get_render_value( $context );
+			}
+		}
+		return '';
+	}
+
+	/**
+	 * Get all the fields of the response.
+	 */
+	public function get_fields() {
+		return $this->fields;
+	}
+
+	/**
+	 * Get the values related to where the form was submitted from.
+	 *
+	 * @return array An array of entry values.
+	 */
+	private function get_entry_values() {
+		// This is a convenience method to get the entry values in a simple array format.
+		$entry_values = array(
+			'email_marketing_consent' => (string) $this->has_consent ? 'yes' : 'no',
+			'entry_title'             => $this->source->get_title(),
+			'entry_permalink'         => $this->source->get_permalink(),
+			'feedback_id'             => $this->legacy_feedback_id,
+		);
+
+		if ( $this->source->get_page_number() > 1 ) {
+			$entry_values['entry_page'] = $this->source->get_page_number();
+		}
+		return $entry_values;
+	}
+
+	/**
+	 * Get all values of the response.
+	 *
+	 * @return array An array of all values, including fields and entry values.
+	 */
+	public function get_all_values() {
+		// This is a legacy method to maintain compatibility with older code.
+		return array_merge( $this->get_compiled_fields( 'default', 'key-value' ), $this->get_entry_values() );
+	}
+
+	/**
+	 * Return the compiled fields for the given context.
+	 *
+	 * @param string $context The context in which the fields are compiled.
+	 * @param string $array_shape The shape of the array to return. Can be 'all', 'value', 'label', or 'key-value'.
+	 *
+	 * @return array An array of compiled fields with labels and values.
+	 */
+	public function get_compiled_fields( $context = 'default', $array_shape = 'all' ) {
+		$compiled_fields = array();
+		foreach ( $this->fields as $field ) {
+			if ( $field->compile_field( $context ) ) {
+				continue; // Skip fields that are not meant to be rendered.
+			}
+
+			// Compile the field based on the requested shape.
+			switch ( $array_shape ) {
+				case 'all':
+					$compiled_fields[ $field->get_key() ] = array(
+						'label' => $field->get_label( $context ),
+						'value' => $field->get_render_value( $context ),
+					);
+					break;
+				case 'label|value':
+					$compiled_fields[] = array(
+						'label' => $field->get_label( $context ),
+						'value' => $field->get_render_value( $context ),
+					);
+					break;
+				case 'value':
+					$compiled_fields[] = $field->get_render_value( $context );
+					break;
+				case 'label':
+					$compiled_fields[] = $field->get_label( $context );
+					break;
+				case 'key-value':
+					$compiled_fields[ $field->get_key() ] = $field->get_render_value( $context );
+					break;
+			}
+		}
+
+		return $compiled_fields;
+	}
+
+	/**
+	 * Get the feedback ID of the response.
+	 * Which is the same as the post name for feedback entries.
+	 * Please note that this is not the same as the feedback post ID.
+	 *
+	 * @return string
+	 */
+	public function get_feedback_id() {
+		return $this->legacy_feedback_id;
+	}
+
+	/**
+	 * Get the feedback title of the response.
+	 *
+	 * This is mostly used for legacy reasons.
+	 *
+	 * @return string
+	 */
+	public function get_title() {
+		return $this->legacy_feedback_title;
+	}
+
+	/**
+	 * Get the time of the feedback entry.
+	 *
+	 * @return string
+	 */
+	public function get_time() {
+		return $this->feedback_time;
+	}
+
+	/**
+	 * Get the askimet vars that are used to check for spam.
+	 *
+	 * These are the variables that are sent to Akismet to check if the feedback is spam or not.
+	 *
+	 * @return array
+	 */
+	public function get_akismet_vars() {
+		$akismet_vars = array(
+			'comment_author'       => $this->author_data->get_name(),
+			'comment_author_email' => $this->author_data->get_email(),
+			'comment_author_url'   => $this->author_data->get_url(),
+			'contact_form_subject' => $this->get_subject(),
+			'comment_author_ip'    => $this->get_ip_address(),
+			'comment_content'      => empty( $this->get_comment_content() ) ? null : $this->get_comment_content(),
+		);
+
+		foreach ( $this->fields as $field ) {
+
+			// Skip any fields that are just a choice from a pre-defined list. They wouldn't have any value
+			// from a spam-filtering point of view.
+			if ( in_array( $field->get_type(), array( 'select', 'checkbox', 'checkbox-multiple', 'radio', 'file' ), true ) ) {
+				continue;
+			}
+
+			// Normalize the label into a slug.
+			$field_slug = trim( // Strip all leading/trailing dashes.
+				preg_replace(   // Normalize everything to a-z0-9_-
+					'/[^a-z0-9_]+/',
+					'-',
+					strtolower( $field->get_label() ) // Lowercase
+				),
+				'-'
+			);
+
+			$field_value = $field->get_render_value( 'akismet' );
+
+			// Skip any values that are already in the array we're sending.
+			if ( $field_value && in_array( $field_value, $akismet_vars, true ) ) {
+				continue;
+			}
+
+			$akismet_vars[ 'contact_form_field_' . $field_slug ] = $field_value;
+		}
+
+		return $akismet_vars;
+	}
+
+	/**
+	 * Get the author name of the feedback entry.
+	 * If the author is not provided we will use the email instead.
+	 *
+	 * @return string
+	 */
+	public function get_author() {
+		return $this->author_data->get_display_name();
+	}
+
+	/**
+	 * Get the author email of a feedback entry.
+	 *
+	 * @return string
+	 */
+	public function get_author_email() {
+		return $this->author_data->get_email();
+	}
+
+	/**
+	 * Get the author's gravatar URL.
+	 *
+	 * This is a convenience method to get the author's gravatar URL.
+	 *
+	 * @return string
+	 */
+	public function get_author_avatar() {
+		return $this->author_data->get_avatar_url();
+	}
+
+	/**
+	 * Get the author url of a feedback entry.
+	 *
+	 * @return string
+	 */
+	public function get_author_url() {
+		return $this->author_data->get_url();
+	}
+
+	/**
+	 * Get the comment content of a feedback entry.
+	 *
+	 * @return string
+	 */
+	public function get_comment_content() {
+		return $this->comment_content;
+	}
+
+	/**
+	 * Get the IP address of the submitted feedback request.
+	 *
+	 * @return string|null
+	 */
+	public function get_ip_address() {
+		return $this->ip_address;
+	}
+
+	/**
+	 * Get the email subject.
+	 *
+	 * @return string
+	 */
+	public function get_subject() {
+		return $this->subject;
+	}
+
+	/**
+	 * Gets the value of the consent field.
+	 *
+	 * @return bool
+	 */
+	public function has_consent() {
+		return $this->has_consent;
+	}
+
+	/**
+	 * Gets the value of the consent field.
+	 *
+	 * @return bool
+	 */
+	public function has_file() {
+		return $this->has_file;
+	}
+
+	/**
+	 * Get the feedback status. For example 'publish', 'spam' or 'trash'.
+	 *
+	 * @return string
+	 */
+	public function get_status() {
+		return $this->status;
+	}
+
+	/**
+	 * Sets the status of the feedback.
+	 *
+	 * @param string $status The status to set for the feedback entry.
+	 * @return void
+	 */
+	public function set_status( $status ) {
+		$this->status = $status;
+	}
+
+	/**
+	 * Get the entry ID of the post that the feedback was submitted from.
+	 *
+	 * This is the post ID of the post or page that the feedback was submitted from.
+	 *
+	 * @return int|null
+	 */
+	public function get_entry_id() {
+		return $this->source->get_id();
+	}
+
+	/**
+	 * Get the entry title of the post that the feedback was submitted from.
+	 *
+	 * This is the title of the post or page that the feedback was submitted from.
+	 *
+	 * @return string
+	 */
+	public function get_entry_title() {
+		return $this->source->get_title();
+	}
+
+	/**
+	 * Get the permalink of the post or page that the feedback was submitted from.
+	 * This includes the page number if the feedback was submitted from a paginated form.
+	 *
+	 * @return string
+	 */
+	public function get_entry_permalink() {
+		return $this->source->get_permalink();
+	}
+	/**
+	 * Get the short permalink of a post.
+	 *
+	 * @return string
+	 */
+	public function get_entry_short_permalink() {
+		return $this->source->get_relative_permalink();
+	}
+	/**
+	 * Save the feedback entry to the database.
+	 *
+	 * @return int
+	 */
+	public function save() {
+		$post_id = wp_insert_post(
+			array(
+				'post_type'      => self::POST_TYPE,
+				'post_status'    => $this->status,
+				'post_title'     => $this->legacy_feedback_title,
+				'post_date'      => $this->feedback_time,
+				'post_name'      => $this->legacy_feedback_id,
+				'post_content'   => $this->serialize(),
+				'post_mime_type' => 'v2', // a way to help us identify what version of the data this is.
+				'post_parent'    => $this->source->get_id(),
+			)
+		);
+
+		$feedback_post = get_post( $post_id );
+		return $feedback_post ?? 0;
+	}
+
+	/**
+	 * Serialize the fields to JSON format.
+	 *
+	 * @return string
+	 */
+	public function serialize() {
+
+		$fields_to_serialize = array_merge(
+			array(
+				'subject' => $this->subject,
+				'ip'      => $this->ip_address,
+			),
+			$this->source->serialize()
+		);
+
+		$fields_to_serialize['fields'] = array();
+		foreach ( $this->fields as $field ) {
+			$fields_to_serialize['fields'][] = $field->serialize();
+		}
+
+		// Check if the IP should be included.
+		if ( apply_filters( 'jetpack_contact_form_forget_ip_address', false, $this->ip_address ) ) {
+			$fields_to_serialize['ip'] = null;
+		}
+
+		return wp_json_encode( $fields_to_serialize );
+	}
+
+	/**
+	 * Helper function to parse the post content.
+	 *
+	 * @param string      $post_content The post content to parse.
+	 * @param string|null $version The version of the content format.
+	 * @return array Parsed fields.
+	 */
+	private function parse_content( $post_content = '', $version = null ) {
+		if ( $version === 'v2' ) {
+			return $this->parse_content_v2( $post_content );
+		}
+		return $this->parse_legacy_content( $post_content );
+	}
+
+	/**
+	 * Parse the content in the v2 format.
+	 *
+	 * @param string $post_content The post content to parse.
+	 *
+	 * @return array Parsed fields.
+	 */
+	private function parse_content_v2( $post_content = '' ) {
+		$decoded_content = json_decode( $post_content, true );
+		if ( $decoded_content === null ) {
+			// If JSON decoding fails, try to decode the second try with stripslashes and trim.
+			// This is a workaround for some cases where the JSON data is not properly formatted.
+			$decoded_content = json_decode( stripslashes( trim( $post_content ) ), true );
+		}
+
+		if ( $decoded_content === null ) {
+			return array();
+		}
+		$fields = array();
+		foreach ( $decoded_content['fields'] as $field ) {
+			$fields[ $field['key'] ] = Feedback_Field::from_serialized( $field );
+			if ( ! $this->has_file && $fields[ $field['key'] ]->has_file() ) {
+				$this->has_file = true;
+			}
+		}
+		$decoded_content['fields'] = $fields;
+		return $decoded_content;
+	}
+
+	/**
+	 * Parse the legacy content format.
+	 *
+	 * @param string $post_content The post content to parse.
+	 *
+	 * @return array Parsed fields.
+	 */
+	private function parse_legacy_content( $post_content = '' ) {
+		$content_parts   = $this->split_legacy_content( $post_content );
+		$comment_content = $content_parts['comment_content'];
+		$field_content   = $content_parts['field_content'];
+
+		$all_values = $this->extract_legacy_values( $field_content );
+		$lines      = $this->extract_legacy_lines( $field_content );
+
+		$decoded_fields           = array();
+		$decoded_fields['fields'] = array();
+
+		// Process lines for specific field types
+		$this->process_legacy_lines( $lines, $decoded_fields );
+
+		// Process all other values
+		$this->process_legacy_values( $all_values, $decoded_fields );
+
+		// Add comment content field
+		$this->add_comment_content_field( $comment_content, $decoded_fields );
+
+		return $decoded_fields;
+	}
+
+	/**
+	 * Split legacy content into comment and field sections.
+	 *
+	 * @param string $post_content The post content to parse.
+	 * @return array Array with 'comment_content' and 'field_content' keys.
+	 */
+	private function split_legacy_content( $post_content ) {
+		$content         = explode( '<!--more-->', $post_content );
+		$comment_content = '';
+		$field_content   = '';
+
+		if ( count( $content ) > 1 ) {
+			$comment_content = $content[0];
+			$field_content   = str_ireplace( array( '<br />', ')</p>' ), '', $content[1] );
+		}
+
+		return array(
+			'comment_content' => $comment_content,
+			'field_content'   => $field_content,
+		);
+	}
+
+	/**
+	 * Extract values from legacy field content.
+	 *
+	 * @param string $field_content The field content to parse.
+	 * @return array Extracted values.
+	 */
+	private function extract_legacy_values( $field_content ) {
+		$all_values = array();
+
+		if ( str_contains( $field_content, 'JSON_DATA' ) ) {
+			$all_values = $this->parse_json_data( $field_content );
+		} else {
+			$all_values = $this->parse_array_format( $field_content );
+		}
+
+		// Ensure all_values is always an array
+		if ( ! is_array( $all_values ) ) {
+			$all_values = array();
+		}
+
+		return $all_values;
+	}
+
+	/**
+	 * Extract lines from legacy field content.
+	 *
+	 * @param string $field_content The field content to parse.
+	 * @return array Filtered lines.
+	 */
+	private function extract_legacy_lines( $field_content ) {
+		if ( str_contains( $field_content, 'JSON_DATA' ) ) {
+			$chunks = explode( "\nJSON_DATA", $field_content );
+			return array_filter( explode( "\n", $chunks[0] ) );
+		} else {
+			return array_filter( explode( "\n", $field_content ) );
+		}
+	}
+
+	/**
+	 * Parse JSON data from field content.
+	 *
+	 * @param string $field_content The field content containing JSON data.
+	 * @return array Parsed JSON data.
+	 */
+	private function parse_json_data( $field_content ) {
+		$chunks    = explode( "\nJSON_DATA", $field_content );
+		$json_data = $chunks[1];
+
+		$all_values = json_decode( $json_data, true );
+
+		if ( $all_values === null ) {
+			// Fallback for improperly formatted JSON
+			$all_values = json_decode( stripslashes( trim( $json_data ) ), true );
+		}
+
+		return $all_values === null ? array() : $all_values;
+	}
+
+	/**
+	 * Parse array format from field content.
+	 *
+	 * @param string $field_content The field content in array format.
+	 * @return array Parsed array data.
+	 */
+	private function parse_array_format( $field_content ) {
+		$fields_array = preg_replace( '/.*Array\s\( (.*)\)/msx', '$1', $field_content );
+
+		// Parse key-value pairs formatted as [Key] => Value
+		preg_match_all( '/^\s*\[([^\]]+)\] =\&gt\; (.*)(?=^\s*(\[[^\]]+\] =\&gt\;)|\z)/msU', $fields_array, $matches );
+
+		if ( count( $matches ) > 1 ) {
+			return array_combine( array_map( 'trim', $matches[1] ), array_map( 'trim', $matches[2] ) );
+		}
+
+		return array();
+	}
+
+	/**
+	 * Process legacy lines into field objects.
+	 *
+	 * We do this so that we can extract specific fields but we don't display the values in the UI.
+	 *
+	 * @param array $lines The lines to process.
+	 * @param array &$decoded_fields Reference to the decoded fields array.
+	 */
+	private function process_legacy_lines( $lines, &$decoded_fields ) {
+		$var_map = array(
+			'AUTHOR'       => array(
+				'type'  => 'name',
+				'label' => 'Author',
+			),
+			'AUTHOR EMAIL' => array(
+				'type'  => 'email',
+				'label' => 'Email',
+			),
+			'AUTHOR URL'   => array(
+				'type'  => 'url',
+				'label' => 'Url',
+			),
+			'SUBJECT'      => array(
+				'type'  => 'subject',
+				'label' => 'Subject',
+			),
+			'IP'           => array(
+				'type'  => 'ip',
+				'label' => 'IP',
+			),
+		);
+
+		foreach ( $lines as $line ) {
+			$line_parts = explode( ': ', $line, 2 );
+
+			if ( count( $line_parts ) !== 2 ) {
+				continue;
+			}
+
+			list( $key, $value ) = $line_parts;
+
+			if ( ! empty( $key ) && isset( $var_map[ $key ] ) ) {
+				$map_to_field = $var_map[ $key ];
+				$value        = Contact_Form_Plugin::strip_tags( trim( $value ) );
+
+				$decoded_fields['fields'][ $key ] = new Feedback_Field(
+					$key,
+					$map_to_field['label'],
+					$value,
+					$map_to_field['type'],
+					array( 'render' => false )
+				);
+			}
+		}
+	}
+
+	/**
+	 * Check if the field is a legacy file upload.
+	 *
+	 * @param array $field The field to check.
+	 *
+	 * @return bool True if it's a legacy file upload, false otherwise.
+	 */
+	private function is_legacy_file_upload( $field ) {
+		return (
+			is_array( $field ) &&
+			! empty( $field['field_id'] ) &&
+			isset( $field['files'] ) &&
+			is_array( $field['files'] )
+		);
+	}
+
+	/**
+	 * Process legacy values into field objects.
+	 *
+	 * @param array $all_values The values to process.
+	 * @param array &$decoded_fields Reference to the decoded fields array.
+	 */
+	private function process_legacy_values( $all_values, &$decoded_fields ) {
+		$non_user_fields = array(
+			'email_marketing_consent',
+			'entry_title',
+			'entry_permalink',
+			'entry_page',
+			'feedback_id',
+		);
+
+		foreach ( $all_values as $key => $value ) {
+			$key   = wp_strip_all_tags( $key );
+			$label = self::extract_label_from_key( $key );
+
+			if ( in_array( $key, $non_user_fields, true ) ) {
+				if ( $key === 'email_marketing_consent' ) {
+					$decoded_fields['fields'][ $key ] = new Feedback_Field(
+						$key,
+						$label,
+						$value,
+						'consent',
+						array( 'render' => false )
+					);
+					continue;
+				}
+				$decoded_fields[ $key ] = $value;
+				continue;
+			}
+
+			// check for file upload data and then set it as a file type field.
+			if ( $this->is_legacy_file_upload( $value ) ) {
+				// If the value is a file upload, we need to handle it differently.
+				$decoded_fields['fields'][ $key ] = new Feedback_Field(
+					$key,
+					$label,
+					$value,
+					'file'
+				);
+				$this->has_file                   = ! empty( $value['files'] ); // Set has_file to true if any file upload is found.
+			} else {
+				$decoded_fields['fields'][ $key ] = new Feedback_Field( $key, $label, $value );
+			}
+		}
+	}
+
+	/**
+	 * Add comment content as a field.
+	 *
+	 * @param string $comment_content The comment content.
+	 * @param array  &$decoded_fields Reference to the decoded fields array.
+	 */
+	private function add_comment_content_field( $comment_content, &$decoded_fields ) {
+		$decoded_fields['fields']['comment_content'] = new Feedback_Field(
+			'comment_content',
+			'Comment Content',
+			trim( Contact_Form_Plugin::strip_tags( $comment_content ) ),
+			'textarea',
+			array( 'render' => false )
+		);
+	}
+
+	/**
+	 * Extract the label from a key that might be in the format "1_label".
+	 *
+	 * @param string $key The key to extract the label from.
+	 * @return string The extracted label.
+	 */
+	private static function extract_label_from_key( $key ) {
+		// Check if the key starts with a number followed by underscore
+		if ( preg_match( '/^\d+_(.+)$/', $key, $matches ) ) {
+			return $matches[1];
+		}
+		// If no number prefix, return the key as is
+		return $key;
+	}
+
+	/**
+	 * Get all the fields of the response, computed from the post data.
+	 *
+	 * @param array        $post_data The post data from the form submission.
+	 * @param Contact_Form $form The form object.
+	 * @return array An array of Feedback_Field objects.
+	 */
+	private function get_computed_fields( $post_data, $form ) {
+
+		$fields = array();
+
+		$field_ids = $form->get_field_ids();
+		// For all fields, grab label and value
+		$i = 1;
+		foreach ( $field_ids['all'] as $field_id ) {
+			$field = $form->fields[ $field_id ];
+			$type  = $field->get_attribute( 'type' );
+			if ( ! $field->is_field_renderable( $type ) ) {
+				continue;
+			}
+
+			$value = $this->get_field_value( $field_id, $post_data );
+			$label = wp_strip_all_tags( $field->get_attribute( 'label' ) );
+			$key   = $i . '_' . $label;
+
+			$fields[ $key ] = new Feedback_Field( $key, $label, $value, $type );
+			if ( ! $this->has_file && $fields[ $key ]->has_file() ) {
+				$this->has_file = true;
+			}
+			++$i; // Increment prefix counter for the next field.
+		}
+
+		return $fields;
+	}
+
+	/**
+	 * Gets the computed subject.
+	 *
+	 * @param array        $post_data The post data from the form submission.
+	 * @param Contact_Form $form The form object.
+	 * @return string
+	 */
+	private function get_computed_subject( $post_data, $form ) {
+
+		$contact_form_subject = $form->get_attribute( 'subject' );
+		$field_ids            = $form->get_field_ids();
+
+		if ( isset( $field_ids['subject'] ) ) {
+			$value = $this->get_field_value( $field_ids['subject'], $post_data );
+			if ( ! empty( $value ) ) {
+				$contact_form_subject = $value;
+			}
+		}
+
+		return apply_filters( 'contact_form_subject', $contact_form_subject, $this->get_all_values() );
+	}
+
+	/**
+	 * Gets the computed comment content.
+	 *
+	 * @param array        $post_data The post data from the form submission.
+	 * @param Contact_Form $form The form object.
+	 * @return string
+	 */
+	private function get_computed_comment_content( $post_data, $form ) {
+		$field_ids = $form->get_field_ids();
+		if ( isset( $field_ids['textarea'] ) ) {
+			$value = $this->get_field_value( $field_ids['textarea'], $post_data );
+			if ( is_string( $value ) ) {
+				return trim( Contact_Form_Plugin::strip_tags( stripslashes( $value ) ) );
+			}
+		}
+		return '';
+	}
+
+	/**
+	 * Gets the computed consent.
+	 *
+	 * @param array        $post_data The post data from the form submission.
+	 * @param Contact_Form $form The form object.
+	 * @return bool
+	 */
+	private function get_computed_consent( $post_data, $form ) {
+		$field_ids = $form->get_field_ids();
+
+		if ( isset( $field_ids['email_marketing_consent_field'] ) && $field_ids['email_marketing_consent_field'] !== null ) {
+			return (bool) $this->get_field_value( $field_ids['email_marketing_consent_field'], $post_data );
+		}
+
+		return false;
+	}
+}

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -2999,20 +2999,22 @@ EOT;
 	}
 
 	public function test_get_forms_count() {
-		new Contact_Form(
+		$form = new Contact_Form(
+			array(
+				'to'      => 'test@email.com',
+				'subject' => 'Test Form',
+			)
+		);
+		$this->assertTrue( is_object( $form ), 'Form should be an object after creation' );
+		$this->assertSame( 1, Contact_Form::get_forms_count(), 'Forms count should be 1 after first form creation' );
+		$form = new Contact_Form(
 			array(
 				'to'      => 'test@email.com',
 				'subject' => 'Test Form',
 			)
 		);
 
-		$this->assertSame( 1, Contact_Form::get_forms_count(), 'Forms count should be 1 after first form creation' );
-		new Contact_Form(
-			array(
-				'to'      => 'test@email.com',
-				'subject' => 'Test Form',
-			)
-		);
+		$this->assertTrue( is_object( $form ), 'Form should be an object after creation' );
 		$this->assertEquals( 2, Contact_Form::get_forms_count(), 'Forms count should be 2 after second form creation' );
 	}
 } // end class

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -3005,7 +3005,7 @@ EOT;
 				'subject' => 'Test Form',
 			)
 		);
-		$this->assertTrue( is_object( $form ), 'Form should be an object after creation' );
+		$this->assertInstanceOf( Contact_Form::class, $form, 'Form should be a Contact_Form instance after creation' );
 		$this->assertSame( 1, Contact_Form::get_forms_count(), 'Forms count should be 1 after first form creation' );
 		$form = new Contact_Form(
 			array(
@@ -3014,7 +3014,7 @@ EOT;
 			)
 		);
 
-		$this->assertTrue( is_object( $form ), 'Form should be an object after creation' );
+		$this->assertInstanceOf( Contact_Form::class, $form, 'Form should be a Contact_Form instance after creation' );
 		$this->assertEquals( 2, Contact_Form::get_forms_count(), 'Forms count should be 2 after second form creation' );
 	}
 } // end class

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -2997,4 +2997,22 @@ EOT;
 
 		Constants::clear_single_constant( 'JETPACK_BLOG_TOKEN' );
 	}
+
+	public function test_get_forms_count() {
+		new Contact_Form(
+			array(
+				'to'      => 'test@email.com',
+				'subject' => 'Test Form',
+			)
+		);
+
+		$this->assertSame( 1, Contact_Form::get_forms_count(), 'Forms count should be 1 after first form creation' );
+		new Contact_Form(
+			array(
+				'to'      => 'test@email.com',
+				'subject' => 'Test Form',
+			)
+		);
+		$this->assertEquals( 2, Contact_Form::get_forms_count(), 'Forms count should be 2 after second form creation' );
+	}
 } // end class

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Author_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Author_Test.php
@@ -1,0 +1,176 @@
+<?php
+/**
+ * Unit Tests for Automattic\Jetpack\Forms\Contact_Form.
+ *
+ * To run the test visit the packages/forms directory and run composer test-php
+ *
+ * @package automattic/jetpack-forms
+ */
+
+namespace Automattic\Jetpack\Forms\ContactForm;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use WorDBless\BaseTestCase;
+
+/**
+ * Test class for Feedback_Author
+ *
+ * @covers \Automattic\Jetpack\Forms\ContactForm\Feedback_Author
+ */
+#[CoversClass( Feedback_Author::class )]
+class Feedback_Author_Test extends BaseTestCase {
+
+	/**
+	 * Test constructor with all parameters.
+	 */
+	public function test_constructor_with_all_parameters() {
+		$author = new Feedback_Author( 'John Doe', 'john@example.com', 'https://example.com' );
+
+		$this->assertEquals( 'John Doe', $author->get_name() );
+		$this->assertEquals( 'john@example.com', $author->get_email() );
+		$this->assertEquals( 'https://example.com', $author->get_url() );
+	}
+
+	/**
+	 * Test constructor with default parameters.
+	 */
+	public function test_constructor_with_default_parameters() {
+		$author = new Feedback_Author();
+
+		$this->assertSame( '', $author->get_name() );
+		$this->assertSame( '', $author->get_email() );
+		$this->assertSame( '', $author->get_url() );
+	}
+
+	/**
+	 * Test get_display_name when name is set.
+	 */
+	public function test_get_display_name_with_name() {
+		$author = new Feedback_Author( 'John Doe', 'john@example.com' );
+
+		$this->assertEquals( 'John Doe', $author->get_display_name() );
+	}
+
+	/**
+	 * Test get_display_name when name is empty, falls back to email.
+	 */
+	public function test_get_display_name_without_name() {
+		$author = new Feedback_Author( '', 'john@example.com' );
+
+		$this->assertEquals( 'john@example.com', $author->get_display_name() );
+	}
+
+	/**
+	 * Test get_display_name when both name and email are empty.
+	 */
+	public function test_get_display_name_empty() {
+		$author = new Feedback_Author();
+
+		$this->assertSame( '', $author->get_display_name() );
+	}
+
+	/**
+	 * Test get_avatar_url with email.
+	 */
+	public function test_get_avatar_url_with_email() {
+		$author = new Feedback_Author( 'John Doe', 'john@example.com' );
+
+		$this->assertNotEmpty( $author->get_avatar_url() );
+		$this->assertStringContainsString( 'gravatar', $author->get_avatar_url() );
+	}
+
+	/**
+	 * Test get_avatar_url without email.
+	 */
+	public function test_get_avatar_url_without_email() {
+		$author = new Feedback_Author( 'John Doe' );
+
+		$this->assertSame( '', $author->get_avatar_url() );
+	}
+
+	/**
+	 * Test from_submission method.
+	 */
+	public function test_from_submission() {
+		$form = $this->createMock( Contact_Form::class );
+		$form->method( 'get_field_ids' )
+			->willReturn(
+				array(
+					'name'  => 'g1-name',
+					'email' => 'g1-email',
+					'url'   => 'g1-url',
+				)
+			);
+
+		$post_data = array(
+			'g1-name'  => 'John Doe',
+			'g1-email' => 'john@example.com',
+			'g1-url'   => 'https://example.com',
+		);
+
+		$author = Feedback_Author::from_submission( $post_data, $form );
+
+		$this->assertInstanceOf( Feedback_Author::class, $author );
+	}
+
+	public function test_from_submission_with_mock_data() {
+		$author_name = 'Mikey Mouse';
+
+		$form_id = Utility::get_form_id();
+		// Create a form submission
+		$_post_data = Utility::get_post_request(
+			array(
+				'name'    => $author_name,
+				'email'   => 'email@email.com',
+				'message' => 'Test message',
+			),
+			'g' . $form_id
+		);
+
+		$form = new Contact_Form(
+			array(
+				'title'       => 'Test Form',
+				'description' => 'This is a test form.',
+			),
+			"[contact-field label='Name' type='name' required='1'/][contact-field label='Email' type='email' required='1'/][contact-field label='Message' type='textarea' required='1'/]"
+		);
+
+		$author = Feedback_Author::from_submission( $_post_data, $form );
+		$this->assertEquals( $author_name, $author->get_name() );
+		$this->assertEquals( 'email@email.com', $author->get_email() );
+	}
+
+	/**
+	 * Test from_submission with missing fields.
+	 */
+	public function test_from_submission_missing_fields() {
+		$form = $this->createMock( Contact_Form::class );
+		$form->method( 'get_field_ids' )
+			->willReturn(
+				array(
+					'name' => 'g1-name',
+				)
+			);
+
+		$post_data = array(
+			'g1-other' => 'some value',
+		);
+
+		$author = Feedback_Author::from_submission( $post_data, $form );
+
+		$this->assertInstanceOf( Feedback_Author::class, $author );
+	}
+
+	/**
+	 * Test getters return correct types.
+	 */
+	public function test_getters_return_strings() {
+		$author = new Feedback_Author( 'John', 'john@test.com', 'http://test.com' );
+
+		$this->assertIsString( $author->get_name() );
+		$this->assertIsString( $author->get_email() );
+		$this->assertIsString( $author->get_url() );
+		$this->assertIsString( $author->get_display_name() );
+		$this->assertIsString( $author->get_avatar_url() );
+	}
+}

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Field_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Field_Test.php
@@ -1,0 +1,258 @@
+<?php
+/**
+ * Unit Tests for Automattic\Jetpack\Forms\Contact_Form.
+ *
+ * To run the test visit the packages/forms directory and run composer test-php
+ *
+ * @package automattic/jetpack-forms
+ */
+
+namespace Automattic\Jetpack\Forms\ContactForm;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use WorDBless\BaseTestCase;
+
+/**
+ * Test class for Feedback_Field
+ *
+ * @covers \Automattic\Jetpack\Forms\ContactForm\Feedback_Field
+ * @covers \Automattic\Jetpack\Forms\ContactForm\Feedback
+ */
+#[CoversClass( Feedback_Field::class )]
+#[CoversClass( Feedback::class )]
+class Feedback_Field_Test extends BaseTestCase {
+	/**
+	 * Test that the Feedback_Field class can be instantiated.
+	 */
+	public function test_Feedback_Field_can_be_instantiated() {
+		$field = new Feedback_Field( 'test_key', 'test_label', 'test_value' );
+		$this->assertInstanceOf( Feedback_Field::class, $field );
+
+		$this->assertEquals( 'test_key', $field->get_key() );
+		$this->assertEquals( 'test_label', $field->get_label() );
+		$this->assertEquals( 'test_value', $field->get_value() );
+		$this->assertEquals( 'basic', $field->get_type() );
+		$this->assertEquals( array(), $field->get_meta() );
+	}
+
+	/**
+	 * Test that the Feedback_Field class can be instantiated with additional parameters.
+	 */
+	public function test_Feedback_Field_with_additional_parameters() {
+		$field = new Feedback_Field( 'test_key', 'test_label', 'test_value', 'text', array( 'meta_key' => 'meta_value' ) );
+		$this->assertEquals( 'test_key', $field->get_key() );
+		$this->assertEquals( 'test_label', $field->get_label() );
+		$this->assertEquals( 'test_value', $field->get_value() );
+		$this->assertEquals( 'text', $field->get_type() );
+		$this->assertEquals( array( 'meta_key' => 'meta_value' ), $field->get_meta() );
+		$this->assertEquals( 'meta_value', $field->get_meta_key_value( 'meta_key' ) );
+		$this->assertNull( $field->get_meta_key_value( 'non_existant' ) );
+	}
+
+	/**
+	 * Test that the Feedback_Field class can handle empty values.
+	 */
+	public function test_Feedback_Field_with_empty_values() {
+		$field = new Feedback_Field( 'test_key', '', '' );
+		$this->assertEquals( 'test_key', $field->get_key() );
+		$this->assertSame( '', $field->get_label() );
+		$this->assertSame( '', $field->get_value() );
+		$this->assertEquals( 'basic', $field->get_type() );
+		$this->assertEquals( array(), $field->get_meta() );
+	}
+
+	/**
+	 * Test that the Feedback_Field can serialize and unserialize correctly.
+	 */
+	public function test_Feedback_Field_serialization() {
+		$field        = new Feedback_Field( 'test_key', 'test_label', 'test_value', 'text', array( 'meta_key' => 'meta_value' ) );
+		$serialized   = $field->serialize();
+		$unserialized = Feedback_Field::from_serialized( $serialized );
+
+		$this->assertInstanceOf( Feedback_Field::class, $unserialized );
+
+		$this->assertEquals( $serialized, $unserialized->serialize() );
+		$this->assertEquals( 'test_key', $unserialized->get_key() );
+		$this->assertEquals( 'test_label', $unserialized->get_label() );
+		$this->assertEquals( 'test_value', $unserialized->get_value() );
+		$this->assertEquals( 'text', $unserialized->get_type() );
+		$this->assertEquals( array( 'meta_key' => 'meta_value' ), $unserialized->get_meta() );
+	}
+
+	/**
+	 * Test that the Feedback_Field can serialize and unserialize correctly.
+	 */
+	public function test_response_from_serialized_is_null() {
+
+		$unserialized = Feedback_Field::from_serialized( array( 'key' => 'test_key' ) );
+
+		$this->assertNull( $unserialized );
+
+		$unserialized = Feedback_Field::from_serialized( array( 'value' => 'test_value' ) );
+
+		$this->assertNull( $unserialized );
+
+		$unserialized = Feedback_Field::from_serialized( array( 'label' => 'test_value' ) );
+
+		$this->assertNull( $unserialized );
+
+		$unserialized = Feedback_Field::from_serialized(
+			array(
+				'label' => 'test_value',
+				'value' => 'value',
+			)
+		);
+
+		$this->assertNull( $unserialized );
+	}
+
+	public function test_get_render_value() {
+		$field = new Feedback_Field( 'test_key', 'test_label', 'test_value' );
+		$this->assertEquals( 'test_value', $field->get_render_value() );
+		$this->assertEquals( 'test_value', $field->get_value() );
+
+		$field = new Feedback_Field( 'test_key', 'test_label', array( 'value1', 'value2' ) );
+		$this->assertEquals( 'value1, value2', $field->get_render_value() );
+		$this->assertEquals( array( 'value1', 'value2' ), $field->get_value() );
+
+		// EMPTY FILE FIELD
+		$field = new Feedback_Field( 'test_key', 'test_label', array( 'files' => array() ), 'file' );
+		$this->assertSame( '', $field->get_render_value() );
+		$this->assertEquals(
+			array( 'files' => array() ),
+			$field->get_value()
+		);
+		$file  = array(
+			'name'    => 'file1.jpg',
+			'type'    => 'image/jpeg',
+			'file_id' => 123,
+			'size'    => 123456789,
+		);
+		$field = new Feedback_Field( 'test_key', 'test_label', array( 'files' => array( $file ) ), 'file' );
+		$this->assertSame( 'file1.jpg (118 MB)', $field->get_render_value() );
+		$this->assertEquals(
+			array( 'files' => array( $file ) ),
+			$field->get_value()
+		);
+	}
+
+	public function test_render_file_field() {
+		$file = array(
+			'name'    => 'file1.jpg',
+			'file_id' => 123,
+			'size'    => 123456789,
+		);
+
+		$field = new Feedback_Field( 'test_key', 'test_label', array( 'files' => array( $file ) ), 'file' );
+		$this->assertStringContainsString( $file['name'], $field->get_render_value() );
+		$this->assertStringContainsString( size_format( $file['size'] ), $field->get_render_value() );
+	}
+
+	public function test_is_of_type() {
+		$field = new Feedback_Field( 'test_key', 'test_label', 'test_value' );
+		$this->assertFalse( $field->is_of_type( 'file' ) );
+
+		$field = new Feedback_Field( 'test_key', 'test_label', array( 'files' => array( 'file1.jpg' ) ), 'file' );
+		$this->assertTrue( $field->is_of_type( 'file' ) );
+
+		$field = new Feedback_Field( 'test_key', 'test_label', array( 'hello' ) );
+		$this->assertTrue(
+			$field->is_of_type( 'basic' ),
+			'Basic field should not be a file field'
+		);
+	}
+
+	public function test_has_file() {
+		$field = new Feedback_Field(
+			'test_key',
+			'test_label',
+			array(
+				'files' => array(
+					array(
+						'name'    => 'file1 . jpg',
+						'file_id' => 123,
+						'size'    => 123456789,
+					),
+				),
+			),
+			'file'
+		);
+		$this->assertTrue( $field->has_file() );
+
+		$field = new Feedback_Field( 'test_key', 'test_label', array( 'files' => array( 'file1 . jpg' ) ), 'file' );
+		$this->assertTrue( $field->has_file() );
+
+		$field = new Feedback_Field( 'test_key', 'test_label', array( 'files' => array() ), 'file' );
+		$this->assertFalse( $field->has_file() );
+
+		$field = new Feedback_Field( 'test_key', 'test_label', 'test_value' );
+		$this->assertFalse( $field->has_file(), 'basic field should not be a file field' );
+
+		$field = new Feedback_Field( 'test_key', 'test_label', array( 'files' => array() ), 'file' );
+		$this->assertFalse( $field->has_file(), 'empty file field should not be non-empty' );
+	}
+
+	public function test_get_render_api_value() {
+		$field = new Feedback_Field( 'test_key', 'test_label', 'test_value' );
+		$this->assertEquals( 'test_value', $field->get_render_value( 'api' ) );
+
+		$field = new Feedback_Field( 'test_key', 'test_label', array( 'value1', 'value2' ) );
+		$this->assertEquals(
+			'value1, value2',
+			$field->get_render_value( 'api' )
+		);
+
+		$expected = array(
+			'files' => array(
+				array(
+					'name'           => 'file1.jpg',
+					'file_id'        => 123,
+					'size'           => '118 MB',
+					'url'            => 'https://example.com/file1.jpg',
+					'is_previewable' => true,
+				),
+			),
+		);
+		$field    = new Feedback_Field(
+			'test_key',
+			'test_label',
+			array(
+				'files' => array(
+					array(
+						'name'    => 'file1.jpg',
+						'file_id' => 123,
+						'size'    => 123456789,
+					),
+				),
+			),
+			'file'
+		);
+
+		add_filter( 'jetpack_unauth_file_download_url', array( $this, 'return_url' ) );
+		$this->assertSame( $expected, $field->get_render_value( 'api' ) );
+		remove_filter( 'jetpack_unauth_file_download_url', array( $this, 'return_url' ) );
+
+		$field = new Feedback_Field(
+			'test_key',
+			'test_label',
+			array(
+				'files' => array(
+					array(),
+				),
+			),
+			'file'
+		);
+
+		add_filter( 'jetpack_unauth_file_download_url', array( $this, 'return_url' ) );
+		$this->assertSame( array( 'files' => array() ), $field->get_render_value( 'api' ) );
+		remove_filter( 'jetpack_unauth_file_download_url', array( $this, 'return_url' ) );
+	}
+	/**
+	 * Helper function to return a URL for the file.
+	 *
+	 * @return string
+	 */
+	public function return_url() {
+		return 'https://example.com/file1.jpg';
+	}
+}

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Source_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Source_Test.php
@@ -1,0 +1,296 @@
+<?php
+/**
+ * Unit Tests for Automattic\Jetpack\Forms\Contact_Form.
+ *
+ * To run the test visit the packages/forms directory and run composer test-php
+ *
+ * @package automattic/jetpack-forms
+ */
+
+namespace Automattic\Jetpack\Forms\ContactForm;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use WorDBless\BaseTestCase;
+
+/**
+ * Test class for Feedback_Source
+ *
+ * @covers \Automattic\Jetpack\Forms\ContactForm\Feedback_Source
+ */
+#[CoversClass( Feedback_Source::class )]
+class Feedback_Source_Test extends BaseTestCase {
+	/**
+	 * Test constructor with invalid ID (0 or negative)
+	 */
+	public function test_constructor_with_invalid_id() {
+		$entry = new Feedback_Source( 0, 'Test Title', 2 );
+
+		$this->assertSame( 0, $entry->get_id() );
+		$this->assertEquals( 'Test Title', $entry->get_title() );
+		$this->assertEquals( 2, $entry->get_page_number() );
+		$this->assertSame( '', $entry->get_permalink() );
+	}
+
+	/**
+	 * Test constructor with negative ID
+	 */
+	public function test_constructor_with_negative_id() {
+		$entry = new Feedback_Source( -5, 'Test Title' );
+
+		$this->assertSame( 0, $entry->get_id() );
+		$this->assertEquals( 'Test Title', $entry->get_title() );
+		$this->assertSame( 1, $entry->get_page_number() );
+		$this->assertSame( '', $entry->get_permalink() );
+	}
+
+	/**
+	 * Test constructor with valid ID but non-existent post
+	 */
+	public function test_constructor_with_nonexistent_post() {
+		$entry = new Feedback_Source( 999999, 'Fallback Title' );
+
+		$this->assertSame( 999999, $entry->get_id() );
+		$this->assertEquals( 'Fallback Title', $entry->get_title() );
+		$this->assertSame( 1, $entry->get_page_number() );
+		$this->assertSame( '', $entry->get_permalink() );
+	}
+
+	/**
+	 * Test constructor with valid public post
+	 */
+	public function test_constructor_with_valid_public_post() {
+		// Create a public post
+		$post_id = wp_insert_post(
+			array(
+				'post_title'  => 'Public Post Title',
+				'post_status' => 'publish',
+				'post_type'   => 'post',
+			)
+		);
+
+		$entry = new Feedback_Source( $post_id, 'Fallback Title', 3 );
+
+		$this->assertEquals( $post_id, $entry->get_id() );
+		$this->assertEquals( 'Public Post Title', $entry->get_title() );
+		$this->assertEquals( 3, $entry->get_page_number() );
+		$this->assertNotEmpty( $entry->get_permalink() );
+	}
+
+	/**
+	 * Test constructor with draft post (non-public)
+	 */
+	public function test_constructor_with_draft_post() {
+		// Create a draft post
+		$post_id = wp_insert_post(
+			array(
+				'post_title'  => 'Draft Post Title',
+				'post_status' => 'draft',
+				'post_type'   => 'post',
+			)
+		);
+
+		$entry = new Feedback_Source( $post_id, 'Fallback Title' );
+
+		$this->assertSame( $post_id, $entry->get_id() );
+		$this->assertEquals( 'Fallback Title', $entry->get_title() );
+		$this->assertSame( 1, $entry->get_page_number() );
+		$this->assertSame( '', $entry->get_permalink() );
+	}
+
+	/**
+	 * Test from_submission with post missing ID
+	 */
+	public function test_from_submission_with_missing_id() {
+		$post = new \WP_Post(
+			(object) array(
+				'post_title' => 'No ID Post',
+			)
+		);
+
+		$entry = Feedback_Source::from_submission( $post );
+
+		$this->assertSame( 0, $entry->get_id() );
+		$this->assertSame( '', $entry->get_title() );
+		$this->assertSame( 1, $entry->get_page_number() );
+	}
+
+	/**
+	 * Test from_submission with post missing title
+	 */
+	public function test_from_submission_with_missing_title() {
+		$post = new \WP_Post(
+			(object) array(
+				'ID' => 456,
+			)
+		);
+
+		$entry = Feedback_Source::from_submission( $post, 3 );
+
+		$this->assertEquals( 456, $entry->get_id() );
+		$this->assertSame( '', $entry->get_title() );
+		$this->assertEquals( 3, $entry->get_page_number() );
+	}
+
+	/**
+	 * Test from_submission with empty post object
+	 */
+	public function test_from_submission_with_empty_post() {
+		$post = new \WP_Post( (object) array() );
+
+		$entry = Feedback_Source::from_submission( $post );
+
+		$this->assertSame( 0, $entry->get_id() );
+		$this->assertSame( '', $entry->get_title() );
+		$this->assertSame( 1, $entry->get_page_number() );
+	}
+
+	/**
+	 * Test get_permalink with page number 1
+	 */
+	public function test_get_permalink_with_page_one() {
+		// Create a public post
+		$post_id = wp_insert_post(
+			array(
+				'post_title'  => 'Test Post',
+				'post_status' => 'publish',
+				'post_type'   => 'post',
+			)
+		);
+
+		$entry     = new Feedback_Source( $post_id, 'Test', 1 );
+		$permalink = $entry->get_permalink();
+
+		$this->assertNotEmpty( $permalink );
+		$this->assertStringNotContainsString( 'page=', $permalink );
+	}
+
+	/**
+	 * Test get_permalink with page number greater than 1
+	 */
+	public function test_get_permalink_with_page_greater_than_one() {
+		// Create a public post
+		$post_id = wp_insert_post(
+			array(
+				'post_title'  => 'Test Post',
+				'post_status' => 'publish',
+				'post_type'   => 'post',
+			)
+		);
+
+		$entry     = new Feedback_Source( $post_id, 'Test', 3 );
+		$permalink = $entry->get_permalink();
+
+		$this->assertStringContainsString( 'page=3', $permalink );
+	}
+
+	/**
+	 * Test get_permalink with no valid post
+	 */
+	public function test_get_permalink_with_no_post() {
+		$entry = new Feedback_Source( 0, 'Test' );
+
+		$this->assertSame( '', $entry->get_permalink() );
+	}
+
+	/**
+	 * Test get_relative_permalink with valid permalink
+	 */
+	public function test_get_relative_permalink_with_valid_permalink() {
+		// Create a public post
+		$post_id = wp_insert_post(
+			array(
+				'post_title'  => 'Test Post',
+				'post_status' => 'publish',
+				'post_type'   => 'post',
+			)
+		);
+
+		$entry              = new Feedback_Source( $post_id, 'Test' );
+		$relative_permalink = $entry->get_relative_permalink();
+
+		$this->assertNotEmpty( $relative_permalink );
+		$this->assertStringStartsNotWith( 'http', $relative_permalink );
+	}
+
+	/**
+	 * Test get_relative_permalink with empty permalink
+	 */
+	public function test_get_relative_permalink_with_empty_permalink() {
+		$entry = new Feedback_Source( 0, 'Test' );
+
+		$this->assertSame( '', $entry->get_relative_permalink() );
+	}
+
+	/**
+	 * Test all getter methods
+	 */
+	public function test_getter_methods() {
+		$entry = new Feedback_Source( 0, 'Test Title', 5 );
+
+		$this->assertSame( 0, $entry->get_id() );
+		$this->assertEquals( 'Test Title', $entry->get_title() );
+		$this->assertEquals( 5, $entry->get_page_number() );
+	}
+
+	/**
+	 * Test serialize method
+	 */
+	public function test_serialize() {
+		$entry      = new Feedback_Source( 0, 'Serialized Title', 2 );
+		$serialized = $entry->serialize();
+
+		$expected = array(
+			'entry_title' => 'Serialized Title',
+			'entry_page'  => 2,
+		);
+
+		$this->assertEquals( $expected, $serialized );
+		$this->assertIsArray( $serialized );
+		$this->assertArrayHasKey( 'entry_title', $serialized );
+		$this->assertArrayHasKey( 'entry_page', $serialized );
+	}
+
+	/**
+	 * Test serialize with empty title
+	 */
+	public function test_serialize_with_empty_title() {
+		$entry      = new Feedback_Source( 0, '', 1 );
+		$serialized = $entry->serialize();
+
+		$expected = array(
+			'entry_title' => '',
+			'entry_page'  => 1,
+		);
+
+		$this->assertEquals( $expected, $serialized );
+	}
+
+	/**
+	 * Test default page number
+	 */
+	public function test_default_page_number() {
+		$entry = new Feedback_Source( 0, 'Test' );
+
+		$this->assertSame( 1, $entry->get_page_number() );
+	}
+
+	/**
+	 * Test constructor overwrites ID when post is not public
+	 */
+	public function test_constructor_overwrites_id_for_non_public_post() {
+		// Create a private post
+		$post_id = wp_insert_post(
+			array(
+				'post_title'  => 'Private Post',
+				'post_status' => 'private',
+				'post_type'   => 'post',
+			)
+		);
+
+		$entry = new Feedback_Source( $post_id, 'Fallback Title' );
+
+		// ID should be reset to 0 for non-public posts
+		$this->assertSame( $post_id, $entry->get_id() );
+		$this->assertEquals( 'Fallback Title', $entry->get_title() );
+	}
+}

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Test.php
@@ -1,0 +1,1515 @@
+<?php
+/**
+ * Unit Tests for Automattic\Jetpack\Forms\Contact_Form.
+ *
+ * To run the test visit the packages/forms directory and run composer test-php
+ *
+ * @package automattic/jetpack-forms
+ */
+
+namespace Automattic\Jetpack\Forms\ContactForm;
+
+require_once __DIR__ . '/class-utility.php'; // phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.NotAbsolutePath
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use WorDBless\BaseTestCase;
+
+/**
+ * Test class for Contact_Form
+ *
+ * @covers Automattic\Jetpack\Forms\ContactForm\Feedback
+ */
+#[CoversClass( Feedback::class )]
+class Feedback_Test extends BaseTestCase {
+
+	public function test_from_post_id_returns_null_for_invalid_post() {
+		$response = Feedback::get( 999999 );
+		$this->assertNull( $response );
+	}
+
+	public function test_from_post_id_returns_instance_for_valid_feedback_post() {
+		$post_id  = \wp_insert_post(
+			array(
+				'post_type'     => 'feedback',
+				'post_status'   => 'publish',
+				'post_title'    => 'Test Feedback',
+				'post_content'  => '{}',
+				'page_template' => 'v2',
+			)
+		);
+		$response = Feedback::get( $post_id );
+		$this->assertInstanceOf( Feedback::class, $response );
+	}
+
+	public function test_from_submission_sets_fields_and_post_data() {
+		$form       = new Contact_Form( array() );
+		$_post_data = array(
+			'name'    => 'John Doe',
+			'email'   => 'john@example.com',
+			'message' => 'Hello!',
+			'ignore'  => 'should not be included',
+		);
+		$response   = Feedback::from_submission( $_post_data, $form );
+		$this->assertInstanceOf( Feedback::class, $response );
+	}
+
+	public function test_feedback_is_matches_empty_data() {
+		$form             = new Contact_Form( array() );
+		$_post_data       = array();
+		$response         = Feedback::from_submission( $_post_data, $form );
+		$feedback_post_id = $response->save();
+
+		$saved_response = Feedback::get( $feedback_post_id );
+
+		$this->assertEquals( $response->serialize(), $saved_response->serialize(), 'Serialized data does not match' );
+		$this->assertEquals( $response->get_fields(), $saved_response->get_fields(), 'Fields data does not match' );
+	}
+
+	public function test_feedback_is_matches_submission_data() {
+		$name    = 'John Doe';
+		$email   = 'john@example.com';
+		$message = 'Test message';
+		$form_id = Utility::get_form_id();
+		// Create a form submission
+		$_post_data = Utility::get_post_request(
+			array(
+				'name'    => $name,
+				'email'   => $email,
+				'message' => $message,
+			),
+			'g' . $form_id
+		);
+
+		$form = new Contact_Form(
+			array(
+				'title'       => 'Test Form',
+				'description' => 'This is a test form.',
+			),
+			"[contact-field label='Name' type='name' required='1'/][contact-field label='Email' type='email' required='1'/][contact-field label='Message' type='textarea' required='1'/]"
+		);
+
+		// Create a contact form
+		$response = Feedback::from_submission( $_post_data, $form );
+		$post_id  = $response->save();
+
+		$saved_response = Feedback::get( $post_id );
+
+		$this->assertEquals( $response->serialize(), $saved_response->serialize() );
+		$this->assertEquals( $response->get_fields(), $saved_response->get_fields() );
+
+		foreach ( $response->get_fields() as $field ) {
+			$this->assertInstanceOf( Feedback_Field::class, $field );
+		}
+
+		foreach ( $saved_response->get_fields() as $field ) {
+			$this->assertInstanceOf( Feedback_Field::class, $field );
+		}
+
+		foreach ( $saved_response->get_fields() as $field_key => $field ) {
+			$this->assertEquals( $response->get_fields()[ $field_key ]->serialize(), $saved_response->get_fields()[ $field_key ]->serialize(), 'Serialized response field should match' );
+		}
+
+		$this->assertEquals( $name, $response->get_fields()['1_Name']->get_value(), 'Response field value should match' );
+		$this->assertEquals( $name, $saved_response->get_fields()['1_Name']->get_value(), 'Saved response field value should match' );
+
+		$this->assertEquals( $name, $response->get_field_value_by_label( 'Name' ), 'Response field value should match' );
+		$this->assertEquals( $name, $saved_response->get_field_value_by_label( 'Name' ), 'Saved response field value should match' );
+
+		$this->assertEquals( 'Name', $response->get_fields()['1_Name']->get_label(), 'Name response field label should match' );
+		$this->assertEquals( 'Name', $saved_response->get_fields()['1_Name']->get_label(), 'Saved response field label should match' );
+		$this->assertEquals( 'name', $response->get_fields()['1_Name']->get_type(), 'Response field type should match' );
+		$this->assertEquals( 'name', $saved_response->get_fields()['1_Name']->get_type(), 'Saved response type value should match' );
+
+		$this->assertEquals( $email, $response->get_fields()['2_Email']->get_value(), 'Response field value should match' );
+		$this->assertEquals( $email, $saved_response->get_fields()['2_Email']->get_value(), 'Saved response field value should match' );
+
+		$this->assertEquals( $message, $response->get_fields()['3_Message']->get_value(), 'Response field value should match' );
+		$this->assertEquals( $message, $saved_response->get_fields()['3_Message']->get_value(), 'Saved Name response field value should match ' );
+	}
+
+	/**
+	 * Test that a previously saved response can be handled correctly.
+	 *
+	 * This test checks if the Feedback class can retrieve and handle
+	 * a response that was saved in the legacy format.
+	 */
+	public function test_handle_previously_saved_response() {
+
+		$post_id = Utility::create_legacy_feedback(
+			array(
+				'1_field' => 'value1',
+				'2_field' => 'value2',
+			)
+		);
+
+		$response = Feedback::get( $post_id );
+
+		$this->assertInstanceOf( Feedback::class, $response );
+
+		$field = $response->get_fields()['1_field'];
+
+		$this->assertInstanceOf( Feedback_Field::class, $field );
+		$this->assertEquals( '1_field', $field->get_key() );
+		$this->assertEquals( 'field', $field->get_label() );
+		$this->assertEquals( 'value1', $field->get_value() );
+
+		$this->assertEquals( 'basic', $field->get_type() ); // Assuming 'basic' is the default type for a simple text field.
+		$this->assertEquals( 'value1', $field->get_render_value() );
+	}
+	/**
+	 * Tests that the feedback ID is computed correctly when saving a from response.
+	 *
+	 * It should be non empty and match the post slug.
+	 */
+	public function test_feedback_computed_feedback_id() {
+		$name    = 'John Doe';
+		$email   = 'john@example.com';
+		$message = 'Test message';
+		$form_id = Utility::get_form_id();
+		// Create a form submission
+		$_post_data = Utility::get_post_request(
+			array(
+				'name'    => $name,
+				'email'   => $email,
+				'message' => $message,
+			),
+			'g' . $form_id
+		);
+
+		$form = new Contact_Form(
+			array(
+				'title'       => 'Test Form',
+				'description' => 'This is a test form.',
+			),
+			"[contact-field label='Name' type='name' required='1'/][contact-field label='Email' type='email' required='1'/][contact-field label='Message' type='textarea' required='1'/]"
+		);
+
+		// Create a contact form
+		$response = Feedback::from_submission( $_post_data, $form );
+		$post_id  = $response->save();
+		$post     = get_post( $post_id );
+
+		$saved_response = Feedback::get( $post_id );
+
+		$this->assertEquals( $response->get_feedback_id(), $saved_response->get_feedback_id(), 'Feedback ID should match' );
+		$this->assertEquals( $post->post_name, $saved_response->get_feedback_id(), 'Feedback ID should match post slug' );
+		$this->assertNotEmpty( $saved_response->get_feedback_id(), 'Feedback ID should not be empty' );
+	}
+
+	/**
+	 * Test the IP address is included in the serialized response.
+	 * It should be always available when the response is created during the form submission.
+	 *
+	 * It should only be empty if the response that has the filter applied to it.
+	 */
+	public function test_ip_address_included_in_serialized_response() {
+
+		$form_id = Utility::get_form_id();
+		// Create a form submission
+		$_post_data = Utility::get_post_request(
+			array(
+				'name'    => 'John Doe',
+				'email'   => 'john@example.com',
+				'message' => 'Test message',
+			),
+			'g' . $form_id
+		);
+
+		$form = new Contact_Form(
+			array(
+				'title'       => 'Test Form',
+				'description' => 'This is a test form.',
+			),
+			"[contact-field label='Name' type='name' required='1'/][contact-field label='Email' type='email' required='1'/][contact-field label='Message' type='textarea' required='1'/]"
+		);
+
+		// Create a contact form
+		$response         = Feedback::from_submission( $_post_data, $form );
+		$feedback_post_id = $response->save();
+		$saved_response   = Feedback::get( $feedback_post_id );
+
+		// The IP address should be present.
+		$this->assertNotEmpty( $response->get_ip_address(), 'IP address should not be empty' );
+		$this->assertNotEmpty( $saved_response->get_ip_address(), 'IP address should not be empty' );
+		$this->assertEquals( $response->get_ip_address(), $saved_response->get_ip_address(), 'IP address should match' );
+
+		add_filter( 'jetpack_contact_form_forget_ip_address', '__return_true' );
+		$new_post_id = $response->save();
+		remove_filter( 'jetpack_contact_form_forget_ip_address', '__return_true' );
+
+		// The IP address should NOT be present.
+		$saved_response = Feedback::get( $new_post_id );
+		$this->assertEmpty( $saved_response->get_ip_address(), 'IP address should BE empty' );
+	}
+
+	/**
+	 * Test the IP address is included in the serialized response.
+	 * It should be always available when the reponse is created during the form submission.
+	 *
+	 * It should only be empty if the response that has the filter applied to it.
+	 */
+	public function test_ip_address_in_legacy() {
+		$ip = 'http://123.123.123.122';
+
+		$post_id = Utility::create_legacy_feedback(
+			array(),
+			null,
+			null,
+			null,
+			null,
+			$ip
+		);
+
+		$saved_response = Feedback::get( $post_id );
+		$this->assertEquals( $ip, $saved_response->get_ip_address(), 'IP should match the legacy feedback  IP' );
+	}
+
+	/**
+	 * Test the subject line is computed for legacy correctly.
+	 */
+	public function test_computed_subject_legacy() {
+		$subject = 'Test Subject';
+		$post_id = Utility::create_legacy_feedback(
+			array(),
+			null,
+			null,
+			null,
+			null,
+			null,
+			$subject
+		);
+
+		$saved_response = Feedback::get( $post_id );
+		$this->assertEquals( $subject, $saved_response->get_subject(), 'Subject should match the legacy feedback post subject' );
+	}
+
+	/**
+	 * Test the subject line is computed correctly.
+	 */
+	public function test_computed_form_subject() {
+		$subject = 'Test Subject';
+		$form_id = Utility::get_form_id();
+		// Create a form submission
+		$_post_data = Utility::get_post_request(
+			array(
+				'name'    => 'John Doe',
+				'email'   => 'john@example.com',
+				'message' => 'Test message',
+			),
+			'g' . $form_id
+		);
+
+		$form = new Contact_Form(
+			array(
+				'title'       => 'Test Form',
+				'description' => 'This is a test form.',
+				'subject'     => $subject,
+			),
+			"[contact-field label='Name' type='name' required='1'/][contact-field label='Email' type='email' required='1'/][contact-field label='Message' type='textarea' required='1'/]"
+		);
+
+		// Create a contact form
+		$response         = Feedback::from_submission( $_post_data, $form );
+		$feedback_post_id = $response->save();
+		$saved_response   = Feedback::get( $feedback_post_id );
+
+		$this->assertEquals( $subject, $response->get_subject(), 'Subject should match the form submission' );
+		$this->assertEquals( $subject, $saved_response->get_subject(), 'Subject should match the saved form submission' );
+	}
+
+	/**
+	 * Test the subject line is computed via field
+	 */
+	public function test_computed_form_subject_field() {
+		$subject = 'Test Subject';
+		$form_id = Utility::get_form_id();
+		// Create a form submission
+		$_post_data = Utility::get_post_request(
+			array(
+				'name'    => 'John Doe',
+				'subject' => $subject,
+				'message' => 'Test message',
+			),
+			'g' . $form_id
+		);
+
+		$form = new Contact_Form(
+			array(
+				'title'       => 'Test Form',
+				'description' => 'This is a test form.',
+			),
+			"[contact-field label='Name' type='name' required='1'/][contact-field label='Subject' type='subject' required='1'/][contact-field label='Message' type='textarea' required='1'/]"
+		);
+
+		// Create a contact form
+		$response         = Feedback::from_submission( $_post_data, $form );
+		$feedback_post_id = $response->save();
+		$saved_response   = Feedback::get( $feedback_post_id );
+
+		$this->assertEquals( $subject, $response->get_subject(), 'Subject should match the form submission' );
+		$this->assertEquals( $subject, $saved_response->get_subject(), 'Subject should match the saved form submission' );
+	}
+
+	/**
+	 * Test the subject line is computed correctly when both a subject attribute and a field is present.
+	 */
+	public function test_computed_form_subject_field_overwrites() {
+		$subject = 'Test Subject';
+		$form_id = Utility::get_form_id();
+		// Create a form submission
+		$_post_data = Utility::get_post_request(
+			array(
+				'name'    => 'John Doe',
+				'subject' => $subject,
+				'message' => 'Test message',
+			),
+			'g' . $form_id
+		);
+
+		$form = new Contact_Form(
+			array(
+				'title'       => 'Test Form',
+				'description' => 'This is a test form.',
+				'subject'     => $subject . ' (from form attributes)',
+			),
+			"[contact-field label='Name' type='name' required='1'/][contact-field label='Subject' type='subject' required='1'/][contact-field label='Message' type='textarea' required='1'/]"
+		);
+
+		// Create a contact form
+		$response         = Feedback::from_submission( $_post_data, $form );
+		$feedback_post_id = $response->save();
+		$saved_response   = Feedback::get( $feedback_post_id );
+
+		$this->assertEquals( $subject, $response->get_subject(), 'Subject should match the form submission' );
+		$this->assertEquals( $subject, $saved_response->get_subject(), 'Subject should match the saved form submission' );
+	}
+
+	/**
+	 * Test the subject line is computed correctly and the filter is applied correctly.
+	 */
+	public function test_computed_form_subject_field_overwrites_filter() {
+		$subject = 'Test Subject';
+		$form_id = Utility::get_form_id();
+		// Create a form submission
+		$_post_data = Utility::get_post_request(
+			array(
+				'name'    => 'John Doe',
+				'subject' => $subject,
+				'message' => 'Test message',
+			),
+			'g' . $form_id
+		);
+
+		$form = new Contact_Form(
+			array(
+				'title'       => 'Test Form',
+				'description' => 'This is a test form.',
+				'subject'     => $subject . ' (from form attributes)',
+			),
+			"[contact-field label='Name' type='name' required='1'/][contact-field label='Subject' type='subject' required='1'/][contact-field label='Message' type='textarea' required='1'/]"
+		);
+
+		add_filter( 'contact_form_subject', array( $this, 'subject_from_filter' ), 10, 2 );
+
+		// Create a contact form
+		$response       = Feedback::from_submission( $_post_data, $form );
+		$post_id        = $response->save();
+		$saved_response = Feedback::get( $post_id );
+		remove_filter( 'contact_form_subject', array( $this, 'subject_from_filter' ) );
+
+		$this->assertEquals( 'Overwritten Subject (from filter)', $response->get_subject(), 'Subject should match the form submission' );
+		$this->assertEquals( 'Overwritten Subject (from filter)', $saved_response->get_subject(), 'Subject should match the saved form submission' );
+	}
+	/**
+	 * Callback for the contact_form_subject filter.
+	 *
+	 * This function is used to overwrite the subject line when the filter is applied.
+	 *
+	 * @return string The overwritten subject line.
+	 */
+	public function subject_from_filter() {
+		// Overwrite the subject with a different value.
+		return 'Overwritten Subject (from filter)';
+	}
+
+	public function test_computed_name_for_legacy() {
+		$author  = 'Mikey Mouse';
+		$post_id = Utility::create_legacy_feedback(
+			array(),
+			null,
+			$author
+		);
+
+		$saved_response = Feedback::get( $post_id );
+		$this->assertEquals( $author, $saved_response->get_author(), 'Author should match the legacy feedback post author' );
+	}
+
+	public function test_computed_name() {
+		$author = 'Mikey Mouse';
+
+		$form_id = Utility::get_form_id();
+		// Create a form submission
+		$_post_data = Utility::get_post_request(
+			array(
+				'name'    => $author,
+				'email'   => 'email@email.com',
+				'message' => 'Test message',
+			),
+			'g' . $form_id
+		);
+
+		$form = new Contact_Form(
+			array(
+				'title'       => 'Test Form',
+				'description' => 'This is a test form.',
+			),
+			"[contact-field label='Name' type='name' required='1'/][contact-field label='Email' type='email' required='1'/][contact-field label='Message' type='textarea' required='1'/]"
+		);
+
+		// Create a contact form
+		$response         = Feedback::from_submission( $_post_data, $form );
+		$feedback_post_id = $response->save();
+		$saved_response   = Feedback::get( $feedback_post_id );
+
+		$this->assertEquals( $author, $response->get_author(), 'Author should match the form submission' );
+		$this->assertEquals( $author, $saved_response->get_author(), 'Author should match the saved form submission' );
+	}
+
+	public function test_computed_name_as_email() {
+		$author = ''; // author is empty
+		$email  = 'email@email.com';
+
+		$form_id = Utility::get_form_id();
+		// Create a form submission
+		$_post_data = Utility::get_post_request(
+			array(
+				'name'    => $author,
+				'email'   => $email,
+				'message' => 'Test message',
+			),
+			'g' . $form_id
+		);
+
+		$form = new Contact_Form(
+			array(
+				'title'       => 'Test Form',
+				'description' => 'This is a test form.',
+			),
+			"[contact-field label='Name' type='name' required='1'/][contact-field label='Email' type='email' required='1'/][contact-field label='Message' type='textarea' required='1'/]"
+		);
+
+		// Create a contact form
+		$response         = Feedback::from_submission( $_post_data, $form );
+		$feedback_post_id = $response->save();
+		$saved_response   = Feedback::get( $feedback_post_id );
+
+		$this->assertEquals( $email, $response->get_author(), 'Author should match the form submission' );
+		$this->assertEquals( $email, $saved_response->get_author(), 'Author should match the saved form submission' );
+	}
+
+	public function test_computed_name_filter() {
+		$author = 'Mikey Mouse';
+
+		$form_id = Utility::get_form_id();
+		// Create a form submission
+		$_post_data = Utility::get_post_request(
+			array(
+				'name'    => $author,
+				'email'   => 'email@email.com',
+				'message' => 'Test message',
+			),
+			'g' . $form_id
+		);
+
+		$form = new Contact_Form(
+			array(
+				'title'       => 'Test Form',
+				'description' => 'This is a test form.',
+			),
+			"[contact-field label='Name' type='name' required='1'/][contact-field label='Email' type='email' required='1'/][contact-field label='Message' type='textarea' required='1'/]"
+		);
+
+		add_filter( 'pre_comment_author_name', array( $this, 'set_filter_as_string' ) );
+		$response = Feedback::from_submission( $_post_data, $form );
+
+		$feedback_post_id = $response->save();
+		$saved_response   = Feedback::get( $feedback_post_id );
+		remove_filter( 'pre_comment_author_name', array( $this, 'set_filter_as_string' ) );
+
+		$this->assertEquals( 'STRING', $response->get_author(), 'Author should match the form submission' );
+		$this->assertEquals( 'STRING', $saved_response->get_author(), 'Author should match the saved form submission' );
+	}
+	/**
+	 * A helper function that sets the filter to return string 'STRING'.
+	 *
+	 * @return string
+	 */
+	public function set_filter_as_string() {
+		return 'STRING';
+	}
+
+	public function test_computed_email_for_legacy() {
+		$email   = 'email@email.com';
+		$post_id = Utility::create_legacy_feedback(
+			array(),
+			null,
+			null,
+			$email
+		);
+
+		$saved_response = Feedback::get( $post_id );
+		$this->assertEquals( $email, $saved_response->get_author_email(), 'Author email should match the legacy feedback post author email' );
+		$this->assertEquals( get_avatar_url( $email ), $saved_response->get_author_avatar(), 'Author email should match the legacy feedback post author email' );
+	}
+
+	public function test_computed_email() {
+
+		$email   = 'email@email.com';
+		$avatar  = get_avatar_url( $email );
+		$form_id = Utility::get_form_id();
+		// Create a form submission
+		$_post_data = Utility::get_post_request(
+			array(
+				'name'    => 'author ',
+				'email'   => $email,
+				'message' => 'Test message',
+			),
+			'g' . $form_id
+		);
+
+		$form = new Contact_Form(
+			array(
+				'title'       => 'Test Form',
+				'description' => 'This is a test form.',
+			),
+			"[contact-field label='Name' type='name' required='1'/][contact-field label='Email' type='email' required='1'/][contact-field label='Message' type='textarea' required='1'/]"
+		);
+
+		// Create a contact form
+		$response         = Feedback::from_submission( $_post_data, $form );
+		$feedback_post_id = $response->save();
+		$saved_response   = Feedback::get( $feedback_post_id );
+
+		$this->assertEquals( $email, $response->get_author_email(), 'Author email should match the form submission' );
+		$this->assertEquals( $avatar, $saved_response->get_author_avatar(), 'Author avatar should match the legacy feedback post author email' );
+		$this->assertEquals( $email, $saved_response->get_author_email(), 'Author email should match the saved form submission' );
+		$this->assertEquals( $avatar, $saved_response->get_author_avatar(), 'Author email should match the legacy feedback post author email' );
+	}
+
+	public function test_computed_email_filter() {
+		$email = 'email@email.com';
+
+		$form_id = Utility::get_form_id();
+		// Create a form submission
+		$_post_data = Utility::get_post_request(
+			array(
+				'name'    => 'joe',
+				'email'   => $email,
+				'message' => 'Test message',
+			),
+			'g' . $form_id
+		);
+
+		$form = new Contact_Form(
+			array(
+				'title'       => 'Test Form',
+				'description' => 'This is a test form.',
+			),
+			"[contact-field label='Name' type='name' required='1'/][contact-field label='Email' type='email' required='1'/][contact-field label='Message' type='textarea' required='1'/]"
+		);
+
+		add_filter( 'pre_comment_author_email', array( $this, 'set_filter_as_string' ) );
+		$response = Feedback::from_submission( $_post_data, $form );
+
+		$feedback_post_id = $response->save();
+		$saved_response   = Feedback::get( $feedback_post_id );
+		remove_filter( 'pre_comment_author_email', array( $this, 'set_filter_as_string' ) );
+		$this->assertEquals( 'STRING', $response->get_author_email(), 'Author email should match the form submission' );
+		$this->assertEquals( 'STRING', $saved_response->get_author_email(), 'Author email should match the saved form submission' );
+	}
+
+	public function test_computed_url_for_legacy() {
+		$url     = 'https://wordpress.com';
+		$post_id = Utility::create_legacy_feedback(
+			array(),
+			null,
+			null,
+			null,
+			$url
+		);
+
+		$saved_response = Feedback::get( $post_id );
+		$this->assertEquals( $url, $saved_response->get_author_url(), 'Author url should match the legacy feedback post author url' );
+	}
+
+	public function test_computed_url() {
+		$url = 'https://wordpress.com';
+
+		$form_id = Utility::get_form_id();
+		// Create a form submission
+		$_post_data = Utility::get_post_request(
+			array(
+				'url'     => $url,
+				'email'   => 'email@email.com',
+				'message' => 'Test message',
+			),
+			'g' . $form_id
+		);
+
+		$form = new Contact_Form(
+			array(
+				'title'       => 'Test Form',
+				'description' => 'This is a test form.',
+			),
+			"[contact-field label='Url' type='url' required='1'/][contact-field label='Email' type='email' required='1'/][contact-field label='Message' type='textarea' required='1'/]"
+		);
+
+		// Create a contact form
+		$response         = Feedback::from_submission( $_post_data, $form );
+		$feedback_post_id = $response->save();
+		$saved_response   = Feedback::get( $feedback_post_id );
+
+		$this->assertEquals( $url, $response->get_author_url(), 'Author url should match the form submission' );
+		$this->assertEquals( $url, $saved_response->get_author_url(), 'Author url should match the saved form submission' );
+	}
+
+	public function test_computed_url_filter() {
+		$url     = 'https://wordpress.com';
+		$form_id = Utility::get_form_id();
+		// Create a form submission
+		$_post_data = Utility::get_post_request(
+			array(
+				'url'     => $url,
+				'email'   => 'email@email.com',
+				'message' => 'Test message',
+			),
+			'g' . $form_id
+		);
+
+		$form = new Contact_Form(
+			array(
+				'title'       => 'Test Form',
+				'description' => 'This is a test form.',
+			),
+			"[contact-field label='Url' type='url' required='1'/][contact-field label='Email' type='email' required='1'/][contact-field label='Message' type='textarea' required='1'/]"
+		);
+
+		add_filter( 'pre_comment_author_url', array( $this, 'set_filter_as_string' ) );
+		$response         = Feedback::from_submission( $_post_data, $form );
+		$feedback_post_id = $response->save();
+		$saved_response   = Feedback::get( $feedback_post_id );
+
+		remove_filter( 'pre_comment_author_url', array( $this, 'set_filter_as_string' ) );
+
+		$this->assertEquals( 'STRING', $response->get_author_url(), 'Author url should match the form submission' );
+		$this->assertEquals( 'STRING', $saved_response->get_author_url(), 'Author url should match the saved form submission' );
+	}
+
+	public function test_computed_comment_content_for_legacy() {
+		$content = 'Some comment content!';
+		$post_id = Utility::create_legacy_feedback(
+			array(),
+			$content
+		);
+
+		$saved_response = Feedback::get( $post_id );
+		$this->assertEquals( $content, $saved_response->get_comment_content(), 'Comment content should match the legacy feedback post author url' );
+	}
+
+	public function test_computed_comment_content() {
+		$content = 'Some comment content!';
+
+		$form_id = Utility::get_form_id();
+		// Create a form submission
+		$_post_data = Utility::get_post_request(
+			array(
+				'url'     => 'https://howdy.com',
+				'email'   => 'email@email.com',
+				'message' => $content,
+			),
+			'g' . $form_id
+		);
+
+		$form = new Contact_Form(
+			array(
+				'title'       => 'Test Form',
+				'description' => 'This is a test form.',
+			),
+			"[contact-field label='Url' type='url' required='1'/][contact-field label='Email' type='email' required='1'/][contact-field label='Message' type='textarea' required='1'/]"
+		);
+
+		// Create a contact form
+		$response         = Feedback::from_submission( $_post_data, $form );
+		$feedback_post_id = $response->save();
+		$saved_response   = Feedback::get( $feedback_post_id );
+
+		$this->assertEquals( $content, $response->get_comment_content(), 'Comment content should match the form submission' );
+		$this->assertEquals( $content, $saved_response->get_comment_content(), 'Comment content should match the saved form submission' );
+	}
+
+	public function test_status_from_legacy() {
+		$status  = 'spam';
+		$post_id = Utility::create_legacy_feedback(
+			array(),
+			null,
+			null,
+			null,
+			null,
+			null,
+			null,
+			'spam'
+		);
+
+		$saved_response = Feedback::get( $post_id );
+		$this->assertEquals( $status, $saved_response->get_status(), 'Status should match the legacy feedback status' );
+	}
+
+	public function test_computed_status() {
+
+		$form_id = Utility::get_form_id();
+		// Create a form submission
+		$_post_data = Utility::get_post_request(
+			array(
+				'email'   => 'email@email.com',
+				'message' => 'Test message',
+			),
+			'g' . $form_id
+		);
+
+		$form = new Contact_Form(
+			array(
+				'title'       => 'Test Form',
+				'description' => 'This is a test form.',
+			),
+			"[contact-field label='Email' type='email' required='1'/][contact-field label='Message' type='textarea' required='1'/]"
+		);
+
+		$response         = Feedback::from_submission( $_post_data, $form );
+		$feedback_post_id = $response->save();
+		$saved_response   = Feedback::get( $feedback_post_id );
+
+		$this->assertEquals( 'publish', $response->get_status(), 'Status should match the form submission' );
+		$this->assertEquals( 'publish', $saved_response->get_status(), 'Status should match the saved form submission' );
+	}
+
+	public function test_set_status() {
+		$status  = 'trash';
+		$form_id = Utility::get_form_id();
+		// Create a form submission
+		$_post_data = Utility::get_post_request(
+			array(
+				'email'   => 'email@email.com',
+				'message' => 'Test message',
+			),
+			'g' . $form_id
+		);
+
+		$form = new Contact_Form(
+			array(
+				'title'       => 'Test Form',
+				'description' => 'This is a test form.',
+			),
+			"[contact-field label='Email' type='email' required='1'/][contact-field label='Message' type='textarea' required='1'/]"
+		);
+
+		$response = Feedback::from_submission( $_post_data, $form );
+		$response->set_status( $status );
+		$feedback_post_id = $response->save();
+		$saved_response   = Feedback::get( $feedback_post_id );
+
+		$this->assertEquals( $status, $response->get_status(), 'Status should match the form submission' );
+		$this->assertEquals( $status, $saved_response->get_status(), 'Status should match the saved form submission' );
+	}
+
+	public function test_consent() {
+
+		$form_id = Utility::get_form_id();
+		// Create a form submission
+		$_post_data = Utility::get_post_request(
+			array(
+				'email'   => 'email@email.com',
+				'consent' => 'Yes',
+			),
+			'g' . $form_id
+		);
+
+		$form = new Contact_Form(
+			array(
+				'title'       => 'Test Form',
+				'description' => 'This is a test form.',
+			),
+			"[contact-field label='Email' type='email' required='1'/][contact-field label='Consent' type='consent' required='1'/]"
+		);
+
+		$response         = Feedback::from_submission( $_post_data, $form );
+		$feedback_post_id = $response->save();
+		$saved_response   = Feedback::get( $feedback_post_id );
+		$this->assertTrue( $response->has_consent(), 'Has consent should match the form submission' );
+		$this->assertTrue( $saved_response->has_consent(), 'Has consent should match the saved form submission' );
+	}
+
+	public function test_empty_consent() {
+
+		$form_id = Utility::get_form_id();
+		// Create a form submission
+		$_post_data = Utility::get_post_request(
+			array(
+				'email'   => 'email@email.com',
+				'consent' => '',
+			),
+			'g' . $form_id
+		);
+
+		$form = new Contact_Form(
+			array(
+				'title'       => 'Test Form',
+				'description' => 'This is a test form.',
+			),
+			"[contact-field label='Email' type='email' required='1'/][contact-field label='Consent' type='consent' required='1'/]"
+		);
+
+		$response         = Feedback::from_submission( $_post_data, $form );
+		$feedback_post_id = $response->save();
+		$saved_response   = Feedback::get( $feedback_post_id );
+		$this->assertFalse( $response->has_consent(), 'Has consent should match the form submission' );
+		$this->assertFalse( $saved_response->has_consent(), 'Has consent should match the saved form submission' );
+	}
+
+	public function test_compute_entry_ID_legacy() {
+		$current_post = Utility::create_post_context();
+		$post_id      = Utility::create_legacy_feedback();
+		Utility::destroy_post_context( $current_post );
+		$saved_response = Feedback::get( $post_id );
+
+		$this->assertSame( $current_post->ID, $saved_response->get_entry_id(), 'Entry_ID should match the saved form submission' );
+	}
+
+	public function test_compute_entry_ID() {
+		$current_post = Utility::create_post_context();
+		$form_id      = Utility::get_form_id();
+		// Create a form submission
+		$_post_data = Utility::get_post_request(
+			array(
+				'email'   => 'email@email.com',
+				'consent' => '',
+			),
+			'g' . $form_id
+		);
+
+		$form = new Contact_Form(
+			array(
+				'title'       => 'Test Form',
+				'description' => 'This is a test form.',
+			),
+			"[contact-field label='Email' type='email' required='1'/][contact-field label='Consent' type='consent' required='1'/]"
+		);
+
+		$response = Feedback::from_submission( $_post_data, $form, $current_post );
+		$post_id  = $response->save();
+		Utility::destroy_post_context( $current_post );
+
+		$saved_response = Feedback::get( $post_id );
+		$this->assertEquals( $current_post->ID, $response->get_entry_id(), 'Entry_ID should match the form submission' );
+		$this->assertEquals( $current_post->ID, $saved_response->get_entry_id(), 'Entry_ID should match the saved form submission' );
+	}
+
+	public function test_compute_entry_title() {
+		$current_post = Utility::create_post_context();
+		$form_id      = Utility::get_form_id();
+		// Create a form submission
+		$_post_data = Utility::get_post_request(
+			array(
+				'email' => 'email@email.com',
+			),
+			'g' . $form_id
+		);
+
+		$form = new Contact_Form(
+			array(
+				'title'       => 'Test Form',
+				'description' => 'This is a test form.',
+			),
+			"[contact-field label='Email' type='email' required='1'/]"
+		);
+
+		$response = Feedback::from_submission( $_post_data, $form, $current_post );
+		$post_id  = $response->save();
+
+		$saved_response = Feedback::get( $post_id );
+		Utility::destroy_post_context( $current_post );
+
+		$this->assertEquals( $current_post->post_title, $response->get_entry_title(), 'Post title should match the form submission' );
+		$this->assertEquals( $current_post->post_title, $saved_response->get_entry_title(), 'Post title should match the saved form submission' );
+	}
+
+	public function test_compute_entry_title_updated() {
+		$current_post = Utility::create_post_context();
+		$form_id      = Utility::get_form_id();
+		// Create a form submission
+		$_post_data = Utility::get_post_request(
+			array(
+				'email' => 'email@email.com',
+			),
+			'g' . $form_id
+		);
+
+		$form = new Contact_Form(
+			array(
+				'title'       => 'Test Form',
+				'description' => 'This is a test form.',
+			),
+			"[contact-field label='Email' type='email' required='1'/]"
+		);
+
+		$response = Feedback::from_submission( $_post_data, $form, $current_post );
+		$post_id  = $response->save();
+
+		// Update the post title to simulate an update.
+		$update_title = 'Updated Title';
+		wp_update_post(
+			array(
+				'ID'         => $current_post->ID,
+				'post_title' => $update_title,
+			)
+		);
+
+		$saved_response = Feedback::get( $post_id );
+		Utility::destroy_post_context( $current_post );
+
+		$this->assertEquals( $update_title, $saved_response->get_entry_title(), 'Post Title should match the new updated title saved form submission' );
+	}
+
+	public function test_compute_entry_title_deleted() {
+		$current_post = Utility::create_post_context();
+		$form_id      = Utility::get_form_id();
+		// Create a form submission
+		$_post_data = Utility::get_post_request(
+			array(
+				'email' => 'email@email.com',
+			),
+			'g' . $form_id
+		);
+
+		$form = new Contact_Form(
+			array(
+				'title'       => 'Test Form',
+				'description' => 'This is a test form.',
+			),
+			"[contact-field label='Email' type='email' required='1'/]"
+		);
+
+		$response = Feedback::from_submission( $_post_data, $form, $current_post );
+		$post_id  = $response->save();
+		Utility::destroy_post_context( $current_post );
+
+		$this->assertSame( '', get_the_title( $current_post->ID ), 'Post title should not be available after the post is deleted' );
+		// At this point we should have a deleted post.
+		$saved_response = Feedback::get( $post_id );
+
+		$this->assertNotEmpty( $saved_response->get_entry_title(), 'Post Title should NOT be empty after the post is deleted' );
+		$this->assertEquals( $current_post->post_title, $saved_response->get_entry_title(), 'Post Title should match the saved form submission Original post title' );
+	}
+
+	public function test_get_all_values() {
+		// Test that the get_all_values method returns all values from the form submission.
+
+		$current_post = Utility::create_post_context();
+		$form_id      = Utility::get_form_id();
+		// Create a form submission
+		$_post_data = Utility::get_post_request(
+			array(
+				'email' => 'email@email.com',
+			),
+			'g' . $form_id
+		);
+
+		$form = new Contact_Form(
+			array(
+				'title'       => 'Test Form',
+				'description' => 'This is a test form.',
+			),
+			"[contact-field label='Email' type='email' required='1'/]"
+		);
+
+		$response            = Feedback::from_submission( $_post_data, $form, $current_post );
+		$post_id             = $response->save();
+		$response_all_values = $response->get_all_values();
+		$saved_response      = Feedback::get( $post_id );
+		Utility::destroy_post_context( $current_post );
+		$saved_all_values = $saved_response->get_all_values();
+
+		$this->assertEquals(
+			$response_all_values,
+			$saved_all_values,
+			'All values from the form submission should match the saved form submission'
+		);
+
+		$keys = array(
+			'1_Email',
+			'email_marketing_consent',
+			'entry_title',
+			'entry_permalink',
+			'feedback_id',
+		);
+
+		foreach ( $keys as $key ) {
+			$this->assertArrayHasKey( $key, $response_all_values, "Key '$key' should be present in the all values array" );
+			$this->assertArrayHasKey( $key, $saved_all_values, "Key '$key' should be present in the saved all values array" );
+		}
+		$this->assertArrayNotHasKey( 'entry_page', $response_all_values, 'Key entry_page should not be present in the all values array' );
+	}
+
+	public function test_get_all_values_with_page_number() {
+		// Test that the get_all_values method returns all values from the form submission.
+
+		$current_post = Utility::create_post_context();
+		$form_id      = Utility::get_form_id();
+		// Create a form submission
+		$_post_data = Utility::get_post_request(
+			array(
+				'email' => 'email@email.com',
+			),
+			'g' . $form_id
+		);
+
+		$form = new Contact_Form(
+			array(
+				'title'       => 'Test Form',
+				'description' => 'This is a test form.',
+			),
+			"[contact-field label='Email' type='email' required='1'/]"
+		);
+
+		$response            = Feedback::from_submission( $_post_data, $form, $current_post, 888 );
+		$post_id             = $response->save();
+		$response_all_values = $response->get_all_values();
+		$saved_response      = Feedback::get( $post_id );
+		Utility::destroy_post_context( $current_post );
+		$saved_all_values = $saved_response->get_all_values();
+
+		$this->assertEquals(
+			$response_all_values,
+			$saved_all_values,
+			'All values from the form submission should match the saved form submission'
+		);
+
+		$keys = array(
+			'1_Email',
+			'email_marketing_consent',
+			'entry_title',
+			'entry_permalink',
+			'feedback_id',
+			'entry_page',
+		);
+
+		foreach ( $keys as $key ) {
+			$this->assertArrayHasKey( $key, $response_all_values, "Key '$key' should be present in the all values array" );
+			$this->assertArrayHasKey( $key, $saved_all_values, "Key '$key' should be present in the saved all values array" );
+		}
+		$this->assertEquals( 888, $response_all_values['entry_page'], 'Key entry_page should be present in the all values array' );
+		$this->assertEquals( 888, $saved_all_values['entry_page'], 'Key entry_page should be present in the saved all values array' );
+
+		$this->assertStringContainsString(
+			'page=888',
+			$response_all_values['entry_permalink'],
+			'Entry permalink should contain the page number'
+		);
+	}
+
+	public function test_get_akismet_vars() {
+		// Test that the get_akismet_vars method returns the correct variables for Akismet.
+
+		$current_post = Utility::create_post_context();
+		$form_id      = Utility::get_form_id();
+		// Create a form submission
+		$_post_data = Utility::get_post_request(
+			array(
+				'email' => 'email@email.com',
+				'name'  => 'Test User',
+				'text'  => 'This is a test message.',
+				'url'   => 'https://www.example.com',
+			),
+			'g' . $form_id
+		);
+
+		$form = new Contact_Form(
+			array(
+				'title'       => 'Test Form',
+				'description' => 'This is a test form.',
+			),
+			"[contact-field label='Url' type='url' required='1'/][contact-field label='Text' type='text' required='1'/][contact-field label='Name' type='name' required='1'/][contact-field label='Email' type='email' required='1'/]"
+		);
+
+		$response = Feedback::from_submission( $_post_data, $form, $current_post );
+		$post_id  = $response->save();
+
+		$saved_response = Feedback::get( $post_id );
+		Utility::destroy_post_context( $current_post );
+
+		$this->assertNotEmpty( $response->get_akismet_vars(), 'Akismet vars should not be empty for the form submission' );
+		$this->assertEquals( $saved_response->get_akismet_vars(), $response->get_akismet_vars(), 'Post ID should match the form submission' );
+		$assert_keys = array(
+			'comment_author',
+			'comment_author_email',
+			'comment_author_url',
+			'contact_form_subject',
+			'comment_author_ip',
+			'comment_content',
+			'contact_form_field_text',
+		);
+
+		foreach ( $assert_keys as $key ) {
+			$this->assertArrayHasKey( $key, $response->get_akismet_vars(), "Akismet vars should contain '$key'" );
+			$this->assertArrayHasKey( $key, $saved_response->get_akismet_vars(), "Akismet vars should contain '$key'" );
+		}
+	}
+
+	public function test_compute_entry_permalink() {
+		$current_post = Utility::create_post_context();
+		$form_id      = Utility::get_form_id();
+		// Create a form submission
+		$_post_data = Utility::get_post_request(
+			array(
+				'email' => 'email@email.com',
+			),
+			'g' . $form_id
+		);
+
+		$form = new Contact_Form(
+			array(
+				'title'       => 'Test Form',
+				'description' => 'This is a test form.',
+			),
+			"[contact-field label='Email' type='email' required='1'/]"
+		);
+
+		$response = Feedback::from_submission( $_post_data, $form, $current_post );
+		$post_id  = $response->save();
+
+		$saved_response = Feedback::get( $post_id );
+		Utility::destroy_post_context( $current_post );
+		$current_permalink = get_the_permalink( $current_post );
+		$this->assertEquals( $current_permalink, $response->get_entry_permalink(), 'Post permalink should match the form submission' );
+
+		$this->assertEquals( $current_permalink, $saved_response->get_entry_permalink(), 'Post permalink should match the saved form submission' );
+	}
+
+	public function test_compute_entry_permalink_deleted_post() {
+		$current_post = Utility::create_post_context();
+		$form_id      = Utility::get_form_id();
+		// Create a form submission
+		$_post_data = Utility::get_post_request(
+			array(
+				'email' => 'email@email.com',
+			),
+			'g' . $form_id
+		);
+
+		$form = new Contact_Form(
+			array(
+				'title'       => 'Test Form',
+				'description' => 'This is a test form.',
+			),
+			"[contact-field label='Email' type='email' required='1'/]"
+		);
+
+		$response = Feedback::from_submission( $_post_data, $form, $current_post );
+		$post_id  = $response->save();
+		Utility::destroy_post_context( $current_post ); // Destroy the post context to simulate a deleted post.
+		$saved_response = Feedback::get( $post_id );
+		$this->assertEmpty( $saved_response->get_entry_permalink(), 'Post permalink should match the form submission' );
+	}
+
+	public function test_compute_entry_permalink_with_page_number() {
+		$current_post = Utility::create_post_context();
+		$form_id      = Utility::get_form_id();
+		// Create a form submission
+		$_post_data = Utility::get_post_request(
+			array(
+				'email' => 'email@email.com',
+			),
+			'g' . $form_id
+		);
+
+		$form = new Contact_Form(
+			array(
+				'title'       => 'Test Form',
+				'description' => 'This is a test form.',
+			),
+			"[contact-field label='Email' type='email' required='1'/]"
+		);
+
+		$response = Feedback::from_submission( $_post_data, $form, $current_post, 999 );
+		$post_id  = $response->save();
+
+		$saved_response = Feedback::get( $post_id );
+		Utility::destroy_post_context( $current_post );
+
+		$this->assertStringContainsString( 'page=999', $response->get_entry_permalink(), 'Post permalink should match the form submission' );
+		$this->assertStringContainsString( 'page=999', $saved_response->get_entry_permalink(), 'Post permalink should match the saved form submission' );
+		$this->assertStringContainsString( 'page=999', $saved_response->get_entry_short_permalink(), 'Post short relative path permalink should match the saved form submission' );
+	}
+
+	public function test_feedback_title() {
+
+		$form_id = Utility::get_form_id();
+		// Create a form submission
+		$_post_data = Utility::get_post_request(
+			array(
+				'name'  => 'Test User',
+				'email' => 'email@email.com',
+			),
+			'g' . $form_id
+		);
+
+		$form = new Contact_Form(
+			array(
+				'title'       => 'Test Form',
+				'description' => 'This is a test form.',
+			),
+			"[contact-field label='Name' type='name' required='1'/][contact-field label='Email' type='email' required='1'/]"
+		);
+
+		$response = Feedback::from_submission( $_post_data, $form );
+		$post_id  = $response->save();
+
+		$post           = get_post( $post_id );
+		$saved_response = Feedback::get( $post_id );
+
+		$this->assertStringContainsString( $post->post_title, $response->get_title(), 'Feedback title should match the form submission' );
+		$this->assertStringContainsString( $post->post_title, $saved_response->get_title(), 'Feedback title should match the saved form submission' );
+	}
+
+	public function test_feedback_title_time() {
+
+		$form_id = Utility::get_form_id();
+		// Create a form submission
+		$_post_data = Utility::get_post_request(
+			array(
+				'name'  => 'Test User',
+				'email' => 'email@email.com',
+			),
+			'g' . $form_id
+		);
+
+		$form = new Contact_Form(
+			array(
+				'title'       => 'Test Form',
+				'description' => 'This is a test form.',
+			),
+			"[contact-field label='Name' type='name' required='1'/][contact-field label='Email' type='email' required='1'/]"
+		);
+
+		$response = Feedback::from_submission( $_post_data, $form );
+		$post_id  = $response->save();
+
+		$post           = get_post( $post_id );
+		$saved_response = Feedback::get( $post_id );
+
+		$this->assertStringContainsString( $post->post_date, $response->get_time(), 'Feedback submitted time should match the form submission' );
+		$this->assertStringContainsString( $post->post_date, $saved_response->get_time(), 'Feedback submitted time should match the saved form submission' );
+	}
+
+	/**
+	 * ======================================================
+	 * Tests for the get_compiled_fields method in Feedback class.
+	 * ======================================================
+	 *
+	 * Test that get_compiled_fields returns empty array for feedback without fields.
+	 */
+	public function test_get_compiled_fields_returns_default_fields_for_empty_form() {
+		// default form will have email, name, url, message fields
+		$form       = new Contact_Form( array() );
+		$_post_data = array();
+		$response   = Feedback::from_submission( $_post_data, $form );
+
+		$compiled_fields = $response->get_compiled_fields();
+
+		$default_form = array(
+			'1_Name'    => array(
+				'label' => 'Name',
+				'value' => '',
+			),
+			'2_Email'   => array(
+				'label' => 'Email',
+				'value' => '',
+			),
+			'3_Website' => array(
+				'label' => 'Website',
+				'value' => '',
+			),
+			'4_Message' => array(
+				'label' => 'Message',
+				'value' => '',
+			),
+		);
+
+		$this->assertEquals( $default_form, $compiled_fields );
+	}
+
+	/**
+	 * Data provider for get_compiled_fields test cases.
+	 *
+	 * @return array Test data with different field format expectations.
+	 */
+	public static function get_compiled_fields_data_provider() {
+		$test_name    = 'John Smith';
+		$test_email   = 'john.smith@example.com';
+		$test_website = 'https://johnsmith.dev';
+		$test_message = 'Hello, this is a test message from our contact form.';
+
+		return array(
+			'all_format'         => array(
+				'format'   => 'all',
+				'expected' => array(
+					'1_Name'    => array(
+						'label' => 'Name',
+						'value' => $test_name,
+					),
+					'2_Email'   => array(
+						'label' => 'Email',
+						'value' => $test_email,
+					),
+					'3_Website' => array(
+						'label' => 'Website',
+						'value' => $test_website,
+					),
+					'4_Message' => array(
+						'label' => 'Message',
+						'value' => $test_message,
+					),
+				),
+				'message'  => 'Compiled fields should match the default form structure with all field data.',
+			),
+			'key_value_format'   => array(
+				'format'   => 'key-value',
+				'expected' => array(
+					'1_Name'    => $test_name,
+					'2_Email'   => $test_email,
+					'3_Website' => $test_website,
+					'4_Message' => $test_message,
+				),
+				'message'  => 'Compiled fields should return key-value pairs only.',
+			),
+			'label-value_format' => array(
+				'format'   => 'label|value',
+				'expected' => array(
+					array(
+						'label' => 'Name',
+						'value' => $test_name,
+					),
+					array(
+						'label' => 'Email',
+						'value' => $test_email,
+					),
+					array(
+						'label' => 'Website',
+						'value' => $test_website,
+					),
+					array(
+						'label' => 'Message',
+						'value' => $test_message,
+					),
+				),
+				'message'  => 'Compiled fields should return label|value pairs only.',
+			),
+			'value_format'       => array(
+				'format'   => 'value',
+				'expected' => array(
+					$test_name,
+					$test_email,
+					$test_website,
+					$test_message,
+				),
+				'message'  => 'Compiled fields should return only values as indexed array.',
+			),
+			'label_format'       => array(
+				'format'   => 'label',
+				'expected' => array(
+					'Name',
+					'Email',
+					'Website',
+					'Message',
+				),
+				'message'  => 'Compiled fields should return only labels as indexed array.',
+			),
+		);
+	}
+
+	/**
+	 * Test get_compiled_fields with different output formats.
+	 *
+	 * @dataProvider get_compiled_fields_data_provider
+	 *
+	 * @param string $format   The format parameter for get_compiled_fields.
+	 * @param array  $expected The expected output.
+	 * @param string $message  The assertion message.
+	 */
+	#[DataProvider( 'get_compiled_fields_data_provider' )]
+	public function test_get_compiled_fields_shapes( $format, $expected, $message ) {
+		// Test data
+		$test_name    = 'John Smith';
+		$test_email   = 'john.smith@example.com';
+		$test_website = 'https://johnsmith.dev';
+		$test_message = 'Hello, this is a test message from our contact form.';
+
+		$form_id = Utility::get_form_id();
+		// Create a form submission
+		$_post_data = Utility::get_post_request(
+			array(
+				'name'    => $test_name,
+				'email'   => $test_email,
+				'website' => $test_website,
+				'message' => $test_message,
+			),
+			'g' . $form_id
+		);
+
+		// Test that get_compiled_fields returns the correct structure for a default form
+		$form     = new Contact_Form( array() );
+		$response = Feedback::from_submission( $_post_data, $form );
+
+		// Test the specified format
+		$compiled_fields = $response->get_compiled_fields( 'default', $format );
+
+		$this->assertEquals( $expected, $compiled_fields, $message );
+	}
+
+	/**
+	 *
+	 * Test file uploads in feedback
+	 */
+	public function test_file_uploads() {
+
+		$file = array(
+			'file_id' => 1234,
+			'name'    => 'test-file.txt',
+			'size'    => 1234,
+			'type'    => 'text/plain',
+		);
+
+		$url     = 'https://wordpress.com';
+		$post_id = Utility::create_legacy_feedback(
+			array(
+				'file upload' => array(
+					'field_id' => 'file_upload',
+					'files'    => array( $file ),
+				),
+			),
+			null,
+			null,
+			null,
+			$url
+		);
+
+		$saved_response = Feedback::get( $post_id );
+		$this->assertEquals( 'test-file.txt (1 KB)', $saved_response->get_field_value_by_label( 'file upload' ) );
+
+		foreach ( $saved_response->get_fields() as $field ) {
+			if ( $field->get_label() === 'file upload' ) {
+				$this->assertEquals( 'file', $field->get_type() );
+			}
+		}
+	}
+}

--- a/projects/packages/forms/tests/php/contact-form/class-utility.php
+++ b/projects/packages/forms/tests/php/contact-form/class-utility.php
@@ -1,0 +1,180 @@
+<?php
+/**
+ * Utility functions for Contact Form tests.
+ */
+
+namespace Automattic\Jetpack\Forms\ContactForm;
+
+class Utility {
+	/**
+	 * Create a legacy feedback post.
+	 *
+	 * This function creates a mock feedback post in the legacy format used by Jetpack Contact Form.
+	 *
+	 * @param array       $all_values               An associative array of field values.
+	 * @param string|null $comment_content          The content of the comment.
+	 * @param string|null $comment_author           The name of the comment author.
+	 * @param string|null $comment_author_email     The email of the comment author.
+	 * @param string|null $comment_author_url       The URL of the comment author.
+	 * @param string|null $comment_ip_text          The IP address of the comment author.
+	 * @param string|null $subject                  The subject of the feedback.
+	 * @param string|null $status                   The status of the post (default is 'publish').
+	 *
+	 * @return int|\WP_Error The ID of the created post on success, or a WP_Error object on failure.
+	 */
+	public static function create_legacy_feedback(
+		$all_values = array(),
+		$comment_content = 'This is a test comment content.',
+		$comment_author = 'Test User',
+		$comment_author_email = 'test@email.com',
+		$comment_author_url = 'http://example.com',
+		$comment_ip_text = 'https://127.0.0.1',
+		$subject = 'Test Subject',
+		$status = 'publish'
+	) {
+		global $post;
+		$feedback_time  = current_time( 'mysql' );
+		$feedback_title = "{$comment_author} - {$feedback_time}";
+		$feedback_id    = md5( $feedback_title );
+
+		if ( empty( $all_values ) ) {
+			$all_values = array(
+				'field1'                  => 'value1',
+				'field2'                  => 'value2',
+				'email_marketing_consent' => 'yes',
+			);
+		}
+		// Ensure all_values is an array and has the necessary keys.
+		$entry_values = array(
+			'entry_title'     => 'Cool Post Title',
+			'entry_permalink' => 'https://example.com/post/123',
+			'feedback_id'     => $feedback_id,
+		);
+
+		if ( isset( $_POST['page'] ) ) {
+			$entry_values['entry_page'] = absint( wp_unslash( $_POST['page'] ) );
+		}
+
+		if ( ! isset( $all_values['email_marketing_consent'] ) ) {
+			$all_values['email_marketing_consent'] = false;
+		}
+
+		$all_values = array_merge(
+			$all_values,
+			$entry_values
+		);
+
+		$content = addslashes( wp_kses( "$comment_content\n<!--more-->\nAUTHOR: {$comment_author}\nAUTHOR EMAIL: {$comment_author_email}\nAUTHOR URL: {$comment_author_url}\nSUBJECT: {$subject}\nIP: {$comment_ip_text}\nJSON_DATA\n" . wp_json_encode( $all_values ), array() ) );
+
+		// Create a mock post with JSON_DATA format
+		return wp_insert_post(
+			array(
+				'post_date'    => addslashes( $feedback_time ),
+				'post_type'    => 'feedback',
+				'post_status'  => addslashes( $status ),
+				'post_parent'  => $post ? $post->ID : 0,
+				'post_title'   => addslashes( wp_kses( $feedback_title, array() ) ),
+				'post_content' => $content, // so that search will pick up this data
+				'post_name'    => $feedback_id,
+			)
+		);
+	}
+
+	/**
+	 * Adds the field values to the global $_POST value.
+	 *
+	 * @param array  $values Array of form fields and values.
+	 * @param string $form_id Optional form ID. If not provided, will use $post_id.
+	 */
+	public static function add_post_request( $values, $form_id = null, $post_id = 0 ) {
+		$post_data = self::get_post_request( $values, $form_id, $post_id );
+		foreach ( $post_data as $key => $value ) {
+			$_POST[ $key ] = $value;
+		}
+	}
+
+	/**
+	 * Gets the form ID from the attributes.
+	 *
+	 * @param array $attributes The form attributes.
+	 * @return string The form ID.
+	 */
+	public static function get_form_id( $attributes = array() ) {
+		global $post, $page;
+		// Ensure 'id' exists in $attributes before trying to use it
+		if ( ! isset( $attributes['id'] ) ) {
+			$attributes['id'] = '';
+		}
+
+		$count = Contact_Form::get_forms_count();
+
+		if ( ! empty( $attributes['widget'] ) && $attributes['widget'] ) {
+			$attributes['id'] = 'widget-' . $attributes['widget'];
+		} elseif ( ! empty( $attributes['block_template'] ) && $attributes['block_template'] ) {
+
+			$attributes['id'] = 'block-template-' . $attributes['block_template'];
+		} elseif ( ! empty( $attributes['block_template_part'] ) && $attributes['block_template_part'] ) {
+			$attributes['id'] = 'block-template-part-' . $attributes['block_template_part'];
+		} elseif ( $post ) {
+			$attributes['id'] = $post->ID;
+		}
+
+		if ( $count ) {
+			// When submitting the page number is not always set, so we need to handle that: TODO: This is a hack, we need to find a better way to handle form identification
+			$page_num = max( 1, intval( $page ) );
+
+			$attributes['id'] = $attributes['id'] . '-' . ( $count + 1 ) . '-' . $page_num;
+		}
+		return $attributes['id'];
+	}
+
+	public static function get_post_request( $values, $form_id = null, $post_id = 0 ) {
+		$prefix    = $form_id ? $form_id : 'g' . $post_id;
+		$post_data = array();
+		foreach ( $values as $key => $val ) {
+			if ( strpos( $key, 'contact-form' ) === 0 || strpos( $key, 'action' ) === 0 ) {
+				$post_data[ $key ] = $val;
+			} else {
+				$post_data[ $prefix . '-' . $key ] = $val;
+			}
+		}
+		return $post_data;
+	}
+
+	public static function create_post_context() {
+		$author_id = wp_insert_user(
+			array(
+				'user_email' => 'john@example.com',
+				'user_login' => 'test_user',
+				'user_pass'  => 'abc123',
+			)
+		);
+
+		$post_id = wp_insert_post(
+			array(
+				'post_title'   => 'POST TITLE ' . microtime(),
+				'post_content' => 'POST CONTENT',
+				'post_status'  => 'publish',
+				'post_author'  => $author_id,
+			),
+			true
+		);
+
+		global $post;
+		$post = get_post( $post_id );
+		return $post;
+	}
+	/**
+	 * Destroys the post context.
+	 *
+	 * @param \WP_Post $post The post object to destroy.
+	 */
+	public static function destroy_post_context( $post ) {
+		if ( $post ) {
+			if ( is_int( $post->post_author ) ) {
+				wp_delete_user( (int) $post->post_author );
+			}
+			wp_delete_post( $post->ID, true );
+		}
+	}
+}


### PR DESCRIPTION
This PR adds new classes that will be used to improve how we store Feedback when users submits the form. 

It breaks down - https://github.com/Automattic/jetpack/pull/44462 PR. 

## Proposed changes:
* New classes. `Feedback` Class is the main class that you can instantiate via a form submission or when you are getting the feedback from the DB. 
* `Feedback_Source` is the class used to store information about where the Feedback was created from. 
* `Feedback_Fields` a helper class that stores information about each of the different individual fields. 
* `Feedback_Author` is a helper class that supports getting author information. Such as email, name and website. 

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?



## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Do the tests pass? 

