### PR TITLE
Forms: Update checkbox styles when checked.

### DIFF
--- a/projects/packages/forms/changelog/update-checkbox-styles-full
+++ b/projects/packages/forms/changelog/update-checkbox-styles-full
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: Improve the selected checkbox style

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -460,6 +460,35 @@
 		line-height: normal;
 	}
 
+	.jetpack-field-option__checkbox:checked {
+		margin-bottom: 10px;
+	}
+
+	.jetpack-field-option__checkbox:checked::after {
+		content: "";
+		position: absolute;
+		transform: translate(0, 0) rotate(40deg);
+		border: solid #fff;
+		width: 0.25em;
+		height: 0.5em;
+		border-width: 0 2px 2px 0;
+		border-radius: 0;
+		margin: 0;
+	}
+
+	.jetpack-field-option__checkbox:checked::before {
+		content: "";
+		margin: 0;
+		transform: translateY(0.15em);
+		background-color: currentColor;
+		width: 1em;
+		height: 1em;
+		float: none;
+		display: flex;
+		vertical-align: middle;
+		margin-bottom: 2px;
+	}
+
 	.jetpack-field-option__checkbox,
 	.jetpack-field-option {
 		display: flex;

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -461,7 +461,7 @@
 	}
 
 	.jetpack-field-option__checkbox:checked {
-		margin-bottom: 10px;
+		margin-bottom: 0.45em;
 	}
 
 	.jetpack-field-option__checkbox:checked::after {

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -89,6 +89,7 @@
 
 .contact-form input[type="radio"],
 .contact-form input[type="checkbox"] {
+	min-width: 1em;
 	width: 1em;
 	height: 1em;
 	margin: 0 0.75rem 0 0;
@@ -980,6 +981,8 @@ on production builds, the attributes are being reordered, causing side-effects
 	border: solid var(--jetpack--contact-form--inverted-text-color, var(--jetpack--contact-form--input-background));
 	border-width: 0 2px 2px 0;
 	transform: translate(-50%, -60%) rotate(40deg);
+	top: 0;
+	left: 0;
 }
 
 .contact-form .is-style-list input.consent:checked::before,
@@ -1004,6 +1007,8 @@ on production builds, the attributes are being reordered, causing side-effects
 	margin-top: 50%;
 	position: absolute;
 	transform: translate(-50%, -50%);
+	top: 0;
+	left: 0;
 }
 
 .contact-form .grunion-field-wrap.grunion-field-checkbox-multiple-wrap.is-style-button-wrap .contact-form-field,

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -92,6 +92,7 @@
 	width: 1em;
 	height: 1em;
 	margin: 0 0.75rem 0 0;
+	opacity: 1;
 }
 
 .contact-form input[type="checkbox"] {

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -946,7 +946,7 @@ on production builds, the attributes are being reordered, causing side-effects
 	appearance: none;
 	border: solid 1px currentColor;
 	color: currentColor;
-	outline-offset: 4px;
+	outline-offset: 1px;
 	transform: translateY(0.15em);
 }
 
@@ -954,24 +954,38 @@ on production builds, the attributes are being reordered, causing side-effects
 	border-radius: 50%;
 }
 
+.contact-form .is-style-list input.consent:checked,
+.contact-form .is-style-list input.checkbox:checked,
+.contact-form .grunion-field-wrap:not(.is-style-plain) input.checkbox-multiple:checked {
+	background-color: currentColor;
+
+}
+
+.contact-form .is-style-list input.consent::before,
+.contact-form .is-style-list input.checkbox::before,
+.contact-form .grunion-field-wrap:not(.is-style-plain) input.checkbox-multiple::before {
+	position: absolute;
+	width: 0.25em;
+	height: 0.5em;
+	content: "";
+	display: block;
+	opacity: 0; /* Hidden by default */
+	scale: 0.7;
+	margin-left: 50%;
+	margin-top: 50%;
+	transition: opacity 0.1s ease-in-out, scale 0.15s ease-in-out;
+
+	font-size: inherit;
+	border: solid var(--jetpack--contact-form--inverted-text-color, --jetpack--contact-form--input-background);
+	border-width: 0 2px 2px 0;
+	transform: translate(-50%, -60%) rotate(40deg);
+}
+
 .contact-form .is-style-list input.consent:checked::before,
 .contact-form .is-style-list input.checkbox:checked::before,
 .contact-form .grunion-field-wrap:not(.is-style-plain) input.checkbox-multiple:checked::before {
-	content: "\2713";
-	position: absolute;
-
-	/* Inherit the font size from the parent element.
-	 * This allows the input to scale with the font size
-	 * set from global styles or from block styles */
-	font-size: inherit;
-	top: calc(1em / 2);
-	left: calc(1em / 2);
-
-	display: block;
-
-	line-height: 1;
-
-	transform: translate(-50%, -50%);
+	scale: 1;
+	opacity: 1;
 }
 
 .contact-form .grunion-field-wrap:not(.is-style-plain) input.radio:checked::before {

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -977,7 +977,7 @@ on production builds, the attributes are being reordered, causing side-effects
 	transition: opacity 0.1s ease-in-out, scale 0.15s ease-in-out;
 
 	font-size: inherit;
-	border: solid var(--jetpack--contact-form--inverted-text-color, --jetpack--contact-form--input-background);
+	border: solid var(--jetpack--contact-form--inverted-text-color, var(--jetpack--contact-form--input-background));
 	border-width: 0 2px 2px 0;
 	transform: translate(-50%, -60%) rotate(40deg);
 }

--- a/projects/plugins/jetpack/changelog/update-checkbox-styles-full
+++ b/projects/plugins/jetpack/changelog/update-checkbox-styles-full
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: Improve the checkbox style


### PR DESCRIPTION
Improve the checkbox style. 

1. Add dark background and light checkbox. Update the checkbox to use a straight lines instead of a font character. 
2. Add small animation 

Before:

https://github.com/user-attachments/assets/ed3e79e6-981f-469f-95c6-b312b1bcddac

After:

https://github.com/user-attachments/assets/ac8413fc-53e5-4220-b79c-834c8e53235e

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1HpG7-wUL-p2

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Add checkbox, multi checkbox and consent. 
Notice that they all look the same. Check the checkboxs across different themes. Notice that it works well. 