### PR TITLE
Search: ensure Photon follows SSL

### DIFF
--- a/projects/packages/search/.gitattributes
+++ b/projects/packages/search/.gitattributes
@@ -12,6 +12,7 @@ package.json                                             export-ignore
 /.size-limit.js                                          production-exclude
 /babel.config*                                           production-exclude
 /jest.config.js                                          production-exclude
+/jest.url-tests.config.js                                production-exclude
 /postcss.config.js                                       production-exclude
 /tools/**                                                production-exclude
 /tests/**                                                production-exclude

--- a/projects/packages/search/changelog/update-search-photon-ssl
+++ b/projects/packages/search/changelog/update-search-photon-ssl
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Images: properly pass SSL argument to Photon for sites with https enabled.

--- a/projects/packages/search/composer.json
+++ b/projects/packages/search/composer.json
@@ -41,7 +41,7 @@
 		"phpunit": [
 			"phpunit-select-config phpunit.#.xml.dist --colors=always"
 		],
-		"test-coverage": "pnpm concurrently --names php,js 'php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\"' 'pnpm:test-coverage'",
+		"test-coverage": "pnpm concurrently --names php,js-dashboard,js-url 'php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\"' 'pnpm:test-scripts --coverage' 'pnpm:test-url-tests --coverage'",
 		"test-js": [
 			"pnpm run test"
 		],

--- a/projects/packages/search/jest.config.js
+++ b/projects/packages/search/jest.config.js
@@ -2,7 +2,10 @@ const baseConfig = require( 'jetpack-js-tools/jest/config.base.js' );
 
 module.exports = {
 	...baseConfig,
-	roots: [ '<rootDir>/src' ],
+	roots: [ '<rootDir>/src', '<rootDir>/tests' ],
+	testEnvironmentOptions: {
+		url: 'https://example.com',
+	},
 	transform: {
 		...baseConfig.transform,
 		'\\.[jt]sx?$': require( 'jetpack-js-tools/jest/babel-jest-config-factory.js' )(

--- a/projects/packages/search/jest.url-tests.config.js
+++ b/projects/packages/search/jest.url-tests.config.js
@@ -2,8 +2,14 @@ const baseConfig = require( 'jetpack-js-tools/jest/config.base.js' );
 
 module.exports = {
 	...baseConfig,
-	roots: [ '<rootDir>/src' ],
-
+	roots: [ '<rootDir>/tests' ], // Only our tests directory
+	testEnvironmentOptions: {
+		...baseConfig.testEnvironmentOptions,
+		url: 'https://example.com',
+	},
+	// Override testMatch to look in our tests directory
+	testMatch: [ '<rootDir>/tests/**/?(*.)+(spec|test).[jt]s?(x)' ],
+	// Keep other settings from base config
 	transform: {
 		...baseConfig.transform,
 		'\\.[jt]sx?$': require( 'jetpack-js-tools/jest/babel-jest-config-factory.js' )(

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -26,7 +26,7 @@
 		"build-production": "NODE_ENV=production BABEL_ENV=production pnpm run build && pnpm run validate",
 		"clean": "rm -rf build/ .cache/",
 		"test": "concurrently 'pnpm:test-scripts' 'pnpm:test-url-tests' 'pnpm:test-size'",
-		"test-coverage": "pnpm run test-scripts --coverage",
+		"test-coverage": "pnpm:test-scripts --coverage && pnpm:test-url-tests --coverage",
 		"test-scripts": "jest --passWithNoTests",
 		"test-size": "NODE_ENV=production BABEL_ENV=production pnpm run build-instant && size-limit",
 		"test-url-tests": "jest --config=jest.url-tests.config.js --passWithNoTests",

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -25,10 +25,11 @@
 		"build-instant": "webpack --config ./tools/webpack.instant.config.js",
 		"build-production": "NODE_ENV=production BABEL_ENV=production pnpm run build && pnpm run validate",
 		"clean": "rm -rf build/ .cache/",
-		"test": "concurrently 'pnpm:test-scripts' 'pnpm:test-size'",
+		"test": "concurrently 'pnpm:test-scripts' 'pnpm:test-url-tests' 'pnpm:test-size'",
 		"test-coverage": "pnpm run test-scripts --coverage",
 		"test-scripts": "jest --passWithNoTests",
 		"test-size": "NODE_ENV=production BABEL_ENV=production pnpm run build-instant && size-limit",
+		"test-url-tests": "jest --config=jest.url-tests.config.js --passWithNoTests",
 		"validate": "pnpm exec validate-es --no-error-on-unmatched-pattern build/",
 		"watch": "concurrently 'pnpm:build-instant --watch' 'pnpm:build-customberg --watch' 'pnpm:build-dashboard --watch' 'pnpm:build-inline --watch'"
 	},

--- a/projects/packages/search/src/instant-search/lib/hooks/use-photon.js
+++ b/projects/packages/search/src/instant-search/lib/hooks/use-photon.js
@@ -2,16 +2,52 @@ import photon from 'photon';
 import { useEffect, useState } from 'react';
 
 /**
- * Strips query string values from URLs; photon can't handle them.
+ * Ensures URLs have the correct protocol by checking if they match the current site domain.
+ * If they do, applies the current window protocol (http/https).
  *
  * @param {string} url - Image URL
- * @return {string} - Image URL without any query strings.
+ * @return {string} - Image URL with correct protocol if it matches current domain
  */
-function stripQueryString( url ) {
+function ensureCorrectProtocol( url ) {
 	if ( ! url ) {
 		return '';
 	}
-	return url.split( '?', 1 )[ 0 ];
+
+	// If URL already has a protocol, return as-is
+	if ( url.match( /^https?:\/\// ) ) {
+		return url;
+	}
+
+	try {
+		// Create a URL object to properly parse the URL
+		// If the URL doesn't have a protocol, we'll need to add one temporarily for parsing
+		const urlToParse = url.includes( '://' ) ? url : `http://${ url }`;
+		const parsedUrl = new URL( urlToParse );
+
+		// Check if this matches the current site's domain
+		if ( parsedUrl.hostname === window.location.hostname ) {
+			return `${ window.location.protocol }//${ url }`;
+		}
+	} catch {
+		// If URL parsing fails, return the original URL unchanged.
+		return url;
+	}
+
+	return url;
+}
+
+/**
+ * Prepares URLs for Photon by ensuring correct protocol and stripping query strings.
+ *
+ * @param {string} url - Image URL
+ * @return {string} - Image URL with correct protocol and without query strings.
+ */
+function prepareUrl( url ) {
+	if ( ! url ) {
+		return '';
+	}
+	const urlWithProtocol = ensureCorrectProtocol( url );
+	return urlWithProtocol.split( '?', 1 )[ 0 ];
 }
 
 /**
@@ -25,35 +61,28 @@ function stripQueryString( url ) {
  */
 export function usePhoton( initialSrc, width, height, isPhotonEnabled = true ) {
 	const [ src, setSrc ] = useState( null );
-	const initialSrcWithoutQueryString = stripQueryString( initialSrc );
+	const initialSrcPrepared = prepareUrl( initialSrc );
 
 	// Photon only supports GIF, JPG, PNG and WebP images
 	// Photon also has partial support for HEIC which currently always
 	// reencodes as JPG regardless of advertised support from the browser
 	// @see https://developer.wordpress.com/docs/photon/
 	const supportedImageTypes = [ 'gif', 'jpg', 'jpeg', 'png', 'webp', 'heic' ];
-	const fileExtension = initialSrcWithoutQueryString
-		?.substring( initialSrcWithoutQueryString.lastIndexOf( '.' ) + 1 )
+	const fileExtension = initialSrcPrepared
+		?.substring( initialSrcPrepared.lastIndexOf( '.' ) + 1 )
 		.toLowerCase();
 	const isSupportedImageType = supportedImageTypes.includes( fileExtension );
 
 	useEffect( () => {
 		if ( isPhotonEnabled && isSupportedImageType ) {
-			const photonSrc = photon( initialSrcWithoutQueryString, {
+			const photonSrc = photon( initialSrcPrepared, {
 				resize: `${ width },${ height }`,
 			} );
 			setSrc( photonSrc ? photonSrc : initialSrc );
 		} else {
 			setSrc( initialSrc );
 		}
-	}, [
-		initialSrc,
-		width,
-		height,
-		isPhotonEnabled,
-		initialSrcWithoutQueryString,
-		isSupportedImageType,
-	] );
+	}, [ initialSrc, width, height, isPhotonEnabled, initialSrcPrepared, isSupportedImageType ] );
 
 	return src;
 }

--- a/projects/packages/search/src/instant-search/lib/hooks/use-photon.js
+++ b/projects/packages/search/src/instant-search/lib/hooks/use-photon.js
@@ -18,6 +18,13 @@ function ensureCorrectProtocol( url ) {
 		return url;
 	}
 
+	// Handle protocol-relative URLs (starting with //)
+	if ( url.startsWith( '//' ) ) {
+		// Protocol-relative URLs should always use the current page's protocol
+		// This matches browser behavior where //example.com becomes https://example.com on HTTPS pages
+		return `${ window.location.protocol }${ url }`;
+	}
+
 	try {
 		// Create a URL object to properly parse the URL
 		// If the URL doesn't have a protocol, we'll need to add one temporarily for parsing

--- a/projects/packages/search/tests/js/instant-search/lib/hooks/use-photon.test.js
+++ b/projects/packages/search/tests/js/instant-search/lib/hooks/use-photon.test.js
@@ -61,6 +61,26 @@ describe( 'usePhoton', () => {
 	} );
 
 	describe( 'URL preparation and query string handling', () => {
+		test( 'handles null URLs gracefully', () => {
+			renderHook( () => usePhoton( null, 300, 200, true ) );
+
+			const photon = require( 'photon' );
+			// Should handle null gracefully and not call photon
+			expect( photon ).not.toHaveBeenCalled();
+		} );
+
+		test( 'handles malformed URLs gracefully', () => {
+			// This URL is malformed in a way that would cause URL parsing to fail
+			// and hit the catch block in ensureCorrectProtocol
+			// It needs to not have a protocol so it goes through the parsing logic
+			renderHook( () => usePhoton( '[invalid-url', 300, 200, true ) );
+
+			const photon = require( 'photon' );
+			// Should handle malformed URL gracefully and not call photon
+			// because it doesn't have a supported file extension
+			expect( photon ).not.toHaveBeenCalled();
+		} );
+
 		test( 'strips query strings from URLs without protocols', () => {
 			renderHook( () =>
 				usePhoton( 'example.com/image.jpg?size=large&format=jpg', 300, 200, true )
@@ -122,6 +142,14 @@ describe( 'usePhoton', () => {
 			const photon = require( 'photon' );
 			expect( photon ).not.toHaveBeenCalled();
 			expect( result.current ).toBe( 'https://example.com/image.jpg' );
+		} );
+
+		test( 'does not call photon when disabled with protocol-less URL', () => {
+			const { result } = renderHook( () => usePhoton( 'example.com/image.jpg', 300, 200, false ) );
+
+			const photon = require( 'photon' );
+			expect( photon ).not.toHaveBeenCalled();
+			expect( result.current ).toBe( 'example.com/image.jpg' );
 		} );
 
 		test( 'handles unsupported image types', () => {

--- a/projects/packages/search/tests/js/instant-search/lib/hooks/use-photon.test.js
+++ b/projects/packages/search/tests/js/instant-search/lib/hooks/use-photon.test.js
@@ -58,6 +58,28 @@ describe( 'usePhoton', () => {
 				resize: '300,200',
 			} );
 		} );
+
+		test( 'handles protocol-relative URLs (//) by using current page protocol', () => {
+			// Jest's testURL is set to https://example.com
+			// Protocol-relative URLs should inherit the current page's protocol
+			renderHook( () => usePhoton( '//example.com/image.jpg', 300, 200, true ) );
+
+			const photon = require( 'photon' );
+			expect( photon ).toHaveBeenCalledWith( 'https://example.com/image.jpg', {
+				resize: '300,200',
+			} );
+		} );
+
+		test( 'handles protocol-relative URLs from different domains', () => {
+			// Protocol-relative URLs from different domains should use the current page's protocol
+			// Jest's testURL is set to https://example.com, so //othersite.com becomes https://othersite.com
+			renderHook( () => usePhoton( '//othersite.com/image.jpg', 300, 200, true ) );
+
+			const photon = require( 'photon' );
+			expect( photon ).toHaveBeenCalledWith( 'https://othersite.com/image.jpg', {
+				resize: '300,200',
+			} );
+		} );
 	} );
 
 	describe( 'URL preparation and query string handling', () => {

--- a/projects/packages/search/tests/js/instant-search/lib/hooks/use-photon.test.js
+++ b/projects/packages/search/tests/js/instant-search/lib/hooks/use-photon.test.js
@@ -1,0 +1,137 @@
+import { renderHook } from '@testing-library/react';
+import { usePhoton } from '../../../../../src/instant-search/lib/hooks/use-photon';
+
+// Mock the photon module
+jest.mock( 'photon', () => {
+	return jest.fn( ( url, options ) => {
+		// Return a mock photon URL
+		return `https://i0.wp.com/${ url.replace( /^https?:\/\//, '' ) }?${ options.resize }`;
+	} );
+} );
+
+describe( 'usePhoton', () => {
+	beforeEach( () => {
+		// Reset mocks
+		jest.clearAllMocks();
+	} );
+
+	describe( 'protocol detection', () => {
+		test( 'adds https protocol to URLs matching current domain', () => {
+			// Jest's testURL is set to https://example.com
+			// Test relative URLs that should get the protocol added
+			renderHook( () => usePhoton( 'example.com/image.jpg', 300, 200, true ) );
+
+			const photon = require( 'photon' );
+			expect( photon ).toHaveBeenCalledWith( 'https://example.com/image.jpg', {
+				resize: '300,200',
+			} );
+		} );
+
+		test( 'does not add protocol to URLs from different domains', () => {
+			// URLs that don't match current domain should remain unchanged
+			renderHook( () => usePhoton( 'othersite.com/image.jpg', 300, 200, true ) );
+
+			const photon = require( 'photon' );
+			expect( photon ).toHaveBeenCalledWith( 'othersite.com/image.jpg', {
+				resize: '300,200',
+			} );
+		} );
+
+		test( 'leaves URLs with existing protocols unchanged', () => {
+			renderHook( () => usePhoton( 'https://othersite.com/image.jpg', 300, 200, true ) );
+
+			const photon = require( 'photon' );
+			expect( photon ).toHaveBeenCalledWith( 'https://othersite.com/image.jpg', {
+				resize: '300,200',
+			} );
+		} );
+
+		test( 'does not add protocol to subdomain URLs from different domains', () => {
+			// Current page is on https://example.com
+			// But we're loading an image from sub.example.com
+			// We shouldn't assume sub.example.com supports HTTPS
+			renderHook( () => usePhoton( 'sub.example.com/image.jpg', 300, 200, true ) );
+
+			const photon = require( 'photon' );
+			// Should NOT add protocol - subdomain might not support HTTPS
+			expect( photon ).toHaveBeenCalledWith( 'sub.example.com/image.jpg', {
+				resize: '300,200',
+			} );
+		} );
+	} );
+
+	describe( 'URL preparation and query string handling', () => {
+		test( 'strips query strings from URLs without protocols', () => {
+			renderHook( () =>
+				usePhoton( 'example.com/image.jpg?size=large&format=jpg', 300, 200, true )
+			);
+
+			const photon = require( 'photon' );
+			// The exact URL passed to photon depends on the Jest environment's window.location
+			// but we can verify that query strings are stripped
+			expect( photon ).toHaveBeenCalledWith( expect.not.stringMatching( /\?/ ), {
+				resize: '300,200',
+			} );
+		} );
+
+		test( 'strips query strings from URLs with existing protocols', () => {
+			renderHook( () =>
+				usePhoton( 'https://example.com/image.jpg?size=large&format=jpg', 300, 200, true )
+			);
+
+			const photon = require( 'photon' );
+			expect( photon ).toHaveBeenCalledWith( 'https://example.com/image.jpg', {
+				resize: '300,200',
+			} );
+		} );
+
+		test( 'leaves URLs with existing protocols unchanged', () => {
+			renderHook( () => usePhoton( 'https://example.com/image.jpg', 300, 200, true ) );
+
+			const photon = require( 'photon' );
+			expect( photon ).toHaveBeenCalledWith( 'https://example.com/image.jpg', {
+				resize: '300,200',
+			} );
+		} );
+
+		test( 'leaves URLs with http protocol unchanged', () => {
+			renderHook( () => usePhoton( 'http://example.com/image.jpg', 300, 200, true ) );
+
+			const photon = require( 'photon' );
+			expect( photon ).toHaveBeenCalledWith( 'http://example.com/image.jpg', {
+				resize: '300,200',
+			} );
+		} );
+	} );
+
+	describe( 'photon functionality', () => {
+		test( 'calls photon with correct parameters when enabled', () => {
+			renderHook( () => usePhoton( 'https://example.com/image.jpg', 300, 200, true ) );
+
+			const photon = require( 'photon' );
+			expect( photon ).toHaveBeenCalledWith( 'https://example.com/image.jpg', {
+				resize: '300,200',
+			} );
+		} );
+
+		test( 'does not call photon when disabled', () => {
+			const { result } = renderHook( () =>
+				usePhoton( 'https://example.com/image.jpg', 300, 200, false )
+			);
+
+			const photon = require( 'photon' );
+			expect( photon ).not.toHaveBeenCalled();
+			expect( result.current ).toBe( 'https://example.com/image.jpg' );
+		} );
+
+		test( 'handles unsupported image types', () => {
+			const { result } = renderHook( () =>
+				usePhoton( 'https://example.com/image.svg', 300, 200, true )
+			);
+
+			const photon = require( 'photon' );
+			expect( photon ).not.toHaveBeenCalled();
+			expect( result.current ).toBe( 'https://example.com/image.svg' );
+		} );
+	} );
+} );

--- a/projects/plugins/jetpack/changelog/update-search-photon-ssl
+++ b/projects/plugins/jetpack/changelog/update-search-photon-ssl
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Search: ensure images are loaded efficiently when on https sites.

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -2752,7 +2752,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/search",
-                "reference": "6b541ca53f442b3751fa6a3094f498f6c5b9cb68"
+                "reference": "2a95b63ad7c0d51c615ac631a309920cdf0fff3f"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -2808,7 +2808,7 @@
                     "phpunit-select-config phpunit.#.xml.dist --colors=always"
                 ],
                 "test-coverage": [
-                    "pnpm concurrently --names php,js 'php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\"' 'pnpm:test-coverage'"
+                    "pnpm concurrently --names php,js-dashboard,js-url 'php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\"' 'pnpm:test-scripts --coverage' 'pnpm:test-url-tests --coverage'"
                 ],
                 "test-js": [
                     "pnpm run test"
@@ -3539,16 +3539,16 @@
     "packages-dev": [
         {
             "name": "antecedent/patchwork",
-            "version": "2.2.1",
+            "version": "2.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/antecedent/patchwork.git",
-                "reference": "1bf183a3e1bd094f231a2128b9ecc5363c269245"
+                "reference": "724f03c777ddcc436ec2c8ecd4c97cdbceef8ab9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/antecedent/patchwork/zipball/1bf183a3e1bd094f231a2128b9ecc5363c269245",
-                "reference": "1bf183a3e1bd094f231a2128b9ecc5363c269245",
+                "url": "https://api.github.com/repos/antecedent/patchwork/zipball/724f03c777ddcc436ec2c8ecd4c97cdbceef8ab9",
+                "reference": "724f03c777ddcc436ec2c8ecd4c97cdbceef8ab9",
                 "shasum": ""
             },
             "require": {
@@ -3581,9 +3581,9 @@
             ],
             "support": {
                 "issues": "https://github.com/antecedent/patchwork/issues",
-                "source": "https://github.com/antecedent/patchwork/tree/2.2.1"
+                "source": "https://github.com/antecedent/patchwork/tree/2.2.2"
             },
-            "time": "2024-12-11T10:19:54+00:00"
+            "time": "2025-08-12T16:59:40+00:00"
         },
         {
             "name": "automattic/jetpack-changelogger",

--- a/projects/plugins/search/changelog/update-search-photon-ssl
+++ b/projects/plugins/search/changelog/update-search-photon-ssl
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search: ensure images are loaded efficiently when on https sites.

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -1560,7 +1560,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/search",
-                "reference": "6b541ca53f442b3751fa6a3094f498f6c5b9cb68"
+                "reference": "2a95b63ad7c0d51c615ac631a309920cdf0fff3f"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -1616,7 +1616,7 @@
                     "phpunit-select-config phpunit.#.xml.dist --colors=always"
                 ],
                 "test-coverage": [
-                    "pnpm concurrently --names php,js 'php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\"' 'pnpm:test-coverage'"
+                    "pnpm concurrently --names php,js-dashboard,js-url 'php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\"' 'pnpm:test-scripts --coverage' 'pnpm:test-url-tests --coverage'"
                 ],
                 "test-js": [
                     "pnpm run test"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes HOG-299

Previously, the Search functionality would pass a protocol-less URL to Photon, so it wouldn't know to append ssl=1 to the URL (leading to more efficient image retrieval).
This updates Search's Photon code to, when the image is on the same domain and the domain is https, to pass https to the photon function, ensuring ssl=1 is appended.

Additionally, adds an unit test to ensure the transformation is done without impacting other URLs.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* I didn't verify the behavior from the frontend. Passing URLs to the functionality should be sufficient, done via the unit tests.
* My understanding would a test case where Instant Search is enabled with posts indexed with featured images.
* The site should be on SSL.
* When instant searching, the results should include the featured image. Verify the URL of those images.
* Before the patch, it would be something like https://i0.wp.com/example.com/image.jpg
* After the patch, it would be something like https://i0.wp.com/example.com/image.jpg?ssl=1 if visiting the site at https://example.com.

