### PR TITLE
Forms: fix some field phone styles

### DIFF
--- a/projects/packages/forms/changelog/change-fix-field-phone-styles
+++ b/projects/packages/forms/changelog/change-fix-field-phone-styles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms Phone Field: fix some styling inconsistencies

--- a/projects/packages/forms/src/blocks/input-phone/editor.scss
+++ b/projects/packages/forms/src/blocks/input-phone/editor.scss
@@ -78,22 +78,16 @@
 			}
 		}
 	}
-
-
 }
 
 .is-style-animated .jetpack-contact-form .jetpack-field.jetpack-field-phone {
 
-	&:not(.is-selected),
-	&:not(.has-child-selected) {
+	&:not(.has-placeholder):not(.is-selected),
+	&:not(.has-placeholder):not(.has-child-selected) {
 
 		.jetpack-field__input-prefix {
 			visibility: hidden;
 		}
-	}
-
-	&.is-selected .animated-label__label:not(.is-selected) {
-		top: calc(2px + var(--jetpack--contact-form--border-top-size, 1px) + calc(var(--jetpack--contact-form--input-padding) / 2));
 	}
 
 	// Target input prefix when field is selected but label is not
@@ -107,8 +101,8 @@
 
 .is-style-outlined .jetpack-contact-form .jetpack-field.jetpack-field-phone {
 
-	&:not(.is-selected),
-	&:not(.has-child-selected) {
+	&:not(.has-placeholder):not(.is-selected),
+	&:not(.has-placeholder):not(.has-child-selected) {
 
 		.jetpack-field__input-prefix {
 			visibility: hidden;

--- a/projects/packages/forms/src/blocks/input-phone/editor.scss
+++ b/projects/packages/forms/src/blocks/input-phone/editor.scss
@@ -3,10 +3,11 @@
 	.jetpack-field__input,
 	.jetpack-field__textarea {
 		box-sizing: border-box;
-
-		border-radius: 4px;
-		border: 1px solid #8c8f94;
-		background-color: #fff;
+		border-color: var(--jetpack--contact-form--border-color);
+		border-radius: var(--jetpack--contact-form--border-radius);
+		border-width: var(--jetpack--contact-form--border-size);
+		font-size: var(--jetpack--contact-form--font-size);
+		line-height: 2; // matches default input line-height
 
 		&.is-selected {
 			border-color: #2271b1;
@@ -16,7 +17,7 @@
 		// these class is used to style input and textarea elements
 		.jetpack-field__input-element {
 			font: inherit;
-			line-height: 2; // mimics default input line-height
+			line-height: inherit;
 			border: 0;
 			color: inherit;
 			outline: none;
@@ -53,6 +54,7 @@
 
 		.jetpack-field__input-prefix {
 			font: inherit;
+			line-height: inherit;
 			border: 0;
 			color: inherit;
 			display: flex;
@@ -60,6 +62,7 @@
 			// these class is used to style select elements
 			.jetpack-field__input-element {
 				font: inherit;
+				line-height: inherit;
 				border: 0;
 				color: inherit;
 				outline: none;

--- a/projects/packages/forms/src/blocks/input-phone/editor.scss
+++ b/projects/packages/forms/src/blocks/input-phone/editor.scss
@@ -9,6 +9,7 @@
 		font-size: var(--jetpack--contact-form--font-size);
 		line-height: 2; // matches default input line-height
 
+		// TODO: Doesn't work well with next version of Gutenberg, should be removed
 		&.is-selected {
 			border-color: #2271b1;
 			box-shadow: 0 0 0 1px #2271b1;
@@ -71,7 +72,7 @@
 
 				&:where(select) {
 					// compensate spacing for downarrow
-					// misbehaves with :focus
+					// TODO: misbehaves with :focus, fixed on next version of Gutenberg
 					padding-right: 24px;
 				}
 

--- a/projects/packages/forms/src/contact-form/css/phone-field.scss
+++ b/projects/packages/forms/src/contact-form/css/phone-field.scss
@@ -52,10 +52,8 @@
 			&:not(:has(*:focus, *:active)) {
 
 				.jetpack-field__input-prefix:not(:has(~ .has-placeholder),:has(~ .has-value)) {
-
-					.jetpack-field__input-element {
-						visibility: hidden;
-					}
+					pointer-events: none;
+					visibility: hidden;
 				}
 			}
 		}
@@ -85,10 +83,8 @@
 				}
 
 				.jetpack-field__input-prefix:not(:has(~ .has-placeholder),:has(~ .has-value)) {
-
-					.jetpack-field__input-element {
-						visibility: hidden;
-					}
+					pointer-events: none;
+					visibility: hidden;
 				}
 			}
 		}


### PR DESCRIPTION

## Proposed changes:
This PR is a follow up to #44635 to address some minor issues with styles: initial values should be inherited by input styles on the wrapper element.
Also, fix a couple nuances on animated and outlined styles.

As co-pilot would put it:

This pull request addresses and fixes several styling inconsistencies in the Phone Field component of the Forms package. The changes focus on improving the consistency of styles by using CSS variables, refining line-height handling, and improving the logic for when the input prefix is shown or hidden. There are also minor code cleanups and comments regarding compatibility with future Gutenberg versions.

**Phone Field Styling Consistency Improvements:**
- Switched to using CSS variables for border color, border radius, border width, and font size in `.jetpack-field__input` and `.jetpack-field__textarea` for more consistent theming. Also updated line-height and added a comment about future Gutenberg compatibility.
- Updated `.jetpack-field__input-element` and `.jetpack-field__input-prefix` to inherit line-height instead of setting it explicitly, ensuring better alignment and consistency. [[1]](diffhunk://#diff-78fa2e6728b481c9a58fa6f1d51aa6673a46f11fa37925b627a9f3c7020b6e9dL19-R21) [[2]](diffhunk://#diff-78fa2e6728b481c9a58fa6f1d51aa6673a46f11fa37925b627a9f3c7020b6e9dR58-R66)
- Adjusted logic for showing/hiding the input prefix in `.is-style-animated` and `.is-style-outlined` form styles, now also considering the `.has-placeholder` class for more accurate visibility control. [[1]](diffhunk://#diff-78fa2e6728b481c9a58fa6f1d51aa6673a46f11fa37925b627a9f3c7020b6e9dL81-L98) [[2]](diffhunk://#diff-78fa2e6728b481c9a58fa6f1d51aa6673a46f11fa37925b627a9f3c7020b6e9dL110-R109)

**Bug Fixes and Cleanups:**
- Fixed the selector and logic for hiding the phone prefix in the main contact form styles, replacing unnecessary nested selectors with `pointer-events: none` and `visibility: hidden` for improved accessibility and maintainability. [[1]](diffhunk://#diff-9af2a6f44e1bd8ea0cc04a827bb19ea69bd3ea6fc5a83453de386a5f8cdf4da7L55-L61) [[2]](diffhunk://#diff-9af2a6f44e1bd8ea0cc04a827bb19ea69bd3ea6fc5a83453de386a5f8cdf4da7L88-L94)
- Added and updated comments to clarify areas that are affected by or will change with future Gutenberg releases.

**Changelog:**
- Added a changelog entry describing the patch and the fixed styling inconsistencies for the Forms Phone Field.


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Insert a form with an International Phone Field. See that the styles look just like any other regular input. 
Switch the form to use animated or outlined style, visit the frontend and check that it aligns with the other inputs behavior.