### PR TITLE
Forms: Fix rating field causing unsaved post state

### DIFF
--- a/projects/packages/forms/changelog/fix-rating-field-dirty-state
+++ b/projects/packages/forms/changelog/fix-rating-field-dirty-state
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+Forms: Fix rating field causing unsaved post state by replacing useEffect pattern with BlockContextProvider

--- a/projects/packages/forms/src/blocks/field-rating/edit.js
+++ b/projects/packages/forms/src/blocks/field-rating/edit.js
@@ -3,13 +3,14 @@ import {
 	useInnerBlocksProps,
 	InspectorControls,
 	BlockControls,
+	BlockContextProvider,
 } from '@wordpress/block-editor';
 import {
 	__experimentalNumberControl as NumberControl, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	PanelBody,
 	RangeControl,
 } from '@wordpress/components';
-import { useEffect, useCallback } from '@wordpress/element';
+import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import JetpackFieldControls from '../shared/components/jetpack-field-controls';
 import RatingToolbar from '../shared/components/rating-toolbar';
@@ -48,10 +49,6 @@ export default function RatingFieldEdit( props ) {
 		[ max, setAttributes ]
 	);
 
-	useEffect( () => {
-		setAttributes( { onChangeDefault } );
-	}, [ onChangeDefault, setAttributes ] );
-
 	const updateClassName = newClassName => {
 		setAttributes( { className: newClassName } );
 	};
@@ -89,7 +86,16 @@ export default function RatingFieldEdit( props ) {
 				/>
 			</BlockControls>
 
-			<div { ...innerBlocksProps } />
+			<BlockContextProvider
+				value={ {
+					'jetpack/field-rating-max': max,
+					'jetpack/field-rating-default': defaultValue,
+					'jetpack/field-rating-className': className,
+					'jetpack/field-rating-onChangeDefault': onChangeDefault,
+				} }
+			>
+				<div { ...innerBlocksProps } />
+			</BlockContextProvider>
 
 			<InspectorControls>
 				<PanelBody title={ __( 'Settings', 'jetpack-forms' ) }>

--- a/projects/packages/forms/src/blocks/field-rating/index.js
+++ b/projects/packages/forms/src/blocks/field-rating/index.js
@@ -63,7 +63,6 @@ const settings = {
 		'jetpack/field-rating-max': 'max',
 		'jetpack/field-rating-default': 'default',
 		'jetpack/field-rating-className': 'className',
-		'jetpack/field-rating-onChangeDefault': 'onChangeDefault',
 	},
 	styles: stylesArray,
 	allowedBlocks: [ 'jetpack/label', 'jetpack/rating-input' ],

--- a/projects/packages/forms/src/blocks/input-rating/edit.js
+++ b/projects/packages/forms/src/blocks/input-rating/edit.js
@@ -1,5 +1,4 @@
 import { useBlockProps } from '@wordpress/block-editor';
-import { useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { DEFAULT_GLYPHS } from './constants';
 import Symbols from './symbols';
@@ -11,21 +10,16 @@ import './editor.scss';
  * Interactive rating component that renders clickable symbols (stars, hearts, etc.)
  * and handles user input. Reads values from parent field-rating block via context.
  *
- * @param {object}   props               - Component props from WordPress block editor
- * @param {object}   props.context       - Block context values from parent block
- * @param {Function} props.setAttributes - Function to update block attributes
- * @param {string}   props.clientId      - Unique identifier for the block instance
+ * @param {object} props          - Component props from WordPress block editor
+ * @param {object} props.context  - Block context values from parent block
+ * @param {string} props.clientId - Unique identifier for the block instance
  * @return {import('react').JSX.Element} Rating input editor component
  */
-export default function RatingInputEdit( { context, setAttributes, clientId } ) {
+export default function RatingInputEdit( { context, clientId } ) {
 	const max = context?.[ 'jetpack/field-rating-max' ] || 5;
 	const defaultValue = context?.[ 'jetpack/field-rating-default' ] || 0;
 	const className = context?.[ 'jetpack/field-rating-className' ] || 'is-style-stars';
 	const onChangeDefault = context?.[ 'jetpack/field-rating-onChangeDefault' ] || ( () => {} );
-
-	useEffect( () => {
-		setAttributes( { className } );
-	}, [ className, setAttributes ] );
 
 	// Get icon component based on className
 	const icon = className.includes( 'is-style-hearts' )


### PR DESCRIPTION
Fixes issue where rating field blocks caused posts to always be in an unsaved state

## Proposed changes:
* Replace `useEffect` + `setAttributes` pattern with `BlockContextProvider` in rating field blocks
* Remove `onChangeDefault` from providesContext since it's now handled by BlockContextProvider  
* Clean up unused imports and parameters in rating input component

### Other information:

- [x] Have you written new tests for your changes, if applicable? - No new tests needed, this is a refactor
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
This addresses feedback about latest field blocks (Rating, Slider, Phone) using context to pass down props and changeHandlers, which causes posts to always be in unsaved state due to useEffect setting attributes.

## Does this pull request change what data or activity we track or use?
No, this is purely a code refactoring that changes how data flows between parent and child blocks without affecting functionality or data tracking.

## Testing instructions:

1. Create a new post/page in the block editor
2. Add a Form block
3. Add a Rating Field block inside the form
4. Change the rating value or maximum rating in the block settings
5. Verify the post is not marked as "unsaved" unless actual content changes are made
6. Verify rating functionality still works as expected (clicking stars, changing max rating, etc.)

**Before**: Post would be marked as unsaved immediately when rating field loaded due to useEffect setting attributes
**After**: Post only marked as unsaved when actual changes are made to content