### PR TITLE
feat: Editor assets endpoint allows the VideoPress block type

### DIFF
--- a/projects/packages/videopress/changelog/include-video-press-editor-state-in-rest-api-requests
+++ b/projects/packages/videopress/changelog/include-video-press-editor-state-in-rest-api-requests
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+VideoPress: include VideoPress editor state in REST API requests.

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -379,19 +379,6 @@ class Initializer {
 			return;
 		}
 
-		// Is this a REST API request?
-		$is_rest = defined( 'REST_API_REQUEST' ) && REST_API_REQUEST;
-
-		if ( $is_rest ) {
-			register_block_type(
-				$videopress_video_metadata_file,
-				array(
-					'render_callback' => array( __CLASS__, 'render_videopress_video_block' ),
-				)
-			);
-			return;
-		}
-
 		$registration = register_block_type(
 			$videopress_video_metadata_file,
 			array(

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-block-editor-assets.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-block-editor-assets.php
@@ -115,6 +115,7 @@ class WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets extends WP_REST_Controller 
 		'premium-content/login-button',
 		'premium-content/subscriber-view',
 		'syntaxhighlighter/code',
+		'videopress/video',
 	);
 
 	/**

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-block-editor-assets.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-block-editor-assets.php
@@ -175,8 +175,34 @@ class WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets extends WP_REST_Controller 
 		$current_wp_styles  = $wp_styles;
 		$current_wp_scripts = $wp_scripts;
 
+		// Preserve allowed plugin scripts registered during the `init` action
+		$preserved_scripts = array();
+		$preserved_styles  = array();
+
+		foreach ( $current_wp_scripts->registered as $handle => $script ) {
+			if ( $this->is_allowed_plugin_handle( $handle ) && ! $this->is_core_or_gutenberg_asset( $script->src ) ) {
+				$preserved_scripts[ $handle ] = clone $script;
+			}
+		}
+
+		foreach ( $current_wp_styles->registered as $handle => $style ) {
+			if ( $this->is_allowed_plugin_handle( $handle ) && ! $this->is_core_or_gutenberg_asset( $style->src ) ) {
+				$preserved_styles[ $handle ] = clone $style;
+			}
+		}
+
+		// Initialize new instances to control which assets are loaded
 		$wp_styles  = new WP_Styles();
 		$wp_scripts = new WP_Scripts();
+
+		// Restore preserved plugin scripts
+		foreach ( $preserved_scripts as $handle => $script ) {
+			$wp_scripts->registered[ $handle ] = $script;
+		}
+
+		foreach ( $preserved_styles as $handle => $style ) {
+			$wp_styles->registered[ $handle ] = $style;
+		}
 
 		// Trigger an action frequently used by plugins to enqueue assets.
 		do_action( 'wp_loaded' );

--- a/projects/plugins/jetpack/changelog/feat-expand-editor-assets-endpoint-allowed-block-types
+++ b/projects/plugins/jetpack/changelog/feat-expand-editor-assets-endpoint-allowed-block-types
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Editor assets endpoint: expand allowed block types

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test.php
@@ -325,4 +325,129 @@ class WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets_Test extends Jetpack_REST_T
 		unregister_post_type( 'custom_type' );
 		remove_role( 'custom_editor' );
 	}
+
+	/**
+	 * Test that plugin scripts registered before endpoint execution are preserved.
+	 */
+	public function test_plugin_scripts_registered_during_init_are_preserved() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
+
+		// Directly register scripts to simulate what happens during init
+		wp_register_script( 'jetpack-init-test-script', 'http://example.org/jetpack-init.js', array(), '1.0', true );
+		wp_register_script( 'videopress-init-test-script', 'http://example.org/videopress-init.js', array(), '1.0', true );
+		wp_register_script( 'jp-init-test-script', 'http://example.org/jp-init.js', array(), '1.0', true );
+		wp_register_script( 'wp-init-test-script', 'http://example.org/wp-init.js', array(), '1.0', true );
+		// Register a disallowed script that should not be preserved
+		wp_register_script( 'random-plugin-script', 'http://example.org/random-plugin.js', array(), '1.0', true );
+
+		// Add enqueue action to test that preserved scripts can be enqueued
+		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_test_scripts' ) );
+
+		$request  = new WP_REST_Request( Requests::GET, '/wpcom/v2/editor-assets' );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		// Use string matching like the working tests
+		$this->assertStringContainsString( 'jetpack-init-test-script', $data['scripts'], 'jetpack- prefixed script should be preserved' );
+		$this->assertStringContainsString( 'videopress-init-test-script', $data['scripts'], 'videopress- prefixed script should be preserved' );
+		$this->assertStringContainsString( 'jp-init-test-script', $data['scripts'], 'jp- prefixed script should be preserved' );
+		$this->assertStringContainsString( 'wp-init-test-script', $data['scripts'], 'wp- prefixed script should be preserved' );
+
+		// Verify disallowed scripts are not in the output (they should be filtered out by unregister_disallowed_plugin_assets)
+		$this->assertStringNotContainsString( 'random-plugin-script', $data['scripts'], 'Disallowed plugin script should not be preserved' );
+
+		remove_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_test_scripts' ) );
+	}
+
+	/**
+	 * Enqueue test scripts during block editor asset loading.
+	 */
+	public function enqueue_test_scripts() {
+		wp_enqueue_script( 'jetpack-init-test-script' );
+		wp_enqueue_script( 'videopress-init-test-script' );
+		wp_enqueue_script( 'jp-init-test-script' );
+		wp_enqueue_script( 'wp-init-test-script' );
+		wp_enqueue_script( 'random-plugin-script' );
+	}
+
+	/**
+	 * Test that plugin styles registered before endpoint execution are preserved.
+	 */
+	public function test_plugin_styles_registered_during_init_are_preserved() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
+
+		// Directly register styles to simulate what happens during init
+		wp_register_style( 'jetpack-init-test-style', 'http://example.org/jetpack-init.css', array(), '1.0' );
+		wp_register_style( 'videopress-init-test-style', 'http://example.org/videopress-init.css', array(), '1.0' );
+		wp_register_style( 'jp-init-test-style', 'http://example.org/jp-init.css', array(), '1.0' );
+		wp_register_style( 'wp-init-test-style', 'http://example.org/wp-init.css', array(), '1.0' );
+		// Register a disallowed style that should not be preserved
+		wp_register_style( 'random-plugin-style', 'http://example.org/random-plugin.css', array(), '1.0' );
+
+		// Add enqueue action to test that preserved styles can be enqueued
+		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_test_styles' ) );
+
+		$request  = new WP_REST_Request( Requests::GET, '/wpcom/v2/editor-assets' );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		// Use string matching like the working tests
+		$this->assertStringContainsString( 'jetpack-init-test-style', $data['styles'], 'jetpack- prefixed style should be preserved' );
+		$this->assertStringContainsString( 'videopress-init-test-style', $data['styles'], 'videopress- prefixed style should be preserved' );
+		$this->assertStringContainsString( 'jp-init-test-style', $data['styles'], 'jp- prefixed style should be preserved' );
+		$this->assertStringContainsString( 'wp-init-test-style', $data['styles'], 'wp- prefixed style should be preserved' );
+
+		// Verify disallowed styles are not in the output
+		$this->assertStringNotContainsString( 'random-plugin-style', $data['styles'], 'Disallowed plugin style should not be preserved' );
+
+		remove_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_test_styles' ) );
+	}
+
+	/**
+	 * Enqueue test styles during block editor asset loading.
+	 */
+	public function enqueue_test_styles() {
+		wp_enqueue_style( 'jetpack-init-test-style' );
+		wp_enqueue_style( 'videopress-init-test-style' );
+		wp_enqueue_style( 'jp-init-test-style' );
+		wp_enqueue_style( 'wp-init-test-style' );
+		wp_enqueue_style( 'random-plugin-style' );
+	}
+
+	/**
+	 * Test that preserved scripts maintain their properties and dependencies.
+	 */
+	public function test_preserved_scripts_maintain_properties() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
+
+		// Register a complex script with dependencies
+		wp_register_script(
+			'jetpack-complex-test-script',
+			'http://example.org/jetpack-complex.js',
+			array( 'jquery', 'wp-data', 'wp-blocks' ),
+			'2.5.0',
+			true
+		);
+		wp_add_inline_script( 'jetpack-complex-test-script', 'var jetpackConfig = { enabled: true };', 'before' );
+
+		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_complex_test_script' ) );
+
+		$request  = new WP_REST_Request( Requests::GET, '/wpcom/v2/editor-assets' );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		// Verify the complex script is preserved and its dependencies are loaded
+		$this->assertStringContainsString( 'jetpack-complex-test-script', $data['scripts'], 'Complex jetpack script should be preserved' );
+		$this->assertStringContainsString( 'jquery', $data['scripts'], 'jQuery dependency should be present' );
+		$this->assertStringContainsString( 'jetpackConfig', $data['scripts'], 'Inline script should be preserved' );
+
+		remove_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_complex_test_script' ) );
+	}
+
+	/**
+	 * Enqueue complex test script.
+	 */
+	public function enqueue_complex_test_script() {
+		wp_enqueue_script( 'jetpack-complex-test-script' );
+	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fix CMM-637. Fix CMM-638.

Allow the VideoPress block type within the GutenbergKit mobile editor.

Ensure block assets registered during the `init` action are preserved.
Previously, these were discarded when creating new `WP_Scripts`/`WP_Styles`
instances.

Ensure the `videoPressEditorState` global is populated for REST API requests, 
allowing for accurate VideoPress activation checks. 

| Before | After |
| - | - |
| <img width="1206" height="2622" alt="gbk-videopress-before" src="https://github.com/user-attachments/assets/61e07468-bb1a-44c7-9fa2-a52039f35579" /> | <img width="1206" height="2622" alt="gbk-videopress-after" src="https://github.com/user-attachments/assets/7fc88fd8-4339-4351-b756-f0271abc4abc" /> |

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
- Allow `videopress/video` block type
- Preserve plugin assets registered within the `init` action
- Assert editor assets endpoint `init` action support
- Register full VideoPress block for REST API requests

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Create a WPCOM site. 
1. Apply these Jetpack changes to your site (see [comment](https://github.com/Automattic/jetpack/pull/44616#issuecomment-3151366867)).  
1. Make a request to the `/wpcom/v2/sites/<site_id>/editor-assets` endpoint for the WPCOM site—via [API Console](https://developer.wordpress.com/docs/api/console/), `curl`, etc. 
1. Verify the 200 response contains the `videopress-video-editor-script` script and the `videoPressEditorState` global.