### PR TITLE
Proxy open state for the Help Center

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/dotcom-14020-help-center-persist-the-minimized-state-along-with-the-open
+++ b/projects/packages/jetpack-mu-wpcom/changelog/dotcom-14020-help-center-persist-the-minimized-state-along-with-the-open
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+WPCOM: proxy Help Center minimized state requests

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-wp-rest-help-center-persisted-open-state.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-wp-rest-help-center-persisted-open-state.php
@@ -64,10 +64,12 @@ class WP_REST_Help_Center_Persisted_Open_State extends \WP_REST_Controller {
 		$response = json_decode( wp_remote_retrieve_body( $body ) );
 
 		$is_open        = $response->help_center_open ?? false;
+		$is_minimized   = $response->help_center_minimized ?? false;
 		$router_history = $response->help_center_router_history ?? null;
 
 		$projected_response = array(
 			'help_center_open'           => (bool) $is_open,
+			'help_center_minimized'      => (bool) $is_minimized,
 			'help_center_router_history' => $router_history,
 		);
 
@@ -82,6 +84,7 @@ class WP_REST_Help_Center_Persisted_Open_State extends \WP_REST_Controller {
 	public function set_state( \WP_REST_Request $request ) {
 		$state          = $request['help_center_open'];
 		$router_history = $request['help_center_router_history'];
+		$minimized      = $request['help_center_minimized'];
 
 		$data = array(
 			'calypso_preferences' => array(),
@@ -93,6 +96,10 @@ class WP_REST_Help_Center_Persisted_Open_State extends \WP_REST_Controller {
 
 		if ( $request->has_param( 'help_center_router_history' ) ) {
 			$data['calypso_preferences']['help_center_router_history'] = $router_history;
+		}
+
+		if ( $request->has_param( 'help_center_minimized' ) ) {
+			$data['calypso_preferences']['help_center_minimized'] = $minimized;
 		}
 
 		$body = Client::wpcom_json_api_request_as_user(
@@ -110,11 +117,13 @@ class WP_REST_Help_Center_Persisted_Open_State extends \WP_REST_Controller {
 
 		$is_open        = $response->calypso_preferences->help_center_open ?? false;
 		$router_history = $response->calypso_preferences->help_center_router_history ?? null;
+		$is_minimized   = $response->calypso_preferences->help_center_minimized ?? false;
 
 		$projected_response = array(
 			'calypso_preferences' => array(
 				'help_center_open'           => (bool) $is_open,
 				'help_center_router_history' => $router_history,
+				'help_center_minimized'      => (bool) $is_minimized,
 			),
 		);
 


### PR DESCRIPTION
Fixes: https://linear.app/a8c/issue/DOTCOM-14020/help-center-persist-the-minimized-state-along-with-the-open-state

## Proposed changes:
- Proxy minimized state as well from user preferences.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:

1. Check out the branch from [this PR](https://github.com/Automattic/wp-calypso/pull/104945).
2. In Calypso, cd into `wp-calypso/apps` and run `yarn dev --sync`.
3. Sync this Jetpack PR to an Atomic site.
4. Sandbox widgets.wp.com.
5. Open the Help Center.
6. Minimized it.
7. Refresh the page.
8. It should stay minimized.