### PR TITLE
Forms: Check consent for MailPoet integration

### DIFF
--- a/projects/packages/forms/changelog/add-forms-mailpoet-check-consent
+++ b/projects/packages/forms/changelog/add-forms-mailpoet-check-consent
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: Check consent for MailPoet integration.

--- a/projects/packages/forms/src/service/class-mailpoet-integration.php
+++ b/projects/packages/forms/src/service/class-mailpoet-integration.php
@@ -182,6 +182,30 @@ class MailPoet_Integration {
 			return;
 		}
 
+		// Get consent field if it exists.
+		$consent_field = null;
+		if ( is_array( $form->fields ) ) {
+			foreach ( $form->fields as $form_field ) {
+				if ( 'consent' === $form_field->get_attribute( 'type' ) ) {
+					$consent_field = $form_field;
+					break;
+				}
+			}
+		}
+
+		// If consent field exists and is explicit, require it to be checked.
+		if ( $consent_field ) {
+			$consent_type = strtolower( (string) $consent_field->get_attribute( 'consenttype' ) );
+			if ( 'explicit' === $consent_type ) {
+				$consent_value           = $consent_field->value;
+				$consent_value_lowercase = is_string( $consent_value ) ? strtolower( trim( $consent_value ) ) : '';
+				$has_explicit_consent    = is_bool( $consent_value ) ? $consent_value : in_array( $consent_value_lowercase, array( 'yes', 'true', '1' ), true );
+				if ( ! $has_explicit_consent ) {
+					return;
+				}
+			}
+		}
+
 		$mailpoet_api = self::get_api();
 		if ( ! $mailpoet_api ) {
 			// MailPoet is not active or not loaded.


### PR DESCRIPTION
Partially addressed [FORMS-234](https://linear.app/a8c/issue/FORMS-234/forms-integrate-opt-in-consent-with-mailpoet)

## Proposed changes:

First of two PRs to integration consent field with MailPoet. This PR just adds the backend logic. The goal is to leverage the existing Consent field to manage user consent to be added to a list. There are a few scenarios:

1. **No consent field**. If no consent field is present, the site owner has determined they do not need to ask for consent. This might happen, for example, in a form that is already explicitly a subscribe form. We proceed like normal, and add the user to the list. 
2. **Implied consent**. If a consent field is present but without the checkbox, that means that by submitting the form, the visitor is agreeing to terms, so we can proceed like normal and add them to the list. 
3. **Explicit consent**. If a consent field is present, and if the site owner is displaying a checkbox, then we will only add the user to a MailPoet list if the checkbox is checked. Basically, the site owner is asking for consent, the visitor did not give it, so we do not add them. 
   
In a follow up PR, we'll show an option in the MailPoet integration card to add the consent field and checkbox to the form as well. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
See linear issue above. 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Enable MailPoet feature flag:
* Add a form to a page and open the Integrations modal.
* If needed install and activate MailPoet from the modal, and add you MailPoet key. 
* Select a list to add your contact too. 
* TESTS
   - **No consent field:** First, confirm no regressions. Save your form with no consent field, go to frontend, submit form, then check that your contact info **IS** added to MailPoet. 
  - **Implied consent:** Second, add a consent field but do not show the checkbox. Save, go to frontend, submit form, then check that your contact info **IS** added to MailPoet.
  - **Explicit consent: Yes.** Third, update consent field to show checkbox. Save, go to frontend, fill out form and **DO check consent**, submit form, then check that your contact info **IS** added to MailPoet.
  - **Explicit consent: No.** Fourth, reload frontend form,  fill out form and **DO NOT check consent**, submit form, and confirm your contact info **IS NOT** been added to MailPoet. 
