### PR TITLE
Add AI excerpt request event

### DIFF
--- a/projects/plugins/jetpack/changelog/add-ai-excerpt-request-event
+++ b/projects/plugins/jetpack/changelog/add-ai-excerpt-request-event
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+AI Excerpt: add tracking event on generation request

--- a/projects/plugins/jetpack/extensions/plugins/ai-content-lens/components/ai-excerpt-control/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-content-lens/components/ai-excerpt-control/index.tsx
@@ -125,6 +125,7 @@ export function AiExcerptControl( {
 				showTooltip={ false }
 				disabled={ disabled }
 				__next40pxDefaultSize
+				__nextHasNoMarginBottom={ true }
 			/>
 		</div>
 	);

--- a/projects/plugins/jetpack/extensions/plugins/ai-content-lens/extend/ai-post-excerpt/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-content-lens/extend/ai-post-excerpt/index.tsx
@@ -193,6 +193,10 @@ ${ postContent }
 		 * when performing a new AI suggestion request.
 		 */
 		dequeueAiAssistantFeatureAsyncRequest();
+		tracks.recordEvent( 'jetpack_ai_assistant_block_request', {
+			feature: 'jetpack-ai-content-lens',
+			model: model,
+		} );
 		request( prompt, { feature: 'jetpack-ai-content-lens', model } );
 	}
 

--- a/projects/plugins/jetpack/extensions/plugins/ai-content-lens/extend/ai-post-excerpt/style.scss
+++ b/projects/plugins/jetpack/extensions/plugins/ai-content-lens/extend/ai-post-excerpt/style.scss
@@ -13,7 +13,7 @@
 
 .jetpack-generated-excerpt__generate-buttons-container {
 	display: flex;
-	margin-bottom: 10px;
+	margin-top: 12px;
 	gap: 12px;
 	justify-content: space-between;
 }


### PR DESCRIPTION


## Proposed changes:
This PR adds an event triggered when the generation is requested: `jetpack_ai_assistant_block_request`

It will carry the feature, `jetpack-ai-content-lens`, and the `model`, "default" or "gemini-nano"

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
No

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Open the editor and look the the excerpt on the sidebar. Keep devtools open and logging messages with `localStorage.setItem( 'debug', '*' )`

Click "Generate" button and see the dops event on the console:

<img width="408" height="80" alt="image" src="https://github.com/user-attachments/assets/31106a6e-c9f6-427a-bedd-5b298c2fe75b" />
