### PR TITLE
Stats icon: Fix a fatal when the first column is "comments"

### DIFF
--- a/projects/packages/stats-admin/changelog/fix-stats-column-fatal
+++ b/projects/packages/stats-admin/changelog/fix-stats-column-fatal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix a PHP fatal error in the stats icon column when the first column is "comments"

--- a/projects/packages/stats-admin/src/class-admin-post-list-column.php
+++ b/projects/packages/stats-admin/src/class-admin-post-list-column.php
@@ -202,11 +202,8 @@ class Admin_Post_List_Column {
 		// If comments position is 0, then prepend the element at the beginning of the array.
 		if ( 0 === $pos ) {
 			return array_merge(
-				array(
-					'stats' => esc_html__( 'Stats', 'jetpack-stats-admin' ),
-					$columns,
-					true,
-				)
+				array( 'stats' => esc_html__( 'Stats', 'jetpack-stats-admin' ) ),
+				$columns
 			);
 		}
 

--- a/projects/packages/stats-admin/src/class-admin-post-list-column.php
+++ b/projects/packages/stats-admin/src/class-admin-post-list-column.php
@@ -199,6 +199,17 @@ class Admin_Post_List_Column {
 			$pos = count( $columns );
 		}
 
+		// If comments position is 0, then prepend the element at the beginning of the array.
+		if ( 0 === $pos ) {
+			return array_merge(
+				array(
+					'stats' => esc_html__( 'Stats', 'jetpack-stats-admin' ),
+					$columns,
+					true,
+				)
+			);
+		}
+
 		$chunks             = array_chunk( $columns, $pos, true );
 		$chunks[0]['stats'] = esc_html__( 'Stats', 'jetpack-stats-admin' );
 

--- a/projects/packages/stats-admin/tests/php/Admin_Post_List_Test.php
+++ b/projects/packages/stats-admin/tests/php/Admin_Post_List_Test.php
@@ -52,6 +52,36 @@ class Admin_Post_List_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Test if the stats column is added when comments is the first column of the table.
+	 *
+	 * @return void
+	 */
+	public function test_adds_stats_column_when_comments_is_the_first_column() {
+		// Prepare a simple columns array
+		$columns = array(
+			'comments' => 'comments',
+			'date'     => 'Date',
+		);
+
+		wp_set_current_user( $this->admin_id );
+
+		$set_cap = function ( $caps ) {
+			$caps['view_stats'] = true;
+
+			return $caps;
+		};
+
+		add_filter( 'user_has_cap', $set_cap );
+		// Call the method to add the stats column
+		$columns_with_stats = Admin_Post_List_Column::register()->add_stats_post_table( $columns );
+		remove_filter( 'user_has_cap', $set_cap );
+
+		// Assert that the 'stats' column is added
+		$this->assertArrayHasKey( 'stats', $columns_with_stats );
+		$this->assertEquals( 'Stats', $columns_with_stats['stats'] );
+	}
+
+	/**
 	 * Test if doesn't add the stats column if they don't have the right to view stats.
 	 *
 	 * @return void


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes DOTCOM-14263

In certain conditions, when the post list contains "comments" as the first column, the stats icon column was throwing a PHP Fatal error.

This PR fixes this issue by handling this scenario. I couldn't reproduce it locally on a test site. Instead, I've wrote a unit test that validates the fix.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Bug fix

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test passes

