### PR TITLE
Status: consider WPCOM_CLI_SCRIPT as a backend request

### DIFF
--- a/projects/packages/status/changelog/add-status-wpcom-cli-scripts
+++ b/projects/packages/status/changelog/add-status-wpcom-cli-scripts
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Requests: consider WPCOM_CLI_SCRIPT as a backend request

--- a/projects/packages/status/src/class-request.php
+++ b/projects/packages/status/src/class-request.php
@@ -31,6 +31,7 @@ class Request {
 			|| Constants::is_true( 'REST_REQUEST' )
 			|| Constants::is_true( 'REST_API_REQUEST' )
 			|| Constants::is_true( 'WP_CLI' )
+			|| Constants::is_true( 'WPCOM_CLI_SCRIPT' ) // Special case for CLI scripts on WP.com that aren't using WP CLI.
 		) {
 			$is_frontend        = false;
 			$is_varying_request = false;

--- a/projects/packages/status/tests/php/Request_Test.php
+++ b/projects/packages/status/tests/php/Request_Test.php
@@ -141,6 +141,12 @@ class Request_Test extends TestCase {
 				'expected_result'    => false,
 				'should_set_headers' => false,
 			),
+			'WPCOM_CLI_SCRIPT constant' => array(
+				'function_mocks'     => $default_functions,
+				'constants'          => array( 'WPCOM_CLI_SCRIPT' => true ),
+				'expected_result'    => false,
+				'should_set_headers' => false,
+			),
 			'json request'              => array(
 				'function_mocks'     => array_merge( $default_functions, array( 'wp_is_json_request' => true ) ),
 				'constants'          => array(),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Ref HOG-132
Ref #44373

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds a check for the `WPCOM_CLI_SCRIPT` constant as a non-frontend request for the `Requests:is_frontend()` check.

We're looking to execute code everywhere _except_ the frontend, so including this constant used on WP.com for CLI scripts that aren't built upon the WP CLI framework.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None directly related to this.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Unit tests should be enough, but can be tested on wp.com post-merge if needed.

