### PR TITLE
Forms: slider - add visually hidden labels for inputs

### DIFF
--- a/projects/packages/forms/changelog/update-forms-slider-labels
+++ b/projects/packages/forms/changelog/update-forms-slider-labels
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: slider - add visually hidden labels for inputs

--- a/projects/packages/forms/src/blocks/input-range/edit.js
+++ b/projects/packages/forms/src/blocks/input-range/edit.js
@@ -1,9 +1,11 @@
 import './editor.scss';
 import { useBlockProps } from '@wordpress/block-editor';
+import { VisuallyHidden } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 import { useState, useEffect } from 'react';
 
 export default function SliderInputEdit( props ) {
-	const { context = {}, isSelected } = props;
+	const { context = {}, isSelected, clientId } = props;
 
 	// Get values from context.
 	const minFromContext = context[ 'jetpack/field-slider-min' ];
@@ -55,7 +57,11 @@ export default function SliderInputEdit( props ) {
 	return (
 		<div { ...blockProps }>
 			<div className="jetpack-field-slider__row">
+				<VisuallyHidden as="label" for={ `${ clientId }-slider-min` }>
+					{ __( 'Slider minimum value', 'jetpack-forms' ) }
+				</VisuallyHidden>
 				<input
+					id={ `${ clientId }-slider-min` }
 					type="number"
 					className={ `jetpack-field-slider__min-input${
 						! isMinValid && minFocused ? ' has-error' : ''
@@ -69,7 +75,11 @@ export default function SliderInputEdit( props ) {
 					} }
 				/>
 				<div className="jetpack-field-slider__input-container">
+					<VisuallyHidden as="label" for={ `${ clientId }-slider-default` }>
+						{ __( 'Slider default value', 'jetpack-forms' ) }
+					</VisuallyHidden>
 					<input
+						id={ `${ clientId }-slider-default` }
 						type="range"
 						min={ minFromContext }
 						max={ maxFromContext }
@@ -84,7 +94,11 @@ export default function SliderInputEdit( props ) {
 						{ defaultFromContext }
 					</div>
 				</div>
+				<VisuallyHidden as="label" for={ `${ clientId }-slider-max` }>
+					{ __( 'Slider maximum value', 'jetpack-forms' ) }
+				</VisuallyHidden>
 				<input
+					id={ `${ clientId }-slider-max` }
 					type="number"
 					className={ `jetpack-field-slider__max-input${
 						! isMaxValid && maxFocused ? ' has-error' : ''


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->



## Proposed changes:
<!--- Explain what functional changes your PR includes -->

Adds accessibility labels around slider field inputs in editor canvas.

Fixes warning:
<img width="1012" height="582" alt="image" src="https://github.com/user-attachments/assets/e43b90eb-d2e8-497c-b42f-61bfc4561160" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add slider field
* Nothing changes visually
* If you use with voice reader, you get labels for each input
