### PR TITLE
Forms: wrap input and textarea elements

### DIFF
--- a/projects/packages/forms/changelog/add-jetpack-forms-input-wrapper
+++ b/projects/packages/forms/changelog/add-jetpack-forms-input-wrapper
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: wrap text inputs (input and textarea). This allows for prepending/appending elements for stylized and compound inputs

--- a/projects/packages/forms/changelog/add-jetpack-forms-phone-with-country
+++ b/projects/packages/forms/changelog/add-jetpack-forms-phone-with-country
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: add country selector support for phone, add prefix support for base inputs

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -51,10 +51,6 @@
 		flex-direction: row;
 		gap: var(--wp--style--block-gap, 1.5rem);
 
-		> div {
-			flex: 1 1 100%;
-		}
-
 		.wp-block {
 			flex: 0 0 100%;
 			margin-top: 0;
@@ -326,21 +322,22 @@
 	padding: 0;
 }
 
-.jetpack-field__textarea {
-	display: block;
-	min-height: 200px;
-}
 
 // Default field styles. (browser default styles)
 .jetpack-field {
 
+	.jetpack-field__textarea {
+		min-height: 200px;
+	}
+
 	.jetpack-field__input,
 	.jetpack-field__textarea {
-		width: 100%;
 		box-sizing: border-box;
 		box-shadow: unset;
 		padding: 16px;
 		margin: 0;
+		display: flex;
+		gap: 8px;
 	}
 
 	// Reduced specificity to 0,1,0 so that global styles can override it.

--- a/projects/packages/forms/src/blocks/input/edit.js
+++ b/projects/packages/forms/src/blocks/input/edit.js
@@ -72,6 +72,7 @@ const InputEdit = ( { attributes, clientId, isSelected, name, setAttributes, con
 		return (
 			<div { ...blockProps }>
 				<textarea
+					className="jetpack-field__input-element"
 					onChange={ onChange }
 					value={ isSelected ? placeholder : '' }
 					placeholder={ placeholder }
@@ -90,6 +91,7 @@ const InputEdit = ( { attributes, clientId, isSelected, name, setAttributes, con
 		<>
 			<div { ...blockProps }>
 				<input
+					className="jetpack-field__input-element"
 					onChange={ onChange }
 					onKeyDown={ onKeyDown }
 					type="text"

--- a/projects/packages/forms/src/blocks/input/edit.js
+++ b/projects/packages/forms/src/blocks/input/edit.js
@@ -7,6 +7,7 @@ import useInsertAfterOnEnterKeyDown from '../shared/hooks/use-insert-after-on-en
 import { useSyncedAttributes } from '../shared/hooks/use-synced-attributes';
 import useVariationStyleProperties from '../shared/hooks/use-variation-style-properties.js';
 import { ALLOWED_FORMATS } from '../shared/util/constants.js';
+import './editor.scss';
 
 const SYNCED_ATTRIBUTE_KEYS = [
 	'backgroundColor',
@@ -69,12 +70,13 @@ const InputEdit = ( { attributes, clientId, isSelected, name, setAttributes, con
 
 	if ( type === 'textarea' ) {
 		return (
-			<textarea
-				{ ...blockProps }
-				onChange={ onChange }
-				value={ isSelected ? placeholder : '' }
-				placeholder={ placeholder }
-			/>
+			<div { ...blockProps }>
+				<textarea
+					onChange={ onChange }
+					value={ isSelected ? placeholder : '' }
+					placeholder={ placeholder }
+				/>
+			</div>
 		);
 	}
 
@@ -86,14 +88,15 @@ const InputEdit = ( { attributes, clientId, isSelected, name, setAttributes, con
 
 	return (
 		<>
-			<input
-				{ ...blockProps }
-				onChange={ onChange }
-				onKeyDown={ onKeyDown }
-				type="text"
-				value={ isSelected ? placeholder : '' }
-				placeholder={ placeholder }
-			/>
+			<div { ...blockProps }>
+				<input
+					onChange={ onChange }
+					onKeyDown={ onKeyDown }
+					type="text"
+					value={ isSelected ? placeholder : '' }
+					placeholder={ placeholder }
+				/>
+			</div>
 			{ type === 'number' && (
 				<InspectorControls>
 					<PanelBody title={ __( 'Settings', 'jetpack-forms' ) }>

--- a/projects/packages/forms/src/blocks/input/editor.scss
+++ b/projects/packages/forms/src/blocks/input/editor.scss
@@ -4,8 +4,8 @@
 	.jetpack-field__textarea {
 		box-sizing: border-box;
 
-		input,
-		textarea {
+		input.jetpack-field__input-element,
+		textarea.jetpack-field__input-element {
 			border: 0;
 			font: inherit;
 			flex: 1;
@@ -15,10 +15,15 @@
 			width: inherit;
 			box-sizing: border-box;
 			resize: none;
+			padding: 0;
 
 			&::before,
 			&::after {
 				box-sizing: inherit;
+			}
+
+			&:focus {
+				box-shadow: none;
 			}
 		}
 	}
@@ -30,12 +35,17 @@
 			border: 0;
 			color: inherit;
 
-			select {
+			select.jetpack-field__input-element {
 				font: inherit;
 				border: 0;
 				color: inherit;
 				outline: none;
 				background: inherit;
+				padding: 0;
+
+				&:focus {
+					box-shadow: none;
+				}
 			}
 		}
 	}

--- a/projects/packages/forms/src/blocks/input/editor.scss
+++ b/projects/packages/forms/src/blocks/input/editor.scss
@@ -7,12 +7,10 @@
 		input,
 		textarea {
 			border: 0;
-			line-height: inherit;
-			font-size: inherit;
+			font: inherit;
 			flex: 1;
 			outline: none;
 			color: inherit;
-			font-family: inherit;
 			background: inherit;
 			width: inherit;
 			box-sizing: border-box;
@@ -28,18 +26,14 @@
 	.jetpack-field__input {
 
 		.jetpack-field__input-prefix {
-			font-size: inherit;
+			font: inherit;
 			border: 0;
-			line-height: inherit;
 			color: inherit;
-			font-family: inherit;
 
 			select {
-				font-size: inherit;
+				font: inherit;
 				border: 0;
-				line-height: inherit;
 				color: inherit;
-				font-family: inherit;
 				outline: none;
 				background: inherit;
 			}

--- a/projects/packages/forms/src/blocks/input/editor.scss
+++ b/projects/packages/forms/src/blocks/input/editor.scss
@@ -1,0 +1,48 @@
+.jetpack-contact-form .jetpack-field {
+
+	.jetpack-field__input,
+	.jetpack-field__textarea {
+		box-sizing: border-box;
+
+		input,
+		textarea {
+			border: 0;
+			line-height: inherit;
+			font-size: inherit;
+			flex: 1;
+			outline: none;
+			color: inherit;
+			font-family: inherit;
+			background: inherit;
+			width: inherit;
+			box-sizing: border-box;
+			resize: none;
+
+			&::before,
+			&::after {
+				box-sizing: inherit;
+			}
+		}
+	}
+
+	.jetpack-field__input {
+
+		.jetpack-field__input-prefix {
+			font-size: inherit;
+			border: 0;
+			line-height: inherit;
+			color: inherit;
+			font-family: inherit;
+
+			select {
+				font-size: inherit;
+				border: 0;
+				line-height: inherit;
+				color: inherit;
+				font-family: inherit;
+				outline: none;
+				background: inherit;
+			}
+		}
+	}
+}

--- a/projects/packages/forms/src/blocks/input/editor.scss
+++ b/projects/packages/forms/src/blocks/input/editor.scss
@@ -4,8 +4,8 @@
 	.jetpack-field__textarea {
 		box-sizing: border-box;
 
-		input.jetpack-field__input-element,
-		textarea.jetpack-field__input-element {
+		// these class is used to style input and textarea elements
+		.jetpack-field__input-element {
 			border: 0;
 			font: inherit;
 			flex: 1;
@@ -35,7 +35,8 @@
 			border: 0;
 			color: inherit;
 
-			select.jetpack-field__input-element {
+			// these class is used to style select elements
+			.jetpack-field__input-element {
 				font: inherit;
 				border: 0;
 				color: inherit;


### PR DESCRIPTION
## Proposed changes:
This PR adds a wrapping element on `input` and `textarea` tags in the editor. This allows for complex inputs to be composed within the wrapper while retaining visual consistency.

Having styles directly applied to the input makes it very complex (or impossible) to compose inputs like the following one:

<img width="691" height="168" alt="image" src="https://github.com/user-attachments/assets/cee0a491-c68b-42c4-beac-385e418d0798" />

<img width="701" height="239" alt="image" src="https://github.com/user-attachments/assets/16e93513-00d4-4942-b6c0-10d19fcd3486" />

However, we need to also consider CSS specificity.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1754060668516739-slack-C052XEUUBL4

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Add all sort of inputs, text or otherwise. Verify there's no noticeable change in the editor nor in frontend.
Load already published form samples to check there are no regressions.
Verify global styles apply properly.