### PR TITLE
Forms: Include HTML id in Feedback classes

### DIFF
--- a/projects/packages/forms/changelog/add-forms-feedback-field-id
+++ b/projects/packages/forms/changelog/add-forms-feedback-field-id
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: Preserve html ids when processing feedback.

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -1371,7 +1371,7 @@ class Contact_Form_Plugin {
 			return false;
 		}
 
-		if ( is_user_logged_in() && ! isset( $_POST['jetpack_contact_form_jwt'] ) ) {
+		if ( is_user_logged_in() ) {
 			check_admin_referer( "contact-form_{$id}" );
 		}
 

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -1371,7 +1371,7 @@ class Contact_Form_Plugin {
 			return false;
 		}
 
-		if ( is_user_logged_in() ) {
+		if ( is_user_logged_in() && ! isset( $_POST['jetpack_contact_form_jwt'] ) ) {
 			check_admin_referer( "contact-form_{$id}" );
 		}
 

--- a/projects/packages/forms/src/contact-form/class-feedback-field.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-field.php
@@ -236,6 +236,18 @@ class Feedback_Field {
 	}
 
 	/**
+	 * Get the original form field ID, if available.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return string|null
+	 */
+	public function get_original_id() {
+		$original_id = $this->get_meta_key_value( 'original_id' );
+		return is_string( $original_id ) && $original_id !== '' ? $original_id : null;
+	}
+
+	/**
 	 * Get the serialized representation of the field.
 	 *
 	 * @return array

--- a/projects/packages/forms/src/contact-form/class-feedback-field.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-field.php
@@ -74,7 +74,7 @@ class Feedback_Field {
 		$this->value         = $value;
 		$this->type          = $type;
 		$this->meta          = $meta;
-		$this->form_field_id = is_string( $form_field_id ) && $form_field_id !== '' ? $form_field_id : null;
+		$this->form_field_id = is_string( $form_field_id ) ? $form_field_id : '';
 	}
 
 	/**
@@ -290,7 +290,7 @@ class Feedback_Field {
 			$data['value'],
 			$data['type'] ?? 'basic',
 			$data['meta'] ?? array(),
-			$data['form_field_id'] ?? null
+			$data['form_field_id'] ?? ''
 		);
 	}
 

--- a/projects/packages/forms/src/contact-form/class-feedback-field.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-field.php
@@ -50,20 +50,31 @@ class Feedback_Field {
 	private $meta;
 
 	/**
+	 * The original form field ID from the form schema.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @var string|null
+	 */
+	protected $form_field_id = null;
+
+	/**
 	 * Constructor.
 	 *
-	 * @param string $key   The key of the field.
-	 * @param mixed  $label The label of the field. Non-string values will be converted to empty string.
-	 * @param mixed  $value The value of the field.
-	 * @param string $type  The type of the field (default is 'basic').
-	 * @param array  $meta  Additional metadata for the field (default is an empty array).
+	 * @param string      $key           The key of the field.
+	 * @param mixed       $label         The label of the field. Non-string values will be converted to empty string.
+	 * @param mixed       $value         The value of the field.
+	 * @param string      $type          The type of the field (default is 'basic').
+	 * @param array       $meta          Additional metadata for the field (default is an empty array).
+	 * @param string|null $form_field_id The original form field ID (default is null).
 	 */
-	public function __construct( $key, $label, $value, $type = 'basic', $meta = array() ) {
-		$this->key   = $key;
-		$this->label = is_string( $label ) ? html_entity_decode( $label, ENT_QUOTES | ENT_HTML5, 'UTF-8' ) : '';
-		$this->value = $value;
-		$this->type  = $type;
-		$this->meta  = $meta;
+	public function __construct( $key, $label, $value, $type = 'basic', $meta = array(), $form_field_id = null ) {
+		$this->key           = $key;
+		$this->label         = is_string( $label ) ? html_entity_decode( $label, ENT_QUOTES | ENT_HTML5, 'UTF-8' ) : '';
+		$this->value         = $value;
+		$this->type          = $type;
+		$this->meta          = $meta;
+		$this->form_field_id = is_string( $form_field_id ) && $form_field_id !== '' ? $form_field_id : null;
 	}
 
 	/**
@@ -105,6 +116,17 @@ class Feedback_Field {
 	 */
 	public function get_value() {
 		return $this->value;
+	}
+
+	/**
+	 * Get the original form field ID.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return string|null
+	 */
+	public function get_form_field_id() {
+		return $this->form_field_id;
 	}
 
 	/**
@@ -236,29 +258,18 @@ class Feedback_Field {
 	}
 
 	/**
-	 * Get the original form field ID, if available.
-	 *
-	 * @since $$next-version$$
-	 *
-	 * @return string|null
-	 */
-	public function get_original_id() {
-		$original_id = $this->get_meta_key_value( 'original_id' );
-		return is_string( $original_id ) && $original_id !== '' ? $original_id : null;
-	}
-
-	/**
 	 * Get the serialized representation of the field.
 	 *
 	 * @return array
 	 */
 	public function serialize() {
 		return array(
-			'key'   => $this->get_key(),
-			'label' => $this->get_label(),
-			'value' => $this->get_value(),
-			'type'  => $this->get_type(),
-			'meta'  => $this->get_meta(),
+			'key'           => $this->get_key(),
+			'label'         => $this->get_label(),
+			'value'         => $this->get_value(),
+			'type'          => $this->get_type(),
+			'meta'          => $this->get_meta(),
+			'form_field_id' => $this->get_form_field_id(),
 		);
 	}
 	/**
@@ -278,7 +289,8 @@ class Feedback_Field {
 			$data['label'],
 			$data['value'],
 			$data['type'] ?? 'basic',
-			$data['meta'] ?? array()
+			$data['meta'] ?? array(),
+			$data['form_field_id'] ?? null
 		);
 	}
 

--- a/projects/packages/forms/src/contact-form/class-feedback-field.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-field.php
@@ -54,9 +54,9 @@ class Feedback_Field {
 	 *
 	 * @since $$next-version$$
 	 *
-	 * @var string|null
+	 * @var string
 	 */
-	protected $form_field_id = null;
+	protected $form_field_id = '';
 
 	/**
 	 * Constructor.
@@ -123,7 +123,7 @@ class Feedback_Field {
 	 *
 	 * @since $$next-version$$
 	 *
-	 * @return string|null
+	 * @return string
 	 */
 	public function get_form_field_id() {
 		return $this->form_field_id;

--- a/projects/packages/forms/src/contact-form/class-feedback.php
+++ b/projects/packages/forms/src/contact-form/class-feedback.php
@@ -1236,8 +1236,7 @@ class Feedback {
 			return null;
 		}
 		foreach ( $this->fields as $field ) {
-			$form_field_id = $field->get_form_field_id();
-			if ( is_string( $form_field_id ) && $form_field_id !== '' && $form_field_id === $id ) {
+			if ( $field->get_form_field_id() === $id ) {
 				return $field;
 			}
 		}

--- a/projects/packages/forms/src/contact-form/class-feedback.php
+++ b/projects/packages/forms/src/contact-form/class-feedback.php
@@ -1023,8 +1023,7 @@ class Feedback {
 					$map_to_field['label'],
 					$value,
 					$map_to_field['type'],
-					array( 'render' => false ),
-					null
+					array( 'render' => false )
 				);
 			}
 		}
@@ -1072,8 +1071,7 @@ class Feedback {
 						$label,
 						$value,
 						'consent',
-						array( 'render' => false ),
-						null
+						array( 'render' => false )
 					);
 					continue;
 				}
@@ -1088,13 +1086,11 @@ class Feedback {
 					$key,
 					$label,
 					$value,
-					'file',
-					array(),
-					null
+					'file'
 				);
 				$this->has_file                   = ! empty( $value['files'] ); // Set has_file to true if any file upload is found.
 			} else {
-				$decoded_fields['fields'][ $key ] = new Feedback_Field( $key, $label, $value, 'basic', array(), null );
+				$decoded_fields['fields'][ $key ] = new Feedback_Field( $key, $label, $value );
 			}
 		}
 	}
@@ -1111,8 +1107,7 @@ class Feedback {
 			'Comment Content',
 			trim( Contact_Form_Plugin::strip_tags( $comment_content ) ),
 			'textarea',
-			array( 'render' => false ),
-			null
+			array( 'render' => false )
 		);
 	}
 
@@ -1161,7 +1156,7 @@ class Feedback {
 			$key   = $i . '_' . $label;
 
 			$meta           = array();
-			$fields[ $key ] = new Feedback_Field( $key, $label, $value, $type, $meta, (string) $field_id );
+			$fields[ $key ] = new Feedback_Field( $key, $label, $value, $type, $meta, $field_id );
 			if ( ! $this->has_file && $fields[ $key ]->has_file() ) {
 				$this->has_file = true;
 			}

--- a/projects/packages/forms/src/contact-form/class-feedback.php
+++ b/projects/packages/forms/src/contact-form/class-feedback.php
@@ -1235,17 +1235,9 @@ class Feedback {
 		if ( ! is_string( $id ) || $id === '' ) {
 			return null;
 		}
-		$needle = strtolower( str_replace( array( ' ', '_' ), '', $id ) );
 		foreach ( $this->fields as $field ) {
-			if ( ! $field instanceof Feedback_Field ) {
-				continue;
-			}
 			$form_field_id = $field->get_form_field_id();
-			if ( ! is_string( $form_field_id ) || $form_field_id === '' ) {
-				continue;
-			}
-			$haystack = strtolower( str_replace( array( ' ', '_' ), '', $form_field_id ) );
-			if ( $haystack === $needle ) {
+			if ( is_string( $form_field_id ) && $form_field_id !== '' && $form_field_id === $id ) {
 				return $field;
 			}
 		}

--- a/projects/packages/forms/src/contact-form/class-feedback.php
+++ b/projects/packages/forms/src/contact-form/class-feedback.php
@@ -1155,7 +1155,8 @@ class Feedback {
 			$label = wp_strip_all_tags( $field->get_attribute( 'label' ) );
 			$key   = $i . '_' . $label;
 
-			$fields[ $key ] = new Feedback_Field( $key, $label, $value, $type );
+			$meta           = array( 'original_id' => (string) $field_id );
+			$fields[ $key ] = new Feedback_Field( $key, $label, $value, $type, $meta );
 			if ( ! $this->has_file && $fields[ $key ]->has_file() ) {
 				$this->has_file = true;
 			}
@@ -1220,5 +1221,51 @@ class Feedback {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Get a field by its original form ID.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param string $id Original form field ID.
+	 * @return Feedback_Field|null
+	 */
+	public function get_field_by_id( $id ) {
+		if ( ! is_string( $id ) || $id === '' ) {
+			return null;
+		}
+		$needle = strtolower( str_replace( array( ' ', '_' ), '', $id ) );
+		foreach ( $this->fields as $field ) {
+			if ( ! $field instanceof Feedback_Field ) {
+				continue;
+			}
+			$original_id = $field->get_original_id();
+			if ( ! is_string( $original_id ) || $original_id === '' ) {
+				continue;
+			}
+			$haystack = strtolower( str_replace( array( ' ', '_' ), '', $original_id ) );
+			if ( $haystack === $needle ) {
+				return $field;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Get a field render value by its original form ID.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param string $id Original form field ID.
+	 * @param string $context Render context.
+	 * @return string
+	 */
+	public function get_field_value_by_id( $id, $context = 'default' ) {
+		$field = $this->get_field_by_id( $id );
+		if ( ! $field ) {
+			return '';
+		}
+		return (string) $field->get_render_value( $context );
 	}
 }

--- a/projects/packages/forms/src/contact-form/class-feedback.php
+++ b/projects/packages/forms/src/contact-form/class-feedback.php
@@ -1023,7 +1023,8 @@ class Feedback {
 					$map_to_field['label'],
 					$value,
 					$map_to_field['type'],
-					array( 'render' => false )
+					array( 'render' => false ),
+					null
 				);
 			}
 		}
@@ -1071,7 +1072,8 @@ class Feedback {
 						$label,
 						$value,
 						'consent',
-						array( 'render' => false )
+						array( 'render' => false ),
+						null
 					);
 					continue;
 				}
@@ -1086,11 +1088,13 @@ class Feedback {
 					$key,
 					$label,
 					$value,
-					'file'
+					'file',
+					array(),
+					null
 				);
 				$this->has_file                   = ! empty( $value['files'] ); // Set has_file to true if any file upload is found.
 			} else {
-				$decoded_fields['fields'][ $key ] = new Feedback_Field( $key, $label, $value );
+				$decoded_fields['fields'][ $key ] = new Feedback_Field( $key, $label, $value, 'basic', array(), null );
 			}
 		}
 	}
@@ -1107,7 +1111,8 @@ class Feedback {
 			'Comment Content',
 			trim( Contact_Form_Plugin::strip_tags( $comment_content ) ),
 			'textarea',
-			array( 'render' => false )
+			array( 'render' => false ),
+			null
 		);
 	}
 
@@ -1155,8 +1160,8 @@ class Feedback {
 			$label = wp_strip_all_tags( $field->get_attribute( 'label' ) );
 			$key   = $i . '_' . $label;
 
-			$meta           = array( 'original_id' => (string) $field_id );
-			$fields[ $key ] = new Feedback_Field( $key, $label, $value, $type, $meta );
+			$meta           = array();
+			$fields[ $key ] = new Feedback_Field( $key, $label, $value, $type, $meta, (string) $field_id );
 			if ( ! $this->has_file && $fields[ $key ]->has_file() ) {
 				$this->has_file = true;
 			}
@@ -1240,11 +1245,11 @@ class Feedback {
 			if ( ! $field instanceof Feedback_Field ) {
 				continue;
 			}
-			$original_id = $field->get_original_id();
-			if ( ! is_string( $original_id ) || $original_id === '' ) {
+			$form_field_id = $field->get_form_field_id();
+			if ( ! is_string( $form_field_id ) || $form_field_id === '' ) {
 				continue;
 			}
-			$haystack = strtolower( str_replace( array( ' ', '_' ), '', $original_id ) );
+			$haystack = strtolower( str_replace( array( ' ', '_' ), '', $form_field_id ) );
 			if ( $haystack === $needle ) {
 				return $field;
 			}

--- a/projects/packages/forms/src/contact-form/class-feedback.php
+++ b/projects/packages/forms/src/contact-form/class-feedback.php
@@ -1231,7 +1231,7 @@ class Feedback {
 	 * @param string $id Original form field ID.
 	 * @return Feedback_Field|null
 	 */
-	public function get_field_by_id( $id ) {
+	public function get_field_by_form_field_id( $id ) {
 		if ( ! is_string( $id ) || $id === '' ) {
 			return null;
 		}
@@ -1253,8 +1253,8 @@ class Feedback {
 	 * @param string $context Render context.
 	 * @return string
 	 */
-	public function get_field_value_by_id( $id, $context = 'default' ) {
-		$field = $this->get_field_by_id( $id );
+	public function get_field_value_by_form_field_id( $id, $context = 'default' ) {
+		$field = $this->get_field_by_form_field_id( $id );
 		if ( ! $field ) {
 			return '';
 		}

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Field_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Field_Test.php
@@ -33,7 +33,7 @@ class Feedback_Field_Test extends BaseTestCase {
 		$this->assertEquals( 'test_value', $field->get_value() );
 		$this->assertEquals( 'basic', $field->get_type() );
 		$this->assertEquals( array(), $field->get_meta() );
-		$this->assertNull( $field->get_form_field_id() );
+		$this->assertSame( '', $field->get_form_field_id() );
 	}
 
 	/**
@@ -61,7 +61,7 @@ class Feedback_Field_Test extends BaseTestCase {
 		$this->assertSame( '', $field->get_value() );
 		$this->assertEquals( 'basic', $field->get_type() );
 		$this->assertEquals( array(), $field->get_meta() );
-		$this->assertNull( $field->get_form_field_id() );
+		$this->assertSame( '', $field->get_form_field_id() );
 	}
 
 	/**

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Field_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Field_Test.php
@@ -33,13 +33,14 @@ class Feedback_Field_Test extends BaseTestCase {
 		$this->assertEquals( 'test_value', $field->get_value() );
 		$this->assertEquals( 'basic', $field->get_type() );
 		$this->assertEquals( array(), $field->get_meta() );
+		$this->assertNull( $field->get_form_field_id() );
 	}
 
 	/**
 	 * Test that the Feedback_Field class can be instantiated with additional parameters.
 	 */
 	public function test_Feedback_Field_with_additional_parameters() {
-		$field = new Feedback_Field( 'test_key', 'test_label', 'test_value', 'text', array( 'meta_key' => 'meta_value' ) );
+		$field = new Feedback_Field( 'test_key', 'test_label', 'test_value', 'text', array( 'meta_key' => 'meta_value' ), 'firstname' );
 		$this->assertEquals( 'test_key', $field->get_key() );
 		$this->assertEquals( 'test_label', $field->get_label() );
 		$this->assertEquals( 'test_value', $field->get_value() );
@@ -47,6 +48,7 @@ class Feedback_Field_Test extends BaseTestCase {
 		$this->assertEquals( array( 'meta_key' => 'meta_value' ), $field->get_meta() );
 		$this->assertEquals( 'meta_value', $field->get_meta_key_value( 'meta_key' ) );
 		$this->assertNull( $field->get_meta_key_value( 'non_existant' ) );
+		$this->assertEquals( 'firstname', $field->get_form_field_id() );
 	}
 
 	/**
@@ -59,6 +61,7 @@ class Feedback_Field_Test extends BaseTestCase {
 		$this->assertSame( '', $field->get_value() );
 		$this->assertEquals( 'basic', $field->get_type() );
 		$this->assertEquals( array(), $field->get_meta() );
+		$this->assertNull( $field->get_form_field_id() );
 	}
 
 	/**

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Test.php
@@ -2008,9 +2008,9 @@ class Feedback_Test extends BaseTestCase {
 		$email_id  = $field_ids['email'];
 
 		$this->assertNotEmpty( $email_id );
-		$this->assertEquals( 'john@example.com', $response->get_field_value_by_id( $email_id ) );
+		$this->assertEquals( 'john@example.com', $response->get_field_value_by_form_field_id( $email_id ) );
 
-		$field = $response->get_field_by_id( $email_id );
+		$field = $response->get_field_by_form_field_id( $email_id );
 		$this->assertInstanceOf( Feedback_Field::class, $field );
 		$this->assertEquals( $email_id, $field->get_form_field_id() );
 	}
@@ -2019,7 +2019,7 @@ class Feedback_Test extends BaseTestCase {
 		$post_id  = Utility::create_legacy_feedback( array() );
 		$response = Feedback::get( $post_id );
 
-		$this->assertSame( '', $response->get_field_value_by_id( 'email' ) );
-		$this->assertNull( $response->get_field_by_id( 'email' ) );
+		$this->assertSame( '', $response->get_field_value_by_form_field_id( 'email' ) );
+		$this->assertNull( $response->get_field_by_form_field_id( 'email' ) );
 	}
 }

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Test.php
@@ -1983,4 +1983,43 @@ class Feedback_Test extends BaseTestCase {
 
 		Contact_Form::reset_errors();
 	}
+
+	public function test_get_field_by_id_and_value_by_id_new_submission() {
+		$form_id    = Utility::get_form_id();
+		$_post_data = Utility::get_post_request(
+			array(
+				'name'    => 'John Doe',
+				'email'   => 'john@example.com',
+				'message' => 'Hello!',
+			),
+			'g' . $form_id
+		);
+
+		$form = new Contact_Form(
+			array(
+				'title'       => 'Test Form',
+				'description' => 'This is a test form.',
+			),
+			"[contact-field label='Name' type='name' required='1'/][contact-field label='Email' type='email' required='1'/][contact-field label='Message' type='textarea' required='1'/]"
+		);
+
+		$response  = Feedback::from_submission( $_post_data, $form );
+		$field_ids = $form->get_field_ids();
+		$email_id  = $field_ids['email'];
+
+		$this->assertNotEmpty( $email_id );
+		$this->assertEquals( 'john@example.com', $response->get_field_value_by_id( $email_id ) );
+
+		$field = $response->get_field_by_id( $email_id );
+		$this->assertInstanceOf( Feedback_Field::class, $field );
+		$this->assertEquals( $email_id, $field->get_form_field_id() );
+	}
+
+	public function test_get_field_by_id_and_value_by_id_legacy() {
+		$post_id  = Utility::create_legacy_feedback( array() );
+		$response = Feedback::get( $post_id );
+
+		$this->assertSame( '', $response->get_field_value_by_id( 'email' ) );
+		$this->assertNull( $response->get_field_by_id( 'email' ) );
+	}
 }

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Test.php
@@ -2013,6 +2013,14 @@ class Feedback_Test extends BaseTestCase {
 		$field = $response->get_field_by_form_field_id( $email_id );
 		$this->assertInstanceOf( Feedback_Field::class, $field );
 		$this->assertEquals( $email_id, $field->get_form_field_id() );
+
+		// Save and reload; ensure the field id and value persist correctly
+		$saved_post_id  = $response->save();
+		$saved_response = Feedback::get( $saved_post_id );
+		$this->assertEquals( 'john@example.com', $saved_response->get_field_value_by_form_field_id( $email_id ) );
+		$saved_field = $saved_response->get_field_by_form_field_id( $email_id );
+		$this->assertInstanceOf( Feedback_Field::class, $saved_field );
+		$this->assertEquals( $email_id, $saved_field->get_form_field_id() );
 	}
 
 	public function test_get_field_by_id_and_value_by_id_legacy() {

--- a/projects/plugins/jetpack/changelog/add-forms-feedback-field-id
+++ b/projects/plugins/jetpack/changelog/add-forms-feedback-field-id
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: Preserve html ids when processing feedback.


### PR DESCRIPTION
## Proposed changes:

**Note:** The diff for this is a bit easier to read if you check the remove whitespace option. 

**What's is added?** This PR adds logic to the Feedback and Feedback_Field classes to preserve and handle the html id for each field. 
* The Feedback Class
   - $field_id is passed in when instantiating Feedback_Field, when relevant. 
   - There are two new methods: `get_field_by_id()` and `get_field_value_by_id()`
* The Feedback_Field Class
   - Now has a $form_field_id property, which is set in the constructor.
   - Has has a simple getter, `get_form_field_id()` to fetch the id.
* Tests are added or updated for both classes. 

**Why?** The new methods are not used in production code yet, but would be used by the MailPoet integration class. We want to be get first and last name when adding subscribers to MailPoet lists, and one of several methods we want to give users is the ability to set those filed by using ids like 'first_name' and 'last_name'. These changes allow us to do something like get_field_value_by_id( 'first-name' ) and confirm a non-null value is returned. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None. 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No. 

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Review new properties and methods and confirm they make sense. 
* Review code to look for any possible regressions or backwards compat issues. 
* Run test and confirm they all pass. Naviage to to projects/packages/forms and run `composer test-php`.

The new property and methods are not used yet, so there's no way to test them in production use. 