### PR TITLE
Summer special promo: Match Atomic Personal/Premium Jetpack menu items with Simple

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/remove-summer-special-menu-items
+++ b/projects/packages/jetpack-mu-wpcom/changelog/remove-summer-special-menu-items
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Removes Stats from Atomic Personal and Premium plans
+Removes broken Stats menu item for Atomic Personal sites

--- a/projects/packages/jetpack-mu-wpcom/changelog/remove-summer-special-menu-items
+++ b/projects/packages/jetpack-mu-wpcom/changelog/remove-summer-special-menu-items
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Removes broken Stats menu item for Atomic Personal sites
+Removes broken menu items for Atomic Personal/Premium sites

--- a/projects/packages/jetpack-mu-wpcom/changelog/remove-summer-special-menu-items
+++ b/projects/packages/jetpack-mu-wpcom/changelog/remove-summer-special-menu-items
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Removes Stats from Atomic Personal and Premium plans

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
@@ -211,7 +211,6 @@ function wpcom_add_jetpack_submenu() {
 	if ( class_exists( '\\Automattic\\Jetpack\\Current_Plan' ) ) {
 		$current_plan           = \Automattic\Jetpack\Current_Plan::get();
 		$plan_class             = $current_plan['class'] ?? '';
-		$plan_class             = isset( $current_plan['class'] ) ? $current_plan['class'] : '';
 		$is_personal_or_premium = in_array( $plan_class, array( 'personal', 'premium' ), true );
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
@@ -206,6 +206,7 @@ function wpcom_add_jetpack_submenu() {
 
 	$domain = wp_parse_url( home_url(), PHP_URL_HOST );
 
+	// @codeCoverageIgnoreStart
 	// Hide certain Jetpack submenus for Atomic sites on Personal or Premium plans.
 	$is_personal_or_premium = false;
 	if ( class_exists( '\\Automattic\\Jetpack\\Current_Plan' ) ) {
@@ -244,8 +245,8 @@ function wpcom_add_jetpack_submenu() {
 			null // @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
 		);
 
-				// Jetpack > Newsletter (Calypso).
-		// Force Calypso for atomic Personal/Premium sites since local Jetpack newsletter page is broken.
+		// Jetpack > Newsletter (Calypso).
+		// Force Calypso for atomic Personal/Premium sites since local Jetpack newsletter page exposes broken pages.
 		add_submenu_page(
 			'jetpack',
 			esc_attr__( 'Newsletter', 'jetpack-mu-wpcom' ),
@@ -254,8 +255,8 @@ function wpcom_add_jetpack_submenu() {
 			'https://wordpress.com/settings/newsletter/' . $domain,
 			null // @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
 		);
-
 	}
+	// @codeCoverageIgnoreEnd
 
 	// Jetpack > Scan.
 	wpcom_hide_submenu_page( 'jetpack', esc_url( Redirect::get_url( 'cloud-scan-history-wp-menu' ) ) );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
@@ -206,6 +206,12 @@ function wpcom_add_jetpack_submenu() {
 
 	$domain = wp_parse_url( home_url(), PHP_URL_HOST );
 
+	$has_summer_special_2025 = (
+		function_exists( 'has_blog_sticker' ) && has_blog_sticker( 'summer-special-2025' )
+	) || (
+		function_exists( 'wpcomsh_is_site_sticker_active' ) && wpcomsh_is_site_sticker_active( 'summer-special-2025' )
+	);
+
 	// Hide certain Jetpack submenus for Atomic sites on Personal or Premium plans.
 	$is_personal_or_premium = false;
 	if ( class_exists( '\\Automattic\\Jetpack\\Current_Plan' ) ) {
@@ -214,7 +220,7 @@ function wpcom_add_jetpack_submenu() {
 		$is_personal_or_premium = in_array( $plan_class, array( 'personal', 'premium' ), true );
 	}
 
-	if ( ! $is_simple_site && $is_personal_or_premium ) {
+	if ( ! $has_summer_special_2025 && $is_personal_or_premium ) {
 		// Jetpack > Stats.
 		wpcom_hide_submenu_page( 'jetpack', 'stats' );
 	}

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
@@ -206,6 +206,19 @@ function wpcom_add_jetpack_submenu() {
 
 	$domain = wp_parse_url( home_url(), PHP_URL_HOST );
 
+	// Hide certain Jetpack submenus for Atomic sites on Personal or Premium plans.
+	$is_personal_or_premium = false;
+	if ( class_exists( '\\Automattic\\Jetpack\\Current_Plan' ) ) {
+		$current_plan           = \Automattic\Jetpack\Current_Plan::get();
+		$plan_class             = isset( $current_plan['class'] ) ? $current_plan['class'] : '';
+		$is_personal_or_premium = in_array( $plan_class, array( 'personal', 'premium' ), true );
+	}
+
+	if ( ! $is_simple_site && $is_personal_or_premium ) {
+		// Jetpack > Stats.
+		wpcom_hide_submenu_page( 'jetpack', 'stats' );
+	}
+
 	// Jetpack > Scan.
 	wpcom_hide_submenu_page( 'jetpack', esc_url( Redirect::get_url( 'cloud-scan-history-wp-menu' ) ) );
 	wpcom_hide_submenu_page( 'jetpack', esc_url( Redirect::get_url( 'calypso-scanner' ) ) );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
@@ -206,21 +206,15 @@ function wpcom_add_jetpack_submenu() {
 
 	$domain = wp_parse_url( home_url(), PHP_URL_HOST );
 
-	$has_summer_special_2025 = (
-		function_exists( 'has_blog_sticker' ) && has_blog_sticker( 'summer-special-2025' )
-	) || (
-		function_exists( 'wpcomsh_is_site_sticker_active' ) && wpcomsh_is_site_sticker_active( 'summer-special-2025' )
-	);
-
 	// Hide certain Jetpack submenus for Atomic sites on Personal or Premium plans.
-	$is_personal_or_premium = false;
+	$is_personal = false;
 	if ( class_exists( '\\Automattic\\Jetpack\\Current_Plan' ) ) {
-		$current_plan           = \Automattic\Jetpack\Current_Plan::get();
-		$plan_class             = isset( $current_plan['class'] ) ? $current_plan['class'] : '';
-		$is_personal_or_premium = in_array( $plan_class, array( 'personal', 'premium' ), true );
+		$current_plan = \Automattic\Jetpack\Current_Plan::get();
+		$plan_class   = isset( $current_plan['class'] ) ? $current_plan['class'] : '';
+		$is_personal  = $plan_class === 'personal';
 	}
 
-	if ( ! $has_summer_special_2025 && $is_personal_or_premium ) {
+	if ( ! $is_simple_site && $is_personal ) {
 		// Jetpack > Stats.
 		wpcom_hide_submenu_page( 'jetpack', 'stats' );
 	}

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
@@ -245,6 +245,17 @@ function wpcom_add_jetpack_submenu() {
 			null // @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
 		);
 
+				// Jetpack > Newsletter (Calypso).
+		// Force Calypso for atomic Personal/Premium sites since local Jetpack newsletter page is broken.
+		add_submenu_page(
+			'jetpack',
+			esc_attr__( 'Newsletter', 'jetpack-mu-wpcom' ),
+			__( 'Newsletter', 'jetpack-mu-wpcom' ),
+			'manage_options',
+			'https://wordpress.com/settings/newsletter/' . $domain,
+			null // @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
+		);
+
 	}
 
 	// Jetpack > Scan.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
@@ -207,16 +207,32 @@ function wpcom_add_jetpack_submenu() {
 	$domain = wp_parse_url( home_url(), PHP_URL_HOST );
 
 	// Hide certain Jetpack submenus for Atomic sites on Personal or Premium plans.
-	$is_personal = false;
+	$is_personal_or_premium = false;
 	if ( class_exists( '\\Automattic\\Jetpack\\Current_Plan' ) ) {
-		$current_plan = \Automattic\Jetpack\Current_Plan::get();
-		$plan_class   = $current_plan['class'] ?? '';
-		$is_personal  = $plan_class === 'personal';
+		$current_plan           = \Automattic\Jetpack\Current_Plan::get();
+		$plan_class             = $current_plan['class'] ?? '';
+		$plan_class             = isset( $current_plan['class'] ) ? $current_plan['class'] : '';
+		$is_personal_or_premium = in_array( $plan_class, array( 'personal', 'premium' ), true );
 	}
 
-	if ( ! $is_simple_site && $is_personal ) {
+	if ( ! $is_simple_site && $is_personal_or_premium ) {
 		// Jetpack > Stats.
-		wpcom_hide_submenu_page( 'jetpack', 'stats' );
+		// Jetpack > My Jetpack.
+		wpcom_hide_submenu_page( 'jetpack', 'my-jetpack' );
+
+		// Jetpack > Settings.
+		wpcom_hide_submenu_page( 'jetpack', admin_url( 'admin.php?page=jetpack#/settings' ) );
+
+		// Jetpack > Traffic (Calypso).
+		add_submenu_page(
+			'jetpack',
+			esc_attr__( 'Traffic', 'jetpack-mu-wpcom' ),
+			__( 'Traffic', 'jetpack-mu-wpcom' ),
+			'manage_options',
+			'https://wordpress.com/marketing/traffic/' . $domain,
+			null // @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
+		);
+
 	}
 
 	// Jetpack > Scan.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
@@ -223,6 +223,18 @@ function wpcom_add_jetpack_submenu() {
 		// Jetpack > Settings.
 		wpcom_hide_submenu_page( 'jetpack', admin_url( 'admin.php?page=jetpack#/settings' ) );
 
+		// Redirect My Jetpack page to Stats for Atomic sites on Personal or Premium plans.
+		add_action(
+			'admin_init',
+			function () {
+				// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- No action taken, just checking page.
+				if ( isset( $_GET['page'] ) && 'my-jetpack' === $_GET['page'] ) {
+					wp_safe_redirect( admin_url( 'admin.php?page=stats' ) );
+					exit;
+				}
+			}
+		);
+
 		// Jetpack > Traffic (Calypso).
 		add_submenu_page(
 			'jetpack',

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
@@ -210,7 +210,7 @@ function wpcom_add_jetpack_submenu() {
 	$is_personal = false;
 	if ( class_exists( '\\Automattic\\Jetpack\\Current_Plan' ) ) {
 		$current_plan = \Automattic\Jetpack\Current_Plan::get();
-		$plan_class   = isset( $current_plan['class'] ) ? $current_plan['class'] : '';
+		$plan_class   = $current_plan['class'] ?? '';
 		$is_personal  = $plan_class === 'personal';
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
@@ -216,7 +216,6 @@ function wpcom_add_jetpack_submenu() {
 	}
 
 	if ( ! $is_simple_site && $is_personal_or_premium ) {
-		// Jetpack > Stats.
 		// Jetpack > My Jetpack.
 		wpcom_hide_submenu_page( 'jetpack', 'my-jetpack' );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes [DOTOBRD-294](https://linear.app/a8c/issue/DOTOBRD-294/multiple-upgrade-buttons-do-not-work)

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* removes the `Jetpack` -> `My Jetpack` menu item from atomic Personal and Premium
* redirects from `My Jetpack` to `Stats` when clicking the parent `Jetpack` item
* adds/restores the `Jetpack` -> `Newsletter` item
* replaces `Jetpack` -> `Settings` with `Traffic`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

* These pages haven't been tested with the scenario where Personal/Premium plans are atomic, showcasing broken functionality and incorrect features. The changes attempt to show the menu items similar to the Simple site scenario.



## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a site with a Personal plan with the Summer Special promo activated (ie. `summer-special-2025` blog-sticker added)
* Add the site to the dev blogs (including dev server pool) - so you can rsync these changes
* Trigger atomic transfer for the site by installing a plugin/theme
* Create a support SFTP user via the Blog RC
* Use the support user to rsync the change via this command:
`pnpm jetpack rsync wpcomsh {SFTP_SUPPORT_URSER}@sftp.wp.com:~/htdocs/wp-content/mu-plugins`
* The `My Jetpack` item should be removed
* The `Newsletter` item should be visible. Apply https://github.com/Automattic/wp-calypso/pull/105154 to see the correct page.
* The `Settings` item should be replaced with the `Traffic` item from Simple sites

<img width="480" alt="Screenshot 2025-08-11 at 11 08 16" src="https://github.com/user-attachments/assets/eeeaadc5-fc48-4919-868d-8186fe7e41f0" />
