### PR TITLE
Fix: image cdn defensive check when trimming photon url

### DIFF
--- a/projects/packages/image-cdn/changelog/fix-image-cdn-defensive-check-when-trimming-photon-url
+++ b/projects/packages/image-cdn/changelog/fix-image-cdn-defensive-check-when-trimming-photon-url
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Image CDN: Added defensive check for is_string before trimming photon url

--- a/projects/packages/image-cdn/src/class-image-cdn-core.php
+++ b/projects/packages/image-cdn/src/class-image-cdn-core.php
@@ -54,6 +54,9 @@ class Image_CDN_Core {
 	 * @return string The raw final URL. You should run this through esc_url() before displaying it.
 	 */
 	public static function cdn_url( $image_url, $args = array(), $scheme = null ) {
+		if ( ! is_string( $image_url ) || empty( $image_url ) ) {
+			return '';
+		}
 		$image_url = trim( $image_url );
 
 		if ( ! defined( 'IS_WPCOM' ) || ! \IS_WPCOM ) {

--- a/projects/packages/image-cdn/tests/php/Image_CDN_Core_Test.php
+++ b/projects/packages/image-cdn/tests/php/Image_CDN_Core_Test.php
@@ -458,7 +458,7 @@ class Image_CDN_Core_Test extends BaseTestCase {
 	public function test_cdn_url_empty_invalid_url() {
 		$this->assertSame( '', Image_CDN_Core::cdn_url( '' ) );
 		$this->assertSame( '', Image_CDN_Core::cdn_url( null ) );
-		$this->assertSame( '', Image_CDN_Core::cdn_url( 123 ) );
+		$this->assertSame( '', Image_CDN_Core::cdn_url( 123 ) ); // @phan-suppress-current-line PhanTypeMismatchArgument
 		$this->assertSame( '', Image_CDN_Core::cdn_url( array() ) );
 	}
 

--- a/projects/packages/image-cdn/tests/php/Image_CDN_Core_Test.php
+++ b/projects/packages/image-cdn/tests/php/Image_CDN_Core_Test.php
@@ -451,6 +451,18 @@ class Image_CDN_Core_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Tests that the cdn_url method returns an empty string when the image URL is empty or invalid.
+	 *
+	 * @since $$next-version$$
+	 */
+	public function test_cdn_url_empty_invalid_url() {
+		$this->assertSame( '', Image_CDN_Core::cdn_url( '' ) );
+		$this->assertSame( '', Image_CDN_Core::cdn_url( null ) );
+		$this->assertSame( '', Image_CDN_Core::cdn_url( 123 ) );
+		$this->assertSame( '', Image_CDN_Core::cdn_url( array() ) );
+	}
+
+	/**
 	 * Data provider for test_photon_banned_domains_banned
 	 */
 	public static function get_photon_domains() {


### PR DESCRIPTION
Fixes VULCAN-286

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes errors like `Fatal error: Uncaught TypeError: trim(): Argument #1 ($string) must be of type string, array given in jetpack-image-cdn/src/class-image-cdn-core.php:57`
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Added defensive check when trimming photon url.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1755516973778689-slack-C034JEXD1RD

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Code Review should suffice