### PR TITLE
Forms: Fix form id computing

### DIFF
--- a/projects/packages/forms/changelog/fix-form-id-assignment
+++ b/projects/packages/forms/changelog/fix-form-id-assignment
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Forms: Fix how form id is calcualted

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -36,6 +36,13 @@ class Contact_Form_Plugin {
 	public $current_widget_id;
 
 	/**
+	 * The Sidebar ID of the sidebar currently being processed.  Used to build the unique contact-form ID for forms embedded in sidebars.
+	 *
+	 * @var string
+	 */
+	public $current_sidebar_id;
+
+	/**
 	 * If the contact form field is being used.
 	 *
 	 * @var bool
@@ -175,9 +182,8 @@ class Contact_Form_Plugin {
 
 		// While generating the output of a text widget with a contact-form shortcode, we need to know its widget ID.
 		add_action( 'dynamic_sidebar', array( $this, 'track_current_widget' ) );
-
-		// Add a "widget" shortcode attribute to all contact-form shortcodes embedded in widgets
-		add_filter( 'widget_text', array( $this, 'widget_atts' ), 0 );
+		add_action( 'dynamic_sidebar_before', array( $this, 'track_current_widget_before' ) );
+		add_action( 'dynamic_sidebar_after', array( $this, 'track_current_widget_after' ) );
 
 		// If Text Widgets don't get shortcode processed, hack ours into place.
 		if (
@@ -1554,6 +1560,39 @@ class Contact_Form_Plugin {
 	 */
 	public function track_current_widget( $widget ) {
 		$this->current_widget_id = $widget['id'];
+	}
+
+	/**
+	 * Tracks the sidebar currently being processed.
+	 * Attached to `dynamic_sidebar_before`
+	 *
+	 * @see $current_sidebar_id - the current sidebar ID.
+	 *
+	 * @param string $index The sidebar index.
+	 */
+	public function track_current_widget_before( $index ) {
+		$this->current_sidebar_id = $index;
+	}
+
+	/**
+	 * Clear the current widget context.
+	 */
+	public function track_current_widget_after() {
+		$this->current_sidebar_id = '';
+		$this->current_widget_id  = '';
+	}
+
+	/**
+	 * Gets the current widget context.
+	 *
+	 * @return string The current widget context or false if not set.
+	 */
+	public function get_current_widget_context() {
+		// If we don't have a current widget ID or sidebar ID, we
+		if ( empty( $this->current_widget_id ) || empty( $this->current_sidebar_id ) ) {
+			return '';
+		}
+		return $this->current_widget_id . '-' . $this->current_sidebar_id;
 	}
 
 	/**

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -133,33 +133,12 @@ class Contact_Form extends Contact_Form_Shortcode {
 		}
 
 		if ( $set_id ) {
-			$is_widget = false;
-
-			if ( ! empty( $attributes['widget'] ) && $attributes['widget'] ) {
-				$attributes['id'] = 'widget-' . $attributes['widget'];
-				$is_widget        = true;
-			} elseif ( ! empty( $attributes['block_template'] ) && $attributes['block_template'] ) {
-				$attributes['id'] = 'block-template-' . $attributes['block_template'];
-			} elseif ( ! empty( $attributes['block_template_part'] ) && $attributes['block_template_part'] ) {
-				$attributes['id'] = 'block-template-part-' . $attributes['block_template_part'];
-			} elseif ( $this->current_post ) {
-				$attributes['id'] = $this->current_post->ID;
-			}
-
-			if ( ! empty( self::$forms ) && ! $is_widget ) {
-				// Ensure 'id' exists in $attributes before trying to modify it
-				if ( ! isset( $attributes['id'] ) ) {
-					$attributes['id'] = '';
-				}
-
-				// When submitting the page number is not always set, so we need to handle that: TODO: This is a hack, we need to find a better way to handle form identification
-				$page_num = max( 1, intval( $page ) );
-
-				$attributes['id'] = $attributes['id'] . '-' . ( count( self::$forms ) + 1 ) . '-' . $page_num;
-			}
+			$attributes['id'] = self::compute_id( $attributes, $this->current_post, $page );
 		}
-		$this->hash                 = sha1( wp_json_encode( $attributes ) );
-		self::$forms[ $this->hash ] = $this;
+		$this->hash = sha1( wp_json_encode( $attributes ) );
+		if ( $set_id ) {
+			self::$forms[ $this->hash ] = $this; // This increments the form count.
+		}
 
 		// Keep reference to $this for parsing form fields.
 		self::$current_form = $this;
@@ -240,6 +219,45 @@ class Contact_Form extends Contact_Form_Shortcode {
 		$form->has_verified_jwt = true;
 		return $form;
 	}
+
+	/**
+	 * Compute the ID for the contact form based on the attributes and post.
+	 *
+	 * @param array        $attributes The attributes of the contact form.
+	 * @param WP_Post|null $post The post object, if available.
+	 * @param int          $page_number The page number, if available.
+	 *
+	 * @return string The ID for the contact form.
+	 */
+	public static function compute_id( $attributes, $post = null, $page_number = 1 ) {
+		$id_part = array();
+		if ( ! empty( $attributes['widget'] ) && $attributes['widget'] ) {
+			$id_part[] = 'widget-' . $attributes['widget'];
+		} elseif ( ! empty( $attributes['block_template'] ) && $attributes['block_template'] ) {
+			$id_part[] = 'block-template-' . $attributes['block_template'];
+		} elseif ( ! empty( $attributes['block_template_part'] ) && $attributes['block_template_part'] ) {
+			$id_part[] = 'block-template-part-' . $attributes['block_template_part'];
+		} elseif ( $post instanceof WP_Post ) {
+			$id_part[] = $post->ID;
+		}
+
+		if ( self::get_forms_count() > 0 ) {
+			$id_part[] = self::get_forms_count();
+		}
+
+		$page_num = max( 1, intval( $page_number ) );
+		if ( $page_num > 1 ) {
+			$id_part[] = $page_num;
+		}
+
+		if ( empty( $id_part ) ) {
+			// If no ID part is set, we use a default value.
+			$id_part[] = 'jp-form'; // Default ID part.
+		}
+
+		return implode( '-', $id_part );
+	}
+
 	/**
 	 * Helper function to get the secret from the Tokens class.
 	 *
@@ -421,6 +439,8 @@ class Contact_Form extends Contact_Form_Shortcode {
 		if ( is_singular() ) {
 			add_action( 'admin_bar_menu', array( __CLASS__, 'add_quick_link_to_admin_bar' ), 100 ); // We use priority 100 so that the link that is added gets added after the "Edit Page" link.
 		}
+		$plugin               = Contact_Form_Plugin::init();
+		$attributes['widget'] = $plugin->get_current_widget_context();
 		// Create a new Contact_Form object (this class)
 		$form = new Contact_Form( $attributes, $content );
 		Contact_Form_Plugin::reset_step();

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -68,6 +68,14 @@ class Contact_Form extends Contact_Form_Shortcode {
 	public static $forms = array();
 
 	/**
+	 * The context for the forms, indexed by context.
+	 * This is used to keep track of how many forms are in a specific context.
+	 *
+	 * @var array
+	 */
+	public static $forms_context = array();
+
+	/**
 	 * Whether to print the grunion.css style when processing the contact-form shortcode
 	 *
 	 * @var bool
@@ -136,8 +144,10 @@ class Contact_Form extends Contact_Form_Shortcode {
 			$attributes['id'] = self::compute_id( $attributes, $this->current_post, $page );
 		}
 		$this->hash = sha1( wp_json_encode( $attributes ) );
+
 		if ( $set_id ) {
 			self::$forms[ $this->hash ] = $this; // This increments the form count.
+			self::increment_form_context_count( $attributes, $this->current_post );
 		}
 
 		// Keep reference to $this for parsing form fields.
@@ -221,6 +231,55 @@ class Contact_Form extends Contact_Form_Shortcode {
 	}
 
 	/**
+	 * Get the context for the contact form based on the attributes and post.
+	 *
+	 * @param array        $attributes The attributes of the contact form.
+	 * @param WP_Post|null $post The post object, if available.
+	 *
+	 * @return string The context for the contact form.
+	 */
+	public static function get_context( $attributes, $post = null ) {
+		$context = 'jp-form';
+		if ( ! empty( $attributes['widget'] ) && $attributes['widget'] ) {
+			$context = 'widget-' . $attributes['widget'];
+		} elseif ( ! empty( $attributes['block_template'] ) && $attributes['block_template'] ) {
+			$context = 'block-template-' . $attributes['block_template'];
+		} elseif ( ! empty( $attributes['block_template_part'] ) && $attributes['block_template_part'] ) {
+			$context = 'block-template-part-' . $attributes['block_template_part'];
+		} elseif ( $post instanceof WP_Post ) {
+			$context = (string) $post->ID;
+		}
+
+		return $context;
+	}
+
+	/**
+	 * Increment the count of forms for a specific context.
+	 *
+	 * @param array        $attributes The attributes of the contact form.
+	 * @param WP_Post|null $post The post object, if available.
+	 *
+	 * @return void
+	 */
+	public static function increment_form_context_count( $attributes, $post ) {
+		$context = self::get_context( $attributes, $post );
+		if ( ! isset( self::$forms_context[ $context ] ) ) {
+			self::$forms_context[ $context ] = 1;
+			return;
+		}
+		self::$forms_context[ $context ] = self::get_forms_context_count( $context ) + 1;
+	}
+
+	/**
+	 * Get the count of forms.
+	 *
+	 * @return int The count of forms.
+	 */
+	public static function get_forms_count() {
+		return count( self::$forms );
+	}
+
+	/**
 	 * Compute the ID for the contact form based on the attributes and post.
 	 *
 	 * @param array        $attributes The attributes of the contact form.
@@ -230,29 +289,17 @@ class Contact_Form extends Contact_Form_Shortcode {
 	 * @return string The ID for the contact form.
 	 */
 	public static function compute_id( $attributes, $post = null, $page_number = 1 ) {
-		$id_part = array();
-		if ( ! empty( $attributes['widget'] ) && $attributes['widget'] ) {
-			$id_part[] = 'widget-' . $attributes['widget'];
-		} elseif ( ! empty( $attributes['block_template'] ) && $attributes['block_template'] ) {
-			$id_part[] = 'block-template-' . $attributes['block_template'];
-		} elseif ( ! empty( $attributes['block_template_part'] ) && $attributes['block_template_part'] ) {
-			$id_part[] = 'block-template-part-' . $attributes['block_template_part'];
-		} elseif ( $post instanceof WP_Post ) {
-			$id_part[] = $post->ID;
-		}
 
-		if ( self::get_forms_count() > 0 ) {
-			$id_part[] = self::get_forms_count();
+		$context = self::get_context( $attributes, $post );
+		$id_part = array( $context );
+
+		if ( self::get_forms_context_count( $context ) > 0 ) {
+			$id_part[] = self::get_forms_context_count( $context );
 		}
 
 		$page_num = max( 1, intval( $page_number ) );
 		if ( $page_num > 1 ) {
 			$id_part[] = $page_num;
-		}
-
-		if ( empty( $id_part ) ) {
-			// If no ID part is set, we use a default value.
-			$id_part[] = 'jp-form'; // Default ID part.
 		}
 
 		return implode( '-', $id_part );
@@ -299,13 +346,21 @@ class Contact_Form extends Contact_Form_Shortcode {
 			self::get_secret()
 		);
 	}
+
 	/**
 	 * Get the count of forms.
 	 *
+	 * @param string $context The context for which to get the count of forms.
+	 *
 	 * @return int The count of forms.
 	 */
-	public static function get_forms_count() {
-		return count( self::$forms );
+	public static function get_forms_context_count( $context ) {
+		if ( ! isset( self::$forms_context[ $context ] ) ) {
+			self::$forms_context[ $context ] = 0;
+			return 0;
+		}
+
+		return self::$forms_context[ $context ];
 	}
 
 	/**

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -3121,12 +3121,6 @@ EOT;
 		$form1 = new Contact_Form( $attributes1, '', false );
 		$id1   = $form1->get_attribute( 'id' );
 
-		$attributes1 = array(
-			'to'      => 'test1@example.com',
-			'subject' => 'Test Subject 1',
-			'id'      => 'form-1',
-		);
-
 		$form2 = new Contact_Form( $attributes1, '', false );
 		$id2   = $form2->get_attribute( 'id' );
 
@@ -3331,5 +3325,61 @@ EOT;
 
 		$this->assertIsString( $computed_id, 'Computed ID should handle array attributes' );
 		$this->assertNotEmpty( $computed_id, 'Computed ID should not be empty with array attributes' );
+	}
+
+	public function test_test_context_in_form_id_creation() {
+
+		$attributes   = array();
+		$post_post_id = wp_insert_post(
+			array(
+				'post_title'   => 'First Test Post',
+				'post_content' => 'First test content',
+				'post_status'  => 'publish',
+				'post_author'  => $this->post->post_author,
+			),
+			true
+		);
+		$post         = get_post( $post_post_id );
+
+		$form_id = Contact_Form::compute_id( $attributes, $post );
+		Contact_Form::increment_form_context_count( $attributes, $post );
+		$this->assertStringContainsString( (string) $post_post_id, $form_id, 'Form ID should contain the post ID of the first post' );
+
+		$form_id_2 = Contact_Form::compute_id( $attributes, $post );
+		$this->assertStringContainsString( (string) $post_post_id, $form_id_2, 'Form ID should contain the post ID of the first post' );
+		$this->assertNotEquals( $form_id, $form_id_2, 'Form IDs should be different for different instances' );
+
+		$second_post_id = wp_insert_post(
+			array(
+				'post_title'   => 'Second Test Post',
+				'post_content' => 'Second test content',
+				'post_status'  => 'publish',
+				'post_author'  => $this->post->post_author,
+			),
+			true
+		);
+		$second_post    = get_post( $second_post_id );
+
+		$form_id_3 = Contact_Form::compute_id( $attributes, $second_post );
+		Contact_Form::increment_form_context_count( $attributes, $second_post );
+
+		$this->assertStringContainsString( (string) $second_post_id, $form_id_3, 'Form ID should contain the post ID of the second post' );
+
+		$form_id_4 = Contact_Form::compute_id( $attributes, $second_post );
+		$this->assertStringContainsString( (string) $second_post_id, $form_id_4, 'Form ID should contain the post ID of the second post' );
+		$this->assertNotEquals( $form_id_3, $form_id_4, 'Form IDs should be different for different instances' );
+
+		$attributes['widget'] = 'sidebar';
+
+		$form_id_5 = Contact_Form::compute_id( $attributes, $second_post );
+		Contact_Form::increment_form_context_count( $attributes, $second_post );
+		$this->assertStringContainsString( 'widget-sidebar', $form_id_5, 'Form ID should contain the post ID of the second post' );
+
+		$form_id_6 = Contact_Form::compute_id( $attributes, $second_post );
+		$this->assertStringContainsString( 'widget-sidebar', $form_id_6, 'Form ID should contain the post ID of the second post' );
+		$this->assertNotEquals( $form_id_5, $form_id_6, 'Form IDs should be different for different instances' );
+
+		// Assert that we have 6 unique form ids.
+		$this->assertCount( 6, array_unique( array( $form_id, $form_id_2, $form_id_3, $form_id_4, $form_id_5, $form_id_6 ) ), 'There should be 6 unique forms' );
 	}
 }

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -2690,7 +2690,7 @@ EOT;
 				'name'    => 'First form name 2',
 				'message' => 'First form message 2',
 			),
-			'g' . $post->ID . '-2-1' // The 2 here is the count and 1 is now always set for page number which in this case is 1.
+			'g' . $post->ID . '-1' // The 2 here is the count and 1 is now always set for page number which in this case is 1.
 		);
 
 		$form2   = new Contact_Form( array(), "[contact-field label='Name' type='name' required='1'/][contact-field label='Message' type='textarea' required='1'/]" );
@@ -2997,24 +2997,339 @@ EOT;
 
 		Constants::clear_single_constant( 'JETPACK_BLOG_TOKEN' );
 	}
+	/**
+	 * Test compute_id method with basic attributes
+	 */
+	public function test_compute_id_with_basic_attributes() {
+		global $post;
 
-	public function test_get_forms_count() {
-		$form = new Contact_Form(
-			array(
-				'to'      => 'test@email.com',
-				'subject' => 'Test Form',
-			)
-		);
-		$this->assertInstanceOf( Contact_Form::class, $form, 'Form should be a Contact_Form instance after creation' );
-		$this->assertSame( 1, Contact_Form::get_forms_count(), 'Forms count should be 1 after first form creation' );
-		$form = new Contact_Form(
-			array(
-				'to'      => 'test@email.com',
-				'subject' => 'Test Form',
-			)
+		$attributes = array(
+			'to'      => 'test@example.com',
+			'subject' => 'Test Subject',
 		);
 
-		$this->assertInstanceOf( Contact_Form::class, $form, 'Form should be a Contact_Form instance after creation' );
-		$this->assertEquals( 2, Contact_Form::get_forms_count(), 'Forms count should be 2 after second form creation' );
+		$computed_id = Contact_Form::compute_id( $attributes, $post );
+
+		$this->assertIsString( $computed_id, 'Computed ID should be a string' );
+		$this->assertNotEmpty( $computed_id, 'Computed ID should not be empty' );
+		$this->assertStringContainsString( (string) $post->ID, $computed_id, 'Computed ID should contain post ID' );
 	}
-} // end class
+
+	/**
+	 * Test compute_id method with null post
+	 */
+	public function test_compute_id_with_null_post() {
+		$attributes = array(
+			'to'      => 'test@example.com',
+			'subject' => 'Test Subject',
+		);
+
+		$computed_id = Contact_Form::compute_id( $attributes, null );
+		$this->assertIsString( $computed_id, 'Computed ID should be a string' );
+		$this->assertNotEmpty( $computed_id, 'Computed ID should not be empty' );
+		$this->assertStringNotContainsString( (string) $this->post->ID, $computed_id, 'Computed ID should not contain post ID when post is null' );
+	}
+
+	/**
+	 * Test compute_id method with widget attribute
+	 */
+	public function test_compute_id_with_widget_attribute() {
+		global $post;
+
+		$attributes = array(
+			'to'     => 'test@example.com',
+			'widget' => 'sidebar-1',
+		);
+
+		$computed_id = Contact_Form::compute_id( $attributes, $post );
+
+		$this->assertIsString( $computed_id, 'Computed ID should be a string' );
+		$this->assertStringContainsString( 'widget', $computed_id, 'Widget form ID should contain "widget"' );
+		$this->assertStringContainsString( 'sidebar-1', $computed_id, 'Widget form ID should contain widget ID' );
+	}
+
+	/**
+	 * Test compute_id method with different page numbers
+	 */
+	public function test_compute_id_with_different_page_numbers() {
+		global $post;
+
+		$attributes = array(
+			'to'      => 'test@example.com',
+			'subject' => 'Test Subject',
+		);
+
+		$id_page_1 = Contact_Form::compute_id( $attributes, $post, 1 );
+		$id_page_2 = Contact_Form::compute_id( $attributes, $post, 2 );
+
+		$this->assertNotEquals( $id_page_1, $id_page_2, 'IDs should be different for different page numbers' );
+		$this->assertEquals( $post->ID, $id_page_1, 'Page 1 ID should match post ID' );
+		$this->assertEquals( $post->ID . '-2', $id_page_2, 'Page 2 ID should match post ID' );
+	}
+
+	/**
+	 * Test compute_id method generates consistent IDs
+	 */
+	public function test_compute_id_generates_consistent_ids() {
+		global $post;
+
+		$attributes = array(
+			'to'      => 'test@example.com',
+			'subject' => 'Test Subject',
+		);
+
+		$id1 = Contact_Form::compute_id( $attributes, $post, 1 );
+		$id2 = Contact_Form::compute_id( $attributes, $post, 1 );
+
+		$this->assertEquals( $id1, $id2, 'Same attributes should generate same ID' );
+	}
+
+	/**
+	 * Test compute_id method with different attributes generates different IDs
+	 */
+	public function test_compute_id_with_different_attributes_generates_different_ids() {
+		$attributes1 = array(
+			'to'      => 'test1@example.com',
+			'subject' => 'Test Subject 1',
+		);
+
+		$form1 = new Contact_Form( $attributes1 );
+		$id1   = $form1->get_attribute( 'id' );
+
+		$attributes2 = array(
+			'to'      => 'test2@example.com',
+			'subject' => 'Test Subject 2',
+		);
+
+		$form2 = new Contact_Form( $attributes2 );
+		$id2   = $form2->get_attribute( 'id' );
+
+		$this->assertNotEquals( $id1, $id2, 'Different form objects should generate equals ID if the match is IDs' );
+	}
+
+	/**
+	 * Test compute_id method with different attributes generates different IDs
+	 */
+	public function test_contact_form_constructor_set_id_parameter() {
+
+		$attributes1 = array(
+			'to'      => 'test1@example.com',
+			'subject' => 'Test Subject 1',
+			'id'      => 'form-1',
+		);
+
+		$form1 = new Contact_Form( $attributes1, '', false );
+		$id1   = $form1->get_attribute( 'id' );
+
+		$attributes1 = array(
+			'to'      => 'test1@example.com',
+			'subject' => 'Test Subject 1',
+			'id'      => 'form-1',
+		);
+
+		$form2 = new Contact_Form( $attributes1, '', false );
+		$id2   = $form2->get_attribute( 'id' );
+
+		$this->assertEquals( 'form-1', $id1, 'If you pass false for the 3rd parameter, the ID should match the one provided in the attributes' );
+		$this->assertEquals( 'form-1', $id2, 'If you pass false for the 3rd parameter, the ID should match the one provided in the attributes' );
+	}
+
+	/**
+	 * Test compute_id method with empty attributes
+	 */
+	public function test_compute_id_with_empty_attributes() {
+		global $post;
+
+		$attributes = array();
+
+		$computed_id = Contact_Form::compute_id( $attributes, $post );
+
+		$this->assertIsString( $computed_id, 'Computed ID should be a string even with empty attributes' );
+		$this->assertNotEmpty( $computed_id, 'Computed ID should not be empty even with empty attributes' );
+	}
+
+	/**
+	 * Test compute_id method with special characters in attributes
+	 */
+	public function test_compute_id_with_special_characters() {
+		global $post;
+
+		$attributes = array(
+			'to'      => 'test+special@example.com',
+			'subject' => 'Test Subject with "quotes" and symbols!@#$%',
+		);
+
+		$computed_id = Contact_Form::compute_id( $attributes, $post );
+
+		$this->assertIsString( $computed_id, 'Computed ID should handle special characters' );
+		$this->assertNotEmpty( $computed_id, 'Computed ID should not be empty with special characters' );
+	}
+
+	/**
+	 * Test compute_id method with form count increment
+	 */
+	public function test_compute_id_with_form_count_increment() {
+		global $post;
+
+		// Reset forms count for consistent testing
+		Contact_Form::$forms = array();
+
+		$attributes = array(
+			'to'      => 'test@example.com',
+			'subject' => 'Test Subject',
+		);
+
+		// Create first form to increment count
+		$id1   = Contact_Form::compute_id( $attributes, $post );
+		$form1 = new Contact_Form( $attributes );
+
+		// Create second form to increment count again
+		$id2   = Contact_Form::compute_id( $attributes, $post );
+		$form2 = new Contact_Form( $attributes );
+
+		$id3 = Contact_Form::compute_id( $attributes, $post );
+		$id4 = Contact_Form::compute_id( $attributes, $post );
+
+		$this->assertNotEquals( $id1, $id2, 'IDs should be different when form count increases' );
+		$this->assertEquals( $id1, $form1->get_attribute( 'id' ), 'IDs should match the form object' );
+		$this->assertEquals( $id2, $form2->get_attribute( 'id' ), 'IDs should match the form object' );
+		$this->assertEquals( 2, Contact_Form::get_forms_count(), 'Forms count should be 2 after second form creation' );
+		$this->assertEquals( $id3, $id4, "IDs should match since calling the function should't have side effects" );
+	}
+
+	/**
+	 * Test compute_id method with block template attributes
+	 */
+	public function test_compute_id_with_block_template_attributes() {
+		global $post;
+
+		$attributes = array(
+			'to'                  => 'test@example.com',
+			'block_template'      => 'contact-template',
+			'block_template_part' => 'header-part',
+		);
+
+		$computed_id = Contact_Form::compute_id( $attributes, $post );
+
+		$this->assertIsString( $computed_id, 'Computed ID should handle block template attributes' );
+		$this->assertNotEmpty( $computed_id, 'Computed ID should not be empty with block template attributes' );
+	}
+
+	/**
+	 * Test compute_id method with all possible attribute combinations
+	 */
+	public function test_compute_id_with_comprehensive_attributes() {
+		global $post;
+
+		$attributes = array(
+			'to'                    => 'comprehensive@example.com',
+			'subject'               => 'Comprehensive Test',
+			'widget'                => false,
+			'block_template'        => 'test-template',
+			'block_template_part'   => 'test-part',
+			'customThankyou'        => 'message',
+			'customThankyouMessage' => 'Thank you!',
+			'jetpackCRM'            => true,
+			'className'             => 'test-class',
+			'hiddenFields'          => array( 'field1' => 'value1' ),
+		);
+
+		$computed_id = Contact_Form::compute_id( $attributes, $post, 3 );
+
+		$this->assertIsString( $computed_id, 'Computed ID should handle comprehensive attributes' );
+		$this->assertNotEmpty( $computed_id, 'Computed ID should not be empty with comprehensive attributes' );
+		$this->assertStringContainsString( '-3', $computed_id, 'ID should contain page number' );
+	}
+
+	/**
+	 * Test compute_id method maintains uniqueness across different posts
+	 */
+	public function test_compute_id_uniqueness_across_posts() {
+		// Create another post for testing
+		$second_post_id = wp_insert_post(
+			array(
+				'post_title'   => 'Second Test Post',
+				'post_content' => 'Second test content',
+				'post_status'  => 'publish',
+				'post_author'  => $this->post->post_author,
+			),
+			true
+		);
+
+		$second_post = get_post( $second_post_id );
+
+		$attributes = array(
+			'to'      => 'test@example.com',
+			'subject' => 'Same Subject',
+		);
+
+		$id_post1 = Contact_Form::compute_id( $attributes, $this->post );
+		$id_post2 = Contact_Form::compute_id( $attributes, $second_post );
+
+		$this->assertNotEquals( $id_post1, $id_post2, 'Same attributes on different posts should generate different IDs' );
+
+		// Clean up
+		wp_delete_post( $second_post_id, true );
+	}
+
+	/**
+	 * Test compute_id method with numeric values in attributes
+	 */
+	public function test_compute_id_with_numeric_attributes() {
+		global $post;
+
+		$attributes = array(
+			'to'          => 'test@example.com',
+			'subject'     => 'Test Subject',
+			'widget'      => 123,
+			'some_number' => 456.789,
+		);
+
+		$computed_id = Contact_Form::compute_id( $attributes, $post );
+
+		$this->assertIsString( $computed_id, 'Computed ID should handle numeric attributes' );
+		$this->assertNotEmpty( $computed_id, 'Computed ID should not be empty with numeric attributes' );
+	}
+
+	/**
+	 * Test compute_id method with boolean attributes
+	 */
+	public function test_compute_id_with_boolean_attributes() {
+		global $post;
+
+		$attributes = array(
+			'to'         => 'test@example.com',
+			'jetpackCRM' => true,
+			'widget'     => false,
+			'required'   => true,
+		);
+
+		$computed_id = Contact_Form::compute_id( $attributes, $post );
+
+		$this->assertIsString( $computed_id, 'Computed ID should handle boolean attributes' );
+		$this->assertNotEmpty( $computed_id, 'Computed ID should not be empty with boolean attributes' );
+	}
+
+	/**
+	 * Test compute_id method with array attributes
+	 */
+	public function test_compute_id_with_array_attributes() {
+		global $post;
+
+		$attributes = array(
+			'to'             => 'test@example.com',
+			'hiddenFields'   => array(
+				'field1' => 'value1',
+				'field2' => 'value2',
+			),
+			'salesforceData' => array(
+				'organizationId' => '12345',
+			),
+		);
+
+		$computed_id = Contact_Form::compute_id( $attributes, $post );
+
+		$this->assertIsString( $computed_id, 'Computed ID should handle array attributes' );
+		$this->assertNotEmpty( $computed_id, 'Computed ID should not be empty with array attributes' );
+	}
+}

--- a/projects/packages/forms/tests/php/contact-form/class-utility.php
+++ b/projects/packages/forms/tests/php/contact-form/class-utility.php
@@ -101,31 +101,7 @@ class Utility {
 	 */
 	public static function get_form_id( $attributes = array() ) {
 		global $post, $page;
-		// Ensure 'id' exists in $attributes before trying to use it
-		if ( ! isset( $attributes['id'] ) ) {
-			$attributes['id'] = '';
-		}
-
-		$count = Contact_Form::get_forms_count();
-
-		if ( ! empty( $attributes['widget'] ) && $attributes['widget'] ) {
-			$attributes['id'] = 'widget-' . $attributes['widget'];
-		} elseif ( ! empty( $attributes['block_template'] ) && $attributes['block_template'] ) {
-
-			$attributes['id'] = 'block-template-' . $attributes['block_template'];
-		} elseif ( ! empty( $attributes['block_template_part'] ) && $attributes['block_template_part'] ) {
-			$attributes['id'] = 'block-template-part-' . $attributes['block_template_part'];
-		} elseif ( $post ) {
-			$attributes['id'] = $post->ID;
-		}
-
-		if ( $count ) {
-			// When submitting the page number is not always set, so we need to handle that: TODO: This is a hack, we need to find a better way to handle form identification
-			$page_num = max( 1, intval( $page ) );
-
-			$attributes['id'] = $attributes['id'] . '-' . ( $count + 1 ) . '-' . $page_num;
-		}
-		return $attributes['id'];
+		return Contact_Form::compute_id( $attributes, $post, $page );
 	}
 
 	public static function get_post_request( $values, $form_id = null, $post_id = 0 ) {

--- a/projects/plugins/jetpack/changelog/fix-form-id-assignment
+++ b/projects/plugins/jetpack/changelog/fix-form-id-assignment
@@ -1,0 +1,4 @@
+Significance: major
+Type: other
+
+Forms: update the way that the form id is being created for consistancy and fix bugs


### PR DESCRIPTION
Currently how we compute the form ID is not really done dynamically but it also has some bugs. 

We want to dynamically assign a form ID so that we can generate form ID that are unique on the render page. 
Since HTML shouldn't have the same ID multiple times. 

We do this by keeping a count of form objects created as well as the context that the form was created in. (does it live in a page, widget, template, what page_number of a page e

This PR improvises how the widget ID is calculated. The context is keep in the plugin object and we add it to the attributes before calling the create form object on parse. 

This PR also fixes an issue where we were creating different IDs if the post was submitted vs when we just rendered the form. We fixed this by only increment the count of forms when we render and not when we process the form submission. This is not possible because we use JWT tokens and not searching for the form in the content. 


## Proposed changes:
* Only increment the form count on rendered forms. 
* Improve context detection for forms in widgets. 
* Add testable compute_id method. 
* 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
* Add a form few different forms on the page. 
* Submit the form. Notice that all the forms have the same form id as before. 
* Add forms in widgets. But as a shortcode and as a block. Notice that they have widget specific IDs. 
* Form submissions should work as expected. 
*