### PR TITLE
Connection: Fix fatal error for invalid structure of stored errors

### DIFF
--- a/projects/packages/connection/changelog/fix-jetpack-connection-errors-invalid-structure-fatal
+++ b/projects/packages/connection/changelog/fix-jetpack-connection-errors-invalid-structure-fatal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix fatal for invalid structure of stored errors.

--- a/projects/packages/connection/src/class-error-handler.php
+++ b/projects/packages/connection/src/class-error-handler.php
@@ -753,7 +753,7 @@ class Error_Handler {
 	private function garbage_collector( $errors ) {
 		foreach ( $errors as $error_code => $users ) {
 			foreach ( $users as $user_id => $error ) {
-				if ( self::ERROR_LIFE_TIME < time() - (int) $error['timestamp'] ) {
+				if ( empty( $error['timestamp'] ) || self::ERROR_LIFE_TIME < time() - (int) $error['timestamp'] ) {
 					unset( $errors[ $error_code ][ $user_id ] );
 				}
 			}


### PR DESCRIPTION
## Proposed changes:
* Fix a fatal that's triggered by invalid connection error structure being stored in the options.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
https://linear.app/a8c/issue/VULCAN-293

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
1. Connect Jetpack.
2. Clean the existing connection errors and create one with an invalid structure:
```bash
wp db query "delete from wp_options where option_name = 'jetpack_connection_xmlrpc_errors'"
wp db query "insert into wp_options set option_value = 'a:1:{s:13:\"invalid_token\";a:1:{i:0;s:6:\"broken\";}}', option_name = 'jetpack_connection_xmlrpc_errors'"
```
3. Confirm the website loads and doesn't fatal. Check the error log, confirm it's empty.
4. Install Jetpack Debug Helper plugin, activate "Broken Token", and go to the "Connection Errors" section: `/wp-admin/admin.php?page=broken-token-connection-errors`
5. Create new error. Run `wp option get jetpack_connection_xmlrpc_errors` and confirm that you only see the newly created error, and the "broken" one is now deleted.