### PR TITLE
Point personal and premium plans to business checkout

### DIFF
--- a/projects/plugins/jetpack/_inc/client/at-a-glance/backups.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/backups.jsx
@@ -113,7 +113,7 @@ class DashBackups extends Component {
 	};
 
 	getJetpackBackupBanner() {
-		const { partnerCoupon, upgradeUrl, siteRawUrl, trackUpgradeButtonView } = this.props;
+		const { partnerCoupon, upgradeUrl, siteRawUrl, trackUpgradeButtonView, blogID } = this.props;
 
 		// Build Business checkout URL variant for WordPress.com non-Business plans, respecting term
 		const isWpcom = isWpcomPlatformSite();
@@ -124,8 +124,8 @@ class DashBackups extends Component {
 		const termSuffix = getPlanTermSuffix( currentPlanSlug );
 		const businessPlanPath = termSuffix ? `business-${ termSuffix }` : 'business';
 		const businessCheckoutHref =
-			isWpcom && ! isBusinessPlan && this.props.blogID
-				? `https://wordpress.com/checkout/${ this.props.blogID }/${ businessPlanPath }`
+			isWpcom && ! isBusinessPlan && blogID
+				? `https://wordpress.com/checkout/${ blogID }/${ businessPlanPath }`
 				: null;
 
 		if ( this.props.hasConnectedOwner ) {

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/backups.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/backups.jsx
@@ -19,6 +19,7 @@ import {
 	getJetpackProductUpsellByFeature,
 	FEATURE_SITE_BACKUPS_JETPACK,
 	getPlanClass,
+	getPlanTermSuffix,
 } from 'lib/plans/constants';
 import { getProductDescriptionUrl } from 'product-descriptions/utils';
 import {
@@ -120,14 +121,8 @@ class DashBackups extends Component {
 		const isBusinessPlan = currentPlanSlug
 			? getPlanClass( currentPlanSlug ) === 'is-business-plan'
 			: false;
-		let businessPlanPath = 'business';
-		if ( /-monthly$/.test( currentPlanSlug ) ) {
-			businessPlanPath = 'business-monthly';
-		} else if ( /-2y$/.test( currentPlanSlug ) ) {
-			businessPlanPath = 'business-2y';
-		} else if ( /-3y$/.test( currentPlanSlug ) ) {
-			businessPlanPath = 'business-3y';
-		}
+		const termSuffix = getPlanTermSuffix( currentPlanSlug );
+		const businessPlanPath = termSuffix ? `business-${ termSuffix }` : 'business';
 		const businessCheckoutHref =
 			isWpcom && ! isBusinessPlan && this.props.blogID
 				? `https://wordpress.com/checkout/${ this.props.blogID }/${ businessPlanPath }`

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/backups.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/backups.jsx
@@ -1,5 +1,5 @@
 import { getRedirectUrl } from '@automattic/jetpack-components';
-import { isWoASite } from '@automattic/jetpack-script-data';
+import { isWoASite, isWpcomPlatformSite } from '@automattic/jetpack-script-data';
 import { ExternalLink } from '@wordpress/components';
 import { dateI18n } from '@wordpress/date';
 import { createInterpolateElement } from '@wordpress/element';
@@ -18,6 +18,7 @@ import analytics from 'lib/analytics';
 import {
 	getJetpackProductUpsellByFeature,
 	FEATURE_SITE_BACKUPS_JETPACK,
+	getPlanClass,
 } from 'lib/plans/constants';
 import { getProductDescriptionUrl } from 'product-descriptions/utils';
 import {
@@ -27,8 +28,8 @@ import {
 	getVaultPressData,
 } from 'state/at-a-glance';
 import { hasConnectedOwner, isOfflineMode, connectUser } from 'state/connection';
-import { getPartnerCoupon, showBackups } from 'state/initial-state';
-import { siteHasFeature, isFetchingSiteData } from 'state/site';
+import { getPartnerCoupon, showBackups, getSiteId } from 'state/initial-state';
+import { siteHasFeature, isFetchingSiteData, getSitePlan } from 'state/site';
 import { isPluginInstalled } from 'state/site/plugins';
 import BackupGettingStarted from './backup-getting-started';
 import BackupUpgrade from './backup-upgrade';
@@ -113,6 +114,25 @@ class DashBackups extends Component {
 	getJetpackBackupBanner() {
 		const { partnerCoupon, upgradeUrl, siteRawUrl, trackUpgradeButtonView } = this.props;
 
+		// Build Business checkout URL variant for WordPress.com non-Business plans, respecting term
+		const isWpcom = isWpcomPlatformSite();
+		const currentPlanSlug = this.props.sitePlan?.product_slug ?? '';
+		const isBusinessPlan = currentPlanSlug
+			? getPlanClass( currentPlanSlug ) === 'is-business-plan'
+			: false;
+		let businessPlanPath = 'business';
+		if ( /-monthly$/.test( currentPlanSlug ) ) {
+			businessPlanPath = 'business-monthly';
+		} else if ( /-2y$/.test( currentPlanSlug ) ) {
+			businessPlanPath = 'business-2y';
+		} else if ( /-3y$/.test( currentPlanSlug ) ) {
+			businessPlanPath = 'business-3y';
+		}
+		const businessCheckoutHref =
+			isWpcom && ! isBusinessPlan && this.props.blogID
+				? `https://wordpress.com/checkout/${ this.props.blogID }/${ businessPlanPath }`
+				: null;
+
 		if ( this.props.hasConnectedOwner ) {
 			if ( partnerCoupon && 'jetpack_backup_daily' === partnerCoupon.product.slug ) {
 				const checkoutUrl = getRedirectUrl( 'jetpack-plugin-partner-coupon-checkout', {
@@ -156,7 +176,7 @@ class DashBackups extends Component {
 							'jetpack'
 						) }
 						disableHref="false"
-						href={ upgradeUrl }
+						href={ businessCheckoutHref || upgradeUrl }
 						eventFeature="backups"
 						path="dashboard"
 						plan={ getJetpackProductUpsellByFeature( FEATURE_SITE_BACKUPS_JETPACK ) }
@@ -518,6 +538,8 @@ class DashBackups extends Component {
 export default connect(
 	state => {
 		return {
+			sitePlan: getSitePlan( state ),
+			blogID: getSiteId( state ),
 			vaultPressData: getVaultPressData( state ),
 			isOfflineMode: isOfflineMode( state ),
 			isVaultPressInstalled: isPluginInstalled( state, 'vaultpress/vaultpress.php' ),

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/videopress.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/videopress.jsx
@@ -7,7 +7,11 @@ import { connect } from 'react-redux';
 import Button from 'components/button';
 import DashItem from 'components/dash-item';
 import JetpackBanner from 'components/jetpack-banner';
-import { getJetpackProductUpsellByFeature, FEATURE_VIDEOPRESS } from 'lib/plans/constants';
+import {
+	getJetpackProductUpsellByFeature,
+	FEATURE_VIDEOPRESS,
+	FEATURE_VIDEO_UPLOADS,
+} from 'lib/plans/constants';
 import { getProductDescriptionUrl } from 'product-descriptions/utils';
 import {
 	connectUser,
@@ -39,6 +43,22 @@ class DashVideoPress extends Component {
 	activateVideoPress = () => this.props.updateOptions( { videopress: true } );
 
 	getContent() {
+		const {
+			hasConnectedOwner,
+			hasVideoPressFeature,
+			hasVideoUploadsFeature,
+			hasVideoPressUnlimitedStorage,
+			isFetching,
+			isOffline,
+			upgradeUrl,
+			videoPressStorageUsed,
+		} = this.props;
+
+		// If the site does not support video uploads, hide the entire VideoPress DashItem
+		if ( ! hasVideoUploadsFeature ) {
+			return null;
+		}
+
 		const labelName = __( 'VideoPress', 'jetpack' );
 
 		const support = {
@@ -48,16 +68,6 @@ class DashVideoPress extends Component {
 			),
 			link: getRedirectUrl( 'jetpack-support-videopress' ),
 		};
-
-		const {
-			hasConnectedOwner,
-			hasVideoPressFeature,
-			hasVideoPressUnlimitedStorage,
-			isFetching,
-			isOffline,
-			upgradeUrl,
-			videoPressStorageUsed,
-		} = this.props;
 
 		const shouldDisplayStorage =
 			hasVideoPressFeature && ! hasVideoPressUnlimitedStorage && null !== videoPressStorageUsed;
@@ -182,6 +192,7 @@ export default connect(
 			siteHasFeature( state, 'videopress-1tb-storage' ) ||
 			siteHasFeature( state, 'videopress-unlimited-storage' ) ||
 			siteHasFeature( state, 'videopress' ),
+		hasVideoUploadsFeature: siteHasFeature( state, FEATURE_VIDEO_UPLOADS ),
 		hasVideoPressUnlimitedStorage: siteHasFeature( state, 'videopress-unlimited-storage' ),
 		isModuleAvailable: isModuleAvailable( state, 'videopress' ),
 		isOffline: isOfflineMode( state ),

--- a/projects/plugins/jetpack/_inc/client/components/settings-card/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/settings-card/index.jsx
@@ -91,7 +91,7 @@ export const SettingsCard = inprops => {
 		scanEnabled = vpData?.data?.features?.security ?? false;
 
 	// Build a direct checkout URL to Business on WordPress.com when applicable
-	const isWpcom = isWpcomPlatformSite();
+	const isWpcom = typeof isWpcomPlatformSite === 'function' ? isWpcomPlatformSite() : false;
 	const currentPlanSlug = props.sitePlan?.product_slug ?? '';
 	const currentPlanClass = currentPlanSlug ? getPlanClass( currentPlanSlug ) : '';
 	const isBusinessPlan = currentPlanClass === 'is-business-plan';

--- a/projects/plugins/jetpack/_inc/client/components/settings-card/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/settings-card/index.jsx
@@ -24,6 +24,15 @@ import {
 	getJetpackProductUpsellByFeature,
 	FEATURE_JETPACK_BLAZE,
 	FEATURE_JETPACK_EARN,
+	// Plan slugs used to detect Personal/Premium tiers (non-Jetpack plan constants)
+	PLAN_PERSONAL,
+	PLAN_PERSONAL_MONTHLY,
+	PLAN_PERSONAL_2_YEARS,
+	PLAN_PERSONAL_3_YEARS,
+	PLAN_PREMIUM,
+	PLAN_PREMIUM_MONTHLY,
+	PLAN_PREMIUM_2_YEARS,
+	PLAN_PREMIUM_3_YEARS,
 } from 'lib/plans/constants';
 import ProStatus from 'pro-status';
 import {
@@ -42,9 +51,10 @@ import {
 	isMultisite,
 	userCanManageModules,
 	shouldInitializeBlaze,
+	getSiteId,
 } from 'state/initial-state';
 import { getModuleOverride, getModule } from 'state/modules';
-import { siteHasFeature, isFetchingSiteData } from 'state/site';
+import { siteHasFeature, isFetchingSiteData, getSitePlan } from 'state/site';
 
 export const SettingsCard = inprops => {
 	const props = {
@@ -85,6 +95,31 @@ export const SettingsCard = inprops => {
 		vpData = props.vaultPressData,
 		backupsEnabled = vpData?.data?.features?.backups ?? false,
 		scanEnabled = vpData?.data?.features?.security ?? false;
+
+	// Determine if the current plan is Personal or Premium (including legacy slugs and multi-year variants)
+	const isPersonalOrPremiumPlan = () => {
+		const currentPlanSlug = props.sitePlan?.product_slug;
+		if ( ! currentPlanSlug ) {
+			return false;
+		}
+		const personalPremiumSlugs = new Set( [
+			PLAN_PERSONAL,
+			PLAN_PERSONAL_MONTHLY,
+			PLAN_PERSONAL_2_YEARS,
+			PLAN_PERSONAL_3_YEARS,
+			PLAN_PREMIUM,
+			PLAN_PREMIUM_MONTHLY,
+			PLAN_PREMIUM_2_YEARS,
+			PLAN_PREMIUM_3_YEARS,
+		] );
+		return personalPremiumSlugs.has( currentPlanSlug );
+	};
+
+	// Build a direct checkout URL to Business on WordPress.com when applicable
+	const businessCheckoutHref =
+		isPersonalOrPremiumPlan() && props.blogID
+			? `https://wordpress.com/checkout/${ props.blogID }/business`
+			: null;
 
 	// Non admin users only get Publicize and Post by Email settings.
 	if (
@@ -154,7 +189,7 @@ export const SettingsCard = inprops => {
 						plan={ getJetpackProductUpsellByFeature( FEATURE_WORDADS_JETPACK ) }
 						feature={ feature }
 						onClick={ handleClickForTracking( feature ) }
-						href={ props.adsUpgradeUrl }
+						href={ businessCheckoutHref || props.adsUpgradeUrl }
 						rna
 					/>
 				) : (
@@ -187,7 +222,7 @@ export const SettingsCard = inprops => {
 							callToAction={ upgradeLabel() }
 							feature={ feature }
 							onClick={ handleClickForTracking( feature ) }
-							href={ props.securityUpgradeUrl }
+							href={ businessCheckoutHref || props.securityUpgradeUrl }
 							rna
 						/>
 					) : (
@@ -215,7 +250,7 @@ export const SettingsCard = inprops => {
 						plan={ getJetpackProductUpsellByFeature( FEATURE_SECURITY_SCANNING_JETPACK ) }
 						feature={ feature }
 						onClick={ handleClickForTracking( feature ) }
-						href={ props.scanUpgradeUrl }
+						href={ businessCheckoutHref || props.scanUpgradeUrl }
 						rna
 					/>
 				) : (
@@ -351,7 +386,7 @@ export const SettingsCard = inprops => {
 						plan={ getJetpackProductUpsellByFeature( FEATURE_GOOGLE_ANALYTICS_JETPACK ) }
 						feature={ feature }
 						onClick={ handleClickForTracking( feature ) }
-						href={ props.gaUpgradeUrl }
+						href={ businessCheckoutHref || props.gaUpgradeUrl }
 						rna
 					/>
 				) : (
@@ -403,7 +438,7 @@ export const SettingsCard = inprops => {
 						title={ __( 'Automatically clear spam from comments and forms.', 'jetpack' ) }
 						plan={ getJetpackProductUpsellByFeature( FEATURE_SPAM_AKISMET_PLUS ) }
 						feature={ feature }
-						href={ props.spamUpgradeUrl }
+						href={ businessCheckoutHref || props.spamUpgradeUrl }
 						rna
 					/>
 				);
@@ -422,7 +457,7 @@ export const SettingsCard = inprops => {
 						) }
 						plan={ getJetpackProductUpsellByFeature( FEATURE_SIMPLE_PAYMENTS_JETPACK ) }
 						feature={ feature }
-						href={ props.simplePaymentsUpgradeUrl }
+						href={ businessCheckoutHref || props.simplePaymentsUpgradeUrl }
 						rna
 					/>
 				) : (
@@ -593,6 +628,8 @@ SettingsCard.propTypes = {
 
 export default connect( state => {
 	return {
+		sitePlan: getSitePlan( state ),
+		blogID: getSiteId( state ),
 		fetchingSiteData: isFetchingSiteData( state ),
 		siteAdminUrl: getSiteAdminUrl( state ),
 		userCanManageModules: userCanManageModules( state ),

--- a/projects/plugins/jetpack/_inc/client/components/settings-card/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/settings-card/index.jsx
@@ -24,6 +24,7 @@ import {
 	FEATURE_POST_BY_EMAIL,
 	getJetpackProductUpsellByFeature,
 	getPlanClass,
+	getPlanTermSuffix,
 	FEATURE_JETPACK_BLAZE,
 	FEATURE_JETPACK_EARN,
 } from 'lib/plans/constants';
@@ -95,16 +96,9 @@ export const SettingsCard = inprops => {
 	const currentPlanClass = currentPlanSlug ? getPlanClass( currentPlanSlug ) : '';
 	const isBusinessPlan = currentPlanClass === 'is-business-plan';
 
-	// Determine Business plan variant based on current plan term (monthly/2y/3y). Default to yearly (no suffix)
-	let businessPlanPath = 'business';
-	if ( /-monthly$/.test( currentPlanSlug ) ) {
-		businessPlanPath = 'business-monthly';
-	} else if ( /-2y$/.test( currentPlanSlug ) ) {
-		businessPlanPath = 'business-2y';
-	} else if ( /-3y$/.test( currentPlanSlug ) ) {
-		businessPlanPath = 'business-3y';
-	}
-
+	// Determine Business plan variant based on current plan term
+	const termSuffix = getPlanTermSuffix( currentPlanSlug );
+	const businessPlanPath = termSuffix ? `business-${ termSuffix }` : 'business';
 	const businessCheckoutHref =
 		isWpcom && ! isBusinessPlan && props.blogID
 			? `https://wordpress.com/checkout/${ props.blogID }/${ businessPlanPath }`

--- a/projects/plugins/jetpack/_inc/client/components/settings-card/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/settings-card/index.jsx
@@ -1,4 +1,5 @@
 import { getUserConnectionUrl } from '@automattic/jetpack-connection';
+import { isWpcomPlatformSite } from '@automattic/jetpack-script-data';
 import { __, _x } from '@wordpress/i18n';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
@@ -22,17 +23,9 @@ import {
 	FEATURE_JETPACK_SOCIAL,
 	FEATURE_POST_BY_EMAIL,
 	getJetpackProductUpsellByFeature,
+	getPlanClass,
 	FEATURE_JETPACK_BLAZE,
 	FEATURE_JETPACK_EARN,
-	// Plan slugs used to detect Personal/Premium tiers (non-Jetpack plan constants)
-	PLAN_PERSONAL,
-	PLAN_PERSONAL_MONTHLY,
-	PLAN_PERSONAL_2_YEARS,
-	PLAN_PERSONAL_3_YEARS,
-	PLAN_PREMIUM,
-	PLAN_PREMIUM_MONTHLY,
-	PLAN_PREMIUM_2_YEARS,
-	PLAN_PREMIUM_3_YEARS,
 } from 'lib/plans/constants';
 import ProStatus from 'pro-status';
 import {
@@ -96,28 +89,14 @@ export const SettingsCard = inprops => {
 		backupsEnabled = vpData?.data?.features?.backups ?? false,
 		scanEnabled = vpData?.data?.features?.security ?? false;
 
-	// Determine if the current plan is Personal or Premium (including legacy slugs and multi-year variants)
-	const isPersonalOrPremiumPlan = () => {
-		const currentPlanSlug = props.sitePlan?.product_slug;
-		if ( ! currentPlanSlug ) {
-			return false;
-		}
-		const personalPremiumSlugs = new Set( [
-			PLAN_PERSONAL,
-			PLAN_PERSONAL_MONTHLY,
-			PLAN_PERSONAL_2_YEARS,
-			PLAN_PERSONAL_3_YEARS,
-			PLAN_PREMIUM,
-			PLAN_PREMIUM_MONTHLY,
-			PLAN_PREMIUM_2_YEARS,
-			PLAN_PREMIUM_3_YEARS,
-		] );
-		return personalPremiumSlugs.has( currentPlanSlug );
-	};
-
 	// Build a direct checkout URL to Business on WordPress.com when applicable
+	const isWpcom = isWpcomPlatformSite();
+	const currentPlanClass = props.sitePlan?.product_slug
+		? getPlanClass( props.sitePlan.product_slug )
+		: '';
+	const isBusinessPlan = currentPlanClass === 'is-business-plan';
 	const businessCheckoutHref =
-		isPersonalOrPremiumPlan() && props.blogID
+		isWpcom && ! isBusinessPlan && props.blogID
 			? `https://wordpress.com/checkout/${ props.blogID }/business`
 			: null;
 

--- a/projects/plugins/jetpack/_inc/client/components/settings-card/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/settings-card/index.jsx
@@ -91,13 +91,23 @@ export const SettingsCard = inprops => {
 
 	// Build a direct checkout URL to Business on WordPress.com when applicable
 	const isWpcom = isWpcomPlatformSite();
-	const currentPlanClass = props.sitePlan?.product_slug
-		? getPlanClass( props.sitePlan.product_slug )
-		: '';
+	const currentPlanSlug = props.sitePlan?.product_slug ?? '';
+	const currentPlanClass = currentPlanSlug ? getPlanClass( currentPlanSlug ) : '';
 	const isBusinessPlan = currentPlanClass === 'is-business-plan';
+
+	// Determine Business plan variant based on current plan term (monthly/2y/3y). Default to yearly (no suffix)
+	let businessPlanPath = 'business';
+	if ( /-monthly$/.test( currentPlanSlug ) ) {
+		businessPlanPath = 'business-monthly';
+	} else if ( /-2y$/.test( currentPlanSlug ) ) {
+		businessPlanPath = 'business-2y';
+	} else if ( /-3y$/.test( currentPlanSlug ) ) {
+		businessPlanPath = 'business-3y';
+	}
+
 	const businessCheckoutHref =
 		isWpcom && ! isBusinessPlan && props.blogID
-			? `https://wordpress.com/checkout/${ props.blogID }/business`
+			? `https://wordpress.com/checkout/${ props.blogID }/${ businessPlanPath }`
 			: null;
 
 	// Non admin users only get Publicize and Post by Email settings.

--- a/projects/plugins/jetpack/_inc/client/lib/plans/constants.js
+++ b/projects/plugins/jetpack/_inc/client/lib/plans/constants.js
@@ -869,6 +869,30 @@ export function getMonthlyPlanByYearly( plan ) {
 }
 
 /**
+ * Returns the plan term suffix for a given plan slug, formatted for checkout paths.
+ * Recognizes '-monthly', '-2y', and '-3y' suffixes in slugs and returns
+ * 'monthly', '2-years', '3-years' respectively; defaults to '' (yearly or unspecified).
+ *
+ * @param {string} plan - The plan slug
+ * @return {string} One of 'monthly', '2-years', '3-years', or '' when no explicit term found
+ */
+export function getPlanTermSuffix( plan ) {
+	if ( typeof plan !== 'string' || plan.length === 0 ) {
+		return '';
+	}
+	if ( /-monthly$/.test( plan ) ) {
+		return 'monthly';
+	}
+	if ( /-2y$/.test( plan ) ) {
+		return '2-years';
+	}
+	if ( /-3y$/.test( plan ) ) {
+		return '3-years';
+	}
+	return '';
+}
+
+/**
  * Determines if the plan or product is a special gifted offering.
  *
  * @param {string} planOrProductSlug - A plan or product slug.

--- a/projects/plugins/jetpack/_inc/client/lib/plans/constants.js
+++ b/projects/plugins/jetpack/_inc/client/lib/plans/constants.js
@@ -880,15 +880,22 @@ export function getPlanTermSuffix( plan ) {
 	if ( typeof plan !== 'string' || plan.length === 0 ) {
 		return '';
 	}
-	if ( /-monthly$/.test( plan ) ) {
-		return 'monthly';
+
+	// Explicit handling for Personal and Premium checkout plan slugs
+	switch ( plan ) {
+		case PLAN_PREMIUM_MONTHLY:
+		case PLAN_PERSONAL_MONTHLY:
+			return 'monthly';
+
+		case PLAN_PREMIUM_2_YEARS:
+		case PLAN_PERSONAL_2_YEARS:
+			return '2-years';
+
+		case PLAN_PREMIUM_3_YEARS:
+		case PLAN_PERSONAL_3_YEARS:
+			return '3-years';
 	}
-	if ( /-2y$/.test( plan ) ) {
-		return '2-years';
-	}
-	if ( /-3y$/.test( plan ) ) {
-		return '3-years';
-	}
+
 	return '';
 }
 

--- a/projects/plugins/jetpack/_inc/client/performance/media.jsx
+++ b/projects/plugins/jetpack/_inc/client/performance/media.jsx
@@ -44,7 +44,7 @@ class Media extends Component {
 		}
 
 		// Hide entire VideoPress settings on WordPress.com when not on Business plan
-		const isWpcom = isWpcomPlatformSite();
+		const isWpcom = typeof isWpcomPlatformSite === 'function' ? isWpcomPlatformSite() : false;
 		const currentPlanSlug = this.props.sitePlan?.product_slug ?? '';
 		const currentPlanClass = currentPlanSlug ? getPlanClass( currentPlanSlug ) : '';
 		const isBusinessPlan = currentPlanClass === 'is-business-plan';

--- a/projects/plugins/jetpack/_inc/client/performance/media.jsx
+++ b/projects/plugins/jetpack/_inc/client/performance/media.jsx
@@ -1,4 +1,5 @@
 import { ProgressBar, ToggleControl, getRedirectUrl } from '@automattic/jetpack-components';
+import { isWpcomPlatformSite } from '@automattic/jetpack-script-data';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, _x, sprintf } from '@wordpress/i18n';
 import { Component } from 'react';
@@ -13,6 +14,7 @@ import {
 	getJetpackProductUpsellByFeature,
 	FEATURE_VIDEOPRESS,
 	FEATURE_VIDEO_HOSTING_JETPACK,
+	getPlanClass,
 } from 'lib/plans/constants';
 import { getProductDescriptionUrl } from 'product-descriptions/utils';
 import { hasConnectedOwner as hasConnectedOwnerSelector, isOfflineMode } from 'state/connection';
@@ -38,6 +40,15 @@ class Media extends Component {
 		const foundVideoPress = this.props.isModuleFound( 'videopress' );
 
 		if ( ! foundVideoPress ) {
+			return null;
+		}
+
+		// Hide entire VideoPress settings on WordPress.com when not on Business plan
+		const isWpcom = isWpcomPlatformSite();
+		const currentPlanSlug = this.props.sitePlan?.product_slug ?? '';
+		const currentPlanClass = currentPlanSlug ? getPlanClass( currentPlanSlug ) : '';
+		const isBusinessPlan = currentPlanClass === 'is-business-plan';
+		if ( isWpcom && ! isBusinessPlan ) {
 			return null;
 		}
 

--- a/projects/plugins/jetpack/_inc/client/traffic/blaze.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/blaze.jsx
@@ -39,7 +39,8 @@ function Blaze( props ) {
 	const { can_init: canInit, reason } = blazeAvailable;
 
 	// On WordPress.com, hide Blaze settings entirely when it cannot initialize, regardless of plan
-	if ( isWpcomPlatformSite() && ! canInit ) {
+	const isWpcom = typeof isWpcomPlatformSite === 'function' ? isWpcomPlatformSite() : false;
+	if ( isWpcom && ! canInit ) {
 		return null;
 	}
 

--- a/projects/plugins/jetpack/_inc/client/traffic/blaze.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/blaze.jsx
@@ -1,5 +1,5 @@
 import { getRedirectUrl, ToggleControl } from '@automattic/jetpack-components';
-import { isWoASite } from '@automattic/jetpack-script-data';
+import { isWoASite, isWpcomPlatformSite } from '@automattic/jetpack-script-data';
 import { __ } from '@wordpress/i18n';
 import { connect } from 'react-redux';
 import Card from 'components/card';
@@ -37,6 +37,11 @@ function Blaze( props ) {
 	} = props;
 
 	const { can_init: canInit, reason } = blazeAvailable;
+
+	// On WordPress.com, hide Blaze settings entirely when it cannot initialize, regardless of plan
+	if ( isWpcomPlatformSite() && ! canInit ) {
+		return null;
+	}
 
 	if ( isWoASite() && ! blazeDashboardEnabled ) {
 		return null;

--- a/projects/plugins/jetpack/changelog/update-point-personal-and-premium-plans-to-business-checkout
+++ b/projects/plugins/jetpack/changelog/update-point-personal-and-premium-plans-to-business-checkout
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Updating upgrade banners and buttons for Personal and Premium


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes DOTOBRD-294

## Proposed changes:

* Introducing Personal and Premium on Atomic enables a lot of previously unused upsells. They don't work. Make them work, if possible, or hide them, if unclear what to do.

The previously unused upsells point to the disabled my-jetpack page and return 403s. If that's hardcoded to not return 403, they point to unsupported JP products. If these are converted to supported products on the backend, it's still broken because the prices are incorrect.

So I chose this approach over disabling the whole Settings page for Personal and Premium, however, we may need to temporarily disable these pages due to the release cycle. These are the upsells:

<img width="1098" height="283" alt="Screenshot 2025-08-08 at 14 58 15" src="https://github.com/user-attachments/assets/4017b29e-866f-4995-95b7-aae7153ad3a0" />

<img width="1393" height="596" alt="Screenshot 2025-08-08 at 14 57 29" src="https://github.com/user-attachments/assets/07c8071a-35f7-4e21-9f6f-023b41f73726" />

<img width="1399" height="399" alt="Screenshot 2025-08-08 at 14 58 25" src="https://github.com/user-attachments/assets/74942040-2050-455d-86c8-d94a3da381ee" />

The change preserves the billing term and points to business.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:

* Create a dev blog with Business using credits / production
* pnpm rsync the changes to the dev blog (this only works once without a happiness_ user)
* Switch to a Personal or Premium plan using SA
* Go to Jetpack -> Settings
* There should be no visible upsells that are broken, previously almost all were broken

This doesn't intend to fix all edge cases, it aims at everything that's broken in the settings screen by default