### PR TITLE
Jetpack: fix one-image slideshow shortcode

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-shortcode-slideshow
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-shortcode-slideshow
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Fixing JS in one-image Slideshow shortcodes.

--- a/projects/plugins/jetpack/modules/shortcodes/js/slideshow-shortcode.js
+++ b/projects/plugins/jetpack/modules/shortcodes/js/slideshow-shortcode.js
@@ -85,10 +85,11 @@ JetpackSlideshow.prototype.makeZeroWidthSpan = function () {
 
 JetpackSlideshow.prototype.finishInit_ = function () {
 	this.showLoadingImage( false );
-	this.renderControls_();
 
 	var self = this;
 	if ( this.images.length > 1 ) {
+		this.renderControls_();
+
 		// Initialize Cycle instance.
 		jQuery( this.element ).cycle( {
 			fx: this.transition,

--- a/projects/plugins/jetpack/modules/shortcodes/js/slideshow-shortcode.js
+++ b/projects/plugins/jetpack/modules/shortcodes/js/slideshow-shortcode.js
@@ -126,9 +126,9 @@ JetpackSlideshow.prototype.finishInit_ = function () {
 				}
 			}
 		} );
-	} else {
-		this.element.children( ':first' ).show();
-		this.element.css( 'position', 'relative' );
+	} else if ( this.element.children.length ) {
+		this.element.children[ 0 ].style.display = 'block';
+		this.element.style.position = 'relative';
 	}
 	this.initialized_ = true;
 };


### PR DESCRIPTION
## Proposed changes:
* Fix a JS error in slideshows created via `[slideshow]` shortcode that contain only a single image.
* Get rid of the slideshow controls for single-image slideshows.

`this.element` used to be a jQuery object, but it's an HTMLElement now, so some jQuery remnants need to be replaced to VanillaJS.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
1. Connect Jetpack.
2. Go to "Media" and upload an image. We'll need that attachment ID.
3. Edit a post or a page, and use the shortcode block to create a one-image slideshow (replace 599 with the attachment ID):
```
[slideshow include="599"][/slideshow]
```
4. Load the post and confirm the slideshow loads the image with no JS errors.
5. Upload more images and add their attachment ID's into the shortcode: `... include="599,699,799"...`
6. Load the post and confirm the slideshow loads all and cycles through the images with no JS errors.