### PR TITLE
Blocks: Move js loading strategy check to a more appropriate place

### DIFF
--- a/projects/packages/blocks/changelog/update-jetpack-blocks-remove-unnecessary-check
+++ b/projects/packages/blocks/changelog/update-jetpack-blocks-remove-unnecessary-check
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Move some code around to reduce checks.
+
+

--- a/projects/packages/blocks/src/class-blocks.php
+++ b/projects/packages/blocks/src/class-blocks.php
@@ -109,11 +109,11 @@ class Blocks {
 			if ( ! isset( $args['editor_style'] ) ) {
 				$args['editor_style'] = 'jetpack-blocks-editor';
 			}
-		}
 
-		// Keep track of the JS loading strategy for any block that specifies it.
-		if ( isset( $args['js_loading_strategy'] ) && class_exists( 'Jetpack_Gutenberg' ) ) {
-			Jetpack_Gutenberg::set_block_js_loading_strategy( $feature_name, $args['js_loading_strategy'] );
+			// Keep track of the JS loading strategy for any block that specifies it.
+			if ( isset( $args['js_loading_strategy'] ) ) {
+				Jetpack_Gutenberg::set_block_js_loading_strategy( $feature_name, $args['js_loading_strategy'] );
+			}
 		}
 
 		return register_block_type( $block_type, $args );


### PR DESCRIPTION
Addresses suggestion from already merged PR - https://github.com/Automattic/jetpack/pull/44734#discussion_r2269437683

There was already a check if the class exists within `is_standalone_block`. This PR just moves the code inside the check.

## Proposed changes:

* Move some code around to avoid doing an unnecessary check.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

https://github.com/Automattic/jetpack/pull/44734#discussion_r2269437683

## Does this pull request change what data or activity we track or use?

no

## Testing instructions:

- Make sure the changes make sense, functionally wise - there should be no difference to how it worked before.