### PR TITLE
Boost: Don't load Yoast's Cornerstone pages, if it's inactive

### DIFF
--- a/projects/plugins/boost/app/lib/cornerstone/class-cornerstone-pages.php
+++ b/projects/plugins/boost/app/lib/cornerstone/class-cornerstone-pages.php
@@ -66,6 +66,11 @@ class Cornerstone_Pages implements Has_Setup {
 	}
 
 	private function get_yoast_cornerstone_pages() {
+		$urls = array();
+		if ( ! function_exists( 'wpseo_init' ) ) {
+			return $urls;
+		}
+
 		$max_pages                 = $this->get_max_pages();
 		$yoast_cornerstone_content = get_posts(
 			array(
@@ -75,8 +80,6 @@ class Cornerstone_Pages implements Has_Setup {
 				'posts_per_page' => $max_pages,
 			)
 		);
-
-		$urls = array();
 
 		foreach ( $yoast_cornerstone_content as $post ) {
 			$permalink = get_permalink( $post->ID );

--- a/projects/plugins/boost/changelog/fix-boost-cornerstone-pages-no-load-pages-yoast-disabled
+++ b/projects/plugins/boost/changelog/fix-boost-cornerstone-pages-no-load-pages-yoast-disabled
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Cornerstone Pages: Fix default pages including cornerpages from Yoast, when Yoast was inactive.


### PR DESCRIPTION
Fixes HOG-220

## Proposed changes:

* Prevent Boost's Cornerstone Pages from loading Yoast's Cornerstone Pages while Yoast is inactive.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

HOG-220

## Does this pull request change what data or activity we track or use?

no

## Testing instructions:

**Pre-requisites**

- You'll need to set up Yoast and tag a few pages as "Cornerstone content" via Yoast's settings panel when editing a page (it's located under the main editor);

<img width="739" height="629" alt="CleanShot 2025-08-05 at 16 11 04" src="https://github.com/user-attachments/assets/994ddf56-cf8a-4957-af25-faebf025f5d6" />

- After tagging a few pages, deactivate the Yoast plugin.
- You can then activate Boost. Make sure to use the Premium version, as it's easier to see the pages you tagged.

**Note**

If you haven't set up Cornerstone Pages on your website previously, just visiting the Boost dashboard, will cause Boost to load default pages for Cornerstone Pages. If you're on trunk and you have Yoast deactivated, it would include Yoast's pages (this is the broken behavior). Boost would also load the WooCommerce shop page if you have WooCommerce running (there's no problem with its behavior).

However, if you're on this PR's branch, you won't see Yoast's pages being loaded (the fixed behavior) if Yoast is disabled.

You can use this CLI command to clear the Cornerstone Pages so you can revisit the Boost settings page and test this between tests:

```sh
wp option delete jetpack_boost_ds_cornerstone_pages_list
```

### (trunk/production behavior) Test that it loads Yoast's cornerstone pages while Yoast is inactive

- Clear the cornerstone pages list and visit the Boost settings page. You should see the Yoast pages loaded in the list.

### (this branch, fixed behavior) Test that it doesn't load Yoast's cornerstone pages while Yoast is inactive

- Clear the cornerstone pages list and visit the Boost settings page. Yoast's pages should not be in the list.

### (this branch) Other tests

- You can activate/deactivate Yoast to verify that you're seeing the expected behavior. Cornerstone Pages from Yoast should only be loaded if it's active.