### PR TITLE
Forms: Add feedback get extra value and get_all_legacy_values methods

### DIFF
--- a/projects/packages/forms/changelog/add-forms-feedback-get_extra-value
+++ b/projects/packages/forms/changelog/add-forms-feedback-get_extra-value
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Forms: Add new method that will make it easier to refactor the save. 

--- a/projects/packages/forms/src/contact-form/class-feedback.php
+++ b/projects/packages/forms/src/contact-form/class-feedback.php
@@ -351,8 +351,8 @@ class Feedback {
 		}
 		$extra_values       = array();
 		$extra_fields_count = $count;
-		$is_present         = array();
-		$non_extra_fields   = array( 'email', 'name', 'url', 'subject', 'textarea', 'ip' );
+		$is_present         = array(); // Used to store the value only once.
+
 		foreach ( $_extra_fields as $field ) {
 			if ( ! in_array( $field->get_type(), $non_extra_fields, true ) || isset( $is_present[ $field->get_type() ] ) ) {
 				$extra_values[ $extra_fields_count . '_' . $field->get_label() ] = $field->get_render_value( 'default' );

--- a/projects/packages/forms/src/contact-form/class-feedback.php
+++ b/projects/packages/forms/src/contact-form/class-feedback.php
@@ -356,14 +356,14 @@ class Feedback {
 			$_extra_fields[] = $field;
 			++$count; // Increment count to ensure unique keys for extra values.
 		}
-		$extra_values = array();
-
-		$is_present       = array();
-		$non_extra_fields = array( 'email', 'name', 'url', 'subject', 'textarea', 'ip' );
+		$extra_values       = array();
+		$extra_fields_count = $count;
+		$is_present         = array();
+		$non_extra_fields   = array( 'email', 'name', 'url', 'subject', 'textarea', 'ip' );
 		foreach ( $_extra_fields as $field ) {
 			if ( ! in_array( $field->get_type(), $non_extra_fields, true ) || isset( $is_present[ $field->get_type() ] ) ) {
-				$extra_values[ $count . '_' . $field->get_label() ] = $field->get_render_value( 'default' );
-				++$count; // Increment count to ensure unique keys for extra values.
+				$extra_values[ $extra_fields_count . '_' . $field->get_label() ] = $field->get_render_value( 'default' );
+				++$extra_fields_count; // Increment count to ensure unique keys for extra values.
 			} else {
 				$is_present[ $field->get_type() ] = true;
 			}

--- a/projects/packages/forms/src/contact-form/class-feedback.php
+++ b/projects/packages/forms/src/contact-form/class-feedback.php
@@ -342,7 +342,7 @@ class Feedback {
 	 *
 	 * @return array An array of extra values, including entry values
 	 */
-	public function get_extra_values() {
+	public function get_legacy_extra_values() {
 		$count         = 1;
 		$_extra_fields = array();
 		foreach ( $this->fields as $field ) {

--- a/projects/packages/forms/src/contact-form/class-feedback.php
+++ b/projects/packages/forms/src/contact-form/class-feedback.php
@@ -254,6 +254,24 @@ class Feedback {
 		}
 		return '';
 	}
+
+	/**
+	 * This is a helper function that helps us check if the value has matched a non-basic field.
+	 *
+	 * @param string $value The value of the field to check.
+	 *
+	 * @return bool True if a matching non-basic field is found, false otherwise.
+	 */
+	private function has_matching_non_basic_field_by_value( $value = '' ) {
+		foreach ( $this->fields as $field ) {
+			if ( $field->get_type() !== 'basic' ) {
+				if ( $field->get_render_value() === $value ) {
+					return true;
+				}
+			}
+		}
+		return false;
+	}
 	/**
 	 * Get the value of the field based on the first type found.
 	 *
@@ -318,6 +336,56 @@ class Feedback {
 		return array_merge( $this->get_compiled_fields( 'default', 'key-value' ), $this->get_entry_values() );
 	}
 
+	/**
+	 * Get extra values.
+	 * This is a legacy method to maintain compatibility with older code.
+	 *
+	 * @return array An array of extra values, including entry values
+	 */
+	public function get_extra_values() {
+		$count         = 1;
+		$_extra_fields = array();
+		foreach ( $this->fields as $field ) {
+			if ( $field->compile_field( 'default' ) ) {
+				continue;
+			}
+			if ( $field->get_type() === 'basic' && $this->has_matching_non_basic_field_by_value( $field->get_render_value() ) ) {
+				++$count;
+				continue; // Skip fields that are already present in the non-extra fields.
+			}
+			$_extra_fields[] = $field;
+			++$count; // Increment count to ensure unique keys for extra values.
+		}
+		$extra_values = array();
+
+		$is_present       = array();
+		$non_extra_fields = array( 'email', 'name', 'url', 'subject', 'textarea', 'ip' );
+		foreach ( $_extra_fields as $field ) {
+			if ( ! in_array( $field->get_type(), $non_extra_fields, true ) || isset( $is_present[ $field->get_type() ] ) ) {
+				$extra_values[ $count . '_' . $field->get_label() ] = $field->get_render_value( 'default' );
+				++$count; // Increment count to ensure unique keys for extra values.
+			} else {
+				$is_present[ $field->get_type() ] = true;
+			}
+		}
+		return $extra_values;
+	}
+
+	/**
+	 * Get all values of the response.
+	 *
+	 * @return array An array of all values, including fields and entry values.
+	 */
+	public function get_all_legacy_values() {
+		return array(
+			'_feedback_author'       => $this->get_author(),
+			'_feedback_author_email' => $this->get_author_email(),
+			'_feedback_author_url'   => $this->get_author_url(),
+			'_feedback_subject'      => $this->get_subject(),
+			'_feedback_ip'           => $this->get_ip_address(),
+			'_feedback_all_fields'   => $this->get_all_values(),
+		);
+	}
 	/**
 	 * Return the compiled fields for the given context.
 	 *

--- a/projects/packages/forms/src/contact-form/class-feedback.php
+++ b/projects/packages/forms/src/contact-form/class-feedback.php
@@ -256,23 +256,6 @@ class Feedback {
 	}
 
 	/**
-	 * This is a helper function that helps us check if the value has matched a non-basic field.
-	 *
-	 * @param string $value The value of the field to check.
-	 *
-	 * @return bool True if a matching non-basic field is found, false otherwise.
-	 */
-	private function has_matching_non_basic_field_by_value( $value = '' ) {
-		foreach ( $this->fields as $field ) {
-			if ( $field->get_type() !== 'basic' ) {
-				if ( $field->get_render_value() === $value ) {
-					return true;
-				}
-			}
-		}
-		return false;
-	}
-	/**
 	 * Get the value of the field based on the first type found.
 	 *
 	 * @param string      $type The type of the field to look for.
@@ -343,13 +326,23 @@ class Feedback {
 	 * @return array An array of extra values, including entry values
 	 */
 	public function get_legacy_extra_values() {
-		$count         = 1;
-		$_extra_fields = array();
+		$count            = 1;
+		$_extra_fields    = array();
+		$special_fields   = array();
+		$non_extra_fields = array( 'email', 'name', 'url', 'subject', 'textarea', 'ip' );
+
+		// Create a map of special fields to check agains their values.
+		foreach ( $this->fields as $field ) {
+			if ( in_array( $field->get_type(), $non_extra_fields, true ) && $field->get_render_value() ) {
+				$special_fields[ $field->get_render_value() ] = true;
+			}
+		}
+
 		foreach ( $this->fields as $field ) {
 			if ( $field->compile_field( 'default' ) ) {
 				continue;
 			}
-			if ( $field->get_type() === 'basic' && $this->has_matching_non_basic_field_by_value( $field->get_render_value() ) ) {
+			if ( $field->get_type() === 'basic' && isset( $special_fields[ $field->get_render_value() ] ) ) {
 				++$count;
 				continue; // Skip fields that are already present in the non-extra fields.
 			}

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -348,7 +348,7 @@ class Contact_Form_Test extends BaseTestCase {
 
 		$response = Feedback::get( $feedback_id );
 
-		$this->assertEquals( $extra_fields, $response->get_extra_values(), 'The extra fields should match the response from the Feedback class' );
+		$this->assertEquals( $extra_fields, $response->get_legacy_extra_values(), 'The extra fields should match the response from the Feedback class' );
 		$this->assertCount( 3, $extra_fields, 'There should be exactly three extra fields when one of the fields is name, and the others are an extra dropdown, radio button field and text field' );
 
 		/*

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -346,6 +346,9 @@ class Contact_Form_Test extends BaseTestCase {
 		// Default metadata should be saved.
 		$extra_fields = get_post_meta( $submission->ID, '_feedback_extra_fields', true );
 
+		$response = Feedback::get( $feedback_id );
+
+		$this->assertEquals( $extra_fields, $response->get_extra_values(), 'The extra fields should match the response from the Feedback class' );
 		$this->assertCount( 3, $extra_fields, 'There should be exactly three extra fields when one of the fields is name, and the others are an extra dropdown, radio button field and text field' );
 
 		/*

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Test.php
@@ -1521,6 +1521,8 @@ class Feedback_Test extends BaseTestCase {
 				$this->assertEquals( 'file', $field->get_type() );
 			}
 		}
+
+		$this->assertSame( '', $saved_response->get_field_value_by_label( 'non existing field' ) );
 	}
 
 	public function test_legacy_get_all_legacy_values() {
@@ -1680,12 +1682,13 @@ class Feedback_Test extends BaseTestCase {
 		$post_id                = Utility::create_legacy_feedback(
 			array(
 				'1_field' => 'value1',
-				'2_field' => 'value2',
+				'2_field' => 'test@email.com',
+				'3_field' => 'value2',
 			)
 		);
 		$expected_legacy_values = array(
-			'3_field' => 'value1',
-			'4_field' => 'value2',
+			'4_field' => 'value1',
+			'5_field' => 'value2',
 		);
 		$response               = Feedback::get( $post_id );
 		$response_legacy        = $response->get_legacy_extra_values();

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Test.php
@@ -1523,7 +1523,7 @@ class Feedback_Test extends BaseTestCase {
 		}
 	}
 
-	public function test_get_extra_values() {
+	public function get_legacy_extra_values() {
 		$form_id = Utility::get_form_id();
 		// Create a form submission
 		$_post_data = Utility::get_post_request(
@@ -1553,10 +1553,10 @@ class Feedback_Test extends BaseTestCase {
 			'7_Email_2' => 'john.smith@example2.com',
 		);
 
-		$this->assertNotEmpty( $response->get_extra_values(), 'Extra values should not be empty for the form submission' );
-		$this->assertEquals( $response->get_extra_values(), $saved_response->get_extra_values(), 'Extra values should match the saved form submission' );
-		$response_extra = $response->get_extra_values();
-		$saved_extra    = $saved_response->get_extra_values();
+		$this->assertNotEmpty( $response->get_legacy_extra_values(), 'Extra values should not be empty for the form submission' );
+		$this->assertEquals( $response->get_legacy_extra_values(), $saved_response->get_legacy_extra_values(), 'Extra values should match the saved form submission' );
+		$response_extra = $response->get_legacy_extra_values();
+		$saved_extra    = $saved_response->get_legacy_extra_values();
 		$this->assertEquals( $expected_extra_values, $response_extra, 'Extra values should match the expected extra values' );
 		$this->assertEquals( $expected_extra_values, $saved_extra, 'Saved extra values should match the expected extra values' );
 	}

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Test.php
@@ -1523,6 +1523,52 @@ class Feedback_Test extends BaseTestCase {
 		}
 	}
 
+	public function test_legacy_get_all_legacy_values() {
+		$post_id = Utility::create_legacy_feedback(
+			array(
+				'1_field' => 'value1',
+				'2_field' => 'value2',
+			)
+		);
+
+		$response = Feedback::get( $post_id );
+
+		$expected_legacy_values = array(
+			'_feedback_author'       => 'Test User',
+			'_feedback_author_email' => 'test@email.com',
+			'_feedback_author_url'   => 'http://example.com',
+			'_feedback_subject'      => 'Test Subject',
+			'_feedback_ip'           => 'https://127.0.0.1',
+			'_feedback_all_fields'   => array(
+				'1_field'                 => 'value1',
+				'2_field'                 => 'value2',
+				'email_marketing_consent' => 'no',
+				'entry_title'             => 'Cool Post Title',
+				'entry_permalink'         => '',
+				'feedback_id'             => 'skip',
+			),
+		);
+
+		$response_legacy = $response->get_all_legacy_values();
+
+		$this->assertNotEmpty( $response_legacy, 'Legacy values should not be empty for the legacy feedback' );
+
+		foreach ( $expected_legacy_values as $key => $value ) {
+			$this->assertArrayHasKey( $key, $response_legacy, 'Extra values should contain the expected key: ' . $key );
+
+			if ( is_array( $value ) ) {
+				foreach ( $value as $sub_key => $sub_value ) {
+					$this->assertArrayHasKey( $sub_key, $response_legacy[ $key ], 'Extra values should contain the expected sub-key: ' . $sub_key );
+					if ( $sub_value !== 'skip' ) {
+						$this->assertEquals( $sub_value, $response_legacy[ $key ][ $sub_key ], 'Extra values should match the expected sub-value for key: ' . $sub_key );
+					}
+				}
+			} else {
+				$this->assertEquals( $value, $response_legacy[ $key ], 'Extra values should match the expected value for key: ' . $key );
+			}
+		}
+	}
+
 	public function test_get_all_legacy_values() {
 		$form_id = Utility::get_form_id( array( 'widget' => 'widget' ) );
 		// Create a form submission
@@ -1586,8 +1632,8 @@ class Feedback_Test extends BaseTestCase {
 					}
 				}
 			} elseif ( $value !== 'skip' ) {
-					$this->assertEquals( $value, $response_legacy[ $key ], 'Extra values should match the expected value for key: ' . $key );
-					$this->assertEquals( $value, $saved_legacy[ $key ], 'Saved extra values should match the expected value for key: ' . $key );
+				$this->assertEquals( $value, $response_legacy[ $key ], 'Extra values should match the expected value for key: ' . $key );
+				$this->assertEquals( $value, $saved_legacy[ $key ], 'Saved extra values should match the expected value for key: ' . $key );
 			}
 		}
 	}
@@ -1628,5 +1674,22 @@ class Feedback_Test extends BaseTestCase {
 		$saved_extra    = $saved_response->get_legacy_extra_values();
 		$this->assertEquals( $expected_extra_values, $response_extra, 'Extra values should match the expected extra values' );
 		$this->assertEquals( $expected_extra_values, $saved_extra, 'Saved extra values should match the expected extra values' );
+	}
+
+	public function test_legacy_get_legacy_extra_values() {
+		$post_id                = Utility::create_legacy_feedback(
+			array(
+				'1_field' => 'value1',
+				'2_field' => 'value2',
+			)
+		);
+		$expected_legacy_values = array(
+			'3_field' => 'value1',
+			'4_field' => 'value2',
+		);
+		$response               = Feedback::get( $post_id );
+		$response_legacy        = $response->get_legacy_extra_values();
+		$this->assertNotEmpty( $response_legacy, 'Legacy values should not be empty for the legacy feedback' );
+		$this->assertEquals( $expected_legacy_values, $response_legacy, 'Legacy extra values should match the expected extra values' );
 	}
 }

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Test.php
@@ -1523,7 +1523,76 @@ class Feedback_Test extends BaseTestCase {
 		}
 	}
 
-	public function get_legacy_extra_values() {
+	public function test_get_all_legacy_values() {
+		$form_id = Utility::get_form_id( array( 'widget' => 'widget' ) );
+		// Create a form submission
+		$_post_data = Utility::get_post_request(
+			array(
+				'text'    => 'Test text',
+				'email'   => 'john.smith@example.com',
+				'email_2' => 'john.smith@example2.com',
+				'website' => 'https://johnsmith.dev',
+				'message' => 'Hello, this is a test message from our contact form.',
+			),
+			'g' . $form_id
+		);
+
+		$form = new Contact_Form(
+			array(
+				'title'       => 'Test Form',
+				'description' => 'This is a test form.',
+				'widget'      => 'widget',
+			),
+			"[contact-field label='Text' type='text' required='1'/][contact-field label='Email' type='email' required='1'/][contact-field label='Email_2' type='email' required='1'/][contact-field label='Website' type='url' required='1'/][contact-field label='Message' type='textarea' required='1'/]"
+		);
+
+		$response               = Feedback::from_submission( $_post_data, $form );
+		$feedback_post_id       = $response->save();
+		$saved_response         = Feedback::get( $feedback_post_id );
+		$expected_legacy_values = array(
+			'_feedback_author'       => 'john.smith@example.com',
+			'_feedback_author_email' => 'john.smith@example.com',
+			'_feedback_author_url'   => 'https://johnsmith.dev',
+			'_feedback_subject'      => 'skip',
+			'_feedback_ip'           => '127.0.0.1',
+			'_feedback_all_fields'   => array(
+				'1_Text'                  => 'Test text',
+				'2_Email'                 => 'john.smith@example.com',
+				'3_Email_2'               => 'john.smith@example2.com',
+				'4_Website'               => 'https://johnsmith.dev',
+				'5_Message'               => 'Hello, this is a test message from our contact form.',
+				'email_marketing_consent' => 'no',
+				'entry_title'             => '',
+				'entry_permalink'         => '',
+				'feedback_id'             => 'skip',
+			),
+		);
+
+		$this->assertNotEmpty( $response->get_all_legacy_values(), 'Extra values should not be empty for the form submission' );
+		$this->assertEquals( $response->get_all_legacy_values(), $saved_response->get_all_legacy_values(), 'Extra values should match the saved form submission' );
+		$response_legacy = $response->get_all_legacy_values();
+		$saved_legacy    = $saved_response->get_all_legacy_values();
+		foreach ( $expected_legacy_values as $key => $value ) {
+			$this->assertArrayHasKey( $key, $response_legacy, 'Extra values should contain the expected key: ' . $key );
+			$this->assertArrayHasKey( $key, $saved_legacy, 'Saved extra values should contain the expected key: ' . $key );
+
+			if ( is_array( $value ) ) {
+				foreach ( $value as $sub_key => $sub_value ) {
+					$this->assertArrayHasKey( $sub_key, $response_legacy[ $key ], 'Extra values should contain the expected sub-key: ' . $sub_key );
+					$this->assertArrayHasKey( $sub_key, $saved_legacy[ $key ], 'Saved extra values should contain the expected sub-key: ' . $sub_key );
+					if ( $sub_value !== 'skip' ) {
+						$this->assertEquals( $sub_value, $response_legacy[ $key ][ $sub_key ], 'Extra values should match the expected sub-value for key: ' . $sub_key );
+						$this->assertEquals( $sub_value, $saved_legacy[ $key ][ $sub_key ], 'Saved extra values should match the expected sub-value for key: ' . $sub_key );
+					}
+				}
+			} elseif ( $value !== 'skip' ) {
+					$this->assertEquals( $value, $response_legacy[ $key ], 'Extra values should match the expected value for key: ' . $key );
+					$this->assertEquals( $value, $saved_legacy[ $key ], 'Saved extra values should match the expected value for key: ' . $key );
+			}
+		}
+	}
+
+	public function test_get_legacy_extra_values() {
 		$form_id = Utility::get_form_id();
 		// Create a form submission
 		$_post_data = Utility::get_post_request(

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Test.php
@@ -1522,4 +1522,42 @@ class Feedback_Test extends BaseTestCase {
 			}
 		}
 	}
+
+	public function test_get_extra_values() {
+		$form_id = Utility::get_form_id();
+		// Create a form submission
+		$_post_data = Utility::get_post_request(
+			array(
+				'text'    => 'Test text',
+				'email'   => 'john.smith@example.com',
+				'email_2' => 'john.smith@example2.com',
+				'website' => 'https://johnsmith.dev',
+				'message' => 'Hello, this is a test message from our contact form.',
+			),
+			'g' . $form_id
+		);
+
+		$form = new Contact_Form(
+			array(
+				'title'       => 'Test Form',
+				'description' => 'This is a test form.',
+			),
+			"[contact-field label='Text' type='text' required='1'/][contact-field label='Email' type='email' required='1'/][contact-field label='Email_2' type='email' required='1'/][contact-field label='Website' type='url' required='1'/][contact-field label='Message' type='textarea' required='1'/]"
+		);
+
+		$response              = Feedback::from_submission( $_post_data, $form );
+		$feedback_post_id      = $response->save();
+		$saved_response        = Feedback::get( $feedback_post_id );
+		$expected_extra_values = array(
+			'6_Text'    => 'Test text',
+			'7_Email_2' => 'john.smith@example2.com',
+		);
+
+		$this->assertNotEmpty( $response->get_extra_values(), 'Extra values should not be empty for the form submission' );
+		$this->assertEquals( $response->get_extra_values(), $saved_response->get_extra_values(), 'Extra values should match the saved form submission' );
+		$response_extra = $response->get_extra_values();
+		$saved_extra    = $saved_response->get_extra_values();
+		$this->assertEquals( $expected_extra_values, $response_extra, 'Extra values should match the expected extra values' );
+		$this->assertEquals( $expected_extra_values, $saved_extra, 'Saved extra values should match the expected extra values' );
+	}
 }


### PR DESCRIPTION
## Proposed changes:
* Add a new get_all_legacy_values and get_legacy_extra_value methods. 

This is being done as part of the Save Feedback in the new format refactor. See https://github.com/Automattic/jetpack/pull/44659/files#diff-7b9bd61b3a54b8da1801e47c3116d448b3d4833bc13a45961bfc1a0a7b8d77b0 

And will be used in the future  see. 
https://github.com/Automattic/jetpack/pull/44659/files#diff-ac9fe037be63c0ce239ab4294bd101f43fcc5ac9e1b1994ac0e1727dfb3feae7R1655-R1656

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* Do the tests pass? 
* Are they covered by tests? 
