### PR TITLE
Slideshow block: Improve security in email rendering

### DIFF
--- a/projects/plugins/jetpack/changelog/update-slideshow-email-rendering
+++ b/projects/plugins/jetpack/changelog/update-slideshow-email-rendering
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Slideshow block: Add additional sanitization and validation.

--- a/projects/plugins/jetpack/extensions/blocks/slideshow/slideshow.php
+++ b/projects/plugins/jetpack/extensions/blocks/slideshow/slideshow.php
@@ -403,7 +403,10 @@ function process_slideshow_images_for_email( $attr ) {
 			}
 
 			$image_url = wp_get_attachment_image_url( $id, 'medium' );
-			$alt_text  = get_post_meta( $id, '_wp_attachment_image_alt', true );
+
+			// Sanitize alt text from post meta
+			$alt_text = get_post_meta( $id, '_wp_attachment_image_alt', true );
+			$alt_text = sanitize_text_field( $alt_text );
 
 			// Get caption from attachment post (stored in post_excerpt)
 			$attachment_post = get_post( $id );
@@ -432,11 +435,26 @@ function process_slideshow_images_for_email( $attr ) {
 		// Fall back to images array if IDs aren't available (for testing)
 		foreach ( $attr['images'] as $image_data ) {
 			if ( ! empty( $image_data['url'] ) ) {
+				// Validate and sanitize URL
+				$url = esc_url_raw( $image_data['url'] );
+				if ( ! $url || ! wp_http_validate_url( $url ) ) {
+					continue;
+				}
+
+				// Sanitize alt text
+				$alt_text = ! empty( $image_data['alt'] ) ? sanitize_text_field( $image_data['alt'] ) : '';
+
+				// Sanitize caption
+				$caption = ! empty( $image_data['caption'] ) ? wp_strip_all_tags( $image_data['caption'] ) : '';
+
+				// Validate ID if present
+				$id = ! empty( $image_data['id'] ) ? absint( $image_data['id'] ) : 0;
+
 				$images[] = array(
-					'url'     => $image_data['url'],
-					'alt'     => ! empty( $image_data['alt'] ) ? $image_data['alt'] : '',
-					'caption' => ! empty( $image_data['caption'] ) ? wp_strip_all_tags( $image_data['caption'] ) : '',
-					'id'      => ! empty( $image_data['id'] ) ? $image_data['id'] : 0,
+					'url'     => $url,
+					'alt'     => $alt_text,
+					'caption' => $caption,
+					'id'      => $id,
 				);
 			}
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add additional sanitization and validation for image urls and attributes.
* Follow up to https://github.com/Automattic/jetpack/pull/44835

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

N/A

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply these changes to your sandbox using `bin/jetpack-downloader test jetpack update/slideshow-email-rendering`.
* Sandbox the API and turn on write access.
* Add the `wc-email-editor` sticker to a test site. See PCYsg-eQj-p2 or I can add you to my test site.
* Create a post with a slideshow block.
* Send yourself a test email.

