### PR TITLE
Forms: Update save to new format

### DIFF
--- a/projects/packages/forms/changelog/update-forms-save-to-new-format-v2
+++ b/projects/packages/forms/changelog/update-forms-save-to-new-format-v2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Forms: use the new Feedback class to save the feedback entries in a new format

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1780,6 +1780,11 @@ class Contact_Form extends Contact_Form_Shortcode {
 
 		$all_values['email_marketing_consent'] = $email_marketing_consent;
 
+		// Build feedback reference
+		$feedback_time  = $response->get_time();
+		$feedback_title = $response->get_title();
+		$feedback_id    = $response->get_feedback_id();
+
 		$entry_values = $response->get_entry_values();
 
 		/** This filter is already documented in \Automattic\Jetpack\Forms\ContactForm\Admin */
@@ -1850,10 +1855,6 @@ class Contact_Form extends Contact_Form_Shortcode {
 			$comment_author_ip = null;
 		}
 
-		$feedback_time  = $response->get_time();
-		$feedback_title = $response->get_title();
-		$feedback_id    = $response->get_feedback_id();
-
 		$comment_ip_text = $comment_author_ip ? "IP: {$comment_author_ip}\n" : null;
 
 		$post_id = wp_insert_post(
@@ -1868,6 +1869,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 				'post_name'    => $feedback_id,
 			)
 		);
+
 		// once insert has finished we don't need this filter any more
 		remove_filter( 'wp_insert_post_data', array( $plugin, 'insert_feedback_filter' ), 10 );
 

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1584,6 +1584,8 @@ class Contact_Form extends Contact_Form_Shortcode {
 	 */
 	public function process_submission() {
 		$page_number = 1;
+
+		// We skip the nonce verification for since nonce earlier in process_form_submission.
 		if ( isset( $_POST['page'] ) ) { // phpcs:Ignore WordPress.Security.NonceVerification.Missing
 			$page_number = absint( wp_unslash( $_POST['page'] ) ); // phpcs:Ignore WordPress.Security.NonceVerification.Missing
 		}

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1652,6 +1652,8 @@ class Contact_Form extends Contact_Form_Shortcode {
 		// Initialize all these "standard" fields to null
 		$comment_author_email = $response->get_author_email();
 		$comment_author       = $response->get_author();
+		$comment_author_url   = $response->get_author_url();
+		$comment_content      = $response->get_comment_content();
 
 		$contact_form_subject = $response->get_subject();
 
@@ -1845,11 +1847,25 @@ class Contact_Form extends Contact_Form_Shortcode {
 		if ( apply_filters( 'jetpack_contact_form_forget_ip_address', false, $comment_author_ip ) ) {
 			$comment_author_ip = null;
 		}
-		$post_id       = 0;
-		$feedback_post = $response->save();
-		if ( $feedback_post instanceof \WP_Post ) {
-			$post_id = $feedback_post->ID;
-		}
+
+		$feedback_time  = $response->get_time();
+		$feedback_title = $response->get_title();
+		$feedback_id    = $response->get_feedback_id();
+
+		$comment_ip_text = $comment_author_ip ? "IP: {$comment_author_ip}\n" : null;
+
+		$post_id = wp_insert_post(
+			array(
+				'post_date'    => addslashes( $feedback_time ),
+				'post_type'    => 'feedback',
+				'post_status'  => addslashes( $feedback_status ),
+				'post_parent'  => $this->current_post ? (int) self::get_post_property( $this->current_post, 'ID' ) : 0,
+				'post_title'   => addslashes( wp_kses( $feedback_title, array() ) ),
+				// phpcs:ignore WordPress.NamingConventions.ValidVariableName.InterpolatedVariableNotSnakeCase, WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.PHP.DevelopmentFunctions.error_log_print_r
+				'post_content' => addslashes( wp_kses( "$comment_content\n<!--more-->\nAUTHOR: {$comment_author}\nAUTHOR EMAIL: {$comment_author_email}\nAUTHOR URL: {$comment_author_url}\nSUBJECT: {$subject}\n{$comment_ip_text}JSON_DATA\n" . @wp_json_encode( $all_values, true ), array() ) ), // so that search will pick up this data
+				'post_name'    => $feedback_id,
+			)
+		);
 		// once insert has finished we don't need this filter any more
 		remove_filter( 'wp_insert_post_data', array( $plugin, 'insert_feedback_filter' ), 10 );
 

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1583,6 +1583,13 @@ class Contact_Form extends Contact_Form_Shortcode {
 	 * Stores feedback.  Sends email.
 	 */
 	public function process_submission() {
+		$page_number = 1;
+		if ( isset( $_POST['page'] ) ) { // phpcs:Ignore WordPress.Security.NonceVerification.Missing
+			$page_number = absint( wp_unslash( $_POST['page'] ) ); // phpcs:Ignore WordPress.Security.NonceVerification.Missing
+		}
+
+		$response = Feedback::from_submission( $_POST, $this, $this->current_post, $page_number ); // phpcs:Ignore WordPress.Security.NonceVerification.Missing
+
 		$plugin = Contact_Form_Plugin::init();
 
 		$id                  = $this->get_attribute( 'id' );
@@ -1642,130 +1649,21 @@ class Contact_Form extends Contact_Form_Shortcode {
 			}
 		}
 
-		$field_ids = $this->get_field_ids();
-
 		// Initialize all these "standard" fields to null
-		$comment_author_email = null;
-		$comment_author       = null;
-		$comment_author_url   = null;
-		$comment_content      = null;
+		$comment_author_email = $response->get_author_email();
+		$comment_author       = $response->get_author();
 
-		// For each of the "standard" fields, grab their field label and value.
-		if ( isset( $field_ids['name'] ) ) {
-			$field = $this->fields[ $field_ids['name'] ];
-
-			if ( is_string( $field->value ) ) {
-				$comment_author = Contact_Form_Plugin::strip_tags(
-					stripslashes(
-						/** This filter is already documented in core/wp-includes/comment-functions.php */
-						apply_filters( 'pre_comment_author_name', addslashes( $field->value ) )
-					)
-				);
-			} elseif ( is_array( $field->value ) ) {
-				$field->value = '';
-			}
-		}
-
-		if ( isset( $field_ids['email'] ) ) {
-			$field = $this->fields[ $field_ids['email'] ];
-
-			if ( is_string( $field->value ) ) {
-				$comment_author_email = Contact_Form_Plugin::strip_tags(
-					stripslashes(
-						/** This filter is already documented in core/wp-includes/comment-functions.php */
-						apply_filters( 'pre_comment_author_email', addslashes( $field->value ) )
-					)
-				);
-			} elseif ( is_array( $field->value ) ) {
-				$field->value = '';
-			}
-		}
-
-		if ( isset( $field_ids['url'] ) ) {
-			$field = $this->fields[ $field_ids['url'] ];
-
-			if ( is_string( $field->value ) ) {
-				$comment_author_url = Contact_Form_Plugin::strip_tags(
-					stripslashes(
-						/** This filter is already documented in core/wp-includes/comment-functions.php */
-						apply_filters( 'pre_comment_author_url', addslashes( $field->value ) )
-					)
-				);
-				if ( 'http://' === $comment_author_url ) {
-					$comment_author_url = '';
-				}
-			} elseif ( is_array( $field->value ) ) {
-				$field->value = '';
-			}
-		}
-
-		if ( isset( $field_ids['textarea'] ) ) {
-			$field = $this->fields[ $field_ids['textarea'] ];
-
-			if ( is_string( $field->value ) ) {
-				$comment_content = trim( Contact_Form_Plugin::strip_tags( $field->value ) );
-			} else {
-				$field->value = '';
-			}
-		}
-
-		if ( isset( $field_ids['subject'] ) ) {
-			$field = $this->fields[ $field_ids['subject'] ];
-			if ( $field->value ) {
-				$contact_form_subject = Contact_Form_Plugin::strip_tags( $field->value );
-			}
-		}
+		$contact_form_subject = $response->get_subject();
 
 		// Set marketing consent
-		$email_marketing_consent = $field_ids['email_marketing_consent'];
+		$email_marketing_consent = $response->has_consent();
 
 		if ( null === $email_marketing_consent ) {
 			$email_marketing_consent = false;
 		}
 
-		$all_values   = array();
-		$extra_values = array();
-		$i            = 1; // Prefix counter for stored metadata
-
-		// For all fields, grab label and value
-		foreach ( $field_ids['all'] as $field_id ) {
-			$field = $this->fields[ $field_id ];
-
-			if ( ! $field->is_field_renderable( $field->get_attribute( 'type' ) ) ) {
-				continue;
-			}
-
-			$label = $i . '_' . wp_strip_all_tags( $field->get_attribute( 'label' ) );
-			if ( $field->get_attribute( 'type' ) === 'file' ) {
-				$field->value = $this->process_file_upload_field( $field_id, $field );
-			}
-			$value = $field->value;
-			if ( is_array( $value ) && ! ( $field->get_attribute( 'type' ) === 'file' ) ) {
-				$value = implode( ', ', $value );
-			}
-			$all_values[ $label ] = $value;
-			++$i; // Increment prefix counter for the next field
-		}
-
-		// For the "non-standard" fields, grab label and value
-		// Extra fields have their prefix starting from count( $all_values ) + 1
-		foreach ( $field_ids['extra'] as $field_id ) {
-			$field = $this->fields[ $field_id ];
-
-			if ( ! $field->is_field_renderable( $field->get_attribute( 'type' ) ) ) {
-				continue;
-			}
-
-			$label = $i . '_' . wp_strip_all_tags( $field->get_attribute( 'label' ) );
-			$value = $field->value;
-			if ( ! ( $field->get_attribute( 'type' ) === 'file' ) ) {
-				if ( is_array( $value ) ) {
-					$value = implode( ', ', $value );
-				}
-			}
-			$extra_values[ $label ] = $value;
-			++$i; // Increment prefix counter for the next extra field
-		}
+		$all_values   = $response->get_all_values();
+		$extra_values = $response->get_legacy_extra_values();
 
 		if ( ! empty( $_REQUEST['is_block'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- not changing the site.
 			$extra_values['is_block'] = true;
@@ -1775,44 +1673,9 @@ class Contact_Form extends Contact_Form_Shortcode {
 
 		$comment_author_ip = Contact_Form_Plugin::get_ip_address();
 
-		$vars = array( 'comment_author', 'comment_author_email', 'comment_author_url', 'contact_form_subject', 'comment_author_ip' );
-		foreach ( $vars as $var ) {
-			$$var = str_replace( array( "\n", "\r" ), '', (string) $$var );
-		}
-
 		// Ensure that Akismet gets all of the relevant information from the contact form,
 		// not just the textarea field and predetermined subject.
-		$akismet_vars                    = compact( $vars );
-		$akismet_vars['comment_content'] = $comment_content;
-
-		foreach ( array_merge( $field_ids['all'], $field_ids['extra'] ) as $field_id ) {
-			$field = $this->fields[ $field_id ];
-
-			// Skip any fields that are just a choice from a pre-defined list. They wouldn't have any value
-			// from a spam-filtering point of view.
-			if ( in_array( $field->get_attribute( 'type' ), array( 'select', 'checkbox', 'checkbox-multiple', 'radio', 'file' ), true ) ) {
-				continue;
-			}
-
-			// Normalize the label into a slug.
-			$field_slug = trim( // Strip all leading/trailing dashes.
-				preg_replace(   // Normalize everything to a-z0-9_-
-					'/[^a-z0-9_]+/',
-					'-',
-					strtolower( $field->get_attribute( 'label' ) ) // Lowercase
-				),
-				'-'
-			);
-
-			$field_value = ( is_array( $field->value ) ) ? trim( implode( ', ', $field->value ) ) : trim( $field->value );
-
-			// Skip any values that are already in the array we're sending.
-			if ( $field_value && in_array( $field_value, $akismet_vars, true ) ) {
-				continue;
-			}
-
-			$akismet_vars[ 'contact_form_field_' . $field_slug ] = $field_value;
-		}
+		$akismet_vars = $response->get_akismet_vars();
 
 		$spam           = '';
 		$akismet_values = $plugin->prepare_for_akismet( $akismet_vars );
@@ -1913,42 +1776,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 
 		$all_values['email_marketing_consent'] = $email_marketing_consent;
 
-		// Build feedback reference
-		$feedback_time  = current_time( 'mysql' );
-		$feedback_title = "{$comment_author} - {$feedback_time}";
-		$feedback_id    = md5( $feedback_title );
-
-		$entry_title     = '';
-		$entry_permalink = '';
-
-		if ( $this->current_post ) {
-			$entry_title     = self::get_post_property( $this->current_post, 'post_title' );
-			$entry_permalink = esc_url( self::get_permalink( self::get_post_property( $this->current_post, 'ID' ) ) );
-		} elseif ( $widget ) {
-			$entry_title     = __( 'Sidebar Widget', 'jetpack-forms' );
-			$entry_permalink = esc_url( home_url( '/' ) );
-		} elseif ( $block_template ) {
-			$entry_title     = __( 'Block Template', 'jetpack-forms' );
-			$entry_permalink = esc_url( home_url( '/' ) );
-		} elseif ( $block_template_part ) {
-			$entry_title     = __( 'Block Template Part', 'jetpack-forms' );
-			$entry_permalink = esc_url( home_url( '/' ) );
-		} else {
-			$entry_title     = the_title_attribute( 'echo=0' );
-			$entry_permalink = esc_url( self::get_permalink( get_the_ID() ) );
-		}
-
-		$entry_values = array(
-			'entry_title'     => $entry_title,
-			'entry_permalink' => $entry_permalink,
-			'feedback_id'     => $feedback_id,
-		);
-
-		if ( isset( $_POST['page'] ) ) { // phpcs:Ignore WordPress.Security.NonceVerification.Missing
-			$entry_values['entry_page'] = absint( wp_unslash( $_POST['page'] ) ); // phpcs:Ignore WordPress.Security.NonceVerification.Missing
-		}
-
-		$all_values = array_merge( $all_values, $entry_values );
+		$entry_values = $response->get_entry_values();
 
 		/** This filter is already documented in \Automattic\Jetpack\Forms\ContactForm\Admin */
 		$subject = apply_filters( 'contact_form_subject', $contact_form_subject, $all_values );
@@ -1975,6 +1803,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 		} else {
 			$feedback_status = 'publish';
 		}
+		$response->set_status( $feedback_status );
 
 		foreach ( (array) $akismet_values as $av_key => $av_value ) {
 			$akismet_values[ $av_key ] = Contact_Form_Plugin::strip_tags( $av_value );
@@ -2016,22 +1845,11 @@ class Contact_Form extends Contact_Form_Shortcode {
 		if ( apply_filters( 'jetpack_contact_form_forget_ip_address', false, $comment_author_ip ) ) {
 			$comment_author_ip = null;
 		}
-
-		$comment_ip_text = $comment_author_ip ? "IP: {$comment_author_ip}\n" : null;
-
-		$post_id = wp_insert_post(
-			array(
-				'post_date'    => addslashes( $feedback_time ),
-				'post_type'    => 'feedback',
-				'post_status'  => addslashes( $feedback_status ),
-				'post_parent'  => $this->current_post ? (int) self::get_post_property( $this->current_post, 'ID' ) : 0,
-				'post_title'   => addslashes( wp_kses( $feedback_title, array() ) ),
-				// phpcs:ignore WordPress.NamingConventions.ValidVariableName.InterpolatedVariableNotSnakeCase, WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.PHP.DevelopmentFunctions.error_log_print_r
-				'post_content' => addslashes( wp_kses( "$comment_content\n<!--more-->\nAUTHOR: {$comment_author}\nAUTHOR EMAIL: {$comment_author_email}\nAUTHOR URL: {$comment_author_url}\nSUBJECT: {$subject}\n{$comment_ip_text}JSON_DATA\n" . @wp_json_encode( $all_values, true ), array() ) ), // so that search will pick up this data
-				'post_name'    => $feedback_id,
-			)
-		);
-
+		$post_id       = 0;
+		$feedback_post = $response->save();
+		if ( $feedback_post instanceof \WP_Post ) {
+			$post_id = $feedback_post->ID;
+		}
 		// once insert has finished we don't need this filter any more
 		remove_filter( 'wp_insert_post_data', array( $plugin, 'insert_feedback_filter' ), 10 );
 

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1666,8 +1666,8 @@ class Contact_Form extends Contact_Form_Shortcode {
 			$email_marketing_consent = false;
 		}
 
-		$all_values   = $response->get_all_values();
-		$extra_values = $response->get_legacy_extra_values();
+		$all_values   = $response->get_all_values( 'submit' );
+		$extra_values = $response->get_legacy_extra_values( 'submit' );
 
 		if ( ! empty( $_REQUEST['is_block'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- not changing the site.
 			$extra_values['is_block'] = true;

--- a/projects/packages/forms/src/contact-form/class-feedback-field.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-field.php
@@ -138,6 +138,8 @@ class Feedback_Field {
 	 */
 	public function get_render_value( $context = 'default' ) {
 		switch ( $context ) {
+			case 'submit':
+				return $this->get_render_submit_value();
 			case 'api':
 				return $this->get_render_api_value();
 			case 'default':
@@ -205,6 +207,38 @@ class Feedback_Field {
 		// This method is deprecated, use render_value instead.
 		return $this->value;
 	}
+	/**
+	 * Get the value of the field for rendering when submitting.
+	 *
+	 * This method is used to prepare the value for submission, especially for file fields.
+	 *
+	 * @return array|string The prepared value for submission.
+	 */
+	private function get_render_submit_value() {
+		if ( $this->is_of_type( 'file' ) ) {
+			$files = array();
+			foreach ( $this->value['files'] as $file ) {
+				if ( ! isset( $file['size'] ) || ! isset( $file['file_id'] ) ) {
+					// this shouldn't happen, todo: log this
+					continue;
+				}
+				$files[] = array(
+					'file_id' => absint( $file['file_id'] ),
+					'name'    => $file['name'] ?? '',
+					'size'    => absint( $file['size'] ),
+					'type'    => $file['type'] ?? '',
+				);
+			}
+
+			return array(
+				'field_id' => $this->get_form_field_id(),
+				'files'    => $files,
+			);
+		}
+
+		return $this->value;
+	}
+
 	/**
 	 * Check if the field is of a specific type.
 	 *
@@ -283,6 +317,8 @@ class Feedback_Field {
 		if ( ! is_array( $data ) || ! isset( $data['key'] ) || ! isset( $data['value'] ) || ! isset( $data['label'] ) ) {
 			return null;
 		}
+
+		l( 'from_serialized', $data );
 
 		return new self(
 			$data['key'],

--- a/projects/packages/forms/src/contact-form/class-feedback-field.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-field.php
@@ -318,8 +318,6 @@ class Feedback_Field {
 			return null;
 		}
 
-		l( 'from_serialized', $data );
-
 		return new self(
 			$data['key'],
 			$data['label'],

--- a/projects/packages/forms/src/contact-form/class-feedback.php
+++ b/projects/packages/forms/src/contact-form/class-feedback.php
@@ -367,20 +367,24 @@ class Feedback {
 	/**
 	 * Get all values of the response.
 	 *
+	 * @param string $context The context in which the values are being retrieved.
+	 *
 	 * @return array An array of all values, including fields and entry values.
 	 */
-	public function get_all_values() {
+	public function get_all_values( $context = 'default' ) {
 		// This is a legacy method to maintain compatibility with older code.
-		return array_merge( $this->get_compiled_fields( 'default', 'key-value' ), $this->get_entry_values() );
+		return array_merge( $this->get_compiled_fields( $context, 'key-value' ), $this->get_entry_values() );
 	}
 
 	/**
 	 * Get extra values.
 	 * This is a legacy method to maintain compatibility with older code.
 	 *
+	 * @param string $context  The context in which the values are being retrieved.
+	 *
 	 * @return array An array of extra values, including entry values
 	 */
-	public function get_legacy_extra_values() {
+	public function get_legacy_extra_values( $context = 'default' ) {
 		$count            = 1;
 		$_extra_fields    = array();
 		$special_fields   = array();
@@ -388,8 +392,8 @@ class Feedback {
 
 		// Create a map of special fields to check agains their values.
 		foreach ( $this->fields as $field ) {
-			if ( in_array( $field->get_type(), $non_extra_fields, true ) && $field->get_render_value() ) {
-				$special_fields[ $field->get_render_value() ] = true;
+			if ( in_array( $field->get_type(), $non_extra_fields, true ) && $field->get_render_value( $context ) ) {
+				$special_fields[ $field->get_render_value( $context ) ] = true;
 			}
 		}
 
@@ -410,7 +414,7 @@ class Feedback {
 
 		foreach ( $_extra_fields as $field ) {
 			if ( ! in_array( $field->get_type(), $non_extra_fields, true ) || isset( $is_present[ $field->get_type() ] ) ) {
-				$extra_values[ $extra_fields_count . '_' . $field->get_label() ] = $field->get_render_value( 'default' );
+				$extra_values[ $extra_fields_count . '_' . $field->get_label() ] = $field->get_render_value( $context );
 				++$extra_fields_count; // Increment count to ensure unique keys for extra values.
 			} else {
 				$is_present[ $field->get_type() ] = true;

--- a/projects/packages/forms/src/contact-form/class-feedback.php
+++ b/projects/packages/forms/src/contact-form/class-feedback.php
@@ -255,7 +255,7 @@ class Feedback {
 		$file_data_array = is_array( $raw_data )
 			? array_map(
 				function ( $json_str ) {
-					$decoded = json_decode( $json_str, true );
+					$decoded = json_decode( stripslashes( $json_str ), true );
 					return array(
 						'file_id' => isset( $decoded['file_id'] ) ? sanitize_text_field( $decoded['file_id'] ) : '',
 						'name'    => isset( $decoded['name'] ) ? sanitize_text_field( $decoded['name'] ) : '',
@@ -349,7 +349,7 @@ class Feedback {
 	 *
 	 * @return array An array of entry values.
 	 */
-	private function get_entry_values() {
+	public function get_entry_values() {
 		// This is a convenience method to get the entry values in a simple array format.
 		$entry_values = array(
 			'email_marketing_consent' => (string) $this->has_consent ? 'yes' : 'no',

--- a/projects/packages/forms/src/contact-form/class-feedback.php
+++ b/projects/packages/forms/src/contact-form/class-feedback.php
@@ -380,7 +380,7 @@ class Feedback {
 	 * Get extra values.
 	 * This is a legacy method to maintain compatibility with older code.
 	 *
-	 * @param string $context  The context in which the values are being retrieved.
+	 * @param string $context The context in which the values are being retrieved.
 	 *
 	 * @return array An array of extra values, including entry values
 	 */

--- a/projects/packages/forms/src/dashboard/inbox/response.js
+++ b/projects/packages/forms/src/dashboard/inbox/response.js
@@ -33,7 +33,7 @@ const getDisplayName = response => {
 };
 
 const isFileUploadField = value => {
-	return value && typeof value === 'object' && 'files' in value && 'field_id' in value;
+	return value && typeof value === 'object' && 'files' in value;
 };
 
 const isLikelyPhoneNumber = value => {
@@ -211,7 +211,7 @@ const InboxResponse = ( { response, loading, onModalStateChange } ) => {
 					{ value.files?.length
 						? value.files.map( file => {
 								if ( ! file || ! file.name ) {
-									return null;
+									return '-';
 								}
 								return (
 									<FileField

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
@@ -20,6 +20,8 @@ use WP_Error;
  */
 #[CoversClass( Contact_Form_Plugin::class )]
 class Contact_Form_Plugin_Test extends BaseTestCase {
+
+	private $get_current_user;
 	/**
 	 * Test that ::revert_that_print works correctly
 	 *
@@ -572,6 +574,8 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 
 	private function setup_token_test( $token = null, $name = null ) {
 		global $post;
+		$this->get_current_user = wp_get_current_user();
+		wp_set_current_user( 0 );
 		$post_id = wp_insert_post(
 			array(
 				'post_title'   => 'Test Contact Form',
@@ -599,6 +603,7 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 
 	private function teardown_post_for_test( $previous_post ) {
 		global $post;
+		wp_set_current_user( $this->get_current_user->ID );
 		wp_delete_post( $post->ID, true ); // Clean up the test post.
 		$post = $previous_post; // Restore the previous post.
 		remove_filter( 'jetpack_contact_form_is_spam', array( $this, 'return_error_for_test' ) );

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -418,11 +418,10 @@ class Contact_Form_Test extends BaseTestCase {
 		$this->assertTrue( is_string( $result ) );
 
 		$feedback_id = end( Posts::init()->posts )->ID;
-		$submission  = get_post( $feedback_id );
-		$this->assertEquals( 'feedback', $submission->post_type, 'Post type doesn\'t match' );
+		$response    = Feedback::get( $feedback_id );
 
 		// Default metadata should be saved.
-		$this->assertStringContainsString( 'SUBJECT: I\\\'m sorry, but the party\\\'s over', $submission->post_content, 'The stored subject didn\'t match the given' );
+		$this->assertStringContainsString( 'I\'m sorry, but the party\'s over', $response->get_subject(), 'The stored subject didn\'t match the given' );
 	}
 
 	/**
@@ -447,10 +446,9 @@ class Contact_Form_Test extends BaseTestCase {
 		$this->assertTrue( is_string( $result ) );
 
 		$feedback_id = end( Posts::init()->posts )->ID;
-		$submission  = get_post( $feedback_id );
-		$this->assertEquals( 'feedback', $submission->post_type, 'Post type doesn\'t match' );
+		$response    = Feedback::get( $feedback_id );
 
-		$this->assertStringContainsString( 'SUBJECT: Hello John Doe from Kansas!', $submission->post_content, 'The stored subject didn\'t match the given' );
+		$this->assertStringContainsString( 'Hello John Doe from Kansas!', $response->get_subject(), 'The stored subject didn\'t match the given' );
 	}
 
 	/**
@@ -474,10 +472,9 @@ class Contact_Form_Test extends BaseTestCase {
 		$this->assertTrue( is_string( $result ) );
 
 		$feedback_id = end( Posts::init()->posts )->ID;
-		$submission  = get_post( $feedback_id );
-		$this->assertEquals( 'feedback', $submission->post_type, 'Post type doesn\'t match' );
+		$response    = Feedback::get( $feedback_id );
 
-		$this->assertStringContainsString( 'SUBJECT: Hello John Doe from Kansas!', $submission->post_content, 'The stored subject didn\'t match the given' );
+		$this->assertStringContainsString( 'Hello John Doe from Kansas!', $response->get_subject(), 'The stored subject didn\'t match the given' );
 	}
 
 	/**
@@ -501,10 +498,9 @@ class Contact_Form_Test extends BaseTestCase {
 		$this->assertTrue( is_string( $result ) );
 
 		$feedback_id = end( Posts::init()->posts )->ID;
-		$submission  = get_post( $feedback_id );
-		$this->assertEquals( 'feedback', $submission->post_type, 'Post type doesn\'t match' );
+		$response    = Feedback::get( $feedback_id );
 
-		$this->assertStringContainsString( 'SUBJECT: Hello John Doe from Kansas!', $submission->post_content, 'The stored subject didn\'t match the given' );
+		$this->assertStringContainsString( 'Hello John Doe from Kansas!', $response->get_subject(), 'The stored subject didn\'t match the given' );
 	}
 
 	/**
@@ -532,13 +528,13 @@ class Contact_Form_Test extends BaseTestCase {
 		$this->assertTrue( is_string( $result ) );
 
 		$feedback_id = end( Posts::init()->posts )->ID;
-		$submission  = get_post( $feedback_id );
-		$this->assertEquals( 'feedback', $submission->post_type, 'Post type doesn\'t match' );
 
-		$this->assertStringContainsString( '\"1_Name\":\"John Doe\"', $submission->post_content, 'Post content did not contain the name label and/or value' );
-		$this->assertStringContainsString( '\"2_Dropdown\":\"First option\"', $submission->post_content, 'Post content did not contain the dropdown label and/or value' );
-		$this->assertStringContainsString( '\"3_Radio\":\"Second option\"', $submission->post_content, 'Post content did not contain the radio button label and/or value' );
-		$this->assertStringContainsString( '\"4_Text\":\"Texty text\"', $submission->post_content, 'Post content did not contain the text field label and/or value' );
+		$response = Feedback::get( $feedback_id );
+
+		$this->assertStringContainsString( 'John Doe', $response->get_field_value_by_label( 'Name' ), 'Post content did not contain the name label and/or value' );
+		$this->assertStringContainsString( 'First option', $response->get_field_value_by_label( 'Dropdown' ), 'Post content did not contain the dropdown label and/or value' );
+		$this->assertStringContainsString( 'Second option', $response->get_field_value_by_label( 'Radio' ), 'Post content did not contain the radio button label and/or value' );
+		$this->assertStringContainsString( 'Texty text', $response->get_field_value_by_label( 'Text' ), 'Post content did not contain the text field label and/or value' );
 	}
 
 	/**

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -411,7 +411,7 @@ class Contact_Form_Test extends BaseTestCase {
 	 * @author tonykova
 	 */
 	public function test_process_submission_will_store_subject_when_specified() {
-		$form   = new Contact_Form( array( 'subject' => "I'm sorry, but the party's over" ) ); // Default form.
+		$form   = new Contact_Form( array( 'subject' => 'I\'m sorry, but the party\'s over' ) ); // Default form.
 		$result = $form->process_submission();
 
 		// Processing should be successful and produce the success message.

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -411,7 +411,7 @@ class Contact_Form_Test extends BaseTestCase {
 	 * @author tonykova
 	 */
 	public function test_process_submission_will_store_subject_when_specified() {
-		$form   = new Contact_Form( array( 'subject' => 'I\'m sorry, but the party\'s over' ) ); // Default form.
+		$form   = new Contact_Form( array( 'subject' => "I'm sorry, but the party's over" ) ); // Default form.
 		$result = $form->process_submission();
 
 		// Processing should be successful and produce the success message.
@@ -421,7 +421,7 @@ class Contact_Form_Test extends BaseTestCase {
 		$response    = Feedback::get( $feedback_id );
 
 		// Default metadata should be saved.
-		$this->assertStringContainsString( 'I\'m sorry, but the party\'s over', $response->get_subject(), 'The stored subject didn\'t match the given' );
+		$this->assertEquals( "I\'m sorry, but the party\'s over", $response->get_subject(), 'The stored subject didn\'t match the given' );
 	}
 
 	/**

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Test.php
@@ -1117,6 +1117,58 @@ class Feedback_Test extends BaseTestCase {
 		);
 	}
 
+	public function test_get_all_values_with_file_upload() {
+
+		add_filter( 'jetpack_forms_is_file_field_renderable', '__return_true' );
+
+		$form_id = Utility::get_form_id();
+		// Create a form submission
+		$_post_data = Utility::get_post_request(
+			array(
+				'uploadafile' => array( '{"file_id":54321,"name":"Screenshot.png","size":19914,"type":"image/png"}', '{}' ),
+			),
+			'g' . $form_id
+		);
+
+		$form = new Contact_Form(
+			array(
+				'title'       => 'Test Form',
+				'description' => 'This is a test form.',
+			),
+			'[contact-field type="file" label="Upload a file" /]'
+		);
+
+		$expected_file = array(
+			'field_id' => 'g2376-1-uploadafile',
+			'files'    => array(
+				array(
+					'file_id' => 54321,
+					'name'    => 'Screenshot.png',
+					'size'    => 19914,
+					'type'    => 'image/png',
+				),
+				array(
+					'file_id' => 0,
+					'name'    => '',
+					'size'    => 0,
+					'type'    => '',
+				),
+			),
+		);
+
+		$response         = Feedback::from_submission( $_post_data, $form );
+		$feedback_post_id = $response->save();
+		$saved_response   = Feedback::get( $feedback_post_id );
+
+		$this->assertEquals( $expected_file, $response->get_all_values( 'submit' )['1_Upload a file'], 'Response all values should match the expected values' );
+		$this->assertEquals( $expected_file, $saved_response->get_all_values( 'submit' )['1_Upload a file'], 'Saved response all values should match the expected values' );
+
+		$this->assertEquals( $expected_file, $response->get_legacy_extra_values( 'submit' )['2_Upload a file'], 'Response all values should match the expected values' );
+		$this->assertEquals( $expected_file, $saved_response->get_legacy_extra_values( 'submit' )['2_Upload a file'], 'Saved response all values should match the expected values' );
+
+		remove_filter( 'jetpack_forms_is_file_field_renderable', '__return_true' );
+	}
+
 	public function test_get_akismet_vars() {
 		// Test that the get_akismet_vars method returns the correct variables for Akismet.
 

--- a/projects/plugins/jetpack/changelog/update-forms-save-to-new-format-v2
+++ b/projects/plugins/jetpack/changelog/update-forms-save-to-new-format-v2
@@ -1,0 +1,4 @@
+Significance: major
+Type: enhancement
+
+Forms: Save feedback entries in a new format


### PR DESCRIPTION
This Pr Implements the saving of the feedback forms in a new format. 

## Proposed changes:
* Update the process_submission function to the the new feedback class and save the submission in the new format. 

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Create a new form with all the fields. 
Save it. 
Can you see the response? Can you export it as before. 
Use the non Ajax way of submitting the form. 
Does it still work as expected? 
Do the values all still match that we are passing into different filters and actions in the process_submission ? 

Do the test pass? 


