### PR TITLE
Boost: Update Critical CSS UI to indicate when generated CSS is too much

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/features/critical-css/lib/describe-critical-css-recommendations.ts
+++ b/projects/plugins/boost/app/assets/src/js/features/critical-css/lib/describe-critical-css-recommendations.ts
@@ -535,6 +535,33 @@ const errorTypeSpecs: { [ type: string ]: ErrorTypeSpec } = {
 			],
 		} ),
 	},
+
+	PayloadTooLargeError: {
+		describeSet: set =>
+			_n(
+				'The Critical CSS generated for the following page is too large to be useful:',
+				'The Critical CSS generated for the following pages is too large to be useful:',
+				urlCount( set ),
+				'jetpack-boost'
+			),
+		rawError: set => Object.values( set.byUrl )[ 0 ].message,
+		suggestion: _set => ( {
+			paragraph: __(
+				'The Critical CSS generated for these pages is too large (over 1MB) to be optimized effectively. Using Critical CSS in this case would defeat its purpose, which is to deliver only the most essential styles quickly.',
+				'jetpack-boost'
+			),
+			list: [
+				__(
+					'<strong>These pages will continue working normally</strong>, using the standard CSS delivery method. This is the best approach for pages with very large CSS requirements.',
+					'jetpack-boost'
+				),
+				__(
+					'<strong>This is normal for some pages</strong>, particularly those using complex themes or page builders that generate large amounts of CSS. No action is needed - Boost will continue optimizing your other pages.',
+					'jetpack-boost'
+				),
+			],
+		} ),
+	},
 };
 
 function getErrorSpec( type: string ): ErrorTypeSpec {

--- a/projects/plugins/boost/app/assets/src/js/features/critical-css/lib/stores/critical-css-state-types.ts
+++ b/projects/plugins/boost/app/assets/src/js/features/critical-css/lib/stores/critical-css-state-types.ts
@@ -20,6 +20,7 @@ const CriticalCssErrorType = z.union( [
 		'XFrameDenyError',
 		'InvalidURLError',
 		'ProviderError',
+		'PayloadTooLargeError',
 	] ),
 	HttpErrorPattern,
 ] );

--- a/projects/plugins/boost/app/assets/src/js/features/critical-css/lib/stores/critical-css-state-types.ts
+++ b/projects/plugins/boost/app/assets/src/js/features/critical-css/lib/stores/critical-css-state-types.ts
@@ -29,7 +29,7 @@ export const CriticalCssErrorDetailsSchema = z.object( {
 	url: z.coerce.string(),
 	message: z.coerce.string(),
 	meta: z.record( JSONSchema ).catch( {} ),
-	type: CriticalCssErrorType,
+	type: CriticalCssErrorType.catch( 'UnknownError' ),
 } );
 
 export const ProviderSchema = z.object( {

--- a/projects/plugins/boost/app/assets/src/js/features/critical-css/show-stopper-error/show-stopper-error.module.scss
+++ b/projects/plugins/boost/app/assets/src/js/features/critical-css/show-stopper-error/show-stopper-error.module.scss
@@ -1,0 +1,3 @@
+.errorLinks a {
+	display: block;
+}

--- a/projects/plugins/boost/app/assets/src/js/features/critical-css/show-stopper-error/show-stopper-error.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/critical-css/show-stopper-error/show-stopper-error.tsx
@@ -15,6 +15,7 @@ import { recordBoostEvent } from '$lib/utils/analytics';
 import { useRetryRegenerate } from '../lib/use-retry-regenerate';
 import RawError from '../raw-error/raw-error';
 import type { FC } from 'react';
+import styles from './show-stopper-error.module.scss';
 
 type ShowStopperErrorTypes = {
 	supportLink?: string;
@@ -73,7 +74,7 @@ const Description = ( { errorSet }: { errorSet: ErrorSet } ) => {
 					b: <b />,
 				} ) }
 			</p>
-			<p>
+			<p className={ styles.errorLinks }>
 				{ displayUrls.map( ( { href, label }, index ) => (
 					<a
 						onClick={ () => {

--- a/projects/plugins/boost/changelog/update-boost-critical-css-ui-support-large-payload-error-hog-258
+++ b/projects/plugins/boost/changelog/update-boost-critical-css-ui-support-large-payload-error-hog-258
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Critical CSS: Updated UI to indicate when generated CSS is too much.


### PR DESCRIPTION
Fixes HOG-258

<img width="809" height="732" alt="CleanShot 2025-08-21 at 16 49 44@2x" src="https://github.com/user-attachments/assets/cfda99d3-5b75-4b7d-9c6c-50c255982d2f" />


## Proposed changes:

* Fix UI freezing when an error not known to Boost was returned from the Boost Cloud;
* Update UI to include steps when the generated Critical CSS is too large (unusable).

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

HOG-258

## Does this pull request change what data or activity we track or use?

no

## Testing instructions:

- Follow the instructions in https://github.com/Automattic/boost-cloud/pull/706.