### PR TITLE
Sitemaps: Add filter to allow suspending cache addition during generation

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-sitemaps-allow-disable-cache-addition-hog-283
+++ b/projects/plugins/jetpack/changelog/update-jetpack-sitemaps-allow-disable-cache-addition-hog-283
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Sitemaps: Add filter to allow suspending object cache addition during generation.

--- a/projects/plugins/jetpack/modules/sitemaps/sitemap-builder.php
+++ b/projects/plugins/jetpack/modules/sitemaps/sitemap-builder.php
@@ -168,11 +168,29 @@ class Jetpack_Sitemap_Builder { // phpcs:ignore Generic.Files.OneObjectStructure
 			}
 		}
 
+		/**
+		 * Filters whether to suspend cache addition for the entire sitemap generation.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param bool|null $suspend_addition Whether to suspend cache addition. Defaults to null.
+		 * @return bool|null Whether to suspend cache addition.
+		 */
+		$suspend_addition = apply_filters( 'jetpack_sitemap_suspend_cache_addition', null );
+
+		// Cache the previous state in case something else changed it.
+		$prev_suspend_addition = wp_suspend_cache_addition();
+
+		wp_suspend_cache_addition( $suspend_addition );
+
 		for ( $i = 1; $i <= JP_SITEMAP_UPDATE_SIZE; $i++ ) {
 			if ( true === $this->build_next_sitemap_file() ) {
 				break; // All finished!
 			}
 		}
+
+		// Restore previous state.
+		wp_suspend_cache_addition( $prev_suspend_addition );
 
 		if ( $this->logger ) {
 			$this->logger->report( '-- ...done for now.' );

--- a/projects/plugins/jetpack/tests/php/modules/sitemaps/Jetpack_Sitemap_Builder_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/sitemaps/Jetpack_Sitemap_Builder_Test.php
@@ -303,4 +303,32 @@ class Jetpack_Sitemap_Builder_Test extends WP_UnitTestCase {
 
 		$this->assertSame( '2024-03-08T01:02:03Z', $result['last_modified'], 'Last modified date is not the one from the other_urls filter.' );
 	}
+
+	/**
+	 * Test that cache suspension state is restored after sitemap update
+	 *
+	 * @group jetpack-sitemap
+	 * @since $$next-version$$
+	 */
+	#[Group( 'jetpack-sitemap' )]
+	public function test_cache_suspension_state_restored() {
+		// Create test content
+		self::factory()->post->create(
+			array(
+				'post_type'   => 'post',
+				'post_status' => 'publish',
+			)
+		);
+
+		$initial_state = wp_suspend_cache_addition();
+
+		add_filter( 'jetpack_sitemap_suspend_cache_addition', '__return_true' );
+
+		$this->builder->update_sitemap();
+
+		$final_state = wp_suspend_cache_addition();
+		$this->assertEquals( $initial_state, $final_state );
+
+		remove_filter( 'jetpack_sitemap_suspend_cache_addition', '__return_true' );
+	}
 }


### PR DESCRIPTION
Fixes HOG-283

Using the filter should reduce OOM errors during sitemap generation, but might lead to script execution timeout errors.

## Proposed changes:

* Add filter to prevent adding to object cache during sitemap generation.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

HOG-283

## Does this pull request change what data or activity we track or use?

no

## Testing instructions:

Make sure added test passes.