### PR TITLE
Forms: reorganise allowed child blocks (core blocks)

### DIFF
--- a/projects/packages/forms/changelog/update-reorganise-allowed-child-blocks-core
+++ b/projects/packages/forms/changelog/update-reorganise-allowed-child-blocks-core
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: reorganise shared lists of allowed inner blocks - core blocks

--- a/projects/packages/forms/src/blocks/contact-form/edit.js
+++ b/projects/packages/forms/src/blocks/contact-form/edit.js
@@ -39,6 +39,7 @@ import JetpackManageResponsesSettings from '../shared/components/jetpack-manage-
 import { useFindBlockRecursively } from '../shared/hooks/use-find-block-recursively';
 import useFormSteps from '../shared/hooks/use-form-steps';
 import { SyncedAttributeProvider } from '../shared/hooks/use-synced-attributes';
+import { CORE_BLOCKS } from '../shared/util/constants';
 import { childBlocks } from './child-blocks';
 import { ContactFormPlaceholder } from './components/jetpack-contact-form-placeholder';
 import ContactFormSkeletonLoader from './components/jetpack-contact-form-skeleton-loader';
@@ -65,23 +66,6 @@ const validFields = childBlocks.filter( ( { settings } ) => {
 
 const ALLOWED_BLOCKS = [ ...validFields.map( block => `jetpack/${ block.name }` ) ];
 
-const ALLOWED_CORE_BLOCKS = [
-	'core/audio',
-	'core/columns',
-	'core/group',
-	'core/heading',
-	'core/html',
-	'core/image',
-	'core/list',
-	'core/paragraph',
-	'core/row',
-	'core/separator',
-	'core/spacer',
-	'core/stack',
-	'core/subhead',
-	'core/video',
-];
-
 // At the top level of a multistep form we allow navigation, progress indicator
 // and the step-container itself (users may add it manually before steps are
 // auto-structured). The core block list remains unchanged.
@@ -90,7 +74,7 @@ const ALLOWED_MULTI_STEP_BLOCKS = [
 	'jetpack/form-progress-indicator',
 	'jetpack/form-step-container',
 	'jetpack/form-step-divider',
-].concat( ALLOWED_CORE_BLOCKS );
+].concat( CORE_BLOCKS );
 
 const REMOVE_FIELDS_FROM_FORM = [
 	'jetpack/form-step-navigation',
@@ -98,7 +82,7 @@ const REMOVE_FIELDS_FROM_FORM = [
 	'jetpack/form-step-container',
 ];
 
-const ALLOWED_FORM_BLOCKS = ALLOWED_BLOCKS.concat( ALLOWED_CORE_BLOCKS ).filter(
+const ALLOWED_FORM_BLOCKS = ALLOWED_BLOCKS.concat( CORE_BLOCKS ).filter(
 	block => ! REMOVE_FIELDS_FROM_FORM.includes( block )
 );
 

--- a/projects/packages/forms/src/blocks/form-step/edit.js
+++ b/projects/packages/forms/src/blocks/form-step/edit.js
@@ -7,6 +7,7 @@ import AddStepControls from '../shared/components/form-add-step-controls';
 import StepControls from '../shared/components/form-step-controls';
 import useFormSteps from '../shared/hooks/use-form-steps';
 import useParentFormClientId from '../shared/hooks/use-parent-form-client-id';
+import { CORE_BLOCKS } from '../shared/util/constants';
 import AttributesControls from './attributes-controls';
 
 import './editor.scss';
@@ -35,20 +36,7 @@ const ALLOWED_BLOCKS = [
 	'jetpack/field-image-select',
 	'jetpack/form-step-navigation',
 	'jetpack/form-step-divider',
-	'core/audio',
-	'core/columns',
-	'core/group',
-	'core/heading',
-	'core/html',
-	'core/image',
-	'core/list',
-	'core/paragraph',
-	'core/row',
-	'core/separator',
-	'core/spacer',
-	'core/stack',
-	'core/subhead',
-	'core/video',
+	...CORE_BLOCKS,
 ];
 
 // Template helper: returns a default template when the previous step already

--- a/projects/packages/forms/src/blocks/shared/util/constants.js
+++ b/projects/packages/forms/src/blocks/shared/util/constants.js
@@ -3,6 +3,23 @@ import { __ } from '@wordpress/i18n';
 export const ALLOWED_FORMATS = [ 'core/bold', 'core/italic' ];
 export const ALLOWED_INNER_BLOCKS = [ 'jetpack/label', 'jetpack/input' ];
 
+export const CORE_BLOCKS = [
+	'core/audio',
+	'core/columns',
+	'core/group',
+	'core/heading',
+	'core/html',
+	'core/image',
+	'core/list',
+	'core/paragraph',
+	'core/row',
+	'core/separator',
+	'core/spacer',
+	'core/stack',
+	'core/subhead',
+	'core/video',
+];
+
 const currentYear = new Date().getFullYear();
 
 // WARNING: sync data with Contact_Form_Field::render_date_field in class-contact-form-field.php


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Share the list of allowed core blocks between multi-step and forms blocks, to consolidate defining them just once.

In a follow-up we should consolidate more for fields, but this was the easiest bit to start with.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Move list of core blocks to a shared constant.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Nothing changes about allowing using core blocks in forms and multi-step forms.

