### PR TITLE
Block Delimiter: Harden performance test to reduce flakiness

### DIFF
--- a/projects/packages/block-delimiter/changelog/harden-performance-test
+++ b/projects/packages/block-delimiter/changelog/harden-performance-test
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhanced
-
-Harden Block_Scanner performance test to reduce flakiness with competitive benchmarking and robust statistics

--- a/projects/packages/block-delimiter/changelog/harden-performance-test
+++ b/projects/packages/block-delimiter/changelog/harden-performance-test
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhanced
+
+Harden Block_Scanner performance test to reduce flakiness with competitive benchmarking and robust statistics

--- a/projects/packages/block-delimiter/changelog/update-block-delimiter-performance-comparision-flakiness-HOG-307
+++ b/projects/packages/block-delimiter/changelog/update-block-delimiter-performance-comparision-flakiness-HOG-307
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Reduce flakiness of Block_Scanner performance comparison unit test
+
+

--- a/projects/packages/block-delimiter/composer.json
+++ b/projects/packages/block-delimiter/composer.json
@@ -16,6 +16,11 @@
 			"src/"
 		]
 	},
+	"autoload-dev": {
+		"psr-4": {
+			"Automattic\\Block_Delimiter\\Tests\\": "tests/php/"
+		}
+	},
 	"scripts": {
 		"phpunit": [
 			"phpunit-select-config phpunit.#.xml.dist --colors=always"

--- a/projects/packages/block-delimiter/composer.json
+++ b/projects/packages/block-delimiter/composer.json
@@ -17,6 +17,9 @@
 		]
 	},
 	"autoload-dev": {
+		"classmap": [
+			"tests/php/lib/"
+		],
 		"psr-4": {
 			"Automattic\\Block_Delimiter\\Tests\\": "tests/php/"
 		}

--- a/projects/packages/block-delimiter/tests/php/Block_Scanner_Test.php
+++ b/projects/packages/block-delimiter/tests/php/Block_Scanner_Test.php
@@ -15,12 +15,15 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass( Block_Scanner::class )]
 class Block_Scanner_Test extends TestCase {
 
-	private const PERF_WARMUPS              = 5;
-	private const PERF_ITERATIONS           = 21;
-	private const PERF_RETRY_ITERATIONS     = 51;
-	private const PERF_TIME_RATIO_THRESHOLD = 1.10;
-	private const PERF_FAVORABLE_PCT        = 80; // percent
-	private const PERF_MEM_TOLERANCE_BYTES  = 65536; // 64KB
+	// Benchmark configuration
+	private const PERF_WARMUP_RUNS                = 5;     // Initial runs to stabilize JIT/opcache before measuring
+	private const PERF_BENCHMARK_ITERATIONS       = 21;    // Main benchmark iterations for statistical significance
+	private const PERF_RETRY_BENCHMARK_ITERATIONS = 51;    // Extra iterations when retrying borderline results
+
+	// Performance assertion thresholds
+	private const PERF_MIN_TIME_RATIO_THRESHOLD   = 1.10;  // Scanner must be 1.10x faster than parse_blocks
+	private const PERF_MIN_FAVORABLE_RUNS_PERCENT = 80;    // % of individual runs that must show scanner advantage
+	private const PERF_MEMORY_TOLERANCE_BYTES     = 65536; // 64KB tolerance for memory usage comparison
 
 	/**
 	 * Test the create method with valid input.
@@ -758,7 +761,7 @@ class Block_Scanner_Test extends TestCase {
 			function () use ( $test_content ) {
 				return $this->find_first_image_with_parse_blocks( $test_content );
 			},
-			self::PERF_ITERATIONS
+			self::PERF_BENCHMARK_ITERATIONS
 		);
 
 		// Verify correctness - both methods should find the same result
@@ -830,7 +833,7 @@ class Block_Scanner_Test extends TestCase {
 		$result        = null;
 
 		// Warmup runs to stabilize opcache/JIT/autoloader effects
-		for ( $warmup = 0; $warmup < self::PERF_WARMUPS; $warmup++ ) {
+		for ( $warmup = 0; $warmup < self::PERF_WARMUP_RUNS; $warmup++ ) {
 			$scanner_callable();
 			$parse_callable();
 		}
@@ -890,8 +893,10 @@ class Block_Scanner_Test extends TestCase {
 			}
 
 			// Keep one result for correctness verification
+			// @phan-suppress-next-line PhanImpossibleTypeComparisonInLoop
 			if ( null === $result && isset( $scanner_result ) && null !== $scanner_result ) {
 				$result = $scanner_result;
+				// @phan-suppress-next-line PhanImpossibleTypeComparisonInLoop
 			} elseif ( null === $result && isset( $parse_result ) && null !== $parse_result ) {
 				$result = $parse_result;
 			}
@@ -928,6 +933,7 @@ class Block_Scanner_Test extends TestCase {
 		$trim_count = (int) floor( $count * 0.2 );
 		$trimmed    = array_slice( $sorted, $trim_count, $count - ( 2 * $trim_count ) );
 
+		// @phan-suppress-next-line PhanImpossibleCondition - Can be empty with very small arrays
 		if ( empty( $trimmed ) ) {
 			return $sorted[ (int) floor( $count / 2 ) ];
 		}
@@ -968,11 +974,10 @@ class Block_Scanner_Test extends TestCase {
 		$parse_mem_stat       = $this->compute_trimmed_median( $parse_mems );
 
 		// Time ratio assertion with retry mechanism
-		$time_ratio      = $parse_time_trimmed / $scanner_time_trimmed;
-		$retry_attempted = false;
+		$time_ratio = $parse_time_trimmed / $scanner_time_trimmed;
 
-		if ( $time_ratio < self::PERF_TIME_RATIO_THRESHOLD ) {
-			if ( $time_ratio >= 1.05 && ! $retry_attempted ) {
+		if ( $time_ratio < self::PERF_MIN_TIME_RATIO_THRESHOLD ) {
+			if ( $time_ratio >= 1.05 ) {
 				// Borderline case - retry once with more iterations using the same test content
 				$retry_results = $this->run_competitive_benchmark(
 					function () use ( $test_content ) {
@@ -981,29 +986,27 @@ class Block_Scanner_Test extends TestCase {
 					function () use ( $test_content ) {
 						return $this->find_first_image_with_parse_blocks( $test_content );
 					},
-					self::PERF_RETRY_ITERATIONS
+					self::PERF_RETRY_BENCHMARK_ITERATIONS
 				);
 
 				$retry_scanner_time = $this->compute_trimmed_median( $retry_results['scanner_times'] );
 				$retry_parse_time   = $this->compute_trimmed_median( $retry_results['parse_times'] );
 				$time_ratio         = $retry_parse_time / $retry_scanner_time;
-				$retry_attempted    = true;
 			}
 
-			if ( $time_ratio < self::PERF_TIME_RATIO_THRESHOLD ) {
+			if ( $time_ratio < self::PERF_MIN_TIME_RATIO_THRESHOLD ) {
 				$this->markTestSkipped(
 					sprintf(
 						'Performance inconclusive under current environment (ratio: %.3f)',
 						$time_ratio
 					)
 				);
-				return;
 			}
 		}
 
 		// Main time ratio assertion
 		$this->assertGreaterThan(
-			self::PERF_TIME_RATIO_THRESHOLD,
+			self::PERF_MIN_TIME_RATIO_THRESHOLD,
 			$time_ratio,
 			sprintf(
 				'Scanner should be measurably faster than parse_blocks (ratio: %.3f, scanner: %.6fs, parse_blocks: %.6fs)',
@@ -1017,13 +1020,13 @@ class Block_Scanner_Test extends TestCase {
 		$favorable_runs = 0;
 		$total_runs     = count( $scanner_times );
 		for ( $i = 0; $i < $total_runs; $i++ ) {
-			if ( $parse_times[ $i ] >= self::PERF_TIME_RATIO_THRESHOLD * $scanner_times[ $i ] ) {
+			if ( $parse_times[ $i ] >= self::PERF_MIN_TIME_RATIO_THRESHOLD * $scanner_times[ $i ] ) {
 				$favorable_runs++;
 			}
 		}
 		$favorable_percentage = ( $favorable_runs / $total_runs ) * 100;
 		$this->assertGreaterThanOrEqual(
-			self::PERF_FAVORABLE_PCT,
+			self::PERF_MIN_FAVORABLE_RUNS_PERCENT,
 			$favorable_percentage,
 			sprintf(
 				'At least 80%% of individual runs should show scanner advantage (actual: %.1f%%)',
@@ -1033,13 +1036,13 @@ class Block_Scanner_Test extends TestCase {
 
 		// Memory assertion with larger tolerance (64KB)
 		$this->assertLessThanOrEqual(
-			$parse_mem_stat * 1.10 + self::PERF_MEM_TOLERANCE_BYTES,
+			$parse_mem_stat * 1.10 + self::PERF_MEMORY_TOLERANCE_BYTES,
 			$scanner_mem_stat,
 			sprintf(
 				'Scanner memory should be comparable to parse_blocks (scanner: %d bytes, parse_blocks: %d bytes, tolerance: %d bytes)',
 				$scanner_mem_stat,
 				$parse_mem_stat,
-				self::PERF_MEM_TOLERANCE_BYTES
+				self::PERF_MEMORY_TOLERANCE_BYTES
 			)
 		);
 	}

--- a/projects/packages/block-delimiter/tests/php/Block_Scanner_Test.php
+++ b/projects/packages/block-delimiter/tests/php/Block_Scanner_Test.php
@@ -2,6 +2,7 @@
 
 namespace Automattic;
 
+use Automattic\Block_Delimiter\Tests\Lib\Performance_Benchmark_Utils;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
@@ -14,16 +15,6 @@ use PHPUnit\Framework\TestCase;
  */
 #[CoversClass( Block_Scanner::class )]
 class Block_Scanner_Test extends TestCase {
-
-	// Benchmark configuration
-	private const PERF_WARMUP_RUNS                = 3;     // Reduced warmup runs for faster CI execution
-	private const PERF_BENCHMARK_ITERATIONS       = 11;    // Fewer iterations for CI stability
-	private const PERF_RETRY_BENCHMARK_ITERATIONS = 21;    // Reduced retry iterations
-
-	// CI-friendly performance assertion thresholds (regression detection vs absolute performance)
-	private const PERF_MIN_TIME_RATIO_THRESHOLD   = 1.02;  // Scanner must not be significantly slower
-	private const PERF_MIN_FAVORABLE_RUNS_PERCENT = 55;    // Majority of runs should show scanner advantage
-	private const PERF_MEMORY_TOLERANCE_BYTES     = 128 * 1024; // 128KB tolerance for CI memory variations
 
 	/**
 	 * Test the create method with valid input.
@@ -753,21 +744,21 @@ class Block_Scanner_Test extends TestCase {
 		}
 
 		// Skip test under high system load conditions to reduce CI flakiness
-		if ( $this->is_system_under_high_load() ) {
+		if ( Performance_Benchmark_Utils::is_system_under_high_load() ) {
 			$this->markTestSkipped( 'System under high load - skipping performance test for stability' );
 		}
 
-		$test_content = $this->generate_test_content_with_target_image();
+		$test_content = Performance_Benchmark_Utils::generate_test_content_with_target_image();
 
 		// Run competitive benchmark with paired measurements
-		$benchmark_results = $this->run_competitive_benchmark(
+		$benchmark_results = Performance_Benchmark_Utils::run_competitive_benchmark(
 			function () use ( $test_content ) {
 				return $this->find_first_image_with_scanner( $test_content );
 			},
 			function () use ( $test_content ) {
 				return $this->find_first_image_with_parse_blocks( $test_content );
 			},
-			self::PERF_BENCHMARK_ITERATIONS
+			Performance_Benchmark_Utils::PERF_BENCHMARK_ITERATIONS
 		);
 
 		// Verify correctness - both methods should find the same result
@@ -775,228 +766,16 @@ class Block_Scanner_Test extends TestCase {
 		$parse_blocks_result = $this->find_first_image_with_parse_blocks( $test_content );
 		$this->assert_same_results( $scanner_result, $parse_blocks_result );
 
-		$this->assert_performance_advantage_paired( $benchmark_results, $test_content );
-	}
-
-	/**
-	 * Generate test content with target image positioned for early termination test.
-	 *
-	 * Creates 10 paragraph blocks before the image, then 100 after for CI-friendly execution while preserving early-exit advantage.
-	 *
-	 * @return string Block content with image at early position.
-	 */
-	private function generate_test_content_with_target_image(): string {
-		$blocks = array();
-
-		// Add 10 paragraph blocks before target (reduced for CI stability)
-		for ( $i = 0; $i < 10; $i++ ) {
-			$blocks[] = array(
-				'blockName'    => 'core/paragraph',
-				'attrs'        => array(),
-				'innerContent' => array( sprintf( '<p>Content %d</p>', $i + 1 ) ),
-			);
-		}
-
-		// Add target image block with attributes
-		$blocks[] = array(
-			'blockName'    => 'core/image',
-			'attrs'        => array(
-				'id'     => 12345,
-				'alt'    => 'Test image',
-				'url'    => 'https://example.com/test.jpg',
-				'width'  => 800,
-				'height' => 600,
-			),
-			'innerContent' => array( '<figure class="wp-block-image"><img src="https://example.com/test.jpg" alt="Test image"/></figure>' ),
+		Performance_Benchmark_Utils::assert_performance_advantage_paired(
+			$this,
+			$benchmark_results,
+			function () use ( $test_content ) {
+				return $this->find_first_image_with_scanner( $test_content );
+			},
+			function () use ( $test_content ) {
+				return $this->find_first_image_with_parse_blocks( $test_content );
+			}
 		);
-
-		// Add blocks after target (100 blocks - still enough to show early-exit advantage but faster for CI)
-		for ( $i = 0; $i < 100; $i++ ) {
-			$blocks[] = array(
-				'blockName'    => 'core/paragraph',
-				'attrs'        => array(),
-				'innerContent' => array( sprintf( '<p>After %d</p>', $i + 1 ) ),
-			);
-		}
-
-		return \serialize_blocks( $blocks );
-	}
-
-	/**
-	 * Check if system is under high load that could affect performance test reliability.
-	 *
-	 * @return bool True if system load is too high for reliable performance testing.
-	 */
-	private function is_system_under_high_load(): bool {
-		// Check available memory - skip if less than 64MB free
-		$memory_limit = ini_get( 'memory_limit' );
-		if ( $memory_limit && $memory_limit !== '-1' ) {
-			$memory_limit_bytes = $this->parse_memory_limit( $memory_limit );
-			$current_usage      = \memory_get_usage( true );
-			$available_memory   = $memory_limit_bytes - $current_usage;
-
-			if ( $available_memory < 64 * 1024 * 1024 ) { // Less than 64MB available
-				return true;
-			}
-		}
-
-		// Basic load average check on Unix systems
-		if ( \function_exists( 'sys_getloadavg' ) ) {
-			$load = \sys_getloadavg();
-			if ( $load && $load[0] > 4.0 ) { // High 1-minute load average
-				return true;
-			}
-		}
-
-		return false;
-	}
-
-	/**
-	 * Parse PHP memory limit string to bytes.
-	 *
-	 * @param string $limit Memory limit string (e.g., '128M', '1G').
-	 * @return int Memory limit in bytes.
-	 */
-	private function parse_memory_limit( string $limit ): int {
-		$limit         = trim( $limit );
-		$last_char     = strtolower( substr( $limit, -1 ) );
-		$numeric_value = (int) substr( $limit, 0, -1 );
-
-		switch ( $last_char ) {
-			case 'g':
-				return $numeric_value * 1024 * 1024 * 1024;
-			case 'm':
-				return $numeric_value * 1024 * 1024;
-			case 'k':
-				return $numeric_value * 1024;
-			default:
-				return (int) $limit;
-		}
-	}
-
-	/**
-	 * Run competitive benchmark with paired measurements to minimize environmental drift.
-	 *
-	 * @param callable $scanner_callable Callable for scanner benchmark.
-	 * @param callable $parse_callable Callable for parse_blocks benchmark.
-	 * @param int      $iterations Number of paired iterations to run.
-	 * @return array{scanner_times: float[], parse_times: float[], scanner_mems: int[], parse_mems: int[], result: mixed}
-	 */
-	private function run_competitive_benchmark( callable $scanner_callable, callable $parse_callable, int $iterations ): array {
-		$scanner_times = array();
-		$parse_times   = array();
-		$scanner_mems  = array();
-		$parse_mems    = array();
-		$result        = null;
-
-		// Warmup runs to stabilize opcache/JIT/autoloader effects
-		for ( $warmup = 0; $warmup < self::PERF_WARMUP_RUNS; $warmup++ ) {
-			$scanner_callable();
-			$parse_callable();
-		}
-
-		for ( $i = 0; $i < $iterations; $i++ ) {
-			// Garbage collection and memory cache cleanup before each iteration
-			if ( \function_exists( 'gc_collect_cycles' ) ) {
-				\gc_collect_cycles();
-			}
-			if ( \function_exists( 'gc_mem_caches' ) ) {
-				\gc_mem_caches();
-			}
-
-			// Alternate order each iteration to avoid order bias
-			$run_scanner_first = ( $i % 2 ) === 0;
-
-			if ( $run_scanner_first ) {
-				// Run scanner first
-				$start_memory    = \memory_get_usage( true );
-				$start_time      = \microtime( true );
-				$scanner_result  = $scanner_callable();
-				$scanner_times[] = \microtime( true ) - $start_time;
-				$scanner_mems[]  = max( 0, \memory_get_usage( true ) - $start_memory );
-				unset( $scanner_result );
-
-				// Brief cleanup between runs
-				if ( \function_exists( 'gc_collect_cycles' ) ) {
-					\gc_collect_cycles();
-				}
-
-				// Run parse_blocks second
-				$start_memory  = \memory_get_usage( true );
-				$start_time    = \microtime( true );
-				$parse_result  = $parse_callable();
-				$parse_times[] = \microtime( true ) - $start_time;
-				$parse_mems[]  = max( 0, \memory_get_usage( true ) - $start_memory );
-			} else {
-				// Run parse_blocks first
-				$start_memory  = \memory_get_usage( true );
-				$start_time    = \microtime( true );
-				$parse_result  = $parse_callable();
-				$parse_times[] = \microtime( true ) - $start_time;
-				$parse_mems[]  = max( 0, \memory_get_usage( true ) - $start_memory );
-				unset( $parse_result );
-
-				// Brief cleanup between runs
-				if ( \function_exists( 'gc_collect_cycles' ) ) {
-					\gc_collect_cycles();
-				}
-
-				// Run scanner second
-				$start_memory    = \memory_get_usage( true );
-				$start_time      = \microtime( true );
-				$scanner_result  = $scanner_callable();
-				$scanner_times[] = \microtime( true ) - $start_time;
-				$scanner_mems[]  = max( 0, \memory_get_usage( true ) - $start_memory );
-			}
-
-			// Keep one result for correctness verification
-			// @phan-suppress-next-line PhanImpossibleTypeComparisonInLoop
-			if ( null === $result && isset( $scanner_result ) && null !== $scanner_result ) {
-				$result = $scanner_result;
-				// @phan-suppress-next-line PhanImpossibleTypeComparisonInLoop
-			} elseif ( null === $result && isset( $parse_result ) && null !== $parse_result ) {
-				$result = $parse_result;
-			}
-
-			// Cleanup results to aid memory reuse
-			unset( $scanner_result, $parse_result );
-		}
-
-		return array(
-			'scanner_times' => $scanner_times,
-			'parse_times'   => $parse_times,
-			'scanner_mems'  => $scanner_mems,
-			'parse_mems'    => $parse_mems,
-			'result'        => $result,
-		);
-	}
-
-	/**
-	 * Compute trimmed statistic by removing top and bottom 20% and taking median.
-	 *
-	 * @param array $values Array of numeric values.
-	 * @return float Trimmed median value.
-	 */
-	private function compute_trimmed_median( array $values ): float {
-		if ( empty( $values ) ) {
-			return 0.0;
-		}
-
-		$sorted = $values;
-		sort( $sorted );
-		$count = count( $sorted );
-
-		// Remove top and bottom 20%
-		$trim_count = (int) floor( $count * 0.2 );
-		$trimmed    = array_slice( $sorted, $trim_count, $count - ( 2 * $trim_count ) );
-
-		// @phan-suppress-next-line PhanImpossibleCondition - Can be empty with very small arrays
-		if ( empty( $trimmed ) ) {
-			return $sorted[ (int) floor( $count / 2 ) ];
-		}
-
-		$trimmed_count = count( $trimmed );
-		return $trimmed[ (int) floor( $trimmed_count / 2 ) ];
 	}
 
 	/**
@@ -1010,95 +789,6 @@ class Block_Scanner_Test extends TestCase {
 		$this->assertNotNull( $parse_blocks_result, 'parse_blocks should find image block' );
 		$this->assertSame( $parse_blocks_result['blockName'], $scanner_result['blockName'] );
 		$this->assertSame( $parse_blocks_result['attrs'], $scanner_result['attrs'] );
-	}
-
-	/**
-	 * Assert Block_Scanner has performance advantage using paired benchmark results with robust statistics.
-	 *
-	 * @param array  $benchmark_results Results from run_competitive_benchmark().
-	 * @param string $test_content Test content to reuse for retry measurements.
-	 */
-	private function assert_performance_advantage_paired( array $benchmark_results, string $test_content ): void {
-		$scanner_times = $benchmark_results['scanner_times'];
-		$parse_times   = $benchmark_results['parse_times'];
-		$scanner_mems  = $benchmark_results['scanner_mems'];
-		$parse_mems    = $benchmark_results['parse_mems'];
-
-		// Compute robust trimmed statistics
-		$scanner_time_trimmed = $this->compute_trimmed_median( $scanner_times );
-		$parse_time_trimmed   = $this->compute_trimmed_median( $parse_times );
-		$scanner_mem_stat     = $this->compute_trimmed_median( $scanner_mems );
-		$parse_mem_stat       = $this->compute_trimmed_median( $parse_mems );
-
-		// Regression-focused time ratio assertion with extended retry mechanism
-		$time_ratio  = $parse_time_trimmed / $scanner_time_trimmed;
-		$retry_count = 0;
-		$max_retries = 2;
-
-		// Multiple retry attempts for CI stability
-		while ( $time_ratio < self::PERF_MIN_TIME_RATIO_THRESHOLD && $retry_count < $max_retries ) {
-			$retry_count++;
-
-			// Retry with progressively more iterations for statistical stability
-			$retry_iterations = self::PERF_RETRY_BENCHMARK_ITERATIONS + ( $retry_count * 10 );
-
-			$retry_results = $this->run_competitive_benchmark(
-				function () use ( $test_content ) {
-					return $this->find_first_image_with_scanner( $test_content );
-				},
-				function () use ( $test_content ) {
-					return $this->find_first_image_with_parse_blocks( $test_content );
-				},
-				$retry_iterations
-			);
-
-			$retry_scanner_time = $this->compute_trimmed_median( $retry_results['scanner_times'] );
-			$retry_parse_time   = $this->compute_trimmed_median( $retry_results['parse_times'] );
-			$time_ratio         = $retry_parse_time / $retry_scanner_time;
-		}
-
-		// Regression-focused assertion: Scanner should not be significantly slower
-		$this->assertGreaterThanOrEqual(
-			self::PERF_MIN_TIME_RATIO_THRESHOLD,
-			$time_ratio,
-			sprintf(
-				'Scanner performance regression detected (ratio: %.3f, scanner: %.6fs, parse_blocks: %.6fs)',
-				$time_ratio,
-				$scanner_time_trimmed,
-				$parse_time_trimmed
-			)
-		);
-
-		// Distribution check - majority of runs should not show regression
-		$favorable_runs = 0;
-		$total_runs     = count( $scanner_times );
-		for ( $i = 0; $i < $total_runs; $i++ ) {
-			if ( $parse_times[ $i ] >= self::PERF_MIN_TIME_RATIO_THRESHOLD * $scanner_times[ $i ] ) {
-				$favorable_runs++;
-			}
-		}
-		$favorable_percentage = ( $favorable_runs / $total_runs ) * 100;
-		$this->assertGreaterThanOrEqual(
-			self::PERF_MIN_FAVORABLE_RUNS_PERCENT,
-			$favorable_percentage,
-			sprintf(
-				'Performance regression in %.1f%% of individual runs (threshold: %d%% must pass)',
-				100 - $favorable_percentage,
-				self::PERF_MIN_FAVORABLE_RUNS_PERCENT
-			)
-		);
-
-		// Memory regression check with CI-friendly tolerance (128KB)
-		$this->assertLessThanOrEqual(
-			$parse_mem_stat * 1.10 + self::PERF_MEMORY_TOLERANCE_BYTES,
-			$scanner_mem_stat,
-			sprintf(
-				'Scanner memory should be comparable to parse_blocks (scanner: %d bytes, parse_blocks: %d bytes, tolerance: %d bytes)',
-				$scanner_mem_stat,
-				$parse_mem_stat,
-				self::PERF_MEMORY_TOLERANCE_BYTES
-			)
-		);
 	}
 
 	/**
@@ -1187,7 +877,7 @@ class Block_Scanner_Test extends TestCase {
 			$this->markTestSkipped( 'serialize_blocks not available. Block editor not available' );
 		}
 
-		$test_content = $this->generate_test_content_with_target_image();
+		$test_content = Performance_Benchmark_Utils::generate_test_content_with_target_image();
 
 		$scanner_result      = $this->find_first_image_with_scanner( $test_content );
 		$parse_blocks_result = $this->find_first_image_with_parse_blocks( $test_content );

--- a/projects/packages/block-delimiter/tests/php/Block_Scanner_Test.php
+++ b/projects/packages/block-delimiter/tests/php/Block_Scanner_Test.php
@@ -1058,7 +1058,7 @@ class Block_Scanner_Test extends TestCase {
 		}
 
 		// Regression-focused assertion: Scanner should not be significantly slower
-		$this->assertGreaterThan(
+		$this->assertGreaterThanOrEqual(
 			self::PERF_MIN_TIME_RATIO_THRESHOLD,
 			$time_ratio,
 			sprintf(

--- a/projects/packages/block-delimiter/tests/php/Block_Scanner_Test.php
+++ b/projects/packages/block-delimiter/tests/php/Block_Scanner_Test.php
@@ -21,8 +21,8 @@ class Block_Scanner_Test extends TestCase {
 	private const PERF_RETRY_BENCHMARK_ITERATIONS = 21;    // Reduced retry iterations
 
 	// CI-friendly performance assertion thresholds (regression detection vs absolute performance)
-	private const PERF_MIN_TIME_RATIO_THRESHOLD   = 1.03;  // Scanner must not be significantly slower (relaxed for CI)
-	private const PERF_MIN_FAVORABLE_RUNS_PERCENT = 55;    // Majority of runs should show scanner advantage (relaxed)
+	private const PERF_MIN_TIME_RATIO_THRESHOLD   = 1.02;  // Scanner must not be significantly slower
+	private const PERF_MIN_FAVORABLE_RUNS_PERCENT = 55;    // Majority of runs should show scanner advantage
 	private const PERF_MEMORY_TOLERANCE_BYTES     = 128 * 1024; // 128KB tolerance for CI memory variations
 
 	/**
@@ -775,7 +775,6 @@ class Block_Scanner_Test extends TestCase {
 		$parse_blocks_result = $this->find_first_image_with_parse_blocks( $test_content );
 		$this->assert_same_results( $scanner_result, $parse_blocks_result );
 
-		// Verify performance advantage with relaxed and robust assertions
 		$this->assert_performance_advantage_paired( $benchmark_results, $test_content );
 	}
 
@@ -1056,17 +1055,6 @@ class Block_Scanner_Test extends TestCase {
 			$retry_scanner_time = $this->compute_trimmed_median( $retry_results['scanner_times'] );
 			$retry_parse_time   = $this->compute_trimmed_median( $retry_results['parse_times'] );
 			$time_ratio         = $retry_parse_time / $retry_scanner_time;
-		}
-
-		// If still below threshold after retries, skip rather than fail (CI-friendly)
-		if ( $time_ratio < self::PERF_MIN_TIME_RATIO_THRESHOLD ) {
-			$this->markTestSkipped(
-				sprintf(
-					'Performance inconclusive after %d retries (ratio: %.3f) - likely CI environment variability',
-					$retry_count,
-					$time_ratio
-				)
-			);
 		}
 
 		// Regression-focused assertion: Scanner should not be significantly slower

--- a/projects/packages/block-delimiter/tests/php/Block_Scanner_Test.php
+++ b/projects/packages/block-delimiter/tests/php/Block_Scanner_Test.php
@@ -16,14 +16,14 @@ use PHPUnit\Framework\TestCase;
 class Block_Scanner_Test extends TestCase {
 
 	// Benchmark configuration
-	private const PERF_WARMUP_RUNS                = 5;     // Initial runs to stabilize JIT/opcache before measuring
-	private const PERF_BENCHMARK_ITERATIONS       = 21;    // Main benchmark iterations for statistical significance
-	private const PERF_RETRY_BENCHMARK_ITERATIONS = 51;    // Extra iterations when retrying borderline results
+	private const PERF_WARMUP_RUNS                = 3;     // Reduced warmup runs for faster CI execution
+	private const PERF_BENCHMARK_ITERATIONS       = 11;    // Fewer iterations for CI stability
+	private const PERF_RETRY_BENCHMARK_ITERATIONS = 21;    // Reduced retry iterations
 
-	// Performance assertion thresholds
-	private const PERF_MIN_TIME_RATIO_THRESHOLD   = 1.10;  // Scanner must be 1.10x faster than parse_blocks
-	private const PERF_MIN_FAVORABLE_RUNS_PERCENT = 80;    // % of individual runs that must show scanner advantage
-	private const PERF_MEMORY_TOLERANCE_BYTES     = 65536; // 64KB tolerance for memory usage comparison
+	// CI-friendly performance assertion thresholds (regression detection vs absolute performance)
+	private const PERF_MIN_TIME_RATIO_THRESHOLD   = 1.03;  // Scanner must not be significantly slower (relaxed for CI)
+	private const PERF_MIN_FAVORABLE_RUNS_PERCENT = 55;    // Majority of runs should show scanner advantage (relaxed)
+	private const PERF_MEMORY_TOLERANCE_BYTES     = 128 * 1024; // 128KB tolerance for CI memory variations
 
 	/**
 	 * Test the create method with valid input.
@@ -735,9 +735,10 @@ class Block_Scanner_Test extends TestCase {
 	}
 
 	/**
-	 * Test performance comparison between parse_blocks and Block_Scanner.
+	 * Test performance regression detection between parse_blocks and Block_Scanner.
 	 *
-	 * Verifies Block_Scanner is faster when finding specific blocks early.
+	 * Ensures Block_Scanner performance doesn't significantly regress compared to parse_blocks.
+	 * Uses CI-friendly thresholds and extensive retry logic to minimize false positives.
 	 *
 	 * @group performance
 	 */
@@ -749,6 +750,11 @@ class Block_Scanner_Test extends TestCase {
 
 		if ( ! \function_exists( 'serialize_blocks' ) ) {
 			$this->markTestSkipped( 'serialize_blocks not available. Block editor not available' );
+		}
+
+		// Skip test under high system load conditions to reduce CI flakiness
+		if ( $this->is_system_under_high_load() ) {
+			$this->markTestSkipped( 'System under high load - skipping performance test for stability' );
 		}
 
 		$test_content = $this->generate_test_content_with_target_image();
@@ -776,15 +782,15 @@ class Block_Scanner_Test extends TestCase {
 	/**
 	 * Generate test content with target image positioned for early termination test.
 	 *
-	 * Creates 50 paragraph blocks before the image, then 2000 after to amplify early-exit advantage.
+	 * Creates 10 paragraph blocks before the image, then 100 after for CI-friendly execution while preserving early-exit advantage.
 	 *
 	 * @return string Block content with image at early position.
 	 */
 	private function generate_test_content_with_target_image(): string {
 		$blocks = array();
 
-		// Add 50 paragraph blocks before target (earlier image position)
-		for ( $i = 0; $i < 50; $i++ ) {
+		// Add 10 paragraph blocks before target (reduced for CI stability)
+		for ( $i = 0; $i < 10; $i++ ) {
 			$blocks[] = array(
 				'blockName'    => 'core/paragraph',
 				'attrs'        => array(),
@@ -805,8 +811,8 @@ class Block_Scanner_Test extends TestCase {
 			'innerContent' => array( '<figure class="wp-block-image"><img src="https://example.com/test.jpg" alt="Test image"/></figure>' ),
 		);
 
-		// Add significantly more blocks after target (2000 blocks for more pronounced early-exit advantage)
-		for ( $i = 0; $i < 2000; $i++ ) {
+		// Add blocks after target (100 blocks - still enough to show early-exit advantage but faster for CI)
+		for ( $i = 0; $i < 100; $i++ ) {
 			$blocks[] = array(
 				'blockName'    => 'core/paragraph',
 				'attrs'        => array(),
@@ -815,6 +821,58 @@ class Block_Scanner_Test extends TestCase {
 		}
 
 		return \serialize_blocks( $blocks );
+	}
+
+	/**
+	 * Check if system is under high load that could affect performance test reliability.
+	 *
+	 * @return bool True if system load is too high for reliable performance testing.
+	 */
+	private function is_system_under_high_load(): bool {
+		// Check available memory - skip if less than 64MB free
+		$memory_limit = ini_get( 'memory_limit' );
+		if ( $memory_limit && $memory_limit !== '-1' ) {
+			$memory_limit_bytes = $this->parse_memory_limit( $memory_limit );
+			$current_usage      = \memory_get_usage( true );
+			$available_memory   = $memory_limit_bytes - $current_usage;
+
+			if ( $available_memory < 64 * 1024 * 1024 ) { // Less than 64MB available
+				return true;
+			}
+		}
+
+		// Basic load average check on Unix systems
+		if ( \function_exists( 'sys_getloadavg' ) ) {
+			$load = \sys_getloadavg();
+			if ( $load && $load[0] > 4.0 ) { // High 1-minute load average
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Parse PHP memory limit string to bytes.
+	 *
+	 * @param string $limit Memory limit string (e.g., '128M', '1G').
+	 * @return int Memory limit in bytes.
+	 */
+	private function parse_memory_limit( string $limit ): int {
+		$limit         = trim( $limit );
+		$last_char     = strtolower( substr( $limit, -1 ) );
+		$numeric_value = (int) substr( $limit, 0, -1 );
+
+		switch ( $last_char ) {
+			case 'g':
+				return $numeric_value * 1024 * 1024 * 1024;
+			case 'm':
+				return $numeric_value * 1024 * 1024;
+			case 'k':
+				return $numeric_value * 1024;
+			default:
+				return (int) $limit;
+		}
 	}
 
 	/**
@@ -973,50 +1031,57 @@ class Block_Scanner_Test extends TestCase {
 		$scanner_mem_stat     = $this->compute_trimmed_median( $scanner_mems );
 		$parse_mem_stat       = $this->compute_trimmed_median( $parse_mems );
 
-		// Time ratio assertion with retry mechanism
-		$time_ratio = $parse_time_trimmed / $scanner_time_trimmed;
+		// Regression-focused time ratio assertion with extended retry mechanism
+		$time_ratio  = $parse_time_trimmed / $scanner_time_trimmed;
+		$retry_count = 0;
+		$max_retries = 2;
 
-		if ( $time_ratio < self::PERF_MIN_TIME_RATIO_THRESHOLD ) {
-			if ( $time_ratio >= 1.05 ) {
-				// Borderline case - retry once with more iterations using the same test content
-				$retry_results = $this->run_competitive_benchmark(
-					function () use ( $test_content ) {
-						return $this->find_first_image_with_scanner( $test_content );
-					},
-					function () use ( $test_content ) {
-						return $this->find_first_image_with_parse_blocks( $test_content );
-					},
-					self::PERF_RETRY_BENCHMARK_ITERATIONS
-				);
+		// Multiple retry attempts for CI stability
+		while ( $time_ratio < self::PERF_MIN_TIME_RATIO_THRESHOLD && $retry_count < $max_retries ) {
+			$retry_count++;
 
-				$retry_scanner_time = $this->compute_trimmed_median( $retry_results['scanner_times'] );
-				$retry_parse_time   = $this->compute_trimmed_median( $retry_results['parse_times'] );
-				$time_ratio         = $retry_parse_time / $retry_scanner_time;
-			}
+			// Retry with progressively more iterations for statistical stability
+			$retry_iterations = self::PERF_RETRY_BENCHMARK_ITERATIONS + ( $retry_count * 10 );
 
-			if ( $time_ratio < self::PERF_MIN_TIME_RATIO_THRESHOLD ) {
-				$this->markTestSkipped(
-					sprintf(
-						'Performance inconclusive under current environment (ratio: %.3f)',
-						$time_ratio
-					)
-				);
-			}
+			$retry_results = $this->run_competitive_benchmark(
+				function () use ( $test_content ) {
+					return $this->find_first_image_with_scanner( $test_content );
+				},
+				function () use ( $test_content ) {
+					return $this->find_first_image_with_parse_blocks( $test_content );
+				},
+				$retry_iterations
+			);
+
+			$retry_scanner_time = $this->compute_trimmed_median( $retry_results['scanner_times'] );
+			$retry_parse_time   = $this->compute_trimmed_median( $retry_results['parse_times'] );
+			$time_ratio         = $retry_parse_time / $retry_scanner_time;
 		}
 
-		// Main time ratio assertion
+		// If still below threshold after retries, skip rather than fail (CI-friendly)
+		if ( $time_ratio < self::PERF_MIN_TIME_RATIO_THRESHOLD ) {
+			$this->markTestSkipped(
+				sprintf(
+					'Performance inconclusive after %d retries (ratio: %.3f) - likely CI environment variability',
+					$retry_count,
+					$time_ratio
+				)
+			);
+		}
+
+		// Regression-focused assertion: Scanner should not be significantly slower
 		$this->assertGreaterThan(
 			self::PERF_MIN_TIME_RATIO_THRESHOLD,
 			$time_ratio,
 			sprintf(
-				'Scanner should be measurably faster than parse_blocks (ratio: %.3f, scanner: %.6fs, parse_blocks: %.6fs)',
+				'Scanner performance regression detected (ratio: %.3f, scanner: %.6fs, parse_blocks: %.6fs)',
 				$time_ratio,
 				$scanner_time_trimmed,
 				$parse_time_trimmed
 			)
 		);
 
-		// Distribution check - at least 80% of runs should satisfy ratio >= 1.10
+		// Distribution check - majority of runs should not show regression
 		$favorable_runs = 0;
 		$total_runs     = count( $scanner_times );
 		for ( $i = 0; $i < $total_runs; $i++ ) {
@@ -1029,12 +1094,13 @@ class Block_Scanner_Test extends TestCase {
 			self::PERF_MIN_FAVORABLE_RUNS_PERCENT,
 			$favorable_percentage,
 			sprintf(
-				'At least 80%% of individual runs should show scanner advantage (actual: %.1f%%)',
-				$favorable_percentage
+				'Performance regression in %.1f%% of individual runs (threshold: %d%% must pass)',
+				100 - $favorable_percentage,
+				self::PERF_MIN_FAVORABLE_RUNS_PERCENT
 			)
 		);
 
-		// Memory assertion with larger tolerance (64KB)
+		// Memory regression check with CI-friendly tolerance (128KB)
 		$this->assertLessThanOrEqual(
 			$parse_mem_stat * 1.10 + self::PERF_MEMORY_TOLERANCE_BYTES,
 			$scanner_mem_stat,

--- a/projects/packages/block-delimiter/tests/php/Block_Scanner_Test.php
+++ b/projects/packages/block-delimiter/tests/php/Block_Scanner_Test.php
@@ -4,6 +4,7 @@ namespace Automattic;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -13,6 +14,13 @@ use PHPUnit\Framework\TestCase;
  */
 #[CoversClass( Block_Scanner::class )]
 class Block_Scanner_Test extends TestCase {
+
+	private const PERF_WARMUPS              = 5;
+	private const PERF_ITERATIONS           = 21;
+	private const PERF_RETRY_ITERATIONS     = 51;
+	private const PERF_TIME_RATIO_THRESHOLD = 1.10;
+	private const PERF_FAVORABLE_PCT        = 80; // percent
+	private const PERF_MEM_TOLERANCE_BYTES  = 65536; // 64KB
 
 	/**
 	 * Test the create method with valid input.
@@ -727,43 +735,53 @@ class Block_Scanner_Test extends TestCase {
 	 * Test performance comparison between parse_blocks and Block_Scanner.
 	 *
 	 * Verifies Block_Scanner is faster when finding specific blocks early.
+	 *
+	 * @group performance
 	 */
+	#[Group( 'performance' )]
 	public function test_performance_comparison(): void {
-		if ( ! function_exists( 'parse_blocks' ) ) {
+		if ( ! \function_exists( 'parse_blocks' ) ) {
 			$this->markTestSkipped( 'parse_blocks not available. Block editor not available' );
 		}
 
-		if ( ! function_exists( 'serialize_blocks' ) ) {
+		if ( ! \function_exists( 'serialize_blocks' ) ) {
 			$this->markTestSkipped( 'serialize_blocks not available. Block editor not available' );
 		}
 
 		$test_content = $this->generate_test_content_with_target_image();
 
-		// Benchmark both approaches
-		// Warm-up to avoid autoloader/JIT noise in timed runs
-		$this->find_first_image_with_scanner( $test_content );
-		$this->find_first_image_with_parse_blocks( $test_content );
+		// Run competitive benchmark with paired measurements
+		$benchmark_results = $this->run_competitive_benchmark(
+			function () use ( $test_content ) {
+				return $this->find_first_image_with_scanner( $test_content );
+			},
+			function () use ( $test_content ) {
+				return $this->find_first_image_with_parse_blocks( $test_content );
+			},
+			self::PERF_ITERATIONS
+		);
 
-		$scanner_metrics      = $this->benchmark_scanner_search_multiple( $test_content, 5 );
-		$parse_blocks_metrics = $this->benchmark_parse_blocks_search_multiple( $test_content, 5 );
+		// Verify correctness - both methods should find the same result
+		$scanner_result      = $this->find_first_image_with_scanner( $test_content );
+		$parse_blocks_result = $this->find_first_image_with_parse_blocks( $test_content );
+		$this->assert_same_results( $scanner_result, $parse_blocks_result );
 
-		// Verify correctness
-		$this->assert_same_results( $scanner_metrics['result'], $parse_blocks_metrics['result'] );
-
-		// Verify performance advantage
-		$this->assert_performance_advantage( $scanner_metrics, $parse_blocks_metrics );
+		// Verify performance advantage with relaxed and robust assertions
+		$this->assert_performance_advantage_paired( $benchmark_results, $test_content );
 	}
 
 	/**
 	 * Generate test content with target image positioned for early termination test.
 	 *
-	 * @return string Block content with image at ~1/3 position.
+	 * Creates 50 paragraph blocks before the image, then 2000 after to amplify early-exit advantage.
+	 *
+	 * @return string Block content with image at early position.
 	 */
 	private function generate_test_content_with_target_image(): string {
 		$blocks = array();
 
-		// Add ~130 paragraph blocks before target
-		for ( $i = 0; $i < 130; $i++ ) {
+		// Add 50 paragraph blocks before target (earlier image position)
+		for ( $i = 0; $i < 50; $i++ ) {
 			$blocks[] = array(
 				'blockName'    => 'core/paragraph',
 				'attrs'        => array(),
@@ -771,18 +789,21 @@ class Block_Scanner_Test extends TestCase {
 			);
 		}
 
-		// Add target image block
+		// Add target image block with attributes
 		$blocks[] = array(
 			'blockName'    => 'core/image',
 			'attrs'        => array(
-				'id'  => 12345,
-				'alt' => 'Test image',
+				'id'     => 12345,
+				'alt'    => 'Test image',
+				'url'    => 'https://example.com/test.jpg',
+				'width'  => 800,
+				'height' => 600,
 			),
-			'innerContent' => array( '<figure class="wp-block-image"><img src="test.jpg" alt="Test image"/></figure>' ),
+			'innerContent' => array( '<figure class="wp-block-image"><img src="https://example.com/test.jpg" alt="Test image"/></figure>' ),
 		);
 
-		// Add more blocks after target (parse_blocks will process these, scanner won't)
-		for ( $i = 0; $i < 270; $i++ ) {
+		// Add significantly more blocks after target (2000 blocks for more pronounced early-exit advantage)
+		for ( $i = 0; $i < 2000; $i++ ) {
 			$blocks[] = array(
 				'blockName'    => 'core/paragraph',
 				'attrs'        => array(),
@@ -790,120 +811,129 @@ class Block_Scanner_Test extends TestCase {
 			);
 		}
 
-		return serialize_blocks( $blocks );
+		return \serialize_blocks( $blocks );
 	}
 
 	/**
-	 * Benchmark Block_Scanner search approach.
+	 * Run competitive benchmark with paired measurements to minimize environmental drift.
 	 *
-	 * @param string $content Content to search.
-	 * @return array Metrics with timing, memory, and result data.
+	 * @param callable $scanner_callable Callable for scanner benchmark.
+	 * @param callable $parse_callable Callable for parse_blocks benchmark.
+	 * @param int      $iterations Number of paired iterations to run.
+	 * @return array{scanner_times: float[], parse_times: float[], scanner_mems: int[], parse_mems: int[], result: mixed}
 	 */
-	private function benchmark_scanner_search( string $content ): array {
-		$start_time   = microtime( true );
-		$start_memory = memory_get_usage();
+	private function run_competitive_benchmark( callable $scanner_callable, callable $parse_callable, int $iterations ): array {
+		$scanner_times = array();
+		$parse_times   = array();
+		$scanner_mems  = array();
+		$parse_mems    = array();
+		$result        = null;
 
-		$result = $this->find_first_image_with_scanner( $content );
-
-		return array(
-			'time'   => microtime( true ) - $start_time,
-			'memory' => memory_get_usage() - $start_memory,
-			'result' => $result,
-		);
-	}
-
-	/**
-	 * Benchmark parse_blocks search approach.
-	 *
-	 * @param string $content Content to search.
-	 * @return array Metrics with timing, memory, and result data.
-	 */
-	private function benchmark_parse_blocks_search( string $content ): array {
-		$start_time   = microtime( true );
-		$start_memory = memory_get_usage();
-
-		$result = $this->find_first_image_with_parse_blocks( $content );
-
-		return array(
-			'time'   => microtime( true ) - $start_time,
-			'memory' => memory_get_usage() - $start_memory,
-			'result' => $result,
-		);
-	}
-
-	/**
-	 * Benchmark Block_Scanner search approach over multiple iterations and aggregate results.
-	 *
-	 * @param string $content    Content to search.
-	 * @param int    $iterations Number of iterations to run.
-	 * @return array Metrics with aggregated timing (median), peak memory delta, and result data.
-	 */
-	private function benchmark_scanner_search_multiple( string $content, int $iterations = 5 ): array {
-		return $this->run_benchmark_multiple(
-			function () use ( $content ) {
-				return $this->find_first_image_with_scanner( $content );
-			},
-			$iterations
-		);
-	}
-
-	/**
-	 * Benchmark parse_blocks search approach over multiple iterations and aggregate results.
-	 *
-	 * @param string $content    Content to search.
-	 * @param int    $iterations Number of iterations to run.
-	 * @return array Metrics with aggregated timing (median), peak memory delta, and result data.
-	 */
-	private function benchmark_parse_blocks_search_multiple( string $content, int $iterations = 5 ): array {
-		return $this->run_benchmark_multiple(
-			function () use ( $content ) {
-				return $this->find_first_image_with_parse_blocks( $content );
-			},
-			$iterations
-		);
-	}
-
-	/**
-	 * Run a callable multiple times, returning aggregated benchmark metrics.
-	 * Uses median time to reduce noise and the maximum observed memory delta as a conservative proxy for peak.
-	 *
-	 * @param callable $callable   Callable to benchmark.
-	 * @param int      $iterations Number of iterations to run.
-	 * @return array{time: float, memory: int, result: mixed}
-	 */
-	private function run_benchmark_multiple( callable $callable, int $iterations ): array {
-		$times  = array();
-		$mems   = array();
-		$result = null;
-
-		for ( $i = 0; $i < $iterations; $i++ ) {
-			// Encourage collection between runs to reduce cross-iteration interference.
-			if ( function_exists( 'gc_collect_cycles' ) ) {
-				gc_collect_cycles();
-			}
-
-			$start_memory = memory_get_usage();
-			$start_time   = microtime( true );
-
-			$run_result = $callable();
-
-			$times[] = microtime( true ) - $start_time;
-			$mems[]  = max( 0, memory_get_usage() - $start_memory );
-
-			if ( null === $result && null !== $run_result ) {
-				$result = $run_result;
-			}
+		// Warmup runs to stabilize opcache/JIT/autoloader effects
+		for ( $warmup = 0; $warmup < self::PERF_WARMUPS; $warmup++ ) {
+			$scanner_callable();
+			$parse_callable();
 		}
 
-		sort( $times );
-		$median_time = $times[ (int) floor( count( $times ) / 2 ) ];
-		$peak_memory = max( $mems );
+		for ( $i = 0; $i < $iterations; $i++ ) {
+			// Garbage collection and memory cache cleanup before each iteration
+			if ( \function_exists( 'gc_collect_cycles' ) ) {
+				\gc_collect_cycles();
+			}
+			if ( \function_exists( 'gc_mem_caches' ) ) {
+				\gc_mem_caches();
+			}
+
+			// Alternate order each iteration to avoid order bias
+			$run_scanner_first = ( $i % 2 ) === 0;
+
+			if ( $run_scanner_first ) {
+				// Run scanner first
+				$start_memory    = \memory_get_usage( true );
+				$start_time      = \microtime( true );
+				$scanner_result  = $scanner_callable();
+				$scanner_times[] = \microtime( true ) - $start_time;
+				$scanner_mems[]  = max( 0, \memory_get_usage( true ) - $start_memory );
+				unset( $scanner_result );
+
+				// Brief cleanup between runs
+				if ( \function_exists( 'gc_collect_cycles' ) ) {
+					\gc_collect_cycles();
+				}
+
+				// Run parse_blocks second
+				$start_memory  = \memory_get_usage( true );
+				$start_time    = \microtime( true );
+				$parse_result  = $parse_callable();
+				$parse_times[] = \microtime( true ) - $start_time;
+				$parse_mems[]  = max( 0, \memory_get_usage( true ) - $start_memory );
+			} else {
+				// Run parse_blocks first
+				$start_memory  = \memory_get_usage( true );
+				$start_time    = \microtime( true );
+				$parse_result  = $parse_callable();
+				$parse_times[] = \microtime( true ) - $start_time;
+				$parse_mems[]  = max( 0, \memory_get_usage( true ) - $start_memory );
+				unset( $parse_result );
+
+				// Brief cleanup between runs
+				if ( \function_exists( 'gc_collect_cycles' ) ) {
+					\gc_collect_cycles();
+				}
+
+				// Run scanner second
+				$start_memory    = \memory_get_usage( true );
+				$start_time      = \microtime( true );
+				$scanner_result  = $scanner_callable();
+				$scanner_times[] = \microtime( true ) - $start_time;
+				$scanner_mems[]  = max( 0, \memory_get_usage( true ) - $start_memory );
+			}
+
+			// Keep one result for correctness verification
+			if ( null === $result && isset( $scanner_result ) && null !== $scanner_result ) {
+				$result = $scanner_result;
+			} elseif ( null === $result && isset( $parse_result ) && null !== $parse_result ) {
+				$result = $parse_result;
+			}
+
+			// Cleanup results to aid memory reuse
+			unset( $scanner_result, $parse_result );
+		}
 
 		return array(
-			'time'   => $median_time,
-			'memory' => $peak_memory,
-			'result' => $result,
+			'scanner_times' => $scanner_times,
+			'parse_times'   => $parse_times,
+			'scanner_mems'  => $scanner_mems,
+			'parse_mems'    => $parse_mems,
+			'result'        => $result,
 		);
+	}
+
+	/**
+	 * Compute trimmed statistic by removing top and bottom 20% and taking median.
+	 *
+	 * @param array $values Array of numeric values.
+	 * @return float Trimmed median value.
+	 */
+	private function compute_trimmed_median( array $values ): float {
+		if ( empty( $values ) ) {
+			return 0.0;
+		}
+
+		$sorted = $values;
+		sort( $sorted );
+		$count = count( $sorted );
+
+		// Remove top and bottom 20%
+		$trim_count = (int) floor( $count * 0.2 );
+		$trimmed    = array_slice( $sorted, $trim_count, $count - ( 2 * $trim_count ) );
+
+		if ( empty( $trimmed ) ) {
+			return $sorted[ (int) floor( $count / 2 ) ];
+		}
+
+		$trimmed_count = count( $trimmed );
+		return $trimmed[ (int) floor( $trimmed_count / 2 ) ];
 	}
 
 	/**
@@ -920,22 +950,97 @@ class Block_Scanner_Test extends TestCase {
 	}
 
 	/**
-	 * Assert Block_Scanner has performance advantage.
+	 * Assert Block_Scanner has performance advantage using paired benchmark results with robust statistics.
 	 *
-	 * @param array $scanner_metrics Scanner performance data.
-	 * @param array $parse_blocks_metrics parse_blocks performance data.
+	 * @param array  $benchmark_results Results from run_competitive_benchmark().
+	 * @param string $test_content Test content to reuse for retry measurements.
 	 */
-	private function assert_performance_advantage( array $scanner_metrics, array $parse_blocks_metrics ): void {
-		// Assert time advantage using median across multiple iterations to reduce noise.
-		$time_ratio = $parse_blocks_metrics['time'] / $scanner_metrics['time'];
-		$this->assertGreaterThan( 1.15, $time_ratio, 'Scanner should be measurably faster than parse_blocks' );
+	private function assert_performance_advantage_paired( array $benchmark_results, string $test_content ): void {
+		$scanner_times = $benchmark_results['scanner_times'];
+		$parse_times   = $benchmark_results['parse_times'];
+		$scanner_mems  = $benchmark_results['scanner_mems'];
+		$parse_mems    = $benchmark_results['parse_mems'];
 
-		// Assert memory is not worse than parse_blocks beyond a small tolerance for measurement noise.
-		$memory_tolerance = 4096; // 4KB tolerance
+		// Compute robust trimmed statistics
+		$scanner_time_trimmed = $this->compute_trimmed_median( $scanner_times );
+		$parse_time_trimmed   = $this->compute_trimmed_median( $parse_times );
+		$scanner_mem_stat     = $this->compute_trimmed_median( $scanner_mems );
+		$parse_mem_stat       = $this->compute_trimmed_median( $parse_mems );
+
+		// Time ratio assertion with retry mechanism
+		$time_ratio      = $parse_time_trimmed / $scanner_time_trimmed;
+		$retry_attempted = false;
+
+		if ( $time_ratio < self::PERF_TIME_RATIO_THRESHOLD ) {
+			if ( $time_ratio >= 1.05 && ! $retry_attempted ) {
+				// Borderline case - retry once with more iterations using the same test content
+				$retry_results = $this->run_competitive_benchmark(
+					function () use ( $test_content ) {
+						return $this->find_first_image_with_scanner( $test_content );
+					},
+					function () use ( $test_content ) {
+						return $this->find_first_image_with_parse_blocks( $test_content );
+					},
+					self::PERF_RETRY_ITERATIONS
+				);
+
+				$retry_scanner_time = $this->compute_trimmed_median( $retry_results['scanner_times'] );
+				$retry_parse_time   = $this->compute_trimmed_median( $retry_results['parse_times'] );
+				$time_ratio         = $retry_parse_time / $retry_scanner_time;
+				$retry_attempted    = true;
+			}
+
+			if ( $time_ratio < self::PERF_TIME_RATIO_THRESHOLD ) {
+				$this->markTestSkipped(
+					sprintf(
+						'Performance inconclusive under current environment (ratio: %.3f)',
+						$time_ratio
+					)
+				);
+				return;
+			}
+		}
+
+		// Main time ratio assertion
+		$this->assertGreaterThan(
+			self::PERF_TIME_RATIO_THRESHOLD,
+			$time_ratio,
+			sprintf(
+				'Scanner should be measurably faster than parse_blocks (ratio: %.3f, scanner: %.6fs, parse_blocks: %.6fs)',
+				$time_ratio,
+				$scanner_time_trimmed,
+				$parse_time_trimmed
+			)
+		);
+
+		// Distribution check - at least 80% of runs should satisfy ratio >= 1.10
+		$favorable_runs = 0;
+		$total_runs     = count( $scanner_times );
+		for ( $i = 0; $i < $total_runs; $i++ ) {
+			if ( $parse_times[ $i ] >= self::PERF_TIME_RATIO_THRESHOLD * $scanner_times[ $i ] ) {
+				$favorable_runs++;
+			}
+		}
+		$favorable_percentage = ( $favorable_runs / $total_runs ) * 100;
+		$this->assertGreaterThanOrEqual(
+			self::PERF_FAVORABLE_PCT,
+			$favorable_percentage,
+			sprintf(
+				'At least 80%% of individual runs should show scanner advantage (actual: %.1f%%)',
+				$favorable_percentage
+			)
+		);
+
+		// Memory assertion with larger tolerance (64KB)
 		$this->assertLessThanOrEqual(
-			$parse_blocks_metrics['memory'] + $memory_tolerance,
-			$scanner_metrics['memory'],
-			'Scanner should use comparable or less memory than parse_blocks'
+			$parse_mem_stat * 1.10 + self::PERF_MEM_TOLERANCE_BYTES,
+			$scanner_mem_stat,
+			sprintf(
+				'Scanner memory should be comparable to parse_blocks (scanner: %d bytes, parse_blocks: %d bytes, tolerance: %d bytes)',
+				$scanner_mem_stat,
+				$parse_mem_stat,
+				self::PERF_MEM_TOLERANCE_BYTES
+			)
 		);
 	}
 
@@ -969,7 +1074,7 @@ class Block_Scanner_Test extends TestCase {
 	 * @return array|null Image block data or null if not found.
 	 */
 	private function find_first_image_with_parse_blocks( string $content ): ?array {
-		$blocks = parse_blocks( $content );
+		$blocks = \parse_blocks( $content );
 
 		foreach ( $blocks as $block ) {
 			$result = $this->search_blocks_recursive( array( $block ), 'core/image' );
@@ -1008,5 +1113,29 @@ class Block_Scanner_Test extends TestCase {
 		}
 
 		return null;
+	}
+
+	/**
+	 * Test that scanner and parse_blocks find the same first image block.
+	 *
+	 * This is an always-on correctness test that verifies both methods return
+	 * the same result without performance assertions.
+	 */
+	public function test_scanner_and_parse_blocks_find_same_first_image(): void {
+		if ( ! \function_exists( 'parse_blocks' ) ) {
+			$this->markTestSkipped( 'parse_blocks not available. Block editor not available' );
+		}
+
+		if ( ! \function_exists( 'serialize_blocks' ) ) {
+			$this->markTestSkipped( 'serialize_blocks not available. Block editor not available' );
+		}
+
+		$test_content = $this->generate_test_content_with_target_image();
+
+		$scanner_result      = $this->find_first_image_with_scanner( $test_content );
+		$parse_blocks_result = $this->find_first_image_with_parse_blocks( $test_content );
+
+		// Verify correctness only
+		$this->assert_same_results( $scanner_result, $parse_blocks_result );
 	}
 }

--- a/projects/packages/block-delimiter/tests/php/lib/class-performance-benchmark-utils.php
+++ b/projects/packages/block-delimiter/tests/php/lib/class-performance-benchmark-utils.php
@@ -1,0 +1,337 @@
+<?php
+/**
+ * Performance benchmarking utilities for Block_Scanner tests.
+ *
+ * This class provides utilities for competitive benchmarking between different approaches,
+ * statistical analysis, system load detection, and performance assertions.
+ *
+ * @package Automattic\Block_Delimiter
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\Block_Delimiter\Tests\Lib;
+
+/**
+ * Utilities for performance benchmarking and statistical analysis.
+ */
+class Performance_Benchmark_Utils {
+
+	// Benchmark configuration constants
+	public const PERF_WARMUP_RUNS                = 3;     // Reduced warmup runs for faster CI execution
+	public const PERF_BENCHMARK_ITERATIONS       = 11;    // Fewer iterations for CI stability
+	public const PERF_RETRY_BENCHMARK_ITERATIONS = 21;    // Reduced retry iterations
+
+	// CI-friendly performance assertion thresholds (regression detection vs absolute performance)
+	public const PERF_MIN_TIME_RATIO_THRESHOLD   = 1.02;  // Scanner must not be significantly slower
+	public const PERF_MIN_FAVORABLE_RUNS_PERCENT = 55;    // Majority of runs should show scanner advantage
+	public const PERF_MEMORY_TOLERANCE_BYTES     = 128 * 1024; // 128KB tolerance for CI memory variations
+
+	/**
+	 * Generate test content with target image positioned for early termination test.
+	 *
+	 * Creates 10 paragraph blocks before the image, then 100 after for CI-friendly execution while preserving early-exit advantage.
+	 *
+	 * @return string Block content with image at early position.
+	 */
+	public static function generate_test_content_with_target_image(): string {
+		$blocks = array();
+
+		// Add 10 paragraph blocks before target (reduced for CI stability)
+		for ( $i = 0; $i < 10; $i++ ) {
+			$blocks[] = array(
+				'blockName'    => 'core/paragraph',
+				'attrs'        => array(),
+				'innerContent' => array( sprintf( '<p>Content %d</p>', $i + 1 ) ),
+			);
+		}
+
+		// Add target image block with attributes
+		$blocks[] = array(
+			'blockName'    => 'core/image',
+			'attrs'        => array(
+				'id'     => 12345,
+				'alt'    => 'Test image',
+				'url'    => 'https://example.com/test.jpg',
+				'width'  => 800,
+				'height' => 600,
+			),
+			'innerContent' => array( '<figure class="wp-block-image"><img src="https://example.com/test.jpg" alt="Test image"/></figure>' ),
+		);
+
+		// Add blocks after target (100 blocks - still enough to show early-exit advantage but faster for CI)
+		for ( $i = 0; $i < 100; $i++ ) {
+			$blocks[] = array(
+				'blockName'    => 'core/paragraph',
+				'attrs'        => array(),
+				'innerContent' => array( sprintf( '<p>After %d</p>', $i + 1 ) ),
+			);
+		}
+
+		return \serialize_blocks( $blocks );
+	}
+
+	/**
+	 * Check if system is under high load that could affect performance test reliability.
+	 *
+	 * @return bool True if system load is too high for reliable performance testing.
+	 */
+	public static function is_system_under_high_load(): bool {
+		// Check available memory - skip if less than 64MB free
+		$memory_limit = ini_get( 'memory_limit' );
+		if ( $memory_limit && $memory_limit !== '-1' ) {
+			$memory_limit_bytes = self::parse_memory_limit( $memory_limit );
+			$current_usage      = \memory_get_usage( true );
+			$available_memory   = $memory_limit_bytes - $current_usage;
+
+			if ( $available_memory < 64 * 1024 * 1024 ) { // Less than 64MB available
+				return true;
+			}
+		}
+
+		// Basic load average check on Unix systems
+		if ( \function_exists( 'sys_getloadavg' ) ) {
+			$load = \sys_getloadavg();
+			if ( $load && $load[0] > 4.0 ) { // High 1-minute load average
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Parse PHP memory limit string to bytes.
+	 *
+	 * @param string $limit Memory limit string (e.g., '128M', '1G').
+	 * @return int Memory limit in bytes.
+	 */
+	public static function parse_memory_limit( string $limit ): int {
+		$limit         = trim( $limit );
+		$last_char     = strtolower( substr( $limit, -1 ) );
+		$numeric_value = (int) substr( $limit, 0, -1 );
+
+		switch ( $last_char ) {
+			case 'g':
+				return $numeric_value * 1024 * 1024 * 1024;
+			case 'm':
+				return $numeric_value * 1024 * 1024;
+			case 'k':
+				return $numeric_value * 1024;
+			default:
+				return (int) $limit;
+		}
+	}
+
+	/**
+	 * Run competitive benchmark with paired measurements to minimize environmental drift.
+	 *
+	 * @param callable $scanner_callable Callable for scanner benchmark.
+	 * @param callable $parse_callable Callable for parse_blocks benchmark.
+	 * @param int      $iterations Number of paired iterations to run.
+	 * @return array{scanner_times: float[], parse_times: float[], scanner_mems: int[], parse_mems: int[], result: mixed}
+	 */
+	public static function run_competitive_benchmark( callable $scanner_callable, callable $parse_callable, int $iterations ): array {
+		$scanner_times = array();
+		$parse_times   = array();
+		$scanner_mems  = array();
+		$parse_mems    = array();
+		$result        = null;
+
+		// Warmup runs to stabilize opcache/JIT/autoloader effects
+		for ( $warmup = 0; $warmup < self::PERF_WARMUP_RUNS; $warmup++ ) {
+			$scanner_callable();
+			$parse_callable();
+		}
+
+		for ( $i = 0; $i < $iterations; $i++ ) {
+			// Garbage collection and memory cache cleanup before each iteration
+			if ( \function_exists( 'gc_collect_cycles' ) ) {
+				\gc_collect_cycles();
+			}
+			if ( \function_exists( 'gc_mem_caches' ) ) {
+				\gc_mem_caches();
+			}
+
+			// Alternate order each iteration to avoid order bias
+			$run_scanner_first = ( $i % 2 ) === 0;
+
+			if ( $run_scanner_first ) {
+				// Run scanner first
+				$start_memory    = \memory_get_usage( true );
+				$start_time      = \microtime( true );
+				$scanner_result  = $scanner_callable();
+				$scanner_times[] = \microtime( true ) - $start_time;
+				$scanner_mems[]  = max( 0, \memory_get_usage( true ) - $start_memory );
+				unset( $scanner_result );
+
+				// Brief cleanup between runs
+				if ( \function_exists( 'gc_collect_cycles' ) ) {
+					\gc_collect_cycles();
+				}
+
+				// Run parse_blocks second
+				$start_memory  = \memory_get_usage( true );
+				$start_time    = \microtime( true );
+				$parse_result  = $parse_callable();
+				$parse_times[] = \microtime( true ) - $start_time;
+				$parse_mems[]  = max( 0, \memory_get_usage( true ) - $start_memory );
+			} else {
+				// Run parse_blocks first
+				$start_memory  = \memory_get_usage( true );
+				$start_time    = \microtime( true );
+				$parse_result  = $parse_callable();
+				$parse_times[] = \microtime( true ) - $start_time;
+				$parse_mems[]  = max( 0, \memory_get_usage( true ) - $start_memory );
+				unset( $parse_result );
+
+				// Brief cleanup between runs
+				if ( \function_exists( 'gc_collect_cycles' ) ) {
+					\gc_collect_cycles();
+				}
+
+				// Run scanner second
+				$start_memory    = \memory_get_usage( true );
+				$start_time      = \microtime( true );
+				$scanner_result  = $scanner_callable();
+				$scanner_times[] = \microtime( true ) - $start_time;
+				$scanner_mems[]  = max( 0, \memory_get_usage( true ) - $start_memory );
+			}
+
+			// Keep one result for correctness verification
+			// @phan-suppress-next-line PhanImpossibleTypeComparisonInLoop
+			if ( null === $result && isset( $scanner_result ) && null !== $scanner_result ) {
+				$result = $scanner_result;
+				// @phan-suppress-next-line PhanImpossibleTypeComparisonInLoop
+			} elseif ( null === $result && isset( $parse_result ) && null !== $parse_result ) {
+				$result = $parse_result;
+			}
+
+			// Cleanup results to aid memory reuse
+			unset( $scanner_result, $parse_result );
+		}
+
+		return array(
+			'scanner_times' => $scanner_times,
+			'parse_times'   => $parse_times,
+			'scanner_mems'  => $scanner_mems,
+			'parse_mems'    => $parse_mems,
+			'result'        => $result,
+		);
+	}
+
+	/**
+	 * Compute trimmed statistic by removing top and bottom 20% and taking median.
+	 *
+	 * @param array $values Array of numeric values.
+	 * @return float Trimmed median value.
+	 */
+	public static function compute_trimmed_median( array $values ): float {
+		if ( empty( $values ) ) {
+			return 0.0;
+		}
+
+		$sorted = $values;
+		sort( $sorted );
+		$count = count( $sorted );
+
+		// Remove top and bottom 20%
+		$trim_count = (int) floor( $count * 0.2 );
+		$trimmed    = array_slice( $sorted, $trim_count, $count - ( 2 * $trim_count ) );
+
+		// @phan-suppress-next-line PhanImpossibleCondition - Can be empty with very small arrays
+		if ( empty( $trimmed ) ) {
+			return $sorted[ (int) floor( $count / 2 ) ];
+		}
+
+		$trimmed_count = count( $trimmed );
+		return $trimmed[ (int) floor( $trimmed_count / 2 ) ];
+	}
+
+	/**
+	 * Assert Block_Scanner has performance advantage using paired benchmark results with robust statistics.
+	 *
+	 * @param \PHPUnit\Framework\TestCase $test_case Test case instance for assertions.
+	 * @param array                       $benchmark_results Results from run_competitive_benchmark().
+	 * @param callable                    $scanner_callable Callable for scanner benchmark (for retries).
+	 * @param callable                    $parse_callable Callable for parse_blocks benchmark (for retries).
+	 */
+	public static function assert_performance_advantage_paired( \PHPUnit\Framework\TestCase $test_case, array $benchmark_results, callable $scanner_callable, callable $parse_callable ): void {
+		$scanner_times = $benchmark_results['scanner_times'];
+		$parse_times   = $benchmark_results['parse_times'];
+		$scanner_mems  = $benchmark_results['scanner_mems'];
+		$parse_mems    = $benchmark_results['parse_mems'];
+
+		// Compute robust trimmed statistics
+		$scanner_time_trimmed = self::compute_trimmed_median( $scanner_times );
+		$parse_time_trimmed   = self::compute_trimmed_median( $parse_times );
+		$scanner_mem_stat     = self::compute_trimmed_median( $scanner_mems );
+		$parse_mem_stat       = self::compute_trimmed_median( $parse_mems );
+
+		// Regression-focused time ratio assertion with extended retry mechanism
+		$time_ratio  = $parse_time_trimmed / $scanner_time_trimmed;
+		$retry_count = 0;
+		$max_retries = 2;
+
+		// Multiple retry attempts for CI stability
+		while ( $time_ratio < self::PERF_MIN_TIME_RATIO_THRESHOLD && $retry_count < $max_retries ) {
+			$retry_count++;
+
+			// Retry with progressively more iterations for statistical stability
+			$retry_iterations = self::PERF_RETRY_BENCHMARK_ITERATIONS + ( $retry_count * 10 );
+
+			$retry_results = self::run_competitive_benchmark(
+				$scanner_callable,
+				$parse_callable,
+				$retry_iterations
+			);
+
+			$retry_scanner_time = self::compute_trimmed_median( $retry_results['scanner_times'] );
+			$retry_parse_time   = self::compute_trimmed_median( $retry_results['parse_times'] );
+			$time_ratio         = $retry_parse_time / $retry_scanner_time;
+		}
+
+		// Regression-focused assertion: Scanner should not be significantly slower
+		$test_case->assertGreaterThanOrEqual(
+			self::PERF_MIN_TIME_RATIO_THRESHOLD,
+			$time_ratio,
+			sprintf(
+				'Scanner performance regression detected (ratio: %.3f, scanner: %.6fs, parse_blocks: %.6fs)',
+				$time_ratio,
+				$scanner_time_trimmed,
+				$parse_time_trimmed
+			)
+		);
+
+		// Distribution check - majority of runs should not show regression
+		$favorable_runs = 0;
+		$total_runs     = count( $scanner_times );
+		for ( $i = 0; $i < $total_runs; $i++ ) {
+			if ( $parse_times[ $i ] >= self::PERF_MIN_TIME_RATIO_THRESHOLD * $scanner_times[ $i ] ) {
+				$favorable_runs++;
+			}
+		}
+		$favorable_percentage = ( $favorable_runs / $total_runs ) * 100;
+		$test_case->assertGreaterThanOrEqual(
+			self::PERF_MIN_FAVORABLE_RUNS_PERCENT,
+			$favorable_percentage,
+			sprintf(
+				'Performance regression in %.1f%% of individual runs (threshold: %d%% must pass)',
+				100 - $favorable_percentage,
+				self::PERF_MIN_FAVORABLE_RUNS_PERCENT
+			)
+		);
+
+		// Memory regression check with CI-friendly tolerance (128KB)
+		$test_case->assertLessThanOrEqual(
+			$parse_mem_stat * 1.10 + self::PERF_MEMORY_TOLERANCE_BYTES,
+			$scanner_mem_stat,
+			sprintf(
+				'Scanner memory should be comparable to parse_blocks (scanner: %d bytes, parse_blocks: %d bytes, tolerance: %d bytes)',
+				$scanner_mem_stat,
+				$parse_mem_stat,
+				self::PERF_MEMORY_TOLERANCE_BYTES
+			)
+		);
+	}
+}

--- a/projects/plugins/jetpack/changelog/update-block-delimiter-performance-comparision-flakiness-HOG-307
+++ b/projects/plugins/jetpack/changelog/update-block-delimiter-performance-comparision-flakiness-HOG-307
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: block-delimiter: Reduce flakiness of Block_Scanner performance comparison unit test
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -12,7 +12,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/block-delimiter",
-                "reference": "85f04d247da736ac8ac7e02729208c97c8721b3c"
+                "reference": "41dd424045497847c74751adbc9efa6063326b63"
             },
             "require": {
                 "php": ">=7.2"
@@ -41,6 +41,11 @@
                 "classmap": [
                     "src/"
                 ]
+            },
+            "autoload-dev": {
+                "psr-4": {
+                    "Automattic\\Block_Delimiter\\Tests\\": "tests/php/"
+                }
             },
             "scripts": {
                 "phpunit": [
@@ -3539,16 +3544,16 @@
     "packages-dev": [
         {
             "name": "antecedent/patchwork",
-            "version": "2.2.1",
+            "version": "2.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/antecedent/patchwork.git",
-                "reference": "1bf183a3e1bd094f231a2128b9ecc5363c269245"
+                "reference": "724f03c777ddcc436ec2c8ecd4c97cdbceef8ab9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/antecedent/patchwork/zipball/1bf183a3e1bd094f231a2128b9ecc5363c269245",
-                "reference": "1bf183a3e1bd094f231a2128b9ecc5363c269245",
+                "url": "https://api.github.com/repos/antecedent/patchwork/zipball/724f03c777ddcc436ec2c8ecd4c97cdbceef8ab9",
+                "reference": "724f03c777ddcc436ec2c8ecd4c97cdbceef8ab9",
                 "shasum": ""
             },
             "require": {
@@ -3581,9 +3586,9 @@
             ],
             "support": {
                 "issues": "https://github.com/antecedent/patchwork/issues",
-                "source": "https://github.com/antecedent/patchwork/tree/2.2.1"
+                "source": "https://github.com/antecedent/patchwork/tree/2.2.2"
             },
-            "time": "2024-12-11T10:19:54+00:00"
+            "time": "2025-08-12T16:59:40+00:00"
         },
         {
             "name": "automattic/jetpack-changelogger",

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -12,7 +12,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/block-delimiter",
-                "reference": "41dd424045497847c74751adbc9efa6063326b63"
+                "reference": "d22d4af194b81a0f9336ea03eb9d9ca65cbcf6bd"
             },
             "require": {
                 "php": ">=7.2"
@@ -43,6 +43,9 @@
                 ]
             },
             "autoload-dev": {
+                "classmap": [
+                    "tests/php/lib/"
+                ],
                 "psr-4": {
                     "Automattic\\Block_Delimiter\\Tests\\": "tests/php/"
                 }


### PR DESCRIPTION
Fixes [HOG-307: Harden Block_Scanner performance test to further remove flakiness](https://linear.app/a8c/issue/HOG-307/harden-block-scanner-performance-test-to-further-remove-flakiness)

## Proposed changes:

- Reduce flakiness of Block_Scanner vs parse_blocks performance test by using more CI-friendly thresholds and fewer iterations.
- Tag the test with #[Group('performance')].
- Slightly adjust generated test content to keep runs fast and stable.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Verify the test passes and demonstrates Scanner performance advantage