### PR TITLE
Infinite Scroll: Prevent PHP warnings in edge cases

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-infinite-scroll-php_warnings_part2
+++ b/projects/plugins/jetpack/changelog/fix-infinite-scroll-php_warnings_part2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Infinite Scroll: Prevent PHP warnings in various edge cases.

--- a/projects/plugins/jetpack/modules/infinite-scroll/infinity.php
+++ b/projects/plugins/jetpack/modules/infinite-scroll/infinity.php
@@ -633,7 +633,7 @@ class The_Neverending_Home_Page {
 
 		// code inspired by WP_Query class
 		if ( preg_match_all( '/".*?("|$)|((?<=[\t ",+])|^)[^\t ",+]+/', self::wp_query()->get( 's' ), $matches ) ) {
-			$search_terms = self::wp_query()->query_vars['search_terms'];
+			$search_terms = self::wp_query()->query_vars['search_terms'] ?? null;
 			// if the search string has only short terms or stopwords, or is 10+ terms long, match it as sentence
 			if ( empty( $search_terms ) || ! is_countable( $search_terms ) || count( $search_terms ) > 9 ) {
 				$search_terms = array( self::wp_query()->get( 's' ) );
@@ -890,6 +890,7 @@ class The_Neverending_Home_Page {
 			if (
 				is_a( $taxonomy, 'WP_Taxonomy' )
 				&& is_countable( $taxonomy->object_type )
+				&& ! empty( $taxonomy->object_type )
 				&& count( $taxonomy->object_type ) < 2
 			) {
 				$post_type = $taxonomy->object_type[0];

--- a/projects/plugins/jetpack/modules/infinite-scroll/infinity.php
+++ b/projects/plugins/jetpack/modules/infinite-scroll/infinity.php
@@ -574,6 +574,9 @@ class The_Neverending_Home_Page {
 		$excluded_posts = array();
 		// loop through posts returned by wp_query call
 		foreach ( self::wp_query()->get_posts() as $post ) {
+			if ( ! $post instanceof \WP_Post ) {
+				continue;
+			}
 
 			$orderby   = isset( self::wp_query()->query_vars['orderby'] ) ? self::wp_query()->query_vars['orderby'] : '';
 			$post_date = ( ! empty( $post->post_date ) ? $post->post_date : false );

--- a/projects/plugins/jetpack/modules/infinite-scroll/infinity.php
+++ b/projects/plugins/jetpack/modules/infinite-scroll/infinity.php
@@ -1535,9 +1535,17 @@ class The_Neverending_Home_Page {
 				// If sharing counts are not initialized for any reason, we initialize them here.
 				if ( ! is_array( $jetpack_sharing_counts ) ) {
 					$jetpack_sharing_counts = array();
+				} else {
+					// Filter out non-string and non-integer values to avoid warnings with array_flip.
+					$flippable_jetpack_sharing_counts = array_filter(
+						$jetpack_sharing_counts,
+						function ( $value ) {
+							return is_string( $value ) || is_int( $value );
+						}
+					);
 				}
 
-				$results['postflair'] = array_flip( $jetpack_sharing_counts );
+				$results['postflair'] = array_flip( $flippable_jetpack_sharing_counts );
 			}
 		} else {
 			/** This action is already documented in modules/infinite-scroll/infinity.php */

--- a/projects/plugins/jetpack/modules/infinite-scroll/infinity.php
+++ b/projects/plugins/jetpack/modules/infinite-scroll/infinity.php
@@ -1549,7 +1549,7 @@ class The_Neverending_Home_Page {
 					);
 				}
 
-				$results['postflair'] = array_flip( $flippable_jetpack_sharing_counts );
+				$results['postflair'] = array_flip( $flippable_jetpack_sharing_counts ?? array() );
 			}
 		} else {
 			/** This action is already documented in modules/infinite-scroll/infinity.php */

--- a/projects/plugins/jetpack/modules/infinite-scroll/infinity.php
+++ b/projects/plugins/jetpack/modules/infinite-scroll/infinity.php
@@ -389,7 +389,7 @@ class The_Neverending_Home_Page {
 		if ( 0 === $entries ) {
 			return (bool) ( ! is_countable( self::wp_query()->posts ) || ( count( self::wp_query()->posts ) < $posts_per_page ) );
 		}
-		$paged = max( 1, self::wp_query()->get( 'paged' ) );
+		$paged = max( 1, (int) self::wp_query()->get( 'paged' ) );
 
 		// Are there enough posts for more than the first page?
 		if ( $entries <= $posts_per_page ) {


### PR DESCRIPTION
Closes MONOREP-61

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

In #44525 the most common warnings in Infinite Scroll were cleaned up. This PR addresses the remaining ones found in the wild. They're not readily replicable, but the intent is to guard against the warnings in a non-breaking way.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

Now line 401, but this can occur if the `max()` from a few lines before can sometimes compare `int` vs. `string`. In PHP < 8 a non-numeric string would be treated as 0, but as of PHP 8, it now returns the string, which can result in the warning below when trying to do multiplication. Solution: explicitly cast the value to an int.
```
PHP Warning: A non-numeric value encountered in /wordpress/plugins/jetpack/14.9-a.7/modules/infinite-scroll/infinity.php on line 397
```

This is subject to the whims of the `infinite_scroll_query_object` filter. We prevent the below warnings by making sure the data we're wanting to process is actually a post:
```
PHP Warning: Attempt to read property "post_modified" on null in /wordpress/plugins/jetpack/14.9-beta/modules/infinite-scroll/infinity.php on line 581
PHP Warning: Attempt to read property "ID" on null in /wordpress/plugins/jetpack/14.9-beta/modules/infinite-scroll/infinity.php on line 587
```

Now line 639, this is also subject to filters, so the easiest fix is adding null-coalesce a few lines before, which is compatible with the already-present conditions:
```
PHP Warning: Undefined array key "search_terms" in /wordpress/plugins/jetpack/14.9-beta/modules/infinite-scroll/infinity.php on line 636
```

Now line 899, we verified that there were less than 2 items in `$taxonomy->object_type` but not that there was at least one. I added an `! empty()` check, which should both account for 0 items as well as strange types should they come up:
```
PHP Warning: Undefined array key 0 in /wordpress/plugins/jetpack/14.9-beta/modules/infinite-scroll/infinity.php on line 895
```

Since this operated on the `$jetpack_sharing_counts` global, and globals can be modified by third-party code, the data structure isn't reliable. In particular, `array_flip()` won't work if a value is a non-string and non-int. As such, I've filtered bad values from the array before flipping it:
```
PHP Warning: array_flip(): Can only flip string and integer values, entry skipped in /wordpress/plugins/jetpack/14.9-beta/modules/infinite-scroll/infinity.php on line 1540
```

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

