### PR TITLE
AI Assistant: use performance API to track generation request time

### DIFF
--- a/projects/plugins/jetpack/changelog/add-jetpack-ai-timelapse-event-prop
+++ b/projects/plugins/jetpack/changelog/add-jetpack-ai-timelapse-event-prop
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+AI Assistant: track generation time on suggestion request

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/text-blocks/with-ai-text-extension.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/text-blocks/with-ai-text-extension.tsx
@@ -98,7 +98,7 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 		const lastRequest = useRef< RequestOptions | null >( null );
 		// Ref to the requesting state to use it in the hideOnBlockFocus effect.
 		const requestingStateRef = useRef< RequestingStateProp | null >( null );
-
+		const timelapse = useRef( null );
 		// Data and functions from the editor.
 		const { undo } = useDispatch( 'core/editor' ) as CoreEditorDispatch;
 		const { postId } = useSelect( select => {
@@ -234,6 +234,8 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 				tracks.recordEvent( 'jetpack_ai_assistant_toolbar_extension_generate', {
 					prompt_type: lastPromptType.current,
 					model: modelUsed,
+					generation_time:
+						timelapse.current !== null ? window?.performance?.now?.() - timelapse.current : null,
 				} );
 
 				if ( lastRequest.current?.message ) {
@@ -361,7 +363,7 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 				dequeueAsyncRequest();
 
 				enableAutoScroll();
-
+				timelapse.current = window?.performance?.now?.() || null;
 				request( messages );
 			},
 			[ dequeueAsyncRequest, enableAutoScroll, getRequestMessages, request, requireUpgrade ]

--- a/projects/plugins/jetpack/extensions/plugins/ai-content-lens/extend/ai-post-excerpt/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-content-lens/extend/ai-post-excerpt/index.tsx
@@ -85,7 +85,7 @@ function AiPostExcerpt() {
 						feature: 'jetpack-ai-content-lens',
 						model: modelUsed,
 						generation_time:
-							timelapse.current !== null ? window.performance?.now?.() - timelapse.current : null,
+							timelapse.current !== null ? window?.performance?.now?.() - timelapse.current : null,
 					} );
 				},
 				[ increaseAiAssistantRequestsCount, tracks ]
@@ -201,7 +201,7 @@ ${ postContent }
 			model: model,
 		} );
 
-		timelapse.current = window.performance?.now?.() || null;
+		timelapse.current = window?.performance?.now?.() || null;
 		request( prompt, { feature: 'jetpack-ai-content-lens', model } );
 	}
 

--- a/projects/plugins/jetpack/extensions/plugins/ai-content-lens/extend/ai-post-excerpt/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-content-lens/extend/ai-post-excerpt/index.tsx
@@ -16,7 +16,7 @@ import {
 	PostTypeSupportCheck,
 	PluginDocumentSettingPanel,
 } from '@wordpress/editor';
-import { useState, useEffect, useCallback } from '@wordpress/element';
+import { useState, useEffect, useCallback, useRef } from '@wordpress/element';
 import { __, sprintf, _n } from '@wordpress/i18n';
 import { count } from '@wordpress/wordcount';
 /**
@@ -46,6 +46,7 @@ type ContentLensMessageContextProps = {
 };
 
 function AiPostExcerpt() {
+	const timelapse = useRef( null );
 	const { excerpt, postId } = useSelect( select => {
 		const { getEditedPostAttribute, getCurrentPostId } = select( editorStore );
 
@@ -83,6 +84,8 @@ function AiPostExcerpt() {
 					tracks.recordEvent( 'jetpack_ai_assistant_block_generate', {
 						feature: 'jetpack-ai-content-lens',
 						model: modelUsed,
+						generation_time:
+							timelapse.current !== null ? window.performance?.now?.() - timelapse.current : null,
 					} );
 				},
 				[ increaseAiAssistantRequestsCount, tracks ]
@@ -197,6 +200,8 @@ ${ postContent }
 			feature: 'jetpack-ai-content-lens',
 			model: model,
 		} );
+
+		timelapse.current = window.performance?.now?.() || null;
 		request( prompt, { feature: 'jetpack-ai-content-lens', model } );
 	}
 


### PR DESCRIPTION

## Proposed changes:
This PR adds `generation_time` prop to `jetpack_ai_assistant_block_generate`  and `jetpack_ai_assistant_toolbar_extension_generate` events

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
none

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Trigger
- AI excerpt generation
- paragraph translation

Check the event on devtools console, see that it now carries the new prop with the amount of ms