### PR TITLE
OG tags: add filter to define a custom site representative image.

### DIFF
--- a/projects/plugins/jetpack/changelog/update-opengraph-filter-custom-fallback
+++ b/projects/plugins/jetpack/changelog/update-opengraph-filter-custom-fallback
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Open Graph Meta tags: add new filter allowing one to define a custom site representative image.

--- a/projects/plugins/jetpack/functions.opengraph.php
+++ b/projects/plugins/jetpack/functions.opengraph.php
@@ -410,6 +410,27 @@ function jetpack_og_get_fallback_social_image( $width, $height ) {
 
 	// Let's get the site's representative image.
 	$site_image = jetpack_og_get_site_image( $width, $height );
+
+	/**
+	 * Define your own site's representative image,
+	 * to override any fallback image found by looking through site's logo, site icon, and blavatar.
+	 * This will allow you to overwrite the default fallback image generated dynamically.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $site_image Your own site's representative image.
+	 * @param array $site_image The site's representative image picked by Jetpack. {
+	 *     @type string $src    The source of the image.
+	 *     @type int    $width  The width of the image.
+	 *     @type int    $height The height of the image.
+	 *     @type string $type   The type of the image.
+	 * }
+	 */
+	$custom_site_image = apply_filters( 'jetpack_og_default_site_image', array(), $site_image );
+	if ( ! empty( $custom_site_image['src'] ) ) {
+		return $custom_site_image;
+	}
+
 	if ( empty( $site_image['src'] ) ) {
 		// When using the default blank image, use a different template in Social Image Generator.
 		$template          = 'highway';


### PR DESCRIPTION
Fixes DOTCOM-14164

## Proposed changes:

Follow-up to #44336.

This filter would allow one to completely bypass the images generated by Social Image Generator, like so:

```php
add_filter(
	'jetpack_og_default_site_image',
	function () {
		return array(
			'src'    => 'https://yourimage.jpg',
			'width'  => 1910,
			'height' => 1000,
			'type'   => 'custom',
		);
	}
);
```


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* p1HpG7-x8w-p2#comment-77014

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

1. Start with a site with a paid plan (Social, Business, or Complete)
2. Go to Jetpack > Settings > Sharing
3. Enable the Sharing module or the Publicize module
4. Load your site's home page
5. View source
6. Check the `og:image` tag
   * When using this branch, the tag should use a `https://s0.wp.com/_si/` URL.
   * That URL should return a preview image using the site title and any representative image you use for the site.
   * Try uploading a site logo if you haven't yet. You can do so in Settings > General for example. It should change the generated image.
7. Now add the snippet above using a functionality plugin.
8. Check your site's home page again
    * When viewing source, the `og:image` tag should now be yours.
