### PR TITLE
Backport mu-wpcom-plugin 2.10.0 Changes

### DIFF
--- a/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
+++ b/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.10.0 - 2025-08-05
+### Added
+- Add archives endpoint support. [#44028]
+- Settings: Add tracking for launch action. [#43859]
+- Code editors: Add advanced code and CSS editors. [#44232]
+
+### Changed
+- My Jetpack: Unify the user connection flow with a unified screen. [#44469]
+- Sync: Ignore the ActivityPub Outbox CPT [#44222]
+- Update package dependencies. [#43839] [#44206]
+
+### Fixed
+- JITM: Fix ineffective caching due to expired plugin sync transient. [#44117]
+- Update JITMs to remove jQuery dependency. [#43783]
+
 ## 2.9.0 - 2025-06-06
 ### Added
 - Featured Content: Add messaging to clarify that the tag name is case-sensitive. [#43165]

--- a/projects/plugins/mu-wpcom-plugin/changelog/2025-07-08-14-34-03-994861
+++ b/projects/plugins/mu-wpcom-plugin/changelog/2025-07-08-14-34-03-994861
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-sync-activity-pub-cpt
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-sync-activity-pub-cpt
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Sync: Ignore the ActivityPub Outbox CPT

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-tracking-to-launch-setting
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-tracking-to-launch-setting
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-add tracking for site settings launch action

--- a/projects/plugins/mu-wpcom-plugin/changelog/feature-wpcom-code-editor
+++ b/projects/plugins/mu-wpcom-plugin/changelog/feature-wpcom-code-editor
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Code editors: Added advanced code and CSS editors.

--- a/projects/plugins/mu-wpcom-plugin/changelog/prerelease
+++ b/projects/plugins/mu-wpcom-plugin/changelog/prerelease
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/changelog/prerelease#10
+++ b/projects/plugins/mu-wpcom-plugin/changelog/prerelease#10
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/changelog/prerelease#11
+++ b/projects/plugins/mu-wpcom-plugin/changelog/prerelease#11
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/changelog/prerelease#12
+++ b/projects/plugins/mu-wpcom-plugin/changelog/prerelease#12
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/changelog/prerelease#13
+++ b/projects/plugins/mu-wpcom-plugin/changelog/prerelease#13
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/changelog/prerelease#2
+++ b/projects/plugins/mu-wpcom-plugin/changelog/prerelease#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/changelog/prerelease#3
+++ b/projects/plugins/mu-wpcom-plugin/changelog/prerelease#3
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/changelog/prerelease#4
+++ b/projects/plugins/mu-wpcom-plugin/changelog/prerelease#4
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/changelog/prerelease#5
+++ b/projects/plugins/mu-wpcom-plugin/changelog/prerelease#5
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/changelog/prerelease#6
+++ b/projects/plugins/mu-wpcom-plugin/changelog/prerelease#6
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/changelog/prerelease#7
+++ b/projects/plugins/mu-wpcom-plugin/changelog/prerelease#7
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/changelog/prerelease#8
+++ b/projects/plugins/mu-wpcom-plugin/changelog/prerelease#8
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/changelog/prerelease#9
+++ b/projects/plugins/mu-wpcom-plugin/changelog/prerelease#9
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/changelog/reish20250626-update-jitm-cache
+++ b/projects/plugins/mu-wpcom-plugin/changelog/reish20250626-update-jitm-cache
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-JITM: Fix ineffective caching due to expired plugin sync transient

--- a/projects/plugins/mu-wpcom-plugin/changelog/renovate-lock-file-maintenance
+++ b/projects/plugins/mu-wpcom-plugin/changelog/renovate-lock-file-maintenance
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/plugins/mu-wpcom-plugin/changelog/renovate-lock-file-maintenance#2
+++ b/projects/plugins/mu-wpcom-plugin/changelog/renovate-lock-file-maintenance#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/plugins/mu-wpcom-plugin/changelog/try-eslint-package-json-files#2
+++ b/projects/plugins/mu-wpcom-plugin/changelog/try-eslint-package-json-files#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Sort and clean up package.json. Should be no change to functionality.
-
-

--- a/projects/plugins/mu-wpcom-plugin/changelog/update-jitms-remove-jquery
+++ b/projects/plugins/mu-wpcom-plugin/changelog/update-jitms-remove-jquery
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Update JITMs to remove jQuery dependency

--- a/projects/plugins/mu-wpcom-plugin/changelog/update-my-jetpack-unify-user-connection-screen
+++ b/projects/plugins/mu-wpcom-plugin/changelog/update-my-jetpack-unify-user-connection-screen
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-My Jetpack: Unify the user connection flow with a unified screen.

--- a/projects/plugins/mu-wpcom-plugin/changelog/update-stats_add_endpoint_archives_support
+++ b/projects/plugins/mu-wpcom-plugin/changelog/update-stats_add_endpoint_archives_support
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add archives endpoint support.

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -48,7 +48,7 @@
 		"release-branch-prefix": "mu-wpcom"
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_9_0",
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_10_0",
 		"allow-plugins": {
 			"automattic/jetpack-composer-plugin": true
 		}

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 2.9.0
+ * Version: 2.10.0
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "2.9.0",
+	"version": "2.10.0",
 	"private": true,
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",


### PR DESCRIPTION
Closes MONOREP-65

 <!--- This template is used for backporting changes made during a plugin release back to trunk. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Backports changes for mu-wpcom-plugin 2.10.0

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/a
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Proofread changes.