### PR TITLE
Revert "P2: Use new helper function from Status\Host package for P2 checks"

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-p2-helper-function-status-host-package
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-p2-helper-function-status-host-package
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-P2: Added a helper function in the Host package and ensured any P2 check uses this.

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -9,8 +9,6 @@
 
 namespace Automattic\Jetpack;
 
-use Automattic\Jetpack\Status\Host;
-
 define( 'WPCOM_ADMIN_BAR_UNIFICATION', true );
 /**
  * Jetpack_Mu_Wpcom main class.
@@ -592,6 +590,8 @@ class Jetpack_Mu_Wpcom {
 			require_once $path_wp_for_teams;
 		}
 
+		// This covers both P2 and P2020 themes.
+		$is_p2     = str_contains( get_stylesheet(), 'pub/p2' ) || function_exists( '\WPForTeams\is_wpforteams_site' ) && is_wpforteams_site( $blog_id );
 		$is_forums = str_contains( get_stylesheet(), 'a8c/supportforums' ); // Not in /forums.
 
 		$verbum_option_enabled = get_blog_option( $blog_id, 'enable_verbum_commenting', true );
@@ -601,7 +601,7 @@ class Jetpack_Mu_Wpcom {
 		}
 
 		// Don't load any comment experience in the Reader, GlotPress, wp-admin, or P2.
-		return ( 1 === $blog_id || TRANSLATE_BLOG_ID === $blog_id || is_admin() || ( new Host() )->is_p2_site() || $is_forums );
+		return ( 1 === $blog_id || TRANSLATE_BLOG_ID === $blog_id || is_admin() || $is_p2 || $is_forums );
 	}
 
 	/**
@@ -680,8 +680,11 @@ class Jetpack_Mu_Wpcom {
 	 * @return array - The modified Jetpack script data.
 	 */
 	public static function add_jetpack_script_data_for_p2( $data ) {
-		$host = new Host();
-		if ( $host->is_p2_site() ) {
+		if (
+		str_contains( get_stylesheet(), 'pub/p2' ) ||
+		( function_exists( '\WPForTeams\is_wpforteams_site' ) && is_wpforteams_site( get_current_blog_id() ) )
+		) {
+			$host = new \Automattic\Jetpack\Status\Host();
 			if ( ! isset( $data['site']['host'] ) ) {
 				$data['site']['host'] = $host->get_known_host_guess();
 			}

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
@@ -9,7 +9,6 @@ namespace A8C\FSE;
 
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Jetpack_Mu_Wpcom\Common;
-use Automattic\Jetpack\Status\Host;
 
 /**
  * Class Help_Center
@@ -431,13 +430,14 @@ class Help_Center {
 		require_once ABSPATH . 'wp-admin/includes/screen.php';
 
 		$can_edit_posts = current_user_can( 'edit_posts' ) && is_user_member_of_blog();
+		$is_p2          = str_contains( get_stylesheet(), 'pub/p2' ) || function_exists( '\WPForTeams\is_wpforteams_site' ) && is_wpforteams_site( get_current_blog_id() );
 
 		// We will show the help center icon in the admin bar when;
 		// 1. On wp-admin
 		// 2. On the front end of the site if the current user can edit posts
 		// 3. On the front end of the site and the theme is not P2
 		// 4. If it is the frontend we show the disconnected version of the help center.
-		if ( ! is_admin() && ( ! $can_edit_posts || ( new Host() )->is_p2_site() ) ) {
+		if ( ! is_admin() && ( ! $can_edit_posts || $is_p2 ) ) {
 			return;
 		} elseif ( $this->is_loading_on_frontend() ) {
 			$variant = 'wp-admin-disconnected';

--- a/projects/packages/jetpack-mu-wpcom/src/features/holiday-snow/class-holiday-snow.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/holiday-snow/class-holiday-snow.php
@@ -48,6 +48,20 @@ class Holiday_Snow {
 	}
 
 	/**
+	 * Check if the site uses p2.
+	 * p2 is currently not compatible with Holiday Snow.
+	 * This covers both P2 and P2020 themes.
+	 *
+	 * @deprecated 6.1.0
+	 *
+	 * @return bool
+	 */
+	private static function is_p2() {
+		return str_contains( get_stylesheet(), 'pub/p2' )
+			|| function_exists( '\WPForTeams\is_wpforteams_site' ) && is_wpforteams_site( get_current_blog_id() );
+	}
+
+	/**
 	 * Check if the snow is enabled.
 	 *
 	 * @return bool

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
@@ -11,7 +11,6 @@ use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Current_Plan;
 use Automattic\Jetpack\Jetpack_Mu_Wpcom;
 use Automattic\Jetpack\Status;
-use Automattic\Jetpack\Status\Host;
 
 // The $icon-color variable for admin color schemes.
 // See: https://github.com/WordPress/wordpress-develop/blob/679cc0c4a261a77bd8fdb140cd9b0b2ff80ebf37/src/wp-admin/css/colors/_variables.scss#L9
@@ -390,13 +389,16 @@ add_action( 'admin_bar_menu', 'wpcom_edit_site_menu_override', 41 );
  */
 function wpcom_add_site_badges_and_plan( $wp_admin_bar ) {
 	// Get the current blog ID
-	$status = new Status();
+	$blog_id = get_current_blog_id();
+	$status  = new Status();
 
 	// Check for various site types
 	$badge_text = '';
 
 	// Check if this is a P2 site
-	if ( ( new Host() )->is_p2_site() ) {
+	if ( str_contains( get_stylesheet(), 'pub/p2' ) ||
+		( function_exists( '\WPForTeams\is_wpforteams_site' ) &&
+		\WPForTeams\is_wpforteams_site( $blog_id ) ) ) {
 		$badge_text = 'P2';
 	} elseif ( (bool) get_option( 'wpcom_is_staging_site' ) ) {
 		// Check for staging site

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor-nux/class-wp-rest-wpcom-block-editor-nux-status-controller.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor-nux/class-wp-rest-wpcom-block-editor-nux-status-controller.php
@@ -7,8 +7,6 @@
 
 namespace Automattic\Jetpack\Jetpack_Mu_Wpcom\NUX;
 
-use Automattic\Jetpack\Status\Host;
-
 /**
  * Class WP_REST_WPCOM_Block_Editor_NUX_Status_Controller.
  */
@@ -81,7 +79,14 @@ class WP_REST_WPCOM_Block_Editor_NUX_Status_Controller extends \WP_REST_Controll
 			$variant = 'tour';
 		}
 
-		if ( ( new Host() )->is_p2_site() ) {
+		if ( defined( 'IS_ATOMIC' ) && IS_ATOMIC ) {
+			$is_p2 = false;
+		} else {
+			$blog_id = get_current_blog_id();
+			$is_p2   = \WPForTeams\is_wpforteams_site( $blog_id );
+		}
+
+		if ( $is_p2 ) {
 			// disable welcome tour for authoring P2s.
 			// see: https://github.com/Automattic/wp-calypso/issues/62973.
 			$nux_status = 'disabled';

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor-nux/class-wpcom-block-editor-nux.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor-nux/class-wpcom-block-editor-nux.php
@@ -7,8 +7,6 @@
 
 namespace Automattic\Jetpack\Jetpack_Mu_Wpcom\NUX;
 
-use Automattic\Jetpack\Status\Host;
-
 require_once __DIR__ . '/../../utils.php';
 
 /**
@@ -67,13 +65,16 @@ class WPCOM_Block_Editor_NUX {
 			'before'
 		);
 
+		$site_id    = \Jetpack_Options::get_option( 'id' );
+		$is_p2_site = str_contains( get_stylesheet(), 'pub/p2' ) || function_exists( '\WPForTeams\is_wpforteams_site' ) && is_wpforteams_site( $site_id );
+
 		/**
 		 * Enqueue the recommended tags modal options.
 		 */
 		$recommended_tags_modal_options = wp_json_encode(
 			array(
 				'isDismissed' => WP_REST_WPCOM_Block_Editor_Recommended_Tags_Modal_Controller::get_wpcom_recommended_tags_modal_dismissed(),
-				'isP2'        => ( new Host() )->is_p2_site(),
+				'isP2'        => $is_p2_site,
 			),
 			JSON_HEX_TAG | JSON_HEX_AMP
 		);

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-command-palette/wpcom-command-palette.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-command-palette/wpcom-command-palette.php
@@ -59,8 +59,9 @@ function wpcom_load_command_palette() {
 			'in_footer' => true,
 		)
 	);
-	$site_id = Jetpack_Options::get_option( 'id' );
-	$data    = wp_json_encode(
+	$site_id    = Jetpack_Options::get_option( 'id' );
+	$is_p2_site = str_contains( get_stylesheet(), 'pub/p2' ) || function_exists( '\WPForTeams\is_wpforteams_site' ) && is_wpforteams_site( $site_id );
+	$data       = wp_json_encode(
 		array(
 			'siteId'           => $site_id,
 			'isAtomic'         => $host->is_woa_site(),
@@ -70,7 +71,7 @@ function wpcom_load_command_palette() {
 			'isPrivate'        => $jetpack_status->is_private_site(),
 			'isComingSoon'     => $jetpack_status->is_coming_soon(),
 			'capabilities'     => get_userdata( get_current_user_id() )->allcaps,
-			'isP2'             => $host->is_p2_site(),
+			'isP2'             => $is_p2_site,
 			'shouldUseWpAdmin' => 'wp-admin' === get_option( 'wpcom_admin_interface' ),
 			'siteHostname'     => wpcom_get_site_slug(),
 			'siteName'         => get_option( 'blogname' ),

--- a/projects/packages/masterbar/changelog/add-p2-helper-function-status-host-package
+++ b/projects/packages/masterbar/changelog/add-p2-helper-function-status-host-package
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-P2: Added a helper function in the Host package and ensured any P2 check uses this.

--- a/projects/packages/masterbar/src/admin-menu/load.php
+++ b/projects/packages/masterbar/src/admin-menu/load.php
@@ -83,7 +83,8 @@ function get_admin_menu_class() {
 		}
 
 		// P2 sites.
-		if ( ( new Host() )->is_p2_site() ) {
+		require_once WP_CONTENT_DIR . '/lib/wpforteams/functions.php';
+		if ( \WPForTeams\is_wpforteams_site( $blog_id ) ) {
 			require_once __DIR__ . '/class-p2-admin-menu.php';
 			return P2_Admin_Menu::class;
 		}

--- a/projects/packages/status/changelog/add-p2-helper-function-status-host-package
+++ b/projects/packages/status/changelog/add-p2-helper-function-status-host-package
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-P2: Added a helper function in the Host package and ensured any P2 check uses this.

--- a/projects/packages/status/src/class-host.php
+++ b/projects/packages/status/src/class-host.php
@@ -79,34 +79,6 @@ class Host {
 	}
 
 	/**
-	 * Determine if this is a P2 site.
-	 * This covers both P2 and P2020 themes.
-	 *
-	 * @return bool
-	 */
-	public function is_p2_site() {
-		$site_id = $this->get_wpcom_site_id();
-		if ( ! $site_id ) {
-			return false;
-		}
-		return str_contains( get_stylesheet(), 'pub/p2' ) || ( function_exists( '\WPForTeams\is_wpforteams_site' ) && is_wpforteams_site( $site_id ) );
-	}
-
-	/**
-	 * Get the current site's WordPress.com ID.
-	 *
-	 * @return mixed The site's WordPress.com ID.
-	 */
-	public function get_wpcom_site_id() {
-		if ( $this->is_wpcom_simple() ) {
-			return get_current_blog_id();
-		} elseif ( class_exists( 'Jetpack' ) && \Jetpack::is_connection_ready() ) {
-			return \Jetpack_Options::get_option( 'id' );
-		}
-		return false;
-	}
-
-	/**
 	 * Add all wordpress.com environments to the safe redirect allowed list.
 	 *
 	 * To be used with a filter of allowed domains for a redirect.

--- a/projects/packages/status/src/class-modules.php
+++ b/projects/packages/status/src/class-modules.php
@@ -27,7 +27,7 @@ class Modules {
 	 * @return bool
 	 */
 	public function is_active( $module, $available_only = true ) {
-		if ( ( new Host() )->is_wpcom_simple() ) {
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
 			return true;
 		}
 

--- a/projects/plugins/jetpack/changelog/add-p2-helper-function-status-host-package
+++ b/projects/plugins/jetpack/changelog/add-p2-helper-function-status-host-package
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-P2: Added a helper function in the Host package and ensured any P2 check uses this. 

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -40,7 +40,8 @@ function register_block() {
 	/*
 	 * Disable the feature on P2 blogs
 	 */
-	if ( ( new Host() )->is_p2_site() ) {
+	if ( function_exists( '\WPForTeams\is_wpforteams_site' ) &&
+		\WPForTeams\is_wpforteams_site( get_current_blog_id() ) ) {
 		return;
 	}
 


### PR DESCRIPTION
Reverts Automattic/jetpack#44333

This PR is a revert of the above PR.

See p1753716923108359-slack-C01U2KGS2PQ for more context.

In short, this primarily helps prevent issues due to third party plugins using copies of the Status package which were not automatically updated. Those older versions of the Status package were referenced, resulting in fatal errors.