### PR TITLE
Forms: Remove MailPoet integration feature flag

### DIFF
--- a/projects/packages/forms/changelog/add-forms-mailpoet-remove-feature-flag
+++ b/projects/packages/forms/changelog/add-forms-mailpoet-remove-feature-flag
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: Remove MailPoet integration feature flag.

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -105,6 +105,6 @@ class Jetpack_Forms {
 		 *
 		 * @param bool false Whether MailPoet integration be enabled. Default is false.
 		 */
-		return apply_filters( 'jetpack_forms_mailpoet_enable', false );
+		return apply_filters( 'jetpack_forms_mailpoet_enable', true );
 	}
 }

--- a/projects/plugins/jetpack/changelog/add-forms-mailpoet-remove-feature-flag
+++ b/projects/plugins/jetpack/changelog/add-forms-mailpoet-remove-feature-flag
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: Add MailPoet integration.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes [FORMS-263](https://linear.app/a8c/issue/FORMS-263/forms-remove-mailpoet-feature-flag)

## Proposed changes:

This removes the feature flag for MailPoet integration. We do not expose this on simple, but it will be fully released to Atomic when deployed there, and will go out with next Jetpack release in early September.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
P2: peKye1-1I2-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

SIMPLE TEST INSTRUCTIONS: Just confirm MailPoet section appears without feature flag, and play with MailPoet settings to confirm they appear. 

DETAILED TEST INSTRUCTIONS (if you want them): 

* **Prep:** If you've tested this before, be sure to remove the MailPoet feature flag. You no longer need to add a MailPoet key to start adding contacts to your lists.
* **Test forms integration dashboard:**
   - Go to Jetpack > Forms > Integrations and confirm the MailPoet section appears.
   - Try installing / activating the plugin here and confirm state updates as expected. 
   - If prompted, complete MailPoet setup.
   - If active and set up is complete, confirm you see the link to the MailPoet dashboard, and it works.
* **Test form block in editor:** 
   - Add a form to a page or post. Your form must have an email field with label of "Emai" or id of "email".  If you include a name field with 'First Name' label or 'firstname' id, that will be added to your lists. If you include a name field with 'Last Name' label or 'lastname' id, that will be added to your lists.
   - Open the integration modal and confirm the MailPoet section appears.
   - Enable MailPoet using the toggle on the top.
   - Select a desired MailPoet list where you want to add contacts (skip consent for now)
* **Test frontend submission:** Go to frontend, submit, and confirm subscriber was added to MailPoet list.
* **Test consent:** In the block editor, you can the toggle to add the consent field. Test frontend form submission with different consent stats. 
   - No consent field: contact will be added to MailPoet
   - Consent field with no checkbox: contact will be added to MailPoet
   - Consent field with 'checked' checkbox: contact will be added to MailPoet
   - Consent field with 'unchecked' checkbox: contact will not be added to MailPoet