### PR TITLE
Media Settings: Add Google Photos connection

### DIFF
--- a/projects/packages/external-media/changelog/dotcom-14240-add-support-to-manage-the-google-photos-connection-in 
+++ b/projects/packages/external-media/changelog/dotcom-14240-add-support-to-manage-the-google-photos-connection-in 
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Media Settings: Add Google Photos connection

--- a/projects/packages/external-media/composer.json
+++ b/projects/packages/external-media/composer.json
@@ -8,6 +8,7 @@
 		"automattic/jetpack-assets": "@dev",
 		"automattic/jetpack-connection": "@dev",
 		"automattic/jetpack-constants": "@dev",
+		"automattic/jetpack-external-connections": "@dev",
 		"automattic/jetpack-status": "@dev"
 	},
 	"require-dev": {

--- a/projects/packages/external-media/src/class-external-media.php
+++ b/projects/packages/external-media/src/class-external-media.php
@@ -10,6 +10,7 @@ namespace Automattic\Jetpack\External_Media;
 use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Connection\Initial_State as Connection_Initial_State;
 use Automattic\Jetpack\Constants;
+use Automattic\Jetpack\External_Connections;
 use Automattic\Jetpack\Status\Host;
 use Jetpack_Options;
 
@@ -39,6 +40,19 @@ class External_Media {
 			// This loads assets specific to the editing interface like the block toolbar, as well as a front-end fallback.
 			add_action( 'enqueue_block_editor_assets', array( __CLASS__, 'enqueue_block_editor_assets' ) );
 		}
+
+		External_Connections::add_settings_for_service(
+			'media',
+			array(
+				'service'      => 'google_photos',
+				'title'        => __( 'Google Photos', 'jetpack-external-media' ),
+				'description'  => __( 'Access photos stored in your Google Photos library.', 'jetpack-external-media' ),
+				'support_link' => array(
+					'wpcom'   => 'https://wordpress.com/support/google-photos/',
+					'jetpack' => 'using-your-google-photos-with-jetpack/',
+				),
+			)
+		);
 	}
 
 	/**

--- a/projects/packages/external-media/src/shared/sources/google-photos/auth-instructions.js
+++ b/projects/packages/external-media/src/shared/sources/google-photos/auth-instructions.js
@@ -29,15 +29,6 @@ function AuthInstructions() {
 						{ __( 'Google Security page', 'jetpack-external-media' ) }
 					</a>
 				</li>
-				<li>
-					<a
-						target="_blank"
-						rel="noopener noreferrer"
-						href="https://wordpress.com/marketing/connections/"
-					>
-						{ __( 'WordPress.com Connections', 'jetpack-external-media' ) }
-					</a>
-				</li>
 			</ul>
 		</Fragment>
 	);

--- a/projects/plugins/jetpack/changelog/dotcom-14240-add-support-to-manage-the-google-photos-connection-in
+++ b/projects/plugins/jetpack/changelog/dotcom-14240-add-support-to-manage-the-google-photos-connection-in
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -1348,17 +1348,86 @@
             }
         },
         {
+            "name": "automattic/jetpack-external-connections",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/external-connections",
+                "reference": "b387edc2bcc648016797a8c23d7e22a8d949aad7"
+            },
+            "require": {
+                "automattic/jetpack-assets": "@dev",
+                "automattic/jetpack-connection": "@dev",
+                "automattic/jetpack-redirect": "@dev",
+                "automattic/jetpack-status": "@dev",
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
+                "automattic/phpunit-select-config": "@dev",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "branch-alias": {
+                    "dev-trunk": "0.1.x-dev"
+                },
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-external-connections/compare/v${old}...v${new}"
+                },
+                "mirror-repo": "Automattic/jetpack-external-connections",
+                "textdomain": "jetpack-external-connections",
+                "version-constants": {
+                    "::PACKAGE_VERSION": "src/class-external-connections.php"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "build-development": [
+                    "pnpm run build-js"
+                ],
+                "build-production": [
+                    "pnpm run build-production-js"
+                ],
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Connect your site to external services.",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
             "name": "automattic/jetpack-external-media",
             "version": "dev-trunk",
             "dist": {
                 "type": "path",
                 "url": "../../packages/external-media",
-                "reference": "7cad8e8882445ccee15d738c566c541323e0e698"
+                "reference": "c0e69c7f79e604ec30d5e592e22fa399e11b4371"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
                 "automattic/jetpack-connection": "@dev",
                 "automattic/jetpack-constants": "@dev",
+                "automattic/jetpack-external-connections": "@dev",
                 "automattic/jetpack-status": "@dev",
                 "php": ">=7.2"
             },


### PR DESCRIPTION
Fixes DOTCOM-14240
Requires https://github.com/Automattic/jetpack/pull/44858

## Proposed changes:

Adds the ability to manage the Google Photos connection in Settings -> Media (`/wp-admin/options-media.php`), effectively removing the necessity of pointing users to Calypso to revoke the access.

<img width="1277" height="890" alt="Screenshot 2025-08-22 at 12 49 56" src="https://github.com/user-attachments/assets/ed1189a5-902f-4f70-a295-4f115ac923a3" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

- Apply these changes to all type of sites and test the same steps across all sites:
  - Self-hosted Jetpack site
  - WP.com Simple site
  - WP.com Atomic site
- Go to wordpress.com/marketing/connections and select your site
- Note the current status of the Google Photos connection
- If it's connected, disconnect it
- Go to Settings > Media
- Make sure there is a new Integrations section that contains the Google Photos connection
- Make sure it reflects the current Google Photos connection
- Click on the "Connect" button
- After granting access to your account, make sure the button changes to "Disconnect"
- Check that the current status in wordpress.com/marketing/connections is also connected
- Go to Posts > Add Post
- Insert an image block
- Click on the "Select image" button and pick the "Google Photos" option
- Since you're already connected, make sure that you can select photos from your Google Photos library
- Back to wp-admin, click on the "Disconnect" button now
- Make sure the button changes to "Connect"
- Check that the current status in wordpress.com/marketing/connections is also disconnected
- Make sure that the "Learn more" link opens the expected support doc

