### PR TITLE
Forms: Add has_field_type method to Feedback class

### DIFF
--- a/projects/packages/forms/changelog/add-forms-feedback-has-field-type-method
+++ b/projects/packages/forms/changelog/add-forms-feedback-has-field-type-method
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: Add has_field_type method to Feedback.

--- a/projects/packages/forms/src/contact-form/class-feedback.php
+++ b/projects/packages/forms/src/contact-form/class-feedback.php
@@ -290,6 +290,21 @@ class Feedback {
 	}
 
 	/**
+	 * Check whether this feedback contains at least one field of a given type.
+	 *
+	 * @param string $type Field type to check for (e.g. 'consent', 'email', 'textarea').
+	 * @return bool True if a field of the given type exists; false otherwise.
+	 */
+	public function has_field_type( $type ) {
+		foreach ( $this->fields as $field ) {
+			if ( method_exists( $field, 'get_type' ) && $field->get_type() === $type ) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
 	 * Get the values related to where the form was submitted from.
 	 *
 	 * @return array An array of entry values.

--- a/projects/packages/forms/src/contact-form/class-feedback.php
+++ b/projects/packages/forms/src/contact-form/class-feedback.php
@@ -297,7 +297,7 @@ class Feedback {
 	 */
 	public function has_field_type( $type ) {
 		foreach ( $this->fields as $field ) {
-			if ( method_exists( $field, 'get_type' ) && $field->get_type() === $type ) {
+			if ( $field->get_type() === $type ) {
 				return true;
 			}
 		}

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Test.php
@@ -1773,4 +1773,4 @@ class Feedback_Test extends BaseTestCase {
 		$this->assertTrue( $response->has_field_type( 'consent' ), 'Legacy feedback should report consent field exists' );
 		$this->assertFalse( $response->has_consent(), 'Legacy consent should default to false (no)' );
 	}
-} // end class
+}

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Test.php
@@ -1695,4 +1695,59 @@ class Feedback_Test extends BaseTestCase {
 		$this->assertNotEmpty( $response_legacy, 'Legacy values should not be empty for the legacy feedback' );
 		$this->assertEquals( $expected_legacy_values, $response_legacy, 'Legacy extra values should match the expected extra values' );
 	}
-}
+
+	public function test_has_field_type_with_consent_explicit_checked() {
+		$form_id = Utility::get_form_id();
+
+		$_post_data = Utility::get_post_request(
+			array(
+				'email'   => 'email@example.com',
+				'consent' => 'Yes',
+			),
+			'g' . $form_id
+		);
+
+		$form = new Contact_Form(
+			array(
+				'title'       => 'Test Form',
+				'description' => 'This is a test form.',
+			),
+			"[contact-field label='Email' type='email' required='1'/]"
+			. "[contact-field label='Consent' type='consent' required='1'/]"
+		);
+
+		$response         = Feedback::from_submission( $_post_data, $form );
+		$feedback_post_id = $response->save();
+		$saved_response   = Feedback::get( $feedback_post_id );
+
+		$this->assertTrue( $saved_response->has_field_type( 'consent' ), 'Feedback should report consent field exists' );
+		$this->assertTrue( $saved_response->has_consent(), 'Consent should be granted when posted as Yes' );
+	}
+
+	public function test_has_field_type_without_consent_field() {
+		$form_id = Utility::get_form_id();
+
+		$_post_data = Utility::get_post_request(
+			array(
+				'email' => 'email@example.com',
+			),
+			'g' . $form_id
+		);
+
+		$form = new Contact_Form(
+			array(
+				'title'       => 'Test Form',
+				'description' => 'This is a test form.',
+			),
+			"[contact-field label='Email' type='email' required='1'/]"
+			. "[contact-field label='Message' type='textarea'/]"
+		);
+
+		$response         = Feedback::from_submission( $_post_data, $form );
+		$feedback_post_id = $response->save();
+		$saved_response   = Feedback::get( $feedback_post_id );
+
+		$this->assertFalse( $saved_response->has_field_type( 'consent' ), 'Feedback should report no consent field' );
+		$this->assertFalse( $saved_response->has_consent(), 'Consent should be false when no consent field was present' );
+	}
+} // end class

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Test.php
@@ -1750,4 +1750,4 @@ class Feedback_Test extends BaseTestCase {
 		$this->assertFalse( $saved_response->has_field_type( 'consent' ), 'Feedback should report no consent field' );
 		$this->assertFalse( $saved_response->has_consent(), 'Consent should be false when no consent field was present' );
 	}
-} // end class
+}

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Test.php
@@ -1720,8 +1720,12 @@ class Feedback_Test extends BaseTestCase {
 		$feedback_post_id = $response->save();
 		$saved_response   = Feedback::get( $feedback_post_id );
 
-		$this->assertTrue( $saved_response->has_field_type( 'consent' ), 'Feedback should report consent field exists' );
-		$this->assertTrue( $saved_response->has_consent(), 'Consent should be granted when posted as Yes' );
+		// Check both the in-memory response and the saved one return the same values.
+		$this->assertTrue( $response->has_field_type( 'consent' ), 'Feedback (response) should report consent field exists' );
+		$this->assertTrue( $response->has_consent(), 'Consent (response) should be granted when posted as Yes' );
+
+		$this->assertTrue( $saved_response->has_field_type( 'consent' ), 'Feedback (saved) should report consent field exists' );
+		$this->assertTrue( $saved_response->has_consent(), 'Consent (saved) should be granted when posted as Yes' );
 	}
 
 	public function test_has_field_type_without_consent_field() {
@@ -1747,7 +1751,26 @@ class Feedback_Test extends BaseTestCase {
 		$feedback_post_id = $response->save();
 		$saved_response   = Feedback::get( $feedback_post_id );
 
-		$this->assertFalse( $saved_response->has_field_type( 'consent' ), 'Feedback should report no consent field' );
-		$this->assertFalse( $saved_response->has_consent(), 'Consent should be false when no consent field was present' );
+		// Check both the in-memory response and the saved one return the same values.
+		$this->assertFalse( $response->has_field_type( 'consent' ), 'Feedback (response) should report no consent field' );
+		$this->assertFalse( $response->has_consent(), 'Consent (response) should be false when no consent field was present' );
+
+		$this->assertFalse( $saved_response->has_field_type( 'consent' ), 'Feedback (saved) should report no consent field' );
+		$this->assertFalse( $saved_response->has_consent(), 'Consent (saved) should be false when no consent field was present' );
 	}
-}
+
+	public function test_has_field_type_legacy_feedback() {
+		// Create a legacy feedback entry and verify has_field_type/has_consent behavior.
+		$post_id  = Utility::create_legacy_feedback(
+			array(
+				'1_field' => 'value1',
+				'2_field' => 'value2',
+			)
+		);
+		$response = Feedback::get( $post_id );
+
+		// Legacy entries include an 'email_marketing_consent' field (default 'no'), typed as 'consent'.
+		$this->assertTrue( $response->has_field_type( 'consent' ), 'Legacy feedback should report consent field exists' );
+		$this->assertFalse( $response->has_consent(), 'Legacy consent should default to false (no)' );
+	}
+} // end class

--- a/projects/plugins/jetpack/changelog/add-forms-feedback-has-field-type-method
+++ b/projects/plugins/jetpack/changelog/add-forms-feedback-has-field-type-method
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: Add has_field_type method to Feedback.


### PR DESCRIPTION
## Proposed changes:

Adds a new has_field_type() method to our new Feedback class. This would allow us to do something like this when processing or working with form data: 

```
if ( $form->has_field_type('consent') ) {
   // take some action, for example, for integrations or email lists
}
```

Note: This PR doesn't use the method yet. I'll use the method in a subsequent PR for checking consent around MailPoet integration.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* The added method is fairly simple. Review code.
* Confirm that tests pass. 

