### PR TITLE
Forms: Fix checkbox upgrade on simple

### DIFF
--- a/projects/packages/forms/changelog/fix-checkbox-upgrade
+++ b/projects/packages/forms/changelog/fix-checkbox-upgrade
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: fix logic for only upgrade once to work on simple sites

--- a/projects/packages/forms/src/blocks/field-checkbox/edit.js
+++ b/projects/packages/forms/src/blocks/field-checkbox/edit.js
@@ -66,11 +66,11 @@ export default function CheckboxFieldEdit( props ) {
 	// Ensure the className is set to 'is-style-list' if it is empty or not set.
 	// By updating the className on the second render, we can make sure that the block doesn't trigger a "Save" action.
 	useEffect( () => {
-		if ( ! className && hasUpgradedToNewStyle.current === 2 ) {
+		if ( ! className && hasUpgradedToNewStyle.current === 1 ) {
 			__unstableMarkNextChangeAsNotPersistent();
 			setAttributes( { className: 'is-style-list' } );
+			hasUpgradedToNewStyle.current = 2;
 		}
-		hasUpgradedToNewStyle.current = 2;
 	}, [ className, setAttributes, __unstableMarkNextChangeAsNotPersistent ] ); // This effect is a placeholder for any future side effects.
 
 	return (

--- a/projects/packages/forms/src/blocks/field-consent/edit.js
+++ b/projects/packages/forms/src/blocks/field-consent/edit.js
@@ -135,11 +135,11 @@ export default function ConsentFieldEdit( props ) {
 	// Ensure the className is set to 'is-style-list' if it is empty or not set.
 	// By updating the className on the second render, we can make sure that the block doesn't trigger a "Save" action.
 	useEffect( () => {
-		if ( ! className && hasUpgradedToNewStyle.current === 2 ) {
+		if ( ! className && hasUpgradedToNewStyle.current === 1 ) {
 			__unstableMarkNextChangeAsNotPersistent();
 			setAttributes( { className: 'is-style-list' } );
+			hasUpgradedToNewStyle.current = 2;
 		}
-		hasUpgradedToNewStyle.current = 2;
 	}, [ className, setAttributes, __unstableMarkNextChangeAsNotPersistent ] ); // This effect is a placeholder for any future side effects.
 
 	const onShareFieldAttributesChange = useCallback(


### PR DESCRIPTION
This PR fixes the PR upgrade process on simple sites

## Proposed changes:
* Only upgrade the classname once. But does it on the first try vs the second try. 

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?
 
## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
test on both jetpack and simple site. 
* Create a page form with a checkbox. 
* Notice that when you load the page in the editor. That you don't see the save button active. Change the page and click save. Notice that the form has updated. 


