### PR TITLE
Forms: Fix checkbox validation

### DIFF
--- a/projects/packages/forms/changelog/fix-form-options-validation
+++ b/projects/packages/forms/changelog/fix-form-options-validation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: fix validation of jetpack multi-checkboxes

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -319,13 +319,25 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 					$this->add_error( sprintf( __( '%s requires at least one selection.', 'jetpack-forms' ), $field_label ) );
 				} else {
 					// Check that the selected options are valid
-					$options           = (array) $this->get_attribute( 'options' );
+					$options      = (array) $this->get_attribute( 'options' );
+					$options_data = (array) $this->get_attribute( 'optionsdata' );
+
+					if ( ! empty( $options_data ) ) {
+						$options = array_map(
+							function ( $option ) {
+								return trim( $option['label'] );
+							},
+							$options_data
+						);
+					}
+
 					$non_empty_options = array_filter(
 						$options,
 						function ( $option ) {
 							return $option !== '';
 						}
 					);
+
 					foreach ( $field_value  as $field_value_item ) {
 						if ( ! in_array( $field_value_item, $non_empty_options, true ) ) {
 							/* translators: %s is the name of a form field */

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -325,7 +325,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 					if ( ! empty( $options_data ) ) {
 						$options = array_map(
 							function ( $option ) {
-								return trim( $option['label'] );
+								return sanitize_text_field( trim( $option['label'] ) );
 							},
 							$options_data
 						);

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -3126,6 +3126,7 @@ EOT;
 				'name'                 => $name,
 				'email'                => $email,
 				'choose'               => array( 'truth' ),
+				'chooseoptions'        => array( 'hello  there' ),
 				'chooseseveraloptions' => array( 'hello, there' ),
 			),
 			'g' . $form_id
@@ -3136,7 +3137,15 @@ EOT;
 				'title'       => 'Test Form',
 				'description' => 'This is a test form.',
 			),
-			'[contact-field label="Name" type="name" /][contact-field label="Email" type="email" /][contact-field label="Choose" type="checkbox-multiple" options="truth,dare" /][contact-field type="checkbox-multiple" label="Choose several options" labelclasses="wp-block-jetpack-label" optionsclasses="wp-block-jetpack-options" options="hello, there,option 1,option 2" optionsdata="&#091;{&quot;label&quot;:&quot;hello&#044; there&quot;&#044;&quot;class&quot;:&quot;wp-block-jetpack-option&quot;}&#044;{&quot;label&quot;:&quot;option 1&quot;&#044;&quot;class&quot;:&quot;wp-block-jetpack-option&quot;}&#044;{&quot;label&quot;:&quot;option 2&quot;&#044;&quot;class&quot;:&quot;wp-block-jetpack-option&quot;}&#093;" stylevariationattributes="" stylevariationclasses="" stylevariationstyles="" fieldwrapperclasses="wp-block-jetpack-field-checkbox-multiple"]&lt;div&gt;
+			'[contact-field label="Name" type="name" /][contact-field label="Email" type="email" /][contact-field label="Choose" type="checkbox-multiple" options="truth,dare" /][contact-field type="checkbox-multiple" label="Choose options" labelclasses="wp-block-jetpack-label" optionsclasses="wp-block-jetpack-options" options="hello  there,option 1,option 2" optionsdata="&#091;{&quot;label&quot;:&quot;hello  there&quot;&#044;&quot;class&quot;:&quot;wp-block-jetpack-option&quot;}&#044;{&quot;label&quot;:&quot;option 1&quot;&#044;&quot;class&quot;:&quot;wp-block-jetpack-option&quot;}&#044;{&quot;label&quot;:&quot;option 2&quot;&#044;&quot;class&quot;:&quot;wp-block-jetpack-option&quot;}&#093;" stylevariationattributes="" stylevariationclasses="" stylevariationstyles="" fieldwrapperclasses="wp-block-jetpack-field-checkbox-multiple"]&lt;div&gt;
+
+
+&lt;ul class=&quot;wp-block-jetpack-options&quot;&gt;
+
+
+
+&lt;/ul&gt;
+&lt;/div&gt;[/contact-field][contact-field type="checkbox-multiple" label="Choose several options" labelclasses="wp-block-jetpack-label" optionsclasses="wp-block-jetpack-options" options="hello, there,option 1,option 2" optionsdata="&#091;{&quot;label&quot;:&quot;hello&#044; there&quot;&#044;&quot;class&quot;:&quot;wp-block-jetpack-option&quot;}&#044;{&quot;label&quot;:&quot;option 1&quot;&#044;&quot;class&quot;:&quot;wp-block-jetpack-option&quot;}&#044;{&quot;label&quot;:&quot;option 2&quot;&#044;&quot;class&quot;:&quot;wp-block-jetpack-option&quot;}&#093;" stylevariationattributes="" stylevariationclasses="" stylevariationstyles="" fieldwrapperclasses="wp-block-jetpack-field-checkbox-multiple"]&lt;div&gt;
 
 
 &lt;ul class=&quot;wp-block-jetpack-options&quot;&gt;

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -3114,4 +3114,44 @@ EOT;
 		$this->assertEquals( array( 'Please fill out at least one field.' ), $form->get_error_messages() );
 		Contact_Form::reset_errors();
 	}
+
+	public function test_validate_checkboxes_form() {
+		$name    = '';
+		$email   = '';
+		$form_id = Utility::get_form_id();
+
+		// Create a form submission
+		$_POST = Utility::get_post_request(
+			array(
+				'name'                 => $name,
+				'email'                => $email,
+				'choose'               => array( 'truth' ),
+				'chooseseveraloptions' => array( 'hello, there' ),
+			),
+			'g' . $form_id
+		);
+
+		$form = new Contact_Form(
+			array(
+				'title'       => 'Test Form',
+				'description' => 'This is a test form.',
+			),
+			'[contact-field label="Name" type="name" /][contact-field label="Email" type="email" /][contact-field label="Choose" type="checkbox-multiple" options="truth,dare" /][contact-field type="checkbox-multiple" label="Choose several options" labelclasses="wp-block-jetpack-label" optionsclasses="wp-block-jetpack-options" options="hello, there,option 1,option 2" optionsdata="&#091;{&quot;label&quot;:&quot;hello&#044; there&quot;&#044;&quot;class&quot;:&quot;wp-block-jetpack-option&quot;}&#044;{&quot;label&quot;:&quot;option 1&quot;&#044;&quot;class&quot;:&quot;wp-block-jetpack-option&quot;}&#044;{&quot;label&quot;:&quot;option 2&quot;&#044;&quot;class&quot;:&quot;wp-block-jetpack-option&quot;}&#093;" stylevariationattributes="" stylevariationclasses="" stylevariationstyles="" fieldwrapperclasses="wp-block-jetpack-field-checkbox-multiple"]&lt;div&gt;
+
+
+&lt;ul class=&quot;wp-block-jetpack-options&quot;&gt;
+
+
+
+&lt;/ul&gt;
+&lt;/div&gt;[/contact-field]'
+		);
+		$form->validate();
+		unset( $_POST ); // Clean up the global $_POST variable after the test.
+
+		// message should be not empty.
+		$this->assertFalse( $form->has_errors(), 'Form should not have errors after validation.' );
+
+		Contact_Form::reset_errors();
+	}
 }

--- a/projects/plugins/jetpack/changelog/fix-form-options-validation
+++ b/projects/plugins/jetpack/changelog/fix-form-options-validation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+


### PR DESCRIPTION
Fixes FORMS-259

Fixes issue where checkbox options labels that have commas don't work. 


## Proposed changes:
* Instead of using the options array we want to use the optionsData array since that contains the correct label that we want to match. 

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?


## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
- Create a form that contains a checkbox multiple choice. 
- Make one of the labels have an comma in it. 
- Notice that the you can select the option as expected. 


