### PR TITLE
fix: Editor assets endpoint disallows the VideoPress block

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-block-editor-assets.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-block-editor-assets.php
@@ -120,7 +120,6 @@ class WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets extends WP_REST_Controller 
 		'premium-content/login-button',
 		'premium-content/subscriber-view',
 		'syntaxhighlighter/code',
-		'videopress/video',
 	);
 
 	/**

--- a/projects/plugins/jetpack/changelog/fix-editor-assets-endpoint-disallows-video-press-block
+++ b/projects/plugins/jetpack/changelog/fix-editor-assets-endpoint-disallows-video-press-block
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Editor assets endpoint: disallow the VideoPress block type


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fix CMM-691. Partially revert https://github.com/Automattic/jetpack/pull/44616. 

Disallow the VideoPress block for the GutenbergKit mobile editor, as the block's AJAX and cookie authentication usage is incompatible with the mobile editor. We need to identify a long-term solution before enabling this block type. 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Remove `videopress/video` from the allowed blocks list. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Apply these Jetpack changes to your site (see [comment](https://github.com/Automattic/jetpack/pull/44848#issuecomment-3201460771)).  
1. Make a request to the `/wpcom/v2/sites/<site_id>/editor-assets` endpoint for the WPCOM site—via [API Console](https://developer.wordpress.com/docs/api/console/), `curl`, etc. 
1. Verify the 200 response does not contain `videopress/video` within the `allowed_block_types` return.

