### PR TITLE
Backport jetpack 15.0-a.3 Changes

### DIFF
--- a/projects/js-packages/ai-client/CHANGELOG.md
+++ b/projects/js-packages/ai-client/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.33.7] - 2025-08-14
+### Changed
+- Update package dependencies. [#44701]
+
 ## [0.33.6] - 2025-08-11
 ### Changed
 - Update package dependencies. [#44677]
@@ -682,6 +686,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - AI Client: stop using smart document visibility handling on the fetchEventSource library, so it does not restart the completion when changing tabs. [#32004]
 - Updated package dependencies. [#31468] [#31659] [#31785]
 
+[0.33.7]: https://github.com/Automattic/jetpack-ai-client/compare/v0.33.6...v0.33.7
 [0.33.6]: https://github.com/Automattic/jetpack-ai-client/compare/v0.33.5...v0.33.6
 [0.33.5]: https://github.com/Automattic/jetpack-ai-client/compare/v0.33.4...v0.33.5
 [0.33.4]: https://github.com/Automattic/jetpack-ai-client/compare/v0.33.3...v0.33.4

--- a/projects/js-packages/ai-client/changelog/renovate-wordpress-monorepo#2
+++ b/projects/js-packages/ai-client/changelog/renovate-wordpress-monorepo#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/js-packages/ai-client/package.json
+++ b/projects/js-packages/ai-client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-ai-client",
-	"version": "0.33.6",
+	"version": "0.33.7",
 	"private": false,
 	"description": "A JS client for consuming Jetpack AI services",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/ai-client/#readme",

--- a/projects/js-packages/charts/CHANGELOG.md
+++ b/projects/js-packages/charts/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.26.0] - 2025-08-14
+### Added
+- Bar Chart: Add composition API. [#44771]
+- Line Chart: Add composition legends. [#44691]
+- Line Chart: Add comparison style to theme. [#44676]
+
+### Changed
+- Updated legend positioning and alignment. [#44747]
+- Update package dependencies. [#44701]
+
 ## [0.25.0] - 2025-08-11
 ### Added
 - Add internationalization. [#44652]
@@ -361,6 +371,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed lints following ESLint rule changes for TS [#40584]
 - Fixing a bug in Chart storybook data. [#40640]
 
+[0.26.0]: https://github.com/Automattic/charts/compare/v0.25.0...v0.26.0
 [0.25.0]: https://github.com/Automattic/charts/compare/v0.24.0...v0.25.0
 [0.24.0]: https://github.com/Automattic/charts/compare/v0.23.1...v0.24.0
 [0.23.1]: https://github.com/Automattic/charts/compare/v0.23.0...v0.23.1

--- a/projects/js-packages/charts/changelog/add-compostion-api-for-legend
+++ b/projects/js-packages/charts/changelog/add-compostion-api-for-legend
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Composition legends for Line Chart

--- a/projects/js-packages/charts/changelog/charts-83-line-chart-add-comparison-type
+++ b/projects/js-packages/charts/changelog/charts-83-line-chart-add-comparison-type
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Line Chart: Add comparison style to theme

--- a/projects/js-packages/charts/changelog/renovate-wordpress-monorepo#2
+++ b/projects/js-packages/charts/changelog/renovate-wordpress-monorepo#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/js-packages/charts/changelog/update-charts-87-inconsistent-legend-prop-naming-alignmentvertical-vs
+++ b/projects/js-packages/charts/changelog/update-charts-87-inconsistent-legend-prop-naming-alignmentvertical-vs
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Charts: updated legend positioning and alignment

--- a/projects/js-packages/charts/changelog/update-charts-89-charts-add-composition-api-for-bar-chart
+++ b/projects/js-packages/charts/changelog/update-charts-89-charts-add-composition-api-for-bar-chart
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Charts: adds composition api to bar chart

--- a/projects/js-packages/charts/package.json
+++ b/projects/js-packages/charts/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/charts",
-	"version": "0.25.0",
+	"version": "0.26.0",
 	"description": "Display charts within Automattic products.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/charts/#readme",
 	"bugs": {

--- a/projects/js-packages/components/CHANGELOG.md
+++ b/projects/js-packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### This is a list detailing changes for the Jetpack RNA Components package releases.
 
+## [1.2.0] - 2025-08-14
+### Added
+- Add new Interstitial component. [#44665]
+
 ## [1.1.19] - 2025-08-13
 ### Changed
 - Update package dependencies. [#44701]
@@ -1504,6 +1508,7 @@
 ### Changed
 - Update node version requirement to 14.16.1
 
+[1.2.0]: https://github.com/Automattic/jetpack-components/compare/1.1.19...1.2.0
 [1.1.19]: https://github.com/Automattic/jetpack-components/compare/1.1.18...1.1.19
 [1.1.18]: https://github.com/Automattic/jetpack-components/compare/1.1.17...1.1.18
 [1.1.17]: https://github.com/Automattic/jetpack-components/compare/1.1.16...1.1.17

--- a/projects/js-packages/components/changelog/add-myjp-upgraded-product-interstitial
+++ b/projects/js-packages/components/changelog/add-myjp-upgraded-product-interstitial
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Added new Interstitial component

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-components",
-	"version": "1.1.19",
+	"version": "1.2.0",
 	"description": "Jetpack Components Package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/components/#readme",
 	"bugs": {

--- a/projects/js-packages/connection/CHANGELOG.md
+++ b/projects/js-packages/connection/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### This is a list detailing changes for the Jetpack RNA Connection Component releases.
 
+## [1.4.3] - 2025-08-14
+### Changed
+- Update dependencies.
+
 ## [1.4.2] - 2025-08-13
 ### Changed
 - Update package dependencies. [#44701]
@@ -1138,6 +1142,7 @@
 - `Main` and `ConnectUser` components added.
 - `JetpackRestApiClient` API client added.
 
+[1.4.3]: https://github.com/Automattic/jetpack-connection-js/compare/v1.4.2...v1.4.3
 [1.4.2]: https://github.com/Automattic/jetpack-connection-js/compare/v1.4.1...v1.4.2
 [1.4.1]: https://github.com/Automattic/jetpack-connection-js/compare/v1.4.0...v1.4.1
 [1.4.0]: https://github.com/Automattic/jetpack-connection-js/compare/v1.3.2...v1.4.0

--- a/projects/js-packages/connection/package.json
+++ b/projects/js-packages/connection/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-connection",
-	"version": "1.4.2",
+	"version": "1.4.3",
 	"description": "Jetpack Connection Component",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/connection/#readme",
 	"bugs": {

--- a/projects/js-packages/idc/CHANGELOG.md
+++ b/projects/js-packages/idc/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### This is a list detailing changes for the Jetpack RNA IDC package releases.
 
+## 1.0.20 - 2025-08-14
+### Changed
+- Update dependencies. [#44300]
+
 ## 1.0.19 - 2025-08-13
 ### Changed
 - Update package dependencies. [#44701]

--- a/projects/js-packages/idc/package.json
+++ b/projects/js-packages/idc/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-idc",
-	"version": "1.0.19",
+	"version": "1.0.20",
 	"description": "Jetpack Connection Component",
 	"license": "GPL-2.0-or-later",
 	"author": "Automattic",

--- a/projects/js-packages/licensing/CHANGELOG.md
+++ b/projects/js-packages/licensing/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.2.1 - 2025-08-14
+### Changed
+- Update package dependencies. [#44701]
+
 ## 1.2.0 - 2025-08-11
 ### Changed
 - Update package dependencies. [#44677]

--- a/projects/js-packages/licensing/changelog/renovate-wordpress-monorepo#2
+++ b/projects/js-packages/licensing/changelog/renovate-wordpress-monorepo#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/js-packages/licensing/package.json
+++ b/projects/js-packages/licensing/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-licensing",
-	"version": "1.2.0",
+	"version": "1.2.1",
 	"private": true,
 	"description": "Jetpack licensing flow",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/licensing/#readme",

--- a/projects/js-packages/partner-coupon/CHANGELOG.md
+++ b/projects/js-packages/partner-coupon/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.0.12 - 2025-08-14
+### Changed
+- Update package dependencies. [#44701]
+
 ## 1.0.11 - 2025-08-11
 ### Changed
 - Update package dependencies. [#44677]

--- a/projects/js-packages/partner-coupon/changelog/renovate-wordpress-monorepo#2
+++ b/projects/js-packages/partner-coupon/changelog/renovate-wordpress-monorepo#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/js-packages/partner-coupon/package.json
+++ b/projects/js-packages/partner-coupon/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-partner-coupon",
-	"version": "1.0.11",
+	"version": "1.0.12",
 	"private": true,
 	"description": "This package aims to add components to make it easier to redeem partner coupons",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/partner-coupon/#readme",

--- a/projects/js-packages/publicize-components/CHANGELOG.md
+++ b/projects/js-packages/publicize-components/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.3] - 2025-08-14
+### Changed
+- Update package dependencies. [#44701]
+
+### Removed
+- Removed unused dependencies. [#44746]
+
 ## [1.2.2] - 2025-08-11
 ### Changed
 - Update package dependencies. [#44677] [#44703]
@@ -1336,6 +1343,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated package dependencies. [#24470]
 
+[1.2.3]: https://github.com/Automattic/jetpack-publicize-components/compare/v1.2.2...v1.2.3
 [1.2.2]: https://github.com/Automattic/jetpack-publicize-components/compare/v1.2.1...v1.2.2
 [1.2.1]: https://github.com/Automattic/jetpack-publicize-components/compare/v1.2.0...v1.2.1
 [1.2.0]: https://github.com/Automattic/jetpack-publicize-components/compare/v1.1.6...v1.2.0

--- a/projects/js-packages/publicize-components/changelog/remove-unused-dependencies
+++ b/projects/js-packages/publicize-components/changelog/remove-unused-dependencies
@@ -1,4 +1,0 @@
-Significance: patch
-Type: removed
-
-Removed unused dependencies.

--- a/projects/js-packages/publicize-components/changelog/renovate-wordpress-monorepo#2
+++ b/projects/js-packages/publicize-components/changelog/renovate-wordpress-monorepo#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/js-packages/publicize-components/package.json
+++ b/projects/js-packages/publicize-components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-publicize-components",
-	"version": "1.2.2",
+	"version": "1.2.3",
 	"private": true,
 	"description": "A library of JS components required by the Publicize editor plugin",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/publicize-components/#readme",

--- a/projects/js-packages/shared-extension-utils/CHANGELOG.md
+++ b/projects/js-packages/shared-extension-utils/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.11] - 2025-08-14
+### Changed
+- Update package dependencies. [#44701]
+
 ## [1.3.10] - 2025-08-11
 ### Changed
 - Update package dependencies. [#44677]
@@ -743,6 +747,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Core: prepare utility for release
 
+[1.3.11]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/1.3.10...1.3.11
 [1.3.10]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/1.3.9...1.3.10
 [1.3.9]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/1.3.8...1.3.9
 [1.3.8]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/1.3.7...1.3.8

--- a/projects/js-packages/shared-extension-utils/changelog/renovate-wordpress-monorepo#2
+++ b/projects/js-packages/shared-extension-utils/changelog/renovate-wordpress-monorepo#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/js-packages/shared-extension-utils/package.json
+++ b/projects/js-packages/shared-extension-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-shared-extension-utils",
-	"version": "1.3.10",
+	"version": "1.3.11",
 	"description": "Utility functions used by the block editor extensions",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/shared-extension-utils/#readme",
 	"bugs": {

--- a/projects/packages/backup/CHANGELOG.md
+++ b/projects/packages/backup/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.2.16] - 2025-08-14
+### Changed
+- Update package dependencies. [#44701]
+
 ## [4.2.15] - 2025-08-11
 ### Changed
 - Update package dependencies. [#44677]
@@ -919,6 +923,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add API endpoints and Jetpack Backup package for managing Help…
 
+[4.2.16]: https://github.com/Automattic/jetpack-backup/compare/v4.2.15...v4.2.16
 [4.2.15]: https://github.com/Automattic/jetpack-backup/compare/v4.2.14...v4.2.15
 [4.2.14]: https://github.com/Automattic/jetpack-backup/compare/v4.2.13...v4.2.14
 [4.2.13]: https://github.com/Automattic/jetpack-backup/compare/v4.2.12...v4.2.13

--- a/projects/packages/backup/changelog/renovate-wordpress-monorepo#2
+++ b/projects/packages/backup/changelog/renovate-wordpress-monorepo#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/backup/src/class-package-version.php
+++ b/projects/packages/backup/src/class-package-version.php
@@ -16,7 +16,7 @@ namespace Automattic\Jetpack\Backup;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '4.2.15';
+	const PACKAGE_VERSION = '4.2.16';
 
 	const PACKAGE_SLUG = 'backup';
 

--- a/projects/packages/blaze/CHANGELOG.md
+++ b/projects/packages/blaze/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.26.3] - 2025-08-14
+### Changed
+- Update package dependencies. [#44701]
+
+### Fixed
+- Fix an issue where the Blaze REST controller did not return the request body when the Content-Type header was text/csv. [#44742]
+
 ## [0.26.2] - 2025-08-11
 ### Changed
 - Update dependencies. [#44673]
@@ -665,6 +672,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated package dependencies. [#27906]
 
+[0.26.3]: https://github.com/automattic/jetpack-blaze/compare/v0.26.2...v0.26.3
 [0.26.2]: https://github.com/automattic/jetpack-blaze/compare/v0.26.1...v0.26.2
 [0.26.1]: https://github.com/automattic/jetpack-blaze/compare/v0.26.0...v0.26.1
 [0.26.0]: https://github.com/automattic/jetpack-blaze/compare/v0.25.37...v0.26.0

--- a/projects/packages/blaze/changelog/fix-dsp-csv-response
+++ b/projects/packages/blaze/changelog/fix-dsp-csv-response
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fixed an issue where the blaze REST controller did not return the request body when the Content-Type header was text/csv.

--- a/projects/packages/blaze/changelog/renovate-wordpress-monorepo#2
+++ b/projects/packages/blaze/changelog/renovate-wordpress-monorepo#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/blaze/package.json
+++ b/projects/packages/blaze/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-blaze",
-	"version": "0.26.2",
+	"version": "0.26.3",
 	"private": true,
 	"description": "Attract high-quality traffic to your site using Blaze. Using this service, you can advertise a post or page on some of the millions of pages across WordPress.com and Tumblr from just $5 per day.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/blaze/#readme",

--- a/projects/packages/blaze/src/class-dashboard.php
+++ b/projects/packages/blaze/src/class-dashboard.php
@@ -21,7 +21,7 @@ class Dashboard {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.26.2';
+	const PACKAGE_VERSION = '0.26.3';
 
 	/**
 	 * List of dependencies needed to render the dashboard in wp-admin.

--- a/projects/packages/blocks/CHANGELOG.md
+++ b/projects/packages/blocks/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.1] - 2025-08-14
+### Added
+- Allow blocks to have their own JavaScript loading strategy. [#44734]
+
 ## [3.1.0] - 2025-04-28
 ### Added
 - Add `get_variation` method to blocks. [#43251]
@@ -247,6 +251,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Blocks: introduce new package for block management
 
+[3.1.1]: https://github.com/Automattic/jetpack-blocks/compare/v3.1.0...v3.1.1
 [3.1.0]: https://github.com/Automattic/jetpack-blocks/compare/v3.0.10...v3.1.0
 [3.0.10]: https://github.com/Automattic/jetpack-blocks/compare/v3.0.9...v3.0.10
 [3.0.9]: https://github.com/Automattic/jetpack-blocks/compare/v3.0.8...v3.0.9

--- a/projects/packages/blocks/changelog/allow-specifying-js-loading-strategy
+++ b/projects/packages/blocks/changelog/allow-specifying-js-loading-strategy
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Allow blocks to have their own JS loading strategy.

--- a/projects/packages/blocks/changelog/update-jetpack-blocks-remove-unnecessary-check
+++ b/projects/packages/blocks/changelog/update-jetpack-blocks-remove-unnecessary-check
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Move some code around to reduce checks.
-
-

--- a/projects/packages/classic-theme-helper/CHANGELOG.md
+++ b/projects/packages/classic-theme-helper/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.15] - 2025-08-14
+### Changed
+- Update package dependencies. [#44701]
+
 ## [0.13.14] - 2025-08-11
 ### Changed
 - Update package dependencies. [#44677]
@@ -356,6 +360,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Add wordpress folder on gitignore. [#37177]
 
+[0.13.15]: https://github.com/Automattic/jetpack-classic-theme-helper/compare/v0.13.14...v0.13.15
 [0.13.14]: https://github.com/Automattic/jetpack-classic-theme-helper/compare/v0.13.13...v0.13.14
 [0.13.13]: https://github.com/Automattic/jetpack-classic-theme-helper/compare/v0.13.12...v0.13.13
 [0.13.12]: https://github.com/Automattic/jetpack-classic-theme-helper/compare/v0.13.11...v0.13.12

--- a/projects/packages/classic-theme-helper/changelog/fix-jetpack-direct_access_fatals_part_3
+++ b/projects/packages/classic-theme-helper/changelog/fix-jetpack-direct_access_fatals_part_3
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Prevent PHP errors by limiting direct access to files.
-
-

--- a/projects/packages/classic-theme-helper/changelog/renovate-wordpress-monorepo#2
+++ b/projects/packages/classic-theme-helper/changelog/renovate-wordpress-monorepo#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/classic-theme-helper/package.json
+++ b/projects/packages/classic-theme-helper/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-classic-theme-helper",
-	"version": "0.13.14",
+	"version": "0.13.15",
 	"private": true,
 	"description": "Features used with classic themes",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/classic-theme-helper/#readme",

--- a/projects/packages/classic-theme-helper/src/class-main.php
+++ b/projects/packages/classic-theme-helper/src/class-main.php
@@ -14,7 +14,7 @@ use WP_Error;
  */
 class Main {
 
-	const PACKAGE_VERSION = '0.13.14';
+	const PACKAGE_VERSION = '0.13.15';
 
 	/**
 	 * Modules to include.

--- a/projects/packages/connection/CHANGELOG.md
+++ b/projects/packages/connection/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.18.0] - 2025-08-14
+### Added
+- Create External_Storage class. [#44631]
+
 ## [6.17.2] - 2025-08-13
 ### Changed
 - Update package dependencies. [#44701]
@@ -1554,6 +1558,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Separate the connection library into its own package.
 
+[6.18.0]: https://github.com/Automattic/jetpack-connection/compare/v6.17.2...v6.18.0
 [6.17.2]: https://github.com/Automattic/jetpack-connection/compare/v6.17.1...v6.17.2
 [6.17.1]: https://github.com/Automattic/jetpack-connection/compare/v6.17.0...v6.17.1
 [6.17.0]: https://github.com/Automattic/jetpack-connection/compare/v6.16.2...v6.17.0

--- a/projects/packages/connection/changelog/add-external-storage-class
+++ b/projects/packages/connection/changelog/add-external-storage-class
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Created External_Storage class.

--- a/projects/packages/connection/composer.json
+++ b/projects/packages/connection/composer.json
@@ -75,7 +75,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "6.17.x-dev"
+			"dev-trunk": "6.18.x-dev"
 		},
 		"dependencies": {
 			"test-only": [

--- a/projects/packages/connection/legacy/class-jetpack-options.php
+++ b/projects/packages/connection/legacy/class-jetpack-options.php
@@ -246,7 +246,7 @@ class Jetpack_Options {
 	/**
 	 * Options that can be stored in external storage.
 	 *
-	 * @since $$next-version$$
+	 * @since 6.18.0
 	 *
 	 * @var array
 	 */

--- a/projects/packages/connection/src/class-external-storage.php
+++ b/projects/packages/connection/src/class-external-storage.php
@@ -36,14 +36,14 @@ require_once __DIR__ . '/interface-storage-provider.php';
 /**
  * External Storage utilities class.
  *
- * @since $$next-version$$
+ * @since 6.18.0
  */
 class External_Storage {
 
 	/**
 	 * Registered storage provider.
 	 *
-	 * @since $$next-version$$
+	 * @since 6.18.0
 	 *
 	 * @var Storage_Provider_Interface|null
 	 */
@@ -52,7 +52,7 @@ class External_Storage {
 	/**
 	 * Register a storage provider for external storage.
 	 *
-	 * @since $$next-version$$
+	 * @since 6.18.0
 	 *
 	 * @param Storage_Provider_Interface $provider Storage provider implementing the interface.
 	 * @return bool True if provider was registered successfully, false otherwise.
@@ -67,7 +67,7 @@ class External_Storage {
 	 *
 	 * Returns null if no provider is registered or if the provider can't provide the value (triggers database fallback).
 	 *
-	 * @since $$next-version$$
+	 * @since 6.18.0
 	 *
 	 * @param string $key The key to retrieve.
 	 * @return mixed The value from external storage, or null for database fallback.
@@ -120,7 +120,7 @@ class External_Storage {
 	 * Report external storage events through Jetpack Connection Error_Handler.
 	 * Includes rate limiting to prevent log spam from noisy events.
 	 *
-	 * @since $$next-version$$
+	 * @since 6.18.0
 	 *
 	 * @param string $event_type  The event type (error, empty, unavailable).
 	 * @param string $key         The key that triggered the event.
@@ -190,7 +190,7 @@ class External_Storage {
 	 * Determine if the current environment should report external storage errors to WordPress.com.
 	 * Allows wpcomsh and other environments to control remote error reporting independently.
 	 *
-	 * @since $$next-version$$
+	 * @since 6.18.0
 	 *
 	 * @return bool True if this environment should report external storage errors to WordPress.com.
 	 */
@@ -208,7 +208,7 @@ class External_Storage {
 	 * On first encounter of empty state, sets a transient. On subsequent encounters
 	 * after 10 minutes, allows reporting (indicating likely disconnection, not sync delay).
 	 *
-	 * @since $$next-version$$
+	 * @since 6.18.0
 	 *
 	 * @param string $key The key that was empty.
 	 * @return bool True if we should report this empty state, false otherwise.
@@ -240,7 +240,7 @@ class External_Storage {
 	 * This prevents log spam from noisy events by applying a simple one-hour
 	 * rate limit per key, regardless of event type.
 	 *
-	 * @since $$next-version$$
+	 * @since 6.18.0
 	 *
 	 * @param string $key        The key that triggered the event.
 	 * @return bool True if the event should be logged, false if rate limited.

--- a/projects/packages/connection/src/class-package-version.php
+++ b/projects/packages/connection/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Connection;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '6.17.2';
+	const PACKAGE_VERSION = '6.18.0';
 
 	const PACKAGE_SLUG = 'connection';
 

--- a/projects/packages/connection/src/interface-storage-provider.php
+++ b/projects/packages/connection/src/interface-storage-provider.php
@@ -16,7 +16,7 @@ namespace Automattic\Jetpack\Connection;
  * All storage providers must implement this interface to ensure
  * compatibility with the External_Storage system.
  *
- * @since $$next-version$$
+ * @since 6.18.0
  */
 interface Storage_Provider_Interface {
 
@@ -26,7 +26,7 @@ interface Storage_Provider_Interface {
 	 * This method should return true if the storage backend is accessible
 	 * and ready to handle requests, false otherwise.
 	 *
-	 * @since $$next-version$$
+	 * @since 6.18.0
 	 *
 	 * @return bool True if storage is available, false otherwise.
 	 */
@@ -38,7 +38,7 @@ interface Storage_Provider_Interface {
 	 * This method allows providers to selectively handle certain options
 	 * based on their configuration, environment, or other criteria.
 	 *
-	 * @since $$next-version$$
+	 * @since 6.18.0
 	 *
 	 * @param string $option_name The name of the option to check.
 	 * @return bool True if this provider should handle the option, false otherwise.
@@ -51,7 +51,7 @@ interface Storage_Provider_Interface {
 	 * This method should return the value from external storage, or null
 	 * if the value is not found or cannot be retrieved.
 	 *
-	 * @since $$next-version$$
+	 * @since 6.18.0
 	 *
 	 * @param string $option_name The name of the option to retrieve.
 	 * @return mixed The option value, or null if not found/available.
@@ -66,7 +66,7 @@ interface Storage_Provider_Interface {
 	 * or storage type (e.g., 'atomic', 'vip', 'kubernetes', etc.).
 	 * Used for logging and debugging purposes.
 	 *
-	 * @since $$next-version$$
+	 * @since 6.18.0
 	 *
 	 * @return string The environment identifier.
 	 */

--- a/projects/packages/explat/CHANGELOG.md
+++ b/projects/packages/explat/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.7] - 2025-08-14
+### Changed
+- Update package dependencies. [#44701]
+
 ## [0.3.6] - 2025-08-11
 ### Changed
 - Update package dependencies. [#44677]
@@ -211,6 +215,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ExPlat: add condition to prevent fetching the experiment assignment if there's not anon id (meaning that Tracks is likely disabled) [#38327]
 - Updated package dependencies. [#38132]
 
+[0.3.7]: https://github.com/Automattic/jetpack-explat/compare/v0.3.6...v0.3.7
 [0.3.6]: https://github.com/Automattic/jetpack-explat/compare/v0.3.5...v0.3.6
 [0.3.5]: https://github.com/Automattic/jetpack-explat/compare/v0.3.4...v0.3.5
 [0.3.4]: https://github.com/Automattic/jetpack-explat/compare/v0.3.3...v0.3.4

--- a/projects/packages/explat/changelog/renovate-wordpress-monorepo#2
+++ b/projects/packages/explat/changelog/renovate-wordpress-monorepo#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/explat/package.json
+++ b/projects/packages/explat/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-explat",
-	"version": "0.3.6",
+	"version": "0.3.7",
 	"private": true,
 	"description": "A package for running A/B tests on the Experimentation Platform (ExPlat) in the plugin.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/explat/#readme",

--- a/projects/packages/explat/src/class-explat.php
+++ b/projects/packages/explat/src/class-explat.php
@@ -20,7 +20,7 @@ class ExPlat {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.3.6';
+	const PACKAGE_VERSION = '0.3.7';
 
 	/**
 	 * Initializer.

--- a/projects/packages/external-media/CHANGELOG.md
+++ b/projects/packages/external-media/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.9] - 2025-08-14
+### Changed
+- Update package dependencies. [#44701]
+
 ## [0.4.8] - 2025-08-11
 ### Changed
 - Update package dependencies. [#44677]
@@ -158,6 +162,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix the button size in the editor for Gutenberg 18 or below. [#41619]
 - Media Library: Fix the Import Media button color in some color schemes. [#41664]
 
+[0.4.9]: https://github.com/Automattic/jetpack-external-media/compare/v0.4.8...v0.4.9
 [0.4.8]: https://github.com/Automattic/jetpack-external-media/compare/v0.4.7...v0.4.8
 [0.4.7]: https://github.com/Automattic/jetpack-external-media/compare/v0.4.6...v0.4.7
 [0.4.6]: https://github.com/Automattic/jetpack-external-media/compare/v0.4.5...v0.4.6

--- a/projects/packages/external-media/changelog/renovate-wordpress-monorepo#2
+++ b/projects/packages/external-media/changelog/renovate-wordpress-monorepo#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/external-media/package.json
+++ b/projects/packages/external-media/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-external-media",
-	"version": "0.4.8",
+	"version": "0.4.9",
 	"private": true,
 	"description": "The external media feature allows users to select and import photos from external media",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/external-media/#readme",

--- a/projects/packages/external-media/src/class-external-media.php
+++ b/projects/packages/external-media/src/class-external-media.php
@@ -17,7 +17,7 @@ use Jetpack_Options;
  * Class External_Media
  */
 class External_Media {
-	const PACKAGE_VERSION = '0.4.8';
+	const PACKAGE_VERSION = '0.4.9';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;
 

--- a/projects/packages/forms/CHANGELOG.md
+++ b/projects/packages/forms/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.3.0] - 2025-08-14
+### Added
+- Add several methods to the Feedback method. [#44713] [#44759] [#44768]
+- MailPoet: Implement email consent. [#44744] [#44780]
+- Slider: Make min/max editable. [#44715]
+
+### Changed
+- Defer loading JavaScript for more responsive page loading. [#44752]
+- Enable SCSS processing for field assets. [#44763]
+- Extract visually-hidden styles to shared SCSS partial for better code reuse. [#44769]
+- Increase default consent field size. [#44690]
+- Move CSS to SCSS files. [#44777]
+- Slider: Add visually hidden labels for inputs. [#44779]
+- Slider: Update `is-selected` styling. [#44783]
+- Slider: Visual update to min/max/default value inputs. [#44778]
+- Update package dependencies. [#44701]
+- Update rating field implementation with improved styling and visual feedback. [#44757]
+
+### Fixed
+- Add radio input field backend validation. [#44739]
+- Fix animated form style in Safari. [#44689]
+- Fix minor CSS glitches in the ratings field. [#44738]
+- Fix validation of jetpack multi-checkboxes [#44722]
+- Use the new Feedback `get_all_legacy_values` method in `parse_fields_from_content`. [#44761]
+
 ## [5.2.0] - 2025-08-11
 ### Added
 - Add initial image select field under feature flag. [#44675]
@@ -1404,6 +1429,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a new jetpack/forms package [#28409]
 - Added a public load_contact_form method for initializing the contact form module. [#28416]
 
+[5.3.0]: https://github.com/automattic/jetpack-forms/compare/v5.2.0...v5.3.0
 [5.2.0]: https://github.com/automattic/jetpack-forms/compare/v5.1.0...v5.2.0
 [5.1.0]: https://github.com/automattic/jetpack-forms/compare/v5.0.0...v5.1.0
 [5.0.0]: https://github.com/automattic/jetpack-forms/compare/v4.0.1...v5.0.0

--- a/projects/packages/forms/changelog/add-feedback-get_files-method
+++ b/projects/packages/forms/changelog/add-feedback-get_files-method
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Forms: Add get_files to the Feedback method

--- a/projects/packages/forms/changelog/add-forms-feedback-get_extra-value
+++ b/projects/packages/forms/changelog/add-forms-feedback-get_extra-value
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Forms: Add new method that will make it easier to refactor the save. 

--- a/projects/packages/forms/changelog/add-forms-feedback-has-field-type-method
+++ b/projects/packages/forms/changelog/add-forms-feedback-has-field-type-method
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Forms: Add has_field_type method to Feedback.

--- a/projects/packages/forms/changelog/add-forms-mailpoet-check-consent
+++ b/projects/packages/forms/changelog/add-forms-mailpoet-check-consent
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Forms: Check consent for MailPoet integration.

--- a/projects/packages/forms/changelog/add-forms-mailpoet-consent-toggle
+++ b/projects/packages/forms/changelog/add-forms-mailpoet-consent-toggle
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Forms: Add MailPoet email consent toggle.

--- a/projects/packages/forms/changelog/add-forms-slider-min-max-inputs
+++ b/projects/packages/forms/changelog/add-forms-slider-min-max-inputs
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Forms: Make slider field min/max editable.

--- a/projects/packages/forms/changelog/add-jetpack-forms-scss-dist-support
+++ b/projects/packages/forms/changelog/add-jetpack-forms-scss-dist-support
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Forms: enable scss processing for field assets

--- a/projects/packages/forms/changelog/add-radio-validation
+++ b/projects/packages/forms/changelog/add-radio-validation
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Forms: add radio input field backend validation 

--- a/projects/packages/forms/changelog/change-jetpack-forms-css-to-scss
+++ b/projects/packages/forms/changelog/change-jetpack-forms-css-to-scss
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Forms: move css to scss files

--- a/projects/packages/forms/changelog/fix-form-options-validation
+++ b/projects/packages/forms/changelog/fix-form-options-validation
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Forms: fix validation of jetpack multi-checkboxes

--- a/projects/packages/forms/changelog/fix-forms-consent-text-size
+++ b/projects/packages/forms/changelog/fix-forms-consent-text-size
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Forms: Increase default consent field size.

--- a/projects/packages/forms/changelog/fix-ratings-field-fixes
+++ b/projects/packages/forms/changelog/fix-ratings-field-fixes
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Forms: minor css fixes for the ratings field

--- a/projects/packages/forms/changelog/fix-safari-animated-style-transiton
+++ b/projects/packages/forms/changelog/fix-safari-animated-style-transiton
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Forms: fix safari animation for animated form style

--- a/projects/packages/forms/changelog/renovate-wordpress-monorepo#2
+++ b/projects/packages/forms/changelog/renovate-wordpress-monorepo#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/forms/changelog/update-forms-defer-js
+++ b/projects/packages/forms/changelog/update-forms-defer-js
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Forms: defer loading JS for more responsive page loading.

--- a/projects/packages/forms/changelog/update-forms-parse_fields_from_content
+++ b/projects/packages/forms/changelog/update-forms-parse_fields_from_content
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Forms: use the new Feedback get_all_legacy_values method in parse_fields_from_content

--- a/projects/packages/forms/changelog/update-forms-rating-field
+++ b/projects/packages/forms/changelog/update-forms-rating-field
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update rating field implementation with improved styling and visual feedback

--- a/projects/packages/forms/changelog/update-forms-slider-labels
+++ b/projects/packages/forms/changelog/update-forms-slider-labels
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Forms: slider - add visually hidden labels for inputs

--- a/projects/packages/forms/changelog/update-forms-slider-min-max-visual
+++ b/projects/packages/forms/changelog/update-forms-slider-min-max-visual
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Forms: slider - visual update to min/max/default value inputs

--- a/projects/packages/forms/changelog/update-forms-slider-selected-visuals
+++ b/projects/packages/forms/changelog/update-forms-slider-selected-visuals
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Forms: slider - update is-selected styling

--- a/projects/packages/forms/changelog/update-forms-visually-hidden-styles
+++ b/projects/packages/forms/changelog/update-forms-visually-hidden-styles
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Extract visually-hidden styles to shared SCSS partial for better code reuse

--- a/projects/packages/forms/composer.json
+++ b/projects/packages/forms/composer.json
@@ -70,7 +70,7 @@
 			"link-template": "https://github.com/automattic/jetpack-forms/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "5.2.x-dev"
+			"dev-trunk": "5.3.x-dev"
 		},
 		"textdomain": "jetpack-forms",
 		"version-constants": {

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-forms",
-	"version": "5.2.0",
+	"version": "5.3.0",
 	"private": true,
 	"description": "Jetpack Forms",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/forms/#readme",

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -14,7 +14,7 @@ use Automattic\Jetpack\Forms\Dashboard\Dashboard;
  */
 class Jetpack_Forms {
 
-	const PACKAGE_VERSION = '5.2.0';
+	const PACKAGE_VERSION = '5.3.0';
 
 	/**
 	 * Load the contact form module.

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -2176,7 +2176,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 			/**
 			 * Check if Jetpack is active for file uploads.
 			 *
-			 * @since $$next-version$$
+			 * @since 5.3.0
 			 *
 			 * @return bool
 			 */

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -2808,7 +2808,7 @@ class Contact_Form_Plugin {
 	 * @return array Parsed fields.
 	 *
 	 * @codeCoverageIgnore - No need to be covered.
-	 * @deprecated since $$next-version$$
+	 * @deprecated since 5.3.0
 	 */
 	public static function parse_feedback_content( $post_content ) {
 		$all_values = array();

--- a/projects/packages/image-cdn/CHANGELOG.md
+++ b/projects/packages/image-cdn/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.16] - 2025-08-14
+### Changed
+- Update package dependencies. [#44725]
+
 ## [0.7.15] - 2025-08-05
 ### Changed
 - Add openlibrary.org CDN to ignore list. [#44627]
@@ -214,6 +218,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add image CDN package. [#29561]
 
+[0.7.16]: https://github.com/Automattic/jetpack-image-cdn/compare/v0.7.15...v0.7.16
 [0.7.15]: https://github.com/Automattic/jetpack-image-cdn/compare/v0.7.14...v0.7.15
 [0.7.14]: https://github.com/Automattic/jetpack-image-cdn/compare/v0.7.13...v0.7.14
 [0.7.13]: https://github.com/Automattic/jetpack-image-cdn/compare/v0.7.12...v0.7.13

--- a/projects/packages/image-cdn/changelog/renovate-lock-file-maintenance
+++ b/projects/packages/image-cdn/changelog/renovate-lock-file-maintenance
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/image-cdn/src/class-image-cdn.php
+++ b/projects/packages/image-cdn/src/class-image-cdn.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Image_CDN;
  */
 final class Image_CDN {
 
-	const PACKAGE_VERSION = '0.7.15';
+	const PACKAGE_VERSION = '0.7.16';
 
 	/**
 	 * Singleton.

--- a/projects/packages/jitm/CHANGELOG.md
+++ b/projects/packages/jitm/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.3.3] - 2025-08-14
+### Changed
+- Update package dependencies. [#44701]
+
 ## [4.3.2] - 2025-08-11
 ### Changed
 - Update package dependencies. [#44677]
@@ -974,6 +978,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update Jetpack to use new JITM package
 
+[4.3.3]: https://github.com/Automattic/jetpack-jitm/compare/v4.3.2...v4.3.3
 [4.3.2]: https://github.com/Automattic/jetpack-jitm/compare/v4.3.1...v4.3.2
 [4.3.1]: https://github.com/Automattic/jetpack-jitm/compare/v4.3.0...v4.3.1
 [4.3.0]: https://github.com/Automattic/jetpack-jitm/compare/v4.2.29...v4.3.0

--- a/projects/packages/jitm/changelog/fix-jetpack-direct_access_fatals_part_3
+++ b/projects/packages/jitm/changelog/fix-jetpack-direct_access_fatals_part_3
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Prevent PHP errors by limiting direct access to files.
-
-

--- a/projects/packages/jitm/changelog/renovate-wordpress-monorepo#2
+++ b/projects/packages/jitm/changelog/renovate-wordpress-monorepo#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/jitm/src/class-jitm.php
+++ b/projects/packages/jitm/src/class-jitm.php
@@ -25,7 +25,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class JITM {
 
-	const PACKAGE_VERSION = '4.3.2';
+	const PACKAGE_VERSION = '4.3.3';
 
 	/**
 	 * List of screen IDs where JITMs are allowed to display.

--- a/projects/packages/masterbar/CHANGELOG.md
+++ b/projects/packages/masterbar/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.21.0] - 2025-08-14
+### Changed
+- Admin Menu: Move Jetpack menu before Posts. [#44733]
+- Update package dependencies. [#44701]
+
 ## [0.20.0] - 2025-08-11
 ### Changed
 - Admin Menu: Move "Hosting > Marketing" to "Tools > Marketing". [#44663]
@@ -407,6 +412,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Notifications: Change Icon [#37676]
 - Updated package dependencies. [#37669] [#37706]
 
+[0.21.0]: https://github.com/Automattic/jetpack-masterbar/compare/v0.20.0...v0.21.0
 [0.20.0]: https://github.com/Automattic/jetpack-masterbar/compare/v0.19.2...v0.20.0
 [0.19.2]: https://github.com/Automattic/jetpack-masterbar/compare/v0.19.1...v0.19.2
 [0.19.1]: https://github.com/Automattic/jetpack-masterbar/compare/v0.19.0...v0.19.1

--- a/projects/packages/masterbar/changelog/dotcom-13889-reorder-all-menu-items-on-all-environments
+++ b/projects/packages/masterbar/changelog/dotcom-13889-reorder-all-menu-items-on-all-environments
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Admin Menu: Move Jetpack menu before Posts

--- a/projects/packages/masterbar/changelog/renovate-wordpress-monorepo#2
+++ b/projects/packages/masterbar/changelog/renovate-wordpress-monorepo#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/masterbar/composer.json
+++ b/projects/packages/masterbar/composer.json
@@ -71,7 +71,7 @@
 	"extra": {
 		"autotagger": true,
 		"branch-alias": {
-			"dev-trunk": "0.20.x-dev"
+			"dev-trunk": "0.21.x-dev"
 		},
 		"changelogger": {
 			"link-template": "https://github.com/Automattic/jetpack-masterbar/compare/v${old}...v${new}"

--- a/projects/packages/masterbar/package.json
+++ b/projects/packages/masterbar/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-masterbar",
-	"version": "0.20.0",
+	"version": "0.21.0",
 	"private": true,
 	"description": "The WordPress.com Toolbar feature replaces the default admin bar and offers quick links to the Reader, all your sites, your WordPress.com profile, and notifications.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/masterbar/#readme",

--- a/projects/packages/masterbar/src/class-main.php
+++ b/projects/packages/masterbar/src/class-main.php
@@ -14,7 +14,7 @@ use Automattic\Jetpack\Status\Host;
  */
 class Main {
 
-	const PACKAGE_VERSION = '0.20.0';
+	const PACKAGE_VERSION = '0.21.0';
 
 	/**
 	 * Initializer.

--- a/projects/packages/my-jetpack/CHANGELOG.md
+++ b/projects/packages/my-jetpack/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.23.0] - 2025-08-14
+### Added
+- Add new Interstitial component. [#44665]
+
+### Changed
+- My Jetpack: Fix multisite availability check for restricted products and modules. [#44710]
+- Update package dependencies. [#44701]
+
 ## [5.22.1] - 2025-08-11
 ### Changed
 - Update dependencies. [#44673]
@@ -2292,6 +2300,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created package
 
+[5.23.0]: https://github.com/Automattic/jetpack-my-jetpack/compare/5.22.1...5.23.0
 [5.22.1]: https://github.com/Automattic/jetpack-my-jetpack/compare/5.22.0...5.22.1
 [5.22.0]: https://github.com/Automattic/jetpack-my-jetpack/compare/5.21.0...5.22.0
 [5.21.0]: https://github.com/Automattic/jetpack-my-jetpack/compare/5.20.2...5.21.0

--- a/projects/packages/my-jetpack/changelog/add-myjp-upgraded-product-interstitial
+++ b/projects/packages/my-jetpack/changelog/add-myjp-upgraded-product-interstitial
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Added new Interstitial component

--- a/projects/packages/my-jetpack/changelog/fix-jetpack-direct_access_fatals_part_3
+++ b/projects/packages/my-jetpack/changelog/fix-jetpack-direct_access_fatals_part_3
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Prevent PHP errors by limiting direct access to files.
-
-

--- a/projects/packages/my-jetpack/changelog/fix-my-jetpack-multi-site
+++ b/projects/packages/my-jetpack/changelog/fix-my-jetpack-multi-site
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-My Jetpack: Fixed multisite availability check for restricted products and modules

--- a/projects/packages/my-jetpack/changelog/renovate-wordpress-monorepo#2
+++ b/projects/packages/my-jetpack/changelog/renovate-wordpress-monorepo#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/my-jetpack/composer.json
+++ b/projects/packages/my-jetpack/composer.json
@@ -82,7 +82,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "5.22.x-dev"
+			"dev-trunk": "5.23.x-dev"
 		},
 		"version-constants": {
 			"::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "5.22.1",
+	"version": "5.23.0",
 	"private": true,
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -39,7 +39,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '5.22.1';
+	const PACKAGE_VERSION = '5.23.0';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.

--- a/projects/packages/paypal-payments/CHANGELOG.md
+++ b/projects/packages/paypal-payments/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.2] - 2025-08-14
+### Changed
+- Update package dependencies. [#44701]
+
 ## [0.4.1] - 2025-08-11
 ### Changed
 - Update dependencies. [#44673]
@@ -43,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Simple Payments: Move Simple Payments block to PayPal Payments package. [#43413]
 
+[0.4.2]: https://github.com/Automattic/jetpack-paypal-payments/compare/v0.4.1...v0.4.2
 [0.4.1]: https://github.com/Automattic/jetpack-paypal-payments/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/Automattic/jetpack-paypal-payments/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/Automattic/jetpack-paypal-payments/compare/v0.2.0...v0.3.0

--- a/projects/packages/paypal-payments/changelog/renovate-wordpress-monorepo#2
+++ b/projects/packages/paypal-payments/changelog/renovate-wordpress-monorepo#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/paypal-payments/package.json
+++ b/projects/packages/paypal-payments/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-paypal-payments",
-	"version": "0.4.1",
+	"version": "0.4.2",
 	"private": true,
 	"description": "Add PayPal, credit, and debit card payment buttons with minimal setup. Good for collecting donations or payments for products and services.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/paypal-payments/#readme",

--- a/projects/packages/paypal-payments/src/class-paypal-payments.php
+++ b/projects/packages/paypal-payments/src/class-paypal-payments.php
@@ -12,5 +12,5 @@ namespace Automattic\Jetpack;
  */
 class PayPal_Payments {
 
-	const PACKAGE_VERSION = '0.4.1';
+	const PACKAGE_VERSION = '0.4.2';
 }

--- a/projects/packages/plugins-installer/CHANGELOG.md
+++ b/projects/packages/plugins-installer/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.7] - 2025-08-14
+### Changed
+- Internal updates.
+
 ## [0.5.6] - 2025-07-21
 ### Changed
 - Internal updates.
@@ -130,6 +134,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fix method logic
 
+[0.5.7]: https://github.com/Automattic/jetpack-plugins-installer/compare/v0.5.6...v0.5.7
 [0.5.6]: https://github.com/Automattic/jetpack-plugins-installer/compare/v0.5.5...v0.5.6
 [0.5.5]: https://github.com/Automattic/jetpack-plugins-installer/compare/v0.5.4...v0.5.5
 [0.5.4]: https://github.com/Automattic/jetpack-plugins-installer/compare/v0.5.3...v0.5.4

--- a/projects/packages/plugins-installer/changelog/fix-jetpack-direct_access_fatals_part_3
+++ b/projects/packages/plugins-installer/changelog/fix-jetpack-direct_access_fatals_part_3
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Prevent PHP errors by limiting direct access to files.
-
-

--- a/projects/packages/post-list/CHANGELOG.md
+++ b/projects/packages/post-list/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.27] - 2025-08-14
+### Changed
+- Update package dependencies. [#44701]
+
 ## [0.8.26] - 2025-08-11
 ### Changed
 - Update package dependencies. [#44677]
@@ -245,6 +249,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated the default columns displayed on the post and page list screens
 - Refactored thumbnail preview to function server side. All javascript removed.
 
+[0.8.27]: https://github.com/automattic/jetpack-post-list/compare/v0.8.26...v0.8.27
 [0.8.26]: https://github.com/automattic/jetpack-post-list/compare/v0.8.25...v0.8.26
 [0.8.25]: https://github.com/automattic/jetpack-post-list/compare/v0.8.24...v0.8.25
 [0.8.24]: https://github.com/automattic/jetpack-post-list/compare/v0.8.23...v0.8.24

--- a/projects/packages/post-list/changelog/renovate-wordpress-monorepo#2
+++ b/projects/packages/post-list/changelog/renovate-wordpress-monorepo#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/post-list/src/class-post-list.php
+++ b/projects/packages/post-list/src/class-post-list.php
@@ -16,7 +16,7 @@ use WP_Screen;
  */
 class Post_List {
 
-	const PACKAGE_VERSION = '0.8.26';
+	const PACKAGE_VERSION = '0.8.27';
 	const FEATURE         = 'enhanced_post_list';
 
 	/**

--- a/projects/packages/publicize/CHANGELOG.md
+++ b/projects/packages/publicize/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.66.7] - 2025-08-14
+### Changed
+- Update package dependencies. [#44701]
+
 ## [0.66.6] - 2025-08-11
 ### Changed
 - Update dependencies. [#44673]
@@ -1079,6 +1083,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Update package.json metadata.
 
+[0.66.7]: https://github.com/Automattic/jetpack-publicize/compare/v0.66.6...v0.66.7
 [0.66.6]: https://github.com/Automattic/jetpack-publicize/compare/v0.66.5...v0.66.6
 [0.66.5]: https://github.com/Automattic/jetpack-publicize/compare/v0.66.4...v0.66.5
 [0.66.4]: https://github.com/Automattic/jetpack-publicize/compare/v0.66.3...v0.66.4

--- a/projects/packages/publicize/changelog/renovate-wordpress-monorepo#2
+++ b/projects/packages/publicize/changelog/renovate-wordpress-monorepo#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/publicize/package.json
+++ b/projects/packages/publicize/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-publicize",
-	"version": "0.66.6",
+	"version": "0.66.7",
 	"private": true,
 	"description": "Publicize makes it easy to share your site’s posts on several social media networks automatically when you publish a new post.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/publicize/#readme",

--- a/projects/packages/search/CHANGELOG.md
+++ b/projects/packages/search/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.52.12] - 2025-08-14
+### Changed
+- Update package dependencies. [#44701]
+
 ## [0.52.11] - 2025-08-11
 ### Changed
 - Update package dependencies. [#44677]
@@ -1303,6 +1307,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Update PHPUnit configs to include just what needs coverage rather than include everything then try to exclude stuff that doesn't.
 
+[0.52.12]: https://github.com/Automattic/jetpack-search/compare/v0.52.11...v0.52.12
 [0.52.11]: https://github.com/Automattic/jetpack-search/compare/v0.52.10...v0.52.11
 [0.52.10]: https://github.com/Automattic/jetpack-search/compare/v0.52.9...v0.52.10
 [0.52.9]: https://github.com/Automattic/jetpack-search/compare/v0.52.8...v0.52.9

--- a/projects/packages/search/changelog/fix-jetpack-direct_access_fatals_part_3
+++ b/projects/packages/search/changelog/fix-jetpack-direct_access_fatals_part_3
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Prevent PHP errors by limiting direct access to files.
-
-

--- a/projects/packages/search/changelog/renovate-wordpress-monorepo#2
+++ b/projects/packages/search/changelog/renovate-wordpress-monorepo#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -15,7 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Search package general information
  */
 class Package {
-	const VERSION = '0.52.11';
+	const VERSION = '0.52.12';
 	const SLUG    = 'search';
 
 	/**

--- a/projects/packages/status/CHANGELOG.md
+++ b/projects/packages/status/CHANGELOG.md
@@ -5,13 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.0.3] - 2025-08-14
+### Changed
+- Update `is_frontend` method to allow not sending "Vary" header. [#44741]
+
 ## [6.0.2] - 2025-08-06
 ### Added
 - Status: Add two new helper functions for P2 and WordPress.com site ID checks. [#44512]
 
 ## [6.0.1] - 2025-08-04
 ### Added
-- Requests: consider WPCOM_CLI_SCRIPT as a backend request. [#44553]
+- Requests: Treat WPCOM_CLI_SCRIPT as a backend request. [#44553]
 
 ## [6.0.0] - 2025-07-21
 ### Removed
@@ -501,6 +505,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Packages: Introduce a status package
 
+[6.0.3]: https://github.com/Automattic/jetpack-status/compare/v6.0.2...v6.0.3
 [6.0.2]: https://github.com/Automattic/jetpack-status/compare/v6.0.1...v6.0.2
 [6.0.1]: https://github.com/Automattic/jetpack-status/compare/v6.0.0...v6.0.1
 [6.0.0]: https://github.com/Automattic/jetpack-status/compare/v5.4.0...v6.0.0

--- a/projects/packages/status/changelog/update-front-end-check-to-allow-skip-send-vary-headers
+++ b/projects/packages/status/changelog/update-front-end-check-to-allow-skip-send-vary-headers
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update is_frontend method to allow not sending vary header.

--- a/projects/packages/status/src/class-request.php
+++ b/projects/packages/status/src/class-request.php
@@ -17,7 +17,7 @@ class Request {
 	 * Determine whether the current request is for accessing the frontend.
 	 * Also update Vary headers to indicate that the response may vary by Accept header.
 	 *
-	 * @since $$next-version$$ Added $send_vary_headers argument.
+	 * @since 6.0.3 Added $send_vary_headers argument.
 	 *
 	 * @param bool $send_vary_headers Whether to send Vary headers.
 	 *
@@ -61,7 +61,7 @@ class Request {
 		 * Filter whether the current request is for accessing the frontend.
 		 *
 		 * @since jetpack-9.0.0
-		 * @since $$next-version$$ Added $send_vary_headers argument.
+		 * @since 6.0.3 Added $send_vary_headers argument.
 		 *
 		 * @param bool $is_frontend Whether the current request is for accessing the frontend.
 		 * @param bool $send_vary_headers Whether to send Vary headers.

--- a/projects/packages/subscribers-dashboard/CHANGELOG.md
+++ b/projects/packages/subscribers-dashboard/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.2 - 2025-08-14
+### Changed
+- Update package dependencies. [#44701]
+
 ## 0.2.1 - 2025-08-11
 ### Changed
 - Update dependencies. [#44673]

--- a/projects/packages/subscribers-dashboard/changelog/renovate-wordpress-monorepo#2
+++ b/projects/packages/subscribers-dashboard/changelog/renovate-wordpress-monorepo#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/subscribers-dashboard/package.json
+++ b/projects/packages/subscribers-dashboard/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-subscribers-dashboard",
-	"version": "0.2.1",
+	"version": "0.2.2",
 	"private": true,
 	"description": "WP Admin page to manage subscribers",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/subscribers-dashboard/#readme",

--- a/projects/packages/subscribers-dashboard/src/class-dashboard.php
+++ b/projects/packages/subscribers-dashboard/src/class-dashboard.php
@@ -17,7 +17,7 @@ use Automattic\Jetpack\Status\Host;
  * @package jetpack-subscribers
  */
 class Dashboard {
-	const VERSION = '0.2.1';
+	const VERSION = '0.2.2';
 	/**
 	 * Whether the class has been initialized
 	 *

--- a/projects/packages/sync/CHANGELOG.md
+++ b/projects/packages/sync/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.18.2] - 2025-08-14
+### Changed
+- Internal updates.
+
 ## [4.18.1] - 2025-08-11
 ### Fixed
 - Prevent PHP errors when directly accessing various files. [#44646]
@@ -1519,6 +1523,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Packages: Move sync to a classmapped package
 
+[4.18.2]: https://github.com/Automattic/jetpack-sync/compare/v4.18.1...v4.18.2
 [4.18.1]: https://github.com/Automattic/jetpack-sync/compare/v4.18.0...v4.18.1
 [4.18.0]: https://github.com/Automattic/jetpack-sync/compare/v4.17.0...v4.18.0
 [4.17.0]: https://github.com/Automattic/jetpack-sync/compare/v4.16.0...v4.17.0

--- a/projects/packages/sync/changelog/fix-jetpack-direct_access_fatals_part_3
+++ b/projects/packages/sync/changelog/fix-jetpack-direct_access_fatals_part_3
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Prevent PHP errors by limiting direct access to files.
-
-

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '4.18.1';
+	const PACKAGE_VERSION = '4.18.2';
 
 	const PACKAGE_SLUG = 'sync';
 

--- a/projects/packages/videopress/CHANGELOG.md
+++ b/projects/packages/videopress/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.32.0] - 2025-08-14
+### Changed
+- Update package dependencies. [#44701]
+- VideoPress: Include VideoPress editor state in REST API requests. [#44616]
+
 ## [0.31.2] - 2025-08-11
 ### Changed
 - Update dependencies. [#44673]
@@ -1715,6 +1720,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created empty package [#24952]
 
+[0.32.0]: https://github.com/Automattic/jetpack-videopress/compare/v0.31.2...v0.32.0
 [0.31.2]: https://github.com/Automattic/jetpack-videopress/compare/v0.31.1...v0.31.2
 [0.31.1]: https://github.com/Automattic/jetpack-videopress/compare/v0.31.0...v0.31.1
 [0.31.0]: https://github.com/Automattic/jetpack-videopress/compare/v0.30.6...v0.31.0

--- a/projects/packages/videopress/changelog/include-video-press-editor-state-in-rest-api-requests
+++ b/projects/packages/videopress/changelog/include-video-press-editor-state-in-rest-api-requests
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-VideoPress: include VideoPress editor state in REST API requests.

--- a/projects/packages/videopress/changelog/renovate-wordpress-monorepo#2
+++ b/projects/packages/videopress/changelog/renovate-wordpress-monorepo#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/videopress/composer.json
+++ b/projects/packages/videopress/composer.json
@@ -67,7 +67,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-videopress/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "0.31.x-dev"
+			"dev-trunk": "0.32.x-dev"
 		},
 		"version-constants": {
 			"::PACKAGE_VERSION": "src/class-package-version.php"

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.31.2",
+	"version": "0.32.0",
 	"private": true,
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",

--- a/projects/packages/videopress/src/class-package-version.php
+++ b/projects/packages/videopress/src/class-package-version.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * The Package_Version class.
  */
 class Package_Version {
-	const PACKAGE_VERSION = '0.31.2';
+	const PACKAGE_VERSION = '0.32.0';
 
 	const PACKAGE_SLUG = 'videopress';
 

--- a/projects/plugins/automattic-for-agencies-client/changelog/prerelease
+++ b/projects/plugins/automattic-for-agencies-client/changelog/prerelease
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/automattic-for-agencies-client/composer.lock
+++ b/projects/plugins/automattic-for-agencies-client/composer.lock
@@ -399,7 +399,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "bb8626ac4e726e2136eb81e90afb74106f7c3243"
+                "reference": "d088808e20090e05e1d5b9a4f74f1ed798a356b0"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -435,7 +435,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "6.17.x-dev"
+                    "dev-trunk": "6.18.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/backup/changelog/prerelease#11
+++ b/projects/plugins/backup/changelog/prerelease#11
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -660,7 +660,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "bb8626ac4e726e2136eb81e90afb74106f7c3243"
+                "reference": "d088808e20090e05e1d5b9a4f74f1ed798a356b0"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -696,7 +696,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "6.17.x-dev"
+                    "dev-trunk": "6.18.x-dev"
                 },
                 "dependencies": {
                     "test-only": [
@@ -1178,7 +1178,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "eb7fe20ee6b54488ae179c01f1fc9a71aa808603"
+                "reference": "f0d31f93658c0edd3fe5c0fbac4b4e8112429e8d"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1217,7 +1217,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "5.22.x-dev"
+                    "dev-trunk": "5.23.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/boost/changelog/prerelease#2
+++ b/projects/plugins/boost/changelog/prerelease#2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -520,7 +520,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "bb8626ac4e726e2136eb81e90afb74106f7c3243"
+                "reference": "d088808e20090e05e1d5b9a4f74f1ed798a356b0"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -556,7 +556,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "6.17.x-dev"
+                    "dev-trunk": "6.18.x-dev"
                 },
                 "dependencies": {
                     "test-only": [
@@ -1099,7 +1099,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "eb7fe20ee6b54488ae179c01f1fc9a71aa808603"
+                "reference": "f0d31f93658c0edd3fe5c0fbac4b4e8112429e8d"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1138,7 +1138,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "5.22.x-dev"
+                    "dev-trunk": "5.23.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/inspect/changelog/prerelease
+++ b/projects/plugins/inspect/changelog/prerelease
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/inspect/composer.lock
+++ b/projects/plugins/inspect/composer.lock
@@ -399,7 +399,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "bb8626ac4e726e2136eb81e90afb74106f7c3243"
+                "reference": "d088808e20090e05e1d5b9a4f74f1ed798a356b0"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -435,7 +435,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "6.17.x-dev"
+                    "dev-trunk": "6.18.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/jetpack/CHANGELOG.md
+++ b/projects/plugins/jetpack/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 ### This is a list detailing changes for all Jetpack releases.
 
+## 15.0-a.3 - 2025-08-14
+### Enhancements
+- Forms: Add `has_field_type` method to Feedback. [#44759]
+- Forms: Defer JavaScript loading for more responsive page loading. [#44752]
+- Shortcodes: Update embed reversal code to only run when content is inserted in the admin. [#44741]
+- Sitemaps: Add filter to allow suspending object cache addition during generation. [#44732]
+- Subscription block: Defer JavaScript loading. [#44734]
+
+### Improved compatibility
+- Open Graph Meta tags: Add new filter allowing one to define a custom site representative image. [#44708]
+
+### Bug fixes
+- Infinite Scroll: Prevent PHP warnings in various edge cases. [#44642]
+- My Jetpack: Fix multisite availability check for restricted products and modules. [#44710]
+- Prevent PHP fatals when handling unexpected data types. [#44765]
+
+### Other changes <!-- Non-user-facing changes go here. This section will not be copied to readme.txt. -->
+- AI Assistant: Track generation time on suggestion request. [#44716]
+- E2E: Add typecheck support. [#44788]
+- E2E: Fix onboarding tests. [#44745]
+- Editor assets endpoint: Expand allowed block types. [#44616]
+- Open Help Center modal for WordPress.com sites and update the support link. [#44774]
+- Update package dependencies. [#44701] [#44725]
+
 ## 15.0-a.1 - 2025-08-11
 ### Enhancements
 - Carousel: Fix crashes on large galleries and reduce server requests by preloading only adjacent images instead of all at once. [#44612]

--- a/projects/plugins/jetpack/changelog/add-forms-feedback-has-field-type-method
+++ b/projects/plugins/jetpack/changelog/add-forms-feedback-has-field-type-method
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Forms: Add has_field_type method to Feedback.

--- a/projects/plugins/jetpack/changelog/add-jetpack-ai-timelapse-event-prop
+++ b/projects/plugins/jetpack/changelog/add-jetpack-ai-timelapse-event-prop
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-AI Assistant: track generation time on suggestion request

--- a/projects/plugins/jetpack/changelog/add-typecheck-for-e2e-tests
+++ b/projects/plugins/jetpack/changelog/add-typecheck-for-e2e-tests
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Added typecheck support for E2E tests.

--- a/projects/plugins/jetpack/changelog/e2e-improve-recommendations-test-url-checks
+++ b/projects/plugins/jetpack/changelog/e2e-improve-recommendations-test-url-checks
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: E2E tests: improve checks for url in recommendations steps test
-
-

--- a/projects/plugins/jetpack/changelog/e2e-update-e2e-tests-docs
+++ b/projects/plugins/jetpack/changelog/e2e-update-e2e-tests-docs
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: E2E tests: updated documentation
-
-

--- a/projects/plugins/jetpack/changelog/feat-expand-editor-assets-endpoint-allowed-block-types
+++ b/projects/plugins/jetpack/changelog/feat-expand-editor-assets-endpoint-allowed-block-types
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Editor assets endpoint: expand allowed block types

--- a/projects/plugins/jetpack/changelog/fix-form-options-validation
+++ b/projects/plugins/jetpack/changelog/fix-form-options-validation
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-

--- a/projects/plugins/jetpack/changelog/fix-infinite-scroll-php_warnings_part2
+++ b/projects/plugins/jetpack/changelog/fix-infinite-scroll-php_warnings_part2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Infinite Scroll: Prevent PHP warnings in various edge cases.

--- a/projects/plugins/jetpack/changelog/fix-jetpack-direct_access_fatals_part_3
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-direct_access_fatals_part_3
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Prevent PHP errors by limiting direct access to files.
-
-

--- a/projects/plugins/jetpack/changelog/fix-jetpack-various_fatals
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-various_fatals
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Prevent PHP fatals when handling unexpected data types.

--- a/projects/plugins/jetpack/changelog/fix-my-jetpack-multi-site
+++ b/projects/plugins/jetpack/changelog/fix-my-jetpack-multi-site
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-My Jetpack: Fixed multisite availability check for restricted products and modules

--- a/projects/plugins/jetpack/changelog/fix-onboarding-e2e-test
+++ b/projects/plugins/jetpack/changelog/fix-onboarding-e2e-test
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Fixed onboarding e2e tests.

--- a/projects/plugins/jetpack/changelog/prerelease
+++ b/projects/plugins/jetpack/changelog/prerelease
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Update composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/renovate-lock-file-maintenance
+++ b/projects/plugins/jetpack/changelog/renovate-lock-file-maintenance
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Update package dependencies.

--- a/projects/plugins/jetpack/changelog/renovate-wordpress-monorepo#2
+++ b/projects/plugins/jetpack/changelog/renovate-wordpress-monorepo#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Update package dependencies.

--- a/projects/plugins/jetpack/changelog/update-blocks-allow-specifying-js-loading-strategy
+++ b/projects/plugins/jetpack/changelog/update-blocks-allow-specifying-js-loading-strategy
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-Blocks: Update subscription block JS to be deferred.

--- a/projects/plugins/jetpack/changelog/update-forms-defer-js
+++ b/projects/plugins/jetpack/changelog/update-forms-defer-js
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Forms: defer loading JS for more responsive page loading.

--- a/projects/plugins/jetpack/changelog/update-help-center-link-in-sharing
+++ b/projects/plugins/jetpack/changelog/update-help-center-link-in-sharing
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Open Help Center modal for WPCOM sites and update the support link

--- a/projects/plugins/jetpack/changelog/update-jetpack-modules-shortcodes-conditionally-hook-on-pre-kses
+++ b/projects/plugins/jetpack/changelog/update-jetpack-modules-shortcodes-conditionally-hook-on-pre-kses
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-Shortcodes: Update embed reversal code to only run when content is inserted in the admin.

--- a/projects/plugins/jetpack/changelog/update-jetpack-sitemaps-allow-disable-cache-addition-hog-283
+++ b/projects/plugins/jetpack/changelog/update-jetpack-sitemaps-allow-disable-cache-addition-hog-283
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-Sitemaps: Add filter to allow suspending object cache addition during generation.

--- a/projects/plugins/jetpack/changelog/update-opengraph-filter-custom-fallback
+++ b/projects/plugins/jetpack/changelog/update-opengraph-filter-custom-fallback
@@ -1,4 +1,0 @@
-Significance: patch
-Type: compat
-
-Open Graph Meta tags: add new filter allowing one to define a custom site representative image.

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -78,7 +78,7 @@ class Jetpack_Gutenberg {
 	 *
 	 * @var array<string, array|bool>
 	 *
-	 * @since $$next-version$$
+	 * @since 15.0
 	 */
 	private static $block_js_loading_strategies = array();
 
@@ -1390,7 +1390,7 @@ class Jetpack_Gutenberg {
 	 * @param string     $block_name The block name.
 	 * @param array|bool $strategy   The JS loading strategy.
 	 *
-	 * @since $$next-version$$
+	 * @since 15.0
 	 */
 	public static function set_block_js_loading_strategy( $block_name, $strategy ) {
 		self::$block_js_loading_strategies[ $block_name ] = $strategy;
@@ -1403,7 +1403,7 @@ class Jetpack_Gutenberg {
 	 *
 	 * @return array|bool The JS loading strategy for the block.
 	 *
-	 * @since $$next-version$$
+	 * @since 15.0
 	 */
 	public static function get_block_js_loading_strategy( $block_name ) {
 		$strategy = false;

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -110,7 +110,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ15_0_a_1",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ15_0_a_3",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -1019,7 +1019,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "bb8626ac4e726e2136eb81e90afb74106f7c3243"
+                "reference": "d088808e20090e05e1d5b9a4f74f1ed798a356b0"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -1055,7 +1055,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "6.17.x-dev"
+                    "dev-trunk": "6.18.x-dev"
                 },
                 "dependencies": {
                     "test-only": [
@@ -1413,7 +1413,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/forms",
-                "reference": "554b089b38fda50c3e066216c2898763b5c365a0"
+                "reference": "985d4a1847f1e78a2ff4d1fd3d9bbb9eaeff172f"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1445,7 +1445,7 @@
                     "link-template": "https://github.com/automattic/jetpack-forms/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "5.2.x-dev"
+                    "dev-trunk": "5.3.x-dev"
                 },
                 "textdomain": "jetpack-forms",
                 "version-constants": {
@@ -1926,7 +1926,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/masterbar",
-                "reference": "1f25cb488f2bf151e5984c1a4278a2ad51382ae5"
+                "reference": "11c54a0dbdf5d94e18a8dd4f270efcfed7e0cd71"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -1956,7 +1956,7 @@
             "extra": {
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "0.20.x-dev"
+                    "dev-trunk": "0.21.x-dev"
                 },
                 "changelogger": {
                     "link-template": "https://github.com/Automattic/jetpack-masterbar/compare/v${old}...v${new}"
@@ -2009,7 +2009,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "eb7fe20ee6b54488ae179c01f1fc9a71aa808603"
+                "reference": "f0d31f93658c0edd3fe5c0fbac4b4e8112429e8d"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -2048,7 +2048,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "5.22.x-dev"
+                    "dev-trunk": "5.23.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"
@@ -3188,7 +3188,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/videopress",
-                "reference": "e3ae7b25b20699546df5019bc59b34b7b21e7542"
+                "reference": "e16aaf84f33ec082e6c325f1efc6d82952e50508"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -3217,7 +3217,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-videopress/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.31.x-dev"
+                    "dev-trunk": "0.32.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-package-version.php"

--- a/projects/plugins/jetpack/functions.opengraph.php
+++ b/projects/plugins/jetpack/functions.opengraph.php
@@ -416,7 +416,7 @@ function jetpack_og_get_fallback_social_image( $width, $height ) {
 	 * to override any fallback image found by looking through site's logo, site icon, and blavatar.
 	 * This will allow you to overwrite the default fallback image generated dynamically.
 	 *
-	 * @since $$next-version$$
+	 * @since 15.0
 	 *
 	 * @param array $site_image Your own site's representative image.
 	 * @param array $site_image The site's representative image picked by Jetpack. {

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 15.0-a.1
+ * Version: 15.0-a.3
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -38,7 +38,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.7' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '7.2' );
-define( 'JETPACK__VERSION', '15.0-a.1' );
+define( 'JETPACK__VERSION', '15.0-a.3' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/modules/shortcodes/shortcode-utils.php
+++ b/projects/plugins/jetpack/modules/shortcodes/shortcode-utils.php
@@ -27,7 +27,7 @@ if ( ! function_exists( 'jetpack_shortcodes_should_hook_pre_kses' ) ) {
 		/**
 		 * Filters whether shortcodes should hook on pre_kses.
 		 *
-		 * @since $$next-version$$
+		 * @since 15.0
 		 *
 		 * @param bool $should_hook Whether shortcodes should hook on pre_kses.
 		 */

--- a/projects/plugins/jetpack/modules/sitemaps/sitemap-builder.php
+++ b/projects/plugins/jetpack/modules/sitemaps/sitemap-builder.php
@@ -175,7 +175,7 @@ class Jetpack_Sitemap_Builder { // phpcs:ignore Generic.Files.OneObjectStructure
 		/**
 		 * Filters whether to suspend cache addition for the entire sitemap generation.
 		 *
-		 * @since $$next-version$$
+		 * @since 15.0
 		 *
 		 * @param bool|null $suspend_addition Whether to suspend cache addition. Defaults to null.
 		 * @return bool|null Whether to suspend cache addition.

--- a/projects/plugins/jetpack/readme.txt
+++ b/projects/plugins/jetpack/readme.txt
@@ -326,19 +326,21 @@ Jetpack Backup can do a full website migration to a new host, migrate theme file
 
 
 == Changelog ==
-### 15.0-a.1 - 2025-08-11
+### 15.0-a.3 - 2025-08-14
 #### Enhancements
-- Carousel: Fix crashes on large galleries and reduce server requests by preloading only adjacent images instead of all at once.
-- Enable Settings > Sharing WP Admin page and ensure all relevant links point to this page.
-- Forms: Add new Time field.
-- Site Accelerator: Ignore images from openlibrary.org.
-- Social: Add font option for Social Image Generator.
+- Forms: Add `has_field_type` method to Feedback.
+- Forms: Defer JavaScript loading for more responsive page loading.
+- Shortcodes: Update embed reversal code to only run when content is inserted in the admin.
+- Sitemaps: Add filter to allow suspending object cache addition during generation.
+- Subscription block: Defer JavaScript loading.
+
+#### Improved compatibility
+- Open Graph Meta tags: Add new filter allowing one to define a custom site representative image.
 
 #### Bug fixes
-- Forms: Fix default checkboxes styles, and allow for "browser" styles as a choice.
-- Forms: Show the form variation picker if you only have the submit button.
-- Sitemaps: Fix PHP warning during generation if there are no posts or pages on the website.
-- Social: Fix image generator token reset on save resulting in font not being saved.
+- Infinite Scroll: Prevent PHP warnings in various edge cases.
+- My Jetpack: Fix multisite availability check for restricted products and modules.
+- Prevent PHP fatals when handling unexpected data types.
 
 --------
 

--- a/projects/plugins/jetpack/tests/php/modules/sitemaps/Jetpack_Sitemap_Builder_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/sitemaps/Jetpack_Sitemap_Builder_Test.php
@@ -308,7 +308,7 @@ class Jetpack_Sitemap_Builder_Test extends WP_UnitTestCase {
 	 * Test that cache suspension state is restored after sitemap update
 	 *
 	 * @group jetpack-sitemap
-	 * @since $$next-version$$
+	 * @since 15.0
 	 */
 	#[Group( 'jetpack-sitemap' )]
 	public function test_cache_suspension_state_restored() {

--- a/projects/plugins/mu-wpcom-plugin/changelog/prerelease#3
+++ b/projects/plugins/mu-wpcom-plugin/changelog/prerelease#3
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -559,7 +559,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "bb8626ac4e726e2136eb81e90afb74106f7c3243"
+                "reference": "d088808e20090e05e1d5b9a4f74f1ed798a356b0"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -595,7 +595,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "6.17.x-dev"
+                    "dev-trunk": "6.18.x-dev"
                 },
                 "dependencies": {
                     "test-only": [
@@ -1010,7 +1010,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/masterbar",
-                "reference": "1f25cb488f2bf151e5984c1a4278a2ad51382ae5"
+                "reference": "11c54a0dbdf5d94e18a8dd4f270efcfed7e0cd71"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -1040,7 +1040,7 @@
             "extra": {
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "0.20.x-dev"
+                    "dev-trunk": "0.21.x-dev"
                 },
                 "changelogger": {
                     "link-template": "https://github.com/Automattic/jetpack-masterbar/compare/v${old}...v${new}"

--- a/projects/plugins/paypal-payment-buttons/changelog/prerelease#3
+++ b/projects/plugins/paypal-payment-buttons/changelog/prerelease#3
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/paypal-payment-buttons/composer.lock
+++ b/projects/plugins/paypal-payment-buttons/composer.lock
@@ -384,7 +384,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "bb8626ac4e726e2136eb81e90afb74106f7c3243"
+                "reference": "d088808e20090e05e1d5b9a4f74f1ed798a356b0"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -420,7 +420,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "6.17.x-dev"
+                    "dev-trunk": "6.18.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/protect/changelog/prerelease#4
+++ b/projects/plugins/protect/changelog/prerelease#4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -644,7 +644,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "bb8626ac4e726e2136eb81e90afb74106f7c3243"
+                "reference": "d088808e20090e05e1d5b9a4f74f1ed798a356b0"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -680,7 +680,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "6.17.x-dev"
+                    "dev-trunk": "6.18.x-dev"
                 },
                 "dependencies": {
                     "test-only": [
@@ -1162,7 +1162,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "eb7fe20ee6b54488ae179c01f1fc9a71aa808603"
+                "reference": "f0d31f93658c0edd3fe5c0fbac4b4e8112429e8d"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1201,7 +1201,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "5.22.x-dev"
+                    "dev-trunk": "5.23.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/search/changelog/prerelease#14
+++ b/projects/plugins/search/changelog/prerelease#14
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -520,7 +520,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "bb8626ac4e726e2136eb81e90afb74106f7c3243"
+                "reference": "d088808e20090e05e1d5b9a4f74f1ed798a356b0"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -556,7 +556,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "6.17.x-dev"
+                    "dev-trunk": "6.18.x-dev"
                 },
                 "dependencies": {
                     "test-only": [
@@ -1038,7 +1038,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "eb7fe20ee6b54488ae179c01f1fc9a71aa808603"
+                "reference": "f0d31f93658c0edd3fe5c0fbac4b4e8112429e8d"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1077,7 +1077,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "5.22.x-dev"
+                    "dev-trunk": "5.23.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/social/changelog/prerelease#2
+++ b/projects/plugins/social/changelog/prerelease#2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -520,7 +520,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/connection",
-				"reference": "bb8626ac4e726e2136eb81e90afb74106f7c3243"
+				"reference": "d088808e20090e05e1d5b9a4f74f1ed798a356b0"
 			},
 			"require": {
 				"automattic/jetpack-a8c-mc-stats": "@dev",
@@ -556,7 +556,7 @@
 					"link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
 				},
 				"branch-alias": {
-					"dev-trunk": "6.17.x-dev"
+					"dev-trunk": "6.18.x-dev"
 				},
 				"dependencies": {
 					"test-only": [
@@ -1038,7 +1038,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/my-jetpack",
-				"reference": "eb7fe20ee6b54488ae179c01f1fc9a71aa808603"
+				"reference": "f0d31f93658c0edd3fe5c0fbac4b4e8112429e8d"
 			},
 			"require": {
 				"automattic/jetpack-admin-ui": "@dev",
@@ -1077,7 +1077,7 @@
 					"link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
 				},
 				"branch-alias": {
-					"dev-trunk": "5.22.x-dev"
+					"dev-trunk": "5.23.x-dev"
 				},
 				"version-constants": {
 					"::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/starter-plugin/changelog/prerelease#13
+++ b/projects/plugins/starter-plugin/changelog/prerelease#13
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -520,7 +520,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "bb8626ac4e726e2136eb81e90afb74106f7c3243"
+                "reference": "d088808e20090e05e1d5b9a4f74f1ed798a356b0"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -556,7 +556,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "6.17.x-dev"
+                    "dev-trunk": "6.18.x-dev"
                 },
                 "dependencies": {
                     "test-only": [
@@ -1038,7 +1038,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "eb7fe20ee6b54488ae179c01f1fc9a71aa808603"
+                "reference": "f0d31f93658c0edd3fe5c0fbac4b4e8112429e8d"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1077,7 +1077,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "5.22.x-dev"
+                    "dev-trunk": "5.23.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/videopress/changelog/prerelease#2
+++ b/projects/plugins/videopress/changelog/prerelease#2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -520,7 +520,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "bb8626ac4e726e2136eb81e90afb74106f7c3243"
+                "reference": "d088808e20090e05e1d5b9a4f74f1ed798a356b0"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -556,7 +556,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "6.17.x-dev"
+                    "dev-trunk": "6.18.x-dev"
                 },
                 "dependencies": {
                     "test-only": [
@@ -1038,7 +1038,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "eb7fe20ee6b54488ae179c01f1fc9a71aa808603"
+                "reference": "f0d31f93658c0edd3fe5c0fbac4b4e8112429e8d"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1077,7 +1077,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "5.22.x-dev"
+                    "dev-trunk": "5.23.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"
@@ -1698,7 +1698,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/videopress",
-                "reference": "e3ae7b25b20699546df5019bc59b34b7b21e7542"
+                "reference": "e16aaf84f33ec082e6c325f1efc6d82952e50508"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1727,7 +1727,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-videopress/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.31.x-dev"
+                    "dev-trunk": "0.32.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-package-version.php"

--- a/projects/plugins/wpcomsh/changelog/prerelease#3
+++ b/projects/plugins/wpcomsh/changelog/prerelease#3
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -768,7 +768,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "bb8626ac4e726e2136eb81e90afb74106f7c3243"
+                "reference": "d088808e20090e05e1d5b9a4f74f1ed798a356b0"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -804,7 +804,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "6.17.x-dev"
+                    "dev-trunk": "6.18.x-dev"
                 },
                 "dependencies": {
                     "test-only": [
@@ -1219,7 +1219,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/masterbar",
-                "reference": "1f25cb488f2bf151e5984c1a4278a2ad51382ae5"
+                "reference": "11c54a0dbdf5d94e18a8dd4f270efcfed7e0cd71"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -1249,7 +1249,7 @@
             "extra": {
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "0.20.x-dev"
+                    "dev-trunk": "0.21.x-dev"
                 },
                 "changelogger": {
                     "link-template": "https://github.com/Automattic/jetpack-masterbar/compare/v${old}...v${new}"


### PR DESCRIPTION
Closes MONOREP-71

 <!--- This template is used for backporting changes made during a plugin release back to trunk. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Backports changes for jetpack 15.0-a.3

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/a
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Proofread changes.