### PR TITLE
Fix onboarding e2e test

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-onboarding-e2e-test
+++ b/projects/plugins/jetpack/changelog/fix-onboarding-e2e-test
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Fixed onboarding e2e tests.

--- a/projects/plugins/jetpack/tests/e2e/helpers/onboarding.ts
+++ b/projects/plugins/jetpack/tests/e2e/helpers/onboarding.ts
@@ -64,7 +64,7 @@ export class Onboarding {
 	}
 
 	/**
-	 * Approves the user connection by clicking on the "Connect my site" button.
+	 * Approves the user connection by clicking on the "Connect account" button.
 	 * It assumes that
 	 * - the user is already logged in to wp.com.
 	 * - we are on the wp.com connect page.
@@ -85,9 +85,9 @@ export class Onboarding {
 			{ timeout: DEFAULT_TIMEOUT }
 		);
 
-		logger.info( 'Click on "Connect my site" button and wait for redirect to My Jetpack' );
+		logger.info( 'Click on "Connect account" button and wait for redirect to My Jetpack' );
 
-		const approveButton = this.page.getByRole( 'button', { name: 'Connect my site', exact: true } );
+		const approveButton = this.page.getByRole( 'button', { name: 'Connect account', exact: true } );
 
 		return Promise.all( [ waitForMyJetpackPage, approveButton.click() ] );
 	}


### PR DESCRIPTION
Following https://github.com/Automattic/wp-calypso/pull/105149, E2E tests for onboarding are broken.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Update the CTA for connect button

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* CI should be all green