### PR TITLE
Forms: add phone number validation 

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2572,6 +2572,9 @@ importers:
       js-sha256:
         specifier: 0.11.1
         version: 0.11.1
+      libphonenumber-js:
+        specifier: 1.12.12
+        version: 1.12.12
       lodash:
         specifier: 4.17.21
         version: 4.17.21
@@ -13165,6 +13168,9 @@ packages:
     resolution: {integrity: sha512-gcxmNFzA4hv8UYi8j43uPlQ7CGcyMJ2KQb5kZASw6SnAKAf10hK12i2fjrS3Cl/ugZa5Ui6WwIu1/6MIXiHttQ==}
     engines: {node: '>=16'}
     hasBin: true
+
+  libphonenumber-js@1.12.12:
+    resolution: {integrity: sha512-aWVR6xXYYRvnK0v/uIwkf5Lthq9Jpn0N8TISW/oDTWlYB2sOimuiLn9Q26aUw4KxkJoiT8ACdiw44Y8VwKFIfQ==}
 
   libsodium-wrappers@0.7.10:
     resolution: {integrity: sha512-pO3F1Q9NPLB/MWIhehim42b/Fwb30JNScCNh8TcQ/kIc+qGLQch8ag8wb0keK3EP5kbGakk1H8Wwo7v+36rNQg==}
@@ -27664,6 +27670,8 @@ snapshots:
   lib0@0.2.114:
     dependencies:
       isomorphic.js: 0.2.5
+
+  libphonenumber-js@1.12.12: {}
 
   libsodium-wrappers@0.7.10:
     dependencies:

--- a/projects/packages/forms/changelog/add-jetpack-forms-phone-validation-lib
+++ b/projects/packages/forms/changelog/add-jetpack-forms-phone-validation-lib
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: add phone number validation on international phone number input

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -66,6 +66,7 @@
 		"email-validator": "2.0.4",
 		"gridicons": "3.4.2",
 		"js-sha256": "0.11.1",
+		"libphonenumber-js": "1.12.12",
 		"lodash": "4.17.21",
 		"react-redux": "7.2.8",
 		"react-router": "7.6.2",

--- a/projects/packages/forms/src/blocks/field-phone/country-list.js
+++ b/projects/packages/forms/src/blocks/field-phone/country-list.js
@@ -22,7 +22,7 @@ export const countries = [
 	},
 	{
 		code: 'AS',
-		label: '🇦🇸 +1684',
+		label: '🇦🇸 +1(684)',
 		value: '+1684',
 		country: 'American Samoa',
 		flag: '🇦🇸',
@@ -43,14 +43,14 @@ export const countries = [
 	},
 	{
 		code: 'AI',
-		label: '🇦🇮 +1264',
+		label: '🇦🇮 +1(264)',
 		value: '+1264',
 		country: 'Anguilla',
 		flag: '🇦🇮',
 	},
 	{
 		code: 'AG',
-		label: '🇦🇬 +1268',
+		label: '🇦🇬 +1(268)',
 		value: '+1268',
 		country: 'Antigua and Barbuda',
 		flag: '🇦🇬',
@@ -99,7 +99,7 @@ export const countries = [
 	},
 	{
 		code: 'BS',
-		label: '🇧🇸 +1242',
+		label: '🇧🇸 +1(242)',
 		value: '+1242',
 		country: 'Bahamas',
 		flag: '🇧🇸',
@@ -120,7 +120,7 @@ export const countries = [
 	},
 	{
 		code: 'BB',
-		label: '🇧🇧 +1246',
+		label: '🇧🇧 +1(246)',
 		value: '+1246',
 		country: 'Barbados',
 		flag: '🇧🇧',
@@ -155,7 +155,7 @@ export const countries = [
 	},
 	{
 		code: 'BM',
-		label: '🇧🇲 +1441',
+		label: '🇧🇲 +1(441)',
 		value: '+1441',
 		country: 'Bermuda',
 		flag: '🇧🇲',
@@ -204,7 +204,7 @@ export const countries = [
 	},
 	{
 		code: 'VG',
-		label: '🇻🇬 +1284',
+		label: '🇻🇬 +1(284)',
 		value: '+1284',
 		country: 'British Virgin Islands',
 		flag: '🇻🇬',
@@ -407,14 +407,14 @@ export const countries = [
 	},
 	{
 		code: 'DM',
-		label: '🇩🇲 +1767',
+		label: '🇩🇲 +1(767)',
 		value: '+1767',
 		country: 'Dominica',
 		flag: '🇩🇲',
 	},
 	{
 		code: 'DO',
-		label: '🇩🇴 +1849',
+		label: '🇩🇴 +1(849)',
 		value: '+1849',
 		country: 'Dominican Republic',
 		flag: '🇩🇴',
@@ -582,7 +582,7 @@ export const countries = [
 	},
 	{
 		code: 'GD',
-		label: '🇬🇩 +1473',
+		label: '🇬🇩 +1(473)',
 		value: '+1473',
 		country: 'Grenada',
 		flag: '🇬🇩',
@@ -596,7 +596,7 @@ export const countries = [
 	},
 	{
 		code: 'GU',
-		label: '🇬🇺 +1671',
+		label: '🇬🇺 +1(671)',
 		value: '+1671',
 		country: 'Guam',
 		flag: '🇬🇺',
@@ -729,7 +729,7 @@ export const countries = [
 	},
 	{
 		code: 'JM',
-		label: '🇯🇲 +1876',
+		label: '🇯🇲 +1(876)',
 		value: '+1876',
 		country: 'Jamaica',
 		flag: '🇯🇲',
@@ -988,7 +988,7 @@ export const countries = [
 	},
 	{
 		code: 'MS',
-		label: '🇲🇸 +1664',
+		label: '🇲🇸 +1(664)',
 		value: '+1664',
 		country: 'Montserrat',
 		flag: '🇲🇸',
@@ -1107,7 +1107,7 @@ export const countries = [
 	},
 	{
 		code: 'MP',
-		label: '🇲🇵 +1670',
+		label: '🇲🇵 +1(670)',
 		value: '+1670',
 		country: 'Northern Mariana Islands',
 		flag: '🇲🇵',
@@ -1205,7 +1205,7 @@ export const countries = [
 	},
 	{
 		code: 'PR',
-		label: '🇵🇷 +1939',
+		label: '🇵🇷 +1(939)',
 		value: '+1939',
 		country: 'Puerto Rico',
 		flag: '🇵🇷',
@@ -1261,14 +1261,14 @@ export const countries = [
 	},
 	{
 		code: 'KN',
-		label: '🇰🇳 +1869',
+		label: '🇰🇳 +1(869)',
 		value: '+1869',
 		country: 'Saint Kitts and Nevis',
 		flag: '🇰🇳',
 	},
 	{
 		code: 'LC',
-		label: '🇱🇨 +1758',
+		label: '🇱🇨 +1(758)',
 		value: '+1758',
 		country: 'Saint Lucia',
 		flag: '🇱🇨',
@@ -1289,7 +1289,7 @@ export const countries = [
 	},
 	{
 		code: 'VC',
-		label: '🇻🇨 +1784',
+		label: '🇻🇨 +1(784)',
 		value: '+1784',
 		country: 'Saint Vincent and the Grenadines',
 		flag: '🇻🇨',
@@ -1520,7 +1520,7 @@ export const countries = [
 	},
 	{
 		code: 'TT',
-		label: '🇹🇹 +1868',
+		label: '🇹🇹 +1(868)',
 		value: '+1868',
 		country: 'Trinidad and Tobago',
 		flag: '🇹🇹',
@@ -1548,7 +1548,7 @@ export const countries = [
 	},
 	{
 		code: 'TC',
-		label: '🇹🇨 +1649',
+		label: '🇹🇨 +1(649)',
 		value: '+1649',
 		country: 'Turks and Caicos Islands',
 		flag: '🇹🇨',
@@ -1562,7 +1562,7 @@ export const countries = [
 	},
 	{
 		code: 'VI',
-		label: '🇻🇮 +1340',
+		label: '🇻🇮 +1(340)',
 		value: '+1340',
 		country: 'U.S. Virgin Islands',
 		flag: '🇻🇮',

--- a/projects/packages/forms/src/blocks/field-phone/edit.js
+++ b/projects/packages/forms/src/blocks/field-phone/edit.js
@@ -48,7 +48,7 @@ export default function PhoneFieldEdit( props ) {
 
 	const countryPairs = useMemo( () => {
 		return countries.map( country => ( {
-			label: country.label,
+			label: country.code + ' ' + country.label,
 			value: country.code,
 		} ) );
 	}, [] );

--- a/projects/packages/forms/src/blocks/field-phone/edit.js
+++ b/projects/packages/forms/src/blocks/field-phone/edit.js
@@ -48,7 +48,7 @@ export default function PhoneFieldEdit( props ) {
 
 	const countryPairs = useMemo( () => {
 		return countries.map( country => ( {
-			label: country.code + ' ' + country.label,
+			label: country.country + ' ' + country.flag + ' ' + country.value,
 			value: country.code,
 		} ) );
 	}, [] );

--- a/projects/packages/forms/src/blocks/field-phone/edit.js
+++ b/projects/packages/forms/src/blocks/field-phone/edit.js
@@ -18,7 +18,15 @@ const EMPTY_ARRAY = [];
 
 export default function PhoneFieldEdit( props ) {
 	const { setAttributes, attributes, clientId, isSelected } = props;
-	const { showCountrySelector, width, id, required, requiredText, placeholder } = attributes;
+	const {
+		showCountrySelector,
+		width,
+		id,
+		required,
+		requiredText,
+		placeholder,
+		default: defaultCountry,
+	} = attributes;
 	const [ countryList, setCountryList ] = useState( EMPTY_ARRAY );
 
 	const { isInnerBlockSelected, hasPlaceholder } = useFieldSelected( clientId );
@@ -54,10 +62,10 @@ export default function PhoneFieldEdit( props ) {
 
 	useEffect( () => {
 		if ( showCountrySelector === undefined || showCountrySelector === true ) {
-			setAttributes( { showCountrySelector: true } );
+			setAttributes( { showCountrySelector: true, default: defaultCountry || 'US' } );
 			setCountryList( countryPairs );
 		}
-	}, [ showCountrySelector, setAttributes, countryPairs ] );
+	}, [ showCountrySelector, setAttributes, countryPairs, defaultCountry ] );
 
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		allowedBlocks: [ 'jetpack/label', 'jetpack/phone-input' ],

--- a/projects/packages/forms/src/blocks/field-phone/edit.js
+++ b/projects/packages/forms/src/blocks/field-phone/edit.js
@@ -5,7 +5,7 @@ import {
 	BlockContextProvider,
 } from '@wordpress/block-editor';
 import { PanelBody, ToggleControl } from '@wordpress/components';
-import { useCallback, useEffect, useState } from '@wordpress/element';
+import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import JetpackFieldControls from '../shared/components/jetpack-field-controls';
@@ -38,19 +38,26 @@ export default function PhoneFieldEdit( props ) {
 
 	useFormWrapper( props );
 
+	const countryPairs = useMemo( () => {
+		return countries.map( country => ( {
+			label: country.label,
+			value: country.code,
+		} ) );
+	}, [] );
+
 	const onChangeShowCountrySelector = value => {
 		setAttributes( {
 			showCountrySelector: value,
 		} );
-		setCountryList( value ? countries : EMPTY_ARRAY );
+		setCountryList( value ? countryPairs : EMPTY_ARRAY );
 	};
 
 	useEffect( () => {
 		if ( showCountrySelector === undefined || showCountrySelector === true ) {
 			setAttributes( { showCountrySelector: true } );
-			setCountryList( countries );
+			setCountryList( countryPairs );
 		}
-	}, [ showCountrySelector, setAttributes ] );
+	}, [ showCountrySelector, setAttributes, countryPairs ] );
 
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		allowedBlocks: [ 'jetpack/label', 'jetpack/phone-input' ],

--- a/projects/packages/forms/src/blocks/input-phone/edit.js
+++ b/projects/packages/forms/src/blocks/input-phone/edit.js
@@ -46,7 +46,7 @@ const PhoneInputEdit = ( { attributes, clientId, isSelected, name, setAttributes
 
 	// Prefix/Country selector
 	const prefixOptions = context?.[ 'jetpack/field-prefix-options' ] || [];
-	const defaultPrefix = context?.[ 'jetpack/field-prefix-default' ] || '';
+	const defaultPrefix = context?.[ 'jetpack/field-prefix-default' ] || 'US';
 	const onChangeDefaultPrefix = context?.[ 'jetpack/field-prefix-onChange' ] || ( () => {} );
 	const showCountrySelector = context?.[ 'jetpack/field-phone-country-toggle' ] || false;
 

--- a/projects/packages/forms/src/blocks/input-phone/editor.scss
+++ b/projects/packages/forms/src/blocks/input-phone/editor.scss
@@ -59,6 +59,7 @@
 			border: 0;
 			color: inherit;
 			display: flex;
+			max-width: 40%;
 
 			// these class is used to style select elements
 			.jetpack-field__input-element {
@@ -69,6 +70,9 @@
 				outline: none;
 				background-color: transparent;
 				padding: 0;
+				max-width: 100%;
+				text-overflow: ellipsis;
+				white-space: nowrap;
 
 				&:where(select) {
 					// compensate spacing for downarrow

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -157,8 +157,6 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 				'variation'                => null,
 				'iconstyle'                => null, // For rating field icon style (lowercase for shortcode compatibility)
 				// full phone field attributes, might become a standalone country list input block
-				'countrylist'              => array(),
-				'countrydata'              => array(),
 				'showcountryselector'      => false,
 			),
 			$attributes,
@@ -194,15 +192,6 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 			$attributes['optionsdata'] = json_decode( html_entity_decode( $attributes['optionsdata'], ENT_COMPAT ), true );
 		}
 
-		// parse countryList and countrydata, HEADS UP: all attrs are forced into lowercase
-		if ( ! empty( $attributes['countrylist'] ) ) {
-			// countrylist is a comma-separated list of country codes, the simplified output from the standard parsing mechanics at Contact_Form::parse_contact_field
-			$attributes['countrylist'] = array_map( 'trim', explode( ',', $attributes['countrylist'] ) );
-		}
-		if ( ! empty( $attributes['countrydata'] ) ) {
-			// countrydata is a JSON object of country codes and their names and flags, making it available for more complex frontend UI
-			$attributes['countrydata'] = json_decode( html_entity_decode( $attributes['countrydata'], ENT_COMPAT ), true );
-		}
 		// allow boolean values for showcountryselector, only if it's set so we don't pollute other fields attrs
 		if ( isset( $attributes['showcountryselector'] ) ) {
 			if ( '1' === $attributes['showcountryselector'] || 'true' === strtolower( $attributes['showcountryselector'] ) ) {

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -943,19 +943,11 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 			$value = '';
 		}
 
-		wp_interactivity_state(
-			'jetpack/form',
-			array(
-				'phoneNumber'      => '',
-				'phoneCountryCode' => $this->get_attribute( 'default' ),
-				'countryList'      => array(),
-			)
-		);
 		ob_start();
 		?>
 		<div class="jetpack-field__input-phone-wrapper <?php echo esc_attr( $this->get_attribute( 'stylevariationclasses' ) ); ?>"
 			style="<?php echo ( ! empty( $this->field_styles ) && is_string( $this->field_styles ) ? esc_attr( $this->field_styles ) : '' ); ?>"
-			data-wp-on--jetpack-form-reset='actions.onReset'
+			data-wp-on--jetpack-form-reset='actions.phoneResetHandler'
 			<?php
 			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- function is supposed to work this way
 			echo wp_interactivity_data_wp_context(
@@ -963,6 +955,12 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 					'fieldId'             => $id,
 					'defaultCountry'      => $this->get_attribute( 'default' ),
 					'showCountrySelector' => $this->get_attribute( 'showcountryselector' ),
+					// dynamic
+					'phoneNumber'         => '',
+					'phoneCountryCode'    => $this->get_attribute( 'default' ),
+					'countryList'         => array(),
+					'fullPhoneNumber'     => '',
+					'countryPrefix'       => '',
 				)
 			);
 			?>
@@ -973,10 +971,10 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 						data-wp-bind--disabled='state.isSubmitting'
 						data-wp-init="callbacks.initializeCountrySelector"
 						data-wp-on--change="actions.onPhoneCountryChange"
-						data-wp-bind--value="state.phoneCountryCode"
+						data-wp-bind--value="context.phoneCountryCode"
 						data-wp-on--blur='actions.onFieldBlur'>
 						<template
-							data-wp-each--country="state.countryList"
+							data-wp-each--country="context.countryList"
 							data-wp-each-key="context.country.code">
 							<option
 								data-wp-bind--value="context.country.value"
@@ -995,7 +993,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 					<?php } ?>
 					data-wp-bind--disabled='state.isSubmitting'
 					data-wp-bind--aria-invalid='state.fieldHasErrors'
-					data-wp-bind--value='state.phoneNumber'
+					data-wp-bind--value='context.phoneNumber'
 					aria-errormessage="<?php echo esc_attr( $id ); ?>-phone-error-message"
 					data-wp-on--input='actions.onPhoneNumberChange'
 					data-wp-on--blur='actions.onFieldBlur'
@@ -1004,7 +1002,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 				<input type="hidden"
 					id="<?php echo esc_attr( $id ); ?>"
 					name="<?php echo esc_attr( $id ); ?>"
-					data-wp-bind--value='state.fullPhoneNumber' />
+					data-wp-bind--value='context.fullPhoneNumber' />
 		</div>
 		<?php
 		$input = ob_get_clean();

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -971,6 +971,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- function is supposed to work this way
 			echo wp_interactivity_data_wp_context(
 				array(
+					'fieldId'             => $id,
 					'defaultCountry'      => $this->get_attribute( 'default' ),
 					'showCountrySelector' => $this->get_attribute( 'showcountryselector' ),
 				)
@@ -983,7 +984,8 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 						data-wp-bind--disabled='state.isSubmitting'
 						data-wp-init="callbacks.initializeCountrySelector"
 						data-wp-on--change="actions.onPhoneCountryChange"
-						data-wp-bind--value="state.phoneCountryCode">
+						data-wp-bind--value="state.phoneCountryCode"
+						data-wp-on--blur='actions.onFieldBlur'>
 						<template
 							data-wp-each--country="state.countryList"
 							data-wp-each-key="context.country.code">

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -514,10 +514,6 @@ class Contact_Form_Plugin {
 					$style_variation_data                     = self::get_style_variation_shortcode_attributes( $block_name, $inner_block['attrs'] );
 					$atts                                     = array_merge( $atts, $style_variation_data );
 					$add_block_style_classes_to_field_wrapper = true;
-					if ( isset( $atts['countryList'] ) ) {
-						// this is necessary (same as optionsdata) to make the countrydata attribute digestible by the Contact_Form_Field class
-						$atts['countryData'] = \wp_json_encode( $atts['countryList'] );
-					}
 
 					continue;
 				}

--- a/projects/packages/forms/src/contact-form/css/phone-field.scss
+++ b/projects/packages/forms/src/contact-form/css/phone-field.scss
@@ -16,6 +16,13 @@
 
 		.jetpack-field__input-prefix:not([hidden]) {
 			display: flex;
+			max-width: 40%;
+
+			.jetpack-field__input-element {
+				max-width: 100%;
+				text-overflow: ellipsis;
+				white-space: nowrap;
+			}
 		}
 
 		.jetpack-field__input-element {

--- a/projects/packages/forms/src/modules/field-phone/view.js
+++ b/projects/packages/forms/src/modules/field-phone/view.js
@@ -23,14 +23,14 @@ const { state, actions } = store( NAMESPACE, {
 				// use our internal full phone number state getter:
 				value = state.fullPhoneNumber;
 				const context = getContext();
-				if ( context.showCountrySelector ) {
+				if ( context.showCountrySelector || value.indexOf( '+' ) === 0 ) {
 					const internationalNumber = parsePhoneNumber( value );
 					if ( ! internationalNumber || ! internationalNumber.isValid() ) {
 						return 'invalid_phone';
 					}
 				}
 
-				// if no country selector, use legacy regex check
+				// if no country selector or value starting with +, use legacy regex check
 				if ( ! /^\+?[0-9\s\-()]+$/.test( value ) ) {
 					return 'invalid_phone';
 				}

--- a/projects/packages/forms/src/modules/field-phone/view.js
+++ b/projects/packages/forms/src/modules/field-phone/view.js
@@ -8,20 +8,11 @@ const { state, actions } = store( NAMESPACE, {
 	state: {
 		validators: {
 			phone: ( value, isRequired ) => {
-				if ( isEmptyValue( value ) && isRequired ) {
+				if ( isEmptyValue( state.phoneNumber ) && isRequired ) {
+					// this is not triggering any error, but then no other input does either
 					return 'is_required';
 				}
-
-				const context = getContext();
-				const triggeringFromSelector =
-					context.showCountrySelector && value === state.phoneCountryCode;
-				// when blur triggers this from the selector, the value
-				// is just the country code, treat as empty
-				if ( triggeringFromSelector ) {
-					value = '';
-				}
-
-				if ( ! isRequired && isEmptyValue( value + state.phoneNumber ) ) {
+				if ( ! isRequired && isEmptyValue( state.phoneNumber ) ) {
 					// No need to validate anything.
 					return 'yes';
 				}
@@ -29,7 +20,7 @@ const { state, actions } = store( NAMESPACE, {
 				// from this point on, we discard the value as we
 				// use our internal full phone number state getter:
 				value = state.fullPhoneNumber;
-
+				const context = getContext();
 				if ( context.showCountrySelector ) {
 					const internationalNumber = parsePhoneNumber( value );
 					if ( ! internationalNumber || ! internationalNumber.isValid() ) {

--- a/projects/packages/forms/src/modules/field-phone/view.js
+++ b/projects/packages/forms/src/modules/field-phone/view.js
@@ -1,9 +1,10 @@
 import { store, getContext } from '@wordpress/interactivity';
+import parsePhoneNumber from 'libphonenumber-js';
 import { countries } from '../../blocks/field-phone/country-list';
 import { isEmptyValue } from '../../contact-form/js/validate-helper';
 const NAMESPACE = 'jetpack/form';
 
-const { state } = store( NAMESPACE, {
+const { state, actions } = store( NAMESPACE, {
 	state: {
 		validators: {
 			phone: ( value, isRequired ) => {
@@ -11,14 +12,36 @@ const { state } = store( NAMESPACE, {
 					return 'is_required';
 				}
 
-				if ( ! isRequired && isEmptyValue( value ) ) {
+				const context = getContext();
+				const triggeringFromSelector =
+					context.showCountrySelector && value === state.phoneCountryCode;
+				// when blur triggers this from the selector, the value
+				// is just the country code, treat as empty
+				if ( triggeringFromSelector ) {
+					value = '';
+				}
+
+				if ( ! isRequired && isEmptyValue( value + state.phoneNumber ) ) {
 					// No need to validate anything.
 					return 'yes';
 				}
 
+				// from this point on, we discard the value as we
+				// use our internal full phone number state getter:
+				value = state.fullPhoneNumber;
+
+				if ( context.showCountrySelector ) {
+					const internationalNumber = parsePhoneNumber( value );
+					if ( ! internationalNumber || ! internationalNumber.isValid() ) {
+						return 'invalid_phone';
+					}
+				}
+
+				// if no country selector, use legacy regex check
 				if ( ! /^\+?[0-9\s\-()]+$/.test( value ) ) {
 					return 'invalid_phone';
 				}
+
 				return 'yes';
 			},
 		},
@@ -44,31 +67,23 @@ const { state } = store( NAMESPACE, {
 		onPhoneNumberChange( event ) {
 			const context = getContext();
 			const value = event.target.value;
-
 			if ( ! context.showCountrySelector ) {
 				state.phoneNumber = value;
 				return;
 			}
-
-			// Check for country code pattern: + followed by 1-3 digits
-			const countryCodeMatch = value.match( /^\+(\d{1,4})/ );
-
-			if ( countryCodeMatch ) {
-				const potentialCode = countryCodeMatch[ 0 ];
-
-				const countryItem = countries?.find( country => country.value === potentialCode );
-
-				state.phoneCountryCode = countryItem?.value || context.phoneCountryCode;
-				// If there's a space after the country code, split the input
-				if ( value.charAt( potentialCode.length ) === ' ' ) {
-					state.phoneNumber = value.substring( potentialCode.length + 1 );
-				} else {
-					// If no space yet, keep the whole input in phoneNumber
-					state.phoneNumber = value;
+			const fieldId = context.fieldId;
+			if ( value.indexOf( '+' ) === 0 && value.length > 1 ) {
+				// user is trying to type an international phone number
+				const internationalNumber = parsePhoneNumber( value );
+				if ( internationalNumber ) {
+					const country = countries.find( item => item.code === internationalNumber.country );
+					state.phoneCountryCode = country?.value || context.defaultCountry;
+					state.phoneNumber = internationalNumber.nationalNumber;
 				}
 			} else {
 				state.phoneNumber = value;
 			}
+			actions.updateField( fieldId, value );
 		},
 		onPhoneCountryChange( event ) {
 			const context = getContext();

--- a/projects/packages/forms/src/modules/field-phone/view.js
+++ b/projects/packages/forms/src/modules/field-phone/view.js
@@ -81,7 +81,7 @@ const { actions } = store( NAMESPACE, {
 			if ( context.showCountrySelector ) {
 				context.countryList = countries.map( country => ( {
 					...country,
-					label: country.code + ' ' + country.label,
+					label: country.country + ' ' + country.flag + ' ' + country.value,
 					value: country.code,
 					selected: country.code === context.defaultCountry,
 				} ) );

--- a/projects/packages/forms/src/modules/field-phone/view.js
+++ b/projects/packages/forms/src/modules/field-phone/view.js
@@ -4,25 +4,25 @@ import { countries } from '../../blocks/field-phone/country-list';
 import { isEmptyValue } from '../../contact-form/js/validate-helper';
 const NAMESPACE = 'jetpack/form';
 
-let asYouType;
+const asYouTypes = {};
 
-const { state, actions } = store( NAMESPACE, {
+const { actions } = store( NAMESPACE, {
 	state: {
 		validators: {
 			phone: ( value, isRequired ) => {
-				if ( isEmptyValue( state.phoneNumber ) && isRequired ) {
+				const context = getContext();
+				if ( isEmptyValue( context.phoneNumber ) && isRequired ) {
 					// this is not triggering any error, but then no other input does either
 					return 'is_required';
 				}
-				if ( ! isRequired && isEmptyValue( state.phoneNumber ) ) {
+				if ( ! isRequired && isEmptyValue( context.phoneNumber ) ) {
 					// No need to validate anything.
 					return 'yes';
 				}
 
 				// from this point on, we discard the value as we
 				// use our internal full phone number state getter:
-				value = state.fullPhoneNumber;
-				const context = getContext();
+				value = context.fullPhoneNumber;
 				if ( context.showCountrySelector || value.indexOf( '+' ) === 0 ) {
 					const internationalNumber = parsePhoneNumber( value );
 					if ( ! internationalNumber || ! internationalNumber.isValid() ) {
@@ -38,67 +38,55 @@ const { state, actions } = store( NAMESPACE, {
 				return 'yes';
 			},
 		},
-		get countryPrefix() {
-			const context = getContext();
-			if ( context.showCountrySelector ) {
-				return countries.find( item => item.code === state.phoneCountryCode )?.value;
-			}
-			return '';
-		},
-		get fullPhoneNumber() {
-			const context = getContext();
-			if ( context.showCountrySelector ) {
-				// if the user has typed the country code and didn't add a space,
-				// assume they already typed a full international phone number
-				if ( state.phoneNumber.indexOf( state.countryPrefix ) === 0 ) {
-					return state.phoneNumber;
-				}
-				return `${ state.countryPrefix } ${ state.phoneNumber }`;
-			}
-			return state.phoneNumber;
-		},
 	},
 	actions: {
-		onReset() {
+		phoneResetHandler() {
 			const context = getContext();
-			state.phoneCountryCode = context.defaultCountry;
-			state.phoneNumber = '';
+			context.phoneCountryCode = context.defaultCountry;
+			context.phoneNumber = '';
 		},
 		onPhoneNumberChange( event ) {
 			const context = getContext();
+			const fieldId = context.fieldId;
 			const value = event.target.value;
 			if ( ! context.showCountrySelector ) {
-				state.phoneNumber = value;
+				context.phoneNumber = context.fullPhoneNumber = value;
 				return;
 			}
-			asYouType.reset();
-			const fieldId = context.fieldId;
-			asYouType.input( value );
-			if ( asYouType.getCountry() ) {
-				state.phoneCountryCode = asYouType.getCountry();
-				state.phoneNumber = asYouType.getNationalNumber();
+			asYouTypes[ fieldId ].reset();
+			asYouTypes[ fieldId ].input( value );
+			if ( asYouTypes[ fieldId ].getCountry() ) {
+				context.phoneCountryCode = asYouTypes[ fieldId ].getCountry();
+				context.phoneNumber = asYouTypes[ fieldId ].getNationalNumber();
+				asYouTypes[ fieldId ] = new AsYouType( context.phoneCountryCode );
 			} else {
-				state.phoneNumber = value;
+				context.phoneNumber = value;
 			}
+			context.countryPrefix = countries.find(
+				item => item.code === context.phoneCountryCode
+			)?.value;
+			context.fullPhoneNumber = context.countryPrefix + ' ' + context.phoneNumber;
 			actions.updateField( fieldId, value );
 		},
 		onPhoneCountryChange( event ) {
 			const context = getContext();
-			state.phoneCountryCode = event?.target?.value || context.defaultCountry;
+			context.countryPrefix = countries.find( item => item.code === event?.target?.value )?.value;
+			context.phoneCountryCode = event?.target?.value || context.defaultCountry;
+			context.fullPhoneNumber = context.countryPrefix + ' ' + context.phoneNumber;
 		},
 	},
 	callbacks: {
 		initializeCountrySelector() {
 			const context = getContext();
 			if ( context.showCountrySelector ) {
-				state.countryList = countries.map( country => ( {
+				context.countryList = countries.map( country => ( {
 					...country,
 					label: country.code + ' ' + country.label,
 					value: country.code,
 					selected: country.code === context.defaultCountry,
 				} ) );
 			}
-			asYouType = new AsYouType( context.defaultCountry );
+			asYouTypes[ context.fieldId ] = new AsYouType( context.defaultCountry );
 		},
 	},
 } );

--- a/projects/packages/forms/src/modules/field-phone/view.js
+++ b/projects/packages/forms/src/modules/field-phone/view.js
@@ -90,8 +90,6 @@ const { state, actions } = store( NAMESPACE, {
 	callbacks: {
 		initializeCountrySelector() {
 			const context = getContext();
-			window.parsePhoneNumber = parsePhoneNumber;
-			window.AsYouType = AsYouType;
 			if ( context.showCountrySelector ) {
 				state.countryList = countries.map( country => ( {
 					...country,

--- a/projects/packages/forms/src/modules/field-phone/view.js
+++ b/projects/packages/forms/src/modules/field-phone/view.js
@@ -23,7 +23,11 @@ const { actions } = store( NAMESPACE, {
 				// from this point on, we discard the value as we
 				// use our internal full phone number state getter:
 				value = context.fullPhoneNumber;
-				if ( context.showCountrySelector || value.indexOf( '+' ) === 0 ) {
+				if (
+					context.showCountrySelector ||
+					value.indexOf( '+' ) === 0 ||
+					value.indexOf( '00' ) === 0
+				) {
 					const internationalNumber = parsePhoneNumber( value );
 					if ( ! internationalNumber || ! internationalNumber.isValid() ) {
 						return 'invalid_phone';
@@ -53,8 +57,10 @@ const { actions } = store( NAMESPACE, {
 				context.phoneNumber = context.fullPhoneNumber = value;
 				return;
 			}
+			const groomedValue = value.indexOf( '00' ) === 0 ? '+' + value.slice( 2 ) : value;
+
 			asYouTypes[ fieldId ].reset();
-			asYouTypes[ fieldId ].input( value );
+			asYouTypes[ fieldId ].input( groomedValue );
 			if ( asYouTypes[ fieldId ].getCountry() ) {
 				context.phoneCountryCode = asYouTypes[ fieldId ].getCountry();
 				context.phoneNumber = asYouTypes[ fieldId ].getNationalNumber();

--- a/projects/packages/forms/src/modules/field-phone/view.js
+++ b/projects/packages/forms/src/modules/field-phone/view.js
@@ -1,8 +1,10 @@
 import { store, getContext } from '@wordpress/interactivity';
-import parsePhoneNumber from 'libphonenumber-js';
+import parsePhoneNumber, { AsYouType } from 'libphonenumber-js';
 import { countries } from '../../blocks/field-phone/country-list';
 import { isEmptyValue } from '../../contact-form/js/validate-helper';
 const NAMESPACE = 'jetpack/form';
+
+let asYouType;
 
 const { state, actions } = store( NAMESPACE, {
 	state: {
@@ -36,15 +38,22 @@ const { state, actions } = store( NAMESPACE, {
 				return 'yes';
 			},
 		},
+		get countryPrefix() {
+			const context = getContext();
+			if ( context.showCountrySelector ) {
+				return countries.find( item => item.code === state.phoneCountryCode )?.value;
+			}
+			return '';
+		},
 		get fullPhoneNumber() {
 			const context = getContext();
 			if ( context.showCountrySelector ) {
 				// if the user has typed the country code and didn't add a space,
 				// assume they already typed a full international phone number
-				if ( state.phoneNumber.indexOf( state.phoneCountryCode ) === 0 ) {
+				if ( state.phoneNumber.indexOf( state.countryPrefix ) === 0 ) {
 					return state.phoneNumber;
 				}
-				return `${ state.phoneCountryCode } ${ state.phoneNumber }`;
+				return `${ state.countryPrefix } ${ state.phoneNumber }`;
 			}
 			return state.phoneNumber;
 		},
@@ -62,15 +71,12 @@ const { state, actions } = store( NAMESPACE, {
 				state.phoneNumber = value;
 				return;
 			}
+			asYouType.reset();
 			const fieldId = context.fieldId;
-			if ( value.indexOf( '+' ) === 0 && value.length > 1 ) {
-				// user is trying to type an international phone number
-				const internationalNumber = parsePhoneNumber( value );
-				if ( internationalNumber ) {
-					const country = countries.find( item => item.code === internationalNumber.country );
-					state.phoneCountryCode = country?.value || context.defaultCountry;
-					state.phoneNumber = internationalNumber.nationalNumber;
-				}
+			asYouType.input( value );
+			if ( asYouType.getCountry() ) {
+				state.phoneCountryCode = asYouType.getCountry();
+				state.phoneNumber = asYouType.getNationalNumber();
 			} else {
 				state.phoneNumber = value;
 			}
@@ -84,12 +90,17 @@ const { state, actions } = store( NAMESPACE, {
 	callbacks: {
 		initializeCountrySelector() {
 			const context = getContext();
+			window.parsePhoneNumber = parsePhoneNumber;
+			window.AsYouType = AsYouType;
 			if ( context.showCountrySelector ) {
 				state.countryList = countries.map( country => ( {
 					...country,
-					selected: country.value === context.defaultCountry,
+					label: country.code + ' ' + country.label,
+					value: country.code,
+					selected: country.code === context.defaultCountry,
 				} ) );
 			}
+			asYouType = new AsYouType( context.defaultCountry );
 		},
 	},
 } );


### PR DESCRIPTION


## Proposed changes:
This pull request introduces phone number validation using the `libphonenumber-js` library for international phone number input in Jetpack Forms. It also updates the phone field UI and logic to improve accuracy and user experience, and makes minor adjustments to the country list formatting.

**Phone validation improvements:**

* Added `libphonenumber-js` as a dependency and integrated it into the phone field validator to perform proper international phone number validation, replacing the previous regex-only approach. [[1]](diffhunk://#diff-df6fba59ecfb31ae58c1e644afcf14b40135dc03caab8891d9b8ffce4f2fbe01R69) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR2575-R2577) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR13172-R13174) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR27674-R27675) [[5]](diffhunk://#diff-dbbe725cf5d399a4ad6662dcb5c9860d42fae84dbeddeb578ba7310f17e76013R2-R44)
* Updated the phone number change handler to parse and separate country codes and national numbers using `libphonenumber-js`, improving input handling for international formats.

**UI and UX enhancements:**

* Added `fieldId` to the phone field context and ensured changes to the country selector trigger validation and field updates, improving reactivity and correctness. [[1]](diffhunk://#diff-00706be2701c1c93bb2f89b98c5e06e22ed43f5b7f673ceab98f432e13b1fec2R974) [[2]](diffhunk://#diff-00706be2701c1c93bb2f89b98c5e06e22ed43f5b7f673ceab98f432e13b1fec2L986-R988) [[3]](diffhunk://#diff-dbbe725cf5d399a4ad6662dcb5c9860d42fae84dbeddeb578ba7310f17e76013R2-R44)
* Improved handling of blur events on the country selector to avoid treating country code selection as valid input. [[1]](diffhunk://#diff-00706be2701c1c93bb2f89b98c5e06e22ed43f5b7f673ceab98f432e13b1fec2L986-R988) [[2]](diffhunk://#diff-dbbe725cf5d399a4ad6662dcb5c9860d42fae84dbeddeb578ba7310f17e76013R2-R44)

**Country list formatting:**

* Updated several entries in the country list to use the `+1(XXX)` format for North American countries, improving clarity for users. [[1]](diffhunk://#diff-52279c8301fb44aa9a8d276e1941bfc1a1700457f9da83b77e1fa9fb4c2e9eaaL25-R25) [[2]](diffhunk://#diff-52279c8301fb44aa9a8d276e1941bfc1a1700457f9da83b77e1fa9fb4c2e9eaaL46-R53) [[3]](diffhunk://#diff-52279c8301fb44aa9a8d276e1941bfc1a1700457f9da83b77e1fa9fb4c2e9eaaL102-R102) [[4]](diffhunk://#diff-52279c8301fb44aa9a8d276e1941bfc1a1700457f9da83b77e1fa9fb4c2e9eaaL123-R123) [[5]](diffhunk://#diff-52279c8301fb44aa9a8d276e1941bfc1a1700457f9da83b77e1fa9fb4c2e9eaaL158-R158) [[6]](diffhunk://#diff-52279c8301fb44aa9a8d276e1941bfc1a1700457f9da83b77e1fa9fb4c2e9eaaL207-R207) [[7]](diffhunk://#diff-52279c8301fb44aa9a8d276e1941bfc1a1700457f9da83b77e1fa9fb4c2e9eaaL410-R417) [[8]](diffhunk://#diff-52279c8301fb44aa9a8d276e1941bfc1a1700457f9da83b77e1fa9fb4c2e9eaaL585-R585) [[9]](diffhunk://#diff-52279c8301fb44aa9a8d276e1941bfc1a1700457f9da83b77e1fa9fb4c2e9eaaL599-R599) [[10]](diffhunk://#diff-52279c8301fb44aa9a8d276e1941bfc1a1700457f9da83b77e1fa9fb4c2e9eaaL732-R732) [[11]](diffhunk://#diff-52279c8301fb44aa9a8d276e1941bfc1a1700457f9da83b77e1fa9fb4c2e9eaaL991-R991) [[12]](diffhunk://#diff-52279c8301fb44aa9a8d276e1941bfc1a1700457f9da83b77e1fa9fb4c2e9eaaL1110-R1110) [[13]](diffhunk://#diff-52279c8301fb44aa9a8d276e1941bfc1a1700457f9da83b77e1fa9fb4c2e9eaaL1208-R1208) [[14]](diffhunk://#diff-52279c8301fb44aa9a8d276e1941bfc1a1700457f9da83b77e1fa9fb4c2e9eaaL1264-R1271) [[15]](diffhunk://#diff-52279c8301fb44aa9a8d276e1941bfc1a1700457f9da83b77e1fa9fb4c2e9eaaL1292-R1292) [[16]](diffhunk://#diff-52279c8301fb44aa9a8d276e1941bfc1a1700457f9da83b77e1fa9fb4c2e9eaaL1523-R1523) [[17]](diffhunk://#diff-52279c8301fb44aa9a8d276e1941bfc1a1700457f9da83b77e1fa9fb4c2e9eaaL1551-R1551) [[18]](diffhunk://#diff-52279c8301fb44aa9a8d276e1941bfc1a1700457f9da83b77e1fa9fb4c2e9eaaL1565-R1565)

**Changelog:**

* Added a changelog entry for the new phone number validation feature.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None yet

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Insert a form and add an International Phone Number input. Mind the "Show country selector" setting on the sidebar as we need to test both with and without the country selector.

With the country selector enabled, visit the frontend and type phone numbers, they will be validated on blur/focusout of the input.

- typing a phone number starting with a "+" sign will try to auto select the country for you
- changing the country selector to a different country will validate the phone number as soon as you switch to a different input
- pasting a phone number should work as typing with a plus sign
- when the field is not required validation should not run when the field is empty, not even changing the country selector
- other validations should occur normally

Disabling the country selector and visiting the frontend again should fallback to simple numeric validation
