### PR TITLE
Forms: Add error codes on ajax submission failure response

### DIFF
--- a/projects/packages/forms/changelog/add-forms-submit-error-codes
+++ b/projects/packages/forms/changelog/add-forms-submit-error-codes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Forms: Add error codes on ajax submission failure response

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -28,6 +28,15 @@ use WP_Error;
 class Contact_Form_Plugin {
 
 	/**
+	 * Error codes for form submission failures
+	 */
+	const ERROR_INVALID_FORM_ID_OR_HASH = '001';
+	const ERROR_INVALID_JWT             = '002';
+	const ERROR_POST_NOT_ACCESSIBLE     = '003';
+	const ERROR_POST_PASSWORD_REQUIRED  = '004';
+	const ERROR_NO_FORM_FOUND           = '005';
+
+	/**
 	 *
 	 * The Widget ID of the widget currently being processed.  Used to build the unique contact-form ID for forms embedded in widgets.
 	 *
@@ -1220,7 +1229,7 @@ class Contact_Form_Plugin {
 		// phpcs:enable
 
 		if ( ! is_string( $id ) || ! is_string( $hash ) ) {
-			return false;
+			return new WP_Error( self::ERROR_INVALID_FORM_ID_OR_HASH, __( 'Invalid form ID or hash provided.', 'jetpack-forms' ) );
 		}
 
 		if ( is_user_logged_in() ) {
@@ -1236,7 +1245,7 @@ class Contact_Form_Plugin {
 			$form = Contact_Form::get_instance_from_jwt( sanitize_text_field( wp_unslash( $_POST['jetpack_contact_form_jwt'] ) ) );
 			if ( ! $form ) { // fail early if the JWT is invalid.
 				// If the JWT is invalid, we can't process the form.
-				return false;
+				return new WP_Error( self::ERROR_INVALID_JWT, __( 'Invalid JWT provided.', 'jetpack-forms' ) );
 			}
 		}
 
@@ -1334,12 +1343,12 @@ class Contact_Form_Plugin {
 
 			if ( ! is_post_publicly_viewable( $id ) && ! current_user_can( 'read_post', $id ) ) {
 				// The user can't see the post.
-				return false;
+				return new WP_Error( self::ERROR_POST_NOT_ACCESSIBLE, __( 'The post is not accessible.', 'jetpack-forms' ) );
 			}
 
 			if ( post_password_required( $id ) ) {
 				// The post is password-protected and the password is not provided.
-				return false;
+				return new WP_Error( self::ERROR_POST_PASSWORD_REQUIRED, __( 'The post is password-protected and the password is not provided.', 'jetpack-forms' ) );
 			}
 
 			$post = get_post( $id );
@@ -1392,7 +1401,7 @@ class Contact_Form_Plugin {
 		}
 
 		if ( ! $form ) {
-			return false;
+			return new WP_Error( self::ERROR_NO_FORM_FOUND, __( 'No form found.', 'jetpack-forms' ) );
 		}
 
 		if ( is_wp_error( $form->errors ) && $form->errors->get_error_codes() ) {
@@ -1415,15 +1424,51 @@ class Contact_Form_Plugin {
 	public function ajax_request() {
 		$submission_result = self::process_form_submission();
 
-		if ( ! $submission_result ) {
+		if ( is_wp_error( $submission_result ) ) {
+			$error_code    = $submission_result->get_error_code();
+			$error_message = $submission_result->get_error_message();
+
+			// Set appropriate HTTP status codes based on error type
+			$http_status = 400; // Default to Bad Request
+
+			switch ( $error_code ) {
+				case self::ERROR_INVALID_FORM_ID_OR_HASH:
+				case self::ERROR_INVALID_JWT:
+				case \Automattic\Jetpack\Forms\ContactForm\Contact_Form::ERROR_WIDGET_ID_MISMATCH:
+				case \Automattic\Jetpack\Forms\ContactForm\Contact_Form::ERROR_BLOCK_TEMPLATE_ID_MISMATCH:
+				case \Automattic\Jetpack\Forms\ContactForm\Contact_Form::ERROR_BLOCK_TEMPLATE_PART_ID_MISMATCH:
+				case \Automattic\Jetpack\Forms\ContactForm\Contact_Form::ERROR_POST_ID_MISMATCH:
+					$http_status = 400; // Bad Request
+					break;
+				case self::ERROR_POST_NOT_ACCESSIBLE:
+				case self::ERROR_POST_PASSWORD_REQUIRED:
+					$http_status = 403; // Forbidden
+					break;
+				case self::ERROR_NO_FORM_FOUND:
+					$http_status = 404; // Not Found
+					break;
+				default:
+					$http_status = 500; // Internal Server Error
+					break;
+			}
+
+			header( 'HTTP/1.1 ' . $http_status . ' ' . $this->get_http_status_text( $http_status ), $http_status, true );
+			echo '<div class="form-error"><ul class="form-errors"><li class="form-error-message">';
+
+			// Display only the error code in the user-facing error message.
+			if ( preg_match( '/^\d{3}$/', $error_code ) ) {
+				esc_html_e( 'An error occurred. Please try again later.', 'jetpack-forms' );
+				echo '<p>' . esc_html__( 'Error code: ', 'jetpack-forms' ) . esc_html( $error_code ) . '</p>';
+			} else {
+				echo esc_html( $error_message );
+			}
+
+			echo '</li></ul></div>';
+		} elseif ( ! $submission_result ) {
+			// Fallback for any remaining false returns
 			header( 'HTTP/1.1 500 Server Error', 500, true );
 			echo '<div class="form-error"><ul class="form-errors"><li class="form-error-message">';
 			esc_html_e( 'An error occurred. Please try again later.', 'jetpack-forms' );
-			echo '</li></ul></div>';
-		} elseif ( is_wp_error( $submission_result ) ) {
-			header( 'HTTP/1.1 400 Bad Request', 403, true );
-			echo '<div class="form-error"><ul class="form-errors"><li class="form-error-message">';
-			echo esc_html( $submission_result->get_error_message() );
 			echo '</li></ul></div>';
 		} else {
 			echo '<h4>' . esc_html__( 'Your message has been sent', 'jetpack-forms' ) . '</h4>' . wp_kses(
@@ -1437,6 +1482,23 @@ class Contact_Form_Plugin {
 		}
 
 		die( 0 );
+	}
+
+	/**
+	 * Get HTTP status text for error codes
+	 *
+	 * @param int $status_code HTTP status code.
+	 * @return string Status text
+	 */
+	private function get_http_status_text( $status_code ) {
+		$status_texts = array(
+			400 => 'Bad Request',
+			403 => 'Forbidden',
+			404 => 'Not Found',
+			500 => 'Internal Server Error',
+		);
+
+		return isset( $status_texts[ $status_code ] ) ? $status_texts[ $status_code ] : 'Unknown Error';
 	}
 
 	/**

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -111,6 +111,14 @@ class Contact_Form extends Contact_Form_Shortcode {
 	public $has_verified_jwt = false;
 
 	/**
+	 * Error codes for form submission failures
+	 */
+	const ERROR_WIDGET_ID_MISMATCH              = '006';
+	const ERROR_BLOCK_TEMPLATE_ID_MISMATCH      = '007';
+	const ERROR_BLOCK_TEMPLATE_PART_ID_MISMATCH = '008';
+	const ERROR_POST_ID_MISMATCH                = '009';
+
+	/**
 	 * Construction function.
 	 *
 	 * @param array  $attributes - the attributes.
@@ -1603,18 +1611,18 @@ class Contact_Form extends Contact_Form_Shortcode {
 			// Make sure we're processing the form we think we're processing... probably a redundant check.
 			if ( $widget ) {
 				if ( isset( $_POST['contact-form-id'] ) && 'widget-' . $widget !== $_POST['contact-form-id'] ) { // phpcs:Ignore WordPress.Security.NonceVerification.Missing -- check done by caller process_form_submission()
-					return false;
+					return new WP_Error( self::ERROR_WIDGET_ID_MISMATCH, __( 'The widget ID does not match the form ID.', 'jetpack-forms' ) );
 				}
 			} elseif ( $block_template ) {
 				if ( isset( $_POST['contact-form-id'] ) && 'block-template-' . $block_template !== $_POST['contact-form-id'] ) { // phpcs:Ignore WordPress.Security.NonceVerification.Missing -- check done by caller process_form_submission()
-					return false;
+					return new WP_Error( self::ERROR_BLOCK_TEMPLATE_ID_MISMATCH, __( 'The block template ID does not match the form ID.', 'jetpack-forms' ) );
 				}
 			} elseif ( $block_template_part ) {
 				if ( isset( $_POST['contact-form-id'] ) && 'block-template-part-' . $block_template_part !== $_POST['contact-form-id'] ) { // phpcs:Ignore WordPress.Security.NonceVerification.Missing -- check done by caller process_form_submission()
-					return false;
+					return new WP_Error( self::ERROR_BLOCK_TEMPLATE_PART_ID_MISMATCH, __( 'The block template part ID does not match the form ID.', 'jetpack-forms' ) );
 				}
 			} elseif ( isset( $_POST['contact-form-id'] ) && ( empty( $this->current_post ) || self::get_post_property( $this->current_post, 'ID' ) !== (int) sanitize_text_field( wp_unslash( $_POST['contact-form-id'] ) ) ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing -- check done by caller process_form_submission()
-				return false;
+				return new WP_Error( self::ERROR_POST_ID_MISMATCH, __( 'The post ID does not match the form ID.', 'jetpack-forms' ) );
 			}
 		}
 

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
@@ -554,7 +554,79 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 		$plugin = Contact_Form_Plugin::init();
 		$result = $plugin->process_form_submission();
 
-		$this->assertFalse( $result, 'Expected a WP_Error when processing the form submission.' );
+		$this->assertInstanceOf( WP_Error::class, $result, 'Expected a WP_Error when processing the form submission.' );
+		$this->assertSame( '002', $result->get_error_code(), 'Expected the error code to be "002".' );
+
+		$this->teardown_post_for_test( $previous_post );
+	}
+
+	/**
+	 * Test that error codes are returned instead of false for form submission failures when the form ID and hash are invalid.
+	 */
+	public function test_form_submission_invalid_form_id_and_hash() {
+		$plugin = Contact_Form_Plugin::init();
+
+		// Test invalid form ID and hash
+		$_POST['contact-form-id']   = null;
+		$_POST['contact-form-hash'] = null;
+
+		$result = $plugin->process_form_submission();
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( '001', $result->get_error_code() );
+		$this->assertEquals( 'Invalid form ID or hash provided.', $result->get_error_message() );
+	}
+
+	/**
+	 * Test that error codes are returned instead of false for form submission failures when the post is not accessible.
+	 */
+	public function test_form_submission_post_not_accessible() {
+		$plugin = Contact_Form_Plugin::init();
+
+		$_POST['contact-form-id']   = '123456';
+		$_POST['contact-form-hash'] = '123456';
+
+		$result = $plugin->process_form_submission();
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( '003', $result->get_error_code() );
+	}
+
+	/**
+	 * Test that error codes are returned instead of false for form submission failures when the post is password-protected and the password is not provided.
+	 */
+	public function test_form_submission_post_password_required() {
+		$previous_post = $this->setup_token_test();
+		add_filter( 'post_password_required', array( $this, 'return_true_for_post_password_required' ) );
+
+		$plugin = Contact_Form_Plugin::init();
+
+		$result = $plugin->process_form_submission();
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( '004', $result->get_error_code() );
+
+		$this->teardown_post_for_test( $previous_post );
+
+		remove_filter( 'post_password_required', array( $this, 'return_true_for_post_password_required' ) );
+	}
+
+	/**
+	 * Test that error codes are returned instead of false for form submission failures when the form is not found.
+	 */
+	public function test_form_submission_form_not_found() {
+		$previous_post = $this->setup_token_test();
+
+		// Remove the JWT from the POST data and set the hash to a wrong value so that the form is not found.
+		unset( $_POST['jetpack_contact_form_jwt'] );
+		$_POST['contact-form-hash'] = 'wrong-hash';
+
+		$plugin = Contact_Form_Plugin::init();
+
+		$result = $plugin->process_form_submission();
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( '005', $result->get_error_code() );
 
 		$this->teardown_post_for_test( $previous_post );
 	}
@@ -589,6 +661,11 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 		unset( $_POST['contact-form-hash'] );
 		unset( $_POST['jetpack_contact_form_jwt'] );
 		unset( $_POST['contact-form-id'] );
+		unset( $_POST['contact-form-hash'] );
+	}
+
+	public function return_true_for_post_password_required() {
+		return true;
 	}
 
 	public function return_error_for_test() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This is to help track down FORMS-248, as we can't reproduce the issue so far.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Adds error codes to the request response on failure so we can narrow down the cause of the issue.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

The intent is to have no change on normal operation.

* Check that tests pass
* Check that there is no regression
* Locally, force a submission failure and check the response on the network tab of the developer console
* Check that there is an error code that points to where the failure happened
