### PR TITLE
Fix DSP stats endpoint

### DIFF
--- a/projects/packages/blaze/changelog/fix-dsp-stats endpoing
+++ b/projects/packages/blaze/changelog/fix-dsp-stats endpoing
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: minor fix
+
+

--- a/projects/packages/blaze/changelog/fix-dsp-stats-endpoint
+++ b/projects/packages/blaze/changelog/fix-dsp-stats-endpoint
@@ -1,5 +1,6 @@
 Significance: patch
 Type: fixed
-Comment: minor fix
+
+Fixed the stats endpoint for DSP
 
 

--- a/projects/packages/blaze/src/class-dashboard-rest-controller.php
+++ b/projects/packages/blaze/src/class-dashboard-rest-controller.php
@@ -598,7 +598,7 @@ class Dashboard_REST_Controller {
 	 */
 	public function edit_dsp_stats( $req ) {
 		$version = $req->get_param( 'api_version' ) ?? 'v1';
-		return $this->get_dsp_generic( "{$version}/stats", $req );
+		return $this->edit_dsp_generic( "{$version}/stats", $req );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #

This is a minor fix. we noticed that the download stats for a Blaze campaign is failing to post to the DSP endpoint

we investigated and we found a typo that was preventing jetpack to connect to the DSP BE

we are tracking in linear in ticket ADS-366

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

a CR is enough (it is a one liner)

if you want to test you will need a campaign with stats

visit the campaign details page and hit the download stats button (on top left of the page)


<img width="410" height="196" alt="Screenshot 2025-08-08 at 15 00 09" src="https://github.com/user-attachments/assets/6210a72c-614d-453d-b228-105c93fe7094" />

