### PR TITLE
[e2e tests] Fix unstable recommendations test - Vaultpress backup step

### DIFF
--- a/projects/plugins/jetpack/changelog/e2e-fix-recommendation-test-vaultpress-step-should-be-visible
+++ b/projects/plugins/jetpack/changelog/e2e-fix-recommendation-test-vaultpress-step-should-be-visible
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: E2E tests: udpate locator to improve flakiness
+
+

--- a/projects/plugins/jetpack/tests/e2e/specs/post-connection/recommendations.test.ts
+++ b/projects/plugins/jetpack/tests/e2e/specs/post-connection/recommendations.test.ts
@@ -112,7 +112,7 @@ test( 'Recommendations (Jetpack Assistant)', async ( { page } ) => {
 		await page.reload();
 
 		await expect(
-			page.getByRole( 'link', { name: 'Get a discount for your first' } ),
+			page.getByRole( 'link', { name: 'Get' } ),
 			'VaultPress Backup step should be visible'
 		).toBeVisible();
 		expect(


### PR DESCRIPTION

Fixes [JETPACK-722](https://linear.app/a8c/issue/JETPACK-722/unstable-recommendations-test-in-vaultpress-backup-step)

## Proposed changes:

Updates the locator used in the Vaultpress backup step in the recommendations which was being unstable.


### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
* e2e tests should pass in CI

