### PR TITLE
WP Cloud: Add basic check to verify the loaded `wpcomsh` isn't breaking things

### DIFF
--- a/.github/workflows/wpcloud.yml
+++ b/.github/workflows/wpcloud.yml
@@ -147,7 +147,7 @@ jobs:
             if [[ $CODE -ne 0 ]]; then
               echo 'Unable to load site! Something is wrong with the site.'
             else
-              echo 'No issues slurping site with `curl`.
+              echo 'No issues slurping site with `curl`.'
             fi
           fi
           echo "::endgroup::"

--- a/.github/workflows/wpcloud.yml
+++ b/.github/workflows/wpcloud.yml
@@ -139,7 +139,7 @@ jobs:
           if [[ $CODE -ne 0 ]]; then
             echo 'Unable to run a basic `wp` command! Something is wrong with the site.'
           elif [[ ! "$SITE_URL" =~ ^https?://[a-z0-9_.-]+$ ]]; then
-            echo 'Site URL retrieved doesn't seem to be a URL.'
+            echo 'Site URL retrieved does not seem to be a URL.'
             CODE=1
           else
             curl -s --fail "$SITE_URL" > /dev/null || CODE=$?

--- a/.github/workflows/wpcloud.yml
+++ b/.github/workflows/wpcloud.yml
@@ -134,8 +134,15 @@ jobs:
 
           # Do a basic check to verify the site is loading
           echo "::group::Verify things load"
-          CODE=0
-          ssh jpwpcomsh "wp option get start_of_week" > /dev/null || CODE=$?
+          SITE_URL=$(ssh jpwpcomsh "wp option get siteurl" 2>/dev/null)
+          CODE=$?
+          if [[ $CODE -ne 0 ]]; then
+            echo 'Unable to run a basic `wp` command! Something is wrong with the site.'
+          else
+            curl -s --fail "$SITE_URL" > /dev/null
+            CODE=$?
+            [[ $CODE -ne 0 ]] && echo 'Unable to load site! Something is wrong with the site.'
+          fi
           echo "::endgroup::"
 
           # Proceed with tests if all seems well
@@ -145,8 +152,6 @@ jobs:
             scp projects/plugins/wpcomsh/phpunit.9.xml.dist jpwpcomsh:/srv/htdocs/wp-content/mu-plugins/wpcomsh/phpunit.xml.dist
             ssh jpwpcomsh "/srv/htdocs/wp-content/mu-plugins/wpcomsh/bin/run-phpunit-tests.sh" || CODE=$?
             echo "::endgroup::"
-          else
-            echo 'Unable to run a basic `wp` command! Something is wrong with the site.'
           fi
 
           echo "::group::teardown"

--- a/.github/workflows/wpcloud.yml
+++ b/.github/workflows/wpcloud.yml
@@ -134,13 +134,15 @@ jobs:
 
           # Do a basic check to verify the site is loading
           echo "::group::Verify things load"
-          SITE_URL=$(ssh jpwpcomsh "wp option get siteurl" 2>/dev/null)
-          CODE=$?
+          CODE=0
+          SITE_URL=$(ssh jpwpcomsh "wp option get siteurl" 2>/dev/null) || CODE=$?
           if [[ $CODE -ne 0 ]]; then
             echo 'Unable to run a basic `wp` command! Something is wrong with the site.'
+          elif [[ ! "$SITE_URL" =~ ^https?://[a-z0-9_.-]+$ ]]; then
+            echo 'Site URL retrieved doesn't seem to be a URL.'
+            CODE=1
           else
-            curl -s --fail "$SITE_URL" > /dev/null
-            CODE=$?
+            curl -s --fail "$SITE_URL" > /dev/null || CODE=$?
             [[ $CODE -ne 0 ]] && echo 'Unable to load site! Something is wrong with the site.'
           fi
           echo "::endgroup::"

--- a/.github/workflows/wpcloud.yml
+++ b/.github/workflows/wpcloud.yml
@@ -102,8 +102,7 @@ jobs:
 
       - name: Configure Github to be able to SSH to the WP Cloud site
         run: |
-          echo "::group::Intializing"
-
+          echo "::group::Initializing"
           mkdir -vp ~/.ssh/
           chmod -v 700 ~/.ssh
 
@@ -122,24 +121,33 @@ jobs:
           echo "  User wpcom-jetpackisbestpack-default-237778992" >> ~/.ssh/config
           echo "  IdentityFile ~/.ssh/id_site" >> ~/.ssh/config
           echo "  IdentitiesOnly yes" >> ~/.ssh/config
-
           echo "::endgroup::"
 
           echo "::group::Transferring wpcomsh to the testing server"
-          ssh jpwpcomsh "wp --skip-plugins --skip-themes dereferenced freshen > /dev/null 2>&1" || CODE=$?
-          echo "wp dereferenced freshen has exited with code $CODE"
+          # This can give errors if the previous state was broken, so ignore them
+          ssh jpwpcomsh "wp --skip-plugins --skip-themes dereferenced freshen > /dev/null 2>&1" || echo "wp dereferenced freshen has exited with code $?"
           ssh jpwpcomsh "rm -rf /tmp/old-* > /dev/null 2>&1"
-          pnpm jetpack rsync --non-interactive wpcomsh jpwpcomsh:~/htdocs/wp-content/mu-plugins
+          pnpm jetpack rsync --non-interactive wpcomsh jpwpcomsh:/srv/htdocs/wp-content/mu-plugins
           scp -r projects/plugins/wpcomsh/bin jpwpcomsh:/srv/htdocs/wp-content/mu-plugins/wpcomsh/
           scp -r projects/plugins/wpcomsh/tests jpwpcomsh:/srv/htdocs/wp-content/mu-plugins/wpcomsh/
-          # The test on WP Cloud won't use `phpunit-select-config`, so select config manually.
-          scp projects/plugins/wpcomsh/phpunit.9.xml.dist jpwpcomsh:/srv/htdocs/wp-content/mu-plugins/wpcomsh/phpunit.xml.dist
-
           echo "::endgroup::"
 
-          echo "::group::execution"
-          ssh jpwpcomsh "/srv/htdocs/wp-content/mu-plugins/wpcomsh/bin/run-phpunit-tests.sh" || CODE=$?
+          # Do a basic check to verify the site is loading
+          echo "::group::Verify things load"
+          CODE=0
+          ssh jpwpcomsh "wp option get start_of_week" > /dev/null || CODE=$?
           echo "::endgroup::"
+
+          # Proceed with tests if all seems well
+          if [[ $CODE -eq 0 ]]; then
+            echo "::group::Run PHPUnit tests"
+            # The test on WP Cloud won't use `phpunit-select-config`, so select config manually.
+            scp projects/plugins/wpcomsh/phpunit.9.xml.dist jpwpcomsh:/srv/htdocs/wp-content/mu-plugins/wpcomsh/phpunit.xml.dist
+            ssh jpwpcomsh "/srv/htdocs/wp-content/mu-plugins/wpcomsh/bin/run-phpunit-tests.sh" || CODE=$?
+            echo "::endgroup::"
+          else
+            echo 'Unable to run a basic `wp` command! Something is wrong with the site.'
+          fi
 
           echo "::group::teardown"
           rm -rvf ~/.ssh/

--- a/.github/workflows/wpcloud.yml
+++ b/.github/workflows/wpcloud.yml
@@ -142,8 +142,13 @@ jobs:
             echo 'Site URL retrieved does not seem to be a URL.'
             CODE=1
           else
+            echo 'No issues using a simple command in WP-CLI.'
             curl -s --fail "$SITE_URL" > /dev/null || CODE=$?
-            [[ $CODE -ne 0 ]] && echo 'Unable to load site! Something is wrong with the site.'
+            if [[ $CODE -ne 0 ]]; then
+              echo 'Unable to load site! Something is wrong with the site.'
+            else
+              echo 'No issues slurping site with `curl`.
+            fi
           fi
           echo "::endgroup::"
 


### PR DESCRIPTION
Closes MONOREP-42

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Right now we run PHPUnit tests against wpcomsh + WP Cloud's Jetpack version. This can catch some stuff, but there's no basic check to make sure the site itself loads.

For now we add the following as rudimentary checks for catastrophic failure:
* a `wp` command to get the site URL (which bootstraps WP and would often fail if plugins trigger a 500)
* a `curl` to the site

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Does the code make sense?
