### PR TITLE
Sitemaps: Add monitor argument to sitemap rebuild CLI command

### DIFF
--- a/projects/plugins/jetpack/changelog/update-sitemaps-rebuild-performance-argument-HOG-289
+++ b/projects/plugins/jetpack/changelog/update-sitemaps-rebuild-performance-argument-HOG-289
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: CLI: add a --monitor flag to `wp jetpack sitemap rebuild` that outputs elapsed time, peak memory usage, and CPU time (user/system) after rebuilding sitemaps.
+
+

--- a/projects/plugins/jetpack/class.jetpack-cli.php
+++ b/projects/plugins/jetpack/class.jetpack-cli.php
@@ -1346,7 +1346,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 			// Clear sitemap-related transients
 			delete_transient( 'jetpack_news_sitemap_xml' );
 			delete_transient( 'jetpack-sitemap-state-lock' );
-			WP_CLI::success( 'Purged all sitemap data and cleared sitemap transients.' );
+			WP_CLI::success( __( 'Purged all sitemap data and cleared sitemap transients.', 'jetpack' ) );
 		}
 
 		$sitemap_builder = new Jetpack_Sitemap_Builder();

--- a/projects/plugins/jetpack/class.jetpack-cli.php
+++ b/projects/plugins/jetpack/class.jetpack-cli.php
@@ -1354,7 +1354,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 
 		WP_CLI::success( __( 'Sitemap rebuilt successfully.', 'jetpack' ) );
 
-		if ( $monitor && isset( $start_time ) && isset( $rusage_start ) ) {
+		if ( $monitor && isset( $start_time ) ) {
 			$end_time     = microtime( true );
 			$peak_memory  = memory_get_peak_usage();
 			$elapsed_time = $end_time - $start_time;
@@ -1367,7 +1367,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 			/* translators: %s is a human-readable memory size (e.g., 128MB) */
 			WP_CLI::log( sprintf( __( 'Peak Memory Usage: %s', 'jetpack' ), size_format( $peak_memory ) ) );
 
-			if ( $rusage_start && $rusage_end ) {
+			if ( ! empty( $rusage_start ) && ! empty( $rusage_end ) ) {
 				$user_cpu_time   = ( $rusage_end['ru_utime.tv_sec'] * 1e6 + $rusage_end['ru_utime.tv_usec'] ) - ( $rusage_start['ru_utime.tv_sec'] * 1e6 + $rusage_start['ru_utime.tv_usec'] );
 				$system_cpu_time = ( $rusage_end['ru_stime.tv_sec'] * 1e6 + $rusage_end['ru_stime.tv_usec'] ) - ( $rusage_start['ru_stime.tv_sec'] * 1e6 + $rusage_start['ru_stime.tv_usec'] );
 

--- a/projects/plugins/jetpack/class.jetpack-cli.php
+++ b/projects/plugins/jetpack/class.jetpack-cli.php
@@ -1354,7 +1354,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 
 		WP_CLI::success( __( 'Sitemap rebuilt successfully.', 'jetpack' ) );
 
-		if ( $monitor ) {
+		if ( $monitor && isset( $start_time ) && isset( $rusage_start ) ) {
 			$end_time     = microtime( true );
 			$peak_memory  = memory_get_peak_usage();
 			$elapsed_time = $end_time - $start_time;

--- a/projects/plugins/jetpack/class.jetpack-cli.php
+++ b/projects/plugins/jetpack/class.jetpack-cli.php
@@ -1311,7 +1311,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 	 *
 	 * rebuild : Rebuild all sitemaps
 	 * --purge : if set, will remove all existing sitemap data before rebuilding
-	 * --monitor : if set, will output elapsed time, peak memory usage, and CPU time (user/system)
+	 * --monitor : if set, will output elapsed time, peak memory usage, CPU time (user/system), and average CPU utilization
 	 *
 	 * ## EXAMPLES
 	 *
@@ -1375,6 +1375,12 @@ class Jetpack_CLI extends WP_CLI_Command {
 				WP_CLI::log( sprintf( __( 'CPU time (user): %d microseconds', 'jetpack' ), $user_cpu_time ) );
 				/* translators: %d is an integer representing microseconds */
 				WP_CLI::log( sprintf( __( 'CPU time (system): %d microseconds', 'jetpack' ), $system_cpu_time ) );
+
+				// Average CPU utilization over the elapsed wall time.
+				$total_cpu_sec = ( $user_cpu_time + $system_cpu_time ) / 1e6;
+				$avg_cpu_pct   = $elapsed_time > 0 ? ( $total_cpu_sec / $elapsed_time ) * 100 : 0.0;
+				/* translators: %s is a percentage like 83.4 */
+				WP_CLI::log( sprintf( __( 'Average CPU Utilization: %.1f%%', 'jetpack' ), $avg_cpu_pct ) );
 			}
 			WP_CLI::log( '----------------------------------' );
 		}

--- a/projects/plugins/jetpack/class.jetpack-cli.php
+++ b/projects/plugins/jetpack/class.jetpack-cli.php
@@ -1311,13 +1311,15 @@ class Jetpack_CLI extends WP_CLI_Command {
 	 *
 	 * rebuild : Rebuild all sitemaps
 	 * --purge : if set, will remove all existing sitemap data before rebuilding
+	 * --monitor : if set, will output peak memory and total execution time
 	 *
 	 * ## EXAMPLES
 	 *
 	 * wp jetpack sitemap rebuild
+	 * wp jetpack sitemap rebuild --monitor
 	 *
 	 * @subcommand sitemap
-	 * @synopsis <rebuild> [--purge]
+	 * @synopsis <rebuild> [--purge] [--monitor]
 	 *
 	 * @param array $args Positional args.
 	 * @param array $assoc_args Named args.
@@ -1328,6 +1330,13 @@ class Jetpack_CLI extends WP_CLI_Command {
 		}
 		if ( ! class_exists( 'Jetpack_Sitemap_Builder' ) ) {
 			WP_CLI::error( __( 'Jetpack Sitemaps module is active, but unavailable. This can happen if your site is set to discourage search engine indexing. Please enable search engine indexing to allow sitemap generation.', 'jetpack' ) );
+		}
+
+		$monitor = isset( $assoc_args['monitor'] ) && $assoc_args['monitor'];
+
+		if ( $monitor ) {
+			$start_time   = microtime( true );
+			$rusage_start = function_exists( 'getrusage' ) ? getrusage() : null;
 		}
 
 		if ( isset( $assoc_args['purge'] ) && $assoc_args['purge'] ) {
@@ -1342,6 +1351,33 @@ class Jetpack_CLI extends WP_CLI_Command {
 
 		$sitemap_builder = new Jetpack_Sitemap_Builder();
 		$sitemap_builder->update_sitemap();
+
+		WP_CLI::success( __( 'Sitemap rebuilt successfully.', 'jetpack' ) );
+
+		if ( $monitor ) {
+			$end_time     = microtime( true );
+			$peak_memory  = memory_get_peak_usage();
+			$elapsed_time = $end_time - $start_time;
+			$rusage_end   = function_exists( 'getrusage' ) ? getrusage() : null;
+
+			WP_CLI::log( '----------------------------------' );
+			WP_CLI::log( 'Performance Metrics:' );
+			/* translators: %s is a float representing seconds */
+			WP_CLI::log( sprintf( __( 'Elapsed Time: %.4f seconds', 'jetpack' ), $elapsed_time ) );
+			/* translators: %s is a human-readable memory size (e.g., 128MB) */
+			WP_CLI::log( sprintf( __( 'Peak Memory Usage: %s', 'jetpack' ), size_format( $peak_memory ) ) );
+
+			if ( $rusage_start && $rusage_end ) {
+				$user_cpu_time   = ( $rusage_end['ru_utime.tv_sec'] * 1e6 + $rusage_end['ru_utime.tv_usec'] ) - ( $rusage_start['ru_utime.tv_sec'] * 1e6 + $rusage_start['ru_utime.tv_usec'] );
+				$system_cpu_time = ( $rusage_end['ru_stime.tv_sec'] * 1e6 + $rusage_end['ru_stime.tv_usec'] ) - ( $rusage_start['ru_stime.tv_sec'] * 1e6 + $rusage_start['ru_stime.tv_usec'] );
+
+				/* translators: %d is an integer representing microseconds */
+				WP_CLI::log( sprintf( __( 'CPU time (user): %d microseconds', 'jetpack' ), $user_cpu_time ) );
+				/* translators: %d is an integer representing microseconds */
+				WP_CLI::log( sprintf( __( 'CPU time (system): %d microseconds', 'jetpack' ), $system_cpu_time ) );
+			}
+			WP_CLI::log( '----------------------------------' );
+		}
 	}
 
 	/**

--- a/projects/plugins/jetpack/class.jetpack-cli.php
+++ b/projects/plugins/jetpack/class.jetpack-cli.php
@@ -1311,7 +1311,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 	 *
 	 * rebuild : Rebuild all sitemaps
 	 * --purge : if set, will remove all existing sitemap data before rebuilding
-	 * --monitor : if set, will output peak memory and total execution time
+	 * --monitor : if set, will output elapsed time, peak memory usage, and CPU time (user/system)
 	 *
 	 * ## EXAMPLES
 	 *
@@ -1361,7 +1361,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 			$rusage_end   = function_exists( 'getrusage' ) ? getrusage() : null;
 
 			WP_CLI::log( '----------------------------------' );
-			WP_CLI::log( 'Performance Metrics:' );
+			WP_CLI::log( __( 'Performance Metrics:', 'jetpack' ) );
 			/* translators: %s is a float representing seconds */
 			WP_CLI::log( sprintf( __( 'Elapsed Time: %.4f seconds', 'jetpack' ), $elapsed_time ) );
 			/* translators: %s is a human-readable memory size (e.g., 128MB) */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes [HOG-289: Add performance parameter to sitemap rebuild command](https://linear.app/a8c/issue/HOG-289/add-performance-parameter-to-sitemap-rebuild-command)

## Proposed changes:
* Add a new `--monitor` flag to the `wp jetpack sitemap rebuild` CLI command that provides detailed performance metrics
* Display elapsed execution time, peak memory usage, and CPU time statistics when the flag is enabled

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
No

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:

**Prerequisites:**
- Ensure Sitemaps is active (Jetpack > Settings > Traffic > Sitemaps).
- XMLWriter is OFF by default; enable it to verify the new path:
  - Docker (recommended): create/edit `tools/docker/mu-plugins/0-snippets.php`:
    ```php
    <?php
    add_filter( 'jetpack_sitemap_use_xmlwriter', '__return_true' );
    ```
    Reload your site. Remove this line to test the DOM path again after purging.
  - Non-Docker: add the same snippet in a small mu-plugin or your theme’s `functions.php`.
- Ensure the PHP `XMLWriter` extension is available if testing outside Docker.

**Note:** If testing locally via Docker, the following pattern can be used instead:

   ```bash
    jetpack docker wp jetpack sitemap rebuild -- --purge --monitor
   ```

**Testing the new --monitor flag:**

1. Run the sitemap rebuild command with monitoring:
   ```bash
   wp jetpack sitemap rebuild --monitor
   ```

2. Verify the command output includes:
   - Success message: "Sitemap rebuilt successfully."
   - Performance metrics section with:
     - Elapsed time in seconds
     - Peak memory usage in human-readable format (MB/GB)
     - CPU time metrics (user and system) if available on the system

3. Test backward compatibility by running without the flag:
   ```bash
   wp jetpack sitemap rebuild
   ```
   - Should work exactly as before with no performance output

4. Test combined with existing --purge flag:
   ```bash
   wp jetpack sitemap rebuild --purge --monitor
   ```
   - Should purge existing data AND show performance metrics

**Expected output format with --monitor:**
```
Success: Purged all sitemap data and cleared sitemap transients. (if --purge used)
Success: Sitemap rebuilt successfully.
----------------------------------
Performance Metrics:
Elapsed Time: 2.3456 seconds
Peak Memory Usage: 45.2 MB
CPU time (user): 1234567 microseconds
CPU time (system): 234567 microseconds
----------------------------------
```

**Additional testing:**
* Test on sites with large amounts of content to see meaningful performance differences
* Verify the command works properly when sitemaps module is inactive (should show appropriate error)
* Test on systems where `getrusage()` function may not be available (CPU metrics should be skipped gracefully)

---

