### PR TITLE
Fix/sidebar width form

### DIFF
--- a/projects/packages/forms/changelog/fix-sidebar-width-form
+++ b/projects/packages/forms/changelog/fix-sidebar-width-form
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Minor bug fix
+
+

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -352,6 +352,19 @@
 	}
 }
 
+.is-nav-unification.auto-fold .jp-forms__inbox__dataviews .dataviews-footer {
+
+	@media (min-width: #{ (breakpoints.$break-medium + 1) }) {
+		left: 272px;
+		width: calc(100% - 272px);
+	}
+
+	@media (min-width: #{ (breakpoints.$break-large + 1) }) {
+		left: variables.$admin-sidebar-width;
+		width: calc(100% - variables.$admin-sidebar-width);
+	}
+}
+
 /*
  * Compensation for the width of the sidebar when the Sidebar
  * is manually collapsed.


### PR DESCRIPTION
Tried to fix the .com sidebar. 

## Proposed changes:
* .com unification uses a different sidebar width. This Pr Accomadates it. 

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1755803413422289-slack-C052XEUUBL4

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Load this PR on .com and notice that it fixes the footer when you visit the forms dashboard.