### PR TITLE
[e2e tests] Add environment readiness checks

### DIFF
--- a/tools/e2e-commons/bin/cloudflaretunnel.js
+++ b/tools/e2e-commons/bin/cloudflaretunnel.js
@@ -113,23 +113,23 @@ async function tunnelChild() {
 			const urlMatch = output.match( /https:\/\/.*\.trycloudflare\.com/ );
 			if ( urlMatch && ! resolved ) {
 				tunnelUrl = urlMatch[ 0 ];
-				console.log( `Cloudflare tunnel started: ${ tunnelUrl }` );
+				console.log( `[tunnel manager] Cloudflare tunnel started: ${ tunnelUrl }` );
 
 				// Wait for DNS to resolve the new subdomain
 				const hostname = new URL( tunnelUrl ).hostname;
-				console.log( `Waiting for DNS to resolve ${ hostname }...` );
+				console.log( `[tunnel manager] Waiting for DNS to resolve ${ hostname }...` );
 
 				const waitForDns = async () => {
 					const maxAttempts = 30; // 30 seconds total
 					for ( let i = 0; i < maxAttempts; i++ ) {
 						try {
 							await dns.resolve4( hostname );
-							console.log( `DNS resolved for ${ hostname }` );
+							console.log( `[tunnel manager] DNS resolved for ${ hostname }` );
 							return true;
 						} catch ( e ) {
 							if ( i === maxAttempts - 1 ) {
 								console.error(
-									`DNS resolution failed after ${ maxAttempts } attempts. ${ e.message }`
+									`[tunnel manager] DNS resolution failed after ${ maxAttempts } attempts. ${ e.message }`
 								);
 								return false;
 							}
@@ -141,21 +141,25 @@ async function tunnelChild() {
 				waitForDns().then( async success => {
 					if ( ! success ) {
 						cloudflaredProcess.kill();
-						reject( new Error( 'DNS resolution failed' ) );
+						reject( new Error( '[tunnel manager] DNS resolution failed' ) );
 						return;
 					}
 
 					// Also verify HTTP connectivity
-					console.log( `Verifying HTTP connectivity to ${ tunnelUrl }...` );
+					console.log( `[tunnel manager] Verifying HTTP connectivity to ${ tunnelUrl }...` );
 					const verifyConnectivity = () =>
 						new Promise( resolveCheck => {
 							https
 								.get( tunnelUrl, { timeout: 5000 }, res => {
-									console.log( `Tunnel is accessible (status: ${ res.statusCode })` );
+									console.log(
+										`[tunnel manager] Tunnel is accessible (status: ${ res.statusCode })`
+									);
 									resolveCheck( true );
 								} )
 								.on( 'error', err => {
-									console.error( `HTTP connectivity check failed: ${ err.message }` );
+									console.error(
+										`[tunnel manager] HTTP connectivity check failed: ${ err.message }`
+									);
 									resolveCheck( false );
 								} );
 						} );
@@ -166,7 +170,7 @@ async function tunnelChild() {
 							connected = true;
 							break;
 						}
-						console.log( `Retry ${ i + 1 }/10 - waiting 1 second...` );
+						console.log( `[tunnel manager] Retry ${ i + 1 }/10 - waiting 1 second...` );
 						await new Promise( r => setTimeout( r, 1000 ) );
 					}
 
@@ -177,9 +181,9 @@ async function tunnelChild() {
 						process.send?.( 'ok' );
 						resolve();
 					} else {
-						console.error( 'Tunnel is not accessible via HTTP' );
+						console.error( '[tunnel manager] Tunnel is not accessible via HTTP' );
 						cloudflaredProcess.kill();
-						reject( new Error( 'Tunnel connectivity check failed' ) );
+						reject( new Error( '[tunnel manager] Tunnel connectivity check failed' ) );
 					}
 				} );
 			}
@@ -190,24 +194,24 @@ async function tunnelChild() {
 
 		cloudflaredProcess.on( 'error', error => {
 			if ( ! resolved ) {
-				console.error( 'Failed to start cloudflared tunnel:', error );
+				console.error( '[tunnel manager] Failed to start cloudflared tunnel:', error );
 				reject( error );
 			}
 		} );
 
 		cloudflaredProcess.on( 'exit', code => {
-			console.log( `Cloudflared process exited with code ${ code }` );
+			console.log( `[tunnel manager] Cloudflared process exited with code ${ code }` );
 			if ( ! resolved && code !== 0 ) {
-				reject( new Error( `Cloudflared exited with code ${ code }` ) );
+				reject( new Error( `[tunnel manager] Cloudflared exited with code ${ code }` ) );
 			}
 		} );
 
 		// Timeout after 30 seconds
 		setTimeout( () => {
 			if ( ! resolved ) {
-				console.error( 'Cloudflared tunnel startup timeout' );
+				console.error( '[tunnel manager] Cloudflared tunnel startup timeout' );
 				cloudflaredProcess.kill();
-				reject( new Error( 'Tunnel startup timeout' ) );
+				reject( new Error( '[tunnel manager] Tunnel startup timeout' ) );
 			}
 		}, 30000 );
 	} );
@@ -219,7 +223,7 @@ async function tunnelChild() {
  * @return {Promise<void>}
  */
 async function tunnelOff() {
-	console.log( 'Stopping cloudflared tunnel...' );
+	console.log( '[tunnel manager] Stopping cloudflared tunnel...' );
 
 	const pidfile = config.get( 'temp.pid' );
 	if ( fs.existsSync( pidfile ) ) {
@@ -233,7 +237,7 @@ async function tunnelOff() {
 			}
 		};
 		if ( pid.match( /^\d+$/ ) && processExists( pid ) ) {
-			console.log( `Terminating cloudflared process ${ pid }` );
+			console.log( `[tunnel manager] Terminating cloudflared process ${ pid }` );
 			process.kill( pid );
 			await new Promise( resolve => {
 				const check = () => {
@@ -255,5 +259,5 @@ async function tunnelOff() {
 		fs.unlinkSync( cloudflaredPath );
 	}
 
-	console.log( 'Cloudflare tunnel stopped' );
+	console.log( '[tunnel manager] Cloudflare tunnel stopped' );
 }

--- a/tools/e2e-commons/bin/cloudflaretunnel.js
+++ b/tools/e2e-commons/bin/cloudflaretunnel.js
@@ -1,7 +1,9 @@
 #!/usr/bin/env node
 
 import childProcess from 'child_process';
+import dns from 'dns/promises';
 import fs from 'fs';
+import https from 'https';
 import config from 'config';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
@@ -113,12 +115,73 @@ async function tunnelChild() {
 				tunnelUrl = urlMatch[ 0 ];
 				console.log( `Cloudflare tunnel started: ${ tunnelUrl }` );
 
-				setTunnelUrl( tunnelUrl );
-				fs.writeFileSync( config.get( 'temp.pid' ), `${ cloudflaredProcess.pid }` );
+				// Wait for DNS to resolve the new subdomain
+				const hostname = new URL( tunnelUrl ).hostname;
+				console.log( `Waiting for DNS to resolve ${ hostname }...` );
 
-				resolved = true;
-				process.send?.( 'ok' );
-				resolve();
+				const waitForDns = async () => {
+					const maxAttempts = 30; // 30 seconds total
+					for ( let i = 0; i < maxAttempts; i++ ) {
+						try {
+							await dns.resolve4( hostname );
+							console.log( `DNS resolved for ${ hostname }` );
+							return true;
+						} catch ( e ) {
+							if ( i === maxAttempts - 1 ) {
+								console.error(
+									`DNS resolution failed after ${ maxAttempts } attempts. ${ e.message }`
+								);
+								return false;
+							}
+							await new Promise( r => setTimeout( r, 1000 ) );
+						}
+					}
+				};
+
+				waitForDns().then( async success => {
+					if ( ! success ) {
+						cloudflaredProcess.kill();
+						reject( new Error( 'DNS resolution failed' ) );
+						return;
+					}
+
+					// Also verify HTTP connectivity
+					console.log( `Verifying HTTP connectivity to ${ tunnelUrl }...` );
+					const verifyConnectivity = () =>
+						new Promise( resolveCheck => {
+							https
+								.get( tunnelUrl, { timeout: 5000 }, res => {
+									console.log( `Tunnel is accessible (status: ${ res.statusCode })` );
+									resolveCheck( true );
+								} )
+								.on( 'error', err => {
+									console.error( `HTTP connectivity check failed: ${ err.message }` );
+									resolveCheck( false );
+								} );
+						} );
+
+					let connected = false;
+					for ( let i = 0; i < 10; i++ ) {
+						if ( await verifyConnectivity() ) {
+							connected = true;
+							break;
+						}
+						console.log( `Retry ${ i + 1 }/10 - waiting 1 second...` );
+						await new Promise( r => setTimeout( r, 1000 ) );
+					}
+
+					if ( connected ) {
+						setTunnelUrl( tunnelUrl );
+						fs.writeFileSync( config.get( 'temp.pid' ), `${ cloudflaredProcess.pid }` );
+						resolved = true;
+						process.send?.( 'ok' );
+						resolve();
+					} else {
+						console.error( 'Tunnel is not accessible via HTTP' );
+						cloudflaredProcess.kill();
+						reject( new Error( 'Tunnel connectivity check failed' ) );
+					}
+				} );
 			}
 		};
 

--- a/tools/e2e-commons/bin/cloudflaretunnel.js
+++ b/tools/e2e-commons/bin/cloudflaretunnel.js
@@ -1,9 +1,7 @@
 #!/usr/bin/env node
 
 import childProcess from 'child_process';
-import dns from 'dns/promises';
 import fs from 'fs';
-import https from 'https';
 import config from 'config';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
@@ -115,77 +113,13 @@ async function tunnelChild() {
 				tunnelUrl = urlMatch[ 0 ];
 				console.log( `[tunnel manager] Cloudflare tunnel started: ${ tunnelUrl }` );
 
-				// Wait for DNS to resolve the new subdomain
-				const hostname = new URL( tunnelUrl ).hostname;
-				console.log( `[tunnel manager] Waiting for DNS to resolve ${ hostname }...` );
-
-				const waitForDns = async () => {
-					const maxAttempts = 30; // 30 seconds total
-					for ( let i = 0; i < maxAttempts; i++ ) {
-						try {
-							await dns.resolve4( hostname );
-							console.log( `[tunnel manager] DNS resolved for ${ hostname }` );
-							return true;
-						} catch ( e ) {
-							if ( i === maxAttempts - 1 ) {
-								console.error(
-									`[tunnel manager] DNS resolution failed after ${ maxAttempts } attempts. ${ e.message }`
-								);
-								return false;
-							}
-							await new Promise( r => setTimeout( r, 1000 ) );
-						}
-					}
-				};
-
-				waitForDns().then( async success => {
-					if ( ! success ) {
-						cloudflaredProcess.kill();
-						reject( new Error( '[tunnel manager] DNS resolution failed' ) );
-						return;
-					}
-
-					// Also verify HTTP connectivity
-					console.log( `[tunnel manager] Verifying HTTP connectivity to ${ tunnelUrl }...` );
-					const verifyConnectivity = () =>
-						new Promise( resolveCheck => {
-							https
-								.get( tunnelUrl, { timeout: 5000 }, res => {
-									console.log(
-										`[tunnel manager] Tunnel is accessible (status: ${ res.statusCode })`
-									);
-									resolveCheck( true );
-								} )
-								.on( 'error', err => {
-									console.error(
-										`[tunnel manager] HTTP connectivity check failed: ${ err.message }`
-									);
-									resolveCheck( false );
-								} );
-						} );
-
-					let connected = false;
-					for ( let i = 0; i < 10; i++ ) {
-						if ( await verifyConnectivity() ) {
-							connected = true;
-							break;
-						}
-						console.log( `[tunnel manager] Retry ${ i + 1 }/10 - waiting 1 second...` );
-						await new Promise( r => setTimeout( r, 1000 ) );
-					}
-
-					if ( connected ) {
-						setTunnelUrl( tunnelUrl );
-						fs.writeFileSync( config.get( 'temp.pid' ), `${ cloudflaredProcess.pid }` );
-						resolved = true;
-						process.send?.( 'ok' );
-						resolve();
-					} else {
-						console.error( '[tunnel manager] Tunnel is not accessible via HTTP' );
-						cloudflaredProcess.kill();
-						reject( new Error( '[tunnel manager] Tunnel connectivity check failed' ) );
-					}
-				} );
+				// Save the tunnel URL and PID immediately
+				// The connectivity checks will be done by the Playwright test
+				setTunnelUrl( tunnelUrl );
+				fs.writeFileSync( config.get( 'temp.pid' ), `${ cloudflaredProcess.pid }` );
+				resolved = true;
+				process.send?.( 'ok' );
+				resolve();
 			}
 		};
 

--- a/tools/e2e-commons/playwright.config.default.ts
+++ b/tools/e2e-commons/playwright.config.default.ts
@@ -43,9 +43,16 @@ process.env.WP_PASSWORD = site.password;
 
 export const setupProjects = [
 	{
+		name: 'environment check',
+		testDir: `${ rootPath }/setup-specs`,
+		testMatch: 'env-check.setup.ts',
+		storageState: undefined,
+	},
+	{
 		name: 'global authentication',
 		testDir: `${ rootPath }/setup-specs`,
 		testMatch: 'auth.setup.ts',
+		dependencies: [ 'environment check' ],
 		storageState: undefined,
 	},
 	{

--- a/tools/e2e-commons/setup-specs/env-check.setup.ts
+++ b/tools/e2e-commons/setup-specs/env-check.setup.ts
@@ -1,5 +1,4 @@
 import dns from 'dns/promises';
-import { allure } from 'allure-playwright';
 import { test as setup, expect } from '../fixtures/base-test';
 import logger from '../logger';
 
@@ -25,7 +24,9 @@ async function retry(
 	const duration = Date.now() - startTime;
 	const successMsg = `${ name } succeeded after ${ pollCount } attempts in ${ duration }ms`;
 	logger.debug( successMsg );
-	allure.description( successMsg );
+
+	// Add a test step with the success message - only for reporting
+	await setup.step( successMsg, async () => {} );
 }
 
 setup( 'verify environment readiness', async ( { baseURL, request, testUtils } ) => {

--- a/tools/e2e-commons/setup-specs/env-check.setup.ts
+++ b/tools/e2e-commons/setup-specs/env-check.setup.ts
@@ -1,7 +1,29 @@
-/* eslint-disable playwright/no-standalone-expect */
 import dns from 'dns/promises';
 import { test as setup, expect } from '../fixtures/base-test';
 import logger from '../logger';
+
+/**
+ * Helper function to run an expectation with polling measurement
+ * @param name    - Name of the check for logging
+ * @param checkFn - The async function to poll
+ * @param options - Polling options (intervals and timeout)
+ */
+async function retry(
+	name: string,
+	checkFn: () => Promise< void >,
+	options = { intervals: [ 1000 ], timeout: 30000 }
+) {
+	let pollCount = 0;
+	const startTime = Date.now();
+
+	await expect( async () => {
+		pollCount++;
+		await checkFn();
+	} ).toPass( options );
+
+	const duration = Date.now() - startTime;
+	logger.debug( `${ name } succeeded after ${ pollCount } attempts in ${ duration }ms` );
+}
 
 setup( 'verify environment readiness', async ( { baseURL, request, testUtils } ) => {
 	// Skip connectivity checks for localhost URLs
@@ -16,36 +38,29 @@ setup( 'verify environment readiness', async ( { baseURL, request, testUtils } )
 		logger.debug( `Checking DNS resolution for ${ baseURL }` );
 		const hostname = new URL( baseURL ).hostname;
 
-		await expect( async () => {
+		await retry( 'DNS resolution', async () => {
 			await dns.resolve4( hostname );
 			logger.debug( `DNS resolved` );
-		} ).toPass( {
-			intervals: [ 1000 ],
-			timeout: 30000, // 30 seconds total
 		} );
 	} );
 
 	await setup.step( 'verify HTTP connectivity', async () => {
 		logger.debug( `Checking HTTP connectivity for ${ baseURL }` );
-		await expect( async () => {
+
+		await retry( 'HTTP connectivity', async () => {
 			const response = await request.get( baseURL, { timeout: 5000 } );
 			logger.debug( `HTTP response status: ${ response.status() }` );
 			// Accept any HTTP response as success (including redirects, 404s, etc)
 			// We just need to know the site is reachable
-		} ).toPass( {
-			intervals: [ 1000 ],
-			timeout: 30000, // 30 seconds total
 		} );
 	} );
 
 	await setup.step( 'verify REST API', async ( {} ) => {
 		logger.debug( `Checking REST API for ${ baseURL }` );
-		await expect( async () => {
+
+		await retry( 'REST API', async () => {
 			const r = await testUtils.requestUtils.rest( { path: 'jetpack/v4/connection/test' } );
 			logger.debug( `Response: ${ JSON.stringify( r ) }` );
-		} ).toPass( {
-			intervals: [ 1000 ],
-			timeout: 30000, // 30 seconds total
 		} );
 	} );
 } );

--- a/tools/e2e-commons/setup-specs/env-check.setup.ts
+++ b/tools/e2e-commons/setup-specs/env-check.setup.ts
@@ -1,4 +1,5 @@
 import dns from 'dns/promises';
+import { allure } from 'allure-playwright';
 import { test as setup, expect } from '../fixtures/base-test';
 import logger from '../logger';
 
@@ -22,7 +23,9 @@ async function retry(
 	} ).toPass( options );
 
 	const duration = Date.now() - startTime;
-	logger.debug( `${ name } succeeded after ${ pollCount } attempts in ${ duration }ms` );
+	const successMsg = `${ name } succeeded after ${ pollCount } attempts in ${ duration }ms`;
+	logger.debug( successMsg );
+	allure.description( successMsg );
 }
 
 setup( 'verify environment readiness', async ( { baseURL, request, testUtils } ) => {

--- a/tools/e2e-commons/setup-specs/env-check.setup.ts
+++ b/tools/e2e-commons/setup-specs/env-check.setup.ts
@@ -1,0 +1,51 @@
+/* eslint-disable playwright/no-standalone-expect */
+import dns from 'dns/promises';
+import { test as setup, expect } from '../fixtures/base-test';
+import logger from '../logger';
+
+setup( 'verify environment readiness', async ( { baseURL, request, testUtils } ) => {
+	// Skip connectivity checks for localhost URLs
+	if ( baseURL.includes( 'localhost' ) || baseURL.includes( '127.0.0.1' ) ) {
+		await setup.step( 'skip - localhost environment', async () => {
+			logger.debug( 'Localhost environment detected, skipping connectivity checks' );
+		} );
+		return;
+	}
+
+	await setup.step( 'verify DNS resolution', async () => {
+		logger.debug( `Checking DNS resolution for ${ baseURL }` );
+		const hostname = new URL( baseURL ).hostname;
+
+		await expect( async () => {
+			await dns.resolve4( hostname );
+			logger.debug( `DNS resolved` );
+		} ).toPass( {
+			intervals: [ 1000 ],
+			timeout: 30000, // 30 seconds total
+		} );
+	} );
+
+	await setup.step( 'verify HTTP connectivity', async () => {
+		logger.debug( `Checking HTTP connectivity for ${ baseURL }` );
+		await expect( async () => {
+			const response = await request.get( baseURL, { timeout: 5000 } );
+			logger.debug( `HTTP response status: ${ response.status() }` );
+			// Accept any HTTP response as success (including redirects, 404s, etc)
+			// We just need to know the site is reachable
+		} ).toPass( {
+			intervals: [ 1000 ],
+			timeout: 30000, // 30 seconds total
+		} );
+	} );
+
+	await setup.step( 'verify REST API', async ( {} ) => {
+		logger.debug( `Checking REST API for ${ baseURL }` );
+		await expect( async () => {
+			const r = await testUtils.requestUtils.rest( { path: 'jetpack/v4/connection/test' } );
+			logger.debug( `Response: ${ JSON.stringify( r ) }` );
+		} ).toPass( {
+			intervals: [ 1000 ],
+			timeout: 30000, // 30 seconds total
+		} );
+	} );
+} );


### PR DESCRIPTION
## Proposed changes:

Part of #44737 

Add environment readiness checks for e2e tests. The Cloudflare tunnel proved unstable in the last few days, adding some checks before the tests run will hopefully improve the results.

While initially I added these in the tunnel script I moved them as a test in a global project for better reporting. If the tunnel script would have failed in CI the tests wouldn't run at all, and no report of the failure would have been created. This way, we get the `environment readiness` test failed in the reports.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
pdWQjU-1o8-p2

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:

* e2e tests should pass in CI