### PR TITLE
Post Images from blocks: move from Block_Delimiter to Block_Scanner

### DIFF
--- a/projects/plugins/jetpack/changelog/update-social-block-scanner-migration-hog-229
+++ b/projects/plugins/jetpack/changelog/update-social-block-scanner-migration-hog-229
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Social: Improve performance when selecting images for OpenGraph tags.

--- a/projects/plugins/jetpack/class.jetpack-post-images.php
+++ b/projects/plugins/jetpack/class.jetpack-post-images.php
@@ -5,7 +5,7 @@
  * @package automattic/jetpack
  */
 
-use Automattic\Block_Delimiter;
+use Automattic\Block_Scanner;
 use Automattic\Jetpack\Image_CDN\Image_CDN_Core;
 
 /**
@@ -423,6 +423,7 @@ class Jetpack_PostImages {
 	 *
 	 * @since 6.9.0
 	 * @since 14.8 Updated to use Block_Delimiter for improved performance.
+	 * @since $$next-version$$ Updated to use Block_Scanner for improved performance.
 	 *
 	 * @param mixed $html_or_id The HTML string to parse for images, or a post id.
 	 * @param int   $width      Minimum Image width.
@@ -437,8 +438,13 @@ class Jetpack_PostImages {
 			return $images;
 		}
 
+		$scanner = Block_Scanner::create( $html_info['html'] );
+		if ( ! $scanner ) {
+			return $images;
+		}
+
 		/*
-		 * Use Block_Delimiter to parse our post content HTML,
+		 * Use Block_Scanner to parse our post content HTML,
 		 * and find all the block delimiters for supported blocks,
 		 * whether they're parent or nested blocks.
 		 */
@@ -451,18 +457,21 @@ class Jetpack_PostImages {
 			'jetpack/story',
 		);
 
-		foreach ( Block_Delimiter::scan_delimiters( $html_info['html'] ) as $where => $delimiter ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		while ( $scanner->next_delimiter() ) {
+			$type               = $scanner->get_delimiter_type();
+			$block_type         = $scanner->get_block_type();
+			$is_supported_block = in_array( $block_type, $supported_blocks, true );
+
 			// Only process opening delimiters for supported block types.
-			if ( Block_Delimiter::OPENER !== $delimiter->get_delimiter_type() ) {
+			if ( Block_Scanner::OPENER !== $type ) {
 				continue;
 			}
 
-			$block_type = $delimiter->allocate_and_return_block_type();
-			if ( ! in_array( $block_type, $supported_blocks, true ) ) {
+			if ( ! $is_supported_block ) {
 				continue;
 			}
 
-			$attributes   = $delimiter->allocate_and_return_parsed_attributes() ?? array();
+			$attributes   = $scanner->allocate_and_return_parsed_attributes() ?? array();
 			$block_images = self::get_images_from_block_attributes( $block_type, $attributes, $html_info, $width, $height );
 
 			if ( ! empty( $block_images ) ) {

--- a/projects/plugins/jetpack/class.jetpack-post-images.php
+++ b/projects/plugins/jetpack/class.jetpack-post-images.php
@@ -458,15 +458,14 @@ class Jetpack_PostImages {
 		);
 
 		while ( $scanner->next_delimiter() ) {
-			$type               = $scanner->get_delimiter_type();
-			$block_type         = $scanner->get_block_type();
-			$is_supported_block = in_array( $block_type, $supported_blocks, true );
-
+			$type = $scanner->get_delimiter_type();
 			// Only process opening delimiters for supported block types.
 			if ( Block_Scanner::OPENER !== $type ) {
 				continue;
 			}
 
+			$block_type         = $scanner->get_block_type();
+			$is_supported_block = in_array( $block_type, $supported_blocks, true );
 			if ( ! $is_supported_block ) {
 				continue;
 			}

--- a/projects/plugins/jetpack/tests/php/media/Jetpack_PostImages_Test.php
+++ b/projects/plugins/jetpack/tests/php/media/Jetpack_PostImages_Test.php
@@ -1058,13 +1058,14 @@ class Jetpack_PostImages_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test if an array of images can be extracted from Image blocks using Block_Delimiter.
+	 * Test if an array of images can be extracted from Image blocks using Block_Scanner.
 	 *
 	 * @since 14.8
+	 * @since $$next-version$$ Updated to use Block_Scanner.
 	 */
-	public function test_from_blocks_with_block_delimiter() {
-		if ( ! class_exists( 'Automattic\Block_Delimiter' ) ) {
-			$this->markTestSkipped( 'Block_Delimiter not available' );
+	public function test_from_blocks_with_block_scanner() {
+		if ( ! class_exists( 'Automattic\Block_Scanner' ) ) {
+			$this->markTestSkipped( 'Block_Scanner not available' );
 		}
 
 		$post_info = $this->get_post_with_image_block();
@@ -1079,13 +1080,14 @@ class Jetpack_PostImages_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test if an array of images can be extracted from Gallery blocks using Block_Delimiter.
+	 * Test if an array of images can be extracted from Gallery blocks using Block_Scanner.
 	 *
 	 * @since 14.8
+	 * @since $$next-version$$ Updated to use Block_Scanner.
 	 */
-	public function test_from_blocks_with_gallery_block_delimiter() {
-		if ( ! class_exists( 'Automattic\Block_Delimiter' ) ) {
-			$this->markTestSkipped( 'Block_Delimiter not available' );
+	public function test_from_blocks_with_gallery_block_scanner() {
+		if ( ! class_exists( 'Automattic\Block_Scanner' ) ) {
+			$this->markTestSkipped( 'Block_Scanner not available' );
 		}
 
 		$post_info = $this->get_post_with_gallery_block();
@@ -1100,13 +1102,14 @@ class Jetpack_PostImages_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test if an array of images can be extracted from Columns blocks using Block_Delimiter.
+	 * Test if an array of images can be extracted from Columns blocks using Block_Scanner.
 	 *
 	 * @since 14.8
+	 * @since $$next-version$$ Updated to use Block_Scanner.
 	 */
-	public function test_from_blocks_with_columns_block_delimiter() {
-		if ( ! class_exists( 'Automattic\Block_Delimiter' ) ) {
-			$this->markTestSkipped( 'Block_Delimiter not available' );
+	public function test_from_blocks_with_columns_block_scanner() {
+		if ( ! class_exists( 'Automattic\Block_Scanner' ) ) {
+			$this->markTestSkipped( 'Block_Scanner not available' );
 		}
 
 		$post_info = $this->get_post_with_columns_block();
@@ -1121,13 +1124,14 @@ class Jetpack_PostImages_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test if an array of images can be extracted from Story blocks using Block_Delimiter.
+	 * Test if an array of images can be extracted from Story blocks using Block_Scanner.
 	 *
 	 * @since 14.8
+	 * @since $$next-version$$ Updated to use Block_Scanner.
 	 */
-	public function test_from_blocks_with_story_block_delimiter() {
-		if ( ! class_exists( 'Automattic\Block_Delimiter' ) ) {
-			$this->markTestSkipped( 'Block_Delimiter not available' );
+	public function test_from_blocks_with_story_block_scanner() {
+		if ( ! class_exists( 'Automattic\Block_Scanner' ) ) {
+			$this->markTestSkipped( 'Block_Scanner not available' );
 		}
 
 		$media_types = array( 'image', 'videopress' );
@@ -1144,13 +1148,14 @@ class Jetpack_PostImages_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test if an array of images can be extracted from mixed blocks using Block_Delimiter.
+	 * Test if an array of images can be extracted from mixed blocks using Block_Scanner.
 	 *
 	 * @since 14.8
+	 * @since $$next-version$$ Updated to use Block_Scanner.
 	 */
-	public function test_from_blocks_with_mixed_blocks_delimiter() {
-		if ( ! class_exists( 'Automattic\Block_Delimiter' ) ) {
-			$this->markTestSkipped( 'Block_Delimiter not available' );
+	public function test_from_blocks_with_mixed_blocks_scanner() {
+		if ( ! class_exists( 'Automattic\Block_Scanner' ) ) {
+			$this->markTestSkipped( 'Block_Scanner not available' );
 		}
 
 		$img_name       = 'image.jpg';


### PR DESCRIPTION
Fixes HOG-229

## Proposed changes:

* Update code that uses Block_Delimiter to use Block_Scanner.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

HOG-228

## Does this pull request change what data or activity we track or use?

no

## Testing instructions:

* Start from a site using no other Open Graph / Sharing plugins
* Activate Jetpack's sharing module.
* Create a new post using the block editor.
* Do not specify any Featured image
* Do not upload any image to that post.
* Instead, insert a new image block and choose from an image you've already uploaded, for another post (this is so `Jetpack_PostImages` does not pick images from attachments to your post)
* Publish your post.
* View source when looking at the post.
    * You should see your image used in the Open Graph Meta tags.
* Repeat by inserting an image from another site, e.g. `https://herve.bzh/wp-content/uploads/2013/01/watson-5818-1.jpg`:
    * it should not be picked.
* Repeat by inserting a gallery block instead, with images originally uploaded to another post.
    * It should be able to pick images.
* Repeat by inserting a tiled gallery block instead, with images originally uploaded to another post.
    * It should be able to pick images.