### PR TITLE
Blogging Prompt: use Scan Delimiter instead of parse_blocks

### DIFF
--- a/projects/plugins/jetpack/changelog/update-blogging-prompt-block-delimiter-migration-HOG-166
+++ b/projects/plugins/jetpack/changelog/update-blogging-prompt-block-delimiter-migration-HOG-166
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Performance: improve processing of blocks with the Blogging Prompt feature.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes [HOG-166: Update blogging-prompt.php](https://linear.app/a8c/issue/HOG-166/update-blogging-promptphp)

## Proposed changes:
* Replace `parse_blocks()` with `\Automattic\Block_Scanner` in the `jetpack_mark_if_post_answers_blogging_prompt()` function for more efficient block processing

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
N/A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

### Test Scenarios:

**Test 1: Basic functionality**
1. Create a new WordPress post
2. Add a `jetpack/blogging-prompt` block / `Writing Prompt`
3. Add additional content (paragraph blocks, images, etc.) to the post
4. Ensure the post has the appropriate `dailyprompt` and `dailyprompt-{id}` tags (See below SQL Script)

**Test 2: Edge cases**
* Test with a post containing only a blogging prompt block (should NOT set meta)
* Test with a post that doesn't contain any blogging prompt blocks (should NOT set meta)

**Test 3: Performance verification**
* Create a post with many blocks (20+ blocks) where the blogging prompt appears early
* Verify the function completes quickly and sets meta correctly
* Test with the blogging prompt block appearing later in the content

### Expected Results:
- Identical behavior to the previous implementation
- Improved performance, especially noticeable with posts containing many blocks

<details>
<summary>SQL Script to Verify Post Meta</summary>

```sql
-- Verify that the _jetpack_blogging_prompt_key post meta is correctly set
-- Replace {POST_ID} with the actual post ID you're testing

SELECT 
    p.ID as post_id,
    p.post_title,
    p.post_status,
    pm.meta_value as prompt_id,
    -- Check for required tags
    GROUP_CONCAT(DISTINCT t.name ORDER BY t.name) as tags
FROM wp_posts p
LEFT JOIN wp_postmeta pm ON p.ID = pm.post_id AND pm.meta_key = '_jetpack_blogging_prompt_key'
LEFT JOIN wp_term_relationships tr ON p.ID = tr.object_id
LEFT JOIN wp_term_taxonomy tt ON tr.term_taxonomy_id = tt.term_taxonomy_id AND tt.taxonomy = 'post_tag'
LEFT JOIN wp_terms t ON tt.term_id = t.term_id AND (t.name LIKE 'dailyprompt%' OR t.name = 'bloganuary')
WHERE p.ID = {POST_ID}
GROUP BY p.ID, p.post_title, p.post_status, pm.meta_value;

-- Alternative query to check all posts with blogging prompt meta
SELECT 
    p.ID as post_id,
    p.post_title,
    pm.meta_value as prompt_id,
    p.post_date,
    -- Check if post content contains blogging prompt block
    CASE 
        WHEN p.post_content LIKE '%jetpack/blogging-prompt%' THEN 'YES'
        ELSE 'NO'
    END as has_prompt_block
FROM wp_posts p
INNER JOIN wp_postmeta pm ON p.ID = pm.post_id 
WHERE pm.meta_key = '_jetpack_blogging_prompt_key'
    AND p.post_status = 'publish'
    AND p.post_type = 'post'
ORDER BY p.post_date DESC
LIMIT 10;
```

**Expected Results:**
- Posts with blogging prompt blocks AND additional content AND proper tags should have `_jetpack_blogging_prompt_key` meta set
- Posts with only blogging prompt blocks (no additional content) should NOT have the meta key
- Posts without proper `dailyprompt` tags should NOT have the meta key
- The `prompt_id` value should match the `promptId` attribute in the block's JSON

</details>
