### PR TITLE
Prevent PHP fatals when directly accessing files

### DIFF
--- a/projects/plugins/jetpack/3rd-party/vaultpress.php
+++ b/projects/plugins/jetpack/3rd-party/vaultpress.php
@@ -7,6 +7,10 @@
 
 use Automattic\Jetpack\Redirect;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * Notify user that VaultPress has been disabled. Hide VaultPress notice that requested attention.
  *

--- a/projects/plugins/jetpack/changelog/fix-jetpack-direct_access_fatals
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-direct_access_fatals
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Prevent PHP errors when directly accessing various files.

--- a/projects/plugins/jetpack/class.jetpack-modules-list-table.php
+++ b/projects/plugins/jetpack/class.jetpack-modules-list-table.php
@@ -7,6 +7,10 @@
 
 use Automattic\Jetpack\Assets;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 if ( ! class_exists( 'WP_List_Table' ) ) {
 	require_once ABSPATH . 'wp-admin/includes/class-wp-list-table.php';
 }

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -40,6 +40,10 @@ use Automattic\Jetpack\Sync\Sender;
 use Automattic\Jetpack\Terms_Of_Service;
 use Automattic\Jetpack\Tracking;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /*
 Options:
 jetpack_options (array)

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-assistant.php
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-assistant.php
@@ -14,6 +14,10 @@ use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Status\Host;
 use Jetpack_Gutenberg;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * Registers our block for use in Gutenberg
  * This is done via an action so that we can disable

--- a/projects/plugins/jetpack/extensions/blocks/business-hours/business-hours.php
+++ b/projects/plugins/jetpack/extensions/blocks/business-hours/business-hours.php
@@ -12,6 +12,10 @@ namespace Automattic\Jetpack\Extensions\Business_Hours;
 use Automattic\Jetpack\Blocks;
 use Jetpack_Gutenberg;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * Registers the block for use in Gutenberg
  * This is done via an action so that we can disable

--- a/projects/plugins/jetpack/extensions/blocks/cookie-consent/cookie-consent.php
+++ b/projects/plugins/jetpack/extensions/blocks/cookie-consent/cookie-consent.php
@@ -12,6 +12,10 @@ namespace Automattic\Jetpack\Extensions\CookieConsent;
 use Automattic\Jetpack\Blocks;
 use Jetpack_Gutenberg;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 const COOKIE_NAME = 'eucookielaw';
 
 /**

--- a/projects/plugins/jetpack/extensions/blocks/podcast-player/templates/playlist-track.php
+++ b/projects/plugins/jetpack/extensions/blocks/podcast-player/templates/playlist-track.php
@@ -10,6 +10,10 @@
 
 namespace Automattic\Jetpack\Extensions\Podcast_Player;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * Template variables.
  *

--- a/projects/plugins/jetpack/extensions/blocks/rating-star/rating-star.php
+++ b/projects/plugins/jetpack/extensions/blocks/rating-star/rating-star.php
@@ -12,6 +12,10 @@ namespace Automattic\Jetpack\Extensions\Rating_Star;
 use Automattic\Jetpack\Blocks;
 use Jetpack_Gutenberg;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 // Load generic function definitions.
 require_once __DIR__ . '/rating-meta.php';
 

--- a/projects/plugins/jetpack/extensions/blocks/recipe/recipe.php
+++ b/projects/plugins/jetpack/extensions/blocks/recipe/recipe.php
@@ -9,6 +9,10 @@
 
 use Automattic\Jetpack\Blocks;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 add_action(
 	'init',
 	function () {

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -17,6 +17,10 @@ use Jetpack_Gutenberg;
 use Jetpack_Memberships;
 use Jetpack_Subscriptions_Widget;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 require_once __DIR__ . '/class-jetpack-subscription-site.php';
 require_once __DIR__ . '/constants.php';
 require_once JETPACK__PLUGIN_DIR . 'extensions/blocks/premium-content/_inc/subscription-service/include.php';

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -16,6 +16,10 @@
 
 use Automattic\Jetpack\Image_CDN\Image_CDN_Core;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /*
 This program is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -14,27 +14,27 @@
  * @package automattic/jetpack
  */
 
+/*
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 use Automattic\Jetpack\Image_CDN\Image_CDN_Core;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit( 0 );
 }
-
-/*
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-as published by the Free Software Foundation; either version 2
-of the License, or (at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program; if not, write to the Free Software
-Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-*/
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.7' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '7.2' );

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-add-widget-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-add-widget-endpoint.php
@@ -5,6 +5,10 @@
  * Endpoint: https://public-api.wordpress.com/rest/v1.1/sites/$site/widgets/new
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 new WPCOM_JSON_API_Add_Widgets_Endpoint(
 	array(
 		'description'          => 'Activate a group of widgets on a site. The bulk version of using the /new endpoint',

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-autosave-post-v1-1-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-autosave-post-v1-1-endpoint.php
@@ -5,6 +5,10 @@
  * @package automattic/jetpack
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 new WPCOM_JSON_API_Autosave_Post_v1_1_Endpoint(
 	array(
 		'description'          => 'Create a post autosave.',

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-bulk-delete-post-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-bulk-delete-post-endpoint.php
@@ -5,6 +5,10 @@
  * Endpoint: /sites/%s/posts/delete
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 new WPCOM_JSON_API_Bulk_Delete_Post_Endpoint(
 	array(
 		'description'          => 'Delete multiple posts. Note: If the trash is enabled, this request will send non-trashed posts to the trash. Trashed posts will be permanently deleted.',

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-bulk-restore-post-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-bulk-restore-post-endpoint.php
@@ -2,6 +2,11 @@
 /**
  * Endpoint: /sites/%s/posts/restore
  */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 new WPCOM_JSON_API_Bulk_Restore_Post_Endpoint(
 	array(
 		'description'          => 'Restore multiple posts.',

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-bulk-update-comments-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-bulk-update-comments-endpoint.php
@@ -3,6 +3,11 @@
  * Endpoints: /sites/%s/comments/status
  *            /sites/%s/comments/delete
  */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 new WPCOM_JSON_API_Bulk_Update_Comments_Endpoint(
 	array(
 		'description'          => 'Update multiple comment\'s status.',

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-comment-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-comment-endpoint.php
@@ -6,6 +6,11 @@
  *
  * @phpcs:disable WordPress.WP.GlobalVariablesOverride.Prohibited
  */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * Comment endpoint class.
  */

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-delete-media-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-delete-media-endpoint.php
@@ -1,5 +1,9 @@
 <?php // phpcs:ignore Squiz.Commenting.FileComment.Missing
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 new WPCOM_JSON_API_Delete_Media_Endpoint(
 	array(
 		'description'          => 'Delete a piece of media.',

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-delete-media-v1-1-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-delete-media-v1-1-endpoint.php
@@ -1,5 +1,9 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 new WPCOM_JSON_API_Delete_Media_v1_1_Endpoint(
 	array(
 		'description'          => 'Delete a piece of media. Note: Media is deleted and not trashed.',

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-edit-media-v1-2-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-edit-media-v1-2-endpoint.php
@@ -1,5 +1,9 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 require_once JETPACK__PLUGIN_DIR . '_inc/lib/class.media.php';
 
 define( 'REVISION_HISTORY_MAXIMUM_AMOUNT', 5 );

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-autosave-v1-1-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-autosave-v1-1-endpoint.php
@@ -5,6 +5,10 @@
  * @package automattic/jetpack
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 new WPCOM_JSON_API_Get_Autosave_v1_1_Endpoint(
 	array(
 		'description'     => 'Get the most recent autosave for a post.',

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-comment-counts-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-comment-counts-endpoint.php
@@ -3,6 +3,10 @@
  * Endpoint: /sites/%s/comment-counts
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 new WPCOM_JSON_API_GET_Comment_Counts_Endpoint(
 	array(
 		'description'      => 'Get comment counts for each available status',

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-comment-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-comment-endpoint.php
@@ -2,6 +2,11 @@
 /**
  * Endpoint: /sites/%s/comments/%d -> $blog_id, $comment_id
  */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 new WPCOM_JSON_API_Get_Comment_Endpoint(
 	array(
 		'description'                          => 'Get a single comment.',

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-comment-history-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-comment-history-endpoint.php
@@ -2,6 +2,11 @@
 /**
  * Endpoint: /sites/%s/comment-history/%d
  */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 new WPCOM_JSON_API_GET_Comment_History_Endpoint(
 	array(
 		'description'     => 'Get the audit history for given comment',

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-comments-tree-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-comments-tree-endpoint.php
@@ -1,5 +1,9 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 new WPCOM_JSON_API_Get_Comments_Tree_Endpoint(
 	array(
 		'description'      => 'Get a comments tree for site.',

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-comments-tree-v1-1-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-comments-tree-v1-1-endpoint.php
@@ -1,5 +1,9 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 new WPCOM_JSON_API_Get_Comments_Tree_v1_1_Endpoint(
 	array(
 		'description'      => 'Get a comments tree for site.',

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-comments-tree-v1-2-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-comments-tree-v1-2-endpoint.php
@@ -1,5 +1,9 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 new WPCOM_JSON_API_Get_Comments_Tree_v1_2_Endpoint(
 	array(
 		'description'      => 'Get a comments tree for site.',

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-customcss.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-customcss.php
@@ -5,6 +5,10 @@
  * Endpoint: https://public-api.wordpress.com/rest/v1.1/sites/$site/customcss/
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 new WPCOM_JSON_API_Get_CustomCss_Endpoint(
 	array(
 		'description'      => 'Retrieve custom-css data for a site.',

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-media-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-media-endpoint.php
@@ -1,5 +1,9 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 new WPCOM_JSON_API_Get_Media_Endpoint(
 	array(
 		'description'          => 'Get a single media item (by ID).',

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-media-v1-1-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-media-v1-1-endpoint.php
@@ -1,5 +1,9 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 new WPCOM_JSON_API_Get_Media_v1_1_Endpoint(
 	array(
 		'description'          => 'Get a single media item (by ID).',

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-media-v1-2-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-media-v1-2-endpoint.php
@@ -1,5 +1,9 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 require_once JETPACK__PLUGIN_DIR . '_inc/lib/class.media.php';
 
 new WPCOM_JSON_API_Get_Media_v1_2_Endpoint(

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-post-counts-v1-1-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-post-counts-v1-1-endpoint.php
@@ -1,5 +1,9 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 new WPCOM_JSON_API_GET_Post_Counts_V1_1_Endpoint(
 	array(
 		'description'      => 'Get number of posts in the post type groups by post status',

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-post-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-post-endpoint.php
@@ -5,6 +5,10 @@
  *            /sites/%s/posts/slug:%s -> $blog_id, $post_id
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 new WPCOM_JSON_API_Get_Post_Endpoint(
 	array(
 		'description'                          => 'Get a single post (by ID).',

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-post-v1-1-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-post-v1-1-endpoint.php
@@ -1,5 +1,9 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 new WPCOM_JSON_API_Get_Post_v1_1_Endpoint(
 	array(
 		'description'                          => 'Get a single post (by ID).',

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -1,5 +1,9 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 new WPCOM_JSON_API_GET_Site_Endpoint(
 	array(
 		'description'                          => 'Get information about a site.',

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-v1-2-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-v1-2-endpoint.php
@@ -1,5 +1,9 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 new WPCOM_JSON_API_GET_Site_V1_2_Endpoint(
 	array(
 		'description'                          => 'Get information about a site.',

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-taxonomies-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-taxonomies-endpoint.php
@@ -1,5 +1,9 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 new WPCOM_JSON_API_Get_Taxonomies_Endpoint(
 	array(
 		'description'                          => "Get a list of a site's categories.",

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-taxonomy-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-taxonomy-endpoint.php
@@ -1,5 +1,9 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 new WPCOM_JSON_API_Get_Taxonomy_Endpoint(
 	array(
 		'description'                          => 'Get information about a single category.',

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-term-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-term-endpoint.php
@@ -1,5 +1,9 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 new WPCOM_JSON_API_Get_Term_Endpoint(
 	array(
 		'description'                          => 'Get information about a single term.',

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-comments-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-comments-endpoint.php
@@ -1,5 +1,9 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * Comments Walker Class.
  */

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-dropdown-pages-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-dropdown-pages-endpoint.php
@@ -1,5 +1,9 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * List dropdown pages endpoint.
  */

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-embeds-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-embeds-endpoint.php
@@ -1,5 +1,9 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * List Embeds endpoint.
  */

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-media-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-media-endpoint.php
@@ -1,5 +1,9 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * List media endpoint.
  */

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-media-v1-1-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-media-v1-1-endpoint.php
@@ -1,5 +1,9 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * List Media v1_1 endpoint.
  */

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-media-v1-2-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-media-v1-2-endpoint.php
@@ -1,5 +1,9 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 require_once JETPACK__PLUGIN_DIR . '_inc/lib/class.media.php';
 
 /**

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-post-type-taxonomies-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-post-type-taxonomies-endpoint.php
@@ -1,5 +1,9 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * List post type taxonomies endpoint.
  */

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-post-types-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-post-types-endpoint.php
@@ -1,5 +1,9 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * List post types endpoint.
  */

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-posts-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-posts-endpoint.php
@@ -1,5 +1,9 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * List posts endpoint.
  */

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-posts-v1-1-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-posts-v1-1-endpoint.php
@@ -1,5 +1,9 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * List posts v1_1 endpoint.
  */

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-posts-v1-2-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-posts-v1-2-endpoint.php
@@ -1,5 +1,9 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * List posts v1_2 endpoint.
  */

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-roles-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-roles-endpoint.php
@@ -1,5 +1,9 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * List roles endpoint.
  */

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-shortcodes-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-shortcodes-endpoint.php
@@ -1,5 +1,9 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * List shortcodes endpoint.
  */

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-terms-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-terms-endpoint.php
@@ -1,5 +1,9 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * List terms endpoint.
  */

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-users-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-users-endpoint.php
@@ -1,5 +1,9 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * List users endpoint.
  */

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-menus-v1-1-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-menus-v1-1-endpoint.php
@@ -2,6 +2,10 @@
 
 // phpcs:disable Generic.Files.OneObjectStructurePerFile.MultipleFound
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * Menus abstract endpoint class.
  */

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-post-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-post-endpoint.php
@@ -1,5 +1,9 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * Post Endpoint class.
  */

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-post-v1-1-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-post-v1-1-endpoint.php
@@ -1,5 +1,9 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * Post v1_1 Endpoint class.
  */

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-render-embed-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-render-embed-endpoint.php
@@ -1,5 +1,9 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 new WPCOM_JSON_API_Render_Embed_Endpoint(
 	array(
 		'description'          => 'Get a rendered embed for a site. Note: The current user must have publishing access.',

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-render-embed-reversal-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-render-embed-reversal-endpoint.php
@@ -1,5 +1,9 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 new WPCOM_JSON_API_Render_Embed_Reversal_Endpoint(
 	array(
 		'description'          => 'Determines if the given embed code can be reversed into a single line embed or a shortcode, and if so returns the embed or shortcode. Note: The current user must have publishing access.',

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-render-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-render-endpoint.php
@@ -1,5 +1,9 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * These are helpers for the shortcode and embed render endpoints.
  */

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-render-shortcode-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-render-shortcode-endpoint.php
@@ -1,5 +1,9 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 new WPCOM_JSON_API_Render_Shortcode_Endpoint(
 	array(
 		'description'          => 'Get a rendered shortcode for a site. Note: The current user must have publishing access.',

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-sharing-buttons-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-sharing-buttons-endpoint.php
@@ -1,6 +1,11 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
 // phpcs:disable Generic.Files.OneObjectStructurePerFile.MultipleFound
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * Sharing button endpoint class.
  */

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -7,6 +7,10 @@
 
 use Automattic\Jetpack\Waf\Brute_Force_Protection\Brute_Force_Protection_Shared_Functions;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 new WPCOM_JSON_API_Site_Settings_Endpoint(
 	array(
 		'description'      => 'Get detailed settings information about a site.',

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-2-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-2-endpoint.php
@@ -1,5 +1,9 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 new WPCOM_JSON_API_Site_Settings_V1_2_Endpoint(
 	array(
 		'description'      => 'Get detailed settings information about a site.',

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-3-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-3-endpoint.php
@@ -1,5 +1,8 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
 
 new WPCOM_JSON_API_Site_Settings_V1_3_Endpoint(
 	array(

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-4-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-4-endpoint.php
@@ -1,5 +1,9 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 new WPCOM_JSON_API_Site_Settings_V1_4_Endpoint(
 	array(
 		'description'      => 'Get detailed settings information about a site.',

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-user-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-user-endpoint.php
@@ -1,5 +1,9 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 new WPCOM_JSON_API_Site_User_Endpoint(
 	array(
 		'description'          => 'Get details of a user of a site by ID.',

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-taxonomy-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-taxonomy-endpoint.php
@@ -1,5 +1,9 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * Taxonomy endpoint.
  */

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-comment-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-comment-endpoint.php
@@ -11,6 +11,10 @@
 
 use Automattic\Jetpack\Status;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 new WPCOM_JSON_API_Update_Comment_Endpoint(
 	array(
 		'description'                          => 'Create a comment on a post.',

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-customcss.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-customcss.php
@@ -5,6 +5,10 @@
  * Endpoint: /sites/%s/customcss
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 new WPCOM_JSON_API_Update_CustomCss_Endpoint(
 	array(
 		'description'          => 'Set custom-css data for a site.',

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-media-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-media-endpoint.php
@@ -5,6 +5,10 @@
  * Endpoint: /sites/%s/media/%d
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 new WPCOM_JSON_API_Update_Media_Endpoint(
 	array(
 		'description'          => 'Edit basic information about a media item.',

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-media-v1-1-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-media-v1-1-endpoint.php
@@ -5,6 +5,10 @@
  * Endpoint: v1.1/sites/%s/media/%d
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 new WPCOM_JSON_API_Update_Media_v1_1_Endpoint(
 	array(
 		'description'          => 'Edit basic information about a media item.',

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-post-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-post-endpoint.php
@@ -9,6 +9,10 @@
  * Restore a post: /sites/%s/posts/%d/restore
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 new WPCOM_JSON_API_Update_Post_Endpoint(
 	array(
 		'description'          => 'Create a post.',

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-post-v1-1-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-post-v1-1-endpoint.php
@@ -9,6 +9,10 @@
  * Restore a post: /sites/%s/posts/%d/restore
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 new WPCOM_JSON_API_Update_Post_v1_1_Endpoint(
 	array(
 		'description'          => 'Create a post.',

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php
@@ -9,6 +9,10 @@
  * Restore a post: /sites/%s/posts/%d/restore
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 new WPCOM_JSON_API_Update_Post_v1_2_Endpoint(
 	array(
 		'description'          => 'Create a post.',

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-site-homepage-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-site-homepage-endpoint.php
@@ -5,6 +5,10 @@
  * Endpoint: /sites/%s/homepage
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 new WPCOM_JSON_API_Update_Site_Homepage_Endpoint(
 	array(
 		'description'          => 'Set site homepage settings',

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-site-logo-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-site-logo-endpoint.php
@@ -7,6 +7,10 @@
  * Delete site logo settings: /sites/%s/logo/delete
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 new WPCOM_JSON_API_Update_Site_Logo_Endpoint(
 	array(
 		'description'          => 'Set site logo settings',

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-taxonomy-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-taxonomy-endpoint.php
@@ -11,6 +11,10 @@
  * Delete a tag:          /sites/%s/tags/slug:%s/delete
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 new WPCOM_JSON_API_Update_Taxonomy_Endpoint(
 	array(
 		'description'          => 'Create a new category.',

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-term-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-term-endpoint.php
@@ -8,6 +8,10 @@
  * Delete a term:     /sites/%s/taxonomies/%s/terms/slug:%s/delete
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 new WPCOM_JSON_API_Update_Term_Endpoint(
 	array(
 		'description'          => 'Create a new term.',

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-user-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-user-endpoint.php
@@ -5,6 +5,10 @@
  * Endpoint: /sites/%s/users/%d/delete
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 new WPCOM_JSON_API_Update_User_Endpoint(
 	array(
 		'description'          => 'Deletes or removes a user of a site.',

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-upload-media-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-upload-media-endpoint.php
@@ -5,6 +5,10 @@
  * Endpoint: /sites/%s/media/new
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 new WPCOM_JSON_API_Upload_Media_Endpoint(
 	array(
 		'description'          => 'Upload a new media item.',

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-upload-media-v1-1-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-upload-media-v1-1-endpoint.php
@@ -5,6 +5,10 @@
  * Endpoint: /sites/%s/media/new
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 new WPCOM_JSON_API_Upload_Media_v1_1_Endpoint(
 	array(
 		'description'                => 'Upload a new piece of media.',

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class-jetpack-json-api-delete-backup-helper-script-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class-jetpack-json-api-delete-backup-helper-script-endpoint.php
@@ -8,6 +8,10 @@
 
 use Automattic\Jetpack\Backup\V0005\Helper_Script_Manager;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * API endpoint /sites/%s/delete-backup-helper-script
  * This API endpoint deletes a Jetpack Backup Helper Script

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class-jetpack-json-api-install-backup-helper-script-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class-jetpack-json-api-install-backup-helper-script-endpoint.php
@@ -8,6 +8,10 @@
 
 use Automattic\Jetpack\Backup\V0005\Helper_Script_Manager;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * API endpoint /sites/%s/install-backup-helper-script
  * This API endpoint installs a Helper Script to assist Jetpack Backup fetch data

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class-jetpack-json-api-modules-list-v1-2-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class-jetpack-json-api-modules-list-v1-2-endpoint.php
@@ -6,6 +6,11 @@
  */
 
 use Automattic\Jetpack\Status;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * List modules v1.2 endpoint.
  *

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-check-capabilities-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-check-capabilities-endpoint.php
@@ -1,5 +1,9 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * Check capabilities endpoint class.
  *

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-core-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-core-endpoint.php
@@ -1,5 +1,9 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * Core endpoint class.
  *

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-core-modify-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-core-modify-endpoint.php
@@ -1,5 +1,9 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * Core modify endpoint class.
  *

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-cron-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-cron-endpoint.php
@@ -1,5 +1,9 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * Cron endpoint class.
  *

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-endpoint.php
@@ -1,5 +1,9 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 require JETPACK__PLUGIN_DIR . '/modules/module-info.php';
 
 /**

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-get-comment-backup-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-get-comment-backup-endpoint.php
@@ -1,5 +1,9 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * The Get comment backup endpoint class.
  *

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-get-database-object-backup-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-get-database-object-backup-endpoint.php
@@ -1,5 +1,9 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * Get Database object backup endpoint class.
  *

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-get-option-backup-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-get-option-backup-endpoint.php
@@ -1,5 +1,9 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * Get option backup endpoint.
  *

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-get-post-backup-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-get-post-backup-endpoint.php
@@ -1,5 +1,9 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * Get post backup endpoint class.
  *

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-get-term-backup-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-get-term-backup-endpoint.php
@@ -1,5 +1,9 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * Get Term backup endpoint class.
  *

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-get-user-backup-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-get-user-backup-endpoint.php
@@ -1,5 +1,9 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * Get user Backup endpoint class.
  *

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-jps-woocommerce-connect-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-jps-woocommerce-connect-endpoint.php
@@ -1,5 +1,9 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * JPS WooCommerce connect endpoint.
  *

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-log-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-log-endpoint.php
@@ -1,5 +1,9 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * Jetpack log endpoint class.
  *

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-maybe-auto-update-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-maybe-auto-update-endpoint.php
@@ -1,5 +1,9 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * Auto update endpoint class.
  *

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-modules-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-modules-endpoint.php
@@ -1,5 +1,9 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * Base class for working with Jetpack Modules.
  */

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-modules-get-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-modules-get-endpoint.php
@@ -1,5 +1,9 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * The Modules get endpoint.
  *

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-modules-list-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-modules-list-endpoint.php
@@ -1,5 +1,9 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileNames
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * Modules list endpoint.
  *

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-modules-modify-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-modules-modify-endpoint.php
@@ -1,5 +1,9 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * Modules modify endpoint class.
  *

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-delete-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-delete-endpoint.php
@@ -1,5 +1,9 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 // POST /sites/%s/plugins/%s/delete
 new Jetpack_JSON_API_Plugins_Delete_Endpoint(
 	array(

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-endpoint.php
@@ -4,6 +4,10 @@ use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Current_Plan;
 use Automattic\Jetpack\Sync\Functions;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * Base class for working with plugins.
  */

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-get-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-get-endpoint.php
@@ -1,5 +1,9 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * JSON API plugins get endpoint.
  */

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-install-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-install-endpoint.php
@@ -2,6 +2,10 @@
 
 use Automattic\Jetpack\Plugins_Installer;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
 require_once ABSPATH . 'wp-admin/includes/file.php';
 // POST /sites/%s/plugins/%s/install

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-list-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-list-endpoint.php
@@ -1,5 +1,9 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 new Jetpack_JSON_API_Plugins_List_Endpoint(
 	array(
 		'description'             => 'Get installed Plugins on your blog',

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
@@ -2,6 +2,10 @@
 
 use Automattic\Jetpack\Constants;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 new Jetpack_JSON_API_Plugins_Modify_Endpoint(
 	array(
 		'description'             => 'Activate/Deactivate a Plugin on your Jetpack Site, or set automatic updates',

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-v1-2-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-v1-2-endpoint.php
@@ -1,4 +1,9 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 new Jetpack_JSON_API_Plugins_Modify_v1_2_Endpoint(
 	array(
 		'description'             => 'Activate/Deactivate a Plugin on your Jetpack Site, or set automatic updates',

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-new-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-new-endpoint.php
@@ -1,9 +1,13 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
+use Automattic\Jetpack\Automatic_Install_Skin;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
 require_once ABSPATH . 'wp-admin/includes/file.php';
-
-use Automattic\Jetpack\Automatic_Install_Skin;
 
 // POST /sites/%s/plugins/new
 new Jetpack_JSON_API_Plugins_New_Endpoint(

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
@@ -9,6 +9,10 @@ use Automattic\Jetpack\Sync\Replicastore;
 use Automattic\Jetpack\Sync\Sender;
 use Automattic\Jetpack\Sync\Settings;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 // phpcs:disable Generic.Files.OneObjectStructurePerFile.MultipleFound
 
 /**

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-themes-active-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-themes-active-endpoint.php
@@ -1,5 +1,9 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * GET  /sites/%s/themes/mine => current theme
  * POST /sites/%s/themes/mine => switch theme

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-themes-delete-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-themes-delete-endpoint.php
@@ -1,5 +1,9 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * Themes delete endpoint class.
  * POST  /sites/%s/plugins/%s/delete

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-themes-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-themes-endpoint.php
@@ -2,6 +2,10 @@
 
 use Automattic\Jetpack\Image_CDN\Image_CDN_Core;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * Base class for working with themes, has useful helper functions.
  */

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-themes-get-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-themes-get-endpoint.php
@@ -1,5 +1,9 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * Themes get endpoint class.
  *

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-themes-install-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-themes-install-endpoint.php
@@ -1,10 +1,14 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
+use Automattic\Jetpack\Automatic_Install_Skin;
+use Automattic\Jetpack\Connection\Client;
+
 require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
 require_once ABSPATH . 'wp-admin/includes/file.php';
 
-use Automattic\Jetpack\Automatic_Install_Skin;
-use Automattic\Jetpack\Connection\Client;
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
 
 /**
  * Themes install endpoint class.

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-themes-install-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-themes-install-endpoint.php
@@ -3,12 +3,12 @@
 use Automattic\Jetpack\Automatic_Install_Skin;
 use Automattic\Jetpack\Connection\Client;
 
-require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
-require_once ABSPATH . 'wp-admin/includes/file.php';
-
 if ( ! defined( 'ABSPATH' ) ) {
 	exit( 0 );
 }
+
+require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
+require_once ABSPATH . 'wp-admin/includes/file.php';
 
 /**
  * Themes install endpoint class.

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-themes-list-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-themes-list-endpoint.php
@@ -1,5 +1,9 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * Theme list endpoint class.
  *

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-themes-modify-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-themes-modify-endpoint.php
@@ -1,5 +1,9 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * Themes modify endpoint class.
  * POST  /sites/%s/themes/%s

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-themes-new-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-themes-new-endpoint.php
@@ -1,9 +1,13 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
+use Automattic\Jetpack\Automatic_Install_Skin;
+
 require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
 require_once ABSPATH . 'wp-admin/includes/file.php';
 
-use Automattic\Jetpack\Automatic_Install_Skin;
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
 
 /**
  * Themes new endpoint class.

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-themes-new-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-themes-new-endpoint.php
@@ -2,12 +2,12 @@
 
 use Automattic\Jetpack\Automatic_Install_Skin;
 
-require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
-require_once ABSPATH . 'wp-admin/includes/file.php';
-
 if ( ! defined( 'ABSPATH' ) ) {
 	exit( 0 );
 }
+
+require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
+require_once ABSPATH . 'wp-admin/includes/file.php';
 
 /**
  * Themes new endpoint class.

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-translations-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-translations-endpoint.php
@@ -1,5 +1,9 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * Translations endpoint class.
  *

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-translations-modify-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-translations-modify-endpoint.php
@@ -1,5 +1,9 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * Translations modify endpoint class.
  * POST /sites/%s/translation

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-updates-status-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-updates-status-endpoint.php
@@ -1,5 +1,9 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * Updates status class.
  *

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-user-connect-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-user-connect-endpoint.php
@@ -3,6 +3,10 @@
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Connection\Tokens;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * User connect endpoint class.
  *

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-user-create-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-user-create-endpoint.php
@@ -3,6 +3,10 @@
 use Automattic\Jetpack\Connection\Utils;
 use Automattic\Jetpack\Constants;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * User create endpoint class.
  *

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.wpcom-json-api-get-option-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.wpcom-json-api-get-option-endpoint.php
@@ -2,6 +2,10 @@
 
 use Automattic\Jetpack\Sync\Defaults;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * Get option endpoint.
  *

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.wpcom-json-api-update-option-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.wpcom-json-api-update-option-endpoint.php
@@ -1,5 +1,9 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * Update option endpoint.
  *

--- a/projects/plugins/jetpack/json-endpoints/jetpack/json-api-jetpack-endpoints.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/json-api-jetpack-endpoints.php
@@ -1,5 +1,9 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 $json_jetpack_endpoints_dir = __DIR__ . '/';
 
 require_once $json_jetpack_endpoints_dir . 'class.jetpack-json-api-endpoint.php';

--- a/projects/plugins/jetpack/modules/infinite-scroll/themes/twentytwelve.php
+++ b/projects/plugins/jetpack/modules/infinite-scroll/themes/twentytwelve.php
@@ -7,6 +7,10 @@
  * @package jetpack
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * Add theme support for infinite scroll
  */

--- a/projects/plugins/jetpack/modules/latex.php
+++ b/projects/plugins/jetpack/modules/latex.php
@@ -13,6 +13,10 @@
  * @package automattic/jetpack
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * LaTeX support.
  *

--- a/projects/plugins/jetpack/modules/markdown/easy-markdown.php
+++ b/projects/plugins/jetpack/modules/markdown/easy-markdown.php
@@ -11,6 +11,10 @@
  * @package automattic/jetpack
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * Copyright (c) Automattic. All rights reserved.
  *

--- a/projects/plugins/jetpack/modules/markdown/easy-markdown.php
+++ b/projects/plugins/jetpack/modules/markdown/easy-markdown.php
@@ -11,10 +11,6 @@
  * @package automattic/jetpack
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit( 0 );
-}
-
 /**
  * Copyright (c) Automattic. All rights reserved.
  *
@@ -36,6 +32,10 @@ if ( ! defined( 'ABSPATH' ) ) {
  * GNU General Public License for more details.
  * **********************************************************************
  */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
 
 /**
  * WPCom_Markdown class.

--- a/projects/plugins/jetpack/modules/shortcodes/mixcloud.php
+++ b/projects/plugins/jetpack/modules/shortcodes/mixcloud.php
@@ -14,6 +14,10 @@
  * @package automattic/jetpack
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /*
  * Register oEmbed provider
  * Example URL: http://app.mixcloud.com/oembed/?url=http://www.mixcloud.com/MalibuRum/play-6-kissy-sellouts-winter-sun-house-party-mix/

--- a/projects/plugins/jetpack/modules/sitemaps/sitemap-buffer-image-xmlwriter.php
+++ b/projects/plugins/jetpack/modules/sitemaps/sitemap-buffer-image-xmlwriter.php
@@ -6,6 +6,10 @@
  * @package automattic/jetpack
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * A buffer for constructing sitemap image xml files using XMLWriter.
  *

--- a/projects/plugins/jetpack/modules/sitemaps/sitemap-buffer-video-fallback.php
+++ b/projects/plugins/jetpack/modules/sitemaps/sitemap-buffer-video-fallback.php
@@ -10,6 +10,10 @@
  * @package automattic/jetpack
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * A buffer for constructing sitemap video xml files for users without libxml support.
  *

--- a/projects/plugins/jetpack/modules/sitemaps/sitemap-buffer-video-xmlwriter.php
+++ b/projects/plugins/jetpack/modules/sitemaps/sitemap-buffer-video-xmlwriter.php
@@ -6,6 +6,10 @@
  * @package automattic/jetpack
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * A buffer for constructing sitemap video xml files using XMLWriter.
  *

--- a/projects/plugins/jetpack/modules/subscriptions/views.php
+++ b/projects/plugins/jetpack/modules/subscriptions/views.php
@@ -2,6 +2,10 @@
 
 // phpcs:disable Universal.Files.SeparateFunctionsFromOO.Mixed -- TODO: Move classes to appropriately-named class files.
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * Jetpack_Subscriptions_Widget main view class.
  */

--- a/projects/plugins/jetpack/modules/tiled-gallery.php
+++ b/projects/plugins/jetpack/modules/tiled-gallery.php
@@ -13,6 +13,10 @@
  * @package jetpack
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * Include the tiled gallery for loading.
  */

--- a/projects/plugins/jetpack/modules/videopress/class.jetpack-videopress.php
+++ b/projects/plugins/jetpack/modules/videopress/class.jetpack-videopress.php
@@ -4,6 +4,11 @@ use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\VideoPress\Attachment_Handler;
 use Automattic\Jetpack\VideoPress\Jwt_Token_Bridge;
 use Automattic\Jetpack\VideoPress\Options as VideoPress_Options;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * VideoPress in Jetpack
  */

--- a/projects/plugins/jetpack/modules/videopress/shortcode.php
+++ b/projects/plugins/jetpack/modules/videopress/shortcode.php
@@ -1,5 +1,9 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * VideoPress Shortcode Handler
  *

--- a/projects/plugins/jetpack/modules/widgets/facebook-likebox.php
+++ b/projects/plugins/jetpack/modules/widgets/facebook-likebox.php
@@ -2,6 +2,10 @@
 
 // phpcs:disable Universal.Files.SeparateFunctionsFromOO.Mixed -- TODO: Move classes to appropriately-named class files.
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 add_action( 'widgets_init', 'jetpack_facebook_likebox_init' );
 /**
  * Register the widget for use in Appearance -> Widgets

--- a/projects/plugins/jetpack/modules/widgets/milestone/class-milestone-widget.php
+++ b/projects/plugins/jetpack/modules/widgets/milestone/class-milestone-widget.php
@@ -7,6 +7,10 @@
 
 use Automattic\Jetpack\Assets;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * Class Milestone_Widget
  */

--- a/projects/plugins/jetpack/modules/wordads.php
+++ b/projects/plugins/jetpack/modules/wordads.php
@@ -13,6 +13,10 @@
  * @package automattic/jetpack
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * Load WordAds.
  */

--- a/projects/plugins/jetpack/modules/wordads/php/class-wordads-admin.php
+++ b/projects/plugins/jetpack/modules/wordads/php/class-wordads-admin.php
@@ -5,6 +5,10 @@
  * @package automattic/jetpack
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * The standard set of admin pages for the user if Jetpack is installed
  */

--- a/projects/plugins/jetpack/modules/wpcom-tos/wpcom-tos.php
+++ b/projects/plugins/jetpack/modules/wpcom-tos/wpcom-tos.php
@@ -11,6 +11,10 @@ namespace Automattic\Jetpack\TOS;
 
 use Automattic\Jetpack\Connection\Client;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * Makes a request to the WP.com legal endpoint to mark the Terms of Service as accepted.
  */

--- a/projects/plugins/jetpack/sal/class.json-api-date.php
+++ b/projects/plugins/jetpack/sal/class.json-api-date.php
@@ -4,6 +4,11 @@
  *
  * @package automattic/jetpack
  */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * Base class for WPCOM_JSON_API_Date.
  */

--- a/projects/plugins/jetpack/sal/class.json-api-links.php
+++ b/projects/plugins/jetpack/sal/class.json-api-links.php
@@ -5,6 +5,10 @@
  * @package automattic/jetpack
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 require_once __DIR__ . '/../class.json-api.php';
 
 /**

--- a/projects/plugins/jetpack/sal/class.json-api-metadata.php
+++ b/projects/plugins/jetpack/sal/class.json-api-metadata.php
@@ -5,6 +5,10 @@
  * @package automattic/jetpack
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * Base class for WPCOM_JSON_API_Metadata
  */

--- a/projects/plugins/jetpack/sal/class.json-api-platform-jetpack.php
+++ b/projects/plugins/jetpack/sal/class.json-api-platform-jetpack.php
@@ -5,6 +5,10 @@
  * @package automattic/jetpack
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 require_once __DIR__ . '/class.json-api-platform.php';
 
 /**

--- a/projects/plugins/jetpack/sal/class.json-api-platform.php
+++ b/projects/plugins/jetpack/sal/class.json-api-platform.php
@@ -5,6 +5,10 @@
  * @package automattic/jetpack
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 require_once __DIR__ . '/class.json-api-token.php';
 
 /**

--- a/projects/plugins/jetpack/sal/class.json-api-post-base.php
+++ b/projects/plugins/jetpack/sal/class.json-api-post-base.php
@@ -11,6 +11,10 @@
 
 use Automattic\Jetpack\Status;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 require_once __DIR__ . '/class.json-api-metadata.php';
 require_once __DIR__ . '/class.json-api-date.php';
 require_once ABSPATH . 'wp-admin/includes/post.php';

--- a/projects/plugins/jetpack/sal/class.json-api-post-jetpack.php
+++ b/projects/plugins/jetpack/sal/class.json-api-post-jetpack.php
@@ -8,6 +8,11 @@
  *
  * @package automattic/jetpack
  */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * Base class for Jetpack_Post.
  */

--- a/projects/plugins/jetpack/sal/class.json-api-site-base.php
+++ b/projects/plugins/jetpack/sal/class.json-api-site-base.php
@@ -15,6 +15,10 @@ use Automattic\Jetpack\Blaze;
 use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Status\Host;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 require_once __DIR__ . '/class.json-api-date.php';
 require_once __DIR__ . '/class.json-api-post-base.php';
 

--- a/projects/plugins/jetpack/sal/class.json-api-site-jetpack-base.php
+++ b/projects/plugins/jetpack/sal/class.json-api-site-jetpack-base.php
@@ -9,6 +9,11 @@
  *
  * @package automattic/jetpack
  */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 require_once __DIR__ . '/class.json-api-site-base.php';
 
 /**

--- a/projects/plugins/jetpack/sal/class.json-api-site-jetpack.php
+++ b/projects/plugins/jetpack/sal/class.json-api-site-jetpack.php
@@ -11,6 +11,10 @@
 use Automattic\Jetpack\Status\Host;
 use Automattic\Jetpack\Sync\Functions;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 require_once __DIR__ . '/class.json-api-site-jetpack-base.php';
 require_once __DIR__ . '/class.json-api-post-jetpack.php';
 

--- a/projects/plugins/jetpack/sal/class.json-api-token.php
+++ b/projects/plugins/jetpack/sal/class.json-api-token.php
@@ -5,6 +5,10 @@
  * @package automattic/jetpack
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * Base class for Jetpack_Site, so that we have a real class instead of just passing around an array.
  */


### PR DESCRIPTION
Closes MONOREP-50

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

The logs show a lot of fatals when accessing files directly. I've addressed several of them per what I saw in the logs, as well as proactively addressing all the endpoint ones (since those seem the most abused).

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Accessing most of these files directly would previously generate a PHP fatal on `trunk` but on this branch it's fixed.