### PR TITLE
Forms: Refactor rating-input block name to input-rating

### DIFF
--- a/projects/packages/forms/changelog/update-forms-rating-field
+++ b/projects/packages/forms/changelog/update-forms-rating-field
@@ -1,4 +1,4 @@
 Significance: patch
-Type: enhancement
+Type: changed
 
 Update rating field implementation with improved styling and visual feedback

--- a/projects/packages/forms/changelog/update-forms-rating-field
+++ b/projects/packages/forms/changelog/update-forms-rating-field
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Update rating field implementation with improved styling and visual feedback

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -228,7 +228,7 @@ class Contact_Form_Block {
 
 		if ( Blocks::get_variation() === 'beta' ) {
 			Blocks::jetpack_register_block(
-				'jetpack/rating-input',
+				'jetpack/input-rating',
 				array(
 					'supports' => array(
 						'color'      => array(

--- a/projects/packages/forms/src/blocks/field-rating/edit.js
+++ b/projects/packages/forms/src/blocks/field-rating/edit.js
@@ -54,7 +54,7 @@ export default function RatingFieldEdit( props ) {
 	} );
 
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
-		allowedBlocks: [ 'jetpack/label', 'jetpack/rating-input' ],
+		allowedBlocks: [ 'jetpack/label', 'jetpack/input-rating' ],
 		template: [
 			[
 				'jetpack/label',
@@ -63,7 +63,7 @@ export default function RatingFieldEdit( props ) {
 					placeholder: __( 'Add label…', 'jetpack-forms' ),
 				},
 			],
-			[ 'jetpack/rating-input', {} ],
+			[ 'jetpack/input-rating', {} ],
 		],
 		templateLock: 'all',
 		__experimentalCaptureToolbars: true,

--- a/projects/packages/forms/src/blocks/field-rating/index.js
+++ b/projects/packages/forms/src/blocks/field-rating/index.js
@@ -67,7 +67,7 @@ const settings = {
 		...defaultSettings.supports,
 	},
 	variations,
-	allowedBlocks: [ 'jetpack/label', 'jetpack/rating-input' ],
+	allowedBlocks: [ 'jetpack/label', 'jetpack/input-rating' ],
 	edit,
 	save,
 	example: {

--- a/projects/packages/forms/src/blocks/input-rating/index.js
+++ b/projects/packages/forms/src/blocks/input-rating/index.js
@@ -5,7 +5,7 @@ import renderMaterialIcon from '../shared/components/render-material-icon';
 import { getIconColor } from '../shared/util/block-icons';
 import edit from './edit';
 
-const name = 'rating-input';
+const name = 'input-rating';
 
 const settings = {
 	apiVersion: 3,

--- a/projects/packages/forms/src/blocks/input-rating/style.scss
+++ b/projects/packages/forms/src/blocks/input-rating/style.scss
@@ -10,6 +10,24 @@
 	.jetpack-field-rating__options {
 		display: flex;
 
+		/* Note: We redefine `.visually-hidden` here
+		   because grunion.css isn't loaded in the editor.
+		   We should follow up with extracting it into a
+		   shared SCSS partial and importing it in both
+		   editor and frontend bundles. */
+		.jetpack-field-rating__input.visually-hidden {
+			position: absolute;
+			width: 1px;
+			height: 1px;
+			padding: 0;
+			margin: -1px;
+			overflow: hidden;
+			clip: rect(0 0 0 0);
+			clip-path: inset(50%);
+			border: 0;
+			white-space: nowrap;
+		}
+
 		.jetpack-field-rating__label {
 			padding-right: 5px;
 
@@ -80,8 +98,6 @@
 				}
 			}
 		}
-
-		/* (duplicates removed) */
 	}
 }
 

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -570,7 +570,7 @@ class Contact_Form_Plugin {
 					continue;
 				}
 
-				if ( 'jetpack/rating-input' === $block_name ) {
+				if ( 'jetpack/input-rating' === $block_name ) {
 					$input_attrs          = self::get_block_support_classes_and_styles( $block_name, $inner_block['attrs'] );
 					$atts['inputclasses'] = isset( $input_attrs['class'] ) ? ' ' . $input_attrs['class'] : '';
 					$atts['inputstyles']  = $input_attrs['style'] ?? null;


### PR DESCRIPTION
## Proposed changes:
* Rename the rating input block from `jetpack/rating-input` to `jetpack/input-rating` for consistency with other input block naming conventions
* Update all references to the block name in PHP and JavaScript files
* Add `.visually-hidden` styles to the input-rating editor side.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A - Block naming refactor for consistency

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

* Go to the WordPress admin dashboard
* Navigate to any post/page editor
* Add a Contact Form block
* Add a Rating Field to the form
* Verify the rating field still works correctly with the renamed block
* Check that the rating field displays and functions as expected
* Submit the form and verify the rating value is captured correctly
* Check existing forms with rating fields to ensure backward compatibility

### Technical details:
* Block name changed from `jetpack/rating-input` to `jetpack/input-rating`
* This aligns with the naming convention of other input blocks in the forms package
* Added necessary accessibility styles for visually hidden inputs