### PR TITLE
e2e: Fix broken tests caused by change in expectation around types

### DIFF
--- a/projects/plugins/boost/changelog/update-fix-tests-types
+++ b/projects/plugins/boost/changelog/update-fix-tests-types
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fixing broken e2e tests
+
+

--- a/projects/plugins/boost/tests/e2e/lib/pages/jetpack-boost-page.ts
+++ b/projects/plugins/boost/tests/e2e/lib/pages/jetpack-boost-page.ts
@@ -1,5 +1,6 @@
-import { expect, Page } from '@playwright/test';
+import { expect } from '@playwright/test';
 import logger from '_jetpack-e2e-commons/logger.js';
+import type { Page } from '@playwright/test';
 
 export default class JetpackBoostPage {
 	page: Page;

--- a/projects/plugins/boost/tests/e2e/lib/utils/boost-utils.ts
+++ b/projects/plugins/boost/tests/e2e/lib/utils/boost-utils.ts
@@ -1,7 +1,8 @@
-import { expect, Page } from '@playwright/test';
+import { expect } from '@playwright/test';
 import logger from '_jetpack-e2e-commons/logger.js';
 import { executeJetpackCommand, executeWpCommand } from '_jetpack-e2e-commons/utils/cli.ts';
 import { JetpackBoostPage } from '../pages';
+import type { Page } from '@playwright/test';
 
 /**
  * Executes a Jetpack Boost CLI command.

--- a/projects/plugins/jetpack/changelog/update-fix-tests-types
+++ b/projects/plugins/jetpack/changelog/update-fix-tests-types
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Fixing broken e2e tests

--- a/projects/plugins/jetpack/tests/e2e/helpers/account-protection-helper.ts
+++ b/projects/plugins/jetpack/tests/e2e/helpers/account-protection-helper.ts
@@ -1,6 +1,6 @@
-import { Page } from '@playwright/test';
 import logger from '_jetpack-e2e-commons/logger.js';
 import { executeWpCommand } from '_jetpack-e2e-commons/utils/cli.ts';
+import type { Page } from '@playwright/test';
 
 const PRIVILEGED_ROLES = [ 'administrator', 'editor', 'author' ];
 const NON_PRIVILEGED_ROLES = [ 'contributor', 'subscriber' ];

--- a/projects/plugins/jetpack/tests/e2e/helpers/onboarding.ts
+++ b/projects/plugins/jetpack/tests/e2e/helpers/onboarding.ts
@@ -9,7 +9,11 @@ type RedirectToWpcomOptions = {
 const DEFAULT_TIMEOUT = 60000;
 
 export class Onboarding {
-	constructor( protected page: Page ) {}
+	protected page: Page;
+
+	constructor( page: Page ) {
+		this.page = page;
+	}
 
 	get CTA() {
 		return this.page.getByRole( 'button', { name: 'Supercharge my site' } );

--- a/projects/plugins/protect/changelog/update-fix-tests-types
+++ b/projects/plugins/protect/changelog/update-fix-tests-types
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fixing broken e2e tests
+
+

--- a/projects/plugins/protect/tests/e2e/flows/connection.ts
+++ b/projects/plugins/protect/tests/e2e/flows/connection.ts
@@ -1,6 +1,6 @@
-import { Page } from '@playwright/test';
 import { expect, Admin } from '_jetpack-e2e-commons/fixtures/base-test.ts';
 import logger from '_jetpack-e2e-commons/logger.js';
+import type { Page } from '@playwright/test';
 
 /**
  * Connect Jetpack Protect

--- a/projects/plugins/protect/tests/e2e/specs/start.test.ts
+++ b/projects/plugins/protect/tests/e2e/specs/start.test.ts
@@ -1,6 +1,6 @@
-import { Page } from '@playwright/test';
 import { expect, test } from '_jetpack-e2e-commons/fixtures/base-test.ts';
 import { connect } from '../flows/connection.ts';
+import type { Page } from '@playwright/test';
 
 /**
  * Checks for and then closes the "Changes saved" notice.

--- a/projects/plugins/search/changelog/update-fix-tests-types
+++ b/projects/plugins/search/changelog/update-fix-tests-types
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fixing broken e2e tests
+
+

--- a/projects/plugins/search/tests/e2e/specs/search-configure.test.ts
+++ b/projects/plugins/search/tests/e2e/specs/search-configure.test.ts
@@ -1,5 +1,5 @@
-import { Page } from '@playwright/test';
 import { test, expect } from '../fixtures/test.ts';
+import type { Page } from '@playwright/test';
 
 test.describe( 'Search Configure', () => {
 	const SEARCH_SETTING_API_PATTERN = /^https?:\/\/.*%2Fwp%2Fv2%2Fsettings/;

--- a/projects/plugins/search/tests/e2e/specs/search-dashboard.test.ts
+++ b/projects/plugins/search/tests/e2e/specs/search-dashboard.test.ts
@@ -1,10 +1,10 @@
-import { Page, Locator } from '@playwright/test';
 import { test, expect } from '_jetpack-e2e-commons/fixtures/base-test.ts';
 import {
 	enableInstantSearch,
 	disableInstantSearch,
 	clearSearchPlanInfo,
 } from '../utils/search-utils.ts';
+import type { Page, Locator } from '@playwright/test';
 
 const SEARCH_SETTING_API_PATTERN = /^https?:\/\/.*jetpack\/v4\/search\/settings/;
 

--- a/projects/plugins/search/tests/e2e/specs/search.test.ts
+++ b/projects/plugins/search/tests/e2e/specs/search.test.ts
@@ -1,4 +1,3 @@
-import { Page } from '@playwright/test';
 import {
 	test,
 	expect,
@@ -6,6 +5,7 @@ import {
 	searchResultForTest2 as originalSearchResultForTest2,
 	SEARCH_API_PATTERN,
 } from '../fixtures/test.ts';
+import type { Page } from '@playwright/test';
 
 // Create deep copies to prevent mutations during tests
 const searchResultForTest1 = JSON.parse( JSON.stringify( originalSearchResultForTest1 ) );

--- a/projects/plugins/social/changelog/update-fix-tests-types
+++ b/projects/plugins/social/changelog/update-fix-tests-types
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fixing broken e2e tests
+
+

--- a/projects/plugins/social/tests/e2e/helpers/connection.ts
+++ b/projects/plugins/social/tests/e2e/helpers/connection.ts
@@ -1,5 +1,6 @@
-import { expect, Page } from '@playwright/test';
+import { expect } from '@playwright/test';
 import logger from '_jetpack-e2e-commons/logger.js';
+import type { Page } from '@playwright/test';
 
 /**
  * Connect Jetpack Social

--- a/tools/e2e-commons/pages/editor-page.ts
+++ b/tools/e2e-commons/pages/editor-page.ts
@@ -1,5 +1,5 @@
-import { Locator } from '@playwright/test';
 import { Editor } from '@wordpress/e2e-test-utils-playwright';
+import type { Locator } from '@playwright/test';
 
 export default class EditorPage extends Editor {
 	/**

--- a/tools/e2e-commons/pages/sidebar.ts
+++ b/tools/e2e-commons/pages/sidebar.ts
@@ -1,4 +1,4 @@
-import { Page } from '@playwright/test';
+import type { Page } from '@playwright/test';
 
 export default class Sidebar {
 	page: Page;


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Update syntax around Page and Locator to use type
* Fix 1 constructor parameter property

Our e2e toolchain runs TypeScript in strip-only mode. In that mode:

- Parameter properties aren’t supported.
- Importing types as values causes runtime parse errors.

Using import type { Page, Locator } from '@playwright/test' aligns with [Playwright’s examples](https://playwright.dev/docs/pom) and prevents value imports of types. See Playwright POM docs for the pattern.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?


## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
NA

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Tests should pass
