### PR TITLE
Forms: Fix MailPoet icon border radius

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-mailpoet-icon-border
+++ b/projects/packages/forms/changelog/fix-forms-mailpoet-icon-border
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Fix MailPoet icon border radius.

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/style.scss
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/style.scss
@@ -148,7 +148,8 @@
 		text-wrap: pretty;
 	}
 
-	&__service-icon--google-sheets {
+	&__service-icon--google-sheets,
+	&__service-icon--mailpoet {
 		border-radius: 0 !important;
 	}
 }


### PR DESCRIPTION
## Proposed changes:

Quick fix for small styling issue for the MailPoet icon in the forms integration modal. By default the icons have 50% border radius, but we need to exclude MailPoet from that like we do Google Sheets. 

**Before**
<img width="699" height="103" alt="mailpoet-icon-round" src="https://github.com/user-attachments/assets/25891ae5-0994-4702-9d67-0cccbd24cb31" />

**After**
<img width="703" height="100" alt="mailpoet-icon-square" src="https://github.com/user-attachments/assets/51204214-63e7-4cad-beb6-f9051e151348" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No. 

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Add a form to page, open the integration modal, and confirm the orange part of the icon is not rounded/cut off, and is square like the 'after' image above. 