### PR TITLE
Forms: Add new form tracking helper class

### DIFF
--- a/projects/packages/forms/changelog/add-form-data
+++ b/projects/packages/forms/changelog/add-form-data
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Forms: add a new tracking class for seperation of concern

--- a/projects/packages/forms/src/contact-form/class-admin.php
+++ b/projects/packages/forms/src/contact-form/class-admin.php
@@ -205,7 +205,8 @@ class Admin {
 
 		$sheet = Google_Drive::create_sheet( $user_id, $spreadsheet_title, $sheet_data );
 
-		$grunion->record_tracks_event( 'forms_export_responses', array( 'format' => 'gsheets' ) );
+		$track_event = new Track_Form_Events();
+		$track_event->record_tracks_event( 'forms_export_responses', array( 'format' => 'gsheets' ) );
 
 		wp_send_json(
 			array(
@@ -410,6 +411,9 @@ class Admin {
 	public function grunion_display_form_view() {
 		if ( current_user_can( 'edit_posts' ) ) {
 			Form_View::display();
+
+			$track_event = new Track_Form_Events();
+			$track_event->record_tracks_event( 'forms_open_form_builder' );
 		}
 		exit( 0 );
 	}

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -16,7 +16,6 @@ use Automattic\Jetpack\Forms\Service\Post_To_Url;
 use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Terms_Of_Service;
 use Automattic\Jetpack\Tracking;
-use Jetpack_Options;
 use WP_Block;
 use WP_Block_Patterns_Registry;
 use WP_Block_Type_Registry;
@@ -1231,13 +1230,17 @@ class Contact_Form_Plugin {
 		$is_block_template      = str_starts_with( $id, 'block-template-' );
 		$is_block_template_part = str_starts_with( $id, 'block-template-part-' );
 
+		$track_event = new Track_Form_Events();
+
 		if ( isset( $_POST['jetpack_contact_form_jwt'] ) ) {
 			$form = Contact_Form::get_instance_from_jwt( sanitize_text_field( wp_unslash( $_POST['jetpack_contact_form_jwt'] ) ) );
 			if ( ! $form ) { // fail early if the JWT is invalid.
 				// If the JWT is invalid, we can't process the form.
+				$track_event->record_bump_event( 'form_submission_attempt', 'invalid_jwt' );
 				return false;
 			}
 
+			$track_event->record_bump_event( 'form_submission_attempt', 'valid_jwt' );
 			$form->validate();
 
 			if ( $form->has_errors() ) {
@@ -1248,8 +1251,11 @@ class Contact_Form_Plugin {
 				Post_To_Url::init();
 			}
 			// Process the form
+
 			return $form->process_submission();
 		}
+
+		$track_event->record_bump_event( 'form_submission_attempt', 'missing_jwt' );
 
 		if ( $is_widget ) {
 			// It's a form embedded in a text widget
@@ -2531,8 +2537,9 @@ class Contact_Form_Plugin {
 		}
 
 		fclose( $output ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
+		$track_event = new Track_Form_Events();
+		$track_event->record_tracks_event( 'forms_export_responses', array( 'format' => 'csv' ) );
 
-		$this->record_tracks_event( 'forms_export_responses', array( 'format' => 'csv' ) );
 		exit( 0 );
 	}
 
@@ -2596,45 +2603,15 @@ class Contact_Form_Plugin {
 	 * @param string $event_name - the name of the event.
 	 * @param array  $event_props - event properties to send.
 	 *
+	 * @deprecated since $$next-version$$ Use Automattic\Jetpack\Tracking instead.
+	 *
 	 * @return null|void
 	 */
 	public function record_tracks_event( $event_name, $event_props ) {
-		/*
-		 * Event details.
-		 */
-		$event_user = wp_get_current_user();
+		_deprecated_function( __METHOD__, 'package-$$next-version$$', 'use  Automattic\Jetpack\Forms\ContactForm\Track_Form_Events()->record_track_event()' );
 
-		/*
-		 * Record event.
-		 * We use different libs on wpcom and Jetpack.
-		 */
-		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-			$event_name             = 'wpcom_' . $event_name;
-			$event_props['blog_id'] = get_current_blog_id();
-			// logged out visitor, record event with blog owner.
-			if ( empty( $event_user->ID ) ) {
-				$event_user_id = wpcom_get_blog_owner( $event_props['blog_id'] );
-				$event_user    = get_userdata( $event_user_id );
-			}
-
-			require_lib( 'tracks/client' );
-			tracks_record_event( $event_user, $event_name, $event_props );
-		} else {
-			$user_connected = ( new \Automattic\Jetpack\Connection\Manager( 'jetpack-forms' ) )->is_user_connected( get_current_user_id() );
-			if ( ! $user_connected ) {
-				return;
-			}
-			// logged out visitor, record event with Jetpack master user.
-			if ( empty( $event_user->ID ) ) {
-				$master_user_id = Jetpack_Options::get_option( 'master_user' );
-				if ( ! empty( $master_user_id ) ) {
-					$event_user = get_userdata( $master_user_id );
-				}
-			}
-
-			$tracking = new Tracking();
-			$tracking->record_user_event( $event_name, $event_props, $event_user );
-		}
+		$track_event = new Track_Form_Events();
+		$track_event->record_tracks_event( $event_name, $event_props );
 	}
 
 	/**

--- a/projects/packages/forms/src/contact-form/class-track-form-events.php
+++ b/projects/packages/forms/src/contact-form/class-track-form-events.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Track Forms Events class.
+ *
+ * @package automattic/jetpack-forms
+ */
+
+namespace Automattic\Jetpack\Forms\ContactForm;
+
+use Automattic\Jetpack\Connection\Manager;
+use Automattic\Jetpack\Status\Host;
+use Automattic\Jetpack\Tracking;
+
+/**
+ * Class to handle tracking events for contact form views.
+ */
+class Track_Form_Events {
+
+	/**
+	 * Send an event to Tracks
+	 *
+	 * @param string $event_name - the name of the event.
+	 * @param array  $event_props - event properties to send.
+	 *
+	 * @return null|void
+	 */
+	public function record_tracks_event( $event_name, $event_props ) {
+		/*
+		 * Event details.
+		 */
+		$event_user = wp_get_current_user();
+
+		/*
+		 * Record event.
+		 * We use different libs on wpcom and Jetpack.
+		 */
+		if ( ( new Host() )->is_wpcom_simple() ) {
+			$event_name             = 'wpcom_' . $event_name;
+			$event_props['blog_id'] = get_current_blog_id();
+			// logged out visitor, record event with blog owner.
+			if ( empty( $event_user->ID ) ) {
+				$event_user_id = wpcom_get_blog_owner( $event_props['blog_id'] );
+				$event_user    = get_userdata( $event_user_id );
+			}
+
+			require_lib( 'tracks/client' );
+			tracks_record_event( $event_user, $event_name, $event_props );
+		} else {
+
+			$user_connected = ( new Manager( 'jetpack-forms' ) )->is_user_connected( get_current_user_id() );
+			if ( ! $user_connected ) {
+				return;
+			}
+			// logged out visitor, record event with Jetpack master user.
+			if ( empty( $event_user->ID ) ) {
+				$master_user_id = ( new Manager( 'jetpack-forms' ) )->get_connection_owner_id();
+				if ( ! empty( $master_user_id ) ) {
+					$event_user = get_userdata( $master_user_id );
+				}
+			}
+
+			$tracking = new Tracking();
+			$tracking->record_user_event( $event_name, $event_props, $event_user );
+		}
+	}
+
+	/**
+	 * Record a bump event
+	 *
+	 * @param string $event_name - the name of the event.
+	 * @param array  $extra - extra data to send with the event.
+	 */
+	public function record_bump_event( $event_name, $extra ) {
+		/** This action is documented in jetpack/modules/widgets/social-media-icons.php */
+		do_action( 'jetpack_bump_stats_extras', 'jetpack_forms_' . $event_name, $extra );
+	}
+}

--- a/projects/packages/forms/src/contact-form/class-track-form-events.php
+++ b/projects/packages/forms/src/contact-form/class-track-form-events.php
@@ -24,7 +24,7 @@ class Track_Form_Events {
 	 *
 	 * @return null|void
 	 */
-	public function record_tracks_event( $event_name, $event_props ) {
+	public function record_tracks_event( $event_name, $event_props = array() ) {
 		/*
 		 * Event details.
 		 */

--- a/projects/packages/forms/src/contact-form/class-util.php
+++ b/projects/packages/forms/src/contact-form/class-util.php
@@ -288,15 +288,13 @@ class Util {
 	public static function jetpack_tracks_record_grunion_pre_message_sent( $post_id, $all_values = array(), $extra_values = array() ) {
 		$post = get_post( $post_id );
 		if ( $post ) {
-			$extra = gmdate( 'Y-W', strtotime( $post->post_date_gmt ) );
+			$extra = 'in_post';
 		} else {
 			$extra = 'no-post';
 		}
 
-		/** This action is documented in jetpack/modules/widgets/social-media-icons.php */
-		do_action( 'jetpack_bump_stats_extras', 'jetpack_forms_message_sent', $extra );
-
-		$form_type = isset( $extra_values['widget'] ) ? 'widget' : 'block';
+		$track_event = new Track_Form_Events();
+		$track_event->record_bump_event( 'jetpack_forms_message_sent', array( 'extra' => $extra ) );
 
 		$context = '';
 		if ( isset( $extra_values['block_template'] ) ) {
@@ -305,13 +303,11 @@ class Util {
 			$context = 'template_part';
 		}
 
-		$plugin = Contact_Form_Plugin::init();
-
-		$plugin->record_tracks_event(
+		$track_event->record_tracks_event(
 			'jetpack_forms_message_sent',
 			array(
 				'post_id'     => $post_id,
-				'form_type'   => $form_type,
+				'form_type'   => isset( $extra_values['widget'] ) ? 'widget' : 'block',
 				'context'     => $context,
 				'has_consent' => empty( $all_values['email_marketing_consent'] ) ? 0 : 1,
 			)

--- a/projects/plugins/jetpack/changelog/add-form-data
+++ b/projects/plugins/jetpack/changelog/add-form-data
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Not really needed
+
+


### PR DESCRIPTION
This PR adds a new form tracking helper class. 

## Proposed changes:
* New Form tracking helper class. 
* Starts tracking the form submission events for errors. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

