### PR TITLE
Critical CSS Gen: Update stylesheet check to be looser

### DIFF
--- a/projects/js-packages/critical-css-gen/changelog/update-less-stricter-rel-check
+++ b/projects/js-packages/critical-css-gen/changelog/update-less-stricter-rel-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix not picking up stylesheets when their rel attribute was more complex.

--- a/projects/js-packages/critical-css-gen/src/browser-interface.ts
+++ b/projects/js-packages/critical-css-gen/src/browser-interface.ts
@@ -63,7 +63,7 @@ export class BrowserInterface {
 	static innerGetCssIncludes( { innerWindow } ) {
 		innerWindow = null === innerWindow ? window : innerWindow;
 		return [ ...innerWindow.document.getElementsByTagName( 'link' ) ]
-			.filter( link => link.rel === 'stylesheet' )
+			.filter( link => link.rel.includes( 'stylesheet' ) )
 			.reduce( ( set, link ) => {
 				set[ link.href ] = {
 					media: link.media || null,

--- a/projects/js-packages/critical-css-gen/tests/data/page-a/index.html
+++ b/projects/js-packages/critical-css-gen/tests/data/page-a/index.html
@@ -5,7 +5,7 @@
 		<link rel="stylesheet" href="print.css" media="print" />
 		<link rel="stylesheet" href="min-width.css" media="(min-width: 50px)" />
 		<link
-			rel="stylesheet"
+			rel="preload stylesheet"
 			type="text/css"
 			media="only screen and (max-device-width: 480px) and (orientation: landscape)"
 			href="complex-rules.css"

--- a/projects/plugins/boost/changelog/update-critical-css-gen-less-stricter-rel-check
+++ b/projects/plugins/boost/changelog/update-critical-css-gen-less-stricter-rel-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Critical CSS: Fix failing generation when a stylesheet had a more complex rel attribute.


### PR DESCRIPTION
Fixes HOG-286

## Proposed changes:

* Update rel check when collecting stylesheets from the page, to be less stricter;
* Update test page to include a more complex rel attribute for one of the stylesheets.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

Internal reference: p1754983805405499-slack-C016BBAFHHS

## Does this pull request change what data or activity we track or use?

no

## Testing instructions:

**Pre-requisites**

- Add this snippet to your website:

```php
add_action( 'template_redirect', function () {
	ob_start( function ( $buffer ) {
		$buffer = str_replace( "rel='stylesheet'", "rel='preload stylesheet'", $buffer );
		return $buffer;
	} );
} );
```

- It will convert regular stylesheets to preload ones. This will also break the manual Critical CSS generation on trunk/production (in theory it should also break Cloud CSS generation).

- After adding it, check the source of your page to confirm that stylesheets show up with `rel='preload stylesheet'`. If they don't, check if they are maybe using double quotes and update the snippet if so.

- Next, add this snippet to limit the amount of pages Critical CSS generation is going to run for:

```php
add_filter( 'jetpack_boost_critical_css_providers', 'jb_sanitize_critical_css_providers', 999999 );
function jb_sanitize_critical_css_providers( $providers ) {
	$sanitized_providers = array();
	foreach ( $providers as $provider ) {
		if ( strpos( $provider['key'], 'cornerstone_' ) === 0 ) {
			$sanitized_providers[] = $provider;
		}
	}

	return $sanitized_providers;
}
```

- This limits generation to only the home page.
- Setup Boost free as it's easiest to test this with manual CSS generation.

### (new behavior) Test that it works

- Try to generate Critical CSS - it should complete without an error.

### (old behavior) Test that it breaks

- Try to generate Critical cSS - it should fail saying that there are no stylesheets found on the page.