### PR TITLE
Forms: Fix empty string submit validation

### DIFF
--- a/projects/packages/forms/changelog/fix-form-empty-string-submit
+++ b/projects/packages/forms/changelog/fix-form-empty-string-submit
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: trim the value before validating if empty form

--- a/projects/packages/forms/src/contact-form/js/validate-helper.js
+++ b/projects/packages/forms/src/contact-form/js/validate-helper.js
@@ -37,6 +37,13 @@ export const validateDate = ( value, format ) => {
 	return date.getFullYear() === year && date.getMonth() === month - 1 && date.getDate() === day;
 };
 
+/**
+ * Validate a number value.
+ *
+ * @param  string value - The value to validate.
+ * @param  object extra  - Additional validation options.
+ * @returns {string} - The validation result.
+ */
 function validateNumber( value, extra ) {
 	// Change the regex to accept both integers and decimals
 	const regex = /^-?\d+(\.\d+)?$/;
@@ -56,6 +63,38 @@ function validateNumber( value, extra ) {
 
 	return 'yes';
 }
+/**
+ * Check if a value is considered empty.
+ *
+ * @param {*} value - The value to check.
+ * @returns {boolean} - True if the value is empty, false otherwise.
+ */
+export const isEmptyValue = value => {
+	if ( value === null || value === undefined ) {
+		return true;
+	}
+
+	if ( typeof value === 'string' && value.trim() === '' ) {
+		return true;
+	}
+
+	if (
+		Array.isArray( value ) &&
+		( value.length === 0 || value.every( item => isEmptyValue( item ) ) )
+	) {
+		return true;
+	}
+
+	if (
+		typeof value === 'object' &&
+		( Object.keys( value ).length === 0 ||
+			Object.values( value ).every( item => isEmptyValue( item ) ) )
+	) {
+		return true;
+	}
+
+	return false;
+};
 
 /**
  * return true or the field error.
@@ -67,18 +106,15 @@ function validateNumber( value, extra ) {
  * @returns {string}
  */
 export const validateField = ( type, value, isRequired, extra = null ) => {
-	if ( value === '' && isRequired ) {
+	if ( isEmptyValue( value ) && isRequired ) {
 		return 'is_required';
 	}
 
-	if ( ! isRequired && value === '' ) {
+	if ( ! isRequired && isEmptyValue( value ) ) {
 		// No need to validate anything.
 		return 'yes';
 	}
 
-	if ( 'checkbox-multiple' === type ) {
-		return value.length !== 0 ? 'yes' : 'is_required';
-	}
 	if ( 'date' === type ) {
 		return validateDate( value, extra ) ? 'yes' : 'invalid_date';
 	}

--- a/projects/packages/forms/src/contact-form/js/validate-helper.js
+++ b/projects/packages/forms/src/contact-form/js/validate-helper.js
@@ -147,9 +147,6 @@ export const validateField = ( type, value, isRequired, extra = null ) => {
 		case 'telephone':
 			regex = /^\+?[0-9\s\-()]+$/;
 			break;
-		case 'number':
-			regex = /^[0-9]+$/;
-			break;
 	}
 
 	if ( regex && ! regex.test( value ) ) {

--- a/projects/packages/forms/src/modules/form/view.js
+++ b/projects/packages/forms/src/modules/form/view.js
@@ -132,7 +132,7 @@ const { state } = store( NAMESPACE, {
 			if ( context?.maxSteps && context.maxSteps > 0 ) {
 				return false;
 			}
-			return ! Object.values( context.fields ).some( field => field.value !== '' );
+			return ! Object.values( context.fields ).some( field => field.value.trim() !== '' );
 		},
 
 		get isFieldEmpty() {

--- a/projects/packages/forms/src/modules/form/view.js
+++ b/projects/packages/forms/src/modules/form/view.js
@@ -13,6 +13,26 @@ import {
 import { validateField } from '../../contact-form/js/validate-helper';
 import { focusNextInput, dispatchSubmitEvent, submitForm } from './shared';
 
+const isEmptyValue = value => {
+	if ( value === null || value === undefined ) {
+		return true;
+	}
+
+	if ( typeof value === 'string' && value.trim() === '' ) {
+		return true;
+	}
+
+	if ( Array.isArray( value ) && value.length === 0 ) {
+		return true;
+	}
+
+	if ( typeof value === 'object' && Object.keys( value ).length === 0 ) {
+		return true;
+	}
+
+	return false;
+};
+
 const withSyncEvent =
 	originalWithSyncEvent ||
 	( cb =>
@@ -132,17 +152,15 @@ const { state } = store( NAMESPACE, {
 			if ( context?.maxSteps && context.maxSteps > 0 ) {
 				return false;
 			}
-			return ! Object.values( context.fields ).some( field => field.value.trim() !== '' );
+
+			return ! Object.values( context.fields ).some( field => ! isEmptyValue( field.value ) );
 		},
 
 		get isFieldEmpty() {
 			const context = getContext();
 			const fieldId = context.fieldId;
 			const field = context.fields[ fieldId ] || {};
-			return !! (
-				field.value === '' ||
-				( Array.isArray( field.value ) && field.value.length === 0 )
-			);
+			return isEmptyValue( field?.value );
 		},
 
 		get hasFieldValue() {

--- a/projects/packages/forms/src/modules/form/view.js
+++ b/projects/packages/forms/src/modules/form/view.js
@@ -298,6 +298,9 @@ const { state } = store( NAMESPACE, {
 				newValues = newValues.filter( v => v !== value );
 			}
 
+			// If the new values array is empty, we set it to an empty string.
+			newValues = newValues.length > 0 ? newValues : '';
+
 			updateField( fieldId, newValues );
 		},
 

--- a/projects/packages/forms/src/modules/form/view.js
+++ b/projects/packages/forms/src/modules/form/view.js
@@ -10,28 +10,8 @@ import {
 /*
  * Internal dependencies
  */
-import { validateField } from '../../contact-form/js/validate-helper';
+import { validateField, isEmptyValue } from '../../contact-form/js/validate-helper';
 import { focusNextInput, dispatchSubmitEvent, submitForm } from './shared';
-
-const isEmptyValue = value => {
-	if ( value === null || value === undefined ) {
-		return true;
-	}
-
-	if ( typeof value === 'string' && value.trim() === '' ) {
-		return true;
-	}
-
-	if ( Array.isArray( value ) && value.length === 0 ) {
-		return true;
-	}
-
-	if ( typeof value === 'object' && Object.keys( value ).length === 0 ) {
-		return true;
-	}
-
-	return false;
-};
 
 const withSyncEvent =
 	originalWithSyncEvent ||
@@ -297,9 +277,6 @@ const { state } = store( NAMESPACE, {
 			} else {
 				newValues = newValues.filter( v => v !== value );
 			}
-
-			// If the new values array is empty, we set it to an empty string.
-			newValues = newValues.length > 0 ? newValues : '';
 
 			updateField( fieldId, newValues );
 		},

--- a/projects/packages/forms/src/modules/form/view.js
+++ b/projects/packages/forms/src/modules/form/view.js
@@ -312,6 +312,7 @@ const { state } = store( NAMESPACE, {
 		onFormReset: () => {
 			const context = getContext();
 			context.fields = [];
+			context.showErrors = false;
 
 			// Dispatch custom events to reset all fields
 			const formElement = document.getElementById( context.elementId );

--- a/projects/packages/forms/tests/js/contact-form/validate-helper.test.js
+++ b/projects/packages/forms/tests/js/contact-form/validate-helper.test.js
@@ -160,6 +160,7 @@ describe( 'validateField', () => {
 
 		test( 'invalidates incorrect number formats', () => {
 			expect( validateField( 'number', '123a', true ) ).toBe( 'invalid_number' );
+			expect( validateField( 'number', 'a', true ) ).toBe( 'invalid_number' );
 		} );
 
 		test( 'invalidates incorrect max number formats', () => {
@@ -168,6 +169,30 @@ describe( 'validateField', () => {
 
 		test( 'invalidates incorrect minnumber formats', () => {
 			expect( validateField( 'number', '9', true, { min: 10 } ) ).toBe( 'invalid_min_number' );
+		} );
+	} );
+
+	describe( 'file validation', () => {
+		test( 'validates file format', () => {
+			expect( validateField( 'file', [], false ) ).toBe( 'yes' );
+			expect(
+				validateField( 'file', [ { name: 'file.txt', size: 12345, isUploaded: true } ], false )
+			).toBe( 'yes' );
+			expect(
+				validateField( 'file', [ { name: 'file.txt', size: 12345, isUploaded: true } ], true )
+			).toBe( 'yes' );
+		} );
+
+		test( 'invalidates incorrect file formats', () => {
+			expect( validateField( 'file', [ { error: true } ], true ) ).toBe(
+				'invalid_file_has_errors'
+			);
+			expect( validateField( 'file', [ { isUploaded: false } ], true ) ).toBe(
+				'invalid_file_uploading'
+			);
+			expect( validateField( 'file', [ { isUploaded: false } ], false ) ).toBe(
+				'invalid_file_uploading'
+			);
 		} );
 	} );
 

--- a/projects/packages/forms/tests/js/contact-form/validate-helper.test.js
+++ b/projects/packages/forms/tests/js/contact-form/validate-helper.test.js
@@ -1,5 +1,9 @@
 // Add these mocks at the top of your test file
-import { validateField, validateDate } from '../../../src/contact-form/js/validate-helper';
+import {
+	validateField,
+	validateDate,
+	isEmptyValue,
+} from '../../../src/contact-form/js/validate-helper';
 
 // To run these test:
 // cd projects/packages/forms && pnpm test
@@ -97,14 +101,20 @@ describe( 'validateField', () => {
 	describe( 'required field validation', () => {
 		test( 'returns is_required for empty required fields', () => {
 			expect( validateField( 'text', '', true ) ).toBe( 'is_required' );
+			expect( validateField( 'text', ' ', true ) ).toBe( 'is_required' );
 			expect( validateField( 'email', '', true ) ).toBe( 'is_required' );
 			expect( validateField( 'number', '', true ) ).toBe( 'is_required' );
+			expect( validateField( 'multiple-checkboxes', [], true ) ).toBe( 'is_required' );
+			expect( validateField( 'multiple-checkboxes', [ '' ], true ) ).toBe( 'is_required' );
 		} );
 
 		test( 'returns yes for empty optional fields', () => {
 			expect( validateField( 'text', '', false ) ).toBe( 'yes' );
 			expect( validateField( 'email', '', false ) ).toBe( 'yes' );
 			expect( validateField( 'number', '', false ) ).toBe( 'yes' );
+			expect( validateField( 'text', ' ', false ) ).toBe( 'yes' );
+			expect( validateField( 'multiple-checkboxes', [], false ) ).toBe( 'yes' );
+			expect( validateField( 'multiple-checkboxes', [ ' ' ], false ) ).toBe( 'yes' );
 		} );
 	} );
 
@@ -200,6 +210,62 @@ describe( 'validateField', () => {
 	describe( 'fallthrough validation', () => {
 		test( 'returns yes for unrecognized field types with values', () => {
 			expect( validateField( 'unknown-type', 'some value', true ) ).toBe( 'yes' );
+		} );
+	} );
+
+	describe( 'isEmptyValue function', () => {
+		test( 'returns true for null and undefined', () => {
+			expect( isEmptyValue( null ) ).toBe( true );
+			expect( isEmptyValue( undefined ) ).toBe( true );
+		} );
+
+		test( 'returns true for empty strings', () => {
+			expect( isEmptyValue( '' ) ).toBe( true );
+			expect( isEmptyValue( ' ' ) ).toBe( true ); // whitespace only
+			expect( isEmptyValue( '\t\n' ) ).toBe( true ); // tabs and newlines
+		} );
+
+		test( 'returns true for empty arrays', () => {
+			expect( isEmptyValue( [] ) ).toBe( true );
+			expect( isEmptyValue( [ '' ] ) ).toBe( true );
+			expect( isEmptyValue( [ ' ' ] ) ).toBe( true );
+			expect( isEmptyValue( [ {} ] ) ).toBe( true );
+		} );
+
+		test( 'returns true for empty objects', () => {
+			expect( isEmptyValue( {} ) ).toBe( true );
+			expect( isEmptyValue( { key: null } ) ).toBe( true ); // object with null value is not empty
+		} );
+
+		test( 'returns false for non-empty strings', () => {
+			expect( isEmptyValue( 'hello' ) ).toBe( false );
+			expect( isEmptyValue( ' hello ' ) ).toBe( false );
+			expect( isEmptyValue( '0' ) ).toBe( false );
+		} );
+
+		test( 'returns false for non-empty arrays', () => {
+			expect( isEmptyValue( [ 'option' ] ) ).toBe( false );
+		} );
+
+		test( 'returns false for non-empty objects', () => {
+			expect( isEmptyValue( { key: 'value' } ) ).toBe( false );
+		} );
+
+		test( 'returns false for numbers including zero', () => {
+			expect( isEmptyValue( 0 ) ).toBe( false );
+			expect( isEmptyValue( 42 ) ).toBe( false );
+			expect( isEmptyValue( -1 ) ).toBe( false );
+			expect( isEmptyValue( 0.5 ) ).toBe( false );
+		} );
+
+		test( 'returns false for boolean values', () => {
+			expect( isEmptyValue( true ) ).toBe( false );
+			expect( isEmptyValue( false ) ).toBe( false );
+		} );
+
+		test( 'returns false for functions', () => {
+			expect( isEmptyValue( function () {} ) ).toBe( false );
+			expect( isEmptyValue( () => {} ) ).toBe( false );
 		} );
 	} );
 } );


### PR DESCRIPTION
Fixes FORM-NEW

Fixes issue where the value could be set to a space and the form would be considered non empty. 

## Proposed changes:
* Trim the value before comparing it on the JS side. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1753989335777329-slack-C052XEUUBL4

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
1. Add the form. 
2. Fill out the form with space characters. 
3. Notice that you can't submit the form any more via a JS enabled browser. 
