### PR TITLE
Jetpack: Fix various PHP fatals found while monitoring logs

### DIFF
--- a/projects/plugins/jetpack/3rd-party/vaultpress.php
+++ b/projects/plugins/jetpack/3rd-party/vaultpress.php
@@ -25,8 +25,8 @@ function jetpack_vaultpress_rewind_enabled_notice() {
 	unset( $_GET['activate'] ); // phpcs:ignore WordPress.Security.NonceVerification
 	$message = sprintf(
 		wp_kses(
-			/* Translators: first variable is the full URL to the new dashboard */
-			__( '<p style="margin-bottom: 0.25em;"><strong>Jetpack is now handling your backups.</strong></p><p>VaultPress is no longer needed and has been deactivated. You can access your backups at <a href="%3$s" target="_blank" rel="noopener noreferrer">this dashboard</a>.</p>', 'jetpack' ),
+			/* Translators: variable is the full URL to the new dashboard */
+			__( '<p style="margin-bottom: 0.25em;"><strong>Jetpack is now handling your backups.</strong></p><p>VaultPress is no longer needed and has been deactivated. You can access your backups at <a href="%s" target="_blank" rel="noopener noreferrer">this dashboard</a>.</p>', 'jetpack' ),
 			array(
 				'a'      => array(
 					'href'   => array(),

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -442,6 +442,11 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 	 * @return array
 	 */
 	private function parse_menu_item( $title ) {
+		// Handle non-string input
+		if ( ! is_string( $title ) ) {
+			return array();
+		}
+
 		$item = array();
 
 		if (

--- a/projects/plugins/jetpack/changelog/fix-jetpack-various_fatals
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-various_fatals
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Prevent PHP fatals when handling unexpected data types.

--- a/projects/plugins/jetpack/extensions/blocks/instagram-gallery/instagram-gallery.php
+++ b/projects/plugins/jetpack/extensions/blocks/instagram-gallery/instagram-gallery.php
@@ -68,7 +68,7 @@ function render_block( $attributes, $content ) { // phpcs:ignore VariableAnalysi
 	}
 	$gallery = Jetpack_Instagram_Gallery_Helper::get_instagram_gallery( $access_token, $count );
 
-	if ( is_wp_error( $gallery ) || ! property_exists( $gallery, 'images' ) || 'ERROR' === $gallery->images ) {
+	if ( ! is_object( $gallery ) || is_wp_error( $gallery ) || ! property_exists( $gallery, 'images' ) || 'ERROR' === $gallery->images ) {
 		if ( ! current_user_can( 'edit_post', get_the_ID() ) ) {
 			return '';
 		}

--- a/projects/plugins/jetpack/functions.opengraph.php
+++ b/projects/plugins/jetpack/functions.opengraph.php
@@ -793,6 +793,11 @@ function jetpack_og_get_description( $description = '', $data = null ) {
  * @return string The description with wp:query blocks removed.
  */
 function jetpack_og_remove_query_blocks( $description ) {
+	// Handle non-string input
+	if ( ! is_string( $description ) ) {
+		return '';
+	}
+
 	$output         = '';
 	$offset         = 0;
 	$depth          = 0;

--- a/projects/plugins/jetpack/modules/shortcodes/youtube.php
+++ b/projects/plugins/jetpack/modules/shortcodes/youtube.php
@@ -467,10 +467,10 @@ function jetpack_shortcode_youtube_dimensions( $query_args ) {
 
 	// If we have $content_width, use it.
 	if ( ! empty( $content_width ) ) {
-		$default_width = $content_width;
+		$default_width = (int) $content_width;
 	} else {
 		// Otherwise get default width from the old, now deprecated embed_size_w option.
-		$default_width = get_option( 'embed_size_w' );
+		$default_width = (int) get_option( 'embed_size_w' );
 	}
 
 	// If we don't know those 2 values use a hardcoded width.

--- a/projects/plugins/jetpack/tests/php/Functions_OpenGraph_Test.php
+++ b/projects/plugins/jetpack/tests/php/Functions_OpenGraph_Test.php
@@ -400,6 +400,18 @@ class Functions_OpenGraph_Test extends Jetpack_Attachment_TestCase {
 				'',
 				'',
 			),
+			'null_input'                => array(
+				null,
+				'',
+			),
+			'bool_input'                => array(
+				true,
+				'',
+			),
+			'array_input'               => array(
+				array(),
+				'',
+			),
 			'plain_text_no_blocks'      => array(
 				'This is just plain text with no blocks at all.',
 				'This is just plain text with no blocks at all.',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This addresses 5 fatals in 5 commits. All the fixes are fairly simple and most simply gate against unexpected input. Line numbers in the error messages are approximate, as code in some of the files has changed over the versions:

```
PHP Fatal error: Uncaught TypeError: Unsupported operand types: string / int in /wordpress/plugins/jetpack/14.9/modules/shortcodes/youtube.php:489
PHP Fatal error: Uncaught ArgumentCountError: 4 arguments are required, 2 given in /wordpress/plugins/jetpack/14.9.1/3rd-party/vaultpress.php:26
PHP Fatal error: Uncaught TypeError: Automattic\Block_Scanner::create(): Argument #1 ($source_text) must be of type string, null given, called in /wordpress/plugins/jetpack/14.9.1/functions.opengraph.php on line 801 and defined in /wordpress/plugins/jetpack/14.9.1/jetpack_vendor/automattic/block-delimiter/src/class-block-scanner.php:156
PHP Fatal error: Uncaught TypeError: property_exists(): Argument #1 ($object_or_class) must be of type object|string, null given in /wordpress/plugins/jetpack/14.9.1/extensions/blocks/instagram-gallery/instagram-gallery.php:71
PHP Fatal error: Uncaught TypeError: str_contains(): Argument #1 ($haystack) must be of type string, array given in /wordpress/plugins/jetpack/14.9.1/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php:444
```

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Look at the code. 🤷 

