### PR TITLE
Forms: defer loading JS for more responsive page loading

### DIFF
--- a/projects/packages/forms/changelog/update-forms-defer-js
+++ b/projects/packages/forms/changelog/update-forms-defer-js
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: defer loading JS for more responsive page loading.

--- a/projects/packages/forms/changelog/update-forms-defer-js
+++ b/projects/packages/forms/changelog/update-forms-defer-js
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Forms: defer loading JS for more responsive page loading.

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -597,6 +597,7 @@ class Contact_Form_Block {
 			__FILE__,
 			array(
 				'in_footer'  => true,
+				'strategy'   => 'defer',
 				'textdomain' => 'jetpack-forms',
 				'enqueue'    => true,
 			)

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -41,11 +41,7 @@ class Contact_Form_Block {
 		Blocks::jetpack_register_block(
 			'jetpack/contact-form',
 			array(
-				'render_callback'     => array( __CLASS__, 'gutenblock_render_form' ),
-				'js_loading_strategy' => array(
-					'in_footer' => true,
-					'strategy'  => 'defer',
-				),
+				'render_callback' => array( __CLASS__, 'gutenblock_render_form' ),
 			)
 		);
 
@@ -278,14 +274,10 @@ class Contact_Form_Block {
 		Blocks::jetpack_register_block(
 			'jetpack/field-date',
 			array(
-				'render_callback'     => array( Contact_Form_Plugin::class, 'gutenblock_render_field_date' ),
-				'provides_context'    => array(
+				'render_callback'  => array( Contact_Form_Plugin::class, 'gutenblock_render_field_date' ),
+				'provides_context' => array(
 					'jetpack/field-required'    => 'required',
 					'jetpack/field-date-format' => 'dateFormat',
-				),
-				'js_loading_strategy' => array(
-					'in_footer' => true,
-					'strategy'  => 'defer',
 				),
 			)
 		);
@@ -365,13 +357,9 @@ class Contact_Form_Block {
 		Blocks::jetpack_register_block(
 			'jetpack/field-file',
 			array(
-				'render_callback'     => array( Contact_Form_Plugin::class, 'gutenblock_render_field_file' ),
-				'provides_context'    => array( 'jetpack/field-required' => 'required' ),
-				'plan_check'          => apply_filters( 'jetpack_unauth_file_upload_plan_check', true ),
-				'js_loading_strategy' => array(
-					'in_footer' => true,
-					'strategy'  => 'defer',
-				),
+				'render_callback'  => array( Contact_Form_Plugin::class, 'gutenblock_render_field_file' ),
+				'provides_context' => array( 'jetpack/field-required' => 'required' ),
+				'plan_check'       => apply_filters( 'jetpack_unauth_file_upload_plan_check', true ),
 			)
 		);
 
@@ -386,25 +374,17 @@ class Contact_Form_Block {
 			Blocks::jetpack_register_block(
 				'jetpack/field-rating',
 				array(
-					'render_callback'     => array( Contact_Form_Plugin::class, 'gutenblock_render_field_rating' ),
-					'provides_context'    => array(
+					'render_callback'  => array( Contact_Form_Plugin::class, 'gutenblock_render_field_rating' ),
+					'provides_context' => array(
 						'jetpack/field-required' => 'required',
-					),
-					'js_loading_strategy' => array(
-						'in_footer' => true,
-						'strategy'  => 'defer',
 					),
 				)
 			);
 			Blocks::jetpack_register_block(
 				'jetpack/field-slider',
 				array(
-					'render_callback'     => array( Contact_Form_Plugin::class, 'gutenblock_render_field_slider' ),
-					'provides_context'    => array( 'jetpack/field-required' => 'required' ),
-					'js_loading_strategy' => array(
-						'in_footer' => true,
-						'strategy'  => 'defer',
-					),
+					'render_callback'  => array( Contact_Form_Plugin::class, 'gutenblock_render_field_slider' ),
+					'provides_context' => array( 'jetpack/field-required' => 'required' ),
 				)
 			);
 			Blocks::jetpack_register_block(

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -41,7 +41,11 @@ class Contact_Form_Block {
 		Blocks::jetpack_register_block(
 			'jetpack/contact-form',
 			array(
-				'render_callback' => array( __CLASS__, 'gutenblock_render_form' ),
+				'render_callback'     => array( __CLASS__, 'gutenblock_render_form' ),
+				'js_loading_strategy' => array(
+					'in_footer' => true,
+					'strategy'  => 'defer',
+				),
 			)
 		);
 
@@ -274,10 +278,14 @@ class Contact_Form_Block {
 		Blocks::jetpack_register_block(
 			'jetpack/field-date',
 			array(
-				'render_callback'  => array( Contact_Form_Plugin::class, 'gutenblock_render_field_date' ),
-				'provides_context' => array(
+				'render_callback'     => array( Contact_Form_Plugin::class, 'gutenblock_render_field_date' ),
+				'provides_context'    => array(
 					'jetpack/field-required'    => 'required',
 					'jetpack/field-date-format' => 'dateFormat',
+				),
+				'js_loading_strategy' => array(
+					'in_footer' => true,
+					'strategy'  => 'defer',
 				),
 			)
 		);
@@ -357,9 +365,13 @@ class Contact_Form_Block {
 		Blocks::jetpack_register_block(
 			'jetpack/field-file',
 			array(
-				'render_callback'  => array( Contact_Form_Plugin::class, 'gutenblock_render_field_file' ),
-				'provides_context' => array( 'jetpack/field-required' => 'required' ),
-				'plan_check'       => apply_filters( 'jetpack_unauth_file_upload_plan_check', true ),
+				'render_callback'     => array( Contact_Form_Plugin::class, 'gutenblock_render_field_file' ),
+				'provides_context'    => array( 'jetpack/field-required' => 'required' ),
+				'plan_check'          => apply_filters( 'jetpack_unauth_file_upload_plan_check', true ),
+				'js_loading_strategy' => array(
+					'in_footer' => true,
+					'strategy'  => 'defer',
+				),
 			)
 		);
 
@@ -374,17 +386,25 @@ class Contact_Form_Block {
 			Blocks::jetpack_register_block(
 				'jetpack/field-rating',
 				array(
-					'render_callback'  => array( Contact_Form_Plugin::class, 'gutenblock_render_field_rating' ),
-					'provides_context' => array(
+					'render_callback'     => array( Contact_Form_Plugin::class, 'gutenblock_render_field_rating' ),
+					'provides_context'    => array(
 						'jetpack/field-required' => 'required',
+					),
+					'js_loading_strategy' => array(
+						'in_footer' => true,
+						'strategy'  => 'defer',
 					),
 				)
 			);
 			Blocks::jetpack_register_block(
 				'jetpack/field-slider',
 				array(
-					'render_callback'  => array( Contact_Form_Plugin::class, 'gutenblock_render_field_slider' ),
-					'provides_context' => array( 'jetpack/field-required' => 'required' ),
+					'render_callback'     => array( Contact_Form_Plugin::class, 'gutenblock_render_field_slider' ),
+					'provides_context'    => array( 'jetpack/field-required' => 'required' ),
+					'js_loading_strategy' => array(
+						'in_footer' => true,
+						'strategy'  => 'defer',
+					),
 				)
 			);
 			Blocks::jetpack_register_block(

--- a/projects/plugins/jetpack/changelog/update-forms-defer-js
+++ b/projects/plugins/jetpack/changelog/update-forms-defer-js
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: defer loading JS for more responsive page loading.

--- a/projects/plugins/jetpack/changelog/update-forms-defer-js
+++ b/projects/plugins/jetpack/changelog/update-forms-defer-js
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Forms: defer loading JS for more responsive page loading.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Follow-up to a new feature in WP which allows deferring JS loading:
- https://github.com/Automattic/jetpack/issues/44547
- https://github.com/Automattic/jetpack/pull/44734

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Defer loading Forms JS to avoid blocking rendering until JS has finished loading, making page render feel quicker and improve Google page vitals.

Note that WP Interactivity API modules (`view.js` files for each interactive field, and the form block itself) still load in the header, and [`wp_enqueue_script_module`](https://developer.wordpress.org/reference/functions/wp_enqueue_script_module/) doesn't offer way to change it. That's fine, as modules are deferred by default:

> There is no need to use the defer attribute (see [<script> attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/script#attributes)) when loading a module script; modules are deferred automatically.
> [via](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules#other_differences_between_modules_and_classic_scripts)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Publish a form with date, file, rating and slider fields.
* See from source HTML now mark script as deferred:
<img width="1919" height="102" alt="Screenshot 2025-08-12 at 13 47 33" src="https://github.com/user-attachments/assets/4d1b2c50-7780-4d77-9525-385eba74d00a" />

* See from network tab loading happen at "low" priority (you might need to enable Priority colum):
<img width="1297" height="736" alt="Screenshot 2025-08-12 at 14 01 03" src="https://github.com/user-attachments/assets/0a6dc3bf-d600-4793-b1ee-922050f85332" />
