### PR TITLE
Connection: extending get_option

### DIFF
--- a/projects/packages/connection/changelog/update-external-storage-option-override
+++ b/projects/packages/connection/changelog/update-external-storage-option-override
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Connection: extended get_option so it can work with external storage.

--- a/projects/packages/connection/legacy/class-jetpack-options.php
+++ b/projects/packages/connection/legacy/class-jetpack-options.php
@@ -265,30 +265,23 @@ class Jetpack_Options {
 	 * @return bool True if external storage should be checked for this option.
 	 */
 	private static function should_use_external_storage( $name ) {
-		// Only handle specific connection options
-		$external_options = array( 'blog_token', 'id' );
-		if ( ! in_array( $name, $external_options, true ) ) {
+		// Quick bailout for unsupported options or killswitch
+		if ( ! in_array( $name, array( 'blog_token', 'id' ), true ) ||
+			( defined( 'JETPACK_EXTERNAL_STORAGE_DISABLED' ) && constant( 'JETPACK_EXTERNAL_STORAGE_DISABLED' ) ) ) {
 			return false;
 		}
-
-		if ( defined( 'JETPACK_EXTERNAL_STORAGE_DISABLED' ) && constant( 'JETPACK_EXTERNAL_STORAGE_DISABLED' ) ) {
-			return false;
-		}
-
-		// Default: disabled (environments can override)
-		$default = false;
 
 		/**
 		 * Filter to control whether external storage should be used for a given option.
-		 * Environments use this to enable external storage.
+		 * Environments use this to opt-in to external storage for their sites.
 		 *
 		 * @since $$next-version$$
 		 *
-		 * @param bool   $enabled     Whether external storage should be used.
+		 * @param bool   $enabled     Whether external storage should be used (default: false).
 		 * @param string $option_name Option name, _without_ `jetpack_%` prefix.
 		 * @return bool True to use external storage, false to use database only.
 		 */
-		return (bool) apply_filters( 'jetpack_should_use_external_storage', $default, $name );
+		return apply_filters( 'jetpack_should_use_external_storage', false, $name );
 	}
 
 	/**

--- a/projects/packages/connection/legacy/class-jetpack-options.php
+++ b/projects/packages/connection/legacy/class-jetpack-options.php
@@ -193,6 +193,30 @@ class Jetpack_Options {
 	 * @return mixed
 	 */
 	public static function get_option( $name, $default = false ) {
+		// Check if external storage should be used for this option
+		if ( self::should_use_external_storage( $name ) ) {
+			/**
+			 * Filter to provide external storage for Jetpack connection options.
+			 * External storage is checked first, with database as fallback.
+			 *
+			 * @since $$next-version$$
+			 *
+			 * @param mixed  $value   Current value (null to let database handle).
+			 * @param string $name    Option name, _without_ `jetpack_%` prefix.
+			 * @param mixed  $default Default value if option doesn't exist.
+			 * @return mixed External storage value, or null to fall back to database.
+			 */
+			$external_value = apply_filters( 'jetpack_external_storage_get', null, $name, $default );
+
+			// If external storage provided a value, use it
+			if ( null !== $external_value ) {
+				return $external_value;
+			}
+		}
+
+		// Fallback to database
+		$database_value = self::get_option_from_database( $name, $default );
+
 		/**
 		 * Filter Jetpack Options.
 		 * Can be useful in environments when Jetpack is running with a different setup
@@ -203,7 +227,7 @@ class Jetpack_Options {
 		 * @param string $name Option name, _without_ `jetpack_%` prefix.
 		 * @return string $value, unless the filters modify it.
 		 */
-		return apply_filters( 'jetpack_options', self::get_option_from_database( $name, $default ), $name );
+		return apply_filters( 'jetpack_options', $database_value, $name );
 	}
 
 	/**
@@ -230,6 +254,41 @@ class Jetpack_Options {
 		}
 
 		return $default;
+	}
+
+	/**
+	 * Determines if external storage should be used for a given option.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param string $name Option name, _without_ `jetpack_%` prefix.
+	 * @return bool True if external storage should be checked for this option.
+	 */
+	private static function should_use_external_storage( $name ) {
+		// Only handle specific connection options
+		$external_options = array( 'blog_token', 'id' );
+		if ( ! in_array( $name, $external_options, true ) ) {
+			return false;
+		}
+
+		if ( defined( 'JETPACK_EXTERNAL_STORAGE_DISABLED' ) && constant( 'JETPACK_EXTERNAL_STORAGE_DISABLED' ) ) {
+			return false;
+		}
+
+		// Default: disabled (environments can override)
+		$default = false;
+
+		/**
+		 * Filter to control whether external storage should be used for a given option.
+		 * Environments use this to enable external storage.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param bool   $enabled     Whether external storage should be used.
+		 * @param string $option_name Option name, _without_ `jetpack_%` prefix.
+		 * @return bool True to use external storage, false to use database only.
+		 */
+		return (bool) apply_filters( 'jetpack_should_use_external_storage', $default, $name );
 	}
 
 	/**

--- a/projects/packages/connection/legacy/class-jetpack-options.php
+++ b/projects/packages/connection/legacy/class-jetpack-options.php
@@ -214,9 +214,6 @@ class Jetpack_Options {
 			}
 		}
 
-		// Fallback to database
-		$database_value = self::get_option_from_database( $name, $default );
-
 		/**
 		 * Filter Jetpack Options.
 		 * Can be useful in environments when Jetpack is running with a different setup
@@ -227,7 +224,7 @@ class Jetpack_Options {
 		 * @param string $name Option name, _without_ `jetpack_%` prefix.
 		 * @return string $value, unless the filters modify it.
 		 */
-		return apply_filters( 'jetpack_options', $database_value, $name );
+		return apply_filters( 'jetpack_options', self::get_option_from_database( $name, $default ), $name );
 	}
 
 	/**


### PR DESCRIPTION
This PR extends the get_option method to utilize external storage for connection data as the primary source, with the local database serving as a fallback.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Closes CONNECT-30

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adding a filter that enables the usage of external storage and defines options to retrieve from the external storage for fine control.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Code review
* Nothing to test other than verifying Jetpack works as usual when this PR is applied. 

