### PR TITLE
Admin Menu: Remove "Users > Subscribers"

### DIFF
--- a/projects/packages/masterbar/changelog/dotcom-13885-untangling-ia-remove-users-subscribers-menu
+++ b/projects/packages/masterbar/changelog/dotcom-13885-untangling-ia-remove-users-subscribers-menu
@@ -1,0 +1,4 @@
+Significance: minor
+Type: removed
+
+Admin Menu: Remove "Users > Subscribers"

--- a/projects/packages/masterbar/src/admin-menu/class-atomic-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-atomic-admin-menu.php
@@ -136,12 +136,6 @@ class Atomic_Admin_Menu extends Admin_Menu {
 			);
 			$this->update_submenus( $slug, $submenus_to_update );
 		}
-
-		// Temporary "Users > Subscribers" menu for existing users that shows a callout informing that the screen has moved to "Jetpack > Subscribers".
-		if ( ! $this->use_wp_admin_interface() && ! apply_filters( 'jetpack_wp_admin_subscriber_management_enabled', false ) && get_current_user_id() < 268854000 ) {
-			// // @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
-			add_submenu_page( 'users.php', esc_attr__( 'Subscribers', 'jetpack-masterbar' ), __( 'Subscribers', 'jetpack-masterbar' ), 'list_users', 'https://wordpress.com/subscribers/jetpack-subscribers/' . $this->domain, null );
-		}
 	}
 
 	/**

--- a/projects/packages/masterbar/src/admin-menu/class-wpcom-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-wpcom-admin-menu.php
@@ -270,12 +270,6 @@ class WPcom_Admin_Menu extends Admin_Menu {
 		$this->update_submenus( $slug, $submenus_to_update );
 		// @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
 		add_submenu_page( 'users.php', esc_attr__( 'Add New User', 'jetpack-masterbar' ), __( 'Add New User', 'jetpack-masterbar' ), 'promote_users', 'https://wordpress.com/people/new/' . $this->domain, null, 1 );
-
-		// Temporary "Users > Subscribers" menu for existing users that shows a callout informing that the screen has moved to "Jetpack > Subscribers".
-		if ( ! apply_filters( 'jetpack_wp_admin_subscriber_management_enabled', false ) && get_current_user_id() < 268854000 ) {
-			// @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
-			add_submenu_page( 'users.php', esc_attr__( 'Subscribers', 'jetpack-masterbar' ), __( 'Subscribers', 'jetpack-masterbar' ), 'list_users', 'https://wordpress.com/subscribers/jetpack-subscribers/' . $this->domain, null, 3 );
-		}
 	}
 
 	/**


### PR DESCRIPTION
Part of DOTCOM-13885

## Proposed changes:

Removes the "Users > Subscribers" menu which was deprecated as of https://github.com/Automattic/jetpack/pull/44302 in favor of "Jetpack > Subscribers".

Before | After
--- | ---
<img width="440" height="139" alt="Screenshot 2025-08-12 at 10 50 39" src="https://github.com/user-attachments/assets/cc236541-7319-44f0-92d1-cdb5f1d0c252" /> | <img width="438" height="113" alt="Screenshot 2025-08-12 at 10 51 34" src="https://github.com/user-attachments/assets/204e8cba-367a-4053-8c8c-af4644ce0a3b" />



### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
- Apply these changes to your WP.com site
- Make sure that "Users > Subscribers" is not visible with the default admin interface

