### PR TITLE
e2e tests: Fix output path for flaky test results in FlakyTestsReporter

### DIFF
--- a/tools/e2e-commons/reporters/flaky-tests-reporter.ts
+++ b/tools/e2e-commons/reporters/flaky-tests-reporter.ts
@@ -58,7 +58,7 @@ export default class FlakyTestsReporter implements Reporter {
 			}
 			case 'flaky': {
 				fs.writeFileSync(
-					`flaky-tests/${ fileNameFormatter( testTitle ) }.json`,
+					`output/flaky-tests/${ fileNameFormatter( testTitle ) }.json`,
 					JSON.stringify( {
 						version: 1,
 						runner: '@playwright/test',

--- a/tools/e2e-commons/reporters/flaky-tests-reporter.ts
+++ b/tools/e2e-commons/reporters/flaky-tests-reporter.ts
@@ -14,6 +14,8 @@ import type { Reporter, TestCase, TestResult } from '@playwright/test/reporter';
 
 type FormattedTestResult = Omit< TestResult, 'steps' >;
 
+const FLAKY_TESTS_REPORTS_PATH = 'output/flaky-tests';
+
 /**
  * Formats the test result to remove the steps.
  *
@@ -34,7 +36,7 @@ export default class FlakyTestsReporter implements Reporter {
 
 	onBegin() {
 		try {
-			fs.mkdirSync( 'flaky-tests' );
+			fs.mkdirSync( FLAKY_TESTS_REPORTS_PATH );
 		} catch ( err ) {
 			if ( err instanceof Error && ( err as NodeJS.ErrnoException ).code === 'EEXIST' ) {
 				// Ignore the error if the directory already exists.
@@ -58,7 +60,7 @@ export default class FlakyTestsReporter implements Reporter {
 			}
 			case 'flaky': {
 				fs.writeFileSync(
-					`output/flaky-tests/${ fileNameFormatter( testTitle ) }.json`,
+					`${ FLAKY_TESTS_REPORTS_PATH }/${ fileNameFormatter( testTitle ) }.json`,
 					JSON.stringify( {
 						version: 1,
 						runner: '@playwright/test',


### PR DESCRIPTION
## Proposed changes:

Updated the output path of FlakyTestsReporter to be the same as all the other reports.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:

* Make a test fail intermittently and run it. A report should exist in output/flaky-tests path. Using testInfo retry property is useful here:

```
if ( testInfo.retry === 0 ) {
	throw new Error( 'Test failed' );
}
```

Then run the test with `--retry=1`.

* e2e tests pass in CI

