### PR TITLE
Forms: Fix ordering of fields when JS is disabled

### DIFF
--- a/projects/packages/forms/changelog/fix-ordering-of-fields
+++ b/projects/packages/forms/changelog/fix-ordering-of-fields
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: fix the ordering of fields on submit when JS is disabled

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1056,9 +1056,6 @@ class Contact_Form extends Contact_Form_Shortcode {
 			}
 		}
 
-		// Sorting lines by the field index
-		ksort( $compiled_form );
-
 		return $compiled_form;
 	}
 


### PR DESCRIPTION
Currently when you submit the form with and JS id disabled the form return is returned.
This PR fixes the order of the response. 

Before:
<img width="1446" height="2422" alt="Screenshot 2025-08-05 at 1 21 19 PM" src="https://github.com/user-attachments/assets/54624409-d225-4c36-ad4e-5c6c35fc3e1b" />


After:
<img width="1430" height="2432" alt="Screenshot 2025-08-05 at 1 22 10 PM" src="https://github.com/user-attachments/assets/9d6ada46-108e-49a1-9c74-2cf989883653" />


## Proposed changes:
* Remove the ksort which is not needed. 

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
* Create a form with fields in a specific order. 
* Submit the form notice that the fields are still in that format. 
This wrong ordering only happens when the form is submited via regular (non ajax route) 
So add `add_filter( 'jetpack_forms_enable_ajax_submission', '__return_false' );` to your `0-sandbox.php` 
