### PR TITLE
Forms: Update feedback endpoint to use the new Feedback Class

### DIFF
--- a/projects/packages/forms/changelog/update-forms-endpoint-new-response
+++ b/projects/packages/forms/changelog/update-forms-endpoint-new-response
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: Use the new Feedback Class in feedback endpoint response

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -552,7 +552,7 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 			$data['author_avatar'] = $response->get_author_avatar();
 		}
 		if ( rest_is_field_included( 'email_marketing_consent', $fields ) ) {
-			$data['email_marketing_consent'] = $response->has_consent() ? __( 'Yes', 'jetpack-forms' ) : __( 'No', 'jetpack-forms' );
+			$data['email_marketing_consent'] = $response->has_consent() ? '1' : '';
 		}
 		if ( rest_is_field_included( 'ip', $fields ) ) {
 			$data['ip'] = $response->get_ip_address();

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -530,99 +530,50 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 		$data     = $response->get_data();
 		$fields   = $this->get_fields_for_response( $request );
 
-		$has_file    = false;
-		$base_fields = array(
-			'email_marketing_consent' => '',
-			'entry_title'             => '',
-			'entry_permalink'         => '',
-			'feedback_id'             => '',
-		);
-
-		$data_defaults = array(
-			'_feedback_author'       => '',
-			'_feedback_author_email' => '',
-			'_feedback_author_url'   => '',
-			'_feedback_all_fields'   => array(),
-			'_feedback_ip'           => '',
-			'_feedback_subject'      => '',
-		);
-
-		$feedback_data = array_merge(
-			$data_defaults,
-			\Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::parse_fields_from_content( $item->ID )
-		);
-
-		$all_fields = array_merge( $base_fields, $feedback_data['_feedback_all_fields'] );
+		$response = Feedback::get( $item->ID );
+		if ( ! $response ) {
+			return rest_ensure_response( $data );
+		}
 
 		$data['date'] = get_the_date( 'c', $data['id'] );
 		if ( rest_is_field_included( 'uid', $fields ) ) {
-			$data['uid'] = $all_fields['feedback_id'];
+			$data['uid'] = $response->get_feedback_id();
 		}
 		if ( rest_is_field_included( 'author_name', $fields ) ) {
-			$data['author_name'] = $feedback_data['_feedback_author'];
+			$data['author_name'] = $response->get_author();
 		}
 		if ( rest_is_field_included( 'author_email', $fields ) ) {
-			$data['author_email'] = $feedback_data['_feedback_author_email'];
+			$data['author_email'] = $response->get_author_email();
 		}
 		if ( rest_is_field_included( 'author_url', $fields ) ) {
-			$data['author_url'] = $feedback_data['_feedback_author_url'];
+			$data['author_url'] = $response->get_author_url();
 		}
 		if ( rest_is_field_included( 'author_avatar', $fields ) ) {
-			$data['author_avatar'] = empty( $feedback_data['_feedback_author_email'] ) ? '' : get_avatar_url( $feedback_data['_feedback_author_email'] );
+			$data['author_avatar'] = $response->get_author_avatar();
 		}
 		if ( rest_is_field_included( 'email_marketing_consent', $fields ) ) {
-			$data['email_marketing_consent'] = $all_fields['email_marketing_consent'];
+			$data['email_marketing_consent'] = $response->has_consent() ? __( 'Yes', 'jetpack-forms' ) : __( 'No', 'jetpack-forms' );
 		}
 		if ( rest_is_field_included( 'ip', $fields ) ) {
-			$data['ip'] = $feedback_data['_feedback_ip'];
+			$data['ip'] = $response->get_ip_address();
 		}
 		if ( rest_is_field_included( 'entry_title', $fields ) ) {
-			$data['entry_title'] = $all_fields['entry_title'];
+			$data['entry_title'] = $response->get_entry_title();
 		}
 		if ( rest_is_field_included( 'entry_permalink', $fields ) ) {
-			$data['entry_permalink'] = $all_fields['entry_permalink'];
+			$data['entry_permalink'] = $response->get_entry_permalink();
 		}
 		if ( rest_is_field_included( 'subject', $fields ) ) {
-			$data['subject'] = $feedback_data['_feedback_subject'];
+			$data['subject'] = $response->get_subject();
 		}
 		if ( rest_is_field_included( 'fields', $fields ) ) {
-			$fields_data = array_diff_key( $all_fields, $base_fields );
+			$data['fields'] = $response->get_compiled_fields( 'api', 'key-value' );
+		}
 
-			foreach ( $fields_data as &$field ) {
-				if ( Contact_Form::is_file_upload_field( $field ) ) {
-
-					foreach ( $field['files'] as &$file ) {
-						if ( ! isset( $file['size'] ) || ! isset( $file['file_id'] ) ) {
-							// this shouldn't happen, todo: log this
-							continue;
-						}
-						$file_id                = absint( $file['file_id'] );
-						$file['file_id']        = $file_id;
-						$file['size']           = size_format( $file['size'] );
-						$file['url']            = apply_filters( 'jetpack_unauth_file_download_url', '', $file_id );
-						$file['is_previewable'] = self::is_previewable_file( $file );
-						$has_file               = true;
-					}
-				}
-			}
-
-			$data['fields']   = $fields_data;
-			$data['has_file'] = $has_file;
+		if ( rest_is_field_included( 'has_file', $fields ) ) {
+			$data['has_file'] = $response->has_file();
 		}
 		return rest_ensure_response( $data );
-	}
-	/**
-	 * Checks if the file is previewable based on its type or extension.
-	 *
-	 * @param array $file File data.
-	 * @return bool True if the file is previewable, false otherwise.
-	 */
-	private static function is_previewable_file( $file ) {
-		$file_type = strtolower( pathinfo( $file['name'], PATHINFO_EXTENSION ) );
-		// Check if the file is previewable based on its type or extension.
-		// Note: This is a simplified check and does not match if the file is allowed to be uploaded by the server.
-		$previewable_types = array( 'jpg', 'jpeg', 'png', 'gif', 'webp' );
-		return in_array( $file_type, $previewable_types, true );
 	}
 
 	/**

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Endpoint_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Endpoint_Test.php
@@ -530,4 +530,74 @@ JSON_DATA{"name":"Test Author","email":"author@example.com","g1-file":{"field_id
 		$this->assertTrue( $file['is_previewable'] );
 		$this->assertTrue( $data['has_file'] );
 	}
+
+	/**
+	 * Test prepare_item_for_response with file fields
+	 */
+	public function test_prepare_item_for_response_with_consent() {
+
+		$post_id = Utility::create_legacy_feedback(
+			array(
+				'field1'                  => 'value1',
+				'field2'                  => 'value2',
+				'email_marketing_consent' => 'yes',
+			),
+			'This is a test comment content.',
+			'Test User'
+		);
+
+		// Test the get_item endpoint
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/feedback/' . $post_id );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$data = $response->get_data();
+
+		// Verify file field data in response
+		$this->assertArrayHasKey( 'fields', $data );
+
+		$this->assertArrayHasKey( 'email_marketing_consent', $data );
+		$this->assertSame( '1', $data['email_marketing_consent'] );
+
+		$this->assertArrayHasKey( 'author_name', $data );
+		$this->assertEquals( 'Test User', $data['author_name'] );
+
+		$this->assertArrayHasKey( 'has_file', $data );
+		$this->assertFalse( $data['has_file'] );
+	}
+
+	/**
+	 * Test prepare_item_for_response with file fields
+	 */
+	public function test_prepare_item_for_response_without_consent() {
+
+		$post_id = Utility::create_legacy_feedback(
+			array(
+				'field1'                  => 'value1',
+				'field2'                  => 'value2',
+				'email_marketing_consent' => '',
+			),
+			'This is a test comment content.',
+			'Test User'
+		);
+
+		// Test the get_item endpoint
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/feedback/' . $post_id );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$data = $response->get_data();
+
+		// Verify file field data in response
+		$this->assertArrayHasKey( 'fields', $data );
+
+		$this->assertArrayHasKey( 'email_marketing_consent', $data );
+		$this->assertSame( '', $data['email_marketing_consent'] );
+
+		$this->assertArrayHasKey( 'author_name', $data );
+		$this->assertEquals( 'Test User', $data['author_name'] );
+
+		$this->assertArrayHasKey( 'has_file', $data );
+		$this->assertFalse( $data['has_file'] );
+	}
 }


### PR DESCRIPTION
This PR update the feedback endpoint to use the new Feedback class. 

This PR breaks https://github.com/Automattic/jetpack/pull/44462 into smaller more testable pieces. 

## Proposed changes:
* Update the Feedback endpoint to use the new Feedback class so that when we switch how the class  

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
* Do the tests pass? 
* Load this PR. 
* Visit the feedback dashboard. Notice that it still loads as before. 
* You should visit different feedback and notice that it is still there. 

