### PR TITLE
Connection: Update connection webhooks to pass skip_pricing to authorization URL

### DIFF
--- a/projects/packages/connection/changelog/update-connection-pass-skip_pricing-to-user-connection
+++ b/projects/packages/connection/changelog/update-connection-pass-skip_pricing-to-user-connection
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated connection webhooks to pass skip_pricing to authorization URL.

--- a/projects/packages/connection/src/class-webhooks.php
+++ b/projects/packages/connection/src/class-webhooks.php
@@ -176,6 +176,8 @@ class Webhooks {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- no site changes.
 		$from = ! empty( $_GET['from'] ) ? sanitize_text_field( wp_unslash( $_GET['from'] ) ) : 'iframe';
 
+		$skip_pricing = filter_input( INPUT_GET, 'skip_pricing', FILTER_VALIDATE_BOOLEAN );
+
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- no site changes, sanitization happens in get_authorization_url()
 		$redirect = ! empty( $_GET['redirect_after_auth'] ) ? wp_unslash( $_GET['redirect_after_auth'] ) : false;
 
@@ -187,6 +189,10 @@ class Webhooks {
 			}
 
 			$connect_url = add_query_arg( 'from', $from, $this->connection->get_authorization_url( null, $redirect ) );
+
+			if ( $skip_pricing ) {
+				$connect_url = add_query_arg( 'skip_pricing', '1', $connect_url );
+			}
 
 			// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- no site changes.
 			if ( isset( $_GET['notes_iframe'] ) ) {


### PR DESCRIPTION


In #44587, I added `skip_pricing` param to the JS changes but missed to pass it along via PHP when redirecting for authorizing.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Update connection webhooks to pass `skip_pricing` param to the authorization URL

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to My Jetpack on a site with only site connection
* Click on "Connect my account" in the footer
* Confirm that the connection redirect URL has `skip_pricing=1`
* Complete the authorization
* Confirm that it doesn't redirect to the pricing page
* Confirm that it redirects directly to My Jetoack
