### PR TITLE
Admin Menu: Remove "Settings > Podcasting"

### DIFF
--- a/projects/packages/masterbar/changelog/dotcom-13937-untangling-ia-remove-settings-podcasting-menu
+++ b/projects/packages/masterbar/changelog/dotcom-13937-untangling-ia-remove-settings-podcasting-menu
@@ -1,0 +1,4 @@
+Significance: minor
+Type: removed
+
+Admin Menu: Remove "Settings > Podcasting"

--- a/projects/packages/masterbar/src/admin-menu/class-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-admin-menu.php
@@ -387,12 +387,6 @@ class Admin_Menu extends Base_Admin_Menu {
 			// @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
 			add_submenu_page( 'options-general.php', esc_attr__( 'Newsletter', 'jetpack-masterbar' ), __( 'Newsletter', 'jetpack-masterbar' ), 'manage_options', 'https://wordpress.com/settings/jetpack-newsletter/' . $this->domain, null, 7 );
 		}
-
-		// Temporary "Settings > Podcasting" menu for existing users that shows a callout informing that the screen has moved to "Jetpack > Podcasting".
-		if ( get_current_user_id() < 268901000 ) {
-			// @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
-			add_submenu_page( 'options-general.php', esc_attr__( 'Podcasting', 'jetpack-masterbar' ), __( 'Podcasting', 'jetpack-masterbar' ), 'manage_options', 'https://wordpress.com/settings/jetpack-podcasting/' . $this->domain, null, 8 );
-		}
 	}
 
 	/**


### PR DESCRIPTION
Part of DOTCOM-13937

## Proposed changes:

Removes the "Settings > Podcasting" menu which was deprecated as of https://github.com/Automattic/jetpack/pull/44367 in favor of "Jetpack > Podcasting".

Before | After
--- | ---
<img width="558" height="293" alt="Screenshot 2025-08-12 at 11 04 06" src="https://github.com/user-attachments/assets/95db1dbe-e2d9-49dc-9bf7-7b0ff6646bf1" /> | <img width="558" height="266" alt="Screenshot 2025-08-12 at 11 05 11" src="https://github.com/user-attachments/assets/572637c3-f753-4c84-be7c-65977c195388" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
- Apply these changes to your WP.com site
- Make sure that "Settings > Podcasting" is not visible with the default admin interface

