### PR TITLE
Forms: Add slider field increment option

### DIFF
--- a/projects/packages/forms/changelog/add-forms-slider-increment-option
+++ b/projects/packages/forms/changelog/add-forms-slider-increment-option
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: Add slider field increment option.

--- a/projects/packages/forms/src/blocks/field-slider/edit.js
+++ b/projects/packages/forms/src/blocks/field-slider/edit.js
@@ -1,4 +1,3 @@
-import './editor.scss';
 import {
 	useBlockProps,
 	useInnerBlocksProps,
@@ -9,6 +8,7 @@ import {
 	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalNumberControl as NumberControl, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	PanelBody,
+	RangeControl,
 } from '@wordpress/components';
 import { useCallback, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -119,7 +119,7 @@ export default function SliderFieldEdit( props ) {
 		<>
 			<InspectorControls>
 				<PanelBody title={ __( 'Settings', 'jetpack-forms' ) }>
-					<HStack alignment="top" className="jp-field-slider-inspector-row">
+					<HStack alignment="top">
 						<NumberControl
 							__next40pxDefaultSize
 							label={ __( 'Min value', 'jetpack-forms' ) }
@@ -137,25 +137,24 @@ export default function SliderFieldEdit( props ) {
 							value={ max }
 						/>
 					</HStack>
-					<HStack alignment="top" className="jp-field-slider-inspector-row">
-						<NumberControl
-							__next40pxDefaultSize
-							help={ __( 'Pre-selected value.', 'jetpack-forms' ) }
-							label={ __( 'Default value', 'jetpack-forms' ) }
-							min={ min }
-							max={ max }
-							value={ defaultValue }
-							onChange={ onChangeDefault }
-						/>
-						<NumberControl
-							__next40pxDefaultSize
-							label={ __( 'Increment', 'jetpack-forms' ) }
-							min={ 0 }
-							step={ step || 1 }
-							value={ step }
-							onChange={ onChangeStep }
-						/>
-					</HStack>
+					<RangeControl
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						help={ __( 'Pre-selected value.', 'jetpack-forms' ) }
+						label={ __( 'Default value', 'jetpack-forms' ) }
+						max={ max }
+						min={ min }
+						onChange={ onChangeDefault }
+						value={ defaultValue }
+					/>
+					<NumberControl
+						__next40pxDefaultSize
+						label={ __( 'Increment', 'jetpack-forms' ) }
+						min={ 0 }
+						step={ step || 1 }
+						value={ step }
+						onChange={ onChangeStep }
+					/>
 				</PanelBody>
 			</InspectorControls>
 			<BlockContextProvider

--- a/projects/packages/forms/src/blocks/field-slider/edit.js
+++ b/projects/packages/forms/src/blocks/field-slider/edit.js
@@ -1,3 +1,4 @@
+import './editor.scss';
 import {
 	useBlockProps,
 	useInnerBlocksProps,
@@ -8,7 +9,6 @@ import {
 	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalNumberControl as NumberControl, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	PanelBody,
-	RangeControl,
 } from '@wordpress/components';
 import { useCallback, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -16,7 +16,15 @@ import JetpackFieldControls from '../shared/components/jetpack-field-controls';
 
 export default function SliderFieldEdit( props ) {
 	const { attributes, setAttributes } = props;
-	const { min = 0, max = 100, default: defaultValue = 0, width, id, required } = attributes;
+	const {
+		min = 0,
+		max = 100,
+		default: defaultValue = 0,
+		step = 1,
+		width,
+		id,
+		required,
+	} = attributes;
 
 	const onChangeMin = useCallback(
 		newMin => {
@@ -47,11 +55,26 @@ export default function SliderFieldEdit( props ) {
 	// This is passed to child input-range block via context.
 	const onChangeDefault = useCallback(
 		newDefault => {
-			const parsedDefault = parseInt( newDefault ) || 0;
+			const parsedDefault = parseFloat( newDefault ) || 0;
 			const validatedDefault = Math.max( Math.min( parsedDefault, max ), min );
 			setAttributes( { default: validatedDefault } );
 		},
 		[ max, min, setAttributes ]
+	);
+
+	const onChangeStep = useCallback(
+		newStep => {
+			const parsedStep = parseFloat( newStep );
+			const safeStep = ! isNaN( parsedStep ) && parsedStep > 0 ? parsedStep : 1;
+			// Snap default to the new step within [min, max]
+			const snappedDefault = ( () => {
+				const ratio = ( defaultValue - min ) / safeStep;
+				const snapped = min + Math.round( ratio ) * safeStep;
+				return Math.max( Math.min( snapped, max ), min );
+			} )();
+			setAttributes( { step: safeStep, default: snappedDefault } );
+		},
+		[ defaultValue, min, max, setAttributes ]
 	);
 
 	// Initialize scalar attributes so they serialize into post markup
@@ -59,15 +82,17 @@ export default function SliderFieldEdit( props ) {
 		if (
 			attributes.min === undefined ||
 			attributes.max === undefined ||
-			attributes.default === undefined
+			attributes.default === undefined ||
+			attributes.step === undefined
 		) {
 			setAttributes( {
 				min: attributes.min ?? 0,
 				max: attributes.max ?? 100,
 				default: attributes.default ?? 0,
+				step: attributes.step ?? 1,
 			} );
 		}
-	}, [ attributes.min, attributes.max, attributes.default, setAttributes ] );
+	}, [ attributes.min, attributes.max, attributes.default, attributes.step, setAttributes ] );
 
 	const blockProps = useBlockProps( {
 		className: `jetpack-field jetpack-field-slider${
@@ -94,7 +119,7 @@ export default function SliderFieldEdit( props ) {
 		<>
 			<InspectorControls>
 				<PanelBody title={ __( 'Settings', 'jetpack-forms' ) }>
-					<HStack alignment="top">
+					<HStack alignment="top" className="jp-field-slider-inspector-row">
 						<NumberControl
 							__next40pxDefaultSize
 							label={ __( 'Min value', 'jetpack-forms' ) }
@@ -112,16 +137,25 @@ export default function SliderFieldEdit( props ) {
 							value={ max }
 						/>
 					</HStack>
-					<RangeControl
-						__next40pxDefaultSize
-						__nextHasNoMarginBottom
-						help={ __( 'Pre-selected value.', 'jetpack-forms' ) }
-						label={ __( 'Default value', 'jetpack-forms' ) }
-						max={ max }
-						min={ min }
-						onChange={ onChangeDefault }
-						value={ defaultValue }
-					/>
+					<HStack alignment="top" className="jp-field-slider-inspector-row">
+						<NumberControl
+							__next40pxDefaultSize
+							help={ __( 'Pre-selected value.', 'jetpack-forms' ) }
+							label={ __( 'Default value', 'jetpack-forms' ) }
+							min={ min }
+							max={ max }
+							value={ defaultValue }
+							onChange={ onChangeDefault }
+						/>
+						<NumberControl
+							__next40pxDefaultSize
+							label={ __( 'Increment', 'jetpack-forms' ) }
+							min={ 0 }
+							step={ step || 1 }
+							value={ step }
+							onChange={ onChangeStep }
+						/>
+					</HStack>
 				</PanelBody>
 			</InspectorControls>
 			<BlockContextProvider

--- a/projects/packages/forms/src/blocks/field-slider/editor.scss
+++ b/projects/packages/forms/src/blocks/field-slider/editor.scss
@@ -1,0 +1,4 @@
+/* Equalize widths for pairs of controls in the slider field inspector */
+.jp-field-slider-inspector-row > div {
+	width: 50%;
+}

--- a/projects/packages/forms/src/blocks/field-slider/editor.scss
+++ b/projects/packages/forms/src/blocks/field-slider/editor.scss
@@ -1,4 +1,0 @@
-/* Equalize widths for pairs of controls in the slider field inspector */
-.jp-field-slider-inspector-row > div {
-	width: 50%;
-}

--- a/projects/packages/forms/src/blocks/field-slider/index.js
+++ b/projects/packages/forms/src/blocks/field-slider/index.js
@@ -28,6 +28,10 @@ const settings = {
 			type: 'number',
 			default: 0,
 		},
+		step: {
+			type: 'number',
+			default: 1,
+		},
 	},
 	edit,
 	save,
@@ -40,12 +44,14 @@ const settings = {
 		'jetpack/field-slider-min': 'min',
 		'jetpack/field-slider-max': 'max',
 		'jetpack/field-slider-default': 'default',
+		'jetpack/field-slider-step': 'step',
 	},
 	example: {
 		attributes: {
 			min: 0,
 			max: 100,
 			default: 0,
+			step: 1,
 		},
 		innerBlocks: [
 			{

--- a/projects/packages/forms/src/blocks/input-range/edit.js
+++ b/projects/packages/forms/src/blocks/input-range/edit.js
@@ -13,6 +13,7 @@ export default function SliderInputEdit( props ) {
 	const minFromContext = context[ 'jetpack/field-slider-min' ];
 	const maxFromContext = context[ 'jetpack/field-slider-max' ];
 	const defaultFromContext = context[ 'jetpack/field-slider-default' ];
+	const stepFromContext = context[ 'jetpack/field-slider-step' ];
 	const onChangeDefault = context[ 'jetpack/field-slider-onChangeDefault' ];
 	const onChangeMin = context[ 'jetpack/field-slider-onChangeMin' ];
 	const onChangeMax = context[ 'jetpack/field-slider-onChangeMax' ];
@@ -96,6 +97,7 @@ export default function SliderInputEdit( props ) {
 						type="range"
 						min={ minFromContext }
 						max={ maxFromContext }
+						step={ stepFromContext || 1 }
 						value={ defaultFromContext }
 						onChange={ e => onChangeDefault( e.target.value ) }
 						className="jetpack-field-slider__range"

--- a/projects/packages/forms/src/blocks/input-range/index.js
+++ b/projects/packages/forms/src/blocks/input-range/index.js
@@ -19,6 +19,7 @@ const settings = {
 		'jetpack/field-slider-onChangeDefault',
 		'jetpack/field-slider-onChangeMin',
 		'jetpack/field-slider-onChangeMax',
+		'jetpack/field-slider-step',
 	],
 };
 

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -145,6 +145,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 				'optionstyles'             => null,
 				'min'                      => null,
 				'max'                      => null,
+				'step'                     => null,
 				'maxfiles'                 => null,
 				'fieldwrapperclasses'      => null,
 				'stylevariationattributes' => array(),
@@ -575,6 +576,9 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 			}
 			if ( is_numeric( $this->get_attribute( 'max' ) ) ) {
 				$extra_attrs['max'] = $this->get_attribute( 'max' );
+			}
+			if ( is_numeric( $this->get_attribute( 'step' ) ) ) {
+				$extra_attrs['step'] = $this->get_attribute( 'step' );
 			}
 		}
 
@@ -2373,6 +2377,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		$min            = isset( $extra_attrs['min'] ) ? $extra_attrs['min'] : 0;
 		$max            = isset( $extra_attrs['max'] ) ? $extra_attrs['max'] : 100;
 		$starting_value = isset( $extra_attrs['default'] ) ? $extra_attrs['default'] : 0;
+		$step           = isset( $extra_attrs['step'] ) ? $extra_attrs['step'] : 1;
 		$current_value  = ( $value !== '' && $value !== null ) ? $value : $starting_value;
 
 		$field = $this->render_label( 'slider', $id, $label, $required, $required_field_text );
@@ -2387,6 +2392,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 					'min'     => $min,
 					'max'     => $max,
 					'default' => $starting_value,
+					'step'    => $step,
 				)
 			);
 			?>
@@ -2400,6 +2406,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 					value="<?php echo esc_attr( $current_value ); ?>"
 					min="<?php echo esc_attr( $min ); ?>"
 					max="<?php echo esc_attr( $max ); ?>"
+					step="<?php echo esc_attr( $step ); ?>"
 					class="<?php echo esc_attr( $class ); ?>"
 					placeholder="<?php echo esc_attr( $placeholder ); ?>"
 					<?php

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -3159,6 +3159,7 @@ class Contact_Form_Plugin {
 		$atts['min']     = isset( $parent_attrs['min'] ) ? $parent_attrs['min'] : 0;
 		$atts['max']     = isset( $parent_attrs['max'] ) ? $parent_attrs['max'] : 100;
 		$atts['default'] = isset( $parent_attrs['default'] ) ? $parent_attrs['default'] : 0;
+		$atts['step']    = isset( $parent_attrs['step'] ) ? $parent_attrs['step'] : 1;
 
 		$atts = self::block_attributes_to_shortcode_attributes( $atts, 'slider', $block );
 		return Contact_Form::parse_contact_field( $atts, $content, $block );


### PR DESCRIPTION
Contributes to [FORMS-66](https://linear.app/a8c/issue/FORMS-66/forms-rangeslider-field)

## Proposed changes:

Adds a new 'increment' or step control to the new Slider Field. Specific changes:
- **Editor**
  - Adds 'step' attribute to Slider field and passes it to the slider input via context
  - Adds inspector number control to set the step field
  - Applies the new step value to the range input in the editor 
- **Frontend**
  - Applies new step property
  
<img width="1185" height="676" alt="slider-increment" src="https://github.com/user-attachments/assets/d98d498d-253d-4774-a54a-6bd0c61eaba1" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None. 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No. 

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Enable beta blocks: define( 'JETPACK_BLOCKS_VARIATION', 'beta' );
* Note: You may need to run jetpack build packages/forms to get the frontend slider-field.css to be built and loaded in the dist directory. Having the watch command running is not sufficient.
* Add a form to a page or post
* Add a new Slider block.
* With slider field selected, confirm the 'Increment' control shows in the sidebar
* Try various combinations of min, max, default, and increment, and confirm increment works as expected
* Save, go to frontend, and confirm that slider field works and obeys whatever increment you set