### PR TITLE
Paypal Payment Button: Fix composer lockfile

### DIFF
--- a/projects/plugins/paypal-payment-buttons/changelog/fix-paypal-payments-button-composer-lockfile
+++ b/projects/plugins/paypal-payment-buttons/changelog/fix-paypal-payments-button-composer-lockfile
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fixed composer lockfile.
+
+

--- a/projects/plugins/paypal-payment-buttons/composer.lock
+++ b/projects/plugins/paypal-payment-buttons/composer.lock
@@ -526,7 +526,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/paypal-payments",
-                "reference": "9a3a07927fb852524773126ddbdb1b799e28b648"
+                "reference": "d7005b7ddf5416d0b8d4ee6a7eee7b00d289c733"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -549,7 +549,7 @@
             "extra": {
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "0.2.x-dev"
+                    "dev-trunk": "0.3.x-dev"
                 },
                 "changelogger": {
                     "link-template": "https://github.com/Automattic/jetpack-paypal-payments/compare/v${old}...v${new}"


### PR DESCRIPTION
PayPal Payments button composer lockfile seems to be out of date - https://github.com/Automattic/jetpack/actions/runs/16615571313/job/47007373463?pr=44469

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fix the outdated composer lockfile for PayPal Payment Button

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* CI should be happy
