### PR TITLE
Forms: Fix periodic PHP null param deprecation warning

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-stripos-null-param-warning
+++ b/projects/packages/forms/changelog/fix-forms-stripos-null-param-warning
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Fix periodic PHP null param warning.

--- a/projects/packages/forms/src/contact-form/class-util.php
+++ b/projects/packages/forms/src/contact-form/class-util.php
@@ -326,6 +326,9 @@ class Util {
 	 * @return string
 	 */
 	public static function grunion_contact_form_apply_block_attribute( $content, $new_attr ) {
+		if ( ! is_string( $content ) || $content === '' ) {
+			return $content;
+		}
 		if ( false === stripos( $content, 'wp:jetpack/contact-form' ) ) {
 			return $content;
 		}


### PR DESCRIPTION
## Proposed changes:

We are seeing this periodic warning. It seems to happen only on some specific wpcomstaging.com sites. 

```
PHP Deprecated: stripos(): Passing null to parameter #1 ($haystack) of type string is deprecated in /wordpress/plugins/jetpack/14.9-a.7/jetpack_vendor/automattic/jetpack-forms/src/contact-form/class-util.php on line 329
```

On the problematic linke, we call `stripos( $content, 'wp:jetpack/contact-form' )`. The $content variable is passed in just before as `$_wp_current_template_content`, a global that can be updated by third party code, so we can't assume that $content is always a string.

This PR just adds a defensive check on $content, and returns early if it is null or is an empty string. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*