### PR TITLE
Forms: Extract visually-hidden styles to shared SCSS partial

### DIFF
--- a/projects/packages/forms/changelog/update-forms-visually-hidden-styles
+++ b/projects/packages/forms/changelog/update-forms-visually-hidden-styles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Extract visually-hidden styles to shared SCSS partial for better code reuse

--- a/projects/packages/forms/src/blocks/field-rating/style.scss
+++ b/projects/packages/forms/src/blocks/field-rating/style.scss
@@ -1,2 +1,3 @@
 /* Rating field block – front-end styles */
+@use "../shared/styles/visually-hidden" as *;
 @use "../input-rating/style";

--- a/projects/packages/forms/src/blocks/input-rating/style.scss
+++ b/projects/packages/forms/src/blocks/input-rating/style.scss
@@ -11,8 +11,6 @@
 	.jetpack-field-rating__options {
 		display: flex;
 
-		/* Use shared visually-hidden helper for editor and frontend */
-
 		.jetpack-field-rating__label {
 			padding-right: 5px;
 

--- a/projects/packages/forms/src/blocks/input-rating/style.scss
+++ b/projects/packages/forms/src/blocks/input-rating/style.scss
@@ -1,4 +1,5 @@
 /* Rating input block – front-end styles */
+@use "../shared/styles/visually-hidden" as *;
 
 .jetpack-field-rating {
 
@@ -10,23 +11,7 @@
 	.jetpack-field-rating__options {
 		display: flex;
 
-		/* Note: We redefine `.visually-hidden` here
-		   because grunion.css isn't loaded in the editor.
-		   We should follow up with extracting it into a
-		   shared SCSS partial and importing it in both
-		   editor and frontend bundles. */
-		.jetpack-field-rating__input.visually-hidden {
-			position: absolute;
-			width: 1px;
-			height: 1px;
-			padding: 0;
-			margin: -1px;
-			overflow: hidden;
-			clip: rect(0 0 0 0);
-			clip-path: inset(50%);
-			border: 0;
-			white-space: nowrap;
-		}
+		/* Use shared visually-hidden helper for editor and frontend */
 
 		.jetpack-field-rating__label {
 			padding-right: 5px;

--- a/projects/packages/forms/src/blocks/shared/styles/_visually-hidden.scss
+++ b/projects/packages/forms/src/blocks/shared/styles/_visually-hidden.scss
@@ -1,0 +1,14 @@
+/* Shared accessibility utility: visually hidden but accessible */
+
+.visually-hidden {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	padding: 0;
+	margin: -1px;
+	overflow: hidden;
+	clip: rect(0 0 0 0);
+	clip-path: inset(50%);
+	border: 0;
+	white-space: nowrap;
+}

--- a/projects/packages/forms/src/blocks/shared/styles/_visually-hidden.scss
+++ b/projects/packages/forms/src/blocks/shared/styles/_visually-hidden.scss
@@ -1,14 +1,11 @@
 /* Shared accessibility utility: visually hidden but accessible */
 
 .visually-hidden {
-	position: absolute;
-	width: 1px;
-	height: 1px;
-	padding: 0;
-	margin: -1px;
-	overflow: hidden;
 	clip: rect(0 0 0 0);
 	clip-path: inset(50%);
-	border: 0;
+	height: 1px;
+	overflow: hidden;
+	position: absolute;
 	white-space: nowrap;
+	width: 1px;
 }

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -1187,15 +1187,8 @@ on production builds, the attributes are being reordered, causing side-effects
 	display: block;
 }
 
-.visually-hidden {
-	clip: rect(0 0 0 0);
-	clip-path: inset(50%);
-	height: 1px;
-	overflow: hidden;
-	position: absolute;
-	white-space: nowrap;
-	width: 1px;
-}
+/* Import shared visually-hidden utility so editor and frontend match */
+@use "../../blocks/shared/styles/visually-hidden" as *;
 
 .contact-form.is-ajax-form.submission-success {
 	display: none;


### PR DESCRIPTION
## Proposed changes:
* Create a shared `_visually-hidden.scss` partial to eliminate duplicate CSS definitions
* Import the shared partial in components that need visually-hidden styles
* Update field-rating and input-rating blocks to use the shared styles
* Clean up grunion.css to use consistent visually-hidden implementation
* Add changelog entry for the forms package

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A - CSS refactoring for better code organization

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

* Go to the WordPress admin dashboard
* Navigate to any post/page editor
* Add a Contact Form block
* Add form fields including a Rating Field
* Verify that visually-hidden elements (like radio inputs in rating fields) are still properly hidden
* Check that screen readers can still access the hidden content
* Test form submission to ensure functionality remains unchanged
* Verify no visual regressions in the form display

### Technical details:
* Extracted common `.visually-hidden` styles into `projects/packages/forms/src/blocks/shared/styles/_visually-hidden.scss`
* This reduces code duplication and ensures consistent accessibility patterns across the forms package
* The shared partial can now be imported wherever visually-hidden styles are needed