### PR TITLE
Forms: Fix console error in MailPoet markup

### DIFF
--- a/projects/packages/forms/changelog/fix-mailpoet-card-error
+++ b/projects/packages/forms/changelog/fix-mailpoet-card-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Fix MailPoet markup console error.

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/style.scss
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/style.scss
@@ -104,6 +104,10 @@
 		}
 	}
 
+	&__section {
+		margin: 12px 0;
+	}
+
 	&__links.components-h-stack {
 
 		@media (max-width: 480px) {

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/mailpoet-card.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/mailpoet-card.tsx
@@ -167,25 +167,23 @@ const MailPoetCard = ( {
 			) : (
 				<div>
 					{ mailpoetLists?.length ? (
-						<p className="integration-card__description">
-							<SelectControl
-								label={ __( 'Which MailPoet list should contacts be added to?', 'jetpack-forms' ) }
-								value={ mailpoet.listId }
-								options={ mailpoetLists.map( list => ( { label: list.name, value: list.id } ) ) }
-								onChange={ value => {
-									const selected = mailpoetLists.find( l => l.id === value );
-									setAttributes( {
-										mailpoet: {
-											...mailpoet,
-											listId: selected?.id ?? null,
-											listName: selected?.name ?? null,
-										},
-									} );
-								} }
-								__next40pxDefaultSize={ true }
-								__nextHasNoMarginBottom={ true }
-							/>
-						</p>
+						<SelectControl
+							label={ __( 'Which MailPoet list should contacts be added to?', 'jetpack-forms' ) }
+							value={ mailpoet.listId }
+							options={ mailpoetLists.map( list => ( { label: list.name, value: list.id } ) ) }
+							onChange={ value => {
+								const selected = mailpoetLists.find( l => l.id === value );
+								setAttributes( {
+									mailpoet: {
+										...mailpoet,
+										listId: selected?.id ?? null,
+										listName: selected?.name ?? null,
+									},
+								} );
+							} }
+							__next40pxDefaultSize={ true }
+							__nextHasNoMarginBottom={ true }
+						/>
 					) : (
 						<p className="integration-card__description">
 							{ __(
@@ -195,12 +193,14 @@ const MailPoetCard = ( {
 						</p>
 					) }
 					{ hasEmailBlock && (
-						<ToggleControl
-							label={ __( 'Add email permission request before submit button', 'jetpack-forms' ) }
-							checked={ !! consentBlock }
-							onChange={ toggleConsent }
-							__nextHasNoMarginBottom
-						/>
+						<div className="integration-card__section">
+							<ToggleControl
+								label={ __( 'Add email permission request before submit button', 'jetpack-forms' ) }
+								checked={ !! consentBlock }
+								onChange={ toggleConsent }
+								__nextHasNoMarginBottom
+							/>
+						</div>
 					) }
 					<p className="integration-card__description">
 						<ExternalLink href={ settingsUrl }>


### PR DESCRIPTION
Note: if you toggle the option to hide whitespace when reviewing, the diff is very simple. 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Fixes a console error when you toggle open the MailPoet card in the integrations modal for the form block. This is caused because be we're loading a SelectControl inside a <p> tag, which you can't do. I removed the <p> tag and added a separate <div> for spacing. 

Issue reported here: 
https://github.com/Automattic/jetpack/pull/44831#pullrequestreview-3129571820

<img width="1496" height="487" alt="mailpoet-console-error" src="https://github.com/user-attachments/assets/24baade0-17ff-46b6-aedb-359f691a3145" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add a form to a page and open the integration modal
* Open the dev console and clear any errors
* Open the MailPoet card and confirm no errors

