### PR TITLE
Connection: create external storage class

### DIFF
--- a/projects/packages/connection/changelog/add-external-storage-class
+++ b/projects/packages/connection/changelog/add-external-storage-class
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Created External_Storage class.

--- a/projects/packages/connection/legacy/class-jetpack-options.php
+++ b/projects/packages/connection/legacy/class-jetpack-options.php
@@ -195,22 +195,12 @@ class Jetpack_Options {
 	public static function get_option( $name, $default = false ) {
 		// Check if external storage should be used for this option
 		if ( self::should_use_external_storage( $name ) ) {
-			/**
-			 * Filter to provide external storage for Jetpack connection options.
-			 * External storage is checked first, with database as fallback.
-			 *
-			 * @since 6.17.0
-			 *
-			 * @param mixed  $value   Current value (null to let database handle).
-			 * @param string $name    Option name, _without_ `jetpack_%` prefix.
-			 * @param mixed  $default Default value if option doesn't exist.
-			 * @return mixed External storage value, or null to fall back to database.
-			 */
-			$external_value = apply_filters( 'jetpack_external_storage_get', null, $name, $default );
-
-			// If external storage provided a value, use it
-			if ( null !== $external_value ) {
-				return $external_value;
+			// Try external storage
+			if ( class_exists( 'Automattic\Jetpack\Connection\External_Storage' ) ) {
+				$external_value = \Automattic\Jetpack\Connection\External_Storage::get_option( $name, $default );
+				if ( null !== $external_value ) {
+					return $external_value;
+				}
 			}
 		}
 
@@ -255,6 +245,7 @@ class Jetpack_Options {
 
 	/**
 	 * Determines if external storage should be used for a given option.
+	 * Simple allowlist check with global killswitch.
 	 *
 	 * @since 6.17.0
 	 *
@@ -262,23 +253,13 @@ class Jetpack_Options {
 	 * @return bool True if external storage should be checked for this option.
 	 */
 	private static function should_use_external_storage( $name ) {
-		// Quick bailout for unsupported options or killswitch
+		// Check allowlist and global killswitch
 		if ( ! in_array( $name, array( 'blog_token', 'id' ), true ) ||
 			( defined( 'JETPACK_EXTERNAL_STORAGE_DISABLED' ) && constant( 'JETPACK_EXTERNAL_STORAGE_DISABLED' ) ) ) {
 			return false;
 		}
 
-		/**
-		 * Filter to control whether external storage should be used for a given option.
-		 * Environments use this to opt-in to external storage for their sites.
-		 *
-		 * @since 6.17.0
-		 *
-		 * @param bool   $enabled     Whether external storage should be used (default: false).
-		 * @param string $option_name Option name, _without_ `jetpack_%` prefix.
-		 * @return bool True to use external storage, false to use database only.
-		 */
-		return apply_filters( 'jetpack_should_use_external_storage', false, $name );
+		return true;
 	}
 
 	/**

--- a/projects/packages/connection/legacy/class-jetpack-options.php
+++ b/projects/packages/connection/legacy/class-jetpack-options.php
@@ -197,7 +197,7 @@ class Jetpack_Options {
 		if ( self::should_use_external_storage( $name ) ) {
 			// Try external storage
 			if ( class_exists( 'Automattic\Jetpack\Connection\External_Storage' ) ) {
-				$external_value = \Automattic\Jetpack\Connection\External_Storage::get_option( $name, $default );
+				$external_value = \Automattic\Jetpack\Connection\External_Storage::get_value( $name );
 				if ( null !== $external_value ) {
 					return $external_value;
 				}
@@ -244,6 +244,15 @@ class Jetpack_Options {
 	}
 
 	/**
+	 * Options that can be stored in external storage.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @var array
+	 */
+	private static $external_storage_allowlist = array( 'blog_token', 'id' );
+
+	/**
 	 * Determines if external storage should be used for a given option.
 	 * Simple allowlist check with global killswitch.
 	 *
@@ -254,7 +263,7 @@ class Jetpack_Options {
 	 */
 	private static function should_use_external_storage( $name ) {
 		// Check allowlist and global killswitch
-		if ( ! in_array( $name, array( 'blog_token', 'id' ), true ) ||
+		if ( ! in_array( $name, self::$external_storage_allowlist, true ) ||
 			( defined( 'JETPACK_EXTERNAL_STORAGE_DISABLED' ) && constant( 'JETPACK_EXTERNAL_STORAGE_DISABLED' ) ) ) {
 			return false;
 		}

--- a/projects/packages/connection/src/class-error-handler.php
+++ b/projects/packages/connection/src/class-error-handler.php
@@ -125,6 +125,9 @@ class Error_Handler {
 		'invalid_nonce',
 		'signature_mismatch',
 		'invalid_connection_owner',
+		'external_storage_fallback_empty',
+		'external_storage_fallback_error',
+		'external_storage_unavailable',
 	);
 
 	/**
@@ -1067,7 +1070,8 @@ class Error_Handler {
 	 * @return bool True if external filters are applied, false otherwise.
 	 */
 	private function has_external_filters() {
-		return has_filter( 'jetpack_connection_get_verified_errors' ) && $this->should_allow_error_filtering();
+		return has_filter( 'jetpack_connection_get_verified_errors' ) &&
+			$this->should_allow_error_filtering();
 	}
 
 	/**

--- a/projects/packages/connection/src/class-error-handler.php
+++ b/projects/packages/connection/src/class-error-handler.php
@@ -125,9 +125,8 @@ class Error_Handler {
 		'invalid_nonce',
 		'signature_mismatch',
 		'invalid_connection_owner',
-		'external_storage_fallback_empty',
-		'external_storage_fallback_error',
-		'external_storage_unavailable',
+		'external_storage_empty',
+		'external_storage_error',
 	);
 
 	/**

--- a/projects/packages/connection/src/class-external-storage.php
+++ b/projects/packages/connection/src/class-external-storage.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * External Storage utilities for Jetpack Connection.
+ *
+ * Provides centralized logging for external storage implementations
+ * across different environments (Atomic, VIP, custom).
+ *
+ * @package automattic/jetpack-connection
+ */
+
+namespace Automattic\Jetpack\Connection;
+
+/**
+ * External Storage utilities class.
+ *
+ * @since $$next-version$$
+ */
+class External_Storage {
+
+	/**
+	 * Log external storage events to the Jetpack Connection Error_Handler.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param string $event_type  The event type (fallback_empty, fallback_error, unavailable).
+	 * @param string $option_name The option name that triggered the event.
+	 * @param string $details     Additional details about the event.
+	 * @param string $environment The environment identifier (atomic, vip, etc.).
+	 */
+	public static function log_event( $event_type, $option_name, $details = '', $environment = 'unknown' ) {
+		// Only log meaningful events
+		$should_log = false;
+
+		if ( 'fallback_error' === $event_type ) {
+			$should_log = true; // Always log errors
+		} elseif ( 'fallback_empty' === $event_type ) {
+			$should_log = ( defined( 'WP_DEBUG' ) && WP_DEBUG ) || self::is_critical_option( $option_name );
+		} elseif ( 'unavailable' === $event_type ) {
+			$should_log = ( defined( 'WP_DEBUG' ) && WP_DEBUG );
+		}
+
+		if ( ! $should_log || ! class_exists( 'Automattic\Jetpack\Connection\Error_Handler' ) ) {
+			return;
+		}
+
+		// Create and report error
+		$error_code    = 'external_storage_' . $event_type;
+		$error_message = sprintf(
+			'External storage %s for option "%s"%s',
+			str_replace( '_', ' ', $event_type ),
+			$option_name,
+			$details ? ': ' . $details : ''
+		);
+
+		$error_data = array(
+			'option_name' => $option_name,
+			'event_type'  => $event_type,
+			'details'     => $details,
+			'environment' => $environment,
+			'timestamp'   => time(),
+			'site_url'    => home_url(),
+		);
+
+		$error = new \WP_Error( $error_code, $error_message, $error_data );
+		Error_Handler::get_instance()->report_error( $error, false, true );
+	}
+
+	/**
+	 * Check if an option is critical and should always be logged.
+	 *
+	 * Critical options are essential for Jetpack connection functionality.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param string $option_name The option name.
+	 * @return bool True if critical, false otherwise.
+	 */
+	public static function is_critical_option( $option_name ) {
+		/**
+		 * Filter the list of critical external storage options.
+		 *
+		 * Critical options have their fallback events logged even when not in debug mode.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param array $critical_options Array of critical option names.
+		 */
+		$critical_options = apply_filters(
+			'jetpack_external_storage_critical_options',
+			array( 'blog_token', 'id' )
+		);
+
+		return in_array( $option_name, $critical_options, true );
+	}
+}

--- a/projects/packages/connection/src/class-external-storage.php
+++ b/projects/packages/connection/src/class-external-storage.php
@@ -22,21 +22,26 @@ class External_Storage {
 	 *
 	 * @since $$next-version$$
 	 *
-	 * @param string $event_type  The event type (fallback_empty, fallback_error, unavailable).
+	 * @param string $event_type  The event type (error, empty, unavailable).
 	 * @param string $option_name The option name that triggered the event.
 	 * @param string $details     Additional details about the event.
 	 * @param string $environment The environment identifier (atomic, vip, etc.).
 	 */
 	public static function log_event( $event_type, $option_name, $details = '', $environment = 'unknown' ) {
-		// Only log meaningful events
 		$should_log = false;
 
-		if ( 'fallback_error' === $event_type ) {
-			$should_log = true; // Always log errors
-		} elseif ( 'fallback_empty' === $event_type ) {
-			$should_log = ( defined( 'WP_DEBUG' ) && WP_DEBUG ) || self::is_critical_option( $option_name );
+		if ( 'error' === $event_type ) {
+			// Report external storage errors for supported environments
+			$should_log = self::should_report_for_environment();
+		} elseif ( 'empty' === $event_type ) {
+			// Use delay mechanism to distinguish disconnection from a delay
+			$should_log = self::should_report_for_environment() && self::should_report_empty_state( $option_name );
 		} elseif ( 'unavailable' === $event_type ) {
-			$should_log = ( defined( 'WP_DEBUG' ) && WP_DEBUG );
+			// Log locally but don't report to WordPress.com
+			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+				error_log( sprintf( 'External storage unavailable: %s in %s%s', $option_name, $environment, $details ? ' - ' . $details : '' ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+			}
+			return;
 		}
 
 		if ( ! $should_log || ! class_exists( 'Automattic\Jetpack\Connection\Error_Handler' ) ) {
@@ -66,30 +71,81 @@ class External_Storage {
 	}
 
 	/**
-	 * Check if an option is critical and should always be logged.
+	 * Check if empty state should be reported for this option.
 	 *
-	 * Critical options are essential for Jetpack connection functionality.
+	 * Only certain connection options (like blog_token, id) trigger empty state
+	 * reporting with the 10-minute delay mechanism. Other options are ignored.
 	 *
 	 * @since $$next-version$$
 	 *
 	 * @param string $option_name The option name.
-	 * @return bool True if critical, false otherwise.
+	 * @return bool True if empty state should be reported for this option.
 	 */
-	public static function is_critical_option( $option_name ) {
+	public static function should_report_empty_for_option( $option_name ) {
 		/**
-		 * Filter the list of critical external storage options.
-		 *
-		 * Critical options have their fallback events logged even when not in debug mode.
+		 * Filter the list of options that trigger empty state reporting.
 		 *
 		 * @since $$next-version$$
 		 *
-		 * @param array $critical_options Array of critical option names.
+		 * @param array $reportable_options Array of option names that should trigger empty state reporting.
 		 */
-		$critical_options = apply_filters(
-			'jetpack_external_storage_critical_options',
+		$reportable_options = apply_filters(
+			'jetpack_external_storage_reportable_empty_options',
 			array( 'blog_token', 'id' )
 		);
 
-		return in_array( $option_name, $critical_options, true );
+		return in_array( $option_name, $reportable_options, true );
+	}
+
+	/**
+	 * Determine if the current environment should report external storage errors.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return bool True if this environment should report external storage errors.
+	 */
+	private static function should_report_for_environment() {
+		if ( defined( 'JETPACK_EXTERNAL_STORAGE_REPORTING_ENABLED' ) && constant( 'JETPACK_EXTERNAL_STORAGE_REPORTING_ENABLED' ) ) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Determine if we should report an empty state based on delay mechanism.
+	 * We need this due to delays in writing in external storage vs writing into the database.
+	 * On first encounter of empty state, sets a transient. On subsequent encounters
+	 * after 10 minutes, allows reporting (indicating likely disconnection, not sync delay).
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param string $option_name The option name that was empty.
+	 * @return bool True if we should report this empty state, false otherwise.
+	 */
+	private static function should_report_empty_state( $option_name ) {
+		// Only report empty state for monitored options
+		if ( ! self::should_report_empty_for_option( $option_name ) ) {
+			return false;
+		}
+
+		$delay_key        = 'jetpack_external_storage_empty_delay_' . $option_name;
+		$first_empty_time = get_transient( $delay_key );
+
+		if ( false === $first_empty_time ) {
+			// First time encountering empty state - set delay transient and don't report yet
+			set_transient( $delay_key, time(), 15 * MINUTE_IN_SECONDS ); // Keep for 15 minutes
+			return false;
+		}
+
+		// Check if 10 minutes have passed since first empty encounter
+		$delay_threshold = 10 * MINUTE_IN_SECONDS;
+		if ( ( time() - $first_empty_time ) >= $delay_threshold ) {
+			// 10+ minutes of empty state - likely disconnection, report it
+			delete_transient( $delay_key );
+			return true;
+		}
+
+		return false;
 	}
 }

--- a/projects/packages/connection/src/class-external-storage.php
+++ b/projects/packages/connection/src/class-external-storage.php
@@ -7,8 +7,8 @@
  *
  * Usage Example:
  *
- *     // 1. Create a storage provider class with required methods:
- *     class My_Storage_Provider {
+ *     // 1. Create a storage provider class implementing the interface:
+ *     class My_Storage_Provider implements Storage_Provider_Interface {
  *         public function is_available() { return true; }
  *         public function should_handle( $option_name ) {
  *             return in_array( $option_name, array( 'blog_token', 'id' ), true );
@@ -16,11 +16,13 @@
  *         public function get( $option_name ) {
  *             // Return value from your external storage or null
  *         }
- *         public function get_environment_id() { return 'my_env'; } // Optional but recommended
+ *         public function get_environment_id() { return 'my_env'; }
  *     }
  *
  *     // 2. Register the provider:
- *     External_Storage::register_provider( new My_Storage_Provider() );
+ *     if ( class_exists( 'Automattic\Jetpack\Connection\External_Storage' ) ) {
+ *         \Automattic\Jetpack\Connection\External_Storage::register_provider( new My_Storage_Provider() );
+ *     }
  *
  *     // 3. External storage is now automatically used by Jetpack_Options::get_option()
  *
@@ -28,6 +30,8 @@
  */
 
 namespace Automattic\Jetpack\Connection;
+
+require_once __DIR__ . '/interface-storage-provider.php';
 
 /**
  * External Storage utilities class.
@@ -41,7 +45,7 @@ class External_Storage {
 	 *
 	 * @since $$next-version$$
 	 *
-	 * @var object|null
+	 * @var Storage_Provider_Interface|null
 	 */
 	private static $provider = null;
 
@@ -50,49 +54,25 @@ class External_Storage {
 	 *
 	 * @since $$next-version$$
 	 *
-	 * @param object $provider Storage provider object with required methods.
+	 * @param Storage_Provider_Interface $provider Storage provider implementing the interface.
 	 * @return bool True if provider was registered successfully, false otherwise.
 	 */
-	public static function register_provider( $provider ) {
-		if ( ! self::validate_provider( $provider ) ) {
-			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-				error_log( 'Invalid storage provider registered: missing required methods' ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
-			}
-			return false;
-		}
+	public static function register_provider( Storage_Provider_Interface $provider ) {
 		self::$provider = $provider;
 		return true;
 	}
 
 	/**
-	 * Validate that a storage provider has all required methods.
-	 *
-	 * @since $$next-version$$
-	 *
-	 * @param object $provider The storage provider to validate.
-	 * @return bool True if provider has all required methods, false otherwise.
-	 */
-	private static function validate_provider( $provider ) {
-		$required_methods = array( 'is_available', 'should_handle', 'get' );
-		foreach ( $required_methods as $method ) {
-			if ( ! method_exists( $provider, $method ) ) {
-				return false;
-			}
-		}
-		return true;
-	}
-
-	/**
-	 * Get option value from external storage provider.
+	 * Get value from external storage provider.
 	 *
 	 * Returns null if no provider is registered or if the provider can't provide the value (triggers database fallback).
 	 *
 	 * @since $$next-version$$
 	 *
-	 * @param string $option_name The option name to retrieve.
-	 * @return mixed The option value from external storage, or null for database fallback.
+	 * @param string $key The key to retrieve.
+	 * @return mixed The value from external storage, or null for database fallback.
 	 */
-	public static function get_option( $option_name ) {
+	public static function get_value( $key ) {
 		$provider = self::$provider;
 
 		// Check if we have a registered provider
@@ -105,30 +85,30 @@ class External_Storage {
 
 		// Check if provider is available in current environment
 		if ( ! $provider->is_available() ) {
-			self::log_event( 'unavailable', $option_name, 'External storage not available', $environment );
+			self::log_event( 'unavailable', $key, 'External storage not available', $environment );
 			return null;
 		}
 
 		// Check if provider should handle this option
-		if ( ! $provider->should_handle( $option_name ) ) {
+		if ( ! $provider->should_handle( $key ) ) {
 			return null;
 		}
 
 		// Try to get value from the provider
 		try {
-			$value = $provider->get( $option_name );
+			$value = $provider->get( $key );
 
-			// Check if we got a valid value (excluding null, false, empty string, and zero)
+			// Check if we got a valid value
 			if ( null !== $value && false !== $value && '' !== $value && 0 !== $value ) {
 				return $value;
 			}
 
 			// Empty value - log it
-			self::log_event( 'empty', $option_name, '', $environment );
+			self::log_event( 'empty', $key, '', $environment );
 
 		} catch ( \Exception $e ) {
 			// Provider threw an exception
-			self::log_event( 'error', $option_name, $e->getMessage(), $environment );
+			self::log_event( 'error', $key, $e->getMessage(), $environment );
 		}
 
 		// Provider couldn't provide value, return null for database fallback
@@ -136,47 +116,65 @@ class External_Storage {
 	}
 
 	/**
-	 * Log external storage events to the Jetpack Connection Error_Handler.
+	 * Log events if WP_DEBUG is enabled.
+	 * Report external storage events through Jetpack Connection Error_Handler.
+	 * Includes rate limiting to prevent log spam from noisy events.
 	 *
 	 * @since $$next-version$$
 	 *
 	 * @param string $event_type  The event type (error, empty, unavailable).
-	 * @param string $option_name The option name that triggered the event.
+	 * @param string $key         The key that triggered the event.
 	 * @param string $details     Additional details about the event.
 	 * @param string $environment The environment identifier (atomic, vip, etc.).
 	 */
-	public static function log_event( $event_type, $option_name, $details = '', $environment = 'unknown' ) {
-		$should_log = false;
+	public static function log_event( $event_type, $key, $details = '', $environment = 'unknown' ) {
+		// Apply rate limiting to prevent log spam
+		if ( ! self::should_log_event( $key ) ) {
+			return;
+		}
+		// Local debug logging (only when WP_DEBUG is enabled)
+		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+			error_log( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+				sprintf(
+					'Jetpack External Storage %s: %s in %s%s',
+					$event_type,
+					$key,
+					$environment,
+					$details ? ' - ' . $details : ''
+				)
+			);
+		}
 
-		if ( 'error' === $event_type ) {
-			// Report external storage errors for supported environments
-			$should_log = self::should_report_for_environment();
-		} elseif ( 'empty' === $event_type ) {
-			// Use delay mechanism to distinguish disconnection from a delay
-			$should_log = self::should_report_for_environment() && self::should_report_empty_state( $option_name );
-		} elseif ( 'unavailable' === $event_type ) {
-			// Log locally but don't report to WordPress.com
-			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-				error_log( sprintf( 'External storage unavailable: %s in %s%s', $option_name, $environment, $details ? ' - ' . $details : '' ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
-			}
+		// Only report 'error' and 'empty' events to WordPress.com
+		if ( 'error' !== $event_type && 'empty' !== $event_type ) {
 			return;
 		}
 
-		if ( ! $should_log || ! class_exists( 'Automattic\Jetpack\Connection\Error_Handler' ) ) {
+		$should_report_remote = false;
+
+		if ( 'error' === $event_type ) {
+			// Report external storage errors for supported environments
+			$should_report_remote = self::should_report_for_environment();
+		} elseif ( 'empty' === $event_type ) {
+			// Use delay mechanism to distinguish disconnection from a delay
+			$should_report_remote = self::should_report_for_environment() && self::should_report_empty_state( $key );
+		}
+
+		if ( ! $should_report_remote || ! class_exists( 'Automattic\Jetpack\Connection\Error_Handler' ) ) {
 			return;
 		}
 
 		// Create and report error
 		$error_code    = 'external_storage_' . $event_type;
 		$error_message = sprintf(
-			'External storage %s for option "%s"%s',
+			'External storage %s for key "%s"%s',
 			str_replace( '_', ' ', $event_type ),
-			$option_name,
+			$key,
 			$details ? ': ' . $details : ''
 		);
 
 		$error_data = array(
-			'option_name' => $option_name,
+			'key'         => $key,
 			'event_type'  => $event_type,
 			'details'     => $details,
 			'environment' => $environment,
@@ -189,11 +187,12 @@ class External_Storage {
 	}
 
 	/**
-	 * Determine if the current environment should report external storage errors.
+	 * Determine if the current environment should report external storage errors to WordPress.com.
+	 * Allows wpcomsh and other environments to control remote error reporting independently.
 	 *
 	 * @since $$next-version$$
 	 *
-	 * @return bool True if this environment should report external storage errors.
+	 * @return bool True if this environment should report external storage errors to WordPress.com.
 	 */
 	private static function should_report_for_environment() {
 		if ( defined( 'JETPACK_EXTERNAL_STORAGE_REPORTING_ENABLED' ) && constant( 'JETPACK_EXTERNAL_STORAGE_REPORTING_ENABLED' ) ) {
@@ -211,11 +210,11 @@ class External_Storage {
 	 *
 	 * @since $$next-version$$
 	 *
-	 * @param string $option_name The option name that was empty.
+	 * @param string $key The key that was empty.
 	 * @return bool True if we should report this empty state, false otherwise.
 	 */
-	private static function should_report_empty_state( $option_name ) {
-		$delay_key        = 'jetpack_external_storage_empty_delay_' . $option_name;
+	private static function should_report_empty_state( $key ) {
+		$delay_key        = 'jetpack_external_storage_empty_delay_' . $key;
 		$first_empty_time = get_transient( $delay_key );
 
 		if ( false === $first_empty_time ) {
@@ -233,5 +232,29 @@ class External_Storage {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Determine if an event should be logged based on rate limiting rules.
+	 *
+	 * This prevents log spam from noisy events by applying a simple one-hour
+	 * rate limit per key, regardless of event type.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param string $key        The key that triggered the event.
+	 * @return bool True if the event should be logged, false if rate limited.
+	 */
+	private static function should_log_event( $key ) {
+		$rate_limit_key = 'jetpack_ext_storage_rate_limit_' . $key;
+
+		// Check if we're still within the rate limit period
+		if ( get_transient( $rate_limit_key ) ) {
+			return false;
+		}
+
+		set_transient( $rate_limit_key, true, HOUR_IN_SECONDS );
+
+		return true;
 	}
 }

--- a/projects/packages/connection/src/class-external-storage.php
+++ b/projects/packages/connection/src/class-external-storage.php
@@ -2,8 +2,27 @@
 /**
  * External Storage utilities for Jetpack Connection.
  *
- * Provides centralized logging for external storage implementations
- * across different environments (Atomic, VIP, custom).
+ * Provides centralized logic for external storage implementations
+ * across different environments (WoA, VIP, other).
+ *
+ * Usage Example:
+ *
+ *     // 1. Create a storage provider class with required methods:
+ *     class My_Storage_Provider {
+ *         public function is_available() { return true; }
+ *         public function should_handle( $option_name ) {
+ *             return in_array( $option_name, array( 'blog_token', 'id' ), true );
+ *         }
+ *         public function get( $option_name ) {
+ *             // Return value from your external storage or null
+ *         }
+ *         public function get_environment_id() { return 'my_env'; } // Optional but recommended
+ *     }
+ *
+ *     // 2. Register the provider:
+ *     External_Storage::register_provider( new My_Storage_Provider() );
+ *
+ *     // 3. External storage is now automatically used by Jetpack_Options::get_option()
  *
  * @package automattic/jetpack-connection
  */
@@ -16,6 +35,105 @@ namespace Automattic\Jetpack\Connection;
  * @since $$next-version$$
  */
 class External_Storage {
+
+	/**
+	 * Registered storage provider.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @var object|null
+	 */
+	private static $provider = null;
+
+	/**
+	 * Register a storage provider for external storage.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param object $provider Storage provider object with required methods.
+	 * @return bool True if provider was registered successfully, false otherwise.
+	 */
+	public static function register_provider( $provider ) {
+		if ( ! self::validate_provider( $provider ) ) {
+			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+				error_log( 'Invalid storage provider registered: missing required methods' ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+			}
+			return false;
+		}
+		self::$provider = $provider;
+		return true;
+	}
+
+	/**
+	 * Validate that a storage provider has all required methods.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param object $provider The storage provider to validate.
+	 * @return bool True if provider has all required methods, false otherwise.
+	 */
+	private static function validate_provider( $provider ) {
+		$required_methods = array( 'is_available', 'should_handle', 'get' );
+		foreach ( $required_methods as $method ) {
+			if ( ! method_exists( $provider, $method ) ) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	/**
+	 * Get option value from external storage provider.
+	 *
+	 * Returns null if no provider is registered or if the provider can't provide the value (triggers database fallback).
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param string $option_name The option name to retrieve.
+	 * @return mixed The option value from external storage, or null for database fallback.
+	 */
+	public static function get_option( $option_name ) {
+		$provider = self::$provider;
+
+		// Check if we have a registered provider
+		if ( null === $provider ) {
+			return null; // No provider registered, use database
+		}
+
+		// Get environment ID from provider
+		$environment = method_exists( $provider, 'get_environment_id' ) ? $provider->get_environment_id() : 'unknown';
+
+		// Check if provider is available in current environment
+		if ( ! $provider->is_available() ) {
+			self::log_event( 'unavailable', $option_name, 'External storage not available', $environment );
+			return null;
+		}
+
+		// Check if provider should handle this option
+		if ( ! $provider->should_handle( $option_name ) ) {
+			return null;
+		}
+
+		// Try to get value from the provider
+		try {
+			$value = $provider->get( $option_name );
+
+			// Check if we got a valid value (excluding null, false, empty string, and zero)
+			if ( null !== $value && false !== $value && '' !== $value && 0 !== $value ) {
+				return $value;
+			}
+
+			// Empty value - log it
+			self::log_event( 'empty', $option_name, '', $environment );
+
+		} catch ( \Exception $e ) {
+			// Provider threw an exception
+			self::log_event( 'error', $option_name, $e->getMessage(), $environment );
+		}
+
+		// Provider couldn't provide value, return null for database fallback
+		return null;
+	}
 
 	/**
 	 * Log external storage events to the Jetpack Connection Error_Handler.
@@ -71,33 +189,6 @@ class External_Storage {
 	}
 
 	/**
-	 * Check if empty state should be reported for this option.
-	 *
-	 * Only certain connection options (like blog_token, id) trigger empty state
-	 * reporting with the 10-minute delay mechanism. Other options are ignored.
-	 *
-	 * @since $$next-version$$
-	 *
-	 * @param string $option_name The option name.
-	 * @return bool True if empty state should be reported for this option.
-	 */
-	public static function should_report_empty_for_option( $option_name ) {
-		/**
-		 * Filter the list of options that trigger empty state reporting.
-		 *
-		 * @since $$next-version$$
-		 *
-		 * @param array $reportable_options Array of option names that should trigger empty state reporting.
-		 */
-		$reportable_options = apply_filters(
-			'jetpack_external_storage_reportable_empty_options',
-			array( 'blog_token', 'id' )
-		);
-
-		return in_array( $option_name, $reportable_options, true );
-	}
-
-	/**
 	 * Determine if the current environment should report external storage errors.
 	 *
 	 * @since $$next-version$$
@@ -124,11 +215,6 @@ class External_Storage {
 	 * @return bool True if we should report this empty state, false otherwise.
 	 */
 	private static function should_report_empty_state( $option_name ) {
-		// Only report empty state for monitored options
-		if ( ! self::should_report_empty_for_option( $option_name ) ) {
-			return false;
-		}
-
 		$delay_key        = 'jetpack_external_storage_empty_delay_' . $option_name;
 		$first_empty_time = get_transient( $delay_key );
 

--- a/projects/packages/connection/src/interface-storage-provider.php
+++ b/projects/packages/connection/src/interface-storage-provider.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Storage Provider Interface for External Storage.
+ *
+ * Defines the contract that all external storage providers must implement
+ * to be compatible with the Jetpack Connection External Storage system.
+ *
+ * @package automattic/jetpack-connection
+ */
+
+namespace Automattic\Jetpack\Connection;
+
+/**
+ * Interface for external storage providers.
+ *
+ * All storage providers must implement this interface to ensure
+ * compatibility with the External_Storage system.
+ *
+ * @since $$next-version$$
+ */
+interface Storage_Provider_Interface {
+
+	/**
+	 * Check if the storage provider is available in the current environment.
+	 *
+	 * This method should return true if the storage backend is accessible
+	 * and ready to handle requests, false otherwise.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return bool True if storage is available, false otherwise.
+	 */
+	public function is_available();
+
+	/**
+	 * Determine if this provider should handle the given option.
+	 *
+	 * This method allows providers to selectively handle certain options
+	 * based on their configuration, environment, or other criteria.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param string $option_name The name of the option to check.
+	 * @return bool True if this provider should handle the option, false otherwise.
+	 */
+	public function should_handle( $option_name );
+
+	/**
+	 * Retrieve a value from external storage.
+	 *
+	 * This method should return the value from external storage, or null
+	 * if the value is not found or cannot be retrieved.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param string $option_name The name of the option to retrieve.
+	 * @return mixed The option value, or null if not found/available.
+	 * @throws \Exception If there's an error retrieving the value.
+	 */
+	public function get( $option_name );
+
+	/**
+	 * Get the environment identifier for this provider.
+	 *
+	 * This method should return a unique identifier for the environment
+	 * or storage type (e.g., 'atomic', 'vip', 'kubernetes', etc.).
+	 * Used for logging and debugging purposes.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return string The environment identifier.
+	 */
+	public function get_environment_id();
+}

--- a/projects/packages/connection/tests/php/External_Storage_Test.php
+++ b/projects/packages/connection/tests/php/External_Storage_Test.php
@@ -23,34 +23,88 @@ class External_Storage_Test extends TestCase {
 	 */
 	public function tearDown(): void {
 		parent::tearDown();
-		remove_all_filters( 'jetpack_external_storage_critical_options' );
+		remove_all_filters( 'jetpack_external_storage_reportable_empty_options' );
 	}
 
 	/**
-	 * Test is_critical_option with default options.
+	 * Test should_report_empty_for_option with default options.
 	 */
-	public function test_is_critical_option() {
-		// Default critical options
-		$this->assertTrue( External_Storage::is_critical_option( 'blog_token' ) );
-		$this->assertTrue( External_Storage::is_critical_option( 'id' ) );
+	public function test_should_report_empty_for_option() {
+		// Default reportable options
+		$this->assertTrue( External_Storage::should_report_empty_for_option( 'blog_token' ) );
+		$this->assertTrue( External_Storage::should_report_empty_for_option( 'id' ) );
 
-		// Non-critical options
-		$this->assertFalse( External_Storage::is_critical_option( 'user_tokens' ) );
-		$this->assertFalse( External_Storage::is_critical_option( 'random_option' ) );
+		// Non-reportable options
+		$this->assertFalse( External_Storage::should_report_empty_for_option( 'user_tokens' ) );
+		$this->assertFalse( External_Storage::should_report_empty_for_option( 'random_option' ) );
 	}
 
 	/**
-	 * Test is_critical_option with filter.
+	 * Test should_report_empty_for_option with filter.
 	 */
-	public function test_is_critical_option_with_filter() {
+	public function test_should_report_empty_for_option_with_filter() {
 		add_filter(
-			'jetpack_external_storage_critical_options',
+			'jetpack_external_storage_reportable_empty_options',
 			function ( $options ) {
 				$options[] = 'master_user';
 				return $options;
 			}
 		);
 
-		$this->assertTrue( External_Storage::is_critical_option( 'master_user' ) );
+		$this->assertTrue( External_Storage::should_report_empty_for_option( 'master_user' ) );
+	}
+
+	/**
+	 * Test log_event handles error and empty event types.
+	 */
+	public function test_log_event() {
+		$this->expectNotToPerformAssertions();
+
+		External_Storage::log_event( 'error', 'blog_token', 'Connection failed', 'atomic' );
+		External_Storage::log_event( 'empty', 'id', '', 'vip' );
+	}
+
+	/**
+	 * Test should_report_for_environment with constant.
+	 */
+	public function test_should_report_for_environment() {
+		// Use reflection to test private method
+		$method = new \ReflectionMethod( External_Storage::class, 'should_report_for_environment' );
+		$method->setAccessible( true );
+
+		// Should be false by default
+		$this->assertFalse( $method->invoke( null ) );
+
+		// Should be true when constant is set
+		if ( ! defined( 'JETPACK_EXTERNAL_STORAGE_REPORTING_ENABLED' ) ) {
+			define( 'JETPACK_EXTERNAL_STORAGE_REPORTING_ENABLED', true );
+		}
+		$this->assertTrue( $method->invoke( null ) );
+	}
+
+	/**
+	 * Test empty state delay mechanism basics.
+	 */
+	public function test_empty_state_delay() {
+		// Clean up
+		delete_transient( 'jetpack_external_storage_empty_delay_blog_token' );
+
+		$method = new \ReflectionMethod( External_Storage::class, 'should_report_empty_state' );
+		$method->setAccessible( true );
+
+		// First call should return false (sets delay)
+		$this->assertFalse( $method->invoke( null, 'blog_token' ) );
+
+		// Verify delay transient was set
+		$this->assertNotFalse( get_transient( 'jetpack_external_storage_empty_delay_blog_token' ) );
+
+		// Second call should still return false (within delay)
+		$this->assertFalse( $method->invoke( null, 'blog_token' ) );
+
+		// Non-reportable option should always return false
+		$this->assertFalse( $method->invoke( null, 'user_tokens' ) );
+
+		// Clean up
+		delete_transient( 'jetpack_external_storage_empty_delay_blog_token' );
 	}
 }

--- a/projects/packages/connection/tests/php/External_Storage_Test.php
+++ b/projects/packages/connection/tests/php/External_Storage_Test.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * External Storage functionality testing.
+ *
+ * @package automattic/jetpack-connection
+ */
+
+namespace Automattic\Jetpack\Connection;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * External Storage functionality testing.
+ *
+ * @covers \Automattic\Jetpack\Connection\External_Storage
+ */
+#[CoversClass( External_Storage::class )]
+class External_Storage_Test extends TestCase {
+
+	/**
+	 * Clean up after tests.
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+		remove_all_filters( 'jetpack_external_storage_critical_options' );
+	}
+
+	/**
+	 * Test is_critical_option with default options.
+	 */
+	public function test_is_critical_option() {
+		// Default critical options
+		$this->assertTrue( External_Storage::is_critical_option( 'blog_token' ) );
+		$this->assertTrue( External_Storage::is_critical_option( 'id' ) );
+
+		// Non-critical options
+		$this->assertFalse( External_Storage::is_critical_option( 'user_tokens' ) );
+		$this->assertFalse( External_Storage::is_critical_option( 'random_option' ) );
+	}
+
+	/**
+	 * Test is_critical_option with filter.
+	 */
+	public function test_is_critical_option_with_filter() {
+		add_filter(
+			'jetpack_external_storage_critical_options',
+			function ( $options ) {
+				$options[] = 'master_user';
+				return $options;
+			}
+		);
+
+		$this->assertTrue( External_Storage::is_critical_option( 'master_user' ) );
+	}
+}

--- a/projects/packages/connection/tests/php/External_Storage_Test.php
+++ b/projects/packages/connection/tests/php/External_Storage_Test.php
@@ -19,6 +19,32 @@ use PHPUnit\Framework\TestCase;
 class External_Storage_Test extends TestCase {
 
 	/**
+	 * Set up a test provider before each test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		// Register a simple test provider for more realistic testing
+		$test_provider = new class() implements \Automattic\Jetpack\Connection\Storage_Provider_Interface {
+			public function is_available() {
+				return true;
+			}
+			public function should_handle( $option_name ) {
+				return in_array( $option_name, array( 'blog_token', 'id', 'test_key' ), true );
+			}
+			public function get( $option_name ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+				// Return null to simulate empty state for testing
+				return null;
+			}
+			public function get_environment_id() {
+				return 'test';
+			}
+		};
+
+		External_Storage::register_provider( $test_provider );
+	}
+
+	/**
 	 * Reset provider after each test.
 	 */
 	public function tearDown(): void {
@@ -32,19 +58,159 @@ class External_Storage_Test extends TestCase {
 	}
 
 	/**
-	 * Test get_option with no provider returns null.
+	 * Test get_value with provider that returns null (empty state).
+	 *
+	 * Note: This test avoids calling get_value() which would trigger logging.
+	 * Instead we test the provider registration and basic functionality.
 	 */
-	public function test_get_option_no_provider() {
-		$this->assertNull( External_Storage::get_option( 'blog_token' ) );
+	public function test_provider_returns_null() {
+		// Test that we can register a provider and it behaves as expected
+		$reflection        = new \ReflectionClass( External_Storage::class );
+		$provider_property = $reflection->getProperty( 'provider' );
+		$provider_property->setAccessible( true );
+		$provider = $provider_property->getValue();
+
+		// Verify provider is registered and behaves correctly
+		$this->assertNotNull( $provider );
+		$this->assertTrue( $provider->is_available() );
+		$this->assertTrue( $provider->should_handle( 'blog_token' ) );
+		$this->assertNull( $provider->get( 'blog_token' ) );
+		$this->assertEquals( 'test', $provider->get_environment_id() );
 	}
 
 	/**
-	 * Test log_event method doesn't throw errors.
+	 * Test provider registration and usage.
 	 */
-	public function test_log_event() {
-		$this->expectNotToPerformAssertions();
+	public function test_provider_registration_and_usage() {
+		// Create a simple mock provider implementing the interface
+		$provider = new class() implements \Automattic\Jetpack\Connection\Storage_Provider_Interface {
+			public function is_available() {
+				return true;
+			}
+			public function should_handle( $option_name ) {
+				return 'blog_token' === $option_name;
+			}
+			public function get( $option_name ) {
+				if ( 'blog_token' === $option_name ) {
+					return 'test-token-value';
+				}
+				return null;
+			}
+			public function get_environment_id() {
+				return 'test';
+			}
+		};
 
-		External_Storage::log_event( 'error', 'blog_token', 'Connection failed', 'atomic' );
-		External_Storage::log_event( 'empty', 'id', '', 'test' );
+		// Register provider
+		$result = External_Storage::register_provider( $provider );
+		$this->assertTrue( $result );
+
+		// Test that it returns the expected value
+		$this->assertEquals( 'test-token-value', External_Storage::get_value( 'blog_token' ) );
+
+		// Test that it returns null for unhandled options
+		$this->assertNull( External_Storage::get_value( 'id' ) );
+	}
+
+	/**
+	 * Test that interface ensures all required methods are implemented.
+	 */
+	public function test_interface_enforces_required_methods() {
+		// Create a provider that implements the interface
+		$provider = new class() implements \Automattic\Jetpack\Connection\Storage_Provider_Interface {
+			public function is_available() {
+				return false;
+			}
+			public function should_handle( $option_name ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+				return false;
+			}
+			public function get( $option_name ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+				return null;
+			}
+			public function get_environment_id() {
+				return 'test-minimal';
+			}
+		};
+
+		// Registration should succeed because all required methods are present
+		$result = External_Storage::register_provider( $provider );
+		$this->assertTrue( $result );
+
+		// Test that the provider works as expected
+		$this->assertFalse( $provider->is_available() );
+		$this->assertFalse( $provider->should_handle( 'blog_token' ) );
+		$this->assertNull( $provider->get( 'blog_token' ) );
+		$this->assertEquals( 'test-minimal', $provider->get_environment_id() );
+	}
+
+	/**
+	 * Test log_event method exists and is callable.
+	 *
+	 * Note: We only test method existence to avoid triggering debug logging.
+	 */
+	public function test_log_event_method_exists() {
+		// Test that the method exists and is callable
+		$this->assertTrue( method_exists( 'Automattic\Jetpack\Connection\External_Storage', 'log_event' ) );
+		$this->assertTrue( is_callable( array( 'Automattic\Jetpack\Connection\External_Storage', 'log_event' ) ) );
+
+		// Don't call the method to avoid debug logging output
+	}
+
+	/**
+	 * Test rate limiting logic by directly testing the private method.
+	 *
+	 * Note: We use reflection to test the rate limiting logic without triggering debug logging.
+	 */
+	public function test_rate_limiting_logic() {
+		// Clear any existing transients
+		delete_transient( 'jetpack_ext_storage_rate_limit_test_key' );
+
+		// Use reflection to access the private should_log_event method
+		$reflection = new \ReflectionClass( External_Storage::class );
+		$method     = $reflection->getMethod( 'should_log_event' );
+		$method->setAccessible( true );
+
+		// First call should return true (no rate limiting yet)
+		$result1 = $method->invoke( null, 'test_key' );
+		$this->assertTrue( $result1 );
+
+		// Verify rate limit transient was set
+		$this->assertNotFalse( get_transient( 'jetpack_ext_storage_rate_limit_test_key' ) );
+
+		// Second immediate call should return false (rate limited)
+		$result2 = $method->invoke( null, 'test_key' );
+		$this->assertFalse( $result2 );
+
+		// Clean up
+		delete_transient( 'jetpack_ext_storage_rate_limit_test_key' );
+	}
+
+	/**
+	 * Test empty state delay logic by directly testing the private method.
+	 *
+	 * Note: We use reflection to test the delay logic without triggering debug logging.
+	 */
+	public function test_empty_state_delay_logic() {
+		// Clear any existing transients
+		delete_transient( 'jetpack_external_storage_empty_delay_test_key' );
+
+		// Use reflection to access the private should_report_empty_state method
+		$reflection = new \ReflectionClass( External_Storage::class );
+		$method     = $reflection->getMethod( 'should_report_empty_state' );
+		$method->setAccessible( true );
+
+		// First call should return false (sets delay, doesn't report yet)
+		$result1 = $method->invoke( null, 'test_key' );
+		$this->assertFalse( $result1 );
+
+		// Verify delay transient was set
+		$this->assertNotFalse( get_transient( 'jetpack_external_storage_empty_delay_test_key' ) );
+
+		// Second immediate call should still return false (within delay period)
+		$result2 = $method->invoke( null, 'test_key' );
+		$this->assertFalse( $result2 );
+
+		// Clean up
+		delete_transient( 'jetpack_external_storage_empty_delay_test_key' );
 	}
 }

--- a/projects/packages/connection/tests/php/External_Storage_Test.php
+++ b/projects/packages/connection/tests/php/External_Storage_Test.php
@@ -19,92 +19,32 @@ use PHPUnit\Framework\TestCase;
 class External_Storage_Test extends TestCase {
 
 	/**
-	 * Clean up after tests.
+	 * Reset provider after each test.
 	 */
 	public function tearDown(): void {
 		parent::tearDown();
-		remove_all_filters( 'jetpack_external_storage_reportable_empty_options' );
+
+		// Reset the provider using reflection
+		$reflection = new \ReflectionClass( External_Storage::class );
+		$property   = $reflection->getProperty( 'provider' );
+		$property->setAccessible( true );
+		$property->setValue( null, null );
 	}
 
 	/**
-	 * Test should_report_empty_for_option with default options.
+	 * Test get_option with no provider returns null.
 	 */
-	public function test_should_report_empty_for_option() {
-		// Default reportable options
-		$this->assertTrue( External_Storage::should_report_empty_for_option( 'blog_token' ) );
-		$this->assertTrue( External_Storage::should_report_empty_for_option( 'id' ) );
-
-		// Non-reportable options
-		$this->assertFalse( External_Storage::should_report_empty_for_option( 'user_tokens' ) );
-		$this->assertFalse( External_Storage::should_report_empty_for_option( 'random_option' ) );
+	public function test_get_option_no_provider() {
+		$this->assertNull( External_Storage::get_option( 'blog_token' ) );
 	}
 
 	/**
-	 * Test should_report_empty_for_option with filter.
-	 */
-	public function test_should_report_empty_for_option_with_filter() {
-		add_filter(
-			'jetpack_external_storage_reportable_empty_options',
-			function ( $options ) {
-				$options[] = 'master_user';
-				return $options;
-			}
-		);
-
-		$this->assertTrue( External_Storage::should_report_empty_for_option( 'master_user' ) );
-	}
-
-	/**
-	 * Test log_event handles error and empty event types.
+	 * Test log_event method doesn't throw errors.
 	 */
 	public function test_log_event() {
 		$this->expectNotToPerformAssertions();
 
 		External_Storage::log_event( 'error', 'blog_token', 'Connection failed', 'atomic' );
-		External_Storage::log_event( 'empty', 'id', '', 'vip' );
-	}
-
-	/**
-	 * Test should_report_for_environment with constant.
-	 */
-	public function test_should_report_for_environment() {
-		// Use reflection to test private method
-		$method = new \ReflectionMethod( External_Storage::class, 'should_report_for_environment' );
-		$method->setAccessible( true );
-
-		// Should be false by default
-		$this->assertFalse( $method->invoke( null ) );
-
-		// Should be true when constant is set
-		if ( ! defined( 'JETPACK_EXTERNAL_STORAGE_REPORTING_ENABLED' ) ) {
-			define( 'JETPACK_EXTERNAL_STORAGE_REPORTING_ENABLED', true );
-		}
-		$this->assertTrue( $method->invoke( null ) );
-	}
-
-	/**
-	 * Test empty state delay mechanism basics.
-	 */
-	public function test_empty_state_delay() {
-		// Clean up
-		delete_transient( 'jetpack_external_storage_empty_delay_blog_token' );
-
-		$method = new \ReflectionMethod( External_Storage::class, 'should_report_empty_state' );
-		$method->setAccessible( true );
-
-		// First call should return false (sets delay)
-		$this->assertFalse( $method->invoke( null, 'blog_token' ) );
-
-		// Verify delay transient was set
-		$this->assertNotFalse( get_transient( 'jetpack_external_storage_empty_delay_blog_token' ) );
-
-		// Second call should still return false (within delay)
-		$this->assertFalse( $method->invoke( null, 'blog_token' ) );
-
-		// Non-reportable option should always return false
-		$this->assertFalse( $method->invoke( null, 'user_tokens' ) );
-
-		// Clean up
-		delete_transient( 'jetpack_external_storage_empty_delay_blog_token' );
+		External_Storage::log_event( 'empty', 'id', '', 'test' );
 	}
 }


### PR DESCRIPTION
This PR introduces a new external storage system for Jetpack connection data (blog tokens and blog IDs for now) that enables storing connection information outside the WordPress database.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Closes: CONNECT-26

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* The  `External_Storage` class implements a pluggable storage provider system.
* Environment-specific providers can be registered via `External_Storage::register_provider()`
* Integrates directly with existing `Jetpack_Options::get_option()` calls
* External storage acts as a primary source with automatic database fallback.
* The class adds storage error handling and reuses the error reporting system from the Error_Handler class.
* Empty storage error is not immediately reported, as this can happen due to a delay in writing into the external storage vs the database. A delay mechanism will wait for 10 minutes before reporting an error.


### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Code review
* Test together with https://github.com/Automattic/jetpack/pull/44755
