### PR TITLE
Boost: Fix Cornerstone Pages URL handling for multisite subdirectory installations

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/features/cornerstone-pages/meta/meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/cornerstone-pages/meta/meta.tsx
@@ -284,6 +284,9 @@ const List: FC< ListProps > = ( {
 			path = path.startsWith( '/' ) ? path : '/' + path;
 		}
 
+		// Clean up multiple consecutive slashes
+		path = path.replace( /\/+/g, '/' );
+
 		// Normalize trailing slashes for consistent deduplication (except root)
 		return path.replace( /\/$/, '' ) || '/';
 	};

--- a/projects/plugins/boost/app/assets/src/js/features/cornerstone-pages/meta/meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/cornerstone-pages/meta/meta.tsx
@@ -267,10 +267,16 @@ const List: FC< ListProps > = ( {
 			const url = new URL( trimmed );
 			if ( url.origin === siteUrl.origin ) {
 				path = url.pathname;
+			} else {
+				// External URL - don't normalize, let validation reject it properly
+				return path;
 			}
 		} catch {
 			// Not a valid absolute URL, treat as relative path
 		}
+
+		// Check if it looks like a protocol URL before processing
+		const looksLikeProtocolUrl = /^https?:\/\//.test( trimmed );
 
 		// Normalize base path for comparison (remove trailing slash)
 		const basePath = siteUrl.pathname.replace( /\/$/, '' );
@@ -284,8 +290,10 @@ const List: FC< ListProps > = ( {
 			path = path.startsWith( '/' ) ? path : '/' + path;
 		}
 
-		// Clean up multiple consecutive slashes
-		path = path.replace( /\/+/g, '/' );
+		// Clean up multiple consecutive slashes (but only for non-protocol URLs)
+		if ( ! looksLikeProtocolUrl ) {
+			path = path.replace( /\/+/g, '/' );
+		}
 
 		// Normalize trailing slashes for consistent deduplication (except root)
 		return path.replace( /\/$/, '' ) || '/';

--- a/projects/plugins/boost/app/assets/src/js/features/cornerstone-pages/meta/meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/cornerstone-pages/meta/meta.tsx
@@ -66,7 +66,7 @@ const CornerstonePagesContent = () => {
 			? newValue
 					.split( '\n' )
 					.map( line => line.trim() )
-					.filter( Boolean )
+					.filter( Boolean ) // Filter empty lines for better UX
 			: [];
 
 		setCornerstonePages( newItems, () => {
@@ -229,94 +229,22 @@ const List: FC< ListProps > = ( {
 		}
 	};
 
-	// URL Resolution - handles all the complex path logic in one place
-	const resolveUrlForSite = ( input: string, siteUrl: URL ): URL => {
-		if ( input.startsWith( '/' ) ) {
-			// Absolute path - normalize base path for comparison
-			const basePath = siteUrl.pathname.replace( /\/$/, '' );
-
-			// Check if input already contains the base path
-			const hasBasePath =
-				basePath !== '' && ( input === basePath || input.startsWith( basePath + '/' ) );
-
-			if ( hasBasePath ) {
-				return new URL( input, siteUrl.origin );
-			}
-
-			// Join base path with input, avoiding double slashes
-			const joinedPath = basePath + input;
-			return new URL( joinedPath, siteUrl.origin );
+	// Helper function to resolve paths for multisite homepage detection
+	const getResolvedPath = ( pathname: string, siteUrl: URL ): string => {
+		// For multisite subdirectory installations, "/" should resolve to the site's base path
+		if ( pathname === '/' ) {
+			return siteUrl.pathname;
 		}
-
-		// Relative path - ensure base URL has trailing slash for proper joining
-		const baseUrl = siteUrl.href.endsWith( '/' ) ? siteUrl.href : siteUrl.href + '/';
-		return new URL( input, baseUrl );
+		return pathname;
 	};
 
-	// Backend Normalization - converts URLs back to relative paths for storage
-	const normalizeForBackend = ( input: string, siteUrl: URL ): string => {
-		// Trim and filter empty strings early
-		const trimmed = input.trim();
-		if ( ! trimmed ) {
-			return '';
-		}
-
-		// Handle absolute URLs by extracting the pathname
-		let path = trimmed;
-		try {
-			const url = new URL( trimmed );
-			if ( url.origin === siteUrl.origin ) {
-				path = url.pathname;
-			} else {
-				// External URL - don't normalize, let validation reject it properly
-				return path;
-			}
-		} catch {
-			// Not a valid absolute URL, treat as relative path
-		}
-
-		// Check if it looks like a protocol URL before processing
-		const looksLikeProtocolUrl = /^https?:\/\//.test( trimmed );
-
-		// Normalize base path for comparison (remove trailing slash)
-		const basePath = siteUrl.pathname.replace( /\/$/, '' );
-
-		// Strip base path if present
-		if ( basePath !== '' && ( path === basePath || path.startsWith( basePath + '/' ) ) ) {
-			const remainingPath = path.substring( basePath.length );
-			path = remainingPath || '/';
-		} else {
-			// Ensure path starts with '/' for consistency
-			path = path.startsWith( '/' ) ? path : '/' + path;
-		}
-
-		// Clean up multiple consecutive slashes (but only for non-protocol URLs)
-		if ( ! looksLikeProtocolUrl ) {
-			path = path.replace( /\/+/g, '/' );
-		}
-
-		// Normalize trailing slashes for consistent deduplication (except root)
-		return path.replace( /\/$/, '' ) || '/';
-	};
-
-	// Input Processing - now much simpler
-	const processInputLines = ( value: string ): string[] => {
-		const siteUrl = new URL( Jetpack_Boost.site.url );
-
+	const validateItems = ( value: string ) => {
 		const lines = value
 			.split( '\n' )
-			.map( line => normalizeForBackend( line, siteUrl ) )
-			.filter( Boolean ); // Remove empty strings after normalization
+			.map( line => line.trim() )
+			.filter( Boolean );
 
-		// Deduplicate to avoid false "over max" errors
-		return Array.from( new Set( lines ) );
-	};
-
-	// Validation - now focused only on validation logic
-	const validateItems = ( value: string ) => {
-		const lines = processInputLines( value );
-
-		if ( value.trim().length > 0 && lines.length === 0 ) {
+		if ( lines.length === 0 ) {
 			throw new Error( __( 'You must add at least one URL.', 'jetpack-boost' ) );
 		}
 
@@ -336,44 +264,35 @@ const List: FC< ListProps > = ( {
 		}
 
 		const siteUrl = new URL( Jetpack_Boost.site.url );
-		const normalizePath = ( p: string ) => p.replace( /\/$/, '' ) || '/';
-		const sitePath = normalizePath( siteUrl.pathname );
 
 		for ( const line of lines ) {
+			let url: URL | undefined;
+			let pathname: string | undefined;
+
 			try {
-				const url = resolveUrlForSite( line, siteUrl );
+				url = new URL( line );
+				pathname = url.pathname;
+			} catch {
+				// If the URL is invalid, they have provided a relative URL, which we will allow.
+				pathname = line;
+			}
 
-				// Check for malformed URLs with double slashes
-				if ( url.pathname.includes( '//' ) ) {
-					throw new Error(
-						/* translators: %s is the URL that is malformed. */
-						sprintf( __( 'Invalid URL format: %s', 'jetpack-boost' ), line )
-					);
-				}
+			if ( url && ! isSameSiteUrl( url, siteUrl ) ) {
+				throw new Error(
+					/* translators: %s is the URL that didn't match the site URL */
+					sprintf( __( 'The URL seems to be a different site: %s', 'jetpack-boost' ), line )
+				);
+			}
 
-				if ( ! isSameSiteUrl( url, siteUrl ) ) {
-					throw new Error(
-						/* translators: %s is the URL that didn't match the site URL */
-						sprintf( __( 'The URL seems to be a different site: %s', 'jetpack-boost' ), line )
-					);
-				}
-
-				if ( normalizePath( url.pathname ) === sitePath ) {
-					throw new Error(
-						__(
-							'The homepage does not need to be added to the list, as it is automatically included.',
-							'jetpack-boost'
-						)
-					);
-				}
-			} catch ( e ) {
-				if ( e instanceof Error && e.message.includes( 'Invalid URL' ) ) {
-					throw new Error(
-						/* translators: %s is the URL that is invalid. */
-						sprintf( __( 'Invalid URL: %s', 'jetpack-boost' ), line )
-					);
-				}
-				throw e;
+			// Fixed multisite homepage detection
+			const resolvedPath = getResolvedPath( pathname, siteUrl );
+			if ( resolvedPath === siteUrl.pathname ) {
+				throw new Error(
+					__(
+						'The homepage does not need to be added to the list, as it is automatically included.',
+						'jetpack-boost'
+					)
+				);
 			}
 		}
 
@@ -381,11 +300,12 @@ const List: FC< ListProps > = ( {
 	};
 
 	function save() {
-		const processedLines = processInputLines( inputValue );
-
-		setItems( processedLines.join( '\n' ) );
+		setItems( inputValue );
 		recordBoostEvent( 'cornerstone_pages_save', {
-			list_length: processedLines.length,
+			list_length: inputValue
+				.split( '\n' )
+				.map( line => line.trim() )
+				.filter( Boolean ).length,
 		} );
 	}
 

--- a/projects/plugins/boost/app/assets/src/js/features/cornerstone-pages/meta/meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/cornerstone-pages/meta/meta.tsx
@@ -62,7 +62,12 @@ const CornerstonePagesContent = () => {
 
 	const updateCornerstonePages = ( newValue: string ) => {
 		// If the user deletes all the URLs, we should set the list to an empty array.
-		const newItems = newValue ? newValue.split( '\n' ).map( line => line.trim() ) : [];
+		const newItems = newValue
+			? newValue
+					.split( '\n' )
+					.map( line => line.trim() )
+					.filter( Boolean )
+			: [];
 
 		setCornerstonePages( newItems, () => {
 			setNotice( {
@@ -224,10 +229,56 @@ const List: FC< ListProps > = ( {
 		}
 	};
 
-	const validateItems = ( value: string ) => {
-		const lines = value.split( '\n' ).map( line => line.trim() );
+	// URL Resolution - handles all the complex path logic in one place
+	const resolveUrlForSite = ( input: string, siteUrl: URL ): URL => {
+		if ( input.startsWith( '/' ) ) {
+			// Absolute path
+			const hasBasePath =
+				siteUrl.pathname !== '/' &&
+				input.startsWith( siteUrl.pathname ) &&
+				( input.length === siteUrl.pathname.length ||
+					input.charAt( siteUrl.pathname.length ) === '/' );
 
-		if ( lines.length === 0 ) {
+			if ( hasBasePath ) {
+				return new URL( input, siteUrl.origin );
+			}
+			return new URL( siteUrl.pathname + input, siteUrl.href );
+		}
+		// Relative path - ensure base URL has trailing slash
+		const baseUrl = siteUrl.href.endsWith( '/' ) ? siteUrl.href : siteUrl.href + '/';
+		return new URL( input, baseUrl );
+	};
+
+	// Backend Normalization - converts URLs back to relative paths for storage
+	const normalizeForBackend = ( input: string, siteUrl: URL ): string => {
+		if ( siteUrl.pathname !== '/' && input.startsWith( siteUrl.pathname ) ) {
+			const remainingPath = input.substring( siteUrl.pathname.length );
+			if ( remainingPath === '' || remainingPath.startsWith( '/' ) ) {
+				return remainingPath || '/';
+			}
+		}
+		return input;
+	};
+
+	// Input Processing - now much simpler
+	const processInputLines = ( value: string ): string[] => {
+		const siteUrl = new URL( Jetpack_Boost.site.url );
+
+		const lines = value
+			.split( '\n' )
+			.map( line => line.trim() )
+			.filter( Boolean )
+			.map( line => normalizeForBackend( line, siteUrl ) );
+
+		// Deduplicate to avoid false "over max" errors
+		return Array.from( new Set( lines ) );
+	};
+
+	// Validation - now focused only on validation logic
+	const validateItems = ( value: string ) => {
+		const lines = processInputLines( value );
+
+		if ( value.trim().length > 0 && lines.length === 0 ) {
 			throw new Error( __( 'You must add at least one URL.', 'jetpack-boost' ) );
 		}
 
@@ -247,33 +298,36 @@ const List: FC< ListProps > = ( {
 		}
 
 		const siteUrl = new URL( Jetpack_Boost.site.url );
+		const normalizePath = ( p: string ) => p.replace( /\/$/, '' ) || '/';
+		const sitePath = normalizePath( siteUrl.pathname );
 
 		for ( const line of lines ) {
-			let url: URL | undefined;
-			let pathname: string | undefined;
-
 			try {
-				url = new URL( line );
-				pathname = url.pathname;
-			} catch {
-				// If the URL is invalid, they have provided a relative URL, which we will allow.
-				pathname = line;
-			}
+				const url = resolveUrlForSite( line, siteUrl );
 
-			if ( url && ! isSameSiteUrl( url, siteUrl ) ) {
-				throw new Error(
-					/* translators: %s is the URL that didn't match the site URL */
-					sprintf( __( 'The URL seems to be a different site: %s', 'jetpack-boost' ), line )
-				);
-			}
+				if ( ! isSameSiteUrl( url, siteUrl ) ) {
+					throw new Error(
+						/* translators: %s is the URL that didn't match the site URL */
+						sprintf( __( 'The URL seems to be a different site: %s', 'jetpack-boost' ), line )
+					);
+				}
 
-			if ( pathname === siteUrl.pathname ) {
-				throw new Error(
-					__(
-						'The homepage does not need to be added to the list, as it is automatically included.',
-						'jetpack-boost'
-					)
-				);
+				if ( normalizePath( url.pathname ) === sitePath ) {
+					throw new Error(
+						__(
+							'The homepage does not need to be added to the list, as it is automatically included.',
+							'jetpack-boost'
+						)
+					);
+				}
+			} catch ( e ) {
+				if ( e instanceof Error && e.message.includes( 'Invalid URL' ) ) {
+					throw new Error(
+						/* translators: %s is the URL that is invalid. */
+						sprintf( __( 'Invalid URL: %s', 'jetpack-boost' ), line )
+					);
+				}
+				throw e;
 			}
 		}
 
@@ -281,9 +335,11 @@ const List: FC< ListProps > = ( {
 	};
 
 	function save() {
-		setItems( inputValue );
+		const processedLines = processInputLines( inputValue );
+
+		setItems( processedLines.join( '\n' ) );
 		recordBoostEvent( 'cornerstone_pages_save', {
-			list_length: inputValue.split( '\n' ).length,
+			list_length: processedLines.length,
 		} );
 	}
 

--- a/projects/plugins/boost/app/assets/src/js/features/cornerstone-pages/meta/meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/cornerstone-pages/meta/meta.tsx
@@ -232,32 +232,60 @@ const List: FC< ListProps > = ( {
 	// URL Resolution - handles all the complex path logic in one place
 	const resolveUrlForSite = ( input: string, siteUrl: URL ): URL => {
 		if ( input.startsWith( '/' ) ) {
-			// Absolute path
+			// Absolute path - normalize base path for comparison
+			const basePath = siteUrl.pathname.replace( /\/$/, '' );
+
+			// Check if input already contains the base path
 			const hasBasePath =
-				siteUrl.pathname !== '/' &&
-				input.startsWith( siteUrl.pathname ) &&
-				( input.length === siteUrl.pathname.length ||
-					input.charAt( siteUrl.pathname.length ) === '/' );
+				basePath !== '' && ( input === basePath || input.startsWith( basePath + '/' ) );
 
 			if ( hasBasePath ) {
 				return new URL( input, siteUrl.origin );
 			}
-			return new URL( siteUrl.pathname + input, siteUrl.href );
+
+			// Join base path with input, avoiding double slashes
+			const joinedPath = basePath + input;
+			return new URL( joinedPath, siteUrl.origin );
 		}
-		// Relative path - ensure base URL has trailing slash
+
+		// Relative path - ensure base URL has trailing slash for proper joining
 		const baseUrl = siteUrl.href.endsWith( '/' ) ? siteUrl.href : siteUrl.href + '/';
 		return new URL( input, baseUrl );
 	};
 
 	// Backend Normalization - converts URLs back to relative paths for storage
 	const normalizeForBackend = ( input: string, siteUrl: URL ): string => {
-		if ( siteUrl.pathname !== '/' && input.startsWith( siteUrl.pathname ) ) {
-			const remainingPath = input.substring( siteUrl.pathname.length );
-			if ( remainingPath === '' || remainingPath.startsWith( '/' ) ) {
-				return remainingPath || '/';
-			}
+		// Trim and filter empty strings early
+		const trimmed = input.trim();
+		if ( ! trimmed ) {
+			return '';
 		}
-		return input;
+
+		// Handle absolute URLs by extracting the pathname
+		let path = trimmed;
+		try {
+			const url = new URL( trimmed );
+			if ( url.origin === siteUrl.origin ) {
+				path = url.pathname;
+			}
+		} catch {
+			// Not a valid absolute URL, treat as relative path
+		}
+
+		// Normalize base path for comparison (remove trailing slash)
+		const basePath = siteUrl.pathname.replace( /\/$/, '' );
+
+		// Strip base path if present
+		if ( basePath !== '' && ( path === basePath || path.startsWith( basePath + '/' ) ) ) {
+			const remainingPath = path.substring( basePath.length );
+			path = remainingPath || '/';
+		} else {
+			// Ensure path starts with '/' for consistency
+			path = path.startsWith( '/' ) ? path : '/' + path;
+		}
+
+		// Normalize trailing slashes for consistent deduplication (except root)
+		return path.replace( /\/$/, '' ) || '/';
 	};
 
 	// Input Processing - now much simpler
@@ -266,9 +294,8 @@ const List: FC< ListProps > = ( {
 
 		const lines = value
 			.split( '\n' )
-			.map( line => line.trim() )
-			.filter( Boolean )
-			.map( line => normalizeForBackend( line, siteUrl ) );
+			.map( line => normalizeForBackend( line, siteUrl ) )
+			.filter( Boolean ); // Remove empty strings after normalization
 
 		// Deduplicate to avoid false "over max" errors
 		return Array.from( new Set( lines ) );
@@ -304,6 +331,14 @@ const List: FC< ListProps > = ( {
 		for ( const line of lines ) {
 			try {
 				const url = resolveUrlForSite( line, siteUrl );
+
+				// Check for malformed URLs with double slashes
+				if ( url.pathname.includes( '//' ) ) {
+					throw new Error(
+						/* translators: %s is the URL that is malformed. */
+						sprintf( __( 'Invalid URL format: %s', 'jetpack-boost' ), line )
+					);
+				}
 
 				if ( ! isSameSiteUrl( url, siteUrl ) ) {
 					throw new Error(

--- a/projects/plugins/boost/app/assets/src/js/features/cornerstone-pages/meta/meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/cornerstone-pages/meta/meta.tsx
@@ -244,8 +244,9 @@ const List: FC< ListProps > = ( {
 			.map( line => line.trim() )
 			.filter( Boolean );
 
+		// Allow empty input - user can clear all cornerstone pages
 		if ( lines.length === 0 ) {
-			throw new Error( __( 'You must add at least one URL.', 'jetpack-boost' ) );
+			return true;
 		}
 
 		// Check if the number of items exceeds maxItems

--- a/projects/plugins/boost/changelog/update-boost-cornerstone-fix-mu-invalidation-issue-HOG-224
+++ b/projects/plugins/boost/changelog/update-boost-cornerstone-fix-mu-invalidation-issue-HOG-224
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Cornerstone Pages: Improve URL handling and validation for WordPress multisite subdirectory installations.


### PR DESCRIPTION
Fixes HOG-224

## Proposed changes:
* **Simplify multisite handling**: Replace complex URL resolution logic (124 lines) with minimal path helper (8 lines) that correctly handles multisite subdirectory homepage detection
* **Fix multisite homepage detection**: Properly detect "/" as homepage in subdirectory installations (e.g., `https://example.com/blog`) 
* **Enable clearing cornerstone pages**: Allow users to save empty textarea to remove all custom pages
* **Maintain all existing functionality**: Preserve URL validation, plan limits, and user experience while significantly improving code maintainability

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

### Prerequisites
Set up test environments to cover different WordPress configurations:
1. **Standard WordPress site**: `https://example.com`
2. **Multisite subdirectory installation**: `https://example.com/subsite`

### Test Case 1: Multisite Subdirectory Homepage Detection (Primary Fix)
**Environment**: WordPress multisite with subdirectory installation (`https://example.com/blog`)

1. Navigate to **Jetpack → Boost → Cornerstone Pages**
2. Open the Cornerstone Pages panel
3. In the custom pages textarea, enter: `/`
4. **Expected Result**: Should show error "The homepage does not need to be added to the list, as it is automatically included"
5. **Before this PR**: Would incorrectly accept `/` as a valid page

### Test Case 2: Empty List Clearing (New Feature)
**Environment**: Any WordPress site with existing cornerstone pages

1. Navigate to **Jetpack → Boost → Cornerstone Pages**
2. Open the Cornerstone Pages panel (should show existing pages)
3. Clear all content from the textarea (make it completely empty)
4. Click **Save**
5. **Expected Result**: Should save successfully, clearing all custom cornerstone pages
6. **Before this PR**: Would show error "You must add at least one URL"

### Test Case 3: Basic Functionality Regression Tests
**Environment**: Any WordPress site

1. **Valid URLs should work**:
   - Input: `/about` → Should save successfully
   - Input: `/about\n/contact` → Should save successfully
   - Input: `https://example.com/page` (same domain) → Should save successfully

2. **Invalid URLs should be rejected**:
   - Input: `https://external.com/page` → Should show error about different site
   - Input: `/` → Should show homepage error message

3. **Empty line filtering**:
   - Input: `/about\n\n/contact` → Should save as 2 pages, ignoring empty line
   - Input: `   \n   \n   ` (only whitespace) → Should save successfully as empty list

### Test Case 4: Plan Limits (Free vs Premium)
**Environment**: Any WordPress site

1. **Free Plan Test** (if applicable):
   - Enter 2 valid URLs (e.g., `/page1`, `/page2`)
   - **Expected**: Error about exceeding free plan limit (1 custom page)

2. **Premium Plan Test** (if applicable):
   - Enter 11 valid URLs
   - **Expected**: Error about exceeding premium plan limit (10 custom pages)

### Test Case 5: Multisite Edge Cases
**Environment**: WordPress multisite subdirectory (`https://example.com/blog`)

1. **Root path variations**:
   - Input: `/` → Should be rejected as homepage
   - Input: `/about` → Should be accepted as valid page
   - Input: `relative` → Should be accepted as valid page

2. **Absolute URL handling**:
   - Input: `https://example.com/blog/about` → Should be accepted (same site)
   - Input: `https://other.com/page` → Should be rejected (different site)