### PR TITLE
Forms: make multi step forms available on Big Sky free trial sites

### DIFF
--- a/projects/packages/forms/changelog/update-forms-multistep-on-big-sky-trial-sites
+++ b/projects/packages/forms/changelog/update-forms-multistep-on-big-sky-trial-sites
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: make multi step forms available on Big Sky free trial sites

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -60,8 +60,9 @@ class Contact_Form_Block {
 		// Features under development.
 		$features['image-select-field'] = apply_filters( 'forms_alpha', false );
 
-		// Features that are only available to users with a paid plan.
-		$features['multistep-form'] = Current_Plan::supports( 'multistep-form' );
+		// Features that are only available to users with a paid plan or on Big Sky trial sites.
+		$is_big_sky_free_trial      = function_exists( 'has_blog_sticker' ) && has_blog_sticker( 'big-sky-free-trial' );
+		$features['multistep-form'] = Current_Plan::supports( 'multistep-form' ) || $is_big_sky_free_trial;
 
 		return $features;
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Convo p1754935154825659-slack-C052XEUUBL4

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fixes multi step not being available on Big Sky trial sites:

<img width="2308" height="1130" alt="image" src="https://github.com/user-attachments/assets/28da8515-6c08-4cee-bc33-e423f9c2cc6d" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*