### PR TITLE
Forms: Fix fatal error when feedback_field formated correctly

### DIFF
--- a/projects/packages/forms/changelog/fix-fatal-error
+++ b/projects/packages/forms/changelog/fix-fatal-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix a case where fatal error might occur after form submission

--- a/projects/packages/forms/src/contact-form/class-feedback.php
+++ b/projects/packages/forms/src/contact-form/class-feedback.php
@@ -840,14 +840,13 @@ class Feedback {
 		$fields = array();
 		foreach ( $decoded_content['fields'] as $field ) {
 			$fields[ $field['key'] ] = Feedback_Field::from_serialized( $field );
-			if ( ! $this->has_file && $fields[ $field['key'] ]->has_file() ) {
+			if ( ! $this->has_file && $fields[ $field['key'] ] && $fields[ $field['key'] ]->has_file() ) {
 				$this->has_file = true;
 			}
 		}
 		$decoded_content['fields'] = $fields;
 		return $decoded_content;
 	}
-
 	/**
 	 * Parse the legacy content format.
 	 *

--- a/projects/packages/forms/src/contact-form/class-feedback.php
+++ b/projects/packages/forms/src/contact-form/class-feedback.php
@@ -847,6 +847,7 @@ class Feedback {
 		$decoded_content['fields'] = $fields;
 		return $decoded_content;
 	}
+
 	/**
 	 * Parse the legacy content format.
 	 *

--- a/projects/packages/forms/src/contact-form/class-feedback.php
+++ b/projects/packages/forms/src/contact-form/class-feedback.php
@@ -843,7 +843,7 @@ class Feedback {
 			if ( $feedback_field instanceof Feedback_Field ) {
 				$fields[ $feedback_field->get_key() ] = $feedback_field;
 				if ( ! $this->has_file && $feedback_field->has_file() ) {
-					$this->has_file = false;
+					$this->has_file = true;
 				}
 			}
 		}

--- a/projects/packages/forms/src/contact-form/class-feedback.php
+++ b/projects/packages/forms/src/contact-form/class-feedback.php
@@ -839,9 +839,12 @@ class Feedback {
 		}
 		$fields = array();
 		foreach ( $decoded_content['fields'] as $field ) {
-			$fields[ $field['key'] ] = Feedback_Field::from_serialized( $field );
-			if ( ! $this->has_file && $fields[ $field['key'] ] && $fields[ $field['key'] ]->has_file() ) {
-				$this->has_file = true;
+			$feedback_field = Feedback_Field::from_serialized( $field );
+			if ( $feedback_field instanceof Feedback_Field ) {
+				$fields[ $feedback_field->get_key() ] = $feedback_field;
+				if ( ! $this->has_file && $feedback_field->has_file() ) {
+					$this->has_file = false;
+				}
 			}
 		}
 		$decoded_content['fields'] = $fields;

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Test.php
@@ -2082,4 +2082,20 @@ class Feedback_Test extends BaseTestCase {
 		$this->assertSame( '', $response->get_field_value_by_form_field_id( 'email' ) );
 		$this->assertNull( $response->get_field_by_form_field_id( 'email' ) );
 	}
+
+	public function test_edgecase_feedback_v2() {
+		// Post data with missing field value.
+		$post_id = wp_insert_post(
+			array(
+				'post_type'      => Feedback::POST_TYPE,
+				'post_title'     => 'Edgecase Feedback',
+				'post_content'   => '{"subject":"[WR8DAR] Contact us!","entry_title":"Contact us!","entry_page":1,"fields":[{"key":"1_key label","label":"key label","value":"abcd","type":"name","meta":[],"form_field_id":"g124-keylabel"},{"key":"2_Awesome","label":"Awesome","type":"email","meta":[],"form_field_id":"g124-awesome"}]}',
+				'post_status'    => 'publish',
+				'post_mime_type' => 'v2',
+			)
+		);
+
+		$response = Feedback::get( $post_id );
+		$this->assertInstanceOf( Feedback::class, $response );
+	}
 }

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Test.php
@@ -1159,6 +1159,8 @@ class Feedback_Test extends BaseTestCase {
 		$response         = Feedback::from_submission( $_post_data, $form );
 		$feedback_post_id = $response->save();
 		$saved_response   = Feedback::get( $feedback_post_id );
+		$this->assertTrue( $response->has_file(), 'Response should have file uploaded' );
+		$this->assertTrue( $saved_response->has_file(), 'Saved response should have file uploaded' );
 
 		$this->assertEquals( $expected_file, $response->get_all_values( 'submit' )['1_Upload a file'], 'Response all values should match the expected values' );
 		$this->assertEquals( $expected_file, $saved_response->get_all_values( 'submit' )['1_Upload a file'], 'Saved response all values should match the expected values' );


### PR DESCRIPTION
This fixes an issue where a fatal error can occur if the feedback data is not decoded correctly. 

## Proposed changes:
* Check if the feedback feed exists before checking for the files.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1755821373716099-slack-C06QF6JJDTM

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Do the tests pass? 
