### PR TITLE
PayPal Payment Buttons: Update instructions with link and interpolate

### DIFF
--- a/projects/packages/paypal-payments/changelog/update-paypal-payment-buttons-instructions-take-2
+++ b/projects/packages/paypal-payments/changelog/update-paypal-payment-buttons-instructions-take-2
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Move link location to instructions.

--- a/projects/packages/paypal-payments/src/paypal-payment-buttons/edit.js
+++ b/projects/packages/paypal-payments/src/paypal-payment-buttons/edit.js
@@ -9,13 +9,11 @@ import {
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
-	__experimentalText as Text,
-	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalItemGroup as ItemGroup,
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalItem as Item,
 } from '@wordpress/components';
-import { useEffect, useState } from '@wordpress/element';
+import { createInterpolateElement, useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import PayPalIcon from './icon';
 import './editor.scss';
@@ -330,13 +328,29 @@ export default function Edit( { attributes, setAttributes, isSelected } ) {
 			>
 				<ItemGroup>
 					<Item>
-						{ __( '1. Go to PayPal to get your button code', 'jetpack-paypal-payments' ) }
+						{ createInterpolateElement(
+							__(
+								'1. <SignupLink><strong>Sign up</strong></SignupLink> or <LoginLink><strong>log in</strong></LoginLink> to PayPal to get your Payment Button code.',
+								'jetpack-paypal-payments'
+							),
+							{
+								SignupLink: <ExternalLink href={ getPayPalSignupUrl() } />,
+								LoginLink: <ExternalLink href={ getPayPalLoginUrl() } />,
+								strong: <strong />,
+							}
+						) }
 					</Item>
 					<Item>
-						{ __(
-							'2. After login, choose Payment Buttons. Enter your product or service details, and build the buttons. Copy the button code for Stacked Buttons (copy html code) or Single Button.',
-							'jetpack-paypal-payments'
-						) }
+						{ 'stacked' === buttonType &&
+							__(
+								'2. After login, choose Payment Buttons. Enter your product or service details, and build the buttons. Copy the button code for Stacked Buttons (copy html code).',
+								'jetpack-paypal-payments'
+							) }
+						{ 'single' === buttonType &&
+							__(
+								'2. After login, choose Payment Buttons. Enter your product or service details, and build the buttons. Copy the button code for Single Button.',
+								'jetpack-paypal-payments'
+							) }
 					</Item>
 					<Item>{ __( '3. Paste the code below.', 'jetpack-paypal-payments' ) }</Item>
 				</ItemGroup>
@@ -405,16 +419,6 @@ export default function Edit( { attributes, setAttributes, isSelected } ) {
 					aria-label={ 'stacked' === buttonType ? stackedButtonCodeLabel : singleButtonCodeLabel }
 					name="paypal-payment-buttons-code-body"
 				/>
-				<Text>
-					<ExternalLink href={ getPayPalSignupUrl() }>
-						<strong>{ __( 'Sign up', 'jetpack-paypal-payments' ) }</strong>
-					</ExternalLink>{ ' ' }
-					{ __( 'or', 'jetpack-paypal-payments' ) }{ ' ' }
-					<ExternalLink href={ getPayPalLoginUrl() }>
-						<strong>{ __( 'log in', 'jetpack-paypal-payments' ) }</strong>
-					</ExternalLink>{ ' ' }
-					{ __( 'to PayPal to get your Payment Button code.', 'jetpack-paypal-payments' ) }
-				</Text>
 			</Placeholder>
 		</div>
 	);

--- a/projects/packages/paypal-payments/src/paypal-payment-buttons/edit.js
+++ b/projects/packages/paypal-payments/src/paypal-payment-buttons/edit.js
@@ -334,8 +334,12 @@ export default function Edit( { attributes, setAttributes, isSelected } ) {
 								'jetpack-paypal-payments'
 							),
 							{
-								SignupLink: <ExternalLink href={ getPayPalSignupUrl() } />,
-								LoginLink: <ExternalLink href={ getPayPalLoginUrl() } />,
+								SignupLink: (
+									<ExternalLink href={ getPayPalSignupUrl() } data-testid="external-link" />
+								),
+								LoginLink: (
+									<ExternalLink href={ getPayPalLoginUrl() } data-testid="external-link" />
+								),
 								strong: <strong />,
 							}
 						) }

--- a/projects/packages/paypal-payments/src/paypal-payment-buttons/edit.js
+++ b/projects/packages/paypal-payments/src/paypal-payment-buttons/edit.js
@@ -334,12 +334,8 @@ export default function Edit( { attributes, setAttributes, isSelected } ) {
 								'jetpack-paypal-payments'
 							),
 							{
-								SignupLink: (
-									<ExternalLink href={ getPayPalSignupUrl() } data-testid="external-link" />
-								),
-								LoginLink: (
-									<ExternalLink href={ getPayPalLoginUrl() } data-testid="external-link" />
-								),
+								SignupLink: <ExternalLink href={ getPayPalSignupUrl() } />,
+								LoginLink: <ExternalLink href={ getPayPalLoginUrl() } />,
 								strong: <strong />,
 							}
 						) }

--- a/projects/packages/paypal-payments/tests/js/paypal-payment-buttons-block-tests/edit.test.js
+++ b/projects/packages/paypal-payments/tests/js/paypal-payment-buttons-block-tests/edit.test.js
@@ -66,7 +66,6 @@ jest.mock( '@wordpress/components', () => ( {
 		);
 	},
 	__experimentalToggleGroupControlOption: () => null, // We're not using the actual implementation
-	__experimentalText: ( { children } ) => <span data-testid="experimental-text">{ children }</span>,
 	__experimentalItemGroup: ( { children } ) => <div data-testid="item-group">{ children }</div>,
 	__experimentalItem: ( { children } ) => <div data-testid="item">{ children }</div>,
 	SVG: props => <svg { ...props } />,
@@ -91,7 +90,34 @@ jest.mock( '@wordpress/element', () => {
 		useEffect: jest.fn().mockImplementation( ( callback, deps ) => {
 			React.useEffect( () => callback(), deps ); // eslint-disable-line react-hooks/exhaustive-deps
 		} ),
-		createInterpolateElement: text => text,
+		createInterpolateElement: ( text, elements ) => {
+			// Simple mock implementation for createInterpolateElement
+			// Replace the text with actual React elements
+			let result = text;
+
+			// Replace SignupLink and LoginLink with actual ExternalLink components
+			if ( elements.SignupLink ) {
+				result = React.createElement(
+					React.Fragment,
+					null,
+					'1. ',
+					React.cloneElement(
+						elements.SignupLink,
+						{ 'data-testid': 'external-link' },
+						React.createElement( 'strong', null, 'Sign up' )
+					),
+					' or ',
+					React.cloneElement(
+						elements.LoginLink,
+						{ 'data-testid': 'external-link' },
+						React.createElement( 'strong', null, 'log in' )
+					),
+					' to PayPal to get your Payment Button code.'
+				);
+			}
+
+			return result;
+		},
 	};
 } );
 
@@ -376,18 +402,6 @@ describe( 'Edit', () => {
 
 		// Reset mock
 		isWpcomPlatformSite.mockReturnValue( false );
-	} );
-
-	describe( 'Instruction Elements', () => {
-		it( 'renders simplified instruction text', () => {
-			render( <Edit { ...defaultProps } /> );
-			const instructionText = screen.getByTestId( 'experimental-text' );
-			expect( instructionText ).toBeInTheDocument();
-			expect( instructionText ).toHaveTextContent( 'Sign up' );
-			expect( instructionText ).toHaveTextContent( 'or' );
-			expect( instructionText ).toHaveTextContent( 'log in' );
-			expect( instructionText ).toHaveTextContent( 'to PayPal to get your Payment Button code.' );
-		} );
 	} );
 
 	describe( 'Parameter Clearing on Button Type Toggle', () => {


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Updates the sign up or login prompt to be in the instructions.
* Tighten language for step 2 dependent on button type.
* Interpolates that instruction for proper translations.

<img width="1318" height="894" alt="CleanShot 2025-07-31 at 22 04 40@2x" src="https://github.com/user-attachments/assets/e3edaa43-b07a-40ac-bc91-c7579459f299" />

<img width="1318" height="780" alt="CleanShot 2025-07-31 at 22 04 57@2x" src="https://github.com/user-attachments/assets/fc304e82-433a-4232-81d2-28df5386f360" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
NA

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Checkout branch
- Build with `jetpack build packages/paypal-payments && jetpack build plugins/paypal-payment-buttons`
- Activate plugin (link if necessary)
- Create a page
- Add PayPal Payment Buttons block
