### PR TITLE
Forms: show terms concent block with and without checkbox as block variation

### DIFF
--- a/projects/packages/forms/changelog/update-forms-terms-concent-variation
+++ b/projects/packages/forms/changelog/update-forms-terms-concent-variation
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: show terms concent block with and without checkbox as block variation"

--- a/projects/packages/forms/src/blocks/field-consent/edit.js
+++ b/projects/packages/forms/src/blocks/field-consent/edit.js
@@ -5,7 +5,7 @@ import {
 	useInnerBlocksProps,
 } from '@wordpress/block-editor';
 import { getBlockType } from '@wordpress/blocks';
-import { BaseControl, PanelBody, SelectControl, ToggleControl } from '@wordpress/components';
+import { PanelBody, ToggleControl } from '@wordpress/components';
 import { usePrevious } from '@wordpress/compose';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useCallback, useEffect, useMemo, useRef } from '@wordpress/element';
@@ -149,13 +149,6 @@ export default function ConsentFieldEdit( props ) {
 		[ setAttributes ]
 	);
 
-	const onConsentTypeChange = useCallback(
-		value => {
-			setAttributes( { consentType: value } );
-		},
-		[ setAttributes ]
-	);
-
 	return (
 		<>
 			<div { ...innerBlocksProps } />
@@ -169,27 +162,6 @@ export default function ConsentFieldEdit( props ) {
 						help={ __( 'Deactivate for individual styling of this block', 'jetpack-forms' ) }
 						__nextHasNoMarginBottom
 					/>
-				</PanelBody>
-				<PanelBody title={ __( 'Consent settings', 'jetpack-forms' ) }>
-					<BaseControl __nextHasNoMarginBottom>
-						<SelectControl
-							label={ __( 'Permission to email', 'jetpack-forms' ) }
-							value={ consentType }
-							options={ [
-								{
-									label: __( 'Mention that you can email', 'jetpack-forms' ),
-									value: 'implicit',
-								},
-								{
-									label: __( 'Add a privacy checkbox', 'jetpack-forms' ),
-									value: 'explicit',
-								},
-							] }
-							onChange={ onConsentTypeChange }
-							__nextHasNoMarginBottom
-							__next40pxDefaultSize
-						/>
-					</BaseControl>
 				</PanelBody>
 			</InspectorControls>
 		</>

--- a/projects/packages/forms/src/blocks/field-consent/index.js
+++ b/projects/packages/forms/src/blocks/field-consent/index.js
@@ -1,17 +1,22 @@
 import { Path } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import renderMaterialIcon from '../shared/components/render-material-icon';
 import defaultSettings from '../shared/settings';
 import { getIconColor } from '../shared/util/block-icons';
 import deprecated from './deprecated';
 import edit from './edit';
 import save from './save';
+import variations from './variations';
 
 const name = 'field-consent';
 const settings = {
 	...defaultSettings,
 	title: __( 'Terms consent', 'jetpack-forms' ),
-	keywords: [ __( 'Consent', 'jetpack-forms' ) ],
+	keywords: [
+		__( 'Consent', 'jetpack-forms' ),
+		__( 'Permission', 'jetpack-forms' ),
+		_x( 'TOS', 'Terms of Service', 'jetpack-forms' ),
+	],
 	description: __(
 		'Communicate site terms and offer visitors consent to those terms.',
 		'jetpack-forms'
@@ -54,6 +59,7 @@ const settings = {
 	},
 	deprecated,
 	save,
+	variations,
 	example: {
 		innerBlocks: [
 			{

--- a/projects/packages/forms/src/blocks/field-consent/variations.js
+++ b/projects/packages/forms/src/blocks/field-consent/variations.js
@@ -1,0 +1,46 @@
+import { Path } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import renderMaterialIcon from '../shared/components/render-material-icon';
+import { getIconColor } from '../shared/util/block-icons';
+
+const variations = [
+	{
+		name: 'field-consent-implicit',
+		title: __( 'Terms concent', 'jetpack-forms' ),
+		description: __( 'Concent without checkbox.', 'jetpack-forms' ),
+		icon: {
+			foreground: getIconColor(),
+			src: renderMaterialIcon(
+				<>
+					<Path d="M7 5.5H17C17.2761 5.5 17.5 5.72386 17.5 6V13H19V6C19 4.89543 18.1046 4 17 4H7C5.89543 4 5 4.89543 5 6V18C5 19.1046 5.89543 20 7 20H11.5V18.5H7C6.72386 18.5 6.5 18.2761 6.5 18V6C6.5 5.72386 6.72386 5.5 7 5.5ZM16 7.75H8V9.25H16V7.75ZM8 11H13V12.5H8V11Z" />
+					<Path d="M20.1087 15.9382L15.9826 21.6689L12.959 18.5194L14.0411 17.4806L15.8175 19.331L18.8914 15.0618L20.1087 15.9382Z" />
+				</>
+			),
+		},
+		attributes: {
+			consentType: 'implicit',
+		},
+		scope: [ 'inserter', 'transform' ],
+		isDefault: true,
+	},
+	{
+		name: 'field-consent-explicit',
+		title: __( 'Concent with checkbox', 'jetpack-forms' ),
+		description: __( 'Concent with checkbox.', 'jetpack-forms' ),
+		icon: {
+			foreground: getIconColor(),
+			src: renderMaterialIcon(
+				<>
+					<Path d="M7 5.5H17C17.2761 5.5 17.5 5.72386 17.5 6V13H19V6C19 4.89543 18.1046 4 17 4H7C5.89543 4 5 4.89543 5 6V18C5 19.1046 5.89543 20 7 20H11.5V18.5H7C6.72386 18.5 6.5 18.2761 6.5 18V6C6.5 5.72386 6.72386 5.5 7 5.5ZM16 7.75H8V9.25H16V7.75ZM8 11H13V12.5H8V11Z" />
+					<Path d="M20.1087 15.9382L15.9826 21.6689L12.959 18.5194L14.0411 17.4806L15.8175 19.331L18.8914 15.0618L20.1087 15.9382Z" />
+				</>
+			),
+		},
+		attributes: {
+			consentType: 'explicit',
+		},
+		scope: [ 'inserter', 'transform' ],
+	},
+];
+
+export default variations;

--- a/projects/plugins/jetpack/changelog/update-forms-terms-concent-variation
+++ b/projects/plugins/jetpack/changelog/update-forms-terms-concent-variation
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: show terms concent block with and without checkbox as block variation


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Previously terms concent was a setting in the sidebar. This changes it to "variation" so that both version appear in block inserter, and you can quickly change variation from sidebar using icons.

TODO:
- Needs different icons for each.
- Variation picker in sidebar doesn't show active variation

No "backend" changes requiring deprecations, we continue using attributes for the variation and the message.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

- Convert versions to "variations"
- Add more keywords to help searching

### Before

<img width="284" height="146" alt="Screenshot 2025-08-08 at 12 24 27" src="https://github.com/user-attachments/assets/b9838f0c-5f58-4c9c-b838-2551be9072f3" />
<img width="284" height="145" alt="Screenshot 2025-08-08 at 12 24 30" src="https://github.com/user-attachments/assets/b6dca290-1ad3-4910-aa9a-364bd8539073" />


### After


https://github.com/user-attachments/assets/b9659f3d-049d-4f70-bb8d-237fd6726272

<img width="773" height="278" alt="Screenshot 2025-08-08 at 12 28 23" src="https://github.com/user-attachments/assets/2cd4ae96-bf9a-4721-81cc-c46ee832ad10" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add terms field to form
* Try variation picker

