### PR TITLE
Remove unused dependencies from publicize-components

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1336,18 +1336,12 @@ importers:
       clsx:
         specifier: 2.1.1
         version: 2.1.1
-      moment:
-        specifier: 2.30.1
-        version: 2.30.1
       prop-types:
         specifier: 15.8.1
         version: 15.8.1
       react-page-visibility:
         specifier: 7.0.0
         version: 7.0.0(react@18.3.1)
-      rememo:
-        specifier: 4.0.1
-        version: 4.0.1
     devDependencies:
       '@automattic/color-studio':
         specifier: 4.1.0
@@ -14837,9 +14831,6 @@ packages:
 
   remark-stringify@11.0.0:
     resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
-
-  rememo@4.0.1:
-    resolution: {integrity: sha512-x/T5q/pCDh8k4OlvJGqkI3eO+O8hmJv9HhJHo4avwlluwUpDbteDvyqw1PTarEITkeH9bfW6GSKeRke+XKgykw==}
 
   rememo@4.0.2:
     resolution: {integrity: sha512-NVfSP9NstE3QPNs/TnegQY0vnJnstKQSpcrsI2kBTB3dB2PkdfKdTa+abbjMIDqpc63fE5LfjLgfMst0ULMFxQ==}
@@ -29703,8 +29694,6 @@ snapshots:
       '@types/mdast': 4.0.4
       mdast-util-to-markdown: 2.1.2
       unified: 11.0.5
-
-  rememo@4.0.1: {}
 
   rememo@4.0.2: {}
 

--- a/projects/js-packages/publicize-components/changelog/remove-unused-dependencies
+++ b/projects/js-packages/publicize-components/changelog/remove-unused-dependencies
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Removed unused dependencies.

--- a/projects/js-packages/publicize-components/package.json
+++ b/projects/js-packages/publicize-components/package.json
@@ -56,10 +56,8 @@
 		"@wordpress/plugins": "7.28.0",
 		"@wordpress/url": "4.28.0",
 		"clsx": "2.1.1",
-		"moment": "2.30.1",
 		"prop-types": "15.8.1",
-		"react-page-visibility": "7.0.0",
-		"rememo": "4.0.1"
+		"react-page-visibility": "7.0.0"
 	},
 	"devDependencies": {
 		"@automattic/color-studio": "4.1.0",


### PR DESCRIPTION
`moment` and `rememo` are no longer used in `publicize-components` and thus we should remove them from the list of dependencies

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Remove `moment` and `rememo` from `publicize-components` dependencies as they are no longer used.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Confirm that those dependencies are no longer used in the package
* CI should be happy?

