### PR TITLE
Forms: Update MailPoet to use Feedback class

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-mailpoet-consent-value
+++ b/projects/packages/forms/changelog/fix-forms-mailpoet-consent-value
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: Update MailPoet to use Feedback class.

--- a/projects/packages/forms/src/contact-form/class-feedback.php
+++ b/projects/packages/forms/src/contact-form/class-feedback.php
@@ -173,7 +173,7 @@ class Feedback {
 		);
 
 		$this->comment_content = $this->get_first_field_of_type( 'textarea' );
-		$this->has_consent     = ( in_array( strtolower( $this->get_first_field_of_type( 'consent' ) ), array( 'yes', 'true', '1' ), true ) );
+		$this->has_consent     = (bool) $this->get_first_field_of_type( 'consent' );
 
 		$this->legacy_feedback_title = $feedback_post->post_title ? $feedback_post->post_title : $this->get_author() . ' - ' . $feedback_post->post_date;
 	}

--- a/projects/packages/forms/src/service/class-mailpoet-integration.php
+++ b/projects/packages/forms/src/service/class-mailpoet-integration.php
@@ -118,11 +118,11 @@ class MailPoet_Integration {
 	/**
 	 * Extract subscriber data (email, first_name, last_name) from form fields.
 	 *
-	 * @param Feedback $feedback   Feedback object for the submission.
-	 * @param array    $fields     Collection of Contact_Form_Field instances.
+	 * @param Feedback                                           $feedback Feedback object for the submission.
+	 * @param \Automattic\Jetpack\Forms\ContactForm\Contact_Form $form Contact form instance.
 	 * @return array Associative array with at least 'email', optionally 'first_name', 'last_name'. Empty array if no email found.
 	 */
-	protected static function get_subscriber_data( $feedback, $fields ) {
+	protected static function get_subscriber_data( $feedback, $form ) {
 		if ( ! $feedback->get_author_email() ) {
 			return array();
 		}
@@ -142,24 +142,13 @@ class MailPoet_Integration {
 		// If no first/last name, try getting via id from form fields.
 		// Can replace when we add $feedback->get_field_value_by_id() to Feedback API.
 		if ( empty( $subscriber_data['first_name'] ) || empty( $subscriber_data['last_name'] ) ) {
-			$form = null;
-			foreach ( $fields as $field ) {
-				if ( ! empty( $field->form ) ) {
-					$form = $field->form;
-					break;
-				}
-			}
-			if ( ! $form || ! is_a( $form, 'Automattic\Jetpack\Forms\ContactForm\Contact_Form' ) ) {
-				return $subscriber_data;
-			}
-
 			foreach ( $form->fields as $field ) {
 				$id    = strtolower( str_replace( array( ' ', '_' ), '', $field->get_attribute( 'id' ) ) );
 				$value = trim( $field->value );
 
-				if ( ( $id === 'firstname' ) && ! empty( $value ) ) {
+				if ( 'firstname' === $id && ! empty( $value ) ) {
 					$subscriber_data['first_name'] = $value;
-				} elseif ( ( $id === 'lastname' ) && ! empty( $value ) ) {
+				} elseif ( 'lastname' === $id && ! empty( $value ) ) {
 					$subscriber_data['last_name'] = $value;
 				}
 			}
@@ -223,7 +212,7 @@ class MailPoet_Integration {
 			return;
 		}
 
-		$subscriber_data = self::get_subscriber_data( $feedback, $fields );
+		$subscriber_data = self::get_subscriber_data( $feedback, $form );
 		if ( empty( $subscriber_data ) ) {
 			// Email is required for MailPoet subscribers.
 			return;

--- a/projects/packages/forms/src/service/class-mailpoet-integration.php
+++ b/projects/packages/forms/src/service/class-mailpoet-integration.php
@@ -182,10 +182,7 @@ class MailPoet_Integration {
 			return;
 		}
 
-		// If the form has a consent field, require consent to be granted.
-		$field_ids         = $form->get_field_ids();
-		$has_consent_field = ! empty( $field_ids['email_marketing_consent_field'] );
-		if ( $has_consent_field && ! $feedback->has_consent() ) {
+		if ( $feedback->has_field_type( 'consent' ) && ! $feedback->has_consent() ) {
 			return;
 		}
 

--- a/projects/packages/forms/src/service/class-mailpoet-integration.php
+++ b/projects/packages/forms/src/service/class-mailpoet-integration.php
@@ -182,8 +182,10 @@ class MailPoet_Integration {
 			return;
 		}
 
-		// If a consent field exists in the submission, require consent to be granted.
-		if ( $feedback->has_field_type( 'consent' ) && ! $feedback->has_consent() ) {
+		// If the form has a consent field, require consent to be granted.
+		$field_ids         = $form->get_field_ids();
+		$has_consent_field = ! empty( $field_ids['email_marketing_consent_field'] );
+		if ( $has_consent_field && ! $feedback->has_consent() ) {
 			return;
 		}
 

--- a/projects/packages/forms/src/service/class-mailpoet-integration.php
+++ b/projects/packages/forms/src/service/class-mailpoet-integration.php
@@ -118,11 +118,10 @@ class MailPoet_Integration {
 	/**
 	 * Extract subscriber data (email, first_name, last_name) from form fields.
 	 *
-	 * @param Feedback                                           $feedback Feedback object for the submission.
-	 * @param \Automattic\Jetpack\Forms\ContactForm\Contact_Form $form Contact form instance.
+	 * @param Feedback $feedback Feedback object for the submission.
 	 * @return array Associative array with at least 'email', optionally 'first_name', 'last_name'. Empty array if no email found.
 	 */
-	protected static function get_subscriber_data( $feedback, $form ) {
+	protected static function get_subscriber_data( $feedback ) {
 		if ( ! $feedback->get_author_email() ) {
 			return array();
 		}
@@ -131,27 +130,20 @@ class MailPoet_Integration {
 		$subscriber_data          = array();
 		$subscriber_data['email'] = $feedback->get_author_email();
 
-		// Try getting first and last name from Feedback API.
+		// Try getting first and name from Feedback API.
 		if ( $feedback->get_field_value_by_label( 'First Name' ) ) {
 			$subscriber_data['first_name'] = $feedback->get_field_value_by_label( 'First Name' );
+		} elseif ( $feedback->get_field_value_by_form_field_id( 'firstname' ) ) {
+			$subscriber_data['first_name'] = $feedback->get_field_value_by_form_field_id( 'firstname' );
+		} elseif ( $feedback->get_field_value_by_form_field_id( 'first-name' ) ) {
+			$subscriber_data['first_name'] = $feedback->get_field_value_by_form_field_id( 'first-name' );
 		}
 		if ( $feedback->get_field_value_by_label( 'Last Name' ) ) {
 			$subscriber_data['last_name'] = $feedback->get_field_value_by_label( 'Last Name' );
-		}
-
-		// If no first/last name, try getting via id from form fields.
-		// Can replace when we add $feedback->get_field_value_by_id() to Feedback API.
-		if ( empty( $subscriber_data['first_name'] ) || empty( $subscriber_data['last_name'] ) ) {
-			foreach ( $form->fields as $field ) {
-				$id    = strtolower( str_replace( array( ' ', '_' ), '', $field->get_attribute( 'id' ) ) );
-				$value = trim( $field->value );
-
-				if ( 'firstname' === $id && ! empty( $value ) ) {
-					$subscriber_data['first_name'] = $value;
-				} elseif ( 'lastname' === $id && ! empty( $value ) ) {
-					$subscriber_data['last_name'] = $value;
-				}
-			}
+		} elseif ( $feedback->get_field_value_by_form_field_id( 'lastname' ) ) {
+			$subscriber_data['last_name'] = $feedback->get_field_value_by_form_field_id( 'lastname' );
+		} elseif ( $feedback->get_field_value_by_form_field_id( 'last-name' ) ) {
+			$subscriber_data['last_name'] = $feedback->get_field_value_by_form_field_id( 'last-name' );
 		}
 
 		return $subscriber_data;
@@ -212,7 +204,7 @@ class MailPoet_Integration {
 			return;
 		}
 
-		$subscriber_data = self::get_subscriber_data( $feedback, $form );
+		$subscriber_data = self::get_subscriber_data( $feedback );
 		if ( empty( $subscriber_data ) ) {
 			// Email is required for MailPoet subscribers.
 			return;

--- a/projects/packages/forms/src/service/class-mailpoet-integration.php
+++ b/projects/packages/forms/src/service/class-mailpoet-integration.php
@@ -7,6 +7,8 @@
 
 namespace Automattic\Jetpack\Forms\Service;
 
+use Automattic\Jetpack\Forms\ContactForm\Feedback;
+
 /**
  * Class MailPoet_Integration
  *
@@ -116,39 +118,51 @@ class MailPoet_Integration {
 	/**
 	 * Extract subscriber data (email, first_name, last_name) from form fields.
 	 *
-	 * @param array $fields Collection of Contact_Form_Field instances.
+	 * @param Feedback $feedback   Feedback object for the submission.
+	 * @param array    $fields     Collection of Contact_Form_Field instances.
 	 * @return array Associative array with at least 'email', optionally 'first_name', 'last_name'. Empty array if no email found.
 	 */
-	protected static function get_subscriber_data_from_fields( $fields ) {
-		// Try and get the form from any of the fields
-		$form = null;
-		foreach ( $fields as $field ) {
-			if ( ! empty( $field->form ) ) {
-				$form = $field->form;
-				break;
-			}
-		}
-		if ( ! $form || ! is_a( $form, 'Automattic\Jetpack\Forms\ContactForm\Contact_Form' ) ) {
+	protected static function get_subscriber_data( $feedback, $fields ) {
+		if ( ! $feedback->get_author_email() ) {
 			return array();
 		}
 
-		$subscriber_data = array();
-		foreach ( $form->fields as $field ) {
-			$id    = strtolower( str_replace( array( ' ', '_' ), '', $field->get_attribute( 'id' ) ) );
-			$label = strtolower( str_replace( array( ' ', '_' ), '', $field->get_attribute( 'label' ) ) );
-			$value = trim( $field->value );
+		// Get email using new Feedback API.
+		$subscriber_data          = array();
+		$subscriber_data['email'] = $feedback->get_author_email();
 
-			if ( ( $id === 'email' || $label === 'email' ) && ! empty( $value ) ) {
-				$subscriber_data['email'] = $value;
-			} elseif ( ( $id === 'firstname' || $label === 'firstname' ) && ! empty( $value ) ) {
-				$subscriber_data['first_name'] = $value;
-			} elseif ( ( $id === 'lastname' || $label === 'lastname' ) && ! empty( $value ) ) {
-				$subscriber_data['last_name'] = $value;
-			}
+		// Try getting first and last name from Feedback API.
+		if ( $feedback->get_field_value_by_label( 'First Name' ) ) {
+			$subscriber_data['first_name'] = $feedback->get_field_value_by_label( 'First Name' );
+		}
+		if ( $feedback->get_field_value_by_label( 'Last Name' ) ) {
+			$subscriber_data['last_name'] = $feedback->get_field_value_by_label( 'Last Name' );
 		}
 
-		if ( empty( $subscriber_data['email'] ) ) {
-			return array();
+		// If no first/last name, try getting via id from form fields.
+		// Can replace when we add $feedback->get_field_value_by_id() to Feedback API.
+		if ( empty( $subscriber_data['first_name'] ) || empty( $subscriber_data['last_name'] ) ) {
+			$form = null;
+			foreach ( $fields as $field ) {
+				if ( ! empty( $field->form ) ) {
+					$form = $field->form;
+					break;
+				}
+			}
+			if ( ! $form || ! is_a( $form, 'Automattic\Jetpack\Forms\ContactForm\Contact_Form' ) ) {
+				return $subscriber_data;
+			}
+
+			foreach ( $form->fields as $field ) {
+				$id    = strtolower( str_replace( array( ' ', '_' ), '', $field->get_attribute( 'id' ) ) );
+				$value = trim( $field->value );
+
+				if ( ( $id === 'firstname' ) && ! empty( $value ) ) {
+					$subscriber_data['first_name'] = $value;
+				} elseif ( ( $id === 'lastname' ) && ! empty( $value ) ) {
+					$subscriber_data['last_name'] = $value;
+				}
+			}
 		}
 
 		return $subscriber_data;
@@ -182,28 +196,14 @@ class MailPoet_Integration {
 			return;
 		}
 
-		// Get consent field if it exists.
-		$consent_field = null;
-		if ( is_array( $form->fields ) ) {
-			foreach ( $form->fields as $form_field ) {
-				if ( 'consent' === $form_field->get_attribute( 'type' ) ) {
-					$consent_field = $form_field;
-					break;
-				}
-			}
+		$feedback = Feedback::get( $post_id );
+		if ( ! $feedback ) {
+			return;
 		}
 
-		// If consent field exists and is explicit, require it to be checked.
-		if ( $consent_field ) {
-			$consent_type = strtolower( (string) $consent_field->get_attribute( 'consenttype' ) );
-			if ( 'explicit' === $consent_type ) {
-				$consent_value           = $consent_field->value;
-				$consent_value_lowercase = is_string( $consent_value ) ? strtolower( trim( $consent_value ) ) : '';
-				$has_explicit_consent    = is_bool( $consent_value ) ? $consent_value : in_array( $consent_value_lowercase, array( 'yes', 'true', '1' ), true );
-				if ( ! $has_explicit_consent ) {
-					return;
-				}
-			}
+		// If a consent field exists in the submission, require consent to be granted.
+		if ( $feedback->has_field_type( 'consent' ) && ! $feedback->has_consent() ) {
+			return;
 		}
 
 		$mailpoet_api = self::get_api();
@@ -223,7 +223,7 @@ class MailPoet_Integration {
 			return;
 		}
 
-		$subscriber_data = self::get_subscriber_data_from_fields( $fields );
+		$subscriber_data = self::get_subscriber_data( $feedback, $fields );
 		if ( empty( $subscriber_data ) ) {
 			// Email is required for MailPoet subscribers.
 			return;


### PR DESCRIPTION
## Proposed changes:

The new Feedback class was added just after we started MailPoet integration. It offers improved ways to work with form data. This PR updates the MailPoet_Integration class to use the Feedback class when checking for email, first name, last name, consent, and other form data. 

**Potential known issues:** 
* @CGastrell found that on translated sites, the consent checkbox was not evaluating correctly during MailPoet submissions. Evaluating the consent value based on '1', 'true', or 'yes', as we do [here](https://github.com/Automattic/jetpack/blob/a8398cde77a4d9f8ec78c5f904a84ec4b6e89ac6/projects/packages/forms/src/contact-form/class-feedback.php#L176) is not sufficient. Assuming that's correct, we can fix that in this PR, or I prepped a separate PR with a suggested fix [here](https://github.com/Automattic/jetpack/pull/44846). 
* This PR still uses the 'old' approach to check for first / last name ids, because the Feedback class doesn't have a way to get field values by ID. I prepped a [PR for that here](https://github.com/Automattic/jetpack/pull/44760). Once merged, I can update that part of the code, too. 
* I find it odd that I still have to iterate over $fields to get the original $form configuration, including attributes. If we're using the Feedback class, it eems like there should be a way to do $feedback->get_form() to return the original form that generated a Feedback post. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Slack: p1755541020421639-slack-C052XEUUBL4

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No. 

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

This is a refactor, so the behavior should be the same before and after. 

* **Prep:** If you've tested this before, be sure to remove the MailPoet feature flag. You no longer need to add a MailPoet key to start adding contacts to your lists.
**Add a form to a page or post.** 
   - Required fields: Your form must have an email field. If you include a name field with 'First Name' label or 'firstname' id, that will be added to your lists. If you include a name field with 'Last Name' label or 'lastname' id, that will be added to your lists.
   - Enable MailPoet: Open the integration modal and install/activate MailPoet if needed. Complete MailPoet setup if prompted. Enable the MailPoet toggle, select a MailPoet list, and choose if you want consent field or not. 
* **Test frontend submission:** Go to frontend, submit, and confirm subscriber was added to MailPoet list.
* **Test consent:** Test different consent states. 
   - No consent field: contact will be added to MailPoet
   - Consent field with no checkbox: contact will be added to MailPoet
   - Consent field with 'checked' checkbox: contact will be added to MailPoet
   - Consent field with 'unchecked' checkbox: contact will not be added to MailPoet