### PR TITLE
Forms: Fix Feedback class has_consent value

### DIFF
--- a/projects/packages/forms/changelog/fix-feedback-class-has-consent-value
+++ b/projects/packages/forms/changelog/fix-feedback-class-has-consent-value
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Fix Feedback class has_consent value.

--- a/projects/packages/forms/src/contact-form/class-feedback.php
+++ b/projects/packages/forms/src/contact-form/class-feedback.php
@@ -173,7 +173,7 @@ class Feedback {
 		);
 
 		$this->comment_content = $this->get_first_field_of_type( 'textarea' );
-		$this->has_consent     = ( in_array( strtolower( $this->get_first_field_of_type( 'consent' ) ), array( 'yes', 'true', '1' ), true ) );
+		$this->has_consent     = (bool) $this->get_first_field_of_type( 'consent' );
 
 		$this->legacy_feedback_title = $feedback_post->post_title ? $feedback_post->post_title : $this->get_author() . ' - ' . $feedback_post->post_date;
 	}

--- a/projects/plugins/jetpack/changelog/fix-feedback-class-has-consent-value
+++ b/projects/plugins/jetpack/changelog/fix-feedback-class-has-consent-value
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: Fix Feedback class has_consent value.


### PR DESCRIPTION
## Proposed changes:

Update how we determine to $feedback->has_consent from checking for '1' / 'yes' / 'true' strings, to just coercing the value to a boolean. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

