### PR TITLE
test-results-to-slack: Fix failed workflow check

### DIFF
--- a/projects/github-actions/test-results-to-slack/changelog/fix-test-results-to-slack-isWorkflowFailed-and-skipped
+++ b/projects/github-actions/test-results-to-slack/changelog/fix-test-results-to-slack-isWorkflowFailed-and-skipped
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Do not consider "skipped" jobs as a failure.

--- a/projects/github-actions/test-results-to-slack/src/github.js
+++ b/projects/github-actions/test-results-to-slack/src/github.js
@@ -30,7 +30,7 @@ async function isWorkflowFailed( token ) {
 	];
 
 	// Decide if any we'll treat this run as failed
-	return !! conclusions.some( conclusion => conclusion !== 'success' );
+	return !! conclusions.some( conclusion => conclusion !== 'success' && conclusion !== 'skipped' );
 }
 
 /**

--- a/projects/github-actions/test-results-to-slack/tests/github.test.js
+++ b/projects/github-actions/test-results-to-slack/tests/github.test.js
@@ -7,6 +7,7 @@ describe( 'Workflow conclusion', () => {
 		${ false } | ${ 'Workflow is successful for empty jobs list' }             | ${ [] }
 		${ false } | ${ 'Workflow is successful for 2 successful completed jobs' } | ${ [ { status: 'completed', conclusion: 'success' }, { status: 'completed', conclusion: 'success' } ] }
 		${ false } | ${ 'Workflow is successful for 2 uncompleted jobs' }          | ${ [ { conclusion: 'failed' }, { status: 'should-not-matter', conclusion: 'failed' } ] }
+		${ false } | ${ 'Workflow is successful for skipped jobs' }                | ${ [ { status: 'completed', conclusion: 'skipped' }, { status: 'completed', conclusion: 'success' } ] }
 		${ true }  | ${ 'Workflow is failed for one failed job' }                  | ${ [ { status: 'completed', conclusion: 'success' }, { status: 'completed', conclusion: 'failed' } ] }
 	`( '$description', async ( { expected, jobs } ) => {
 		const { mockGitHubContext } = require( './test-utils' );


### PR DESCRIPTION
Closes MONOREP-44

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
`isWorkflowFailed` should not consider "skipped" as a failure.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1753749226573929/1753734368.041189-slack-C01U2KGS2PQ

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Actual testing would probably have to fork, make sure the E2Es can run in your fork (i.e. set up needed secrets), and then trigger via a repository dispatch like `.github/files/gh-e2e/workflows/e2e-tests.yml` does.
* For unit testing, see CI.