### PR TITLE
Forms: Fix PHP warnings in Contact_Form_Plugin class

### DIFF
--- a/projects/packages/forms/changelog/fix-contact-form-class-php-warnings
+++ b/projects/packages/forms/changelog/fix-contact-form-class-php-warnings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Fix PHP warnings in Contact_Form_Plugin class.

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -1572,7 +1572,7 @@ class Contact_Form_Plugin {
 		if ( ! is_string( $text ) ) {
 			return $text;
 		}
-		return preg_replace( '/\\[contact-form([^a-zA-Z_-])/', '[contact-form widget="' . $this->current_widget_id . '"\\1', $text );
+		return preg_replace( '/\[contact-form([^a-zA-Z_-])/', '[contact-form widget="' . $this->current_widget_id . '"\\1', $text );
 	}
 
 	/**

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -1569,9 +1569,7 @@ class Contact_Form_Plugin {
 	 */
 	public function widget_atts( $text ) {
 		Contact_Form::style( true );
-		if ( ! is_string( $text ) ) {
-			return $text;
-		}
+
 		return preg_replace( '/\[contact-form([^a-zA-Z_-])/', '[contact-form widget="' . $this->current_widget_id . '"\\1', $text );
 	}
 

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -1371,7 +1371,9 @@ class Contact_Form_Plugin {
 				$attributes = get_post_meta( $id, "_g_feedback_shortcode_atts_{$hash}", true );
 				if ( ! empty( $attributes ) && is_array( $attributes ) ) {
 					foreach ( array_filter( $attributes ) as $param => $value ) {
-						$parameters .= " $param=\"$value\"";
+						if ( is_scalar( $value ) ) {
+							$parameters .= ' ' . $param . '="' . esc_attr( $value ) . '"';
+						}
 					}
 				}
 
@@ -1567,8 +1569,10 @@ class Contact_Form_Plugin {
 	 */
 	public function widget_atts( $text ) {
 		Contact_Form::style( true );
-
-		return preg_replace( '/\[contact-form([^a-zA-Z_-])/', '[contact-form widget="' . $this->current_widget_id . '"\\1', $text );
+		if ( ! is_string( $text ) ) {
+			return $text;
+		}
+		return preg_replace( '/\\[contact-form([^a-zA-Z_-])/', '[contact-form widget="' . $this->current_widget_id . '"\\1', $text );
 	}
 
 	/**

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -1372,7 +1372,7 @@ class Contact_Form_Plugin {
 				if ( ! empty( $attributes ) && is_array( $attributes ) ) {
 					foreach ( array_filter( $attributes ) as $param => $value ) {
 						if ( is_scalar( $value ) ) {
-							$parameters .= ' ' . $param . '="' . esc_attr( $value ) . '"';
+							$parameters .= " $param=\"$value\"";
 						}
 					}
 				}


### PR DESCRIPTION
## Proposed changes:

The following periodic PHP warning was reported. This PR adds a check to ensure we are dealing with expected data types. 

```
PHP Warning: Array to string conversion in /wordpress/plugins/jetpack/14.9-a.7/jetpack_vendor/automattic/jetpack-forms/src/contact-form/class-contact-form-plugin.php on line 1374
```

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

This is a small refactor to add type checks that should not change the code behavior in any way. Please review the code and confirm that's the case. 
