### PR TITLE
Forms: Add feedback get_files method

### DIFF
--- a/projects/packages/forms/changelog/add-feedback-get_files-method
+++ b/projects/packages/forms/changelog/add-feedback-get_files-method
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: Add get_files to the Feedback method

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -2140,8 +2140,15 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		}
 
 		// File field requires Jetpack to be active
-		if ( $type === 'file' && ! defined( 'JETPACK__PLUGIN_DIR' ) ) {
-			return false;
+		if ( $type === 'file' ) {
+			/**
+			 * Check if Jetpack is active for file uploads.
+			 *
+			 * @since $$next-version$$
+			 *
+			 * @return bool
+			 */
+			return apply_filters( 'jetpack_forms_is_file_field_renderable', defined( 'JETPACK__PLUGIN_DIR' ) );
 		}
 
 		return true;

--- a/projects/packages/forms/src/contact-form/class-feedback.php
+++ b/projects/packages/forms/src/contact-form/class-feedback.php
@@ -221,12 +221,19 @@ class Feedback {
 	/**
 	 * Get a sanitized value from the post data.
 	 *
-	 * @param string $key The key to look for in the post data.
-	 * @param array  $post_data The post data array, typically $_POST.
+	 * @param string      $key The key to look for in the post data.
+	 * @param array       $post_data The post data array, typically $_POST.
+	 * @param string|null $type The type of the field, if applicable (e.g., 'file').
 	 *
 	 * @return string|array The sanitized value, or an empty string if the key is not found.
 	 */
-	private function get_field_value( $key, $post_data ) {
+	private function get_field_value( $key, $post_data, $type = null ) {
+		if ( $type === 'file' ) {
+			if ( isset( $post_data[ $key ] ) ) {
+				return self::process_file_field_value( $post_data[ $key ] );
+			}
+			return array( 'files' => array() );
+		}
 		if ( isset( $post_data[ $key ] ) ) {
 			if ( is_array( $post_data[ $key ] ) ) {
 				return array_map( 'sanitize_text_field', wp_unslash( $post_data[ $key ] ) );
@@ -235,6 +242,39 @@ class Feedback {
 			}
 		}
 		return '';
+	}
+
+	/**
+	 * Process the file field value.
+	 *
+	 * @param array $raw_data The raw post data from the file field.
+	 *
+	 * @return array The processed file data.
+	 */
+	public static function process_file_field_value( $raw_data ) {
+		$file_data_array = is_array( $raw_data )
+			? array_map(
+				function ( $json_str ) {
+					$decoded = json_decode( $json_str, true );
+					return array(
+						'file_id' => isset( $decoded['file_id'] ) ? sanitize_text_field( $decoded['file_id'] ) : '',
+						'name'    => isset( $decoded['name'] ) ? sanitize_text_field( $decoded['name'] ) : '',
+						'size'    => isset( $decoded['size'] ) ? absint( $decoded['size'] ) : 0,
+						'type'    => isset( $decoded['type'] ) ? sanitize_text_field( $decoded['type'] ) : '',
+					);
+				},
+				$raw_data
+			) : array();
+
+		if ( empty( $file_data_array ) ) {
+			return array(
+				'files' => array(),
+			);
+		}
+
+		return array(
+			'files' => $file_data_array,
+		);
 	}
 
 	/**
@@ -613,6 +653,43 @@ class Feedback {
 	 */
 	public function has_file() {
 		return $this->has_file;
+	}
+
+	/**
+	 * Get the uploaded files from the feedback entry.
+	 *
+	 * @return array
+	 */
+	public function get_files() {
+		$files = array();
+		foreach ( $this->fields as $field ) {
+			if ( $field->get_type() === 'file' ) {
+				$field_value = $field->get_value();
+				if ( ! empty( $field_value['files'] ) && is_array( $field_value['files'] ) ) {
+					$field_value['files'] = array_filter(
+						$field_value['files'],
+						function ( $file ) {
+							if ( empty( $file['file_id'] ) ) {
+								return false;
+							}
+							if ( empty( $file['name'] ) ) {
+								return false;
+							}
+							if ( empty( $file['size'] ) ) {
+								return false;
+							}
+							if ( empty( $file['type'] ) ) {
+								return false;
+							}
+							return true;
+						}
+					);
+
+					$files = array_merge( $files, $field_value['files'] );
+				}
+			}
+		}
+		return $files;
 	}
 
 	/**
@@ -1074,7 +1151,7 @@ class Feedback {
 				continue;
 			}
 
-			$value = $this->get_field_value( $field_id, $post_data );
+			$value = $this->get_field_value( $field_id, $post_data, $type );
 			$label = wp_strip_all_tags( $field->get_attribute( 'label' ) );
 			$key   = $i . '_' . $label;
 

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Test.php
@@ -1910,7 +1910,9 @@ class Feedback_Test extends BaseTestCase {
 		// Create a form submission
 		$_post_data = Utility::get_post_request(
 			array(
-				'uploadafile' => null,
+				'uploadafile'       => null,
+				'uploadanotherfile' => array(),
+				'uploademptyfile'   => array( '{}' ),
 			),
 			'g' . $form_id
 		);
@@ -1920,7 +1922,7 @@ class Feedback_Test extends BaseTestCase {
 				'title'       => 'Test Form',
 				'description' => 'This is a test form.',
 			),
-			'[contact-field type="file" label="Upload a file" /]'
+			'[contact-field type="file" label="Upload a file" /][contact-field type="file" label="Upload another file" /][contact-field type="file" label="Upload empty file" /]'
 		);
 
 		$response         = Feedback::from_submission( $_post_data, $form );

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Test.php
@@ -1759,18 +1759,146 @@ class Feedback_Test extends BaseTestCase {
 		$this->assertFalse( $saved_response->has_consent(), 'Consent (saved) should be false when no consent field was present' );
 	}
 
-	public function test_has_field_type_legacy_feedback() {
-		// Create a legacy feedback entry and verify has_field_type/has_consent behavior.
-		$post_id  = Utility::create_legacy_feedback(
+	public function test_get_files_legacy() {
+		$file1 = array(
+			'file_id' => 1234,
+			'name'    => 'test-file.txt',
+			'size'    => 1234,
+			'type'    => 'text/plain',
+		);
+
+		$file2 = array(
+			'file_id' => 5678,
+			'name'    => 'test-file.png',
+			'size'    => 4567,
+			'type'    => 'image/png',
+		);
+
+		$empty_file = array(
+			'file_id' => null,
+			'name'    => '',
+			'size'    => null,
+			'type'    => '',
+		);
+
+		$empty_file_2 = array(
+			'file_id' => 123,
+			'name'    => '',
+			'size'    => null,
+			'type'    => '',
+		);
+		$empty_file_3 = array(
+			'file_id' => 123,
+			'name'    => 'name',
+			'size'    => null,
+			'type'    => '',
+		);
+
+		$empty_file_4 = array(
+			'file_id' => 123,
+			'name'    => 'name',
+			'size'    => 12345,
+			'type'    => '',
+		);
+
+		$post_id = Utility::create_legacy_feedback(
 			array(
-				'1_field' => 'value1',
-				'2_field' => 'value2',
+				'1_file upload' => array(
+					'field_id' => 'file_upload',
+					'files'    => array( $file1, $empty_file, $empty_file_2, $empty_file_3, $empty_file_4, $file2 ),
+				),
+				'2_images'      => array(
+					'field_id' => 'file_upload2',
+					'files'    => array( $file2, $file1 ),
+				),
+				'3_docs'        => array(
+					'field_id' => 'file_upload3',
+					'files'    => array(),
+				),
 			)
 		);
-		$response = Feedback::get( $post_id );
 
-		// Legacy entries include an 'email_marketing_consent' field (default 'no'), typed as 'consent'.
-		$this->assertTrue( $response->has_field_type( 'consent' ), 'Legacy feedback should report consent field exists' );
-		$this->assertFalse( $response->has_consent(), 'Legacy consent should default to false (no)' );
+		$expected_legacy_values = array(
+			$file1,
+			$file2,
+			$file2,
+			$file1,
+		);
+
+		$response = Feedback::get( $post_id );
+		$this->assertNotEmpty( $response->get_files(), 'Legacy file values should not be empty for the legacy feedback' );
+		$this->assertEquals( $expected_legacy_values, $response->get_files(), 'Legacy extra values should match the expected extra values' );
+	}
+
+	public function test_get_files_empty() {
+
+		$form_id = Utility::get_form_id();
+		// Create a form submission
+		$_post_data = Utility::get_post_request(
+			array(
+				'text'    => 'Test text',
+				'email'   => 'john.smith@example.com',
+				'email_2' => 'john.smith@example2.com',
+				'website' => 'https://johnsmith.dev',
+				'message' => 'Hello, this is a test message from our contact form.',
+			),
+			'g' . $form_id
+		);
+
+		$form = new Contact_Form(
+			array(
+				'title'       => 'Test Form',
+				'description' => 'This is a test form.',
+			),
+			"[contact-field label='Text' type='text' required='1'/][contact-field label='Email' type='email' required='1'/][contact-field label='Email_2' type='email' required='1'/][contact-field label='Website' type='url' required='1'/][contact-field label='Message' type='textarea' required='1'/]"
+		);
+
+		$response         = Feedback::from_submission( $_post_data, $form );
+		$feedback_post_id = $response->save();
+		$saved_response   = Feedback::get( $feedback_post_id );
+
+		$this->assertEmpty( $response->get_files(), 'Files should be empty for the form submission without file uploads' );
+		$this->assertEmpty( $saved_response->get_files(), 'Files should be empty for the saved response without file uploads' );
+	}
+
+	public function test_get_files_valid() {
+		// This is needed for the test to run correctly.
+		add_filter( 'jetpack_forms_is_file_field_renderable', '__return_true' );
+
+		$form_id = Utility::get_form_id();
+		// Create a form submission
+		$_post_data = Utility::get_post_request(
+			array(
+				'uploadafile' => array( '{"file_id":54321,"name":"Screenshot.png","size":19914,"type":"image/png"}', '{}' ),
+			),
+			'g' . $form_id
+		);
+
+		$form = new Contact_Form(
+			array(
+				'title'       => 'Test Form',
+				'description' => 'This is a test form.',
+			),
+			'[contact-field type="file" label="Upload a file" /]'
+		);
+
+		$expected         = array(
+			array(
+				'file_id' => 54321,
+				'name'    => 'Screenshot.png',
+				'size'    => 19914,
+				'type'    => 'image/png',
+			),
+		);
+		$response         = Feedback::from_submission( $_post_data, $form );
+		$feedback_post_id = $response->save();
+		$saved_response   = Feedback::get( $feedback_post_id );
+
+		$this->assertNotEmpty( $response->get_files(), 'Files should not be empty for the form submission with file uploads' );
+		$this->assertNotEmpty( $saved_response->get_files(), 'Files should not be empty for the saved response with file uploads' );
+		$this->assertEquals( $response->get_files(), $saved_response->get_files(), 'Files should match between the response and the saved response' );
+		$this->assertEquals( $expected, $response->get_files(), 'Response files should match the expected files' );
+
+		remove_filter( 'jetpack_forms_is_file_field_renderable', '__return_true' );
 	}
 }

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Test.php
@@ -1901,4 +1901,35 @@ class Feedback_Test extends BaseTestCase {
 
 		remove_filter( 'jetpack_forms_is_file_field_renderable', '__return_true' );
 	}
+
+	public function test_get_files_invalid() {
+		// This is needed for the test to run correctly.
+		add_filter( 'jetpack_forms_is_file_field_renderable', '__return_true' );
+
+		$form_id = Utility::get_form_id();
+		// Create a form submission
+		$_post_data = Utility::get_post_request(
+			array(
+				'uploadafile' => null,
+			),
+			'g' . $form_id
+		);
+
+		$form = new Contact_Form(
+			array(
+				'title'       => 'Test Form',
+				'description' => 'This is a test form.',
+			),
+			'[contact-field type="file" label="Upload a file" /]'
+		);
+
+		$response         = Feedback::from_submission( $_post_data, $form );
+		$feedback_post_id = $response->save();
+		$saved_response   = Feedback::get( $feedback_post_id );
+
+		$this->assertEmpty( $response->get_files(), 'Files should not be empty for the form submission with file uploads' );
+		$this->assertEmpty( $saved_response->get_files(), 'Files should not be empty for the saved response with file uploads' );
+
+		remove_filter( 'jetpack_forms_is_file_field_renderable', '__return_true' );
+	}
 }


### PR DESCRIPTION
This new method will be used on the .com backend to get files for each of the feedbacks across all the files. 

Related .com PR see:  190565-ghe-Automattic/wpcom

## Proposed changes:
* Add a new helper method for that helps us get an array of valid file data. 

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?



## Does this pull request change what data or activity we track or use?
no.

## Testing instructions:
Do the tests pass?