### PR TITLE
e2e tests: Fix unstable waf-blocking test

### DIFF
--- a/projects/plugins/jetpack/changelog/jetpack-755-e2e-tests-waf-blocking-test-always-fails-on-first-attempt
+++ b/projects/plugins/jetpack/changelog/jetpack-755-e2e-tests-waf-blocking-test-always-fails-on-first-attempt
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: E2E tests: fix unstable waf-blocking test
+
+

--- a/projects/plugins/jetpack/tests/e2e/helpers/waf-helper.ts
+++ b/projects/plugins/jetpack/tests/e2e/helpers/waf-helper.ts
@@ -8,7 +8,7 @@ import { executeWpCommand } from '_jetpack-e2e-commons/utils/cli';
 export async function enableAutomaticRules(): Promise< void > {
 	logger.debug( 'Enabling automatic firewall rules' );
 	await executeWpCommand( 'option update jetpack_waf_automatic_rules 1' );
-	await executeWpCommand( 'jetpack-waf generate_rules' );
+	await generateRules();
 }
 
 /**

--- a/projects/plugins/jetpack/tests/e2e/helpers/waf-helper.ts
+++ b/projects/plugins/jetpack/tests/e2e/helpers/waf-helper.ts
@@ -7,8 +7,8 @@ import { executeWpCommand } from '_jetpack-e2e-commons/utils/cli';
  */
 export async function enableAutomaticRules(): Promise< void > {
 	logger.debug( 'Enabling automatic firewall rules' );
-	executeWpCommand( 'option update jetpack_waf_automatic_rules 1' );
-	executeWpCommand( 'jetpack-waf generate_rules' );
+	await executeWpCommand( 'option update jetpack_waf_automatic_rules 1' );
+	await executeWpCommand( 'jetpack-waf generate_rules' );
 }
 
 /**
@@ -17,5 +17,5 @@ export async function enableAutomaticRules(): Promise< void > {
  */
 export async function generateRules(): Promise< string > {
 	logger.debug( 'Generating firewall rules' );
-	return executeWpCommand( 'jetpack-waf generate_rules' );
+	return await executeWpCommand( 'jetpack-waf generate_rules' );
 }

--- a/projects/plugins/jetpack/tests/e2e/helpers/waf-helper.ts
+++ b/projects/plugins/jetpack/tests/e2e/helpers/waf-helper.ts
@@ -17,5 +17,5 @@ export async function enableAutomaticRules(): Promise< void > {
  */
 export async function generateRules(): Promise< string > {
 	logger.debug( 'Generating firewall rules' );
-	return await executeWpCommand( 'jetpack-waf generate_rules' );
+	return executeWpCommand( 'jetpack-waf generate_rules' );
 }

--- a/projects/plugins/jetpack/tests/e2e/specs/post-connection/waf-blocking.test.ts
+++ b/projects/plugins/jetpack/tests/e2e/specs/post-connection/waf-blocking.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '_jetpack-e2e-commons/fixtures/base-test';
-import { enableAutomaticRules, generateRules } from '../../helpers/waf-helper';
+import { enableAutomaticRules } from '../../helpers/waf-helper';
 
 test.describe.parallel( 'WAF Blocking', () => {
 	test.beforeAll( async ( { testUtils } ) => {
@@ -8,7 +8,6 @@ test.describe.parallel( 'WAF Blocking', () => {
 		 */
 		await testUtils.activateModule( 'waf' );
 		await enableAutomaticRules();
-		await generateRules();
 	} );
 
 	test( 'Block a simple request', async ( { page } ) => {

--- a/projects/plugins/jetpack/tests/e2e/specs/post-connection/waf-blocking.test.ts
+++ b/projects/plugins/jetpack/tests/e2e/specs/post-connection/waf-blocking.test.ts
@@ -12,15 +12,17 @@ test.describe.parallel( 'WAF Blocking', () => {
 
 	test( 'Block a simple request', async ( { page } ) => {
 		await test.step( 'Block it', async () => {
-			const response = await page.goto( '/?blubb=<script>' );
-			expect( response!.status() ).toStrictEqual( 403 );
+			await expect( async () => {
+				const response = await page.goto( '/?blubb=<script>' );
+				expect( response!.status() ).toStrictEqual( 403 );
 
-			/*
-			The job of the WAF is to block certain requests, and that is what we are testing here.
-			Given that when a request is blocked, the code does die() with a specific message, we never render the page.
-			The assertion is just to ensure that we indeed do not see a page rendered in the output.
-			 */
-			expect( response!.body() ).not.toContain( '<html>' );
+				/*
+				The job of the WAF is to block certain requests, and that is what we are testing here.
+				Given that when a request is blocked, the code does die() with a specific message, we never render the page.
+				The assertion is just to ensure that we indeed do not see a page rendered in the output.
+				 */
+				expect( response!.body() ).not.toContain( '<html>' );
+			} ).toPass( { intervals: [ 1000 ], timeout: 30000 } );
 		} );
 	} );
 } );


### PR DESCRIPTION

Fixes https://github.com/Automattic/jetpack/issues/44819

## Proposed changes:

`'Block a simple request'` test was consistently failing on a first attempt in CI, most probably due to a race condition. There were 2 `await` missing in the setup, but those did not completely fix the issue. Using `toPass()` which polls for the expected result seems to have fixed it.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
* e2e tests pass in CI. Check the run for `'Block a simple request'` test, which should pass on the first attempt. See https://github.com/Automattic/jetpack/actions/runs/17076542725/job/48419915112?pr=44844#step:13:103

