### PR TITLE
Charts: Fix legend alignment issues for right-aligned vertical legends

### DIFF
--- a/projects/js-packages/charts/changelog/charts-39-legends-resolve-legendorientation-vertical-issues
+++ b/projects/js-packages/charts/changelog/charts-39-legends-resolve-legendorientation-vertical-issues
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Charts: fix legend alignment issues for right-aligned vertical legends by using visx-native itemDirection prop

--- a/projects/js-packages/charts/src/components/legend/base-legend.tsx
+++ b/projects/js-packages/charts/src/components/legend/base-legend.tsx
@@ -50,6 +50,10 @@ export const BaseLegend = forwardRef< HTMLDivElement, BaseLegendProps >(
 		} );
 		const domain = legendScale.domain();
 
+		// For right-aligned vertical legends, use row-reverse to align text consistently
+		const isRightAlignedVertical = orientation === 'vertical' && alignmentHorizontal === 'right';
+		const adjustedItemDirection = isRightAlignedVertical ? 'row-reverse' : itemDirection;
+
 		const getShapeStyle = useCallback(
 			( { index }: { index: number } ) => {
 				return items[ index ]?.shapeStyle ?? theme.legendShapeStyles?.[ index ] ?? {};
@@ -86,7 +90,7 @@ export const BaseLegend = forwardRef< HTMLDivElement, BaseLegendProps >(
 								data-testid="legend-item"
 								key={ `legend-${ label.text }-${ i }` }
 								margin={ itemMargin }
-								flexDirection={ itemDirection }
+								flexDirection={ adjustedItemDirection }
 								{ ...legendItemProps }
 							>
 								{ items[ i ]?.renderGlyph ? (

--- a/projects/js-packages/charts/src/components/legend/base-legend.tsx
+++ b/projects/js-packages/charts/src/components/legend/base-legend.tsx
@@ -51,8 +51,6 @@ export const BaseLegend = forwardRef< HTMLDivElement, BaseLegendProps >(
 		const domain = legendScale.domain();
 
 		// For right-aligned vertical legends, use row-reverse to align text consistently
-		const isRightAlignedVertical = orientation === 'vertical' && alignmentHorizontal === 'right';
-		const adjustedItemDirection = isRightAlignedVertical ? 'row-reverse' : itemDirection;
 
 		const getShapeStyle = useCallback(
 			( { index }: { index: number } ) => {
@@ -90,7 +88,11 @@ export const BaseLegend = forwardRef< HTMLDivElement, BaseLegendProps >(
 								data-testid="legend-item"
 								key={ `legend-${ label.text }-${ i }` }
 								margin={ itemMargin }
-								flexDirection={ adjustedItemDirection }
+								flexDirection={
+									orientation === 'vertical' && alignmentHorizontal === 'right'
+										? 'row-reverse'
+										: itemDirection
+								}
 								{ ...legendItemProps }
 							>
 								{ items[ i ]?.renderGlyph ? (

--- a/projects/js-packages/charts/src/components/legend/legend.module.scss
+++ b/projects/js-packages/charts/src/components/legend/legend.module.scss
@@ -11,6 +11,18 @@
 		display: flex;
 		flex-direction: column;
 		gap: 8px;
+
+		&.legend--horizontal-align-left {
+			align-items: flex-start;
+		}
+
+		&.legend--horizontal-align-center {
+			align-items: center;
+		}
+
+		&.legend--horizontal-align-right {
+			align-items: flex-end;
+		}
 	}
 
 	// Vertical alignment positioning


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

Fixes [CHARTS-39: Legends: Resolve LegendOrientation=vertical issues](https://linear.app/a8c/issue/CHARTS-39/legends-resolve-legendorientation-vertical-issues)

## Proposed changes:
<!-- Explain what functional changes your PR includes -->
* Fix legend alignment issues where right-aligned vertical legends had inconsistent text positioning
* Use visx's native `itemDirection="row-reverse"` prop instead of CSS overrides  
* Add proper CSS alignment rules for vertical legend containers

**Technical details:**
- Added `align-items` CSS rules for left, center, and right horizontal alignment of vertical legend containers
- Implemented visx-native `itemDirection="row-reverse"` for right-aligned vertical legends to ensure consistent text alignment
- Leveraged visx's intended API instead of fighting their internal layout system with custom CSS

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
Charts package improvement - internal alignment fix using visx native APIs.

## Does this pull request change what data or activity we track or use?
<!-- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
No, this PR only improves the visual alignment of legend components without changing functionality or data handling.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->

* Test right-aligned vertical legends in charts to verify consistent text alignment regardless of text length
* Test left and center aligned vertical legends still work correctly  
* Test horizontal legends are unaffected
* Verify in different chart contexts (pie, donut, bar charts, etc.) that legends display properly
* Check Storybook examples to ensure no visual regressions

**Specific test cases:**
1. Create a chart with vertical legend, right alignment, and varying text lengths (short/long labels)
2. Verify all legend text starts at the same left position
3. Test center and left alignments still work as expected
4. Ensure horizontal legends remain unchanged