### PR TITLE
Forms: fix label encoding issues, and handle empty- and duplicate label names

### DIFF
--- a/projects/packages/forms/changelog/fix-form-label-edge-cases
+++ b/projects/packages/forms/changelog/fix-form-label-edge-cases
@@ -1,4 +1,4 @@
 Significance: minor
 Type: fixed
 
-Forms: fix encoding and empty label and duplicate label names
+Forms: fix label encoding issues, and handle empty- and duplicate label names

--- a/projects/packages/forms/changelog/fix-form-label-edge-cases
+++ b/projects/packages/forms/changelog/fix-form-label-edge-cases
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+Forms: fix encoding and empty label and duplicate label names

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -568,7 +568,7 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 			$data['subject'] = $response->get_subject();
 		}
 		if ( rest_is_field_included( 'fields', $fields ) ) {
-			$data['fields'] = $response->get_compiled_fields( 'api', 'key-value' );
+			$data['fields'] = $response->get_compiled_fields( 'api', 'label-value' );
 		}
 
 		if ( rest_is_field_included( 'has_file', $fields ) ) {

--- a/projects/packages/forms/src/contact-form/class-feedback-field.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-field.php
@@ -60,7 +60,7 @@ class Feedback_Field {
 	 */
 	public function __construct( $key, $label, $value, $type = 'basic', $meta = array() ) {
 		$this->key   = $key;
-		$this->label = mb_convert_encoding( $label, 'UTF-8', 'HTML-ENTITIES' );
+		$this->label = is_string( $label ) ? html_entity_decode( $label, ENT_QUOTES | ENT_HTML5, 'UTF-8' ) : '';
 		$this->value = $value;
 		$this->type  = $type;
 		$this->meta  = $meta;
@@ -78,10 +78,24 @@ class Feedback_Field {
 	/**
 	 * Get the label of the field.
 	 *
+	 * @param string $context The context in which the label is being rendered (default is 'default').
+	 * @param int    $count   The count of the label occurrences (default is 1).
+	 *
 	 * @return string
 	 */
-	public function get_label() {
-		return $this->label;
+	public function get_label( $context = 'default', $count = 1 ) {
+
+		$postfix = $count > 1 ? " ({$count})" : '';
+
+		if ( 'api' === $context ) {
+			if ( empty( $this->label ) ) {
+				return __( 'Field', 'jetpack-forms' ) . $postfix;
+			}
+
+			return $this->label . $postfix;
+		}
+		// For API context, we return the label as is.
+		return $this->label . $postfix;
 	}
 
 	/**

--- a/projects/packages/forms/src/contact-form/class-feedback-field.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-field.php
@@ -53,7 +53,7 @@ class Feedback_Field {
 	 * Constructor.
 	 *
 	 * @param string $key   The key of the field.
-	 * @param string $label The label of the field.
+	 * @param mixed  $label The label of the field. Non-string values will be converted to empty string.
 	 * @param mixed  $value The value of the field.
 	 * @param string $type  The type of the field (default is 'basic').
 	 * @param array  $meta  Additional metadata for the field (default is an empty array).

--- a/projects/packages/forms/src/contact-form/class-feedback-field.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-field.php
@@ -94,7 +94,7 @@ class Feedback_Field {
 
 			return $this->label . $postfix;
 		}
-		// For API context, we return the label as is.
+
 		return $this->label . $postfix;
 	}
 

--- a/projects/packages/forms/src/contact-form/class-feedback.php
+++ b/projects/packages/forms/src/contact-form/class-feedback.php
@@ -960,15 +960,19 @@ class Feedback {
 	 * Extract the label from a key that might be in the format "1_label".
 	 *
 	 * @param string $key The key to extract the label from.
-	 * @return string The extracted label.
+	 * @return string|null The extracted label.
 	 */
 	private static function extract_label_from_key( $key ) {
-		// Check if the key starts with a number followed by underscore
+		// Check if the key starts with a number followed by underscore and has content after underscore
 		if ( preg_match( '/^\d+_(.+)$/', $key, $matches ) ) {
 			return $matches[1];
 		}
-		// If no number prefix, return the key as is
-		return null;
+		// If the key is just a number followed by underscore (like "2_"), return null
+		if ( preg_match( '/^\d+_$/', $key ) ) {
+			return null;
+		}
+		// If the key doesn't start with a number followed by underscore, return the key as is
+		return $key;
 	}
 
 	/**

--- a/projects/packages/forms/src/contact-form/class-feedback.php
+++ b/projects/packages/forms/src/contact-form/class-feedback.php
@@ -962,16 +962,16 @@ class Feedback {
 	 * Extract the label from a key that might be in the format "1_label".
 	 *
 	 * @param string $key The key to extract the label from.
-	 * @return string|null The extracted label.
+	 * @return string The extracted label.
 	 */
 	private static function extract_label_from_key( $key ) {
 		// Check if the key starts with a number followed by underscore and has content after underscore
 		if ( preg_match( '/^\d+_(.+)$/', $key, $matches ) ) {
 			return $matches[1];
 		}
-		// If the key is just a number followed by underscore (like "2_"), return null
+		// If the key is just a number followed by underscore (like "2_"), return empty string
 		if ( preg_match( '/^\d+_$/', $key ) ) {
-			return null;
+			return '';
 		}
 		// If the key doesn't start with a number followed by underscore, return the key as is
 		return $key;

--- a/projects/packages/forms/src/contact-form/class-feedback.php
+++ b/projects/packages/forms/src/contact-form/class-feedback.php
@@ -248,7 +248,7 @@ class Feedback {
 	public function get_field_value_by_label( $label, $context = 'default' ) {
 		// This method is used to get the value of a field by its label.
 		foreach ( $this->fields as $field ) {
-			if ( $field->get_label() === $label ) {
+			if ( $field->get_label( $context ) === $label ) {
 				return $field->get_render_value( $context );
 			}
 		}
@@ -328,13 +328,22 @@ class Feedback {
 	 */
 	public function get_compiled_fields( $context = 'default', $array_shape = 'all' ) {
 		$compiled_fields = array();
+
+		$count_field_labels = array();
 		foreach ( $this->fields as $field ) {
 			if ( $field->compile_field( $context ) ) {
 				continue; // Skip fields that are not meant to be rendered.
 			}
 
+			if ( ! isset( $count_field_labels[ $field->get_label( $context ) ] ) ) {
+				$count_field_labels[ $field->get_label( $context ) ] = 1;
+			} else {
+				++$count_field_labels[ $field->get_label( $context ) ];
+			}
+
 			// Compile the field based on the requested shape.
 			switch ( $array_shape ) {
+				case 'default':
 				case 'all':
 					$compiled_fields[ $field->get_key() ] = array(
 						'label' => $field->get_label( $context ),
@@ -355,6 +364,9 @@ class Feedback {
 					break;
 				case 'key-value':
 					$compiled_fields[ $field->get_key() ] = $field->get_render_value( $context );
+					break;
+				case 'label-value':
+						$compiled_fields[ $field->get_label( $context, $count_field_labels[ $field->get_label( $context ) ] ) ] = $field->get_render_value( $context );
 					break;
 			}
 		}
@@ -956,7 +968,7 @@ class Feedback {
 			return $matches[1];
 		}
 		// If no number prefix, return the key as is
-		return $key;
+		return null;
 	}
 
 	/**

--- a/projects/packages/forms/src/contact-form/class-feedback.php
+++ b/projects/packages/forms/src/contact-form/class-feedback.php
@@ -335,10 +335,12 @@ class Feedback {
 				continue; // Skip fields that are not meant to be rendered.
 			}
 
-			if ( ! isset( $count_field_labels[ $field->get_label( $context ) ] ) ) {
-				$count_field_labels[ $field->get_label( $context ) ] = 1;
+			$label = $field->get_label( $context );
+
+			if ( ! isset( $count_field_labels[ $label ] ) ) {
+				$count_field_labels[ $label ] = 1;
 			} else {
-				++$count_field_labels[ $field->get_label( $context ) ];
+				++$count_field_labels[ $label ];
 			}
 
 			// Compile the field based on the requested shape.
@@ -346,13 +348,13 @@ class Feedback {
 				case 'default':
 				case 'all':
 					$compiled_fields[ $field->get_key() ] = array(
-						'label' => $field->get_label( $context ),
+						'label' => $label,
 						'value' => $field->get_render_value( $context ),
 					);
 					break;
 				case 'label|value':
 					$compiled_fields[] = array(
-						'label' => $field->get_label( $context ),
+						'label' => $label,
 						'value' => $field->get_render_value( $context ),
 					);
 					break;
@@ -360,13 +362,13 @@ class Feedback {
 					$compiled_fields[] = $field->get_render_value( $context );
 					break;
 				case 'label':
-					$compiled_fields[] = $field->get_label( $context );
+					$compiled_fields[] = $label;
 					break;
 				case 'key-value':
 					$compiled_fields[ $field->get_key() ] = $field->get_render_value( $context );
 					break;
 				case 'label-value':
-						$compiled_fields[ $field->get_label( $context, $count_field_labels[ $field->get_label( $context ) ] ) ] = $field->get_render_value( $context );
+						$compiled_fields[ $field->get_label( $context, $count_field_labels[ $label ] ) ] = $field->get_render_value( $context );
 					break;
 			}
 		}

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Endpoint_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Endpoint_Test.php
@@ -517,7 +517,7 @@ JSON_DATA{"1_name":"Test Author","2_email":"author@example.com","3_file":{"field
 
 		$this->assertEquals( 200, $response->get_status() );
 		$data = $response->get_data();
-		// var_dump( $data );
+
 		// Verify file field data in response
 		$this->assertArrayHasKey( 'fields', $data );
 		$this->assertArrayHasKey( 'file', $data['fields'] );

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Endpoint_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Endpoint_Test.php
@@ -484,15 +484,15 @@ IP: 127.0.0.1
 
 <!--more-->
 
-JSON_DATA{"name":"Test Author","email":"author@example.com","g1-file":{"field_id":"g1-file","files":[{"file_id":123,"name":"test.jpg","size":1024,"type":"image/jpeg"}]}}',
+JSON_DATA{"1_name":"Test Author","2_email":"author@example.com","3_file":{"field_id":"g1-file","files":[{"file_id":123,"name":"test.jpg","size":1024,"type":"image/jpeg"}]}}',
 			)
 		);
 
 		// Add test metadata
 		$all_fields = array(
-			'name'    => 'Test Author',
-			'email'   => 'author@example.com',
-			'g1-file' => array(
+			'1_name'  => 'Test Author',
+			'2_email' => 'author@example.com',
+			'3_file'  => array(
 				'field_id' => 'g1-file',
 				'files'    => array(
 					array(
@@ -517,13 +517,13 @@ JSON_DATA{"name":"Test Author","email":"author@example.com","g1-file":{"field_id
 
 		$this->assertEquals( 200, $response->get_status() );
 		$data = $response->get_data();
-
+		// var_dump( $data );
 		// Verify file field data in response
 		$this->assertArrayHasKey( 'fields', $data );
-		$this->assertArrayHasKey( 'g1-file', $data['fields'] );
-		$this->assertArrayHasKey( 'files', $data['fields']['g1-file'] );
+		$this->assertArrayHasKey( 'file', $data['fields'] );
+		$this->assertArrayHasKey( 'files', $data['fields']['file'] );
 
-		$file = $data['fields']['g1-file']['files'][0];
+		$file = $data['fields']['file']['files'][0];
 		$this->assertEquals( 123, $file['file_id'] );
 		$this->assertEquals( 'test.jpg', $file['name'] );
 		$this->assertEquals( '1 KB', $file['size'] );

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
@@ -753,7 +753,7 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 			array(
 				'1_field' => 'value1',
 				'2_field' => 'value2',
-				'email'   => 'hello@example.com',
+				'3_email' => 'hello@example.com',
 			)
 		);
 

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Field_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Field_Test.php
@@ -247,6 +247,23 @@ class Feedback_Field_Test extends BaseTestCase {
 		$this->assertSame( array( 'files' => array() ), $field->get_render_value( 'api' ) );
 		remove_filter( 'jetpack_unauth_file_download_url', array( $this, 'return_url' ) );
 	}
+
+	public function test_render_label_in_different_contexts() {
+		$field = new Feedback_Field( 'test_key', 'test_label', 'test_value' );
+		$this->assertEquals( 'test_label', $field->get_label() );
+
+		$field = new Feedback_Field( 'test_key', '', 'test_value' );
+		$this->assertSame( '', $field->get_label() );
+
+		$field = new Feedback_Field( 'test_key', null, 'test_value' );
+		$this->assertSame( '', $field->get_label() );
+
+		$field = new Feedback_Field( 'test_key', false, 'test_value' );
+		$this->assertSame( '', $field->get_label() );
+
+		$field = new Feedback_Field( 'test_key', 'á&#044; ç&#044; ü&#044; ń&#044; ğ', 'test_value' );
+		$this->assertSame( 'á, ç, ü, ń, ğ', $field->get_label() );
+	}
 	/**
 	 * Helper function to return a URL for the file.
 	 *

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Test.php
@@ -1392,7 +1392,7 @@ class Feedback_Test extends BaseTestCase {
 				),
 				'message'  => 'Compiled fields should return key-value pairs only.',
 			),
-			'label-value_format' => array(
+			'label|value_format' => array(
 				'format'   => 'label|value',
 				'expected' => array(
 					array(
@@ -1423,6 +1423,16 @@ class Feedback_Test extends BaseTestCase {
 					$test_message,
 				),
 				'message'  => 'Compiled fields should return only values as indexed array.',
+			),
+			'label-value_format' => array(
+				'format'   => 'label-value',
+				'expected' => array(
+					'Name'    => $test_name,
+					'Email'   => $test_email,
+					'Website' => $test_website,
+					'Message' => $test_message,
+				),
+				'message'  => 'Compiled fields should return only labels as indexed array.',
 			),
 			'label_format'       => array(
 				'format'   => 'label',
@@ -1492,7 +1502,7 @@ class Feedback_Test extends BaseTestCase {
 		$url     = 'https://wordpress.com';
 		$post_id = Utility::create_legacy_feedback(
 			array(
-				'file upload' => array(
+				'1_file upload' => array(
 					'field_id' => 'file_upload',
 					'files'    => array( $file ),
 				),


### PR DESCRIPTION
Fixes FORMS-240

## Proposed changes:
* Fix labels with a number of edge cases. 
1. Empty label.  (low prio)
2. Repeating Label (low prio)
3. Label with special characters (high prio)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add form with special characters (accents éú, umlauts üäö, Chinese 汉字, etc) in label
* Remove text from one label
* Duplicate one label to be same across two fields
* Test form itself, submission confirmation, email, inbox view and export
