### PR TITLE
Admin Menu: Register "Jetpack > Traffic" on Simple sites

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/dotcom-14125-untangling-ia-register-jetpack-traffic-on-simple-sites
+++ b/projects/packages/jetpack-mu-wpcom/changelog/dotcom-14125-untangling-ia-register-jetpack-traffic-on-simple-sites
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Admin Menu: Register "Jetpack > Traffic" on Simple sites

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
@@ -265,14 +265,25 @@ function wpcom_add_jetpack_submenu() {
 		null // @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
 	);
 
-	// Jetpack > Newsletter.
+
 	if ( $is_simple_site ) {
+		// Jetpack > Newsletter.
 		add_submenu_page(
 			'jetpack',
 			__( 'Newsletter', 'jetpack-mu-wpcom' ),
 			__( 'Newsletter', 'jetpack-mu-wpcom' ),
 			'manage_options',
 			'https://wordpress.com/settings/newsletter/' . $domain,
+			null // @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
+		);
+
+		// Jetpack > Traffic
+		add_submenu_page(
+			'jetpack',
+			__( 'Traffic', 'jetpack-mu-wpcom' ),
+			__( 'Traffic', 'jetpack-mu-wpcom' ),
+			'manage_options',
+			'https://wordpress.com/marketing/traffic/' . $domain,
 			null // @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
 		);
 	}
@@ -311,6 +322,7 @@ function wpcom_add_jetpack_submenu() {
 		'subscribers',
 		'newsletter',
 		'podcasting',
+		'traffic',
 		'jetpack#/settings',
 	);
 	$ordered_submenu = array();

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
@@ -265,7 +265,6 @@ function wpcom_add_jetpack_submenu() {
 		null // @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
 	);
 
-
 	if ( $is_simple_site ) {
 		// Jetpack > Newsletter.
 		add_submenu_page(


### PR DESCRIPTION
Fixes DOTCOM-14125

## Proposed changes:

Register the "Jetpack > Traffic" menu on Simple sites. This will contain the current content of Hosting/Tools -> Marketing -> Traffic (see https://github.com/Automattic/wp-calypso/pull/105084).

<img width="1278" height="1017" alt="Screenshot 2025-08-06 at 14 21 04" src="https://github.com/user-attachments/assets/26d73e4b-157f-44d9-8981-d9c4910081f8" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
- Apply these changes to your WP.com site
- Make sure that "Jetpack > Traffic" is visible on all Simple sites.
- Make sure it points to `/marketing/traffic/:site`
- Check https://github.com/Automattic/wp-calypso/pull/105084 to test the Jetpack > Traffic content and the Hosting/Tools -> Marketing -> Traffic callout.

