### PR TITLE
Forms: Add option to select MailPoet list

### DIFF
--- a/projects/packages/forms/changelog/add-mailpoet-lists-endpoint
+++ b/projects/packages/forms/changelog/add-mailpoet-lists-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: Add mailpoet/lists endpoint.

--- a/projects/packages/forms/src/blocks/contact-form/attributes.js
+++ b/projects/packages/forms/src/blocks/contact-form/attributes.js
@@ -44,8 +44,12 @@ export default {
 			sendToSalesforce: false,
 		},
 	},
-	connectMailPoet: {
-		type: 'boolean',
-		default: false,
+	mailpoet: {
+		type: 'object',
+		default: {
+			enabledForForm: false,
+			listId: null,
+			listName: null,
+		},
 	},
 };

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/active-integrations/index.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/active-integrations/index.js
@@ -32,7 +32,7 @@ export default function ActiveIntegrations( { integrations, attributes, isLoadin
 				}
 				break;
 			case 'mailpoet':
-				if ( integration.isActive && attributes.connectMailPoet ) {
+				if ( integration.isActive && attributes.mailpoet?.enabledForForm ) {
 					acc.push( {
 						...integration,
 						icon: <MailPoetOrangeIcon width={ 30 } height={ 30 } />,

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/index.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/index.tsx
@@ -98,7 +98,7 @@ const IntegrationsModal = ( {
 						onToggle={ () => toggleCard( 'mailpoet' ) }
 						data={ findIntegrationById( 'mailpoet' ) }
 						refreshStatus={ refreshIntegrations }
-						connectMailPoet={ attributes.connectMailPoet }
+						mailpoet={ attributes.mailpoet }
 						setAttributes={ setAttributes }
 					/>
 				) }

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/style.scss
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/style.scss
@@ -123,11 +123,7 @@
 		padding-top: 8px;
 		padding-bottom: 24px;
 		padding-left: 60px; // this is to align with the row above's icon + gap (44 + 16)
-		padding-right: 0;
-
-		:last-child {
-			margin-bottom: 0;
-		}
+		padding-right: 20px;
 
 		@media (max-width: 782px) {
 			padding-left: 46px;

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/style.scss
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/style.scss
@@ -90,9 +90,12 @@
 		color: var(--jp-gray-50);
 		font-size: 13px;
 		line-height: 1.5;
-		margin-top: 0;
 		width: 100%;
 		order: 3;
+
+		&:first-of-type {
+			margin-top: 0;
+		}
 
 		@media (max-width: 782px) {
 			text-wrap: balance;
@@ -123,10 +126,11 @@
 		padding-top: 8px;
 		padding-bottom: 24px;
 		padding-left: 60px; // this is to align with the row above's icon + gap (44 + 16)
-		padding-right: 20px;
+		padding-right: 40px;
 
 		@media (max-width: 782px) {
 			padding-left: 46px;
+			padding-right: 20px;
 		}
 	}
 

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/mailpoet-card.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/mailpoet-card.tsx
@@ -1,5 +1,10 @@
-import { Button, ExternalLink, __experimentalHStack as HStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
-import { createInterpolateElement } from '@wordpress/element';
+import {
+	Button,
+	ExternalLink,
+	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+	SelectControl,
+} from '@wordpress/components';
+import { createInterpolateElement, useEffect, useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import MailPoetIcon from '../../../../icons/mailpoet';
 import IntegrationCard from './integration-card';
@@ -16,6 +21,8 @@ interface MailPoetCardProps extends SingleIntegrationCardProps {
 	} ) => void;
 }
 
+type MailPoetList = { id: string; name: string };
+
 const MailPoetCard = ( {
 	isExpanded,
 	onToggle,
@@ -29,6 +36,44 @@ const MailPoetCard = ( {
 		settingsUrl = '',
 		marketingUrl = '',
 	} = data || {};
+
+	const mailpoetLists: MailPoetList[] = useMemo(
+		() => ( Array.isArray( data?.details?.lists ) ? ( data.details.lists as MailPoetList[] ) : [] ),
+		[ data?.details?.lists ]
+	);
+
+	useEffect( () => {
+		if ( ! mailpoet.enabledForForm ) {
+			return;
+		}
+
+		// If there are no lists, clear the selection
+		if ( mailpoetLists.length === 0 ) {
+			if ( mailpoet.listId || mailpoet.listName ) {
+				setAttributes( {
+					mailpoet: {
+						...mailpoet,
+						listId: null,
+						listName: null,
+					},
+				} );
+			}
+			return;
+		}
+
+		// If no list is selected, or the selected list no longer exists, set to the first available
+		const listIsValid =
+			mailpoet.listId && mailpoetLists.some( list => list.id === mailpoet.listId );
+		if ( ! listIsValid ) {
+			setAttributes( {
+				mailpoet: {
+					...mailpoet,
+					listId: mailpoetLists[ 0 ].id,
+					listName: mailpoetLists[ 0 ].name,
+				},
+			} );
+		}
+	}, [ mailpoet, mailpoetLists, setAttributes ] );
 
 	const cardData: IntegrationCardData = {
 		...data,
@@ -54,7 +99,6 @@ const MailPoetCard = ( {
 			'jetpack-forms'
 		),
 	};
-
 	return (
 		<IntegrationCard
 			title={ __( 'MailPoet Email Marketing', 'jetpack-forms' ) }
@@ -98,12 +142,35 @@ const MailPoetCard = ( {
 				</div>
 			) : (
 				<div>
+					{ mailpoetLists?.length ? (
+						<SelectControl
+							label={ __( 'Which MailPoet list should contacts be added to?', 'jetpack-forms' ) }
+							value={ mailpoet.listId }
+							options={ mailpoetLists.map( list => ( { label: list.name, value: list.id } ) ) }
+							onChange={ value => {
+								const selected = mailpoetLists.find( l => l.id === value );
+								setAttributes( {
+									mailpoet: {
+										...mailpoet,
+										listId: selected?.id ?? null,
+										listName: selected?.name ?? null,
+									},
+								} );
+							} }
+						/>
+					) : (
+						<p className="integration-card__description">
+							{ __(
+								'You do not have any MailPoet lists yet. Click the dashboard button below to create one, or contacts will be added to a "Jetpack Forms Subscribers" list.',
+								'jetpack-forms'
+							) }
+						</p>
+					) }
 					<p className="integration-card__description">
-						{ __( 'You can now send marketing emails with MailPoet.', 'jetpack-forms' ) }
+						<Button variant="link" href={ settingsUrl } target="_blank" rel="noopener noreferrer">
+							{ __( 'View MailPoet dashboard', 'jetpack-forms' ) }
+						</Button>
 					</p>
-					<Button variant="link" href={ settingsUrl } target="_blank" rel="noopener noreferrer">
-						{ __( 'View MailPoet dashboard', 'jetpack-forms' ) }
-					</Button>
 				</div>
 			) }
 		</IntegrationCard>

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/mailpoet-card.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/mailpoet-card.tsx
@@ -6,14 +6,20 @@ import IntegrationCard from './integration-card';
 import type { SingleIntegrationCardProps, IntegrationCardData } from '../../../../types';
 
 interface MailPoetCardProps extends SingleIntegrationCardProps {
-	connectMailPoet: boolean;
-	setAttributes: ( attrs: { connectMailPoet: boolean } ) => void;
+	mailpoet: {
+		enabledForForm: boolean;
+		listId?: string | null;
+		listName?: string | null;
+	};
+	setAttributes: ( attrs: {
+		mailpoet: { enabledForForm: boolean; listId?: string | null; listName?: string | null };
+	} ) => void;
 }
 
 const MailPoetCard = ( {
 	isExpanded,
 	onToggle,
-	connectMailPoet,
+	mailpoet,
 	setAttributes,
 	data,
 	refreshStatus,
@@ -27,9 +33,10 @@ const MailPoetCard = ( {
 	const cardData: IntegrationCardData = {
 		...data,
 		showHeaderToggle: true,
-		headerToggleValue: connectMailPoet ?? false,
+		headerToggleValue: mailpoet?.enabledForForm ?? false,
 		isHeaderToggleEnabled: true,
-		onHeaderToggleChange: ( value: boolean ) => setAttributes( { connectMailPoet: value } ),
+		onHeaderToggleChange: ( value: boolean ) =>
+			setAttributes( { mailpoet: { ...mailpoet, enabledForForm: value } } ),
 		isLoading: ! data || typeof data.isInstalled === 'undefined',
 		refreshStatus,
 		trackEventName: 'jetpack_forms_upsell_mailpoet_click',

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/mailpoet-card.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/mailpoet-card.tsx
@@ -101,7 +101,7 @@ const MailPoetCard = ( {
 	};
 	return (
 		<IntegrationCard
-			title={ __( 'MailPoet Email Marketing', 'jetpack-forms' ) }
+			title={ __( 'MailPoet email marketing', 'jetpack-forms' ) }
 			description={ __(
 				'Send newsletters and marketing emails directly from your site.',
 				'jetpack-forms'
@@ -143,21 +143,25 @@ const MailPoetCard = ( {
 			) : (
 				<div>
 					{ mailpoetLists?.length ? (
-						<SelectControl
-							label={ __( 'Which MailPoet list should contacts be added to?', 'jetpack-forms' ) }
-							value={ mailpoet.listId }
-							options={ mailpoetLists.map( list => ( { label: list.name, value: list.id } ) ) }
-							onChange={ value => {
-								const selected = mailpoetLists.find( l => l.id === value );
-								setAttributes( {
-									mailpoet: {
-										...mailpoet,
-										listId: selected?.id ?? null,
-										listName: selected?.name ?? null,
-									},
-								} );
-							} }
-						/>
+						<p className="integration-card__description">
+							<SelectControl
+								label={ __( 'Which MailPoet list should contacts be added to?', 'jetpack-forms' ) }
+								value={ mailpoet.listId }
+								options={ mailpoetLists.map( list => ( { label: list.name, value: list.id } ) ) }
+								onChange={ value => {
+									const selected = mailpoetLists.find( l => l.id === value );
+									setAttributes( {
+										mailpoet: {
+											...mailpoet,
+											listId: selected?.id ?? null,
+											listName: selected?.name ?? null,
+										},
+									} );
+								} }
+								__next40pxDefaultSize={ true }
+								__nextHasNoMarginBottom={ true }
+							/>
+						</p>
 					) : (
 						<p className="integration-card__description">
 							{ __(
@@ -167,9 +171,9 @@ const MailPoetCard = ( {
 						</p>
 					) }
 					<p className="integration-card__description">
-						<Button variant="link" href={ settingsUrl } target="_blank" rel="noopener noreferrer">
+						<ExternalLink href={ settingsUrl }>
 							{ __( 'View MailPoet dashboard', 'jetpack-forms' ) }
-						</Button>
+						</ExternalLink>
 					</p>
 				</div>
 			) }

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -187,17 +187,6 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 				),
 			)
 		);
-
-		// MailPoet: List all lists
-		register_rest_route(
-			$this->namespace,
-			$this->rest_base . '/mailpoet/lists',
-			array(
-				'methods'             => \WP_REST_Server::READABLE,
-				'callback'            => array( $this, 'get_mailpoet_lists' ),
-				'permission_callback' => array( $this, 'get_items_permissions_check' ),
-			)
-		);
 	}
 
 	/**
@@ -956,19 +945,11 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 						$response['isConnected'] = (bool) $checker->isMailPoetAPIKeyValid( false ); // @phan-suppress-current-line PhanUndeclaredClassMethod -- we're checking the method exists first
 					}
 				}
+				// Add MailPoet lists to details
+				$response['details']['lists'] = MailPoet_Integration::get_all_lists();
 				break;
 		}
 
 		return $response;
-	}
-
-	/**
-	 * REST callback for /mailpoet-lists
-	 *
-	 * @return WP_REST_Response
-	 */
-	public function get_mailpoet_lists() {
-		$lists = MailPoet_Integration::get_all_lists();
-		return rest_ensure_response( $lists );
 	}
 }

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -10,6 +10,7 @@ namespace Automattic\Jetpack\Forms\ContactForm;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch;
 use Automattic\Jetpack\Forms\Service\Google_Drive;
+use Automattic\Jetpack\Forms\Service\MailPoet_Integration;
 use Automattic\Jetpack\Redirect;
 use Automattic\Jetpack\Status\Host;
 use WP_Error;
@@ -184,6 +185,17 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 						'default'  => 'trash',
 					),
 				),
+			)
+		);
+
+		// MailPoet: List all lists
+		register_rest_route(
+			$this->namespace,
+			$this->rest_base . '/mailpoet/lists',
+			array(
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_mailpoet_lists' ),
+				'permission_callback' => array( $this, 'get_items_permissions_check' ),
 			)
 		);
 	}
@@ -948,5 +960,15 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 		}
 
 		return $response;
+	}
+
+	/**
+	 * REST callback for /mailpoet-lists
+	 *
+	 * @return WP_REST_Response
+	 */
+	public function get_mailpoet_lists() {
+		$lists = MailPoet_Integration::get_all_lists();
+		return rest_ensure_response( $lists );
 	}
 }

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -169,7 +169,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 			'customThankyouMessage'  => __( 'Thank you for your submission!', 'jetpack-forms' ), // The message to show when customThankyou is set to 'message'.
 			'customThankyouRedirect' => '', // The URL to redirect to when customThankyou is set to 'redirect'.
 			'jetpackCRM'             => true, // Whether Jetpack CRM should store the form submission.
-			'connectMailPoet'        => false, // Whether to send contact to MailPoet.
+			'mailpoet'               => null,
 			'className'              => null,
 			'postToUrl'              => null,
 			'salesforceData'         => null,

--- a/projects/packages/forms/src/service/class-mailpoet-integration.php
+++ b/projects/packages/forms/src/service/class-mailpoet-integration.php
@@ -190,8 +190,8 @@ class MailPoet_Integration {
 
 		// Get listId and listName from the mailpoet attribute
 		$mailpoet_attr = is_array( $form->attributes['mailpoet'] ) ? $form->attributes['mailpoet'] : array();
-		$list_id       = isset( $mailpoet_attr['listId'] ) ? $mailpoet_attr['listId'] : null;
-		$list_name     = isset( $mailpoet_attr['listName'] ) ? $mailpoet_attr['listName'] : null;
+		$list_id       = $mailpoet_attr['listId'] ?? null;
+		$list_name     = $mailpoet_attr['listName'] ?? null;
 
 		$list_id = self::get_or_create_list_id( $mailpoet_api, $list_id, $list_name );
 		if ( ! $list_id ) {

--- a/projects/packages/forms/src/service/class-mailpoet-integration.php
+++ b/projects/packages/forms/src/service/class-mailpoet-integration.php
@@ -151,7 +151,7 @@ class MailPoet_Integration {
 			return;
 		}
 
-		if ( empty( $form->attributes['connectMailPoet'] ) ) {
+		if ( empty( $form->attributes['mailpoet']['enabledForForm'] ?? null ) ) {
 			return;
 		}
 

--- a/projects/packages/forms/src/service/class-mailpoet-integration.php
+++ b/projects/packages/forms/src/service/class-mailpoet-integration.php
@@ -37,27 +37,54 @@ class MailPoet_Integration {
 	 * Get or create a MailPoet list for Jetpack Forms.
 	 *
 	 * @param mixed       $mailpoet_api The MailPoet API instance.
-	 * @param string|null $list_name Optional. The name of the list to get or create. Defaults to 'Jetpack Form Subscribers'.
+	 * @param string|null $list_id Optional. The ID of the list to use if it exists.
+	 * @param string|null $list_name Optional. The name of the list to create if no ID is provided. Defaults to 'Jetpack Form Subscribers'.
 	 * @return string|null List ID or null on failure.
 	 */
-	protected static function get_or_create_list_id( $mailpoet_api, $list_name = null ) {
+	protected static function get_or_create_list_id( $mailpoet_api, $list_id = null, $list_name = null ) {
+		// 1. If listId is provided, check if it exists
+		if ( $list_id ) {
+			try {
+				$lists = $mailpoet_api->getLists();
+				foreach ( $lists as $list ) {
+					if ( $list['id'] === $list_id && empty( $list['deleted_at'] ) ) {
+						return $list['id'];
+					}
+				}
+			} catch ( \Exception $e ) { // phpcs:ignore Squiz.PHP.EmptyCatchComment,Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+				// Intentionally empty: fall through to next step
+			}
+		}
+
+		// 2. If listName is provided, create a new list
+		if ( $list_name ) {
+			try {
+				$new_list = $mailpoet_api->addList(
+					array(
+						'name'        => $list_name,
+						'description' => 'Created by Jetpack Forms',
+					)
+				);
+				return $new_list['id'];
+			} catch ( \Exception $e ) { // phpcs:ignore Squiz.PHP.EmptyCatchComment,Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+				// Intentionally empty: fall through to default
+			}
+		}
+
+		// 3. Fallback: use or create the default list
 		$default_list_name        = 'Jetpack Form Subscribers';
 		$default_list_description = 'Subscribers from Jetpack Forms';
-		$list_name                = $list_name ? $list_name : $default_list_name;
-		$list_description         = $list_name === $default_list_name ? $default_list_description : $list_name;
 		try {
 			$lists = $mailpoet_api->getLists();
-			// Look for an existing list with the given name (not deleted)
 			foreach ( $lists as $list ) {
-				if ( $list['name'] === $list_name && empty( $list['deleted_at'] ) ) {
+				if ( $list['name'] === $default_list_name && empty( $list['deleted_at'] ) ) {
 					return $list['id'];
 				}
 			}
-			// Not found, create it
 			$new_list = $mailpoet_api->addList(
 				array(
-					'name'        => $list_name,
-					'description' => $list_description,
+					'name'        => $default_list_name,
+					'description' => $default_list_description,
 				)
 			);
 			return $new_list['id'];
@@ -161,7 +188,12 @@ class MailPoet_Integration {
 			return;
 		}
 
-		$list_id = self::get_or_create_list_id( $mailpoet_api );
+		// Get listId and listName from the mailpoet attribute
+		$mailpoet_attr = is_array( $form->attributes['mailpoet'] ) ? $form->attributes['mailpoet'] : array();
+		$list_id       = isset( $mailpoet_attr['listId'] ) ? $mailpoet_attr['listId'] : null;
+		$list_name     = isset( $mailpoet_attr['listName'] ) ? $mailpoet_attr['listName'] : null;
+
+		$list_id = self::get_or_create_list_id( $mailpoet_api, $list_id, $list_name );
 		if ( ! $list_id ) {
 			// Could not get or create the list; bail out.
 			return;

--- a/projects/packages/forms/src/service/class-mailpoet-integration.php
+++ b/projects/packages/forms/src/service/class-mailpoet-integration.php
@@ -72,8 +72,8 @@ class MailPoet_Integration {
 		}
 
 		// 3. Fallback: use or create the default list
-		$default_list_name        = 'Jetpack Form Subscribers';
-		$default_list_description = 'Subscribers from Jetpack Forms';
+		$default_list_name        = 'Jetpack Forms';
+		$default_list_description = __( 'Subscribers from Jetpack Forms', 'jetpack-forms' );
 		try {
 			$lists = $mailpoet_api->getLists();
 			foreach ( $lists as $list ) {

--- a/projects/packages/forms/src/service/class-mailpoet-integration.php
+++ b/projects/packages/forms/src/service/class-mailpoet-integration.php
@@ -175,4 +175,21 @@ class MailPoet_Integration {
 
 		self::add_subscriber_to_list( $mailpoet_api, $list_id, $subscriber_data );
 	}
+
+	/**
+	 * Get all MailPoet lists.
+	 *
+	 * @return array List of MailPoet lists, or empty array on failure.
+	 */
+	public static function get_all_lists() {
+		$mailpoet_api = self::get_api();
+		if ( ! $mailpoet_api ) {
+			return array();
+		}
+		try {
+			return $mailpoet_api->getLists();
+		} catch ( \Exception $e ) {
+			return array();
+		}
+	}
 }

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -2468,7 +2468,7 @@ EOT;
 				'hiddenField2' => 'value2',
 			), // Hidden fields to include in the form.
 			'stepTransition'         => 'fade-slide',
-			'connectMailPoet'        => false,
+			'mailpoet'               => '',
 		);
 		// Add a widget ID to the attributes for testing.
 		$expected_attributes                        = $attributes;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes [FORMS-233](https://linear.app/a8c/issue/FORMS-233/forms-provide-mailpoet-list-options)

**Feature flag:** All MailPoet integration remains behind a feature flag which is false by default. Enable the feature flag with: `add_filter( 'jetpack_forms_mailpoet_enable', '__return_true' );`

## Proposed changes:

Improves our MailPoet integration by fetching all MailPoet lists and displaying them in the block editor integrations modal so users can select which list to add form submission contacts to.

**Choose a MailPoet list**
<img width="712" height="473" alt="mailpoet-with-lists" src="https://github.com/user-attachments/assets/8f24ba23-765a-48ae-81c5-8a1a3dfe73ca" />

**If there are are no MailPoet lists**
<img width="711" height="544" alt="mailpoet-no-lists" src="https://github.com/user-attachments/assets/4017b7a8-f4ce-4604-92ba-6b0862f7baba" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* **Enable feature flag:** Enable the MailPoet feature flag with: `add_filter( 'jetpack_forms_mailpoet_enable', '__return_true' );`
* **Get MailPoet key:** To test, you will need to get a free MailPoet key. Create a free account at https://account.mailpoet.com.
* **Add Form:** Add a form to a page. Be sure to include at least an "Email" field. You can also try adding "First Name" and "Last Name".
* **Enable MailPoet for the form:** If needed, install and activate MailPoet from the modal. Add your key. Then enable MailPoet by turning on the toggle on the MailPoet card header. 
* **Test list selection and submission:** Confirm you see a select dropdown with available MailPoet lists. Select one to add contacts to. Save your form, submit it on the frontend, and confirm you contact is added to the selected list. 
* **Try adding more lists:** Add more MailPoet lists. Then refresh or go back to the block editor and confirm that your new lists appear in the dropdown. Select one to add contacts to. Save your form, submit it on the frontend, and confirm you contact is added to the selected list. 
* **Try deleting all lists:** Delete all your MailPoet lists. Then refresh or go back to the block editor and confirm that you see a message that you have no lists and we'll create a new one for you (see screenshot above). Save your form, submit it on the frontend, and confirm (a) your new list is created and (b) you contact is added to the new list. 


