### PR TITLE
Forms: Make slider field min/max editable

### DIFF
--- a/projects/packages/forms/changelog/add-forms-slider-min-max-inputs
+++ b/projects/packages/forms/changelog/add-forms-slider-min-max-inputs
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: Make slider field min/max editable.

--- a/projects/packages/forms/src/blocks/field-slider/edit.js
+++ b/projects/packages/forms/src/blocks/field-slider/edit.js
@@ -8,25 +8,31 @@ export default function SliderFieldEdit( props ) {
 	const { attributes, setAttributes } = props;
 	const { min = 0, max = 100, default: defaultValue = 0, width, id, required } = attributes;
 
-	const updateMin = newMin => {
-		const parsedMin = parseInt( newMin ) || 0;
-		const validatedMin = Math.min( parsedMin, max );
-		const validatedDefault = Math.max( defaultValue, validatedMin );
-		setAttributes( {
-			min: validatedMin,
-			default: validatedDefault,
-		} );
-	};
+	const onChangeMin = useCallback(
+		newMin => {
+			const parsedMin = parseInt( newMin ) || 0;
+			const validatedMin = Math.min( parsedMin, max );
+			const validatedDefault = Math.max( defaultValue, validatedMin );
+			setAttributes( {
+				min: validatedMin,
+				default: validatedDefault,
+			} );
+		},
+		[ max, defaultValue, setAttributes ]
+	);
 
-	const updateMax = newMax => {
-		const parsedMax = parseInt( newMax ) || 0;
-		const validatedMax = Math.max( parsedMax, min );
-		const validatedDefault = Math.min( defaultValue, validatedMax );
-		setAttributes( {
-			max: validatedMax,
-			default: validatedDefault,
-		} );
-	};
+	const onChangeMax = useCallback(
+		newMax => {
+			const parsedMax = parseInt( newMax ) || 0;
+			const validatedMax = Math.max( parsedMax, min );
+			const validatedDefault = Math.min( defaultValue, validatedMax );
+			setAttributes( {
+				max: validatedMax,
+				default: validatedDefault,
+			} );
+		},
+		[ min, defaultValue, setAttributes ]
+	);
 
 	// This is passed to child input-range block via context.
 	const onChangeDefault = useCallback(
@@ -40,8 +46,8 @@ export default function SliderFieldEdit( props ) {
 
 	// Make callback available in block attributes for context.
 	useEffect( () => {
-		setAttributes( { onChangeDefault } );
-	}, [ onChangeDefault, setAttributes ] );
+		setAttributes( { onChangeDefault, onChangeMin, onChangeMax } );
+	}, [ onChangeDefault, onChangeMin, onChangeMax, setAttributes ] );
 
 	// Ensure min, max, and default are always set when the block is first added.
 	useEffect( () => {
@@ -89,7 +95,7 @@ export default function SliderFieldEdit( props ) {
 						min={ Number.MIN_SAFE_INTEGER }
 						max={ max }
 						value={ min }
-						onChange={ updateMin }
+						onChange={ onChangeMin }
 					/>
 					<NumberControl
 						label={ __( 'Maximum value', 'jetpack-forms' ) }
@@ -97,7 +103,7 @@ export default function SliderFieldEdit( props ) {
 						min={ min }
 						max={ Number.MAX_SAFE_INTEGER }
 						value={ max }
-						onChange={ updateMax }
+						onChange={ onChangeMax }
 					/>
 					<NumberControl
 						label={ __( 'Default value', 'jetpack-forms' ) }

--- a/projects/packages/forms/src/blocks/field-slider/edit.js
+++ b/projects/packages/forms/src/blocks/field-slider/edit.js
@@ -1,6 +1,11 @@
-import { useBlockProps, useInnerBlocksProps, InspectorControls } from '@wordpress/block-editor';
+import {
+	useBlockProps,
+	useInnerBlocksProps,
+	InspectorControls,
+	BlockContextProvider,
+} from '@wordpress/block-editor';
 import { PanelBody, __experimentalNumberControl as NumberControl } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
-import { useEffect, useCallback } from '@wordpress/element';
+import { useCallback, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import JetpackFieldControls from '../shared/components/jetpack-field-controls';
 
@@ -44,12 +49,7 @@ export default function SliderFieldEdit( props ) {
 		[ max, min, setAttributes ]
 	);
 
-	// Make callback available in block attributes for context.
-	useEffect( () => {
-		setAttributes( { onChangeDefault, onChangeMin, onChangeMax } );
-	}, [ onChangeDefault, onChangeMin, onChangeMax, setAttributes ] );
-
-	// Ensure min, max, and default are always set when the block is first added.
+	// Initialize scalar attributes so they serialize into post markup
 	useEffect( () => {
 		if (
 			attributes.min === undefined ||
@@ -115,7 +115,15 @@ export default function SliderFieldEdit( props ) {
 					/>
 				</PanelBody>
 			</InspectorControls>
-			<div { ...innerBlocksProps } />
+			<BlockContextProvider
+				value={ {
+					'jetpack/field-slider-onChangeDefault': onChangeDefault,
+					'jetpack/field-slider-onChangeMin': onChangeMin,
+					'jetpack/field-slider-onChangeMax': onChangeMax,
+				} }
+			>
+				<div { ...innerBlocksProps } />
+			</BlockContextProvider>
 			<JetpackFieldControls
 				attributes={ attributes }
 				id={ id }

--- a/projects/packages/forms/src/blocks/field-slider/index.js
+++ b/projects/packages/forms/src/blocks/field-slider/index.js
@@ -40,9 +40,6 @@ const settings = {
 		'jetpack/field-slider-min': 'min',
 		'jetpack/field-slider-max': 'max',
 		'jetpack/field-slider-default': 'default',
-		'jetpack/field-slider-onChangeDefault': 'onChangeDefault',
-		'jetpack/field-slider-onChangeMin': 'onChangeMin',
-		'jetpack/field-slider-onChangeMax': 'onChangeMax',
 	},
 	example: {
 		attributes: {

--- a/projects/packages/forms/src/blocks/field-slider/index.js
+++ b/projects/packages/forms/src/blocks/field-slider/index.js
@@ -41,6 +41,8 @@ const settings = {
 		'jetpack/field-slider-max': 'max',
 		'jetpack/field-slider-default': 'default',
 		'jetpack/field-slider-onChangeDefault': 'onChangeDefault',
+		'jetpack/field-slider-onChangeMin': 'onChangeMin',
+		'jetpack/field-slider-onChangeMax': 'onChangeMax',
 	},
 	example: {
 		attributes: {

--- a/projects/packages/forms/src/blocks/input-range/edit.js
+++ b/projects/packages/forms/src/blocks/input-range/edit.js
@@ -2,15 +2,17 @@ import './editor.scss';
 import { useBlockProps } from '@wordpress/block-editor';
 
 export default function SliderInputEdit( props ) {
-	const { context = {} } = props;
+	const { context = {}, isSelected } = props;
 
 	const min = context[ 'jetpack/field-slider-min' ];
 	const max = context[ 'jetpack/field-slider-max' ];
 	const defaultValue = context[ 'jetpack/field-slider-default' ];
 	const onChangeDefault = context[ 'jetpack/field-slider-onChangeDefault' ];
+	const onChangeMin = context[ 'jetpack/field-slider-onChangeMin' ];
+	const onChangeMax = context[ 'jetpack/field-slider-onChangeMax' ];
 
 	const blockProps = useBlockProps( {
-		className: 'jetpack-input-range',
+		className: `jetpack-input-range${ isSelected ? ' is-selected' : '' }`,
 	} );
 
 	const onChange = event => {
@@ -32,7 +34,18 @@ export default function SliderInputEdit( props ) {
 	return (
 		<div { ...blockProps }>
 			<div className="jetpack-field-slider__row">
-				<span className="jetpack-field-slider__min-label">{ min }</span>
+				<input
+					type="number"
+					className="jetpack-field-slider__min-input"
+					value={ min }
+					onChange={ e => {
+						const val = e.target.value.replace( /[^\d-]/g, '' );
+						onChangeMin && onChangeMin( val === '' ? 0 : val );
+					} }
+					min={ Number.MIN_SAFE_INTEGER }
+					max={ max }
+					style={ { width: '3em', textAlign: 'center' } }
+				/>
 				<div className="jetpack-field-slider__input-container">
 					<input
 						type="range"
@@ -49,7 +62,18 @@ export default function SliderInputEdit( props ) {
 						{ defaultValue }
 					</div>
 				</div>
-				<span className="jetpack-field-slider__max-label">{ max }</span>
+				<input
+					type="number"
+					className="jetpack-field-slider__max-input"
+					value={ max }
+					onChange={ e => {
+						const val = e.target.value.replace( /[^\d-]/g, '' );
+						onChangeMax && onChangeMax( val === '' ? 0 : val );
+					} }
+					min={ min }
+					max={ Number.MAX_SAFE_INTEGER }
+					style={ { width: '3em', textAlign: 'center' } }
+				/>
 			</div>
 		</div>
 	);

--- a/projects/packages/forms/src/blocks/input-range/edit.js
+++ b/projects/packages/forms/src/blocks/input-range/edit.js
@@ -39,12 +39,8 @@ export default function SliderInputEdit( props ) {
 					className="jetpack-field-slider__min-input"
 					value={ min }
 					onChange={ e => {
-						const val = e.target.value.replace( /[^\d-]/g, '' );
-						onChangeMin && onChangeMin( val === '' ? 0 : val );
+						onChangeMin && onChangeMin( e.target.value === '' ? 0 : e.target.value );
 					} }
-					min={ Number.MIN_SAFE_INTEGER }
-					max={ max }
-					style={ { width: '3em', textAlign: 'center' } }
 				/>
 				<div className="jetpack-field-slider__input-container">
 					<input
@@ -67,12 +63,8 @@ export default function SliderInputEdit( props ) {
 					className="jetpack-field-slider__max-input"
 					value={ max }
 					onChange={ e => {
-						const val = e.target.value.replace( /[^\d-]/g, '' );
-						onChangeMax && onChangeMax( val === '' ? 0 : val );
+						onChangeMax && onChangeMax( e.target.value === '' ? 0 : e.target.value );
 					} }
-					min={ min }
-					max={ Number.MAX_SAFE_INTEGER }
-					style={ { width: '3em', textAlign: 'center' } }
 				/>
 			</div>
 		</div>

--- a/projects/packages/forms/src/blocks/input-range/edit.js
+++ b/projects/packages/forms/src/blocks/input-range/edit.js
@@ -15,6 +15,13 @@ export default function SliderInputEdit( props ) {
 		className: `jetpack-input-range${ isSelected ? ' is-selected' : '' }`,
 	} );
 
+	const removeLeadingZero = val => {
+		if ( typeof val === 'string' && val.length > 1 ) {
+			return val.replace( /^0+/, '' ) || '0';
+		}
+		return val;
+	};
+
 	const onChange = event => {
 		if ( onChangeDefault ) {
 			onChangeDefault( event.target.value );
@@ -37,7 +44,7 @@ export default function SliderInputEdit( props ) {
 				<input
 					type="number"
 					className="jetpack-field-slider__min-input"
-					value={ min }
+					value={ removeLeadingZero( String( min ) ) }
 					onChange={ e => {
 						onChangeMin && onChangeMin( e.target.value === '' ? 0 : e.target.value );
 					} }
@@ -61,7 +68,7 @@ export default function SliderInputEdit( props ) {
 				<input
 					type="number"
 					className="jetpack-field-slider__max-input"
-					value={ max }
+					value={ removeLeadingZero( String( max ) ) }
 					onChange={ e => {
 						onChangeMax && onChangeMax( e.target.value === '' ? 0 : e.target.value );
 					} }

--- a/projects/packages/forms/src/blocks/input-range/edit.js
+++ b/projects/packages/forms/src/blocks/input-range/edit.js
@@ -1,15 +1,27 @@
 import './editor.scss';
 import { useBlockProps } from '@wordpress/block-editor';
+import { useState, useEffect } from 'react';
 
 export default function SliderInputEdit( props ) {
 	const { context = {}, isSelected } = props;
 
-	const min = context[ 'jetpack/field-slider-min' ];
-	const max = context[ 'jetpack/field-slider-max' ];
-	const defaultValue = context[ 'jetpack/field-slider-default' ];
+	// Get values from context.
+	const minFromContext = context[ 'jetpack/field-slider-min' ];
+	const maxFromContext = context[ 'jetpack/field-slider-max' ];
+	const defaultFromContext = context[ 'jetpack/field-slider-default' ];
 	const onChangeDefault = context[ 'jetpack/field-slider-onChangeDefault' ];
 	const onChangeMin = context[ 'jetpack/field-slider-onChangeMin' ];
 	const onChangeMax = context[ 'jetpack/field-slider-onChangeMax' ];
+
+	// Setup local state.
+	const [ localMin, setLocalMin ] = useState( String( minFromContext ) );
+	const [ localMax, setLocalMax ] = useState( String( maxFromContext ) );
+	const [ minFocused, setMinFocused ] = useState( false );
+	const [ maxFocused, setMaxFocused ] = useState( false );
+
+	// Derived variables
+	const isMinValid = Number( localMin ) <= Number( localMax );
+	const isMaxValid = Number( localMax ) >= Number( localMin );
 
 	const blockProps = useBlockProps( {
 		className: `jetpack-input-range${ isSelected ? ' is-selected' : '' }`,
@@ -22,55 +34,67 @@ export default function SliderInputEdit( props ) {
 		return val;
 	};
 
-	const onChange = event => {
-		if ( onChangeDefault ) {
-			onChangeDefault( event.target.value );
-		}
-	};
-
 	const getSliderPosition = () => {
-		const minNum = Number( min );
-		const maxNum = Number( max );
-		let valueNum = Number( defaultValue );
-		valueNum = valueNum < minNum ? minNum : valueNum;
-		valueNum = valueNum > maxNum ? maxNum : valueNum;
-		const percent = ( ( valueNum - minNum ) * 100 ) / ( maxNum - minNum );
+		const min = Number( minFromContext );
+		const max = Number( maxFromContext );
+		const value = Number( defaultFromContext );
+		const percent = ( ( value - min ) * 100 ) / ( max - min );
 		return `calc(${ percent }% + (${ 8 - percent * 0.15 }px))`;
 	};
+
+	// Sync min/max if context updates or min/max input loses focus.
+	useEffect( () => {
+		if ( ! minFocused ) {
+			setLocalMin( String( minFromContext ) );
+		}
+		if ( ! maxFocused ) {
+			setLocalMax( String( maxFromContext ) );
+		}
+	}, [ minFromContext, maxFromContext, minFocused, maxFocused ] );
 
 	return (
 		<div { ...blockProps }>
 			<div className="jetpack-field-slider__row">
 				<input
 					type="number"
-					className="jetpack-field-slider__min-input"
-					value={ removeLeadingZero( String( min ) ) }
-					onChange={ e => {
-						onChangeMin && onChangeMin( e.target.value === '' ? 0 : e.target.value );
+					className={ `jetpack-field-slider__min-input${
+						! isMinValid && minFocused ? ' has-error' : ''
+					}` }
+					value={ removeLeadingZero( localMin ) }
+					onChange={ e => setLocalMin( e.target.value ) }
+					onFocus={ () => setMinFocused( true ) }
+					onBlur={ () => {
+						setMinFocused( false );
+						onChangeMin( localMin );
 					} }
 				/>
 				<div className="jetpack-field-slider__input-container">
 					<input
 						type="range"
-						min={ min }
-						max={ max }
-						value={ defaultValue }
-						onChange={ onChange }
+						min={ minFromContext }
+						max={ maxFromContext }
+						value={ defaultFromContext }
+						onChange={ e => onChangeDefault( e.target.value ) }
 						className="jetpack-field-slider__range"
 					/>
 					<div
 						className="jetpack-field-slider__value-indicator"
 						style={ { left: getSliderPosition() } }
 					>
-						{ defaultValue }
+						{ defaultFromContext }
 					</div>
 				</div>
 				<input
 					type="number"
-					className="jetpack-field-slider__max-input"
-					value={ removeLeadingZero( String( max ) ) }
-					onChange={ e => {
-						onChangeMax && onChangeMax( e.target.value === '' ? 0 : e.target.value );
+					className={ `jetpack-field-slider__max-input${
+						! isMaxValid && maxFocused ? ' has-error' : ''
+					}` }
+					value={ removeLeadingZero( localMax ) }
+					onChange={ e => setLocalMax( e.target.value ) }
+					onFocus={ () => setMaxFocused( true ) }
+					onBlur={ () => {
+						setMaxFocused( false );
+						onChangeMax( localMax );
 					} }
 				/>
 			</div>

--- a/projects/packages/forms/src/blocks/input-range/editor.scss
+++ b/projects/packages/forms/src/blocks/input-range/editor.scss
@@ -94,7 +94,8 @@
 	}
 
 	&.has-error {
-		border: 1px solid #d63638;
+		border: 1px solid var(--color-error, #d63638);
+		box-shadow: none;
 	}
 
 	&::-webkit-outer-spin-button,

--- a/projects/packages/forms/src/blocks/input-range/editor.scss
+++ b/projects/packages/forms/src/blocks/input-range/editor.scss
@@ -84,7 +84,7 @@
 	background: transparent;
 	font: inherit;
 	font-size: 0.9em;
-	padding: 0;
+	padding: 0 0.5em;
 	margin: 0;
 	appearance: textfield;
 

--- a/projects/packages/forms/src/blocks/input-range/editor.scss
+++ b/projects/packages/forms/src/blocks/input-range/editor.scss
@@ -6,12 +6,6 @@
 	margin-top: 30px;
 }
 
-.jetpack-field-slider__min-label,
-.jetpack-field-slider__max-label {
-	font-size: 0.9em;
-	text-align: center;
-}
-
 .jetpack-field-slider__input-container {
 	display: flex;
 	flex: 1 1 auto;
@@ -78,4 +72,28 @@
 	padding: 2px 8px;
 	font-size: 0.7em;
 	z-index: 2;
+}
+
+.jetpack-field-slider__min-input[type="number"],
+.jetpack-field-slider__max-input[type="number"] {
+	border: none;
+	background: transparent;
+	width: 3em;
+	text-align: center;
+	font: inherit;
+	font-size: 0.9em;
+	padding: 0;
+	margin: 0;
+	appearance: textfield;
+
+	.is-selected &,
+	&:focus {
+		border: 1px solid var(--wp-admin-theme-color, #2271b1);
+	}
+
+	&::-webkit-outer-spin-button,
+	&::-webkit-inner-spin-button {
+		-webkit-appearance: none;
+		margin: 0;
+	}
 }

--- a/projects/packages/forms/src/blocks/input-range/editor.scss
+++ b/projects/packages/forms/src/blocks/input-range/editor.scss
@@ -76,10 +76,11 @@
 
 .jetpack-field-slider__min-input[type="number"],
 .jetpack-field-slider__max-input[type="number"] {
+	field-sizing: content;
+	max-width: 7ch;
+	text-align: center;
 	border: none;
 	background: transparent;
-	width: 3em;
-	text-align: center;
 	font: inherit;
 	font-size: 0.9em;
 	padding: 0;

--- a/projects/packages/forms/src/blocks/input-range/editor.scss
+++ b/projects/packages/forms/src/blocks/input-range/editor.scss
@@ -77,7 +77,8 @@
 .jetpack-field-slider__min-input[type="number"],
 .jetpack-field-slider__max-input[type="number"] {
 	field-sizing: content;
-	max-width: 7ch;
+	min-width: 2ch;
+	max-width: 8ch;
 	text-align: center;
 	border: none;
 	background: transparent;
@@ -90,6 +91,10 @@
 	.is-selected &,
 	&:focus {
 		border: 1px solid var(--wp-admin-theme-color, #2271b1);
+	}
+
+	&.has-error {
+		border: 1px solid #d63638;
 	}
 
 	&::-webkit-outer-spin-button,

--- a/projects/packages/forms/src/blocks/input-range/index.js
+++ b/projects/packages/forms/src/blocks/input-range/index.js
@@ -17,6 +17,8 @@ const settings = {
 		'jetpack/field-slider-max',
 		'jetpack/field-slider-default',
 		'jetpack/field-slider-onChangeDefault',
+		'jetpack/field-slider-onChangeMin',
+		'jetpack/field-slider-onChangeMax',
 	],
 };
 


### PR DESCRIPTION
## Proposed changes:

Make the min/max labels for the new slider field editable directly on the block editor content area. Before this, you could only edit them in the field inspector sidebar. We now output number inputs rather than text. 

See [comment](https://github.com/Automattic/jetpack/pull/44150#discussion_r2215415009) on original slider field PR for context. 

**Before**
Coming...

**After**
<img width="698" height="110" alt="slider-minmax-inputs" src="https://github.com/user-attachments/assets/3dc97ae1-41ff-438a-baa1-d72cb40294f1" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
See [comment](https://github.com/Automattic/jetpack/pull/44150#discussion_r2215415009) on original slider field PR for context. 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Enable beta blocks: define( 'JETPACK_BLOCKS_VARIATION', 'beta' );
* Note: You may need to run jetpack build packages/forms to get the frontend slider-field.css to be built and loaded in the dist directory. Having the watch command running is not sufficient.
* Add a form to a page or post
* Add a new Slider block.
* Confirm the block continues to work generally as expected (no regressions)
   - It renders correctly. 
   - You can update min/max/default on sidebar.
   - Save and confirm it renders on frontend correctly. 
* Confirm you can update min/max directly in the editor
   - When the block is not selected, you should not see borders around the min/max inputs
   - When the block is selected, you should see borders around the min/max inputs
   - Update the inputs in the editor, then check that sidebar min/max is also updated the sidebar for the field
   - Save and confirm frontend works using newly change min/max
  

