### PR TITLE
Newsletter launchpad: Add import steps when goal is import-subscribers

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-launchpad-missing-newsletter-import-steps
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-launchpad-missing-newsletter-import-steps
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Newsletter launchpad: Add import steps when goal is import-subscribers.

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -105,8 +105,6 @@ function wpcom_launchpad_get_task_list_definitions() {
 			},
 			'task_ids'            => array(
 				'verify_email',
-				'migrate_content',
-				'subscribers_added',
 				'site_title',
 				'start_building_your_audience',
 				'customize_welcome_message',
@@ -218,6 +216,8 @@ function wpcom_launchpad_get_task_list_definitions() {
 			'task_ids'            => array(
 				'enable_subscribers_modal',
 				'verify_email',
+				'migrate_content',
+				'subscribers_added',
 				'share_site',
 				'manage_subscribers',
 				'update_about_page',
@@ -232,6 +232,8 @@ function wpcom_launchpad_get_task_list_definitions() {
 			'task_ids'            => array(
 				'enable_subscribers_modal',
 				'verify_email',
+				'migrate_content',
+				'subscribers_added',
 				'share_site',
 				'set_up_payments',
 				'manage_subscribers',

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -105,6 +105,8 @@ function wpcom_launchpad_get_task_list_definitions() {
 			},
 			'task_ids'            => array(
 				'verify_email',
+				'migrate_content',
+				'subscribers_added',
 				'site_title',
 				'start_building_your_audience',
 				'customize_welcome_message',

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Launchpad_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Launchpad_Test.php
@@ -461,9 +461,9 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad_Test extends \WorDBless\BaseTestCase 
 	}
 
 	/**
-	 * Tests that the intent-newsletter-goal task list includes import tasks.
+	 * Tests that the intent-free-newsletter task list includes import tasks.
 	 */
-	public function test_intent_newsletter_goal_includes_import_tasks() {
+	public function test_intent_free_newsletter_includes_import_tasks() {
 		\Brain\Monkey\Functions\when( 'get_blog_count_for_user' )->justReturn( 1 );
 		\Mockery::mock( 'alias:Email_Verification' )->shouldReceive( 'is_email_unverified' )->andReturn( true );
 
@@ -471,7 +471,7 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad_Test extends \WorDBless\BaseTestCase 
 		update_option( 'site_goals', array( 'import-subscribers' ) );
 
 		$data = array(
-			'checklist_slug'    => 'intent-newsletter-goal',
+			'checklist_slug'    => 'intent-free-newsletter',
 			'launchpad_context' => 'customer-home',
 		);
 
@@ -483,8 +483,8 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad_Test extends \WorDBless\BaseTestCase 
 		$task_ids = array_column( $result->get_data()['checklist'], 'id' );
 
 		// Verify that import tasks are included
-		$this->assertContains( 'migrate_content', $task_ids, 'migrate_content task should be in intent-newsletter-goal task list' );
-		$this->assertContains( 'subscribers_added', $task_ids, 'subscribers_added task should be in intent-newsletter-goal task list' );
+		$this->assertContains( 'migrate_content', $task_ids, 'migrate_content task should be in intent-free-newsletter task list' );
+		$this->assertContains( 'subscribers_added', $task_ids, 'subscribers_added task should be in intent-free-newsletter task list' );
 
 		// Verify the order: migrate_content should come before subscribers_added
 		$migrate_index     = array_search( 'migrate_content', $task_ids, true );

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Launchpad_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Launchpad_Test.php
@@ -461,6 +461,38 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad_Test extends \WorDBless\BaseTestCase 
 	}
 
 	/**
+	 * Tests that the intent-newsletter-goal task list includes import tasks.
+	 */
+	public function test_intent_newsletter_goal_includes_import_tasks() {
+		\Brain\Monkey\Functions\when( 'get_blog_count_for_user' )->justReturn( 1 );
+		\Mockery::mock( 'alias:Email_Verification' )->shouldReceive( 'is_email_unverified' )->andReturn( true );
+
+		wp_set_current_user( $this->admin_id );
+		update_option( 'site_goals', array( 'import-subscribers' ) );
+
+		$data = array(
+			'checklist_slug'    => 'intent-newsletter-goal',
+			'launchpad_context' => 'customer-home',
+		);
+
+		$result = $this->call_launchpad_api( Requests::GET, $data );
+
+		$this->assertEquals( 200, $result->get_status() );
+		$this->assertIsArray( $result->get_data()['checklist'] );
+
+		$task_ids = array_column( $result->get_data()['checklist'], 'id' );
+
+		// Verify that import tasks are included
+		$this->assertContains( 'migrate_content', $task_ids, 'migrate_content task should be in intent-newsletter-goal task list' );
+		$this->assertContains( 'subscribers_added', $task_ids, 'subscribers_added task should be in intent-newsletter-goal task list' );
+
+		// Verify the order: migrate_content should come before subscribers_added
+		$migrate_index     = array_search( 'migrate_content', $task_ids, true );
+		$subscribers_index = array_search( 'subscribers_added', $task_ids, true );
+		$this->assertLessThan( $subscribers_index, $migrate_index, 'migrate_content should come before subscribers_added' );
+	}
+
+	/**
 	 * Helper function to create a new WP_REST_Request and call the Launchpad REST API.
 	 *
 	 * @param string     $method The HTTP method to use.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://linear.app/a8c/issue/CML-809/import-step-is-missing-from-import-intent-flow

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add back "Import content" and "Import subscribers" tasks when import subscribers goal is chosen.
* Add a test.

Before | After
---- | ----
<img width="737" height="378" alt="Screenshot 2025-08-19 at 3 16 27 PM" src="https://github.com/user-attachments/assets/1d356d00-d7cf-4d76-97a9-dda6dad5f9b9" /> | <img width="733" height="494" alt="Screenshot 2025-08-19 at 6 15 17 PM" src="https://github.com/user-attachments/assets/fdff60fe-a3e0-4cfc-aa8f-2ce997eaf378" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

N/A

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this change to your sandbox: `bin/jetpack-downloader test jetpack-mu-wpcom-plugin fix/launchpad-missing-newsletter-import-steps`
* Sandbox the API.
* Go to wordpress.com/newsletter
* Choose the import goal.
* Create the site and get to My Home.
* Check that the import tasks are visible.
* Regression test choosing the free and paid newsletter goals, and the import tasks should not be visible.

