### PR TITLE
[e2e tests] Improve checks for url in recommendations test

### DIFF
--- a/projects/plugins/jetpack/changelog/e2e-improve-recommendations-test-url-checks
+++ b/projects/plugins/jetpack/changelog/e2e-improve-recommendations-test-url-checks
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: E2E tests: improve checks for url in recommendations steps test
+
+

--- a/projects/plugins/jetpack/tests/e2e/specs/post-connection/recommendations.test.ts
+++ b/projects/plugins/jetpack/tests/e2e/specs/post-connection/recommendations.test.ts
@@ -30,10 +30,9 @@ test( 'Recommendations (Jetpack Assistant)', async ( { page } ) => {
 	await test.step( 'Navigate to the Recommendations module', async () => {
 		await page.goto( '/wp-admin/admin.php?page=jetpack#/recommendations' );
 
-		expect(
-			page.url().includes( 'site-type' ),
-			'URL should be in sync with the step name'
-		).toBeTruthy();
+		await expect( page, 'URL should be in sync with the step name' ).toHaveURL(
+			/recommendations\/site-type/
+		);
 	} );
 
 	await test.step( 'Check Personal and Other checkboxes', async () => {
@@ -61,10 +60,9 @@ test( 'Recommendations (Jetpack Assistant)', async ( { page } ) => {
 			page.getByRole( 'link', { name: 'Enable Downtime Monitoring' } ),
 			'Monitor step should be visible'
 		).toBeVisible();
-		expect(
-			page.url().includes( 'monitor' ),
-			'URL should be in sync with the step name'
-		).toBeTruthy();
+		await expect( page, 'URL should be in sync with the step name' ).toHaveURL(
+			/recommendations\/monitor/
+		);
 
 		await page.getByRole( 'link', { name: 'Enable Downtime Monitoring' } ).click();
 		await page.reload();
@@ -73,10 +71,9 @@ test( 'Recommendations (Jetpack Assistant)', async ( { page } ) => {
 			page.getByRole( 'link', { name: 'Enable Related Posts' } ),
 			'Related posts step should be visible'
 		).toBeVisible();
-		expect(
-			page.url().includes( 'related-posts' ),
-			'URL should be in sync with the step name'
-		).toBeTruthy();
+		await expect( page, 'URL should be in sync with the step name' ).toHaveURL(
+			/recommendations\/related-posts/
+		);
 	} );
 
 	await test.step( 'Enable Related Posts and continue to Newsletter step', async () => {
@@ -87,10 +84,9 @@ test( 'Recommendations (Jetpack Assistant)', async ( { page } ) => {
 			page.getByRole( 'link', { name: 'Enable Newsletter' } ),
 			'Newsletter step should be visible'
 		).toBeVisible();
-		expect(
-			page.url().includes( 'newsletter' ),
-			'URL should be in sync with the step name'
-		).toBeTruthy();
+		await expect( page, 'URL should be in sync with the step name' ).toHaveURL(
+			/recommendations\/newsletter/
+		);
 	} );
 
 	await test.step( 'Enable Newsletter and continue to Site Accelerator', async () => {
@@ -101,10 +97,9 @@ test( 'Recommendations (Jetpack Assistant)', async ( { page } ) => {
 			page.getByRole( 'link', { name: 'Enable Site Accelerator' } ),
 			'Site Accelerator step should be visible'
 		).toBeVisible();
-		expect(
-			page.url().includes( 'site-accelerator' ),
-			'URL should be in sync with the step name'
-		).toBeTruthy();
+		await expect( page, 'URL should be in sync with the step name' ).toHaveURL(
+			/recommendations\/site-accelerator/
+		);
 	} );
 
 	await test.step( 'Skip Site Accelerator and continue to VaultPress Backup card', async () => {
@@ -115,10 +110,9 @@ test( 'Recommendations (Jetpack Assistant)', async ( { page } ) => {
 			page.getByRole( 'link', { name: 'Get' } ),
 			'VaultPress Backup step should be visible'
 		).toBeVisible();
-		expect(
-			page.url().includes( 'vaultpress-backup' ),
-			'URL should be in sync with the step name'
-		).toBeTruthy();
+		await expect( page, 'URL should be in sync with the step name' ).toHaveURL(
+			/recommendations\/vaultpress-backup/
+		);
 	} );
 
 	await test.step( 'Skip VaultPress Backup card and continue to Summary', async () => {
@@ -134,30 +128,32 @@ test( 'Recommendations (Jetpack Assistant)', async ( { page } ) => {
 			'Summary sidebar should be visible'
 		).toBeVisible();
 
-		expect(
-			page.url().includes( 'summary' ),
-			'URL should be in sync with the step name'
-		).toBeTruthy();
+		await expect( page, 'URL should be in sync with the step name' ).toHaveURL(
+			/recommendations\/summary/
+		);
 	} );
 
 	await test.step( 'Verify Monitoring, Newsletter, and Related Posts are enabled', async () => {
-		const isMonitoringFeatureEnabled = await page
-			.locator(
+		await expect(
+			page.locator(
 				'.jp-recommendations-feature-summary.is-feature-enabled >> a >> text="Downtime Monitoring"'
-			)
-			.isVisible();
-		const isRelatedPostsFeatureEnabled = await page
-			.locator(
+			),
+			'Monitoring feature should be enabled'
+		).toBeVisible();
+
+		await expect(
+			page.locator(
 				'.jp-recommendations-feature-summary.is-feature-enabled >> a >> text="Related Posts"'
-			)
-			.isVisible();
-		const isNewsletterFeatureEnabled = await page
-			.locator( '.jp-recommendations-feature-summary.is-feature-enabled >> a >> text="Newsletter"' )
-			.isVisible();
-		expect(
-			isMonitoringFeatureEnabled && isNewsletterFeatureEnabled && isRelatedPostsFeatureEnabled,
-			'Monitoring feature, Newsletter, and Related Posts should be enabled'
-		).toBeTruthy();
+			),
+			'Related Posts should be enabled'
+		).toBeVisible();
+
+		await expect(
+			page.locator(
+				'.jp-recommendations-feature-summary.is-feature-enabled >> a >> text="Newsletter"'
+			),
+			'Newsletter should be enabled'
+		).toBeVisible();
 	} );
 
 	await test.step( 'Verify Site Accelerator is disabled', async () => {


### PR DESCRIPTION


## Proposed changes:

  - Refactored URL assertions to use Playwright's `toHaveURL()` with regex patterns instead of `page.url().includes()`

This ensures more helpful error messages:

```
Error: URL should be in sync with the step name
Timed out 20000ms waiting for expect(locator).toHaveURL(expected)
Expected pattern: /recommendations\/site-type/
Received string:  "https://fuzzy-octopus-41.a8c-localtunnel.cyou/wp-admin/admin.php?page=jetpack#/recommendations/something-else"
```

instead of

```
Error: URL should be in sync with the step name
expect(received).toBeTruthy()
Received: false
```


  - Split combined feature verification into individual assertions for better test granularity


### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:

* e2e tests pass in CI

