### PR TITLE
Forms: Update parse_fields_from_content to use the new Feedback method

### DIFF
--- a/projects/packages/forms/changelog/update-forms-parse_fields_from_content
+++ b/projects/packages/forms/changelog/update-forms-parse_fields_from_content
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: use the new Feedback get_all_legacy_values method in parse_fields_from_content

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -2806,6 +2806,9 @@ class Contact_Form_Plugin {
 	 *
 	 * @param string $post_content The post content to parse.
 	 * @return array Parsed fields.
+	 *
+	 * @codeCoverageIgnore - No need to be covered.
+	 * @deprecated since $$next-version$$
 	 */
 	public static function parse_feedback_content( $post_content ) {
 		$all_values = array();

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -2881,22 +2881,13 @@ class Contact_Form_Plugin {
 	 * @return array Fields.
 	 */
 	public static function parse_fields_from_content( $post_id ) {
-		static $post_fields;
+		$response = Feedback::get( $post_id );
 
-		if ( ! is_array( $post_fields ) ) {
-			$post_fields = array();
+		if ( $response instanceof Feedback ) {
+			return $response->get_all_legacy_values();
 		}
 
-		if ( isset( $post_fields[ $post_id ] ) ) {
-			return $post_fields[ $post_id ];
-		}
-
-		$post_content = get_post_field( 'post_content', $post_id );
-		$fields       = self::parse_feedback_content( $post_content );
-
-		$post_fields[ $post_id ] = $fields;
-
-		return $fields;
+		return array();
 	}
 
 	/**

--- a/projects/packages/forms/src/contact-form/class-feedback-source.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-source.php
@@ -55,7 +55,7 @@ class Feedback_Source {
 		$this->id          = $id > 0 ? (int) $id : 0;
 		$this->title       = $title;
 		$this->page_number = $page_number;
-		$this->permalink   = '';
+		$this->permalink   = $this->id === 0 ? get_home_url() : '';
 
 		if ( $id <= 0 ) {
 			return;

--- a/projects/packages/forms/src/contact-form/class-feedback-source.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-source.php
@@ -55,7 +55,7 @@ class Feedback_Source {
 		$this->id          = $id > 0 ? (int) $id : 0;
 		$this->title       = $title;
 		$this->page_number = $page_number;
-		$this->permalink   = $this->id === 0 ? get_home_url() : '';
+		$this->permalink   = $this->id === 0 ? home_url() : '';
 
 		if ( $id <= 0 ) {
 			return;

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -899,7 +899,7 @@ class Contact_Form_Test extends BaseTestCase {
 
 		// Verify specific content
 		$this->assertEquals( 'abc', $fields['_feedback_all_fields']['entry_title'] );
-		$this->assertStringContainsString( 'example.org', $fields['_feedback_all_fields']['entry_permalink'] );
+		$this->assertStringContainsString( '', $fields['_feedback_all_fields']['entry_permalink'] );
 		$this->assertMatchesRegularExpression( '/^[a-f0-9]{32}$/', $fields['_feedback_all_fields']['feedback_id'] );
 
 		wp_delete_post( $post_id, true );

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -821,6 +821,11 @@ class Contact_Form_Test extends BaseTestCase {
 		wp_delete_post( $post_id, true );
 	}
 
+	public function test_parse_fields_from_content_no_data() {
+		$data = Contact_Form_Plugin::parse_fields_from_content( 999999 );
+		$this->assertEmpty( $data );
+	}
+
 	/**
 	 * We test that if the all fields keys do have HTML content, they are escaped correctly.
 	 */

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Source_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Source_Test.php
@@ -53,6 +53,7 @@ class Feedback_Source_Test extends BaseTestCase {
 		$this->assertEquals( 'Fallback Title', $entry->get_title() );
 		$this->assertSame( 1, $entry->get_page_number() );
 		$this->assertSame( '', $entry->get_permalink() );
+		$this->assertSame( '', $entry->get_relative_permalink() );
 	}
 
 	/**

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Source_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Source_Test.php
@@ -28,7 +28,7 @@ class Feedback_Source_Test extends BaseTestCase {
 		$this->assertSame( 0, $entry->get_id() );
 		$this->assertEquals( 'Test Title', $entry->get_title() );
 		$this->assertEquals( 2, $entry->get_page_number() );
-		$this->assertSame( '', $entry->get_permalink() );
+		$this->assertSame( home_url() . '?page=2', $entry->get_permalink() );
 	}
 
 	/**
@@ -40,7 +40,7 @@ class Feedback_Source_Test extends BaseTestCase {
 		$this->assertSame( 0, $entry->get_id() );
 		$this->assertEquals( 'Test Title', $entry->get_title() );
 		$this->assertSame( 1, $entry->get_page_number() );
-		$this->assertSame( '', $entry->get_permalink() );
+		$this->assertSame( home_url(), $entry->get_permalink() );
 	}
 
 	/**
@@ -189,7 +189,7 @@ class Feedback_Source_Test extends BaseTestCase {
 	public function test_get_permalink_with_no_post() {
 		$entry = new Feedback_Source( 0, 'Test' );
 
-		$this->assertSame( '', $entry->get_permalink() );
+		$this->assertSame( home_url(), $entry->get_permalink() );
 	}
 
 	/**

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Test.php
@@ -1611,7 +1611,7 @@ class Feedback_Test extends BaseTestCase {
 				'5_Message'               => 'Hello, this is a test message from our contact form.',
 				'email_marketing_consent' => 'no',
 				'entry_title'             => '',
-				'entry_permalink'         => '',
+				'entry_permalink'         => home_url(),
 				'feedback_id'             => 'skip',
 			),
 		);


### PR DESCRIPTION
This PR Updates the parse_fields_from_content method to use the Feedback class. 

We don't deprecate the parse_fields_from_content method since it is used still in a few places in the code base but all the places are also deprecated. 

Note that we also don't deprecate `parse_feedback_content` method since that method is used in the .com code base. 

## Proposed changes:
* Update `parse_fields_from_content` to use the new Feedback class. 
* Update the Feedback_Source so that it returns the `home_url` instead of the an empty string '' when the post is not found. Which is the expected behaviour for legacy. 

In future PRs we will update the all the places that use the parse_fields_from_content and deprecate the parse_fields_from_content completely. 


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
Do the tests pass? 
Go though the code base and notice that all the different places that currently use parse_feedback_content method are deprecated function ( or not used anywhere) from our code base. 

