### PR TITLE
Forms: Add radio field validation

### DIFF
--- a/projects/packages/forms/changelog/add-radio-validation
+++ b/projects/packages/forms/changelog/add-radio-validation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: add radio input field backend validation 

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -347,6 +347,38 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 					}
 				}
 				break;
+			case 'radio':
+				// Check that there is at least one option selected
+				if ( empty( $field_value ) ) {
+					/* translators: %s is the name of a form field */
+					$this->add_error( sprintf( __( '%s requires at least one selection.', 'jetpack-forms' ), $field_label ) );
+				} else {
+					// Check that the selected options are valid
+					$options      = (array) $this->get_attribute( 'options' );
+					$options_data = (array) $this->get_attribute( 'optionsdata' );
+
+					if ( ! empty( $options_data ) ) {
+						$options = array_map(
+							function ( $option ) {
+								return sanitize_text_field( trim( $option['label'] ) );
+							},
+							$options_data
+						);
+					}
+					$non_empty_options = array_filter(
+						$options,
+						function ( $option ) {
+							return $option !== '';
+						}
+					);
+
+					if ( ! in_array( $field_value, $non_empty_options, true ) ) {
+						/* translators: %s is the name of a form field */
+						$this->add_error( sprintf( __( '%s requires at least one selection.', 'jetpack-forms' ), $field_label ) );
+						break;
+					}
+				}
+				break;
 			case 'number':
 				// Make sure the number address is valid
 				if ( ! is_numeric( $field_value ) ) {

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -3041,11 +3041,13 @@ EOT;
 		// Create a form submission
 		$_POST = Utility::get_post_request(
 			array(
-				'name'   => $name,
-				'email'  => $email,
-				'invite' => 'hello@world', // not required
-				'choose' => $choose,
-				'pick'   => $pick,
+				'name'        => $name,
+				'email'       => $email,
+				'invite'      => 'hello@world', // not required
+				'choose'      => $choose,
+				'chooseradio' => 'not-a-value',
+				'radioempty'  => '',
+				'pick'        => $pick,
 			),
 			'g' . $form_id
 		);
@@ -3055,7 +3057,7 @@ EOT;
 				'title'       => 'Test Form',
 				'description' => 'This is a test form.',
 			),
-			"[contact-field label='Name' type='name' required='1'/][contact-field label='Email' type='email' required='1'/][contact-field label='Invite' type='email' /][contact-field label='Choose' type='checkbox-multiple' options='truth,dare' required='1'/][contact-field label='Pick' type='checkbox-multiple' options='truth,dare' required='1'/]"
+			"[contact-field label='Name' type='name' required='1'/][contact-field label='Email' type='email' required='1'/][contact-field label='Invite' type='email' /][contact-field label='Choose' type='checkbox-multiple' options='truth,dare' required='1'/][contact-field label='Choose Radio' type='radio' options='truth,dare' required='1'/][contact-field label='Choose Empty' type='radio' options='truth,dare' required='1'/][contact-field label='Pick' type='checkbox-multiple' options='truth,dare' required='1'/]"
 		);
 		$form->validate();
 		unset( $_POST ); // Clean up the global $_POST variable after the test.
@@ -3068,6 +3070,8 @@ EOT;
 				'Email requires a valid email address.',
 				'Invite requires a valid email address.',
 				'Choose requires at least one selection.',
+				'Choose Radio requires at least one selection.',
+				'Choose Empty requires at least one selection.',
 				'Pick requires at least one selection.',
 			),
 			$form->get_error_messages()

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -3041,13 +3041,14 @@ EOT;
 		// Create a form submission
 		$_POST = Utility::get_post_request(
 			array(
-				'name'        => $name,
-				'email'       => $email,
-				'invite'      => 'hello@world', // not required
-				'choose'      => $choose,
-				'chooseradio' => 'not-a-value',
-				'radioempty'  => '',
-				'pick'        => $pick,
+				'name'           => $name,
+				'email'          => $email,
+				'invite'         => 'hello@world', // not required
+				'choose'         => $choose,
+				'chooseradio'    => 'not-a-value',
+				'radioempty'     => '',
+				'radioemptydata' => '',
+				'pick'           => $pick,
 			),
 			'g' . $form_id
 		);
@@ -3057,7 +3058,15 @@ EOT;
 				'title'       => 'Test Form',
 				'description' => 'This is a test form.',
 			),
-			"[contact-field label='Name' type='name' required='1'/][contact-field label='Email' type='email' required='1'/][contact-field label='Invite' type='email' /][contact-field label='Choose' type='checkbox-multiple' options='truth,dare' required='1'/][contact-field label='Choose Radio' type='radio' options='truth,dare' required='1'/][contact-field label='Choose Empty' type='radio' options='truth,dare' required='1'/][contact-field label='Pick' type='checkbox-multiple' options='truth,dare' required='1'/]"
+			"
+			[contact-field label='Name' type='name' required='1'/]
+			[contact-field label='Email' type='email' required='1'/]
+			[contact-field label='Invite' type='email' /]
+			[contact-field label='Choose' type='checkbox-multiple' options='truth,dare' required='1'/]
+			[contact-field label='Choose Radio' type='radio' options='truth,dare' required='1'/]
+			[contact-field label='Choose Empty' type='radio' options='truth,dare' required='1'/]
+			[contact-field label='Choose Empty Data' type='radio' options='truth,dare' optionsdata='&#091;{&quot;label&quot;:&quot;hello  there&quot;&#044;&quot;class&quot;:&quot;wp-block-jetpack-option&quot;}&#044;{&quot;label&quot;:&quot;option 1&quot;&#044;&quot;class&quot;:&quot;wp-block-jetpack-option&quot;}&#044;{&quot;label&quot;:&quot;option 2&quot;&#044;&quot;class&quot;:&quot;wp-block-jetpack-option&quot;}&#093;' required='1'/]
+			[contact-field label='Pick' type='checkbox-multiple' options='truth,dare' required='1'/]"
 		);
 		$form->validate();
 		unset( $_POST ); // Clean up the global $_POST variable after the test.
@@ -3072,6 +3081,7 @@ EOT;
 				'Choose requires at least one selection.',
 				'Choose Radio requires at least one selection.',
 				'Choose Empty requires at least one selection.',
+				'Choose Empty Data requires at least one selection.',
 				'Pick requires at least one selection.',
 			),
 			$form->get_error_messages()

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Test.php
@@ -1773,4 +1773,53 @@ class Feedback_Test extends BaseTestCase {
 		$this->assertTrue( $response->has_field_type( 'consent' ), 'Legacy feedback should report consent field exists' );
 		$this->assertFalse( $response->has_consent(), 'Legacy consent should default to false (no)' );
 	}
+
+	public function test_validate_radio_form() {
+		$name    = '';
+		$email   = '';
+		$form_id = Utility::get_form_id();
+
+		// Create a form submission
+		$_POST = Utility::get_post_request(
+			array(
+				'name'                 => $name,
+				'email'                => $email,
+				'choose'               => 'truth',
+				'chooseoptions'        => 'hello  there',
+				'chooseseveraloptions' => 'hello, there',
+			),
+			'g' . $form_id
+		);
+
+		$form = new Contact_Form(
+			array(
+				'title'       => 'Test Form',
+				'description' => 'This is a test form.',
+			),
+			'[contact-field label="Name" type="name" /][contact-field label="Email" type="email" /][contact-field label="Choose" type="radio" options="truth,dare" /][contact-field type="radio" label="Choose options" labelclasses="wp-block-jetpack-label" optionsclasses="wp-block-jetpack-options" options="hello  there,option 1,option 2" optionsdata="&#091;{&quot;label&quot;:&quot;hello  there&quot;&#044;&quot;class&quot;:&quot;wp-block-jetpack-option&quot;}&#044;{&quot;label&quot;:&quot;option 1&quot;&#044;&quot;class&quot;:&quot;wp-block-jetpack-option&quot;}&#044;{&quot;label&quot;:&quot;option 2&quot;&#044;&quot;class&quot;:&quot;wp-block-jetpack-option&quot;}&#093;" stylevariationattributes="" stylevariationclasses="" stylevariationstyles="" fieldwrapperclasses="wp-block-jetpack-field-checkbox-multiple"]&lt;div&gt;
+
+
+&lt;ul class=&quot;wp-block-jetpack-options&quot;&gt;
+
+
+
+&lt;/ul&gt;
+&lt;/div&gt;[/contact-field][contact-field type="radio" label="Choose several options" labelclasses="wp-block-jetpack-label" optionsclasses="wp-block-jetpack-options" options="hello, there,option 1,option 2" optionsdata="&#091;{&quot;label&quot;:&quot;hello&#044; there&quot;&#044;&quot;class&quot;:&quot;wp-block-jetpack-option&quot;}&#044;{&quot;label&quot;:&quot;option 1&quot;&#044;&quot;class&quot;:&quot;wp-block-jetpack-option&quot;}&#044;{&quot;label&quot;:&quot;option 2&quot;&#044;&quot;class&quot;:&quot;wp-block-jetpack-option&quot;}&#093;" stylevariationattributes="" stylevariationclasses="" stylevariationstyles="" fieldwrapperclasses="wp-block-jetpack-field-checkbox-multiple"]&lt;div&gt;
+
+
+&lt;ul class=&quot;wp-block-jetpack-options&quot;&gt;
+
+
+
+&lt;/ul&gt;
+&lt;/div&gt;[/contact-field]'
+		);
+		$form->validate();
+		unset( $_POST ); // Clean up the global $_POST variable after the test.
+
+		// message should be not empty.
+		$this->assertFalse( $form->has_errors(), 'Form should not have errors after validation.' );
+
+		Contact_Form::reset_errors();
+	}
 }


### PR DESCRIPTION
Currently we don't do radio field validation on the backend. 
This PR fixes this by making checking that we only accept data was was provided as an option. 

Follow up on https://github.com/Automattic/jetpack/pull/44722 

## Proposed changes:
* Validate the radio field. 

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?


## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Add a form with the radio field. 
Fill it out form with the radio button. Does the form work as expected? 
Change the HTML of the form so that the radio value is different from the back end. 
Do you see an error? 


