### PR TITLE
Docker: Prevent warnings when `update_plugins` site transient isn't complete

### DIFF
--- a/tools/docker/mu-plugins/avoid-plugin-deletion.php
+++ b/tools/docker/mu-plugins/avoid-plugin-deletion.php
@@ -81,7 +81,7 @@ add_action( 'delete_plugin', 'jetpack_docker_disable_delete_plugin', 10, 2 );
  */
 function jetpack_docker_disable_plugin_update( $plugins ) {
 	// No updates detected, so abort.
-	if ( ! is_object( $plugins ) || $plugins->response ) {
+	if ( ! is_object( $plugins ) || empty( $plugins->response ) ) {
 		return $plugins;
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR fixes an errant condition in the plugin update blocker for the Docker environment.

---

WP sets the transient as part of the plugin update check:
https://github.com/WordPress/WordPress/blob/41eb91c33bdc3c04d79f6ca98e306ecf0e2439bf/wp-includes/update.php#L457

If it succeeds, the transient is then populated with a bunch of data to be used by the update mechanism. However, if it fails, the transient only has partial data. The code blocking updates in Docker was trying to access `$plugins->response`, which doesn't always exist, triggering a warning. The condition was also wrong, so rather than returning, it proceed to try to run and gave further warnings:

```
[22-Aug-2025 17:49:08 UTC] PHP Warning:  Undefined property: stdClass::$response in /var/www/html/wp-content/mu-plugins/avoid-plugin-deletion.php on line 84
[22-Aug-2025 17:49:08 UTC] PHP Warning:  Undefined property: stdClass::$response in /var/www/html/wp-content/mu-plugins/avoid-plugin-deletion.php on line 91
[22-Aug-2025 17:49:08 UTC] PHP Warning:  foreach() argument must be of type array|object, null given in /var/www/html/wp-content/mu-plugins/avoid-plugin-deletion.php on line 91
```

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

The easiest way to reproduce this is to set to manually set the `_site_transient_update_plugins` option in the database to this value, then refresh WP Admin:
`O:8:"stdClass":1:{s:12:"last_checked";i:1855884447;}`