### PR TITLE
e2e tests: Fix intermitted failures of search test

### DIFF
--- a/projects/plugins/search/changelog/jetpack-763-e2e-tests-can-perform-search-with-default-settings-is
+++ b/projects/plugins/search/changelog/jetpack-763-e2e-tests-can-perform-search-with-default-settings-is
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: E2E tests: fixed intermittent failures of search test
+
+

--- a/projects/plugins/search/tests/e2e/fixtures/test.ts
+++ b/projects/plugins/search/tests/e2e/fixtures/test.ts
@@ -358,14 +358,17 @@ const test = baseTest.extend< object, { searchUtils: SearchUtils } >( {
 			const params = url.searchParams;
 
 			// loads response for queries
+			// IMPORTANT: We must create a deep copy of the results array to avoid mutating
+			// the original mock data. Without this, sorting operations would permanently
+			// modify the mock data, causing inconsistent test results on subsequent runs.
 			let body;
 			switch ( params.get( 'query' ) ) {
 				case 'test1':
-					body = { ...searchResultForTest1 };
+					body = { ...searchResultForTest1, results: [ ...searchResultForTest1.results ] };
 					break;
 				case 'test2':
 				default:
-					body = { ...searchResultForTest2 };
+					body = { ...searchResultForTest2, results: [ ...searchResultForTest2.results ] };
 					break;
 			}
 

--- a/projects/plugins/search/tests/e2e/fixtures/test.ts
+++ b/projects/plugins/search/tests/e2e/fixtures/test.ts
@@ -353,7 +353,7 @@ const test = baseTest.extend< object, { searchUtils: SearchUtils } >( {
 	 */
 	page: async ( { page }, use ) => {
 		await page.route( SEARCH_API_PATTERN, ( route, request ) => {
-			logger.info( `intercepted search API call: ${ request.url() }` );
+			logger.debug( `intercepted search API call: ${ request.url() }` );
 			const url = new URL( request.url() );
 			const params = url.searchParams;
 
@@ -396,12 +396,18 @@ const test = baseTest.extend< object, { searchUtils: SearchUtils } >( {
 			const tag = params.get( 'filter[bool][must][0][term][tag.slug]' );
 
 			if ( category ) {
-				body.results = body.results.filter( v => v?.categories?.includes( category ) );
+				body.results = body.results.filter(
+					( v: { categories: string | string[] } ) => v?.categories?.includes( category )
+				);
 			}
 
 			if ( tag ) {
-				body.results = body.results.filter( v => v?.tags?.includes( tag ) );
+				body.results = body.results.filter(
+					( v: { tags: string | string[] } ) => v?.tags?.includes( tag )
+				);
 			}
+
+			logger.debug( `returning ${ JSON.stringify( body ) }` );
 
 			route.fulfill( {
 				contentType: 'application/json',

--- a/projects/plugins/search/tests/e2e/specs/search-dashboard.test.ts
+++ b/projects/plugins/search/tests/e2e/specs/search-dashboard.test.ts
@@ -29,13 +29,13 @@ async function toggle( page: Page, toggleLocator: Locator ): Promise< void > {
 
 test.describe( 'Search Dashboard', () => {
 	test.beforeAll( async ( { testUtils } ) => {
-		clearSearchPlanInfo();
+		await clearSearchPlanInfo();
 		await testUtils.activateModule( 'search' );
-		enableInstantSearch();
+		await enableInstantSearch();
 	} );
 
 	test.afterAll( async () => {
-		disableInstantSearch();
+		await disableInstantSearch();
 	} );
 
 	test( 'Can manage search module and instant search.', async ( { page } ) => {

--- a/projects/plugins/search/tests/e2e/specs/search.test.ts
+++ b/projects/plugins/search/tests/e2e/specs/search.test.ts
@@ -8,13 +8,22 @@ import {
 import type { Page, Response } from '@playwright/test';
 
 /**
- * Returns the inner HTML of the first search result title.
- * @param {Page} page - instance of a Playwright Page type
- * @return {Promise<string>} The inner HTML of the first search result title.
+ * Asserts that the first result title matches the expected value with retry logic.
+ * @param {Page}   page          - instance of a Playwright Page type
+ * @param {string} expectedTitle - the expected title to match
+ * @return {Promise<void>} - A promise that resolves when the assertion passes.
  */
-async function getFirstResultTitle( page: Page ): Promise< string > {
-	const resultTitleSelector = '.jetpack-instant-search__search-result-title-link > span';
-	return page.innerHTML( resultTitleSelector );
+async function expectFirstResultTitle( page: Page, expectedTitle: string ): Promise< void > {
+	await expect( async () => {
+		const resultTitleSelector = '.jetpack-instant-search__search-result-title-link > span';
+		const firstResultTitle = await page.innerHTML( resultTitleSelector );
+		expect( firstResultTitle, 'First result title should match the expected value' ).toBe(
+			expectedTitle
+		);
+	} ).toPass( {
+		intervals: [ 1000 ],
+		timeout: 30000,
+	} );
 }
 
 /**
@@ -87,15 +96,7 @@ test.describe( 'Instant Search', () => {
 		} );
 
 		await test.step( 'Can sort results by relevance by default', async () => {
-			await expect( async () => {
-				const firstResultTitle = await getFirstResultTitle( page );
-				expect( firstResultTitle, 'First result title should match the expected value' ).toEqual(
-					searchResultForTest1.results[ 0 ].highlight.title[ 0 ]
-				);
-			} ).toPass( {
-				intervals: [ 1000 ],
-				timeout: 30000,
-			} );
+			await expectFirstResultTitle( page, searchResultForTest1.results[ 0 ].highlight.title[ 0 ] );
 		} );
 
 		const overlaySearchInput = page.getByRole( 'searchbox', {
@@ -111,16 +112,7 @@ test.describe( 'Instant Search', () => {
 		} );
 
 		await test.step( 'The first result is updated by relevance', async () => {
-			await expect( async () => {
-				const firstResultTitle = await getFirstResultTitle( page );
-				expect(
-					firstResultTitle,
-					'First result title should match the most relevant value'
-				).toContain( '<mark>Test2</mark> Record 1' );
-			} ).toPass( {
-				intervals: [ 1000 ],
-				timeout: 30000,
-			} );
+			await expectFirstResultTitle( page, '<mark>Test2</mark> Record 1' );
 		} );
 
 		await test.step( 'Can change sort order', async () => {
@@ -135,19 +127,7 @@ test.describe( 'Instant Search', () => {
 				"'newest' sorting link should be selected"
 			).toBeVisible();
 
-			await expect( async () => {
-				const firstResultTitle = await getFirstResultTitle( page );
-				expect(
-					firstResultTitle,
-					`First result title should match the newest value: ${
-						searchResultForTest2.results[ searchResultForTest2.results.length - 1 ].highlight
-							.title[ 0 ]
-					}`
-				).toBe( '<mark>Test2</mark> Record 3' );
-			} ).toPass( {
-				intervals: [ 1000 ],
-				timeout: 30000,
-			} );
+			await expectFirstResultTitle( page, '<mark>Test2</mark> Record 3' );
 
 			searchResponsePromise = page.waitForResponse( resp => SEARCH_API_PATTERN.test( resp.url() ) );
 			await page.getByRole( 'button', { name: 'Oldest' } ).click();
@@ -160,15 +140,7 @@ test.describe( 'Instant Search', () => {
 				"'oldest' sorting link should be selected"
 			).toBeVisible();
 
-			await expect( async () => {
-				const firstResultTitle = await getFirstResultTitle( page );
-				expect( firstResultTitle, 'First result title should match the oldest value' ).toBe(
-					'<mark>Test2</mark> Record 2'
-				);
-			} ).toPass( {
-				intervals: [ 1000 ],
-				timeout: 30000,
-			} );
+			await expectFirstResultTitle( page, '<mark>Test2</mark> Record 2' );
 		} );
 
 		await test.step( 'Can apply filters', async () => {
@@ -176,30 +148,14 @@ test.describe( 'Instant Search', () => {
 			await page.getByRole( 'checkbox', { name: 'Category 2' } ).check();
 			await searchResponsePromise;
 
-			await expect( async () => {
-				const firstResultTitle = await getFirstResultTitle( page );
-				expect( firstResultTitle, 'First result title should match the expected value' ).toBe(
-					'<mark>Test2</mark> Record 2'
-				);
-			} ).toPass( {
-				intervals: [ 1000 ],
-				timeout: 30000,
-			} );
+			await expectFirstResultTitle( page, '<mark>Test2</mark> Record 2' );
 
 			searchResponsePromise = page.waitForResponse( resp => SEARCH_API_PATTERN.test( resp.url() ) );
 			await page.getByRole( 'checkbox', { name: 'Category 2' } ).uncheck();
 			await page.getByRole( 'checkbox', { name: 'Tag 3' } ).check();
 			await searchResponsePromise;
 
-			await expect( async () => {
-				const firstResultTitle = await getFirstResultTitle( page );
-				expect( firstResultTitle, 'First result title should match the expected value' ).toBe(
-					'<mark>Test2</mark> Record 3'
-				);
-			} ).toPass( {
-				intervals: [ 1000 ],
-				timeout: 30000,
-			} );
+			await expectFirstResultTitle( page, '<mark>Test2</mark> Record 3' );
 		} );
 
 		await test.step( 'Can close overlay by clicking the cross', async () => {

--- a/projects/plugins/search/tests/e2e/specs/search.test.ts
+++ b/projects/plugins/search/tests/e2e/specs/search.test.ts
@@ -1,15 +1,11 @@
 import {
 	test,
 	expect,
-	searchResultForTest1 as originalSearchResultForTest1,
-	searchResultForTest2 as originalSearchResultForTest2,
+	searchResultForTest1,
+	searchResultForTest2,
 	SEARCH_API_PATTERN,
 } from '../fixtures/test';
 import type { Page, Response } from '@playwright/test';
-
-// Create deep copies to prevent mutations during tests
-const searchResultForTest1 = JSON.parse( JSON.stringify( originalSearchResultForTest1 ) );
-const searchResultForTest2 = JSON.parse( JSON.stringify( originalSearchResultForTest2 ) );
 
 /**
  * Returns the inner HTML of the first search result title.

--- a/projects/plugins/search/tests/e2e/specs/search.test.ts
+++ b/projects/plugins/search/tests/e2e/specs/search.test.ts
@@ -5,7 +5,7 @@ import {
 	searchResultForTest2 as originalSearchResultForTest2,
 	SEARCH_API_PATTERN,
 } from '../fixtures/test';
-import type { Page } from '@playwright/test';
+import type { Page, Response } from '@playwright/test';
 
 // Create deep copies to prevent mutations during tests
 const searchResultForTest1 = JSON.parse( JSON.stringify( originalSearchResultForTest1 ) );
@@ -52,7 +52,7 @@ test.describe( 'Instant Search', () => {
 	} );
 
 	test( 'Can perform search with default settings', async ( { page } ) => {
-		let searchResponsePromise;
+		let searchResponsePromise: Promise< Response >;
 
 		await page.goto( '/?result_format=expanded' );
 
@@ -91,10 +91,15 @@ test.describe( 'Instant Search', () => {
 		} );
 
 		await test.step( 'Can sort results by relevance by default', async () => {
-			expect(
-				await getFirstResultTitle( page ),
-				'First result title should match the expected value'
-			).toEqual( searchResultForTest1.results[ 0 ].highlight.title[ 0 ] );
+			await expect( async () => {
+				const firstResultTitle = await getFirstResultTitle( page );
+				expect( firstResultTitle, 'First result title should match the expected value' ).toEqual(
+					searchResultForTest1.results[ 0 ].highlight.title[ 0 ]
+				);
+			} ).toPass( {
+				intervals: [ 1000 ],
+				timeout: 30000,
+			} );
 		} );
 
 		const overlaySearchInput = page.getByRole( 'searchbox', {
@@ -110,10 +115,16 @@ test.describe( 'Instant Search', () => {
 		} );
 
 		await test.step( 'The first result is updated by relevance', async () => {
-			expect(
-				await getFirstResultTitle( page ),
-				'First result title should match the most relevant value'
-			).toContain( '<mark>Test2</mark>' );
+			await expect( async () => {
+				const firstResultTitle = await getFirstResultTitle( page );
+				expect(
+					firstResultTitle,
+					'First result title should match the most relevant value'
+				).toContain( '<mark>Test2</mark>' );
+			} ).toPass( {
+				intervals: [ 1000 ],
+				timeout: 30000,
+			} );
 		} );
 
 		await test.step( 'Can change sort order', async () => {
@@ -128,13 +139,19 @@ test.describe( 'Instant Search', () => {
 				"'newest' sorting link should be selected"
 			).toBeVisible();
 
-			expect(
-				await getFirstResultTitle( page ),
-				`First result title should match the newest value: ${
-					searchResultForTest2.results[ searchResultForTest2.results.length - 1 ].highlight
-						.title[ 0 ]
-				}`
-			).toBe( '<mark>Test2</mark> Record 3' );
+			await expect( async () => {
+				const firstResultTitle = await getFirstResultTitle( page );
+				expect(
+					firstResultTitle,
+					`First result title should match the newest value: ${
+						searchResultForTest2.results[ searchResultForTest2.results.length - 1 ].highlight
+							.title[ 0 ]
+					}`
+				).toBe( '<mark>Test2</mark> Record 3' );
+			} ).toPass( {
+				intervals: [ 1000 ],
+				timeout: 30000,
+			} );
 
 			searchResponsePromise = page.waitForResponse( resp => SEARCH_API_PATTERN.test( resp.url() ) );
 			await page.getByRole( 'button', { name: 'Oldest' } ).click();
@@ -147,10 +164,15 @@ test.describe( 'Instant Search', () => {
 				"'oldest' sorting link should be selected"
 			).toBeVisible();
 
-			expect(
-				await getFirstResultTitle( page ),
-				'First result title should match the oldest value'
-			).toBe( '<mark>Test2</mark> Record 2' );
+			await expect( async () => {
+				const firstResultTitle = await getFirstResultTitle( page );
+				expect( firstResultTitle, 'First result title should match the oldest value' ).toBe(
+					'<mark>Test2</mark> Record 2'
+				);
+			} ).toPass( {
+				intervals: [ 1000 ],
+				timeout: 30000,
+			} );
 		} );
 
 		await test.step( 'Can apply filters', async () => {
@@ -158,20 +180,30 @@ test.describe( 'Instant Search', () => {
 			await page.getByRole( 'checkbox', { name: 'Category 2' } ).check();
 			await searchResponsePromise;
 
-			expect(
-				await getFirstResultTitle( page ),
-				'First result title should match the expected value'
-			).toBe( '<mark>Test2</mark> Record 2' );
+			await expect( async () => {
+				const firstResultTitle = await getFirstResultTitle( page );
+				expect( firstResultTitle, 'First result title should match the expected value' ).toBe(
+					'<mark>Test2</mark> Record 2'
+				);
+			} ).toPass( {
+				intervals: [ 1000 ],
+				timeout: 30000,
+			} );
 
 			searchResponsePromise = page.waitForResponse( resp => SEARCH_API_PATTERN.test( resp.url() ) );
 			await page.getByRole( 'checkbox', { name: 'Category 2' } ).uncheck();
 			await page.getByRole( 'checkbox', { name: 'Tag 3' } ).check();
 			await searchResponsePromise;
 
-			expect(
-				await getFirstResultTitle( page ),
-				'First result title should match the expected value'
-			).toBe( '<mark>Test2</mark> Record 3' );
+			await expect( async () => {
+				const firstResultTitle = await getFirstResultTitle( page );
+				expect( firstResultTitle, 'First result title should match the expected value' ).toBe(
+					'<mark>Test2</mark> Record 3'
+				);
+			} ).toPass( {
+				intervals: [ 1000 ],
+				timeout: 30000,
+			} );
 		} );
 
 		await test.step( 'Can close overlay by clicking the cross', async () => {

--- a/projects/plugins/search/tests/e2e/specs/search.test.ts
+++ b/projects/plugins/search/tests/e2e/specs/search.test.ts
@@ -120,7 +120,7 @@ test.describe( 'Instant Search', () => {
 				expect(
 					firstResultTitle,
 					'First result title should match the most relevant value'
-				).toContain( '<mark>Test2</mark>' );
+				).toContain( '<mark>Test2</mark> Record 1' );
 			} ).toPass( {
 				intervals: [ 1000 ],
 				timeout: 30000,


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/44849

## Proposed changes:

Test `specs/search.test.ts#Instant Search Can perform search with default settings` had intermittent failures because the mock data was being mutated between tests. Fixed by making proper copies of the data.
The test only failed if `search-configure.test.ts` was running before.

Also updated the assertions to use `.toPass()`, which will retry, as a defence for race conditions.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:

* e2e tests should pass in CI. Check the results, the tests should pass on the first attempt.
