### PR TITLE
PayPal Payment Buttons: Remove admin page

### DIFF
--- a/projects/plugins/paypal-payment-buttons/changelog/update-paypal-payment-buttons-remove-admin-page
+++ b/projects/plugins/paypal-payment-buttons/changelog/update-paypal-payment-buttons-remove-admin-page
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Removed admin page for PayPal Payment Buttons plugin.

--- a/projects/plugins/paypal-payment-buttons/src/class-paypal-payment-buttons.php
+++ b/projects/plugins/paypal-payment-buttons/src/class-paypal-payment-buttons.php
@@ -9,7 +9,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit( 0 );
 }
 
-use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Blocks;
 use Automattic\Jetpack\PaypalPayments\PayPal_Payment_Buttons as Jetpack_PayPal_Payment_Buttons;
 
@@ -74,9 +73,6 @@ class PayPal_Payment_Buttons {
 		if ( is_admin() ) {
 			add_action( 'enqueue_block_assets', array( Jetpack_PayPal_Payment_Buttons::class, 'load_editor_styles' ), 9 );
 		}
-
-		// Add admin menu
-		add_action( 'admin_menu', array( $this, 'add_admin_menu' ) );
 	}
 
 	/**
@@ -127,59 +123,6 @@ class PayPal_Payment_Buttons {
 			'jp-paypal-payments-ncps-blocks',
 			'Jetpack_Editor_Initial_State',
 			$availability_data
-		);
-	}
-
-	/**
-	 * Add admin menu for the plugin.
-	 */
-	public function add_admin_menu() {
-		$page_suffix = add_menu_page(
-			__( 'PayPal Payment Buttons', 'paypal-payment-buttons' ),
-			_x( 'PayPal Buttons', 'The PayPal Payment Buttons product name, without the Jetpack prefix', 'paypal-payment-buttons' ),
-			'manage_options',
-			'paypal-payment-buttons',
-			array( $this, 'plugin_settings_page' ),
-			'dashicons-money-alt'
-		);
-		add_action( 'load-' . $page_suffix, array( $this, 'admin_init' ) );
-	}
-
-	/**
-	 * Initialize the admin resources.
-	 */
-	public function admin_init() {
-		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_scripts' ) );
-	}
-
-	/**
-	 * Main plugin settings page.
-	 */
-	public function plugin_settings_page() {
-		?>
-		<div id="paypal-payment-buttons-root"></div>
-		<?php
-	}
-
-	/**
-	 * Enqueue plugin admin scripts and styles.
-	 *
-	 * @param string $hook_suffix The current admin page hook suffix.
-	 */
-	public function enqueue_admin_scripts( $hook_suffix ) {
-		if ( 'toplevel_page_paypal-payment-buttons' !== $hook_suffix ) {
-			return;
-		}
-
-		Assets::register_script(
-			'paypal-payment-buttons-admin',
-			'build/index.js',
-			PAYPAL_PAYMENT_BUTTONS_ROOT_FILE,
-			array(
-				'in_footer'  => true,
-				'textdomain' => 'paypal-payment-buttons',
-				'enqueue'    => true,
-			)
 		);
 	}
 

--- a/projects/plugins/paypal-payment-buttons/src/js/index.js
+++ b/projects/plugins/paypal-payment-buttons/src/js/index.js
@@ -1,51 +1,9 @@
-import * as WPElement from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
-
 /**
- * Simple admin page component.
+ * PayPal Payment Buttons Plugin Entry Point
  *
- * @return {object} The admin page component.
+ * This file serves as the main JavaScript entry point for the PayPal Payment Buttons plugin.
+ * The actual block functionality is provided by the jetpack-paypal-payments package.
  */
-const AdminPage = () => {
-	return (
-		<div className="wrap">
-			<h1>{ __( 'PayPal Payment Buttons', 'paypal-payment-buttons' ) }</h1>
-			<div className="card">
-				<h2>{ __( 'Block Available', 'paypal-payment-buttons' ) }</h2>
-				<p>
-					{ __(
-						'The PayPal Payment Buttons block is now available in your block editor. You can find it in the "Monetize" category when adding blocks to your posts and pages.',
-						'paypal-payment-buttons'
-					) }
-				</p>
-				<h3>{ __( 'How to use:', 'paypal-payment-buttons' ) }</h3>
-				<ol>
-					<li>{ __( 'Edit a post or page', 'paypal-payment-buttons' ) }</li>
-					<li>{ __( 'Click the "+" button to add a new block', 'paypal-payment-buttons' ) }</li>
-					<li>
-						{ __(
-							'Look for "PayPal Payment Buttons" in the Monetize category',
-							'paypal-payment-buttons'
-						) }
-					</li>
-					<li>{ __( 'Configure your PayPal button settings', 'paypal-payment-buttons' ) }</li>
-				</ol>
-			</div>
-		</div>
-	);
-};
 
-/**
- * Initial render function.
- */
-function renderApp() {
-	const container = document.getElementById( 'paypal-payment-buttons-root' );
-
-	if ( null === container ) {
-		return;
-	}
-
-	WPElement.createRoot( container ).render( <AdminPage /> );
-}
-
-renderApp();
+// Currently no frontend JavaScript functionality is needed
+// The PayPal Payment Buttons block is registered and handled by the jetpack-paypal-payments package


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Removes the unnecessary admin page for the PayPal Payment Buttons page.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
NA

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Build plugin with `jetpack build --deps plugins/paypal-payment-buttons`
- Ensure no errors and that block remains functioning.
