### PR TITLE
Contact form: lower specificity in the editor to match the frontend

### DIFF
--- a/projects/packages/forms/changelog/try-form-specificity
+++ b/projects/packages/forms/changelog/try-form-specificity
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Updated specificity and css on the site editor to match the frontend for forms

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -726,7 +726,8 @@
 
 		.jetpack-field__input,
 		.jetpack-field__textarea {
-			color: #787c82; //Simulates a placeholder color
+			&:placeholder {
+				opacity: 0.5;
 		}
 	}
 

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -343,25 +343,6 @@
 		margin: 0;
 	}
 
-	// Reduced specificity to 0,1,0 so that global styles can override it.
-	:where(.jetpack-field__input, .jetpack-field__textarea, .jetpack-field-dropdown__toggle) {
-		font: inherit;
-		border: 1px solid #8c8f94;
-		border-radius: 0;
-	}
-
-	:where(.jetpack-field-dropdown__toggle) {
-		background-color: var(--jetpack--contact-form--input-background);
-	}
-
-	// Reduced specificity to 0,1,0 so that global styles can override it.
-	:where(.jetpack-field__textarea) {
-		border: var(--jetpack--contact-form--border, 1px solid #8c8f94);
-		border-color: var(--jetpack--contact-form--border-color, #8c8f94);
-		border-style: var(--jetpack--contact-form--border-style, solid);
-		border-width: var(--jetpack--contact-form--border-left-size, 1px);
-	}
-
 	.components-base-control__field {
 		margin-bottom: 0;
 	}
@@ -384,6 +365,30 @@
 		justify-content: flex-start;
 	}
 
+}
+
+// Selectors with specificity to 0,0,0 so that global styles can override it.
+
+:where(.jetpack-field .jetpack-field__input, .jetpack-field .jetpack-field__textarea) {
+	padding: 16px;
+	margin: 0;
+}
+
+:where(.jetpack-field .jetpack-field__textarea) {
+	border: var(--jetpack--contact-form--border, 1px solid #8c8f94);
+	border-color: var(--jetpack--contact-form--border-color, #8c8f94);
+	border-style: var(--jetpack--contact-form--border-style, solid);
+	border-width: var(--jetpack--contact-form--border-left-size, 1px);
+}
+
+:where(.jetpack-field .jetpack-field__input, .jetpack-field .jetpack-field__textarea, .jetpack-field .jetpack-field-dropdown__toggle) {
+	font: inherit;
+	border: 1px solid #8c8f94;
+	border-radius: 0;
+}
+
+:where(.jetpack-field .jetpack-field-dropdown__toggle) {
+	background-color: var(--jetpack--contact-form--input-background);
 }
 
 // Default field styles other the plain.

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -726,8 +726,10 @@
 
 		.jetpack-field__input,
 		.jetpack-field__textarea {
-			&:placeholder {
+
+			&::placeholder {
 				opacity: 0.5;
+			}
 		}
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

The frontend has a 0,0,0 specificity for the CSS that can be changed by the user, whereas the editor has a 0,1,0. This is not a problem today, but it will be an issue when https://github.com/WordPress/gutenberg/pull/70378 gets merged. The GB PR aims to add the ability to style inputs via the elements API with theme.json. It works out of the box for Jetpack with the current styles but only in the frontend, the editor is still too specific. This PR aligns the two so it will work when the GB changes land.

Frontend:

<img width="1845" height="919" alt="Screenshot 2025-08-18 at 12 37 48" src="https://github.com/user-attachments/assets/8d22c10d-d7a7-4781-a63a-7b720703a2f6" />


Editor:

<img width="1770" height="996" alt="Screenshot 2025-08-18 at 12 38 30" src="https://github.com/user-attachments/assets/fcb9219d-3f87-40fd-9228-1289d9b4ca19" />


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Maintained the same selectors but moved the `:where()` to encase all of it instead of partially to fit the specificity requirement

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Insert a contact form, inspect the styles for inputs in the editor and frontend. The specificity should be the same
* Check that custom user styles still apply correctly.

If possible, test with [the GB PR](https://github.com/WordPress/gutenberg/pull/70378) active too:

* Change your theme.json to have changes such as
```
"elements": {
			"textInput": {
				"border": {
					"radius": "0",
					"style": "solid",
					"width": "1px",
					"color": "red"
				},
				"color": {
					"text": "blue"
				},
				"typography": {
					"fontFamily": "var(--wp--preset--font-family--inter)"
				}
			},
}
```
* The input's border should have changed to be red both in the frontend and the editor (prior to this PR the editor would not reflect the changes)

