### PR TITLE
WooCommerce Analytics: Replace URL tracking with breadcrumb-based landing page tracking

### DIFF
--- a/projects/packages/woocommerce-analytics/changelog/wooa7s-355-breadcrumb-landing-page
+++ b/projects/packages/woocommerce-analytics/changelog/wooa7s-355-breadcrumb-landing-page
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Replace URL-based landing page tracking with breadcrumb-based hierarchical page tracking

--- a/projects/packages/woocommerce-analytics/src/class-woo-analytics-trait.php
+++ b/projects/packages/woocommerce-analytics/src/class-woo-analytics-trait.php
@@ -61,11 +61,11 @@ trait Woo_Analytics_Trait {
 	protected $session_id = '';
 
 	/**
-	 *  Landing page where session started.
+	 *  Landing page breadcrumb trail where session started (stored as JSON string).
 	 *
-	 *  @var array
+	 *  @var string
 	 */
-	protected $landing_page = array();
+	protected $landing_page = '';
 
 	/**
 	 *  Indicates when a session is engaged in the current request.
@@ -294,7 +294,7 @@ trait Woo_Analytics_Trait {
 			'store_id'                           => defined( '\\WC_Install::STORE_ID_OPTION' ) ? get_option( \WC_Install::STORE_ID_OPTION ) : false,
 			'ui'                                 => $this->get_user_id(),
 			'url'                                => home_url(),
-			'landing_page'                       => empty( $landing_page ) ? '' : wp_json_encode( $landing_page ),
+			'landing_page'                       => $landing_page,
 			'woo_version'                        => WC()->version,
 			'wp_version'                         => get_bloginfo( 'version' ),
 			'store_admin'                        => in_array( array( 'administrator', 'shop_manager' ), wp_get_current_user()->roles, true ) ? 1 : 0,
@@ -382,7 +382,7 @@ trait Woo_Analytics_Trait {
 			return;
 		}
 		$session_data['is_engaged'] = true;
-		$encoded_session_data       = wp_json_encode( $session_data );
+		$encoded_session_data       = rawurlencode( wp_json_encode( $session_data ) );
 		$cookie_js                  = "document.cookie = 'woocommerceanalytics_session={$encoded_session_data}; expires={$session_data['expires']}; path=/; secure; samesite=strict';";
 		wc_enqueue_js( $cookie_js );
 
@@ -399,7 +399,7 @@ trait Woo_Analytics_Trait {
 		if ( ! $this->get_session_id() ) {
 			$session_id           = wp_generate_uuid4();
 			$this->session_id     = $session_id;
-			$this->landing_page   = $this->get_breadcrumb_titles();
+			$this->landing_page   = wp_json_encode( $this->get_breadcrumb_titles() );
 			$this->is_new_session = true;
 
 			$session_expiration = $this->get_session_expiration_time();
@@ -408,7 +408,7 @@ trait Woo_Analytics_Trait {
 				'landing_page' => $this->landing_page,
 				'expires'      => $session_expiration,
 			);
-			$encoded_data       = wp_json_encode( $session_data );
+			$encoded_data       = rawurlencode( wp_json_encode( $session_data ) );
 			$cookie_js          = "document.cookie = 'woocommerceanalytics_session={$encoded_data}; expires={$session_expiration}; path=/; secure; samesite=strict';";
 			wc_enqueue_js( $cookie_js ); // save the session cookie for further events in the session
 
@@ -821,7 +821,7 @@ trait Woo_Analytics_Trait {
 			return array();
 		}
 
-		$decoded = json_decode( $raw_cookie, true );
+		$decoded = json_decode( rawurldecode( $raw_cookie ), true );
 		return is_array( $decoded ) ? $decoded : array();
 	}
 

--- a/projects/packages/woocommerce-analytics/src/class-woo-analytics-trait.php
+++ b/projects/packages/woocommerce-analytics/src/class-woo-analytics-trait.php
@@ -63,9 +63,9 @@ trait Woo_Analytics_Trait {
 	/**
 	 *  Landing page where session started.
 	 *
-	 *  @var string
+	 *  @var array
 	 */
-	protected $landing_page = '';
+	protected $landing_page = array();
 
 	/**
 	 *  Indicates when a session is engaged in the current request.
@@ -294,7 +294,7 @@ trait Woo_Analytics_Trait {
 			'store_id'                           => defined( '\\WC_Install::STORE_ID_OPTION' ) ? get_option( \WC_Install::STORE_ID_OPTION ) : false,
 			'ui'                                 => $this->get_user_id(),
 			'url'                                => home_url(),
-			'landing_page'                       => wp_json_encode( $landing_page ),
+			'landing_page'                       => empty( $landing_page ) ? '' : wp_json_encode( $landing_page ),
 			'woo_version'                        => WC()->version,
 			'wp_version'                         => get_bloginfo( 'version' ),
 			'store_admin'                        => in_array( array( 'administrator', 'shop_manager' ), wp_get_current_user()->roles, true ) ? 1 : 0,

--- a/projects/packages/woocommerce-analytics/src/class-woo-analytics-trait.php
+++ b/projects/packages/woocommerce-analytics/src/class-woo-analytics-trait.php
@@ -294,7 +294,7 @@ trait Woo_Analytics_Trait {
 			'store_id'                           => defined( '\\WC_Install::STORE_ID_OPTION' ) ? get_option( \WC_Install::STORE_ID_OPTION ) : false,
 			'ui'                                 => $this->get_user_id(),
 			'url'                                => home_url(),
-			'landing_page'                       => $landing_page,
+			'landing_page'                       => wp_json_encode( $landing_page ),
 			'woo_version'                        => WC()->version,
 			'wp_version'                         => get_bloginfo( 'version' ),
 			'store_admin'                        => in_array( array( 'administrator', 'shop_manager' ), wp_get_current_user()->roles, true ) ? 1 : 0,
@@ -381,10 +381,9 @@ trait Woo_Analytics_Trait {
 		if ( empty( $session_data ) ) {
 			return;
 		}
-		$session_data['is_engaged']   = true;
-		$session_data['landing_page'] = rawurlencode( $session_data['landing_page'] );
-		$encoded_session_data         = wp_json_encode( $session_data );
-		$cookie_js                    = "document.cookie = 'woocommerceanalytics_session={$encoded_session_data}; expires={$session_data['expires']}; path=/; secure; samesite=strict';";
+		$session_data['is_engaged'] = true;
+		$encoded_session_data       = wp_json_encode( $session_data );
+		$cookie_js                  = "document.cookie = 'woocommerceanalytics_session={$encoded_session_data}; expires={$session_data['expires']}; path=/; secure; samesite=strict';";
 		wc_enqueue_js( $cookie_js );
 
 		wc_enqueue_js( "_wca.push({$event_js});" );
@@ -400,13 +399,13 @@ trait Woo_Analytics_Trait {
 		if ( ! $this->get_session_id() ) {
 			$session_id           = wp_generate_uuid4();
 			$this->session_id     = $session_id;
-			$this->landing_page   = $this->get_current_url();
+			$this->landing_page   = $this->get_breadcrumb_titles();
 			$this->is_new_session = true;
 
 			$session_expiration = $this->get_session_expiration_time();
 			$session_data       = array(
 				'session_id'   => $this->session_id,
-				'landing_page' => rawurlencode( $this->landing_page ),
+				'landing_page' => $this->landing_page,
 				'expires'      => $session_expiration,
 			);
 			$encoded_data       = wp_json_encode( $session_data );
@@ -895,5 +894,75 @@ trait Woo_Analytics_Trait {
 	private function is_initial_page_view( $event ) {
 		$initial_events = array( 'woocommerceanalytics_page_view', 'woocommerceanalytics_product_view', 'woocommerceanalytics_cart_view' );
 		return in_array( $event, $initial_events, true ) && ( ! $this->get_session_id() || $this->is_new_session );
+	}
+
+	/**
+	 * Retrieves the breadcrumb trail as an array of page titles.
+	 *
+	 * This function attempts to generate a hierarchical breadcrumb trail for the current page or post.
+	 * - For the front page, it returns "Home".
+	 * - For WooCommerce product, category, or tag pages, it uses the WooCommerce breadcrumb generator and prepends the shop page title if needed.
+	 * - For regular pages, it builds the breadcrumb from the page's ancestors, ordered from top-level to current.
+	 * - For all other cases, it returns the current page's title.
+	 *
+	 * @return array The breadcrumb trail as an array of titles.
+	 */
+	private function get_breadcrumb_titles() {
+		if ( is_front_page() ) {
+			return array( __( 'Home', 'woocommerce-analytics' ) );
+		}
+
+		if ( class_exists( '\WC_Breadcrumb' ) ) {
+			$breadcrumb = new \WC_Breadcrumb();
+			$crumbs     = $breadcrumb->generate();
+			$titles     = wp_list_pluck( $crumbs, 0 );
+
+			if ( is_product() || is_product_category() || is_product_tag() ) {
+				$titles = $this->prepend_shop_page_title( $titles );
+			}
+
+			if ( ! empty( $titles ) ) {
+				return $titles;
+			}
+		}
+
+		// If it's a page, get the hierarchical title.
+		if ( is_page() ) {
+			$titles    = array();
+			$page_id   = get_queried_object_id();
+			$ancestors = get_post_ancestors( $page_id );
+			// Reverse the ancestors to get the top-level first.
+			$ancestors = array_reverse( $ancestors );
+
+			foreach ( $ancestors as $ancestor ) {
+				$titles[] = get_the_title( $ancestor );
+			}
+			$titles[] = get_the_title( $page_id );
+
+			return $titles;
+		}
+
+		return array( get_the_title() );
+	}
+
+	/**
+	 * Prepend the shop page title if it's not already present.
+	 *
+	 * @param array $titles The titles to prepend the shop page title to.
+	 * @return array The titles with the shop page title prepended.
+	 */
+	private function prepend_shop_page_title( array $titles ) {
+		$shop_page_id = wc_get_page_id( 'shop' );
+		if ( ! $shop_page_id ) {
+			return $titles;
+		}
+
+		$shop_page_title = get_the_title( $shop_page_id );
+
+		if ( ! $shop_page_title || ( ! empty( $titles ) && $titles[0] === $shop_page_title ) ) {
+			return $titles;
+		}
+
+		return array_merge( array( $shop_page_title ), $titles );
 	}
 }


### PR DESCRIPTION
Fixes WOOPRD-778

## Proposed changes:

Replace URL-based landing page tracking with breadcrumb-based hierarchical page tracking in WooCommerce Analytics.

### Why?

Currently, landing pages are recorded as plain URL strings (e.g., "https://example.com"). However, we want to display the page breadcrumb trail in the "Top Landing Pages Over Time" widget instead of the URL.

<img width="214" height="220" alt="Screenshot 2025-08-15 at 14 34 44" src="https://github.com/user-attachments/assets/ca7733a5-bc6e-4e01-b41c-1ade3ecd01da" />


### How?

Rather than introducing a new property, I updated the `landing_page` property to store the breadcrumb titles instead of the URL. The `woocommerceanalytics_session_started` event already includes the `url` property, so the widget can still display the page URL by referencing that field if needed. With this update, landing page data is now saved as JSON-encoded arrays representing the breadcrumb trail of page titles. This allows the widget to directly display the navigation path without needing to convert from a URL. The widget can also choose to present either the entire breadcrumb trail or just the final page title.

### Key Changes:

* Add new `get_breadcrumb_titles()` method to generate hierarchical breadcrumb trails for different page types (front page, WooCommerce pages, regular pages)
* Add `prepend_shop_page_title()` helper method to ensure WooCommerce shop page context is preserved in breadcrumbs
* Store landing page data as JSON-encoded breadcrumb array instead of raw URL string
* Remove unnecessary URL encoding from session data handling

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?

**Yes** - This PR changes the format of landing page tracking data:
- **Before**: Landing page stored as raw URL string
- **After**: Landing page stored as JSON-encoded array of hierarchical breadcrumb titles
- **Impact**: Provides richer context about page hierarchy and navigation path instead of just the URL
- **Data**: Page titles are collected to build breadcrumb trails, but no additional personal data is tracked

## Testing instructions:


### Test Cases:

*The landing page value is a JSON-encoded array, and it's escaped by the `ecs_js()` function when injected into the page, so it's like this: `[&quot;Home&quot;]` instead of `["Home"]`. In the ClickHouse table, the value will be URL-encoded, so it’s like this: `%5B%22Home%22%5D`.*

**1. Test Front Page Breadcrumb**
1. Navigate to the site's front page
2. Open browser developer tools > Network tab
3. Search for `w.gif ` request
4. Verify `landing_page` prop is a JSON-encoded array like: `[&quot;Home&quot;]`

**2. Test WooCommerce Product Page Breadcrumb**

1. Navigate to a product page
2. Clear the `woocommerce_analytics_session` cookie and refresh the page
3 Search for `w.gif ` request
4 Verify `landing_page` prop contains a hierarchical breadcrumb like: `[&quot;Shop&quot;,&quot;Automotive &amp; Sports&quot;,&quot;Gorgeous Rubber Knife&quot;]`

**3. Test Regular Page Hierarchy**

1. Go to WP Admin > Pages
2. Create nested pages: `Parent Page > Child Page`
3. Navigate to the Child page
4. Clear `woocommerce_analytics_session` cookie  and refresh the page
5. Verify `landing_page` contains: `[&quot;Parent Page&quot;,&quot;Child Page&quot;]`

**4. Test WooCommerce Category/Tag Pages**

1. Navigate to a product category or tag page
2. Clear `woocommerce_analytics_session` cookie and refresh the page
3. Verify breadcrumb includes shop page context appropriately, e.g `[&quot;Shop&quot;,&quot;Computers, Games &amp; Music&quot;]` for Computers, Games & Music category

<img width="352" height="281" alt="Screenshot 2025-08-14 at 17 18 16" src="https://github.com/user-attachments/assets/44644260-532f-402b-b112-4c9f1afc3dfc" />


### Expected Results:

- Session cookies should contain JSON-encoded breadcrumb arrays instead of URL strings
- Analytics events should include hierarchical page context
- No JavaScript errors in console