### PR TITLE
CDN: gracefully handle a non-string

### DIFF
--- a/projects/packages/image-cdn/changelog/update-jetpack-no-null-content-cdn-HOG-301
+++ b/projects/packages/image-cdn/changelog/update-jetpack-no-null-content-cdn-HOG-301
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+CDN: gracefully handle an attempt to filter null.

--- a/projects/packages/image-cdn/src/class-image-cdn.php
+++ b/projects/packages/image-cdn/src/class-image-cdn.php
@@ -325,17 +325,17 @@ final class Image_CDN {
 	/**
 	 * Identify images in post content, and if images are local (uploaded to the current site), pass through Photon.
 	 *
-	 * @param string $content The content.
+	 * @param string|mixed $content The content; should be a string but will convert to an empty string if not.
 	 *
 	 * @uses self::validate_image_url, apply_filters, Image_CDN_Core::cdn_url, esc_url
 	 * @filter the_content
 	 *
-	 * @return string|mixed The content, which typically is a string, but the original value if malformed content was passed.
+	 * @return string The content.
 	 */
 	public static function filter_the_content( $content ) {
 		// Early return if content is empty or not a string.
 		if ( ! is_string( $content ) || '' === $content ) {
-			return $content;
+			return '';
 		}
 
 		static $image_tags      = array( 'IMG', 'AMP-IMG', 'AMP-ANIM' );

--- a/projects/packages/image-cdn/src/class-image-cdn.php
+++ b/projects/packages/image-cdn/src/class-image-cdn.php
@@ -334,7 +334,7 @@ final class Image_CDN {
 	 */
 	public static function filter_the_content( $content ) {
 		// Early return if content is null, empty, or not a string.
-		if ( null === $content || ! is_string( $content ) || '' === $content ) {
+		if ( ! is_string( $content ) || '' === $content ) {
 			return $content;
 		}
 

--- a/projects/packages/image-cdn/src/class-image-cdn.php
+++ b/projects/packages/image-cdn/src/class-image-cdn.php
@@ -330,7 +330,7 @@ final class Image_CDN {
 	 * @uses self::validate_image_url, apply_filters, Image_CDN_Core::cdn_url, esc_url
 	 * @filter the_content
 	 *
-	 * @return string
+	 * @return string|mixed The content, which typically is a string, but the original value if malformed content was passed.
 	 */
 	public static function filter_the_content( $content ) {
 		// Early return if content is null, empty, or not a string.

--- a/projects/packages/image-cdn/src/class-image-cdn.php
+++ b/projects/packages/image-cdn/src/class-image-cdn.php
@@ -333,7 +333,7 @@ final class Image_CDN {
 	 * @return string|mixed The content, which typically is a string, but the original value if malformed content was passed.
 	 */
 	public static function filter_the_content( $content ) {
-		// Early return if content is null, empty, or not a string.
+		// Early return if content is empty or not a string.
 		if ( ! is_string( $content ) || '' === $content ) {
 			return $content;
 		}

--- a/projects/packages/image-cdn/src/class-image-cdn.php
+++ b/projects/packages/image-cdn/src/class-image-cdn.php
@@ -333,6 +333,11 @@ final class Image_CDN {
 	 * @return string
 	 */
 	public static function filter_the_content( $content ) {
+		// Early return if content is null, empty, or not a string.
+		if ( null === $content || ! is_string( $content ) || '' === $content ) {
+			return $content;
+		}
+
 		static $image_tags      = array( 'IMG', 'AMP-IMG', 'AMP-ANIM' );
 		$content_width          = null;
 		$image_sizes            = null;

--- a/projects/packages/image-cdn/tests/php/Image_CDN_Test.php
+++ b/projects/packages/image-cdn/tests/php/Image_CDN_Test.php
@@ -1097,6 +1097,36 @@ class Image_CDN_Test extends Image_CDN_Attachment_TestCase {
 	}
 
 	/**
+	 * Tests that filter_the_content returns original content when passed null.
+	 *
+	 * @since $$next-version$$
+	 */
+	public function test_image_cdn_filter_the_content_returns_original_content_when_passed_null() {
+		$filtered_content = Image_CDN::filter_the_content( null );
+		$this->assertSame( null, $filtered_content );
+	}
+
+	/**
+	 * Tests that filter_the_content returns original content when passed empty string.
+	 *
+	 * @since $$next-version$$
+	 */
+	public function test_image_cdn_filter_the_content_returns_original_content_when_passed_empty_string() {
+		$filtered_content = Image_CDN::filter_the_content( '' );
+		$this->assertSame( '', $filtered_content );
+	}
+
+	/**
+	 * Tests that filter_the_content returns original content when passed non-string input.
+	 *
+	 * @since $$next-version$$
+	 */
+	public function test_image_cdn_filter_the_content_returns_original_content_when_passed_non_string() {
+		$filtered_content = Image_CDN::filter_the_content( 123 );
+		$this->assertSame( 123, $filtered_content );
+	}
+
+	/**
 	 * Data provider for filtered attributes.
 	 *
 	 * @return array[]

--- a/projects/packages/image-cdn/tests/php/Image_CDN_Test.php
+++ b/projects/packages/image-cdn/tests/php/Image_CDN_Test.php
@@ -1102,9 +1102,8 @@ class Image_CDN_Test extends Image_CDN_Attachment_TestCase {
 	 * @since $$next-version$$
 	 */
 	public function test_image_cdn_filter_the_content_returns_original_content_when_passed_null() {
-		/** @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal */
 		$filtered_content = Image_CDN::filter_the_content( null );
-		$this->assertSame( null, $filtered_content );
+		$this->assertSame( '', $filtered_content );
 	}
 
 	/**
@@ -1123,9 +1122,8 @@ class Image_CDN_Test extends Image_CDN_Attachment_TestCase {
 	 * @since $$next-version$$
 	 */
 	public function test_image_cdn_filter_the_content_returns_original_content_when_passed_non_string() {
-		/** @phan-suppress-next-line PhanTypeMismatchArgument */
 		$filtered_content = Image_CDN::filter_the_content( 123 );
-		$this->assertSame( 123, $filtered_content );
+		$this->assertSame( '', $filtered_content );
 	}
 
 	/**

--- a/projects/packages/image-cdn/tests/php/Image_CDN_Test.php
+++ b/projects/packages/image-cdn/tests/php/Image_CDN_Test.php
@@ -1102,6 +1102,7 @@ class Image_CDN_Test extends Image_CDN_Attachment_TestCase {
 	 * @since $$next-version$$
 	 */
 	public function test_image_cdn_filter_the_content_returns_original_content_when_passed_null() {
+		/** @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal */
 		$filtered_content = Image_CDN::filter_the_content( null );
 		$this->assertSame( null, $filtered_content );
 	}
@@ -1122,6 +1123,7 @@ class Image_CDN_Test extends Image_CDN_Attachment_TestCase {
 	 * @since $$next-version$$
 	 */
 	public function test_image_cdn_filter_the_content_returns_original_content_when_passed_non_string() {
+		/** @phan-suppress-next-line PhanTypeMismatchArgument */
 		$filtered_content = Image_CDN::filter_the_content( 123 );
 		$this->assertSame( 123, $filtered_content );
 	}

--- a/projects/plugins/boost/changelog/update-jetpack-no-null-content-cdn-HOG-301
+++ b/projects/plugins/boost/changelog/update-jetpack-no-null-content-cdn-HOG-301
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-CDN: gracefully handle an attempt to filter null.
+Image CDN: gracefully handle an attempt to filter null.

--- a/projects/plugins/boost/changelog/update-jetpack-no-null-content-cdn-HOG-301
+++ b/projects/plugins/boost/changelog/update-jetpack-no-null-content-cdn-HOG-301
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+CDN: gracefully handle an attempt to filter null.

--- a/projects/plugins/jetpack/changelog/update-jetpack-no-null-content-cdn-HOG-301
+++ b/projects/plugins/jetpack/changelog/update-jetpack-no-null-content-cdn-HOG-301
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+CDN: gracefully handle an attempt to filter null.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes HOG-301

The WP_HTML_Tag_Processor will construct with any value passed to it, but `get_updated_html` is type-restricted to only returning a string. This will lead to a runtime fatal.

While this is something Core can (should?) address, we can save a lot of work by just returning early a value that we won't be able to do anything with.

The Core issue is proposed and patched via https://core.trac.wordpress.org/ticket/63854

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* If a non-string is passed to `filter_the_content`, early return the passed value.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Run `Image_CDN::filter_the_content(null);` before and after this patch.
* Before: runtime fatal.
* After: no fatal, returns `null`.

