### PR TITLE
Add typecheck for e2e tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -455,7 +455,7 @@ jobs:
         run: |
           EXIT=0
           set -o pipefail
-          for DIR in $( jq -r 'if .scripts.typecheck then input_filename | sub( "/package.json"; "" ) else empty end' projects/*/*/package.json ); do
+          for DIR in $( jq -r 'if .scripts.typecheck then input_filename | sub( "/package.json"; "" ) else empty end' projects/*/*/package.json projects/*/*/tests/e2e/package.json tools/*/package.json 2>/dev/null ); do
             echo "::group::$DIR"
             if ! ( cd "$DIR" && pnpm run typecheck ) | sed -uE 's#^.+\([0-9,]+\): error #'"$DIR"'/&#'; then
               EXIT=1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4293,6 +4293,9 @@ importers:
       '@playwright/test':
         specifier: 1.51.1
         version: 1.51.1
+      '@types/node':
+        specifier: ^20.4.2
+        version: 20.19.10
       _jetpack-e2e-commons:
         specifier: workspace:*
         version: link:../../../../../tools/e2e-commons
@@ -4302,6 +4305,9 @@ importers:
       config:
         specifier: 3.3.12
         version: 3.3.12
+      typescript:
+        specifier: 5.8.3
+        version: 5.8.3
 
   projects/plugins/classic-theme-helper-plugin:
     dependencies:
@@ -4387,6 +4393,9 @@ importers:
       '@playwright/test':
         specifier: 1.51.1
         version: 1.51.1
+      '@types/node':
+        specifier: ^20.4.2
+        version: 20.19.10
       _jetpack-e2e-commons:
         specifier: workspace:*
         version: link:../../../../../tools/e2e-commons
@@ -4396,6 +4405,9 @@ importers:
       config:
         specifier: 3.3.12
         version: 3.3.12
+      typescript:
+        specifier: 5.8.3
+        version: 5.8.3
 
   projects/plugins/crm:
     dependencies:
@@ -5006,6 +5018,9 @@ importers:
       '@playwright/test':
         specifier: 1.51.1
         version: 1.51.1
+      '@types/node':
+        specifier: ^20.4.2
+        version: 20.19.10
       _jetpack-e2e-commons:
         specifier: workspace:*
         version: link:../../../../../tools/e2e-commons
@@ -5015,6 +5030,9 @@ importers:
       config:
         specifier: 3.3.12
         version: 3.3.12
+      typescript:
+        specifier: 5.8.3
+        version: 5.8.3
 
   projects/plugins/mu-wpcom-plugin: {}
 
@@ -5202,6 +5220,9 @@ importers:
       '@playwright/test':
         specifier: 1.51.1
         version: 1.51.1
+      '@types/node':
+        specifier: ^20.4.2
+        version: 20.19.10
       _jetpack-e2e-commons:
         specifier: workspace:*
         version: link:../../../../../tools/e2e-commons
@@ -5211,6 +5232,9 @@ importers:
       config:
         specifier: 3.3.12
         version: 3.3.12
+      typescript:
+        specifier: 5.8.3
+        version: 5.8.3
 
   projects/plugins/search: {}
 
@@ -5219,6 +5243,9 @@ importers:
       '@playwright/test':
         specifier: 1.51.1
         version: 1.51.1
+      '@types/node':
+        specifier: ^20.4.2
+        version: 20.19.10
       _jetpack-e2e-commons:
         specifier: workspace:*
         version: link:../../../../../tools/e2e-commons
@@ -5228,6 +5255,9 @@ importers:
       config:
         specifier: 3.3.12
         version: 3.3.12
+      typescript:
+        specifier: 5.8.3
+        version: 5.8.3
 
   projects/plugins/social:
     devDependencies:
@@ -5240,6 +5270,9 @@ importers:
       '@playwright/test':
         specifier: 1.51.1
         version: 1.51.1
+      '@types/node':
+        specifier: ^20.4.2
+        version: 20.19.10
       _jetpack-e2e-commons:
         specifier: workspace:*
         version: link:../../../../../tools/e2e-commons
@@ -5249,6 +5282,9 @@ importers:
       config:
         specifier: 3.3.12
         version: 3.3.12
+      typescript:
+        specifier: 5.8.3
+        version: 5.8.3
 
   projects/plugins/starter-plugin:
     dependencies:
@@ -5331,6 +5367,9 @@ importers:
       '@playwright/test':
         specifier: 1.51.1
         version: 1.51.1
+      '@types/node':
+        specifier: ^20.4.2
+        version: 20.19.10
       _jetpack-e2e-commons:
         specifier: workspace:*
         version: link:../../../../../tools/e2e-commons
@@ -5340,6 +5379,9 @@ importers:
       config:
         specifier: 3.3.12
         version: 3.3.12
+      typescript:
+        specifier: 5.8.3
+        version: 5.8.3
 
   projects/plugins/super-cache: {}
 
@@ -5442,6 +5484,9 @@ importers:
       '@playwright/test':
         specifier: 1.51.1
         version: 1.51.1
+      '@types/node':
+        specifier: ^20.4.2
+        version: 20.19.10
       _jetpack-e2e-commons:
         specifier: workspace:*
         version: link:../../../../../tools/e2e-commons
@@ -5451,6 +5496,9 @@ importers:
       config:
         specifier: 3.3.12
         version: 3.3.12
+      typescript:
+        specifier: 5.8.3
+        version: 5.8.3
 
   projects/plugins/wpcomsh:
     devDependencies:
@@ -5560,6 +5608,9 @@ importers:
       '@types/lodash-es':
         specifier: 4.17.12
         version: 4.17.12
+      '@types/node':
+        specifier: ^20.4.2
+        version: 20.19.10
       '@wordpress/e2e-test-utils-playwright':
         specifier: 1.28.0
         version: 1.28.0(@playwright/test@1.51.1)
@@ -5584,6 +5635,9 @@ importers:
       shell-escape:
         specifier: 0.2.0
         version: 0.2.0
+      typescript:
+        specifier: 5.8.3
+        version: 5.8.3
       winston:
         specifier: 3.8.1
         version: 3.8.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5393,6 +5393,9 @@ importers:
       '@types/node':
         specifier: ^20.4.2
         version: 20.19.10
+      _jetpack-e2e-commons:
+        specifier: workspace:*
+        version: link:../../../../../tools/e2e-commons
       axios:
         specifier: 1.11.0
         version: 1.11.0

--- a/projects/plugins/boost/changelog/add-typecheck-for-e2e-tests
+++ b/projects/plugins/boost/changelog/add-typecheck-for-e2e-tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Added typecheck support for E2E tests.

--- a/projects/plugins/boost/tests/e2e/package.json
+++ b/projects/plugins/boost/tests/e2e/package.json
@@ -15,14 +15,17 @@
 		"test:run": "playwright install chromium && NODE_CONFIG_DIR='./config' ALLURE_RESULTS_DIR=./output/allure-results NODE_PATH=\"$PWD/node_modules\" playwright test",
 		"tunnel:down": "tunnel down",
 		"tunnel:reset": "tunnel reset",
-		"tunnel:up": "tunnel up"
+		"tunnel:up": "tunnel up",
+		"typecheck": "tsc --noEmit"
 	},
 	"browserslist": [],
 	"devDependencies": {
 		"@playwright/test": "1.51.1",
+		"@types/node": "^20.4.2",
 		"_jetpack-e2e-commons": "workspace:*",
 		"allure-playwright": "2.9.2",
-		"config": "3.3.12"
+		"config": "3.3.12",
+		"typescript": "5.8.3"
 	},
 	"ci": {
 		"pluginSlug": "jetpack-boost",

--- a/projects/plugins/boost/tests/e2e/specs/cornerstone/cornerstone.test.ts
+++ b/projects/plugins/boost/tests/e2e/specs/cornerstone/cornerstone.test.ts
@@ -1,6 +1,14 @@
 import { test, expect } from '../../lib/fixtures/test';
 
-/* global Jetpack_Boost */
+declare global {
+	interface Window {
+		Jetpack_Boost: {
+			site: {
+				url: string;
+			};
+		};
+	}
+}
 
 test.describe( 'Cornerstone Pages', () => {
 	test.beforeAll( async ( { boostUtils } ) => {
@@ -56,7 +64,7 @@ test.describe( 'Cornerstone Pages', () => {
 		await jetpackBoostPage.openCornerstonePagesPanel();
 
 		// Check that homepage is listed in predefined pages
-		const homeUrl = await page.evaluate( () => Jetpack_Boost.site.url );
+		const homeUrl = await page.evaluate( () => window.Jetpack_Boost.site.url );
 		await expect(
 			page.locator( `text=${ homeUrl }` ).first(),
 			'Homepage should be listed in predefined pages'
@@ -96,7 +104,7 @@ test.describe( 'Cornerstone Pages', () => {
 		).toBeVisible();
 
 		// Test homepage URL (should be rejected)
-		const homeUrl = await page.evaluate( () => Jetpack_Boost.site.url );
+		const homeUrl = await page.evaluate( () => window.Jetpack_Boost.site.url );
 		await jetpackBoostPage.enterCornerstonePageUrl( homeUrl );
 		await expect(
 			page.getByText( 'The homepage does not need to be added' ),

--- a/projects/plugins/classic-theme-helper-plugin/changelog/add-typecheck-for-e2e-tests
+++ b/projects/plugins/classic-theme-helper-plugin/changelog/add-typecheck-for-e2e-tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Added typecheck support for E2E tests.

--- a/projects/plugins/classic-theme-helper-plugin/tests/e2e/package.json
+++ b/projects/plugins/classic-theme-helper-plugin/tests/e2e/package.json
@@ -13,14 +13,17 @@
 		"test:run": "playwright install chromium && NODE_CONFIG_DIR='./config' ALLURE_RESULTS_DIR=./output/allure-results NODE_PATH=\"$PWD/node_modules\" playwright test",
 		"tunnel:down": "tunnel down",
 		"tunnel:reset": "tunnel reset",
-		"tunnel:up": "tunnel up"
+		"tunnel:up": "tunnel up",
+		"typecheck": "tsc --noEmit"
 	},
 	"browserslist": [],
 	"devDependencies": {
 		"@playwright/test": "1.51.1",
+		"@types/node": "^20.4.2",
 		"_jetpack-e2e-commons": "workspace:*",
 		"allure-playwright": "2.9.2",
-		"config": "3.3.12"
+		"config": "3.3.12",
+		"typescript": "5.8.3"
 	},
 	"ci": {
 		"targets": [

--- a/projects/plugins/jetpack/changelog/add-typecheck-for-e2e-tests
+++ b/projects/plugins/jetpack/changelog/add-typecheck-for-e2e-tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Added typecheck support for E2E tests.

--- a/projects/plugins/jetpack/tests/e2e/package.json
+++ b/projects/plugins/jetpack/tests/e2e/package.json
@@ -21,14 +21,17 @@
 		"test:run": "playwright install chromium && NODE_CONFIG_DIR='./config' ALLURE_RESULTS_DIR=./output/allure-results NODE_PATH=\"$PWD/node_modules\" playwright test",
 		"tunnel:down": "tunnel down",
 		"tunnel:reset": "tunnel reset",
-		"tunnel:up": "tunnel up"
+		"tunnel:up": "tunnel up",
+		"typecheck": "tsc --noEmit"
 	},
 	"browserslist": [],
 	"devDependencies": {
 		"@playwright/test": "1.51.1",
+		"@types/node": "^20.4.2",
 		"_jetpack-e2e-commons": "workspace:*",
 		"allure-playwright": "2.9.2",
-		"config": "3.3.12"
+		"config": "3.3.12",
+		"typescript": "5.8.3"
 	},
 	"ci": {
 		"pluginSlug": "jetpack",

--- a/projects/plugins/jetpack/tests/e2e/specs/forms/submission.test.ts
+++ b/projects/plugins/jetpack/tests/e2e/specs/forms/submission.test.ts
@@ -29,7 +29,7 @@ test.afterEach( async ( { requestUtils } ) => {
 } );
 
 test.describe( 'Forms: Submission', () => {
-	test( 'Submits a simple contact form', async ( { admin, editor, page } ) => {
+	test( 'Submits a simple contact form', async ( { admin, editor } ) => {
 		const formTitle = 'E2E Test Form';
 		await test.step( 'Visit the block editor and insert a form', async () => {
 			await admin.createNewPost();
@@ -44,8 +44,7 @@ test.describe( 'Forms: Submission', () => {
 		} );
 
 		await test.step( 'Visit the post on the frontend and submit the form', async () => {
-			const editorPage = page;
-			const previewPage = await editor.openPreviewPage( editorPage );
+			const previewPage = await editor.openPreviewPage();
 
 			const form = previewPage.getByRole( 'form', { name: formTitle } );
 			await form.getByRole( 'textbox', { name: 'Name' } ).fill( 'John Doe' );
@@ -74,7 +73,6 @@ test.describe( 'Forms: Submission', () => {
 	test( 'Submits the correct from when multiple forms are on the same page', async ( {
 		admin,
 		editor,
-		page,
 	} ) => {
 		const contactFormInnerBlocks = [
 			{
@@ -117,8 +115,7 @@ test.describe( 'Forms: Submission', () => {
 		} );
 
 		await test.step( 'Visit the post on the frontend and submit one of the forms', async () => {
-			const editorPage = page;
-			const previewPage = await editor.openPreviewPage( editorPage );
+			const previewPage = await editor.openPreviewPage();
 
 			const formToSubmit = previewPage.getByRole( 'form', { name: 'Submit this form' } );
 			// Get the form ID from the wrapping element, this will allow us to check the contents

--- a/projects/plugins/protect/changelog/add-typecheck-for-e2e-tests
+++ b/projects/plugins/protect/changelog/add-typecheck-for-e2e-tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Added typecheck support for E2E tests.

--- a/projects/plugins/protect/tests/e2e/package.json
+++ b/projects/plugins/protect/tests/e2e/package.json
@@ -14,14 +14,17 @@
 		"test:run": "playwright install chromium && NODE_CONFIG_DIR='./config' ALLURE_RESULTS_DIR=./output/allure-results NODE_PATH=\"$PWD/node_modules\" playwright test",
 		"tunnel:down": "tunnel down",
 		"tunnel:reset": "tunnel reset",
-		"tunnel:up": "tunnel up"
+		"tunnel:up": "tunnel up",
+		"typecheck": "tsc --noEmit"
 	},
 	"browserslist": [],
 	"devDependencies": {
 		"@playwright/test": "1.51.1",
+		"@types/node": "^20.4.2",
 		"_jetpack-e2e-commons": "workspace:*",
 		"allure-playwright": "2.9.2",
-		"config": "3.3.12"
+		"config": "3.3.12",
+		"typescript": "5.8.3"
 	},
 	"ci": {
 		"targets": [

--- a/projects/plugins/search/changelog/add-typecheck-for-e2e-tests
+++ b/projects/plugins/search/changelog/add-typecheck-for-e2e-tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Added typecheck support for E2E tests.

--- a/projects/plugins/search/tests/e2e/package.json
+++ b/projects/plugins/search/tests/e2e/package.json
@@ -15,14 +15,17 @@
 		"test:run": "playwright install chromium && NODE_CONFIG_DIR='./config' ALLURE_RESULTS_DIR=./output/allure-results NODE_PATH=\"$PWD/node_modules\" playwright test",
 		"tunnel:down": "tunnel down",
 		"tunnel:reset": "tunnel reset",
-		"tunnel:up": "tunnel up"
+		"tunnel:up": "tunnel up",
+		"typecheck": "tsc --noEmit"
 	},
 	"browserslist": [],
 	"devDependencies": {
 		"@playwright/test": "1.51.1",
+		"@types/node": "^20.4.2",
 		"_jetpack-e2e-commons": "workspace:*",
 		"allure-playwright": "2.9.2",
-		"config": "3.3.12"
+		"config": "3.3.12",
+		"typescript": "5.8.3"
 	},
 	"ci": {
 		"pluginSlug": "jetpack-search",

--- a/projects/plugins/social/changelog/add-typecheck-for-e2e-tests
+++ b/projects/plugins/social/changelog/add-typecheck-for-e2e-tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Added typecheck support for E2E tests.

--- a/projects/plugins/social/tests/e2e/package.json
+++ b/projects/plugins/social/tests/e2e/package.json
@@ -16,14 +16,17 @@
 		"test:run": "playwright install chromium && NODE_CONFIG_DIR='./config' ALLURE_RESULTS_DIR=./output/allure-results NODE_PATH=\"$PWD/node_modules\" playwright test",
 		"tunnel:down": "tunnel down",
 		"tunnel:reset": "tunnel reset",
-		"tunnel:up": "tunnel up"
+		"tunnel:up": "tunnel up",
+		"typecheck": "tsc --noEmit"
 	},
 	"browserslist": [],
 	"devDependencies": {
 		"@playwright/test": "1.51.1",
+		"@types/node": "^20.4.2",
 		"_jetpack-e2e-commons": "workspace:*",
 		"allure-playwright": "2.9.2",
-		"config": "3.3.12"
+		"config": "3.3.12",
+		"typescript": "5.8.3"
 	},
 	"ci": {
 		"pluginSlug": "jetpack-social",

--- a/projects/plugins/starter-plugin/changelog/add-typecheck-for-e2e-tests
+++ b/projects/plugins/starter-plugin/changelog/add-typecheck-for-e2e-tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Added typecheck support for E2E tests.

--- a/projects/plugins/starter-plugin/tests/e2e/package.json
+++ b/projects/plugins/starter-plugin/tests/e2e/package.json
@@ -14,14 +14,17 @@
 		"test:run": "playwright install chromium && NODE_CONFIG_DIR='./config' ALLURE_RESULTS_DIR=./output/allure-results NODE_PATH=\"$PWD/node_modules\" playwright test",
 		"tunnel:down": "tunnel down",
 		"tunnel:reset": "tunnel reset",
-		"tunnel:up": "tunnel up"
+		"tunnel:up": "tunnel up",
+		"typecheck": "tsc --noEmit"
 	},
 	"browserslist": [],
 	"devDependencies": {
 		"@playwright/test": "1.51.1",
+		"@types/node": "^20.4.2",
 		"_jetpack-e2e-commons": "workspace:*",
 		"allure-playwright": "2.9.2",
-		"config": "3.3.12"
+		"config": "3.3.12",
+		"typescript": "5.8.3"
 	},
 	"ci": {
 		"targets": [

--- a/projects/plugins/super-cache/changelog/add-typecheck-for-e2e-tests
+++ b/projects/plugins/super-cache/changelog/add-typecheck-for-e2e-tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Added typecheck support for E2E tests.

--- a/projects/plugins/super-cache/tests/e2e/package.json
+++ b/projects/plugins/super-cache/tests/e2e/package.json
@@ -14,6 +14,7 @@
 	"devDependencies": {
 		"@jest/globals": "^30.0.0",
 		"@types/node": "^20.4.2",
+		"_jetpack-e2e-commons": "workspace:*",
 		"axios": "1.11.0",
 		"cheerio": "1.0.0-rc.12",
 		"dotenv": "16.0.2",

--- a/projects/plugins/super-cache/tests/e2e/package.json
+++ b/projects/plugins/super-cache/tests/e2e/package.json
@@ -8,7 +8,8 @@
 		"env:down": "docker-compose down",
 		"env:up": "docker-compose up -d",
 		"pretest:run": "pnpm run clean",
-		"test:run": "jest --runInBand"
+		"test:run": "jest --runInBand",
+		"typecheck": "tsc --noEmit"
 	},
 	"devDependencies": {
 		"@jest/globals": "^30.0.0",

--- a/projects/plugins/super-cache/tests/e2e/tsconfig.json
+++ b/projects/plugins/super-cache/tests/e2e/tsconfig.json
@@ -1,4 +1,5 @@
 {
+	"extends": "_jetpack-e2e-commons/tsconfig.json",
 	"compilerOptions": {
 		"esModuleInterop": true
 	}

--- a/projects/plugins/videopress/changelog/add-typecheck-for-e2e-tests
+++ b/projects/plugins/videopress/changelog/add-typecheck-for-e2e-tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Added typecheck support for E2E tests.

--- a/projects/plugins/videopress/tests/e2e/package.json
+++ b/projects/plugins/videopress/tests/e2e/package.json
@@ -14,14 +14,17 @@
 		"test:run": "playwright install chromium && NODE_CONFIG_DIR='./config' ALLURE_RESULTS_DIR=./output/allure-results NODE_PATH=\"$PWD/node_modules\" playwright test",
 		"tunnel:down": "tunnel down",
 		"tunnel:reset": "tunnel reset",
-		"tunnel:up": "tunnel up"
+		"tunnel:up": "tunnel up",
+		"typecheck": "tsc --noEmit"
 	},
 	"browserslist": [],
 	"devDependencies": {
 		"@playwright/test": "1.51.1",
+		"@types/node": "^20.4.2",
 		"_jetpack-e2e-commons": "workspace:*",
 		"allure-playwright": "2.9.2",
-		"config": "3.3.12"
+		"config": "3.3.12",
+		"typescript": "5.8.3"
 	},
 	"ci": {
 		"pluginSlug": "jetpack-videopress",

--- a/tools/e2e-commons/package.json
+++ b/tools/e2e-commons/package.json
@@ -26,13 +26,15 @@
 		"jetpack-connect": "node bin/e2e-jetpack-connector.js",
 		"tunnel:off": "./bin/tunnel.sh down",
 		"tunnel:on": "./bin/tunnel.sh up",
-		"tunnel:reset": "./bin/tunnel.sh reset"
+		"tunnel:reset": "./bin/tunnel.sh reset",
+		"typecheck": "tsc --noEmit"
 	},
 	"browserslist": [],
 	"devDependencies": {
 		"@playwright/test": "1.51.1",
 		"@slack/web-api": "7.9.1",
 		"@types/lodash-es": "4.17.12",
+		"@types/node": "^20.4.2",
 		"@wordpress/e2e-test-utils-playwright": "1.28.0",
 		"allure-playwright": "2.9.2",
 		"axios": "1.11.0",
@@ -41,6 +43,7 @@
 		"localtunnel": "2.0.2",
 		"lodash-es": "4.17.21",
 		"shell-escape": "0.2.0",
+		"typescript": "5.8.3",
 		"winston": "3.8.1",
 		"yargs": "17.6.2"
 	}

--- a/tools/e2e-commons/tsconfig.json
+++ b/tools/e2e-commons/tsconfig.json
@@ -4,6 +4,7 @@
 		"module": "ES2022",
 		"moduleResolution": "bundler",
 		"noEmit": true,
+		"skipLibCheck": true,
 		"target": "ES2022"
 	}
 }

--- a/tools/e2e-commons/utils/jetpack.ts
+++ b/tools/e2e-commons/utils/jetpack.ts
@@ -9,7 +9,7 @@ import { executeJetpackCommand } from './cli';
 export async function activateModule( modules: string | string[] ): Promise< void > {
 	const moduleArray = Array.isArray( modules ) ? modules : [ modules ];
 	for ( const mod of moduleArray ) {
-		await executeJetpackCommand( `module activate ${ mod }`, true );
+		await executeJetpackCommand( `module activate ${ mod }` );
 	}
 }
 
@@ -22,7 +22,7 @@ export async function activateModule( modules: string | string[] ): Promise< voi
 export async function deactivateModule( modules: string | string[] ): Promise< void > {
 	const moduleArray = Array.isArray( modules ) ? modules : [ modules ];
 	for ( const mod of moduleArray ) {
-		await executeJetpackCommand( `module deactivate ${ mod }`, true );
+		await executeJetpackCommand( `module deactivate ${ mod }` );
 	}
 }
 


### PR DESCRIPTION
Following #40869, we now have almost all of the E2E tests in TypeScript but type-checking is not done for them on CI. This PR addresses that.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add `typecheck` script to all the E2E test workspaces
* Fix TS errors in E2E tests

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* CI should be happy

