### PR TITLE
Forms: more visual time field

### DIFF
--- a/projects/packages/forms/changelog/update-forms-time-visual-update
+++ b/projects/packages/forms/changelog/update-forms-time-visual-update
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-Forms: more visual time field"
+Forms: update beta-time field to be more visual.

--- a/projects/packages/forms/changelog/update-forms-time-visual-update
+++ b/projects/packages/forms/changelog/update-forms-time-visual-update
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: more visual time field"

--- a/projects/packages/forms/src/blocks/field-time/style.scss
+++ b/projects/packages/forms/src/blocks/field-time/style.scss
@@ -1,0 +1,54 @@
+.jetpack-forms-field-time {
+	display: flex;
+}
+
+.jetpack-field-time__separator {
+	display: inline-block;
+	padding-top: calc(var(--jetpack--contact-form--input-padding-top, 16px) + 4px);
+
+	color: var(--jetpack--contact-form--text-color);
+	font-family: var(--jetpack--contact-form--font-family);
+	font-size: var(--jetpack--contact-form--font-size);
+
+	border-color: var(--jetpack--contact-form--border-color);
+	border-style: var(--jetpack--contact-form--border-style);
+	border-top-width: var(--jetpack--contact-form--border-top-size, var(--jetpack--contact-form--border-size));
+	border-bottom-width: var(--jetpack--contact-form--border-bottom-size, var(--jetpack--contact-form--border-size));
+	border-left-width: 0;
+	border-right-width: 0;
+	border-radius: unset;
+	max-width: 100px;
+	background-color: var(--jetpack--contact-form--input-background);
+}
+
+.jetpack-field-time__minutes-input-wrap,
+.jetpack-field-time__hours-input-wrap {
+	box-sizing: border-box;
+	width: calc(60px);
+	z-index: 2; // Ensures outline is always visible and not under separator
+}
+
+/* Remove native arrow buttons */
+.jetpack-field-time__hours-input,
+.jetpack-field-time__minutes-input {
+	-moz-appearance: textfield;
+	appearance: textfield;
+
+	&::-webkit-outer-spin-button,
+	&::-webkit-inner-spin-button {
+		-webkit-appearance: none;
+		margin: 0;
+	}
+}
+
+.jetpack-field-time__hours-input {
+	border-left: 0;
+	padding-left: 0;
+	text-align: center;
+}
+
+.jetpack-field-time__minutes-input {
+	border-right: 0;
+	padding-right: 0;
+	text-align: center;
+}

--- a/projects/packages/forms/src/blocks/input-phone/editor.scss
+++ b/projects/packages/forms/src/blocks/input-phone/editor.scss
@@ -1,0 +1,48 @@
+.jetpack-contact-form .jetpack-field.jetpack-field-phone {
+
+	.jetpack-field__input,
+	.jetpack-field__textarea {
+		box-sizing: border-box;
+
+		input,
+		textarea {
+			font: inherit;
+			border: 0;
+			flex: 1;
+			outline: none;
+			color: inherit;
+			background: inherit;
+			width: inherit;
+			box-sizing: border-box;
+			resize: none;
+			padding-top: 0;
+
+			&::before,
+			&::after {
+				box-sizing: inherit;
+			}
+		}
+	}
+
+	.jetpack-field__input {
+		// this here while we work on wrapping the inputs
+		display: flex;
+		gap: 8px;
+
+		.jetpack-field__input-prefix {
+			font: inherit;
+			border: 0;
+			color: inherit;
+
+			select {
+				vertical-align: text-bottom;
+				font: inherit;
+				border: 0;
+				line-height: inherit;
+				color: inherit;
+				outline: none;
+				background: inherit;
+			}
+		}
+	}
+}

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -1623,11 +1623,10 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 	 * @param string $class - the field class.
 	 * @param bool   $required - if the field is marked as required.
 	 * @param string $required_field_text - the text in the required text field.
-	 * @param string $placeholder - the field placeholder content.
 	 *
 	 * @return string HTML
 	 */
-	public function render_time_field( $id, $label, $value, $class, $required, $required_field_text, $placeholder ) {
+	public function render_time_field( $id, $label, $value, $class, $required, $required_field_text ) {
 		wp_enqueue_style(
 			'jetpack-form-field-time',
 			plugins_url( '../../dist/blocks/field-time/style.css', __FILE__ ),
@@ -1637,13 +1636,17 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 
 		$this->set_invalid_message( 'time', __( 'Please enter a valid time.', 'jetpack-forms' ) );
 
-		$field = $this->render_label( 'time', $id, $label, $required, $required_field_text );
+		$fieldset_id = "id='" . esc_attr( "$id-label" ) . "'";
+		$field       = "<fieldset {$fieldset_id} class='jetpack-field-time__fieldset'" . ( $required ? 'data-required' : '' ) . ' data-wp-bind--aria-invalid="state.fieldHasErrors">';
+
+		$field .= $this->render_legend_as_label( 'time', $id, $label, $required, $required_field_text );
 
 		$value_minutes = '';
 		$value_hours   = '';
 
 		$class_minutes = preg_replace( "/class=['\"]([^'\"]*)['\"]/", 'class="$1 jetpack-field-time__minutes-input"', $class );
 		$class_hours   = preg_replace( "/class=['\"]([^'\"]*)['\"]/", 'class="$1 jetpack-field-time__hours-input"', $class );
+
 		ob_start();
 		?>
 		<div class="jetpack-forms-field-time">
@@ -1653,20 +1656,21 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 				</label>
 				<input
 					<?php echo $class_minutes; ?>
-					style="<?php echo esc_attr( $this->field_styles ); ?>"
 					autocomplete="off"
+					data-wp-bind--aria-invalid="state.fieldHasErrors"
+					data-wp-on--change="actions.onFieldChange"
+					id="<?php echo esc_attr( $id . '-hours' ); ?>"
 					inputmode="numeric"
 					max="23"
 					min="0"
+					step="1"
+					style="<?php echo esc_attr( $this->field_styles ); ?>"
+					type="number"
+					value="<?php echo esc_attr( $value_hours ); ?>"
 					<?php
 					if ( $required ) :
 						?>
 						required<?php endif; ?>
-					step="1"
-					id="<?php echo esc_attr( $id . '-hours' ); ?>"
-					type="number"
-					value="<?php echo esc_attr( $value_hours ); ?>"
-					data-wp-bind--aria-invalid="state.fieldHasErrors"
 				>
 			</div>
 			<span class="jetpack-field-time__separator" aria-hidden="true">:</span>
@@ -1676,71 +1680,29 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 				</label>
 				<input
 					<?php echo $class_hours; ?>
-					style="<?php echo esc_attr( $this->field_styles ); ?>"
 					autocomplete="off"
+					data-wp-bind--aria-invalid="state.fieldHasErrors"
+					id="<?php echo esc_attr( $id . '-minutes' ); ?>"
 					inputmode="numeric"
 					max="59"
 					min="0"
+					step="1"
+					style="<?php echo esc_attr( $this->field_styles ); ?>"
+					type="number"
+					value="<?php echo esc_attr( $value_minutes ); ?>"
 					<?php
 					if ( $required ) :
 						?>
 						required<?php endif; ?>
-					step="1"
-					id="<?php echo esc_attr( $id . '-minutes' ); ?>"
-					type="number"
-					value="<?php echo esc_attr( $value_minutes ); ?>"
-					data-wp-bind--aria-invalid="state.fieldHasErrors"
 				>
 			</div>
 		</div>
 		<?php
-		/*
-		?>
-		<div class="jetpack-field-slider__input-row"
-			data-wp-context='
-			<?php
-			echo wp_json_encode(
-				array(
-					'min'     => $min,
-					'max'     => $max,
-					'default' => $starting_value,
-				)
-			);
-			?>
-			'>
-			<span class="jetpack-field-slider__min-label"><?php echo esc_html( $min ); ?></span>
-			<div class="jetpack-field-slider__input-container">
-				<input
-					type="range"
-					name="<?php echo esc_attr( $id ); ?>"
-					id="<?php echo esc_attr( $id ); ?>"
-					value="<?php echo esc_attr( $current_value ); ?>"
-					min="<?php echo esc_attr( $min ); ?>"
-					max="<?php echo esc_attr( $max ); ?>"
-					class="<?php echo esc_attr( $class ); ?>"
-					placeholder="<?php echo esc_attr( $placeholder ); ?>"
-					<?php
-					if ( $required ) :
-						?>
-						required<?php endif; ?>
-					data-wp-bind--value="state.getSliderValue"
-					data-wp-on--input="actions.onSliderChange"
-					data-wp-bind--aria-invalid="state.fieldHasErrors"
-				/>
-				<div
-					class="jetpack-field-slider__value-indicator"
-					data-wp-text="state.getSliderValue"
-					data-wp-style--left="state.getSliderPosition"
-				><?php echo esc_html( $current_value ); ?></div>
-			</div>
-			<span class="jetpack-field-slider__max-label"><?php echo esc_html( $max ); ?></span>
-		</div>
-		<?php
-		*/
-		$field .= ob_get_clean();
-		return $field . $this->get_error_div( $id, 'slider' );
 
-		return $field;
+		$field .= ob_get_clean();
+		$field .= '</fieldset>';
+
+		return $field . $this->get_error_div( $id, 'time' );
 	}
 
 	/**
@@ -2138,7 +2100,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 				);
 				break;
 			case 'time':
-				$field .= $this->render_time_field( $id, $label, $value, $field_class, $required, $required_field_text, $field_placeholder );
+				$field .= $this->render_time_field( $id, $label, $value, $field_class, $required, $required_field_text );
 				break;
 			case 'image-select':
 				$field .= $this->render_image_select_field( $id, $label, $value, $field_class, $required, $required_field_text );

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -1628,10 +1628,117 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 	 * @return string HTML
 	 */
 	public function render_time_field( $id, $label, $value, $class, $required, $required_field_text, $placeholder ) {
+		wp_enqueue_style(
+			'jetpack-form-field-time',
+			plugins_url( '../../dist/blocks/field-time/style.css', __FILE__ ),
+			array(),
+			Constants::get_constant( 'JETPACK__VERSION' )
+		);
+
 		$this->set_invalid_message( 'time', __( 'Please enter a valid time.', 'jetpack-forms' ) );
 
-		$field  = $this->render_label( 'time', $id, $label, $required, $required_field_text );
-		$field .= $this->render_input_field( 'time', $id, $value, $class, $placeholder, $required );
+		$field = $this->render_label( 'time', $id, $label, $required, $required_field_text );
+
+		$value_minutes = '';
+		$value_hours   = '';
+
+		$class_minutes = preg_replace( "/class=['\"]([^'\"]*)['\"]/", 'class="$1 jetpack-field-time__minutes-input"', $class );
+		$class_hours   = preg_replace( "/class=['\"]([^'\"]*)['\"]/", 'class="$1 jetpack-field-time__hours-input"', $class );
+		ob_start();
+		?>
+		<div class="jetpack-forms-field-time">
+			<div class="jetpack-field-time__hours-input-wrap">
+				<label for="<?php echo esc_attr( $id . '-hours' ); ?>" class="visually-hidden">
+					<?php esc_html_e( 'Hours', 'jetpack-forms' ); ?>
+				</label>
+				<input
+					<?php echo $class_minutes; ?>
+					style="<?php echo esc_attr( $this->field_styles ); ?>"
+					autocomplete="off"
+					inputmode="numeric"
+					max="23"
+					min="0"
+					<?php
+					if ( $required ) :
+						?>
+						required<?php endif; ?>
+					step="1"
+					id="<?php echo esc_attr( $id . '-hours' ); ?>"
+					type="number"
+					value="<?php echo esc_attr( $value_hours ); ?>"
+					data-wp-bind--aria-invalid="state.fieldHasErrors"
+				>
+			</div>
+			<span class="jetpack-field-time__separator" aria-hidden="true">:</span>
+			<div class="jetpack-field-time__minutes-input-wrap">
+				<label for="<?php echo esc_attr( $id . '-minutes' ); ?>" class="visually-hidden">
+					<?php esc_html_e( 'Minutes', 'jetpack-forms' ); ?>
+				</label>
+				<input
+					<?php echo $class_hours; ?>
+					style="<?php echo esc_attr( $this->field_styles ); ?>"
+					autocomplete="off"
+					inputmode="numeric"
+					max="59"
+					min="0"
+					<?php
+					if ( $required ) :
+						?>
+						required<?php endif; ?>
+					step="1"
+					id="<?php echo esc_attr( $id . '-minutes' ); ?>"
+					type="number"
+					value="<?php echo esc_attr( $value_minutes ); ?>"
+					data-wp-bind--aria-invalid="state.fieldHasErrors"
+				>
+			</div>
+		</div>
+		<?php
+		/*
+		?>
+		<div class="jetpack-field-slider__input-row"
+			data-wp-context='
+			<?php
+			echo wp_json_encode(
+				array(
+					'min'     => $min,
+					'max'     => $max,
+					'default' => $starting_value,
+				)
+			);
+			?>
+			'>
+			<span class="jetpack-field-slider__min-label"><?php echo esc_html( $min ); ?></span>
+			<div class="jetpack-field-slider__input-container">
+				<input
+					type="range"
+					name="<?php echo esc_attr( $id ); ?>"
+					id="<?php echo esc_attr( $id ); ?>"
+					value="<?php echo esc_attr( $current_value ); ?>"
+					min="<?php echo esc_attr( $min ); ?>"
+					max="<?php echo esc_attr( $max ); ?>"
+					class="<?php echo esc_attr( $class ); ?>"
+					placeholder="<?php echo esc_attr( $placeholder ); ?>"
+					<?php
+					if ( $required ) :
+						?>
+						required<?php endif; ?>
+					data-wp-bind--value="state.getSliderValue"
+					data-wp-on--input="actions.onSliderChange"
+					data-wp-bind--aria-invalid="state.fieldHasErrors"
+				/>
+				<div
+					class="jetpack-field-slider__value-indicator"
+					data-wp-text="state.getSliderValue"
+					data-wp-style--left="state.getSliderPosition"
+				><?php echo esc_html( $current_value ); ?></div>
+			</div>
+			<span class="jetpack-field-slider__max-label"><?php echo esc_html( $max ); ?></span>
+		</div>
+		<?php
+		*/
+		$field .= ob_get_clean();
+		return $field . $this->get_error_div( $id, 'slider' );
 
 		return $field;
 	}

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -1644,8 +1644,8 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		$value_minutes = '';
 		$value_hours   = '';
 
-		$class_minutes = preg_replace( "/class=['\"]([^'\"]*)['\"]/", 'class="$1 jetpack-field-time__minutes-input"', $class );
-		$class_hours   = preg_replace( "/class=['\"]([^'\"]*)['\"]/", 'class="$1 jetpack-field-time__hours-input"', $class );
+		$class_minutes = preg_replace( "/class=['\"]([^'\"]*)['\"]/", '$1 jetpack-field-time__minutes-input', $class );
+		$class_hours   = preg_replace( "/class=['\"]([^'\"]*)['\"]/", '$1 jetpack-field-time__hours-input', $class );
 
 		ob_start();
 		?>
@@ -1655,8 +1655,8 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 					<?php esc_html_e( 'Hours', 'jetpack-forms' ); ?>
 				</label>
 				<input
-					<?php echo $class_minutes; ?>
 					autocomplete="off"
+					class="<?php echo esc_attr( $class_minutes ); ?>"
 					data-wp-bind--aria-invalid="state.fieldHasErrors"
 					data-wp-on--change="actions.onFieldChange"
 					id="<?php echo esc_attr( $id . '-hours' ); ?>"
@@ -1679,8 +1679,8 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 					<?php esc_html_e( 'Minutes', 'jetpack-forms' ); ?>
 				</label>
 				<input
-					<?php echo $class_hours; ?>
 					autocomplete="off"
+					class="<?php echo esc_attr( $class_hours ); ?>"
 					data-wp-bind--aria-invalid="state.fieldHasErrors"
 					id="<?php echo esc_attr( $id . '-minutes' ); ?>"
 					inputmode="numeric"

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -887,7 +887,8 @@ on production builds, the attributes are being reordered, causing side-effects
 	margin-left: var(--jetpack--contact-form--border-left-size, var(--jetpack--contact-form--border-size));
 }
 
-/* fields with multiple options */
+/* fields with multiple options or inputs */
+.wp-block-jetpack-contact-form:not(.is-style-outlined) .jetpack-field-time__fieldset,
 .wp-block-jetpack-contact-form:not(.is-style-outlined) .jetpack-field-multiple__fieldset {
 	padding: 8px 0 0 0;
 	border: 0;

--- a/projects/packages/forms/tools/webpack.config.blocks.js
+++ b/projects/packages/forms/tools/webpack.config.blocks.js
@@ -18,6 +18,7 @@ const sharedWebpackConfig = {
 		'form-progress-indicator/style': './src/blocks/form-progress-indicator/style.scss',
 		'form-step-navigation/style': './src/blocks/form-step-navigation/style.scss',
 		'field-rating/style': './src/blocks/field-rating/style.scss',
+		'field-time/style': './src/blocks/field-time/style.scss',
 	},
 	output: {
 		...jetpackWebpackConfig.output,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Resolves FORMS-18

Follow-up to native time field added in:
- https://github.com/Automattic/jetpack/pull/44272

<img width="229" height="146" alt="image" src="https://github.com/user-attachments/assets/45a88913-319c-44eb-90bd-d7293b8031aa" />


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

