### PR TITLE
Forms: handle textarea placeholder

### DIFF
--- a/projects/packages/forms/changelog/fix-jetpack-forms-textarea-placeholder
+++ b/projects/packages/forms/changelog/fix-jetpack-forms-textarea-placeholder
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: handle placeholder for textareas in the editor the same way input tags do

--- a/projects/packages/forms/src/blocks/input/edit.js
+++ b/projects/packages/forms/src/blocks/input/edit.js
@@ -66,7 +66,14 @@ const InputEdit = ( { attributes, clientId, isSelected, name, setAttributes, con
 	}
 
 	if ( type === 'textarea' ) {
-		return <textarea { ...blockProps } onChange={ onChange } value={ placeholder } />;
+		return (
+			<textarea
+				{ ...blockProps }
+				onChange={ onChange }
+				value={ isSelected ? placeholder : '' }
+				placeholder={ placeholder }
+			/>
+		);
 	}
 
 	return (


### PR DESCRIPTION


## Proposed changes:
This PR fixes a placeholder issue on textarea tags where the value would remain instead of the placeholder. Thus making the textarea text look different. It's the same placeholder management we use for input tags.

Try it: insert a multi-line and and text input on a form. Edit their placeholders to see the difference: inputs will show placeholder greyed out but textareas will retain the theme/selected text color.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Insert a form with a text input and a multi-line text input (textarea). Play with text and background colors. See that the input texts respect the selected color while editing them, but de-selecting the block will show the text as placeholders do (greyed out). See that now textarea inputs behave the same way.
Verify the inputs look as expected on the frontend.