### PR TITLE
Update deprecated getMedia calls to getEntityRecord

### DIFF
--- a/projects/js-packages/ai-client/changelog/update-deprecated_getMedia_calls
+++ b/projects/js-packages/ai-client/changelog/update-deprecated_getMedia_calls
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update deprecated getMedia() calls to getEntityRecord().
+
+

--- a/projects/js-packages/ai-client/src/components/ai-image/hooks/use-ai-image.ts
+++ b/projects/js-packages/ai-client/src/components/ai-image/hooks/use-ai-image.ts
@@ -119,7 +119,8 @@ export default function useAiImage( {
 
 	// the selec/useEffect combo...
 	const loadedMedia = useSelect(
-		( select: ( store ) => CoreSelectors ) => select( 'core' )?.getMedia?.( previousMediaId ),
+		( select: ( store ) => CoreSelectors ) =>
+			select( 'core' )?.getEntityRecord?.( 'postType', 'attachment', previousMediaId ),
 		[ previousMediaId ]
 	);
 	useEffect( () => {

--- a/projects/js-packages/ai-client/src/components/ai-image/types.ts
+++ b/projects/js-packages/ai-client/src/components/ai-image/types.ts
@@ -12,7 +12,11 @@ export interface EditorSelectors {
 }
 
 export interface CoreSelectors {
-	getMedia: ( mediaId: number ) => {
+	getEntityRecord: (
+		kind: string,
+		name: string,
+		key: number
+	) => {
 		id: number;
 		source_url: string;
 	} | null;

--- a/projects/js-packages/publicize-components/changelog/update-deprecated_getMedia_calls
+++ b/projects/js-packages/publicize-components/changelog/update-deprecated_getMedia_calls
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update deprecated getMedia() calls to getEntityRecord().
+
+

--- a/projects/js-packages/publicize-components/src/components/generated-image-preview/index.js
+++ b/projects/js-packages/publicize-components/src/components/generated-image-preview/index.js
@@ -60,7 +60,7 @@ export const calculateImageUrl = (
 	customImageId,
 	featuredImageId,
 	defaultImageId,
-	getMedia
+	getEntityRecord
 ) => {
 	if ( hasNoValidImage( imageType, customImageId, featuredImageId, defaultImageId ) ) {
 		return null;
@@ -68,7 +68,7 @@ export const calculateImageUrl = (
 
 	const usedImageId = getImageId( imageType, customImageId, featuredImageId, defaultImageId );
 
-	const media = getMedia( usedImageId );
+	const media = getEntityRecord( 'postType', 'attachment', usedImageId );
 	if ( ! media ) {
 		return FEATURED_IMAGE_STILL_LOADING;
 	}
@@ -98,12 +98,8 @@ export default function GeneratedImagePreview( {
 		const featuredImage = select( editorStore ).getEditedPostAttribute( 'featured_media' );
 		return {
 			title: select( editorStore ).getEditedPostAttribute( 'title' ),
-			imageUrl: calculateImageUrl(
-				imageType,
-				imageId,
-				featuredImage,
-				defaultImageId,
-				select( 'core' ).getMedia
+			imageUrl: calculateImageUrl( imageType, imageId, featuredImage, defaultImageId, mediaID =>
+				select( 'core' ).getEntityRecord( 'postType', 'attachment', mediaID )
 			),
 		};
 	} );

--- a/projects/js-packages/publicize-components/src/components/generated-image-preview/index.js
+++ b/projects/js-packages/publicize-components/src/components/generated-image-preview/index.js
@@ -60,7 +60,7 @@ export const calculateImageUrl = (
 	customImageId,
 	featuredImageId,
 	defaultImageId,
-	getEntityRecord
+	getMedia
 ) => {
 	if ( hasNoValidImage( imageType, customImageId, featuredImageId, defaultImageId ) ) {
 		return null;
@@ -68,7 +68,7 @@ export const calculateImageUrl = (
 
 	const usedImageId = getImageId( imageType, customImageId, featuredImageId, defaultImageId );
 
-	const media = getEntityRecord( 'postType', 'attachment', usedImageId );
+	const media = getMedia( usedImageId );
 	if ( ! media ) {
 		return FEATURED_IMAGE_STILL_LOADING;
 	}

--- a/projects/js-packages/publicize-components/src/components/generated-image-preview/index.js
+++ b/projects/js-packages/publicize-components/src/components/generated-image-preview/index.js
@@ -1,6 +1,7 @@
 import { ThemeProvider } from '@automattic/jetpack-components';
 import apiFetch from '@wordpress/api-fetch';
 import { Spinner, BaseControl } from '@wordpress/components';
+import { store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { __, _x } from '@wordpress/i18n';
@@ -99,7 +100,7 @@ export default function GeneratedImagePreview( {
 		return {
 			title: select( editorStore ).getEditedPostAttribute( 'title' ),
 			imageUrl: calculateImageUrl( imageType, imageId, featuredImage, defaultImageId, mediaID =>
-				select( 'core' ).getEntityRecord( 'postType', 'attachment', mediaID )
+				select( coreStore ).getEntityRecord( 'postType', 'attachment', mediaID )
 			),
 		};
 	} );

--- a/projects/js-packages/publicize-components/src/components/generated-image-preview/test/index.test.js
+++ b/projects/js-packages/publicize-components/src/components/generated-image-preview/test/index.test.js
@@ -106,66 +106,48 @@ describe( 'GeneratedImagePreview', () => {
 		const CUSTOM_ID = 1;
 		const FEATURED_ID = 2;
 		const DEFAULT_ID = 10;
-		const getMediaMock = id => ( {
+		const getEntityRecordMock = ( kind, name, id ) => ( {
 			source_url: id,
 		} );
 
 		it( 'should use the default image if the type is default', () => {
-			const imageUrl = calculateImageUrl(
-				'default',
-				CUSTOM_ID,
-				FEATURED_ID,
-				DEFAULT_ID,
-				getMediaMock
+			const imageUrl = calculateImageUrl( 'default', CUSTOM_ID, FEATURED_ID, DEFAULT_ID, mediaId =>
+				getEntityRecordMock( 'postType', 'attachment', mediaId )
 			);
 			expect( imageUrl ).toBe( DEFAULT_ID );
 		} );
 
 		it( 'should use the default image if the type is null and there is no featured image', () => {
-			const imageUrl = calculateImageUrl( null, 0, 0, DEFAULT_ID, getMediaMock );
+			const imageUrl = calculateImageUrl( null, 0, 0, DEFAULT_ID, mediaId =>
+				getEntityRecordMock( 'postType', 'attachment', mediaId )
+			);
 			expect( imageUrl ).toBe( DEFAULT_ID );
 		} );
 
 		it( 'should use the custom image if the type is custom', () => {
-			const imageUrl = calculateImageUrl(
-				'custom',
-				CUSTOM_ID,
-				FEATURED_ID,
-				DEFAULT_ID,
-				getMediaMock
+			const imageUrl = calculateImageUrl( 'custom', CUSTOM_ID, FEATURED_ID, DEFAULT_ID, mediaId =>
+				getEntityRecordMock( 'postType', 'attachment', mediaId )
 			);
 			expect( imageUrl ).toBe( CUSTOM_ID );
 		} );
 
 		it( 'should use the featured image if the type is featured', () => {
-			const imageUrl = calculateImageUrl(
-				'featured',
-				CUSTOM_ID,
-				FEATURED_ID,
-				DEFAULT_ID,
-				getMediaMock
+			const imageUrl = calculateImageUrl( 'featured', CUSTOM_ID, FEATURED_ID, DEFAULT_ID, mediaId =>
+				getEntityRecordMock( 'postType', 'attachment', mediaId )
 			);
 			expect( imageUrl ).toBe( FEATURED_ID );
 		} );
 
 		it( 'should return null if type is none', () => {
-			const imageUrl = calculateImageUrl(
-				'none',
-				CUSTOM_ID,
-				FEATURED_ID,
-				DEFAULT_ID,
-				getMediaMock
+			const imageUrl = calculateImageUrl( 'none', CUSTOM_ID, FEATURED_ID, DEFAULT_ID, mediaId =>
+				getEntityRecordMock( 'postType', 'attachment', mediaId )
 			);
 			expect( imageUrl ).toBeNull();
 		} );
 
 		it( 'should return null the type is custom but there is no image picked', () => {
-			const imageUrl = calculateImageUrl(
-				'custom',
-				undefined,
-				FEATURED_ID,
-				DEFAULT_ID,
-				getMediaMock
+			const imageUrl = calculateImageUrl( 'custom', undefined, FEATURED_ID, DEFAULT_ID, mediaId =>
+				getEntityRecordMock( 'postType', 'attachment', mediaId )
 			);
 			expect( imageUrl ).toBeNull();
 		} );
@@ -182,7 +164,9 @@ describe( 'GeneratedImagePreview', () => {
 		} );
 
 		it( 'should return null if type is default but defaultImageId is 0', () => {
-			const imageUrl = calculateImageUrl( 'default', null, 0, 0, getMediaMock );
+			const imageUrl = calculateImageUrl( 'default', null, 0, 0, mediaId =>
+				getEntityRecordMock( 'postType', 'attachment', mediaId )
+			);
 			expect( imageUrl ).toBeNull();
 		} );
 	} );

--- a/projects/js-packages/publicize-components/src/components/generated-image-preview/test/index.test.js
+++ b/projects/js-packages/publicize-components/src/components/generated-image-preview/test/index.test.js
@@ -106,48 +106,66 @@ describe( 'GeneratedImagePreview', () => {
 		const CUSTOM_ID = 1;
 		const FEATURED_ID = 2;
 		const DEFAULT_ID = 10;
-		const getEntityRecordMock = ( kind, name, id ) => ( {
+		const getMediaMock = id => ( {
 			source_url: id,
 		} );
 
 		it( 'should use the default image if the type is default', () => {
-			const imageUrl = calculateImageUrl( 'default', CUSTOM_ID, FEATURED_ID, DEFAULT_ID, mediaId =>
-				getEntityRecordMock( 'postType', 'attachment', mediaId )
+			const imageUrl = calculateImageUrl(
+				'default',
+				CUSTOM_ID,
+				FEATURED_ID,
+				DEFAULT_ID,
+				getMediaMock
 			);
 			expect( imageUrl ).toBe( DEFAULT_ID );
 		} );
 
 		it( 'should use the default image if the type is null and there is no featured image', () => {
-			const imageUrl = calculateImageUrl( null, 0, 0, DEFAULT_ID, mediaId =>
-				getEntityRecordMock( 'postType', 'attachment', mediaId )
-			);
+			const imageUrl = calculateImageUrl( null, 0, 0, DEFAULT_ID, getMediaMock );
 			expect( imageUrl ).toBe( DEFAULT_ID );
 		} );
 
 		it( 'should use the custom image if the type is custom', () => {
-			const imageUrl = calculateImageUrl( 'custom', CUSTOM_ID, FEATURED_ID, DEFAULT_ID, mediaId =>
-				getEntityRecordMock( 'postType', 'attachment', mediaId )
+			const imageUrl = calculateImageUrl(
+				'custom',
+				CUSTOM_ID,
+				FEATURED_ID,
+				DEFAULT_ID,
+				getMediaMock
 			);
 			expect( imageUrl ).toBe( CUSTOM_ID );
 		} );
 
 		it( 'should use the featured image if the type is featured', () => {
-			const imageUrl = calculateImageUrl( 'featured', CUSTOM_ID, FEATURED_ID, DEFAULT_ID, mediaId =>
-				getEntityRecordMock( 'postType', 'attachment', mediaId )
+			const imageUrl = calculateImageUrl(
+				'featured',
+				CUSTOM_ID,
+				FEATURED_ID,
+				DEFAULT_ID,
+				getMediaMock
 			);
 			expect( imageUrl ).toBe( FEATURED_ID );
 		} );
 
 		it( 'should return null if type is none', () => {
-			const imageUrl = calculateImageUrl( 'none', CUSTOM_ID, FEATURED_ID, DEFAULT_ID, mediaId =>
-				getEntityRecordMock( 'postType', 'attachment', mediaId )
+			const imageUrl = calculateImageUrl(
+				'none',
+				CUSTOM_ID,
+				FEATURED_ID,
+				DEFAULT_ID,
+				getMediaMock
 			);
 			expect( imageUrl ).toBeNull();
 		} );
 
 		it( 'should return null the type is custom but there is no image picked', () => {
-			const imageUrl = calculateImageUrl( 'custom', undefined, FEATURED_ID, DEFAULT_ID, mediaId =>
-				getEntityRecordMock( 'postType', 'attachment', mediaId )
+			const imageUrl = calculateImageUrl(
+				'custom',
+				undefined,
+				FEATURED_ID,
+				DEFAULT_ID,
+				getMediaMock
 			);
 			expect( imageUrl ).toBeNull();
 		} );
@@ -164,9 +182,7 @@ describe( 'GeneratedImagePreview', () => {
 		} );
 
 		it( 'should return null if type is default but defaultImageId is 0', () => {
-			const imageUrl = calculateImageUrl( 'default', null, 0, 0, mediaId =>
-				getEntityRecordMock( 'postType', 'attachment', mediaId )
-			);
+			const imageUrl = calculateImageUrl( 'default', null, 0, 0, getMediaMock );
 			expect( imageUrl ).toBeNull();
 		} );
 	} );

--- a/projects/js-packages/publicize-components/src/components/social-previews/use-post-data.js
+++ b/projects/js-packages/publicize-components/src/components/social-previews/use-post-data.js
@@ -15,7 +15,7 @@ import { getMediaSourceUrl, getPostImageUrl } from './utils';
 export function usePostData() {
 	const { attachedMedia, imageGeneratorSettings } = usePostMeta();
 
-	const { getMedia } = useSelect( coreStore, [] );
+	const { getEntityRecord } = useSelect( coreStore, [] );
 	const { getEditedPostAttribute, getEditedPostContent } = useSelect( editorStore, [] );
 
 	return useMemo(
@@ -24,7 +24,9 @@ export function usePostData() {
 			const featuredImageId = getEditedPostAttribute( 'featured_media' );
 
 			// Use the featured image by default, if it's available.
-			let image = featuredImageId ? getMediaSourceUrl( getMedia( featuredImageId ) ) : '';
+			let image = featuredImageId
+				? getMediaSourceUrl( getEntityRecord( 'postType', 'attachment', featuredImageId ) )
+				: '';
 
 			const sigImageUrl = imageGeneratorSettings.enabled
 				? getSigImageUrl( imageGeneratorSettings.token )
@@ -46,7 +48,7 @@ export function usePostData() {
 			const media = [];
 
 			const getMediaDetails = id => {
-				const mediaItem = getMedia( id );
+				const mediaItem = getEntityRecord( 'postType', 'attachment', id );
 				if ( ! mediaItem ) {
 					return null;
 				}
@@ -92,7 +94,7 @@ export function usePostData() {
 			attachedMedia,
 			getEditedPostAttribute,
 			getEditedPostContent,
-			getMedia,
+			getEntityRecord,
 			imageGeneratorSettings.enabled,
 			imageGeneratorSettings.token,
 		]

--- a/projects/js-packages/publicize-components/src/hooks/use-attached-media/README.md
+++ b/projects/js-packages/publicize-components/src/hooks/use-attached-media/README.md
@@ -12,7 +12,7 @@ function AttachedMediaSection() {
 	const { attachedMedia, updateAttachedMedia } = useAttachedMedia();
 
 	const mediaObject = useSelect( select =>
-		select( 'core' ).getMedia( attachedMedia[ 0 ] || null, { context: 'view' } )
+		select( 'core' ).getEntityRecord( 'postType', 'attachment', attachedMedia[ 0 ] || null, { context: 'view' } )
 	);
 
 	return (

--- a/projects/js-packages/publicize-components/src/hooks/use-media-details/index.js
+++ b/projects/js-packages/publicize-components/src/hooks/use-media-details/index.js
@@ -94,7 +94,8 @@ export default function useMediaDetails( mediaId = null ) {
 	const [ mediaDetails, setMediaDetails ] = useState( [ {} ] );
 
 	const mediaObject = useSelect(
-		select => select( 'core' ).getMedia( mediaId, { context: 'view' } ),
+		select =>
+			select( 'core' ).getEntityRecord( 'postType', 'attachment', mediaId, { context: 'view' } ),
 		[ mediaId ]
 	);
 

--- a/projects/packages/paypal-payments/changelog/update-deprecated_getMedia_calls
+++ b/projects/packages/paypal-payments/changelog/update-deprecated_getMedia_calls
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update deprecated getMedia() calls to getEntityRecord().
+
+

--- a/projects/packages/paypal-payments/src/block/deprecated/v2/edit.js
+++ b/projects/packages/paypal-payments/src/block/deprecated/v2/edit.js
@@ -589,7 +589,7 @@ class SimplePaymentsEdit extends Component {
 }
 
 const mapSelectToProps = withSelect( ( select, props ) => {
-	const { getEntityRecord, getMedia } = select( 'core' );
+	const { getEntityRecord } = select( 'core' );
 	const { isSavingPost, getCurrentPost } = select( 'core/editor' );
 
 	const { productId, featuredMediaId } = props.attributes;
@@ -614,7 +614,9 @@ const mapSelectToProps = withSelect( ( select, props ) => {
 		hasPublishAction: !! post?._links?.[ 'wp:action-publish' ],
 		isSaving: !! isSavingPost(),
 		simplePayment,
-		featuredMedia: featuredMediaId ? getMedia( featuredMediaId ) : null,
+		featuredMedia: featuredMediaId
+			? getEntityRecord( 'postType', 'attachment', featuredMediaId )
+			: null,
 		postLinkUrl: post.link,
 	};
 } );

--- a/projects/packages/paypal-payments/src/block/edit.js
+++ b/projects/packages/paypal-payments/src/block/edit.js
@@ -549,7 +549,7 @@ export const SimplePaymentsEdit = ( {
 };
 
 const mapSelectToProps = withSelect( ( select, props ) => {
-	const { getEntityRecord, getMedia } = select( 'core' );
+	const { getEntityRecord } = select( 'core' );
 	const { getCurrentPost } = select( 'core/editor' );
 	const { __experimentalGetDirtyEntityRecords, isSavingEntityRecord } = select( 'core' );
 	const getDirtyEntityRecords = __experimentalGetDirtyEntityRecords;
@@ -578,7 +578,9 @@ const mapSelectToProps = withSelect( ( select, props ) => {
 			isSavingEntityRecord( record.kind, record.name, record.key )
 		),
 		simplePayment,
-		featuredMedia: featuredMediaId ? getMedia( featuredMediaId ) : null,
+		featuredMedia: featuredMediaId
+			? getEntityRecord( 'postType', 'attachment', featuredMediaId )
+			: null,
 		postLinkUrl: post?.guid?.raw,
 		isPostEditor: Object.keys( getCurrentPost() ).length > 0,
 	};

--- a/projects/packages/videopress/changelog/update-deprecated_getMedia_calls
+++ b/projects/packages/videopress/changelog/update-deprecated_getMedia_calls
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update deprecated getMedia() calls to getEntityRecord().
+
+

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/uploader-progress.native.js
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/uploader-progress.native.js
@@ -54,7 +54,7 @@ const UploaderProgress = ( { file, onDone, onReset, isInteractionDisabled } ) =>
 			media:
 				! isFetchingGUID || typeof mediaServerID === 'undefined'
 					? undefined
-					: select( coreStore ).getMedia( mediaServerID ),
+					: select( coreStore ).getEntityRecord( 'postType', 'attachment', mediaServerID ),
 		} ),
 		[ isFetchingGUID, mediaServerID ]
 	);

--- a/projects/plugins/jetpack/changelog/update-deprecated_getMedia_calls
+++ b/projects/plugins/jetpack/changelog/update-deprecated_getMedia_calls
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Update deprecated getMedia() calls to getEntityRecord().
+
+

--- a/projects/plugins/jetpack/extensions/blocks/slideshow/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/slideshow/edit.js
@@ -217,9 +217,9 @@ export default compose(
 		}
 
 		// If not in cache, calculate new value
-		const { getMedia } = select( 'core' );
+		const { getEntityRecord } = select( 'core' );
 		const resizedImages = ids.reduce( ( currentResizedImages, id ) => {
-			const image = getMedia( id );
+			const image = getEntityRecord( 'postType', 'attachment', id );
 			const sizes = image?.media_details?.sizes;
 			return [ ...currentResizedImages, { id, sizes } ];
 		}, [] );

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/deprecated/v8/gallery-image/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/deprecated/v8/gallery-image/edit.js
@@ -164,10 +164,10 @@ class GalleryImageEdit extends Component {
 }
 
 export default withSelect( ( select, ownProps ) => {
-	const { getMedia } = select( 'core' );
+	const { getEntityRecord } = select( 'core' );
 	const { id } = ownProps;
 
 	return {
-		image: id ? getMedia( id ) : null,
+		image: id ? getEntityRecord( 'postType', 'attachment', id ) : null,
 	};
 } )( GalleryImageEdit );

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/gallery-image/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/gallery-image/edit.js
@@ -165,10 +165,10 @@ class GalleryImageEdit extends Component {
 }
 
 export default withSelect( ( select, ownProps ) => {
-	const { getMedia } = select( 'core' );
+	const { getEntityRecord } = select( 'core' );
 	const { id } = ownProps;
 
 	return {
-		image: id ? getMedia( id ) : null,
+		image: id ? getEntityRecord( 'postType', 'attachment', id ) : null,
 	};
 } )( GalleryImageEdit );

--- a/projects/plugins/jetpack/extensions/plugins/post-publish-qr-post-panel/hooks/use-site-logo.js
+++ b/projects/plugins/jetpack/extensions/plugins/post-publish-qr-post-panel/hooks/use-site-logo.js
@@ -22,7 +22,7 @@ export default function useSiteLogo( { generateDataUrl = false } = {} ) {
 		const siteLogoId = canUserEdit ? siteLogo : readOnlyLogo;
 		const mediaItem =
 			siteLogoId &&
-			select( coreStore ).getMedia( siteLogoId, {
+			select( coreStore ).getEntityRecord( 'postType', 'attachment', siteLogoId, {
 				context: 'view',
 			} );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

In preparation for #44701 as a result of WordPress/gutenberg#71038, we need to update some stuff to keep tests happy.
* Old: `getMedia( id )`
* New: `getEntityRecord( 'postType', 'attachment', id )`

This only directly affected one test `extensions/blocks/tiled-gallery/test/edit.js`, but I went ahead and updated everywhere else.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Is CI happy?
* Did I make any mistakes?