### PR TITLE
Carousel: return original image in additional situations

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-photon-return-full-size-image
+++ b/projects/plugins/jetpack/changelog/fix-photon-return-full-size-image
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Carousel: improve image size processing to return higher quality images in additional situations.

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -956,12 +956,12 @@
 					return args.largeFile;
 				}
 
+				// Sanitize the URL to remove non-cosmetic changes like resize, fit, etc.
+				var sanitizedUrl = sanitizePhotonUrl( args.largeFile );
+
 				// If we have a really large image load a smaller version
 				// that is closer to the viewable size
 				if ( args.origWidth > args.maxWidth || args.origHeight > args.maxHeight ) {
-					// Sanitize the URL to remove non-cosmetic changes like resize, fit, etc.
-					var sanitizedUrl = sanitizePhotonUrl( args.largeFile );
-
 					// @2x the max sizes so we get a high enough resolution for zooming.
 					args.origMaxWidth = args.maxWidth * 2;
 					args.origMaxHeight = args.maxHeight * 2;
@@ -970,7 +970,8 @@
 					return sanitizedUrl.toString();
 				}
 
-				return args.largeFile;
+				// Return a clean Photon URL without sizing parameters, but with other params like quality, ssl, etc.
+				return sanitizedUrl.toString();
 			}
 
 			return args.origFile;

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -967,10 +967,9 @@
 					args.origMaxHeight = args.maxHeight * 2;
 					// Add the fit arg to the list of Photon args.
 					sanitizedUrl.searchParams.set( 'fit', args.origMaxWidth + ',' + args.origMaxHeight );
-					return sanitizedUrl.toString();
 				}
 
-				// Return a clean Photon URL without sizing parameters, but with other params like quality, ssl, etc.
+				// Return a Photon URL image that's better fitted for the viewport.
 				return sanitizedUrl.toString();
 			}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes HOG-309

Summary
The Jetpack carousel was experiencing inconsistent image quality where images would sometimes display at a poor resolution (e.g., 604x403) instead of optimal larger sizes. This issue was particularly noticeable on high-DPI displays and occurred when the carousel's image selection logic fell back to the largeFile URL.

Root Cause
The selectBestImageUrl function in jetpack-carousel.js had a flaw in its fallback logic. When the original image dimensions were not considered "too large" for the current viewport (often due to device pixel ratio adjustments), the function would return the args.largeFile as-is, including any existing Photon sizing parameters like ?fit=604%2C403&quality=89&ssl=1.
This meant that even when the carousel should have been serving high-quality images, users would get stuck with low-resolution images that were sized for different contexts.

The Fix
Modified the selectBestImageUrl function to:
Move the sanitizePhotonUrl() call outside the conditional logic - Now it runs for both the high-quality URL generation path and the fallback path
Ensure both paths return sanitized URLs - The fallback now returns a clean Photon URL without problematic sizing parameters, while preserving important parameters like quality and ssl

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Update image src determination in Carousel

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

The fix addresses the specific scenario where:
Original image dimensions (e.g., 2560x1707) are not considered "too large" for the viewport
The function falls back to the largeFile URL
Previously this would potentially return a low-size image (whatever "large" that was passed through, even if that was smaller than the original size)
Now it returns the original image at full quality
This resolves the inconsistent image quality behavior reported by users across different browser sessions and monitor configurations.

* Add a gallery with various images ~2500 pixel wide.
* Open the carousel on various monitors - regular DPI, DPI x2 (retina), etc.
* Notice that on regular DPI, generally, the images are large. On DPI x2, they're not.
* [More specific details can be provided as needed]

