### PR TITLE
Forms: Fix PHP warning in Admin class

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-admin-class-php-warning
+++ b/projects/packages/forms/changelog/fix-forms-admin-class-php-warning
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Fix PHP warning in forms admin class.

--- a/projects/packages/forms/src/contact-form/class-admin.php
+++ b/projects/packages/forms/src/contact-form/class-admin.php
@@ -878,7 +878,7 @@ class Admin {
 	public function grunion_manage_post_row_actions( $actions ) {
 		global $post;
 
-		if ( ! ( is_object( $post ) && isset( $post->post_type ) && 'feedback' === $post->post_type ) ) {
+		if ( ! $post instanceof \WP_Post || 'feedback' !== $post->post_type ) ) {
 			return $actions;
 		}
 

--- a/projects/packages/forms/src/contact-form/class-admin.php
+++ b/projects/packages/forms/src/contact-form/class-admin.php
@@ -878,7 +878,7 @@ class Admin {
 	public function grunion_manage_post_row_actions( $actions ) {
 		global $post;
 
-		if ( 'feedback' !== $post->post_type ) {
+		if ( ! ( is_object( $post ) && isset( $post->post_type ) && 'feedback' === $post->post_type ) ) {
 			return $actions;
 		}
 

--- a/projects/packages/forms/src/contact-form/class-admin.php
+++ b/projects/packages/forms/src/contact-form/class-admin.php
@@ -878,7 +878,7 @@ class Admin {
 	public function grunion_manage_post_row_actions( $actions ) {
 		global $post;
 
-		if ( ! $post instanceof \WP_Post || 'feedback' !== $post->post_type ) ) {
+		if ( ! ( $post instanceof \WP_Post ) || 'feedback' !== $post->post_type ) {
 			return $actions;
 		}
 


### PR DESCRIPTION
## Proposed changes:

The following periodic PHP warning was reported. This PR adds checks to ensure we are dealing with expected data types. 

```
PHP Warning: Attempt to read property "post_type" on null in /wordpress/plugins/jetpack/14.9-a.7/jetpack_vendor/automattic/jetpack-forms/src/contact-form/class-admin.php on line 881
```

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

This is a small refactor to add a check that should not change the code behavior in any way. Please review the code and confirm that's the case. 