### PR TITLE
Jetpack Social OG tags: Replace Block_Delimiter with Block_Scanner

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-social-open-graph-block-scanner-migration-hog-230
+++ b/projects/plugins/jetpack/changelog/update-jetpack-social-open-graph-block-scanner-migration-hog-230
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Social: Improve performance when sanitizing OpenGraph tags.


### PR DESCRIPTION
Fixes HOG-230

Props to @LiamSarsfield on this one, as I thought it wasn't possible.

## Proposed changes:

* Update `jetpack_og_remove_query_blocks` to use `Block_Scanner` instead of `Block_Delimiter`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

HOG-140

## Does this pull request change what data or activity we track or use?

no

## Testing instructions:

Taken from https://github.com/Automattic/jetpack/pull/44155 as the changes touch on the same thing the PR did.

* Do the tests pass?

* Start with a site running a block-based theme. On a self-hosted site, make sure you've activated both Jetpack > Settings > Sharing > Sharing buttons and Jetpack > Settings > Traffic > SEO.
* Create a new page named "Blog".
* In that page, insert a query loop block returning some posts.
    * Inside the query loop, add a "no results" block (`<!-- wp:query-no-results -->`)
    * Add some content in the block, like "No posts found here, move along".
* Publish your post.
* View source.

=> The Open Graph Meta tags should be set to "Visit the post for more."
=> The `<meta name="description"` tag should be set to the site title. (On WordPress.com simple your site must use a paid plan to see that tag)