### PR TITLE
Forms: Add safeguards when getting post properties during AJAX calls

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-post-property-get
+++ b/projects/packages/forms/changelog/fix-forms-post-property-get
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Add safeguards when getting post properties during AJAX calls

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -524,7 +524,7 @@ class Contact_Form_Block {
 
 		$data = array(
 			'defaults' => array(
-				'to'                   => Contact_Form::get_default_to( $post ? $post->post_author : null ),
+				'to'                   => Contact_Form::get_default_to( $post ? Contact_Form::get_post_property( $post, 'post_author' ) : null ),
 				'subject'              => Contact_Form::get_default_subject( array() ),
 				'formsResponsesUrl'    => $form_responses_url,
 				'akismetActiveWithKey' => $akismet_active_with_key,

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -133,8 +133,9 @@ class Contact_Form extends Contact_Form_Shortcode {
 		$this->is_response_without_reload_enabled = apply_filters( 'jetpack_forms_enable_ajax_submission', true );
 
 		// Set up the default subject and recipient for this form.
-		$default_to      = self::get_default_to( $this->current_post ? $this->current_post->post_author : null );
-		$default_subject = self::get_default_subject( $attributes );
+		$post_author_id  = self::get_post_property( $this->current_post, 'post_author' );
+		$default_to      = self::get_default_to( $post_author_id );
+		$default_subject = self::get_default_subject( $attributes, $this->current_post );
 
 		if ( ! isset( $attributes ) || ! is_array( $attributes ) ) {
 			$attributes = array();
@@ -371,7 +372,6 @@ class Contact_Form extends Contact_Form_Shortcode {
 	 * @return string The default recipient email address.
 	 */
 	public static function get_default_to( $post_author_id = null ) {
-
 		if ( $post_author_id ) {
 			$post_author = get_userdata( $post_author_id );
 			if ( ! empty( $post_author->user_email ) ) {
@@ -385,23 +385,53 @@ class Contact_Form extends Contact_Form_Shortcode {
 	}
 
 	/**
+	 * Safely get a property from post data (object or array).
+	 *
+	 * @param mixed  $post_data Post data (object or array).
+	 * @param string $property  Property name to get.
+	 *
+	 * @return mixed|null The property value or null if not found.
+	 */
+	public static function get_post_property( $post_data, $property ) {
+		if ( ! $post_data ) {
+			return null;
+		}
+
+		if ( is_object( $post_data ) && isset( $post_data->$property ) ) {
+			return $post_data->$property;
+		} elseif ( is_array( $post_data ) && isset( $post_data[ $property ] ) ) {
+			return $post_data[ $property ];
+		}
+
+		return null;
+	}
+
+	/**
 	 * Get the default subject for the contact form.
 	 *
 	 * @param array $attributes The attributes of the contact form.
+	 * @param mixed $post_data Optional post data (object or array).
 	 *
 	 * @return string The default subject for the contact form.
 	 */
-	public static function get_default_subject( $attributes ) {
+	public static function get_default_subject( $attributes, $post_data = null ) {
 		global $post;
 		// Get the default subject for the contact form.
 		$default_subject = '[' . get_option( 'blogname' ) . ']';
 
-		if ( $post ) {
+		// Get post title safely
+		$post_title = self::get_post_property( $post_data, 'post_title' );
+
+		if ( ! $post_title && $post ) {
+			$post_title = self::get_post_property( $post, 'post_title' );
+		}
+
+		if ( $post_title ) {
 			$default_subject = sprintf(
 				// translators: the blog name and post title.
 				_x( '%1$s %2$s', '%1$s = blog name, %2$s = post title', 'jetpack-forms' ),
 				$default_subject,
-				Contact_Form_Plugin::strip_tags( $post->post_title )
+				Contact_Form_Plugin::strip_tags( $post_title )
 			);
 		}
 
@@ -1661,7 +1691,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 				if ( isset( $_POST['contact-form-id'] ) && 'block-template-part-' . $block_template_part !== $_POST['contact-form-id'] ) { // phpcs:Ignore WordPress.Security.NonceVerification.Missing -- check done by caller process_form_submission()
 					return false;
 				}
-			} elseif ( isset( $_POST['contact-form-id'] ) && ( empty( $this->current_post ) || $this->current_post->ID !== (int) sanitize_text_field( wp_unslash( $_POST['contact-form-id'] ) ) ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing -- check done by caller process_form_submission()
+			} elseif ( isset( $_POST['contact-form-id'] ) && ( empty( $this->current_post ) || self::get_post_property( $this->current_post, 'ID' ) !== (int) sanitize_text_field( wp_unslash( $_POST['contact-form-id'] ) ) ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing -- check done by caller process_form_submission()
 				return false;
 			}
 		}
@@ -1946,8 +1976,8 @@ class Contact_Form extends Contact_Form_Shortcode {
 		$entry_permalink = '';
 
 		if ( $this->current_post ) {
-			$entry_title     = $this->current_post->post_title;
-			$entry_permalink = esc_url( self::get_permalink( $this->current_post->ID ) );
+			$entry_title     = self::get_post_property( $this->current_post, 'post_title' );
+			$entry_permalink = esc_url( self::get_permalink( self::get_post_property( $this->current_post, 'ID' ) ) );
 		} elseif ( $widget ) {
 			$entry_title     = __( 'Sidebar Widget', 'jetpack-forms' );
 			$entry_permalink = esc_url( home_url( '/' ) );
@@ -1983,7 +2013,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 		if ( $block_template || $block_template_part || $widget ) {
 			$url = home_url( '/' );
 		} else {
-			$url = self::get_permalink( $this->current_post ? $this->current_post->ID : 0 );
+			$url = self::get_permalink( $this->current_post ? self::get_post_property( $this->current_post, 'ID' ) : 0 );
 		}
 
 		// translators: the time of the form submission.
@@ -2048,7 +2078,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 				'post_date'    => addslashes( $feedback_time ),
 				'post_type'    => 'feedback',
 				'post_status'  => addslashes( $feedback_status ),
-				'post_parent'  => $this->current_post ? (int) $this->current_post->ID : 0,
+				'post_parent'  => $this->current_post ? (int) self::get_post_property( $this->current_post, 'ID' ) : 0,
 				'post_title'   => addslashes( wp_kses( $feedback_title, array() ) ),
 				// phpcs:ignore WordPress.NamingConventions.ValidVariableName.InterpolatedVariableNotSnakeCase, WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.PHP.DevelopmentFunctions.error_log_print_r
 				'post_content' => addslashes( wp_kses( "$comment_content\n<!--more-->\nAUTHOR: {$comment_author}\nAUTHOR EMAIL: {$comment_author_email}\nAUTHOR URL: {$comment_author_url}\nSUBJECT: {$subject}\n{$comment_ip_text}JSON_DATA\n" . @wp_json_encode( $all_values, true ), array() ) ), // so that search will pick up this data

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -2891,4 +2891,35 @@ EOT;
 		// Assert that we have 6 unique form ids.
 		$this->assertCount( 6, array_unique( array( $form_id, $form_id_2, $form_id_3, $form_id_4, $form_id_5, $form_id_6 ) ), 'There should be 6 unique forms' );
 	}
+
+	/**
+	 * Test get_post_property method with various scenarios
+	 */
+	public function test_get_post_property() {
+		global $post;
+
+		// Test null/false/empty inputs
+		$this->assertNull( Contact_Form::get_post_property( null, 'ID' ), 'Should return null for null post data' );
+		$this->assertNull( Contact_Form::get_post_property( false, 'ID' ), 'Should return null for false post data' );
+		$this->assertNull( Contact_Form::get_post_property( 'not an object nor array', 'ID' ), 'Should return null for non-object/array post data' );
+
+		// Test object properties
+		$this->assertEquals( $post->ID, Contact_Form::get_post_property( $post, 'ID' ), 'Should return object property value' );
+		$this->assertEquals( $post->post_title, Contact_Form::get_post_property( $post, 'post_title' ), 'Should return object string property' );
+		$this->assertNull( Contact_Form::get_post_property( $post, 'non_existent_property' ), 'Should return null for non-existent object property' );
+
+		// Test array properties
+		$array_post = array(
+			'ID'         => 123,
+			'post_title' => 'Test Post',
+			'meta'       => array( 'key' => 'value' ),
+		);
+		$this->assertEquals( 123, Contact_Form::get_post_property( $array_post, 'ID' ), 'Should return array property value' );
+		$this->assertEquals( 'Test Post', Contact_Form::get_post_property( $array_post, 'post_title' ), 'Should return array string property' );
+		$this->assertEquals( array( 'key' => 'value' ), Contact_Form::get_post_property( $array_post, 'meta' ), 'Should return array property with nested array' );
+		$this->assertNull( Contact_Form::get_post_property( $array_post, 'non_existent_property' ), 'Should return null for non-existent array property' );
+
+		// Test empty array
+		$this->assertNull( Contact_Form::get_post_property( array(), 'ID' ), 'Should return null for empty array' );
+	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
The following warnings were reported:
```
PHP Warning: Attempt to read property "post_author" on array in /wordpress/plugins/jetpack/14.9-a.7/jetpack_vendor/automattic/jetpack-forms/src/contact-form/class-contact-form.php on line 128
```
``` 
PHP Warning: Attempt to read property "post_title" on array in /wordpress/plugins/jetpack/14.9-a.7/jetpack_vendor/automattic/jetpack-forms/src/contact-form/class-contact-form.php on line 331
```

During AJAX calls we can't rely on a global `$post`, so we get the post by the form id. This PR adds a more robust way to get post data during form submission, when the post may not be an object as expected, as shown by the warnings.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Review the code
* The warnings should stop, but I can't find a way to replicate the issue locally
