### PR TITLE
Forms: Fix custom redirect on ajax requests. 

### DIFF
--- a/projects/packages/forms/changelog/fix-jp-forms-redirect-ajax
+++ b/projects/packages/forms/changelog/fix-jp-forms-redirect-ajax
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Fix redirect message on ajax requests

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -2276,7 +2276,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 			'contact-form-hash' => $this->hash,
 			'_wpnonce'          => wp_create_nonce( "contact-form-sent-{$post_id}" ), // wp_nonce_url HTMLencodes :( .
 		);
-
+		$redirect     = $this->get_redirect_url( $refresh_args, $id, $post_id );
 		// If the request accepts JSON, return a JSON response instead of redirecting
 		$accepts_json = isset( $_SERVER['HTTP_ACCEPT'] ) && false !== strpos( strtolower( sanitize_text_field( wp_unslash( $_SERVER['HTTP_ACCEPT'] ) ) ), 'application/json' );
 
@@ -2288,6 +2288,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 					'success'     => true,
 					'data'        => self::get_json_data( $post_id, $this ),
 					'refreshArgs' => $refresh_args,
+					'redirectUrl' => $this->has_custom_redirect() ? $redirect : '',
 				)
 			);
 
@@ -2298,30 +2299,62 @@ class Contact_Form extends Contact_Form_Shortcode {
 			return self::success_message( $post_id, $this );
 		}
 
+		// phpcs:ignore WordPress.Security.SafeRedirect.wp_redirect_wp_redirect -- We intentially allow external redirects here.
+		wp_redirect( $redirect );
+		exit( 0 );
+	}
+
+	/**
+	 * Check if the contact form has a custom redirect.
+	 *
+	 * @return bool True if the contact form has a custom redirect, false otherwise.
+	 */
+	public function has_custom_redirect() {
+		if ( ! empty( $this->get_attribute( 'customThankyouRedirect' ) ) && 'redirect' === $this->get_attribute( 'customThankyou' ) ) {
+			return true;
+		}
+		/**
+		 * Filter to check if the contact form has a redirect filter.
+		 *
+		 * @module contact-form
+		 *
+		 * @since 1.9.0
+		 *
+		 * @param bool $has_redirect True if the contact form has a redirect filter, false otherwise.
+		 */
+		return (bool) has_filter( 'grunion_contact_form_redirect_url' );
+	}
+
+	/**
+	 * Get the URL where the reader is redirected after submitting a form.
+	 *
+	 * @param array $refresh_args The arguments to be added to the redirect URL.
+	 * @param int   $id           Contact Form ID.
+	 * @param int   $post_id      Post ID.
+	 *
+	 * @return string The redirect URL.
+	 */
+	public function get_redirect_url( $refresh_args, $id, $post_id ) {
 		$redirect        = '';
 		$custom_redirect = false;
 		if ( 'redirect' === $this->get_attribute( 'customThankyou' ) ) {
 			$custom_redirect = true;
 			$redirect        = esc_url_raw( $this->get_attribute( 'customThankyouRedirect' ) );
 		}
-
 		if ( ! $redirect ) {
 			$custom_redirect = false;
 			$redirect        = wp_get_referer();
 		}
-
 		if ( ! $redirect ) { // wp_get_referer() returns false if the referer is the same as the current page.
 			$custom_redirect = false;
 			$redirect        = isset( $_SERVER['REQUEST_URI'] ) ? esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
 		}
-
 		if ( ! $custom_redirect ) {
 			$redirect = add_query_arg(
 				urlencode_deep( $refresh_args ),
 				$redirect
 			);
 		}
-
 		/**
 		 * Filter the URL where the reader is redirected after submitting a form.
 		 *
@@ -2333,11 +2366,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 		 * @param int $id Contact Form ID.
 		 * @param int $post_id Post ID.
 		 */
-		$redirect = apply_filters( 'grunion_contact_form_redirect_url', $redirect, $id, $post_id );
-
-		// phpcs:ignore WordPress.Security.SafeRedirect.wp_redirect_wp_redirect -- We intentially allow external redirects here.
-		wp_redirect( $redirect );
-		exit( 0 );
+		return apply_filters( 'grunion_contact_form_redirect_url', $redirect, $id, $post_id );
 	}
 
 	/**

--- a/projects/packages/forms/src/modules/form/view.js
+++ b/projects/packages/forms/src/modules/form/view.js
@@ -343,11 +343,19 @@ const { state } = store( NAMESPACE, {
 				event.stopPropagation();
 				context.submissionError = null;
 
-				const { success, error, data, refreshArgs } = yield submitForm( context.formHash );
+				const { success, error, data, refreshArgs, redirectUrl } = yield submitForm(
+					context.formHash
+				);
 
 				if ( success ) {
 					setSubmissionData( data );
 					context.submissionSuccess = true;
+
+					if ( redirectUrl ) {
+						// If a redirect URL is provided, we can use it to navigate.
+						window.location = redirectUrl;
+						return;
+					}
 
 					if ( refreshArgs ) {
 						const url = new URL( window.location.href );

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -2891,4 +2891,76 @@ EOT;
 		// Assert that we have 6 unique form ids.
 		$this->assertCount( 6, array_unique( array( $form_id, $form_id_2, $form_id_3, $form_id_4, $form_id_5, $form_id_6 ) ), 'There should be 6 unique forms' );
 	}
+
+	public function test_get_redirect_url() {
+		$post_id = wp_insert_post(
+			array(
+				'post_title'   => 'Test Post',
+				'post_content' => 'Test content',
+				'post_status'  => 'publish',
+				'post_author'  => $this->post->post_author,
+			),
+			true
+		);
+
+		$attributes = array(
+			'customThankyou'         => 'redirect',
+			'customThankyouRedirect' => 'https://example.com/thank-you',
+		);
+
+		$form = new Contact_Form( $attributes, '' );
+
+		// Test with custom thank you redirect URL.
+		$redirect_url = $form->get_redirect_url( array(), 123, $post_id );
+		$this->assertEquals( 'https://example.com/thank-you', $redirect_url, 'Redirect URL should match the custom thank you redirect URL.' );
+
+		// Test with no custom thank you redirect URL.
+		unset( $attributes['customThankyouRedirect'] );
+		$previous_request_uri         = $_REQUEST['_wp_http_referer'] ?? '';
+		$_REQUEST['_wp_http_referer'] = '/test-uri';
+
+		$form_no_redirect         = new Contact_Form( $attributes, '' );
+		$redirect_url_no_redirect = $form_no_redirect->get_redirect_url( array(), 123, $post_id );
+
+		if ( ! empty( $previous_request_uri ) ) {
+			$_REQUEST['_wp_http_referer'] = $previous_request_uri;
+		} else {
+			unset( $_REQUEST['_wp_http_referer'] );
+		}
+		// Restore the original request URI.
+
+		$this->assertEquals( '/test-uri', $redirect_url_no_redirect, 'Redirect URL should be empty when no custom thank you redirect URL is set.' );
+
+		$form_has_filter = new Contact_Form( $attributes, '' );
+		add_filter( 'grunion_contact_form_redirect_url', array( $this, 'redeirect_filter' ), 10 );
+		$redirect_url_via_filter = $form_has_filter->get_redirect_url( array(), 123, $post_id );
+		remove_filter( 'grunion_contact_form_redirect_url', array( $this, 'redeirect_filter' ), 10 );
+		$this->assertEquals( 'https://example.com/redirected', $redirect_url_via_filter, 'Redirect URL should match the filter return value.' );
+	}
+
+	public function redeirect_filter() {
+		return 'https://example.com/redirected';
+	}
+
+	public function test_has_custom_redirect() {
+		$attributes = array(
+			'customThankyou'         => 'redirect',
+			'customThankyouRedirect' => 'https://example.com/thank-you',
+		);
+
+		$form = new Contact_Form( $attributes, '' );
+
+		$this->assertTrue( $form->has_custom_redirect(), 'Form should have a custom redirect URL.' );
+
+		unset( $attributes['customThankyouRedirect'] );
+
+		$form_no_redirect = new Contact_Form( $attributes, '' );
+
+		$this->assertFalse( $form_no_redirect->has_custom_redirect(), 'Form should not have a custom redirect URL.' );
+
+		$form_has_filter = new Contact_Form( $attributes, '' );
+		add_filter( 'grunion_contact_form_redirect_url', array( $this, 'redeirect_filter' ), 10, 3 );
+		$this->assertTrue( $form_has_filter->has_custom_redirect(), 'Form should have a custom redirect URL.' );
+		remove_filter( 'grunion_contact_form_redirect_url', array( $this, 'redeirect_filter' ), 10 );
+	}
 }


### PR DESCRIPTION
Fixes FORMS-236



## Proposed changes:
* Send A redirect URL if there is a custom URL set for a form to the JS side so that we know when to show the message and when to show the redirect. 
* Added 2 new methods to make it encapsulate the $redirect feature. get_redirect and has_redirect. 
* Added tests. 

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

