### PR TITLE
My Jetpack: Add product interstitials state management

### DIFF
--- a/projects/js-packages/components/changelog/update-my-jetpack-wire-up-product-plugin-activation
+++ b/projects/js-packages/components/changelog/update-my-jetpack-wire-up-product-plugin-activation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+My Jetpack: Add product interstitials state management

--- a/projects/js-packages/components/components/pricing-table/styles.module.scss
+++ b/projects/js-packages/components/components/pricing-table/styles.module.scss
@@ -2,6 +2,9 @@
 
 .container {
 	--padding: calc(var(--spacing-base) * 4);
+	--padding-horizontal: calc(var(--spacing-base) * 3);
+	--padding-vertical: var(--spacing-base);
+	--item-border-color: #f0f0f0;
 	color: var(--jp-black);
 }
 
@@ -45,7 +48,7 @@
 	// Border styles for all columns (default gray borders)
 	> :first-child {
 		border-style: solid;
-		border-color: var(--jp-gray-10);
+		border-color: var(--item-border-color);
 		border-width: 1.5px 1.5px 0;
 		border-start-start-radius: 8px;
 		border-start-end-radius: 8px;
@@ -53,14 +56,14 @@
 
 	> :last-child {
 		border-style: solid;
-		border-color: var(--jp-gray-10);
+		border-color: var(--item-border-color);
 		border-width: 0 1.5px 1.5px;
 		border-end-start-radius: 8px;
 		border-end-end-radius: 8px;
 	}
 
 	> :not(:first-child):not(:last-child) {
-		border-inline: 1.5px solid var(--jp-gray-10);
+		border-inline: 1.5px solid var(--item-border-color);
 	}
 
 	> * {
@@ -136,18 +139,19 @@
 .item {
 	display: flex;
 	align-items: center;
-	padding-bottom: calc(var(--spacing-base) * 2);
+	padding-bottom: var(--padding-vertical);
 	position: relative;
+	line-height: 20px;
 
 	&:not(:nth-child(2)):not(.empty) {
-		padding-top: calc(var(--spacing-base) * 2);
+		padding-top: var(--padding-vertical);
 
 		&::before {
 			content: "";
 			position: absolute;
 			top: 0;
-			inset-inline-start: var(--padding);
-			inset-inline-end: var(--padding);
+			inset-inline-start: var(--padding-horizontal);
+			inset-inline-end: var(--padding-horizontal);
 			height: 1px;
 
 			z-index: 5;
@@ -165,7 +169,7 @@
 	}
 
 	&:last-of-type {
-		padding-bottom: var(--padding);
+		padding-bottom: var(--padding-vertical);
 	}
 }
 
@@ -174,8 +178,8 @@
 }
 
 .value {
-	padding-left: var(--padding);
-	padding-right: var(--padding);
+	padding-left: var(--padding-horizontal);
+	padding-right: var(--padding-horizontal);
 }
 
 .icon {

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/product-card-action.tsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/product-card-action.tsx
@@ -8,11 +8,14 @@ import useActivatePlugins from '../../../data/products/use-activate-plugins';
 import { useDeactivatePlugins } from '../../../data/products/use-deactivate-plugins';
 import useProduct from '../../../data/products/use-product';
 import { ProductCamelCase } from '../../../data/types';
+import { useInterstitialsState } from '../../../hooks/use-interstitials-state';
+import { MyJetpackModule } from '../../../types';
 import { PRODUCT_STATUSES } from '../../product-card';
 import { useProductFiltersContext } from './products-tracking-context';
 
 export type ProductCardActionProps = {
 	product: ProductCamelCase;
+	module?: MyJetpackModule;
 };
 
 /**
@@ -106,7 +109,13 @@ function ActivationToggle( {
  *
  * @return The rendered component
  */
-export function ProductCardAction( { product }: ProductCardActionProps ) {
+export function ProductCardAction( { product, module: $module }: ProductCardActionProps ) {
+	const { data: interstitials } = useInterstitialsState();
+
+	if ( ! product.hasPaidPlanForProduct && ! interstitials?.[ product.slug ] ) {
+		return <UpgradeAction product={ product } />;
+	}
+
 	// If we already have a standalone plugin installed, we render the activation toggle
 	if (
 		PRODUCTS_MUST_HAVE_A_STANDALONE_PLUGIN.includes( product.slug ) &&
@@ -130,8 +139,6 @@ export function ProductCardAction( { product }: ProductCardActionProps ) {
 			return <UpgradeAction product={ product } />;
 
 		default:
-			// We assume that the product is active but can't be deactivated
-			// For example AI Assistant.
-			return <ActivationToggle product={ product } disabled />;
+			return <ActivationToggle product={ product } disabled={ ! $module?.available } />;
 	}
 }

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/product-card.tsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/product-card.tsx
@@ -10,8 +10,6 @@ import {
 } from '@wordpress/components';
 import { ProductCamelCase } from '../../../data/types';
 import { MyJetpackModule } from '../../../types';
-import { ModuleStatus } from '../../module-status';
-import { ModuleToggle } from '../../module-toggle';
 import { PRODUCT_ICONS } from './mappings';
 import { ProductCardAction } from './product-card-action';
 import styles from './styles.module.scss';
@@ -52,16 +50,8 @@ export function ProductCard( { product, headingLevel = 3, module: $module }: Pro
 						</Flex>
 					</FlexBlock>
 					{ isAvailable ? (
-						// Hide action buttons and status if not available.
 						<FlexItem>
-							{ $module?.available ? (
-								<Flex gap={ 4 }>
-									<ModuleStatus module={ $module } />
-									<ModuleToggle module={ $module } />
-								</Flex>
-							) : (
-								<ProductCardAction product={ product } />
-							) }
+							<ProductCardAction product={ product } module={ $module } />
 						</FlexItem>
 					) : null }
 				</Flex>

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/pricing-interstitial.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/pricing-interstitial.jsx
@@ -229,8 +229,11 @@ export default function PricingInterstitial( { slug } ) {
 	const { update: updateInterstitialsState } = useInterstitialsState();
 
 	const handleFreeActivation = useCallback( () => {
+		if ( ! config?.tiers?.free ) {
+			return;
+		}
 		setLoadingButton( 'free' );
-		trackProductOrBundleClick( { isFreePlan: true, ctaText: config?.tiers?.free?.cta } );
+		trackProductOrBundleClick( { isFreePlan: true, ctaText: config.tiers.free.cta } );
 
 		// Products like Search have wpcomFreeProductSlug, so they need checkout even for free
 		const hasPurchasableFree = !! detail?.pricingForUi?.wpcomFreeProductSlug;
@@ -248,7 +251,7 @@ export default function PricingInterstitial( { slug } ) {
 		trackProductOrBundleClick,
 		clickHandler,
 		detail,
-		config?.tiers?.free?.cta,
+		config?.tiers?.free,
 		freeCheckoutRun,
 		updateInterstitialsState,
 		slug,
@@ -311,33 +314,35 @@ export default function PricingInterstitial( { slug } ) {
 						showIntroOfferDisclaimer={ false }
 						headerLogo={ config.logo ? <config.logo height={ 32 } /> : null }
 					>
-						<PricingTableColumn className={ styles[ 'pricing-column' ] }>
-							<PricingTableHeader title={ config.tiers.free.name }>
-								<ProductPrice
-									price={ 0 }
-									legend=""
-									currency={ currencyCode }
-									hidePriceFraction
-									variant="simple"
-								/>
-								<Button
-									fullWidth
-									variant="secondary"
-									onClick={ handleFreeActivation }
-									isLoading={ loadingButton === 'free' }
-									disabled={ buttonsDisabled }
-								>
-									{ config.tiers.free.cta }
-								</Button>
-							</PricingTableHeader>
-							{ config.features.map( ( feature, index ) => (
-								<PricingTableItem
-									key={ index }
-									isIncluded={ feature.free.included }
-									label={ feature.free.label }
-								/>
-							) ) }
-						</PricingTableColumn>
+						{ config.tiers.free && (
+							<PricingTableColumn className={ styles[ 'pricing-column' ] }>
+								<PricingTableHeader title={ config.tiers.free.name }>
+									<ProductPrice
+										price={ 0 }
+										legend=""
+										currency={ currencyCode }
+										hidePriceFraction
+										variant="simple"
+									/>
+									<Button
+										fullWidth
+										variant="secondary"
+										onClick={ handleFreeActivation }
+										isLoading={ loadingButton === 'free' }
+										disabled={ buttonsDisabled }
+									>
+										{ config.tiers.free.cta }
+									</Button>
+								</PricingTableHeader>
+								{ config.features.map( ( feature, index ) => (
+									<PricingTableItem
+										key={ index }
+										isIncluded={ feature.free?.included || false }
+										label={ feature.free?.label || '' }
+									/>
+								) ) }
+							</PricingTableColumn>
+						) }
 						<PricingTableColumn primary className={ styles[ 'pricing-column' ] }>
 							<PricingTableHeader title={ config.tiers.paid.name }>
 								{ productPricing ? (

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/pricing-interstitial.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/pricing-interstitial.jsx
@@ -28,6 +28,7 @@ import useActivatePlugins from '../../data/products/use-activate-plugins';
 import useProduct from '../../data/products/use-product';
 import useAnalytics from '../../hooks/use-analytics';
 import { useGoBack } from '../../hooks/use-go-back';
+import { useInterstitialsState } from '../../hooks/use-interstitials-state';
 import useMyJetpackConnection from '../../hooks/use-my-jetpack-connection';
 import useMyJetpackNavigate from '../../hooks/use-my-jetpack-navigate';
 import GoBackLink from '../go-back-link';
@@ -225,6 +226,8 @@ export default function PricingInterstitial( { slug } ) {
 		}
 	}, [ trackProductOrBundleClick, clickHandler, bundleCheckoutRun, bundleDetail, config ] );
 
+	const { update: updateInterstitialsState } = useInterstitialsState();
+
 	const handleFreeActivation = useCallback( () => {
 		setLoadingButton( 'free' );
 		trackProductOrBundleClick( { isFreePlan: true, ctaText: config?.tiers?.free?.cta } );
@@ -233,13 +236,22 @@ export default function PricingInterstitial( { slug } ) {
 		const hasPurchasableFree = !! detail?.pricingForUi?.wpcomFreeProductSlug;
 		const checkout = hasPurchasableFree ? freeCheckoutRun : null;
 
-		clickHandler( { checkout, product: detail, tier: 'free' } );
+		updateInterstitialsState(
+			{ [ slug ]: true },
+			{
+				onSettled() {
+					clickHandler( { checkout, product: detail, tier: 'free' } );
+				},
+			}
+		);
 	}, [
 		trackProductOrBundleClick,
 		clickHandler,
 		detail,
 		config?.tiers?.free?.cta,
 		freeCheckoutRun,
+		updateInterstitialsState,
+		slug,
 	] );
 
 	// If no config exists, fallback to old ProductInterstitial

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/products/backup.ts
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/products/backup.ts
@@ -9,8 +9,7 @@ import { getTranslatableFeatureLabels, SECURITY, SECURITY_SLUG } from './shared-
  * @return The configuration object for the product.
  */
 export function getBackupConfig(): ProductConfig {
-	const { INCLUDED, NOT_INCLUDED, FREE, START_FOR_FREE, GET_SECURITY } =
-		getTranslatableFeatureLabels();
+	const { INCLUDED, GET_SECURITY } = getTranslatableFeatureLabels();
 
 	return {
 		title: __( 'The best real-time WordPress backup plugin', 'jetpack-my-jetpack' ),
@@ -19,19 +18,16 @@ export function getBackupConfig(): ProductConfig {
 		features: [
 			{
 				name: __( 'Real-time backups', 'jetpack-my-jetpack' ),
-				free: { included: false, label: __( 'Manual backups only', 'jetpack-my-jetpack' ) },
 				paid: { included: true, label: INCLUDED },
 				bundle: { included: true, label: __( 'Real-time cloud backups', 'jetpack-my-jetpack' ) },
 			},
 			{
 				name: __( 'Cloud backup storage', 'jetpack-my-jetpack' ),
-				free: { included: true, label: __( '250 MB', 'jetpack-my-jetpack' ) },
 				paid: { included: true, label: __( '10 GB', 'jetpack-my-jetpack' ) },
 				bundle: { included: true, label: __( '10GB of backup storage', 'jetpack-my-jetpack' ) },
 			},
 			{
 				name: __( 'One-click restores', 'jetpack-my-jetpack' ),
-				free: { included: true, label: INCLUDED },
 				paid: { included: true, label: __( '30-day history', 'jetpack-my-jetpack' ) },
 				bundle: { included: true, label: __( 'Automated malware scan', 'jetpack-my-jetpack' ) },
 			},
@@ -41,7 +37,6 @@ export function getBackupConfig(): ProductConfig {
 					'Backup retention is still subject to the overall storage limit and usage.',
 					'jetpack-my-jetpack'
 				),
-				free: { included: true, label: __( 'Latest snapshot only', 'jetpack-my-jetpack' ) },
 				paid: { included: true, label: __( '30-day log', 'jetpack-my-jetpack' ) },
 				bundle: {
 					included: true,
@@ -50,34 +45,26 @@ export function getBackupConfig(): ProductConfig {
 			},
 			{
 				name: __( 'Activity log', 'jetpack-my-jetpack' ),
-				free: { included: true, label: __( 'Last 20 events', 'jetpack-my-jetpack' ) },
 				paid: { included: true, label: INCLUDED },
 				bundle: { included: true, label: __( 'Spam protection', 'jetpack-my-jetpack' ) },
 			},
 			{
 				name: __( 'File Browser (granular restore)', 'jetpack-my-jetpack' ),
-				free: { included: false, label: NOT_INCLUDED },
 				paid: { included: true, label: INCLUDED },
 				bundle: { included: true, label: '' },
 			},
 			{
 				name: __( 'Copy to Staging', 'jetpack-my-jetpack' ),
-				free: { included: false, label: NOT_INCLUDED },
 				paid: { included: true, label: INCLUDED },
 				bundle: { included: true, label: '' },
 			},
 			{
 				name: __( 'Scheduled Backups', 'jetpack-my-jetpack' ),
-				free: { included: false, label: NOT_INCLUDED },
 				paid: { included: true, label: INCLUDED },
 				bundle: { included: true, label: '' },
 			},
 		],
 		tiers: {
-			free: {
-				name: FREE,
-				cta: START_FOR_FREE,
-			},
 			paid: {
 				name: 'Backup',
 				cta: __( 'Get Backup', 'jetpack-my-jetpack' ),

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/types.ts
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/types.ts
@@ -9,7 +9,7 @@ export interface FeatureTier {
 export interface ProductFeature {
 	name: string;
 	tooltipInfo?: React.ReactNode;
-	free: FeatureTier;
+	free?: FeatureTier;
 	paid: FeatureTier;
 	bundle: FeatureTier;
 }
@@ -25,7 +25,7 @@ export interface ProductConfig {
 	bundle: string;
 	features: ProductFeature[];
 	tiers: {
-		free: ProductTier;
+		free?: ProductTier;
 		paid: ProductTier;
 		bundle: ProductTier;
 	};

--- a/projects/packages/my-jetpack/_inc/data/constants.ts
+++ b/projects/packages/my-jetpack/_inc/data/constants.ts
@@ -8,6 +8,7 @@ export const REST_API_CHAT_AVAILABILITY_ENDPOINT = `${ REST_API_NAMESPACE }/chat
 export const REST_API_CHAT_AUTHENTICATION_ENDPOINT = `${ REST_API_NAMESPACE }/chat/authentication`;
 export const REST_API_SITE_PRODUCTS_ENDPOINT = `${ REST_API_NAMESPACE }/site/products`;
 export const REST_API_SITE_PRODUCTS_OWNERSHIP_ENDPOINT = `${ REST_API_NAMESPACE }/site/products-ownership`;
+export const REST_API_SITE_PRODUCTS_INTERSTITIALS_ENDPOINT = `${ REST_API_NAMESPACE }/site/products/interstitials`;
 export const REST_API_VIDEOPRESS_FEATURED_STATS = 'videopress/v1/stats/featured';
 export const REST_API_SITE_DISMISS_BANNER = `${ REST_API_NAMESPACE }/site/dismiss-welcome-banner`;
 export const REST_API_EVALUATE_SITE_RECOMMENDATIONS = `${ REST_API_NAMESPACE }/site/recommendations/evaluation`;
@@ -28,6 +29,7 @@ export const getStatsVisitsEndpoint = ( blogId: string ) =>
 // Query names
 export const QUERY_PRODUCT_KEY = 'product';
 export const QUERY_PRODUCT_BY_OWNERSHIP_KEY = 'product ownership';
+export const QUERY_PRODUCT_INTERSTITIALS_KEY = 'product interstitials';
 export const QUERY_ACTIVATE_PRODUCT_KEY = 'activate product';
 export const QUERY_INSTALL_PRODUCT_KEY = 'install product';
 export const QUERY_VIDEOPRESS_STATS_KEY = 'videopress stats';

--- a/projects/packages/my-jetpack/_inc/hooks/use-interstitials-state/index.ts
+++ b/projects/packages/my-jetpack/_inc/hooks/use-interstitials-state/index.ts
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import {
 	QUERY_PRODUCT_INTERSTITIALS_KEY,
 	REST_API_SITE_PRODUCTS_INTERSTITIALS_ENDPOINT,
@@ -22,7 +22,7 @@ export function useInterstitialsState() {
 		query: { path: REST_API_SITE_PRODUCTS_INTERSTITIALS_ENDPOINT },
 	} );
 
-	const { mutate: update, isPending } = useSimpleMutation< InterstitialsData >( {
+	const { mutate, isPending } = useSimpleMutation< InterstitialsData >( {
 		name: QUERY_PRODUCT_INTERSTITIALS_KEY + '-update',
 		query: {
 			path: REST_API_SITE_PRODUCTS_INTERSTITIALS_ENDPOINT,
@@ -34,6 +34,13 @@ export function useInterstitialsState() {
 			},
 		},
 	} );
+
+	const update = useCallback(
+		( products: InterstitialsData[ 'products' ], options: Parameters< typeof mutate >[ 1 ] ) => {
+			mutate( { data: { products } }, options );
+		},
+		[ mutate ]
+	);
 
 	return useMemo(
 		() => ( {

--- a/projects/packages/my-jetpack/_inc/hooks/use-interstitials-state/index.ts
+++ b/projects/packages/my-jetpack/_inc/hooks/use-interstitials-state/index.ts
@@ -1,0 +1,48 @@
+import { useMemo } from 'react';
+import {
+	QUERY_PRODUCT_INTERSTITIALS_KEY,
+	REST_API_SITE_PRODUCTS_INTERSTITIALS_ENDPOINT,
+} from '../../data/constants';
+import { ProductCamelCase } from '../../data/types';
+import useSimpleMutation from '../../data/use-simple-mutation';
+import useSimpleQuery from '../../data/use-simple-query';
+
+interface InterstitialsData {
+	products: { [ Key in ProductCamelCase[ 'slug' ] ]?: boolean };
+}
+
+/**
+ * Custom hook to manage interstitials state.
+ *
+ * @return The interstitials state and actions.
+ */
+export function useInterstitialsState() {
+	const { data, isLoading, error, refetch } = useSimpleQuery< InterstitialsData >( {
+		name: QUERY_PRODUCT_INTERSTITIALS_KEY,
+		query: { path: REST_API_SITE_PRODUCTS_INTERSTITIALS_ENDPOINT },
+	} );
+
+	const { mutate: update, isPending } = useSimpleMutation< InterstitialsData >( {
+		name: QUERY_PRODUCT_INTERSTITIALS_KEY + '-update',
+		query: {
+			path: REST_API_SITE_PRODUCTS_INTERSTITIALS_ENDPOINT,
+			method: 'POST',
+		},
+		options: {
+			onSuccess: () => {
+				refetch();
+			},
+		},
+	} );
+
+	return useMemo(
+		() => ( {
+			data: data?.products,
+			isLoading,
+			isUpdating: isPending,
+			update,
+			error,
+		} ),
+		[ data, isLoading, error, isPending, update ]
+	);
+}

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-wire-up-product-plugin-activation
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-wire-up-product-plugin-activation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Added product interstitials state management.

--- a/projects/packages/my-jetpack/src/class-products.php
+++ b/projects/packages/my-jetpack/src/class-products.php
@@ -32,6 +32,8 @@ class Products {
 	public const STATUS_NEEDS_ATTENTION__WARNING    = 'needs_attention_warning';
 	public const STATUS_NEEDS_ATTENTION__ERROR      = 'needs_attention_error';
 
+	public const INTERSTITIALS_OPTION_NAME = 'my_jetpack_products_interstitials_state';
+
 	/**
 	 * List of statuses that display the module as disabled
 	 * This is defined as the statuses in which the user willingly has the module disabled whether it be by
@@ -132,7 +134,7 @@ class Products {
 			'creator'          => Products\Creator::class,
 			'extras'           => Products\Extras::class,
 			'jetpack-ai'       => Products\Jetpack_Ai::class,
-			// TODO: Remove this duplicate class ('ai')? See: https://github.com/Automattic/jetpack/pull/35910#pullrequestreview-2456462227
+			// TODO: Remove this duplicate class ('ai')? See: https://github.com/Automattic/jetpack/pull/35910#pullrequestreview-2456462227.
 			'ai'               => Products\Jetpack_Ai::class,
 			'scan'             => Products\Scan::class,
 			'search'           => Products\Search::class,
@@ -143,7 +145,7 @@ class Products {
 			'stats'            => Products\Stats::class,
 			'growth'           => Products\Growth::class,
 			'complete'         => Products\Complete::class,
-			// Features
+			// Features.
 			'newsletter'       => Products\Newsletter::class,
 			'site-accelerator' => Products\Site_Accelerator::class,
 			'related-posts'    => Products\Related_Posts::class,
@@ -225,7 +227,7 @@ class Products {
 	public static function get_products( $product_slugs = array() ) {
 		$all_classes = self::get_products_classes();
 		$products    = array();
-		// If an array of $product_slugs are passed, return only the products specified in $product_slugs array
+		// If an array of $product_slugs are passed, return only the products specified in $product_slugs array.
 		if ( $product_slugs ) {
 			foreach ( $product_slugs as $product_slug ) {
 				if ( isset( $all_classes[ $product_slug ] ) ) {
@@ -253,7 +255,7 @@ class Products {
 	public static function get_products_api_data( $product_slugs = array() ) {
 		$all_classes = self::get_products_classes();
 		$products    = array();
-		// If an array of $product_slugs are passed, return only the products specified in $product_slugs array
+		// If an array of $product_slugs are passed, return only the products specified in $product_slugs array.
 		if ( $product_slugs ) {
 			foreach ( $product_slugs as $product_slug ) {
 				if ( isset( $all_classes[ $product_slug ] ) ) {
@@ -297,7 +299,7 @@ class Products {
 			if ( $class::is_owned() ) {
 				// This sorts the the products in the order of active -> warning -> inactive.
 				// This enables the frontend to display them in that order.
-				// This is not needed for unowned products as those will always have a status of 'inactive'
+				// This is not needed for unowned products as those will always have a status of 'inactive'.
 				if ( in_array( $status, self::$active_module_statuses, true ) ) {
 					array_push( $owned_active_products, $product_slug );
 				} elseif ( in_array( $status, self::$warning_module_statuses, true ) ) {
@@ -461,5 +463,29 @@ class Products {
 			$class_name = self::get_product_class( $product );
 			$class_name::extend_plugin_action_links();
 		}
+	}
+
+	/**
+	 * Get interstitials state for the products
+	 *
+	 * @return array A key-value array of product slugs and their interstitial states. True means the interstitial was seen by the user for that product.
+	 */
+	public static function get_interstitials_state() {
+		return get_option( self::INTERSTITIALS_OPTION_NAME, array() );
+	}
+
+	/**
+	 * Update interstitials state for the products
+	 *
+	 * @param array $new_state A key-value array of product slugs and their interstitial states.
+	 *
+	 * @return bool True if the option was updated successfully, false otherwise.
+	 */
+	public static function update_interstitials_state( $new_state ) {
+
+		// Merge the existing interstitials state with the new state.
+		$interstitials_state = array_merge( self::get_interstitials_state(), $new_state );
+
+		return update_option( self::INTERSTITIALS_OPTION_NAME, $interstitials_state );
 	}
 }

--- a/projects/packages/my-jetpack/src/class-rest-products.php
+++ b/projects/packages/my-jetpack/src/class-rest-products.php
@@ -8,6 +8,9 @@
 namespace Automattic\Jetpack\My_Jetpack;
 
 use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
 
 /**
  * Registers the REST routes for Products.
@@ -76,6 +79,56 @@ class REST_Products {
 					'permission_callback' => __CLASS__ . '::edit_permissions_callback',
 					'args'                => array(
 						'products' => $products_arg,
+					),
+				),
+			)
+		);
+
+		register_rest_route(
+			'my-jetpack/v1',
+			'site/products/interstitials',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( self::class, 'get_interstitials_state' ),
+					'permission_callback' => array( self::class, 'edit_permissions_callback' ),
+				),
+				array(
+					'methods'             => WP_REST_Server::EDITABLE,
+					'callback'            => array( self::class, 'update_interstitials_state' ),
+					'permission_callback' => array( self::class, 'edit_permissions_callback' ),
+					'args'                => array(
+						'products' => array(
+							'description'          => __( 'Key-value pairs of product slugs and their interstitial states.', 'jetpack-my-jetpack' ),
+							'type'                 => 'object',
+							'required'             => true,
+							'properties'           => array_fill_keys(
+								Products::get_products_slugs(),
+								array(
+									'type' => 'boolean',
+								)
+							),
+							'additionalProperties' => false,
+							'minProperties'        => 1,
+						),
+					),
+				),
+				'schema' => array(
+					'$schema'    => 'http://json-schema.org/draft-04/schema#',
+					'title'      => 'Products interstitials',
+					'type'       => 'object',
+					'properties' => array(
+						'products' => array(
+							'type'        => 'object',
+							'description' => __( 'Key-value pairs of product slugs and their interstitial states.', 'jetpack-my-jetpack' ),
+							'properties'  => array_fill_keys(
+								Products::get_products_slugs(),
+								array(
+									'description' => __( 'Interstitial state for the product. True means that the user has seen the interstitial for the product.', 'jetpack-my-jetpack' ),
+									'type'        => 'boolean',
+								)
+							),
+						),
 					),
 				),
 			)
@@ -360,5 +413,44 @@ class REST_Products {
 		}
 
 		return rest_ensure_response( Products::get_products( $products_array ) );
+	}
+
+	/**
+	 * Get interstitials state for the products
+	 *
+	 * @return WP_REST_Response
+	 */
+	public static function get_interstitials_state() {
+
+		return rest_ensure_response(
+			array(
+				'products' => Products::get_interstitials_state(),
+			)
+		);
+	}
+
+	/**
+	 * Update interstitials state for the products
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 * @return WP_REST_Response
+	 */
+	public static function update_interstitials_state( WP_REST_Request $request ) {
+
+		$success = Products::update_interstitials_state( $request->get_param( 'products' ) );
+
+		if ( ! $success ) {
+			return new WP_Error(
+				'my_jetpack_interstitials_update_error',
+				__( 'Failed to update interstitials state.', 'jetpack-my-jetpack' ),
+				array( 'status' => 500 )
+			);
+		}
+
+		return rest_ensure_response(
+			array(
+				'products' => Products::get_interstitials_state(),
+			)
+		);
 	}
 }

--- a/projects/packages/my-jetpack/src/class-rest-products.php
+++ b/projects/packages/my-jetpack/src/class-rest-products.php
@@ -433,7 +433,7 @@ class REST_Products {
 	 * Update interstitials state for the products
 	 *
 	 * @param WP_REST_Request $request The request object.
-	 * @return WP_REST_Response
+	 * @return WP_REST_Response|WP_Error
 	 */
 	public static function update_interstitials_state( WP_REST_Request $request ) {
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Completes MYJP-225

The PR ensure that in the Products tab in My Jetpack, the users see the "Learn more" link which leads to the interstitials for the products which they don't have a plan for or haven't "Started for free".

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Introduces frontend and backend support for tracking and updating the interstitial state per product.
* Adds a custom hook, REST API endpoints, and related constants to enable storing and retrieving whether a user has seen interstitials for specific products.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to My Jetpack > Products
* Confirm that you see Learn more for product with cards like Social, VideoPress
* Click on Learn More
* Confirm that you see the interstitial
* Click on Start for free
* Confirm that the plugin/module is activated
* Go to My Jetpack > Products
* Confirm that you don't see Learn more again
* Confirm that you rather see the toggle
* Now click Learn more for another product and purchase a plan
* Go to My Jetpack > Products
* Confirm that you don't see the Learn more now
* 
<img width="774" height="402" alt="image" src="https://github.com/user-attachments/assets/0012e845-33ec-4b65-96ab-0b378266620b" />
