### PR TITLE
Forms: Fix jwt form submission validation

### DIFF
--- a/projects/packages/forms/changelog/fix-jwt-validation
+++ b/projects/packages/forms/changelog/fix-jwt-validation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: validate form on submission

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -250,7 +250,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 	 */
 	public function has_value() {
 		$field_id    = $this->get_attribute( 'id' );
-		$field_value = isset( $_POST[ $field_id ] ) ? sanitize_text_field( wp_unslash( $_POST[ $field_id ] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Missing -- no site changes.
+		$field_value = isset( $_POST[ $field_id ] ) ? trim( sanitize_text_field( wp_unslash( $_POST[ $field_id ] ) ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Missing -- no site changes.
 
 		return ! empty( $field_value );
 	}

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -272,7 +272,11 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 
 		$field_type = $this->maybe_override_type();
 		// If it's not required, there's nothing to validate
-		if ( ! $this->get_attribute( 'required' ) || ! $this->is_field_renderable( $field_type ) ) {
+		if ( ! $this->get_attribute( 'required' ) && ! $this->has_value() ) {
+			return;
+		}
+
+		if ( ! $this->is_field_renderable( $field_type ) ) {
 			return;
 		}
 

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -227,12 +227,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 	 */
 	public function add_error( $message ) {
 		$this->error = true;
-
-		if ( ! is_wp_error( $this->form->errors ) ) {
-			$this->form->errors = new \WP_Error();
-		}
-
-		$this->form->errors->add( $this->get_attribute( 'id' ), $message );
+		$this->form->add_error( $this->get_attribute( 'id' ), $message );
 	}
 
 	/**
@@ -244,6 +239,20 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 	 */
 	public function is_error() {
 		return $this->error;
+	}
+
+	/**
+	 * Check if the field has a value.
+	 *
+	 * This is used to determine if the field has been filled out by the user.
+	 *
+	 * @return bool True if the field has a value, false otherwise.
+	 */
+	public function has_value() {
+		$field_id    = $this->get_attribute( 'id' );
+		$field_value = isset( $_POST[ $field_id ] ) ? sanitize_text_field( wp_unslash( $_POST[ $field_id ] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Missing -- no site changes.
+
+		return ! empty( $field_value );
 	}
 
 	/**
@@ -277,28 +286,28 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 					$field_value
 				) ) {
 					/* translators: %s is the name of a form field */
-					$this->add_error( sprintf( __( '%s: Please enter a valid URL - https://www.example.com', 'jetpack-forms' ), $field_label ) );
+					$this->add_error( sprintf( __( '%s: Please enter a valid URL - https://www.example.com.', 'jetpack-forms' ), $field_label ) );
 				}
 				break;
 			case 'email':
 				// Make sure the email address is valid
 				if ( ! is_string( $field_value ) || ! is_email( $field_value ) ) {
 					/* translators: %s is the name of a form field */
-					$this->add_error( sprintf( __( '%s requires a valid email address', 'jetpack-forms' ), $field_label ) );
+					$this->add_error( sprintf( __( '%s requires a valid email address.', 'jetpack-forms' ), $field_label ) );
 				}
 				break;
 			case 'checkbox-multiple':
 				// Check that there is at least one option selected
 				if ( empty( $field_value ) ) {
 					/* translators: %s is the name of a form field */
-					$this->add_error( sprintf( __( '%s requires at least one selection', 'jetpack-forms' ), $field_label ) );
+					$this->add_error( sprintf( __( '%s requires at least one selection.', 'jetpack-forms' ), $field_label ) );
 				}
 				break;
 			case 'number':
 				// Make sure the number address is valid
 				if ( ! is_numeric( $field_value ) ) {
 					/* translators: %s is the name of a form field */
-					$this->add_error( sprintf( __( '%s requires a number', 'jetpack-forms' ), $field_label ) );
+					$this->add_error( sprintf( __( '%s requires a number.', 'jetpack-forms' ), $field_label ) );
 				}
 				break;
 			case 'file':
@@ -312,7 +321,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 				// Just check for presence of any text
 				if ( ! is_string( $field_value ) || ! strlen( trim( $field_value ) ) ) {
 					/* translators: %s is the name of a form field */
-					$this->add_error( sprintf( __( '%s is required', 'jetpack-forms' ), $field_label ) );
+					$this->add_error( sprintf( __( '%s field is required.', 'jetpack-forms' ), $field_label ) );
 				}
 		}
 	}

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -259,6 +259,11 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 	 * Validates the form input
 	 */
 	public function validate() {
+		// If the field is already invalid, don't validate it again.
+		if ( $this->is_error() ) {
+			return;
+		}
+
 		$field_type = $this->maybe_override_type();
 		// If it's not required, there's nothing to validate
 		if ( ! $this->get_attribute( 'required' ) || ! $this->is_field_renderable( $field_type ) ) {

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -250,9 +250,15 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 	 */
 	public function has_value() {
 		$field_id    = $this->get_attribute( 'id' );
-		$field_value = isset( $_POST[ $field_id ] ) ? trim( sanitize_text_field( wp_unslash( $_POST[ $field_id ] ) ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Missing -- no site changes.
+		$field_value = isset( $_POST[ $field_id ] ) ? wp_unslash( $_POST[ $field_id ] ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- no site changes.
 
-		return ! empty( $field_value );
+		if ( is_array( $field_value ) ) {
+			if ( empty( $field_value ) ) {
+				return false;
+			}
+			return ! empty( array_filter( $field_value ) );
+		}
+		return ! empty( trim( $field_value ) );
 	}
 
 	/**
@@ -306,6 +312,22 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 				if ( empty( $field_value ) ) {
 					/* translators: %s is the name of a form field */
 					$this->add_error( sprintf( __( '%s requires at least one selection.', 'jetpack-forms' ), $field_label ) );
+				} else {
+					// Check that the selected options are valid
+					$options           = (array) $this->get_attribute( 'options' );
+					$non_empty_options = array_filter(
+						$options,
+						function ( $option ) {
+							return $option !== '';
+						}
+					);
+					foreach ( $field_value  as $field_value_item ) {
+						if ( ! in_array( $field_value_item, $non_empty_options, true ) ) {
+							/* translators: %s is the name of a form field */
+							$this->add_error( sprintf( __( '%s requires at least one selection.', 'jetpack-forms' ), $field_label ) );
+							break;
+						}
+					}
 				}
 				break;
 			case 'number':

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -1240,6 +1240,16 @@ class Contact_Form_Plugin {
 			}
 
 			$form->validate();
+
+			if ( is_wp_error( $form->errors ) && $form->errors->get_error_codes() ) {
+				return $form->errors;
+			}
+
+			if ( ! empty( $form->attributes['salesforceData'] ) || ! empty( $form->attributes['postToUrl'] ) ) {
+				Post_To_Url::init();
+			}
+			// Process the form
+			return $form->process_submission();
 		}
 
 		if ( $is_widget ) {

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -1231,7 +1231,6 @@ class Contact_Form_Plugin {
 		$is_block_template      = str_starts_with( $id, 'block-template-' );
 		$is_block_template_part = str_starts_with( $id, 'block-template-part-' );
 
-		$form = false;
 		if ( isset( $_POST['jetpack_contact_form_jwt'] ) ) {
 			$form = Contact_Form::get_instance_from_jwt( sanitize_text_field( wp_unslash( $_POST['jetpack_contact_form_jwt'] ) ) );
 			if ( ! $form ) { // fail early if the JWT is invalid.
@@ -1241,7 +1240,7 @@ class Contact_Form_Plugin {
 
 			$form->validate();
 
-			if ( is_wp_error( $form->errors ) && $form->errors->get_error_codes() ) {
+			if ( $form->has_errors() ) {
 				return $form->errors;
 			}
 
@@ -1370,10 +1369,9 @@ class Contact_Form_Plugin {
 				apply_filters( 'the_content', $content );
 			}
 		}
-		if ( ! $form ) {
-			// In future version we will be able to skip this step.
-			$form = isset( Contact_Form::$forms[ $hash ] ) ? Contact_Form::$forms[ $hash ] : null;
-		}
+
+		// In future version we will be able to skip this step.
+		$form = isset( Contact_Form::$forms[ $hash ] ) ? Contact_Form::$forms[ $hash ] : null;
 
 		// No form may mean user is using do_shortcode, grab the form using the stored post meta
 		if ( ! $form && is_numeric( $id ) && $hash ) {
@@ -1407,8 +1405,8 @@ class Contact_Form_Plugin {
 			return false;
 		}
 
-		if ( is_wp_error( $form->errors ) && $form->errors->get_error_codes() ) {
-			return $form->errors;
+		if ( $form->has_errors() ) {
+			return false;
 		}
 
 		if ( ! empty( $form->attributes['salesforceData'] ) || ! empty( $form->attributes['postToUrl'] ) ) {

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -1238,6 +1238,8 @@ class Contact_Form_Plugin {
 				// If the JWT is invalid, we can't process the form.
 				return false;
 			}
+
+			$form->validate();
 		}
 
 		if ( $is_widget ) {

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -934,8 +934,10 @@ class Contact_Form extends Contact_Form_Shortcode {
 		if ( $submission_success ) {
 			$classes .= ' submission-success';
 		}
+		$back_url = remove_query_arg( array( 'contact-form-id', 'contact-form-sent', '_wpnonce', 'contact-form-hash' ) );
+
 		$html  = '<div class="' . esc_attr( $classes ) . '" data-wp-class--submission-success="context.submissionSuccess">';
-		$html .= '<p class="go-back-message"> <a class="link" role="button" tabindex="0" data-wp-on--click="actions.goBack">' . esc_html__( 'Go back', 'jetpack-forms' ) . '</a> </p>';
+		$html .= '<p class="go-back-message"><a class="link" role="button" tabindex="0" data-wp-on--click="actions.goBack" href="' . esc_url( $back_url ) . '">' . esc_html__( 'Go back', 'jetpack-forms' ) . '</a> </p>';
 		$html .=
 			'<h4 id="contact-form-success-header">' . esc_html( $form->get_attribute( 'customThankyouHeading' ) ) .
 			"</h4>\n\n";

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1368,6 +1368,17 @@ class Contact_Form extends Contact_Form_Shortcode {
 			$form->fields[] = $field;
 		}
 
+		if ( // phpcs:disable WordPress.Security.NonceVerification.Missing
+			isset( $_POST['action'] ) && 'grunion-contact-form' === $_POST['action']
+			&&
+			isset( $_POST['contact-form-id'] ) && (string) $form->get_attribute( 'id' ) === $_POST['contact-form-id']
+			&&
+			isset( $_POST['contact-form-hash'] ) && is_string( $_POST['contact-form-hash'] ) && hash_equals( $form->hash, wp_unslash( $_POST['contact-form-hash'] ) )
+		) { // phpcs:enable
+			// If we're processing a POST submission for this contact form, validate the field value so we can show errors as necessary.
+			$field->validate();
+		}
+
 		// Output HTML
 		return $field->render();
 	}

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -76,6 +76,18 @@ class Contact_Form extends Contact_Form_Shortcode {
 	public static $forms_context = array();
 
 	/**
+	 * The default attributes for the contact form.
+	 *
+	 * @var WP_Error
+	 */
+	public static $static_errors;
+	/**
+	 * The default attributes for the contact form.
+	 *
+	 * @var array
+	 */
+
+	/**
 	 * Whether to print the grunion.css style when processing the contact-form shortcode
 	 *
 	 * @var bool
@@ -614,7 +626,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 		$default_context = array(
 			'formId'                  => $id,
 			'formHash'                => $form->hash,
-			'showErrors'              => false, // We toggle this to true when we want to show the user errors right away.
+			'showErrors'              => $form->has_errors(), // We toggle this to true when we want to show the user errors right away.
 			'errors'                  => array(), // This should be a associative array.
 			'fields'                  => array(),
 			'isMultiStep'             => $is_multistep, // Whether the form is a multistep form.
@@ -654,10 +666,10 @@ class Contact_Form extends Contact_Form_Shortcode {
 			$r .= self::render_ajax_success_wrapper( $form, $submission_success, $formatted_submission_data );
 		}
 
-		if ( is_wp_error( $form->errors ) && $form->errors->get_error_codes() ) {
+		if ( $form->has_errors() ) {
 			// There are errors.  Display them
 			$r .= "<div class='form-error'>\n<h3>" . __( 'Error!', 'jetpack-forms' ) . "</h3>\n<ul class='form-errors'>\n";
-			foreach ( $form->errors->get_error_messages() as $message ) {
+			foreach ( $form->get_error_messages() as $message ) {
 				$r .= "\t<li class='form-error-message'>" . esc_html( $message ) . "</li>\n";
 			}
 			$r .= "</ul>\n</div>\n\n";
@@ -2706,5 +2718,81 @@ class Contact_Form extends Contact_Form_Shortcode {
 
 		$theme_json_class = get_class( $theme_json_data );
 		return new $theme_json_class( $data, 'default' );
+	}
+
+	/**
+	 * Validate the contact form fields.
+	 *
+	 * This method checks each field for errors and ensures that at least one field has a value.
+	 * If no fields have values and there are no errors, it adds an error indicating that the form is empty.
+	 */
+	public function validate() {
+		$has_value = false;
+		// Validate the form fields before processing the form.
+		foreach ( $this->fields as $field ) {
+			$field->validate();
+			if ( ! $has_value && $field->has_value() ) {
+				$has_value = true;
+			}
+		}
+
+		if ( ! $has_value && ! $this->has_errors() ) {
+			$this->add_error( 'empty', __( 'Please fill out at least one field.', 'jetpack-forms' ) );
+		}
+	}
+
+	/**
+	 * Reset the static errors for the contact form.
+	 *
+	 * @param string $id The ID of the contact form to reset errors for. If null, resets all static errors.
+	 *
+	 * This method is used to clear the static errors stored in the class.
+	 */
+	public static function reset_errors( $id = null ) {
+		if ( $id && isset( self::$static_errors[ $id ] ) ) {
+			unset( self::$static_errors[ $id ] );
+			return;
+		}
+		self::$static_errors = array();
+	}
+
+	/**
+	 * Add an error to the contact form.
+	 *
+	 * @param string $error_code    The error code.
+	 * @param string $error_message The error message.
+	 */
+	public function add_error( $error_code, $error_message ) {
+		if ( ! is_wp_error( $this->errors ) ) {
+			$this->errors = new \WP_Error();
+		}
+		// for backward compatibility, we need to add the error code and message
+		$this->errors->add( $error_code, $error_message );
+		self::$static_errors[ $this->get_attribute( 'id' ) ] = $this->errors;
+	}
+	/**
+	 * Check if the contact form has errors.
+	 *
+	 * @return bool True if the contact form has errors, false otherwise.
+	 */
+	public function has_errors() {
+		$id = $this->get_attribute( 'id' );
+		if ( ! isset( self::$static_errors[ $id ] ) ) {
+			return false;
+		}
+		return is_wp_error( self::$static_errors[ $id ] ) && ! empty( self::$static_errors[ $id ]->get_error_codes() );
+	}
+
+	/**
+	 * Get the error messages of the contact form.
+	 *
+	 * @return array The errors of the contact form.
+	 */
+	public function get_error_messages() {
+		if ( ! $this->has_errors() ) {
+			return array();
+		}
+		$id = $this->get_attribute( 'id' );
+		return self::$static_errors[ $id ]->get_error_messages();
 	}
 }

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1368,17 +1368,6 @@ class Contact_Form extends Contact_Form_Shortcode {
 			$form->fields[] = $field;
 		}
 
-		if ( // phpcs:disable WordPress.Security.NonceVerification.Missing
-			isset( $_POST['action'] ) && 'grunion-contact-form' === $_POST['action']
-			&&
-			isset( $_POST['contact-form-id'] ) && (string) $form->get_attribute( 'id' ) === $_POST['contact-form-id']
-			&&
-			isset( $_POST['contact-form-hash'] ) && is_string( $_POST['contact-form-hash'] ) && hash_equals( $form->hash, wp_unslash( $_POST['contact-form-hash'] ) )
-		) { // phpcs:enable
-			// If we're processing a POST submission for this contact form, validate the field value so we can show errors as necessary.
-			$field->validate();
-		}
-
 		// Output HTML
 		return $field->render();
 	}

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -2758,12 +2758,12 @@ class Contact_Form extends Contact_Form_Shortcode {
 	 * @param string $error_message The error message.
 	 */
 	public function add_error( $error_code, $error_message ) {
-		if ( ! is_wp_error( $this->errors ) ) {
-			$this->errors = new \WP_Error();
+		$id = $this->get_attribute( 'id' );
+		if ( ! isset( self::$static_errors[ $id ] ) ) {
+			self::$static_errors[ $id ] = new \WP_Error();
 		}
-		// for backward compatibility, we need to add the error code and message
-		$this->errors->add( $error_code, $error_message );
-		self::$static_errors[ $this->get_attribute( 'id' ) ] = $this->errors;
+		self::$static_errors[ $id ]->add( $error_code, $error_message );
+		$this->errors = self::$static_errors[ $id ];
 	}
 	/**
 	 * Check if the contact form has errors.

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -76,16 +76,11 @@ class Contact_Form extends Contact_Form_Shortcode {
 	public static $forms_context = array();
 
 	/**
-	 * The default attributes for the contact form.
-	 *
-	 * @var WP_Error
-	 */
-	public static $static_errors;
-	/**
-	 * The default attributes for the contact form.
+	 * Array of WP_Error objects that are keyed by form id.
 	 *
 	 * @var array
 	 */
+	public static $static_errors = array();
 
 	/**
 	 * Whether to print the grunion.css style when processing the contact-form shortcode

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -934,7 +934,8 @@ class Contact_Form extends Contact_Form_Shortcode {
 		if ( $submission_success ) {
 			$classes .= ' submission-success';
 		}
-		$back_url = remove_query_arg( array( 'contact-form-id', 'contact-form-sent', '_wpnonce', 'contact-form-hash' ) );
+		$back_url  = remove_query_arg( array( 'contact-form-id', 'contact-form-sent', '_wpnonce', 'contact-form-hash' ) );
+		$back_url .= '#contact-form-' . $form->get_attribute( 'id' );
 
 		$html  = '<div class="' . esc_attr( $classes ) . '" data-wp-class--submission-success="context.submissionSuccess">';
 		$html .= '<p class="go-back-message"><a class="link" role="button" tabindex="0" data-wp-on--click="actions.goBack" href="' . esc_url( $back_url ) . '">' . esc_html__( 'Go back', 'jetpack-forms' ) . '</a> </p>';

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1369,6 +1369,8 @@ class Contact_Form extends Contact_Form_Shortcode {
 		}
 
 		if ( // phpcs:disable WordPress.Security.NonceVerification.Missing
+			! isset( $_POST['jetpack_contact_form_jwt'] )
+			&&
 			isset( $_POST['action'] ) && 'grunion-contact-form' === $_POST['action']
 			&&
 			isset( $_POST['contact-form-id'] ) && (string) $form->get_attribute( 'id' ) === $_POST['contact-form-id']

--- a/projects/packages/forms/src/modules/form/view.js
+++ b/projects/packages/forms/src/modules/form/view.js
@@ -435,6 +435,7 @@ const { state } = store( NAMESPACE, {
 			url.searchParams.delete( 'contact-form-hash' );
 			url.searchParams.delete( '_wpnonce' );
 			window.history.replaceState( null, '', url.toString() );
+			return false;
 		},
 	},
 

--- a/projects/packages/forms/src/modules/form/view.js
+++ b/projects/packages/forms/src/modules/form/view.js
@@ -417,7 +417,9 @@ const { state } = store( NAMESPACE, {
 			}
 		} ),
 
-		goBack: () => {
+		goBack: event => {
+			event.preventDefault();
+			event.stopPropagation();
 			const context = getContext();
 
 			const form = document.getElementById( context.elementId );
@@ -435,7 +437,6 @@ const { state } = store( NAMESPACE, {
 			url.searchParams.delete( 'contact-form-hash' );
 			url.searchParams.delete( '_wpnonce' );
 			window.history.replaceState( null, '', url.toString() );
-			return false;
 		},
 	},
 

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
@@ -537,13 +537,24 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 	}
 
 	public function test_process_from_with_jwt() {
-		$previous_post = $this->setup_token_test();
+		$previous_post = $this->setup_token_test( null, 'Test User' );
 
 		$plugin = Contact_Form_Plugin::init();
 		$result = $plugin->process_form_submission();
 
 		$this->assertInstanceOf( WP_Error::class, $result, 'Expected a WP_Error when processing the form submission.' );
 		$this->assertEquals( 'check_spam', $result->get_error_code(), 'Expected the error code to be "check_spam".' );
+
+		$this->teardown_post_for_test( $previous_post );
+	}
+
+	public function test_process_from_with_jwt_validation_error() {
+		$previous_post = $this->setup_token_test( null );
+
+		$plugin = Contact_Form_Plugin::init();
+		$result = $plugin->process_form_submission();
+		$this->assertInstanceOf( WP_Error::class, $result, 'Expected a WP_Error when processing the form submission.' );
+		$this->assertEquals( 'Name field is required.', $result->get_error_message(), 'Expected the error code to be "check_spam".' );
 
 		$this->teardown_post_for_test( $previous_post );
 	}
@@ -559,7 +570,7 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 		$this->teardown_post_for_test( $previous_post );
 	}
 
-	private function setup_token_test( $token = null ) {
+	private function setup_token_test( $token = null, $name = null ) {
 		global $post;
 		$post_id = wp_insert_post(
 			array(
@@ -578,6 +589,11 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 		$_POST['jetpack_contact_form_jwt'] = $token ?? $form->get_jwt();
 		$_POST['contact-form-hash']        = $form->hash;
 		$_POST['contact-form-id']          = $post_id;
+
+		if ( $name ) {
+			$_POST[ 'g' . $post_id . '-name' ] = $name;
+		}
+
 		return $previous_post;
 	}
 
@@ -589,6 +605,7 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 		unset( $_POST['contact-form-hash'] );
 		unset( $_POST['jetpack_contact_form_jwt'] );
 		unset( $_POST['contact-form-id'] );
+		unset( $_POST[ 'g' . $post->ID . '-name' ] );
 	}
 
 	public function return_error_for_test() {

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -3001,15 +3001,15 @@ EOT;
 	public function test_validate_form() {
 		$name    = 'John Doe';
 		$email   = 'john@example.com';
-		$message = 'Test message';
+		$choose  = array( 'truth' );
 		$form_id = Utility::get_form_id();
 
 		// Create a form submission
 		$_POST = Utility::get_post_request(
 			array(
-				'name'    => $name,
-				'email'   => $email,
-				'message' => $message,
+				'name'   => $name,
+				'email'  => $email,
+				'choose' => $choose,
 			),
 			'g' . $form_id
 		);
@@ -3019,27 +3019,29 @@ EOT;
 				'title'       => 'Test Form',
 				'description' => 'This is a test form.',
 			),
-			"[contact-field label='Name' type='name' required='1'/][contact-field label='Email' type='email' required='1'/][contact-field label='Message' type='textarea' required='1'/]"
+			'[contact-field label="Name" type="name" required="1"/][contact-field label="Email" type="email" required="1"/][contact-field label="Choose" type="checkbox-multiple"  options="truth,dare"  required="1"]'
 		);
 
 		$form->validate();
 		unset( $_POST ); // Clean up the global $_POST variable after the test.
-
+		$this->assertEquals( array(), $form->get_error_messages() );
 		$this->assertFalse( $form->has_errors(), 'Form should not have errors after validation.' );
 	}
 
 	public function test_validate_form_with_errors() {
-		$name    = 'John Doe';
-		$email   = 'john@example.com';
-		$message = '';
+		$name    = ''; // required field
+		$email   = 'hello@world'; // Invalid email
+		$choose  = array( '' ); // required field
+		$pick    = array( 'not-a-value' ); // required field
 		$form_id = Utility::get_form_id();
 
 		// Create a form submission
 		$_POST = Utility::get_post_request(
 			array(
-				'name'    => $name,
-				'email'   => $email,
-				'message' => $message,
+				'name'   => $name,
+				'email'  => $email,
+				'choose' => $choose,
+				'pick'   => $pick,
 			),
 			'g' . $form_id
 		);
@@ -3049,14 +3051,22 @@ EOT;
 				'title'       => 'Test Form',
 				'description' => 'This is a test form.',
 			),
-			"[contact-field label='Name' type='name' required='1'/][contact-field label='Email' type='email' required='1'/][contact-field label='Message' type='textarea' required='1'/]"
+			"[contact-field label='Name' type='name' required='1'/][contact-field label='Email' type='email' required='1'/][contact-field label='Choose' type='checkbox-multiple' options='truth,dare' required='1'/][contact-field label='Pick' type='checkbox-multiple' options='truth,dare' required='1'/]"
 		);
 		$form->validate();
 		unset( $_POST ); // Clean up the global $_POST variable after the test.
 
 		// message should be not empty.
 		$this->assertTrue( $form->has_errors(), 'Form should not have errors after validation.' );
-		$this->assertEquals( array( 'Message field is required.' ), $form->get_error_messages() );
+		$this->assertEquals(
+			array(
+				'Name field is required.',
+				'Email requires a valid email address.',
+				'Choose requires at least one selection.',
+				'Pick requires at least one selection.',
+			),
+			$form->get_error_messages()
+		);
 		Contact_Form::reset_errors();
 		$this->assertFalse( $form->has_errors(), 'Form should not have errors after validation.' );
 		$this->assertEquals( array(), $form->get_error_messages() );
@@ -3074,15 +3084,15 @@ EOT;
 	public function test_validate_empty_form() {
 		$name    = '';
 		$email   = '';
-		$message = '';
+		$choose  = array( '' );
 		$form_id = Utility::get_form_id();
 
 		// Create a form submission
 		$_POST = Utility::get_post_request(
 			array(
-				'name'    => $name,
-				'email'   => $email,
-				'message' => $message,
+				'name'   => $name,
+				'email'  => $email,
+				'choose' => $choose,
 			),
 			'g' . $form_id
 		);
@@ -3092,7 +3102,7 @@ EOT;
 				'title'       => 'Test Form',
 				'description' => 'This is a test form.',
 			),
-			"[contact-field label='Name' type='name' /][contact-field label='Email' type='email' /][contact-field label='Message' type='textarea' /]"
+			'[contact-field label="Name" type="name" /][contact-field label="Email" type="email" /][contact-field label="Choose" type="checkbox-multiple" options="truth,dare" /]'
 		);
 		$form->validate();
 		unset( $_POST ); // Clean up the global $_POST variable after the test.

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -3057,5 +3057,17 @@ EOT;
 		// message should be not empty.
 		$this->assertTrue( $form->has_errors(), 'Form should not have errors after validation.' );
 		$this->assertEquals( array( 'Message field is required.' ), $form->get_error_messages() );
+		Contact_Form::reset_errors();
+		$this->assertFalse( $form->has_errors(), 'Form should not have errors after validation.' );
+		$this->assertEquals( array(), $form->get_error_messages() );
+
+		$form->add_error( 'custom_error', 'This is a custom error message.' );
+		$this->assertTrue( $form->has_errors(), 'Form should have custom error after adding it.' );
+		$this->assertEquals( array( 'This is a custom error message.' ), $form->get_error_messages(), 'Form should return custom error message.' );
+
+		// Reset errors and check again.
+		Contact_Form::reset_errors( $form->get_attribute( 'id' ) );
+		$this->assertFalse( $form->has_errors(), 'Form should not have errors after resetting.' );
+		$this->assertEquals( array(), $form->get_error_messages() );
 	}
 }

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -3040,6 +3040,7 @@ EOT;
 			array(
 				'name'   => $name,
 				'email'  => $email,
+				'invite' => 'hello@world', // not required
 				'choose' => $choose,
 				'pick'   => $pick,
 			),
@@ -3051,7 +3052,7 @@ EOT;
 				'title'       => 'Test Form',
 				'description' => 'This is a test form.',
 			),
-			"[contact-field label='Name' type='name' required='1'/][contact-field label='Email' type='email' required='1'/][contact-field label='Choose' type='checkbox-multiple' options='truth,dare' required='1'/][contact-field label='Pick' type='checkbox-multiple' options='truth,dare' required='1'/]"
+			"[contact-field label='Name' type='name' required='1'/][contact-field label='Email' type='email' required='1'/][contact-field label='Invite' type='email' /][contact-field label='Choose' type='checkbox-multiple' options='truth,dare' required='1'/][contact-field label='Pick' type='checkbox-multiple' options='truth,dare' required='1'/]"
 		);
 		$form->validate();
 		unset( $_POST ); // Clean up the global $_POST variable after the test.
@@ -3062,6 +3063,7 @@ EOT;
 			array(
 				'Name field is required.',
 				'Email requires a valid email address.',
+				'Invite requires a valid email address.',
 				'Choose requires at least one selection.',
 				'Pick requires at least one selection.',
 			),

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -3070,4 +3070,36 @@ EOT;
 		$this->assertFalse( $form->has_errors(), 'Form should not have errors after resetting.' );
 		$this->assertEquals( array(), $form->get_error_messages() );
 	}
+
+	public function test_validate_empty_form() {
+		$name    = '';
+		$email   = '';
+		$message = '';
+		$form_id = Utility::get_form_id();
+
+		// Create a form submission
+		$_POST = Utility::get_post_request(
+			array(
+				'name'    => $name,
+				'email'   => $email,
+				'message' => $message,
+			),
+			'g' . $form_id
+		);
+
+		$form = new Contact_Form(
+			array(
+				'title'       => 'Test Form',
+				'description' => 'This is a test form.',
+			),
+			"[contact-field label='Name' type='name' /][contact-field label='Email' type='email' /][contact-field label='Message' type='textarea' /]"
+		);
+		$form->validate();
+		unset( $_POST ); // Clean up the global $_POST variable after the test.
+
+		// message should be not empty.
+		$this->assertTrue( $form->has_errors(), 'Form should not have errors after validation.' );
+		$this->assertEquals( array( 'Please fill out at least one field.' ), $form->get_error_messages() );
+		Contact_Form::reset_errors();
+	}
 }

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -2997,4 +2997,65 @@ EOT;
 		$this->assertTrue( $form_has_filter->has_custom_redirect(), 'Form should have a custom redirect URL.' );
 		remove_filter( 'grunion_contact_form_redirect_url', array( $this, 'redirect_filter' ), 10 );
 	}
+
+	public function test_validate_form() {
+		$name    = 'John Doe';
+		$email   = 'john@example.com';
+		$message = 'Test message';
+		$form_id = Utility::get_form_id();
+
+		// Create a form submission
+		$_POST = Utility::get_post_request(
+			array(
+				'name'    => $name,
+				'email'   => $email,
+				'message' => $message,
+			),
+			'g' . $form_id
+		);
+
+		$form = new Contact_Form(
+			array(
+				'title'       => 'Test Form',
+				'description' => 'This is a test form.',
+			),
+			"[contact-field label='Name' type='name' required='1'/][contact-field label='Email' type='email' required='1'/][contact-field label='Message' type='textarea' required='1'/]"
+		);
+
+		$form->validate();
+		unset( $_POST ); // Clean up the global $_POST variable after the test.
+
+		$this->assertFalse( $form->has_errors(), 'Form should not have errors after validation.' );
+	}
+
+	public function test_validate_form_with_errors() {
+		$name    = 'John Doe';
+		$email   = 'john@example.com';
+		$message = '';
+		$form_id = Utility::get_form_id();
+
+		// Create a form submission
+		$_POST = Utility::get_post_request(
+			array(
+				'name'    => $name,
+				'email'   => $email,
+				'message' => $message,
+			),
+			'g' . $form_id
+		);
+
+		$form = new Contact_Form(
+			array(
+				'title'       => 'Test Form',
+				'description' => 'This is a test form.',
+			),
+			"[contact-field label='Name' type='name' required='1'/][contact-field label='Email' type='email' required='1'/][contact-field label='Message' type='textarea' required='1'/]"
+		);
+		$form->validate();
+		unset( $_POST ); // Clean up the global $_POST variable after the test.
+
+		// message should be not empty.
+		$this->assertTrue( $form->has_errors(), 'Form should not have errors after validation.' );
+		$this->assertEquals( array( 'Message field is required.' ), $form->get_error_messages() );
+	}
 }


### PR DESCRIPTION
Fixes FORMS-NEW

Fixes form submissions with empty fields on the backend. Currently we limit form submission for fields via JS but not for form submissions. 

## Proposed changes:
* Validate form fields before processing the form. 
* Check that at least one field is valid and has a value. 

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?


## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Disable JS in your browser and submit the empty form. 
You should see an error. 
If the fields are required you should see the field specific errors. 

You should be able to submit the form as expected if the form is filled out correctly without JS. 

In future PRs it would be good to display the error message in the fields as expected. 