### PR TITLE
e2e tests: Fix unstable recommendations test

### DIFF
--- a/projects/plugins/boost/changelog/jetpack-754-e2e-tests-recommendations-e2e-test-always-fails-on-first
+++ b/projects/plugins/boost/changelog/jetpack-754-e2e-tests-recommendations-e2e-test-always-fails-on-first
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: E2E tests: remove unsed eslint rule
+
+

--- a/projects/plugins/boost/tests/e2e/lib/fixtures/test.ts
+++ b/projects/plugins/boost/tests/e2e/lib/fixtures/test.ts
@@ -5,7 +5,6 @@ import { BoostUtils } from '../utils/index';
 const test = baseTest.extend< { jetpackBoostPage: JetpackBoostPage }, { boostUtils: BoostUtils } >(
 	{
 		jetpackBoostPage: async ( { page }, use ) => {
-			// eslint-disable-next-line react-hooks/rules-of-hooks
 			await use( new JetpackBoostPage( page ) );
 		},
 		boostUtils: [

--- a/projects/plugins/jetpack/changelog/jetpack-754-e2e-tests-recommendations-e2e-test-always-fails-on-first
+++ b/projects/plugins/jetpack/changelog/jetpack-754-e2e-tests-recommendations-e2e-test-always-fails-on-first
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: E2E tests: fix unstable recommendations test
+
+

--- a/projects/plugins/jetpack/tests/e2e/helpers/account-protection-helper.ts
+++ b/projects/plugins/jetpack/tests/e2e/helpers/account-protection-helper.ts
@@ -1,4 +1,5 @@
 import logger from '_jetpack-e2e-commons/logger';
+import { executeWpCommand } from '_jetpack-e2e-commons/utils/cli';
 import { createUser, deleteUser } from '_jetpack-e2e-commons/utils/user';
 import type { Page } from '@playwright/test';
 

--- a/projects/plugins/jetpack/tests/e2e/helpers/account-protection-helper.ts
+++ b/projects/plugins/jetpack/tests/e2e/helpers/account-protection-helper.ts
@@ -1,5 +1,5 @@
 import logger from '_jetpack-e2e-commons/logger';
-import { executeWpCommand } from '_jetpack-e2e-commons/utils/cli';
+import { createUser, deleteUser } from '_jetpack-e2e-commons/utils/user';
 import type { Page } from '@playwright/test';
 
 const PRIVILEGED_ROLES = [ 'administrator', 'editor', 'author' ];
@@ -14,15 +14,21 @@ export async function insertTestUsers(): Promise< void > {
 
 	// Create user accounts with compromised passwords.
 	for ( const role of [ ...PRIVILEGED_ROLES, ...NON_PRIVILEGED_ROLES ] ) {
-		await executeWpCommand(
-			`user create ${ role } ${ role }@example.com --role=${ role } --user_pass=password`
-		);
+		await createUser( {
+			username: role,
+			email: `${ role }@example.com`,
+			role,
+			password: 'password',
+		} );
 	}
 
 	// Create a user with a secure password.
-	await executeWpCommand(
-		`user create secure_user secure_user@example.com --role=administrator --user_pass=87h23foi2uhfljhdakdh9812df`
-	);
+	await createUser( {
+		username: 'secure_user',
+		email: 'secure_user@example.com',
+		role: 'administrator',
+		password: '87h23foi2uhfljhdakdh9812df',
+	} );
 }
 
 /**
@@ -35,7 +41,7 @@ export async function deleteTestUsers(): Promise< void > {
 	// Delete users by role name
 	for ( const role of [ ...PRIVILEGED_ROLES, ...NON_PRIVILEGED_ROLES ] ) {
 		try {
-			await executeWpCommand( `user delete ${ role } --yes` );
+			await deleteUser( role );
 		} catch {
 			logger.debug( `User ${ role } not found or already deleted` );
 		}
@@ -43,7 +49,7 @@ export async function deleteTestUsers(): Promise< void > {
 
 	// Delete the secure user
 	try {
-		await executeWpCommand( `user delete secure_user --yes` );
+		await deleteUser( 'secure_user' );
 	} catch {
 		logger.debug( `User secure_user not found or already deleted` );
 	}

--- a/projects/plugins/jetpack/tests/e2e/specs/post-connection/account-protection/requirements.test.ts
+++ b/projects/plugins/jetpack/tests/e2e/specs/post-connection/account-protection/requirements.test.ts
@@ -88,9 +88,5 @@ test.describe.parallel( 'Strong password requirements', () => {
 
 		// Validate that the password was updated.
 		await expect( page.getByText( 'Profile updated.' ) ).toBeVisible();
-
-		// Need to save the storage state after the password update, otherwise the next test will fail.
-		// TODO: we should use a different user for this test instead of updating the password of the main user.
-		await page.context().storageState( { path: process.env.STORAGE_STATE_PATH } );
 	} );
 } );

--- a/projects/plugins/jetpack/tests/e2e/specs/post-connection/account-protection/requirements.test.ts
+++ b/projects/plugins/jetpack/tests/e2e/specs/post-connection/account-protection/requirements.test.ts
@@ -1,4 +1,23 @@
-import { test, expect } from '_jetpack-e2e-commons/fixtures/base-test';
+import { test as baseTest, expect } from '_jetpack-e2e-commons/fixtures/base-test';
+import { submitCredentials } from '../../../helpers/account-protection-helper';
+
+const test = baseTest.extend< {
+	testUser: { username: string; password: string; role: string };
+} >( {
+	storageState: { cookies: [], origins: [] },
+	testUser: async ( { testUtils }, use ) => {
+		const user = {
+			username: `test_user_${ Date.now().toString( 36 ) }`,
+			password: 'SecurePass123!',
+			role: 'subscriber',
+		};
+		await testUtils.createUser( user );
+
+		await use( user );
+
+		await testUtils.deleteUser( user.username );
+	},
+} );
 
 test.beforeAll( async ( { testUtils } ) => {
 	await testUtils.activateModule( 'account-protection' );
@@ -10,10 +29,12 @@ test.beforeAll( async ( { testUtils } ) => {
 } );
 
 test.describe.parallel( 'Strong password requirements', () => {
-	test( 'Enforces strong password requirements', async ( { page } ) => {
+	test( 'Enforces strong password requirements', async ( { page, testUser } ) => {
 		await page.goto( '/wp-admin/profile.php' );
+		await submitCredentials( page, testUser.username, testUser.password );
+		await page.waitForLoadState();
 
-		await page.getByRole( 'button' ).filter( { hasText: 'set new password' } ).click();
+		await page.getByRole( 'button', { name: 'Set New Password' } ).click();
 
 		// Validate that the Jetpack password strength meter replaces the default one.
 		await expect( page.locator( '.strength-meter' ) ).toBeVisible();

--- a/projects/plugins/jetpack/tests/e2e/specs/post-connection/account-protection/requirements.test.ts
+++ b/projects/plugins/jetpack/tests/e2e/specs/post-connection/account-protection/requirements.test.ts
@@ -6,12 +6,13 @@ const test = baseTest.extend< {
 } >( {
 	storageState: { cookies: [], origins: [] },
 	testUser: async ( { testUtils }, use ) => {
-		const user = {
-			username: `test_user_${ Date.now().toString( 36 ) }`,
-			password: 'SecurePass123!',
-			role: 'subscriber',
-		};
-		await testUtils.createUser( user );
+		// const user = {
+		// 	username: `test_user_${ Date.now().toString( 36 ) }`,
+		// 	password: 'SecurePass123!',
+		// 	email: `test_user_${ Date.now().toString( 36 ) }@example.com`,
+		// 	role: 'subscriber',
+		// };
+		const user = await testUtils.createUser();
 
 		await use( user );
 

--- a/projects/plugins/jetpack/tests/e2e/specs/post-connection/recommendations.test.ts
+++ b/projects/plugins/jetpack/tests/e2e/specs/post-connection/recommendations.test.ts
@@ -11,6 +11,13 @@ test.beforeEach( async ( { testUtils, requestUtils } ) => {
 		await testUtils.executeWpCommand( cmd );
 	}
 
+	const initialData = await requestUtils.rest( {
+		method: 'GET',
+		path: '/jetpack/v4/recommendations/data',
+	} );
+
+	console.log( initialData );
+
 	// Reset the recommendations data
 	await requestUtils.rest( {
 		method: 'POST',

--- a/projects/plugins/jetpack/tests/e2e/specs/post-connection/recommendations.test.ts
+++ b/projects/plugins/jetpack/tests/e2e/specs/post-connection/recommendations.test.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '_jetpack-e2e-commons/fixtures/base-test';
 
-test.beforeEach( async ( { testUtils, requestUtils } ) => {
+test.beforeEach( async ( { testUtils } ) => {
 	const cleanupCMDs = [
 		'jetpack module deactivate monitor',
 		'jetpack module deactivate related-posts',
@@ -10,14 +10,9 @@ test.beforeEach( async ( { testUtils, requestUtils } ) => {
 	for ( const cmd of cleanupCMDs ) {
 		await testUtils.executeWpCommand( cmd );
 	}
+} );
 
-	const initialData = await requestUtils.rest( {
-		method: 'GET',
-		path: '/jetpack/v4/recommendations/data',
-	} );
-
-	console.log( initialData );
-
+test.afterEach( async ( { requestUtils } ) => {
 	// Reset the recommendations data
 	await requestUtils.rest( {
 		method: 'POST',

--- a/projects/plugins/jetpack/tests/e2e/specs/post-connection/recommendations.test.ts
+++ b/projects/plugins/jetpack/tests/e2e/specs/post-connection/recommendations.test.ts
@@ -10,11 +10,9 @@ test.beforeEach( async ( { testUtils } ) => {
 	for ( const cmd of cleanupCMDs ) {
 		await testUtils.executeWpCommand( cmd );
 	}
-} );
 
-test.afterEach( async ( { requestUtils } ) => {
 	// Reset the recommendations data
-	await requestUtils.rest( {
+	await testUtils.requestUtils.rest( {
 		method: 'POST',
 		path: '/jetpack/v4/recommendations/data',
 		data: {

--- a/tools/e2e-commons/eslint.config.mjs
+++ b/tools/e2e-commons/eslint.config.mjs
@@ -35,6 +35,7 @@ export function makeE2eConfig( configurl, opts = {} ) {
 			'no-console': 'off',
 			'n/no-process-exit': 'off',
 			'playwright/no-skipped-test': 'off',
+			'react-hooks/rules-of-hooks': 'off',
 		},
 	} );
 }

--- a/tools/e2e-commons/setup-specs/auth.setup.ts
+++ b/tools/e2e-commons/setup-specs/auth.setup.ts
@@ -9,10 +9,8 @@ setup( 'authenticate users', async ( { testUtils } ) => {
 	} );
 
 	await setup.step( 'authenticate wordpress.com user', async () => {
-		await testUtils.authenticateUser(
-			testUtils,
-			testUtils.getDotComCredentials(),
-			'https://wordpress.com'
-		);
+		await testUtils.authenticateUser( testUtils, testUtils.getDotComCredentials(), {
+			siteUrl: 'https://wordpress.com',
+		} );
 	} );
 } );

--- a/tools/e2e-commons/setup-specs/env-check.setup.ts
+++ b/tools/e2e-commons/setup-specs/env-check.setup.ts
@@ -63,7 +63,7 @@ setup( 'verify environment readiness', async ( { baseURL, request, testUtils } )
 		logger.debug( `Checking REST API for ${ baseURL }` );
 
 		await retry( 'REST API', async () => {
-			const r = await testUtils.requestUtils.rest( { path: '/jetpack/v4/recommendations/data' } );
+			const r = await testUtils.requestUtils.rest( { path: '/jetpack/v4/connection/test' } );
 			logger.debug( `Response: ${ JSON.stringify( r ) }` );
 		} );
 	} );

--- a/tools/e2e-commons/setup-specs/env-check.setup.ts
+++ b/tools/e2e-commons/setup-specs/env-check.setup.ts
@@ -63,7 +63,7 @@ setup( 'verify environment readiness', async ( { baseURL, request, testUtils } )
 		logger.debug( `Checking REST API for ${ baseURL }` );
 
 		await retry( 'REST API', async () => {
-			const r = await testUtils.requestUtils.rest( { path: 'jetpack/v4/connection/test' } );
+			const r = await testUtils.requestUtils.rest( { path: '/jetpack/v4/recommendations/data' } );
 			logger.debug( `Response: ${ JSON.stringify( r ) }` );
 		} );
 	} );

--- a/tools/e2e-commons/utils/index.ts
+++ b/tools/e2e-commons/utils/index.ts
@@ -25,6 +25,7 @@ import {
 import { activateModule, deactivateModule, isModuleActive } from './jetpack';
 import { authenticateUser } from './login';
 import { setMockPlanData } from './plan';
+import { createUser, deleteUser } from './user';
 
 class TestUtils {
 	requestUtils: RequestUtils;
@@ -66,6 +67,10 @@ class TestUtils {
 	getSiteCredentials: typeof getSiteCredentials = getSiteCredentials;
 	getDotComCredentials: typeof getDotComCredentials = getDotComCredentials;
 	resetEnvironment: typeof resetEnvironment = resetEnvironment;
+
+	// user utilities
+	createUser: typeof createUser = createUser;
+	deleteUser: typeof deleteUser = deleteUser;
 }
 
 export { TestUtils };

--- a/tools/e2e-commons/utils/login.ts
+++ b/tools/e2e-commons/utils/login.ts
@@ -2,17 +2,21 @@ import { TestUtils } from '.';
 
 /**
  * Utility function to authenticate a user in the WordPress site by sending a POST request to the login endpoint.
- * @param testUtils            - Instance of TestUtils that contains the requestUtils.
- * @param credentials          - User credentials object. It should have `username` and `password` properties.
- * @param credentials.username - Username of the user to authenticate.
- * @param credentials.password - Password of the user to authenticate.
- * @param siteUrl              - Optional site URL to prepend to the login endpoint.
+ * @param testUtils                - Instance of TestUtils that contains the requestUtils.
+ * @param credentials              - User credentials object. It should have `username` and `password` properties.
+ * @param credentials.username     - Username of the user to authenticate.
+ * @param credentials.password     - Password of the user to authenticate.
+ * @param options                  - Optional parameters for the login request.
+ * @param options.siteUrl          - Site URL to prepend to the login endpoint.
+ * @param options.storageStatePath - Path to the storage state file.
  */
 export async function authenticateUser(
 	testUtils: TestUtils,
 	credentials: { username: string; password: string },
-	siteUrl = ''
+	options: { siteUrl?: string; storageStatePath?: string } = {}
 ) {
+	const { siteUrl = '', storageStatePath = '' } = options;
+
 	await testUtils.requestUtils.request.post( `${ siteUrl ? siteUrl : '.' }/wp-login.php`, {
 		form: {
 			log: credentials.username,
@@ -22,5 +26,7 @@ export async function authenticateUser(
 
 	const { STORAGE_STATE_PATH } = process.env;
 
-	await testUtils.requestUtils.request.storageState( { path: STORAGE_STATE_PATH } );
+	await testUtils.requestUtils.request.storageState( {
+		path: storageStatePath || STORAGE_STATE_PATH,
+	} );
 }

--- a/tools/e2e-commons/utils/user.ts
+++ b/tools/e2e-commons/utils/user.ts
@@ -1,6 +1,5 @@
 import logger from '../logger';
 import { executeWpCommand } from './cli';
-import { randomBytes } from 'crypto';
 
 /**
  * Creates a new WordPress user using WP-CLI.
@@ -34,10 +33,9 @@ export async function createUser( user?: {
 	role?: string;
 } ): Promise< { username: string; password: string; email: string; role: string } > {
 	const timestamp = Date.now().toString( 36 );
-	const randomSuffix = randomBytes(4).toString('base36').substring(0, 5);
 	const finalUser = {
-		username: user?.username || `user_${ timestamp }_${ randomSuffix }`,
-		password: user?.password || `Pass_${ timestamp }_${ randomSuffix }!`,
+		username: user?.username || `user_${ timestamp }`,
+		password: user?.password || `Pass_${ timestamp }!`,
 		email: user?.email || `user_${ timestamp }@example.com`,
 		role: user?.role || 'subscriber',
 	};

--- a/tools/e2e-commons/utils/user.ts
+++ b/tools/e2e-commons/utils/user.ts
@@ -4,52 +4,58 @@ import { executeWpCommand } from './cli';
 /**
  * Creates a new WordPress user using WP-CLI.
  *
- * @param user          - User object containing the user details
- * @param user.username - The username for the new user (must be unique, alphanumeric with underscores/hyphens)
- * @param user.password - The password for the new user (required)
- * @param user.role     - WordPress role for the user (e.g., 'administrator', 'editor', 'author', 'contributor', 'subscriber')
- * @return Promise that resolves when the user is created successfully
+ * @param user          - Optional user object containing the user details
+ * @param user.username - The username for the new user (optional, will be generated if not provided)
+ * @param user.password - The password for the new user (optional, will be generated if not provided)
+ * @param user.email    - The email address for the new user (optional, will be generated if not provided)
+ * @param user.role     - WordPress role for the user (optional, defaults to 'subscriber')
+ * @return Promise that resolves with the complete user object including any generated values
  *
  * @example
  * ```typescript
- * await createUser({
+ * // Create user with all specified properties
+ * const user1 = await createUser({
  *   username: 'testuser',
  *   password: 'SecurePass123!',
+ *   email: 'testuser@example.com',
  *   role: 'subscriber'
  * });
+ *
+ * // Create user with generated properties
+ * const user2 = await createUser({});
+ * console.log(user2.username); // e.g., 'user_a3b2c1'
  * ```
  */
-export async function createUser( user: {
-	username: string;
-	password: string;
-	role: string;
-} ): Promise< void > {
-	if ( ! user.username || typeof user.username !== 'string' ) {
-		throw new Error( 'Username is required and must be a string' );
-	}
-
-	if ( ! user.password || typeof user.password !== 'string' ) {
-		throw new Error( 'Password is required and must be a string' );
-	}
-
-	if ( ! user.role || typeof user.role !== 'string' ) {
-		throw new Error( 'Role is required and must be a string' );
-	}
+export async function createUser( user?: {
+	username?: string;
+	password?: string;
+	email?: string;
+	role?: string;
+} ): Promise< { username: string; password: string; email: string; role: string } > {
+	const timestamp = Date.now().toString( 36 );
+	const randomSuffix = Math.random().toString( 36 ).substring( 2, 7 );
+	const finalUser = {
+		username: user?.username || `user_${ timestamp }_${ randomSuffix }`,
+		password: user?.password || `Pass_${ timestamp }_${ randomSuffix }!`,
+		email: user?.email || `user_${ timestamp }@example.com`,
+		role: user?.role || 'subscriber',
+	};
 
 	// Validate username format (alphanumeric, underscores, hyphens)
 	const usernameRegex = /^[a-zA-Z0-9_-]+$/;
-	if ( ! usernameRegex.test( user.username ) ) {
+	if ( ! usernameRegex.test( finalUser.username ) ) {
 		throw new Error(
 			'Username must contain only alphanumeric characters, underscores, and hyphens'
 		);
 	}
 
-	// Log the user creation attempt
-	logger.debug( `Creating WordPress user: ${ user.username } with role: ${ user.role }` );
+	logger.debug( `Creating WordPress user: ${ finalUser.username } with role: ${ finalUser.role }` );
 
 	await executeWpCommand(
-		`user create ${ user.username } ${ user.username }@example.com --role=${ user.role } --user_pass=${ user.password }`
+		`user create ${ finalUser.username } ${ finalUser.email } --role=${ finalUser.role } --user_pass=${ finalUser.password }`
 	);
+
+	return finalUser;
 }
 
 /**

--- a/tools/e2e-commons/utils/user.ts
+++ b/tools/e2e-commons/utils/user.ts
@@ -1,0 +1,68 @@
+import logger from '../logger';
+import { executeWpCommand } from './cli';
+
+/**
+ * Creates a new WordPress user using WP-CLI.
+ *
+ * @param user          - User object containing the user details
+ * @param user.username - The username for the new user (must be unique, alphanumeric with underscores/hyphens)
+ * @param user.password - The password for the new user (required)
+ * @param user.role     - WordPress role for the user (e.g., 'administrator', 'editor', 'author', 'contributor', 'subscriber')
+ * @return Promise that resolves when the user is created successfully
+ *
+ * @example
+ * ```typescript
+ * await createUser({
+ *   username: 'testuser',
+ *   password: 'SecurePass123!',
+ *   role: 'subscriber'
+ * });
+ * ```
+ */
+export async function createUser( user: {
+	username: string;
+	password: string;
+	role: string;
+} ): Promise< void > {
+	if ( ! user.username || typeof user.username !== 'string' ) {
+		throw new Error( 'Username is required and must be a string' );
+	}
+
+	if ( ! user.password || typeof user.password !== 'string' ) {
+		throw new Error( 'Password is required and must be a string' );
+	}
+
+	if ( ! user.role || typeof user.role !== 'string' ) {
+		throw new Error( 'Role is required and must be a string' );
+	}
+
+	// Validate username format (alphanumeric, underscores, hyphens)
+	const usernameRegex = /^[a-zA-Z0-9_-]+$/;
+	if ( ! usernameRegex.test( user.username ) ) {
+		throw new Error(
+			'Username must contain only alphanumeric characters, underscores, and hyphens'
+		);
+	}
+
+	// Log the user creation attempt
+	logger.debug( `Creating WordPress user: ${ user.username } with role: ${ user.role }` );
+
+	await executeWpCommand(
+		`user create ${ user.username } ${ user.username }@example.com --role=${ user.role } --user_pass=${ user.password }`
+	);
+}
+
+/**
+ * Deletes a WordPress user using WP-CLI.
+ * @param username - The username of the user to delete
+ */
+export async function deleteUser( username: string ) {
+	if ( ! username || typeof username !== 'string' ) {
+		throw new Error( 'Username is required and must be a string' );
+	}
+
+	// Log the user deletion attempt
+	logger.debug( `Deleting WordPress user: ${ username }` );
+
+	await executeWpCommand( `user delete ${ username } --yes` );
+}

--- a/tools/e2e-commons/utils/user.ts
+++ b/tools/e2e-commons/utils/user.ts
@@ -1,5 +1,6 @@
 import logger from '../logger';
 import { executeWpCommand } from './cli';
+import { randomBytes } from 'crypto';
 
 /**
  * Creates a new WordPress user using WP-CLI.
@@ -33,7 +34,7 @@ export async function createUser( user?: {
 	role?: string;
 } ): Promise< { username: string; password: string; email: string; role: string } > {
 	const timestamp = Date.now().toString( 36 );
-	const randomSuffix = Math.random().toString( 36 ).substring( 2, 7 );
+	const randomSuffix = randomBytes(4).toString('base36').substring(0, 5);
 	const finalUser = {
 		username: user?.username || `user_${ timestamp }_${ randomSuffix }`,
 		password: user?.password || `Pass_${ timestamp }_${ randomSuffix }!`,


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/44818

## Proposed changes:

Fix the recommendations test always failing on first attempt. The issue is not with the failing test, but with the previous one which changes the password for the default username and it messes up the storage state. Even though after changing the password the new state is saved, the requestUtils in the next beforeEach hook are not picking that up and fail the API request.

Using another user for the change password flow is the fix here, there was already a TODO on that exact part. 

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:

* All e2e tests pass in CI. Check the `specs/post-connection/recommendations.test.ts:29:1 › Recommendations (Jetpack Assistant)` - it should pass on the first try. See https://github.com/Automattic/jetpack/actions/runs/17075237384/job/48415301983?pr=44842#step:13:113

