### PR TITLE
Forms: Fix phone validation in responses

### DIFF
--- a/projects/packages/forms/changelog/fix-form-inbox-phone-numbers
+++ b/projects/packages/forms/changelog/fix-form-inbox-phone-numbers
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Fix phone validation in responses.

--- a/projects/packages/forms/src/dashboard/inbox/response.js
+++ b/projects/packages/forms/src/dashboard/inbox/response.js
@@ -36,6 +36,38 @@ const isFileUploadField = value => {
 	return value && typeof value === 'object' && 'files' in value && 'field_id' in value;
 };
 
+const isLikelyPhoneNumber = value => {
+	// Only operate on strings to avoid coercing numbers (e.g., 2024) into strings that could match
+	if ( typeof value !== 'string' ) {
+		return false;
+	}
+
+	const normalizedValue = value.trim();
+
+	// Allow only digits, spaces, parentheses, hyphens, dots, plus
+	if ( ! /^[\d+\-\s().]+$/.test( normalizedValue ) ) {
+		return false;
+	}
+
+	// Exclude common date formats to avoid false positives
+	// - ISO-like: 2025-11-01 or 2025/11/01
+	if ( /^\d{4}[-/]\d{1,2}[-/]\d{1,2}$/.test( normalizedValue ) ) {
+		return false;
+	}
+	// - Locale-like: 01/11/2025, 1/11/25, 11-01-2025
+	if ( /^\d{1,2}[-/]\d{1,2}[-/]\d{2,4}$/.test( normalizedValue ) ) {
+		return false;
+	}
+
+	// Strip non-digits and validate digit count within a typical global range
+	const digits = normalizedValue.replace( /\D/g, '' );
+	if ( digits.length < 7 || digits.length > 15 ) {
+		return false;
+	}
+
+	return true;
+};
+
 const PreviewFile = ( { file, isLoading, onImageLoaded } ) => {
 	const imageClass = clsx( 'jp-forms__inbox-file-preview-container', {
 		'is-loading': isLoading,
@@ -205,10 +237,8 @@ const InboxResponse = ( { response, loading, onModalStateChange } ) => {
 			);
 		}
 
-		// Phone numberes
-		// No alphabetical characters but allow dots, dashes, and brackets.
-		const phoneNumberRegEx = /^[+]?[\s./0-9]*[(]?[0-9]{1,4}[)]?[-\s./0-9]*$/;
-		if ( phoneNumberRegEx.test( value ) ) {
+		// Phone numbers
+		if ( isLikelyPhoneNumber( value ) ) {
 			return (
 				<div className="phone-field">
 					<a href={ `tel:${ value }` }>{ value }</a>

--- a/projects/plugins/jetpack/changelog/fix-form-inbox-phone-numbers
+++ b/projects/plugins/jetpack/changelog/fix-form-inbox-phone-numbers
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: Fix phone validation for responses.


### PR DESCRIPTION
## Proposed changes:

In a recent PR, we updated form responses to show a link for phone numbers. But the validation regex we used to determine phone numbers was too permissive and is resulting in non-phone numbers being links. This PR improves and tightens the validation. 

If we wanted to go further, we could use a library like:
https://www.npmjs.com/package/libphonenumber-js

**Before**
<img width="527" height="630" alt="phone-link-before" src="https://github.com/user-attachments/assets/032f20f0-d819-4388-beab-88d51e4a784c" />

**After**
<img width="524" height="617" alt="phone-link-after" src="https://github.com/user-attachments/assets/61c96af4-70f7-40d0-96d5-383f3c821c27" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None,

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add a form to a page
* Add phone field, and also fields that produce number-like outputs such as slider, rating, number, date
* Save and submit the form on the backend
* Confirm that only the phone number is linked

If helpful, you can copy in this form which is what I used to test and for the screenshots above:

```
<!-- wp:jetpack/contact-form {"variationName":"default"} -->
<div class="wp-block-jetpack-contact-form"><!-- wp:jetpack/field-name {"required":true} -->
<div><!-- wp:jetpack/label {"label":"Name"} /-->

<!-- wp:jetpack/input /--></div>
<!-- /wp:jetpack/field-name -->

<!-- wp:jetpack/field-email {"required":true} -->
<div><!-- wp:jetpack/label {"label":"Email"} /-->

<!-- wp:jetpack/input /--></div>
<!-- /wp:jetpack/field-email -->

<!-- wp:jetpack/field-telephone -->
<div><!-- wp:jetpack/label {"label":"Phone"} /-->

<!-- wp:jetpack/input {"type":"tel"} /--></div>
<!-- /wp:jetpack/field-telephone -->

<!-- wp:jetpack/field-slider -->
<div><!-- wp:jetpack/label {"label":"Slider","placeholder":"Add label…"} /-->

<!-- wp:jetpack/input-range -->
<div class="wp-block-jetpack-input-range"></div>
<!-- /wp:jetpack/input-range --></div>
<!-- /wp:jetpack/field-slider -->

<!-- wp:jetpack/field-rating {"default":4} -->
<div><!-- wp:jetpack/label {"label":"Rating","placeholder":"Add label…"} /-->

<!-- wp:jetpack/input-rating /--></div>
<!-- /wp:jetpack/field-rating -->

<!-- wp:jetpack/field-date -->
<div><!-- wp:jetpack/label {"label":"Date"} /-->

<!-- wp:jetpack/input /--></div>
<!-- /wp:jetpack/field-date -->

<!-- wp:jetpack/field-number -->
<div><!-- wp:jetpack/label {"label":"Number"} /-->

<!-- wp:jetpack/input {"type":"number"} /--></div>
<!-- /wp:jetpack/field-number -->

<!-- wp:jetpack/button {"element":"button","text":"Contact Us","lock":{"remove":true}} /--></div>
<!-- /wp:jetpack/contact-form -->
```


