### PR TITLE
Forms: Fix safari animated style transiton

### DIFF
--- a/projects/packages/forms/changelog/fix-safari-animated-style-transiton
+++ b/projects/packages/forms/changelog/fix-safari-animated-style-transiton
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: fix safari animation for animated form style

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -816,19 +816,16 @@ on production builds, the attributes are being reordered, causing side-effects
 	pointer-events: none;
 	margin: 0;
 	transform: translateY(-50%);
-	transition: all 150ms cubic-bezier(0.4, 0, 0.2, 1);
-	will-change: transform, top;
+	transition: translatey 150ms cubic-bezier(0.4, 0, 0.2, 1);
 	z-index: 2;
 }
 
 .contact-form .is-style-animated .grunion-field-wrap .grunion-label-text {
 	transition: font-size 150ms cubic-bezier(0.4, 0, 0.2, 1);
-	will-change: font-size;
 }
 
 .contact-form .is-style-animated .grunion-field-wrap .grunion-label-required {
 	transition: font-size 150ms cubic-bezier(0.4, 0, 0.2, 1);
-	will-change: font-size;
 }
 
 .contact-form .is-style-animated .grunion-field-textarea-wrap .animated-label__label {


### PR DESCRIPTION
Fixes FORMS-239 

Before:

https://github.com/user-attachments/assets/8807ecca-a5dd-431b-b89e-829afc9824f6


After:

https://github.com/user-attachments/assets/4c8a1ce3-a6e4-49ae-b1dd-4e5a8991c155


## Proposed changes:
* Remove the ` will-change:` CSS property - https://developer.mozilla.org/en-US/docs/Web/CSS/will-change provides a warning to only use it sparingly and only animate the y translation.  


### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?



## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Apply this PR. 
Check that the animated style works nicer. Test in safari and other browsers. 


