### PR TITLE
Add typecheck for protect plugin and fix errors

### DIFF
--- a/projects/js-packages/scan/changelog/update-add-typecheck-for-protect-plugin
+++ b/projects/js-packages/scan/changelog/update-add-typecheck-for-protect-plugin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Added missing types for protect plugin.

--- a/projects/js-packages/scan/src/types/status.ts
+++ b/projects/js-packages/scan/src/types/status.ts
@@ -1,5 +1,25 @@
 import { Threat } from './threats.ts';
 
+export type ExtensionStatus = {
+	/** The name of the extension. */
+	name: string;
+
+	/** The slug of the extension. */
+	slug: string;
+
+	/** The version of the extension. */
+	version: string;
+
+	/** The threats found in the extension. */
+	threats: Threat[];
+
+	/** The type of extension. */
+	type: 'plugins' | 'themes';
+
+	/** Whether the extension was checked in the latest scan. */
+	checked: boolean;
+};
+
 export type ScanStatus = {
 	/** The current status of the scanner. */
 	status: 'unavailable' | 'provisioning' | 'idle' | 'scanning' | 'scheduled';
@@ -30,4 +50,10 @@ export type ScanStatus = {
 
 	/** The detected threats. */
 	threats: Threat[];
+
+	core: ExtensionStatus | ExtensionStatus[];
+	plugins: ExtensionStatus[];
+	themes: ExtensionStatus[];
+	files: Threat[];
+	database: Threat[];
 };

--- a/projects/plugins/protect/changelog/update-add-typecheck-for-protect-plugin
+++ b/projects/plugins/protect/changelog/update-add-typecheck-for-protect-plugin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Added typecheck script.

--- a/projects/plugins/protect/package.json
+++ b/projects/plugins/protect/package.json
@@ -18,6 +18,7 @@
 		"build-concurrently": "pnpm run clean && concurrently 'pnpm:build-client'",
 		"build-production-concurrently": "pnpm run clean && concurrently 'NODE_ENV=production BABEL_ENV=production pnpm run build-client' && pnpm run validate",
 		"clean": "rm -rf build/",
+		"typecheck": "tsc --noEmit",
 		"validate": "pnpm exec validate-es build/",
 		"watch": "pnpm run build && webpack watch"
 	},

--- a/projects/plugins/protect/src/js/data/scan/use-scan-status-query.ts
+++ b/projects/plugins/protect/src/js/data/scan/use-scan-status-query.ts
@@ -65,7 +65,7 @@ export default function useScanStatusQuery( {
 		skipUserConnection: true,
 	} );
 
-	return useQuery( {
+	return useQuery< ScanStatus >( {
 		queryKey: [ QUERY_SCAN_STATUS_KEY ],
 		queryFn: async () => {
 			// Fetch scan status data from the API

--- a/projects/plugins/protect/src/js/hooks/use-notices.tsx
+++ b/projects/plugins/protect/src/js/hooks/use-notices.tsx
@@ -79,7 +79,6 @@ export default function useNotices() {
 							),
 							{
 								supportLink: (
-									// @ts-expect-error TS says, `children` is missing but it's passed dynamically by createInterpolateElement
 									<ExternalLink
 										href={ hasPlan ? PAID_PLUGIN_SUPPORT_URL : FREE_PLUGIN_SUPPORT_URL }
 									/>

--- a/projects/plugins/protect/src/js/hooks/use-notices.tsx
+++ b/projects/plugins/protect/src/js/hooks/use-notices.tsx
@@ -79,6 +79,7 @@ export default function useNotices() {
 							),
 							{
 								supportLink: (
+									// @ts-expect-error TS says, `children` is missing but it's passed dynamically by createInterpolateElement
 									<ExternalLink
 										href={ hasPlan ? PAID_PLUGIN_SUPPORT_URL : FREE_PLUGIN_SUPPORT_URL }
 									/>

--- a/projects/plugins/protect/src/js/hooks/use-plan.tsx
+++ b/projects/plugins/protect/src/js/hooks/use-plan.tsx
@@ -52,7 +52,7 @@ export default function usePlan( { redirectUrl }: { redirectUrl?: string } = {} 
 		siteProductAvailabilityHandler: API.checkPlan,
 		useBlogIdSuffix: true,
 		connectAfterCheckout: false,
-		from: () => 'protect',
+		from: 'protect',
 	} ) as unknown as {
 		run: ( event?: Event, redirect?: string ) => void;
 		isRegistered: boolean;

--- a/projects/plugins/protect/src/js/hooks/use-protect-data/index.ts
+++ b/projects/plugins/protect/src/js/hooks/use-protect-data/index.ts
@@ -140,7 +140,7 @@ export default function useProtectData(
 
 		// Core data may be either a single object or an array of multiple objects.
 		let cores = Array.isArray( data.core ) ? data.core : [];
-		if ( data?.core && 'threats' in data.core && data.core?.threats ) {
+		if ( data?.core && 'threats' in data.core && data.core.threats ) {
 			cores = [ data.core ];
 		}
 

--- a/projects/plugins/protect/src/js/hooks/use-protect-data/index.ts
+++ b/projects/plugins/protect/src/js/hooks/use-protect-data/index.ts
@@ -140,7 +140,7 @@ export default function useProtectData(
 
 		// Core data may be either a single object or an array of multiple objects.
 		let cores = Array.isArray( data.core ) ? data.core : [];
-		if ( data?.core?.threats ) {
+		if ( data?.core && 'threats' in data.core && data.core?.threats ) {
 			cores = [ data.core ];
 		}
 

--- a/projects/plugins/protect/src/js/routes/firewall/firewall-admin-section-hero.tsx
+++ b/projects/plugins/protect/src/js/routes/firewall/firewall-admin-section-hero.tsx
@@ -1,5 +1,5 @@
 import { Status, Text } from '@automattic/jetpack-components';
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { useMemo } from 'react';
 import AdminSectionHero from '../../components/admin-section-hero';
 import useWafData from '../../hooks/use-waf-data';
@@ -29,7 +29,7 @@ const FirewallAdminSectionHero = () => {
 		if ( status === 'on' ) {
 			return standaloneMode
 				? __( 'Standalone mode', 'jetpack-protect' )
-				: __( 'Active', 'jetpack-protect', 0 );
+				: _x( 'Active', 'The module status', 'jetpack-protect' );
 		}
 
 		return __( 'Inactive', 'jetpack-protect' );
@@ -43,10 +43,10 @@ const FirewallAdminSectionHero = () => {
 					{ wafSupported &&
 						( jetpackWafAutomaticRules
 							? __( 'Automatic firewall is on', 'jetpack-protect' )
-							: __(
+							: _x(
 									'Firewall is on',
-									'jetpack-protect',
-									/* dummy arg to avoid bad minification */ 0
+									'Explanatory text for firewall on status',
+									'jetpack-protect'
 							  ) ) }
 				</>
 			);
@@ -59,10 +59,10 @@ const FirewallAdminSectionHero = () => {
 					{ wafSupported &&
 						( automaticRulesAvailable
 							? __( 'Automatic firewall is off', 'jetpack-protect' )
-							: __(
+							: _x(
 									'Firewall is off',
-									'jetpack-protect',
-									/* dummy arg to avoid bad minification */ 0
+									'Explanatory text for firewall off status',
+									'jetpack-protect'
 							  ) ) }
 				</>
 			);

--- a/projects/plugins/protect/src/js/routes/scan/history/history-admin-section-hero.tsx
+++ b/projects/plugins/protect/src/js/routes/scan/history/history-admin-section-hero.tsx
@@ -19,7 +19,7 @@ const HistoryAdminSectionHero: FC = () => {
 	} );
 	const { counts, error } = useProtectData( {
 		sourceType: 'history',
-		filter: { status: filter },
+		filter: { status: filter, key: null },
 	} );
 	const { threats: numAllThreats } = counts.all;
 
@@ -55,7 +55,7 @@ const HistoryAdminSectionHero: FC = () => {
 							? sprintf(
 									/* translators: %1$s: Total number of threats, %2$s: singular or plural form of "threat" */
 									__( '%1$s previously active %2$s', 'jetpack-protect' ),
-									numAllThreats,
+									numAllThreats.toString(),
 									numAllThreats === 1 ? 'threat' : 'threats'
 							  )
 							: __( 'No previously active threats', 'jetpack-protect' ) }

--- a/projects/plugins/protect/src/js/routes/scan/scan-admin-section-hero.tsx
+++ b/projects/plugins/protect/src/js/routes/scan/scan-admin-section-hero.tsx
@@ -1,6 +1,6 @@
 import { Text, Status, useBreakpointMatch } from '@automattic/jetpack-components';
 import { dateI18n } from '@wordpress/date';
-import { __, _n, sprintf } from '@wordpress/i18n';
+import { __, _n, _x, sprintf } from '@wordpress/i18n';
 import { useState } from 'react';
 import AdminSectionHero from '../../components/admin-section-hero';
 import ErrorAdminSectionHero from '../../components/error-admin-section-hero';
@@ -57,7 +57,7 @@ const ScanAdminSectionHero: FC = () => {
 							? sprintf(
 									/* translators: %1$s: the total number of threats/vulnerabilities, %2$s: the singular or plural form of "threat" or "vulnerability". */
 									__( '%1$s %2$s found', 'jetpack-protect' ),
-									numThreats,
+									numThreats.toString(),
 									hasPlan
 										? _n( 'threat', 'threats', numThreats, 'jetpack-protect' )
 										: _n( 'vulnerability', 'vulnerabilities', numThreats, 'jetpack-protect' )
@@ -67,11 +67,7 @@ const ScanAdminSectionHero: FC = () => {
 									__( 'No %s found', 'jetpack-protect' ),
 									hasPlan
 										? __( 'threats', 'jetpack-protect' )
-										: __(
-												'vulnerabilities',
-												'jetpack-protect',
-												/* dummy arg to avoid bad minification */ 0
-										  )
+										: _x( 'vulnerabilities', 'Plural of vulnerability', 'jetpack-protect' )
 							  ) }
 					</AdminSectionHero.Heading>
 					<AdminSectionHero.Subheading>

--- a/projects/plugins/protect/tsconfig.json
+++ b/projects/plugins/protect/tsconfig.json
@@ -1,10 +1,9 @@
 {
 	"extends": "jetpack-js-tools/tsconfig.base.json",
-	"include": [ "./src/js" ],
+	"include": [ "src/js" ],
 	"compilerOptions": {
 		"sourceMap": true,
 		"outDir": "./build/",
-		"target": "esnext",
-		"typeRoots": [ "./node_modules/@types/", "./src/js/types" ]
+		"target": "esnext"
 	}
 }


### PR DESCRIPTION
The `plugins/protect` uses TypeScript but is not set up for type-checking.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add `typecheck` script for Protect plugin and fix type errors

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* CI should be happy
