### PR TITLE
Boost: Ensure pending Optimization message appears immediately when enabling LCP

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/features/lcp/lcp.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/lcp/lcp.tsx
@@ -3,11 +3,13 @@ import Pill from '$features/ui/pill/pill';
 import { recordBoostEvent } from '$lib/utils/analytics';
 import RefreshIcon from '$svg/refresh';
 import { Button } from '@automattic/jetpack-components';
+import { queryClient } from '@automattic/jetpack-react-data-sync-client';
 import { __ } from '@wordpress/i18n';
-import styles from './status/status.module.scss';
 import { useLcpState, useOptimizeLcpAction } from './lib/stores/lcp-state';
-import Status from './status/status';
+import { LcpState } from './lib/stores/lcp-state-types';
 import { ErrorDetails } from './status/error-details';
+import Status from './status/status';
+import styles from './status/status.module.scss';
 
 const Lcp = () => {
 	const [ query ] = useLcpState();
@@ -18,6 +20,16 @@ const Lcp = () => {
 	const handleEnable = () => {
 		// Refetch the lcp State as when the module is enabled, the Analyzer will start running.
 		query.refetch();
+	};
+
+	const handleBeforeToggle = ( newStatus: boolean ) => {
+		if ( newStatus ) {
+			// Ensure that the state is optimistically set to pending when the module is enabled.
+			queryClient.setQueryData( [ 'lcp_state' ], ( lcp: LcpState ) => ( {
+				...lcp,
+				status: 'pending',
+			} ) );
+		}
 	};
 
 	const handleClickOptimize = () => {
@@ -44,6 +56,7 @@ const Lcp = () => {
 				</p>
 			}
 			onEnable={ handleEnable }
+			onBeforeToggle={ handleBeforeToggle }
 		>
 			<div className={ styles.status }>
 				<div className={ styles.summary }>

--- a/projects/plugins/boost/changelog/fix-boost-lcp-optimistic-update-firing-HOG-227
+++ b/projects/plugins/boost/changelog/fix-boost-lcp-optimistic-update-firing-HOG-227
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+LCP Optimization: Ensure pending Optimization message appears immediately when enabling Optimize LCP Images


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes [HOG-227: Boost: Ensure that LCP Optimization status is updated when module toggled](https://linear.app/a8c/issue/HOG-227/boost-ensure-that-lcp-optimization-status-is-updated-when-module)

## Proposed changes:
* When users enable the "Optimize LCP Images" toggle, the interface now immediately shows a "pending" state instead of the "not_analyzed" fallback state

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
No

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
### Prerequisites
Ensure there is no LCP state existing already in your environment by running the following query:
```sql
DELETE FROM `wp_options` WHERE `option_name` LIKE '%lcp%';
```

### Before
1. Go to Jetpack Boost admin page
2. Scroll to "Optimize LCP Images" module 
3. Enable the toggle
4. **Bug**: Notice the brief "not_analyzed" state appears before changing to "pending"

### After  
1. Go to Jetpack Boost admin page
2. Scroll to "Optimize LCP Images" module
3. Enable the toggle
4. **Fixed**: Immediately see "pending" state with no intermediate "not_analyzed" flash

