### PR TITLE
Sync: Themes module add default value for inactive widgets

### DIFF
--- a/projects/packages/sync/changelog/update-sync-themes-add-default-value-for-inactive-widgets
+++ b/projects/packages/sync/changelog/update-sync-themes-add-default-value-for-inactive-widgets
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Sync: Themes module, added default value when updating sidebar widgets

--- a/projects/packages/sync/src/modules/class-themes.php
+++ b/projects/packages/sync/src/modules/class-themes.php
@@ -745,6 +745,7 @@ class Themes extends Module {
 
 		$moved_to_inactive_ids = array();
 		$moved_to_sidebar      = array();
+		$new_inactive_widgets  = $new_value['wp_inactive_widgets'] ?? array();
 
 		foreach ( $new_value as $sidebar => $new_widgets ) {
 			if ( in_array( $sidebar, array( 'array_version', 'wp_inactive_widgets' ), true ) ) {
@@ -757,8 +758,7 @@ class Themes extends Module {
 			if ( ! is_array( $new_widgets ) ) {
 				$new_widgets = array();
 			}
-
-			$moved_to_inactive_recently = $this->sync_remove_widgets_from_sidebar( $new_widgets, $old_widgets, $sidebar, $new_value['wp_inactive_widgets'] );
+			$moved_to_inactive_recently = $this->sync_remove_widgets_from_sidebar( $new_widgets, $old_widgets, $sidebar, $new_inactive_widgets );
 			$moved_to_inactive_ids      = array_merge( $moved_to_inactive_ids, $moved_to_inactive_recently );
 
 			$moved_to_sidebar_recently = $this->sync_add_widgets_to_sidebar( $new_widgets, $old_widgets, $sidebar );


### PR DESCRIPTION
Fixes VULCAN-292

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Assigning default value in case wp_inactive_widgets is not there from sidebars_widgets option.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1755760444635639/1755757566.519839-slack-C034JEXD1RD
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Code Review should suffice