### PR TITLE
My Jetpack: Prevent expiration alerts for products covered by active bundles

### DIFF
--- a/projects/packages/my-jetpack/changelog/fix-MYJP-245-expired-plan-w-complete
+++ b/projects/packages/my-jetpack/changelog/fix-MYJP-245-expired-plan-w-complete
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: Prevent expiration alerts for products covered by active bundles

--- a/projects/packages/my-jetpack/src/class-red-bubble-notifications.php
+++ b/projects/packages/my-jetpack/src/class-red-bubble-notifications.php
@@ -254,25 +254,43 @@ class Red_Bubble_Notifications {
 			if ( $product::has_paid_plan_for_product() ) {
 				$purchase = $product::get_paid_plan_purchase_for_product();
 				if ( $purchase ) {
-					$redbubble_notice_data = array(
-						'product_slug'   => $purchase->product_slug,
-						'product_name'   => $purchase->product_name,
-						'expiry_date'    => $purchase->expiry_date,
-						'expiry_message' => $purchase->expiry_message,
-						'manage_url'     => $product::get_manage_paid_plan_purchase_url(),
-					);
-
-					if ( $product::is_paid_plan_expired() && empty( $_COOKIE[ "$purchase->product_slug--plan_expired_dismissed" ] ) ) {
-						$red_bubble_slugs[ "$purchase->product_slug--plan_expired" ] = $redbubble_notice_data;
-						if ( ! $product::is_bundle_product() ) {
-							$products_included_in_expiring_plan[ "$purchase->product_slug--plan_expired" ][] = $product::get_name();
+					// Check if this product is covered by an active bundle plan
+					$is_covered_by_active_bundle = false;
+					if ( ! $product::is_bundle_product() ) {
+						foreach ( $product_classes as $bundle_product ) {
+							if ( $bundle_product::is_bundle_product() &&
+								$bundle_product::has_paid_plan_for_product() &&
+								! $bundle_product::is_paid_plan_expired() &&
+								method_exists( $bundle_product, 'get_supported_products' ) &&
+								in_array( $key, $bundle_product::get_supported_products(), true ) ) {
+								$is_covered_by_active_bundle = true;
+								break;
+							}
 						}
 					}
-					if ( $product::is_paid_plan_expiring() && empty( $_COOKIE[ "$purchase->product_slug--plan_expiring_soon_dismissed" ] ) ) {
-						$red_bubble_slugs[ "$purchase->product_slug--plan_expiring_soon" ]               = $redbubble_notice_data;
-						$red_bubble_slugs[ "$purchase->product_slug--plan_expiring_soon" ]['manage_url'] = $product::get_renew_paid_plan_purchase_url();
-						if ( ! $product::is_bundle_product() ) {
-							$products_included_in_expiring_plan[ "$purchase->product_slug--plan_expiring_soon" ][] = $product::get_name();
+
+					// Only show expiration alerts if not covered by an active bundle
+					if ( ! $is_covered_by_active_bundle ) {
+						$redbubble_notice_data = array(
+							'product_slug'   => $purchase->product_slug,
+							'product_name'   => $purchase->product_name,
+							'expiry_date'    => $purchase->expiry_date,
+							'expiry_message' => $purchase->expiry_message,
+							'manage_url'     => $product::get_manage_paid_plan_purchase_url(),
+						);
+
+						if ( $product::is_paid_plan_expired() && empty( $_COOKIE[ "$purchase->product_slug--plan_expired_dismissed" ] ) ) {
+							$red_bubble_slugs[ "$purchase->product_slug--plan_expired" ] = $redbubble_notice_data;
+							if ( ! $product::is_bundle_product() ) {
+								$products_included_in_expiring_plan[ "$purchase->product_slug--plan_expired" ][] = $product::get_name();
+							}
+						}
+						if ( $product::is_paid_plan_expiring() && empty( $_COOKIE[ "$purchase->product_slug--plan_expiring_soon_dismissed" ] ) ) {
+							$red_bubble_slugs[ "$purchase->product_slug--plan_expiring_soon" ]               = $redbubble_notice_data;
+							$red_bubble_slugs[ "$purchase->product_slug--plan_expiring_soon" ]['manage_url'] = $product::get_renew_paid_plan_purchase_url();
+							if ( ! $product::is_bundle_product() ) {
+								$products_included_in_expiring_plan[ "$purchase->product_slug--plan_expiring_soon" ][] = $product::get_name();
+							}
 						}
 					}
 				}

--- a/projects/packages/my-jetpack/src/products/class-complete.php
+++ b/projects/packages/my-jetpack/src/products/class-complete.php
@@ -257,6 +257,7 @@ class Complete extends Module_Product {
 			'social',
 			'stats',
 			'videopress',
+			'jetpack-ai',
 		);
 	}
 

--- a/projects/plugins/backup/changelog/fix-MYJP-245-expired-plan-w-complete
+++ b/projects/plugins/backup/changelog/fix-MYJP-245-expired-plan-w-complete
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: Prevent expiration alerts for products covered by active bundles

--- a/projects/plugins/boost/changelog/fix-MYJP-245-expired-plan-w-complete
+++ b/projects/plugins/boost/changelog/fix-MYJP-245-expired-plan-w-complete
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: Prevent expiration alerts for products covered by active bundles

--- a/projects/plugins/jetpack/changelog/fix-MYJP-245-expired-plan-w-complete
+++ b/projects/plugins/jetpack/changelog/fix-MYJP-245-expired-plan-w-complete
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+My Jetpack: Prevent expiration alerts for products covered by active bundles

--- a/projects/plugins/protect/changelog/fix-MYJP-245-expired-plan-w-complete
+++ b/projects/plugins/protect/changelog/fix-MYJP-245-expired-plan-w-complete
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: Prevent expiration alerts for products covered by active bundles

--- a/projects/plugins/search/changelog/fix-MYJP-245-expired-plan-w-complete
+++ b/projects/plugins/search/changelog/fix-MYJP-245-expired-plan-w-complete
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: Prevent expiration alerts for products covered by active bundles

--- a/projects/plugins/social/changelog/fix-MYJP-245-expired-plan-w-complete
+++ b/projects/plugins/social/changelog/fix-MYJP-245-expired-plan-w-complete
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: Prevent expiration alerts for products covered by active bundles

--- a/projects/plugins/starter-plugin/changelog/fix-MYJP-245-expired-plan-w-complete
+++ b/projects/plugins/starter-plugin/changelog/fix-MYJP-245-expired-plan-w-complete
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: Prevent expiration alerts for products covered by active bundles

--- a/projects/plugins/videopress/changelog/fix-MYJP-245-expired-plan-w-complete
+++ b/projects/plugins/videopress/changelog/fix-MYJP-245-expired-plan-w-complete
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: Prevent expiration alerts for products covered by active bundles


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes MYJP-245

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* skip expired plan alert if the product is included in an active bundle

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Checkout JN site and activate Jetpack
* Purchase AI Assistant
* make it expire in SA
* verify that you see a banner about it (screenshot below for reference)
* purchase a Complete bundle for the same site
* verify that you don't see the AI error banner but you see the expired plan in the footer (screenshot below for reference)

<img width="897" height="273" alt="SCR-20250801-lvqw" src="https://github.com/user-attachments/assets/22798114-b635-4866-bacd-119b2116a402" />

<img width="353" height="302" alt="SCR-20250801-lvtr" src="https://github.com/user-attachments/assets/8d48c0f1-10ed-43be-be30-803cb5ebe0f2" />
