### PR TITLE
CRM: Improves the invoice statements functionality

### DIFF
--- a/projects/plugins/crm/admin/company/view.page.php
+++ b/projects/plugins/crm/admin/company/view.page.php
@@ -200,8 +200,9 @@ function jpcrm_render_company_view_page( $id = -1 ) {
 				}
 
 				// retrieve any additional tabs peeps have prepared
-				$companyVitalTabs = apply_filters( 'jetpack-crm-company-vital-tabs', array(), $id );
-
+				// phpcs:disable
+				$companyVitalTabs = apply_filters( 'jetpack-crm-company-vital-tabs', array(), $id, $company );
+				// phpcs:enable
 				?>
 
 				<div id="zbs-vitals-box">

--- a/projects/plugins/crm/admin/settings/transactions.page.php
+++ b/projects/plugins/crm/admin/settings/transactions.page.php
@@ -180,7 +180,7 @@ if ( $sbupdated ) {
 			</tr>
 
 			<tr>
-				<td class="wfieldname"><label><?php esc_html_e( 'Include these statuses in the transaction total value', 'zero-bs-crm' ); ?>:</label><br /><?php esc_html_e( 'Tick which statuses to include when calculating total transaction value and total overall value of contacts.', 'zero-bs-crm' ); ?>
+				<td class="wfieldname"><label><?php esc_html_e( 'Include these statuses in total values and as payments against invoices', 'zero-bs-crm' ); ?>:</label><br /><?php esc_html_e( 'Tick which statuses to include when calculating total transaction value, total overall value of contacts, and as payments against invoices in statements.', 'zero-bs-crm' ); ?>
 					<br /><br /></td>
 				<td style="width:540px" id="jpcrm-transaction-include-status">
 					<?php

--- a/projects/plugins/crm/changelog/fix-invoice-statements
+++ b/projects/plugins/crm/changelog/fix-invoice-statements
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-Brings the invoice statment to a contact tab
+Brings the invoice statement to a contact tab

--- a/projects/plugins/crm/changelog/fix-invoice-statements
+++ b/projects/plugins/crm/changelog/fix-invoice-statements
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Brings the invoice statment to a contact tab

--- a/projects/plugins/crm/includes/ZeroBSCRM.AJAX.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.AJAX.php
@@ -5363,7 +5363,7 @@ function zeroBSCRM_AJAX_sendStatement() {
 			array(
 				'type'           => 'email',
 				'shortdesc'      => __( 'Statement Sent', 'zero-bs-crm' ),
-				'longdesc'       => sprintf( __( 'Invoice statement sent to: %s', 'zero-bs-crm' ), $email ),
+				'longdesc'       => sprintf( __( 'Invoice statement sent to: %s', 'zero-bs-crm' ), (string) $email ),
 				'meta_assoc_src' => 'statement',
 			)
 		);
@@ -5486,7 +5486,7 @@ function zeroBSCRM_AJAX_sendCompanyStatement() {
 			array(
 				'type'           => 'email',
 				'shortdesc'      => __( 'Statement Sent', 'zero-bs-crm' ),
-				'longdesc'       => sprintf( __( 'Invoice statement sent to: %s', 'zero-bs-crm' ), $email ),
+				'longdesc'       => sprintf( __( 'Invoice statement sent to: %s', 'zero-bs-crm' ), (string) $email ),
 				'meta_assoc_src' => 'statement',
 			)
 		);

--- a/projects/plugins/crm/includes/ZeroBSCRM.AJAX.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.AJAX.php
@@ -5368,7 +5368,7 @@ function zeroBSCRM_AJAX_sendStatement() {
 			)
 		);
 
-		$r['success'] = __( 'Sent', 'zero-bs-crm' );
+		$r['success'] = ( string ) __( 'Sent', 'zero-bs-crm' );
 		wp_send_json( $r );
 }
 
@@ -5392,7 +5392,7 @@ function zeroBSCRM_AJAX_sendCompanyStatement() {
 	// validate the email
 	if ( ! zeroBSCRM_validateEmail( $em ) ) {
 
-		$r['error'] = __( 'Not a valid email', 'zero-bs-crm' );
+		$r['error'] = ( string ) __( 'Not a valid email', 'zero-bs-crm' );
 		wp_send_json_error( $r );
 
 	} else {
@@ -5413,7 +5413,7 @@ function zeroBSCRM_AJAX_sendCompanyStatement() {
 
 	// check worked
 	if ( ! file_exists( $statementPDFfilepath ) ) {
-		$r['error'] = __( 'Could not generate statement PDF', 'zero-bs-crm' );
+		$r['error'] = ( string ) __( 'Could not generate statement PDF', 'zero-bs-crm' );
 		wp_send_json_error( $r );
 	}
 
@@ -5491,7 +5491,7 @@ function zeroBSCRM_AJAX_sendCompanyStatement() {
 			)
 		);
 
-	$r['success'] = __( 'Sent', 'zero-bs-crm' );
+	$r['success'] = ( string ) __( 'Sent', 'zero-bs-crm' );
 	wp_send_json_success( $r );
 }
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.AJAX.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.AJAX.php
@@ -5393,8 +5393,7 @@ function zeroBSCRM_AJAX_sendCompanyStatement() {
 	if ( ! zeroBSCRM_validateEmail( $em ) ) {
 
 		$r['error'] = __( 'Not a valid email', 'zero-bs-crm' );
-		zeroBSCRM_sendJSONError( $r );
-		exit( 0 );
+		wp_send_json_error( $r );
 
 	} else {
 		$email = $em;
@@ -5404,8 +5403,7 @@ function zeroBSCRM_AJAX_sendCompanyStatement() {
 	if ( $cID <= 0 || empty( $email ) || ! zeroBSCRM_permsInvoices() ) {
 
 		$r['error'] = '';
-		zeroBSCRM_sendJSONError( $r );
-		exit( 0 );
+		wp_send_json_error( $r );
 
 	}
 
@@ -5416,8 +5414,7 @@ function zeroBSCRM_AJAX_sendCompanyStatement() {
 	// check worked
 	if ( ! file_exists( $statementPDFfilepath ) ) {
 		$r['error'] = __( 'Could not generate statement PDF', 'zero-bs-crm' );
-		zeroBSCRM_sendJSONError( $r );
-		exit( 0 );
+		wp_send_json_error( $r );
 	}
 
 	// ==== SEND VIA EMAIL ATTACHMENT
@@ -5470,8 +5467,7 @@ function zeroBSCRM_AJAX_sendCompanyStatement() {
 		// Check if sending failed
 		if ( ! $sent ) {
 			$r['error'] = __( 'Could not send statement email', 'zero-bs-crm' );
-			zeroBSCRM_sendJSONError( $r );
-			exit( 0 );
+			wp_send_json_error( $r );
 		}
 
 		// =================================== / MAIL SENDING =======================================
@@ -5496,8 +5492,7 @@ function zeroBSCRM_AJAX_sendCompanyStatement() {
 		);
 
 	$r['success'] = __( 'Sent', 'zero-bs-crm' );
-	zeroBSCRM_sendJSONSuccess( $r );
-	exit( 0 );
+	wp_send_json_success( $r );
 }
 
 /*

--- a/projects/plugins/crm/includes/ZeroBSCRM.AJAX.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.AJAX.php
@@ -11,6 +11,8 @@
  */
 use Automattic\JetpackCRM\Segment_Condition_Exception;
 
+// phpcs:disable
+
 /*
 ======================================================
 	Breaking Checks ( stops direct access )
@@ -2747,8 +2749,8 @@ function zeroBSCRM_AJAX_listViewRetrieveData() {
 						}
 					}
 
-						if ( isset( $listViewParams['sortorder'] ) && ! empty( $listViewParams['sortorder'] ) ) {
-							$sortOrder = $listViewParams['sortorder'];
+					if ( isset( $listViewParams['sortorder'] ) && ! empty( $listViewParams['sortorder'] ) ) {
+						$sortOrder = $listViewParams['sortorder'];
 					}
 				}
 
@@ -2876,8 +2878,8 @@ function zeroBSCRM_AJAX_listViewRetrieveData() {
 						}
 					}
 
-						if ( isset( $listViewParams['sortorder'] ) && ! empty( $listViewParams['sortorder'] ) ) {
-							$sortOrder = $listViewParams['sortorder'];
+					if ( isset( $listViewParams['sortorder'] ) && ! empty( $listViewParams['sortorder'] ) ) {
+						$sortOrder = $listViewParams['sortorder'];
 					}
 				}
 
@@ -3017,8 +3019,8 @@ function zeroBSCRM_AJAX_listViewRetrieveData() {
 						}
 					}
 
-						if ( isset( $listViewParams['sortorder'] ) && ! empty( $listViewParams['sortorder'] ) ) {
-							$sortOrder = $listViewParams['sortorder'];
+					if ( isset( $listViewParams['sortorder'] ) && ! empty( $listViewParams['sortorder'] ) ) {
+						$sortOrder = $listViewParams['sortorder'];
 					}
 				}
 
@@ -3132,8 +3134,8 @@ function zeroBSCRM_AJAX_listViewRetrieveData() {
 						}
 					}
 
-						if ( isset( $listViewParams['sortorder'] ) && ! empty( $listViewParams['sortorder'] ) ) {
-							$sortOrder = $listViewParams['sortorder'];
+					if ( isset( $listViewParams['sortorder'] ) && ! empty( $listViewParams['sortorder'] ) ) {
+						$sortOrder = $listViewParams['sortorder'];
 					}
 				}
 
@@ -3255,8 +3257,8 @@ function zeroBSCRM_AJAX_listViewRetrieveData() {
 
 					}
 
-						if ( isset( $listViewParams['sortorder'] ) && ! empty( $listViewParams['sortorder'] ) ) {
-							$sortOrder = strtoupper( $listViewParams['sortorder'] );
+					if ( isset( $listViewParams['sortorder'] ) && ! empty( $listViewParams['sortorder'] ) ) {
+						$sortOrder = strtoupper( $listViewParams['sortorder'] );
 					}
 				}
 
@@ -3356,8 +3358,8 @@ function zeroBSCRM_AJAX_listViewRetrieveData() {
 						}
 					}
 
-						if ( isset( $listViewParams['sortorder'] ) && ! empty( $listViewParams['sortorder'] ) ) {
-							$sortOrder = $listViewParams['sortorder'];
+					if ( isset( $listViewParams['sortorder'] ) && ! empty( $listViewParams['sortorder'] ) ) {
+						$sortOrder = $listViewParams['sortorder'];
 					}
 				}
 
@@ -3477,8 +3479,8 @@ function zeroBSCRM_AJAX_listViewRetrieveData() {
 						}
 					}
 
-						if ( isset( $listViewParams['sortorder'] ) && ! empty( $listViewParams['sortorder'] ) ) {
-							$sortOrder = $listViewParams['sortorder'];
+					if ( isset( $listViewParams['sortorder'] ) && ! empty( $listViewParams['sortorder'] ) ) {
+						$sortOrder = $listViewParams['sortorder'];
 					}
 				}
 
@@ -4929,13 +4931,13 @@ function zeroBSCRM_AJAX_saveScreenOptions() {
 		foreach ( $screenOpts as $k => $v ) {
 			if ( isset( $screenOptionsFilters[ $k ]['filter'] ) && $screenOptionsFilters[ $k ]['filter'] === FILTER_UNSAFE_RAW && $v !== null ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 				foreach ( $v as $k2 => $v2 ) {
-					$screenOpts[$k][$k2] = strtr(
+					$screenOpts[ $k ][ $k2 ] = strtr(
 						strip_tags( $v2 ),
 						array(
 							"\0" => '',
-							'"' => '&#34;',
-							"'" => '&#39;',
-							"<" => '',
+							'"'  => '&#34;',
+							"'"  => '&#39;',
+							'<'  => '',
 						)
 					);
 				}
@@ -5778,8 +5780,9 @@ function zeroBSCRM_ajax_mark_task_complete() {
 	wp_send_json_error( array( 'params_error' => 1 ), 400 );
 }
 
+// phpcs:enable
+
 /*
 ======================================================
 	/ Admin AJAX: Tasks
 ====================================================== */
-

--- a/projects/plugins/crm/includes/ZeroBSCRM.AJAX.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.AJAX.php
@@ -5353,8 +5353,149 @@ function zeroBSCRM_AJAX_sendStatement() {
 		// delete the PDF file once it's been read (i.e. sent)
 		unlink( $statementPDFfilepath );
 
+		// Add activity log entry
+		zeroBS_addUpdateContactLog(
+			$cID,
+			-1,
+			-1,
+			array(
+				'type'           => 'email',
+				'shortdesc'      => __( 'Statement Sent', 'zero-bs-crm' ),
+				'longdesc'       => sprintf( __( 'Invoice statement sent to: %s', 'zero-bs-crm' ), $email ),
+				'meta_assoc_src' => 'statement',
+			)
+		);
+
 		$r['success'] = __( 'Sent', 'zero-bs-crm' );
 		wp_send_json( $r );
+}
+
+// } AJAX Send Company Statement
+add_action( 'wp_ajax_zbs_company_send_statement', 'zeroBSCRM_AJAX_sendCompanyStatement' );
+function zeroBSCRM_AJAX_sendCompanyStatement() {
+
+	// } Check nonce
+	check_ajax_referer( 'zbscrmjs-glob-ajax-nonce', 'sec' );  // nonce to bounce out if not from right page
+
+	$cID = -1;
+	$em  = '';
+	$r   = array();
+	if ( isset( $_POST['cid'] ) && ! empty( $_POST['cid'] ) ) {
+		$cID = (int) sanitize_text_field( $_POST['cid'] );  // accepts the company ID
+	}
+	if ( isset( $_POST['em'] ) && ! empty( $_POST['em'] ) ) {
+		$em = sanitize_text_field( $_POST['em'] );
+	}
+
+	// validate the email
+	if ( ! zeroBSCRM_validateEmail( $em ) ) {
+
+		$r['error'] = __( 'Not a valid email', 'zero-bs-crm' );
+		zeroBSCRM_sendJSONError( $r );
+		exit( 0 );
+
+	} else {
+		$email = $em;
+	}
+
+	// } Check id + perms + em
+	if ( $cID <= 0 || empty( $email ) || ! zeroBSCRM_permsInvoices() ) {
+
+		$r['error'] = '';
+		zeroBSCRM_sendJSONError( $r );
+		exit( 0 );
+
+	}
+
+	// ==== BUILD STATEMENT PDF
+	// generates pdf file
+	$statementPDFfilepath = zeroBSCRM_invoicing_generateCompanyStatementPDF( $cID, false );
+
+	// check worked
+	if ( ! file_exists( $statementPDFfilepath ) ) {
+		$r['error'] = __( 'Could not generate statement PDF', 'zero-bs-crm' );
+		zeroBSCRM_sendJSONError( $r );
+		exit( 0 );
+	}
+
+	// ==== SEND VIA EMAIL ATTACHMENT
+	// ==========================================================================================
+	// =================================== MAIL SENDING =========================================
+
+	// Attachment
+	$attachments = array(
+		array( $statementPDFfilepath, __( 'statement', 'zero-bs-crm' ) . '.pdf' ),
+	);
+
+	// generate html
+	$emailHTML = zeroBSCRM_company_statement_generateNotificationHTML( $cID, true );
+
+		// build send array
+		$mailArray = array(
+			'toEmail'     => $email,
+			'toName'      => '',
+			'subject'     => zeroBSCRM_mailTemplate_getSubject( ZBSEMAIL_STATEMENT ),
+			'headers'     => zeroBSCRM_mailTemplate_getHeaders( ZBSEMAIL_STATEMENT ),
+			'body'        => $emailHTML,
+			'textbody'    => '',
+			'attachments' => $attachments,
+			'options'     => array(
+				'html' => 1,
+			),
+			'tracking'    => array(
+				// tracking :D (auto-inserted pixel + saved in history db)
+				'emailTypeID'     => ZBSEMAIL_STATEMENT,
+				'targetObjID'     => $cID,
+				'senderWPID'      => -15, // wh added -15 you have a statement sent to customer,
+				'associatedObjID' => -1,
+			),
+		);
+
+		// DEBUG echo 'Sending:<pre>'; print_r($mailArray); echo '</pre>Result:';
+
+		// Sends email, including tracking, via setting stored route out, (or default if none)
+		// and logs trcking :)
+
+		// discern del method
+		$mailDeliveryMethod = zeroBSCRM_mailTemplate_getMailDelMethod( ZBSEMAIL_STATEMENT );
+		if ( ! isset( $mailDeliveryMethod ) || empty( $mailDeliveryMethod ) ) {
+			$mailDeliveryMethod = -1;
+		}
+
+		// send
+		$sent = zeroBSCRM_mailDelivery_sendMessage( $mailDeliveryMethod, $mailArray );
+
+		// Check if sending failed
+		if ( ! $sent ) {
+			$r['error'] = __( 'Could not send statement email', 'zero-bs-crm' );
+			zeroBSCRM_sendJSONError( $r );
+			exit( 0 );
+		}
+
+		// =================================== / MAIL SENDING =======================================
+		// ==========================================================================================
+
+		// DELETE statement
+		// delete the PDF file once it's been read (i.e. sent)
+		unlink( $statementPDFfilepath );
+
+		// Add activity log entry
+		zeroBS_addUpdateObjLog(
+			ZBS_TYPE_COMPANY,
+			$cID,
+			-1,
+			-1,
+			array(
+				'type'           => 'email',
+				'shortdesc'      => __( 'Statement Sent', 'zero-bs-crm' ),
+				'longdesc'       => sprintf( __( 'Invoice statement sent to: %s', 'zero-bs-crm' ), $email ),
+				'meta_assoc_src' => 'statement',
+			)
+		);
+
+	$r['success'] = __( 'Sent', 'zero-bs-crm' );
+	zeroBSCRM_sendJSONSuccess( $r );
+	exit( 0 );
 }
 
 /*

--- a/projects/plugins/crm/includes/ZeroBSCRM.Actions.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Actions.php
@@ -104,13 +104,6 @@ function zeroBS_contact_actions( $cID = -1, $cObj = false ) {
 
 						}
 						
-						// Add Generate Statement action
-						$actions_array['viewstatement'] = array(
-							'url'   => jpcrm_esc_link( 'view', $cID, 'zerobs_customer' ) . '&tab=statement',
-							'label' => __( 'Generate Statement', 'zero-bs-crm' ),
-							'ico'   => 'file text outline icon',
-						);
-						
 						$actions_array['sendstatement'] = array(
 
 							// take out url if JS fired action 'url' => '#sendstatement',

--- a/projects/plugins/crm/includes/ZeroBSCRM.Actions.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Actions.php
@@ -1,4 +1,5 @@
 <?php
+// @phpcs:disable
 /*
 !
  * Jetpack CRM
@@ -102,6 +103,14 @@ function zeroBS_contact_actions( $cID = -1, $cObj = false ) {
 							$sendTo = zeroBS_customerEmail( $cID );
 
 						}
+						
+						// Add Generate Statement action
+						$actions_array['viewstatement'] = array(
+							'url'   => jpcrm_esc_link( 'view', $cID, 'zerobs_customer' ) . '&tab=statement',
+							'label' => __( 'Generate Statement', 'zero-bs-crm' ),
+							'ico'   => 'file text outline icon',
+						);
+						
 						$actions_array['sendstatement'] = array(
 
 							// take out url if JS fired action 'url' => '#sendstatement',
@@ -213,3 +222,4 @@ function zeroBS_company_actions( $coID = -1 ) {
 ======================================================
 	/ Action helper funcs
 	====================================================== */
+// @phpcs:enable

--- a/projects/plugins/crm/includes/ZeroBSCRM.Core.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Core.php
@@ -1296,6 +1296,7 @@ final class ZeroBSCRM {
 		require_once ZEROBSCRM_INCLUDE_PATH . 'ZeroBSCRM.Forms.php';
 		require_once ZEROBSCRM_INCLUDE_PATH . 'ZeroBSCRM.InvoiceBuilder.php';
 		require_once ZEROBSCRM_INCLUDE_PATH . 'ZeroBSCRM.QuoteBuilder.php';
+		require_once ZEROBSCRM_INCLUDE_PATH . 'jpcrm-statement-tab.php';
 
 		require_once ZEROBSCRM_INCLUDE_PATH . 'ZeroBSCRM.SystemChecks.php';
 		require_once ZEROBSCRM_INCLUDE_PATH . 'ZeroBSCRM.IntegrationFuncs.php';

--- a/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Obj.Transactions.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Obj.Transactions.php
@@ -2472,23 +2472,24 @@ class zbsDAL_transactions extends zbsDAL_ObjectLayer {
      *
      * @return array 
      */
-    function getTransactionStatusesToInclude(){
+		public function getTransactionStatusesToInclude() {
 
-        // load (accept from cache)
-        $setting = $this->DAL()->setting( 'transinclude_status', 'all', true );
+			// load (accept from cache)
+			$setting = $this->DAL()->setting( 'transinclude_status', 'all', true );
 
-        if (is_string($setting) && strpos($setting, ',') > 0){
+			// If it's already an array, return it
+			if ( is_array( $setting ) ) {
+				return $setting;
+			}
 
-            return explode(',', $setting);
-        } elseif (is_array($setting)){
+			// If it's a string with commas, split it
+			if ( is_string( $setting ) && strpos( $setting, ',' ) > 0 ) {
+				return explode( ',', $setting );
+			}
 
-            return $setting;
-            
-        }
-
-        return 'all';
-        
-    }
+			// If it's 'all' or any other string, return 'all'
+			return 'all';
+		}
 
     /**
      * returns an SQL query addition which will allow filtering of transactions

--- a/projects/plugins/crm/includes/ZeroBSCRM.FormatHelpers.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.FormatHelpers.php
@@ -9,6 +9,8 @@
  * Date: 01/11/16
  */
 
+// phpcs:disable
+
 defined( 'ZEROBSCRM_PATH' ) || exit( 0 );
 
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.FormatHelpers.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.FormatHelpers.php
@@ -799,6 +799,15 @@ function zeroBSCRM_html_companyTimeline($companyID=-1,$logs=false,$companyObj=fa
 								echo ' &mdash; <i class="clock icon"></i>' . esc_html( $log['nicetime'] );
 							}
 						}
+						// if has long desc, show/hide
+						if ( !empty( $log['longdesc'] ) ) {
+							?>
+							<i class="angle down icon zbs-show-longdesc"></i><i class="angle up icon zbs-hide-longdesc"></i>
+							<div class="zbs-long-desc">
+								<?php echo wp_kses( html_entity_decode( $log['longdesc'], ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 ), $zbs->acceptable_restricted_html ); ?>
+							</div>
+							<?php
+						}
 						?>
 						</p>
                     </div>

--- a/projects/plugins/crm/includes/ZeroBSCRM.FormatHelpers.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.FormatHelpers.php
@@ -800,7 +800,7 @@ function zeroBSCRM_html_companyTimeline($companyID=-1,$logs=false,$companyObj=fa
 							}
 						}
 						// if has long desc, show/hide
-						if ( !empty( $log['longdesc'] ) ) {
+						if ( ! empty( $log['longdesc'] ) ) {
 							?>
 							<i class="angle down icon zbs-show-longdesc"></i><i class="angle up icon zbs-hide-longdesc"></i>
 							<div class="zbs-long-desc">

--- a/projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php
@@ -630,7 +630,7 @@ function zeroBSCRM_invoicing_generateStatementHTML_v3( $contact_id = -1, $return
 
 						// Check if this transaction status should be included
 						$should_include_transaction = false;
-						if ( $transaction_statuses_to_include === 'all' ) {
+						if ( 'all' === $transaction_statuses_to_include ) {
 							$should_include_transaction = true;
 						} elseif ( is_array( $transaction_statuses_to_include ) && isset( $partial['status'] ) ) {
 							$should_include_transaction = in_array( $partial['status'], $transaction_statuses_to_include, true );

--- a/projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php
@@ -9,6 +9,8 @@
  * Date: 01/11/16
  */
 
+// phpcs:disable
+
 defined( 'ZEROBSCRM_PATH' ) || exit( 0 );
 
 // takes inv meta and works out if due
@@ -1896,3 +1898,4 @@ function zeroBSCRM_invoicing_generateInvPart_tableHeaders( $zbs_invoice_hours_or
 	$table_headers .= '</tr>';
 	return $table_headers;
 }
+// phpcs:enable

--- a/projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php
@@ -739,6 +739,252 @@ function zeroBSCRM_invoicing_generateStatementHTML_v3( $contact_id = -1, $return
 	return false;
 }
 
+/* ======================================================
+    ZBS Invoicing - COMPANY STATEMENT FUNCTIONS
+   ====================================================== */
+
+#} this generates a PDF statement for a company, either returning the filepath or a PDF download prompt
+function zeroBSCRM_invoicing_generateCompanyStatementPDF( $companyID = -1, $returnPDF = false ){
+
+	if ( ! zeroBSCRM_permsInvoices() ) {
+		exit( 0 );
+	}
+
+	global $zbs;
+
+    #} Check ID
+    $companyID = (int)$companyID;
+    #} If user has no perms, or id not present, die
+    if (!zeroBSCRM_permsInvoices() || empty($companyID) || $companyID <= 0){
+		die( 0 );
+    }
+
+    $html = zeroBSCRM_invoicing_generateCompanyStatementHTML($companyID);
+    
+    // check if HTML generation worked
+    if ( empty( $html ) ) {
+        return false;
+    }
+
+    // build PDF
+    $dompdf = $zbs->pdf_engine();
+    $dompdf->loadHtml($html,'UTF-8');
+    $dompdf->render();
+
+    // target dir
+    $upload_dir = wp_upload_dir();
+    $zbsInvoicingDir = $upload_dir['basedir'].'/invoices/';
+
+    if ( ! file_exists( $zbsInvoicingDir ) ) {
+        wp_mkdir_p( $zbsInvoicingDir );
+    }
+    // got it?
+    if ( ! file_exists( $zbsInvoicingDir ) ) {
+        return false;
+    }
+
+    // make a hash
+    // here we've tried to protect against someone overriding the security,
+    // but if they're inside... it's too late anyhow.
+    $hash = wp_generate_password(14, false);
+    if (empty($hash) || strlen($hash) < 14) $hash = md5(time().'xcsac'); // backup 
+    
+    $statementFilename = $zbsInvoicingDir.$hash.'-'.__('company-statement','zero-bs-crm').'-'.$companyID.'.pdf';
+
+    //save the pdf file on the server
+    file_put_contents($statementFilename, $dompdf->output());  
+
+    if (file_exists( $statementFilename )) {
+
+        // if return pdf, return, otherwise return filepath
+        if ($returnPDF){
+
+            //print the pdf file to the screen for saving
+            header('Content-type: application/pdf');
+            header('Content-Disposition: attachment; filename="company-statement-'.$companyID.'.pdf"');
+            header('Content-Transfer-Encoding: binary');
+            header('Content-Length: ' . filesize($statementFilename));
+            header('Accept-Ranges: bytes');
+            readfile($statementFilename);
+
+            //delete the PDF file once it's been read (i.e. downloaded)
+            unlink($statementFilename); 
+
+        } else {
+
+            return $statementFilename;
+
+        }
+
+
+    } // if file
+
+    return false;
+}
+
+/**
+ * Generates the HTML of a company statement based on the template in templates/invoices/statement-pdf.html
+ * if $return, it'll return, otherwise it'll echo + exit
+ **/
+function zeroBSCRM_invoicing_generateCompanyStatementHTML( $company_id = -1, $return = true ) {
+
+	if ( ! empty( $company_id ) && $company_id > 0 ) {
+
+		// Discern template and retrieve
+		$global_statement_pdf_template = zeroBSCRM_getSetting( 'statement_pdf_template' );
+		if ( ! empty( $global_statement_pdf_template ) ) {
+			$templated_html = jpcrm_retrieve_template( $global_statement_pdf_template, false );
+		}
+
+		// fallback to default template  
+		if ( ! isset( $templated_html ) || empty( $templated_html ) ) {
+			// template failed as setting potentially holds out of date (removed) template
+			// so use the default (same as contact version)
+			$templated_html = jpcrm_retrieve_template( 'invoices/statement-pdf.html', false );
+		}
+
+		// If still empty, let's try a different approach
+		if ( empty( $templated_html ) ) {
+			$template_path = ZEROBSCRM_PATH . 'templates/invoices/statement-pdf.html';
+			if ( file_exists( $template_path ) ) {
+				$templated_html = file_get_contents( $template_path );
+			}
+		}
+		return zeroBSCRM_invoicing_generateCompanyStatementHTML_v3( $company_id, $return, $templated_html );
+
+	}
+
+	return false;
+}
+
+function zeroBSCRM_invoicing_generateCompanyStatementHTML_v3( $company_id = -1, $return = true, $templated_html = '' ) {
+
+	if ( $company_id > 0 && $templated_html !== '' ) {
+
+		global $zbs;
+
+		// load templating
+		$placeholder_templating = $zbs->get_templating();
+
+		// Get company statement data
+		$statement_data = jpcrm_get_company_statement_data( $company_id );
+		if ( ! $statement_data ) {
+			return '';
+		}
+
+		// Globals
+		$statement_extra = zeroBSCRM_getSetting( 'statementextra' );
+		$logo_url        = zeroBSCRM_getSetting( 'invoicelogourl' );
+		$biz_name        = zeroBSCRM_getSetting( 'businessname' );
+
+		$statement_table = '';
+
+		// logo header
+		if ( ! empty( $logo_url ) ) {
+			$statement_table .= sprintf(
+				"<div class='header-image'><img src='%s' alt='%s'></div>",
+				esc_url( $logo_url ),
+				esc_attr( $biz_name )
+			);
+		}
+
+		// title
+		$statement_table .= sprintf(
+			'<div class="div-table" role="table" aria-label="Statement Details">
+				<div class="div-table-row-group">
+					<div class="div-table-row">
+						<div class="div-table-cell">
+							<h2 style="margin: 0; font-size: 24px;">%s</h2>
+						</div>
+					</div>
+				</div>
+			</div>',
+			esc_html__( 'STATEMENT', 'zero-bs-crm' )
+		);
+
+		// company and business info
+		$statement_table .= '<div class="div-table" style="margin-bottom: 20px;">
+			<div class="div-table-row-group">
+				<div class="div-table-row">
+					<div class="div-table-cell" style="border: none; width: 50%;">
+						<h4>' . esc_html( $statement_data['company']['name'] ) . '</h4>';
+
+		if ( ! empty( $statement_data['company']['address'] ) ) {
+			$statement_table .= '<div>' . wp_kses_post( implode( '<br>', $statement_data['company']['address'] ) ) . '</div>';
+		}
+
+		$statement_table .= '</div>
+					<div class="div-table-cell right" style="border: none; width: 50%;">
+						<h4>' . esc_html( $statement_data['business']['name'] ) . '</h4>';
+
+		if ( ! empty( $statement_data['business']['address'] ) ) {
+			$statement_table .= '<div>' . wp_kses_post( implode( '<br>', $statement_data['business']['address'] ) ) . '</div>';
+		}
+
+		$statement_table .= '<div style="margin-top: 10px;"><strong>' . esc_html__( 'Statement Date', 'zero-bs-crm' ) . ':</strong> ' . esc_html( $statement_data['statement_date'] ) . '</div>
+					</div>
+				</div>
+			</div>
+		</div>';
+
+		// statement items table
+		if ( ! empty( $statement_data['items'] ) ) {
+			$statement_table .= '<div class="div-table" style="margin-bottom: 20px;">
+				<div class="div-table-head">
+					<div class="div-table-row">
+						<div class="div-table-heading">' . esc_html__( 'Date', 'zero-bs-crm' ) . '</div>
+						<div class="div-table-heading">' . esc_html__( 'Reference', 'zero-bs-crm' ) . '</div>
+						<div class="div-table-heading">' . esc_html__( 'Due Date', 'zero-bs-crm' ) . '</div>
+						<div class="div-table-heading right">' . esc_html__( 'Amount', 'zero-bs-crm' ) . '</div>
+						<div class="div-table-heading right">' . esc_html__( 'Payments', 'zero-bs-crm' ) . '</div>
+						<div class="div-table-heading right">' . esc_html__( 'Balance', 'zero-bs-crm' ) . '</div>
+					</div>
+				</div>
+				<div class="div-table-row-group">';
+
+			foreach ( $statement_data['items'] as $item ) {
+				$statement_table .= '<div class="div-table-row">
+					<div class="div-table-cell">' . esc_html( $item['date'] ) . '</div>
+					<div class="div-table-cell">' . esc_html( $item['reference'] ) . '</div>
+					<div class="div-table-cell">' . esc_html( $item['due_date'] ) . '</div>
+					<div class="div-table-cell right">' . zeroBSCRM_formatCurrency( $item['amount'] ) . '</div>
+					<div class="div-table-cell right">' . zeroBSCRM_formatCurrency( $item['payments'] ) . '</div>
+					<div class="div-table-cell right">' . zeroBSCRM_formatCurrency( $item['balance'] ) . '</div>
+				</div>';
+			}
+
+			$statement_table .= '</div>
+			</div>';
+
+			// Total balance due
+			$statement_table .= '<div class="div-footer">
+				<div class="div-footer-cell right">
+					<h3 style="margin: 0;">' . esc_html__( 'BALANCE DUE', 'zero-bs-crm' ) . ': ' . zeroBSCRM_formatCurrency( $statement_data['total_balance_due'] ) . '</h3>
+				</div>
+			</div>';
+		}
+
+		// statement extra (if any)
+		if ( ! empty( $statement_extra ) ) {
+			$statement_table .= '<div style="margin-top: 20px; font-size: 12px;">' . wp_kses_post( $statement_extra ) . '</div>';
+		}
+
+		// main content build using templating engine like the contact version
+		$html = $placeholder_templating->replace_single_placeholder( 'invoice-statement-html', $statement_table, $templated_html );
+
+		// return
+		if ( ! $return ) {
+			echo $html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			exit( 0 );
+		}
+
+		return $html;
+
+	} // /if anything
+
+	return false;
+}
+
 // phpcs:ignore Squiz.Commenting.FunctionComment.MissingParamTag,Generic.Commenting.DocComment.MissingShort
 /**
  *

--- a/projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php
@@ -620,11 +620,23 @@ function zeroBSCRM_invoicing_generateStatementHTML_v3( $contact_id = -1, $return
 
 				} elseif ( is_array( $partials ) ) {
 
+					// Get transaction statuses that should be included in total value
+					// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+					$transaction_statuses_to_include = $zbs->DAL->transactions->getTransactionStatusesToInclude();
+
 					foreach ( $partials as $partial ) {
 
-						// ignore if status_bool (non-completed status)
+						// Check if this transaction status should be included
+						$should_include_transaction = false;
+						if ( $transaction_statuses_to_include === 'all' ) {
+							$should_include_transaction = true;
+						} elseif ( is_array( $transaction_statuses_to_include ) && isset( $partial['status'] ) ) {
+							$should_include_transaction = in_array( $partial['status'], $transaction_statuses_to_include, true );
+						}
+
+						// ignore if status_bool (non-completed status) or if transaction status not included
 						$partial['status_bool'] = (int) $partial['status_bool'];
-						if ( isset( $partial ) && $partial['status_bool'] == 1 && isset( $partial['total'] ) && $partial['total'] > 0 ) { // phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual
+						if ( isset( $partial ) && $partial['status_bool'] == 1 && isset( $partial['total'] ) && $partial['total'] > 0 && $should_include_transaction ) { // phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual
 
 							// v3.0+ has + or - partials. Account for that:
 							if ( $partial['type_accounting'] === 'credit' ) {

--- a/projects/plugins/crm/includes/jpcrm-mail-templating.php
+++ b/projects/plugins/crm/includes/jpcrm-mail-templating.php
@@ -9,6 +9,8 @@
  * Date: 09/01/2017
  */
 
+ // phpcs:disable
+
 defined( 'ZEROBSCRM_PATH' ) || exit( 0 );
 
 

--- a/projects/plugins/crm/includes/jpcrm-mail-templating.php
+++ b/projects/plugins/crm/includes/jpcrm-mail-templating.php
@@ -689,6 +689,75 @@ function zeroBSCRM_statement_generateNotificationHTML( $contact_id = -1, $return
 	// FAIL
 	return;
 }
+
+// generates company statement email html based on template in sys mail
+function zeroBSCRM_company_statement_generateNotificationHTML( $company_id = -1, $return = true ) {
+
+	global $zbs;
+
+	if ( !empty( $company_id ) ) {
+		$company = $zbs->DAL->companies->getCompany( $company_id );
+
+		$pWrap = '<p style="font-family:sans-serif;font-size:14px;font-weight:normal;margin:0;Margin-bottom:15px;">';
+
+		// load templater
+		$placeholder_templating = $zbs->get_templating();
+
+		// Get templated notify email
+
+		// body template
+		$mailTemplate = zeroBSCRM_mailTemplate_get( ZBSEMAIL_STATEMENT );
+		$bodyHTML = $mailTemplate->zbsmail_body;
+
+		// html template
+		$html = jpcrm_retrieve_template( 'emails/default-email.html', false );
+		$html = $placeholder_templating->replace_single_placeholder( 'msg-content', $bodyHTML, $html );
+
+		// Act
+		if ( !empty( $html ) ) {
+
+			// the business info from the settings
+			$zbs_biz_name = zeroBSCRM_getSetting( 'businessname' );
+			$zbs_biz_yourname = zeroBSCRM_getSetting( 'businessyourname' );
+			$zbs_biz_extra = zeroBSCRM_getSetting( 'businessextra' );
+
+			// For now, use this, ripped from invoices:
+			// (We need to centralise)
+			$bizInfoTable = '<table class="table zbs-table" style="width:100%;">';
+			$bizInfoTable .= '<tbody>';
+			$bizInfoTable .= '<tr><td style="font-family:sans-serif;font-size:14px;vertical-align:top;padding-bottom:5px;"><strong>' . $zbs_biz_name . '</strong></td></tr>';
+			$bizInfoTable .= '<tr><td style="font-family:sans-serif;font-size:14px;vertical-align:top;padding-bottom:5px;">' . $zbs_biz_yourname . '</td></tr>';
+			$bizInfoTable .= '<tr><td style="font-family:sans-serif;font-size:14px;vertical-align:top;padding-bottom:5px;">' . $zbs_biz_extra . '</td></tr>';
+			$bizInfoTable .= '</tbody>';
+			$bizInfoTable .= '</table>';
+
+					// get generics
+			$replacements = $placeholder_templating->get_generic_replacements();
+
+			// view in portal?
+			$replacements['title'] = __( 'Statement', 'zero-bs-crm' );
+			$replacements['biz-info'] = $bizInfoTable;
+
+			// replacements
+			$html = $placeholder_templating->replace_placeholders( array( 'global', 'company' ), $html, $replacements, array( ZBS_TYPE_COMPANY => $company ) );
+
+			// return
+			if ( !$return ) {
+
+				echo $html;
+				exit( 0 );
+
+			}
+
+		}
+
+		return $html;
+
+	}
+	// FAIL
+	return;
+}
+
 /* ======================================================
 	/ ZBS Invoices - Generate HTML (notification email)
    ====================================================== */

--- a/projects/plugins/crm/includes/jpcrm-statement-tab.php
+++ b/projects/plugins/crm/includes/jpcrm-statement-tab.php
@@ -244,6 +244,8 @@ function jpcrm_render_statement_html( $statement_data ) {
 
 /**
  * AJAX handler for downloading statement
+ *
+ * @return never Function exits via wp_die/exit and never returns.
  */
 function jpcrm_ajax_download_statement() {
 
@@ -381,7 +383,7 @@ function jpcrm_get_statement_data( $contact_id ) {
 			}
 
 			$statement_items[] = array(
-				'date'      => isset( $invoice['date_date'] ) ? $invoice['date_date'] : '',
+				'date'      => $invoice['date_date'] ?? '',
 				'reference' => isset( $invoice['id_override'] ) && ! empty( $invoice['id_override'] ) ? $invoice['id_override'] : $invoice['id'],
 				'due_date'  => isset( $invoice['due_date'] ) && $invoice['due_date'] > 0 ? $invoice['due_date_date'] : __( 'No due date', 'zero-bs-crm' ),
 				'amount'    => $total,
@@ -499,7 +501,7 @@ function jpcrm_render_company_statement_tab_content( $company_id = -1, $company 
 						<a href="<?php echo esc_url( admin_url( 'admin-ajax.php?action=zbs_download_company_statement&cid=' . $company_id . '&sec=' . wp_create_nonce( 'zbs-download-company-statement' ) ) ); ?>" class="ui button" target="_blank">
 							<i class="download icon"></i> <?php esc_html_e( 'Download PDF', 'zero-bs-crm' ); ?>
 						</a>
-						<button class="ui button primary" onclick="zbsSendCompanyStatement(<?php echo esc_js( $company_id ); ?>, '<?php echo esc_js( $company_email ); ?>')">
+						<button class="ui button primary" onclick="zbsSendCompanyStatement(<?php echo (int) $company_id; ?>, '<?php echo esc_js( $company_email ); ?>')">
 							<i class="mail icon"></i> <?php esc_html_e( 'Email Statement', 'zero-bs-crm' ); ?>
 						</button>
 					</div>
@@ -597,8 +599,7 @@ function jpcrm_render_company_statement_html( $statement_data ) {
 	if ( ! empty( $statement_data['company']['address'] ) ) {
 		$html .= '<p>' . wp_kses_post( implode( '<br>', $statement_data['company']['address'] ) ) . '</p>';
 	}
-	$html .= '</div>';
-	$html .= '</div>';
+	$html .= '</div></div>';
 	$html .= '<div class="column">';
 	$html .= '<div class="ui segment">';
 	if ( ! empty( $statement_data['business']['name'] ) ) {
@@ -608,9 +609,7 @@ function jpcrm_render_company_statement_html( $statement_data ) {
 		$html .= '<p>' . wp_kses_post( implode( '<br>', $statement_data['business']['address'] ) ) . '</p>';
 	}
 	$html .= '<p><strong>' . esc_html__( 'Statement Date', 'zero-bs-crm' ) . ':</strong> ' . esc_html( $statement_data['statement_date'] ) . '</p>';
-	$html .= '</div>';
-	$html .= '</div>';
-	$html .= '</div>';
+	$html .= '</div></div></div>';
 
 	// Statement table.
 	if ( ! empty( $statement_data['items'] ) ) {
@@ -646,9 +645,7 @@ function jpcrm_render_company_statement_html( $statement_data ) {
 		$html .= '<div class="ui grid">';
 		$html .= '<div class="sixteen wide column right aligned">';
 		$html .= '<h3 class="ui header">' . esc_html__( 'BALANCE DUE', 'zero-bs-crm' ) . ': ' . zeroBSCRM_formatCurrency( $statement_data['total_balance_due'] ) . '</h3>';
-		$html .= '</div>';
-		$html .= '</div>';
-		$html .= '</div>';
+		$html .= '</div></div></div>';
 	}
 
 	return $html;
@@ -656,6 +653,8 @@ function jpcrm_render_company_statement_html( $statement_data ) {
 
 /**
  * AJAX handler for downloading company statement
+ *
+ * @return never
  */
 function jpcrm_ajax_download_company_statement() {
 
@@ -793,7 +792,7 @@ function jpcrm_get_company_statement_data( $company_id ) {
 			}
 
 			$statement_items[] = array(
-				'date'      => isset( $invoice['date_date'] ) ? $invoice['date_date'] : '',
+				'date'      => $invoice['date_date'] ?? '',
 				'reference' => isset( $invoice['id_override'] ) && ! empty( $invoice['id_override'] ) ? $invoice['id_override'] : $invoice['id'],
 				'due_date'  => isset( $invoice['due_date'] ) && $invoice['due_date'] > 0 ? $invoice['due_date_date'] : __( 'No due date', 'zero-bs-crm' ),
 				'amount'    => $total,

--- a/projects/plugins/crm/includes/jpcrm-statement-tab.php
+++ b/projects/plugins/crm/includes/jpcrm-statement-tab.php
@@ -92,7 +92,7 @@ function jpcrm_render_statement_tab_content( $contact_id = -1, $contact = array(
 						<a href="<?php echo esc_url( admin_url( 'admin-ajax.php?action=zbs_download_statement&cid=' . $contact_id . '&sec=' . wp_create_nonce( 'zbs-download-statement' ) ) ); ?>" class="ui button" target="_blank">
 							<i class="download icon"></i> <?php esc_html_e( 'Download PDF', 'zero-bs-crm' ); ?>
 						</a>
-						<button class="ui button primary" onclick="zbsSendStatement(<?php echo esc_js( $contact_id ); ?>, '<?php echo esc_js( $contact_email ); ?>')">
+						<button class="ui button primary" onclick="zbsSendStatement(<?php echo (int) $contact_id; ?>, '<?php echo esc_js( $contact_email ); ?>')">
 							<i class="mail icon"></i> <?php esc_html_e( 'Email Statement', 'zero-bs-crm' ); ?>
 						</button>
 					</div>
@@ -190,8 +190,7 @@ function jpcrm_render_statement_html( $statement_data ) {
 	if ( ! empty( $statement_data['contact']['address'] ) ) {
 		$html .= '<p>' . wp_kses_post( implode( '<br>', $statement_data['contact']['address'] ) ) . '</p>';
 	}
-	$html .= '</div>';
-	$html .= '</div>';
+	$html .= '</div></div>';
 	$html .= '<div class="column">';
 	$html .= '<div class="ui segment">';
 	if ( ! empty( $statement_data['business']['name'] ) ) {
@@ -201,9 +200,7 @@ function jpcrm_render_statement_html( $statement_data ) {
 		$html .= '<p>' . wp_kses_post( implode( '<br>', $statement_data['business']['address'] ) ) . '</p>';
 	}
 	$html .= '<p><strong>' . esc_html__( 'Statement Date', 'zero-bs-crm' ) . ':</strong> ' . esc_html( $statement_data['statement_date'] ) . '</p>';
-	$html .= '</div>';
-	$html .= '</div>';
-	$html .= '</div>';
+	$html .= '</div></div></div>';
 
 	// Statement table.
 	if ( ! empty( $statement_data['items'] ) ) {
@@ -239,9 +236,7 @@ function jpcrm_render_statement_html( $statement_data ) {
 		$html .= '<div class="ui grid">';
 		$html .= '<div class="sixteen wide column right aligned">';
 		$html .= '<h3 class="ui header">' . esc_html__( 'BALANCE DUE', 'zero-bs-crm' ) . ': ' . zeroBSCRM_formatCurrency( $statement_data['total_balance_due'] ) . '</h3>';
-		$html .= '</div>';
-		$html .= '</div>';
-		$html .= '</div>';
+		$html .= '</div></div></div>';
 	}
 
 	return $html;

--- a/projects/plugins/crm/includes/jpcrm-statement-tab.php
+++ b/projects/plugins/crm/includes/jpcrm-statement-tab.php
@@ -1,0 +1,418 @@
+<?php
+/**
+ * Jetpack CRM
+ * https://jetpackcrm.com
+ *
+ * Statement Tab functionality for contacts
+ *
+ * @package ZeroBSCRM
+ */
+
+// stop direct access
+if ( ! defined( 'ZEROBSCRM_PATH' ) ) {
+	exit( 0 );
+}
+
+/**
+ * Add statement tab to contact vital tabs
+ *
+ * @param array $tabs Array of tabs.
+ * @param int   $contact_id Contact ID.
+ * @param array $contact Contact data.
+ * @return array Modified tabs array.
+ */
+function jpcrm_add_statement_tab_to_contact( $tabs = array(), $contact_id = -1, $contact = array() ) {
+
+	global $zbs;
+
+	// Only add if invoices module is active and contact has invoices
+	$feat_invs = zeroBSCRM_getSetting( 'feat_invs' );
+	// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+	$has_invoice = $zbs->DAL->contacts->contactHasInvoice( $contact_id );
+
+	if ( ( $feat_invs === '1' || $feat_invs === 1 ) && $has_invoice ) {
+
+		$tabs[] = array(
+			'id'      => 'statement',
+			'name'    => __( 'Invoice Statement', 'zero-bs-crm' ),
+			'content' => jpcrm_render_statement_tab_content( $contact_id, $contact ),
+		);
+
+	}
+
+	return $tabs;
+}
+add_filter( 'jetpack-crm-contact-vital-tabs', 'jpcrm_add_statement_tab_to_contact', 10, 3 );
+
+/**
+ * Render the statement tab content
+ *
+ * @param int   $contact_id Contact ID.
+ * @param array $contact Contact data.
+ * @return string HTML content.
+ */
+function jpcrm_render_statement_tab_content( $contact_id = -1, $contact = array() ) {
+
+	if ( $contact_id <= 0 ) {
+		return '';
+	}
+
+	// Get contact email for sending
+	$contact_email = '';
+	if ( isset( $contact['email'] ) ) {
+		$contact_email = $contact['email'];
+	} else {
+		$contact_email = zeroBS_customerEmail( $contact_id );
+	}
+
+	// Get statement data
+	$statement_data = jpcrm_get_statement_data( $contact_id );
+
+	ob_start();
+	?>
+	<div class="zbs-statement-tab-content">
+		
+		<?php if ( $statement_data && ! empty( $statement_data['items'] ) ) : ?>
+			
+			<!-- Statement Preview -->
+			<div class="ui segment">
+				<h3><?php esc_html_e( 'Invoice Statement', 'zero-bs-crm' ); ?></h3>
+				<p><?php esc_html_e( 'Preview of the statement that would be sent to the contact.', 'zero-bs-crm' ); ?></p>
+			</div>
+			
+			<!-- Statement Content -->
+			<div class="ui segment">
+				<?php echo wp_kses_post( jpcrm_render_statement_html( $statement_data ) ); ?>
+			</div>
+
+			<!-- Statement Actions -->
+			<div class="ui segment">
+				<div class="ui center aligned basic segment">
+					<div class="ui buttons">
+						<a href="<?php echo esc_url( admin_url( 'admin-ajax.php?action=zbs_download_statement&cid=' . $contact_id . '&sec=' . wp_create_nonce( 'zbs-download-statement' ) ) ); ?>" class="ui button" target="_blank">
+							<i class="download icon"></i> <?php esc_html_e( 'Download PDF', 'zero-bs-crm' ); ?>
+						</a>
+						<button class="ui button primary" onclick="zbsSendStatement(<?php echo esc_js( $contact_id ); ?>, '<?php echo esc_js( $contact_email ); ?>')">
+							<i class="mail icon"></i> <?php esc_html_e( 'Email Statement', 'zero-bs-crm' ); ?>
+						</button>
+					</div>
+				</div>
+			</div>
+
+		<?php else : ?>
+			
+			<!-- No Invoices Message -->
+			<div class="ui segment">
+				<div class="ui info message">
+					<i class="info circle icon"></i>
+					<?php esc_html_e( 'No invoices found for this contact.', 'zero-bs-crm' ); ?>
+				</div>
+			</div>
+
+		<?php endif; ?>
+
+	</div>
+
+	<script type="text/javascript">
+	function zbsSendStatement(cid, email) {
+		// Use the existing send statement modal
+		swal({
+			title: '<i class="envelope outline icon"></i> ' + zeroBSCRMJS_globViewLang('sendstatement'),
+			html: '<div style="font-size: 1.2em;padding: 0.3em;">' +
+				zeroBSCRMJS_globViewLang('sendstatementaddr') +
+				'<br /><div class="ui input"><input type="text" name="zbs-send-pdf-statement-to-email" id="zbs-send-pdf-statement-to-email" value="' +
+				email +
+				'" placeholder="' +
+				zeroBSCRMJS_globViewLang('enteremail') +
+				'" readonly style="background-color: #f9f9f9; color: #666;" /></div></div>',
+			type: '',
+			showCancelButton: true,
+			confirmButtonColor: '#000',
+			cancelButtonColor: '#fff',
+			cancelButtonText: '<span style="color: #000">' + zeroBSCRMJS_globViewLang('cancel') + '</span>',
+			confirmButtonText: zeroBSCRMJS_globViewLang('send'),
+		}).then(function(result) {
+			if (result.value) {
+				var data = {
+					action: 'zbs_invoice_send_statement',
+					sec: window.zbs_root.zbsnonce,
+					cid: cid,
+					em: email,
+				};
+				jQuery.ajax({
+					type: 'POST',
+					url: ajaxurl,
+					data: data,
+					dataType: 'json',
+					timeout: 20000,
+					success: function() {
+						swal(
+							zeroBSCRMJS_globViewLang('sent'),
+							zeroBSCRMJS_globViewLang('statementsent'),
+							'success'
+						);
+					},
+					error: function() {
+						swal(
+							zeroBSCRMJS_globViewLang('notsent'),
+							zeroBSCRMJS_globViewLang('statementnotsent'),
+							'warning'
+						);
+					},
+				});
+			}
+		});
+	}
+	</script>
+	<?php
+	return ob_get_clean();
+}
+
+/**
+ * Render statement HTML
+ *
+ * @param array $statement_data Statement data array.
+ * @return string HTML output.
+ */
+function jpcrm_render_statement_html( $statement_data ) {
+
+	$html = '';
+
+	// Header
+	$html .= '<div class="ui two column stackable grid">';
+	$html .= '<div class="column">';
+	$html .= '<div class="ui segment">';
+	$html .= '<h4 class="ui header">' . esc_html( $statement_data['contact']['name'] ) . '</h4>';
+	if ( ! empty( $statement_data['contact']['address'] ) ) {
+		$html .= '<p>' . wp_kses_post( implode( '<br>', $statement_data['contact']['address'] ) ) . '</p>';
+	}
+	$html .= '</div>';
+	$html .= '</div>';
+	$html .= '<div class="column">';
+	$html .= '<div class="ui segment">';
+	$html .= '<h4 class="ui header">' . esc_html( $statement_data['business']['name'] ) . '</h4>';
+	if ( ! empty( $statement_data['business']['address'] ) ) {
+		$html .= '<p>' . wp_kses_post( implode( '<br>', $statement_data['business']['address'] ) ) . '</p>';
+	}
+	$html .= '<p><strong>' . esc_html__( 'Statement Date', 'zero-bs-crm' ) . ':</strong> ' . esc_html( $statement_data['statement_date'] ) . '</p>';
+	$html .= '</div>';
+	$html .= '</div>';
+	$html .= '</div>';
+
+	// Statement table
+	if ( ! empty( $statement_data['items'] ) ) {
+		$html .= '<div class="ui segment">';
+		$html .= '<table class="ui celled table">';
+		$html .= '<thead><tr>';
+		$html .= '<th>' . esc_html__( 'Date', 'zero-bs-crm' ) . '</th>';
+		$html .= '<th>' . esc_html__( 'Reference', 'zero-bs-crm' ) . '</th>';
+		$html .= '<th>' . esc_html__( 'Due Date', 'zero-bs-crm' ) . '</th>';
+		$html .= '<th class="right aligned">' . esc_html__( 'Amount', 'zero-bs-crm' ) . '</th>';
+		$html .= '<th class="right aligned">' . esc_html__( 'Payments', 'zero-bs-crm' ) . '</th>';
+		$html .= '<th class="right aligned">' . esc_html__( 'Balance', 'zero-bs-crm' ) . '</th>';
+		$html .= '</tr></thead>';
+		$html .= '<tbody>';
+
+		foreach ( $statement_data['items'] as $item ) {
+			$html .= '<tr>';
+			$html .= '<td>' . esc_html( $item['date'] ) . '</td>';
+			$html .= '<td>' . esc_html( $item['reference'] ) . '</td>';
+			$html .= '<td>' . esc_html( $item['due_date'] ) . '</td>';
+			$html .= '<td class="right aligned">' . zeroBSCRM_formatCurrency( $item['amount'] ) . '</td>';
+			$html .= '<td class="right aligned">' . zeroBSCRM_formatCurrency( $item['payments'] ) . '</td>';
+			$html .= '<td class="right aligned">' . zeroBSCRM_formatCurrency( $item['balance'] ) . '</td>';
+			$html .= '</tr>';
+		}
+
+		$html .= '</tbody>';
+		$html .= '</table>';
+		$html .= '</div>';
+
+		// Total balance due
+		$html .= '<div class="ui segment">';
+		$html .= '<div class="ui grid">';
+		$html .= '<div class="sixteen wide column right aligned">';
+		$html .= '<h3 class="ui header">' . esc_html__( 'BALANCE DUE', 'zero-bs-crm' ) . ': ' . zeroBSCRM_formatCurrency( $statement_data['total_balance_due'] ) . '</h3>';
+		$html .= '</div>';
+		$html .= '</div>';
+		$html .= '</div>';
+	}
+
+	return $html;
+}
+
+/**
+ * AJAX handler for downloading statement
+ */
+function jpcrm_ajax_download_statement() {
+
+	// Check nonce
+	check_ajax_referer( 'zbs-download-statement', 'sec' );
+
+	// Check permissions
+	if ( ! zeroBSCRM_permsInvoices() ) {
+		wp_die( esc_html__( 'Insufficient permissions', 'zero-bs-crm' ) );
+	}
+
+	$contact_id = isset( $_GET['cid'] ) ? (int) $_GET['cid'] : 0;
+
+	if ( $contact_id <= 0 ) {
+		wp_die( esc_html__( 'Invalid contact ID', 'zero-bs-crm' ) );
+	}
+
+	// Generate and download the statement
+	zeroBSCRM_invoicing_generateStatementPDF( $contact_id, true );
+
+	exit;
+}
+add_action( 'wp_ajax_zbs_download_statement', 'jpcrm_ajax_download_statement' );
+
+/**
+ * Get statement data for a contact
+ *
+ * @param int $contact_id Contact ID.
+ * @return array|false Statement data array or false on failure.
+ */
+function jpcrm_get_statement_data( $contact_id ) {
+
+	global $zbs;
+
+	if ( $contact_id <= 0 ) {
+		return false;
+	}
+
+	// Get contact details
+	// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+	$contact = $zbs->DAL->contacts->getContact(
+		$contact_id,
+		array(
+			'withCustomFields' => true,
+			'withQuotes'       => false,
+			'withInvoices'     => false,
+			'withTransactions' => false,
+			'withLogs'         => false,
+			'withLastLog'      => false,
+			'withTags'         => false,
+			'withCompanies'    => false,
+			'withOwner'        => false,
+			'withValues'       => false,
+		)
+	);
+
+	if ( ! $contact ) {
+		return false;
+	}
+
+	// Get invoices for this contact
+	// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+	$invoices = $zbs->DAL->invoices->getInvoices(
+		array(
+			'assignedContact'  => $contact_id,
+			'assignedCompany'  => false,
+			'withLineItems'    => true,
+			'withCustomFields' => true,
+			'withTransactions' => true,
+			'withTags'         => false,
+			'sortByField'      => 'ID',
+			'sortOrder'        => 'ASC',
+		)
+	);
+
+	// Get business info
+	$business_name    = zeroBSCRM_getSetting( 'businessname' );
+	$business_address = array();
+	$address_fields   = array( 'addr1', 'addr2', 'city', 'county', 'postcode' );
+	foreach ( $address_fields as $field ) {
+		$value = zeroBSCRM_getSetting( 'business' . $field );
+		if ( ! empty( $value ) ) {
+			$business_address[] = $value;
+		}
+	}
+
+	// Process invoices and calculate totals
+	$statement_items   = array();
+	$total_balance_due = 0;
+
+	if ( is_array( $invoices ) ) {
+		foreach ( $invoices as $invoice ) {
+			$total    = isset( $invoice['total'] ) ? (float) $invoice['total'] : 0;
+			$payments = 0;
+			$balance  = $total;
+
+			// Calculate payments based on transaction status settings
+			if ( isset( $invoice['transactions'] ) && is_array( $invoice['transactions'] ) ) {
+				// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+				$transaction_statuses_to_include = $zbs->DAL->transactions->getTransactionStatusesToInclude();
+
+				foreach ( $invoice['transactions'] as $transaction ) {
+					$should_include_transaction = false;
+
+					if ( $transaction_statuses_to_include === 'all' ) {
+						$should_include_transaction = true;
+					} elseif ( is_array( $transaction_statuses_to_include ) && isset( $transaction['status'] ) ) {
+						$should_include_transaction = in_array( $transaction['status'], $transaction_statuses_to_include, true );
+					}
+
+					// Only process transactions that are completed (status_bool = 1) AND have the correct status
+					if ( isset( $transaction['status_bool'] ) && $transaction['status_bool'] === 1 &&
+						isset( $transaction['total'] ) && $transaction['total'] > 0 && $should_include_transaction ) {
+
+						if ( $transaction['type_accounting'] === 'credit' ) {
+							$balance  += $transaction['total'];
+							$payments += $transaction['total'];
+						} else {
+							$balance  -= $transaction['total'];
+							$payments += $transaction['total'];
+						}
+					}
+				}
+			}
+
+			// If invoice is marked as paid, we should still respect transaction status settings
+			// Only override if we have no valid transactions or all transactions are excluded
+			if ( isset( $invoice['status'] ) && $invoice['status'] === 'Paid' ) {
+				// If we have no valid transactions (payments = 0), then assume fully paid
+				if ( $payments === 0 ) {
+					$balance  = 0;
+					$payments = $total;
+				}
+				// Otherwise use the calculated payments and balance from valid transactions
+			}
+
+			$statement_items[] = array(
+				'date'      => isset( $invoice['date_date'] ) ? $invoice['date_date'] : '',
+				'reference' => isset( $invoice['id_override'] ) && ! empty( $invoice['id_override'] ) ? $invoice['id_override'] : $invoice['id'],
+				'due_date'  => isset( $invoice['due_date'] ) && $invoice['due_date'] > 0 ? $invoice['due_date_date'] : __( 'No due date', 'zero-bs-crm' ),
+				'amount'    => $total,
+				'payments'  => $payments,
+				'balance'   => $balance,
+			);
+
+			if ( $balance > 0 ) {
+				$total_balance_due += $balance;
+			}
+		}
+	}
+
+	return array(
+		'contact'           => array(
+			'name'    => trim( $contact['fname'] . ' ' . $contact['lname'] ),
+			'address' => array_filter(
+				array(
+					$contact['addr1'],
+					$contact['addr2'],
+					$contact['city'],
+					$contact['county'],
+					$contact['postcode'],
+				)
+			),
+		),
+		'business'          => array(
+			'name'    => $business_name,
+			'address' => $business_address,
+		),
+		'statement_date'    => zeroBSCRM_locale_utsToDate( time() ),
+		'items'             => $statement_items,
+		'total_balance_due' => $total_balance_due,
+	);
+}

--- a/projects/plugins/crm/includes/jpcrm-statement-tab.php
+++ b/projects/plugins/crm/includes/jpcrm-statement-tab.php
@@ -8,7 +8,7 @@
  * @package ZeroBSCRM
  */
 
-// stop direct access
+// Stop direct access.
 if ( ! defined( 'ZEROBSCRM_PATH' ) ) {
 	exit( 0 );
 }
@@ -25,12 +25,12 @@ function jpcrm_add_statement_tab_to_contact( $tabs = array(), $contact_id = -1, 
 
 	global $zbs;
 
-	// Only add if invoices module is active and contact has invoices
+	// Only add if invoices module is active and contact has invoices.
 	$feat_invs = zeroBSCRM_getSetting( 'feat_invs' );
 	// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 	$has_invoice = $zbs->DAL->contacts->contactHasInvoice( $contact_id );
 
-	if ( ( $feat_invs === '1' || $feat_invs === 1 ) && $has_invoice ) {
+	if ( ( '1' === $feat_invs || 1 === $feat_invs ) && $has_invoice ) {
 
 		$tabs[] = array(
 			'id'      => 'statement',
@@ -57,7 +57,7 @@ function jpcrm_render_statement_tab_content( $contact_id = -1, $contact = array(
 		return '';
 	}
 
-	// Get contact email for sending
+	// Get contact email for sending.
 	$contact_email = '';
 	if ( isset( $contact['email'] ) ) {
 		$contact_email = $contact['email'];
@@ -65,7 +65,7 @@ function jpcrm_render_statement_tab_content( $contact_id = -1, $contact = array(
 		$contact_email = zeroBS_customerEmail( $contact_id );
 	}
 
-	// Get statement data
+	// Get statement data.
 	$statement_data = jpcrm_get_statement_data( $contact_id );
 
 	ob_start();
@@ -124,7 +124,7 @@ function jpcrm_render_statement_tab_content( $contact_id = -1, $contact = array(
 				email +
 				'" placeholder="' +
 				zeroBSCRMJS_globViewLang('enteremail') +
-				'" readonly style="background-color: #f9f9f9; color: #666;" /></div></div>',
+				'" style="width: 100%;" /></div></div>',
 			type: '',
 			showCancelButton: true,
 			confirmButtonColor: '#000',
@@ -133,11 +133,13 @@ function jpcrm_render_statement_tab_content( $contact_id = -1, $contact = array(
 			confirmButtonText: zeroBSCRMJS_globViewLang('send'),
 		}).then(function(result) {
 			if (result.value) {
+				// Get the email from the input field
+				var emailToSend = jQuery('#zbs-send-pdf-statement-to-email').val();
 				var data = {
 					action: 'zbs_invoice_send_statement',
 					sec: window.zbs_root.zbsnonce,
 					cid: cid,
-					em: email,
+					em: emailToSend,
 				};
 				jQuery.ajax({
 					type: 'POST',
@@ -148,7 +150,7 @@ function jpcrm_render_statement_tab_content( $contact_id = -1, $contact = array(
 					success: function() {
 						swal(
 							zeroBSCRMJS_globViewLang('sent'),
-							zeroBSCRMJS_globViewLang('statementsent'),
+							zeroBSCRMJS_globViewLang('statementsent') + ' ' + emailToSend,
 							'success'
 						);
 					},
@@ -178,11 +180,13 @@ function jpcrm_render_statement_html( $statement_data ) {
 
 	$html = '';
 
-	// Header
+	// Header.
 	$html .= '<div class="ui two column stackable grid">';
 	$html .= '<div class="column">';
 	$html .= '<div class="ui segment">';
-	$html .= '<h4 class="ui header">' . esc_html( $statement_data['contact']['name'] ) . '</h4>';
+	if ( ! empty( $statement_data['contact']['name'] ) ) {
+		$html .= '<h4 class="ui header">' . esc_html( $statement_data['contact']['name'] ) . '</h4>';
+	}
 	if ( ! empty( $statement_data['contact']['address'] ) ) {
 		$html .= '<p>' . wp_kses_post( implode( '<br>', $statement_data['contact']['address'] ) ) . '</p>';
 	}
@@ -190,7 +194,9 @@ function jpcrm_render_statement_html( $statement_data ) {
 	$html .= '</div>';
 	$html .= '<div class="column">';
 	$html .= '<div class="ui segment">';
-	$html .= '<h4 class="ui header">' . esc_html( $statement_data['business']['name'] ) . '</h4>';
+	if ( ! empty( $statement_data['business']['name'] ) ) {
+		$html .= '<h4 class="ui header">' . esc_html( $statement_data['business']['name'] ) . '</h4>';
+	}
 	if ( ! empty( $statement_data['business']['address'] ) ) {
 		$html .= '<p>' . wp_kses_post( implode( '<br>', $statement_data['business']['address'] ) ) . '</p>';
 	}
@@ -199,7 +205,7 @@ function jpcrm_render_statement_html( $statement_data ) {
 	$html .= '</div>';
 	$html .= '</div>';
 
-	// Statement table
+	// Statement table.
 	if ( ! empty( $statement_data['items'] ) ) {
 		$html .= '<div class="ui segment">';
 		$html .= '<table class="ui celled table">';
@@ -228,7 +234,7 @@ function jpcrm_render_statement_html( $statement_data ) {
 		$html .= '</table>';
 		$html .= '</div>';
 
-		// Total balance due
+		// Total balance due.
 		$html .= '<div class="ui segment">';
 		$html .= '<div class="ui grid">';
 		$html .= '<div class="sixteen wide column right aligned">';
@@ -246,10 +252,10 @@ function jpcrm_render_statement_html( $statement_data ) {
  */
 function jpcrm_ajax_download_statement() {
 
-	// Check nonce
+	// Check nonce.
 	check_ajax_referer( 'zbs-download-statement', 'sec' );
 
-	// Check permissions
+	// Check permissions.
 	if ( ! zeroBSCRM_permsInvoices() ) {
 		wp_die( esc_html__( 'Insufficient permissions', 'zero-bs-crm' ) );
 	}
@@ -260,7 +266,7 @@ function jpcrm_ajax_download_statement() {
 		wp_die( esc_html__( 'Invalid contact ID', 'zero-bs-crm' ) );
 	}
 
-	// Generate and download the statement
+	// Generate and download the statement.
 	zeroBSCRM_invoicing_generateStatementPDF( $contact_id, true );
 
 	exit;
@@ -281,7 +287,7 @@ function jpcrm_get_statement_data( $contact_id ) {
 		return false;
 	}
 
-	// Get contact details
+	// Get contact details.
 	// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 	$contact = $zbs->DAL->contacts->getContact(
 		$contact_id,
@@ -303,7 +309,7 @@ function jpcrm_get_statement_data( $contact_id ) {
 		return false;
 	}
 
-	// Get invoices for this contact
+	// Get invoices for this contact.
 	// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 	$invoices = $zbs->DAL->invoices->getInvoices(
 		array(
@@ -318,7 +324,7 @@ function jpcrm_get_statement_data( $contact_id ) {
 		)
 	);
 
-	// Get business info
+	// Get business info.
 	$business_name    = zeroBSCRM_getSetting( 'businessname' );
 	$business_address = array();
 	$address_fields   = array( 'addr1', 'addr2', 'city', 'county', 'postcode' );
@@ -329,7 +335,7 @@ function jpcrm_get_statement_data( $contact_id ) {
 		}
 	}
 
-	// Process invoices and calculate totals
+	// Process invoices and calculate totals.
 	$statement_items   = array();
 	$total_balance_due = 0;
 
@@ -339,7 +345,7 @@ function jpcrm_get_statement_data( $contact_id ) {
 			$payments = 0;
 			$balance  = $total;
 
-			// Calculate payments based on transaction status settings
+			// Calculate payments based on transaction status settings.
 			if ( isset( $invoice['transactions'] ) && is_array( $invoice['transactions'] ) ) {
 				// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 				$transaction_statuses_to_include = $zbs->DAL->transactions->getTransactionStatusesToInclude();
@@ -347,17 +353,17 @@ function jpcrm_get_statement_data( $contact_id ) {
 				foreach ( $invoice['transactions'] as $transaction ) {
 					$should_include_transaction = false;
 
-					if ( $transaction_statuses_to_include === 'all' ) {
+					if ( 'all' === $transaction_statuses_to_include ) {
 						$should_include_transaction = true;
 					} elseif ( is_array( $transaction_statuses_to_include ) && isset( $transaction['status'] ) ) {
 						$should_include_transaction = in_array( $transaction['status'], $transaction_statuses_to_include, true );
 					}
 
-					// Only process transactions that are completed (status_bool = 1) AND have the correct status
-					if ( isset( $transaction['status_bool'] ) && $transaction['status_bool'] === 1 &&
-						isset( $transaction['total'] ) && $transaction['total'] > 0 && $should_include_transaction ) {
+					// Only process transactions that are completed (status_bool = 1) AND have the correct status.
+					if ( isset( $transaction['status_bool'] ) && 1 === $transaction['status_bool'] &&
+						isset( $transaction['total'] ) && 0 < $transaction['total'] && $should_include_transaction ) {
 
-						if ( $transaction['type_accounting'] === 'credit' ) {
+						if ( 'credit' === $transaction['type_accounting'] ) {
 							$balance  += $transaction['total'];
 							$payments += $transaction['total'];
 						} else {
@@ -369,14 +375,14 @@ function jpcrm_get_statement_data( $contact_id ) {
 			}
 
 			// If invoice is marked as paid, we should still respect transaction status settings
-			// Only override if we have no valid transactions or all transactions are excluded
-			if ( isset( $invoice['status'] ) && $invoice['status'] === 'Paid' ) {
-				// If we have no valid transactions (payments = 0), then assume fully paid
-				if ( $payments === 0 ) {
+			// Only override if we have no valid transactions or all transactions are excluded.
+			if ( isset( $invoice['status'] ) && 'Paid' === $invoice['status'] ) {
+				// If we have no valid transactions (payments = 0), then assume fully paid.
+				if ( 0 === $payments ) {
 					$balance  = 0;
 					$payments = $total;
 				}
-				// Otherwise use the calculated payments and balance from valid transactions
+				// Otherwise use the calculated payments and balance from valid transactions.
 			}
 
 			$statement_items[] = array(
@@ -404,6 +410,418 @@ function jpcrm_get_statement_data( $contact_id ) {
 					$contact['city'],
 					$contact['county'],
 					$contact['postcode'],
+				)
+			),
+		),
+		'business'          => array(
+			'name'    => $business_name,
+			'address' => $business_address,
+		),
+		'statement_date'    => zeroBSCRM_locale_utsToDate( time() ),
+		'items'             => $statement_items,
+		'total_balance_due' => $total_balance_due,
+	);
+}
+
+/**
+ * Add statement tab to company vital tabs
+ *
+ * @param array $tabs Array of tabs.
+ * @param int   $company_id Company ID.
+ * @param array $company Company data.
+ * @return array Modified tabs array.
+ */
+function jpcrm_add_statement_tab_to_company( $tabs = array(), $company_id = -1, $company = array() ) {
+
+	// Only add if invoices module is active and company has invoices.
+	$feat_invs = zeroBSCRM_getSetting( 'feat_invs' );
+
+	// Check if company has invoices by looking at the invoices_count.
+	$has_invoice = false;
+	if ( isset( $company['invoices_count'] ) && 0 < $company['invoices_count'] ) {
+		$has_invoice = true;
+	}
+
+	if ( ( '1' === $feat_invs || 1 === $feat_invs ) && $has_invoice ) {
+
+		$tabs[] = array(
+			'id'      => 'statement',
+			'name'    => __( 'Invoice Statement', 'zero-bs-crm' ),
+			'content' => jpcrm_render_company_statement_tab_content( $company_id, $company ),
+		);
+
+	}
+
+	return $tabs;
+}
+add_filter( 'jetpack-crm-company-vital-tabs', 'jpcrm_add_statement_tab_to_company', 10, 3 );
+
+/**
+ * Render the company statement tab content
+ *
+ * @param int   $company_id Company ID.
+ * @param array $company Company data.
+ * @return string HTML content.
+ */
+function jpcrm_render_company_statement_tab_content( $company_id = -1, $company = array() ) {
+
+	if ( $company_id <= 0 ) {
+		return '';
+	}
+
+	// Get company email for sending.
+	$company_email = '';
+	if ( isset( $company['email'] ) ) {
+		$company_email = $company['email'];
+	} else {
+		$company_email = zeroBS_companyEmail( $company_id );
+	}
+
+	// Get statement data.
+	$statement_data = jpcrm_get_company_statement_data( $company_id );
+
+	ob_start();
+	?>
+	<div class="zbs-statement-tab-content">
+		
+		<?php if ( $statement_data && ! empty( $statement_data['items'] ) ) : ?>
+			
+			<!-- Statement Preview -->
+			<div class="ui segment">
+				<h3><?php esc_html_e( 'Invoice Statement', 'zero-bs-crm' ); ?></h3>
+				<p><?php esc_html_e( 'Preview of the statement that would be sent to the company.', 'zero-bs-crm' ); ?></p>
+			</div>
+			
+			<!-- Statement Content -->
+			<div class="ui segment">
+				<?php echo wp_kses_post( jpcrm_render_company_statement_html( $statement_data ) ); ?>
+			</div>
+
+			<!-- Statement Actions -->
+			<div class="ui segment">
+				<div class="ui center aligned basic segment">
+					<div class="ui buttons">
+						<a href="<?php echo esc_url( admin_url( 'admin-ajax.php?action=zbs_download_company_statement&cid=' . $company_id . '&sec=' . wp_create_nonce( 'zbs-download-company-statement' ) ) ); ?>" class="ui button" target="_blank">
+							<i class="download icon"></i> <?php esc_html_e( 'Download PDF', 'zero-bs-crm' ); ?>
+						</a>
+						<button class="ui button primary" onclick="zbsSendCompanyStatement(<?php echo esc_js( $company_id ); ?>, '<?php echo esc_js( $company_email ); ?>')">
+							<i class="mail icon"></i> <?php esc_html_e( 'Email Statement', 'zero-bs-crm' ); ?>
+						</button>
+					</div>
+				</div>
+			</div>
+
+		<?php else : ?>
+			
+			<!-- No Invoices Message -->
+			<div class="ui segment">
+				<div class="ui info message">
+					<i class="info circle icon"></i>
+					<?php esc_html_e( 'No invoices found for this company.', 'zero-bs-crm' ); ?>
+				</div>
+			</div>
+
+		<?php endif; ?>
+
+	</div>
+
+	<script type="text/javascript">
+	function zbsSendCompanyStatement(cid, email) {
+		// Use the existing send statement modal
+		swal({
+			title: '<i class="envelope outline icon"></i> ' + zeroBSCRMJS_globViewLang('sendstatement'),
+			html: '<div style="font-size: 1.2em;padding: 0.3em;">' +
+				zeroBSCRMJS_globViewLang('sendstatementaddr') +
+				'<br /><div class="ui input"><input type="text" name="zbs-send-pdf-company-statement-to-email" id="zbs-send-pdf-company-statement-to-email" value="' +
+				email +
+				'" placeholder="' +
+				zeroBSCRMJS_globViewLang('enteremail') +
+				'" style="width: 100%;" /></div></div>',
+			type: '',
+			showCancelButton: true,
+			confirmButtonColor: '#000',
+			cancelButtonColor: '#fff',
+			cancelButtonText: '<span style="color: #000">' + zeroBSCRMJS_globViewLang('cancel') + '</span>',
+			confirmButtonText: zeroBSCRMJS_globViewLang('send'),
+		}).then(function(result) {
+			if (result.value) {
+				// Get the email from the input field
+				var emailToSend = jQuery('#zbs-send-pdf-company-statement-to-email').val();
+				var data = {
+					action: 'zbs_company_send_statement',
+					sec: window.zbs_root.zbsnonce,
+					cid: cid,
+					em: emailToSend,
+				};
+				jQuery.ajax({
+					type: 'POST',
+					url: ajaxurl,
+					data: data,
+					dataType: 'json',
+					timeout: 20000,
+					success: function() {
+						swal(
+							zeroBSCRMJS_globViewLang('sent'),
+							zeroBSCRMJS_globViewLang('statementsent') + ' ' + emailToSend,
+							'success'
+						);
+					},
+					error: function() {
+						swal(
+							zeroBSCRMJS_globViewLang('notsent'),
+							zeroBSCRMJS_globViewLang('statementnotsent'),
+							'warning'
+						);
+					},
+				});
+			}
+		});
+	}
+	</script>
+	<?php
+	return ob_get_clean();
+}
+
+/**
+ * Render company statement HTML
+ *
+ * @param array $statement_data Statement data array.
+ * @return string HTML output.
+ */
+function jpcrm_render_company_statement_html( $statement_data ) {
+
+	$html = '';
+
+	// Header.
+	$html .= '<div class="ui two column stackable grid">';
+	$html .= '<div class="column">';
+	$html .= '<div class="ui segment">';
+	if ( ! empty( $statement_data['company']['name'] ) ) {
+		$html .= '<h4 class="ui header">' . esc_html( $statement_data['company']['name'] ) . '</h4>';
+	}
+	if ( ! empty( $statement_data['company']['address'] ) ) {
+		$html .= '<p>' . wp_kses_post( implode( '<br>', $statement_data['company']['address'] ) ) . '</p>';
+	}
+	$html .= '</div>';
+	$html .= '</div>';
+	$html .= '<div class="column">';
+	$html .= '<div class="ui segment">';
+	if ( ! empty( $statement_data['business']['name'] ) ) {
+		$html .= '<h4 class="ui header">' . esc_html( $statement_data['business']['name'] ) . '</h4>';
+	}
+	if ( ! empty( $statement_data['business']['address'] ) ) {
+		$html .= '<p>' . wp_kses_post( implode( '<br>', $statement_data['business']['address'] ) ) . '</p>';
+	}
+	$html .= '<p><strong>' . esc_html__( 'Statement Date', 'zero-bs-crm' ) . ':</strong> ' . esc_html( $statement_data['statement_date'] ) . '</p>';
+	$html .= '</div>';
+	$html .= '</div>';
+	$html .= '</div>';
+
+	// Statement table.
+	if ( ! empty( $statement_data['items'] ) ) {
+		$html .= '<div class="ui segment">';
+		$html .= '<table class="ui celled table">';
+		$html .= '<thead><tr>';
+		$html .= '<th>' . esc_html__( 'Date', 'zero-bs-crm' ) . '</th>';
+		$html .= '<th>' . esc_html__( 'Reference', 'zero-bs-crm' ) . '</th>';
+		$html .= '<th>' . esc_html__( 'Due Date', 'zero-bs-crm' ) . '</th>';
+		$html .= '<th class="right aligned">' . esc_html__( 'Amount', 'zero-bs-crm' ) . '</th>';
+		$html .= '<th class="right aligned">' . esc_html__( 'Payments', 'zero-bs-crm' ) . '</th>';
+		$html .= '<th class="right aligned">' . esc_html__( 'Balance', 'zero-bs-crm' ) . '</th>';
+		$html .= '</tr></thead>';
+		$html .= '<tbody>';
+
+		foreach ( $statement_data['items'] as $item ) {
+			$html .= '<tr>';
+			$html .= '<td>' . esc_html( $item['date'] ) . '</td>';
+			$html .= '<td>' . esc_html( $item['reference'] ) . '</td>';
+			$html .= '<td>' . esc_html( $item['due_date'] ) . '</td>';
+			$html .= '<td class="right aligned">' . zeroBSCRM_formatCurrency( $item['amount'] ) . '</td>';
+			$html .= '<td class="right aligned">' . zeroBSCRM_formatCurrency( $item['payments'] ) . '</td>';
+			$html .= '<td class="right aligned">' . zeroBSCRM_formatCurrency( $item['balance'] ) . '</td>';
+			$html .= '</tr>';
+		}
+
+		$html .= '</tbody>';
+		$html .= '</table>';
+		$html .= '</div>';
+
+		// Total balance due.
+		$html .= '<div class="ui segment">';
+		$html .= '<div class="ui grid">';
+		$html .= '<div class="sixteen wide column right aligned">';
+		$html .= '<h3 class="ui header">' . esc_html__( 'BALANCE DUE', 'zero-bs-crm' ) . ': ' . zeroBSCRM_formatCurrency( $statement_data['total_balance_due'] ) . '</h3>';
+		$html .= '</div>';
+		$html .= '</div>';
+		$html .= '</div>';
+	}
+
+	return $html;
+}
+
+/**
+ * AJAX handler for downloading company statement
+ */
+function jpcrm_ajax_download_company_statement() {
+
+	// Check nonce.
+	check_ajax_referer( 'zbs-download-company-statement', 'sec' );
+
+	// Check permissions.
+	if ( ! zeroBSCRM_permsInvoices() ) {
+		wp_die( esc_html__( 'Insufficient permissions', 'zero-bs-crm' ) );
+	}
+
+	$company_id = isset( $_GET['cid'] ) ? (int) $_GET['cid'] : 0;
+
+	if ( $company_id <= 0 ) {
+		wp_die( esc_html__( 'Invalid company ID', 'zero-bs-crm' ) );
+	}
+
+	// Generate and download the statement.
+	zeroBSCRM_invoicing_generateCompanyStatementPDF( $company_id, true );
+
+	exit;
+}
+add_action( 'wp_ajax_zbs_download_company_statement', 'jpcrm_ajax_download_company_statement' );
+
+/**
+ * Get statement data for a company
+ *
+ * @param int $company_id Company ID.
+ * @return array|false Statement data array or false on failure.
+ */
+function jpcrm_get_company_statement_data( $company_id ) {
+
+	global $zbs;
+
+	if ( $company_id <= 0 ) {
+		return false;
+	}
+
+	// Get company details.
+	// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+	$company = $zbs->DAL->companies->getCompany(
+		$company_id,
+		array(
+			'withCustomFields' => true,
+			'withQuotes'       => false,
+			'withInvoices'     => false,
+			'withTransactions' => false,
+			'withLogs'         => false,
+			'withLastLog'      => false,
+			'withTags'         => false,
+			'withContacts'     => false,
+			'withOwner'        => false,
+			'withValues'       => false,
+		)
+	);
+
+	if ( ! $company ) {
+		return false;
+	}
+
+	// Get invoices for this company.
+	// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+	$invoices = $zbs->DAL->invoices->getInvoices(
+		array(
+			'assignedContact'  => false,
+			'assignedCompany'  => $company_id,
+			'withLineItems'    => true,
+			'withCustomFields' => true,
+			'withTransactions' => true,
+			'withTags'         => false,
+			'sortByField'      => 'ID',
+			'sortOrder'        => 'ASC',
+		)
+	);
+
+	// Get business info.
+	$business_name    = zeroBSCRM_getSetting( 'businessname' );
+	$business_address = array();
+	$address_fields   = array( 'addr1', 'addr2', 'city', 'county', 'postcode' );
+	foreach ( $address_fields as $field ) {
+		$value = zeroBSCRM_getSetting( 'business' . $field );
+		if ( ! empty( $value ) ) {
+			$business_address[] = $value;
+		}
+	}
+
+	// Process invoices and calculate totals.
+	$statement_items   = array();
+	$total_balance_due = 0;
+
+	if ( is_array( $invoices ) ) {
+		foreach ( $invoices as $invoice ) {
+			$total    = isset( $invoice['total'] ) ? (float) $invoice['total'] : 0;
+			$payments = 0;
+			$balance  = $total;
+
+			// Calculate payments based on transaction status settings.
+			if ( isset( $invoice['transactions'] ) && is_array( $invoice['transactions'] ) ) {
+				// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+				$transaction_statuses_to_include = $zbs->DAL->transactions->getTransactionStatusesToInclude();
+
+				foreach ( $invoice['transactions'] as $transaction ) {
+					$should_include_transaction = false;
+
+					if ( 'all' === $transaction_statuses_to_include ) {
+						$should_include_transaction = true;
+					} elseif ( is_array( $transaction_statuses_to_include ) && isset( $transaction['status'] ) ) {
+						$should_include_transaction = in_array( $transaction['status'], $transaction_statuses_to_include, true );
+					}
+
+					// Only process transactions that are completed (status_bool = 1) AND have the correct status.
+					if ( isset( $transaction['status_bool'] ) && 1 === $transaction['status_bool'] &&
+						isset( $transaction['total'] ) && 0 < $transaction['total'] && $should_include_transaction ) {
+
+						if ( 'credit' === $transaction['type_accounting'] ) {
+							$balance  += $transaction['total'];
+							$payments += $transaction['total'];
+						} else {
+							$balance  -= $transaction['total'];
+							$payments += $transaction['total'];
+						}
+					}
+				}
+			}
+
+			// If invoice is marked as paid, we should still respect transaction status settings
+			// Only override if we have no valid transactions or all transactions are excluded.
+			if ( isset( $invoice['status'] ) && 'Paid' === $invoice['status'] ) {
+				// If we have no valid transactions (payments = 0), then assume fully paid.
+				if ( 0 === $payments ) {
+					$balance  = 0;
+					$payments = $total;
+				}
+				// Otherwise use the calculated payments and balance from valid transactions.
+			}
+
+			$statement_items[] = array(
+				'date'      => isset( $invoice['date_date'] ) ? $invoice['date_date'] : '',
+				'reference' => isset( $invoice['id_override'] ) && ! empty( $invoice['id_override'] ) ? $invoice['id_override'] : $invoice['id'],
+				'due_date'  => isset( $invoice['due_date'] ) && $invoice['due_date'] > 0 ? $invoice['due_date_date'] : __( 'No due date', 'zero-bs-crm' ),
+				'amount'    => $total,
+				'payments'  => $payments,
+				'balance'   => $balance,
+			);
+
+			if ( $balance > 0 ) {
+				$total_balance_due += $balance;
+			}
+		}
+	}
+
+	return array(
+		'company'           => array(
+			'name'    => $company['name'],
+			'address' => array_filter(
+				array(
+					$company['addr1'],
+					$company['addr2'],
+					$company['city'],
+					$company['county'],
+					$company['postcode'],
 				)
 			),
 		),

--- a/projects/plugins/crm/js/ZeroBSCRM.admin.singleview.js
+++ b/projects/plugins/crm/js/ZeroBSCRM.admin.singleview.js
@@ -236,6 +236,9 @@ function zeroBSCRMJS_viewCompanyInit() {
 
 	// files
 	zeroBSCRMJS_bindViewFiles();
+
+	// log long desc toggles
+	zeroBSCRMJS_bindActivityStream();
 }
 
 /* ============================================================================================================

--- a/projects/plugins/crm/sass/_ZeroBSCRM.editview.scss
+++ b/projects/plugins/crm/sass/_ZeroBSCRM.editview.scss
@@ -67,40 +67,115 @@
 	.action-button {
 		cursor: pointer;
 		display: inline-block;
-		min-height: 1em;
-		outline: none;
-		border: none;
-		vertical-align: baseline;
-		//background: #E0E1E2 none;
-		font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
-		margin: 0 0.25em 0 0;
-		padding: 0.78571429em 1.5em 0.78571429em;
-		line-height: 1;
-		font-style: normal;
-		text-align: center;
-		text-decoration: none;
-		-webkit-user-select: none;
-		-moz-user-select: none;
-		-ms-user-select: none;
-		user-select: none;
-		transition: opacity 0.1s ease, background-color 0.1s ease, color 0.1s ease, box-shadow 0.1s ease, background 0.1s ease;
-		will-change: "";
-		-webkit-tap-highlight-color: transparent;
-
-		font-size: 1rem;
-
-		//background: transparent none !important;
-		font-weight: 400;
-		border-radius: 0.28571429rem;
-		text-transform: none;
-		text-shadow: none !important;
-
-		box-shadow: 0 0 0 1px #21ba45 inset !important;
-		color: #21ba45 !important;
-
-		background: #fff !important;
 	}
 
+	// Statement tab styles
+	.zbs-statement-tab-content {
+
+		.zbs-statement-preview {
+			margin-bottom: 20px;
+		}
+
+		.zbs-statement-html-preview {
+
+			.ui.segment {
+				max-height: 600px;
+				overflow-y: auto;
+				padding: 20px;
+			}
+		}
+
+		// Statement action buttons - consolidated styles
+		#zbs-statement-actions {
+			margin-top: 1rem;
+
+			.ui.segment {
+				padding: 1rem;
+			}
+
+			.ui.buttons {
+				display: flex;
+				justify-content: center;
+				gap: 1rem;
+				flex-wrap: wrap;
+
+				.ui.button {
+					height: auto;
+					padding: 0.75rem 1rem;
+					font-size: 0.9rem;
+					min-width: 140px;
+					margin: 0.25rem;
+
+					@media (max-width: 768px) {
+						padding: 0.5rem 0.75rem;
+						font-size: 0.8rem;
+						min-width: 120px;
+					}
+				}
+			}
+		}
+
+		// Initial statement actions (before generation)
+		.zbs-statement-actions {
+
+			.ui.segment {
+				text-align: center;
+				padding: 2rem;
+
+				h3 {
+					margin-bottom: 0.5rem;
+				}
+
+				p {
+					margin-bottom: 1.5rem;
+					color: #666;
+				}
+
+				.ui.buttons {
+					justify-content: center;
+
+					.ui.button {
+						min-width: 160px;
+					}
+				}
+			}
+		}
+
+		// General button styles
+		.ui.buttons {
+			display: flex;
+			flex-wrap: wrap;
+			gap: 0.5rem;
+			max-width: 100%;
+
+			.ui.button {
+				flex: 0 1 auto;
+				min-width: 0;
+				max-width: 100%;
+				margin-left: 5px;
+			}
+		}
+
+		// Stackable grid specific fixes
+		.ui.stackable.grid {
+
+			.six.wide.column {
+
+				@media (max-width: 768px) {
+					width: 100% !important;
+
+					.ui.buttons {
+						justify-content: center;
+					}
+				}
+			}
+		}
+
+		// Remove bottom border from all tabs
+		[data-tab] {
+			border-bottom: none !important;
+		}
+	}
 }
 
 // prev: #zerobs-customer-tags-box

--- a/projects/plugins/crm/tests/codeception/acceptance/50_JPCRM_Settings_Cest.php
+++ b/projects/plugins/crm/tests/codeception/acceptance/50_JPCRM_Settings_Cest.php
@@ -280,7 +280,7 @@ class JPCRM_Settings_Cest {
 		$I->see( 'Transactions', 'h1.header' );
 		$I->see( 'Use Shipping' );
 		$I->see( 'Use Paid/Completed Dates' );
-		$I->see( 'Include these statuses in the transaction total value' );
+		$I->see( 'Include these statuses in total values and as payments against invoices' );
 		$I->see( 'Transaction Status' );
 
 		$I->see( 'Additional settings on transactions' );


### PR DESCRIPTION
Proposed changes:

  - Adds Invoice Statement tabs to both contact and company pages that display comprehensive
  statements of all invoices and transactions
  - Creates new statement tab functionality (jpcrm-statement-tab.php) that shows invoice history,
   transaction details, and account balance for both contacts and companies
  - Implements PDF download and email functionality for invoice statements with proper attachment
   handling
  - Adds comprehensive activity logging when statements are sent, including detailed longdesc
  information with expandable view
  - Enhances transaction filtering in invoice statements to respect the "Include Transaction
  Statuses" setting from CRM settings
  - Improves transaction status handling in the transactions DAL for better array processing and
  validation
  - Adds email notification system for both contact and company statements with HTML email
  templates
  - Implements editable email fields in statement sending modals for flexible delivery to people other than the contact
  - Enhances company timeline display to show activity log longdesc with toggle functionality

  Other information:

  - [ ] Have you written new tests for your changes, if applicable?
  - [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
  - [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated
  comment below with a script to run)?

  Jetpack product discussion

  N/A - Enhancement following customer requirements for comprehensive invoice statement
  functionality across both contacts and companies.

  Does this pull request change what data or activity we track or use?

No

  Testing instructions:

  Contact Statement Testing:

  - Go to 'Contacts' in the CRM admin
  - Select a contact that has invoices and transactions
  - Click on the contact to view their details
  - Look for the new "Invoice Statement" tab in the contact tabs
  - Verify the statement shows invoice history, transactions, and account balance
  - Test the "Download PDF" button to ensure it generates a statement PDF
  - Test the "Email Statement" button with editable email field
  - Verify activity log shows statement sent with expandable details

  Company Statement Testing:

  - Go to 'Companies' in the CRM admin
  - Select a company that has invoices and transactions
  - Click on the company to view their details
  - Look for the new "Invoice Statement" tab in the company tabs
  - Verify the statement shows company invoice history and transactions
  - Test PDF download and email functionality for companies
  - Verify company activity timeline shows statement activity with longdesc toggle

  Transaction Status Filter Testing:

  - Go to Settings > Transactions and configure "Include Transaction Statuses" to specific
  statuses
  - Return to contact/company statements and verify only transactions with configured statuses
  are included
  - Test with different status combinations to ensure filtering works correctly

  Email and Activity Log Testing:

  - Send statements to different email addresses using the editable email field
  - Verify each send creates an activity log entry with proper details
  - Test the expandable longdesc functionality in the company activity timelines
  - Confirm email delivery includes proper PDF attachment and formatting

