### PR TITLE
Add summer special sticker to the get site endpoint

### DIFF
--- a/projects/plugins/jetpack/changelog/update-add-summer-special-to-site-endpoint
+++ b/projects/plugins/jetpack/changelog/update-add-summer-special-to-site-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Add promotional sticker to the get site endpoint

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -208,7 +208,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'was_created_with_blank_canvas_design',
 		'videopress_storage_used',
 		'is_difm_lite_in_progress',
-		'is_summer_special_2005',
+		'is_summer_special_2025',
 		'site_intent',
 		'site_partner_bundle',
 		'onboarding_segment',
@@ -886,8 +886,8 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 				case 'is_difm_lite_in_progress':
 					$options[ $key ] = $site->is_difm_lite_in_progress();
 					break;
-				case 'is_summer_special_2005':
-					$options[ $key ] = $site->is_summer_special_2005();
+				case 'is_summer_special_2025':
+					$options[ $key ] = $site->is_summer_special_2025();
 					break;
 				case 'site_intent':
 					$options[ $key ] = $site->get_site_intent();

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -208,6 +208,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'was_created_with_blank_canvas_design',
 		'videopress_storage_used',
 		'is_difm_lite_in_progress',
+		'is_summer_special_2005',
 		'site_intent',
 		'site_partner_bundle',
 		'onboarding_segment',
@@ -884,6 +885,9 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 					break;
 				case 'is_difm_lite_in_progress':
 					$options[ $key ] = $site->is_difm_lite_in_progress();
+					break;
+				case 'is_summer_special_2005':
+					$options[ $key ] = $site->is_summer_special_2005();
 					break;
 				case 'site_intent':
 					$options[ $key ] = $site->get_site_intent();

--- a/projects/plugins/jetpack/sal/class.json-api-site-base.php
+++ b/projects/plugins/jetpack/sal/class.json-api-site-base.php
@@ -1514,16 +1514,16 @@ abstract class SAL_Site {
 	}
 
 	/**
-	 * Check if the site has the summer-special-2005 blog sticker.
+	 * Check if the site has the summer-special-2025 blog sticker.
 	 *
 	 * @return bool
 	 */
-	public function is_summer_special_2005() {
+	public function is_summer_special_2025() {
 		if ( function_exists( 'has_blog_sticker' ) ) {
-			return has_blog_sticker( 'summer-special-2005' );
+			return has_blog_sticker( 'summer-special-2025' );
 		} elseif ( function_exists( 'wpcomsh_is_site_sticker_active' ) ) {
 			// For atomic sites
-			return wpcomsh_is_site_sticker_active( 'summer-special-2005' );
+			return wpcomsh_is_site_sticker_active( 'summer-special-2025' );
 		}
 		return false;
 	}

--- a/projects/plugins/jetpack/sal/class.json-api-site-base.php
+++ b/projects/plugins/jetpack/sal/class.json-api-site-base.php
@@ -1514,6 +1514,21 @@ abstract class SAL_Site {
 	}
 
 	/**
+	 * Check if the site has the summer-special-2005 blog sticker.
+	 *
+	 * @return bool
+	 */
+	public function is_summer_special_2005() {
+		if ( function_exists( 'has_blog_sticker' ) ) {
+			return has_blog_sticker( 'summer-special-2005' );
+		} elseif ( function_exists( 'wpcomsh_is_site_sticker_active' ) ) {
+			// For atomic sites
+			return wpcomsh_is_site_sticker_active( 'summer-special-2005' );
+		}
+		return false;
+	}
+
+	/**
 	 * Get the option of site intent which value is coming from the Hero Flow
 	 *
 	 * @return string


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add a is_summer_special_2005 option similar to the is_difm_lite_in_progress. It's based on a blog sticker and would indicate the participation in the promotion

We initially did that with an active promotion but sites subject to the promotion will have to remain with that sticker permanently so the permanent status of the change makes it inappropriate to use the active promotion endpoint.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Use https://github.com/Automattic/wp-calypso/pull/104888 for the front-end or simply apply the change to your sandbox (test with a simple site) and then
* Reload the /plans page
* The response should include the is_summer_special_2005 option - you can try adding a blog sticker 'summer-special-2025' to see that it changes from false to true
<img width="1076" height="329" alt="Screenshot 2025-07-29 at 11 32 14" src="https://github.com/user-attachments/assets/35721bcc-f0c1-4178-972a-f30c4a7b64ce" />

