### PR TITLE
Image CDN: Add covers.openlibrary.org to ignore list

### DIFF
--- a/projects/packages/image-cdn/changelog/update-photon-ignore-openlibrary-cdn
+++ b/projects/packages/image-cdn/changelog/update-photon-ignore-openlibrary-cdn
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Add openlibrary.org CDN to ignore list.

--- a/projects/packages/image-cdn/src/class-image-cdn-core.php
+++ b/projects/packages/image-cdn/src/class-image-cdn-core.php
@@ -386,6 +386,7 @@ class Image_CDN_Core {
 			'/^(commons|upload)\.wikimedia\.org$/',
 			'/\.wikipedia\.org$/',
 			'/^m\.media-amazon\.com$/',
+			'/^covers\.openlibrary\.org$/',
 		);
 
 		$host = wp_parse_url( $image_url, PHP_URL_HOST );

--- a/projects/packages/image-cdn/tests/php/Image_CDN_Core_Test.php
+++ b/projects/packages/image-cdn/tests/php/Image_CDN_Core_Test.php
@@ -487,6 +487,10 @@ class Image_CDN_Core_Test extends BaseTestCase {
 				true,
 				'http://m.media-amazon.com/images/I/41YeeCMUwTL._SL300_.jpg',
 			),
+			'Banned Open Library domain' => array(
+				true,
+				'https://covers.openlibrary.org/b/id/10728667-L.jpg',
+			),
 		);
 	}
 

--- a/projects/plugins/boost/changelog/update-photon-ignore-openlibrary-cdn
+++ b/projects/plugins/boost/changelog/update-photon-ignore-openlibrary-cdn
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Image CDN: Ignore images from openlibrary.org.

--- a/projects/plugins/jetpack/changelog/update-photon-ignore-openlibrary-cdn
+++ b/projects/plugins/jetpack/changelog/update-photon-ignore-openlibrary-cdn
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Site Accelerator: Ignore images from openlibrary.org.


### PR DESCRIPTION
Fixes HOG-273, related to HOG-233

## Proposed changes:

* Add openlibrary.org CDN to list of banned domains.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

HOG-273

## Does this pull request change what data or activity we track or use?

no

## Testing instructions:

- Make sure you're running a publicly available website so Photon/Image CDN/Site Accelerator (yes it has many names) can work properly;
- Insert an image block to any page and add the image via `Insert from URL`. Use this image - https://covers.openlibrary.org/b/id/10728667-L.jpg (or any other you wish from the same domain);
- View the page in the front-end and the image should load normally (inspect the URL just to make sure it's not photonized).