### PR TITLE
Prevent PHP fatals with `robots_txt` filter

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-robots_fatal
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-robots_fatal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Handle robots.txt when data passed to `robots_txt` filter is malformed.

--- a/projects/packages/jetpack-mu-wpcom/src/features/blog-privacy/blog-privacy.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/blog-privacy/blog-privacy.php
@@ -18,8 +18,8 @@ namespace Automattic\Jetpack\Jetpack_Mu_Wpcom\Blog_Privacy;
 /**
  * Filters the robots.txt contents based on the value of the wpcom_data_sharing_opt_out option.
  *
- * @param string|null $output The contents of robots.txt.
- * @param int|string  $public The value of the blog_public option.
+ * @param string $output The contents of robots.txt.
+ * @param bool   $public Whether the site is considered public.
  * @return string
  */
 function robots_txt( $output, $public ): string {

--- a/projects/packages/jetpack-mu-wpcom/src/features/blog-privacy/blog-privacy.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/blog-privacy/blog-privacy.php
@@ -27,6 +27,7 @@ function robots_txt( $output, $public ): string {
 		$output = '';
 	}
 
+	// WordPress passes in a bool. Re-fetch as an int to handle our custom "-1" value.
 	$public = (int) get_option( 'blog_public' );
 
 	// If the site is completely private, don't bother with the additional restrictions.

--- a/projects/packages/jetpack-mu-wpcom/src/features/blog-privacy/blog-privacy.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/blog-privacy/blog-privacy.php
@@ -18,11 +18,15 @@ namespace Automattic\Jetpack\Jetpack_Mu_Wpcom\Blog_Privacy;
 /**
  * Filters the robots.txt contents based on the value of the wpcom_data_sharing_opt_out option.
  *
- * @param string     $output The contents of robots.txt.
- * @param int|string $public The value of the blog_public option.
+ * @param string|null $output The contents of robots.txt.
+ * @param int|string  $public The value of the blog_public option.
  * @return string
  */
-function robots_txt( string $output, $public ): string {
+function robots_txt( ?string $output, $public ): string {
+	if ( ! is_string( $output ) ) {
+		$output = '';
+	}
+
 	$public = (int) $public;
 
 	// If the site is completely private, don't bother with the additional restrictions.

--- a/projects/packages/jetpack-mu-wpcom/src/features/blog-privacy/blog-privacy.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/blog-privacy/blog-privacy.php
@@ -27,7 +27,7 @@ function robots_txt( $output, $public ): string {
 		$output = '';
 	}
 
-	$public = (int) $public;
+	$public = (int) get_option( 'blog_public' );
 
 	// If the site is completely private, don't bother with the additional restrictions.
 	// For blog_public=0, WP.com Disallows all user agents and Core does not (relying on <meta name="robots">).

--- a/projects/packages/jetpack-mu-wpcom/src/features/blog-privacy/blog-privacy.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/blog-privacy/blog-privacy.php
@@ -22,7 +22,7 @@ namespace Automattic\Jetpack\Jetpack_Mu_Wpcom\Blog_Privacy;
  * @param int|string  $public The value of the blog_public option.
  * @return string
  */
-function robots_txt( ?string $output, $public ): string {
+function robots_txt( $output, $public ): string {
 	if ( ! is_string( $output ) ) {
 		$output = '';
 	}

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/blog-privacy/Blog_Privacy_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/blog-privacy/Blog_Privacy_Test.php
@@ -22,6 +22,7 @@ class Blog_Privacy_Test extends \WorDBless\BaseTestCase {
 	 * Post-test suite actions.
 	 */
 	public static function tear_down_after_class() {
+		\delete_option( 'blog_public' );
 		\delete_option( 'wpcom_data_sharing_opt_out' );
 	}
 
@@ -80,36 +81,42 @@ Disallow: /
 AI_BLOCKS;
 
 		yield 'public, no discourage AI' => array(
+			'init_content'               => 'TEST',
 			'blog_public'                => '1',
 			'wpcom_data_sharing_opt_out' => null,
 			'expected'                   => 'TEST',
 		);
 
 		yield 'public, discourage AI' => array(
+			'init_content'               => 'TEST',
 			'blog_public'                => '1',
 			'wpcom_data_sharing_opt_out' => '1',
 			'expected'                   => "TEST\n$ai_blocks",
 		);
 
 		yield 'discourage search, no discourage AI' => array(
+			'init_content'               => 'TEST',
 			'blog_public'                => '0',
 			'wpcom_data_sharing_opt_out' => null,
 			'expected'                   => "TEST\n$ai_blocks",
 		);
 
 		yield 'discourage search, discourage AI' => array(
+			'init_content'               => 'TEST',
 			'blog_public'                => '0',
 			'wpcom_data_sharing_opt_out' => '1',
 			'expected'                   => "TEST\n$ai_blocks",
 		);
 
 		yield 'private, no discourage AI' => array(
+			'init_content'               => 'TEST',
 			'blog_public'                => '-1',
 			'wpcom_data_sharing_opt_out' => null,
 			'expected'                   => 'TEST',
 		);
 
 		yield 'private, discourage AI' => array(
+			'init_content'               => 'TEST',
 			'blog_public'                => '-1',
 			'wpcom_data_sharing_opt_out' => '1',
 			'expected'                   => 'TEST', // Private overrides wpcom_data_sharing_opt_out setting.
@@ -127,18 +134,23 @@ AI_BLOCKS;
 	 * Tests for robots_txt().
 	 *
 	 * @dataProvider provide_robots_txt
+	 * @param string     $init_content The initial robots.txt content.
 	 * @param mixed      $blog_public The value of the blog_public option.
 	 * @param mixed|null $wpcom_data_sharing_opt_out The value of the wpcom_data_sharing_opt_out option (null if the option is not set).
 	 * @param string     $expected The expected output for robots.txt.
 	 */
 	#[DataProvider( 'provide_robots_txt' )]
-	public function test_robots_txt( $blog_public, $wpcom_data_sharing_opt_out, string $expected ) {
+	public function test_robots_txt( $init_content, $blog_public, $wpcom_data_sharing_opt_out, string $expected ) {
+		// We use the option rather than the passed value, as the passed value is supposed to be a bool and WP.com uses -1 as well.
+		\update_option( 'blog_public', $blog_public );
+
 		if ( null === $wpcom_data_sharing_opt_out ) {
 			\delete_option( 'wpcom_data_sharing_opt_out' );
 		} else {
 			\update_option( 'wpcom_data_sharing_opt_out', $wpcom_data_sharing_opt_out );
 		}
 
-		$this->assertSame( $expected, robots_txt( 'TEST', $blog_public ) );
+		// Note again that we don't use the value of $blog_public, but let's pass it along in case that changes someday.
+		$this->assertSame( $expected, robots_txt( $init_content, (bool) $blog_public ) );
 	}
 }

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/blog-privacy/Blog_Privacy_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/blog-privacy/Blog_Privacy_Test.php
@@ -121,6 +121,13 @@ AI_BLOCKS;
 			'wpcom_data_sharing_opt_out' => '1',
 			'expected'                   => 'TEST', // Private overrides wpcom_data_sharing_opt_out setting.
 		);
+
+		yield 'discourage search, bad content'    => array(
+			'init_content'               => null, // We'll treat this like an empty string.
+			'blog_public'                => '0',
+			'wpcom_data_sharing_opt_out' => null,
+			'expected'                   => "\n$ai_blocks",
+		);
 	}
 
 	/**


### PR DESCRIPTION
Closes MONOREP-47

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

If bad data was passed to the `robots_txt` filter (e.g. `null`) we'd get a fatal, since the data should be a string. This resets the param to an empty string if it isn't already a string.

I recently became aware of another set of logs to monitor, and this popped up as an easy but important one to fix.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

You can probably reproduce with by adding filter, but the code should be pretty straightforward.