### PR TITLE
Forms: plain text email reply

### DIFF
--- a/projects/packages/forms/changelog/update-forms-plain-text-email-reply
+++ b/projects/packages/forms/changelog/update-forms-plain-text-email-reply
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: allow reply via email in plain text

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1112,10 +1112,11 @@ class Contact_Form extends Contact_Form_Shortcode {
 	 *
 	 * @param int          $feedback_id - the feedback ID.
 	 * @param Contact_Form $form - the form.
+	 * @param bool         $urlencoded - should the response be in urlencoded plain text, or HTML.
 	 *
 	 * @return array $lines
 	 */
-	public static function get_compiled_form_for_email( $feedback_id, $form ) {
+	public static function get_compiled_form_for_email( $feedback_id, $form, $urlencoded = false ) {
 		$compiled_form = array();
 		$response      = Feedback::get( $feedback_id );
 
@@ -1136,25 +1137,32 @@ class Contact_Form extends Contact_Form_Shortcode {
 		 * @param Contact_Form $form a copy of this object
 		 */
 		$updated_compiled_form = apply_filters( 'jetpack_forms_response_email', $compiled_form, $feedback_id, $form );
+
 		if ( $updated_compiled_form !== $compiled_form ) {
 			$compiled_form = $updated_compiled_form;
 		} else {
-			// add styling to the array
+			// Add styling to the array
 			foreach ( $compiled_form as $key => $value ) {
 				$safe_display_label = self::escape_and_sanitize_field_label( $value['label'] );
+				$safe_display_label = self::maybe_add_colon_to_label( $safe_display_label );
 				$safe_display_value = self::escape_and_sanitize_field_value( $value['value'] );
+				$nl                 = '%0A'; // URLEncoded newlines
 
 				if ( ! empty( $safe_display_label ) ) {
-					$compiled_form[ $key ] = sprintf(
-						'<p><strong>%1$s</strong><br /><span>%2$s</span></p>',
-						self::maybe_add_colon_to_label( $safe_display_label ),
-						$safe_display_value
-					);
+					$compiled_form[ $key ] = $urlencoded
+						? rawurlencode( $safe_display_label ) . $nl . rawurlencode( $safe_display_value ) . $nl . $nl
+						: sprintf(
+							'<p><strong>%1$s</strong><br /><span>%2$s</span></p>',
+							$safe_display_label,
+							$safe_display_value
+						);
 				} else {
-					$compiled_form[ $key ] = sprintf(
-						'<p><span>%s</span></p>',
-						$safe_display_value
-					);
+					$compiled_form[ $key ] = $urlencoded
+						? rawurlencode( $safe_display_value ) . $nl . $nl
+						: sprintf(
+							'<p><span>%s</span></p>',
+							$safe_display_value
+						);
 				}
 			}
 		}
@@ -2104,6 +2112,15 @@ class Contact_Form extends Contact_Form_Shortcode {
 			__( 'Mark as spam', 'jetpack-forms' )
 		);
 
+		$message_urlencoded = self::get_compiled_form_for_email( $post_id, $this, true );
+		$reply_mailto_url   =
+			'mailto:' .
+			rawurlencode( $reply_to_addr ) .
+			'?subject=' .
+			rawurlencode( 'Re: ' . $subject ) .
+			'&body=' .
+			implode( '', $message_urlencoded );
+
 		$footer = implode(
 			'',
 			/**
@@ -2130,7 +2147,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 		);
 
 		$actions = sprintf(
-			'<table class="button_block" border="0" cellpadding="0" cellspacing="0" role="presentation">
+			'<table class="button_block" border="0" cellpadding="0" cellspacing="8" role="presentation">
 				<tr>
 					<td class="pad" align="center">
 						<a rel="noopener" target="_blank" href="%1$s" data-tracks-link-desc="">
@@ -2143,10 +2160,23 @@ class Contact_Form extends Contact_Form_Shortcode {
 							<![endif]-->
 						</a>
 					</td>
+					<td class="pad" align="center">
+						<a rel="noopener" target="_blank" href="%3$s" data-tracks-link-desc="">
+							<!--[if mso]>
+							<i style="mso-text-raise: 30pt;">&nbsp;</i>
+							<![endif]-->
+							<span>%4$s</span>
+							<!--[if mso]>
+							<i>&nbsp;</i>
+							<![endif]-->
+						</a>
+					</td>
 				</tr>
 			</table>',
 			esc_url( $dashboard_url ),
-			__( 'View in dashboard', 'jetpack-forms' )
+			__( 'View in dashboard', 'jetpack-forms' ),
+			esc_url( $reply_mailto_url ),
+			__( 'Reply via email', 'jetpack-forms' )
 		);
 
 		/**

--- a/projects/plugins/jetpack/changelog/update-forms-plain-text-email-reply
+++ b/projects/plugins/jetpack/changelog/update-forms-plain-text-email-reply
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: allow reply via email in plain text


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Allow replying in plain text to form submissions, without including rest of the UI or links:

<img width="695" height="351" alt="Screenshot 2025-08-14 at 12 27 18" src="https://github.com/user-attachments/assets/2652ca79-5146-4e67-9860-961a2f530a05" />
<img width="672" height="379" alt="Screenshot 2025-08-14 at 12 27 58" src="https://github.com/user-attachments/assets/541d30c5-2a9e-4c68-ad9a-99cdf479cb21" />



## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

