### PR TITLE
Forms: Update resend_email to use Feedback class 

### DIFF
--- a/projects/packages/forms/changelog/update-forms-re-email
+++ b/projects/packages/forms/changelog/update-forms-re-email
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Not signicicant
+
+

--- a/projects/packages/forms/changelog/update-forms-re-email
+++ b/projects/packages/forms/changelog/update-forms-re-email
@@ -1,5 +1,5 @@
 Significance: patch
 Type: changed
-Comment: Not signicicant
+Comment: Not significant
 
 

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -469,54 +469,43 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 		$blog_url             = wp_parse_url( site_url() );
 
 		// resend the original email
-		$email          = get_post_meta( $post_id, '_feedback_email', true );
-		$content_fields = Contact_Form_Plugin::parse_fields_from_content( $post_id );
+		$email = get_post_meta( $post_id, '_feedback_email', true );
 
-		if ( ! empty( $email ) && ! empty( $content_fields ) ) {
-			if ( isset( $content_fields['_feedback_author_email'] ) ) {
-				$comment_author_email = $content_fields['_feedback_author_email'];
-			}
-
-			if ( isset( $email['to'] ) ) {
-				$to = $email['to'];
-			}
-
-			if ( isset( $email['message'] ) ) {
-				$message = $email['message'];
-			}
-
-			if ( isset( $email['headers'] ) ) {
-				$headers = $email['headers'];
-			} else {
-				$headers = 'From: "' . $content_fields['_feedback_author'] . '" <wordpress@' . $blog_url['host'] . ">\r\n";
-
-				if ( ! empty( $comment_author_email ) ) {
-					$reply_to_addr = $comment_author_email;
-				} elseif ( is_array( $to ) ) {
-					$reply_to_addr = $to[0];
-				}
-
-				if ( $reply_to_addr ) {
-					$headers .= 'Reply-To: "' . $content_fields['_feedback_author'] . '" <' . $reply_to_addr . ">\r\n";
-				}
-
-				$headers .= 'Content-Type: text/plain; charset="' . get_option( 'blog_charset' ) . '"';
-			}
-
-			/**
-			 * Filters the subject of the email sent after a contact form submission.
-			 *
-			 * @module contact-form
-			 *
-			 * @since 3.0.0
-			 *
-			 * @param string $content_fields['_feedback_subject'] Feedback's subject line.
-			 * @param array $content_fields['_feedback_all_fields'] Feedback's data from old fields.
-			 */
-			$subject = apply_filters( 'contact_form_subject', $content_fields['_feedback_subject'], $content_fields['_feedback_all_fields'] );
-
-			Contact_Form::wp_mail( $to, $subject, $message, $headers );
+		$response = Feedback::get( $post_id );
+		if ( ! $response ) {
+			return;
 		}
+
+		if ( ! empty( $response->get_author_email() ) ) {
+			$comment_author_email = $response->get_author_email();
+		}
+
+		if ( isset( $email['to'] ) ) {
+			$to = $email['to'];
+		}
+
+		if ( isset( $email['message'] ) ) {
+			$message = $email['message'];
+		}
+
+		if ( isset( $email['headers'] ) ) {
+			$headers = $email['headers'];
+		} else {
+			$headers = 'From: "' . $response->get_author() . '" <wordpress@' . $blog_url['host'] . ">\r\n";
+
+			if ( ! empty( $comment_author_email ) ) {
+				$reply_to_addr = $comment_author_email;
+			} elseif ( is_array( $to ) ) {
+				$reply_to_addr = $to[0];
+			}
+
+			if ( $reply_to_addr ) {
+				$headers .= 'Reply-To: "' . $response->get_author() . '" <' . $reply_to_addr . ">\r\n";
+			}
+
+			$headers .= 'Content-Type: text/plain; charset="' . get_option( 'blog_charset' ) . '"';
+		}
+		Contact_Form::wp_mail( $to, $response->get_subject(), $message, $headers );
 	}
 
 	/**

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Endpoint_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Endpoint_Test.php
@@ -17,6 +17,7 @@ use WP_REST_Server;
  */
 class Contact_Form_Endpoint_Test extends TestCase {
 
+	private $send_email_called = false;
 	/**
 	 * REST Server object.
 	 *
@@ -407,13 +408,19 @@ class Contact_Form_Endpoint_Test extends TestCase {
 	 */
 	public function test_resend_email() {
 		// Create a test feedback post
-		$post_id = wp_insert_post(
+		$post_id = Utility::create_legacy_feedback(
 			array(
-				'post_type'   => 'feedback',
-				'post_status' => 'publish',
-			)
+				'name'  => 'author name',
+				'email' => 'email@example.com',
+			),
+			'This is a test comment content.',
+			'author name',
+			'test@example.com',
+			null,
+			null,
+			'Test Subject',
+			'spam'
 		);
-
 		// Add test metadata
 		add_post_meta(
 			$post_id,
@@ -427,27 +434,26 @@ class Contact_Form_Endpoint_Test extends TestCase {
 
 		add_post_meta( $post_id, '_feedback_subject', 'Test Subject' );
 
-		// Create test content fields
-		$content_fields = array(
-			'_feedback_author'       => 'Test Author',
-			'_feedback_author_email' => 'author@example.com',
-			'_feedback_subject'      => 'Test Subject',
-			'_feedback_all_fields'   => array(
-				'name'  => 'Test Author',
-				'email' => 'author@example.com',
-			),
-		);
-		add_post_meta( $post_id, '_feedback_all_fields', $content_fields );
-
 		// Test the update_item method which triggers resend_email
 		$request = new WP_REST_Request( 'PUT', '/wp/v2/feedback/' . $post_id );
 		$request->set_param( 'status', 'publish' );
 
 		// Mock the previous status
-		add_post_meta( $post_id, '_wp_trash_meta_status', 'spam' );
-
+		add_filter( 'wp_mail', array( $this, 'mock_wp_mail_succeeded' ) );
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 200, $response->get_status() );
+		$this->assertTrue( $this->send_email_called, 'Email should have been sent' );
+
+		$this->send_email_called = false; // Reset the flag
+		remove_filter( 'wp_mail', array( $this, 'mock_wp_mail_succeeded' ) );
+	}
+
+	/**
+	 * Mock wp_mail_succeeded filter
+	 */
+	public function mock_wp_mail_succeeded( $data ) {
+		$this->send_email_called = true;
+		return $data;
 	}
 
 	/**


### PR DESCRIPTION
The current resend email method doesn't use the new Feedback class just yet. This PR updates it to use it. 

This PR - breaks up - https://github.com/Automattic/jetpack/pull/44659. 

## Proposed changes:
* Re implements the new Feedback class in the resend_email method. 

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?


## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
* Do the test pass? 
* Resend your email by setting the feedback as spam and then marking as not spam again. 

