### PR TITLE
Forms: consolidate beta blocks and remove forms_alpha filter

### DIFF
--- a/projects/packages/forms/changelog/update-forms-consolidate-beta-blocks
+++ b/projects/packages/forms/changelog/update-forms-consolidate-beta-blocks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: consolidate beta blocks, remove forms_alpha filter

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -58,7 +58,7 @@ class Contact_Form_Block {
 	 */
 	public static function register_feature( $features ) {
 		// Features under development.
-		$features['image-select-field'] = Blocks::get_variation() === 'beta';
+		$features['image-select-field'] = Blocks::get_variation() === 'beta' && apply_filters( 'forms_alpha', false );
 
 		// Features that are only available to users with a paid plan.
 		$features['multistep-form'] = Current_Plan::supports( 'multistep-form' );
@@ -356,27 +356,6 @@ class Contact_Form_Block {
 
 		// Blocks under development
 		if ( Blocks::get_variation() === 'beta' ) {
-			Blocks::jetpack_register_block(
-				'jetpack/field-image-select',
-				array(
-					'render_callback'  => array( Contact_Form_Plugin::class, 'gutenblock_render_field_image_select' ),
-					'provides_context' => array( 'jetpack/field-required' => 'required' ),
-				)
-			);
-
-			Blocks::jetpack_register_block(
-				'jetpack/form-image-select-choices',
-				array(
-					'render_callback' => array( Contact_Form_Plugin::class, 'gutenblock_render_form_image_select_choices' ),
-				)
-			);
-
-			Blocks::jetpack_register_block(
-				'jetpack/form-image-select-choice',
-				array(
-					'render_callback' => array( Contact_Form_Plugin::class, 'gutenblock_render_form_image_select_choice' ),
-				)
-			);
 
 			Blocks::jetpack_register_block(
 				'jetpack/field-rating',
@@ -418,6 +397,31 @@ class Contact_Form_Block {
 					'provides_context' => array( 'jetpack/field-required' => 'required' ),
 				)
 			);
+
+			// Blocks under heavy development, not ready for testing yet
+			if ( apply_filters( 'forms_alpha', false ) ) {
+				Blocks::jetpack_register_block(
+					'jetpack/field-image-select',
+					array(
+						'render_callback'  => array( Contact_Form_Plugin::class, 'gutenblock_render_field_image_select' ),
+						'provides_context' => array( 'jetpack/field-required' => 'required' ),
+					)
+				);
+
+				Blocks::jetpack_register_block(
+					'jetpack/form-image-select-choices',
+					array(
+						'render_callback' => array( Contact_Form_Plugin::class, 'gutenblock_render_form_image_select_choices' ),
+					)
+				);
+
+				Blocks::jetpack_register_block(
+					'jetpack/form-image-select-choice',
+					array(
+						'render_callback' => array( Contact_Form_Plugin::class, 'gutenblock_render_form_image_select_choice' ),
+					)
+				);
+			}
 		}
 
 		// Paid file field block

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -58,7 +58,7 @@ class Contact_Form_Block {
 	 */
 	public static function register_feature( $features ) {
 		// Features under development.
-		$features['image-select-field'] = apply_filters( 'forms_alpha', false );
+		$features['image-select-field'] = Blocks::get_variation() === 'beta';
 
 		// Features that are only available to users with a paid plan.
 		$features['multistep-form'] = Current_Plan::supports( 'multistep-form' );
@@ -226,22 +226,6 @@ class Contact_Form_Block {
 			)
 		);
 
-		if ( Blocks::get_variation() === 'beta' ) {
-			Blocks::jetpack_register_block(
-				'jetpack/input-rating',
-				array(
-					'supports' => array(
-						'color'      => array(
-							'text'       => true,
-							'background' => false,
-						),
-						'typography' => array(
-							'fontSize' => true,
-						),
-					),
-				)
-			);
-		}
 		// Field render methods.
 		Blocks::jetpack_register_block(
 			'jetpack/field-text',
@@ -370,7 +354,30 @@ class Contact_Form_Block {
 			)
 		);
 
+		// Blocks under development
 		if ( Blocks::get_variation() === 'beta' ) {
+			Blocks::jetpack_register_block(
+				'jetpack/field-image-select',
+				array(
+					'render_callback'  => array( Contact_Form_Plugin::class, 'gutenblock_render_field_image_select' ),
+					'provides_context' => array( 'jetpack/field-required' => 'required' ),
+				)
+			);
+
+			Blocks::jetpack_register_block(
+				'jetpack/form-image-select-choices',
+				array(
+					'render_callback' => array( Contact_Form_Plugin::class, 'gutenblock_render_form_image_select_choices' ),
+				)
+			);
+
+			Blocks::jetpack_register_block(
+				'jetpack/form-image-select-choice',
+				array(
+					'render_callback' => array( Contact_Form_Plugin::class, 'gutenblock_render_form_image_select_choice' ),
+				)
+			);
+
 			Blocks::jetpack_register_block(
 				'jetpack/field-rating',
 				array(
@@ -380,6 +387,22 @@ class Contact_Form_Block {
 					),
 				)
 			);
+
+			Blocks::jetpack_register_block(
+				'jetpack/input-rating',
+				array(
+					'supports' => array(
+						'color'      => array(
+							'text'       => true,
+							'background' => false,
+						),
+						'typography' => array(
+							'fontSize' => true,
+						),
+					),
+				)
+			);
+
 			Blocks::jetpack_register_block(
 				'jetpack/field-slider',
 				array(
@@ -387,6 +410,7 @@ class Contact_Form_Block {
 					'provides_context' => array( 'jetpack/field-required' => 'required' ),
 				)
 			);
+
 			Blocks::jetpack_register_block(
 				'jetpack/field-time',
 				array(
@@ -450,31 +474,6 @@ class Contact_Form_Block {
 		Blocks::jetpack_register_block(
 			'jetpack/form-step-container'
 		);
-
-		// Block under development.
-		if ( apply_filters( 'forms_alpha', false ) ) {
-			Blocks::jetpack_register_block(
-				'jetpack/field-image-select',
-				array(
-					'render_callback'  => array( Contact_Form_Plugin::class, 'gutenblock_render_field_image_select' ),
-					'provides_context' => array( 'jetpack/field-required' => 'required' ),
-				)
-			);
-
-			Blocks::jetpack_register_block(
-				'jetpack/form-image-select-choices',
-				array(
-					'render_callback' => array( Contact_Form_Plugin::class, 'gutenblock_render_form_image_select_choices' ),
-				)
-			);
-
-			Blocks::jetpack_register_block(
-				'jetpack/form-image-select-choice',
-				array(
-					'render_callback' => array( Contact_Form_Plugin::class, 'gutenblock_render_form_image_select_choice' ),
-				)
-			);
-		}
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Move all beta blocks in one spot so that they're easier to see all at once, and wrap current alpha block in beta block as well.

In your local env, enable beta blocks by:

```php
define( 'JETPACK_BLOCKS_VARIATION', 'beta' ); // beta | experimental
```

and alpha block by:

```php
add_filter( 'forms_alpha', '__return_true' ); 
```


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

