### PR TITLE
Untangling: Remove Account settings and Site Settings menu items

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-remove-site-settings-from-hosting
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-remove-site-settings-from-hosting
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Remove Hosting > Site Settings and Users > Account Settings
+
+

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
@@ -181,15 +181,6 @@ function wpcom_add_hosting_menu() {
 		null // @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal
 	);
 
-	add_submenu_page(
-		$parent_slug,
-		esc_attr__( 'Site Settings', 'jetpack-mu-wpcom' ),
-		esc_attr__( 'Site Settings', 'jetpack-mu-wpcom' ),
-		'manage_options',
-		esc_url( "https://wordpress.com/sites/settings/site/$domain" ),
-		null // @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal
-	);
-
 	// By default, WordPress adds a submenu item for the parent menu item, which we don't want.
 	remove_submenu_page(
 		$parent_slug,

--- a/projects/packages/masterbar/changelog/update-remove-site-settings-from-hosting
+++ b/projects/packages/masterbar/changelog/update-remove-site-settings-from-hosting
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Remove Hosting > Site Settings and Users > Account Settings
+
+

--- a/projects/packages/masterbar/src/admin-menu/class-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-admin-menu.php
@@ -329,7 +329,6 @@ class Admin_Menu extends Base_Admin_Menu {
 
 		$slug = current_user_can( 'list_users' ) ? 'users.php' : 'profile.php';
 		$this->update_submenus( $slug, $submenus_to_update );
-		add_submenu_page( $slug, esc_attr__( 'Account Settings', 'jetpack-masterbar' ), __( 'Account Settings', 'jetpack-masterbar' ), 'read', 'https://wordpress.com/me/account' );
 	}
 
 	/**

--- a/projects/packages/masterbar/src/admin-menu/class-atomic-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-atomic-admin-menu.php
@@ -142,9 +142,6 @@ class Atomic_Admin_Menu extends Admin_Menu {
 			// // @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
 			add_submenu_page( 'users.php', esc_attr__( 'Subscribers', 'jetpack-masterbar' ), __( 'Subscribers', 'jetpack-masterbar' ), 'list_users', 'https://wordpress.com/subscribers/jetpack-subscribers/' . $this->domain, null );
 		}
-
-		// Users who can't 'list_users' will see "Profile" menu & "Profile > Account Settings" as submenu.
-		add_submenu_page( $slug, esc_attr__( 'Account Settings', 'jetpack-masterbar' ), __( 'Account Settings', 'jetpack-masterbar' ), 'read', 'https://wordpress.com/me/account' );
 	}
 
 	/**

--- a/projects/packages/masterbar/tests/php/Admin_Menu_Test.php
+++ b/projects/packages/masterbar/tests/php/Admin_Menu_Test.php
@@ -291,19 +291,16 @@ class Admin_Menu_Test extends TestCase {
 
 		// On multisite the administrator is not allowed to create users.
 		grant_super_admin( self::$user_id );
-		$account_key = 5;
 
 		static::$admin_menu->add_users_menu();
 
 		// On WP.com users can only invite other users, not create them (missing create_users cap).
 		if ( ! defined( 'IS_WPCOM' ) || ! IS_WPCOM ) {
 			$this->assertSame( 'https://wordpress.com/people/new/' . static::$domain, $submenu['users.php'][2][2] );
-			$account_key = 6;
 		}
 
 		$this->assertSame( 'https://wordpress.com/people/team/' . static::$domain, $submenu['users.php'][0][2] );
 		$this->assertSame( 'https://wordpress.com/me', $submenu['users.php'][3][2] );
-		$this->assertSame( 'https://wordpress.com/me/account', $submenu['users.php'][ $account_key ][2] );
 	}
 
 	/**

--- a/projects/packages/masterbar/tests/php/Admin_Menu_Test.php
+++ b/projects/packages/masterbar/tests/php/Admin_Menu_Test.php
@@ -283,7 +283,6 @@ class Admin_Menu_Test extends TestCase {
 
 		'@phan-var non-empty-array $submenu';
 		$this->assertSame( 'https://wordpress.com/me', $submenu['profile.php'][0][2] );
-		$this->assertSame( 'https://wordpress.com/me/account', $submenu['profile.php'][2][2] );
 
 		// Reset.
 		wp_set_current_user( static::$user_id );

--- a/projects/packages/masterbar/tests/php/Atomic_Admin_Menu_Test.php
+++ b/projects/packages/masterbar/tests/php/Atomic_Admin_Menu_Test.php
@@ -163,7 +163,6 @@ class Atomic_Admin_Menu_Test extends TestCase {
 		$this->assertSame( 'https://wordpress.com/people/team/' . static::$domain, $submenu['users.php'][0][2] );
 		$this->assertSame( 'user-new.php', $submenu['users.php'][2][2] );
 		$this->assertSame( 'profile.php', $submenu['users.php'][3][2] );
-		$this->assertSame( 'https://wordpress.com/me/account', $submenu['users.php'][5][2] );
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes DOTCOM-14033, DOTCOM-14032

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Remove Hosting > Site Settings menu item
* Remove Users > Account Settings menu item

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this PR on your Atomic site (WordPress.com features)
* Make sure you have the default interface enabled on your site
* Notice that there's no "Users > Account Settings" menu item
* Apply the PR on your site (both AT & SImple)
* Enable the classic interface
* Notice that in the Hosting menu we no longer have the "Site Settings" submenu item

