### PR TITLE
Boost/WPSC: Ignore Yandex tracking parameters

### DIFF
--- a/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/class-boost-cache.php
+++ b/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/class-boost-cache.php
@@ -570,7 +570,7 @@ class Boost_Cache {
 		 */
 		$get_parameters = apply_filters(
 			'jetpack_boost_ignore_get_parameters',
-			array( 'utm_source', 'utm_medium', 'utm_campaign', 'utm_content', 'utm_term' )
+			array( 'utm_source', 'utm_medium', 'utm_campaign', 'utm_content', 'utm_term', 'ysclid', 'srsltid', 'yclid' )
 		);
 
 		$get_parameters = array_unique(

--- a/projects/plugins/boost/changelog/add-boost-remove-tracking-parameters-HOG-217
+++ b/projects/plugins/boost/changelog/add-boost-remove-tracking-parameters-HOG-217
@@ -1,4 +1,4 @@
 Significance: patch
 Type: added
 
-Caching: ignore Yandex parameters so those visitors are served from the cache.
+Page Cache: Ignore Yandex parameters so those visitors are served from the cache.

--- a/projects/plugins/boost/changelog/add-boost-remove-tracking-parameters-HOG-217
+++ b/projects/plugins/boost/changelog/add-boost-remove-tracking-parameters-HOG-217
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Caching: ignore Yandex parameters so those visitors are served from the cache.

--- a/projects/plugins/super-cache/changelog/add-super-cache-remove-tracking-parameters-HOG-217
+++ b/projects/plugins/super-cache/changelog/add-super-cache-remove-tracking-parameters-HOG-217
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Caching: ignore Yandex parameters so those visitors are served from the cache.

--- a/projects/plugins/super-cache/wp-cache.php
+++ b/projects/plugins/super-cache/wp-cache.php
@@ -1741,7 +1741,7 @@ function wpsc_edit_tracking_parameters() {
 	wpsc_update_tracking_parameters();
 
 	if ( ! isset( $wpsc_tracking_parameters ) ) {
-		$wpsc_tracking_parameters = array( 'fbclid', 'ref', 'gclid', 'fb_source', 'mc_cid', 'mc_eid', 'utm_source', 'utm_medium', 'utm_campaign', 'utm_term', 'utm_content', 'utm_expid', 'mtm_source', 'mtm_medium', 'mtm_campaign', 'mtm_keyword', 'mtm_content', 'mtm_cid', 'mtm_group', 'mtm_placement' );
+		$wpsc_tracking_parameters = array( 'fbclid', 'ref', 'gclid', 'fb_source', 'mc_cid', 'mc_eid', 'utm_source', 'utm_medium', 'utm_campaign', 'utm_term', 'utm_content', 'utm_expid', 'mtm_source', 'mtm_medium', 'mtm_campaign', 'mtm_keyword', 'mtm_content', 'mtm_cid', 'mtm_group', 'mtm_placement', 'ysclid', 'srsltid', 'yclid' );
 	}
 
 	if ( ! isset( $wpsc_ignore_tracking_parameters ) ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #44364

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds requested Yandex parameters to be excluded as tracking so otherwise cache-eligible visits will hit the cache.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
See HOG-217

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* None really; adding parameters to existing logic/setup.

