### PR TITLE
Merge `release/woocommerce-analytics-0.5.0` into trunk

### DIFF
--- a/projects/packages/woocommerce-analytics/changelog/add-clickhouse-param
+++ b/projects/packages/woocommerce-analytics/changelog/add-clickhouse-param
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Add clickhouse param to record events

--- a/projects/packages/woocommerce-analytics/changelog/add-engagement-tracking
+++ b/projects/packages/woocommerce-analytics/changelog/add-engagement-tracking
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add Session Engagement Tracking

--- a/projects/packages/woocommerce-analytics/changelog/add-page-view
+++ b/projects/packages/woocommerce-analytics/changelog/add-page-view
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Track Page Views

--- a/projects/packages/woocommerce-analytics/changelog/enhance-js-url-sanitize
+++ b/projects/packages/woocommerce-analytics/changelog/enhance-js-url-sanitize
@@ -1,0 +1,3 @@
+Significance: patch
+Type: fixed
+Comment: enhance sanitize logic, no change log need since not released yet

--- a/projects/packages/woocommerce-analytics/changelog/fix-cart-update-remove-event
+++ b/projects/packages/woocommerce-analytics/changelog/fix-cart-update-remove-event
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix logic for capturing cart update event
+
+

--- a/projects/packages/woocommerce-analytics/changelog/fix-update-cart
+++ b/projects/packages/woocommerce-analytics/changelog/fix-update-cart
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix update cart not being triggered

--- a/projects/packages/woocommerce-analytics/changelog/tweak-analytics_session_id
+++ b/projects/packages/woocommerce-analytics/changelog/tweak-analytics_session_id
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Set woocommerceanalytics_session

--- a/projects/packages/woocommerce-analytics/changelog/tweak-session-expiration-30-mins-midnight
+++ b/projects/packages/woocommerce-analytics/changelog/tweak-session-expiration-30-mins-midnight
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Set expiration time for session cookie to 30 mins or midnight UTC

--- a/projects/packages/woocommerce-analytics/changelog/update-clickhouse-event-triggering-to-require-explicit
+++ b/projects/packages/woocommerce-analytics/changelog/update-clickhouse-event-triggering-to-require-explicit
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update ClickHouse Event Triggering to Require Explicit Invocation, no need for a changelog entry since the feature not released yet
+
+

--- a/projects/packages/woocommerce-analytics/src/class-universal.php
+++ b/projects/packages/woocommerce-analytics/src/class-universal.php
@@ -36,6 +36,7 @@ class Universal {
 
 		// Capture cart events.
 		add_action( 'woocommerce_add_to_cart', array( $this, 'capture_add_to_cart' ), 10, 6 );
+		add_action( 'woocommerce_after_cart_item_quantity_update', array( $this, 'capture_cart_quantity_update' ), 10, 4 );
 		add_action( 'woocommerce_cart_item_removed', array( $this, 'capture_remove_from_cart' ), 10, 2 );
 		add_action( 'woocommerce_after_cart', array( $this, 'remove_from_cart' ) );
 		add_action( 'woocommerce_after_mini_cart', array( $this, 'remove_from_cart' ) );
@@ -139,7 +140,7 @@ class Universal {
 	}
 
 	/**
-	 * Capture remove from cart events in mini-cart and cart blocls
+	 * Capture remove from cart events in mini-cart and cart blocks
 	 *
 	 * @param string   $cart_item_key The cart item removed.
 	 * @param \WC_Cart $cart The cart.
@@ -148,8 +149,27 @@ class Universal {
 	 */
 	public function capture_remove_from_cart( $cart_item_key, $cart ) {
 		$item = $cart->removed_cart_contents[ $cart_item_key ] ?? null;
-		$this->record_event( 'woocommerceanalytics_remove_from_cart' );
 		$this->capture_event_in_session_data( (int) $item['product_id'], (int) $item['quantity'], 'woocommerceanalytics_remove_from_cart' );
+	}
+
+	/**
+	 * Capture remove/add from cart events using the Cart Controller
+	 *
+	 * @param string   $cart_item_key The cart item updated.
+	 * @param int      $quantity Contains the new quantity of the item.
+	 * @param int      $old_quantity Contains the old quantity of the item.
+	 * @param \WC_Cart $cart The cart.
+	 *
+	 * @return void
+	 */
+	public function capture_cart_quantity_update( $cart_item_key, $quantity, $old_quantity, $cart ) {
+		$product_id = $cart->cart_contents[ $cart_item_key ]['product_id'];
+		if ( $quantity > $old_quantity ) {
+			$this->capture_event_in_session_data( $product_id, $quantity, 'woocommerceanalytics_add_to_cart' );
+			$this->lock_add_to_cart_events = true;
+		} else {
+			$this->capture_event_in_session_data( $product_id, $quantity, 'woocommerceanalytics_remove_from_cart' );
+		}
 	}
 
 	/**
@@ -424,14 +444,9 @@ class Universal {
 	 * @param array  $cart_item_data Other cart data.
 	 */
 	public function capture_add_to_cart( $cart_item_key, $product_id, $quantity, $variation_id, $variation, $cart_item_data ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-		$referer_postid = isset( $_SERVER['HTTP_REFERER'] ) ? url_to_postid( esc_url_raw( wp_unslash( $_SERVER['HTTP_REFERER'] ) ) ) : 0;
-		// if the referring post is not a product OR the product being added is not the same as post.
-		// (eg. related product list on single product page) then include a product view event.
-		$product_by_referer_postid = wc_get_product( $referer_postid );
-		if ( ! $product_by_referer_postid instanceof WC_Product || (int) $product_id !== $referer_postid ) {
-			$this->capture_event_in_session_data( $product_id, $quantity, 'woocommerceanalytics_product_view' );
+		if ( $this->lock_add_to_cart_events ) {
+			return;
 		}
-		// add cart event to the session data.
 		$this->capture_event_in_session_data( $product_id, $quantity, 'woocommerceanalytics_add_to_cart' );
 	}
 

--- a/projects/packages/woocommerce-analytics/src/class-universal.php
+++ b/projects/packages/woocommerce-analytics/src/class-universal.php
@@ -88,12 +88,16 @@ class Universal {
 						'pq' => $data_instance['quantity'],
 					);
 
-					// Attach the session ID to this event in case it's saved in the Data Instance
+					// Attach the session ID, engagement status and landing_page to this event in case it's saved in the Data Instance.
+					// Otherwise, keep it unset to allow override.
 					if ( $data_instance['session_id'] ) {
 						$event_props['session_id'] = $data_instance['session_id'];
 					}
 
-					// Attach the Landing Page to this event in case it's saved in the Data Instance
+					if ( $data_instance['is_engaged'] ) {
+						$event_props['is_engaged'] = $data_instance['is_engaged'];
+					}
+
 					if ( $data_instance['landing_page'] ) {
 						$event_props['landing_page'] = $data_instance['landing_page'];
 					}
@@ -483,6 +487,7 @@ class Universal {
 			'quantity'     => (string) $quantity,
 			'session_id'   => $this->get_session_id(),
 			'landing_page' => $this->get_landing_page(),
+			'is_engaged'   => $this->is_engaged_session(),
 		);
 
 		// append new data.

--- a/projects/packages/woocommerce-analytics/src/class-universal.php
+++ b/projects/packages/woocommerce-analytics/src/class-universal.php
@@ -12,7 +12,7 @@ use WC_Order;
 use WC_Product;
 
 /**
- * Filters and Actions added to Store pages to perform analytics
+ * Filters and Actions added to Store pages to perform analytics.
  */
 class Universal {
 	/**
@@ -30,9 +30,6 @@ class Universal {
 
 		// delayed events stored in session (can be add_to_carts, product_views...)
 		add_action( 'wp_head', array( $this, 'loop_session_events' ), 2 );
-
-		// Initialize session
-		add_action( 'template_redirect', array( $this, 'initialize_woocommerceanalytics_session' ) );
 
 		// Capture search
 		add_action( 'template_redirect', array( $this, 'capture_search_query' ), 11 );
@@ -75,35 +72,6 @@ class Universal {
 	}
 
 	/**
-	 * Set a UUID for the current session if is not yet loaded and record the session started event
-	 */
-	public function initialize_woocommerceanalytics_session() {
-		if ( ! isset( $_COOKIE['woocommerceanalytics_session'] ) ) {
-			$session_id         = wp_generate_uuid4();
-			$this->session_id   = $session_id;
-			$this->landing_page = sanitize_url( wp_unslash( ( empty( $_SERVER['HTTPS'] ) ? 'http' : 'https' ) . "://$_SERVER[HTTP_HOST]$_SERVER[REQUEST_URI]" ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidatedNotSanitized -- actually escaped with sanitize_url.
-			// Disabled the below temporarily to avoid caching issues.
-			// phpcs:disable Squiz.PHP.CommentedOutCode.Found
-			// setcookie(
-			// 'woocommerceanalytics_session',
-			// wp_json_encode(
-			// array(
-			// 'session_id'   => $this->session_id,
-			// 'landing_page' => $this->landing_page,
-			// )
-			// ),
-			// 0,
-			// COOKIEPATH,
-			// COOKIE_DOMAIN,
-			// is_ssl(),
-			// true
-			// );
-			// $this->record_event( 'woocommerceanalytics_session_started' );
-			// phpcs:enable Squiz.PHP.CommentedOutCode.Found
-		}
-	}
-
-	/**
 	 * On product lists or other non-product pages, add an event listener to "Add to Cart" button click
 	 */
 	public function loop_session_events() {
@@ -112,11 +80,23 @@ class Universal {
 			$data = WC()->session->get( 'wca_session_data' );
 			if ( ! empty( $data ) ) {
 				foreach ( $data as $data_instance ) {
+					$event_props = array(
+						'pq' => $data_instance['quantity'],
+					);
+
+					// Attach the session ID to this event in case it's saved in the Data Instance
+					if ( $data_instance['session_id'] ) {
+						$event_props['session_id'] = $data_instance['session_id'];
+					}
+
+					// Attach the Landing Page to this event in case it's saved in the Data Instance
+					if ( $data_instance['landing_page'] ) {
+						$event_props['landing_page'] = $data_instance['landing_page'];
+					}
+
 					$this->record_event(
 						$data_instance['event'],
-						array(
-							'pq' => $data_instance['quantity'],
-						),
+						$event_props,
 						$data_instance['product_id']
 					);
 				}
@@ -480,9 +460,11 @@ class Universal {
 
 		// extract new event data.
 		$new_data = array(
-			'event'      => $event,
-			'product_id' => (string) $product_id,
-			'quantity'   => (string) $quantity,
+			'event'        => $event,
+			'product_id'   => (string) $product_id,
+			'quantity'     => (string) $quantity,
+			'session_id'   => $this->get_session_id(),
+			'landing_page' => $this->get_landing_page(),
 		);
 
 		// append new data.

--- a/projects/packages/woocommerce-analytics/src/class-universal.php
+++ b/projects/packages/woocommerce-analytics/src/class-universal.php
@@ -69,6 +69,9 @@ class Universal {
 
 		// cart page view
 		add_action( 'wp_footer', array( $this, 'capture_cart_view' ), 11 );
+
+		// page view
+		add_action( 'wp_footer', array( $this, 'capture_page_view' ), 11 );
 	}
 
 	/**
@@ -534,6 +537,13 @@ class Universal {
 				)
 			);
 		}
+	}
+
+	/**
+	 * Track page views
+	 */
+	public function capture_page_view() {
+		$this->record_event( 'woocommerceanalytics_page_view', array( 'url' => $this->get_current_url() ) );
 	}
 
 	/**

--- a/projects/packages/woocommerce-analytics/src/class-universal.php
+++ b/projects/packages/woocommerce-analytics/src/class-universal.php
@@ -171,8 +171,12 @@ class Universal {
 		if ( $quantity > $old_quantity ) {
 			$this->capture_event_in_session_data( $product_id, $quantity, 'woocommerceanalytics_add_to_cart' );
 			$this->lock_add_to_cart_events = true;
-		} else {
+			return;
+		}
+
+		if ( $quantity < $old_quantity ) {
 			$this->capture_event_in_session_data( $product_id, $quantity, 'woocommerceanalytics_remove_from_cart' );
+			return;
 		}
 	}
 

--- a/projects/packages/woocommerce-analytics/src/class-universal.php
+++ b/projects/packages/woocommerce-analytics/src/class-universal.php
@@ -567,7 +567,7 @@ class Universal {
 	 * Track page views
 	 */
 	public function capture_page_view() {
-		$this->record_event( 'woocommerceanalytics_page_view', array( 'url' => $this->get_current_url() ) );
+		$this->record_event( 'woocommerceanalytics_page_view' );
 	}
 
 	/**

--- a/projects/packages/woocommerce-analytics/src/class-woo-analytics-trait.php
+++ b/projects/packages/woocommerce-analytics/src/class-woo-analytics-trait.php
@@ -339,7 +339,7 @@ trait Woo_Analytics_Trait {
 		if ( ! $this->get_session_id() ) {
 			$session_id         = wp_generate_uuid4();
 			$this->session_id   = $session_id;
-			$this->landing_page = sanitize_url( wp_unslash( ( empty( $_SERVER['HTTPS'] ) ? 'http' : 'https' ) . "://$_SERVER[HTTP_HOST]$_SERVER[REQUEST_URI]" ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidatedNotSanitized -- actually escaped with sanitize_url.
+			$this->landing_page = $this->get_current_url();
 			$event_js           = $this->process_event_properties( 'woocommerceanalytics_session_started' );
 			$cookie_js          = "
             const sessionData = JSON.stringify({
@@ -732,6 +732,15 @@ trait Woo_Analytics_Trait {
 	}
 
 	/**
+	 * Get the current request URL
+	 *
+	 * @return string
+	 */
+	public function get_current_url() {
+		return sanitize_url( wp_unslash( ( empty( $_SERVER['HTTPS'] ) ? 'http' : 'https' ) . "://$_SERVER[HTTP_HOST]$_SERVER[REQUEST_URI]" ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidatedNotSanitized -- actually escaped with sanitize_url.
+	}
+
+	/**
 	 * Get the allowed CH Events.
 	 *
 	 * @return string[] The allowed CH Events.
@@ -748,6 +757,7 @@ trait Woo_Analytics_Trait {
 			'woocommerceanalytics_product_purchase',
 			'woocommerceanalytics_order_confirmation_view',
 			'woocommerceanalytics_search',
+			'woocommerceanalytics_page_view',
 		);
 	}
 

--- a/projects/packages/woocommerce-analytics/src/class-woo-analytics-trait.php
+++ b/projects/packages/woocommerce-analytics/src/class-woo-analytics-trait.php
@@ -344,16 +344,18 @@ trait Woo_Analytics_Trait {
 	 * @return void
 	 */
 	public function record_event( $event_name, $properties = array(), $product_id = null ) {
-		if ( ! isset( $properties['session_id'] ) && $this->is_clickhouse( $event_name ) ) {
+		if ( ! isset( $properties['session_id'] ) && $this->should_send_to_clickhouse( $event_name ) ) {
 			$this->maybe_start_session();
-		}
-
-		if ( ! $this->is_initial_page_view( $event_name ) && ! isset( $properties['is_engaged'] ) && ! $this->is_engaged_session() ) {
-			$this->record_engagement( $properties );
 		}
 
 		$js = $this->process_event_properties( $event_name, $properties, $product_id );
 		wc_enqueue_js( "_wca.push({$js});" );
+
+		// If the event is an initial page view, we don't need to record engagement.
+		if ( $this->is_initial_page_view( $event_name ) ) {
+			return;
+		}
+		$this->maybe_record_engagement( $properties );
 	}
 
 	/**
@@ -362,7 +364,17 @@ trait Woo_Analytics_Trait {
 	 * @param array $properties Optional array of (key => value) event properties.
 	 * @return void
 	 */
-	public function record_engagement( $properties = array() ) {
+	private function maybe_record_engagement( $properties = array() ) {
+		if ( ! $this->is_clickhouse_enabled() ) {
+			// For now, engagement is only recorded when ClickHouse is enabled to prevent changes to current event tracking.
+			return;
+		}
+
+		if ( ! empty( $properties['is_engaged'] ) || $this->is_engaged_session() ) {
+			// Engagement event was already recorded.
+			return;
+		}
+
 		$event_js                    = $this->process_event_properties( 'woocommerceanalytics_session_engagement', $properties );
 		$add_engagement_to_cookie_js = "
 		    const cookies = document.cookie.split('; ').reduce((acc, cookie) => {
@@ -506,7 +518,7 @@ trait Woo_Analytics_Trait {
 		$js = "{'_en': '" . esc_js( $event_name ) . "'";
 
 		// ch param is needed to identify ClickHouse queries in the JS Analytics library.
-		if ( $this->is_clickhouse( $event_name ) ) {
+		if ( $this->should_send_to_clickhouse( $event_name ) ) {
 			$js .= ",'ch':'1'";
 		}
 
@@ -842,13 +854,32 @@ trait Woo_Analytics_Trait {
 	}
 
 	/**
+	 * Check if ClickHouse is enabled.
+	 *
+	 * @return bool
+	 */
+	private function is_clickhouse_enabled() {
+		/**
+		 * Filter to enable/disable ClickHouse event tracking.
+		 *
+		 * @module woocommerce-analytics
+		 *
+		 * @since 0.5.0
+		 *
+		 * @param bool $enabled Whether ClickHouse event tracking is enabled.
+		 */
+		return apply_filters( 'woocommerce_analytics_clickhouse_enabled', false );
+	}
+
+	/**
 	 * Check if the event should be sent to ClickHouse
 	 *
 	 * @param string $event The event name.
 	 * @return bool True if it should be sent to ClickHouse
 	 */
-	private function is_clickhouse( $event ) {
-		return in_array( $event, $this->get_clickhouse_events(), true );
+	private function should_send_to_clickhouse( $event ) {
+		return $this->is_clickhouse_enabled() &&
+			in_array( $event, $this->get_clickhouse_events(), true );
 	}
 
 	/**

--- a/projects/packages/woocommerce-analytics/src/class-woo-analytics-trait.php
+++ b/projects/packages/woocommerce-analytics/src/class-woo-analytics-trait.php
@@ -340,17 +340,30 @@ trait Woo_Analytics_Trait {
 			$session_id         = wp_generate_uuid4();
 			$this->session_id   = $session_id;
 			$this->landing_page = $this->get_current_url();
+			$session_expiration = $this->get_session_expiration_time();
 			$event_js           = $this->process_event_properties( 'woocommerceanalytics_session_started' );
 			$cookie_js          = "
             const sessionData = JSON.stringify({
                     session_id: '{$this->session_id}',
                     landing_page: encodeURIComponent('{$this->landing_page}'),
             });
-            document.cookie = `woocommerceanalytics_session=\${sessionData}; path=/; secure; samesite=strict`;
+            document.cookie = `woocommerceanalytics_session=\${sessionData}; expires={$session_expiration}; path=/; secure; samesite=strict`;
             ";
 			wc_enqueue_js( $cookie_js ); // save the session cookie for further events in the session
 			wc_enqueue_js( "_wca.push({$event_js});" ); // trigger session started event
 		}
+	}
+
+	/**
+	 * Get a 30 minutes expiration time from now or at midnight UTC, whichever comes first.
+	 *
+	 * @return string
+	 */
+	public function get_session_expiration_time() {
+		$thirty_minutes_from_now = time() + ( 30 * 60 ); // 30 minutes from now
+		$midnight                = strtotime( 'tomorrow UTC' ) - 1; // 1 second before midnight
+		$expiration_time         = min( $thirty_minutes_from_now, $midnight ); // Get the earliest expiration time
+		return gmdate( 'D, d M Y H:i:s \G\M\T', $expiration_time );
 	}
 
 	/**

--- a/projects/packages/woocommerce-analytics/src/class-woo-analytics-trait.php
+++ b/projects/packages/woocommerce-analytics/src/class-woo-analytics-trait.php
@@ -68,8 +68,22 @@ trait Woo_Analytics_Trait {
 	protected $landing_page = '';
 
 	/**
+	 *  Indicates when a session is engaged in the current request.
+	 *
+	 *  @var bool
+	 */
+	protected $engaged_session = false;
+
+	/**
+	 *  Indicates when a new session has been created in the current request.
+	 *
+	 *  @var bool
+	 */
+	protected $is_new_session = false;
+
+	/**
 	 *  Locks Add to Cart Events Tracking in the current request avoiding duplications.
-	 *  i.e If update_cart and add_to_cart actions happens in the same request.
+	 *  i.e. If update_cart and add_to_cart actions happens in the same request.
 	 *
 	 *  @var bool If true. Cart events are locked for the current request.
 	 */
@@ -279,7 +293,7 @@ trait Woo_Analytics_Trait {
 			'blog_id'                            => Jetpack_Connection::get_site_id(),
 			'store_id'                           => defined( '\\WC_Install::STORE_ID_OPTION' ) ? get_option( \WC_Install::STORE_ID_OPTION ) : false,
 			'ui'                                 => $this->get_user_id(),
-			'url'                                => home_url(),
+			'url'                                => $this->get_current_url(),
 			'landing_page'                       => $landing_page,
 			'woo_version'                        => WC()->version,
 			'wp_version'                         => get_bloginfo( 'version' ),
@@ -334,8 +348,39 @@ trait Woo_Analytics_Trait {
 			$this->maybe_start_session();
 		}
 
+		if ( ! $this->is_initial_page_view( $event_name ) && ! isset( $properties['is_engaged'] ) && ! $this->is_engaged_session() ) {
+			$this->record_engagement( $properties );
+		}
+
 		$js = $this->process_event_properties( $event_name, $properties, $product_id );
 		wc_enqueue_js( "_wca.push({$js});" );
+	}
+
+	/**
+	 * Record woocommerceanalytics_session_engagement event and set a flag in the session cookie.
+	 *
+	 * @param array $properties Optional array of (key => value) event properties.
+	 * @return void
+	 */
+	public function record_engagement( $properties = array() ) {
+		$event_js                    = $this->process_event_properties( 'woocommerceanalytics_session_engagement', $properties );
+		$add_engagement_to_cookie_js = "
+		    const cookies = document.cookie.split('; ').reduce((acc, cookie) => {
+	            const [name, value] = cookie.split('=');
+			    acc[name] = value;
+				return acc;
+    		}, {});
+
+    		if (cookies.woocommerceanalytics_session) {
+            	let sessionData = JSON.parse(decodeURIComponent(cookies.woocommerceanalytics_session));
+                sessionData.is_engaged = true;
+           	    document.cookie = `woocommerceanalytics_session=\${JSON.stringify(sessionData)}; expires=\${sessionData.expires}; path=/; secure; samesite=strict`;
+   		 	}
+        ";
+
+		wc_enqueue_js( $add_engagement_to_cookie_js );
+		wc_enqueue_js( "_wca.push({$event_js});" );
+		$this->engaged_session = true;
 	}
 
 	/**
@@ -345,17 +390,20 @@ trait Woo_Analytics_Trait {
 	 */
 	public function maybe_start_session() {
 		if ( ! $this->get_session_id() ) {
-			$session_id         = wp_generate_uuid4();
-			$this->session_id   = $session_id;
-			$this->landing_page = $this->get_current_url();
+			$session_id           = wp_generate_uuid4();
+			$this->session_id     = $session_id;
+			$this->landing_page   = $this->get_current_url();
+			$this->is_new_session = true;
+
 			$session_expiration = $this->get_session_expiration_time();
 			$event_js           = $this->process_event_properties( 'woocommerceanalytics_session_started' );
 			$cookie_js          = "
             const sessionData = JSON.stringify({
-                    session_id: '{$this->session_id}',
-                    landing_page: encodeURIComponent('{$this->landing_page}'),
+                    session_id: '$this->session_id',
+                    landing_page: encodeURIComponent('$this->landing_page'),
+                    expires: '$session_expiration',
             });
-            document.cookie = `woocommerceanalytics_session=\${sessionData}; expires={$session_expiration}; path=/; secure; samesite=strict`;
+            document.cookie = `woocommerceanalytics_session=\${sessionData}; expires=$session_expiration; path=/; secure; samesite=strict`;
             ";
 			wc_enqueue_js( $cookie_js ); // save the session cookie for further events in the session
 			wc_enqueue_js( "_wca.push({$event_js});" ); // trigger session started event
@@ -611,16 +659,16 @@ trait Woo_Analytics_Trait {
 		return $info;
 	}
 
-		/**
-		 * Search a specific post for text content.
-		 *
-		 * Note: similar code is in a WooCommerce core PR:
-		 * https://github.com/woocommerce/woocommerce/pull/25932
-		 *
-		 * @param integer $post_id The id of the post to search.
-		 * @param string  $text    The text to search for.
-		 * @return integer 1 if post contains $text (otherwise 0).
-		 */
+	/**
+	 * Search a specific post for text content.
+	 *
+	 * Note: similar code is in a WooCommerce core PR:
+	 * https://github.com/woocommerce/woocommerce/pull/25932
+	 *
+	 * @param integer $post_id The id of the post to search.
+	 * @param string  $text    The text to search for.
+	 * @return integer 1 if post contains $text (otherwise 0).
+	 */
 	public function post_contains_text( $post_id, $text ) {
 		global $wpdb;
 
@@ -733,6 +781,16 @@ trait Woo_Analytics_Trait {
 	}
 
 	/**
+	 * Check if the session is engaged.
+	 *
+	 * @return bool
+	 */
+	public function is_engaged_session() {
+		$cookie = $this->get_session_cookie();
+		return $cookie['is_engaged'] ?? $this->engaged_session;
+	}
+
+	/**
 	 * Return the landing page.
 	 * First try to get it from the cookie. Fallback to $this->landing_page.
 	 *
@@ -769,6 +827,7 @@ trait Woo_Analytics_Trait {
 	private function get_clickhouse_events() {
 		return array(
 			'woocommerceanalytics_session_started',
+			'woocommerceanalytics_session_engagement',
 			'woocommerceanalytics_product_view',
 			'woocommerceanalytics_cart_view',
 			'woocommerceanalytics_add_to_cart',
@@ -790,5 +849,16 @@ trait Woo_Analytics_Trait {
 	 */
 	private function is_clickhouse( $event ) {
 		return in_array( $event, $this->get_clickhouse_events(), true );
+	}
+
+	/**
+	 * Check if the event is the initial page view event starting the session.
+	 *
+	 * @param string $event The event name.
+	 * @return bool
+	 */
+	private function is_initial_page_view( $event ) {
+		$initial_events = array( 'woocommerceanalytics_page_view', 'woocommerceanalytics_product_view', 'woocommerceanalytics_cart_view' );
+		return in_array( $event, $initial_events, true ) && ( ! $this->get_session_id() || $this->is_new_session );
 	}
 }

--- a/projects/packages/woocommerce-analytics/src/class-woo-analytics-trait.php
+++ b/projects/packages/woocommerce-analytics/src/class-woo-analytics-trait.php
@@ -293,7 +293,7 @@ trait Woo_Analytics_Trait {
 			'blog_id'                            => Jetpack_Connection::get_site_id(),
 			'store_id'                           => defined( '\\WC_Install::STORE_ID_OPTION' ) ? get_option( \WC_Install::STORE_ID_OPTION ) : false,
 			'ui'                                 => $this->get_user_id(),
-			'url'                                => $this->get_current_url(),
+			'url'                                => home_url(),
 			'landing_page'                       => $landing_page,
 			'woo_version'                        => WC()->version,
 			'wp_version'                         => get_bloginfo( 'version' ),

--- a/projects/packages/woocommerce-analytics/src/class-woo-analytics-trait.php
+++ b/projects/packages/woocommerce-analytics/src/class-woo-analytics-trait.php
@@ -68,6 +68,14 @@ trait Woo_Analytics_Trait {
 	protected $landing_page = '';
 
 	/**
+	 *  Locks Add to Cart Events Tracking in the current request avoiding duplications.
+	 *  i.e If update_cart and add_to_cart actions happens in the same request.
+	 *
+	 *  @var bool If true. Cart events are locked for the current request.
+	 */
+	protected $lock_add_to_cart_events = false;
+
+	/**
 	 * Format Cart Items or Order Items to an array
 	 *
 	 * @param array|WC_Order_Item[] $items Cart Items or Order Items.

--- a/projects/packages/woocommerce-analytics/src/class-woo-analytics-trait.php
+++ b/projects/packages/woocommerce-analytics/src/class-woo-analytics-trait.php
@@ -375,22 +375,18 @@ trait Woo_Analytics_Trait {
 			return;
 		}
 
-		$event_js                    = $this->process_event_properties( 'woocommerceanalytics_session_engagement', $properties );
-		$add_engagement_to_cookie_js = "
-		    const cookies = document.cookie.split('; ').reduce((acc, cookie) => {
-	            const [name, value] = cookie.split('=');
-			    acc[name] = value;
-				return acc;
-    		}, {});
+		$event_js = $this->process_event_properties( 'woocommerceanalytics_session_engagement', $properties );
 
-    		if (cookies.woocommerceanalytics_session) {
-            	let sessionData = JSON.parse(decodeURIComponent(cookies.woocommerceanalytics_session));
-                sessionData.is_engaged = true;
-           	    document.cookie = `woocommerceanalytics_session=\${JSON.stringify(sessionData)}; expires=\${sessionData.expires}; path=/; secure; samesite=strict`;
-   		 	}
-        ";
+		$session_data = $this->get_session_cookie();
+		if ( empty( $session_data ) ) {
+			return;
+		}
+		$session_data['is_engaged']   = true;
+		$session_data['landing_page'] = rawurlencode( $session_data['landing_page'] );
+		$encoded_session_data         = wp_json_encode( $session_data );
+		$cookie_js                    = "document.cookie = 'woocommerceanalytics_session={$encoded_session_data}; expires={$session_data['expires']}; path=/; secure; samesite=strict';";
+		wc_enqueue_js( $cookie_js );
 
-		wc_enqueue_js( $add_engagement_to_cookie_js );
 		wc_enqueue_js( "_wca.push({$event_js});" );
 		$this->engaged_session = true;
 	}
@@ -408,16 +404,16 @@ trait Woo_Analytics_Trait {
 			$this->is_new_session = true;
 
 			$session_expiration = $this->get_session_expiration_time();
-			$event_js           = $this->process_event_properties( 'woocommerceanalytics_session_started' );
-			$cookie_js          = "
-            const sessionData = JSON.stringify({
-                    session_id: '$this->session_id',
-                    landing_page: encodeURIComponent('$this->landing_page'),
-                    expires: '$session_expiration',
-            });
-            document.cookie = `woocommerceanalytics_session=\${sessionData}; expires=$session_expiration; path=/; secure; samesite=strict`;
-            ";
+			$session_data       = array(
+				'session_id'   => $this->session_id,
+				'landing_page' => rawurlencode( $this->landing_page ),
+				'expires'      => $session_expiration,
+			);
+			$encoded_data       = wp_json_encode( $session_data );
+			$cookie_js          = "document.cookie = 'woocommerceanalytics_session={$encoded_data}; expires={$session_expiration}; path=/; secure; samesite=strict';";
 			wc_enqueue_js( $cookie_js ); // save the session cookie for further events in the session
+
+			$event_js = $this->process_event_properties( 'woocommerceanalytics_session_started' );
 			wc_enqueue_js( "_wca.push({$event_js});" ); // trigger session started event
 		}
 	}
@@ -819,7 +815,15 @@ trait Woo_Analytics_Trait {
 	 * @return array
 	 */
 	public function get_session_cookie() {
-		return json_decode( sanitize_text_field( wp_unslash( $_COOKIE['woocommerceanalytics_session'] ?? '' ) ), true ) ?? array();
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- JSON is decoded and validated below. We don't need to sanitize the cookie value because we're not outputting it but decoding it as JSON. Sanitization might break the JSON.
+		$raw_cookie = isset( $_COOKIE['woocommerceanalytics_session'] ) ? wp_unslash( $_COOKIE['woocommerceanalytics_session'] ) : '';
+
+		if ( ! $raw_cookie ) {
+			return array();
+		}
+
+		$decoded = json_decode( $raw_cookie, true );
+		return is_array( $decoded ) ? $decoded : array();
 	}
 
 	/**
@@ -828,7 +832,7 @@ trait Woo_Analytics_Trait {
 	 * @return string
 	 */
 	public function get_current_url() {
-		return sanitize_url( wp_unslash( ( empty( $_SERVER['HTTPS'] ) ? 'http' : 'https' ) . "://$_SERVER[HTTP_HOST]$_SERVER[REQUEST_URI]" ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidatedNotSanitized -- actually escaped with sanitize_url.
+		return home_url( add_query_arg( null, null ) );
 	}
 
 	/**

--- a/projects/packages/woocommerce-analytics/src/class-woo-analytics-trait.php
+++ b/projects/packages/woocommerce-analytics/src/class-woo-analytics-trait.php
@@ -58,14 +58,14 @@ trait Woo_Analytics_Trait {
 	 *
 	 *  @var string
 	 */
-	protected $session_id;
+	protected $session_id = '';
 
 	/**
 	 *  Landing page where session started.
 	 *
 	 *  @var string
 	 */
-	protected $landing_page;
+	protected $landing_page = '';
 
 	/**
 	 * Format Cart Items or Order Items to an array
@@ -264,19 +264,15 @@ trait Woo_Analytics_Trait {
 	 * @return array Array of standard event props.
 	 */
 	public function get_common_properties() {
-		// phpcs:disable Squiz.PHP.CommentedOutCode.Found
-		// Disabled the below temporarily to avoid caching issues.
-		// $session_data       = json_decode( sanitize_text_field( wp_unslash( $_COOKIE['woocommerceanalytics_session'] ?? '' ) ), true ) ?? array();
-		// $session_id         = sanitize_text_field( $session_data['session_id'] ?? $this->session_id );
-		// $landing_page       = sanitize_url( $session_data['landing_page'] ?? $this->landing_page );
-		// phpcs:enable Squiz.PHP.CommentedOutCode.Found
+		$session_id         = $this->get_session_id();
+		$landing_page       = $this->get_landing_page();
 		$site_info          = array(
-			'session_id'                         => null,
+			'session_id'                         => $session_id,
 			'blog_id'                            => Jetpack_Connection::get_site_id(),
 			'store_id'                           => defined( '\\WC_Install::STORE_ID_OPTION' ) ? get_option( \WC_Install::STORE_ID_OPTION ) : false,
 			'ui'                                 => $this->get_user_id(),
 			'url'                                => home_url(),
-			'landing_page'                       => null,
+			'landing_page'                       => $landing_page,
 			'woo_version'                        => WC()->version,
 			'wp_version'                         => get_bloginfo( 'version' ),
 			'store_admin'                        => in_array( array( 'administrator', 'shop_manager' ), wp_get_current_user()->roles, true ) ? 1 : 0,
@@ -319,15 +315,42 @@ trait Woo_Analytics_Trait {
 	/**
 	 * Record an event with optional product and custom properties.
 	 *
-	 * @param string  $event_name The name of the event to record.
-	 * @param array   $properties Optional array of (key => value) event properties.
-	 * @param integer $product_id The id of the product relating to the event.
+	 * @param string       $event_name The name of the event to record.
+	 * @param array        $properties Optional array of (key => value) event properties.
+	 * @param integer|null $product_id The id of the product relating to the event.
 	 *
-	 * @return string|void
+	 * @return void
 	 */
 	public function record_event( $event_name, $properties = array(), $product_id = null ) {
+		if ( ! isset( $properties['session_id'] ) && $this->is_clickhouse( $event_name ) ) {
+			$this->maybe_start_session();
+		}
+
 		$js = $this->process_event_properties( $event_name, $properties, $product_id );
 		wc_enqueue_js( "_wca.push({$js});" );
+	}
+
+	/**
+	 * In case session_id is empty and woocommerceanalytics_session cookie is not set. A new session should be created.
+	 *
+	 * @return void
+	 */
+	public function maybe_start_session() {
+		if ( ! $this->get_session_id() ) {
+			$session_id         = wp_generate_uuid4();
+			$this->session_id   = $session_id;
+			$this->landing_page = sanitize_url( wp_unslash( ( empty( $_SERVER['HTTPS'] ) ? 'http' : 'https' ) . "://$_SERVER[HTTP_HOST]$_SERVER[REQUEST_URI]" ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidatedNotSanitized -- actually escaped with sanitize_url.
+			$event_js           = $this->process_event_properties( 'woocommerceanalytics_session_started' );
+			$cookie_js          = "
+            const sessionData = JSON.stringify({
+                    session_id: '{$this->session_id}',
+                    landing_page: encodeURIComponent('{$this->landing_page}'),
+            });
+            document.cookie = `woocommerceanalytics_session=\${sessionData}; path=/; secure; samesite=strict`;
+            ";
+			wc_enqueue_js( $cookie_js ); // save the session cookie for further events in the session
+			wc_enqueue_js( "_wca.push({$event_js});" ); // trigger session started event
+		}
 	}
 
 	/**
@@ -377,9 +400,9 @@ trait Woo_Analytics_Trait {
 	/**
 	 * Compose event properties.
 	 *
-	 * @param string  $event_name The name of the event to record.
-	 * @param array   $properties Optional array of (key => value) event properties.
-	 * @param integer $product_id Optional id of the product relating to the event.
+	 * @param string       $event_name The name of the event to record.
+	 * @param array        $properties Optional array of (key => value) event properties.
+	 * @param integer|null $product_id Optional id of the product relating to the event.
 	 *
 	 * @return string|void
 	 */
@@ -413,8 +436,13 @@ trait Woo_Analytics_Trait {
 
 		$js = "{'_en': '" . esc_js( $event_name ) . "'";
 
+		// ch param is needed to identify ClickHouse queries in the JS Analytics library.
+		if ( $this->is_clickhouse( $event_name ) ) {
+			$js .= ",'ch':'1'";
+		}
+
 		if ( isset( $product_details ) ) {
-				$all_props = array_merge( $all_props, $product_details );
+			$all_props = array_merge( $all_props, $product_details );
 		}
 
 		$js .= ',' . $this->render_properties_as_js( $all_props ) . '}';
@@ -670,5 +698,66 @@ trait Woo_Analytics_Trait {
 			return 0;
 		}
 		return $cart->get_cart_contents_count();
+	}
+
+	/**
+	 * Return the session_id.
+	 * First try to get it from the cookie. Fallback to $this->session_id.
+	 *
+	 * @return string
+	 */
+	public function get_session_id() {
+		$cookie = $this->get_session_cookie();
+		return $cookie['session_id'] ?? $this->session_id;
+	}
+
+	/**
+	 * Return the landing page.
+	 * First try to get it from the cookie. Fallback to $this->landing_page.
+	 *
+	 * @return string
+	 */
+	public function get_landing_page() {
+		$cookie = $this->get_session_cookie();
+		return $cookie['landing_page'] ?? $this->landing_page;
+	}
+
+	/**
+	 * Get the sanitized session cookie as an array
+	 *
+	 * @return array
+	 */
+	public function get_session_cookie() {
+		return json_decode( sanitize_text_field( wp_unslash( $_COOKIE['woocommerceanalytics_session'] ?? '' ) ), true ) ?? array();
+	}
+
+	/**
+	 * Get the allowed CH Events.
+	 *
+	 * @return string[] The allowed CH Events.
+	 */
+	private function get_clickhouse_events() {
+		return array(
+			'woocommerceanalytics_session_started',
+			'woocommerceanalytics_product_view',
+			'woocommerceanalytics_cart_view',
+			'woocommerceanalytics_add_to_cart',
+			'woocommerceanalytics_remove_from_cart',
+			'woocommerceanalytics_checkout_view',
+			'woocommerceanalytics_product_checkout',
+			'woocommerceanalytics_product_purchase',
+			'woocommerceanalytics_order_confirmation_view',
+			'woocommerceanalytics_search',
+		);
+	}
+
+	/**
+	 * Check if the event should be sent to ClickHouse
+	 *
+	 * @param string $event The event name.
+	 * @return bool True if it should be sent to ClickHouse
+	 */
+	private function is_clickhouse( $event ) {
+		return in_array( $event, $this->get_clickhouse_events(), true );
 	}
 }

--- a/projects/packages/woocommerce-analytics/src/class-woocommerce-analytics.php
+++ b/projects/packages/woocommerce-analytics/src/class-woocommerce-analytics.php
@@ -77,7 +77,7 @@ class Woocommerce_Analytics {
 		}
 
 		// Tracking only Site pages.
-		if ( is_admin() || wp_doing_ajax() || is_login() ) {
+		if ( is_admin() || wp_doing_ajax() || wp_is_xml_request() || is_login() || is_feed() || ( defined( 'WP_CLI' ) && WP_CLI ) ) {
 			return false;
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes [WOOA7S-316](https://linear.app/a8c/issue/WOOA7S-316/test-and-deploy-woocommerce-analytics-package-050)

## Proposed changes
<!--- Explain what functional changes your PR includes -->

This PR merges all the changes of `woocommerce-analytics-0.5.0` into the trunk branch. It includes:

### New Features

- **ClickHouse Integration** (default: disabled)
  - Related PRs:
    - #41476
    - #44653
- **Session & Engagement Tracking** (default: disabled)
  - Related PRs:
    - #41085
    - #42286
    - #42423
- **Page View Tracking**
  - Related PR:
    - #42259

### Bug Fixes

- #42369
### Other information

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

Yes. We do add new event `woocommerceanalytics_page_view` and track `woocommerce_session_engagement` and save "is_enagaged" param as well as "expires" param in the session cookie when ClickHouse is enabled.

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

All PRs merged into this release branch have already been tested. However, it's still advisable to review the changes and retest the main features to ensure everything works as expected.

**When ClickHouse feature is enabled**

*Other than the addition of the new page view tracking event and the included bug fixes, existing functionality should remain unchanged.*

1. Check out and build the JP plugin with this PR applied, or set up a JN site using this branch
2. Make sure to turn off any ad blockers you may have enabled
3. Go to any page (post, page, shop, product, cart, checkout, account page...) and see `t.gif` with `woocommerceanalytics_page_view` event in the network tab without `ch` query parameter.
4. Confirm `session_id` and `landing_page` are empty in the event payload
5. Confirm `wocommerceanalytics_session` cookie is NOT set
6. Confirm that no session tracking events are present in the network tab.
7. Confirm that `w.gif` is not present in the network tab

<img width="1267" height="462" alt="Screenshot 2025-08-11 at 14 03 44" src="https://github.com/user-attachments/assets/7915fe6f-a58e-4b90-b01e-e0910fd1c478" />


**When ClickHouse feature is enabled:**

1. Add filter: `add_filter('woocommerce_analytics_clickhouse_enabled', '__return_true')`
2. Go to any frontend page (post, page, shop, product, cart, checkout, account page...)
3. Check that both `t.gif` and `w.gif` are present in the network tab with `ch` query parameter = 1.
4. Confirm `woocommerceanalytics_session_started` event is fired
5. See the `wocommerceanalytics_session` session cookie is created with an expiration of 30 (UTC) from the time you are or midnight (UTC), whichever is earlier.
6. Engage with the site (go to another page, add to cart, checkout, etc.)
7. Check that `woocommerceanalytics_session_engagement` is present in the network tab
9. Check that `is_enagaged` is set to `true` in the session cookie.
10. Refresh again or visit any page. Please take a look at the session_engagement event NOT triggered.

<img width="1270" height="454" alt="Screenshot 2025-08-11 at 14 04 09" src="https://github.com/user-attachments/assets/446358e2-d90a-478f-817b-0bf6af78ecca" />


**Testing with WooCommerce Analytics plugin integration**

1. Use https://github.com/woocommerce/woocommerce-analytics/pull/1089
2. In WA's `composer.json`, add a "repositories" entry pointing to your package’s path:

```
{
    "repositories": [
        {
            "type": "path",
            "url": "<PATH_TO_JETPACK_WOOCOMMERCE_ANALYTICS_PACKAGE>"
        }
    ]
}
```

3. Run `composer require automattic/woocommerce-analytics:@dev` to install the package.
4. Visit any frontend page (such as a post, product, cart, or checkout).
   - Open your browser’s developer tools and go to the "Network" tab.
   - Confirm that a request to `w.gif` appears, and that the request URL includes the query parameter `ch=1`.
5. Check your site's `wp-content/debug.log` file (or wherever your WordPress debug log is configured).
   - Ensure that no new errors or warnings related to WooCommerce Analytics are present after performing the above steps.
6. Repeat the above tests with the Jetpack plugin activated/deactivated.
   - This ensures compatibility and that the integration works correctly regardless of Jetpack’s status.