### PR TITLE
Forms: Update slider field inspector controls

### DIFF
--- a/projects/packages/forms/changelog/update-forms-rearrange-inspector-controls
+++ b/projects/packages/forms/changelog/update-forms-rearrange-inspector-controls
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: Adjust slider field controls.

--- a/projects/packages/forms/src/blocks/field-slider/edit.js
+++ b/projects/packages/forms/src/blocks/field-slider/edit.js
@@ -148,6 +148,7 @@ export default function SliderFieldEdit( props ) {
 							min={ Number.MIN_SAFE_INTEGER }
 							onChange={ onChangeMin }
 							value={ min }
+							spinControls="custom"
 						/>
 						<NumberControl
 							__next40pxDefaultSize
@@ -157,26 +158,7 @@ export default function SliderFieldEdit( props ) {
 							min={ min }
 							onChange={ onChangeMax }
 							value={ max }
-						/>
-					</HStack>
-					<HStack alignment="top" className="jp-field-slider-inspector-row">
-						<NumberControl
-							__next40pxDefaultSize
-							__nextHasNoMarginBottom
-							label={ __( 'Default value', 'jetpack-forms' ) }
-							min={ min }
-							max={ max }
-							value={ defaultValue }
-							onChange={ onChangeDefault }
-						/>
-						<NumberControl
-							__next40pxDefaultSize
-							__nextHasNoMarginBottom
-							label={ __( 'Increment', 'jetpack-forms' ) }
-							min={ 0 }
-							step={ 1 }
-							value={ step }
-							onChange={ onChangeStep }
+							spinControls="custom"
 						/>
 					</HStack>
 					<HStack alignment="top" className="jp-field-slider-inspector-row">
@@ -193,6 +175,28 @@ export default function SliderFieldEdit( props ) {
 							label={ __( 'Max label', 'jetpack-forms' ) }
 							value={ maxLabel }
 							onChange={ onChangeMaxLabel }
+						/>
+					</HStack>
+					<HStack alignment="top" className="jp-field-slider-inspector-row">
+						<NumberControl
+							__next40pxDefaultSize
+							__nextHasNoMarginBottom
+							label={ __( 'Default value', 'jetpack-forms' ) }
+							min={ min }
+							max={ max }
+							value={ defaultValue }
+							onChange={ onChangeDefault }
+							spinControls="custom"
+						/>
+						<NumberControl
+							__next40pxDefaultSize
+							__nextHasNoMarginBottom
+							label={ __( 'Increment', 'jetpack-forms' ) }
+							min={ 0 }
+							step={ 1 }
+							value={ step }
+							onChange={ onChangeStep }
+							spinControls="custom"
 						/>
 					</HStack>
 				</PanelBody>


### PR DESCRIPTION
## Proposed changes:

* Updates number controls to have the "custom" spinner style with the + / - controls
* Moves min/max label fields up under the min/max value fields

**After**
<img width="1232" height="348" alt="slider-controls-after" src="https://github.com/user-attachments/assets/eb8bf596-eb70-4ffd-bebf-302ed0281a90" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None. 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No. 

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Ensure you have Jetpack beta blocks enabled
* Add a form to page, and add a slider field
* Confirm all number controls have the +/- style like screenshot
* Confirm the min/max label controls are directly after the min/max value controls