### PR TITLE
Boost: Add cornerstone pages filter

### DIFF
--- a/projects/plugins/boost/app/data-sync/class-cornerstone-pages-entry.php
+++ b/projects/plugins/boost/app/data-sync/class-cornerstone-pages-entry.php
@@ -23,7 +23,8 @@ class Cornerstone_Pages_Entry implements Entry_Can_Get, Entry_Can_Set {
 		}
 
 		/**
-		 * Filters the list of cornerstone pages.
+		 * Filters the list of cornerstone pages. This list only includes the custom pages.
+		 * If you want the full list, use `jetpack_boost_cornerstone_pages_list_complete` instead.
 		 *
 		 * @since 3.7.0
 		 *

--- a/projects/plugins/boost/app/lib/cornerstone/class-cornerstone-utils.php
+++ b/projects/plugins/boost/app/lib/cornerstone/class-cornerstone-utils.php
@@ -12,7 +12,15 @@ class Cornerstone_Utils {
 	 * @return string[] The relative URLs of all the cornerstone pages.
 	 */
 	public static function get_list() {
-		return array_merge( self::get_predefined_list(), self::get_custom_list() );
+		/**
+		 * Filters the list of cornerstone pages. This list includes the predefined and custom pages.
+		 * If you want to change the list of custom pages, use `jetpack_boost_cornerstone_pages_list` instead.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param string[] $urls The absolute URLs of all the cornerstone pages.
+		 */
+		return apply_filters( 'jetpack_boost_cornerstone_pages_list_complete', array_merge( self::get_predefined_list(), self::get_custom_list() ) );
 	}
 
 	/**

--- a/projects/plugins/boost/changelog/update-boost-cornerstone-pages-filter-complete-list
+++ b/projects/plugins/boost/changelog/update-boost-cornerstone-pages-filter-complete-list
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Cornerstone Pages: Add filter to allow the full list of pages to be changed.


### PR DESCRIPTION
Related to HOG-303

When we moved the home page to be a permanent cornerstone page, we forgot to add a filter to allow us to change the entire list. Having the ability to change the entire list makes it easier to debug tickets.

This PR adds a filter and clarifies the existing filter about the difference between the two.

## Proposed changes:

* Add filter to allow changing the entire list of cornerstone pages (both predefined and custom);
* Update comments on existing `jetpack_boost_cornerstone_pages_list` to clarify the difference between it and the newly introduced one.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

HOG-303

## Does this pull request change what data or activity we track or use?

no

## Testing instructions:

- Since this is used frequently for debugging user issues, follow the instructions in https://github.com/Automattic/boost-developer/pull/44