### PR TITLE
WPCOM Imports: Add Squarespace and Medium entries in import.php

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-wpcom-imports
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-wpcom-imports
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Add Medium and Squarespace importers in WP-Admin/import.php

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -258,6 +258,7 @@ class Jetpack_Mu_Wpcom {
 	 * Load features that don't need any special loading considerations.
 	 */
 	public static function load_features() {
+
 		// Please keep the features in alphabetical order.
 		require_once __DIR__ . '/features/100-year-plan/enhanced-ownership.php';
 		require_once __DIR__ . '/features/100-year-plan/locked-mode.php';
@@ -283,6 +284,7 @@ class Jetpack_Mu_Wpcom {
 		require_once __DIR__ . '/features/wpcom-block-editor/class-jetpack-wpcom-block-editor.php';
 		require_once __DIR__ . '/features/wpcom-block-editor/functions.editor-type.php';
 		require_once __DIR__ . '/features/wpcom-hotfixes/wpcom-hotfixes.php';
+		require_once __DIR__ . '/features/wpcom-imports/wpcom-imports.php';
 		require_once __DIR__ . '/features/wpcom-logout/wpcom-logout.php';
 		require_once __DIR__ . '/features/wpcom-themes/wpcom-theme-fixes.php';
 		require_once __DIR__ . '/features/wpcom-post-list/wpcom-post-types-tracking.php';

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -284,7 +284,6 @@ class Jetpack_Mu_Wpcom {
 		require_once __DIR__ . '/features/wpcom-block-editor/class-jetpack-wpcom-block-editor.php';
 		require_once __DIR__ . '/features/wpcom-block-editor/functions.editor-type.php';
 		require_once __DIR__ . '/features/wpcom-hotfixes/wpcom-hotfixes.php';
-		require_once __DIR__ . '/features/wpcom-imports/wpcom-imports.php';
 		require_once __DIR__ . '/features/wpcom-logout/wpcom-logout.php';
 		require_once __DIR__ . '/features/wpcom-themes/wpcom-theme-fixes.php';
 		require_once __DIR__ . '/features/wpcom-post-list/wpcom-post-types-tracking.php';
@@ -328,6 +327,7 @@ class Jetpack_Mu_Wpcom {
 		require_once __DIR__ . '/features/wpcom-command-palette/wpcom-command-palette.php';
 		require_once __DIR__ . '/features/wpcom-comments/wpcom-comments.php';
 		require_once __DIR__ . '/features/wpcom-dashboard-widgets/wpcom-dashboard-widgets.php';
+		require_once __DIR__ . '/features/wpcom-imports/wpcom-imports.php';
 		require_once __DIR__ . '/features/wpcom-locale/sync-locale-from-calypso-to-atomic.php';
 		require_once __DIR__ . '/features/wpcom-media/wpcom-media-url-upload.php';
 		require_once __DIR__ . '/features/wpcom-media/wpcom-export-media-files.php';

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-imports/wpcom-imports.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-imports/wpcom-imports.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Register Calypso import entries in WP-Admin/import.php
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+declare(strict_types=1);
+
+/**
+ * Register the imports.
+ *
+ * WPCOM Simple has a custom filter for the url. However, that filter is not available on AT.
+ * To avoid having duplicate implementations, the implementation uses a redirect.
+ *
+ * @return void
+ */
+function wpcom_imports_register_imports() {
+	$page = function () { };
+
+	$squarespace_description = __( 'Import <strong>posts, comments, images and tags</strong> from a Squarespace export file.', 'jetpack-mu-wpcom' );
+	$medium_description      = __( 'Import <strong>posts</strong> from a Medium export file.', 'jetpack-mu-wpcom' );
+
+	register_importer( 'wpcom-squarespace', __( 'Squarespace', 'jetpack-mu-wpcom' ), $squarespace_description, $page );
+	register_importer( 'wpcom-medium', __( 'Medium', 'jetpack-mu-wpcom' ), $medium_description, $page );
+}
+
+add_action( 'admin_init', 'wpcom_imports_register_imports' );
+
+/**
+ * Redirect to Calypso Stepper Squarespace importer.
+ */
+add_action(
+	'load-importer-wpcom-squarespace',
+	function () {
+		$domain = wp_parse_url( home_url(), PHP_URL_HOST );
+		wp_redirect( 'https://wordpress.com/setup/site-setup/importerSquarespace?ref=wp-admin-importers-list-direct-importer&siteSlug=' . $domain );
+		exit();
+	}
+);
+
+/**
+ * Redirect to Calypso Stepper Medium importer.
+ */
+add_action(
+	'load-importer-wpcom-medium',
+	function () {
+		$domain = wp_parse_url( home_url(), PHP_URL_HOST );
+		wp_redirect( 'https://wordpress.com/setup/site-setup/importerMedium?ref=wp-admin-importers-list-direct-importer&siteSlug=' . $domain );
+		exit();
+	}
+);

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-imports/wpcom-imports.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-imports/wpcom-imports.php
@@ -32,6 +32,11 @@ add_action( 'admin_init', 'wpcom_imports_register_imports' );
  */
 add_action(
 	'load-importer-wpcom-squarespace',
+	/**
+	 * Redirect to the Squarespace importer in the Calypso Stepper.
+	 *
+	 * @return never-return
+	 */
 	function () {
 		$domain = wp_parse_url( home_url(), PHP_URL_HOST );
 		wp_redirect( 'https://wordpress.com/setup/site-setup/importerSquarespace?ref=wp-admin-importers-list-direct-importer&siteSlug=' . $domain );
@@ -44,6 +49,11 @@ add_action(
  */
 add_action(
 	'load-importer-wpcom-medium',
+	/**
+	 * Redirect to the Medium importer in the Calypso Stepper.
+	 *
+	 * @return never-return
+	 */
 	function () {
 		$domain = wp_parse_url( home_url(), PHP_URL_HOST );
 		wp_redirect( 'https://wordpress.com/setup/site-setup/importerMedium?ref=wp-admin-importers-list-direct-importer&siteSlug=' . $domain );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-imports/wpcom-imports.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-imports/wpcom-imports.php
@@ -39,6 +39,7 @@ add_action(
 	 */
 	function () {
 		$domain = wp_parse_url( home_url(), PHP_URL_HOST );
+		// phpcs:ignore WordPress.Security.SafeRedirect.wp_redirect_wp_redirect
 		wp_redirect( 'https://wordpress.com/setup/site-setup/importerSquarespace?ref=wp-admin-importers-list-direct-importer&siteSlug=' . $domain );
 		exit();
 	}
@@ -56,6 +57,7 @@ add_action(
 	 */
 	function () {
 		$domain = wp_parse_url( home_url(), PHP_URL_HOST );
+		// phpcs:ignore WordPress.Security.SafeRedirect.wp_redirect_wp_redirect
 		wp_redirect( 'https://wordpress.com/setup/site-setup/importerMedium?ref=wp-admin-importers-list-direct-importer&siteSlug=' . $domain );
 		exit();
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes DOTCOM-14257, DOTCOM-14230

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add a Squarespace and a Medium entry in wp-admin/import.php

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this PR on your sandbox
* Apply this PR on your Atomic site
* Go to /wp-admin/import.php
* Notice that we have two new entries: Squarespace and Medium
* Grab the URL on the "Run importer"
* Open the live link from this [Calypso PR](https://github.com/Automattic/wp-calypso/pull/105280)
* Open the URL you've copied from the Run Importer URL.
* Notice that when you press the back link you're sent back to wp-admin/import.php

