### PR TITLE
Remove "Dashboard" link from Jetpack admin menu

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/remove-dashboard-link-from-jetpack
+++ b/projects/packages/jetpack-mu-wpcom/changelog/remove-dashboard-link-from-jetpack
@@ -1,4 +1,4 @@
 Significance: patch
 Type: removed
 
-Removed Dashboard link from Jetpack admin manu.
+Removed Dashboard link from Jetpack admin menu.

--- a/projects/packages/jetpack-mu-wpcom/changelog/remove-dashboard-link-from-jetpack
+++ b/projects/packages/jetpack-mu-wpcom/changelog/remove-dashboard-link-from-jetpack
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Removed Dashboard link from Jetpack admin manu.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
@@ -318,7 +318,6 @@ function wpcom_add_jetpack_submenu() {
 		'newsletter',
 		'podcasting',
 		'jetpack#/settings',
-		'jetpack#/dashboard',
 	);
 	$ordered_submenu = array();
 

--- a/projects/packages/masterbar/changelog/remove-dashboard-link-from-jetpack
+++ b/projects/packages/masterbar/changelog/remove-dashboard-link-from-jetpack
@@ -1,4 +1,4 @@
 Significance: patch
 Type: removed
 
-Removed Dashboard link from Jetpack admin manu.
+Removed Dashboard link from Jetpack admin menu.

--- a/projects/packages/masterbar/changelog/remove-dashboard-link-from-jetpack
+++ b/projects/packages/masterbar/changelog/remove-dashboard-link-from-jetpack
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Removed Dashboard link from Jetpack admin manu.

--- a/projects/packages/masterbar/tests/php/Admin_Menu_Test.php
+++ b/projects/packages/masterbar/tests/php/Admin_Menu_Test.php
@@ -342,7 +342,7 @@ class Admin_Menu_Test extends TestCase {
 		Jetpack_Admin_UI_Admin::admin_menu_hook_callback();
 		static::$admin_menu->add_jetpack_menu();
 
-		$this->assertSame( 'https://wordpress.com/activity-log/' . static::$domain, $submenu['jetpack'][3][2] );
+		$this->assertSame( 'https://wordpress.com/activity-log/' . static::$domain, $submenu['jetpack'][2][2] );
 	}
 
 	/**

--- a/projects/packages/masterbar/tests/php/data/admin-menu.php
+++ b/projects/packages/masterbar/tests/php/data/admin-menu.php
@@ -451,12 +451,6 @@ function get_submenu_fixture() {
 		),
 		'jetpack'                              => array(
 			1 => array(
-				'Dashboard',
-				'jetpack_admin_page',
-				'jetpack#/dashboard',
-				'Dashboard',
-			),
-			2 => array(
 				'Settings',
 				'jetpack_admin_page',
 				'jetpack#/settings',

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -100,26 +100,6 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 	}
 
 	/**
-	 * Add Jetpack Dashboard sub-link and point it to AAG if the user can view stats, manage modules or if Protect is active.
-	 *
-	 * Works in Dev Mode or when user is connected.
-	 *
-	 * @since 4.3.0
-	 */
-	public function jetpack_add_dashboard_sub_nav_item() {
-		if ( ( new Status() )->is_offline_mode() || Jetpack::is_connection_ready() ) {
-			Admin_Menu::add_menu(
-				__( 'Dashboard', 'jetpack' ),
-				__( 'Dashboard', 'jetpack' ),
-				'jetpack_admin_page',
-				Jetpack::admin_url( array( 'page' => 'jetpack#/dashboard' ) ),
-				null,
-				14
-			);
-		}
-	}
-
-	/**
 	 * Determine whether a user can access the Jetpack Settings page.
 	 *
 	 * Rules are:

--- a/projects/plugins/jetpack/changelog/remove-dashboard-link-from-jetpack
+++ b/projects/plugins/jetpack/changelog/remove-dashboard-link-from-jetpack
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Removed Dashboard link from Jetpack admin manu.

--- a/projects/plugins/jetpack/changelog/remove-dashboard-link-from-jetpack
+++ b/projects/plugins/jetpack/changelog/remove-dashboard-link-from-jetpack
@@ -1,4 +1,4 @@
 Significance: patch
 Type: other
 
-Removed Dashboard link from Jetpack admin manu.
+Removed Dashboard link from Jetpack admin menu.

--- a/projects/plugins/jetpack/class.jetpack-admin.php
+++ b/projects/plugins/jetpack/class.jetpack-admin.php
@@ -62,7 +62,6 @@ class Jetpack_Admin {
 		add_action( 'admin_init', array( $jetpack_react, 'react_redirects' ), 0 );
 		add_action( 'admin_menu', array( $jetpack_react, 'add_actions' ), 998 );
 		add_action( 'admin_menu', array( $jetpack_react, 'remove_jetpack_menu' ), 2000 );
-		add_action( 'jetpack_admin_menu', array( $jetpack_react, 'jetpack_add_dashboard_sub_nav_item' ) );
 		add_action( 'jetpack_admin_menu', array( $jetpack_react, 'jetpack_add_settings_sub_nav_item' ) );
 		add_action( 'jetpack_admin_menu', array( $this, 'admin_menu_debugger' ) );
 		add_action( 'jetpack_admin_menu', array( $fallback_page, 'add_actions' ) );

--- a/projects/plugins/jetpack/tests/php/general/Jetpack_Admin_Menu_Test.php
+++ b/projects/plugins/jetpack/tests/php/general/Jetpack_Admin_Menu_Test.php
@@ -77,7 +77,6 @@ class Jetpack_Admin_Menu_Test extends WP_UnitTestCase {
 		$backup_submenu_position     = array_search( 'Jetpack VaultPress Backup', $submenu_names, true );
 		$search_submenu_position     = array_search( 'Jetpack Search', $submenu_names, true );
 		$settings_submenu_position   = array_search( 'Settings', $submenu_names, true );
-		$dashboard_submenu_position  = array_search( 'Dashboard', $submenu_names, true );
 
 		// Some sites - multisites / WoA for example - may not have all of the menu items.
 		if ( in_array( 'My Jetpack', $submenu_names, true ) ) {
@@ -94,6 +93,5 @@ class Jetpack_Admin_Menu_Test extends WP_UnitTestCase {
 		$this->assertLessThan( $backup_submenu_position, $videopress_submenu_position, 'Jetpack VideoPress should be above Jetpack VaultPress Backup in the submenu order.' );
 		$this->assertLessThan( $search_submenu_position, $backup_submenu_position, 'Jetpack VaultPress Backup should be above Search in the submenu order.' );
 		$this->assertLessThan( $settings_submenu_position, $search_submenu_position, 'Search should be above Settings in the submenu order.' );
-		$this->assertLessThan( $dashboard_submenu_position, $settings_submenu_position, 'Settings should be above Dashboard in the submenu order.' );
 	}
 }

--- a/projects/plugins/jetpack/tests/php/general/Jetpack_Admin_Menu_Test.php
+++ b/projects/plugins/jetpack/tests/php/general/Jetpack_Admin_Menu_Test.php
@@ -53,7 +53,6 @@ class Jetpack_Admin_Menu_Test extends WP_UnitTestCase {
 
 		require_once JETPACK__PLUGIN_DIR . '_inc/lib/admin-pages/class.jetpack-react-page.php';
 		$jetpack_react = new Jetpack_React_Page();
-		$jetpack_react->jetpack_add_dashboard_sub_nav_item();
 		$jetpack_react->jetpack_add_settings_sub_nav_item();
 
 		$jetpack_stats = new Dashboard();


### PR DESCRIPTION
Completes MYJP-235

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Remove "Dashboard" link from Jetpack admin menu, still keeping it accessible directly via the URL.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to wp-admin
* Under Jetpack, confirm that the Dashboard link is not visible
* Go to `/wp-admin/admin.php?page=jetpack#/dashboard`
* Confirm that the Dashboard loads fine
