### PR TITLE
VideoPress: Prevent PHP fatals when provided URL is not a string

### DIFF
--- a/projects/packages/videopress/changelog/fix-videopress-php_error
+++ b/projects/packages/videopress/changelog/fix-videopress-php_error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Prevent PHP fatal if URL is not a string.

--- a/projects/packages/videopress/src/class-utils.php
+++ b/projects/packages/videopress/src/class-utils.php
@@ -74,6 +74,9 @@ class Utils {
 	 * @return bool True if the URL is a VideoPress URL, false otherwise.
 	 */
 	public static function is_videopress_url( $url ) {
+		if ( ! is_string( $url ) ) {
+			return false;
+		}
 		$pattern = '/^https?:\/\/(?:(?:v(?:ideo)?\.wordpress\.com|videopress\.com)\/(?:v|embed)|v\.wordpress\.com)\/([a-z\d]{8})(\/|\b)/i'; // phpcs:ignore WordPress.WP.CapitalPDangit.MisspelledInText
 		return (bool) preg_match( $pattern, $url );
 	}

--- a/projects/packages/videopress/tests/php/UtilsTest.php
+++ b/projects/packages/videopress/tests/php/UtilsTest.php
@@ -164,6 +164,10 @@ class UtilsTest extends BaseTestCase {
 			// Missing VideoPress GUID (shortened URL)
 			'https://v.wordpress.com/',
 			'http://v.wordpress.com/',
+
+			// Not a string
+			array( 'https://v.wordpress.com/' ),
+			null,
 		);
 
 		foreach ( $invalid_urls as $url ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Some sites have this:
```
PHP Fatal error: Uncaught TypeError: preg_match(): Argument #2 ($subject) must be of type string, array given in /wordpress/plugins/jetpack/14.9-beta/jetpack_vendor/automattic/jetpack-videopress/src/class-utils.php:78
```

Because the URL ultimately passes through filter, we can't rely on it being a string, and apparently sometimes it isn't.

This adds a simple guard (along with two test cases).

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Do CI tests pass?