### PR TITLE
Forms: Fixes PHP notice in grunion contact form apply block attribute method

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-php-notice-grunion_contact_form_apply_block_attribute
+++ b/projects/packages/forms/changelog/fix-forms-php-notice-grunion_contact_form_apply_block_attribute
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: remove a PHP notice when non string is passed in

--- a/projects/packages/forms/src/contact-form/class-util.php
+++ b/projects/packages/forms/src/contact-form/class-util.php
@@ -326,6 +326,11 @@ class Util {
 	 * @return string
 	 */
 	public static function grunion_contact_form_apply_block_attribute( $content, $new_attr ) {
+		if ( ! is_string( $content ) ) {
+			// If the content is not a string, we cannot process it.
+			return $content;
+		}
+
 		if ( false === stripos( $content, 'wp:jetpack/contact-form' ) ) {
 			return $content;
 		}

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -2656,6 +2656,17 @@ EOT;
 			$expected,
 			Util::grunion_contact_form_apply_block_attribute( $original, array( 'foo' => 'bar' ) )
 		);
+
+		// Check that the function return null if the function gets null.
+		$this->assertNull(
+			Util::grunion_contact_form_apply_block_attribute( null, array( 'foo' => 'bar' ) )
+		);
+
+		// Check that the function return array if the function gets null.
+		$this->assertEquals(
+			array(),
+			Util::grunion_contact_form_apply_block_attribute( array(), array( 'foo' => 'bar' ) )
+		);
 	}
 	/**
 	 * Helper function that tracks the ids of the feedbacks that got created.

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -2662,7 +2662,7 @@ EOT;
 			Util::grunion_contact_form_apply_block_attribute( null, array( 'foo' => 'bar' ) )
 		);
 
-		// Check that the function return array if the function gets null.
+		// Check that the function returns an array if the function gets an empty array.
 		$this->assertEquals(
 			array(),
 			Util::grunion_contact_form_apply_block_attribute( array(), array( 'foo' => 'bar' ) )

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -2659,12 +2659,13 @@ EOT;
 
 		// Check that the function return null if the function gets null.
 		$this->assertNull(
+			// @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal
 			Util::grunion_contact_form_apply_block_attribute( null, array( 'foo' => 'bar' ) )
 		);
 
 		// Check that the function returns an array if the function gets an empty array.
 		$this->assertEquals(
-			array(),
+			array(), // @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal
 			Util::grunion_contact_form_apply_block_attribute( array(), array( 'foo' => 'bar' ) )
 		);
 	}


### PR DESCRIPTION
Fixes PHP Notice when a non string is passed in. 

## Proposed changes:
* Check that $content is a sting before trying to find the form block. 

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1753807420428449-slack-C052XEUUBL4

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Do the tests pass? 
