### PR TITLE
Forms: Update slider default and increment controls

### DIFF
--- a/projects/packages/forms/changelog/update-forms-slider-default-control
+++ b/projects/packages/forms/changelog/update-forms-slider-default-control
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: Update slider default and step controls.

--- a/projects/packages/forms/src/blocks/field-slider/edit.js
+++ b/projects/packages/forms/src/blocks/field-slider/edit.js
@@ -119,7 +119,7 @@ export default function SliderFieldEdit( props ) {
 		<>
 			<InspectorControls>
 				<PanelBody title={ __( 'Settings', 'jetpack-forms' ) }>
-					<HStack alignment="top">
+					<HStack alignment="top" className="jp-field-slider-inspector-row">
 						<NumberControl
 							__next40pxDefaultSize
 							label={ __( 'Min value', 'jetpack-forms' ) }

--- a/projects/packages/forms/src/blocks/field-slider/edit.js
+++ b/projects/packages/forms/src/blocks/field-slider/edit.js
@@ -1,3 +1,4 @@
+import './editor.scss';
 import {
 	useBlockProps,
 	useInnerBlocksProps,
@@ -8,7 +9,6 @@ import {
 	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalNumberControl as NumberControl, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	PanelBody,
-	RangeControl,
 } from '@wordpress/components';
 import { useCallback, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -137,24 +137,24 @@ export default function SliderFieldEdit( props ) {
 							value={ max }
 						/>
 					</HStack>
-					<RangeControl
-						__next40pxDefaultSize
-						__nextHasNoMarginBottom
-						help={ __( 'Pre-selected value.', 'jetpack-forms' ) }
-						label={ __( 'Default value', 'jetpack-forms' ) }
-						max={ max }
-						min={ min }
-						onChange={ onChangeDefault }
-						value={ defaultValue }
-					/>
-					<NumberControl
-						__next40pxDefaultSize
-						label={ __( 'Increment', 'jetpack-forms' ) }
-						min={ 0 }
-						step={ step || 1 }
-						value={ step }
-						onChange={ onChangeStep }
-					/>
+					<HStack alignment="top" className="jp-field-slider-inspector-row">
+						<NumberControl
+							__next40pxDefaultSize
+							label={ __( 'Default value', 'jetpack-forms' ) }
+							min={ min }
+							max={ max }
+							value={ defaultValue }
+							onChange={ onChangeDefault }
+						/>
+						<NumberControl
+							__next40pxDefaultSize
+							label={ __( 'Increment', 'jetpack-forms' ) }
+							min={ 0 }
+							step={ 1 }
+							value={ step }
+							onChange={ onChangeStep }
+						/>
+					</HStack>
 				</PanelBody>
 			</InspectorControls>
 			<BlockContextProvider

--- a/projects/packages/forms/src/blocks/field-slider/edit.js
+++ b/projects/packages/forms/src/blocks/field-slider/edit.js
@@ -1,4 +1,3 @@
-import './editor.scss';
 import {
 	useBlockProps,
 	useInnerBlocksProps,
@@ -13,6 +12,7 @@ import {
 import { useCallback, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import JetpackFieldControls from '../shared/components/jetpack-field-controls';
+import './editor.scss';
 
 export default function SliderFieldEdit( props ) {
 	const { attributes, setAttributes } = props;

--- a/projects/packages/forms/src/blocks/field-slider/editor.scss
+++ b/projects/packages/forms/src/blocks/field-slider/editor.scss
@@ -1,4 +1,4 @@
 /* Ensure equal width for paired controls in the slider field inspector */
-.jp-field-slider-inspector-row.components-h-stack > div {
+.jp-field-slider-inspector-row > div {
 	width: 50%;
 }

--- a/projects/packages/forms/src/blocks/field-slider/editor.scss
+++ b/projects/packages/forms/src/blocks/field-slider/editor.scss
@@ -1,0 +1,4 @@
+/* Ensure equal width for paired controls in the slider field inspector */
+.jp-field-slider-inspector-row.components-h-stack > div {
+	width: 50%;
+}


### PR DESCRIPTION
Partially addresses FORMS-66

## Proposed changes:

This updates controls for the new Slider field block to match designs. Specifically: 
* Updates the 'default value' control to be a number input rather than range
* Uses HStack to position 'default value' and 'increment' together on a row
* Adds CSS to ensure the numbers controls for the min/max and default/increment roles are each 50%
* Fixes a small bug where increment value was going up by factors of 2 (1,2,4,8,16) vs 1 (1,2,3,4,5)

**Before**
<img width="1185" height="676" alt="slider-increment" src="https://github.com/user-attachments/assets/3fb856c1-b0c6-4fa5-84bb-3a80eeca69fa" />

**After**
<img width="1179" height="485" alt="slider-default-increment-after" src="https://github.com/user-attachments/assets/5e8e2f95-c0b8-4309-9aa4-a2ca7d01c313" />

**Original designs**
<img width="2526" height="2034" alt="slider-designs" src="https://github.com/user-attachments/assets/ed92bedc-364a-4649-a938-a52514c4620b" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None. 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No. 

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Enable beta blocks: define( 'JETPACK_BLOCKS_VARIATION', 'beta' );
* Note: You may need to run jetpack build packages/forms to get the frontend slider-field.css to be built and loaded in the dist directory. Having the watch command running is not sufficient.
* Add a form to a page or post
* Add a new Slider block and be sure the field (not input) is selected
* Confirm 'default value' control is now a number input and works as expected
* Confirm 'increment' control works as expected
* Confirm 'default' and 'increment' controls are on the same line, each 50% of width
* Confirm min and max controls are on the same line, each 50% of the width
* Play with min, max, default, and increment to be sure they behavior well together
* Save, go to frontend, and confirm slider works as expected based on settings
* With slider field selected, confirm the 'Increment' control shows in the sidebar
* Try various combinations of min, max, default, and increment, and confirm increment works as expected
* Save, go to frontend, and confirm that slider field works and obeys whatever increment you set

