### PR TITLE
Social Image Generator: allow private sites to use endpoint

### DIFF
--- a/projects/packages/publicize/changelog/fix-social-image-generator-private-sites
+++ b/projects/packages/publicize/changelog/fix-social-image-generator-private-sites
@@ -1,0 +1,4 @@
+Significance: patch
+Type: deprecated
+
+Social Image Generator: ensure it can be used on WordPress.com Private sites.

--- a/projects/packages/publicize/src/rest-api/class-social-image-generator-controller.php
+++ b/projects/packages/publicize/src/rest-api/class-social-image-generator-controller.php
@@ -50,10 +50,13 @@ class Social_Image_Generator_Controller extends Base_Controller {
 			$this->namespace,
 			'/' . $this->rest_base . '/generate-token',
 			array(
-				'methods'             => WP_REST_Server::CREATABLE,
-				'callback'            => array( $this, 'generate_preview_token' ),
-				'permission_callback' => array( $this, 'permissions_check' ),
-				'args'                => array(
+				'methods'                        => WP_REST_Server::CREATABLE,
+				'callback'                       => array( $this, 'generate_preview_token' ),
+				'permission_callback'            => array( $this, 'permissions_check' ),
+				'private_site_security_settings' => array(
+					'allow_blog_token_access' => true,
+				),
+				'args'                           => array(
 					'text'      => array(
 						'description' => __( 'The text to be used to generate the image.', 'jetpack-publicize-pkg' ),
 						'type'        => 'string',
@@ -76,7 +79,7 @@ class Social_Image_Generator_Controller extends Base_Controller {
 						'enum'        => Templates::TEMPLATES,
 					),
 				),
-				'schema'              => array(
+				'schema'                         => array(
 					'$schema' => 'http://json-schema.org/draft-04/schema#',
 					'title'   => 'publicize-sig-generate-token',
 					'type'    => 'string',


### PR DESCRIPTION
Fixes DOTCOM-14112

## Proposed changes:

The social image generator feature is currently used in 2 areas:

- In the post editor, as an add-on to the Jetpack Social, aka Publicize feature => private sites do not have access to that.
- On the frontend, as part of the Open Graph Meta tags => private sites typically do not have access to that either, but sync issues can cause a public site to be considered as private on the WordPress.com end.

In this latter scenario, we would want those sites to be able to make requests to WordPress.com to get an image.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

Internal reference: p1754329599310139-slack-C01U2KGS2PQ

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

> [!NOTE]
> This can be tested on a private WoA dev site.

* Start with a **public** WoA dev site.
* That site should **not** use a static front page.
* Find the site's cache site in Network Admin.
* Update that cache site's `blog_public` option from `0` to `-1`.
* Edit the Jetpack plugin on the site to ensure that no transient is taken into account here: https://github.com/Automattic/jetpack/blob/b52a6b72542239aff742622c2387e94ff17595ac/projects/plugins/jetpack/functions.opengraph.php#L582-L584
* Go to Jetpack > Settings > Social and enable the sharing buttons.
* Check the site's source code for your home page: you should see the Open Graph Meta tags added by the Jetpack plugin. The `og:image` tag should be WordPress.com's `https://s0.wp.com/i/blank.jpg` image.
* Apply this change to your WordPress.com sandbox.
* Point your site to your WordPress.com sandbox with `JETPACK__SANDBOX_DOMAIN`
* Check out this branch.
* Reload your site's home page.
    * The `og:image` tag should now be an image URL starting with `https://s0.wp.com/_si/?t=`.
