### PR TITLE
Blocks: Update JS loading strategy of subscriptions block

### DIFF
--- a/projects/packages/blocks/changelog/allow-specifying-js-loading-strategy
+++ b/projects/packages/blocks/changelog/allow-specifying-js-loading-strategy
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Allow blocks to have their own JS loading strategy.

--- a/projects/packages/blocks/src/class-blocks.php
+++ b/projects/packages/blocks/src/class-blocks.php
@@ -111,6 +111,11 @@ class Blocks {
 			}
 		}
 
+		// Keep track of the JS loading strategy for any block that specifies it.
+		if ( isset( $args['js_loading_strategy'] ) && class_exists( 'Jetpack_Gutenberg' ) ) {
+			Jetpack_Gutenberg::set_block_js_loading_strategy( $feature_name, $args['js_loading_strategy'] );
+		}
+
 		return register_block_type( $block_type, $args );
 	}
 

--- a/projects/plugins/jetpack/changelog/update-blocks-allow-specifying-js-loading-strategy
+++ b/projects/plugins/jetpack/changelog/update-blocks-allow-specifying-js-loading-strategy
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Blocks: Update subscription block JS to be deferred.

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -74,6 +74,15 @@ class Jetpack_Gutenberg {
 	private static $preset_cache = null;
 
 	/**
+	 * Keep track of JS loading strategies for each block that needs it.
+	 *
+	 * @var array<string, array|bool>
+	 *
+	 * @since $$next-version$$
+	 */
+	private static $block_js_loading_strategies = array();
+
+	/**
 	 * Check to see if a minimum version of Gutenberg is available. Because a Gutenberg version is not available in
 	 * php if the Gutenberg plugin is not installed, if we know which minimum WP release has the required version we can
 	 * optionally fall back to that.
@@ -599,9 +608,10 @@ class Jetpack_Gutenberg {
 			$script_version = self::get_asset_version( $script_relative_path );
 			$view_script    = plugins_url( $script_relative_path, JETPACK__PLUGIN_FILE );
 			$view_script    = add_query_arg( 'minify', 'false', $view_script );
+			$strategy       = self::get_block_js_loading_strategy( $type );
 
 			// Enqueue dependencies.
-			wp_enqueue_script( 'jetpack-block-' . $type, $view_script, $script_dependencies, $script_version, false );
+			wp_enqueue_script( 'jetpack-block-' . $type, $view_script, $script_dependencies, $script_version, $strategy );
 
 			// If this is a customizer preview, enqueue the dependencies and render the script directly to the preview after autosave.
 			// phpcs:ignore WordPress.Security.NonceVerification.Recommended
@@ -1371,6 +1381,37 @@ class Jetpack_Gutenberg {
 
 			remove_filter( 'doing_it_wrong_trigger_error', array( __CLASS__, 'bypass_block_metadata_doing_it_wrong' ), 10 );
 		}
+	}
+
+	/**
+	 * Set the JS loading strategy for a block.
+	 *
+	 * @param string     $block_name The block name.
+	 * @param array|bool $strategy   The JS loading strategy.
+	 *
+	 * @since $$next-version$$
+	 */
+	public static function set_block_js_loading_strategy( $block_name, $strategy ) {
+		self::$block_js_loading_strategies[ $block_name ] = $strategy;
+	}
+
+	/**
+	 * Get the JS loading strategy for a block.
+	 *
+	 * @param string $block_name The block name.
+	 *
+	 * @return array|bool The JS loading strategy for the block.
+	 *
+	 * @since $$next-version$$
+	 */
+	public static function get_block_js_loading_strategy( $block_name ) {
+		$strategy = false;
+
+		if ( isset( self::$block_js_loading_strategies[ $block_name ] ) ) {
+			$strategy = self::$block_js_loading_strategies[ $block_name ];
+		}
+
+		return $strategy;
 	}
 }
 

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -240,9 +240,10 @@ class Jetpack_Gutenberg {
 	 * @return void
 	 */
 	public static function reset() {
-		self::$extensions          = null;
-		self::$availability        = array();
-		self::$cached_availability = null;
+		self::$extensions                  = null;
+		self::$availability                = array();
+		self::$cached_availability         = null;
+		self::$block_js_loading_strategies = array();
 	}
 
 	/**

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -62,13 +62,17 @@ function register_block() {
 		Blocks::jetpack_register_block(
 			__DIR__,
 			array(
-				'render_callback' => __NAMESPACE__ . '\render_block',
-				'supports'        => array(
+				'render_callback'     => __NAMESPACE__ . '\render_block',
+				'supports'            => array(
 					'spacing' => array(
 						'margin'  => true,
 						'padding' => true,
 					),
 					'align'   => array( 'wide', 'full' ),
+				),
+				'js_loading_strategy' => array(
+					'in_footer' => true,
+					'strategy'  => 'defer',
 				),
 			)
 		);

--- a/projects/plugins/jetpack/tests/php/general/Jetpack_Gutenberg_Test.php
+++ b/projects/plugins/jetpack/tests/php/general/Jetpack_Gutenberg_Test.php
@@ -348,4 +348,107 @@ class Jetpack_Gutenberg_Test extends WP_UnitTestCase {
 			}
 		}
 	}
+
+	/**
+	 * Test setting and getting a JS loading strategy for a block.
+	 */
+	public function test_set_and_get_block_js_loading_strategy() {
+		$block_name = 'test-block';
+		$strategy   = array( 'strategy' => 'defer' );
+
+		// Set the strategy
+		Jetpack_Gutenberg::set_block_js_loading_strategy( $block_name, $strategy );
+
+		// Get the strategy and verify it matches
+		$retrieved_strategy = Jetpack_Gutenberg::get_block_js_loading_strategy( $block_name );
+		$this->assertEquals( $strategy, $retrieved_strategy );
+	}
+
+	/**
+	 * Test that getting a JS loading strategy for a non-existent block returns false.
+	 */
+	public function test_get_block_js_loading_strategy_returns_false_for_nonexistent_block() {
+		$block_name = 'nonexistent-block';
+
+		$strategy = Jetpack_Gutenberg::get_block_js_loading_strategy( $block_name );
+		$this->assertFalse( $strategy );
+	}
+
+	/**
+	 * Test setting a boolean JS loading strategy for a block.
+	 */
+	public function test_set_block_js_loading_strategy_with_boolean() {
+		$block_name = 'boolean-strategy-block';
+		$strategy   = true;
+
+		// Set the strategy
+		Jetpack_Gutenberg::set_block_js_loading_strategy( $block_name, $strategy );
+
+		// Get the strategy and verify it matches
+		$retrieved_strategy = Jetpack_Gutenberg::get_block_js_loading_strategy( $block_name );
+		$this->assertEquals( $strategy, $retrieved_strategy );
+	}
+
+	/**
+	 * Test setting multiple JS loading strategies for different blocks.
+	 */
+	public function test_set_multiple_block_js_loading_strategies() {
+		$strategies = array(
+			'block-one'   => array( 'strategy' => 'defer' ),
+			'block-two'   => array( 'strategy' => 'async' ),
+			'block-three' => true,
+			'block-four'  => false,
+		);
+
+		// Set all strategies
+		foreach ( $strategies as $block_name => $strategy ) {
+			Jetpack_Gutenberg::set_block_js_loading_strategy( $block_name, $strategy );
+		}
+
+		// Verify all strategies are retrieved correctly
+		foreach ( $strategies as $block_name => $expected_strategy ) {
+			$retrieved_strategy = Jetpack_Gutenberg::get_block_js_loading_strategy( $block_name );
+			$this->assertEquals( $expected_strategy, $retrieved_strategy, "Strategy mismatch for block: {$block_name}" );
+		}
+	}
+
+	/**
+	 * Test overwriting an existing JS loading strategy for a block.
+	 */
+	public function test_overwrite_block_js_loading_strategy() {
+		$block_name       = 'overwrite-test-block';
+		$initial_strategy = array( 'strategy' => 'defer' );
+		$new_strategy     = array( 'strategy' => 'async' );
+
+		// Set initial strategy
+		Jetpack_Gutenberg::set_block_js_loading_strategy( $block_name, $initial_strategy );
+		$retrieved_strategy = Jetpack_Gutenberg::get_block_js_loading_strategy( $block_name );
+		$this->assertEquals( $initial_strategy, $retrieved_strategy );
+
+		// Overwrite with new strategy
+		Jetpack_Gutenberg::set_block_js_loading_strategy( $block_name, $new_strategy );
+		$retrieved_strategy = Jetpack_Gutenberg::get_block_js_loading_strategy( $block_name );
+		$this->assertEquals( $new_strategy, $retrieved_strategy );
+	}
+	/**
+	 * Test that the reset method clears JS loading strategies.
+	 */
+	public function test_reset_clears_js_loading_strategies() {
+		$block_name = 'reset-test-block';
+		$strategy   = array( 'strategy' => 'defer' );
+
+		// Set a strategy
+		Jetpack_Gutenberg::set_block_js_loading_strategy( $block_name, $strategy );
+
+		// Verify it's set
+		$retrieved_strategy = Jetpack_Gutenberg::get_block_js_loading_strategy( $block_name );
+		$this->assertEquals( $strategy, $retrieved_strategy );
+
+		// Reset the class
+		Jetpack_Gutenberg::reset();
+
+		// Verify the strategy is cleared
+		$retrieved_strategy = Jetpack_Gutenberg::get_block_js_loading_strategy( $block_name );
+		$this->assertFalse( $retrieved_strategy );
+	}
 }


### PR DESCRIPTION
Fixes HOG-234
Fixes #44547

## Proposed changes:

* Allow specifying loading strategy for Jetpack blocks JS file;
* Update JS loading strategy for Subscriptions block to footer, defer.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:

**Pre-requisites**

Make sure to enable the Blocks module from Jetpack -> Modules:

<img width="763" height="144" alt="CleanShot 2025-08-11 at 20 27 49" src="https://github.com/user-attachments/assets/ccd27cfb-275a-4235-9520-fc6f37f93d8c" />

Make sure `Newsletter` is enabled. Jetpack -> Settings -> Newsletter:

<img width="1166" height="469" alt="CleanShot 2025-08-11 at 20 28 58" src="https://github.com/user-attachments/assets/be2c8b85-d381-4b40-b948-13ed6ae44b42" />

Add the Subscribe block to a page for testing:

<img width="358" height="349" alt="CleanShot 2025-08-11 at 20 29 49" src="https://github.com/user-attachments/assets/2fca6d61-6f94-4c3e-9ed3-76cbcc8e67df" />

### (this branch, new behavior) Test that subscribe block JS is deferred

- Open the page with the subscribe block and view its source;
- You should see the `subscriptions/view.js` deferred and in the footer:

<img width="560" height="54" alt="CleanShot 2025-08-11 at 20 31 41" src="https://github.com/user-attachments/assets/f8aa5126-96bc-4bf8-9c7d-608038cbf175" />

- When loading the page, the priority of the JS should be `Low` (Network tab, usually far right column).

### (trunk/production, old behavior) Test default behavior (optional)

- Open the page with the subscribe block and view its source;
- You should see the `subscriptions/view.js` should not be deferred and it should be in the header;
- The priority of the JS is `Medium`.