### PR TITLE
Social: Fix reshare UX without user connection

### DIFF
--- a/projects/js-packages/publicize-components/changelog/fix-social-reshare-ux-without-user-connection
+++ b/projects/js-packages/publicize-components/changelog/fix-social-reshare-ux-without-user-connection
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed bad UX for Social modal for resharing without user connection.

--- a/projects/js-packages/publicize-components/src/components/social-post-modal/settings-section.tsx
+++ b/projects/js-packages/publicize-components/src/components/social-post-modal/settings-section.tsx
@@ -1,3 +1,4 @@
+import { getMyJetpackUrl } from '@automattic/jetpack-script-data';
 import { Panel } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
@@ -9,6 +10,7 @@ import { useSchedulePost } from '../../hooks/use-schedule-post';
 import useSocialMediaConnections from '../../hooks/use-social-media-connections';
 import { store as socialStore } from '../../social-store';
 import { SharePostForm } from '../form/share-post-form';
+import Notice from '../notice';
 import ScheduleButton from '../schedule-button';
 import { SharePostButton } from '../share-post';
 import { ScheduledShares } from './scheduled-shares';
@@ -64,6 +66,16 @@ export function SettingsSection( { onReShared } ) {
 					) }
 				</p>
 				<SharePostForm analyticsData={ { location: 'preview-modal' } } />
+				<Notice type={ 'warning' }>
+					{ __(
+						'You must connect your WordPress.com account to be able to re-share posts.',
+						'jetpack-publicize-components'
+					) }
+					&nbsp;
+					<a href={ getMyJetpackUrl( '#/connection' ) }>
+						{ __( 'Connect now', 'jetpack-publicize-components' ) }
+					</a>
+				</Notice>
 				{ isPostPublished && ! isRePublicizeUpgradableViaUpsell && (
 					<div className={ styles[ 'share-actions' ] }>
 						<ScheduleButton

--- a/projects/js-packages/publicize-components/src/components/social-post-modal/settings-section.tsx
+++ b/projects/js-packages/publicize-components/src/components/social-post-modal/settings-section.tsx
@@ -28,7 +28,7 @@ export function SettingsSection( { onReShared } ) {
 	const isSavingPost = useSelect( select => select( editorStore ).isSavingPost(), [] );
 	const postId = useSelect( select => select( editorStore ).getCurrentPostId(), [] );
 
-	const { isRePublicizeUpgradableViaUpsell } = usePublicizeConfig();
+	const { isRePublicizeUpgradableViaUpsell, needsUserConnection } = usePublicizeConfig();
 	const isReSharingPossible = useIsReSharingPossible();
 	const { enabledConnections } = useSocialMediaConnections();
 
@@ -66,16 +66,18 @@ export function SettingsSection( { onReShared } ) {
 					) }
 				</p>
 				<SharePostForm analyticsData={ { location: 'preview-modal' } } />
-				<Notice type={ 'warning' }>
-					{ __(
-						'You must connect your WordPress.com account to be able to re-share posts.',
-						'jetpack-publicize-components'
-					) }
-					&nbsp;
-					<a href={ getMyJetpackUrl( '#/connection' ) }>
-						{ __( 'Connect now', 'jetpack-publicize-components' ) }
-					</a>
-				</Notice>
+				{ needsUserConnection && (
+					<Notice type={ 'warning' }>
+						{ __(
+							'You must connect your WordPress.com account to be able to re-share posts.',
+							'jetpack-publicize-components'
+						) }
+						&nbsp;
+						<a href={ getMyJetpackUrl( '#/connection' ) }>
+							{ __( 'Connect now', 'jetpack-publicize-components' ) }
+						</a>
+					</Notice>
+				) }
 				{ isPostPublished && ! isRePublicizeUpgradableViaUpsell && (
 					<div className={ styles[ 'share-actions' ] }>
 						<ScheduleButton

--- a/projects/js-packages/publicize-components/src/components/social-post-modal/settings-section.tsx
+++ b/projects/js-packages/publicize-components/src/components/social-post-modal/settings-section.tsx
@@ -1,5 +1,5 @@
 import { getMyJetpackUrl } from '@automattic/jetpack-script-data';
-import { Panel } from '@wordpress/components';
+import { Notice, Panel } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { __, _x } from '@wordpress/i18n';
@@ -10,7 +10,6 @@ import { useSchedulePost } from '../../hooks/use-schedule-post';
 import useSocialMediaConnections from '../../hooks/use-social-media-connections';
 import { store as socialStore } from '../../social-store';
 import { SharePostForm } from '../form/share-post-form';
-import Notice from '../notice';
 import ScheduleButton from '../schedule-button';
 import { SharePostButton } from '../share-post';
 import { ScheduledShares } from './scheduled-shares';
@@ -67,15 +66,21 @@ export function SettingsSection( { onReShared } ) {
 				</p>
 				<SharePostForm analyticsData={ { location: 'preview-modal' } } />
 				{ needsUserConnection && (
-					<Notice type={ 'warning' }>
+					<Notice
+						status={ 'warning' }
+						isDismissible={ false }
+						actions={ [
+							{
+								url: getMyJetpackUrl( '#/connection' ),
+								label: __( 'Connect now', 'jetpack-publicize-components' ),
+								variant: 'link',
+							},
+						] }
+					>
 						{ __(
 							'You must connect your WordPress.com account to be able to re-share posts.',
 							'jetpack-publicize-components'
 						) }
-						&nbsp;
-						<a href={ getMyJetpackUrl( '#/connection' ) }>
-							{ __( 'Connect now', 'jetpack-publicize-components' ) }
-						</a>
 					</Notice>
 				) }
 				{ isPostPublished && ! isRePublicizeUpgradableViaUpsell && (

--- a/projects/js-packages/publicize-components/src/hooks/use-is-resharing-possible/index.ts
+++ b/projects/js-packages/publicize-components/src/hooks/use-is-resharing-possible/index.ts
@@ -16,13 +16,18 @@ import useSharePost from '../use-share-post';
  * @return {boolean} Whether re-sharing is possible.
  */
 export function useIsReSharingPossible() {
-	const { isPublicizeEnabled } = usePublicizeConfig();
+	const { isPublicizeEnabled, needsUserConnection } = usePublicizeConfig();
 	const isSharingPossible = useIsSharingPossible();
 	const { isFetching } = useSharePost();
 
 	const { isCurrentPostPublished: isPostPublished, isSavingPost } = useSelect( editorStore, [] );
 
 	return (
-		isPublicizeEnabled && isSharingPossible && ! isFetching && isPostPublished() && ! isSavingPost()
+		isPublicizeEnabled &&
+		isSharingPossible &&
+		! isFetching &&
+		isPostPublished() &&
+		! isSavingPost() &&
+		! needsUserConnection
 	);
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of SOCIAL-121

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Updated the `useIsReSharingPossible` hook to take user connection into consideration

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?


## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

On trunk
* Create a shared connection with admin account
* Create an editor account and switch to it
* Try sharing a post with that accoun on the global connection, it should work. Try resharing it, you should see this after clicking share in the modal:
<img width="2938" height="2026" alt="CleanShot 2025-07-29 at 10 05 44 png" src="https://github.com/user-attachments/assets/c5a92667-3240-4e45-a90c-9e9df2ef865f" />

With this patch:
- The buttons should be disabled, and you should see a notice with an action to connect the account

<img width="1886" height="1590" alt="CleanShot 2025-07-29 at 11 22 25 png" src="https://github.com/user-attachments/assets/9183dbf8-f8f8-4c5c-9db4-eac452275e80" />


