### PR TITLE
Forms: remove 'default' value from unreleased rating field

### DIFF
--- a/projects/packages/forms/changelog/update-forms-rating-remove-default
+++ b/projects/packages/forms/changelog/update-forms-rating-remove-default
@@ -1,0 +1,4 @@
+Significance: minor
+Type: removed
+
+Forms: remove "default" value from unreleased rating field

--- a/projects/packages/forms/src/blocks/field-rating/edit.js
+++ b/projects/packages/forms/src/blocks/field-rating/edit.js
@@ -5,7 +5,6 @@ import {
 	BlockControls,
 } from '@wordpress/block-editor';
 import { PanelBody, RangeControl } from '@wordpress/components';
-import { useEffect, useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import JetpackFieldControls from '../shared/components/jetpack-field-controls';
 import RatingToolbar from '../shared/components/rating-toolbar';
@@ -22,31 +21,17 @@ import useFormWrapper from '../shared/hooks/use-form-wrapper';
  */
 export default function RatingFieldEdit( props ) {
 	const { attributes, setAttributes, clientId } = props;
-	const { max = 5, default: defaultValue = 0, required, id, width, className = '' } = attributes;
+	const { max = 5, required, id, width, className = '' } = attributes;
 
 	useFormWrapper( props );
 
 	// Direct update functions for rating attributes
 	const updateMax = newMax => {
 		const validatedMax = Math.min( Math.max( parseInt( newMax ) || 5, 2 ), 10 );
-		const validatedDefault = Math.min( defaultValue, validatedMax );
 		setAttributes( {
 			max: validatedMax,
-			default: validatedDefault,
 		} );
 	};
-
-	const onChangeDefault = useCallback(
-		newDefault => {
-			const validatedDefault = Math.min( Math.max( parseInt( newDefault ) || 0, 0 ), max );
-			setAttributes( { default: validatedDefault } );
-		},
-		[ max, setAttributes ]
-	);
-
-	useEffect( () => {
-		setAttributes( { onChangeDefault } );
-	}, [ onChangeDefault, setAttributes ] );
 
 	const updateClassName = newClassName => {
 		setAttributes( { className: newClassName } );
@@ -96,14 +81,6 @@ export default function RatingFieldEdit( props ) {
 						max={ 10 }
 						value={ max }
 						onChange={ updateMax }
-					/>
-					<RangeControl
-						label={ __( 'Default rating', 'jetpack-forms' ) }
-						help={ __( 'Pre-selected rating value (0 for no selection)', 'jetpack-forms' ) }
-						min={ 0 }
-						max={ max }
-						value={ defaultValue }
-						onChange={ onChangeDefault }
 					/>
 				</PanelBody>
 			</InspectorControls>

--- a/projects/packages/forms/src/blocks/field-rating/index.js
+++ b/projects/packages/forms/src/blocks/field-rating/index.js
@@ -52,18 +52,11 @@ const settings = {
 			default: 5,
 			role: 'content',
 		},
-		default: {
-			type: 'number',
-			default: 0,
-			role: 'content',
-		},
 	},
 	providesContext: {
 		...defaultSettings.providesContext,
 		'jetpack/field-rating-max': 'max',
-		'jetpack/field-rating-default': 'default',
 		'jetpack/field-rating-className': 'className',
-		'jetpack/field-rating-onChangeDefault': 'onChangeDefault',
 	},
 	styles: stylesArray,
 	allowedBlocks: [ 'jetpack/label', 'jetpack/rating-input' ],
@@ -72,7 +65,6 @@ const settings = {
 	example: {
 		attributes: {
 			max: 5,
-			default: 3,
 		},
 		innerBlocks: [
 			{

--- a/projects/packages/forms/src/blocks/input-rating/edit.js
+++ b/projects/packages/forms/src/blocks/input-rating/edit.js
@@ -19,9 +19,7 @@ import './editor.scss';
  */
 export default function RatingInputEdit( { context, setAttributes, clientId } ) {
 	const max = context?.[ 'jetpack/field-rating-max' ] || 5;
-	const defaultValue = context?.[ 'jetpack/field-rating-default' ] || 0;
 	const className = context?.[ 'jetpack/field-rating-className' ] || 'is-style-stars';
-	const onChangeDefault = context?.[ 'jetpack/field-rating-onChangeDefault' ] || ( () => {} );
 
 	useEffect( () => {
 		setAttributes( { className } );
@@ -43,13 +41,7 @@ export default function RatingInputEdit( { context, setAttributes, clientId } ) 
 
 	return (
 		<div { ...blockProps }>
-			<Symbols
-				max={ max }
-				value={ defaultValue }
-				onChange={ onChangeDefault }
-				icon={ icon }
-				uniqueId={ clientId }
-			/>
+			<Symbols max={ max } icon={ icon } uniqueId={ clientId } />
 		</div>
 	);
 }

--- a/projects/packages/forms/src/blocks/input-rating/index.js
+++ b/projects/packages/forms/src/blocks/input-rating/index.js
@@ -41,12 +41,7 @@ const settings = {
 		),
 	},
 	attributes: {},
-	usesContext: [
-		'jetpack/field-rating-max',
-		'jetpack/field-rating-default',
-		'jetpack/field-rating-className',
-		'jetpack/field-rating-onChangeDefault',
-	],
+	usesContext: [ 'jetpack/field-rating-max', 'jetpack/field-rating-className' ],
 	supports: {
 		reusable: false,
 		html: false,

--- a/projects/packages/forms/src/blocks/input-rating/symbols.js
+++ b/projects/packages/forms/src/blocks/input-rating/symbols.js
@@ -116,11 +116,7 @@ export default function Symbols( {
 								aria-hidden="true"
 								className="jetpack-field-rating__button"
 								onKeyDown={ event => handleKeyDown( event, position ) }
-								onClick={ () => {
-									// eslint-disable-next-line no-console
-									console.log( 'set!', value );
-									handleSelect( value );
-								} }
+								onClick={ handleSelect( position ) }
 							>
 								<span className={ isSelected ? 'is-rating-filled' : 'is-rating-unfilled' }>
 									{ icon }

--- a/projects/packages/forms/src/blocks/input-rating/symbols.js
+++ b/projects/packages/forms/src/blocks/input-rating/symbols.js
@@ -116,6 +116,11 @@ export default function Symbols( {
 								aria-hidden="true"
 								className="jetpack-field-rating__button"
 								onKeyDown={ event => handleKeyDown( event, position ) }
+								onClick={ () => {
+									// eslint-disable-next-line no-console
+									console.log( 'set!', value );
+									handleSelect( value );
+								} }
 							>
 								<span className={ isSelected ? 'is-rating-filled' : 'is-rating-unfilled' }>
 									{ icon }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Removes "default" value handling; there's no need setting starting value, we can assume it always start at zero. We'll thus keep the feature simpler, and if customers share feedback that this is needed, we can easily add it back.

WIP: currently this takes out the ability to click and preview different star values, which we should add back.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

