### PR TITLE
Forms: rename 'Stars Rating' to 'Stars rating field'

### DIFF
--- a/projects/packages/forms/changelog/update-forms-rating-field-rename
+++ b/projects/packages/forms/changelog/update-forms-rating-field-rename
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: rename 'Stars Rating' to 'Stars rating field'

--- a/projects/packages/forms/src/blocks/field-rating/variations.js
+++ b/projects/packages/forms/src/blocks/field-rating/variations.js
@@ -6,8 +6,8 @@ import { getIconColor } from '../shared/util/block-icons';
 const variations = [
 	{
 		name: 'stars',
-		title: __( 'Stars Rating', 'jetpack-forms' ),
-		description: __( 'Rating field with star icons', 'jetpack-forms' ),
+		title: __( 'Stars rating field', 'jetpack-forms' ),
+		description: __( 'Rating field with star icons.', 'jetpack-forms' ),
 		icon: {
 			foreground: getIconColor(),
 			src: renderMaterialIcon(
@@ -28,7 +28,7 @@ const variations = [
 	{
 		name: 'hearts',
 		title: __( 'Hearts rating field', 'jetpack-forms' ),
-		description: __( 'Rating field with heart icons', 'jetpack-forms' ),
+		description: __( 'Rating field with heart icons.', 'jetpack-forms' ),
 		icon: {
 			foreground: getIconColor(),
 			src: renderMaterialIcon(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Simple rename of the variation to make it easier to find in block picker:

Before

<img width="366" height="221" alt="Screenshot 2025-08-21 at 13 41 49" src="https://github.com/user-attachments/assets/3cbc18c9-db05-49e0-86d1-06b5cad6c0db" />

After

<img width="358" height="222" alt="image" src="https://github.com/user-attachments/assets/b85ff542-7248-4b59-994d-a61ef25019eb" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

