### PR TITLE
Update ClickHouse Event Triggering to Require Explicit Invocation

### DIFF
--- a/projects/packages/woocommerce-analytics/changelog/update-clickhouse-event-triggering-to-require-explicit
+++ b/projects/packages/woocommerce-analytics/changelog/update-clickhouse-event-triggering-to-require-explicit
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update ClickHouse Event Triggering to Require Explicit Invocation, no need for a changelog entry since the feature not released yet
+
+

--- a/projects/packages/woocommerce-analytics/src/class-woo-analytics-trait.php
+++ b/projects/packages/woocommerce-analytics/src/class-woo-analytics-trait.php
@@ -344,16 +344,18 @@ trait Woo_Analytics_Trait {
 	 * @return void
 	 */
 	public function record_event( $event_name, $properties = array(), $product_id = null ) {
-		if ( ! isset( $properties['session_id'] ) && $this->is_clickhouse( $event_name ) ) {
+		if ( ! isset( $properties['session_id'] ) && $this->should_send_to_clickhouse( $event_name ) ) {
 			$this->maybe_start_session();
-		}
-
-		if ( ! $this->is_initial_page_view( $event_name ) && ! isset( $properties['is_engaged'] ) && ! $this->is_engaged_session() ) {
-			$this->record_engagement( $properties );
 		}
 
 		$js = $this->process_event_properties( $event_name, $properties, $product_id );
 		wc_enqueue_js( "_wca.push({$js});" );
+
+		// If the event is an initial page view, we don't need to record engagement.
+		if ( $this->is_initial_page_view( $event_name ) ) {
+			return;
+		}
+		$this->maybe_record_engagement( $properties );
 	}
 
 	/**
@@ -362,7 +364,17 @@ trait Woo_Analytics_Trait {
 	 * @param array $properties Optional array of (key => value) event properties.
 	 * @return void
 	 */
-	public function record_engagement( $properties = array() ) {
+	private function maybe_record_engagement( $properties = array() ) {
+		if ( ! $this->is_clickhouse_enabled() ) {
+			// For now, engagement is only recorded when ClickHouse is enabled to prevent changes to current event tracking.
+			return;
+		}
+
+		if ( ! empty( $properties['is_engaged'] ) || $this->is_engaged_session() ) {
+			// Engagement event was already recorded.
+			return;
+		}
+
 		$event_js                    = $this->process_event_properties( 'woocommerceanalytics_session_engagement', $properties );
 		$add_engagement_to_cookie_js = "
 		    const cookies = document.cookie.split('; ').reduce((acc, cookie) => {
@@ -506,7 +518,7 @@ trait Woo_Analytics_Trait {
 		$js = "{'_en': '" . esc_js( $event_name ) . "'";
 
 		// ch param is needed to identify ClickHouse queries in the JS Analytics library.
-		if ( $this->is_clickhouse( $event_name ) ) {
+		if ( $this->should_send_to_clickhouse( $event_name ) ) {
 			$js .= ",'ch':'1'";
 		}
 
@@ -842,13 +854,32 @@ trait Woo_Analytics_Trait {
 	}
 
 	/**
+	 * Check if ClickHouse is enabled.
+	 *
+	 * @return bool
+	 */
+	private function is_clickhouse_enabled() {
+		/**
+		 * Filter to enable/disable ClickHouse event tracking.
+		 *
+		 * @module woocommerce-analytics
+		 *
+		 * @since 0.5.0
+		 *
+		 * @param bool $enabled Whether ClickHouse event tracking is enabled.
+		 */
+		return apply_filters( 'woocommerce_analytics_clickhouse_enabled', false );
+	}
+
+	/**
 	 * Check if the event should be sent to ClickHouse
 	 *
 	 * @param string $event The event name.
 	 * @return bool True if it should be sent to ClickHouse
 	 */
-	private function is_clickhouse( $event ) {
-		return in_array( $event, $this->get_clickhouse_events(), true );
+	private function should_send_to_clickhouse( $event ) {
+		return $this->is_clickhouse_enabled() &&
+			in_array( $event, $this->get_clickhouse_events(), true );
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes

Fixes WOOA7S-315

The WooCommerce Analytics package is used to track WooCommerce frontend events such as cart views, product views, checkout views, etc. It's currently [enabled in the JP plugin](https://github.com/Automattic/jetpack/blob/275bf663dd2d8e0a3b2fb11e13b3a30fa6566643/projects/plugins/jetpack/modules/woocommerce-analytics.php#L16-L30) (not ideal, we will migrate it to WC Core later).

For more context: 

The [`release/woocommerce-analytics-0.5.0`](https://github.com/Automattic/jetpack/compare/trunk...release/woocommerce-analytics-0.5.0) branch is not yet merged into trunk and contains significant changes to the WooCommerce Analytics module, including:

1. ClickHouse Integration
2. Session Engagement Tracking - Added engagement detection when users interact with the
site
3. Page View Tracking - Implemented comprehensive page view analytics
4. Enhanced Session Management - Improved session handling with UUID generation and
proper cookie management

To prevent unintentional ClickHouse event traffic and unexpected side effects, ClickHouse should remain disabled by default on all Jetpack + WooCommerce sites. We only want to enable it on sites where the WooCommerce Analytics **plugin** is enabled.

Therefore, this PR adds a WordPress filter to control whether ClickHouse events are triggered so we can enable it in WooCommerce Analytics plugin explicitly.

**Key Changes:**

- Implement WordPress filter-based control (`woocommerce_analytics_clickhouse_enabled`) for ClickHouse events
- Rename `is_clickhouse()` to `should_send_to_clickhouse()` for better code clarity
- Add `is_clickhouse_enabled()` helper method for cleaner organization
- Refactor engagement tracking logic for improved efficiency

## Testing instructions

**Verify ClickHouse is disabled by default:**

1. Check out and build JP plugin with this PR applied
2. Make sure to turn off any ad blockers you may have enabled
3. Open browser dev tools > network tab
4. Go to any frontend page (post, page, shop, product, cart, checkout, account page...) 
5. Check that `w.gif` is not present in the network tab (w.gif is used to send events to ClickHouse), but `t.gif` is present (t.gif is used to send events to Tracks) without `ch` query parameter
6. Engage with the site (go to another page, add to cart, checkout, etc.)
7. Check that `woocommerceanalytics_session_engagement` is not present in the network tab

<img width="649" height="607" alt="Screenshot 2025-08-06 at 16 08 26" src="https://github.com/user-attachments/assets/26fbc408-d60a-4ab5-a9e1-18b5a21b6099" />

**Test explicit enablement:**

1. Add filter: `add_filter('woocommerce_analytics_clickhouse_enabled', '__return_true')`
2. Go to any frontend page (post, page, shop, product, cart, checkout, account page...) 
3. Check that `w.gif` is present in the network tab with `ch` query parameter = 1.
4. Engage with the site (go to another page, add to cart, checkout, etc.)
5. Check that `woocommerceanalytics_session_engagement` is present in the network tab

<img width="664" height="613" alt="Screenshot 2025-08-06 at 16 10 25" src="https://github.com/user-attachments/assets/82d61e00-d122-4e45-862e-6ac6eb2186d1" />
<img width="643" height="604" alt="Screenshot 2025-08-06 at 16 11 47" src="https://github.com/user-attachments/assets/24f67ed8-52e0-4e12-883e-8465e6b4922a" />


## Pre-flight checklist

- [ ] This change has to be documented in the changelog
- [ ] Some tests are needed (if the PR needs tests but you haven't written them yet, just check this box and make a follow up issue to write the tests)
- [ ] Code changes review / Jetpack developer review only if it affects the server

## Jetpack product discussion

Discussed with Woo Analytics team as part of ClickHouse integration project.

## Does this pull request change what data or activity we track or use?

No, this PR only changes when ClickHouse events are triggered (disabled by default), but doesn't modify what data is collected or tracked.

Add WordPress filter control for ClickHouse event triggering in WooCommerce Analytics

