### PR TITLE
Forms: Update export personal data to use the new Feedback class

### DIFF
--- a/projects/packages/forms/changelog/update-forms-export-personal-data
+++ b/projects/packages/forms/changelog/update-forms-export-personal-data
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Forms: update internal_personal_data_exporter to use new Feedback class

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -2030,36 +2030,61 @@ class Contact_Form_Plugin {
 	 * @return array            Associative array with keys expected by core.
 	 */
 	public function internal_personal_data_exporter( $email, $page = 1, $per_page = 250 ) {
+		$post_ids = $this->personal_data_post_ids_by_email( $email, $per_page, $page );
+
+		return array(
+			'data' => $this->internal_personal_data_formater( $post_ids ),
+			'done' => count( $post_ids ) < $per_page,
+		);
+	}
+
+	/**
+	 * Formats personal data for export.
+	 *
+	 * @param  array $post_ids Array of post IDs to format.
+	 *
+	 * @return array $export_data Formatted personal data for export.
+	 */
+	public function internal_personal_data_formater( $post_ids ) {
 		$export_data = array();
-		$post_ids    = $this->personal_data_post_ids_by_email( $email, $per_page, $page );
-
 		foreach ( $post_ids as $post_id ) {
-			$post_fields = $this->get_parsed_field_contents_of_post( $post_id );
-
-			if ( ! is_array( $post_fields ) || empty( $post_fields['_feedback_subject'] ) ) {
-				continue; // Corrupt data.
-			}
-
-			$post_fields['_feedback_main_comment'] = $this->get_post_content_for_csv_export( $post_id );
-			$post_fields                           = $this->map_parsed_field_contents_of_post_to_field_names( $post_fields );
-
-			if ( ! is_array( $post_fields ) || empty( $post_fields ) ) {
-				continue; // No fields to export.
-			}
-
-			$post_meta = $this->get_post_meta_for_csv_export( $post_id );
-			$post_meta = is_array( $post_meta ) ? $post_meta : array();
-
 			$post_export_data = array();
-			$post_data        = array_merge( $post_fields, $post_meta );
-			ksort( $post_data );
+			$feedback         = Feedback::get( $post_id );
+			if ( ! $feedback ) {
+				continue;
+			}
+			$fields             = $feedback->get_compiled_fields( 'personal_export', 'all' );
+			$post_export_data[] = array(
+				'name'  => __( 'Date', 'jetpack-forms' ),
+				'value' => $feedback->get_time(),
+			);
 
-			foreach ( $post_data as $post_data_key => $post_data_value ) {
+			$post_export_data[] = array(
+				'name'  => __( 'Source Title', 'jetpack-forms' ),
+				'value' => $feedback->get_entry_title(),
+			);
+
+			$post_export_data[] = array(
+				'name'  => __( 'Source URL:', 'jetpack-forms' ),
+				'value' => $feedback->get_entry_permalink(),
+			);
+
+			foreach ( $fields as $field ) {
 				$post_export_data[] = array(
-					'name'  => preg_replace( '/^[0-9]+_/', '', $post_data_key ),
-					'value' => $post_data_value,
+					'name'  => $field['label'],
+					'value' => $field['value'],
 				);
 			}
+
+			$post_export_data[] = array(
+				'name'  => __( 'Consent', 'jetpack-forms' ),
+				'value' => $feedback->has_consent() ? __( 'Yes', 'jetpack-forms' ) : __( 'No', 'jetpack-forms' ),
+			);
+
+			$post_export_data[] = array(
+				'name'  => __( 'IP Address', 'jetpack-forms' ),
+				'value' => $feedback->get_ip_address(),
+			);
 
 			$export_data[] = array(
 				'group_id'    => 'feedback',
@@ -2069,10 +2094,7 @@ class Contact_Form_Plugin {
 			);
 		}
 
-		return array(
-			'data' => $export_data,
-			'done' => count( $post_ids ) < $per_page,
-		);
+		return $export_data;
 	}
 
 	/**

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
@@ -744,6 +744,7 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 
 	public function test_interpersonal_data_exporter() {
 		global $post;
+
 		$post_id = Utility::create_legacy_feedback(
 			array(
 				'1_field' => 'value1',
@@ -766,7 +767,7 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 				),
 				array(
 					'name'  => 'Source Title',
-					'value' => '',
+					'value' => 'Cool Post Title', // the default value in the create_legacy_feedback
 				),
 				array(
 					'name'  => 'Source URL:',

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
@@ -741,4 +741,64 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 
 		Utility::destroy_post_context( $current_post );
 	}
+
+	public function test_interpersonal_data_exporter() {
+		global $post;
+		$post_id = Utility::create_legacy_feedback(
+			array(
+				'1_field' => 'value1',
+				'2_field' => 'value2',
+				'email'   => 'hello@example.com',
+			)
+		);
+
+		$plugin   = Contact_Form_Plugin::init();
+		$exporter = $plugin->internal_personal_data_formater( array( $post_id ) );
+
+		$assert = array(
+			'group_id'    => 'feedback',
+			'group_label' => 'Feedback',
+			'item_id'     => 'feedback-' . $post_id,
+			'data'        => array(
+				array(
+					'name'  => 'Date',
+					'value' => get_post_field( 'post_date', $post_id ),
+				),
+				array(
+					'name'  => 'Source Title',
+					'value' => '',
+				),
+				array(
+					'name'  => 'Source URL:',
+					'value' => get_permalink( $post->ID ),
+				),
+				array(
+					'name'  => 'field',
+					'value' => 'value1',
+				),
+				array(
+					'name'  => 'field',
+					'value' => 'value2',
+				),
+				array(
+					'name'  => 'email',
+					'value' => 'hello@example.com',
+				),
+				array(
+					'name'  => 'Consent',
+					'value' => 'No',
+				),
+				array(
+					'name'  => 'IP Address',
+					'value' => 'https://127.0.0.1',
+				), // same as the default value in the create_legacy_feedback
+			),
+		);
+
+		$this->assertEquals(
+			$assert,
+			$exporter[0]
+		);
+		$this->assertIsArray( $exporter, 'Expected the exporter to return an array.' );
+	}
 }


### PR DESCRIPTION
This PR update the export personal data to use the new Feedback class.

This PR breaks https://github.com/Automattic/jetpack/pull/44462 into smaller more testable pieces.

## Proposed changes:
* Updete internal_personal_data_exporter to use the new class. 
* Implements a new internal_personal_data_formater method for easier unit testing of the new format. 

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Visit Tools > Export Personal Data and search for an email that has submitted data. 
Then notice that this export looks like before. 
