### PR TITLE
Forms: integrations - opt-in toggle controls into 'next no margin'

### DIFF
--- a/projects/packages/forms/changelog/update-forms-integrations-toggle-margins
+++ b/projects/packages/forms/changelog/update-forms-integrations-toggle-margins
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: integrations - opt-in toggle controls into 'next no margin'

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/creative-mail-card.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/creative-mail-card.tsx
@@ -78,6 +78,7 @@ const CreativeMailCard = ( {
 						label={ __( 'Add email permission request before submit button', 'jetpack-forms' ) }
 						checked={ !! consentBlock }
 						onChange={ toggleConsent }
+						__nextHasNoMarginBottom
 					/>
 				) }
 				<Button

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/integration-card-header.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/integration-card-header.tsx
@@ -157,7 +157,7 @@ const IntegrationCardHeader = ( {
 									checked={ headerToggleValue && ( isActive || isConnected ) }
 									onChange={ handleToggleChange }
 									disabled={ ! isHeaderToggleEnabled || ! ( isActive || isConnected ) }
-									__nextHasNoMarginBottom={ true }
+									__nextHasNoMarginBottom
 								/>
 							</span>
 						</Tooltip>

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/mailpoet-card.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/mailpoet-card.tsx
@@ -199,6 +199,7 @@ const MailPoetCard = ( {
 							label={ __( 'Add email permission request before submit button', 'jetpack-forms' ) }
 							checked={ !! consentBlock }
 							onChange={ toggleConsent }
+							__nextHasNoMarginBottom
 						/>
 					) }
 					<p className="integration-card__description">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes warnings and preps for future visual changes in WP.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

