### PR TITLE
Sitemaps: Fix warnings when there are no posts/pages on a site

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-sitemap-php-warnings
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-sitemap-php-warnings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Sitemaps: Fix PHP warning during generation if there are no posts or pages on the website.

--- a/projects/plugins/jetpack/modules/sitemaps/sitemap-builder.php
+++ b/projects/plugins/jetpack/modules/sitemaps/sitemap-builder.php
@@ -375,8 +375,10 @@ class Jetpack_Sitemap_Builder { // phpcs:ignore Generic.Files.OneObjectStructure
 	private function build_next_sitemap_index_of_type( $index_type, $next_type, $state ) {
 		$sitemap_type = jp_sitemap_child_type_of( $index_type );
 
+		$sitemap_type_exists = isset( $state['max'][ $sitemap_type ] ) && is_array( $state['max'][ $sitemap_type ] );
+
 		// If only 0 or 1 sitemaps were built, advance to the next type and return.
-		if ( 1 >= $state['max'][ $sitemap_type ]['number'] ) {
+		if ( $sitemap_type_exists && 1 >= $state['max'][ $sitemap_type ]['number'] ) {
 			Jetpack_Sitemap_State::check_in(
 				array(
 					'sitemap-type'  => $next_type,
@@ -492,7 +494,7 @@ class Jetpack_Sitemap_Builder { // phpcs:ignore Generic.Files.OneObjectStructure
 			return;
 		}
 
-		if ( 0 < $max[ JP_PAGE_SITEMAP_TYPE ]['number'] ) {
+		if ( isset( $max[ JP_PAGE_SITEMAP_TYPE ] ) && 0 < $max[ JP_PAGE_SITEMAP_TYPE ]['number'] ) {
 			if ( 1 === $max[ JP_PAGE_SITEMAP_TYPE ]['number'] ) {
 				$page['filename']      = jp_sitemap_filename( JP_PAGE_SITEMAP_TYPE, 1 );
 				$page['last_modified'] = jp_sitemap_datetime( $max[ JP_PAGE_SITEMAP_TYPE ]['lastmod'] );
@@ -514,7 +516,7 @@ class Jetpack_Sitemap_Builder { // phpcs:ignore Generic.Files.OneObjectStructure
 			);
 		}
 
-		if ( 0 < $max[ JP_IMAGE_SITEMAP_TYPE ]['number'] ) {
+		if ( isset( $max[ JP_IMAGE_SITEMAP_TYPE ] ) && 0 < $max[ JP_IMAGE_SITEMAP_TYPE ]['number'] ) {
 			if ( 1 === $max[ JP_IMAGE_SITEMAP_TYPE ]['number'] ) {
 				$image['filename']      = jp_sitemap_filename( JP_IMAGE_SITEMAP_TYPE, 1 );
 				$image['last_modified'] = jp_sitemap_datetime( $max[ JP_IMAGE_SITEMAP_TYPE ]['lastmod'] );
@@ -536,7 +538,7 @@ class Jetpack_Sitemap_Builder { // phpcs:ignore Generic.Files.OneObjectStructure
 			);
 		}
 
-		if ( 0 < $max[ JP_VIDEO_SITEMAP_TYPE ]['number'] ) {
+		if ( isset( $max[ JP_VIDEO_SITEMAP_TYPE ] ) && 0 < $max[ JP_VIDEO_SITEMAP_TYPE ]['number'] ) {
 			if ( 1 === $max[ JP_VIDEO_SITEMAP_TYPE ]['number'] ) {
 				$video['filename']      = jp_sitemap_filename( JP_VIDEO_SITEMAP_TYPE, 1 );
 				$video['last_modified'] = jp_sitemap_datetime( $max[ JP_VIDEO_SITEMAP_TYPE ]['lastmod'] );


### PR DESCRIPTION
Fixes HOG-275

This problem only happens when a website doesn't have any pages/posts during sitemap generation.

## Proposed changes:

* Fix sitemap generation throwing PHP warnings.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

HOG-275

## Does this pull request change what data or activity we track or use?

no

## Testing instructions:

**Pre-requisites**

- Spin up a site and remove all the posts/pages from the website;
- Add a single image to the website;
- Add this script to your website so you can easily regenerate the sitemaps:

```php
add_action( 'template_redirect', function() {
	if ( ! isset( $_GET['jp-test-sitemap-regeneration'] ) ) {
		return;
	}

	$sitemap_builder = new Jetpack_Sitemap_Builder();
	$sitemap_builder->update_sitemap();

	exit;
} );
```

### (this branch) Test that there are no more PHP warnings during sitemap generation

- Run `?jp-test-sitemap-regeneration` to regenerate the sitemap;
- Check your `debug.log` to make sure there are no PHP warnings related to sitemaps;
- Visit `sitemap.xml` - there should be an image sitemap.

### (trunk/production version) Test that there are PHP warnings during sitemap generation

- Repeat the steps above and there should be warnings in the `debug.log`.