### PR TITLE
Tooling: Exclude Jetpack `to-test.md` from changelog requirement

### DIFF
--- a/tools/check-changelogger-use.php
+++ b/tools/check-changelogger-use.php
@@ -174,6 +174,7 @@ fclose( $pipes[0] );
 
 $ok_projects      = array();
 $touched_projects = array();
+$files_to_ignore  = array( 'projects/plugins/jetpack/to-test.md' );
 // phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
 while ( ( $line = fgets( $pipes[1] ) ) ) {
 	$line                  = trim( $line );
@@ -185,14 +186,14 @@ while ( ( $line = fgets( $pipes[1] ) ) ) {
 	}
 	$slug = "{$parts[1]}/{$parts[2]}";
 	if ( ! isset( $changelogger_projects[ $slug ] ) ) {
-		debug( 'Ignoring file %s, project %s does not use changelogger.', $file, $slug );
+		debug( 'Ignoring file %s, as project %s does not use changelogger.', $file, $slug );
 		continue;
 	}
 	if ( $parts[3] === $changelogger_projects[ $slug ]['changelog'] ) {
 		if ( $status === 'A' ) {
-			debug( 'PR adds changelog file %s, this does not count as having a change file.', $file );
+			debug( 'Changes add changelog file %s, but this does not count as having a change file.', $file );
 		} else {
-			debug( 'PR touches changelog file %s, marking %s as having a change file.', $file, $slug );
+			debug( 'Changes touch changelog file %s, so marking %s as having a change file.', $file, $slug );
 			$ok_projects[ $slug ] = true;
 			continue;
 		}
@@ -201,9 +202,13 @@ while ( ( $line = fgets( $pipes[1] ) ) ) {
 		if ( '.' === $parts[4][0] ) {
 			debug( 'Ignoring changes dir dotfile %s.', $file );
 		} else {
-			debug( 'PR touches file %s, marking %s as having a change file.', $file, $slug );
+			debug( 'Changes touch file %s, so marking %s as having a change file.', $file, $slug );
 			$ok_projects[ $slug ] = true;
 		}
+		continue;
+	}
+	if ( in_array( $file, $files_to_ignore, true ) ) {
+		debug( 'Ignoring file %s, as it is explicitly set to be ignored.', $file );
 		continue;
 	}
 


### PR DESCRIPTION
Closes MONOREP-56

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

When updating the `to-test.md`, we shouldn't need a changelog entry.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Create a new branch based on `trunk`.
2. Commit a change to `projects/plugins/jetpack/to-test.md`.
3. Try pushing. You'll get an error that you need a changelog entry.
4. Create a new branch based on this `update/tooling/allow_specific_files_to_bypass_changelog_requirement` branch.
5. Commit a change to `projects/plugins/jetpack/to-test.md`.
6. Try pushing. No errors occur.

You can also try running the script manually:
`tools/check-changelogger-use.php -v <oldref> HEAD`