### PR TITLE
[CI] Ignore changelog paths in e2e tests workflow

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths-ignore:
       - '**.md'
+      - '**/changelog/**'
   repository_dispatch:
     types: [ 'e2e tests**' ]
 


### PR DESCRIPTION
## Proposed changes:

The e2e-tests workflow ignores `*.md` files, but doesn't ignore changelog file. #44792 only updated docs, but because it required changelogs the e2e tests still ran and that was not necessary.


### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:

Tested with a fork. Tests [triggered on a a js file update](https://github.com/adimoldovan/jetpack/pull/2/checks?sha=23070616f188fc913676b66e4293c208c16fefde), not triggered when for [only *.md and changelog files](https://github.com/adimoldovan/jetpack/pull/2/checks?sha=15d01127eeebc6301ba94609398f725d4d173d5a)

