### PR TITLE
Media Uploader: Restrict unsupported files from being uploaded 

### DIFF
--- a/projects/plugins/wpcomsh/changelog/update-restrict-files-upload-summer-special
+++ b/projects/plugins/wpcomsh/changelog/update-restrict-files-upload-summer-special
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+

--- a/projects/plugins/wpcomsh/changelog/update-restrict-files-upload-summer-special
+++ b/projects/plugins/wpcomsh/changelog/update-restrict-files-upload-summer-special
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-
+Description: Restrict unsupported file types from being selectable in media uploader based on site features.

--- a/projects/plugins/wpcomsh/feature-plugins/hooks.php
+++ b/projects/plugins/wpcomsh/feature-plugins/hooks.php
@@ -282,6 +282,50 @@ function wpcomsh_maybe_restrict_mimetypes( $mimes ) {
 add_filter( 'upload_mimes', 'wpcomsh_maybe_restrict_mimetypes', PHP_INT_MAX );
 
 /**
+ * Add clean JavaScript to restrict file picker at selection level.
+ * This is the only way to prevent file selection (vs blocking after selection).
+ *
+ * @since $$next-version$$
+ */
+function wpcomsh_add_file_picker_restrictions() {
+	// Only load on media pages
+	$screen = get_current_screen();
+	if ( ! $screen || ! in_array( $screen->id, array( 'upload', 'media' ), true ) ) {
+		return;
+	}
+
+	// Get allowed extensions
+	$allowed_mimes = get_allowed_mime_types();
+	$extensions    = array();
+	foreach ( $allowed_mimes as $ext_pattern => $mime_type ) {
+		$extensions = array_merge( $extensions, explode( '|', $ext_pattern ) );
+	}
+	$accept_value = '.' . implode( ',.', $extensions );
+	?>
+	<script>
+	document.addEventListener('DOMContentLoaded', function() {
+		var acceptValue = <?php echo wp_json_encode( $accept_value ); ?>;
+
+		function setFileInputAccept() {
+			document.querySelectorAll('input[type="file"]').forEach(function(input) {
+				if (!input.hasAttribute('data-wpcomsh-restricted')) {
+					input.setAttribute('accept', acceptValue);
+					input.setAttribute('data-wpcomsh-restricted', '1');
+				}
+			});
+		}
+
+		// Apply immediately and when DOM changes
+		setFileInputAccept();
+		var observer = new MutationObserver(setFileInputAccept);
+		observer.observe(document.body, { childList: true, subtree: true });
+	});
+	</script>
+	<?php
+}
+add_action( 'admin_footer', 'wpcomsh_add_file_picker_restrictions' );
+
+/**
  * Redirect plugins.php and plugin-install.php to their Calypso counterparts if this site doesn't have the
  * MANAGE_PLUGINS feature.
  */

--- a/projects/plugins/wpcomsh/feature-plugins/hooks.php
+++ b/projects/plugins/wpcomsh/feature-plugins/hooks.php
@@ -249,64 +249,42 @@ function wpcomsh_maybe_disable_permalink_page() {
 add_action( 'load-options-permalink.php', 'wpcomsh_maybe_disable_permalink_page' );
 
 /**
- * Restricts the allowed mime types if the site have does NOT have access to the required feature.
- *
- * @param array $mimes Mime types keyed by the file extension regex corresponding to those types.
- * @return array Allowed mime types.
- */
-function wpcomsh_maybe_restrict_mimetypes( $mimes ) {
-	// Remove audio/* unless the site has explicit audio upload capability.
-	if ( ! wpcom_site_has_feature( WPCOM_Features::UPLOAD_AUDIO_FILES ) ) {
-		foreach ( $mimes as $ext_pattern => $mime ) {
-			if ( 0 === strpos( $mime, 'audio/' ) ) {
-				unset( $mimes[ $ext_pattern ] );
-			}
-		}
-	}
-
-	// Remove video/* unless the site has VideoPress.
-	if ( ! wpcom_site_has_feature( WPCOM_Features::VIDEOPRESS ) ) {
-		foreach ( $mimes as $ext_pattern => $mime ) {
-			if ( 0 === strpos( $mime, 'video/' ) ) {
-				unset( $mimes[ $ext_pattern ] );
-			}
-		}
-	}
-
-	return $mimes;
-}
-add_filter( 'upload_mimes', 'wpcomsh_maybe_restrict_mimetypes', PHP_INT_MAX );
-
-/**
- * Filter plupload settings to match Simple sites behavior.
- * This ensures the same file upload restrictions apply to both Simple and Atomic sites.
- * Mirrors the implementation from wp-content/mu-plugins/misc.php wpcom_upload_file_exts()
+ * Restrict selectable files in the Media uploader by setting Plupload filters only.
+ * Minimal change: selection-only; no server-side mime policy changes.
  *
  * @since $$next-version$$
  *
  * @param array $options Plupload options.
- * @return array Modified plupload options.
+ * @return array
  */
 function wpcomsh_plupload_file_restrictions( $options ) {
-	// Derive allowed extensions directly from get_allowed_mime_types() so it reflects all filters.
-	$allowed_extensions = wpcomsh_get_allowed_extensions_from_mimes();
+	// Build allowed extensions from the full mime map, excluding categories based on features.
+	$mimes_map   = wp_get_mime_types();
+	$allow_audio = wpcom_site_has_feature( WPCOM_Features::UPLOAD_AUDIO_FILES );
+	$allow_video = wpcom_site_has_feature( WPCOM_Features::VIDEOPRESS );
 
-	if ( ! empty( $allowed_extensions ) ) {
-		if ( ! isset( $options['filters'] ) || ! is_array( $options['filters'] ) ) {
-			$options['filters'] = array();
+	$allowed_extensions = array();
+	foreach ( $mimes_map as $ext_pattern => $mime ) {
+		if ( 0 === strpos( $mime, 'audio/' ) && ! $allow_audio ) {
+			continue;
 		}
-
-		$options['filters']['mime_types'] = array(
-			array(
-				'title'      => __( 'Allowed Files', 'wpcomsh' ),
-				'extensions' => implode( ',', $allowed_extensions ),
-			),
-		);
-
-		if ( ! isset( $options['filters']['max_file_size'] ) ) {
-			$options['filters']['max_file_size'] = wp_max_upload_size() . 'b';
+		if ( 0 === strpos( $mime, 'video/' ) && ! $allow_video ) {
+			continue;
 		}
+		$allowed_extensions = array_merge( $allowed_extensions, explode( '|', $ext_pattern ) );
 	}
+
+	$allowed_extensions = array_values( array_unique( $allowed_extensions ) );
+	if ( empty( $allowed_extensions ) ) {
+		return $options;
+	}
+
+	if ( ! isset( $options['filters'] ) || ! is_array( $options['filters'] ) ) {
+		$options['filters'] = array();
+	}
+	$options['filters']['mime_types'] = array(
+		array( 'extensions' => implode( ',', $allowed_extensions ) ),
+	);
 
 	return $options;
 }
@@ -379,20 +357,3 @@ function wpcomsh_remove_jetpack_manage_menu_item() {
 }
 
 add_action( 'admin_menu', 'wpcomsh_remove_jetpack_manage_menu_item', 1001 ); // Automattic\Jetpack\Admin_UI\Admin_Menu uses 1000.
-
-/**
- * Compute allowed file extensions from get_allowed_mime_types(),
- * flattening patterns like 'jpg|jpeg|jpe' into individual extensions.
- *
- * @since $$next-version$$
- *
- * @return string[] List of allowed extensions (no leading dots).
- */
-function wpcomsh_get_allowed_extensions_from_mimes() {
-	$allowed_mimes      = get_allowed_mime_types();
-	$allowed_extensions = array();
-	foreach ( $allowed_mimes as $ext_pattern => $mime_type ) {
-		$allowed_extensions = array_merge( $allowed_extensions, explode( '|', $ext_pattern ) );
-	}
-	return array_values( array_unique( $allowed_extensions ) );
-}

--- a/projects/plugins/wpcomsh/feature-plugins/hooks.php
+++ b/projects/plugins/wpcomsh/feature-plugins/hooks.php
@@ -255,23 +255,19 @@ add_action( 'load-options-permalink.php', 'wpcomsh_maybe_disable_permalink_page'
  * @return array Allowed mime types.
  */
 function wpcomsh_maybe_restrict_mimetypes( $mimes ) {
-	$disallowed_mimes = array();
-	if ( ! wpcom_site_has_feature( WPCOM_Features::UPGRADED_UPLOAD_FILETYPES ) ) {
-		// Copied from WPCOM (see `WPCOM_UPLOAD_FILETYPES_FOR_UPGRADES` in `.config/wpcom-options.php`).
-		$upgraded_upload_filetypes = 'mp3 m4a wav ogg zip txt tiff bmp';
-		$disallowed_mimes          = array_merge( $disallowed_mimes, explode( ' ', $upgraded_upload_filetypes ) );
-	}
-
-	if ( ! wpcom_site_has_feature( WPCOM_Features::VIDEOPRESS ) ) {
-		// Copied from WPCOM (see `WPCOM_UPLOAD_FILETYPES_FOR_VIDEOS` in `.config/wpcom-options.php`).
-		// The `ttml` extension is set by `wp-content/mu-plugins/videopress/subtitles.php`.
-		$video_upload_filetypes = 'ogv mp4 m4v mov wmv avi mpg 3gp 3g2 ttml';
-		$disallowed_mimes       = array_merge( $disallowed_mimes, explode( ' ', $video_upload_filetypes ) );
-	}
-
-	foreach ( $disallowed_mimes as $disallowed_mime ) {
+	// Remove audio/* unless the site has explicit audio upload capability.
+	if ( ! wpcom_site_has_feature( WPCOM_Features::UPLOAD_AUDIO_FILES ) ) {
 		foreach ( $mimes as $ext_pattern => $mime ) {
-			if ( strpos( $ext_pattern, $disallowed_mime ) !== false ) {
+			if ( 0 === strpos( $mime, 'audio/' ) ) {
+				unset( $mimes[ $ext_pattern ] );
+			}
+		}
+	}
+
+	// Remove video/* unless the site has VideoPress.
+	if ( ! wpcom_site_has_feature( WPCOM_Features::VIDEOPRESS ) ) {
+		foreach ( $mimes as $ext_pattern => $mime ) {
+			if ( 0 === strpos( $mime, 'video/' ) ) {
 				unset( $mimes[ $ext_pattern ] );
 			}
 		}
@@ -282,48 +278,40 @@ function wpcomsh_maybe_restrict_mimetypes( $mimes ) {
 add_filter( 'upload_mimes', 'wpcomsh_maybe_restrict_mimetypes', PHP_INT_MAX );
 
 /**
- * Add clean JavaScript to restrict file picker at selection level.
- * This is the only way to prevent file selection (vs blocking after selection).
+ * Filter plupload settings to match Simple sites behavior.
+ * This ensures the same file upload restrictions apply to both Simple and Atomic sites.
+ * Mirrors the implementation from wp-content/mu-plugins/misc.php wpcom_upload_file_exts()
  *
  * @since $$next-version$$
+ *
+ * @param array $options Plupload options.
+ * @return array Modified plupload options.
  */
-function wpcomsh_add_file_picker_restrictions() {
-	// Only load on media pages
-	$screen = get_current_screen();
-	if ( ! $screen || ! in_array( $screen->id, array( 'upload', 'media' ), true ) ) {
-		return;
-	}
+function wpcomsh_plupload_file_restrictions( $options ) {
+	// Derive allowed extensions directly from get_allowed_mime_types() so it reflects all filters.
+	$allowed_extensions = wpcomsh_get_allowed_extensions_from_mimes();
 
-	// Get allowed extensions
-	$allowed_mimes = get_allowed_mime_types();
-	$extensions    = array();
-	foreach ( $allowed_mimes as $ext_pattern => $mime_type ) {
-		$extensions = array_merge( $extensions, explode( '|', $ext_pattern ) );
-	}
-	$accept_value = '.' . implode( ',.', $extensions );
-	?>
-	<script>
-	document.addEventListener('DOMContentLoaded', function() {
-		var acceptValue = <?php echo wp_json_encode( $accept_value ); ?>;
-
-		function setFileInputAccept() {
-			document.querySelectorAll('input[type="file"]').forEach(function(input) {
-				if (!input.hasAttribute('data-wpcomsh-restricted')) {
-					input.setAttribute('accept', acceptValue);
-					input.setAttribute('data-wpcomsh-restricted', '1');
-				}
-			});
+	if ( ! empty( $allowed_extensions ) ) {
+		if ( ! isset( $options['filters'] ) || ! is_array( $options['filters'] ) ) {
+			$options['filters'] = array();
 		}
 
-		// Apply immediately and when DOM changes
-		setFileInputAccept();
-		var observer = new MutationObserver(setFileInputAccept);
-		observer.observe(document.body, { childList: true, subtree: true });
-	});
-	</script>
-	<?php
+		$options['filters']['mime_types'] = array(
+			array(
+				'title'      => __( 'Allowed Files', 'wpcomsh' ),
+				'extensions' => implode( ',', $allowed_extensions ),
+			),
+		);
+
+		if ( ! isset( $options['filters']['max_file_size'] ) ) {
+			$options['filters']['max_file_size'] = wp_max_upload_size() . 'b';
+		}
+	}
+
+	return $options;
 }
-add_action( 'admin_footer', 'wpcomsh_add_file_picker_restrictions' );
+add_filter( 'plupload_init', 'wpcomsh_plupload_file_restrictions', PHP_INT_MAX );
+add_filter( 'plupload_default_settings', 'wpcomsh_plupload_file_restrictions', PHP_INT_MAX );
 
 /**
  * Redirect plugins.php and plugin-install.php to their Calypso counterparts if this site doesn't have the
@@ -391,3 +379,20 @@ function wpcomsh_remove_jetpack_manage_menu_item() {
 }
 
 add_action( 'admin_menu', 'wpcomsh_remove_jetpack_manage_menu_item', 1001 ); // Automattic\Jetpack\Admin_UI\Admin_Menu uses 1000.
+
+/**
+ * Compute allowed file extensions from get_allowed_mime_types(),
+ * flattening patterns like 'jpg|jpeg|jpe' into individual extensions.
+ *
+ * @since $$next-version$$
+ *
+ * @return string[] List of allowed extensions (no leading dots).
+ */
+function wpcomsh_get_allowed_extensions_from_mimes() {
+	$allowed_mimes      = get_allowed_mime_types();
+	$allowed_extensions = array();
+	foreach ( $allowed_mimes as $ext_pattern => $mime_type ) {
+		$allowed_extensions = array_merge( $allowed_extensions, explode( '|', $ext_pattern ) );
+	}
+	return array_values( array_unique( $allowed_extensions ) );
+}

--- a/projects/plugins/wpcomsh/feature-plugins/hooks.php
+++ b/projects/plugins/wpcomsh/feature-plugins/hooks.php
@@ -252,29 +252,29 @@ add_action( 'load-options-permalink.php', 'wpcomsh_maybe_disable_permalink_page'
  * Restrict selectable files in the Media uploader by setting Plupload filters only.
  * Minimal change: selection-only; no server-side mime policy changes.
  *
- * @since $$next-version$$
- *
  * @param array $options Plupload options.
- * @return array
+ * @return array Plupload options with restricted mime types.
  */
 function wpcomsh_plupload_file_restrictions( $options ) {
-	// Build allowed extensions from the full mime map, excluding categories based on features.
-	$mimes_map   = wp_get_mime_types();
-	$allow_audio = wpcom_site_has_feature( WPCOM_Features::UPLOAD_AUDIO_FILES );
-	$allow_video = wpcom_site_has_feature( WPCOM_Features::VIDEOPRESS );
+	$mimes_map = get_allowed_mime_types();
 
 	$allowed_extensions = array();
+	$allowed_mime_types = array();
+
 	foreach ( $mimes_map as $ext_pattern => $mime ) {
-		if ( 0 === strpos( $mime, 'audio/' ) && ! $allow_audio ) {
-			continue;
+		// Extract real file extensions (filter out 'x-' prefixed ones)
+		// This prevents issues with non-standard extensions like 'x-wav' that aren't real file extensions
+		$extensions = explode( '|', $ext_pattern );
+		foreach ( $extensions as $ext ) {
+			// Only include extensions that don't start with 'x-'
+			if ( ! str_starts_with( $ext, 'x-' ) ) {
+				$allowed_extensions[] = $ext;
+			}
 		}
-		if ( 0 === strpos( $mime, 'video/' ) && ! $allow_video ) {
-			continue;
-		}
-		$allowed_extensions = array_merge( $allowed_extensions, explode( '|', $ext_pattern ) );
+
+		$allowed_mime_types[] = $mime;
 	}
 
-	$allowed_extensions = array_values( array_unique( $allowed_extensions ) );
 	if ( empty( $allowed_extensions ) ) {
 		return $options;
 	}
@@ -286,19 +286,13 @@ function wpcomsh_plupload_file_restrictions( $options ) {
 		array( 'extensions' => implode( ',', $allowed_extensions ) ),
 	);
 
+	// Store MIME types for potential use in HTML file inputs
+	$options['allowed_mime_types'] = $allowed_mime_types;
+
 	return $options;
 }
 
-/**
- * Register Plupload restrictions only in the Media Library UI.
- *
- * @since $$next-version$$
- */
-function wpcomsh_register_plupload_file_restrictions_filters() {
-	add_filter( 'plupload_init', 'wpcomsh_plupload_file_restrictions', PHP_INT_MAX );
-	add_filter( 'plupload_default_settings', 'wpcomsh_plupload_file_restrictions', PHP_INT_MAX );
-}
-add_action( 'wp_enqueue_media', 'wpcomsh_register_plupload_file_restrictions_filters' );
+add_action( 'plupload_init', 'wpcomsh_plupload_file_restrictions' );
 
 /**
  * Restricts the allowed mime types if the site have does NOT have access to the required feature.

--- a/projects/plugins/wpcomsh/feature-plugins/hooks.php
+++ b/projects/plugins/wpcomsh/feature-plugins/hooks.php
@@ -288,8 +288,50 @@ function wpcomsh_plupload_file_restrictions( $options ) {
 
 	return $options;
 }
-add_filter( 'plupload_init', 'wpcomsh_plupload_file_restrictions', PHP_INT_MAX );
-add_filter( 'plupload_default_settings', 'wpcomsh_plupload_file_restrictions', PHP_INT_MAX );
+
+/**
+ * Register Plupload restrictions only in the Media Library UI.
+ *
+ * @since $$next-version$$
+ */
+function wpcomsh_register_plupload_file_restrictions_filters() {
+	add_filter( 'plupload_init', 'wpcomsh_plupload_file_restrictions', PHP_INT_MAX );
+	add_filter( 'plupload_default_settings', 'wpcomsh_plupload_file_restrictions', PHP_INT_MAX );
+}
+add_action( 'wp_enqueue_media', 'wpcomsh_register_plupload_file_restrictions_filters' );
+
+/**
+ * Restricts the allowed mime types if the site have does NOT have access to the required feature.
+ *
+ * @param array $mimes Mime types keyed by the file extension regex corresponding to those types.
+ * @return array Allowed mime types.
+ */
+function wpcomsh_maybe_restrict_mimetypes( $mimes ) {
+	$disallowed_mimes = array();
+	if ( ! wpcom_site_has_feature( WPCOM_Features::UPGRADED_UPLOAD_FILETYPES ) ) {
+		// Copied from WPCOM (see `WPCOM_UPLOAD_FILETYPES_FOR_UPGRADES` in `.config/wpcom-options.php`).
+		$upgraded_upload_filetypes = 'mp3 m4a wav ogg zip txt tiff bmp';
+		$disallowed_mimes          = array_merge( $disallowed_mimes, explode( ' ', $upgraded_upload_filetypes ) );
+	}
+
+	if ( ! wpcom_site_has_feature( WPCOM_Features::VIDEOPRESS ) ) {
+		// Copied from WPCOM (see `WPCOM_UPLOAD_FILETYPES_FOR_VIDEOS` in `.config/wpcom-options.php`).
+		// The `ttml` extension is set by `wp-content/mu-plugins/videopress/subtitles.php`.
+		$video_upload_filetypes = 'ogv mp4 m4v mov wmv avi mpg 3gp 3g2 ttml';
+		$disallowed_mimes       = array_merge( $disallowed_mimes, explode( ' ', $video_upload_filetypes ) );
+	}
+
+	foreach ( $disallowed_mimes as $disallowed_mime ) {
+		foreach ( $mimes as $ext_pattern => $mime ) {
+			if ( strpos( $ext_pattern, $disallowed_mime ) !== false ) {
+				unset( $mimes[ $ext_pattern ] );
+			}
+		}
+	}
+
+	return $mimes;
+}
+add_filter( 'upload_mimes', 'wpcomsh_maybe_restrict_mimetypes', PHP_INT_MAX );
 
 /**
  * Redirect plugins.php and plugin-install.php to their Calypso counterparts if this site doesn't have the


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes [DOTOBRD-293](https://linear.app/a8c/issue/DOTOBRD-293/video-files-can-be-selected-during-upload)

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* adds the unsupported media types to the media uploader section so that the users don't need to wait for the file to upload to discover it's not supported

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->


## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
* Create a WoA dev pool site with Personal/Premium
* rsync the changes to the site 
* go to `/wp-admin/media-new.php`
* video (and other unsupported) files should not be selectable in the file browser

<img width="480" height="493" alt="Screenshot 2025-08-18 at 16 09 17" src="https://github.com/user-attachments/assets/490facb6-0c1e-4b32-985c-b9fe8a432753" />
