### PR TITLE
Forms: Ratings field fixes 

### DIFF
--- a/projects/packages/forms/changelog/fix-ratings-field-fixes
+++ b/projects/packages/forms/changelog/fix-ratings-field-fixes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: minor css fixes for the ratings field

--- a/projects/packages/forms/src/blocks/input-rating/edit.js
+++ b/projects/packages/forms/src/blocks/input-rating/edit.js
@@ -53,7 +53,7 @@ export default function RatingInputEdit( { context, clientId } ) {
 					type="radio"
 					name={ `rating-${ clientId }` }
 					value={ `${ i }/${ max }` }
-					className="jetpack-field-rating__input"
+					className="jetpack-field-rating__input visually-hidden"
 					checked={ defaultValue === i }
 					onChange={ () => handleChange( i ) }
 				/>

--- a/projects/packages/forms/src/blocks/input-rating/style.scss
+++ b/projects/packages/forms/src/blocks/input-rating/style.scss
@@ -2,11 +2,16 @@
 
 .jetpack-field-rating {
 
+	.jetpack-field-rating__option:last-child .jetpack-field-rating__label {
+		padding-right: 0;
+	}
+
 	/* Layout */
 	.jetpack-field-rating__options {
 		display: flex;
 
 		.jetpack-field-rating__label {
+			padding-right: 5px;
 
 			/* Guard against theme label font-size overrides (e.g., Twenty Sixteen) */
 			font-size: inherit;
@@ -24,19 +29,6 @@
 			}
 		}
 
-		/* Accessibly hide the actual radios */
-		input[type="radio"].jetpack-field-rating__input {
-			position: absolute;
-			opacity: 0;
-			width: 1px;
-			height: 1px;
-			margin: 0;
-			padding: 0;
-			border: 0;
-			clip: rect(1px, 1px, 1px, 1px);
-			overflow: hidden;
-		}
-
 		// Filled states: current (checked/hover)
 		:is(
 		input[type="radio"].jetpack-field-rating__input:checked + .jetpack-field-rating__label,
@@ -47,6 +39,16 @@
 				fill: var(--jetpack--contact-form--rating-star-color, currentColor);
 			}
 		}
+
+		// Filled states: current (checked/hover)
+		:is(
+		input[type="radio"].jetpack-field-rating__input:focus-visible + .jetpack-field-rating__label) {
+
+			.jetpack-field-rating__icon {
+				scale: 1.3;
+			}
+		}
+
 
 		/* Filled states: previous siblings */
 		.jetpack-field-rating__option {

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -2210,9 +2210,9 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 						name="%2$s"
 						value="%3$s/%4$s"
 						data-wp-on--change="actions.onFieldChange"
-						class="jetpack-field-rating__input"
+						class="jetpack-field-rating__input visually-hidden"
 						%5$s
-						%6$s /> 
+						%6$s />
 					<label for="%1$s" class="jetpack-field-rating__label">
 						%7$s
 					</label>


### PR DESCRIPTION
This PR fixes a number of issues. 
- use the visually hidden class. (remove the redundent css) 
- add some css when the user uses the keyboard to know that the have selected the ratings field. 
- add a bit of padding between the different fields. 


After:
https://github.com/user-attachments/assets/73aedf24-feb1-4db8-bc8e-ec799661d4de


## Proposed changes:
*

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1754620475385039-slack-C052XEUUBL4

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Add the ratings field. 
- On the front end. Use the keyboard to add focus on the ratings field. 
- Do you see which field was selected. 
Are you able to submit the form using the keyboard? 
