### PR TITLE
Untangling Sharing Buttons: Enable Settings > Sharing on Jetpack sites

### DIFF
--- a/projects/plugins/jetpack/_inc/client/sharing/share-buttons.jsx
+++ b/projects/plugins/jetpack/_inc/client/sharing/share-buttons.jsx
@@ -18,15 +18,12 @@ export const ShareButtons = withModuleSettingsFormHelpers(
 			analytics.tracks.recordJetpackClick( {
 				target: 'configure-sharing',
 				page: 'sharing',
+				platform: isWpcomPlatformSite() ? 'wpcom' : 'jetpack',
 			} );
 		}
 
 		render() {
-			const isLinked = this.props.isLinked,
-				siteRawUrl = this.props.siteRawUrl,
-				blogID = this.props.blogID,
-				siteAdminUrl = this.props.siteAdminUrl,
-				isOfflineMode = this.props.isOfflineMode,
+			const siteAdminUrl = this.props.siteAdminUrl,
 				hasSharingBlock = this.props.hasSharingBlock,
 				isBlockTheme = this.props.isBlockTheme,
 				isActive = this.props.getOptionValue( 'sharedaddy' );
@@ -52,17 +49,11 @@ export const ShareButtons = withModuleSettingsFormHelpers(
 					compact: true,
 					className: 'jp-settings-card__configure-link',
 					href: `${ siteAdminUrl }options-general.php?page=sharing`,
+					onClick: this.trackClickConfigure,
 				};
 
 				if ( shouldShowSharingBlock ) {
 					cardProps.href = `${ siteAdminUrl }site-editor.php?path=%2Fwp_template`;
-				} else if ( isLinked && ! isOfflineMode && ! isWpcomPlatformSite() ) {
-					cardProps.href = getRedirectUrl( 'calypso-marketing-sharing-buttons', {
-						site: blogID ?? siteRawUrl,
-					} );
-					cardProps.onClick = this.trackClickConfigure;
-					cardProps.target = '_blank';
-					cardProps.rel = 'noopener noreferrer';
 				}
 
 				return <Card { ...cardProps }>{ __( 'Configure your sharing buttons', 'jetpack' ) }</Card>;

--- a/projects/plugins/jetpack/changelog/update-enable-sharing-page
+++ b/projects/plugins/jetpack/changelog/update-enable-sharing-page
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Enable Settings > Sharing WP-Admin page and replace all the links pointing to Calypso with a link pointing to this WP-Admin page

--- a/projects/plugins/jetpack/modules/sharedaddy.php
+++ b/projects/plugins/jetpack/modules/sharedaddy.php
@@ -15,10 +15,6 @@
  * @package automattic/jetpack
  */
 
-use Automattic\Jetpack\Connection\Manager as Connection_Manager;
-use Automattic\Jetpack\Redirect;
-use Automattic\Jetpack\Status;
-
 if ( ! defined( 'ABSPATH' ) ) {
 	exit( 0 );
 }
@@ -34,19 +30,5 @@ add_action( 'jetpack_modules_loaded', 'sharedaddy_loaded' );
  */
 function sharedaddy_loaded() {
 	Jetpack::enable_module_configurable( __FILE__ );
-	add_filter( 'jetpack_module_configuration_url_sharedaddy', 'jetpack_sharedaddy_configuration_url' );
-}
-
-/**
- * Return Jetpack Sharing configuration URL
- *
- * @return string Sharing config URL
- */
-function jetpack_sharedaddy_configuration_url() {
-	$status = new Status();
-	if ( $status->is_offline_mode() || $status->in_safe_mode() || ! ( new Connection_Manager( 'jetpack' ) )->is_user_connected() ) {
-		return admin_url( 'options-general.php?page=sharing' );
-	}
-
-	return Redirect::get_url( 'calypso-marketing-sharing-buttons' );
+	add_filter( 'jetpack_module_configuration_url_sharedaddy', 'get_sharing_buttons_customisation_url' );
 }

--- a/projects/plugins/jetpack/modules/sharedaddy/sharing-service.php
+++ b/projects/plugins/jetpack/modules/sharedaddy/sharing-service.php
@@ -13,8 +13,6 @@
 // phpcs:disable Universal.Files.SeparateFunctionsFromOO.Mixed -- TODO: Move classes to appropriately-named class files.
 
 use Automattic\Jetpack\Assets;
-use Automattic\Jetpack\Redirect;
-use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Sync\Settings;
 
 require_once __DIR__ . '/sharing-sources.php';
@@ -939,12 +937,12 @@ if ( isset( $_GET['share'] ) ) {
 }
 
 /**
- * Gets the url to customise the sharing buttons in Calypso.
+ * Gets the url to customise the sharing buttons WP-Admin.
  *
- * @return string the customisation URL or null if it couldn't be determinde.
+ * @return string the customisation URL.
  */
 function get_sharing_buttons_customisation_url() {
-	return Redirect::get_url( 'calypso-marketing-sharing-buttons', array( 'site' => ( new Status() )->get_site_suffix() ) );
+	return admin_url( 'options-general.php?page=sharing' );
 }
 
 /**

--- a/projects/plugins/jetpack/modules/sharedaddy/sharing-service.php
+++ b/projects/plugins/jetpack/modules/sharedaddy/sharing-service.php
@@ -937,7 +937,7 @@ if ( isset( $_GET['share'] ) ) {
 }
 
 /**
- * Gets the url to customise the sharing buttons WP-Admin.
+ * Gets the url to customise the sharing buttons in WP-Admin.
  *
  * @return string the customisation URL.
  */

--- a/projects/plugins/jetpack/modules/sharedaddy/sharing.php
+++ b/projects/plugins/jetpack/modules/sharedaddy/sharing.php
@@ -8,10 +8,8 @@
 // phpcs:disable Universal.Files.SeparateFunctionsFromOO.Mixed -- TODO: Move classes to appropriately-named class files.
 
 use Automattic\Jetpack\Assets;
-use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Redirect;
 use Automattic\Jetpack\Status;
-use Automattic\Jetpack\Status\Host;
 
 if ( ! defined( 'WP_SHARING_PLUGIN_URL' ) ) {
 	define( 'WP_SHARING_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
@@ -126,26 +124,17 @@ class Sharing_Admin {
 	}
 
 	/**
-	 * Register Sharing settings menu page in offline mode or when wp-admin interface is enabled.
+	 * Register Sharing settings menu page in Settings > Sharing.
 	 */
 	public function subscription_menu() {
-		$is_user_connected = ( new Connection_Manager() )->is_user_connected();
-
-		if (
-			( new Status() )->is_offline_mode()
-			// Always enable Settings > Sharing on Atomic and Simple.
-			|| ( new Host() )->is_wpcom_platform()
-			|| ! $is_user_connected
-		) {
-			add_submenu_page(
-				'options-general.php',
-				__( 'Sharing Settings', 'jetpack' ),
-				__( 'Sharing', 'jetpack' ),
-				'manage_options',
-				'sharing',
-				array( $this, 'wrapper_admin_page' )
-			);
-		}
+		add_submenu_page(
+			'options-general.php',
+			__( 'Sharing Settings', 'jetpack' ),
+			__( 'Sharing', 'jetpack' ),
+			'manage_options',
+			'sharing',
+			array( $this, 'wrapper_admin_page' )
+		);
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Instead of pointing the users to a Calypso page, we are now pointing them to the WP-Admin page we use for offline mode.

Fixes DOTCOM-14147 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Enable the Settings > Sharing page for all sites
* Replace the Calypso links with a link to the new page

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this on your sandbox and on a Jurassic Ninja site
* Notice that you have a Settings > Sharing menu
* Enable a classic theme
* Go to Jetpack > Settings > Sharing
* Notice that the link points to the WP-Admin page
* Go to the front-end
* Check for the "Customize sharing buttons" link next to the buttons

