### PR TITLE
Full sync: Stuck adjustment consider full sync started

### DIFF
--- a/projects/packages/sync/changelog/update-full-sync-stuckl-adjustment-consider-full-sync-started
+++ b/projects/packages/sync/changelog/update-full-sync-stuckl-adjustment-consider-full-sync-started
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Full Sync: For stuck adjustment, consider started time of full sync to avoid checks for different full syncs.

--- a/projects/packages/sync/src/modules/class-callables.php
+++ b/projects/packages/sync/src/modules/class-callables.php
@@ -293,10 +293,11 @@ class Callables extends Module {
 	 * @param array $config Full sync configuration for this sync module.
 	 * @param array $status This Module Full Sync Status.
 	 * @param int   $send_until The timestamp until the current request can send.
+	 * @param int   $started The timestamp when the full sync started.
 	 *
 	 * @return array This Module Full Sync Status.
 	 */
-	public function send_full_sync_actions( $config, $status, $send_until ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+	public function send_full_sync_actions( $config, $status, $send_until, $started ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		// we call this instead of do_action when sending immediately.
 		$result = $this->send_action( 'jetpack_full_sync_callables', array( true ) );
 

--- a/projects/packages/sync/src/modules/class-constants.php
+++ b/projects/packages/sync/src/modules/class-constants.php
@@ -148,10 +148,11 @@ class Constants extends Module {
 	 * @param array $config Full sync configuration for this sync module.
 	 * @param array $status This module Full Sync status.
 	 * @param int   $send_until The timestamp until the current request can send.
+	 * @param int   $started The timestamp when the full sync started.
 	 *
 	 * @return array This module Full Sync status.
 	 */
-	public function send_full_sync_actions( $config, $status, $send_until ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+	public function send_full_sync_actions( $config, $status, $send_until, $started ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		// we call this instead of do_action when sending immediately.
 		$result = $this->send_action( 'jetpack_full_sync_constants', array( true ) );
 

--- a/projects/packages/sync/src/modules/class-full-sync-immediately.php
+++ b/projects/packages/sync/src/modules/class-full-sync-immediately.php
@@ -390,7 +390,7 @@ class Full_Sync_Immediately extends Module {
 		$started = $this->get_status()['started'];
 
 		foreach ( $this->get_remaining_modules_to_send() as $module ) {
-			$progress[ $module->name() ] = $module->send_full_sync_actions( $config[ $module->name() ], $progress[ $module->name() ], $send_until );
+			$progress[ $module->name() ] = $module->send_full_sync_actions( $config[ $module->name() ], $progress[ $module->name() ], $send_until, $started );
 			if ( isset( $progress[ $module->name() ]['error'] ) ) {
 				unset( $progress[ $module->name() ]['error'] );
 				$this->update_status( array( 'progress' => $progress ) );

--- a/projects/packages/sync/src/modules/class-module.php
+++ b/projects/packages/sync/src/modules/class-module.php
@@ -401,10 +401,11 @@ abstract class Module {
 	 * @param string $config Full sync configuration for this module.
 	 * @param array  $status the current module full sync status.
 	 * @param float  $send_until timestamp until we want this request to send full sync events.
+	 * @param int    $started The timestamp when the full sync started.
 	 *
 	 * @return array Status, the module full sync status updated.
 	 */
-	public function send_full_sync_actions( $config, $status, $send_until ) {
+	public function send_full_sync_actions( $config, $status, $send_until, $started ) {
 		global $wpdb;
 
 		if ( empty( $status['last_sent'] ) ) {
@@ -417,7 +418,7 @@ abstract class Module {
 				'max_chunks' => 10,
 				'chunk_size' => 100,
 			);
-		$limits['chunk_size'] = $this->adjust_chunk_size_if_stuck( $status['last_sent'], $limits['chunk_size'] );
+		$limits['chunk_size'] = $this->adjust_chunk_size_if_stuck( $status['last_sent'], $limits['chunk_size'], $started );
 
 		$chunks_sent = 0;
 
@@ -463,10 +464,11 @@ abstract class Module {
 	 *
 	 * @param string $last_sent The current last_sent marker.
 	 * @param int    $default_chunk_size The default chunk size.
+	 * @param int    $started The timestamp when the full sync started.
 	 * @return int Adjusted chunk size.
 	 */
-	private function adjust_chunk_size_if_stuck( $last_sent, $default_chunk_size ) {
-		$transient_key       = 'jetpack_sync_last_sent_' . $this->name();
+	private function adjust_chunk_size_if_stuck( $last_sent, $default_chunk_size, $started ) {
+		$transient_key       = 'jetpack_sync_last_sent_' . $this->name() . '_' . $started;
 		$stuck_data          = get_transient( $transient_key );
 		$stuck_count         = 0;
 		$adjusted_chunk_size = $default_chunk_size;

--- a/projects/packages/sync/src/modules/class-network-options.php
+++ b/projects/packages/sync/src/modules/class-network-options.php
@@ -122,10 +122,11 @@ class Network_Options extends Module {
 	 * @param array $config Full sync configuration for this sync module.
 	 * @param array $status This module Full Sync status.
 	 * @param int   $send_until The timestamp until the current request can send.
+	 * @param int   $started The timestamp when the full sync started.
 	 *
 	 * @return array This module Full Sync status.
 	 */
-	public function send_full_sync_actions( $config, $status, $send_until ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+	public function send_full_sync_actions( $config, $status, $send_until, $started ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		// we call this instead of do_action when sending immediately.
 		$result = $this->send_action( 'jetpack_full_sync_network_options', array( true ) );
 

--- a/projects/packages/sync/src/modules/class-options.php
+++ b/projects/packages/sync/src/modules/class-options.php
@@ -174,10 +174,11 @@ class Options extends Module {
 	 * @param array $config Full sync configuration for this sync module.
 	 * @param array $status This module Full Sync status.
 	 * @param int   $send_until The timestamp until the current request can send.
+	 * @param int   $started The timestamp when the full sync started.
 	 *
 	 * @return array This module Full Sync status.
 	 */
-	public function send_full_sync_actions( $config, $status, $send_until ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+	public function send_full_sync_actions( $config, $status, $send_until, $started ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		// we call this instead of do_action when sending immediately.
 		$result = $this->send_action( 'jetpack_full_sync_options', array( true ) );
 

--- a/projects/packages/sync/src/modules/class-themes.php
+++ b/projects/packages/sync/src/modules/class-themes.php
@@ -511,10 +511,11 @@ class Themes extends Module {
 	 * @param array $config Full sync configuration for this sync module.
 	 * @param array $status This module Full Sync status.
 	 * @param int   $send_until The timestamp until the current request can send.
+	 * @param int   $started The timestamp when the full sync started.
 	 *
 	 * @return array This module Full Sync status.
 	 */
-	public function send_full_sync_actions( $config, $status, $send_until ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+	public function send_full_sync_actions( $config, $status, $send_until, $started ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		// we call this instead of do_action when sending immediately.
 		$result = $this->send_action( 'jetpack_full_sync_theme_data', array( true ) );
 

--- a/projects/packages/sync/src/modules/class-updates.php
+++ b/projects/packages/sync/src/modules/class-updates.php
@@ -393,10 +393,11 @@ class Updates extends Module {
 	 * @param array $config Full sync configuration for this sync module.
 	 * @param array $status This module Full Sync status.
 	 * @param int   $send_until The timestamp until the current request can send.
+	 * @param int   $started The timestamp when the full sync started.
 	 *
 	 * @return array This module Full Sync status.
 	 */
-	public function send_full_sync_actions( $config, $status, $send_until ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+	public function send_full_sync_actions( $config, $status, $send_until, $started ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		// we call this instead of do_action when sending immediately.
 		$result = $this->send_action( 'jetpack_full_sync_updates', array( true ) );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->
Fixes [VULCAN-256](https://linear.app/a8c/issue/VULCAN-256/investigate-oom-during-full-sync-rollout-to-500-posts-in-the-package)
Continuation of  #44454 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Added `started` as param to `send_full_sync_actions` to avoid considering stuck actions coming from different full syncs.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

The problem we are trying to solve is that multiple Full Syncs within the hour will trigger the adjustment.

I'd recommend to lower the 10 minute to consider the full sync is stuck to something like 30 seconds for faster testing.

In trunk. 
- Test running a Full Sync for everything into a site.
- After it finishes. Try another Full Sync.
- You will see that even though Full Sync will advance, `jetpack_full_sync_stuck_adjustment` actions will be sent to wpcom in the jetpack-audit-* index.

In this branch. 
- Repeat the above for another test site (it can be the same.  Just run two full syncs) . No `jetpack_full_sync_stuck_adjustment` actions will be sent to wpcom in the jetpack-audit-* index.

Repeat **Testing the stuck adjustment** test instructions in  #44454 

