### PR TITLE
Forms: Check MailPoet setup for integration

### DIFF
--- a/projects/packages/forms/changelog/udpate-forms-mailpoet-check-full-setup
+++ b/projects/packages/forms/changelog/udpate-forms-mailpoet-check-full-setup
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: Check MailPoet setup not key.

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/mailpoet-card.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/mailpoet-card.tsx
@@ -141,7 +141,7 @@ const MailPoetCard = ( {
 					<p className="integration-card__description">
 						{ createInterpolateElement(
 							__(
-								'MailPoet is active. There is one step left. Please add your <a>MailPoet key</a>.',
+								'MailPoet is active. There is one step left. Please complete <a>MailPoet setup</a>.',
 								'jetpack-forms'
 							),
 							{
@@ -157,7 +157,7 @@ const MailPoetCard = ( {
 							rel="noopener noreferrer"
 							__next40pxDefaultSize={ true }
 						>
-							{ __( 'Add MailPoet key', 'jetpack-forms' ) }
+							{ __( 'Complete MailPoet setup', 'jetpack-forms' ) }
 						</Button>
 						<Button variant="tertiary" onClick={ refreshStatus } __next40pxDefaultSize={ true }>
 							{ __( 'Refresh status', 'jetpack-forms' ) }

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -932,10 +932,11 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 				break;
 			case 'mailpoet':
 				$response['needsConnection'] = true;
-				if ( class_exists( '\MailPoet\Config\ServicesChecker' ) ) {
-					$checker = new \MailPoet\Config\ServicesChecker(); // @phan-suppress-current-line PhanUndeclaredClassMethod -- we're checking the class exists first
-					if ( method_exists( $checker, 'isMailPoetAPIKeyValid' ) ) {
-						$response['isConnected'] = (bool) $checker->isMailPoetAPIKeyValid( false ); // @phan-suppress-current-line PhanUndeclaredClassMethod -- we're checking the method exists first
+				// Determine if MailPoet setup is complete using the public API.
+				if ( class_exists( \MailPoet\API\API::class ) ) {
+					$mailpoet_api = \MailPoet\API\API::MP( 'v1' );
+					if ( $mailpoet_api && method_exists( $mailpoet_api, 'isSetupComplete' ) ) {
+						$response['isConnected'] = (bool) $mailpoet_api->isSetupComplete();
 					}
 				}
 				// Add MailPoet lists to details

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -933,10 +933,10 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 			case 'mailpoet':
 				$response['needsConnection'] = true;
 				// Determine if MailPoet setup is complete using the public API.
-				if ( class_exists( \MailPoet\API\API::class ) ) {
+				if ( class_exists( \MailPoet\API\API::class ) ) { // @phan-suppress-current-line PhanUndeclaredClassReference
 					$mailpoet_api = \MailPoet\API\API::MP( 'v1' ); // @phan-suppress-current-line PhanUndeclaredClassMethod
 					if ( $mailpoet_api && method_exists( $mailpoet_api, 'isSetupComplete' ) ) {
-						$response['isConnected'] = (bool) $mailpoet_api->isSetupComplete(); // @phan-suppress-current-line PhanUndeclaredMethod
+						$response['isConnected'] = (bool) $mailpoet_api->isSetupComplete();
 					}
 				}
 				// Add MailPoet lists to details

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -933,10 +933,10 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 			case 'mailpoet':
 				$response['needsConnection'] = true;
 				// Determine if MailPoet setup is complete using the public API.
-				if ( class_exists( \MailPoet\API\API::class ) ) {
-					$mailpoet_api = \MailPoet\API\API::MP( 'v1' );
+				if ( class_exists( \MailPoet\API\API::class ) ) { // @phan-suppress-current-line PhanUndeclaredClassReference
+					$mailpoet_api = \MailPoet\API\API::MP( 'v1' ); // @phan-suppress-current-line PhanUndeclaredStaticMethod
 					if ( $mailpoet_api && method_exists( $mailpoet_api, 'isSetupComplete' ) ) {
-						$response['isConnected'] = (bool) $mailpoet_api->isSetupComplete();
+						$response['isConnected'] = (bool) $mailpoet_api->isSetupComplete(); // @phan-suppress-current-line PhanUndeclaredMethod
 					}
 				}
 				// Add MailPoet lists to details

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -933,8 +933,8 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 			case 'mailpoet':
 				$response['needsConnection'] = true;
 				// Determine if MailPoet setup is complete using the public API.
-				if ( class_exists( \MailPoet\API\API::class ) ) { // @phan-suppress-current-line PhanUndeclaredClassReference
-					$mailpoet_api = \MailPoet\API\API::MP( 'v1' ); // @phan-suppress-current-line PhanUndeclaredStaticMethod
+				if ( class_exists( \MailPoet\API\API::class ) ) {
+					$mailpoet_api = \MailPoet\API\API::MP( 'v1' ); // @phan-suppress-current-line PhanUndeclaredClassMethod
 					if ( $mailpoet_api && method_exists( $mailpoet_api, 'isSetupComplete' ) ) {
 						$response['isConnected'] = (bool) $mailpoet_api->isSetupComplete(); // @phan-suppress-current-line PhanUndeclaredMethod
 					}

--- a/projects/packages/forms/src/dashboard/integrations/mailpoet-card.tsx
+++ b/projects/packages/forms/src/dashboard/integrations/mailpoet-card.tsx
@@ -56,7 +56,7 @@ const MailPoetDashboardCard = ( {
 					<p className="integration-card__description">
 						{ createInterpolateElement(
 							__(
-								'MailPoet is active. There is one step left. Please add your <a>MailPoet key</a>.',
+								'MailPoet is active. There is one step left. Please complete <a>MailPoet setup</a>.',
 								'jetpack-forms'
 							),
 							{
@@ -72,7 +72,7 @@ const MailPoetDashboardCard = ( {
 							rel="noopener noreferrer"
 							__next40pxDefaultSize={ true }
 						>
-							{ __( 'Add MailPoet key', 'jetpack-forms' ) }
+							{ __( 'Complete MailPoet setup', 'jetpack-forms' ) }
 						</Button>
 						<Button variant="tertiary" onClick={ refreshStatus } __next40pxDefaultSize={ true }>
 							{ __( 'Refresh status', 'jetpack-forms' ) }


### PR DESCRIPTION
Fixes [FORMS-217](https://linear.app/a8c/issue/FORMS-217/improve-mailpoet-integration-card)

## Proposed changes:

Updates how we check for valid MailPoet connection before allowing integration on forms. Before we were checking for a valid key. Based on feedback, we now check MailPoet's isSetupComplete method. Because we're checking different conditions, there are also small updates in text and nudges. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
See Linear issue above. 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No. 

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

**Testing on a Jurassic tube dev site**
* Enable MailPoet feature flag: 
* Add a form to a page and open the integrations modal. You'll need at least an `Email` field. You can also consider adding `First Name` and `Last Name` fields. 
* If needed install and activate the MailPoet plugin from the modal.
* If needed (setup is not complete), you'll be prompted to complete update. Click the link to complete. 
* If setup is complete, you'll see the MailPoet settings. Enable MailPoet for the form and choose a list.
* Save, go to frontend, submit form, and confirm that contact details

**This cannot be tested on a simple site due to plugin install**