### PR TITLE
Forms: slider, changes to "selected" borders and instant focus on input click

### DIFF
--- a/projects/packages/forms/changelog/update-forms-slider-selected-visuals
+++ b/projects/packages/forms/changelog/update-forms-slider-selected-visuals
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: slider - update is-selected styling

--- a/projects/packages/forms/src/blocks/input-range/edit.js
+++ b/projects/packages/forms/src/blocks/input-range/edit.js
@@ -61,12 +61,14 @@ export default function SliderInputEdit( props ) {
 					{ __( 'Slider minimum value', 'jetpack-forms' ) }
 				</VisuallyHidden>
 				<input
+					tabIndex="0"
 					id={ `${ clientId }-slider-min` }
 					type="number"
 					className={ `jetpack-field-slider__min-input${
 						! isMinValid && minFocused ? ' has-error' : ''
 					}` }
 					value={ removeLeadingZero( localMin ) }
+					placeholder="0"
 					onChange={ e => setLocalMin( e.target.value ) }
 					onFocus={ () => setMinFocused( true ) }
 					onBlur={ () => {
@@ -98,12 +100,14 @@ export default function SliderInputEdit( props ) {
 					{ __( 'Slider maximum value', 'jetpack-forms' ) }
 				</VisuallyHidden>
 				<input
+					tabIndex="0"
 					id={ `${ clientId }-slider-max` }
 					type="number"
 					className={ `jetpack-field-slider__max-input${
 						! isMaxValid && maxFocused ? ' has-error' : ''
 					}` }
 					value={ removeLeadingZero( localMax ) }
+					placeholder="0"
 					onChange={ e => setLocalMax( e.target.value ) }
 					onFocus={ () => setMaxFocused( true ) }
 					onBlur={ () => {

--- a/projects/packages/forms/src/blocks/input-range/edit.js
+++ b/projects/packages/forms/src/blocks/input-range/edit.js
@@ -71,7 +71,6 @@ export default function SliderInputEdit( props ) {
 					{ __( 'Slider minimum value', 'jetpack-forms' ) }
 				</VisuallyHidden>
 				<input
-					tabIndex="0"
 					id={ `${ clientId }-slider-min` }
 					type="number"
 					className={ `jetpack-field-slider__min-input${
@@ -112,7 +111,6 @@ export default function SliderInputEdit( props ) {
 					{ __( 'Slider maximum value', 'jetpack-forms' ) }
 				</VisuallyHidden>
 				<input
-					tabIndex="0"
 					id={ `${ clientId }-slider-max` }
 					type="number"
 					className={ `jetpack-field-slider__max-input${

--- a/projects/packages/forms/src/blocks/input-range/edit.js
+++ b/projects/packages/forms/src/blocks/input-range/edit.js
@@ -2,10 +2,12 @@ import './editor.scss';
 import { useBlockProps } from '@wordpress/block-editor';
 import { VisuallyHidden } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 
 export default function SliderInputEdit( props ) {
 	const { context = {}, isSelected, clientId } = props;
+	const minInputRef = useRef( null );
+	const maxInputRef = useRef( null );
 
 	// Get values from context.
 	const minFromContext = context[ 'jetpack/field-slider-min' ];
@@ -44,6 +46,14 @@ export default function SliderInputEdit( props ) {
 		return `calc(${ percent }% + (${ 8 - percent * 0.15 }px))`;
 	};
 
+	const handleMinClick = e => {
+		minInputRef.current?.ownerDocument.activeElement === e.target || e.target.focus();
+	};
+
+	const handleMaxClick = e => {
+		maxInputRef.current?.ownerDocument.activeElement === e.target || e.target.focus();
+	};
+
 	// Sync min/max if context updates or min/max input loses focus.
 	useEffect( () => {
 		if ( ! minFocused ) {
@@ -57,7 +67,7 @@ export default function SliderInputEdit( props ) {
 	return (
 		<div { ...blockProps }>
 			<div className="jetpack-field-slider__row">
-				<VisuallyHidden as="label" for={ `${ clientId }-slider-min` }>
+				<VisuallyHidden as="label" htmlFor={ `${ clientId }-slider-min` }>
 					{ __( 'Slider minimum value', 'jetpack-forms' ) }
 				</VisuallyHidden>
 				<input
@@ -70,6 +80,8 @@ export default function SliderInputEdit( props ) {
 					value={ removeLeadingZero( localMin ) }
 					placeholder="0"
 					onChange={ e => setLocalMin( e.target.value ) }
+					ref={ minInputRef }
+					onClick={ handleMinClick }
 					onFocus={ () => setMinFocused( true ) }
 					onBlur={ () => {
 						setMinFocused( false );
@@ -77,7 +89,7 @@ export default function SliderInputEdit( props ) {
 					} }
 				/>
 				<div className="jetpack-field-slider__input-container">
-					<VisuallyHidden as="label" for={ `${ clientId }-slider-default` }>
+					<VisuallyHidden as="label" htmlFor={ `${ clientId }-slider-default` }>
 						{ __( 'Slider default value', 'jetpack-forms' ) }
 					</VisuallyHidden>
 					<input
@@ -109,6 +121,8 @@ export default function SliderInputEdit( props ) {
 					value={ removeLeadingZero( localMax ) }
 					placeholder="0"
 					onChange={ e => setLocalMax( e.target.value ) }
+					ref={ maxInputRef }
+					onClick={ handleMaxClick }
 					onFocus={ () => setMaxFocused( true ) }
 					onBlur={ () => {
 						setMaxFocused( false );

--- a/projects/packages/forms/src/blocks/input-range/editor.scss
+++ b/projects/packages/forms/src/blocks/input-range/editor.scss
@@ -88,13 +88,6 @@
 	margin: 0;
 	appearance: textfield;
 
-	/*
-	.is-selected &,
-	&:focus {
-		border: 1px solid var(--wp-admin-theme-color, #2271b1);
-	}
-	*/
-
 	&.has-error {
 		border: 1px solid var(--color-error, #d63638);
 		box-shadow: none;

--- a/projects/packages/forms/src/blocks/input-range/editor.scss
+++ b/projects/packages/forms/src/blocks/input-range/editor.scss
@@ -23,42 +23,42 @@
 	transition: background 0.3s;
 	width: 100%;
 	box-sizing: border-box;
-}
 
-.jetpack-field-slider__range:focus {
-	outline: none;
-	opacity: 1;
-}
+	&:focus {
+		outline: none;
+		opacity: 1;
+	}
 
-.jetpack-field-slider__range::-webkit-slider-thumb {
-	-webkit-appearance: none;
-	appearance: none;
-	width: 16px;
-	height: 16px;
-	background: var(--jetpack--contact-form--button-primary--background-color);
-	border-radius: 50%;
-	cursor: pointer;
-	transition: background 0.3s;
-	box-shadow: 0 0 2px rgba(0, 0, 0, 0.2);
-}
+	&::-webkit-slider-thumb {
+		-webkit-appearance: none;
+		appearance: none;
+		width: 16px;
+		height: 16px;
+		background: var(--jetpack--contact-form--button-primary--background-color);
+		border-radius: 50%;
+		cursor: pointer;
+		transition: background 0.3s;
+		box-shadow: 0 0 2px rgba(0, 0, 0, 0.2);
+	}
 
-.jetpack-field-slider__range::-moz-range-thumb,
-.jetpack-field-slider__range::-ms-thumb {
-	width: 16px;
-	height: 16px;
-	background: var(--jetpack--contact-form--button-primary--background-color);
-	border-radius: 50%;
-	cursor: pointer;
-	transition: background 0.3s;
-}
+	&::-moz-range-thumb,
+	&::-ms-thumb {
+		width: 16px;
+		height: 16px;
+		background: var(--jetpack--contact-form--button-primary--background-color);
+		border-radius: 50%;
+		cursor: pointer;
+		transition: background 0.3s;
+	}
 
-.jetpack-field-slider__range:focus::-webkit-slider-thumb,
-.jetpack-field-slider__range:focus::-moz-range-thumb,
-.jetpack-field-slider__range::-ms-fill-lower,
-.jetpack-field-slider__range::-ms-fill-upper,
-.jetpack-field-slider__range:focus::-ms-fill-lower,
-.jetpack-field-slider__range:focus::-ms-fill-upper {
-	background: var(--jetpack--contact-form--button-primary--background-color);
+	&:focus::-webkit-slider-thumb,
+	&:focus::-moz-range-thumb,
+	&::-ms-fill-lower,
+	&::-ms-fill-upper,
+	&:focus::-ms-fill-lower,
+	&:focus::-ms-fill-upper {
+		background: var(--jetpack--contact-form--button-primary--background-color);
+	}
 }
 
 .jetpack-field-slider__value-indicator {
@@ -88,10 +88,12 @@
 	margin: 0;
 	appearance: textfield;
 
+	/*
 	.is-selected &,
 	&:focus {
 		border: 1px solid var(--wp-admin-theme-color, #2271b1);
 	}
+	*/
 
 	&.has-error {
 		border: 1px solid var(--color-error, #d63638);

--- a/projects/packages/forms/src/blocks/input-range/editor.scss
+++ b/projects/packages/forms/src/blocks/input-range/editor.scss
@@ -77,8 +77,8 @@
 .jetpack-field-slider__min-input[type="number"],
 .jetpack-field-slider__max-input[type="number"] {
 	field-sizing: content;
-	min-width: 2ch;
-	max-width: 8ch;
+	min-width: 1ch;
+	max-width: 10ch;
 	text-align: center;
 	border: none;
 	background: transparent;
@@ -89,7 +89,7 @@
 	appearance: textfield;
 
 	&.has-error {
-		border: 1px solid var(--color-error, #d63638);
+		outline-color: var(--color-error, #d63638);
 		box-shadow: none;
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->



## Proposed changes:
<!--- Explain what functional changes your PR includes -->

* Remove borders from inputs when range input block is selected; combined with on-click-focus change I hope it's still clear enough they can edit values, and they also still have the sidebar if they don't realise. We generally don't have other similar affordances around areas they can edit (which can be more or less obvious), so this keeps editing experience and selected-borders more consistent and clean.

    Before
    <img width="680" height="107" alt="image" src="https://github.com/user-attachments/assets/15c36957-41a6-46de-a4be-40200a656931" />

    After
    <img width="679" height="168" alt="Screenshot 2025-08-13 at 22 18 14" src="https://github.com/user-attachments/assets/b9971844-2e2b-4541-8514-42ae28124dee" />

* Capture focus instantly when clicking inputs, if not already. Previously when you clicked, you selected field, so it might've seemed like you couldn't edit numbers. This is weird since other inputs in other fields capture focus instantly. I did focus-on-click but it feels slightly hacky and could lead to odd placements of the cursor. 🤔 

    Before

https://github.com/user-attachments/assets/b738f8af-aa8d-4033-81bc-562027ab9a77

    After

https://github.com/user-attachments/assets/ce2dd32d-a3db-4a6a-a72c-538ced661370

* Allow bigger numbers without cutting out, and shring input for single digits; avoids too much empty space around small numbers. Big numbers... why not 😅 

    Before
    <img width="718" height="127" alt="Screenshot 2025-08-13 at 21 49 40" src="https://github.com/user-attachments/assets/421e007a-df18-4594-8536-eca5475f341d" />

    After
    <img width="695" height="171" alt="Screenshot 2025-08-13 at 21 49 19" src="https://github.com/user-attachments/assets/6e5a2d0c-4882-4ace-829a-5f47706554a5" />

* Mark outline as red on errors, instead of border (now that we don't have border)
* Add placeholder "0" on empty inputs to anticipate input turning "0" anyway when unfocusing input. This could be annoying too, and happy to remove.

    <img width="692" height="117" alt="Screenshot 2025-08-13 at 21 48 17" src="https://github.com/user-attachments/assets/1c168c46-499d-4b7e-8ac2-ce4c2be8027d" />

* Fix bug `for=""` should be `htmlFor=""` — my bad, missed [in previous PR](https://github.com/Automattic/jetpack/pull/44779).

    <img width="626" height="80" alt="image" src="https://github.com/user-attachments/assets/4d61d788-0802-4bed-8071-ae140cc73a82" />


*  Move some CSS inside `.jetpack-field-slider__range` — just reads clarer to me but happy to have it either way.



### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Try the heck outta slider field 😅 
