### PR TITLE
WPCOMSH: Change diagnostic command to diag; add theme status

### DIFF
--- a/projects/plugins/wpcomsh/changelog/update-wpcomsh-diag-cli-command
+++ b/projects/plugins/wpcomsh/changelog/update-wpcomsh-diag-cli-command
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Internal tool
+
+

--- a/projects/plugins/wpcomsh/class-wpcomsh-cli-commands.php
+++ b/projects/plugins/wpcomsh/class-wpcomsh-cli-commands.php
@@ -1163,7 +1163,7 @@ if ( class_exists( 'WP_CLI_Command' ) ) {
 		/**
 		 * Runs comprehensive site diagnostics including Jetpack status, admin users, plugins, purchases, and PHP errors
 		 *
-		 * @subcommand diagnostic
+		 * @subcommand diag
 		 */
 		public function diagnostic( $args, $assoc_args ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter, VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 			WP_CLI::log( WP_CLI::colorize( '%B=== SITE DIAGNOSTICS ===%n' ) );
@@ -1229,7 +1229,27 @@ if ( class_exists( 'WP_CLI_Command' ) ) {
 
 			WP_CLI::log( '' );
 
-			// 4. WPCOMSH Purchases (formatted as table)
+			// 4. Theme Status
+			WP_CLI::log( WP_CLI::colorize( '%Y--- Theme Status ---%n' ) );
+			$theme_status_result = WP_CLI::runcommand(
+				'theme status',
+				array(
+					'launch'     => false,
+					'return'     => 'all',
+					'exit_error' => false,
+				)
+			);
+
+			if ( 0 === $theme_status_result->return_code ) {
+				WP_CLI::log( $theme_status_result->stdout );
+			} else {
+				WP_CLI::log( WP_CLI::colorize( '%RTheme status command failed:%n' ) );
+				WP_CLI::log( $theme_status_result->stderr );
+			}
+
+			WP_CLI::log( '' );
+
+			// 5. WPCOMSH Purchases (formatted as table)
 			WP_CLI::log( WP_CLI::colorize( '%Y--- Site Purchases ---%n' ) );
 			$purchases_result = WP_CLI::runcommand(
 				'wpcomsh purchases --format=json',
@@ -1270,7 +1290,7 @@ if ( class_exists( 'WP_CLI_Command' ) ) {
 
 			WP_CLI::log( '' );
 
-			// 5. PHP Errors (filtered to recent fatals and errors)
+			// 6. PHP Errors (filtered to recent fatals and errors)
 			WP_CLI::log( WP_CLI::colorize( '%Y--- Recent PHP Errors ---%n' ) );
 			$php_errors_result = WP_CLI::runcommand(
 				'php-errors',


### PR DESCRIPTION
Fixes feedback in DOTCOM-13947

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Changes command to `wp wpcomsh diag` from `wp wpcomsh diagnostic`
* Add `theme status`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
DOTCOM-13947

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Checkout branch
- `jetpack build plugins/wpcomsh`
- `jetpack rsync wpcomsh` to a WoW dev site
- SSH to site and run `wp wpcomsh diag`

