### PR TITLE
Forms: Add styles for image select field on frontend

### DIFF
--- a/projects/packages/forms/changelog/update-forms-image-select-frontend-styles
+++ b/projects/packages/forms/changelog/update-forms-image-select-frontend-styles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Forms: Add styles for image select field on frontend

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -518,21 +518,89 @@ class Contact_Form_Block {
 				'jetpack/field-image-select',
 				array(
 					'render_callback'  => array( Contact_Form_Plugin::class, 'gutenblock_render_field_image_select' ),
-					'provides_context' => array( 'jetpack/field-required' => 'required' ),
+					'provides_context' => array(
+						'jetpack/field-required' => 'required',
+						'jetpack/field-image-select-show-labels' => 'showLabels',
+						'jetpack/field-image-select-is-supersized' => 'isSupersized',
+						'jetpack/field-image-select-is-multiple' => 'isMultiple',
+						'jetpack/field-image-select-randomize-options' => 'randomizeOptions',
+						'jetpack/field-image-select-show-other-option' => 'showOtherOption',
+					),
 				)
 			);
 
 			Blocks::jetpack_register_block(
 				'jetpack/fieldset-image-options',
 				array(
-					'render_callback' => array( Contact_Form_Plugin::class, 'gutenblock_render_fieldset_image_options' ),
+					'uses_context'     => array(
+						'jetpack/field-image-select-is-supersized',
+						'jetpack/field-image-select-is-multiple',
+						'jetpack/field-share-attributes',
+					),
+					'provides_context' => array(
+						'jetpack/field-image-options-type' => 'type',
+					),
 				)
 			);
 
 			Blocks::jetpack_register_block(
 				'jetpack/input-image-option',
 				array(
-					'render_callback' => array( Contact_Form_Plugin::class, 'gutenblock_render_input_image_option' ),
+					'supports'         => array(
+						'color'                => array(
+							'background' => true,
+							'text'       => true,
+							'gradients'  => false,
+							'__experimentalDefaultControls' => array(
+								'background' => true,
+								'text'       => true,
+							),
+						),
+						'typography'           => array(
+							'fontSize'                     => true,
+							'lineHeight'                   => true,
+							'__experimentalFontFamily'     => true,
+							'__experimentalFontWeight'     => true,
+							'__experimentalFontStyle'      => true,
+							'__experimentalTextTransform'  => true,
+							'__experimentalTextDecoration' => true,
+							'__experimentalLetterSpacing'  => true,
+							'__experimentalDefaultControls' => array(
+								'fontSize' => true,
+							),
+						),
+						'__experimentalBorder' => array(
+							'color'  => true,
+							'radius' => true,
+							'style'  => true,
+							'width'  => true,
+							'__experimentalDefaultControls' => array(
+								'color'  => true,
+								'radius' => true,
+								'style'  => true,
+								'width'  => true,
+							),
+						),
+						'spacing'              => array(
+							'margin'  => true,
+							'padding' => true,
+							'__experimentalDefaultControls' => array(
+								'margin'  => true,
+								'padding' => true,
+							),
+						),
+					),
+					'uses_context'     => array(
+						'jetpack/field-image-select-is-supersized',
+						'jetpack/field-image-select-show-labels',
+						'jetpack/field-image-options-type',
+						'jetpack/field-share-attributes',
+					),
+					'provides_context' => array(
+						'allowResize' => 'allowResize',
+						'imageCrop'   => 'imageCrop',
+						'fixedHeight' => 'fixedHeight',
+					),
 				)
 			);
 		}

--- a/projects/packages/forms/src/blocks/field-image-select/edit.tsx
+++ b/projects/packages/forms/src/blocks/field-image-select/edit.tsx
@@ -19,7 +19,7 @@ import JetpackFieldControls from '../shared/components/jetpack-field-controls';
 import useAddImageOption from '../shared/hooks/use-add-image-option';
 import useFormWrapper from '../shared/hooks/use-form-wrapper';
 import useJetpackFieldStyles from '../shared/hooks/use-jetpack-field-styles';
-import './editor.scss';
+import './style.scss';
 /**
  * Types
  */
@@ -63,7 +63,7 @@ export default function ImageSelectFieldEdit( props ) {
 			[
 				'jetpack/label',
 				{
-					label: __( 'Choose one option', 'jetpack-forms' ),
+					label: __( 'Choose one image', 'jetpack-forms' ),
 					required,
 				},
 			],

--- a/projects/packages/forms/src/blocks/field-image-select/editor.scss
+++ b/projects/packages/forms/src/blocks/field-image-select/editor.scss
@@ -34,9 +34,23 @@
 			}
 		}
 
-		.jetpack-input-image-option__label {
+		.jetpack-input-image-option__label-wrapper {
+			--jetpack-input-image-option-label-top-padding: 3px;
+			display: flex;
+			gap: 8px;
+			align-items: center;
 			padding-top: 8px;
-			padding-left: 8px;
+
+			.jetpack-input-image-option__label-code {
+				display: flex;
+				justify-content: center;
+				align-self: baseline;
+				padding: var(--jetpack-input-image-option-label-top-padding) calc(2 * var(--jetpack-input-image-option-label-top-padding));
+				background-color: #fff;
+				border-radius: 2px;
+				border: 1px solid #ccc;
+				line-height: 1;
+			}
 		}
 	}
 }

--- a/projects/packages/forms/src/blocks/field-image-select/style.scss
+++ b/projects/packages/forms/src/blocks/field-image-select/style.scss
@@ -8,25 +8,59 @@
 	flex-basis: unset;
 }
 
+.jetpack-field-image-select fieldset {
+	margin: 0;
+	padding: 0;
+	border: none;
+}
+
 .jetpack-fieldset-image-options__wrapper {
 	--jetpack-field-image-options-gap: 16px;
 	display: flex;
 	flex-wrap: wrap;
 	gap: var(--jetpack-field-image-options-gap);
 
-	.jetpack-input-image-option {
-		box-sizing: border-box;
+	.jetpack-input-image-option__outer {
 		display: flex;
-		flex-direction: column;
 		width: calc(( 1 / 4 ) * 100% - var(--jetpack-field-image-options-gap) * ( 3 / 4 ));
 
 		&.is-supersized {
 			width: calc(( 1 / 2 ) * 100% - var(--jetpack-field-image-options-gap) * ( 1 / 2 ));
 		}
+	}
+
+	.jetpack-input-image-option {
+		box-sizing: border-box;
+		display: flex;
+		flex-direction: column;
+		width: 100%;
+		overflow: hidden;
+
+		&:not(.wp-block):hover {
+			backdrop-filter: contrast(0.9) saturate(1.2);
+			cursor: pointer;
+		}
 
 		.jetpack-input-image-option__wrapper {
 			width: 100%;
 			overflow: hidden;
+			position: relative;
+
+			.jetpack-input-image-option__input {
+				position: absolute;
+				top: 4px;
+				right: 4px;
+				margin: 0;
+
+				&:not(:checked) {
+
+					@extend %visually-hidden;
+				}
+			}
+
+			figure {
+				margin: 0;
+			}
 
 			figcaption {
 
@@ -41,6 +75,11 @@
 			align-items: center;
 			padding-top: 8px;
 
+			.jetpack-input-image-option__label {
+				min-width: 1px;
+				overflow-wrap: break-word;
+			}
+
 			.jetpack-input-image-option__label-code {
 				display: flex;
 				justify-content: center;
@@ -50,6 +89,7 @@
 				border-radius: 2px;
 				border: 1px solid #ccc;
 				line-height: 1;
+				color: #333;
 			}
 		}
 	}

--- a/projects/packages/forms/src/blocks/fieldset-image-options/edit.tsx
+++ b/projects/packages/forms/src/blocks/fieldset-image-options/edit.tsx
@@ -9,6 +9,7 @@ import {
 } from '@wordpress/block-editor';
 import { ToolbarButton, ToolbarGroup } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 /**
@@ -23,8 +24,9 @@ import useJetpackFieldStyles from '../shared/hooks/use-jetpack-field-styles';
 import type { BlockEditorStoreSelect } from '../../types';
 
 export default function ImageOptionsFieldsetEdit( props ) {
-	const { attributes, clientId, isSelected } = props;
+	const { attributes, clientId, isSelected, context, setAttributes } = props;
 	const { blockStyle } = useJetpackFieldStyles( attributes );
+	const { 'jetpack/field-image-select-is-multiple': isMultiple } = context || {};
 
 	const { addOption } = useAddImageOption( clientId );
 
@@ -38,6 +40,15 @@ export default function ImageOptionsFieldsetEdit( props ) {
 		},
 		[ clientId ]
 	);
+
+	// Update the type attribute when the parent's isMultiple context changes
+	useEffect( () => {
+		const newType = isMultiple ? 'checkbox' : 'radio';
+
+		if ( attributes.type !== newType ) {
+			setAttributes( { type: newType } );
+		}
+	}, [ isMultiple, attributes.type, setAttributes ] );
 
 	const blockProps = useBlockProps( {
 		className: clsx( 'jetpack-field jetpack-fieldset-image-options', {

--- a/projects/packages/forms/src/blocks/fieldset-image-options/index.tsx
+++ b/projects/packages/forms/src/blocks/fieldset-image-options/index.tsx
@@ -17,7 +17,21 @@ const settings = {
 	description: __( 'A list of image options for an image select field.', 'jetpack-forms' ),
 	icon,
 	parent: [ 'jetpack/field-image-select' ],
-	usesContext: [ 'jetpack/field-image-select-is-supersized', 'jetpack/field-share-attributes' ],
+	attributes: {
+		type: {
+			type: 'string',
+			default: 'radio',
+		},
+	},
+	allowedBlocks: [ 'jetpack/input-image-option' ],
+	providesContext: {
+		'jetpack/field-image-options-type': 'type',
+	},
+	usesContext: [
+		'jetpack/field-image-select-is-supersized',
+		'jetpack/field-image-select-is-multiple',
+		'jetpack/field-share-attributes',
+	],
 	edit,
 	save,
 };

--- a/projects/packages/forms/src/blocks/input-image-option/edit.tsx
+++ b/projects/packages/forms/src/blocks/input-image-option/edit.tsx
@@ -100,14 +100,17 @@ export default function ImageOptionInputEdit( props ) {
 	return (
 		<div { ...blockProps }>
 			<div { ...innerBlocksProps } />
-			<RichText
-				tagName="span"
-				className={ labelClassName }
-				value={ label }
-				placeholder={ __( 'Add option…', 'jetpack-forms' ) }
-				__unstableDisableFormats
-				onChange={ ( newLabel: string ) => setAttributes( { label: newLabel } ) }
-			/>
+			<div className="jetpack-input-image-option__label-wrapper">
+				<div className="jetpack-input-image-option__label-code">A</div>
+				<RichText
+					tagName="span"
+					className={ labelClassName }
+					value={ label }
+					placeholder={ __( 'Add option…', 'jetpack-forms' ) }
+					__unstableDisableFormats
+					onChange={ ( newLabel: string ) => setAttributes( { label: newLabel } ) }
+				/>
+			</div>
 		</div>
 	);
 }

--- a/projects/packages/forms/src/blocks/input-image-option/edit.tsx
+++ b/projects/packages/forms/src/blocks/input-image-option/edit.tsx
@@ -16,6 +16,7 @@ import clsx from 'clsx';
  */
 import useJetpackFieldStyles from '../shared/hooks/use-jetpack-field-styles';
 import { useSyncedAttributes } from '../shared/hooks/use-synced-attributes';
+import { getImageOptionLetter } from './label';
 /**
  * Types
  */
@@ -37,17 +38,27 @@ export default function ImageOptionInputEdit( props ) {
 
 	useSyncedAttributes( name, isSynced, SYNCED_ATTRIBUTE_KEYS, attributes, setAttributes );
 
-	const { isInnerBlockSelected, imageBlockAttributes } = useSelect(
+	const { isInnerBlockSelected, imageBlockAttributes, positionLetter } = useSelect(
 		select => {
-			const { getBlock, hasSelectedInnerBlock } = select(
-				blockEditorStore
-			) as BlockEditorStoreSelect;
+			const blockEditor = select( blockEditorStore ) as BlockEditorStoreSelect;
+			const { getBlock, hasSelectedInnerBlock } = blockEditor;
 
 			const currentBlock = getBlock( clientId );
+			const parentClientIds = blockEditor.getBlockParentsByBlockName(
+				clientId,
+				'jetpack/fieldset-image-options'
+			);
+			const parentId = parentClientIds[ parentClientIds.length - 1 ];
+			const parentBlock = getBlock( parentId );
+
+			// Find position within parent's inner blocks
+			const position =
+				parentBlock.innerBlocks.findIndex( block => block.clientId === clientId ) + 1;
 
 			return {
 				isInnerBlockSelected: hasSelectedInnerBlock( clientId, true ),
 				imageBlockAttributes: currentBlock?.innerBlocks[ 1 ]?.attributes,
+				positionLetter: getImageOptionLetter( position ),
 			};
 		},
 		[ clientId ]
@@ -101,7 +112,7 @@ export default function ImageOptionInputEdit( props ) {
 		<div { ...blockProps }>
 			<div { ...innerBlocksProps } />
 			<div className="jetpack-input-image-option__label-wrapper">
-				<div className="jetpack-input-image-option__label-code">A</div>
+				<div className="jetpack-input-image-option__label-code">{ positionLetter }</div>
 				<RichText
 					tagName="span"
 					className={ labelClassName }

--- a/projects/packages/forms/src/blocks/input-image-option/edit.tsx
+++ b/projects/packages/forms/src/blocks/input-image-option/edit.tsx
@@ -67,6 +67,7 @@ export default function ImageOptionInputEdit( props ) {
 	const {
 		'jetpack/field-image-select-is-supersized': isSupersized,
 		'jetpack/field-image-select-show-labels': showLabels,
+		'jetpack/field-image-options-type': selectionType = 'radio',
 	} = context || {};
 
 	// Use the block's own synced attributes for styling
@@ -77,6 +78,7 @@ export default function ImageOptionInputEdit( props ) {
 			'is-selected': isSelected || isInnerBlockSelected,
 			'has-image': !! imageBlockAttributes?.url,
 			'is-supersized': isSupersized,
+			[ `is-${ selectionType }` ]: !! selectionType,
 		} ),
 		style: blockStyle,
 	} );

--- a/projects/packages/forms/src/blocks/input-image-option/edit.tsx
+++ b/projects/packages/forms/src/blocks/input-image-option/edit.tsx
@@ -73,11 +73,16 @@ export default function ImageOptionInputEdit( props ) {
 	// Use the block's own synced attributes for styling
 	const { blockStyle } = useJetpackFieldStyles( attributes );
 
+	const outerClassName = useMemo( () => {
+		return clsx( 'jetpack-input-image-option__outer', {
+			'is-supersized': isSupersized,
+		} );
+	}, [ isSupersized ] );
+
 	const blockProps = useBlockProps( {
 		className: clsx( 'jetpack-field jetpack-input-image-option', {
 			'is-selected': isSelected || isInnerBlockSelected,
 			'has-image': !! imageBlockAttributes?.url,
-			'is-supersized': isSupersized,
 			[ `is-${ selectionType }` ]: !! selectionType,
 		} ),
 		style: blockStyle,
@@ -111,18 +116,20 @@ export default function ImageOptionInputEdit( props ) {
 	);
 
 	return (
-		<div { ...blockProps }>
-			<div { ...innerBlocksProps } />
-			<div className="jetpack-input-image-option__label-wrapper">
-				<div className="jetpack-input-image-option__label-code">{ positionLetter }</div>
-				<RichText
-					tagName="span"
-					className={ labelClassName }
-					value={ label }
-					placeholder={ __( 'Add option…', 'jetpack-forms' ) }
-					__unstableDisableFormats
-					onChange={ ( newLabel: string ) => setAttributes( { label: newLabel } ) }
-				/>
+		<div className={ outerClassName }>
+			<div { ...blockProps }>
+				<div { ...innerBlocksProps } />
+				<div className="jetpack-input-image-option__label-wrapper">
+					<div className="jetpack-input-image-option__label-code">{ positionLetter }</div>
+					<RichText
+						tagName="span"
+						className={ labelClassName }
+						value={ label }
+						placeholder={ __( 'Add option…', 'jetpack-forms' ) }
+						__unstableDisableFormats
+						onChange={ ( newLabel: string ) => setAttributes( { label: newLabel } ) }
+					/>
+				</div>
 			</div>
 		</div>
 	);

--- a/projects/packages/forms/src/blocks/input-image-option/index.tsx
+++ b/projects/packages/forms/src/blocks/input-image-option/index.tsx
@@ -20,6 +20,7 @@ const settings = {
 	usesContext: [
 		'jetpack/field-image-select-is-supersized',
 		'jetpack/field-image-select-show-labels',
+		'jetpack/field-image-options-type',
 		'jetpack/field-share-attributes',
 	],
 	providesContext: {

--- a/projects/packages/forms/src/blocks/input-image-option/label.tsx
+++ b/projects/packages/forms/src/blocks/input-image-option/label.tsx
@@ -4,6 +4,27 @@
 import { __, sprintf } from '@wordpress/i18n';
 
 /**
+ * Generates a letter-based label for image option fields.
+ * Converts position to letters: 1=A, 2=B, ..., 26=Z, 27=AA, 28=AB, etc.
+ *
+ * @param {number} position - The 1-based position of the image option.
+ * @return {string} The letter-based label (A, B, C, ..., Z, AA, AB, ...).
+ */
+export const getImageOptionLetter = ( position: number ): string => {
+	if ( position < 1 ) return '';
+
+	let result = '';
+
+	while ( position > 0 ) {
+		position--;
+		result = String.fromCharCode( 65 + ( position % 26 ) ) + result;
+		position = Math.floor( position / 26 );
+	}
+
+	return result;
+};
+
+/**
  * Generates a translated label for image option fields.
  *
  * @param {number} index - The 1-based index of the image option.

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -1985,9 +1985,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 				$label_classes  = 'jetpack-input-image-option__label';
 				$label_classes .= $show_labels ? '' : ' visually-hidden';
 				$field         .= "<span class='{$label_classes}'>" . esc_html( $option_label ) . '</span>';
-				$field         .= '</div>';
-				$field         .= '</div>';
-				$field         .= '</div>';
+				$field         .= '</div></div></div>';
 			}
 		}
 

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -1876,6 +1876,8 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 	 * @return string HTML
 	 */
 	public function render_image_select_field( $id, $label, $value, $class, $required, $required_field_text ) {
+		wp_enqueue_style( 'jetpack-form-field-image-select-style', plugins_url( '../../dist/blocks/field-image-select/style.css', __FILE__ ), array(), Constants::get_constant( 'JETPACK__VERSION' ) );
+
 		$is_multiple       = $this->get_attribute( 'ismultiple' );
 		$show_labels       = $this->get_attribute( 'showlabels' );
 		$randomize_options = $this->get_attribute( 'randomizeoptions' );

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -1881,21 +1881,26 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		$is_multiple       = $this->get_attribute( 'ismultiple' );
 		$show_labels       = $this->get_attribute( 'showlabels' );
 		$randomize_options = $this->get_attribute( 'randomizeoptions' );
+		$is_supersized     = $this->get_attribute( 'issupersized' );
 
 		$input_type = $is_multiple ? 'checkbox' : 'radio';
 		$input_name = $is_multiple ? $id . '[]' : $id;
 
-		$options_classes   = $this->get_attribute( 'optionsclasses' );
-		$options_styles    = $this->get_attribute( 'optionsstyles' );
+		$field = "<div class='jetpack-field jetpack-field-image-select'>";
+
 		$form_style        = $this->get_form_style();
 		$is_outlined_style = 'outlined' === $form_style; // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- TODO: Implement style variations
 		$fieldset_id       = "id='" . esc_attr( "$id-label" ) . "'";
 
-		$field = "<fieldset {$fieldset_id} class='jetpack-field-image-select__fieldset' data-wp-bind--aria-invalid='state.fieldHasErrors' >";
+		$field .= "<fieldset {$fieldset_id} data-wp-bind--aria-invalid='state.fieldHasErrors' >";
 
 		$field .= $this->render_legend_as_label( '', $id, $label, $required, $required_field_text );
 
-		$field .= "<div class='grunion-image-select-options " . esc_attr( $options_classes ) . "' style='" . esc_attr( $options_styles ) . "'>";
+		$options_classes = $this->get_attribute( 'optionsclasses' );
+		$options_styles  = $this->get_attribute( 'optionsstyles' );
+
+		$field .= "<div class='" . esc_attr( $options_classes ) . " jetpack-field jetpack-fieldset-image-options' style='" . esc_attr( $options_styles ) . "'>";
+		$field .= "<div class='jetpack-fieldset-image-options__wrapper'>";
 
 		$options_data  = $this->get_attribute( 'optionsdata' );
 		$used_html_ids = array();
@@ -1920,34 +1925,77 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 				$option_label                = Contact_Form_Plugin::strip_tags( $option['label'] );
 				$option_letter               = Contact_Form_Plugin::strip_tags( $option['letter'] );
 				$option_value                = $this->get_option_value( $this->get_attribute( 'values' ), $option_index, $option_letter );
+				$image_block                 = $option['image'];
 				$option_id                   = $id . '-' . sanitize_html_class( $option_value );
 				$used_html_ids[ $option_id ] = true;
 
-				$default_classes = 'contact-form-field';
-				$option_styles   = empty( $option['style'] ) ? '' : "style='" . esc_attr( $option['style'] ) . "'";
-				$option_classes  = empty( $option['class'] ) ? $default_classes : $default_classes . ' ' . esc_attr( $option['class'] );
+				// To be able to apply the backdrop-filter for the hover effect, we need to separate the background into an outer div.
+				// This outer div needs the color styles separately, and also the border radius to match the inner div without sticking out.
+				$option_outer_classes = "jetpack-input-image-option__outer {$option['classcolor']}";
 
-				$field .= "<p {$option_styles} class='{$option_classes}'>";
+				if ( $is_supersized ) {
+					$option_outer_classes .= ' is-supersized';
+				}
+
+				$border_styles = '';
+				preg_match( '/border-radius:([^;]+)/', $option['style'], $radius_match );
+				preg_match( '/border-width:([^;]+)/', $option['style'], $width_match );
+
+				if ( ! empty( $radius_match[1] ) ) {
+					$radius_value = trim( $radius_match[1] );
+
+					if ( ! empty( $width_match[1] ) ) {
+							$width_value   = trim( $width_match[1] );
+							$border_styles = "border-radius:calc({$radius_value} + {$width_value});";
+					} else {
+							$border_styles = "border-radius:{$radius_value};";
+					}
+				}
+
+				$option_outer_styles = ( empty( $option['stylecolor'] ) ? '' : $option['stylecolor'] ) . $border_styles;
+				$option_outer_styles = empty( $option_outer_styles ) ? '' : "style='" . esc_attr( $option_outer_styles ) . "'";
+
+				$field .= "<div class='{$option_outer_classes}' {$option_outer_styles}>";
+
+				$default_classes = 'jetpack-field jetpack-input-image-option';
+				$option_styles   = empty( $option['style'] ) ? '' : "style='" . esc_attr( $option['style'] ) . "'";
+				$option_classes  = "class='" . ( empty( $option['class'] ) ? $default_classes : $default_classes . ' ' . $option['class'] ) . "'";
+
+				$field .= "<div {$option_classes} {$option_styles} data-wp-on--click='actions.onImageOptionClick'>";
+
+				$field .= "<div class='jetpack-input-image-option__wrapper'>";
 				$field .= "<input
-								id='" . esc_attr( $option_id ) . "'
-								type='" . esc_attr( $input_type ) . "'
-								name='" . esc_attr( $input_name ) . "'
-								value='" . esc_attr( $option_value ) . "'
-								data-wp-on--change='" . ( $is_multiple ? 'actions.onMultipleFieldChange' : 'actions.onFieldChange' ) . "' "
-								. $class
-								. ( $is_multiple ? checked( in_array( $option_value, (array) $value, true ), true, false ) : checked( $option_value, $value, false ) ) . ' '
-								. ( $required ? "required aria-required='true'" : '' )
-								. '/> ';
-				$field .= "<label for='" . esc_attr( $option_id ) . "' class='grunion-image-select-label " . esc_attr( $input_type ) . ( $this->is_error() ? ' form-error' : '' ) . "'>";
-				$field .= "<span class='grunion-field-text'>" . esc_html( $original_letters[ $option_index ] ) . ( $show_labels ? ' - ' . esc_html( $option_label ) : '' ) . '</span>';
-				$field .= '</label>';
-				$field .= '</p>';
+				id='" . esc_attr( $option_id ) . "'
+				class='jetpack-input-image-option__input'
+				type='" . esc_attr( $input_type ) . "'
+				name='" . esc_attr( $input_name ) . "'
+				value='" . esc_attr( $option_value ) . "'
+				data-wp-on--change='" . ( $is_multiple ? 'actions.onMultipleFieldChange' : 'actions.onFieldChange' ) . "' "
+				. $class
+				. ( $is_multiple ? checked( in_array( $option_value, (array) $value, true ), true, false ) : checked( $option_value, $value, false ) ) . ' '
+				. ( $required ? "required aria-required='true'" : '' )
+				. '/> ';
+
+				$field .= render_block( $image_block );
+				$field .= '</div>';
+
+				$field .= "<div class='jetpack-input-image-option__label-wrapper'>";
+				$field .= "<div class='jetpack-input-image-option__label-code'>" . esc_html( $original_letters[ $option_index ] ) . '</div>';
+
+				$label_classes  = 'jetpack-input-image-option__label';
+				$label_classes .= $show_labels ? '' : ' visually-hidden';
+				$field         .= "<span class='{$label_classes}'>" . esc_html( $option_label ) . '</span>';
+				$field         .= '</div>';
+				$field         .= '</div>';
+				$field         .= '</div>';
 			}
 		}
 
-		$field .= '</div>';
+		$field .= '</div></div>';
 
 		$field .= '</fieldset>';
+
+		$field .= '</div>';
 
 		return $field;
 	}

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -160,6 +160,12 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 				'iconstyle'                => null, // For rating field icon style (lowercase for shortcode compatibility)
 				// full phone field attributes, might become a standalone country list input block
 				'showcountryselector'      => false,
+				// Image select field attributes
+				'ismultiple'               => null,
+				'showlabels'               => null,
+				'issupersized'             => null,
+				'randomizeoptions'         => null,
+				'showotheroption'          => null,
 			),
 			$attributes,
 			'contact-field'
@@ -394,6 +400,51 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 						/* translators: %s is the name of a form field */
 						$this->add_error( sprintf( __( '%s requires at least one selection.', 'jetpack-forms' ), $field_label ) );
 						break;
+					}
+				}
+				break;
+			case 'image-select':
+				// Check that there is at least one option selected
+				if ( empty( $field_value ) ) {
+					/* translators: %s is the name of a form field */
+					$this->add_error( sprintf( __( '%s requires at least one selection.', 'jetpack-forms' ), $field_label ) );
+				} else {
+					// Check that the selected options are valid
+					$options      = (array) $this->get_attribute( 'options' );
+					$options_data = (array) $this->get_attribute( 'optionsdata' );
+
+					if ( ! empty( $options_data ) ) {
+						// Extract letters from options_data for validation
+						$options = array_map(
+							function ( $option ) {
+								return sanitize_text_field( trim( $option['letter'] ?? '' ) );
+							},
+							$options_data
+						);
+					}
+
+					$non_empty_options = array_filter(
+						$options,
+						function ( $option ) {
+							return $option !== '';
+						}
+					);
+
+					// For single selection (radio), check if the value is in the options
+					if ( ! $this->get_attribute( 'ismultiple' ) ) {
+						if ( ! in_array( $field_value, $non_empty_options, true ) ) {
+							/* translators: %s is the name of a form field */
+							$this->add_error( sprintf( __( '%s requires a valid selection.', 'jetpack-forms' ), $field_label ) );
+						}
+					} else {
+						// For multiple selection (checkbox), check each selected value
+						foreach ( $field_value as $field_value_item ) {
+							if ( ! in_array( $field_value_item, $non_empty_options, true ) ) {
+								/* translators: %s is the name of a form field */
+								$this->add_error( sprintf( __( '%s requires valid selections.', 'jetpack-forms' ), $field_label ) );
+								break;
+							}
+						}
 					}
 				}
 				break;
@@ -1825,8 +1876,76 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 	 * @return string HTML
 	 */
 	public function render_image_select_field( $id, $label, $value, $class, $required, $required_field_text ) {
-		$field = $this->render_label( 'image-select', $id, $label, $required, $required_field_text );
-		// TODO: Implement the image select field rendering.
+		$is_multiple       = $this->get_attribute( 'ismultiple' );
+		$show_labels       = $this->get_attribute( 'showlabels' );
+		$randomize_options = $this->get_attribute( 'randomizeoptions' );
+
+		$input_type = $is_multiple ? 'checkbox' : 'radio';
+		$input_name = $is_multiple ? $id . '[]' : $id;
+
+		$options_classes   = $this->get_attribute( 'optionsclasses' );
+		$options_styles    = $this->get_attribute( 'optionsstyles' );
+		$form_style        = $this->get_form_style();
+		$is_outlined_style = 'outlined' === $form_style; // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- TODO: Implement style variations
+		$fieldset_id       = "id='" . esc_attr( "$id-label" ) . "'";
+
+		$field = "<fieldset {$fieldset_id} class='jetpack-field-image-select__fieldset' data-wp-bind--aria-invalid='state.fieldHasErrors' >";
+
+		$field .= $this->render_legend_as_label( '', $id, $label, $required, $required_field_text );
+
+		$field .= "<div class='grunion-image-select-options " . esc_attr( $options_classes ) . "' style='" . esc_attr( $options_styles ) . "'>";
+
+		$options_data  = $this->get_attribute( 'optionsdata' );
+		$used_html_ids = array();
+
+		if ( ! empty( $options_data ) ) {
+			// Create a separate array of original letters in sequence (A, B, C...)
+			$original_letters = array();
+
+			foreach ( $options_data as $option ) {
+				$original_letters[] = Contact_Form_Plugin::strip_tags( $option['letter'] );
+			}
+
+			// Create a working copy of options for potential randomization
+			$working_options = $options_data;
+
+			// Randomize options if requested, but preserve original letter values
+			if ( $randomize_options ) {
+				shuffle( $working_options );
+			}
+
+			foreach ( $working_options as $option_index => $option ) {
+				$option_label                = Contact_Form_Plugin::strip_tags( $option['label'] );
+				$option_letter               = Contact_Form_Plugin::strip_tags( $option['letter'] );
+				$option_value                = $this->get_option_value( $this->get_attribute( 'values' ), $option_index, $option_letter );
+				$option_id                   = $id . '-' . sanitize_html_class( $option_value );
+				$used_html_ids[ $option_id ] = true;
+
+				$default_classes = 'contact-form-field';
+				$option_styles   = empty( $option['style'] ) ? '' : "style='" . esc_attr( $option['style'] ) . "'";
+				$option_classes  = empty( $option['class'] ) ? $default_classes : $default_classes . ' ' . esc_attr( $option['class'] );
+
+				$field .= "<p {$option_styles} class='{$option_classes}'>";
+				$field .= "<input
+								id='" . esc_attr( $option_id ) . "'
+								type='" . esc_attr( $input_type ) . "'
+								name='" . esc_attr( $input_name ) . "'
+								value='" . esc_attr( $option_value ) . "'
+								data-wp-on--change='" . ( $is_multiple ? 'actions.onMultipleFieldChange' : 'actions.onFieldChange' ) . "' "
+								. $class
+								. ( $is_multiple ? checked( in_array( $option_value, (array) $value, true ), true, false ) : checked( $option_value, $value, false ) ) . ' '
+								. ( $required ? "required aria-required='true'" : '' )
+								. '/> ';
+				$field .= "<label for='" . esc_attr( $option_id ) . "' class='grunion-image-select-label " . esc_attr( $input_type ) . ( $this->is_error() ? ' form-error' : '' ) . "'>";
+				$field .= "<span class='grunion-field-text'>" . esc_html( $original_letters[ $option_index ] ) . ( $show_labels ? ' - ' . esc_html( $option_label ) : '' ) . '</span>';
+				$field .= '</label>';
+				$field .= '</p>';
+			}
+		}
+
+		$field .= '</div>';
+
+		$field .= '</fieldset>';
 
 		return $field;
 	}
@@ -2292,9 +2411,9 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 	 * @return bool
 	 */
 	public function is_field_renderable( $type ) {
-		// Check that radio, select, and multiple choice
-		// fields have at leaast one valid option.
-		if ( $type === 'radio' || $type === 'checkbox-multiple' || $type === 'select' ) {
+		// Check that radio, select, multiple choice, and image select
+		// fields have at least one valid option.
+		if ( $type === 'radio' || $type === 'checkbox-multiple' || $type === 'select' || $type === 'image-select' ) {
 			$options           = (array) $this->get_attribute( 'options' );
 			$non_empty_options = array_filter(
 				$options,

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -626,10 +626,12 @@ class Contact_Form_Plugin {
 						// Generate letter for this option (A, B, C, ..., AA, AB, etc.)
 						$option_letter = self::get_image_option_letter( $option_index + 1 );
 
-						$option_attrs = self::get_block_support_classes_and_styles( 'jetpack/input-image-option', $option['attrs'] );
-						$option_data  = array(
+						$option_attrs       = self::get_block_support_classes_and_styles( 'jetpack/input-image-option', $option['attrs'], array( 'typography', 'border', 'custom', 'spacing' ) );
+						$option_attrs_color = self::get_block_support_classes_and_styles( 'jetpack/input-image-option', $option['attrs'], array( 'color' ) );
+						$option_data        = array(
 							'label'  => $option_label,
 							'letter' => $option_letter,
+							'image'  => $option['innerBlocks'][0],
 						);
 
 						if ( isset( $option_attrs['class'] ) ) {
@@ -637,9 +639,15 @@ class Contact_Form_Plugin {
 						} else {
 							$option_data['class'] = 'wp-block-jetpack-input-image-option';
 						}
+						if ( isset( $option_attrs_color['class'] ) ) {
+							$option_data['classcolor'] = $option_attrs_color['class'];
+						}
 
 						if ( isset( $option_attrs['style'] ) ) {
 							$option_data['style'] = $option_attrs['style'];
+						}
+						if ( isset( $option_attrs_color['style'] ) ) {
+							$option_data['stylecolor'] = $option_attrs_color['style'];
 						}
 
 						$options[]      = $option_letter; // Legacy shortcode attribute - use letter for consistent submission

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -590,6 +590,68 @@ class Contact_Form_Plugin {
 					continue;
 				}
 
+				if ( 'jetpack/fieldset-image-options' === $block_name ) {
+					$option_blocks           = $inner_block['innerBlocks'] ?? array();
+					$options                 = array();
+					$options_data            = array();
+					$atts['optionsclasses']  = 'wp-block-jetpack-fieldset-image-options';
+					$options_attrs           = self::get_block_support_classes_and_styles( $block_name, $inner_block['attrs'] );
+					$atts['optionsclasses'] .= isset( $options_attrs['class'] ) ? ' ' . $options_attrs['class'] : '';
+
+					// Check if the block has left border, then apply a class for indentation.
+					$global_styles = wp_get_global_styles(
+						array( 'border' ),
+						array(
+							'block_name' => $block_name,
+							'transforms' => array( 'resolve-variables' ),
+						)
+					);
+
+					if ( isset( $inner_block['attrs']['style']['border']['width'] ) || isset( $inner_block['attrs']['style']['border']['left']['width'] ) || isset( $global_styles['width'] ) || isset( $global_styles['left']['width'] ) ) {
+						$atts['optionsclasses'] .= ' jetpack-field-image-select__list--has-border';
+					}
+
+					$atts['optionsstyles'] = $options_attrs['style'] ?? null;
+
+					foreach ( $option_blocks as $option_index => $option ) {
+						$option_label = trim( $option['attrs']['label'] ?? '' );
+
+						// Generate letter for this option (A, B, C, ..., AA, AB, etc.)
+						$option_letter = self::get_image_option_letter( $option_index + 1 );
+
+						$option_attrs = self::get_block_support_classes_and_styles( 'jetpack/input-image-option', $option['attrs'] );
+						$option_data  = array(
+							'label'  => $option_label,
+							'letter' => $option_letter,
+						);
+
+						if ( isset( $option_attrs['class'] ) ) {
+							$option_data['class'] = $option_attrs['class'] . ' wp-block-jetpack-input-image-option';
+						} else {
+							$option_data['class'] = 'wp-block-jetpack-input-image-option';
+						}
+
+						if ( isset( $option_attrs['style'] ) ) {
+							$option_data['style'] = $option_attrs['style'];
+						}
+
+						$options[]      = $option_letter; // Legacy shortcode attribute - use letter for consistent submission
+						$options_data[] = $option_data;
+					}
+
+					$atts['options']     = implode( ',', $options );
+					$atts['optionsdata'] = \wp_json_encode( $options_data );
+
+					/*
+						Borders for the outlined notched HTML.
+					*/
+					$style_variation_atts                     = self::get_style_variation_shortcode_attributes( $block_name, $inner_block['attrs'] );
+					$atts                                     = array_merge( $atts, $style_variation_atts );
+					$add_block_style_classes_to_field_wrapper = true;
+
+					continue;
+				}
+
 				if ( 'jetpack/input-rating' === $block_name ) {
 					$input_attrs          = self::get_block_support_classes_and_styles( $block_name, $inner_block['attrs'] );
 					$atts['inputclasses'] = isset( $input_attrs['class'] ) ? ' ' . $input_attrs['class'] : '';
@@ -617,6 +679,28 @@ class Contact_Form_Plugin {
 		}
 
 		return $atts;
+	}
+
+	/**
+	 * Generates a letter for image options based on position (A, B, C, ..., AA, AB, etc.)
+	 *
+	 * @param int $position The 1-based position of the option.
+	 * @return string The letter representation.
+	 */
+	private static function get_image_option_letter( $position ) {
+		if ( $position < 1 ) {
+			return '';
+		}
+
+		$result = '';
+
+		while ( $position > 0 ) {
+			--$position;
+			$result   = chr( 65 + ( $position % 26 ) ) . $result;
+			$position = floor( $position / 26 );
+		}
+
+		return $result;
 	}
 
 	/**
@@ -1206,6 +1290,11 @@ class Contact_Form_Plugin {
 	 */
 	public static function gutenblock_render_field_image_select( $atts, $content, $block ) {
 		$atts = self::block_attributes_to_shortcode_attributes( $atts, 'image-select', $block );
+
+		// Ensure showLabels is always present in the shortcode attributes, as it defaults to true.
+		if ( ! array_key_exists( 'showLabels', $atts ) ) {
+			$atts['showLabels'] = true;
+		}
 
 		return Contact_Form::parse_contact_field( $atts, $content, $block );
 	}

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -1300,26 +1300,6 @@ class Contact_Form_Plugin {
 	}
 
 	/**
-	 * Render the image choices field.
-	 *
-	 * @return string HTML for the image choices form field.
-	 */
-	public static function gutenblock_render_fieldset_image_options() {
-		// TODO: Implement the block rendering
-		return '';
-	}
-
-	/**
-	 * Render the image choice field.
-	 *
-	 * @return string HTML for the image choice form field.
-	 */
-	public static function gutenblock_render_input_image_option() {
-		// TODO: Implement the block rendering
-		return '';
-	}
-
-	/**
 	 * Add the 'Form Responses' menu item as a submenu of Feedback.
 	 */
 	public function admin_menu() {

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -348,21 +348,26 @@ class Contact_Form_Plugin {
 	 *
 	 * @param string $block_name - the block name.
 	 * @param array  $attrs      - the block attributes.
+	 * @param array  $options    - the types of support to apply.
 	 *
 	 * @return array
 	 */
-	private static function get_block_support_classes_and_styles( $block_name, $attrs ) {
+	private static function get_block_support_classes_and_styles( $block_name, $attrs, $options = array() ) {
 		$block_type = WP_Block_Type_Registry::get_instance()->get_registered( $block_name );
 
 		if ( ! $block_type ) {
 			return array();
 		}
 
+		$default_options = array( 'color', 'typography', 'border', 'custom', 'spacing' );
+		$enabled_options = empty( $options ) ? $default_options : $options;
+
 		// Leverage the individual core block support functions to generate classes and styles.
-		$color_styles      = \wp_apply_colors_support( $block_type, $attrs );
-		$typography_styles = \wp_apply_typography_support( $block_type, $attrs );
-		$border_styles     = \wp_apply_border_support( $block_type, $attrs );
-		$custom_classname  = \wp_apply_custom_classname_support( $block_type, $attrs );
+		$color_styles      = in_array( 'color', $enabled_options, true ) ? \wp_apply_colors_support( $block_type, $attrs ) : array();
+		$typography_styles = in_array( 'typography', $enabled_options, true ) ? \wp_apply_typography_support( $block_type, $attrs ) : array();
+		$border_styles     = in_array( 'border', $enabled_options, true ) ? \wp_apply_border_support( $block_type, $attrs ) : array();
+		$custom_classname  = in_array( 'custom', $enabled_options, true ) ? \wp_apply_custom_classname_support( $block_type, $attrs ) : array();
+		$spacing_styles    = in_array( 'spacing', $enabled_options, true ) ? \wp_apply_spacing_support( $block_type, $attrs ) : array();
 
 		// Merge all the block support classes and styles.
 		$classes = array_filter(
@@ -371,6 +376,7 @@ class Contact_Form_Plugin {
 				$typography_styles['class'] ?? '',
 				$border_styles['class'] ?? '',
 				$custom_classname['class'] ?? '',
+				$spacing_styles['class'] ?? '',
 			),
 			'strlen'
 		);
@@ -380,6 +386,7 @@ class Contact_Form_Plugin {
 				$color_styles['style'] ?? '',
 				$typography_styles['style'] ?? '',
 				$border_styles['style'] ?? '',
+				$spacing_styles['style'] ?? '',
 			),
 			'strlen'
 		);

--- a/projects/packages/forms/src/modules/form/view.js
+++ b/projects/packages/forms/src/modules/form/view.js
@@ -304,6 +304,30 @@ const { state, actions } = store( NAMESPACE, {
 			actions.updateField( fieldId, newValues );
 		},
 
+		onImageOptionClick: event => {
+			// Find the parent container that has the data-wp-on--click attribute
+			let target = event.target;
+			while ( target && ! target.classList.contains( 'jetpack-input-image-option' ) ) {
+				target = target.parentElement;
+			}
+
+			if ( target ) {
+				// Find the input inside this container
+				const input = target.querySelector( '.jetpack-input-image-option__input' );
+				if ( input ) {
+					// Toggle the input state
+					if ( input.type === 'checkbox' ) {
+						input.checked = ! input.checked;
+					} else if ( input.type === 'radio' ) {
+						input.checked = true;
+					}
+
+					// Dispatch change event to trigger any change handlers
+					input.dispatchEvent( new Event( 'change', { bubbles: true } ) );
+				}
+			}
+		},
+
 		onFieldBlur: event => {
 			const context = getContext();
 			actions.updateField( context.fieldId, event.target.value, true );

--- a/projects/packages/forms/src/types/index.ts
+++ b/projects/packages/forms/src/types/index.ts
@@ -191,4 +191,6 @@ export type BlockEditorStoreSelect = {
 	hasSelectedInnerBlock: ( clientId: string, isInnerBlock: boolean ) => boolean;
 	getBlockRootClientId: ( clientId: string ) => string;
 	getSelectedBlock: () => Block;
+	getBlockIndex: ( clientId: string ) => number;
+	getBlockParentsByBlockName: ( clientId: string, blockName: string ) => string[];
 };

--- a/projects/packages/forms/tools/webpack.config.blocks.js
+++ b/projects/packages/forms/tools/webpack.config.blocks.js
@@ -18,6 +18,7 @@ const sharedWebpackConfig = {
 		'form-progress-indicator/style': './src/blocks/form-progress-indicator/style.scss',
 		'form-step-navigation/style': './src/blocks/form-step-navigation/style.scss',
 		'field-rating/style': './src/blocks/field-rating/style.scss',
+		'field-image-select/style': './src/blocks/field-image-select/style.scss',
 	},
 	output: {
 		...jetpackWebpackConfig.output,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of FORMS-60

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR does the plumbing to get the field to actually work, and also updated the styles to work on the frontend as well.
Those options should work:
- Show labels
- Supersized
- Multiple selection (partially, there is no max number of selected options yet)
- Randomize (partially, the options are displayed randomized, but the post-submission screen shows the original letters)

Not implemented:
- "Other" option

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Enable the `forms_alpha` feature flag and go to the block editor
* Add an image select field
* Add some options with images[1] and mess around with the available styling
* Publish the post
* Check that you can see the image choices and select one or more (depending on the "Multiple selection" toggle)
* Check that you can submit the form
* Check that the selected option letters are displayed in the post-submission screen
* Check that they are displayed in the email
* Check that they are displayed in the dashboard view

Observations:
- The style is not supposed to be finished. The input styling, specifically, is not correct, it is just a default radio or checkbox at this point.
- The submission value will change later to have the user-perceived letter and the image URL(s), to be displayed in the post-submission screen and dashboard
- The empty image case is not treated yet
- The "Other" option is not implemented

| Editor | Frontend |
| - | - |
| <img width="897" height="447" alt="Screenshot from 2025-08-22 22-37-18" src="https://github.com/user-attachments/assets/101ba37c-0f10-48c2-bae3-b7e643fdd407" /> | <img width="709" height="340" alt="Screenshot from 2025-08-22 22-37-40" src="https://github.com/user-attachments/assets/dd9543df-afec-4392-a19c-87f2cf3a717f" /> |
| <img width="864" height="667" alt="Screenshot from 2025-08-22 22-39-36" src="https://github.com/user-attachments/assets/681bd1a3-1e1a-4b87-a6a8-7dac2834dd76" /> | <img width="739" height="864" alt="Screenshot from 2025-08-22 22-41-23" src="https://github.com/user-attachments/assets/154a81ca-b3fa-4d22-a068-be48098448de" /> |