### PR TITLE
WooCommerce Analytics: fix logic for capturing cart update event

### DIFF
--- a/projects/packages/woocommerce-analytics/changelog/fix-cart-update-remove-event
+++ b/projects/packages/woocommerce-analytics/changelog/fix-cart-update-remove-event
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix logic for capturing cart update event
+
+

--- a/projects/packages/woocommerce-analytics/src/class-universal.php
+++ b/projects/packages/woocommerce-analytics/src/class-universal.php
@@ -171,8 +171,12 @@ class Universal {
 		if ( $quantity > $old_quantity ) {
 			$this->capture_event_in_session_data( $product_id, $quantity, 'woocommerceanalytics_add_to_cart' );
 			$this->lock_add_to_cart_events = true;
-		} else {
+			return;
+		}
+
+		if ( $quantity < $old_quantity ) {
 			$this->capture_event_in_session_data( $product_id, $quantity, 'woocommerceanalytics_remove_from_cart' );
+			return;
 		}
 	}
 


### PR DESCRIPTION
## Proposed changes:


<!--- Explain what functional changes your PR includes -->

This PR resolves an issue where the `woocommerceanalytics_remove_from_cart` event was incorrectly triggered during cart quantity updates, even when the quantity remained unchanged.

The root cause was that the `capture_cart_quantity_update` method failed to account for cases where the cart item's quantity was not modified. It's a bug introduced in https://github.com/Automattic/jetpack/pull/42369.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not
break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a
generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack
Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what
changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need.
-->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented?
-->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly
  as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Ensure you are using this branch and have a WooCommerce store set up.
2. In your WooCommerce admin, create a new product and publish it.
3. On the frontend, navigate to the shop page.
4. Add the product to your cart.
5. Click "x in cart" button to add one more item.
6. Open your browser’s developer tools and go to the "Network" tab.
7. Refresh the page to ensure all analytics events are triggered.
8. In the network requests, look for analytics events:
   - Confirm that two `woocommerceanalytics_add_to_cart` events are recorded (one for each addition to the cart).
   - Confirm that a `woocommerceanalytics_page_view` event is also recorded.
9. Verify that **no** `woocommerceanalytics_remove_from_cart` event is triggered when the quantity is increased or remains unchanged.
10. Optionally, decrease the quantity or remove the product from the cart and refresh the page. Confirm that `woocommerceanalytics_remove_from_cart` event is triggered.

https://github.com/user-attachments/assets/410174b6-6d7d-4629-a3f8-c8f4a8cb3ca9


