### PR TITLE
Forms: Fix decoding issue

### DIFF
--- a/projects/packages/forms/changelog/fix-decoding-issue
+++ b/projects/packages/forms/changelog/fix-decoding-issue
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: switch to v3 and fix v2 encoding

--- a/projects/packages/forms/src/contact-form/class-feedback-field.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-field.php
@@ -376,6 +376,10 @@ class Feedback_Field {
 			$data['value'] = self::normalize_unicode( $data['value'] );
 		}
 
+		if ( is_string( $data['label'] ) ) { // just normalize plain string for now.
+			$data['label'] = self::normalize_unicode( $data['label'] );
+		}
+
 		return new self(
 			$data['key'],
 			$data['label'],

--- a/projects/packages/forms/src/contact-form/class-feedback-field.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-field.php
@@ -341,7 +341,7 @@ class Feedback_Field {
 		// Case 1: JSON-style escapes, e.g. "\u003cstrong\u003e" or "\ud83d\ude48"
 		if ( strpos( $string, '\u' ) !== false ) {
 			$decoded = json_decode( '"' . $string . '"' );
-			if ( $decoded !== null && json_last_error() === JSON_ERROR_NONE ) {
+			if ( self::is_valid_json_decode( $decoded ) ) {
 				return $decoded;
 			}
 		}
@@ -351,13 +351,23 @@ class Feedback_Field {
 			// Add missing backslashes before each uXXXX
 			$json_ready = preg_replace( '/u([0-9a-fA-F]{4})/', '\\\\u$1', $string );
 			$decoded    = json_decode( '"' . $json_ready . '"' );
-			if ( $decoded !== null && json_last_error() === JSON_ERROR_NONE ) {
+			if ( self::is_valid_json_decode( $decoded ) ) {
 				return $decoded;
 			}
 		}
 
 		// Fallback: return unchanged
 		return $string;
+	}
+
+	/**
+	 * Check if the decoded JSON is valid.
+	 *
+	 * @param mixed $decoded The decoded JSON data.
+	 * @return bool True if there are no errors, false otherwise.
+	 */
+	private static function is_valid_json_decode( $decoded ) {
+		return $decoded !== null && json_last_error() === JSON_ERROR_NONE;
 	}
 
 	/**

--- a/projects/packages/forms/src/contact-form/class-feedback-field.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-field.php
@@ -329,6 +329,64 @@ class Feedback_Field {
 	}
 
 	/**
+	 * Normalize Unicode characters in a string.
+	 *
+	 * This is only used for V2 version of the feedback. Since we didn't escape special characters
+	 *
+	 * @param string $string The string to normalize.
+	 *
+	 * @return string
+	 */
+	public static function normalize_unicode( $string ) {
+		// Case 1: JSON-style escapes, e.g. "\u003cstrong\u003e" or "\ud83d\ude48"
+		if ( strpos( $string, '\u' ) !== false ) {
+			$decoded = json_decode( '"' . $string . '"' );
+			if ( $decoded !== null && json_last_error() === JSON_ERROR_NONE ) {
+				return $decoded;
+			}
+		}
+
+		// Case 2: Raw surrogate dumps, e.g. "ud83dude48" or "u003cstrongu003e"
+		if ( preg_match( '/u[0-9a-fA-F]{4}/', $string ) ) {
+			// Add missing backslashes before each uXXXX
+			$json_ready = preg_replace( '/u([0-9a-fA-F]{4})/', '\\\\u$1', $string );
+			$decoded    = json_decode( '"' . $json_ready . '"' );
+			if ( $decoded !== null && json_last_error() === JSON_ERROR_NONE ) {
+				return $decoded;
+			}
+		}
+
+		// Fallback: return unchanged
+		return $string;
+	}
+
+	/**
+	 * Create a Feedback_Field object from serialized data.
+	 *
+	 * @param array $data The serialized data.
+	 *
+	 * @return Feedback_Field|null Returns a Feedback_Field object or null if the data is invalid.
+	 */
+	public static function from_serialized_v2( $data ) {
+		if ( ! is_array( $data ) || ! isset( $data['key'] ) || ! isset( $data['value'] ) || ! isset( $data['label'] ) ) {
+			return null;
+		}
+
+		if ( is_string( $data['value'] ) ) { // just normalize plain string for now.
+			$data['value'] = self::normalize_unicode( $data['value'] );
+		}
+
+		return new self(
+			$data['key'],
+			$data['label'],
+			$data['value'],
+			$data['type'] ?? 'basic',
+			$data['meta'] ?? array(),
+			$data['form_field_id'] ?? ''
+		);
+	}
+
+	/**
 	 * Check if the field has a file
 	 *
 	 * @return bool

--- a/projects/packages/forms/src/contact-form/class-feedback.php
+++ b/projects/packages/forms/src/contact-form/class-feedback.php
@@ -767,8 +767,8 @@ class Feedback {
 				'post_title'     => $this->legacy_feedback_title,
 				'post_date'      => $this->feedback_time,
 				'post_name'      => $this->legacy_feedback_id,
-				'post_content'   => $this->serialize(),
-				'post_mime_type' => 'v2', // a way to help us identify what version of the data this is.
+				'post_content'   => addslashes( $this->serialize() ),
+				'post_mime_type' => 'v3', // a way to help us identify what version of the data this is.
 				'post_parent'    => $this->source->get_id(),
 			)
 		);
@@ -813,6 +813,9 @@ class Feedback {
 	 * @return array Parsed fields.
 	 */
 	private function parse_content( $post_content = '', $version = null ) {
+		if ( $version === 'v3' ) {
+			return $this->parse_content_v3( $post_content );
+		}
 		if ( $version === 'v2' ) {
 			return $this->parse_content_v2( $post_content );
 		}
@@ -821,6 +824,8 @@ class Feedback {
 
 	/**
 	 * Parse the content in the v2 format.
+	 *
+	 * V2 Format was a short lived format that accidently contains slash escaped unicode characters.
 	 *
 	 * @param string $post_content The post content to parse.
 	 *
@@ -834,6 +839,37 @@ class Feedback {
 			$decoded_content = json_decode( stripslashes( trim( $post_content ) ), true );
 		}
 
+		if ( $decoded_content === null ) {
+			return array();
+		}
+		$fields = array();
+		foreach ( $decoded_content['fields'] as $field ) {
+			$feedback_field = Feedback_Field::from_serialized_v2( $field );
+			if ( $feedback_field instanceof Feedback_Field ) {
+				$fields[ $feedback_field->get_key() ] = $feedback_field;
+				if ( ! $this->has_file && $feedback_field->has_file() ) {
+					$this->has_file = true;
+				}
+			}
+		}
+		$decoded_content['fields'] = $fields;
+		return $decoded_content;
+	}
+
+	/**
+	 * Parse the content in the v3 format.
+	 *
+	 * @param string $post_content The post content to parse.
+	 *
+	 * @return array Parsed fields.
+	 */
+	private function parse_content_v3( $post_content = '' ) {
+		$decoded_content = json_decode( $post_content, true );
+		if ( $decoded_content === null ) {
+			// If JSON decoding fails, try to decode the second try with stripslashes and trim.
+			// This is a workaround for some cases where the JSON data is not properly formatted.
+			$decoded_content = json_decode( stripslashes( trim( $post_content ) ), true );
+		}
 		if ( $decoded_content === null ) {
 			return array();
 		}

--- a/projects/packages/forms/src/contact-form/class-feedback.php
+++ b/projects/packages/forms/src/contact-form/class-feedback.php
@@ -767,7 +767,7 @@ class Feedback {
 				'post_title'     => $this->legacy_feedback_title,
 				'post_date'      => $this->feedback_time,
 				'post_name'      => $this->legacy_feedback_id,
-				'post_content'   => addslashes( $this->serialize() ),
+				'post_content'   => $this->serialize(), // In V3 we started to addslashes.
 				'post_mime_type' => 'v3', // a way to help us identify what version of the data this is.
 				'post_parent'    => $this->source->get_id(),
 			)

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Field_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Field_Test.php
@@ -82,6 +82,55 @@ class Feedback_Field_Test extends BaseTestCase {
 		$this->assertEquals( array( 'meta_key' => 'meta_value' ), $unserialized->get_meta() );
 	}
 
+	public function test_Feedback_Field_serialization_v2() {
+		$field        = new Feedback_Field( 'test_key', 'test_label', 'test_value', 'text', array( 'meta_key' => 'meta_value' ) );
+		$serialized   = $field->serialize();
+		$unserialized = Feedback_Field::from_serialized_v2( $serialized );
+
+		$this->assertInstanceOf( Feedback_Field::class, $unserialized );
+
+		$this->assertEquals( $serialized, $unserialized->serialize() );
+		$this->assertEquals( 'test_key', $unserialized->get_key() );
+		$this->assertEquals( 'test_label', $unserialized->get_label() );
+		$this->assertEquals( 'test_value', $unserialized->get_value() );
+		$this->assertEquals( 'text', $unserialized->get_type() );
+		$this->assertEquals( array( 'meta_key' => 'meta_value' ), $unserialized->get_meta() );
+	}
+
+	public function test_Feedback_Field_serialization_v2_special() {
+		$field        = new Feedback_Field( 'test_key', 'test_label 🙈', 'test_value 🙈', 'text', array( 'meta_key' => 'meta_value' ), 'id' );
+		$serialized   = $field->serialize();
+		$unserialized = Feedback_Field::from_serialized_v2( $serialized );
+
+		$this->assertInstanceOf( Feedback_Field::class, $unserialized );
+
+		$this->assertEquals( $serialized, $unserialized->serialize() );
+		$this->assertEquals( 'test_key', $unserialized->get_key() );
+		$this->assertEquals( 'test_label 🙈', $unserialized->get_label() );
+		$this->assertEquals( 'test_value 🙈', $unserialized->get_value() );
+		$this->assertEquals( 'text', $unserialized->get_type() );
+		$this->assertEquals( 'id', $unserialized->get_form_field_id() );
+		$this->assertEquals( array( 'meta_key' => 'meta_value' ), $unserialized->get_meta() );
+	}
+
+	public function test_Feedback_Field_serialization_v2_special_plain() {
+
+		$serialized   = array(
+			'key'           => 'test_key',
+			'label'         => 'test_label ud83dude48',
+			'value'         => 'test_value ud83dude48',
+			'type'          => 'text',
+			'meta'          => array( 'meta_key' => 'meta_value' ),
+			'form_field_id' => 'id',
+		);
+		$unserialized = Feedback_Field::from_serialized_v2( $serialized );
+
+		$this->assertInstanceOf( Feedback_Field::class, $unserialized );
+
+		$this->assertEquals( 'test_label 🙈', $unserialized->get_label() );
+		$this->assertEquals( 'test_value 🙈', $unserialized->get_value() );
+	}
+
 	/**
 	 * Test that the Feedback_Field can serialize and unserialize correctly.
 	 */
@@ -137,6 +186,41 @@ class Feedback_Field_Test extends BaseTestCase {
 			array( 'files' => array( $file ) ),
 			$field->get_value()
 		);
+	}
+
+	public function test_get_render_value_submit() {
+		$field = new Feedback_Field( 'test_key', 'test_label', 'test_value' );
+		$this->assertEquals( 'test_value', $field->get_render_value( 'submit' ) );
+
+		$field = new Feedback_Field( 'test_key', 'test_label', array( 'value1', 'value2' ) );
+		$this->assertEquals( array( 'value1', 'value2' ), $field->get_render_value( 'submit' ) );
+
+		// EMPTY FILE FIELD
+		$field = new Feedback_Field( 'test_key', 'test_label', array( 'files' => array() ), 'file', array(), 'id' );
+		$this->assertEquals(
+			array(
+				'field_id' => 'id',
+				'files'    => array(),
+			),
+			$field->get_render_value( 'submit' )
+		);
+		$this->assertFalse( $field->has_file() );
+
+		$file  = array(
+			'file_id' => 123,
+			'name'    => 'file1.jpg',
+			'size'    => 123456789,
+			'type'    => 'image/jpeg',
+		);
+		$field = new Feedback_Field( 'test_key', 'test_label', array( 'files' => array( $file ) ), 'file', array(), 'id' );
+		$this->assertSame(
+			array(
+				'field_id' => 'id',
+				'files'    => array( $file ),
+			),
+			$field->get_render_value( 'submit' )
+		);
+		$this->assertTrue( $field->has_file() );
 	}
 
 	public function test_render_file_field() {
@@ -277,6 +361,18 @@ class Feedback_Field_Test extends BaseTestCase {
 	public function test_normalize_unicode_non_escaped() {
 		$input    = 'á, ç, ü, ń, ğ hello world ud83dude48';
 		$expected = 'á, ç, ü, ń, ğ hello world 🙈';
+		$this->assertEquals( $expected, Feedback_Field::normalize_unicode( $input ) );
+	}
+
+	public function test_normalize_unicode_non_escaped_test_string() {
+		$input    = 'test_label ud83dude48';
+		$expected = 'test_label 🙈';
+		$this->assertEquals( $expected, Feedback_Field::normalize_unicode( $input ) );
+	}
+
+	public function test_normalize_unicode_plain() {
+		$input    = 'hello world';
+		$expected = 'hello world';
 		$this->assertEquals( $expected, Feedback_Field::normalize_unicode( $input ) );
 	}
 

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Field_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Field_Test.php
@@ -267,6 +267,19 @@ class Feedback_Field_Test extends BaseTestCase {
 		$field = new Feedback_Field( 'test_key', 'á&#044; ç&#044; ü&#044; ń&#044; ğ', 'test_value' );
 		$this->assertSame( 'á, ç, ü, ń, ğ', $field->get_label() );
 	}
+
+	public function test_normalize_unicode() {
+		$input    = 'hello world \ud83d\ude48';
+		$expected = 'hello world 🙈';
+		$this->assertEquals( $expected, Feedback_Field::normalize_unicode( $input ) );
+	}
+
+	public function test_normalize_unicode_non_escaped() {
+		$input    = 'á, ç, ü, ń, ğ hello world ud83dude48';
+		$expected = 'á, ç, ü, ń, ğ hello world 🙈';
+		$this->assertEquals( $expected, Feedback_Field::normalize_unicode( $input ) );
+	}
+
 	/**
 	 * Helper function to return a URL for the file.
 	 *

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Test.php
@@ -2085,7 +2085,7 @@ class Feedback_Test extends BaseTestCase {
 		$this->assertNull( $response->get_field_by_form_field_id( 'email' ) );
 	}
 
-	public function test_edgecase_feedback_v2() {
+	public function test_edgecase_feedback_v2_missing_field_value() {
 		// Post data with missing field value.
 		$post_id = wp_insert_post(
 			array(

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Test.php
@@ -2166,4 +2166,66 @@ class Feedback_Test extends BaseTestCase {
 		$this->assertEquals( $expected_content, $response->get_field_value_by_label( 'Message' ), 'Field value should match the original content for the form submission when new lines are present' );
 		$this->assertEquals( $expected_content, $saved_response->get_field_value_by_label( 'Message' ), 'Field value should match the original content for the saved response when new lines are present' );
 	}
+
+	public function test_escape_legacy_special_characters_handeling() {
+		$post_id = Utility::create_legacy_feedback(
+			array(
+				'special' => 'こんにちは世界',
+				'message' => '🙈',
+			)
+		);
+
+		$response = Feedback::get( $post_id );
+
+		$this->assertEquals( 'こんにちは世界', $response->get_field_value_by_label( 'special' ), 'Special field value should match' );
+		$this->assertEquals( '🙈', $response->get_field_value_by_label( 'message' ), 'Message field value should match' );
+	}
+
+	public function test_escape_legacy_v2_special_characters_handeling() {
+		$post_id = Utility::create_legacy_feedback_v2(
+			array(
+				'Special こんにちは世界' => 'こんにちは世界',
+				'Message'         => '🙈',
+			)
+		);
+
+		$post_object = get_post( $post_id );
+		$this->assertTrue( str_contains( $post_object->post_content, 'ud83dude48' ) ); // ud83dude48 => 🙈 withouth the /
+
+		$response = Feedback::get( $post_id );
+
+		$this->assertEquals( 'こんにちは世界', $response->get_field_value_by_label( 'Special こんにちは世界' ), 'Special field value should match' );
+		$this->assertEquals( '🙈', $response->get_field_value_by_label( 'Message' ), 'Message field value should match' );
+	}
+
+	public function test_special_characters_handling() {
+		$form_id = Utility::get_form_id();
+
+		$_post_data = Utility::get_post_request(
+			array(
+				'special' => 'こんにちは世界',
+				'message' => '🙈',
+			),
+			'g' . $form_id
+		);
+
+		$form = new Contact_Form(
+			array(
+				'title'       => 'Test Form',
+				'description' => 'This is a test form.',
+			),
+			"[contact-field label='Special' type='text' required='1'/]"
+			. "[contact-field label='Message' type='textarea'/]"
+		);
+
+		$response         = Feedback::from_submission( $_post_data, $form );
+		$feedback_post_id = $response->save();
+		$saved_response   = Feedback::get( $feedback_post_id );
+
+		$this->assertEquals( 'こんにちは世界', $response->get_field_value_by_label( 'Special' ), 'Special field value should match' );
+		$this->assertEquals( '🙈', $response->get_field_value_by_label( 'Message' ), 'Message field value should match' );
+
+		$this->assertEquals( 'こんにちは世界', $saved_response->get_field_value_by_label( 'Special' ), 'Special field value should match saved value' );
+		$this->assertEquals( '🙈', $saved_response->get_field_value_by_label( 'Message' ), 'Message field value should match saved value' );
+	}
 }

--- a/projects/packages/forms/tests/php/contact-form/class-utility.php
+++ b/projects/packages/forms/tests/php/contact-form/class-utility.php
@@ -113,7 +113,7 @@ class Utility {
 		$fields = array();
 		$i      = 1;
 		foreach ( $all_values as $key => $value ) {
-			$fields[] = new \Automattic\Jetpack\Forms\ContactForm\Feedback_Field( $i . '_' . $key, $key, $value, 'textarea', array(), $key )->serialize();
+			$fields[] = new Feedback_Field( $i . '_' . $key, $key, $value, 'textarea', array(), $key )->serialize();
 			++$i;
 		}
 
@@ -121,7 +121,7 @@ class Utility {
 			'subject'     => $subject,
 			'ip'          => $comment_ip_text,
 			'entry_title' => $entry_values['entry_title'],
-			'entry_page'  => isset( $entry_values['entry_page'] ) ? $entry_values['entry_page'] : 1,
+			'entry_page'  => $entry_values['entry_page'] ?? 1,
 			'fields'      => $fields,
 		);
 

--- a/projects/packages/forms/tests/php/contact-form/class-utility.php
+++ b/projects/packages/forms/tests/php/contact-form/class-utility.php
@@ -80,6 +80,66 @@ class Utility {
 		);
 	}
 
+	public static function create_legacy_feedback_v2(
+		$all_values = array(),
+		$comment_author = 'Test User',
+		$comment_ip_text = 'https://127.0.0.1',
+		$subject = 'Test Subject',
+		$status = 'publish'
+	) {
+		global $post;
+		$feedback_time  = current_time( 'mysql' );
+		$feedback_title = "{$comment_author} - {$feedback_time}";
+		$feedback_id    = md5( $feedback_title );
+
+		if ( empty( $all_values ) ) {
+			$all_values = array(
+				'field1'                  => 'value1',
+				'field2'                  => 'value2',
+				'email_marketing_consent' => 'yes',
+			);
+		}
+
+		$entry_values = array(
+			'entry_title'     => 'Cool Post Title',
+			'entry_permalink' => 'https://example.com/post/123',
+			'feedback_id'     => $feedback_id,
+		);
+
+		if ( isset( $_POST['page'] ) ) {
+			$entry_values['entry_page'] = absint( wp_unslash( $_POST['page'] ) );
+		}
+
+		$fields = array();
+		$i      = 1;
+		foreach ( $all_values as $key => $value ) {
+			$fields[] = new \Automattic\Jetpack\Forms\ContactForm\Feedback_Field( $i . '_' . $key, $key, $value, 'textarea', array(), $key )->serialize();
+			++$i;
+		}
+
+		$content = array(
+			'subject'     => $subject,
+			'ip'          => $comment_ip_text,
+			'entry_title' => $entry_values['entry_title'],
+			'entry_page'  => isset( $entry_values['entry_page'] ) ? $entry_values['entry_page'] : 1,
+			'fields'      => $fields,
+		);
+
+		// Create a mock post with JSON_DATA format
+		return wp_insert_post(
+			array(
+				'post_type'      => 'feedback',
+				'post_status'    => $status,
+				'post_title'     => addslashes( wp_kses( $feedback_title, array() ) ),
+				'post_date'      => $feedback_time,
+				'post_name'      => $feedback_id,
+				'post_content'   => wp_json_encode( $content ),
+				'post_mime_type' => 'v2', // a way to help us identify what version of the data this is.
+				'post_parent'    => $post ? $post->ID : 0,
+			)
+		);
+	}
+
 	/**
 	 * Adds the field values to the global $_POST value.
 	 *

--- a/projects/packages/forms/tests/php/contact-form/class-utility.php
+++ b/projects/packages/forms/tests/php/contact-form/class-utility.php
@@ -113,7 +113,8 @@ class Utility {
 		$fields = array();
 		$i      = 1;
 		foreach ( $all_values as $key => $value ) {
-			$fields[] = new Feedback_Field( $i . '_' . $key, $key, $value, 'textarea', array(), $key )->serialize();
+			$field    = new Feedback_Field( $i . '_' . $key, $key, $value, 'textarea', array(), $key );
+			$fields[] = $field->serialize();
 			++$i;
 		}
 


### PR DESCRIPTION
This PR fixed the endocing issue by making sure that v2 version of the encoding gets. 

The problem was that in V2 unicode strings such as special characters (emojies or languages such as japanse ) 
stripped the / from the content. This made it so that we don't know that the characters were unicode when the conversion happened in decode_json. 

Fixes FORMS-271

## Proposed changes:
1. Switch the default version to v3 and add a test to make sure that the encoding works as expected. 
2. Wrap the content with `addslashes()` before saving the content in V3
3. Deal with V2 string field values in a way that we decode content properly again. (We assume the content doesn't have the slashes) + Added tests.  

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1755930976939539-slack-C086RGTJT1D

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Do the tests pass? 

On a post with special characters. Do you see the content as expected now?
