### PR TITLE
Boost: Fix opcache warnings when working with Page Cache

### DIFF
--- a/projects/plugins/boost/app/modules/optimizations/page-cache/class-page-cache-setup.php
+++ b/projects/plugins/boost/app/modules/optimizations/page-cache/class-page-cache-setup.php
@@ -421,6 +421,11 @@ define( \'WP_CACHE\', true ); // ' . Page_Cache::ADVANCED_CACHE_SIGNATURE,
 	 * Clear opcache for a file.
 	 */
 	private static function clear_opcache( $file ) {
+		// If API functions are restricted, we can't do anything.
+		if ( ini_get( 'opcache.restrict_api' ) ) {
+			return;
+		}
+
 		if ( function_exists( 'opcache_invalidate' ) ) {
 			opcache_invalidate( $file, true );
 		}

--- a/projects/plugins/boost/changelog/fix-boost-page-cache-opcache-warning-hog-235
+++ b/projects/plugins/boost/changelog/fix-boost-page-cache-opcache-warning-hog-235
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Page Cache: Fix php warnings related to opcache calls when API is disabled.


### PR DESCRIPTION
Fixes HOG-235

## Proposed changes:

* Check if opcache API is available before calling it's API functions.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

HOG-235

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:

**Pre-requisites**

This requires you to restrict opcache's API functions by adding this `opcache.restrict_api=on` to your `php.ini`/`opcache.ini` config.

You can use your local monorepo to test things out, as it's easiest. By default the API in the monorepo is not restricted (the value is set to empty string/off) so you won't get a warning. To restrict it, I used `opcache.ini` located in the wordpress docker container in `/etc/php/8.2/mods-available/opcache.ini`.

If using OrbStack, you can navigate through the container files using the finder by selecting the following:

<img width="775" height="851" alt="CleanShot 2025-08-05 at 14 06 48" src="https://github.com/user-attachments/assets/8a8b63a3-ae42-47d1-9de8-ebf9a3364d71" />

Once you add that, make sure to restart only the wordpress container. Don't use `jetpack docker down/up`, otherwise changes you've made to the container files will be removed.

After that, you can move onto testing.

### (trunk behavior) Test to make sure it does throw a warning

- Load up Boost without any other caching solution;
- Make sure WordPress logging is enabled;
- Enable `Page Cache` in Boost and check `debug.log` - you should get PHP warnings like the following:

```
Warning: Zend OPcache API is restricted by "restrict_api" configuration directive in /srv/htdocs/wp-content/plugins/jetpack-boost-dev/app/modules/optimizations/page-cache/class-page-cache-setup.php on line 425
Warning: Zend OPcache API is restricted by "restrict_api" configuration directive in /srv/htdocs/wp-content/plugins/jetpack-boost-dev/app/modules/optimizations/page-cache/class-page-cache-setup.php on line 425
```

### (this branch) Test to make sure there are no warnings

- Repeat the steps above and there should be no warnings in the `debug.log`.