### PR TITLE
e2e tests: Update environment readiness checks to  enforce 200 status response

### DIFF
--- a/tools/e2e-commons/setup-specs/env-check.setup.ts
+++ b/tools/e2e-commons/setup-specs/env-check.setup.ts
@@ -1,3 +1,4 @@
+/* eslint-disable playwright/no-standalone-expect */
 import dns from 'dns/promises';
 import { test as setup, expect } from '../fixtures/base-test';
 import logger from '../logger';
@@ -52,10 +53,9 @@ setup( 'verify environment readiness', async ( { baseURL, request, testUtils } )
 		logger.debug( `Checking HTTP connectivity for ${ baseURL }` );
 
 		await retry( 'HTTP connectivity', async () => {
-			const response = await request.get( baseURL, { timeout: 5000 } );
+			const response = await request.get( baseURL );
 			logger.debug( `HTTP response status: ${ response.status() }` );
-			// Accept any HTTP response as success (including redirects, 404s, etc)
-			// We just need to know the site is reachable
+			expect( response.status() ).toBe( 200 );
 		} );
 	} );
 


### PR DESCRIPTION

## Proposed changes:

Follow-up of #44816, update the env readiness test to also check that HTTP 200 is returned.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:

- e2e tests should pass in CI

