### PR TITLE
Forms: ratings field - fix partial translation

### DIFF
--- a/projects/packages/forms/changelog/update-forms-rating-fix-partial-translation
+++ b/projects/packages/forms/changelog/update-forms-rating-fix-partial-translation
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: ratings field - fix partial translation

--- a/projects/packages/forms/src/blocks/input-rating/symbols.js
+++ b/projects/packages/forms/src/blocks/input-rating/symbols.js
@@ -1,5 +1,5 @@
 import { useCallback, useMemo } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Interactive rating symbol row with full accessibility support.
@@ -105,10 +105,12 @@ export default function Symbols( {
 								checked={ value === position }
 								onChange={ handleSelect( position ) }
 								className="jetpack-field-rating__input screen-reader-text"
-								aria-label={ `${ position } ${ __( 'out of', 'jetpack-forms' ) } ${ max } ${ __(
-									'stars',
-									'jetpack-forms'
-								) }` }
+								aria-label={ sprintf(
+									// translators: 1: selected symbol. 2: total number of symbols.
+									__( '%1$d out of %2$d symbols', 'jetpack-forms' ),
+									position,
+									max
+								) }
 							/>
 							<span
 								role="presentation"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Don't use partial sentences for translations but instead use complete sentece

Symbols are either "stars" or "hearts" so I'm keeping the aria label generic.


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

