### PR TITLE
Sitemaps: Ensure Parity with Original Implementation

### DIFF
--- a/projects/plugins/jetpack/changelog/update-sitemaps-xmlwriter-parity-domdocument
+++ b/projects/plugins/jetpack/changelog/update-sitemaps-xmlwriter-parity-domdocument
@@ -1,0 +1,5 @@
+Significance: patch
+Type: compat
+Comment: Sitemaps: The XMLWriter sitemap implementation now behaves more like the original implementation
+
+

--- a/projects/plugins/jetpack/modules/sitemaps/sitemap-buffer-image-xmlwriter.php
+++ b/projects/plugins/jetpack/modules/sitemaps/sitemap-buffer-image-xmlwriter.php
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Jetpack_Sitemap_Buffer_Image_XMLWriter extends Jetpack_Sitemap_Buffer_XMLWriter {
 	/**
-	 * Initialize the buffer with required headers and root element.
+	 * Initialize the buffer with required headers (no root element here).
 	 */
 	protected function initialize_buffer() {
 		// Add generator comment
@@ -29,8 +29,12 @@ class Jetpack_Sitemap_Buffer_Image_XMLWriter extends Jetpack_Sitemap_Buffer_XMLW
 			'xml-stylesheet',
 			'type="text/xsl" href="' . $this->finder->construct_sitemap_url( 'image-sitemap.xsl' ) . '"'
 		);
+	}
 
-		// Start root element with namespaces
+	/**
+	 * Start the root element and write its namespaces.
+	 */
+	protected function start_root() {
 		$this->writer->startElement( 'urlset' );
 
 		/**

--- a/projects/plugins/jetpack/modules/sitemaps/sitemap-buffer-master-xmlwriter.php
+++ b/projects/plugins/jetpack/modules/sitemaps/sitemap-buffer-master-xmlwriter.php
@@ -14,7 +14,7 @@
 class Jetpack_Sitemap_Buffer_Master_XMLWriter extends Jetpack_Sitemap_Buffer_XMLWriter {
 
 	/**
-	 * Initialize the buffer with required headers and root element.
+	 * Initialize the buffer with required headers (no root element here).
 	 */
 	protected function initialize_buffer() {
 		// Add generator comment
@@ -26,8 +26,12 @@ class Jetpack_Sitemap_Buffer_Master_XMLWriter extends Jetpack_Sitemap_Buffer_XML
 			'xml-stylesheet',
 			'type="text/xsl" href="' . $this->finder->construct_sitemap_url( 'sitemap-index.xsl' ) . '"'
 		);
+	}
 
-		// Start root element with namespaces
+	/**
+	 * Start the root element and write its namespaces.
+	 */
+	protected function start_root() {
 		$this->writer->startElement( 'sitemapindex' );
 		$this->writer->writeAttribute( 'xmlns', 'http://www.sitemaps.org/schemas/sitemap/0.9' );
 	}

--- a/projects/plugins/jetpack/modules/sitemaps/sitemap-buffer-news-xmlwriter.php
+++ b/projects/plugins/jetpack/modules/sitemaps/sitemap-buffer-news-xmlwriter.php
@@ -14,7 +14,7 @@
 class Jetpack_Sitemap_Buffer_News_XMLWriter extends Jetpack_Sitemap_Buffer_XMLWriter {
 
 	/**
-	 * Initialize the buffer with required headers and root element.
+	 * Initialize the buffer with required headers (no root element here).
 	 */
 	protected function initialize_buffer() {
 		// Add generator comment
@@ -26,8 +26,12 @@ class Jetpack_Sitemap_Buffer_News_XMLWriter extends Jetpack_Sitemap_Buffer_XMLWr
 			'xml-stylesheet',
 			'type="text/xsl" href="' . $this->finder->construct_sitemap_url( 'news-sitemap.xsl' ) . '"'
 		);
+	}
 
-		// Start root element with namespaces
+	/**
+	 * Start the root element and write its namespaces.
+	 */
+	protected function start_root() {
 		$this->writer->startElement( 'urlset' );
 
 		/**

--- a/projects/plugins/jetpack/modules/sitemaps/sitemap-buffer-news.php
+++ b/projects/plugins/jetpack/modules/sitemaps/sitemap-buffer-news.php
@@ -60,10 +60,10 @@ class Jetpack_Sitemap_Buffer_News extends Jetpack_Sitemap_Buffer {
 			$namespaces = apply_filters(
 				'jetpack_sitemap_news_ns',
 				array(
-					'xmlns:xsi'          => 'http://www.w3.org/2001/XMLSchema-instance',
-					'xsi:schemaLocation' => 'http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd',
 					'xmlns'              => 'http://www.sitemaps.org/schemas/sitemap/0.9',
 					'xmlns:news'         => 'http://www.google.com/schemas/sitemap-news/0.9',
+					'xmlns:xsi'          => 'http://www.w3.org/2001/XMLSchema-instance',
+					'xsi:schemaLocation' => 'http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd',
 				)
 			);
 

--- a/projects/plugins/jetpack/modules/sitemaps/sitemap-buffer-page-xmlwriter.php
+++ b/projects/plugins/jetpack/modules/sitemaps/sitemap-buffer-page-xmlwriter.php
@@ -14,7 +14,7 @@
 class Jetpack_Sitemap_Buffer_Page_XMLWriter extends Jetpack_Sitemap_Buffer_XMLWriter {
 
 	/**
-	 * Initialize the buffer with required headers and root element.
+	 * Initialize the buffer with required headers (no root element here).
 	 */
 	protected function initialize_buffer() {
 		// Add generator comment
@@ -26,8 +26,12 @@ class Jetpack_Sitemap_Buffer_Page_XMLWriter extends Jetpack_Sitemap_Buffer_XMLWr
 			'xml-stylesheet',
 			'type="text/xsl" href="' . $this->finder->construct_sitemap_url( 'sitemap.xsl' ) . '"'
 		);
+	}
 
-		// Start root element with namespaces
+	/**
+	 * Start the root element and write its namespaces.
+	 */
+	protected function start_root() {
 		$this->writer->startElement( 'urlset' );
 
 		/**

--- a/projects/plugins/jetpack/modules/sitemaps/sitemap-buffer-video-xmlwriter.php
+++ b/projects/plugins/jetpack/modules/sitemaps/sitemap-buffer-video-xmlwriter.php
@@ -18,7 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Jetpack_Sitemap_Buffer_Video_XMLWriter extends Jetpack_Sitemap_Buffer_XMLWriter {
 
 	/**
-	 * Initialize the buffer with required headers and root element.
+	 * Initialize the buffer with required headers (no root element here).
 	 */
 	protected function initialize_buffer() {
 		// Add generator comment
@@ -30,8 +30,12 @@ class Jetpack_Sitemap_Buffer_Video_XMLWriter extends Jetpack_Sitemap_Buffer_XMLW
 			'xml-stylesheet',
 			'type="text/xsl" href="' . $this->finder->construct_sitemap_url( 'video-sitemap.xsl' ) . '"'
 		);
+	}
 
-		// Start root element with namespaces
+	/**
+	 * Start the root element and write its namespaces.
+	 */
+	protected function start_root() {
 		$this->writer->startElement( 'urlset' );
 
 		/**

--- a/projects/plugins/jetpack/modules/sitemaps/sitemap-buffer-xmlwriter.php
+++ b/projects/plugins/jetpack/modules/sitemaps/sitemap-buffer-xmlwriter.php
@@ -350,7 +350,7 @@ abstract class Jetpack_Sitemap_Buffer_XMLWriter {
 	 * This is only here to satisfy the jetpack_print_sitemap filter.
 	 *
 	 * @since 14.6
-	 * @return null
+	 * @return DOMDocument DOM representation of the current sitemap contents.
 	 */
 	public function get_document() {
 		if ( $this->dom_document instanceof DOMDocument ) {

--- a/projects/plugins/jetpack/modules/sitemaps/sitemap-buffer-xmlwriter.php
+++ b/projects/plugins/jetpack/modules/sitemaps/sitemap-buffer-xmlwriter.php
@@ -41,6 +41,15 @@ abstract class Jetpack_Sitemap_Buffer_XMLWriter {
 	protected $is_full_flag;
 
 	/**
+	 * Flag which detects when the buffer is empty.
+	 * Set true on construction and flipped to false only after a successful append.
+	 *
+	 * @since $$next-version$$
+	 * @var bool
+	 */
+	protected $is_empty_flag = true;
+
+	/**
 	 * The most recent timestamp seen by the buffer.
 	 *
 	 * @access protected
@@ -86,9 +95,10 @@ abstract class Jetpack_Sitemap_Buffer_XMLWriter {
 	 * @param string $time The initial datetime of the buffer. Must be in 'YYYY-MM-DD hh:mm:ss' format.
 	 */
 	public function __construct( $item_limit, $byte_limit, $time ) {
-		$this->is_full_flag = false;
-		$this->timestamp    = $time;
-		$this->finder       = new Jetpack_Sitemap_Finder();
+		$this->is_full_flag  = false;
+		$this->is_empty_flag = true;
+		$this->timestamp     = $time;
+		$this->finder        = new Jetpack_Sitemap_Finder();
 
 		$this->writer = new XMLWriter();
 		$this->writer->openMemory();
@@ -136,6 +146,8 @@ abstract class Jetpack_Sitemap_Buffer_XMLWriter {
 		$this->content  .= $current_content;
 
 		$this->append_item( $array );
+		// Mark non-empty only if we actually appended an item.
+		$this->is_empty_flag = false;
 
 		$new_content    = $this->writer->outputMemory( true );
 		$this->content .= $new_content;
@@ -179,10 +191,9 @@ abstract class Jetpack_Sitemap_Buffer_XMLWriter {
 				$this->writer->startElement( $tag );
 				$this->array_to_xml( $value );
 				$this->writer->endElement();
-			} elseif ( 'loc' === $tag || 'image:loc' === $tag || 'video:content_loc' === $tag || 'video:thumbnail_loc' === $tag ) {
-				$this->writer->writeElement( $tag, esc_url( $value ) );
 			} else {
-				$this->writer->writeElement( $tag, esc_html( strval( $value ) ) );
+				// Write raw text; XMLWriter will escape XML-reserved chars, matching DOMDocument behavior.
+				$this->writer->writeElement( $tag, (string) $value );
 			}
 		}
 	}
@@ -223,9 +234,7 @@ abstract class Jetpack_Sitemap_Buffer_XMLWriter {
 	 * @return bool True if the buffer is empty, false otherwise.
 	 */
 	public function is_empty() {
-		$current        = $this->writer->outputMemory( true );
-		$this->content .= $current;
-		return empty( $this->content );
+		return $this->is_empty_flag;
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/sitemaps/sitemap-buffer-xmlwriter.php
+++ b/projects/plugins/jetpack/modules/sitemaps/sitemap-buffer-xmlwriter.php
@@ -86,6 +86,14 @@ abstract class Jetpack_Sitemap_Buffer_XMLWriter {
 	protected $content = '';
 
 	/**
+	 * Tracks whether the root element has been started.
+	 *
+	 * @since $$next-version$$
+	 * @var bool
+	 */
+	protected $root_started = false;
+
+	/**
 	 * Construct a new Jetpack_Sitemap_Buffer_XMLWriter.
 	 *
 	 * @since 14.6
@@ -108,7 +116,17 @@ abstract class Jetpack_Sitemap_Buffer_XMLWriter {
 		$this->item_capacity = max( 1, (int) $item_limit );
 		$this->byte_capacity = max( 1, (int) $byte_limit );
 
+		// Capture and account the XML declaration bytes to mirror DOM behavior.
+		$declaration          = $this->writer->outputMemory( true );
+		$this->content       .= $declaration;
+		$this->byte_capacity -= strlen( $declaration );
+
+		// Allow subclasses to write comments and processing instructions only.
 		$this->initialize_buffer();
+
+		// Capture pre-root bytes (comments/PI). Do not subtract from capacity.
+		$pre_root_output = $this->writer->outputMemory( true );
+		$this->content  .= $pre_root_output;
 	}
 
 	/**
@@ -119,6 +137,34 @@ abstract class Jetpack_Sitemap_Buffer_XMLWriter {
 	 * @since 14.6
 	 */
 	abstract protected function initialize_buffer();
+
+	/**
+	 * Start the root element (e.g., urlset or sitemapindex) and write its attributes.
+	 * Implemented by subclasses.
+	 *
+	 * @since $$next-version$$
+	 * @access protected
+	 * @return void
+	 */
+	abstract protected function start_root();
+
+	/**
+	 * Ensure the root element has been started and account its bytes once.
+	 *
+	 * @since $$next-version$$
+	 * @access protected
+	 * @return void
+	 */
+	protected function ensure_root_started() {
+		if ( $this->root_started ) {
+			return;
+		}
+		$this->start_root();
+		$root_chunk           = $this->writer->outputMemory( true );
+		$this->content       .= $root_chunk;
+		$this->byte_capacity -= strlen( $root_chunk );
+		$this->root_started   = true;
+	}
 
 	/**
 	 * Append an item to the buffer.
@@ -142,8 +188,8 @@ abstract class Jetpack_Sitemap_Buffer_XMLWriter {
 			return false;
 		}
 
-		$current_content = $this->writer->outputMemory( true );
-		$this->content  .= $current_content;
+		// Ensure root is started on first append and account its bytes.
+		$this->ensure_root_started();
 
 		$this->append_item( $array );
 		// Mark non-empty only if we actually appended an item.
@@ -205,6 +251,8 @@ abstract class Jetpack_Sitemap_Buffer_XMLWriter {
 	 * @return string The contents of the buffer.
 	 */
 	public function contents() {
+		// If contents is requested, ensure the root exists so closing tags are valid.
+		$this->ensure_root_started();
 		$this->writer->endElement(); // End root element (urlset/sitemapindex)
 		$this->writer->endDocument();
 		$final_content  = $this->writer->outputMemory( true );

--- a/projects/plugins/jetpack/modules/sitemaps/sitemap-buffer-xmlwriter.php
+++ b/projects/plugins/jetpack/modules/sitemaps/sitemap-buffer-xmlwriter.php
@@ -226,18 +226,26 @@ abstract class Jetpack_Sitemap_Buffer_XMLWriter {
 		// Ensure root is started on first append and account its bytes.
 		$this->ensure_root_started();
 
+		// Attempt to render the item. Subclasses may decide to skip writing
+		// if the input structure is invalid for that sitemap type.
 		$this->append_item( $array );
-		// Mark non-empty only if we actually appended an item.
-		$this->is_empty_flag = false;
 
-		$new_content    = $this->writer->outputMemory( true );
-		$this->content .= $new_content;
+		// Capture only the bytes produced by this item.
+		$new_content = $this->writer->outputMemory( true );
 
-		// Update capacities after successful append
+		// If nothing was written, treat as a no-op: keep the buffer "empty"
+		// and do not consume item/byte capacities.
+		if ( '' === $new_content ) {
+			return true;
+		}
+
+		// Persist newly written bytes and update capacities.
+		$this->content       .= $new_content;
 		$this->item_capacity -= 1;
 		$this->byte_capacity -= strlen( $new_content );
+		$this->is_empty_flag  = false;
 
-		// Check both capacity limits
+		// Check both capacity limits.
 		if ( 0 >= $this->item_capacity || $this->byte_capacity <= 0 ) {
 			$this->is_full_flag = true;
 		}

--- a/projects/plugins/jetpack/modules/sitemaps/sitemap-buffer-xmlwriter.php
+++ b/projects/plugins/jetpack/modules/sitemaps/sitemap-buffer-xmlwriter.php
@@ -94,6 +94,22 @@ abstract class Jetpack_Sitemap_Buffer_XMLWriter {
 	protected $root_started = false;
 
 	/**
+	 * Mirror DOMDocument built on-demand for jetpack_print_sitemap compatibility.
+	 *
+	 * @since $$next-version$$
+	 * @var DOMDocument|null
+	 */
+	protected $dom_document = null;
+
+	/**
+	 * Tracks whether XMLWriter document has been finalized (closed and flushed).
+	 *
+	 * @since $$next-version$$
+	 * @var bool
+	 */
+	protected $is_finalized = false;
+
+	/**
 	 * Construct a new Jetpack_Sitemap_Buffer_XMLWriter.
 	 *
 	 * @since 14.6
@@ -164,6 +180,25 @@ abstract class Jetpack_Sitemap_Buffer_XMLWriter {
 		$this->content       .= $root_chunk;
 		$this->byte_capacity -= strlen( $root_chunk );
 		$this->root_started   = true;
+	}
+
+	/**
+	 * Finalize writer output once by closing the root and document and flushing.
+	 *
+	 * @since $$next-version$$
+	 * @access protected
+	 * @return void
+	 */
+	protected function finalize_writer_output() {
+		if ( $this->is_finalized ) {
+			return;
+		}
+		$this->ensure_root_started();
+		$this->writer->endElement(); // End root element (urlset/sitemapindex)
+		$this->writer->endDocument();
+		$final_content      = $this->writer->outputMemory( true );
+		$this->content     .= $final_content;
+		$this->is_finalized = true;
 	}
 
 	/**
@@ -251,13 +286,10 @@ abstract class Jetpack_Sitemap_Buffer_XMLWriter {
 	 * @return string The contents of the buffer.
 	 */
 	public function contents() {
-		// If contents is requested, ensure the root exists so closing tags are valid.
-		$this->ensure_root_started();
-		$this->writer->endElement(); // End root element (urlset/sitemapindex)
-		$this->writer->endDocument();
-		$final_content  = $this->writer->outputMemory( true );
-		$this->content .= $final_content;
-
+		$this->finalize_writer_output();
+		if ( $this->dom_document instanceof DOMDocument ) {
+			return $this->dom_document->saveXML();
+		}
 		if ( empty( $this->content ) ) {
 			// If buffer is empty, return a minimal valid XML structure
 			return "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\"></urlset>";
@@ -313,6 +345,19 @@ abstract class Jetpack_Sitemap_Buffer_XMLWriter {
 	 * @return null
 	 */
 	public function get_document() {
-		return null;
+		if ( $this->dom_document instanceof DOMDocument ) {
+			return $this->dom_document;
+		}
+
+		$this->finalize_writer_output();
+
+		$dom                     = new DOMDocument( '1.0', 'UTF-8' );
+		$dom->formatOutput       = true; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+		$dom->preserveWhiteSpace = false; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+		// Load current XML content into DOM for compatibility with filters.
+		@$dom->loadXML( $this->content ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- Avoid fatal on unexpected content
+
+		$this->dom_document = $dom;
+		return $this->dom_document;
 	}
 }

--- a/projects/plugins/jetpack/modules/sitemaps/sitemap-builder.php
+++ b/projects/plugins/jetpack/modules/sitemaps/sitemap-builder.php
@@ -951,11 +951,15 @@ class Jetpack_Sitemap_Builder { // phpcs:ignore Generic.Files.OneObjectStructure
 			$this->logger->report( "-- Building $index_debug_name" );
 		}
 
-		$buffer = new Jetpack_Sitemap_Buffer_Master(
+		$buffer = Jetpack_Sitemap_Buffer_Factory::create(
+			'master',
 			JP_SITEMAP_MAX_ITEMS,
 			JP_SITEMAP_MAX_BYTES,
 			$datetime
 		);
+		if ( ! $buffer ) {
+			return false;
+		}
 
 		// Add pointer to the previous sitemap index (unless we're at the first one).
 		if ( 1 !== $number ) {

--- a/projects/plugins/jetpack/tests/php/modules/sitemaps/Jetpack_Sitemap_Buffer_XMLWriter_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/sitemaps/Jetpack_Sitemap_Buffer_XMLWriter_Test.php
@@ -311,4 +311,94 @@ class Jetpack_Sitemap_Buffer_XMLWriter_Test extends WP_UnitTestCase {
 		$buffer->view_time( '2024-03-30 12:00:00' );
 		$this->assertEquals( '2024-03-31 12:00:00', $buffer->last_modified() );
 	}
+
+	/**
+	 * Ensure that a subclass no-op append keeps the buffer empty and does not consume item capacity.
+	 *
+	 * @group jetpack-sitemap
+	 * @since 14.6
+	 */
+	#[Group( 'jetpack-sitemap' )]
+	public function test_noop_append_keeps_buffer_empty() {
+		$buffer = new Jetpack_Sitemap_Buffer_Video_XMLWriter(
+			1, // Max items
+			4096, // Max bytes
+			'1970-01-01 00:00:00'
+		);
+
+		// Missing required 'video:video' makes append_item() a no-op in the video buffer.
+		$noop_item = array(
+			'url' => array(
+				'loc'     => 'https://example.com/page',
+				'lastmod' => '2024-01-01 00:00:00',
+			),
+		);
+
+		$this->assertTrue( $buffer->append( $noop_item ) );
+		$this->assertTrue( $buffer->is_empty(), 'Buffer should remain empty after a no-op append.' );
+
+		// Now append a valid video item; should succeed despite prior no-op, and mark non-empty.
+		$valid_item = array(
+			'url' => array(
+				'loc'         => 'https://example.com/page',
+				'lastmod'     => '2024-01-02 00:00:00',
+				'video:video' => array(
+					'video:title'         => 'Title',
+					'video:thumbnail_loc' => 'https://example.com/thumb.jpg',
+					'video:content_loc'   => 'https://example.com/video.mp4',
+				),
+			),
+		);
+		$this->assertTrue( $buffer->append( $valid_item ) );
+		$this->assertFalse( $buffer->is_empty(), 'Buffer should be non-empty after a valid append.' );
+
+		$content = $buffer->contents();
+		$this->assertStringContainsString( '<video:video>', $content );
+		$this->assertStringContainsString( '<loc>https://example.com/page</loc>', $content );
+	}
+
+	/**
+	 * Mutating the DOMDocument returned by get_document() should be reflected in contents().
+	 *
+	 * @group jetpack-sitemap
+	 * @since 14.6
+	 */
+	#[Group( 'jetpack-sitemap' )]
+	public function test_dom_mutation_affects_contents() {
+		$buffer = new Jetpack_Sitemap_Buffer_Page_XMLWriter(
+			2,
+			8192,
+			'1970-01-01 00:00:00'
+		);
+
+		$buffer->append(
+			array(
+				'url' => array(
+					'loc'     => 'https://example.com/first',
+					'lastmod' => '2024-03-31 12:00:00',
+				),
+			)
+		);
+
+		// Obtain DOM mirror and inject an additional <url> node.
+		$doc = $buffer->get_document();
+		$this->assertInstanceOf( DOMDocument::class, $doc );
+
+		// Root element should exist; guard for static analysis.
+		$root = $doc->documentElement; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+		$this->assertNotNull( $root, 'Root element should exist on DOMDocument' );
+		if ( ! $root ) {
+			$this->fail( 'Root element missing from DOMDocument' );
+			return;
+		}
+
+		$url = $doc->createElement( 'url' );
+		$loc = $doc->createElement( 'loc', 'https://example.com/second' );
+		$url->appendChild( $loc );
+		$root->appendChild( $url );
+
+		$xml = $buffer->contents();
+		$this->assertStringContainsString( '<loc>https://example.com/first</loc>', $xml );
+		$this->assertStringContainsString( '<loc>https://example.com/second</loc>', $xml );
+	}
 }

--- a/projects/plugins/jetpack/tests/php/modules/sitemaps/Jetpack_Sitemap_Buffer_XMLWriter_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/sitemaps/Jetpack_Sitemap_Buffer_XMLWriter_Test.php
@@ -384,13 +384,9 @@ class Jetpack_Sitemap_Buffer_XMLWriter_Test extends WP_UnitTestCase {
 		$doc = $buffer->get_document();
 		$this->assertInstanceOf( DOMDocument::class, $doc );
 
-		// Root element should exist; guard for static analysis.
+		// Root element should exist.
 		$root = $doc->documentElement; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 		$this->assertNotNull( $root, 'Root element should exist on DOMDocument' );
-		if ( ! $root ) {
-			$this->fail( 'Root element missing from DOMDocument' );
-			return;
-		}
 
 		$url = $doc->createElement( 'url' );
 		$loc = $doc->createElement( 'loc', 'https://example.com/second' );


### PR DESCRIPTION
Fixes [HOG-281: Ensure Parity with DOMDocument Solution](https://linear.app/a8c/issue/HOG-281/ensure-parity-with-domdocument-solution)

### Proposed changes:
- Align XMLWriter with DOMDocument for sitemap generation to reduce divergence and ensure spec-compliant output (lazy root, built‑in XML escaping).
- Improve integration and reliability: accurate emptiness reporting, optional DOM mirror for filters, and unified buffer creation in the builder via the factory.

### Other information:
- [x] New tests added
- [x] E2E CI verified
- [ ] Tested on WordPress.com (if applicable)

### Jetpack product discussion
No

### Does this pull request change what data or activity we track or use?
No

### Testing instructions:

Prerequisites
- Ensure Sitemaps is active (Jetpack > Settings > Traffic > Sitemaps).
- XMLWriter is OFF by default; enable it to verify the new path:
  - Docker (recommended): create/edit `tools/docker/mu-plugins/0-snippets.php`:
    ```php
    <?php
    add_filter( 'jetpack_sitemap_use_xmlwriter', '__return_true' );
    ```
    Reload your site. Remove this line to test the DOM path again after purging.
  - Non-Docker: add the same snippet in a small mu-plugin or your theme’s `functions.php`.
- Ensure the PHP `XMLWriter` extension is available if testing outside Docker.
- Make sure to purge the sitemap after every test.
    ```bash
    wp jetpack sitemap rebuild --purge
    ```
    Or locally if using Docker
    ```bash
    jetpack docker wp jetpack sitemap rebuild -- --purge
    ```

Manual verification
1. Build and run (if needed):
   - `jetpack build plugins/jetpack --deps`
   - `jetpack docker up`
2. Visit endpoints and validate:
   - Master index: `[site]/sitemap.xml`
   - News: `[site]/news-sitemap.xml`
   - Image: `[site]/image-sitemap-1.xml` and `image-sitemap-index-1.xml` (if present)
   - Video: `[site]/video-sitemap-1.xml` and `video-sitemap-index-1.xml` (if present)
3. Confirm:
   - XML is well-formed; root and namespaces correct; values with `& < > " '` are escaped.
   - Pagination/limits respected for large sites.
   - With XMLWriter enabled, output remains spec-compliant and functionally equivalent to DOM output.
4. Optional checks:
   - Create posts/titles with special characters and verify escaping appears correctly.
   - Toggle XMLWriter filter off to compare DOM vs XMLWriter behavior quickly.
   - To purge the existing site maps via WP CLI:
    ```bash
    wp jetpack sitemap rebuild --purge
    ```
    Or locally if using Docker
    ```bash
    jetpack docker wp jetpack sitemap rebuild -- --purge
    ```
5. Optional local validation:
   - `curl -s https://example.test/sitemap.xml | xmllint --noout -`

Unit tests
- Docker:
  ```sh
  jetpack docker phpunit jetpack -- --group jetpack-sitemap
  ```
- Local (from `projects/plugins/jetpack`):
  ```sh
  phpunit --group jetpack-sitemap
  ```

Expected results
- Endpoints render valid XML (both XMLWriter and DOM paths).
- No-op appends do not mark buffers non-empty.
- DOM mutations via `get_document()` are reflected in `contents()`.
- Builder master index uses the factory and functions as before.

### Before/After
- Before: XMLWriter started root immediately, manually escaped some values, and could incorrectly report non-empty after no-op appends.
- After: XMLWriter mirrors DOM behavior for root timing and escaping, supports DOM mirroring, and has hardened emptiness logic.