### PR TITLE
Update/paypal payment buttons change package location

### DIFF
--- a/projects/plugins/paypal-payment-buttons/changelog/update-paypal-payment-buttons-change-package-location
+++ b/projects/plugins/paypal-payment-buttons/changelog/update-paypal-payment-buttons-change-package-location
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Fixes path used to require package
+
+

--- a/projects/plugins/paypal-payment-buttons/src/class-paypal-payment-buttons.php
+++ b/projects/plugins/paypal-payment-buttons/src/class-paypal-payment-buttons.php
@@ -80,7 +80,7 @@ class PayPal_Payment_Buttons {
 	 */
 	public function register_paypal_block() {
 		// Get the path to the dist directory in the paypal-payments package
-		$package_dir = dirname( __DIR__ ) . '/vendor/automattic/jetpack-paypal-payments';
+		$package_dir = dirname( __DIR__ ) . '/jetpack_vendor/automattic/jetpack-paypal-payments';
 		$dist_dir    = $package_dir . '/dist/paypal-payment-buttons';
 
 		if ( ! is_dir( $dist_dir ) ) {


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fixes an issue where block was not being registered correctly.

I hadn't previously noticed this issue in testing. I noticed it when testing with a Playground blueprint. With some debugging, I was able to reproduce with  `rm -rf plugins/paypal-payment-buttons/vendor` and then building again.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
NA

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Build plugin with `jetpack build --deps plugins/paypal-payment-buttons`
- Test and ensure the block works in the editor
- Save the block
- Load the page
- Ensure block renders