### PR TITLE
WPCOMSH: CLI: Fix and simplify diag command errors searching

### DIFF
--- a/projects/plugins/wpcomsh/changelog/update-update-wpcomsh-diag-find-errors
+++ b/projects/plugins/wpcomsh/changelog/update-update-wpcomsh-diag-find-errors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Improves errors searching for diag command.

--- a/projects/plugins/wpcomsh/class-wpcomsh-cli-commands.php
+++ b/projects/plugins/wpcomsh/class-wpcomsh-cli-commands.php
@@ -1290,80 +1290,22 @@ if ( class_exists( 'WP_CLI_Command' ) ) {
 
 			WP_CLI::log( '' );
 
-			// 6. PHP Errors (filtered to recent fatals and errors)
+			// 6. PHP Errors (filtered to critical errors)
 			WP_CLI::log( WP_CLI::colorize( '%Y--- Recent PHP Errors ---%n' ) );
-			$php_errors_result = WP_CLI::runcommand(
-				'php-errors',
-				array(
-					'launch'     => false,
-					'return'     => 'all',
-					'exit_error' => false,
-				)
-			);
+			$error_log_file = '/tmp/php-errors';
 
-			if ( 0 === $php_errors_result->return_code ) {
-				$error_lines     = explode( "\n", trim( $php_errors_result->stdout ) );
-				$filtered_errors = array();
+			if ( file_exists( $error_log_file ) ) {
+				// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_shell_exec
+				$output = system_exec( "grep -E 'Fatal error|PHP Fatal error|Parse error|Uncaught Error|Uncaught Exception|TypeError|ArgumentCountError|Compile error' " . escapeshellarg( $error_log_file ) . ' | tail -n 100' );
 
-				$recent_dates = array(
-					gmdate( 'd-M-Y' ),
-					gmdate( 'd-M-Y', strtotime( '-1 day' ) ),
-					gmdate( 'd-M-Y', strtotime( '-2 days' ) ),
-				);
-
-				foreach ( $error_lines as $line ) {
-					if ( empty( trim( $line ) ) ) {
-						continue;
-					}
-
-					$is_recent = false;
-					foreach ( $recent_dates as $date ) {
-						if ( strpos( $line, $date ) !== false ) {
-							$is_recent = true;
-							break;
-						}
-					}
-
-					if ( $is_recent ) {
-						// Check for various types of critical/fatal errors
-						$critical_patterns = array(
-							'Fatal error',
-							'PHP Fatal error',
-							'Parse error',
-							'Uncaught Error',
-							'Uncaught Exception',
-							'TypeError',
-							'ArgumentCountError',
-							'Compile error',
-						);
-
-						foreach ( $critical_patterns as $pattern ) {
-							if ( strpos( $line, $pattern ) !== false ) {
-								$filtered_errors[] = $line;
-								break;
-							}
-						}
-					}
-				}
-
-				if ( ! empty( $filtered_errors ) ) {
-					WP_CLI::log( WP_CLI::colorize( '%RRecent Critical PHP Errors:%n' ) );
-					foreach ( $filtered_errors as $error ) {
-						WP_CLI::log( $error );
-					}
+				if ( ! empty( trim( $output ) ) ) {
+					WP_CLI::log( WP_CLI::colorize( '%RCritical PHP Errors:%n' ) );
+					WP_CLI::log( trim( $output ) );
 				} else {
-					// Show last 10 errors of any type if no recent critical errors
-					WP_CLI::log( WP_CLI::colorize( '%GNo recent critical errors found. Last 10 PHP errors:%n' ) );
-					$recent_errors = array_slice( $error_lines, -10 );
-					foreach ( $recent_errors as $error ) {
-						if ( ! empty( trim( $error ) ) ) {
-							WP_CLI::log( $error );
-						}
-					}
+					WP_CLI::log( WP_CLI::colorize( '%GNo critical PHP errors found.%n' ) );
 				}
 			} else {
-				WP_CLI::log( WP_CLI::colorize( '%RPHP errors command failed:%n' ) );
-				WP_CLI::log( $php_errors_result->stderr );
+				WP_CLI::log( WP_CLI::colorize( '%RPHP errors file not found:%n /tmp/php-errors' ) );
 			}
 
 			WP_CLI::log( '' );

--- a/projects/plugins/wpcomsh/class-wpcomsh-cli-commands.php
+++ b/projects/plugins/wpcomsh/class-wpcomsh-cli-commands.php
@@ -1291,16 +1291,15 @@ if ( class_exists( 'WP_CLI_Command' ) ) {
 			WP_CLI::log( '' );
 
 			// 6. PHP Errors (filtered to critical errors)
-			WP_CLI::log( WP_CLI::colorize( '%Y--- Recent PHP Errors ---%n' ) );
+			WP_CLI::log( WP_CLI::colorize( '%Y--- Critical PHP Errors ---%n' ) );
 			$error_log_file = '/tmp/php-errors';
 
 			if ( file_exists( $error_log_file ) ) {
 				// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_shell_exec
-				$output = system_exec( "grep -E 'Fatal error|PHP Fatal error|Parse error|Uncaught Error|Uncaught Exception|TypeError|ArgumentCountError|Compile error' " . escapeshellarg( $error_log_file ) . ' | tail -n 100' );
+				$output = shell_exec( "grep -E 'Fatal error|PHP Fatal error|Parse error|Uncaught Error|Uncaught Exception|TypeError|ArgumentCountError|Compile error' " . escapeshellarg( $error_log_file ) . ' | tail -n 100' );
 
-				if ( ! empty( trim( $output ) ) ) {
-					WP_CLI::log( WP_CLI::colorize( '%RCritical PHP Errors:%n' ) );
-					WP_CLI::log( trim( $output ) );
+				if ( ! empty( trim( (string) $output ) ) ) {
+					WP_CLI::log( trim( (string) $output ) );
 				} else {
 					WP_CLI::log( WP_CLI::colorize( '%GNo critical PHP errors found.%n' ) );
 				}


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->

Previously, the `wp wpcomsh diag` command would call `wp php-errors` and then filter down to critical errors. The issue with this is that `wp php-errors` limits to 100 items in the error log. For sites with many warnings, this could mean that valid errors do not get displayed.

The original `wp php-errors` command works by tailing the `/tmp/php-errors` file. This PR updates the diag command so that we're also using a system command to grep for fatal errors and then limit to 100 items, bypassing the `wp php-errors` command.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
NA

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Build plugin and sync to a WoW dev site
* SSH to server
* Run `wp wpcomsh diag` with the following: Non-existent `/tmp/php-errors`, `/tmp/php-errors` with no fatals, `/tmp/php-errors` with fatals.
* Ensure that you get no errors for each of those cases and unique messaging in the output.
