### PR TITLE
Revert " Forms: Submit forms without page reload"

### DIFF
--- a/projects/packages/forms/changelog/update-forms-submit-ajax-json-release
+++ b/projects/packages/forms/changelog/update-forms-submit-ajax-json-release
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Forms: Submit forms without page reload

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -86,7 +86,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 	 *
 	 * @var bool
 	 */
-	public $is_response_without_reload_enabled = true;
+	public $is_response_without_reload_enabled = false;
 
 	/**
 	 * The current post object for this form.
@@ -122,7 +122,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 		}
 		// phpcs:enable
 
-		$this->is_response_without_reload_enabled = apply_filters( 'jetpack_forms_enable_ajax_submission', true );
+		$this->is_response_without_reload_enabled = apply_filters( 'jetpack_forms_enable_ajax_submission', false );
 
 		// Set up the default subject and recipient for this form.
 		$default_to      = self::get_default_to( $this->current_post ? $this->current_post->post_author : null );

--- a/projects/plugins/jetpack/changelog/update-forms-submit-ajax-json-release
+++ b/projects/plugins/jetpack/changelog/update-forms-submit-ajax-json-release
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Forms: Submit forms without page reload

--- a/projects/plugins/jetpack/tests/e2e/specs/forms/submission.test.js
+++ b/projects/plugins/jetpack/tests/e2e/specs/forms/submission.test.js
@@ -56,18 +56,9 @@ test.describe( 'Forms: Submission', () => {
 			await expect(
 				previewPage.getByRole( 'heading', { name: 'Your message has been sent' } )
 			).toBeVisible();
-
-			// The form should disappear after submission.
-			await expect( form ).toBeHidden();
-
-			// The success wrapper should appear after submission.
-			const successWrapper = previewPage.locator( '.contact-form-submission' );
-			await expect( successWrapper ).toBeVisible();
-
-			// The form contents should be visible in the success wrapper.
-			await expect( successWrapper.getByText( 'John Doe' ) ).toBeVisible();
-			await expect( successWrapper.getByText( 'john@doe.com' ) ).toBeVisible();
-			await expect( successWrapper.getByText( 'Hello, world!' ) ).toBeVisible();
+			await expect( previewPage.getByText( 'John Doe' ) ).toBeVisible();
+			await expect( previewPage.getByText( 'john@doe.com' ) ).toBeVisible();
+			await expect( previewPage.getByText( 'Hello, world!' ) ).toBeVisible();
 		} );
 	} );
 
@@ -133,23 +124,13 @@ test.describe( 'Forms: Submission', () => {
 			await formToSubmit.getByRole( 'button', { name: 'Contact Us' } ).click();
 
 			// Check the correct form was submitted.
-			const submittedFormWrapper = previewPage.locator( `#${ formId }` );
+			const submittedForm = previewPage.locator( `#${ formId }` );
 			await expect(
-				submittedFormWrapper.getByRole( 'heading', { name: 'Your message has been sent' } )
+				submittedForm.getByRole( 'heading', { name: 'Your message has been sent' } )
 			).toBeVisible();
-
-			const submittedForm = submittedFormWrapper.getByRole( 'form', { name: 'Submit this form' } );
-
-			// The form should disappear after submission.
-			await expect( submittedForm ).toBeHidden();
-
-			// The success wrapper should appear after submission.
-			const successWrapper = submittedFormWrapper.locator( '.contact-form-submission' );
-			await expect( successWrapper ).toBeVisible();
-
-			await expect( successWrapper.getByText( 'John Doe' ) ).toBeVisible();
-			await expect( successWrapper.getByText( 'john@doe.com' ) ).toBeVisible();
-			await expect( successWrapper.getByText( 'Hello, world!' ) ).toBeVisible();
+			await expect( submittedForm.getByText( 'John Doe' ) ).toBeVisible();
+			await expect( submittedForm.getByText( 'john@doe.com' ) ).toBeVisible();
+			await expect( submittedForm.getByText( 'Hello, world!' ) ).toBeVisible();
 
 			// Check the other forms were not submitted.
 			const firstForm = previewPage.getByRole( 'form', { name: 'First form' } );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Reverts Automattic/jetpack#44422

In case anything goes wrong with the release.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

This is a revert.