### PR TITLE
Admin Menu: Remove "Tools > Monetize"

### DIFF
--- a/projects/packages/masterbar/changelog/dotcom-13810-untangling-ia-show-jetpack-monetize-menu
+++ b/projects/packages/masterbar/changelog/dotcom-13810-untangling-ia-show-jetpack-monetize-menu
@@ -1,0 +1,4 @@
+Significance: minor
+Type: removed
+
+Admin Menu: Remove "Tools > Monetize"

--- a/projects/packages/masterbar/src/admin-menu/class-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-admin-menu.php
@@ -345,12 +345,6 @@ class Admin_Menu extends Base_Admin_Menu {
 		$this->update_submenus( 'tools.php', $submenus_to_update );
 
 		$this->hide_submenu_page( 'tools.php', 'delete-blog' );
-
-		// Temporary "Tools > Monetize" menu for existing users that shows a callout informing that the screen has moved to "Jetpack > Monetize".
-		if ( ! $this->use_wp_admin_interface() && get_current_user_id() < 268854000 ) {
-			// @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
-			add_submenu_page( 'tools.php', esc_attr__( 'Monetize', 'jetpack-masterbar' ), __( 'Monetize', 'jetpack-masterbar' ), 'manage_options', 'https://wordpress.com/earn/jetpack-monetize/' . $this->domain, null, 2 );
-		}
 	}
 
 	/**

--- a/projects/packages/masterbar/tests/php/Admin_Menu_Test.php
+++ b/projects/packages/masterbar/tests/php/Admin_Menu_Test.php
@@ -311,8 +311,8 @@ class Admin_Menu_Test extends TestCase {
 
 		static::$admin_menu->add_tools_menu();
 
-		$this->assertSame( 'https://wordpress.com/import/' . static::$domain, $submenu['tools.php'][3][2] );
-		$this->assertSame( 'https://wordpress.com/export/' . static::$domain, $submenu['tools.php'][4][2] );
+		$this->assertSame( 'https://wordpress.com/import/' . static::$domain, $submenu['tools.php'][2][2] );
+		$this->assertSame( 'https://wordpress.com/export/' . static::$domain, $submenu['tools.php'][3][2] );
 	}
 
 	/**


### PR DESCRIPTION
Part of DOTCOM-13811

## Proposed changes:

Removes the "Tools > Monetize" menu which was deprecated as of https://github.com/Automattic/jetpack/pull/44216 in favor of "Jetpack > Monetize".

Before | After
--- | ---
<img width="556" height="158" alt="Screenshot 2025-08-12 at 10 32 14" src="https://github.com/user-attachments/assets/01702f5e-6873-4695-a18c-47f1d7dbdc72" /> | <img width="557" height="129" alt="Screenshot 2025-08-12 at 10 33 46" src="https://github.com/user-attachments/assets/ad7e31bb-a027-4637-be68-de88c314b697" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
- Apply these changes to your WP.com site
- Make sure that "Tools > Monetize" is not visible with the default admin interface

