### PR TITLE
WooCommerce Analytics: Fix various PHP warnings

### DIFF
--- a/projects/packages/woocommerce-analytics/changelog/fix-woocommerce-analytics-php-warnings
+++ b/projects/packages/woocommerce-analytics/changelog/fix-woocommerce-analytics-php-warnings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix PHP warnings for undefined array keys and null object properties

--- a/projects/packages/woocommerce-analytics/src/class-universal.php
+++ b/projects/packages/woocommerce-analytics/src/class-universal.php
@@ -85,20 +85,20 @@ class Universal {
 			if ( ! empty( $data ) ) {
 				foreach ( $data as $data_instance ) {
 					$event_props = array(
-						'pq' => $data_instance['quantity'],
+						'pq' => $data_instance['quantity'] ?? null,
 					);
 
 					// Attach the session ID, engagement status and landing_page to this event in case it's saved in the Data Instance.
 					// Otherwise, keep it unset to allow override.
-					if ( $data_instance['session_id'] ) {
+					if ( isset( $data_instance['session_id'] ) && $data_instance['session_id'] ) {
 						$event_props['session_id'] = $data_instance['session_id'];
 					}
 
-					if ( $data_instance['is_engaged'] ) {
+					if ( isset( $data_instance['is_engaged'] ) && $data_instance['is_engaged'] ) {
 						$event_props['is_engaged'] = $data_instance['is_engaged'];
 					}
 
-					if ( $data_instance['landing_page'] ) {
+					if ( isset( $data_instance['landing_page'] ) && $data_instance['landing_page'] ) {
 						$event_props['landing_page'] = $data_instance['landing_page'];
 					}
 
@@ -256,7 +256,7 @@ class Universal {
 		global $post;
 		$checkout_page_id    = wc_get_page_id( 'checkout' );
 		$cart                = WC()->cart->get_cart();
-		$is_in_checkout_page = $checkout_page_id === $post->ID ? 'Yes' : 'No';
+		$is_in_checkout_page = isset( $post->ID ) && $checkout_page_id === $post->ID ? 'Yes' : 'No';
 		$session             = WC()->session;
 		if ( is_object( $session ) ) {
 			$session->set( 'checkout_page_used', 'Yes' === $is_in_checkout_page );
@@ -718,7 +718,7 @@ class Universal {
 			return;
 		}
 
-		$is_in_checkout_page                       = $checkout_page_id === $post->ID ? 'Yes' : 'No';
+		$is_in_checkout_page                       = isset( $post->ID ) && $checkout_page_id === $post->ID ? 'Yes' : 'No';
 		$checkout_page_contains_checkout_block     = '0';
 		$checkout_page_contains_checkout_shortcode = '1';
 


### PR DESCRIPTION
## Proposed changes:
* Fix PHP warnings for undefined array keys in WooCommerce Analytics session data handling
* Add proper `isset()` checks before accessing array keys `session_id`, `is_engaged`, and `landing_page`
* Add null check before accessing `ID` property on potentially null object

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<\!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<\!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
No, this PR only adds defensive programming checks to prevent PHP warnings. No data tracking or usage is changed.

## Testing instructions:
* Install WooCommerce and use this branch
* Trigger scenarios where session data might be incomplete or malformed by commenting out [these lines](https://github.com/Automattic/jetpack/blob/14420b4d74e7248dbdd1f24faab5ee9248a5ff89/projects/packages/woocommerce-analytics/src/class-universal.php#L492-L494).
* Go to the shop page
* Add a product to the cart
* Refresh the page
* Verify no PHP warnings are logged in error logs for:
  - `Undefined array key "session_id"` in class-universal.php line 93
  - `Undefined array key "is_engaged"` in class-universal.php line 97  
  - `Undefined array key "landing_page"` in class-universal.php line 101

--
I don't know how to reproduce this error. `Attempt to read property "ID" on null in class-universal.php line 259`, but I think reviewing the code should be enough.