### PR TITLE
Forms: Ensure slider default obeys step

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-slider-default-validation
+++ b/projects/packages/forms/changelog/fix-forms-slider-default-validation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Ensure slider default obeys step.

--- a/projects/packages/forms/src/blocks/field-slider/edit.js
+++ b/projects/packages/forms/src/blocks/field-slider/edit.js
@@ -10,7 +10,7 @@ import {
 	PanelBody,
 	TextControl,
 } from '@wordpress/components';
-import { useCallback, useEffect } from '@wordpress/element';
+import { useCallback, useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import JetpackFieldControls from '../shared/components/jetpack-field-controls';
 import useFormWrapper from '../shared/hooks/use-form-wrapper';
@@ -31,6 +31,24 @@ export default function SliderFieldEdit( props ) {
 		minLabel = '',
 		maxLabel = '',
 	} = attributes;
+
+	const [ localDefault, setLocalDefault ] = useState( String( defaultValue ) );
+	const [ defaultFocused, setDefaultFocused ] = useState( false );
+
+	useEffect( () => {
+		if ( ! defaultFocused ) {
+			setLocalDefault( String( defaultValue ) );
+		}
+	}, [ defaultValue, defaultFocused ] );
+
+	const snapToStep = useCallback(
+		val => {
+			const v = Number( val );
+			const clamped = Math.min( Math.max( v, min ), max );
+			return min + Math.round( ( clamped - min ) / step ) * step;
+		},
+		[ min, max, step ]
+	);
 
 	const onChangeMin = useCallback(
 		newMin => {
@@ -61,11 +79,11 @@ export default function SliderFieldEdit( props ) {
 	// This is passed to child input-range block via context.
 	const onChangeDefault = useCallback(
 		newDefault => {
-			const parsedDefault = parseFloat( newDefault ) || 0;
-			const validatedDefault = Math.max( Math.min( parsedDefault, max ), min );
-			setAttributes( { default: validatedDefault } );
+			const snapped = snapToStep( newDefault );
+			setAttributes( { default: snapped } );
+			setLocalDefault( String( snapped ) );
 		},
-		[ max, min, setAttributes ]
+		[ snapToStep, setAttributes ]
 	);
 
 	const onChangeStep = useCallback(
@@ -184,9 +202,16 @@ export default function SliderFieldEdit( props ) {
 							label={ __( 'Default value', 'jetpack-forms' ) }
 							min={ min }
 							max={ max }
-							value={ defaultValue }
-							onChange={ onChangeDefault }
+							value={ localDefault }
+							onChange={ val => {
+								setLocalDefault( val );
+								const snapped = snapToStep( val );
+								setAttributes( { default: snapped } );
+							} }
+							onFocus={ () => setDefaultFocused( true ) }
+							onBlur={ () => setDefaultFocused( false ) }
 							spinControls="custom"
+							step={ step || 1 }
 						/>
 						<NumberControl
 							__next40pxDefaultSize

--- a/projects/packages/forms/src/blocks/field-slider/edit.js
+++ b/projects/packages/forms/src/blocks/field-slider/edit.js
@@ -42,9 +42,9 @@ export default function SliderFieldEdit( props ) {
 	}, [ defaultValue, defaultFocused ] );
 
 	const snapToStep = useCallback(
-		( val, stepSize ) => {
-			const clamped = Math.min( Math.max( val, min ), max );
-			return min + Math.round( ( clamped - min ) / stepSize ) * stepSize;
+		( val, stepSize, base = min ) => {
+			const clamped = Math.min( Math.max( val, base ), max );
+			return base + Math.round( ( clamped - base ) / stepSize ) * stepSize;
 		},
 		[ min, max ]
 	);
@@ -54,12 +54,13 @@ export default function SliderFieldEdit( props ) {
 			const parsedMin = parseInt( newMin ) || 0;
 			const validatedMin = Math.min( parsedMin, max );
 			const validatedDefault = Math.max( defaultValue, validatedMin );
+			const snappedDefault = snapToStep( validatedDefault, step, validatedMin );
 			setAttributes( {
 				min: validatedMin,
-				default: validatedDefault,
+				default: snappedDefault,
 			} );
 		},
-		[ max, defaultValue, setAttributes ]
+		[ max, defaultValue, step, setAttributes, snapToStep ]
 	);
 
 	const onChangeMax = useCallback(

--- a/projects/packages/forms/src/blocks/field-slider/edit.js
+++ b/projects/packages/forms/src/blocks/field-slider/edit.js
@@ -42,12 +42,11 @@ export default function SliderFieldEdit( props ) {
 	}, [ defaultValue, defaultFocused ] );
 
 	const snapToStep = useCallback(
-		val => {
-			const v = Number( val );
-			const clamped = Math.min( Math.max( v, min ), max );
-			return min + Math.round( ( clamped - min ) / step ) * step;
+		( val, stepSize ) => {
+			const clamped = Math.min( Math.max( val, min ), max );
+			return min + Math.round( ( clamped - min ) / stepSize ) * stepSize;
 		},
-		[ min, max, step ]
+		[ min, max ]
 	);
 
 	const onChangeMin = useCallback(
@@ -79,26 +78,20 @@ export default function SliderFieldEdit( props ) {
 	// This is passed to child input-range block via context.
 	const onChangeDefault = useCallback(
 		newDefault => {
-			const snapped = snapToStep( newDefault );
+			const snapped = snapToStep( newDefault, step );
 			setAttributes( { default: snapped } );
 			setLocalDefault( String( snapped ) );
 		},
-		[ snapToStep, setAttributes ]
+		[ snapToStep, step, setAttributes ]
 	);
 
 	const onChangeStep = useCallback(
 		newStep => {
-			const parsedStep = parseFloat( newStep );
-			const safeStep = ! isNaN( parsedStep ) && parsedStep > 0 ? parsedStep : 1;
-			// Snap default to the new step within [min, max]
-			const snappedDefault = ( () => {
-				const ratio = ( defaultValue - min ) / safeStep;
-				const snapped = min + Math.round( ratio ) * safeStep;
-				return Math.max( Math.min( snapped, max ), min );
-			} )();
-			setAttributes( { step: safeStep, default: snappedDefault } );
+			const stepSize = newStep > 0 ? newStep : 1;
+			const snappedDefault = snapToStep( defaultValue, stepSize );
+			setAttributes( { step: stepSize, default: snappedDefault } );
 		},
-		[ defaultValue, min, max, setAttributes ]
+		[ defaultValue, setAttributes, snapToStep ]
 	);
 
 	const onChangeMinLabel = useCallback(
@@ -205,7 +198,7 @@ export default function SliderFieldEdit( props ) {
 							value={ localDefault }
 							onChange={ val => {
 								setLocalDefault( val );
-								const snapped = snapToStep( val );
+								const snapped = snapToStep( val, step );
 								setAttributes( { default: snapped } );
 							} }
 							onFocus={ () => setDefaultFocused( true ) }

--- a/projects/packages/forms/src/contact-form/class-admin.php
+++ b/projects/packages/forms/src/contact-form/class-admin.php
@@ -675,11 +675,10 @@ class Admin {
 	 */
 	public function grunion_manage_post_column_response( $post ) {
 
-		$post_content  = get_post_field( 'post_content', $post->ID );
-		$content_parts = explode( '<!--more-->', (string) $post_content );
-		$content       = isset( $content_parts[1] ) ? $content_parts[1] : (string) $post_content;
-		$content       = str_ireplace( array( '<br />', ')</p>' ), '', $content );
-		$chunks        = explode( "\nJSON_DATA", $content );
+		$post_content = get_post_field( 'post_content', $post->ID );
+		$content      = explode( '<!--more-->', $post_content );
+		$content      = str_ireplace( array( '<br />', ')</p>' ), '', $content[1] );
+		$chunks       = explode( "\nJSON_DATA", $content );
 		// Get content fields.
 		$content_fields = Contact_Form_Plugin::parse_fields_from_content( $post->ID );
 

--- a/projects/packages/forms/src/contact-form/class-admin.php
+++ b/projects/packages/forms/src/contact-form/class-admin.php
@@ -675,10 +675,11 @@ class Admin {
 	 */
 	public function grunion_manage_post_column_response( $post ) {
 
-		$post_content = get_post_field( 'post_content', $post->ID );
-		$content      = explode( '<!--more-->', $post_content );
-		$content      = str_ireplace( array( '<br />', ')</p>' ), '', $content[1] );
-		$chunks       = explode( "\nJSON_DATA", $content );
+		$post_content  = get_post_field( 'post_content', $post->ID );
+		$content_parts = explode( '<!--more-->', (string) $post_content );
+		$content       = isset( $content_parts[1] ) ? $content_parts[1] : (string) $post_content;
+		$content       = str_ireplace( array( '<br />', ')</p>' ), '', $content );
+		$chunks        = explode( "\nJSON_DATA", $content );
 		// Get content fields.
 		$content_fields = Contact_Form_Plugin::parse_fields_from_content( $post->ID );
 


### PR DESCRIPTION
## Proposed changes:

@dhasilva found a minor issue in prior testing of the slider. If you update step/increment to 10, we still allow you to then set the default to a non-step-obeying number like 17. This PR adds checks/validation to enforce step. We need to handle two ways to update default: clicking the +/- on the number control (easily fix by updating the step value); typing in a value which we handle with some separate validation code after the user moves out of the input. 

<img width="1239" height="296" alt="slider-default-validate" src="https://github.com/user-attachments/assets/a5a9b7c9-f273-4e7f-b942-fb7ec97cdf3d" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No. 

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add a form to page and add a slider field
* Just try to 'break' the syncing between default and increment any way you can. It should not be possible :).
* You can also try changing min/max. All values should always stay valid. 