### PR TITLE
PayPal Payment Buttons: Update block instructions to add steps

### DIFF
--- a/projects/packages/paypal-payments/changelog/update-paypal-payment-buttons-instructions
+++ b/projects/packages/paypal-payments/changelog/update-paypal-payment-buttons-instructions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated copy of PayPal Payment Buttons block to add numbered steps.

--- a/projects/packages/paypal-payments/src/paypal-payment-buttons/edit.js
+++ b/projects/packages/paypal-payments/src/paypal-payment-buttons/edit.js
@@ -10,6 +10,10 @@ import {
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalText as Text,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalItemGroup as ItemGroup,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalItem as Item,
 } from '@wordpress/components';
 import { useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -324,6 +328,18 @@ export default function Edit( { attributes, setAttributes, isSelected } ) {
 				instructions={ buttonType === 'stacked' ? stackedInstructions : singleInstructions }
 				notices={ notice }
 			>
+				<ItemGroup>
+					<Item>
+						{ __( '1. Go to PayPal to get your button code', 'jetpack-paypal-payments' ) }
+					</Item>
+					<Item>
+						{ __(
+							'2. After login, choose Payment Buttons. Enter your product or service details, and build the buttons. Copy the button code for Stacked Buttons (copy html code) or Single Button.',
+							'jetpack-paypal-payments'
+						) }
+					</Item>
+					<Item>{ __( '3. Paste the code below.', 'jetpack-paypal-payments' ) }</Item>
+				</ItemGroup>
 				<ToggleGroupControl
 					label={ __( 'Button type', 'jetpack-paypal-payments' ) }
 					value={ buttonType }
@@ -357,16 +373,6 @@ export default function Edit( { attributes, setAttributes, isSelected } ) {
 						label={ __( 'Single Button', 'jetpack-paypal-payments' ) }
 					/>
 				</ToggleGroupControl>
-				<Text>
-					<ExternalLink href={ getPayPalSignupUrl() }>
-						<strong>{ __( 'Sign up', 'jetpack-paypal-payments' ) }</strong>
-					</ExternalLink>{ ' ' }
-					{ __( 'or', 'jetpack-paypal-payments' ) }{ ' ' }
-					<ExternalLink href={ getPayPalLoginUrl() }>
-						<strong>{ __( 'log in', 'jetpack-paypal-payments' ) }</strong>
-					</ExternalLink>{ ' ' }
-					{ __( 'to PayPal to get your Payment Button code.', 'jetpack-paypal-payments' ) }
-				</Text>
 				{ 'stacked' === buttonType && (
 					<PlainText
 						value={ rawHeadCode }
@@ -399,6 +405,16 @@ export default function Edit( { attributes, setAttributes, isSelected } ) {
 					aria-label={ 'stacked' === buttonType ? stackedButtonCodeLabel : singleButtonCodeLabel }
 					name="paypal-payment-buttons-code-body"
 				/>
+				<Text>
+					<ExternalLink href={ getPayPalSignupUrl() }>
+						<strong>{ __( 'Sign up', 'jetpack-paypal-payments' ) }</strong>
+					</ExternalLink>{ ' ' }
+					{ __( 'or', 'jetpack-paypal-payments' ) }{ ' ' }
+					<ExternalLink href={ getPayPalLoginUrl() }>
+						<strong>{ __( 'log in', 'jetpack-paypal-payments' ) }</strong>
+					</ExternalLink>{ ' ' }
+					{ __( 'to PayPal to get your Payment Button code.', 'jetpack-paypal-payments' ) }
+				</Text>
 			</Placeholder>
 		</div>
 	);

--- a/projects/packages/paypal-payments/tests/js/paypal-payment-buttons-block-tests/edit.test.js
+++ b/projects/packages/paypal-payments/tests/js/paypal-payment-buttons-block-tests/edit.test.js
@@ -67,6 +67,8 @@ jest.mock( '@wordpress/components', () => ( {
 	},
 	__experimentalToggleGroupControlOption: () => null, // We're not using the actual implementation
 	__experimentalText: ( { children } ) => <span data-testid="experimental-text">{ children }</span>,
+	__experimentalItemGroup: ( { children } ) => <div data-testid="item-group">{ children }</div>,
+	__experimentalItem: ( { children } ) => <div data-testid="item">{ children }</div>,
 	SVG: props => <svg { ...props } />,
 	Path: props => <path { ...props } />,
 } ) );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Update copy of block after feedback from PayPal.

<img width="1336" height="948" alt="CleanShot 2025-07-30 at 20 21 50@2x" src="https://github.com/user-attachments/assets/7bca61e0-2e08-48be-8439-3219d80fc3d1" />
<img width="1364" height="840" alt="CleanShot 2025-07-30 at 20 22 01@2x" src="https://github.com/user-attachments/assets/36b38b23-2a6d-41e6-a45b-3c59602851ef" />



### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
NA

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On a Jetpack connected site, ensure that blocks and widgets are enabled.
* Create a page
* Insert the `PayPal Payment Buttons` block
* Toggle between `Stacked Buttons` and `Single Buttons`
* Ensure that placeholder content changes near the top of the block
