### PR TITLE
Forms: Add MailPoet consent toggle

### DIFF
--- a/projects/packages/forms/changelog/add-forms-mailpoet-consent-toggle
+++ b/projects/packages/forms/changelog/add-forms-mailpoet-consent-toggle
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: Add MailPoet email consent toggle.

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/mailpoet-card.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/mailpoet-card.tsx
@@ -1,9 +1,13 @@
+import { store as blockEditorStore } from '@wordpress/block-editor';
+import { createBlock } from '@wordpress/blocks';
 import {
 	Button,
 	ExternalLink,
 	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	SelectControl,
+	ToggleControl,
 } from '@wordpress/components';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { createInterpolateElement, useEffect, useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import MailPoetIcon from '../../../../icons/mailpoet';
@@ -41,6 +45,26 @@ const MailPoetCard = ( {
 		() => ( Array.isArray( data?.details?.lists ) ? ( data.details.lists as MailPoetList[] ) : [] ),
 		[ data?.details?.lists ]
 	);
+
+	const selectedBlock = useSelect( select => select( blockEditorStore ).getSelectedBlock(), [] );
+	const { insertBlock, removeBlock } = useDispatch( blockEditorStore );
+	const hasEmailBlock = selectedBlock?.innerBlocks?.some(
+		( { name }: { name: string } ) => name === 'jetpack/field-email'
+	);
+	const consentBlock = selectedBlock?.innerBlocks?.find(
+		( { name }: { name: string } ) => name === 'jetpack/field-consent'
+	);
+	const toggleConsent = async () => {
+		if ( consentBlock ) {
+			await removeBlock( consentBlock.clientId, false );
+		} else {
+			const buttonBlockIndex = selectedBlock.innerBlocks.findIndex(
+				( { name }: { name: string } ) => name === 'jetpack/button'
+			);
+			const newConsentBlock = await createBlock( 'jetpack/field-consent' );
+			await insertBlock( newConsentBlock, buttonBlockIndex, selectedBlock.clientId, false );
+		}
+	};
 
 	useEffect( () => {
 		if ( ! mailpoet.enabledForForm ) {
@@ -169,6 +193,13 @@ const MailPoetCard = ( {
 								'jetpack-forms'
 							) }
 						</p>
+					) }
+					{ hasEmailBlock && (
+						<ToggleControl
+							label={ __( 'Add email permission request before submit button', 'jetpack-forms' ) }
+							checked={ !! consentBlock }
+							onChange={ toggleConsent }
+						/>
 					) }
 					<p className="integration-card__description">
 						<ExternalLink href={ settingsUrl }>


### PR DESCRIPTION
Fixes [FORMS-234](https://linear.app/a8c/issue/FORMS-234/forms-integrate-opt-in-consent-with-mailpoet)

## Proposed changes:

A previous PR ensures that we check consent status on the backend when adding contacts to MailPoet.

This PR adds a quick toggle to the MailPoet integration card that allows (and encourages) a site owner to add a consent field to their form if they are connecting their form to MailPoet. 

<img width="960" height="660" alt="mailpoet-consent-toggle" src="https://github.com/user-attachments/assets/840091d2-cbfc-4690-a586-aee9d9131ee6" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
See Linear issue above.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Enable the MailPoet feature flag:
* Add a form to page and open the integrations modal
* If needed, install and activate MailPoet from the modal, and add your MailPoet key
* Confirm you now see a toggle to add a consent notice to the form
* Toggle it on and off, and confirm that you see the consent field being added/removed in the background for the form


