### PR TITLE
Forms: Fix options radio validation

### DIFF
--- a/projects/packages/forms/changelog/fix-options-radio-validation
+++ b/projects/packages/forms/changelog/fix-options-radio-validation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: fix radio button validation 

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -348,10 +348,12 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 					if ( ! empty( $options_data ) ) {
 						$options = array_map(
 							function ( $option ) {
-								return sanitize_text_field( trim( $option['label'] ) );
+								return $this->sanitize_text_field( trim( $option['label'] ) );
 							},
 							$options_data
 						);
+					} else {
+						$options = array_map( array( $this, 'sanitize_text_field' ), $options );
 					}
 
 					$non_empty_options = array_filter(
@@ -383,10 +385,12 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 					if ( ! empty( $options_data ) ) {
 						$options = array_map(
 							function ( $option ) {
-								return sanitize_text_field( trim( $option['label'] ) );
+								return $this->sanitize_text_field( trim( $option['label'] ) );
 							},
 							$options_data
 						);
+					} else {
+						$options = array_map( array( $this, 'sanitize_text_field' ), $options );
 					}
 					$non_empty_options = array_filter(
 						$options,
@@ -430,6 +434,15 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 					$this->add_error( sprintf( __( '%s field is required.', 'jetpack-forms' ), $field_label ) );
 				}
 		}
+	}
+	/**
+	 * Sanitize a text field value and html_entity_decode the field.
+	 *
+	 * @param string $field_value The field value to sanitize.
+	 * @return string The sanitized field value.
+	 */
+	public function sanitize_text_field( $field_value ) {
+		return sanitize_text_field( html_entity_decode( $field_value ) );
 	}
 
 	/**

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -442,7 +442,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 	 * @return string The sanitized field value.
 	 */
 	public function sanitize_text_field( $field_value ) {
-		return sanitize_text_field( html_entity_decode( $field_value ) );
+		return sanitize_text_field( html_entity_decode( $field_value, ENT_COMPAT ) );
 	}
 
 	/**

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Field_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Field_Test.php
@@ -174,9 +174,9 @@ class Contact_Form_Field_Test extends BaseTestCase {
 		);
 
 		$unsanitized_value = '<script>alert("XSS")</script>';
-		$this->assertEquals( sanitize_text_field( html_entity_decode( $unsanitized_value ) ), $field->sanitize_text_field( $unsanitized_value ) );
+		$this->assertEquals( sanitize_text_field( html_entity_decode( $unsanitized_value, ENT_QUOTES ) ), $field->sanitize_text_field( $unsanitized_value ) );
 
-		$unsanitized_value = '';
-		$this->assertEquals( sanitize_text_field( html_entity_decode( $unsanitized_value ) ), $field->sanitize_text_field( $unsanitized_value ) );
+		$unsanitized_value = 'hello&#044; world';
+		$this->assertEquals( sanitize_text_field( html_entity_decode( $unsanitized_value, ENT_QUOTES ) ), $field->sanitize_text_field( $unsanitized_value ) );
 	}
 } // end class

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Field_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Field_Test.php
@@ -161,4 +161,22 @@ class Contact_Form_Field_Test extends BaseTestCase {
 
 		$this->assertEquals( 'default', $result );
 	}
+
+	/**
+	 * Test sanitization of field values.
+	 */
+	public function test_sanitizes_field_values() {
+		$field = $this->get_new_field_instance(
+			array(
+				'type' => 'text',
+				'id'   => 'test_field',
+			)
+		);
+
+		$unsanitized_value = '<script>alert("XSS")</script>';
+		$this->assertEquals( sanitize_text_field( html_entity_decode( $unsanitized_value ) ), $field->sanitize_text_field( $unsanitized_value ) );
+
+		$unsanitized_value = '';
+		$this->assertEquals( sanitize_text_field( html_entity_decode( $unsanitized_value ) ), $field->sanitize_text_field( $unsanitized_value ) );
+	}
 } // end class

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -3187,11 +3187,13 @@ EOT;
 		// Create a form submission
 		$_POST = Utility::get_post_request(
 			array(
-				'name'                 => $name,
-				'email'                => $email,
-				'choose'               => array( 'truth' ),
-				'chooseoptions'        => array( 'hello  there' ),
-				'chooseseveraloptions' => array( 'hello, there' ),
+				'name'                        => $name,
+				'email'                       => $email,
+				'choose'                      => array( 'truth' ),
+				'chooseoptions'               => array( 'hello  there' ),
+				'chooseseveraloptions'        => array( 'hello, there' ),
+				'chooseseveraloptionsspecial' => array( 'hello, world' ),
+
 			),
 			'g' . $form_id
 		);
@@ -3217,11 +3219,43 @@ EOT;
 
 
 &lt;/ul&gt;
-&lt;/div&gt;[/contact-field]'
+&lt;/div&gt;[/contact-field][contact-field label="Choose several options special" type="checkbox-multiple" options="hello&#044; world,dare" /]'
 		);
 		$form->validate();
 		unset( $_POST ); // Clean up the global $_POST variable after the test.
 
+		// message should be not empty.
+		$this->assertFalse( $form->has_errors(), 'Form should not have errors after validation.' );
+
+		Contact_Form::reset_errors();
+	}
+
+	public function test_validate_radio_form() {
+		$name    = '';
+		$email   = '';
+		$form_id = Utility::get_form_id();
+
+		// Create a form submission
+		$_POST = Utility::get_post_request(
+			array(
+				'name'   => $name,
+				'email'  => $email,
+				'choose' => 'hello, world',
+			),
+			'g' . $form_id
+		);
+
+		$form = new Contact_Form(
+			array(
+				'title'       => 'Test Form',
+				'description' => 'This is a test form.',
+			),
+			'[contact-field label="Choose" type="radio" options="hello&#044; world,dare" /]'
+		);
+		$form->validate();
+		unset( $_POST ); // Clean up the global $_POST variable after the test.
+
+		$this->assertEquals( array(), $form->get_error_messages() );
 		// message should be not empty.
 		$this->assertFalse( $form->has_errors(), 'Form should not have errors after validation.' );
 


### PR DESCRIPTION
For some radio fields we don't have any `optionsData` attribute. So we end up using the `options` attribute instead. 

The issue arises when the `options` attribute contains special HTML characters such as a `,` which gets converted to `&#044;`. 

This PR fixes it by making sure that the HTML special characters get converted to the expected characters since they are what the value is that is being set to in the POST. 

 
## Proposed changes:
* convert special characters when validation the the radio and checkbox fields. 

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1755559873911719/1755110667.244879-slack-C052XEUUBL4

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
This is a a but tricky. Since by default new fields that area created do not store only the options field. 

You can test out the contact form like this. 
[contact-form] 
[contact-field label="Choose" type="radio" options="hello&#044; world,dare" /]
[/contact-form] 

Notice that the form submits as expected.