### PR TITLE
Forms: Require MailPoet key to connect form

### DIFF
--- a/projects/packages/forms/changelog/fix-mailpoet-requires-key
+++ b/projects/packages/forms/changelog/fix-mailpoet-requires-key
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Disallow connecting MailPoet without key.

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/active-integrations/index.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/active-integrations/index.js
@@ -32,7 +32,11 @@ export default function ActiveIntegrations( { integrations, attributes, isLoadin
 				}
 				break;
 			case 'mailpoet':
-				if ( integration.isActive && attributes.mailpoet?.enabledForForm ) {
+				if (
+					integration.isActive &&
+					integration.isConnected &&
+					attributes.mailpoet?.enabledForForm
+				) {
 					acc.push( {
 						...integration,
 						icon: <MailPoetOrangeIcon width={ 30 } height={ 30 } />,

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/mailpoet-card.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/mailpoet-card.tsx
@@ -78,8 +78,8 @@ const MailPoetCard = ( {
 	const cardData: IntegrationCardData = {
 		...data,
 		showHeaderToggle: true,
-		headerToggleValue: mailpoet?.enabledForForm ?? false,
-		isHeaderToggleEnabled: true,
+		headerToggleValue: ( mailpoetActiveWithKey && mailpoet?.enabledForForm ) ?? false,
+		isHeaderToggleEnabled: mailpoetActiveWithKey,
 		onHeaderToggleChange: ( value: boolean ) =>
 			setAttributes( { mailpoet: { ...mailpoet, enabledForForm: value } } ),
 		isLoading: ! data || typeof data.isInstalled === 'undefined',


### PR DESCRIPTION
## Proposed changes:

We discovered a small bug in forms MailPoet integration during a call this morning. We're allowing a user to connect a form to MailPoet in the block editor even before they have added a key. This fixes that bug. When no key is present, the toggle to enable MailPoet is disabled. 

**Screenshot**
<img width="709" height="541" alt="mailpoet-key" src="https://github.com/user-attachments/assets/bebf2451-c7bd-4c2f-8186-5895d1bc9f98" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Ensure MailPoet is installed and active without a key.
* Add a form to a page or post and open the integrations modal. 
* Confirm that the toggle on the card header for MailPoet is disabled and cannot be turned on.

