### PR TITLE
Nav-unification: sanitize the css ids for svg icons

### DIFF
--- a/projects/packages/masterbar/changelog/fix-nav-unification-admin-menu-icons
+++ b/projects/packages/masterbar/changelog/fix-nav-unification-admin-menu-icons
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix an issue with WooCommerce Payments admin menu icon for Atomic sites.
+
+

--- a/projects/packages/masterbar/src/admin-menu/class-base-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-base-admin-menu.php
@@ -410,6 +410,8 @@ abstract class Base_Admin_Menu {
 				$menu_item[5] = preg_replace( '![:/.]+!', '_', $menu_item[5] );
 			}
 
+			$menu_item[5] = preg_replace( '|[^a-zA-Z0-9_:.]|', '-', $menu_item[5] );
+
 			if ( str_starts_with( $menu_item[6], 'data:image/svg+xml' ) && 'site-card' !== $menu_item[3] ) {
 				$svg_items[]   = array(
 					'icon' => $menu_item[6],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Unlike WP Core, when admin menu items have a menu ID created from a URL, nav-unification doesn't transform that URL id into a valid id.  

This caused the selectors to not be created properly in the nav-unification svg override. This PR simply replicates the behavior we have in core.

Fixes DOTSITE-13

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Transform the element ids to the correct format

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Enable WooCommerce on an Atomic site
* Make sure you use the default interface
* Notice that you have a "Payments" admin menu item with a broken icon
* Apply this PR on your Atomic Dev Site using the Beta tester (Jetpack plugin & WordPress.com features)
* Notice that the icon is now displaying properly.

Before
<img width="267" height="183" alt="Screenshot 2025-07-30 at 13 12 33" src="https://github.com/user-attachments/assets/227df335-db22-4b16-b48a-d510b06fe85a" />

After
<img width="278" height="203" alt="Screenshot 2025-07-30 at 13 11 17" src="https://github.com/user-attachments/assets/b83511ae-cce0-418f-8079-0475ae98f4e8" />


