### PR TITLE
My Jetpack: fix multi-site availability check

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/modules-list/utils.ts
+++ b/projects/packages/my-jetpack/_inc/components/modules-list/utils.ts
@@ -14,7 +14,7 @@ export const JETPACK_MODULES_NOT_FOR_MULTISITE = [ 'waf', 'wordads' ];
 export function getModuleStatus( $module: MyJetpackModule ) {
 	// If the module is not supported on multisite, we set the availability to false and provide a reason.
 	if ( getScriptData().site.is_multisite ) {
-		if ( ! JETPACK_MODULES_NOT_FOR_MULTISITE.includes( $module.module ) ) {
+		if ( JETPACK_MODULES_NOT_FOR_MULTISITE.includes( $module.module ) ) {
 			return {
 				isAvailable: false,
 				reason: __( 'Not available on multisite', 'jetpack-my-jetpack' ),

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/utils.ts
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/utils.ts
@@ -127,7 +127,7 @@ export function getProductStatus( product: ProductCamelCase ) {
 	// If the product is not supported on multisite, we set the available to false and provide a reason.
 	if ( getScriptData().site.is_multisite ) {
 		if (
-			! JETPACK_PRODUCTS_NOT_FOR_MULTISITE.includes(
+			JETPACK_PRODUCTS_NOT_FOR_MULTISITE.includes(
 				product.slug as ( typeof JETPACK_PRODUCTS_NOT_FOR_MULTISITE )[ number ]
 			)
 		) {

--- a/projects/packages/my-jetpack/_inc/hooks/use-filtered-products/index.tsx
+++ b/projects/packages/my-jetpack/_inc/hooks/use-filtered-products/index.tsx
@@ -1,4 +1,6 @@
+import { getScriptData } from '@automattic/jetpack-script-data';
 import { useCallback, useEffect, useState } from 'react';
+import { JETPACK_PRODUCTS_NOT_FOR_MULTISITE } from '../../components/my-jetpack-tab-panel/products/constants';
 import useProductsByOwnership from '../../data/products/use-products-by-ownership';
 import { getMyJetpackWindowInitialState } from '../../data/utils/get-my-jetpack-window-state';
 
@@ -47,6 +49,11 @@ const useFilteredProducts = () => {
 			// If the user cannot view stats, filter out the stats card
 			if ( ! canUserViewStats ) {
 				productsWithNoCard.push( 'stats' );
+			}
+
+			// If on multisite, filter out products that are not supported
+			if ( getScriptData().site.is_multisite ) {
+				productsWithNoCard.push( ...JETPACK_PRODUCTS_NOT_FOR_MULTISITE );
 			}
 
 			return products.filter( product => {

--- a/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-backup-needs-attention-notice.tsx
+++ b/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-backup-needs-attention-notice.tsx
@@ -58,7 +58,11 @@ const useBackupNeedsAttentionNotice: NoticeHookType = ( redBubbleAlerts, isLoadi
 	}, [ recordEvent, status, contactSupportUrl ] );
 
 	useEffect( () => {
-		if ( ! redBubbleAlerts?.backup_failure || status === 'backups-deactivated' ) {
+		if (
+			! redBubbleAlerts?.backup_failure ||
+			status === 'backups-deactivated' ||
+			status === 'multisite_not_supported'
+		) {
 			return;
 		}
 

--- a/projects/packages/my-jetpack/changelog/fix-my-jetpack-multi-site
+++ b/projects/packages/my-jetpack/changelog/fix-my-jetpack-multi-site
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Fixed multisite availability check for restricted products and modules

--- a/projects/packages/my-jetpack/changelog/fix-my-jetpack-multi-site
+++ b/projects/packages/my-jetpack/changelog/fix-my-jetpack-multi-site
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Fixed multisite availability check for restricted products and modules
+My Jetpack: Fixed multisite availability check for restricted products and modules

--- a/projects/plugins/backup/changelog/fix-my-jetpack-multi-site
+++ b/projects/plugins/backup/changelog/fix-my-jetpack-multi-site
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Fixed multisite availability check for restricted products and modules

--- a/projects/plugins/backup/changelog/fix-my-jetpack-multi-site
+++ b/projects/plugins/backup/changelog/fix-my-jetpack-multi-site
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Fixed multisite availability check for restricted products and modules
+My Jetpack: Fixed multisite availability check for restricted products and modules

--- a/projects/plugins/boost/changelog/fix-my-jetpack-multi-site
+++ b/projects/plugins/boost/changelog/fix-my-jetpack-multi-site
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Fixed multisite availability check for restricted products and modules

--- a/projects/plugins/boost/changelog/fix-my-jetpack-multi-site
+++ b/projects/plugins/boost/changelog/fix-my-jetpack-multi-site
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Fixed multisite availability check for restricted products and modules
+My Jetpack: Fixed multisite availability check for restricted products and modules

--- a/projects/plugins/jetpack/changelog/fix-my-jetpack-multi-site
+++ b/projects/plugins/jetpack/changelog/fix-my-jetpack-multi-site
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+My Jetpack: Fixed multisite availability check for restricted products and modules

--- a/projects/plugins/protect/changelog/fix-my-jetpack-multi-site
+++ b/projects/plugins/protect/changelog/fix-my-jetpack-multi-site
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Fixed multisite availability check for restricted products and modules

--- a/projects/plugins/protect/changelog/fix-my-jetpack-multi-site
+++ b/projects/plugins/protect/changelog/fix-my-jetpack-multi-site
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Fixed multisite availability check for restricted products and modules
+My Jetpack: Fixed multisite availability check for restricted products and modules

--- a/projects/plugins/search/changelog/fix-my-jetpack-multi-site
+++ b/projects/plugins/search/changelog/fix-my-jetpack-multi-site
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Fixed multisite availability check for restricted products and modules

--- a/projects/plugins/search/changelog/fix-my-jetpack-multi-site
+++ b/projects/plugins/search/changelog/fix-my-jetpack-multi-site
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Fixed multisite availability check for restricted products and modules
+My Jetpack: Fixed multisite availability check for restricted products and modules

--- a/projects/plugins/social/changelog/fix-my-jetpack-multi-site
+++ b/projects/plugins/social/changelog/fix-my-jetpack-multi-site
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Fixed multisite availability check for restricted products and modules

--- a/projects/plugins/social/changelog/fix-my-jetpack-multi-site
+++ b/projects/plugins/social/changelog/fix-my-jetpack-multi-site
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Fixed multisite availability check for restricted products and modules
+My Jetpack: Fixed multisite availability check for restricted products and modules

--- a/projects/plugins/starter-plugin/changelog/fix-my-jetpack-multi-site
+++ b/projects/plugins/starter-plugin/changelog/fix-my-jetpack-multi-site
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Fixed multisite availability check for restricted products and modules

--- a/projects/plugins/starter-plugin/changelog/fix-my-jetpack-multi-site
+++ b/projects/plugins/starter-plugin/changelog/fix-my-jetpack-multi-site
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Fixed multisite availability check for restricted products and modules
+My Jetpack: Fixed multisite availability check for restricted products and modules

--- a/projects/plugins/videopress/changelog/fix-my-jetpack-multi-site
+++ b/projects/plugins/videopress/changelog/fix-my-jetpack-multi-site
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Fixed multisite availability check for restricted products and modules

--- a/projects/plugins/videopress/changelog/fix-my-jetpack-multi-site
+++ b/projects/plugins/videopress/changelog/fix-my-jetpack-multi-site
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Fixed multisite availability check for restricted products and modules
+My Jetpack: Fixed multisite availability check for restricted products and modules


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes BACKUP-235
Related to #44260

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fix multisite availability logic: correct inverted logic in `getProductStatus()` and `getModuleStatus()` functions that was showing “Not available on multisite” for wrong products.
* Suppress backup failure notices: don't show red bubble notifications when backup status is `multisite_not_supported` since this is an expected restriction, not an error.
* Hide unsupported products card on multisite: use the `JETPACK_PRODUCTS_NOT_FOR_MULTISITE` constant to filter out unsupported products from card display on multisite installations. Currently it only impacts VaultPress Backup.


| Before | After |
|---|---|
| <img width="2134" height="1060" alt="CleanShot 2025-08-08 at 13 38 12@2x" src="https://github.com/user-attachments/assets/658cfe7f-af76-4452-9af4-048345094827" /> | <img width="2090" height="1002" alt="CleanShot 2025-08-08 at 13 41 21@2x" src="https://github.com/user-attachments/assets/13b2897a-10f3-4be8-998b-88876e297286" /> |
| <img width="2122" height="1310" alt="CleanShot 2025-08-08 at 13 38 23@2x" src="https://github.com/user-attachments/assets/08e7c880-a139-49e2-8a2a-b8d9e9b893a0" /> | <img width="2102" height="1296" alt="CleanShot 2025-08-08 at 13 41 38@2x" src="https://github.com/user-attachments/assets/ef1fab0e-9dee-4b10-9a0a-4d01ec7c8e4c" /> |

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1754628544681619-slack-C08JR97D3J4

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the “[Status] Needs Privacy Updates” label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### Test Case 1: Regression Test (Products Tab)
1. Follow the same tests as described in https://github.com/Automattic/jetpack/pull/44260
2. Confirm that you see the unavailability warning for Backup, Firewall, and Ads as mentioned in [support docs](https://jetpack.com/support/multisite/#unsupported-features).

https://github.com/user-attachments/assets/618c636e-3cd1-4510-a935-2b24db2305d6

### Test Case 2: Site with Premium Plan

If a site has a plan that includes various products, like Jetpack Premium, we should ensure the VaultPress Backup card remains hidden on multisite.

1. Spin up a Jurassic Ninja multi-site with a Jetpack Premium plan using this branch.
2. Similar to Test Case 1, activate Jetpack network-wide, and connect the site to Jetpack (complete the onboarding process).
3. Verify on My Jetpack main page:
   - Navigate to `/wp-admin/admin.php?page=my-jetpack`
   - Confirm VaultPress Backup card is not visible.
4. Verify on Products tab:
   - Navigate to My Jetpack → Products tab  
   - Confirm VaultPress Backup still shows the “Not available on multisite” message.

#### Alternative: Testing a multi-site with Jetpack Premium locally with simulation

You could use this snippet on mu-plugins to simulate the Jetpack Premium scenario reported in BACKUP-235, you can add it on `tools/docker/mu-plugins/0-snippets.php`:

<details>
<summary>Snippet (click to expand)</summary>

```
<?php
// Simulate your site is a multi-site
add_filter('jetpack_admin_js_script_data', function($data) {
    $data['site']['is_multisite'] = true;
    return $data;
});

add_filter( 'pre_http_request', function ( $response, $parsed_args, $url ) {
	// Mock paid plan for Jetpack Premium
	if ( false !== strpos( $url, '/purchases' ) ) {
		return array(
			'response' => array( 'code' => 200 ),
			'body'     => wp_json_encode( array(
				array(
					'product_slug'     => 'jetpack_premium',
					'product_name'     => 'Jetpack Premium',
					'expiry_date'      => '2025-12-31',
					'subscribed_date'  => '2025-01-01',
					'expiry_message'   => '',
					'active'           => true,
				)
			)),
		);
	}

	// Mock /rewind endpoint to return multisite not supported state  
	if ( false !== strpos( $url, '/rewind?force=wpcom' ) && false === strpos( $url, '/rewind/backups' ) ) {
		return array(
			'response' => array( 'code' => 200 ),
			'body'     => wp_json_encode( array(
				'state'        => 'unavailable',
				'last_updated' => '2025-08-07T23:47:56.378+00:00',
				'reason'       => 'multisite_not_supported',
				'has_cloud'    => false,
			)),
		);
	}

	// Mock /rewind/backups endpoint to return empty array
	if ( false !== strpos( $url, '/rewind/backups' ) ) {
		return array(
			'response' => array( 'code' => 200 ),
			'body'     => wp_json_encode( array() ),
		);
	}

	return $response;
}, 10, 3 );
```
</details>

| Before | After |
|---|---|
| <img width="1108" height="1402" alt="CleanShot 2025-08-08 at 14 03 42@2x" src="https://github.com/user-attachments/assets/ba3bbe3a-2d2a-48d5-a571-7706b810b1e9" /> | <img width="1108" height="1402" alt="CleanShot 2025-08-08 at 14 04 29@2x" src="https://github.com/user-attachments/assets/5923be35-c639-4ed7-a042-d3ecd025c753" /> |