### PR TITLE
Carousel: Only load the current, previous and next images

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-carousel-prevent-excessive-image-loading
+++ b/projects/plugins/jetpack/changelog/update-jetpack-carousel-prevent-excessive-image-loading
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Carousel: Preload only adjacent images instead of all at once, reducing memory usage and preventing crashes on large galleries.

--- a/projects/plugins/jetpack/changelog/update-jetpack-carousel-prevent-excessive-image-loading
+++ b/projects/plugins/jetpack/changelog/update-jetpack-carousel-prevent-excessive-image-loading
@@ -1,4 +1,4 @@
 Significance: patch
 Type: enhancement
 
-Carousel: Preload only adjacent images instead of all at once, reducing memory usage and preventing crashes on large galleries.
+Carousel: Fix crashes on large galleries and reduce server requests, by preloading only adjacent images instead of all at once.

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -777,7 +777,11 @@
 			var current = carousel.currentSlide;
 			var attachmentId = current.attrs.attachmentId;
 
+			// Load current image immediately
 			loadFullImage( carousel.slides[ index ] );
+
+			// Preload adjacent images in background
+			preloadAdjacentImages( index );
 
 			if (
 				Number( jetpackCarouselStrings.display_background_image ) === 1 &&
@@ -1308,6 +1312,38 @@
 			}
 		}
 
+		function preloadAdjacentImages( currentIndex ) {
+			var indicesToPreload = [];
+			var totalSlides = carousel.slides.length;
+
+			// Only preload adjacent images if we have more than one slide (matching loop condition)
+			if ( totalSlides > 1 ) {
+				// Previous image (with loop handling)
+				var prevIndex = currentIndex > 0 ? currentIndex - 1 : totalSlides - 1;
+				indicesToPreload.push( prevIndex );
+
+				// Next image (with loop handling)
+				var nextIndex = currentIndex < totalSlides - 1 ? currentIndex + 1 : 0;
+				indicesToPreload.push( nextIndex );
+			}
+
+			indicesToPreload.forEach( function ( index ) {
+				var slide = carousel.slides[ index ];
+				if ( slide ) {
+					// Load in background without showing
+					loadFullImage( slide );
+
+					// Also load background image if enabled
+					if (
+						Number( jetpackCarouselStrings.display_background_image ) === 1 &&
+						! slide.backgroundImage
+					) {
+						loadBackgroundImage( slide );
+					}
+				}
+			} );
+		}
+
 		function loadBackgroundImage( slide ) {
 			var currentSlide = slide.el;
 
@@ -1438,7 +1474,6 @@
 					// Initially, the image is a 1x1 transparent gif.
 					// The preview is shown as a background image on the slide itself.
 					var image = new Image();
-					image.src = attrs.src;
 
 					var slideEl = document.createElement( 'div' );
 					slideEl.classList.add( 'swiper-slide' );


### PR DESCRIPTION
Previously the carousel was loading all available images. For large galleries, that meant all images had to be downloaded at the same time which flooded the server with requests and sometimes the server would return a 503 for an image. This would happen every time the gallery was closed and re-opened.

Fixes HOG-236

## Proposed changes:

* Only load current, previous and next images;
* Navigating the gallery preloads the next or previous images related to the current one (if an image is already loaded, it isn't loaded again).

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

HOG-236

## Does this pull request change what data or activity we track or use?

no

## Testing instructions:

**Pre-requisites**

* Setup Jetpack on a publicly accessible website and make sure to enable the Carousel module (if not enabled already):

  <img width="1522" height="458" alt="CleanShot 2025-08-04 at 14 55 44@2x" src="https://github.com/user-attachments/assets/fcaea0db-3284-4545-b1d3-f7927c300a7b" />

* You'll need to add a gallery block to a page and add hundreds of images to the gallery. I didn't have hundreds of images lying around, so I downloaded images from https://wordpress.org/photos/ using the instructions below.

<details><summary>Instructions</summary>

```js
import axios from 'axios';
import * as cheerio from 'cheerio';
import fs from 'fs';
import path from 'path';
import { pipeline } from 'stream/promises';

const OUTPUT_DIR = './wp-images';
const TOTAL_IMAGES = 300;
const IMAGES_PER_PAGE = 24;

if (!fs.existsSync(OUTPUT_DIR)) fs.mkdirSync(OUTPUT_DIR);

function stripSizeSuffix(url) {
  return url.replace(/-\d+x\d+(?=\.\w{3,4}$)/, '');
}

let downloaded = 0;
let page = 1;

while (downloaded < TOTAL_IMAGES) {
  const url = `https://wordpress.org/photos/page/${page}/`;
  const { data } = await axios.get(url);
  const $ = cheerio.load(data);

  const images = $('figure img')
    .map((i, el) => {
      const thumb = $(el).attr('src')?.replace(/\?.*$/, '');
      return thumb ? stripSizeSuffix(thumb) : null;
    })
    .get()
    .filter(Boolean);

  for (const imgUrl of images) {
    if (downloaded >= TOTAL_IMAGES) break;
    const filename = path.join(OUTPUT_DIR, path.basename(imgUrl));
    try {
      const response = await axios.get(imgUrl, { responseType: 'stream' });
      await pipeline(response.data, fs.createWriteStream(filename));
      downloaded++;
      console.log(`Downloaded ${downloaded}: ${filename}`);
    } catch (err) {
      console.warn(`Failed: ${imgUrl}`);
    }
  }

  page++;
}
```

Make sure to create a script in a folder, call it `index.js`. Then in the folder where the script is, install dependencies using:

```
npm install axios cheerio
```

And finally, run the script with:

```
node index.js
```

This will start to download images in a folder called `wp-images`. After you've downloaded enough images, add them to the gallery.

</details>

#### Test that opening the gallery loads a lot of images (current behavior on trunk/production)

- Open the page with the gallery and wait for it to load;
- Open the network tab and filter by `Img` (clear the requests to make it easier to see what's going on);
- Click on an image and notice the amount of images loaded - it should load all images from the gallery.

#### Test that opening the gallery loads a few images (new behavior on this branch)

- Repeat the above steps;
- You should see only 3 images loaded when you click on one.
- Navigate with the next/previous arrows and notice how many images are loaded as you navigate. If you check the markup of the slides (img tag specifically), images that have been preloaded will have an src, while ones that haven't been loaded will have no src.