### PR TITLE
Social: Fix image generator token reset on save

### DIFF
--- a/projects/packages/publicize/changelog/fix-social-image-generator-token-on-save
+++ b/projects/packages/publicize/changelog/fix-social-image-generator-token-on-save
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed image generator token reset on save resulting in font not being saved.

--- a/projects/packages/publicize/src/social-image-generator/class-post-settings.php
+++ b/projects/packages/publicize/src/social-image-generator/class-post-settings.php
@@ -172,6 +172,15 @@ class Post_Settings {
 	}
 
 	/**
+	 * Get the font to use for the text in the generated image.
+	 *
+	 * @return string
+	 */
+	public function get_font() {
+		return $this->settings['font'] ?? '';
+	}
+
+	/**
 	 * Get an image token.
 	 *
 	 * @return string

--- a/projects/packages/publicize/src/social-image-generator/class-setup.php
+++ b/projects/packages/publicize/src/social-image-generator/class-setup.php
@@ -45,7 +45,8 @@ class Setup {
 		$token = fetch_token(
 			$post_settings->get_custom_text(),
 			$post_settings->get_image_url(),
-			$post_settings->get_template()
+			$post_settings->get_template(),
+			$post_settings->get_font()
 		);
 
 		if ( is_wp_error( $token ) ) {

--- a/projects/plugins/jetpack/changelog/fix-social-image-generator-token-on-save
+++ b/projects/plugins/jetpack/changelog/fix-social-image-generator-token-on-save
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Social: Fix image generator token reset on save resulting in font not being saved.


### PR DESCRIPTION
Follow up of #44514,

Because of the `wp_after_insert_post` hook, the token got regenerated, but the font option was not passed in that call, resulting in the wrong image being saved.



## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Pass the font option when the image generator token is regenerated on save.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a post with a Japanese title - `"美味しい寿司" (yummy sushi)`
* Select the "Noto Sans Japanese" font in SIG settings
* Publish the post
* Confirm that the correct image is shared to social media

