### PR TITLE
Forms: Add text labels for min/max

### DIFF
--- a/projects/packages/forms/changelog/add-forms-slider-minmax-labels
+++ b/projects/packages/forms/changelog/add-forms-slider-minmax-labels
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: Add slider min/max labels.

--- a/projects/packages/forms/src/blocks/field-slider/edit.js
+++ b/projects/packages/forms/src/blocks/field-slider/edit.js
@@ -144,6 +144,20 @@ export default function SliderFieldEdit( props ) {
 						/>
 					</HStack>
 					<HStack alignment="top" className="jp-field-slider-inspector-row">
+						<TextControl
+							__next40pxDefaultSize
+							label={ __( 'Min label', 'jetpack-forms' ) }
+							value={ minLabel }
+							onChange={ value => setAttributes( { minLabel: value } ) }
+						/>
+						<TextControl
+							__next40pxDefaultSize
+							label={ __( 'Max label', 'jetpack-forms' ) }
+							value={ maxLabel }
+							onChange={ value => setAttributes( { maxLabel: value } ) }
+						/>
+					</HStack>
+					<HStack alignment="top" className="jp-field-slider-inspector-row">
 						<NumberControl
 							__next40pxDefaultSize
 							label={ __( 'Default value', 'jetpack-forms' ) }
@@ -159,20 +173,6 @@ export default function SliderFieldEdit( props ) {
 							step={ 1 }
 							value={ step }
 							onChange={ onChangeStep }
-						/>
-					</HStack>
-					<HStack alignment="top" className="jp-field-slider-inspector-row">
-						<TextControl
-							__next40pxDefaultSize
-							label={ __( 'Min label', 'jetpack-forms' ) }
-							value={ minLabel }
-							onChange={ value => setAttributes( { minLabel: value } ) }
-						/>
-						<TextControl
-							__next40pxDefaultSize
-							label={ __( 'Max label', 'jetpack-forms' ) }
-							value={ maxLabel }
-							onChange={ value => setAttributes( { maxLabel: value } ) }
 						/>
 					</HStack>
 				</PanelBody>

--- a/projects/packages/forms/src/blocks/field-slider/edit.js
+++ b/projects/packages/forms/src/blocks/field-slider/edit.js
@@ -163,11 +163,13 @@ export default function SliderFieldEdit( props ) {
 					</HStack>
 					<HStack alignment="top" className="jp-field-slider-inspector-row">
 						<TextControl
+							__next40pxDefaultSize
 							label={ __( 'Min label', 'jetpack-forms' ) }
 							value={ minLabel }
 							onChange={ value => setAttributes( { minLabel: value } ) }
 						/>
 						<TextControl
+							__next40pxDefaultSize
 							label={ __( 'Max label', 'jetpack-forms' ) }
 							value={ maxLabel }
 							onChange={ value => setAttributes( { maxLabel: value } ) }

--- a/projects/packages/forms/src/blocks/field-slider/edit.js
+++ b/projects/packages/forms/src/blocks/field-slider/edit.js
@@ -83,6 +83,20 @@ export default function SliderFieldEdit( props ) {
 		[ defaultValue, min, max, setAttributes ]
 	);
 
+	const onChangeMinLabel = useCallback(
+		newMinLabel => {
+			setAttributes( { minLabel: newMinLabel } );
+		},
+		[ setAttributes ]
+	);
+
+	const onChangeMaxLabel = useCallback(
+		newMaxLabel => {
+			setAttributes( { maxLabel: newMaxLabel } );
+		},
+		[ setAttributes ]
+	);
+
 	// Initialize scalar attributes so they serialize into post markup
 	useEffect( () => {
 		if (
@@ -144,20 +158,6 @@ export default function SliderFieldEdit( props ) {
 						/>
 					</HStack>
 					<HStack alignment="top" className="jp-field-slider-inspector-row">
-						<TextControl
-							__next40pxDefaultSize
-							label={ __( 'Min label', 'jetpack-forms' ) }
-							value={ minLabel }
-							onChange={ value => setAttributes( { minLabel: value } ) }
-						/>
-						<TextControl
-							__next40pxDefaultSize
-							label={ __( 'Max label', 'jetpack-forms' ) }
-							value={ maxLabel }
-							onChange={ value => setAttributes( { maxLabel: value } ) }
-						/>
-					</HStack>
-					<HStack alignment="top" className="jp-field-slider-inspector-row">
 						<NumberControl
 							__next40pxDefaultSize
 							label={ __( 'Default value', 'jetpack-forms' ) }
@@ -175,6 +175,20 @@ export default function SliderFieldEdit( props ) {
 							onChange={ onChangeStep }
 						/>
 					</HStack>
+					<HStack alignment="top" className="jp-field-slider-inspector-row">
+						<TextControl
+							__next40pxDefaultSize
+							label={ __( 'Min label', 'jetpack-forms' ) }
+							value={ minLabel }
+							onChange={ onChangeMinLabel }
+						/>
+						<TextControl
+							__next40pxDefaultSize
+							label={ __( 'Max label', 'jetpack-forms' ) }
+							value={ maxLabel }
+							onChange={ onChangeMaxLabel }
+						/>
+					</HStack>
 				</PanelBody>
 			</InspectorControls>
 			<BlockContextProvider
@@ -182,6 +196,8 @@ export default function SliderFieldEdit( props ) {
 					'jetpack/field-slider-onChangeDefault': onChangeDefault,
 					'jetpack/field-slider-onChangeMin': onChangeMin,
 					'jetpack/field-slider-onChangeMax': onChangeMax,
+					'jetpack/field-slider-onChangeMinLabel': onChangeMinLabel,
+					'jetpack/field-slider-onChangeMaxLabel': onChangeMaxLabel,
 				} }
 			>
 				<div { ...innerBlocksProps } />

--- a/projects/packages/forms/src/blocks/field-slider/edit.js
+++ b/projects/packages/forms/src/blocks/field-slider/edit.js
@@ -8,6 +8,7 @@ import {
 	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalNumberControl as NumberControl, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	PanelBody,
+	TextControl,
 } from '@wordpress/components';
 import { useCallback, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -27,6 +28,8 @@ export default function SliderFieldEdit( props ) {
 		width,
 		id,
 		required,
+		minLabel = '',
+		maxLabel = '',
 	} = attributes;
 
 	const onChangeMin = useCallback(
@@ -156,6 +159,18 @@ export default function SliderFieldEdit( props ) {
 							step={ 1 }
 							value={ step }
 							onChange={ onChangeStep }
+						/>
+					</HStack>
+					<HStack alignment="top" className="jp-field-slider-inspector-row">
+						<TextControl
+							label={ __( 'Min label', 'jetpack-forms' ) }
+							value={ minLabel }
+							onChange={ value => setAttributes( { minLabel: value } ) }
+						/>
+						<TextControl
+							label={ __( 'Max label', 'jetpack-forms' ) }
+							value={ maxLabel }
+							onChange={ value => setAttributes( { maxLabel: value } ) }
 						/>
 					</HStack>
 				</PanelBody>

--- a/projects/packages/forms/src/blocks/field-slider/edit.js
+++ b/projects/packages/forms/src/blocks/field-slider/edit.js
@@ -142,6 +142,7 @@ export default function SliderFieldEdit( props ) {
 					<HStack alignment="top" className="jp-field-slider-inspector-row">
 						<NumberControl
 							__next40pxDefaultSize
+							__nextHasNoMarginBottom
 							label={ __( 'Min value', 'jetpack-forms' ) }
 							max={ max }
 							min={ Number.MIN_SAFE_INTEGER }
@@ -150,6 +151,7 @@ export default function SliderFieldEdit( props ) {
 						/>
 						<NumberControl
 							__next40pxDefaultSize
+							__nextHasNoMarginBottom
 							label={ __( 'Max value', 'jetpack-forms' ) }
 							max={ Number.MAX_SAFE_INTEGER }
 							min={ min }
@@ -160,6 +162,7 @@ export default function SliderFieldEdit( props ) {
 					<HStack alignment="top" className="jp-field-slider-inspector-row">
 						<NumberControl
 							__next40pxDefaultSize
+							__nextHasNoMarginBottom
 							label={ __( 'Default value', 'jetpack-forms' ) }
 							min={ min }
 							max={ max }
@@ -168,6 +171,7 @@ export default function SliderFieldEdit( props ) {
 						/>
 						<NumberControl
 							__next40pxDefaultSize
+							__nextHasNoMarginBottom
 							label={ __( 'Increment', 'jetpack-forms' ) }
 							min={ 0 }
 							step={ 1 }
@@ -178,12 +182,14 @@ export default function SliderFieldEdit( props ) {
 					<HStack alignment="top" className="jp-field-slider-inspector-row">
 						<TextControl
 							__next40pxDefaultSize
+							__nextHasNoMarginBottom
 							label={ __( 'Min label', 'jetpack-forms' ) }
 							value={ minLabel }
 							onChange={ onChangeMinLabel }
 						/>
 						<TextControl
 							__next40pxDefaultSize
+							__nextHasNoMarginBottom
 							label={ __( 'Max label', 'jetpack-forms' ) }
 							value={ maxLabel }
 							onChange={ onChangeMaxLabel }

--- a/projects/packages/forms/src/blocks/field-slider/index.js
+++ b/projects/packages/forms/src/blocks/field-slider/index.js
@@ -32,6 +32,14 @@ const settings = {
 			type: 'number',
 			default: 1,
 		},
+		minLabel: {
+			type: 'string',
+			default: '',
+		},
+		maxLabel: {
+			type: 'string',
+			default: '',
+		},
 	},
 	edit,
 	save,
@@ -45,6 +53,8 @@ const settings = {
 		'jetpack/field-slider-max': 'max',
 		'jetpack/field-slider-default': 'default',
 		'jetpack/field-slider-step': 'step',
+		'jetpack/field-slider-minLabel': 'minLabel',
+		'jetpack/field-slider-maxLabel': 'maxLabel',
 	},
 	example: {
 		attributes: {

--- a/projects/packages/forms/src/blocks/input-range/edit.js
+++ b/projects/packages/forms/src/blocks/input-range/edit.js
@@ -19,6 +19,8 @@ export default function SliderInputEdit( props ) {
 	const onChangeMin = context[ 'jetpack/field-slider-onChangeMin' ];
 	const onChangeMax = context[ 'jetpack/field-slider-onChangeMax' ];
 	const onKeyDown = useInsertAfterOnEnterKeyDown( clientId );
+	const minTextLabel = context[ 'jetpack/field-slider-minLabel' ];
+	const maxTextLabel = context[ 'jetpack/field-slider-maxLabel' ];
 
 	// Setup local state.
 	const [ localMin, setLocalMin ] = useState( String( minFromContext ) );
@@ -135,6 +137,12 @@ export default function SliderInputEdit( props ) {
 					onKeyDown={ onKeyDown }
 				/>
 			</div>
+			{ ( minTextLabel || maxTextLabel ) && (
+				<div className="jetpack-field-slider__text-labels" aria-hidden="true">
+					<span className="jetpack-field-slider__min-text-label">{ minTextLabel }</span>
+					<span className="jetpack-field-slider__max-text-label">{ maxTextLabel }</span>
+				</div>
+			) }
 		</div>
 	);
 }

--- a/projects/packages/forms/src/blocks/input-range/edit.js
+++ b/projects/packages/forms/src/blocks/input-range/edit.js
@@ -141,7 +141,7 @@ export default function SliderInputEdit( props ) {
 					onKeyDown={ onKeyDown }
 				/>
 			</div>
-			<div className="jetpack-field-slider__text-labels" aria-hidden="true">
+			<div className="jetpack-field-slider__text-labels">
 				<input
 					className="jetpack-field-slider__min-text-label"
 					type="text"

--- a/projects/packages/forms/src/blocks/input-range/edit.js
+++ b/projects/packages/forms/src/blocks/input-range/edit.js
@@ -31,8 +31,6 @@ export default function SliderInputEdit( props ) {
 	const [ maxFocused, setMaxFocused ] = useState( false );
 	const [ localMinLabel, setLocalMinLabel ] = useState( String( minTextLabel ) );
 	const [ localMaxLabel, setLocalMaxLabel ] = useState( String( maxTextLabel ) );
-	const [ minLabelFocused, setMinLabelFocused ] = useState( false );
-	const [ maxLabelFocused, setMaxLabelFocused ] = useState( false );
 
 	// Derived variables
 	const isMinValid = Number( localMin ) <= Number( localMax );
@@ -74,16 +72,6 @@ export default function SliderInputEdit( props ) {
 			setLocalMax( String( maxFromContext ) );
 		}
 	}, [ minFromContext, maxFromContext, minFocused, maxFocused ] );
-
-	// Sync labels if context updates or label inputs lose focus.
-	useEffect( () => {
-		if ( ! minLabelFocused ) {
-			setLocalMinLabel( String( minTextLabel ) );
-		}
-		if ( ! maxLabelFocused ) {
-			setLocalMaxLabel( String( maxTextLabel ) );
-		}
-	}, [ minTextLabel, maxTextLabel, minLabelFocused, maxLabelFocused ] );
 
 	return (
 		<div { ...blockProps }>
@@ -161,9 +149,7 @@ export default function SliderInputEdit( props ) {
 					value={ localMinLabel }
 					placeholder={ __( 'Add label…', 'jetpack-forms' ) }
 					onChange={ e => setLocalMinLabel( e.target.value ) }
-					onFocus={ () => setMinLabelFocused( true ) }
 					onBlur={ () => {
-						setMinLabelFocused( false );
 						onChangeMinLabel?.( localMinLabel );
 					} }
 				/>
@@ -174,9 +160,7 @@ export default function SliderInputEdit( props ) {
 					value={ localMaxLabel }
 					placeholder={ __( 'Add label…', 'jetpack-forms' ) }
 					onChange={ e => setLocalMaxLabel( e.target.value ) }
-					onFocus={ () => setMaxLabelFocused( true ) }
 					onBlur={ () => {
-						setMaxLabelFocused( false );
 						onChangeMaxLabel?.( localMaxLabel );
 					} }
 				/>

--- a/projects/packages/forms/src/blocks/input-range/edit.js
+++ b/projects/packages/forms/src/blocks/input-range/edit.js
@@ -155,6 +155,7 @@ export default function SliderInputEdit( props ) {
 				/>
 				<input
 					className="jetpack-field-slider__max-text-label"
+					autocomplete="off"
 					type="text"
 					size={ Math.max( 3, localMaxLabel.length ) }
 					value={ localMaxLabel }

--- a/projects/packages/forms/src/blocks/input-range/edit.js
+++ b/projects/packages/forms/src/blocks/input-range/edit.js
@@ -21,12 +21,18 @@ export default function SliderInputEdit( props ) {
 	const onKeyDown = useInsertAfterOnEnterKeyDown( clientId );
 	const minTextLabel = context[ 'jetpack/field-slider-minLabel' ];
 	const maxTextLabel = context[ 'jetpack/field-slider-maxLabel' ];
+	const onChangeMinLabel = context[ 'jetpack/field-slider-onChangeMinLabel' ];
+	const onChangeMaxLabel = context[ 'jetpack/field-slider-onChangeMaxLabel' ];
 
 	// Setup local state.
 	const [ localMin, setLocalMin ] = useState( String( minFromContext ) );
 	const [ localMax, setLocalMax ] = useState( String( maxFromContext ) );
 	const [ minFocused, setMinFocused ] = useState( false );
 	const [ maxFocused, setMaxFocused ] = useState( false );
+	const [ localMinLabel, setLocalMinLabel ] = useState( String( minTextLabel ) );
+	const [ localMaxLabel, setLocalMaxLabel ] = useState( String( maxTextLabel ) );
+	const [ minLabelFocused, setMinLabelFocused ] = useState( false );
+	const [ maxLabelFocused, setMaxLabelFocused ] = useState( false );
 
 	// Derived variables
 	const isMinValid = Number( localMin ) <= Number( localMax );
@@ -59,7 +65,7 @@ export default function SliderInputEdit( props ) {
 		maxInputRef.current?.ownerDocument.activeElement === e.target || e.target.focus();
 	};
 
-	// Sync min/max if context updates or min/max input loses focus.
+	// Sync min/max numbers if context updates or min/max input loses focus.
 	useEffect( () => {
 		if ( ! minFocused ) {
 			setLocalMin( String( minFromContext ) );
@@ -68,6 +74,16 @@ export default function SliderInputEdit( props ) {
 			setLocalMax( String( maxFromContext ) );
 		}
 	}, [ minFromContext, maxFromContext, minFocused, maxFocused ] );
+
+	// Sync labels if context updates or label inputs lose focus.
+	useEffect( () => {
+		if ( ! minLabelFocused ) {
+			setLocalMinLabel( String( minTextLabel ) );
+		}
+		if ( ! maxLabelFocused ) {
+			setLocalMaxLabel( String( maxTextLabel ) );
+		}
+	}, [ minTextLabel, maxTextLabel, minLabelFocused, maxLabelFocused ] );
 
 	return (
 		<div { ...blockProps }>
@@ -137,12 +153,34 @@ export default function SliderInputEdit( props ) {
 					onKeyDown={ onKeyDown }
 				/>
 			</div>
-			{ ( minTextLabel || maxTextLabel ) && (
-				<div className="jetpack-field-slider__text-labels" aria-hidden="true">
-					<span className="jetpack-field-slider__min-text-label">{ minTextLabel }</span>
-					<span className="jetpack-field-slider__max-text-label">{ maxTextLabel }</span>
-				</div>
-			) }
+			<div className="jetpack-field-slider__text-labels" aria-hidden="true">
+				<input
+					className="jetpack-field-slider__min-text-label"
+					type="text"
+					size={ Math.max( 3, localMinLabel.length ) }
+					value={ localMinLabel }
+					placeholder={ __( 'Add label…', 'jetpack-forms' ) }
+					onChange={ e => setLocalMinLabel( e.target.value ) }
+					onFocus={ () => setMinLabelFocused( true ) }
+					onBlur={ () => {
+						setMinLabelFocused( false );
+						onChangeMinLabel?.( localMinLabel );
+					} }
+				/>
+				<input
+					className="jetpack-field-slider__max-text-label"
+					type="text"
+					size={ Math.max( 3, localMaxLabel.length ) }
+					value={ localMaxLabel }
+					placeholder={ __( 'Add label…', 'jetpack-forms' ) }
+					onChange={ e => setLocalMaxLabel( e.target.value ) }
+					onFocus={ () => setMaxLabelFocused( true ) }
+					onBlur={ () => {
+						setMaxLabelFocused( false );
+						onChangeMaxLabel?.( localMaxLabel );
+					} }
+				/>
+			</div>
 		</div>
 	);
 }

--- a/projects/packages/forms/src/blocks/input-range/edit.js
+++ b/projects/packages/forms/src/blocks/input-range/edit.js
@@ -155,7 +155,7 @@ export default function SliderInputEdit( props ) {
 				/>
 				<input
 					className="jetpack-field-slider__max-text-label"
-					autocomplete="off"
+					autoComplete="off"
 					type="text"
 					size={ Math.max( 3, localMaxLabel.length ) }
 					value={ localMaxLabel }

--- a/projects/packages/forms/src/blocks/input-range/editor.scss
+++ b/projects/packages/forms/src/blocks/input-range/editor.scss
@@ -84,17 +84,9 @@
 	background: transparent;
 	font: inherit;
 	font-size: 0.9em;
-	padding: 0 0.5em;
+	padding: 0 0.2em;
 	margin: 0;
 	appearance: textfield;
-
-	&.jetpack-field-slider__min-input {
-		padding-left: 0;
-	}
-
-	&.jetpack-field-slider__max-input {
-		padding-right: 0;
-	}
 
 	&.has-error {
 		outline-color: var(--color-error, #d63638);
@@ -115,12 +107,12 @@
 	font-size: 0.9em;
 }
 
-.jetpack-field-slider__min-text-label,
-.jetpack-field-slider__max-text-label {
+input[type="text"].jetpack-field-slider__min-text-label,
+input[type="text"].jetpack-field-slider__max-text-label {
 	border: none;
 	background: transparent;
 	font: inherit;
-	padding: 0;
+	padding: 0 0.2em;
 	margin: 0;
 	width: auto;
 	field-sizing: content;

--- a/projects/packages/forms/src/blocks/input-range/editor.scss
+++ b/projects/packages/forms/src/blocks/input-range/editor.scss
@@ -88,6 +88,14 @@
 	margin: 0;
 	appearance: textfield;
 
+	&.jetpack-field-slider__min-input {
+		padding-left: 0;
+	}
+
+	&.jetpack-field-slider__max-input {
+		padding-right: 0;
+	}
+
 	&.has-error {
 		outline-color: var(--color-error, #d63638);
 		box-shadow: none;

--- a/projects/packages/forms/src/blocks/input-range/editor.scss
+++ b/projects/packages/forms/src/blocks/input-range/editor.scss
@@ -115,6 +115,19 @@
 	font-size: 0.9em;
 }
 
+.jetpack-field-slider__min-text-label,
+.jetpack-field-slider__max-text-label {
+	border: none;
+	background: transparent;
+	font: inherit;
+	padding: 0;
+	margin: 0;
+	width: auto;
+	field-sizing: content;
+	min-width: 3ch;
+	max-width: 24ch;
+}
+
 .jetpack-field-slider__min-text-label {
 	text-align: left;
 }

--- a/projects/packages/forms/src/blocks/input-range/editor.scss
+++ b/projects/packages/forms/src/blocks/input-range/editor.scss
@@ -99,3 +99,18 @@
 		margin: 0;
 	}
 }
+
+.jetpack-field-slider__text-labels {
+	display: flex;
+	justify-content: space-between;
+	margin-top: 6px;
+	font-size: 0.9em;
+}
+
+.jetpack-field-slider__min-text-label {
+	text-align: left;
+}
+
+.jetpack-field-slider__max-text-label {
+	text-align: right;
+}

--- a/projects/packages/forms/src/blocks/input-range/index.js
+++ b/projects/packages/forms/src/blocks/input-range/index.js
@@ -20,6 +20,8 @@ const settings = {
 		'jetpack/field-slider-onChangeMin',
 		'jetpack/field-slider-onChangeMax',
 		'jetpack/field-slider-step',
+		'jetpack/field-slider-minLabel',
+		'jetpack/field-slider-maxLabel',
 	],
 };
 

--- a/projects/packages/forms/src/blocks/input-range/index.js
+++ b/projects/packages/forms/src/blocks/input-range/index.js
@@ -22,6 +22,8 @@ const settings = {
 		'jetpack/field-slider-step',
 		'jetpack/field-slider-minLabel',
 		'jetpack/field-slider-maxLabel',
+		'jetpack/field-slider-onChangeMinLabel',
+		'jetpack/field-slider-onChangeMaxLabel',
 	],
 };
 

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -145,6 +145,8 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 				'optionstyles'             => null,
 				'min'                      => null,
 				'max'                      => null,
+				'minlabel'                 => null,
+				'maxlabel'                 => null,
 				'step'                     => null,
 				'maxfiles'                 => null,
 				'fieldwrapperclasses'      => null,
@@ -614,6 +616,17 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 			}
 			if ( is_numeric( $this->get_attribute( 'step' ) ) ) {
 				$extra_attrs['step'] = $this->get_attribute( 'step' );
+			}
+		}
+
+		if ( $field_type === 'slider' ) {
+			$minlabel = $this->get_attribute( 'minlabel' );
+			$maxlabel = $this->get_attribute( 'maxlabel' );
+			if ( null !== $minlabel && '' !== $minlabel ) {
+				$extra_attrs['minLabel'] = $minlabel;
+			}
+			if ( null !== $maxlabel && '' !== $maxlabel ) {
+				$extra_attrs['maxLabel'] = $maxlabel;
 			}
 		}
 
@@ -2507,6 +2520,8 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		$starting_value = isset( $extra_attrs['default'] ) ? $extra_attrs['default'] : 0;
 		$step           = isset( $extra_attrs['step'] ) ? $extra_attrs['step'] : 1;
 		$current_value  = ( $value !== '' && $value !== null ) ? $value : $starting_value;
+		$min_text_label = isset( $extra_attrs['minLabel'] ) ? $extra_attrs['minLabel'] : '';
+		$max_text_label = isset( $extra_attrs['maxLabel'] ) ? $extra_attrs['maxLabel'] : '';
 
 		$field = $this->render_label( 'slider', $id, $label, $required, $required_field_text );
 
@@ -2540,7 +2555,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 					<?php
 					if ( $required ) :
 						?>
-						required<?php endif; ?>
+					required<?php endif; ?>
 					data-wp-bind--value="state.getSliderValue"
 					data-wp-on--input="actions.onSliderChange"
 					data-wp-bind--aria-invalid="state.fieldHasErrors"
@@ -2553,6 +2568,12 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 			</div>
 			<span class="jetpack-field-slider__max-label"><?php echo esc_html( $max ); ?></span>
 		</div>
+		<?php if ( '' !== $min_text_label || '' !== $max_text_label ) : ?>
+			<div class="jetpack-field-slider__text-labels" aria-hidden="true">
+				<span class="jetpack-field-slider__min-text-label"><?php echo esc_html( $min_text_label ); ?></span>
+				<span class="jetpack-field-slider__max-text-label"><?php echo esc_html( $max_text_label ); ?></span>
+			</div>
+		<?php endif; ?>
 		<?php
 		$field .= ob_get_clean();
 		return $field . $this->get_error_div( $id, 'slider' );

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -3254,11 +3254,13 @@ class Contact_Form_Plugin {
 	 */
 	public static function gutenblock_render_field_slider( $atts, $content, $block ) {
 		// Get min, max, and default from the parent block's attributes.
-		$parent_attrs    = $block->parsed_block['attrs'] ?? array();
-		$atts['min']     = isset( $parent_attrs['min'] ) ? $parent_attrs['min'] : 0;
-		$atts['max']     = isset( $parent_attrs['max'] ) ? $parent_attrs['max'] : 100;
-		$atts['default'] = isset( $parent_attrs['default'] ) ? $parent_attrs['default'] : 0;
-		$atts['step']    = isset( $parent_attrs['step'] ) ? $parent_attrs['step'] : 1;
+		$parent_attrs     = $block->parsed_block['attrs'] ?? array();
+		$atts['min']      = isset( $parent_attrs['min'] ) ? $parent_attrs['min'] : 0;
+		$atts['max']      = isset( $parent_attrs['max'] ) ? $parent_attrs['max'] : 100;
+		$atts['default']  = isset( $parent_attrs['default'] ) ? $parent_attrs['default'] : 0;
+		$atts['step']     = isset( $parent_attrs['step'] ) ? $parent_attrs['step'] : 1;
+		$atts['minLabel'] = isset( $parent_attrs['minLabel'] ) ? $parent_attrs['minLabel'] : '';
+		$atts['maxLabel'] = isset( $parent_attrs['maxLabel'] ) ? $parent_attrs['maxLabel'] : '';
 
 		$atts = self::block_attributes_to_shortcode_attributes( $atts, 'slider', $block );
 		return Contact_Form::parse_contact_field( $atts, $content, $block );

--- a/projects/packages/forms/src/contact-form/css/slider-field.scss
+++ b/projects/packages/forms/src/contact-form/css/slider-field.scss
@@ -87,6 +87,7 @@
 
 	&__text-labels {
 		display: flex;
+		flex-wrap: wrap;
 		justify-content: space-between;
 		margin-top: 6px;
 		font-size: 0.9em;

--- a/projects/packages/forms/src/contact-form/css/slider-field.scss
+++ b/projects/packages/forms/src/contact-form/css/slider-field.scss
@@ -84,4 +84,19 @@
 		font-size: 0.7em;
 		z-index: 2;
 	}
+
+	&__text-labels {
+		display: flex;
+		justify-content: space-between;
+		margin-top: 6px;
+		font-size: 0.9em;
+	}
+
+	&__min-text-label {
+		text-align: left;
+	}
+
+	&__max-text-label {
+		text-align: right;
+	}
 }


### PR DESCRIPTION
## Proposed changes:

This adds text labels that will appear between the slider min/max values, on the left and right. The labels can be updated from the inspector sidebar, or directly from the block editor canvas. 

Deferred for separate PR:
* We do not try to override font styling. We'll add typography controls in a separate PR to control these, but that will require some discussion.

**Screenshot: editor**
<img width="1241" height="412" alt="slider-minmax-labels-editor5" src="https://github.com/user-attachments/assets/c3892d71-eda7-4757-9362-e320dd8a5cdf" />

**Screenshot: frontend**
<img width="706" height="164" alt="slider-minmax-labels-frontend2" src="https://github.com/user-attachments/assets/f47400fc-e304-49c7-b1c9-30ae4972c92a" />

**Screenshot: Original design**
<img width="868" height="429" alt="slider-minmax-label-designs" src="https://github.com/user-attachments/assets/de956832-3bc0-430c-8e74-4b5504413e81" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Enable beta blocks: `define( 'JETPACK_BLOCKS_VARIATION', 'beta' );`
* CSS caching: You may need to run jetpack build packages/forms to get the frontend slider-field.css to be built and loaded in the dist directory. Having the watch command running is not sufficient. I also had to hard reload the stylecheeet several times to get CSS cache to clear. 
* Add a form to a page or post
* Try editing the min/max text labels in the block editor canvas
* Try editing the min/max text labels in the sidebar (need to select parent field)
* Publish post, check frontend, and confirm that min/max labels render correctly