### PR TITLE
Fix LaTeX frontend script

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-latex-rendering
+++ b/projects/plugins/jetpack/changelog/fix-latex-rendering
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Fix LaTex Block selector

--- a/projects/plugins/jetpack/extensions/blocks/latex/view.js
+++ b/projects/plugins/jetpack/extensions/blocks/latex/view.js
@@ -3,7 +3,7 @@ import katex from 'katex';
 import './style.scss';
 
 function renderAllLatexBlocks() {
-	const blocks = document.querySelectorAll( '.jetpack-latex' );
+	const blocks = document.querySelectorAll( '.wp-block-jetpack-latex' );
 	blocks.forEach( block => {
 		const latex = block.getAttribute( 'data-latex' ) || '';
 		const renderContainers = block.querySelectorAll( '.jetpack-latex-render' );


### PR DESCRIPTION
## Proposed changes:
When addressing https://github.com/Automattic/jetpack/pull/44895#discussion_r2293878326, I forgot to update the selector on the frontend. This updates it.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1755886480680769-slack-C04DZ8M0GHW
## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
1. Apply this on a simple site.
2. Sandbox and visit https://testsitemmrworld.wordpress.com/2025/08/22/latex-test/
3. LaTeX should render.