### PR TITLE
Connection: cleanup fallback code for old error handler class

### DIFF
--- a/projects/plugins/wpcomsh/changelog/update-protected-owner-error-cleanup
+++ b/projects/plugins/wpcomsh/changelog/update-protected-owner-error-cleanup
@@ -1,0 +1,4 @@
+Significance: minor
+Type: removed
+
+Removed backward compatibility for old version of Error_Handler class.

--- a/projects/plugins/wpcomsh/connection/class-protected-owner-error-handler.php
+++ b/projects/plugins/wpcomsh/connection/class-protected-owner-error-handler.php
@@ -2,17 +2,6 @@
 /**
  * The Jetpack Connection Protected Owner Error Handler class file.
  *
- * USAGE EXAMPLES:
- *
- * 1. Basic usage (automatic - no code required):
- *    The class automatically handles protected owner errors when they occur.
- *
- * 2. Check if enhanced features are available:
- *    $handler = Protected_Owner_Error_Handler::get_instance();
- *    if ( $handler->has_enhanced_error_handling() ) {
- *        // Enhanced features are available
- *    }
- *
  * @package wpcomsh
  */
 
@@ -31,9 +20,6 @@ namespace Automattic\WPComSH\Connection;
  * user creation form when creating missing protected owner accounts. It overrides the
  * default User_Admin class behavior to ensure the WP.com invitation checkbox is not
  * pre-checked when creating protected owner accounts.
- *
- * Automatically uses enhanced error handling when available in newer connection package versions,
- * with backward compatibility for older versions.
  *
  * @since 7.0.0
  */
@@ -138,14 +124,8 @@ class Protected_Owner_Error_Handler {
 		$user_id   = '0';
 		$timestamp = $raw_error['timestamp'] ?? time();
 
-		// Check if we have the new Error_Handler class with build_action_error_data method
-		// This provides enhanced error data for newer connection package versions
-		$error_data = $this->build_enhanced_error_data( $raw_error );
-
-		// Fallback to legacy error data if enhanced method is not available
-		if ( false === $error_data ) {
-			$error_data = $this->build_legacy_error_data( $raw_error );
-		}
+		// Build error data using the connection package build_action_error_data method
+		$error_data = $this->build_error_data( $raw_error );
 
 		$error_details = array(
 			'error_code'    => $error_code,
@@ -167,24 +147,18 @@ class Protected_Owner_Error_Handler {
 	}
 
 	/**
-	 * Build enhanced error data using the new connection package methods
+	 * Build error data using the connection package methods
 	 *
-	 * This method leverages the new build_action_error_data method available in
-	 * new connection package version to provide enhanced
-	 * error handling with secondary button support.
+	 * This method leverages the build_action_error_data method from the
+	 * connection package to provide consistent error handling.
 	 *
 	 * @param array $raw_error The raw error data from the stored option.
-	 * @return array|false Enhanced error data array or false if method not available.
+	 * @return array Error data array.
 	 */
-	private function build_enhanced_error_data( $raw_error ) {
-		// Check if enhanced error handling is available
-		if ( ! $this->has_enhanced_error_handling() ) {
-			return false;
-		}
-
+	private function build_error_data( $raw_error ) {
 		$error_handler = \Automattic\Jetpack\Connection\Error_Handler::get_instance();
 
-		// Build enhanced error data with improved action handling
+		// Build error data with action handling
 		$args = array(
 			'action'         => 'create_missing_account',
 			'action_label'   => __( 'Create Account', 'wpcomsh' ),
@@ -198,52 +172,12 @@ class Protected_Owner_Error_Handler {
 			),
 			'tracking_event' => 'jetpack_protected_owner_create_account_click',
 			'extra_data'     => array(
-				'email'       => $raw_error['email'],
-				'error_type'  => $raw_error['error_type'],
-				'support_url' => admin_url( 'user-new.php' ), // Backward compatibility
+				'email'      => $raw_error['email'],
+				'error_type' => $raw_error['error_type'],
 			),
 		);
 
 		return $error_handler->build_action_error_data( $args );
-	}
-
-	/**
-	 * Build legacy error data for backward compatibility
-	 *
-	 * This method provides the original error data structure for older
-	 * connection package versions that don't support the enhanced features.
-	 *
-	 * @since 7.0.0
-	 *
-	 * @param array $raw_error The raw error data from the stored option.
-	 * @return array Legacy error data array.
-	 */
-	private function build_legacy_error_data( $raw_error ) {
-		$legacy_data = array(
-			'email'       => $raw_error['email'],
-			'error_type'  => $raw_error['error_type'],
-			'action'      => 'create_missing_account',
-			'support_url' => admin_url( 'user-new.php' ),
-		);
-
-		return $legacy_data;
-	}
-
-	/**
-	 * Check if enhanced error handling is available
-	 *
-	 * This method can be used to determine if the current connection package version
-	 * supports the enhanced error handling features.
-	 *
-	 * @return bool True if enhanced features are available, false otherwise.
-	 */
-	public function has_enhanced_error_handling() {
-		if ( ! class_exists( '\Automattic\Jetpack\Connection\Error_Handler' ) ) {
-			return false;
-		}
-
-		$error_handler = \Automattic\Jetpack\Connection\Error_Handler::get_instance();
-		return method_exists( $error_handler, 'build_action_error_data' );
 	}
 
 	/**

--- a/projects/plugins/wpcomsh/tests/ProtectedOwnerErrorHandlerTest.php
+++ b/projects/plugins/wpcomsh/tests/ProtectedOwnerErrorHandlerTest.php
@@ -43,22 +43,9 @@ class ProtectedOwnerErrorHandlerTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test has_enhanced_error_handling method.
+	 * Test build_error_data method.
 	 */
-	public function test_has_enhanced_error_handling() {
-		$result = $this->handler->has_enhanced_error_handling();
-		$this->assertIsBool( $result );
-	}
-
-	/**
-	 * Test build_enhanced_error_data method when enhanced error handling is available.
-	 */
-	public function test_build_enhanced_error_data_when_available() {
-		// Skip if enhanced error handling is not available
-		if ( ! $this->handler->has_enhanced_error_handling() ) {
-			$this->markTestSkipped( 'Enhanced error handling not available' );
-		}
-
+	public function test_build_error_data() {
 		$raw_error = array(
 			'error_type' => 'missing_owner',
 			'email'      => 'test@example.com',
@@ -66,7 +53,7 @@ class ProtectedOwnerErrorHandlerTest extends WP_UnitTestCase {
 
 		// Use reflection to access private method
 		$reflection = new ReflectionClass( $this->handler );
-		$method     = $reflection->getMethod( 'build_enhanced_error_data' );
+		$method     = $reflection->getMethod( 'build_error_data' );
 		$method->setAccessible( true );
 
 		$result = $method->invoke( $this->handler, $raw_error );
@@ -74,51 +61,8 @@ class ProtectedOwnerErrorHandlerTest extends WP_UnitTestCase {
 		$this->assertIsArray( $result );
 		$this->assertEquals( 'create_missing_account', $result['action'] );
 		$this->assertEquals( 'test@example.com', $result['email'] );
-	}
-
-	/**
-	 * Test build_enhanced_error_data method when enhanced error handling is not available.
-	 */
-	public function test_build_enhanced_error_data_when_not_available() {
-		// Skip if enhanced error handling is available
-		if ( $this->handler->has_enhanced_error_handling() ) {
-			$this->markTestSkipped( 'Enhanced error handling is available' );
-		}
-
-		$raw_error = array(
-			'error_type' => 'missing_owner',
-			'email'      => 'test@example.com',
-		);
-
-		// Use reflection to access private method
-		$reflection = new ReflectionClass( $this->handler );
-		$method     = $reflection->getMethod( 'build_enhanced_error_data' );
-		$method->setAccessible( true );
-
-		$result = $method->invoke( $this->handler, $raw_error );
-
-		$this->assertFalse( $result );
-	}
-
-	/**
-	 * Test build_legacy_error_data method.
-	 */
-	public function test_build_legacy_error_data() {
-		$raw_error = array(
-			'error_type' => 'missing_owner',
-			'email'      => 'test@example.com',
-		);
-
-		// Use reflection to access private method
-		$reflection = new ReflectionClass( $this->handler );
-		$method     = $reflection->getMethod( 'build_legacy_error_data' );
-		$method->setAccessible( true );
-
-		$result = $method->invoke( $this->handler, $raw_error );
-
-		$this->assertIsArray( $result );
-		$this->assertEquals( 'test@example.com', $result['email'] );
-		$this->assertEquals( 'create_missing_account', $result['action'] );
+		$this->assertEquals( 'missing_owner', $result['error_type'] );
+		$this->assertArrayHasKey( 'blog_id', $result );
 	}
 
 	/**


### PR DESCRIPTION
This PR is removing the fallback code in wpcomsh that was needed [when we refactored the Error_Handler class](https://github.com/Automattic/jetpack/pull/44284).

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Closes: CONNECT-31 

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a WoA dev site. I recommend switching to Classic view in the general settings to override Calypso. If this is an old dev site, make sure you are running the latest Jetpack release candidate version.
* Create a secondary admin account and connect it.
* Log in as the secondary admin and delete the primary admin account via cli. Do not transfer ownership.
* Run JP debugger tool and use the Restore user connection button (but don't force create a missing account!). This will trigger the error.
* The error should show up in the Jetpack dashboard and My Jetpack for the secondary admin. Button to create an account should work.
* Use beta tester to load this PR for the wpcomsh plugin. Everything should be the same.

