### PR TITLE
Forms: Update on submit to use new feedback class.

### DIFF
--- a/projects/packages/forms/changelog/update-forms-on-submit-use-feedback
+++ b/projects/packages/forms/changelog/update-forms-on-submit-use-feedback
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: Update how the success messages to use the new Feedback class

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -600,7 +600,13 @@ class Contact_Form extends Contact_Form_Shortcode {
 
 		// Initial data used to render the success message when the page is reloaded after a successful submission
 		// Don't show the feedback details unless the nonce matches
-		$submission_data           = $is_reload_after_success && $is_reload_nonce_valid ? self::get_json_data( (int) $_GET['contact-form-sent'], $form ) : null;
+		$submission_data = null;
+		if ( $is_reload_after_success && $is_reload_nonce_valid ) {
+			$response = Feedback::get( (int) $_GET['contact-form-sent'] );
+			if ( $response ) {
+				$submission_data = $response->get_compiled_fields( 'web', 'label|value' );
+			}
+		}
 		$formatted_submission_data = $submission_data ? self::format_submission_data( $submission_data ) : array();
 		$submission_success        = $form->is_response_without_reload_enabled && $is_reload_after_success;
 		$has_custom_redirect       = $form->has_custom_redirect();
@@ -994,7 +1000,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 			);
 			$message      = wp_kses( $raw_message, $allowed_html );
 		} else {
-			$compiled_form = self::get_compiled_form( $feedback_id, $form );
+			$compiled_form = self::get_compiled_form( $feedback_id );
 			$message       = '<p>' . implode( '</p><p>', $compiled_form ) . '</p>';
 		}
 
@@ -1006,12 +1012,16 @@ class Contact_Form extends Contact_Form_Shortcode {
 	 * of lines.
 	 *
 	 * @param int          $feedback_id - the feedback ID.
-	 * @param Contact_Form $form - the form.
+	 * @param Contact_Form $form - the form. This parameter is deprecated and will be removed in the next version.
 	 *
 	 * @return array $lines
 	 */
-	public static function get_compiled_form( $feedback_id, $form ) {
-		$compiled_form = self::get_raw_compiled_form_data( $feedback_id, $form );
+	public static function get_compiled_form( $feedback_id, $form = null ) {
+
+		if ( $form ) {
+			_deprecated_argument( __METHOD__, '$$next-version$$', '$form is deprecated' );
+		}
+		$compiled_form = self::get_raw_compiled_form_data( $feedback_id );
 
 		foreach ( $compiled_form as $field_index => $data ) {
 			$safe_display_value = self::escape_and_sanitize_field_value( $data['value'] );
@@ -1046,140 +1056,48 @@ class Contact_Form extends Contact_Form_Shortcode {
 	 * Returns the JSON data for the form submission.
 	 *
 	 * @param int          $feedback_id - the feedback ID.
-	 * @param Contact_Form $form - the form.
+	 * @param Contact_Form $form - the form. This parameter is deprecated and will be removed in the next version.
+	 *
+	 * @deprecated $$next-version$$
 	 *
 	 * @return array $json_data
 	 */
-	public static function get_json_data( $feedback_id, $form ) {
-		$raw_data  = self::get_raw_compiled_form_data( $feedback_id, $form );
-		$json_data = array();
+	public static function get_json_data( $feedback_id, $form = null ) {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Feedback::get( $feedback_id )->get_compiled_fields(\'ajax\', \'label|value\' )' );
 
-		// Sort by field index to maintain the correct order
-		ksort( $raw_data );
-
-		// Handle file upload field (new structure with field_id and files array)
-		foreach ( $raw_data as $field_data ) {
-			$value = $field_data['value'];
-			$label = $field_data['label'];
-
-			if ( self::is_file_upload_field( $value ) ) {
-				$files = $value['files'];
-
-				if ( empty( $files ) ) {
-					continue;
-				}
-
-				foreach ( $files as $file ) {
-					if ( ! empty( $file['file_id'] ) ) {
-						$file_name = isset( $file['name'] ) ? $file['name'] : __( 'Attached file', 'jetpack-forms' );
-						$file_size = isset( $file['size'] ) ? size_format( $file['size'] ) : '';
-
-						$json_data[] = array(
-							'label' => $label,
-							'value' => array(
-								'name' => $file_name,
-								'size' => $file_size,
-							),
-						);
-					}
-				}
-			} else {
-				$json_data[] = array(
-					'label' => $label,
-					'value' => $value,
-				);
-			}
+		if ( $form ) {
+			_deprecated_argument( __METHOD__, '$$next-version$$', '$form is deprecated' );
 		}
 
-		return $json_data;
+		$response = Feedback::get( $feedback_id );
+		if ( ! $response ) {
+			return array();
+		}
+
+		return $response->get_compiled_fields( 'ajax', 'label|value' );
 	}
 
 	/**
 	 * Retrieves raw compiled form data.
 	 *
 	 * @param int          $feedback_id - the feedback ID.
-	 * @param Contact_Form $form - the form.
+	 * @param Contact_Form $form - the form. This parameter is deprecated and will be removed in the next version.
 	 *
 	 * @return array $raw_data Associative array where keys are field_index and values are arrays with 'label' and 'value'.
 	 */
-	private static function get_raw_compiled_form_data( $feedback_id, $form ) {
-		$feedback       = get_post( $feedback_id );
-		$field_ids      = $form->get_field_ids();
-		$content_fields = Contact_Form_Plugin::parse_fields_from_content( $feedback_id );
+	private static function get_raw_compiled_form_data( $feedback_id, $form = null ) {
 
-		// Maps field_ids to post_meta keys
-		$field_value_map = array(
-			'name'     => 'author',
-			'email'    => 'author_email',
-			'url'      => 'author_url',
-			'subject'  => 'subject',
-			'textarea' => false, // not a post_meta key.  This is stored in post_content
-		);
-
-		$raw_data = array();
-
-		// "Standard" field allowed list.
-		foreach ( $field_value_map as $type => $meta_key ) {
-			if ( isset( $field_ids[ $type ] ) ) {
-				$field = $form->fields[ $field_ids[ $type ] ];
-				$value = null;
-
-				if ( $meta_key ) {
-					if ( isset( $content_fields[ "_feedback_{$meta_key}" ] ) ) {
-						if ( 'name' === $type ) {
-							// If a form contains both email and name fields but the user doesn't provide a name, we don't need to show the name field
-							// in the success message after submision. We have this specific check because in the above case the `author` field gets
-							// a fallback value of the provided email and is used in the backend in various places.
-							if ( isset( $content_fields['_feedback_author_email'] ) && $content_fields['_feedback_author'] === $content_fields['_feedback_author_email'] ) {
-								continue;
-							}
-						}
-						$value = $content_fields[ "_feedback_{$meta_key}" ];
-					}
-				} else {
-					// The feedback content is stored as the first "half" of post_content
-					$current_value         = ( is_object( $feedback ) && is_a( $feedback, '\WP_Post' ) ) ?
-									$feedback->post_content : '';
-					list( $current_value ) = explode( '<!--more-->', $current_value );
-					$value                 = trim( $current_value );
-				}
-
-				$field_index = array_search( $field_ids[ $type ], $field_ids['all'], true );
-				$field_label = $field->get_attribute( 'label' );
-
-				$raw_data[ $field_index ] = array(
-					'label' => $field_label,
-					'value' => $value,
-				);
-			}
+		if ( $form ) {
+			_deprecated_argument( __METHOD__, '$$next-version$$', '$form is deprecated' );
 		}
 
-		// "Non-standard" fields
-		if ( $field_ids['extra'] ) {
-			// array indexed by field label (not field id)
-			$extra_fields = get_post_meta( $feedback_id, '_feedback_extra_fields', true );
-			/**
-			 * Only get data for the compiled form if `$extra_fields` is a valid and non-empty array.
-			 */
-			if ( is_array( $extra_fields ) && ! empty( $extra_fields ) ) {
-
-				$extra_field_keys = array_keys( $extra_fields );
-
-				$i = 0;
-				foreach ( $field_ids['extra'] as $field_id ) {
-					$field                    = $form->fields[ $field_id ];
-					$field_index              = array_search( $field_id, $field_ids['all'], true );
-					$field_label              = $field->get_attribute( 'label' );
-					$value                    = isset( $extra_field_keys[ $i ] ) && isset( $extra_fields[ $extra_field_keys[ $i ] ] ) ? $extra_fields[ $extra_field_keys[ $i ] ] : '';
-					$raw_data[ $field_index ] = array(
-						'label' => $field_label,
-						'value' => $value,
-					);
-					++$i;
-				}
-			}
+		$response = Feedback::get( $feedback_id );
+		if ( $response instanceof Feedback ) {
+			// If the response is an instance of Feedback, we can use its method to get compiled fields.
+			return $response->get_compiled_fields( 'web', 'all' );
 		}
-		return $raw_data;
+
+		return array();
 	}
 
 	/**
@@ -1192,7 +1110,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 	 * @return array $lines
 	 */
 	public static function get_compiled_form_for_email( $feedback_id, $form ) {
-		$compiled_form = self::get_raw_compiled_form_data( $feedback_id, $form );
+		$compiled_form = self::get_raw_compiled_form_data( $feedback_id );
 
 		/**
 		 * This filter allows a site owner to customize the response to be emailed, by adding their own HTML around it for example.
@@ -2314,10 +2232,15 @@ class Contact_Form extends Contact_Form_Shortcode {
 		if ( $this->is_response_without_reload_enabled && $accepts_json ) {
 			header( 'Content-Type: application/json' );
 
+			$data     = array();
+			$response = Feedback::get( $post_id );
+			if ( $response instanceof Feedback ) {
+				$data = $response->get_compiled_fields( 'ajax', 'label|value' );
+			}
 			echo wp_json_encode(
 				array(
 					'success'     => true,
-					'data'        => self::get_json_data( $post_id, $this ),
+					'data'        => $data,
 					'refreshArgs' => $refresh_args,
 				)
 			);

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1110,7 +1110,13 @@ class Contact_Form extends Contact_Form_Shortcode {
 	 * @return array $lines
 	 */
 	public static function get_compiled_form_for_email( $feedback_id, $form ) {
-		$compiled_form = self::get_raw_compiled_form_data( $feedback_id );
+		$compiled_form = array();
+		$response      = Feedback::get( $feedback_id );
+
+		if ( $response instanceof Feedback ) {
+			// If the response is an instance of Feedback, we can use its method to get compiled fields.
+			$compiled_form = $response->get_compiled_fields( 'email', 'all' );
+		}
 
 		/**
 		 * This filter allows a site owner to customize the response to be emailed, by adding their own HTML around it for example.
@@ -1146,9 +1152,6 @@ class Contact_Form extends Contact_Form_Shortcode {
 				}
 			}
 		}
-
-		// Sorting lines by the field index
-		ksort( $compiled_form );
 
 		return $compiled_form;
 	}

--- a/projects/packages/forms/src/contact-form/class-feedback.php
+++ b/projects/packages/forms/src/contact-form/class-feedback.php
@@ -25,6 +25,15 @@ class Feedback {
 	protected $fields = array();
 
 	/**
+	 * Static cache for feedback fields.
+	 *
+	 * This is used to avoid recomputing the feedback fields for the same post ID.
+	 *
+	 * @var array
+	 */
+	private static $feedback_fields = array();
+
+	/**
 	 * Does the response have files attached to it?
 	 *
 	 * @var bool
@@ -118,14 +127,18 @@ class Feedback {
 	 * @return static|null
 	 */
 	public static function get( $feedback_post_id ) {
-
 		$feedback_post = get_post( $feedback_post_id );
 		if ( ! $feedback_post || self::POST_TYPE !== $feedback_post->post_type ) {
 			return null;
 		}
 
+		if ( isset( self::$feedback_fields[ $feedback_post->ID ] ) ) {
+			return self::$feedback_fields[ $feedback_post->ID ];
+		}
+
 		$instance = new self();
 		$instance->load_from_post( $feedback_post );
+		self::$feedback_fields[ $feedback_post->ID ] = $instance;
 		return $instance;
 	}
 


### PR DESCRIPTION
This PR update the form submission data to use the new Feedback class.

This PR breaks https://github.com/Automattic/jetpack/pull/44462 into smaller more testable pieces.

## Proposed changes:
* Deprecates the get_json_data method. 
* Deprecates the get_raw_compiled_form_data $form parameter. Since it is no longer needed.


### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
1. Fill out the form. Notice that it still works as expected. 
2. Update the `add_filter( 'jetpack_forms_enable_ajax_submission', '__return_true' );` filter. Notice that it still works as expected. 
3. Notice that the emails that get created still work look like before. 


