### PR TITLE
Forms: Fix flacky csv export test

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-test-csv-export
+++ b/projects/packages/forms/changelog/fix-forms-test-csv-export
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Form: fix flaky csv export test

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
@@ -599,29 +599,33 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 		$plugin       = Contact_Form_Plugin::init();
 		$current_post = Utility::create_post_context();
 		$post_ids     = array();
-		$post_ids[]   = Utility::create_legacy_feedback(
+
+		$post_id_1  = Utility::create_legacy_feedback(
 			array(
 				'1_field_A' => 'value1',
 				'2_field_B' => 'value2',
 			)
 		);
+		$post_1     = get_post( $post_id_1 );
+		$post_ids[] = $post_id_1;
 
-		$post_ids[] = Utility::create_legacy_feedback(
+		$post_id_2  = Utility::create_legacy_feedback(
 			array(
 				'1_field_A' => 'value1',
 				'2_field_C' => 'value2',
 			)
 		);
+		$post_2     = get_post( $post_id_2 );
+		$post_ids[] = $post_id_2;
 
-		$current_time    = current_time( 'mysql' );
 		$default_consent = 'No';
 		$ip              = 'https://127.0.0.1';
 
 		$this->assertEquals(
 			array(
 
-				'ID'         => array( $post_ids[0], $post_ids[1] ),
-				'Date'       => array( $current_time, $current_time ),
+				'ID'         => array( $post_id_1, $post_id_2 ),
+				'Date'       => array( $post_1->post_date, $post_2->post_date ),
 				'Title'      => array( $current_post->post_title, $current_post->post_title ),
 				'field_A'    => array( 'value1', 'value1' ),
 				'field_B'    => array( 'value2', '' ),


### PR DESCRIPTION
The current test uses current_time function but this would cause the tests to fail since sometime the current time woun't match the expected results. 

This PR fixes it by using the form feedback data. 

## Proposed changes:
* Fix tests to check against real data. 

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1753811363937129-slack-C052XEUUB L4

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
Do the tests pass? 
