### PR TITLE
Forms: Increase consent field default size

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-consent-text-size
+++ b/projects/packages/forms/changelog/fix-forms-consent-text-size
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: Increase default consent field size.

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -606,7 +606,7 @@
 	font-weight: 400;
 
 	:where(.wp-block-jetpack-option) {
-		font-size: 13px;
+		font-size: 16px;
 	}
 }
 

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -113,7 +113,7 @@
 }
 
 .contact-form :where(label.consent) {
-	font-size: var(--jetpack--contact-form--label--font-size, 13px);
+	font-size: var(--jetpack--contact-form--label--font-size, 16px);
 	font-weight: 400;
 }
 


### PR DESCRIPTION
## Proposed changes:

In meeting with @simison and @ilonagl this morning, we decided we should increase the default size of the consent field text and checkbox. This is set in CSS, but can be overridden via block typography settings. I bumped the size from 13px to 16px. 

Note: This has backwards compatibility implications. The consent text size will change on the frontend for any use who has not overridden the size. We made this same choice to just deploy the font text-transform change for this field [here](https://github.com/Automattic/jetpack/pull/44078). 

**Before**
<img width="671" height="302" alt="consent-font-13" src="https://github.com/user-attachments/assets/108b388e-20f9-41e4-b223-1234af6b482c" />

**After**
<img width="676" height="310" alt="consent-16px" src="https://github.com/user-attachments/assets/24079a50-8c0c-4856-aa1c-9caf383969b0" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add a form to page
* Add a consent field and confirm that font now loads sllightly larger by default
* Save and confirm the same thing on the frontend
* Try overriding the font size using block controls on the field and confirm those continue to override