### PR TITLE
Sitemaps: Fix XMLWriter array to string conversion

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-sitemaps-sitemap-filter-conversion
+++ b/projects/plugins/jetpack/changelog/fix-sitemaps-sitemap-filter-conversion
@@ -1,0 +1,5 @@
+Significance: patch
+Type: bugfix
+Comment: Sitemaps: The XMLWriter sitemap implementation now correctly handles nested data from filters, preventing "Array to string conversion" errors and malformed XML.
+
+

--- a/projects/plugins/jetpack/modules/sitemaps/sitemap-buffer-image-xmlwriter.php
+++ b/projects/plugins/jetpack/modules/sitemaps/sitemap-buffer-image-xmlwriter.php
@@ -67,6 +67,15 @@ class Jetpack_Sitemap_Buffer_Image_XMLWriter extends Jetpack_Sitemap_Buffer_XMLW
 			return;
 		}
 
+		if ( isset( $array['url']['image:image'] ) ) {
+			if ( empty( $array['url']['image:image']['image:title'] ) ) {
+				unset( $array['url']['image:image']['image:title'] );
+			}
+			if ( empty( $array['url']['image:image']['image:caption'] ) ) {
+				unset( $array['url']['image:image']['image:caption'] );
+			}
+		}
+
 		$this->array_to_xml( $array );
 	}
 }

--- a/projects/plugins/jetpack/modules/sitemaps/sitemap-buffer-image-xmlwriter.php
+++ b/projects/plugins/jetpack/modules/sitemaps/sitemap-buffer-image-xmlwriter.php
@@ -67,39 +67,6 @@ class Jetpack_Sitemap_Buffer_Image_XMLWriter extends Jetpack_Sitemap_Buffer_XMLW
 			return;
 		}
 
-		$url = $array['url'];
-
-		$this->writer->startElement( 'url' );
-
-		if ( isset( $url['loc'] ) ) {
-			$this->writer->writeElement( 'loc', esc_url( $url['loc'] ) );
-		}
-
-		if ( isset( $url['lastmod'] ) ) {
-			$this->writer->writeElement( 'lastmod', esc_html( $url['lastmod'] ) );
-		}
-
-		if ( isset( $url['image:image'] ) && is_array( $url['image:image'] ) ) {
-			$this->writer->startElement( 'image:image' );
-
-			// Required image loc
-			if ( isset( $url['image:image']['image:loc'] ) ) {
-				$this->writer->writeElement( 'image:loc', esc_url( $url['image:image']['image:loc'] ) );
-			}
-
-			// Optional image title
-			if ( ! empty( $url['image:image']['image:title'] ) ) {
-				$this->writer->writeElement( 'image:title', esc_html( $url['image:image']['image:title'] ) );
-			}
-
-			// Optional image caption
-			if ( ! empty( $url['image:image']['image:caption'] ) ) {
-				$this->writer->writeElement( 'image:caption', esc_html( $url['image:image']['image:caption'] ) );
-			}
-
-			$this->writer->endElement(); // image:image
-		}
-
-		$this->writer->endElement(); // url
+		$this->array_to_xml( $array );
 	}
 }

--- a/projects/plugins/jetpack/modules/sitemaps/sitemap-buffer-master-xmlwriter.php
+++ b/projects/plugins/jetpack/modules/sitemaps/sitemap-buffer-master-xmlwriter.php
@@ -39,13 +39,7 @@ class Jetpack_Sitemap_Buffer_Master_XMLWriter extends Jetpack_Sitemap_Buffer_XML
 	 */
 	protected function append_item( $array ) {
 		if ( ! empty( $array['sitemap'] ) ) {
-			$this->writer->startElement( 'sitemap' );
-
-			foreach ( $array['sitemap'] as $tag => $value ) {
-				$this->writer->writeElement( $tag, strval( $value ) );
-			}
-
-			$this->writer->endElement(); // sitemap
+			$this->array_to_xml( $array );
 		}
 	}
 }

--- a/projects/plugins/jetpack/modules/sitemaps/sitemap-buffer-news-xmlwriter.php
+++ b/projects/plugins/jetpack/modules/sitemaps/sitemap-buffer-news-xmlwriter.php
@@ -62,30 +62,7 @@ class Jetpack_Sitemap_Buffer_News_XMLWriter extends Jetpack_Sitemap_Buffer_XMLWr
 	 */
 	protected function append_item( $array ) {
 		if ( ! empty( $array['url'] ) ) {
-			$this->writer->startElement( 'url' );
-
-			// Add URL elements
-			foreach ( $array['url'] as $tag => $value ) {
-				if ( $tag === 'news:news' ) {
-					$this->writer->startElement( 'news:news' );
-					foreach ( $value as $news_tag => $news_value ) {
-						if ( $news_tag === 'news:publication' ) {
-							$this->writer->startElement( 'news:publication' );
-							foreach ( $news_value as $pub_tag => $pub_value ) {
-								$this->writer->writeElement( $pub_tag, strval( $pub_value ) );
-							}
-							$this->writer->endElement(); // news:publication
-						} else {
-							$this->writer->writeElement( $news_tag, strval( $news_value ) );
-						}
-					}
-					$this->writer->endElement(); // news:news
-				} else {
-					$this->writer->writeElement( $tag, strval( $value ) );
-				}
-			}
-
-			$this->writer->endElement(); // url
+			$this->array_to_xml( $array );
 		}
 	}
 }

--- a/projects/plugins/jetpack/modules/sitemaps/sitemap-buffer-news-xmlwriter.php
+++ b/projects/plugins/jetpack/modules/sitemaps/sitemap-buffer-news-xmlwriter.php
@@ -20,7 +20,6 @@ class Jetpack_Sitemap_Buffer_News_XMLWriter extends Jetpack_Sitemap_Buffer_XMLWr
 		// Add generator comment
 		$this->writer->writeComment( "generator='jetpack-" . JETPACK__VERSION . "'" );
 		$this->writer->writeComment( 'Jetpack_Sitemap_Buffer_News_XMLWriter' );
-		$this->writer->writeComment( 'TEST COMMENT - GENERATED AT: ' . gmdate( 'Y-m-d H:i:s' ) );
 
 		// Add stylesheet
 		$this->writer->writePi(

--- a/projects/plugins/jetpack/modules/sitemaps/sitemap-buffer-page-xmlwriter.php
+++ b/projects/plugins/jetpack/modules/sitemaps/sitemap-buffer-page-xmlwriter.php
@@ -60,13 +60,7 @@ class Jetpack_Sitemap_Buffer_Page_XMLWriter extends Jetpack_Sitemap_Buffer_XMLWr
 	 */
 	protected function append_item( $array ) {
 		if ( ! empty( $array['url'] ) ) {
-			$this->writer->startElement( 'url' );
-
-			foreach ( $array['url'] as $tag => $value ) {
-				$this->writer->writeElement( $tag, strval( $value ) );
-			}
-
-			$this->writer->endElement(); // url
+			$this->array_to_xml( $array );
 		}
 	}
 }

--- a/projects/plugins/jetpack/modules/sitemaps/sitemap-buffer-video-xmlwriter.php
+++ b/projects/plugins/jetpack/modules/sitemaps/sitemap-buffer-video-xmlwriter.php
@@ -69,23 +69,6 @@ class Jetpack_Sitemap_Buffer_Video_XMLWriter extends Jetpack_Sitemap_Buffer_XMLW
 			return;
 		}
 
-		$this->writer->startElement( 'url' );
-
-		// Add URL elements
-		foreach ( $array['url'] as $url_tag => $url_value ) {
-			if ( $url_tag === 'video:video' ) {
-				// Add video:video element and its children.
-				$this->writer->startElement( 'video:video' );
-				foreach ( $array['url']['video:video'] as $video_tag => $video_value ) {
-					$this->writer->writeElement( $video_tag, strval( $video_value ) );
-				}
-				$this->writer->endElement(); // video
-			} else {
-				// Add other eleents.
-				$this->writer->writeElement( $url_tag, strval( $url_value ) );
-			}
-		}
-
-		$this->writer->endElement(); // url
+		$this->array_to_xml( $array );
 	}
 }

--- a/projects/plugins/jetpack/modules/sitemaps/sitemap-buffer-xmlwriter.php
+++ b/projects/plugins/jetpack/modules/sitemaps/sitemap-buffer-xmlwriter.php
@@ -179,8 +179,10 @@ abstract class Jetpack_Sitemap_Buffer_XMLWriter {
 				$this->writer->startElement( $tag );
 				$this->array_to_xml( $value );
 				$this->writer->endElement();
+			} elseif ( 'loc' === $tag || 'image:loc' === $tag || 'video:content_loc' === $tag || 'video:thumbnail_loc' === $tag ) {
+				$this->writer->writeElement( $tag, esc_url( $value ) );
 			} else {
-				$this->writer->writeElement( $tag, strval( $value ) );
+				$this->writer->writeElement( $tag, esc_html( strval( $value ) ) );
 			}
 		}
 	}

--- a/projects/plugins/jetpack/modules/sitemaps/sitemap-buffer-xmlwriter.php
+++ b/projects/plugins/jetpack/modules/sitemaps/sitemap-buffer-xmlwriter.php
@@ -163,6 +163,29 @@ abstract class Jetpack_Sitemap_Buffer_XMLWriter {
 	abstract protected function append_item( $array );
 
 	/**
+	 * Recursively writes XML elements from an associative array.
+	 *
+	 * This method iterates through an array and writes XML elements using the XMLWriter instance.
+	 * If a value in the array is itself an array, it calls itself recursively.
+	 *
+	 * @access protected
+	 * @since $$next-version$$
+	 *
+	 * @param array $data The array to convert to XML.
+	 */
+	protected function array_to_xml( $data ) {
+		foreach ( (array) $data as $tag => $value ) {
+			if ( is_array( $value ) ) {
+				$this->writer->startElement( $tag );
+				$this->array_to_xml( $value );
+				$this->writer->endElement();
+			} else {
+				$this->writer->writeElement( $tag, strval( $value ) );
+			}
+		}
+	}
+
+	/**
 	 * Retrieve the contents of the buffer.
 	 *
 	 * @since 14.6


### PR DESCRIPTION
Fixes [HOG-118: Sitemaps: XMLWriter news sitemap images stored as array](https://linear.app/a8c/issue/HOG-118/sitemaps-xmlwriter-news-sitemap-images-stored-as-array)

## Proposed changes:

This PR addresses a critical bug in the `XMLWriter` sitemap implementation where it would fail to correctly process nested array data added via filters like `jetpack_sitemap_news_sitemap_item`.

Previously, the `append_item` methods in the `XMLWriter` buffers were rigid and non-recursive. This caused a fatal **"Array to string conversion"** error if a filter added nested data, resulting in malformed XML (e.g., `<image: image>Array</image: image>`).

The fix introduces a new, generic, and recursive `array_to_xml()` helper method to the base `Jetpack_Sitemap_Buffer_XMLWriter` class. All sitemap-specific buffers (`News`, `Image`, `Video`, `Page`) have been refactored to use this, ensuring they can correctly handle nested data from filters. This brings the `XMLWriter` behavior in line with the flexible `DOMDocument` implementation it is meant to replace.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

### 1. Configure Jetpack & Sitemaps

1.  Connect Jetpack to a WordPress.com account.
2.  In the WP Admin dashboard, navigate to **Jetpack -> Settings -> Traffic**.
3.  Scroll down and enable the **"Generate XML sitemaps"** option.

### 2. Create Test Content

Create a variety of content to populate all sitemap types:

*   **For News & Image Sitemaps**: Create at least two new **Posts**.
    *   For each post, write some content and **assign a "Featured Image"**.
    *   Publish the posts. They must be recent to appear in the News Sitemap.
*   **For the Page Sitemap**: Create a new **Page** and publish it.
*   **For the Video Sitemap**:
    *   Upload a video file (e.g., an `.mp4`) to the Media Library.
    *   Create a new **Post** and embed this video using the "Video" block.
    *   Publish the post.

### 3. Add a Comprehensive Test Filter

This is the most important step. It will test the fix against all affected sitemap types.

1.  Create a new file at `/wp-content/mu-plugins/sitemap-test-filters.php`.
2.  Add the following PHP code to this file. It adds nested data structures to each sitemap type, which would have previously broken the `XMLWriter` implementation.

```php
<?php
/**
 * Plugin Name: Sitemap XMLWriter Test Filters
 * Description: Tests nested array handling in all sitemap types.
 */

// Test 1: News Sitemap - Add a nested <image:image> element
add_filter('jetpack_sitemap_news_sitemap_item', function( $entry, $post_id ) {
    $thumbnail_id = get_post_thumbnail_id( $post_id );
    if ( $thumbnail_id && isset( $entry['url'] ) ) {
        $image_url = wp_get_attachment_url( $thumbnail_id );
        if ( $image_url ) {
            $entry['url']['image:image'] = [ 'image:loc' => $image_url ];
        }
    }
    return $entry;
}, 10, 2);

// Test 2: Image Sitemap - Add nested geo-location data
add_filter('jetpack_sitemap_image_sitemap_item', function( $entry ) {
    if ( isset( $entry['url']['image:image'] ) ) {
        $entry['url']['image:image']['image:geo_location'] = [ 'image:geo' => 'Jetpack HQ' ];
    }
    return $entry;
}, 10, 1);

// Test 3: Video Sitemap - Add a nested <video:gallery_loc> element
add_filter('jetpack_sitemap_video_sitemap_item', function( $entry ) {
    $entry['url']['video:video']['video:gallery_loc'] = [
            'loc' => 'https://jetpack.com',
            'title' => 'Video Gallery'
        ];
    return $entry;
}, 10, 1);

// Test 4: Page/Post Sitemap - Add a nested <custom:data> element
add_filter('jetpack_sitemap_url', function( $entry) {
	if ( isset( $entry['url'] ) ) {
		$entry['url']['custom:data'] = array( 'custom:post_type' => 'Test type' );
	}
	return $entry;
});
```

### 4. Test with the `XMLWriter` Implementation (The Fix)

1.  To force WordPress to use the new `XMLWriter` code, add this line to the end of your `sitemap-test-filters.php` mu-plugin:
    ```php
    add_filter( 'jetpack_sitemap_use_xmlwriter', '__return_true' );
    ```
2.  **Important**: Regenerate sitemaps. You can do this WP CLI:
    ```bash
    wp jetpack sitemap rebuild --purge
    ```
    Or locally if using Docker
    ```bash
    jetpack docker wp jetpack sitemap rebuild -- --purge
    ```

3.  Visit the following sitemap URLs in your browser. Verify they load as valid XML without PHP errors and that the custom nested data is present and correctly formatted.

#### **Verification:**

*   **News Sitemap (`/news-sitemap.xml`)**:
    *   Find a `<url>` entry. It should contain a nested `<image:image><image:loc>...</image:loc></image:image>`.
    *   It must **not** contain `<image:image>Array</image: image>`.

*   **Image Sitemap (`/image-sitemap-1.xml`)**:
    *   Find an `<image:image>` entry. It should contain a nested `<image:geo_location><image:geo>Jetpack HQ</image:geo></image:geo_location>`.

*   **Video Sitemap (`/video-sitemap-1.xml`)**:
    *   Find a `<video:video>` entry. It should contain a nested `<video:gallery_loc><loc>...</loc><title>...</title></video:gallery_loc>`.

*   **Page Sitemap (`/sitemap-1.xml`)**:
    *   Find the `<url>` entry for the page and posts you created. Each should contain a nested `<custom:data><custom:post_type>page</custom:post_type></custom: data>` (or `post`).

*   **Master Sitemap (`/sitemap.xml`)**:
    *   Verify this still appears structured. (And will be later compared against the `DOMDocument` Implementation.

### 5. Compare with the Default `DOMDocument` Implementation

1.  In your `sitemap-test-filters.php` mu-plugin, **comment out** the `add_filter( 'jetpack_sitemap_use_xmlwriter', '__return_true' );` line.
2.  Regenerate the sitemaps again (via CLI).
3.  Visit the same four sitemap URLs.

#### **Verification:**

*   The XML structure in each sitemap file should be **structurally identical** to the one generated by `XMLWriter` in the previous step. This confirms that the fix makes the two implementations produce the same output for complex, filtered data across all sitemap types.
*   Check your `debug.log` file to ensure no "Array to string conversion" warnings were logged during either test run.