### PR TITLE
PayPal Payment Buttons: Remove redirect and settings link to non-existent settings page

### DIFF
--- a/projects/plugins/paypal-payment-buttons/changelog/update-paypal-payment-buttons-remove-redirect-settings-link
+++ b/projects/plugins/paypal-payment-buttons/changelog/update-paypal-payment-buttons-remove-redirect-settings-link
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Plugin is not released
+
+

--- a/projects/plugins/paypal-payment-buttons/paypal-payment-buttons.php
+++ b/projects/plugins/paypal-payment-buttons/paypal-payment-buttons.php
@@ -103,35 +103,6 @@ if ( is_readable( $jetpack_autoloader ) ) {
 	return;
 }
 
-// Redirect to plugin page when the plugin is activated.
-add_action( 'activated_plugin', 'paypal_payment_buttons_activation' );
-
-/**
- * Redirects to plugin page when the plugin is activated
- *
- * @param string $plugin Path to the plugin file relative to the plugins directory.
- */
-function paypal_payment_buttons_activation( $plugin ) {
-	if (
-		PAYPAL_PAYMENT_BUTTONS_ROOT_FILE_RELATIVE_PATH === $plugin &&
-		( new \Automattic\Jetpack\Paths() )->is_current_request_activating_plugin_from_plugins_screen( PAYPAL_PAYMENT_BUTTONS_ROOT_FILE_RELATIVE_PATH )
-	) {
-		wp_safe_redirect( esc_url( admin_url( 'admin.php?page=paypal-payment-buttons' ) ) );
-		exit( 0 );
-	}
-}
-
-// Add "Settings" link to plugins page.
-add_filter(
-	'plugin_action_links_' . PAYPAL_PAYMENT_BUTTONS_FOLDER . '/paypal-payment-buttons.php',
-	function ( $actions ) {
-		$settings_link = '<a href="' . esc_url( admin_url( 'admin.php?page=paypal-payment-buttons' ) ) . '">' . __( 'Settings', 'paypal-payment-buttons' ) . '</a>';
-		array_unshift( $actions, $settings_link );
-
-		return $actions;
-	}
-);
-
 register_deactivation_hook( __FILE__, array( 'PayPal_Payment_Buttons', 'plugin_deactivation' ) );
 
 // Initialize plugin.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Remove references to previously removed settings page.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
NA

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
NO
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Install plugin
- Activate plugin
- Ensure that you don't get redirected to settings page after activating
- View plugin listing page. Ensure that you don't see a settings link in the plugin row

