### PR TITLE
Forms: Let MailPoet handle old and new data formats

### DIFF
--- a/projects/packages/forms/changelog/update-forms-mailpoet-alternative-methods
+++ b/projects/packages/forms/changelog/update-forms-mailpoet-alternative-methods
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: Let MailPoet handle old/new form data.

--- a/projects/packages/forms/src/service/class-mailpoet-integration.php
+++ b/projects/packages/forms/src/service/class-mailpoet-integration.php
@@ -117,6 +117,48 @@ class MailPoet_Integration {
 
 	/**
 	 * Extract subscriber data (email, first_name, last_name) from form fields.
+	 * Once refactored form storage is in place, use get_subscriber_data() instead.
+	 *
+	 * @param array $fields Collection of Contact_Form_Field instances.
+	 * @return array Associative array with at least 'email', optionally 'first_name', 'last_name'. Empty array if no email found.
+	 */
+	protected static function get_subscriber_data_from_fields( $fields ) {
+		// Try and get the form from any of the fields
+		$form = null;
+		foreach ( $fields as $field ) {
+			if ( ! empty( $field->form ) ) {
+				$form = $field->form;
+				break;
+			}
+		}
+		if ( ! $form || ! is_a( $form, 'Automattic\Jetpack\Forms\ContactForm\Contact_Form' ) ) {
+			return array();
+		}
+
+		$subscriber_data = array();
+		foreach ( $form->fields as $field ) {
+			$id    = strtolower( str_replace( array( ' ', '_' ), '', $field->get_attribute( 'id' ) ) );
+			$label = strtolower( str_replace( array( ' ', '_' ), '', $field->get_attribute( 'label' ) ) );
+			$value = trim( $field->value );
+
+			if ( ( $id === 'email' || $label === 'email' ) && ! empty( $value ) ) {
+				$subscriber_data['email'] = $value;
+			} elseif ( ( $id === 'firstname' || $label === 'firstname' ) && ! empty( $value ) ) {
+				$subscriber_data['first_name'] = $value;
+			} elseif ( ( $id === 'lastname' || $label === 'lastname' ) && ! empty( $value ) ) {
+				$subscriber_data['last_name'] = $value;
+			}
+		}
+
+		if ( empty( $subscriber_data['email'] ) ) {
+			return array();
+		}
+
+		return $subscriber_data;
+	}
+
+	/**
+	 * Extract subscriber data (email, first_name, last_name) from form fields.
 	 *
 	 * @param Feedback $feedback Feedback object for the submission.
 	 * @return array Associative array with at least 'email', optionally 'first_name', 'last_name'. Empty array if no email found.
@@ -182,8 +224,29 @@ class MailPoet_Integration {
 			return;
 		}
 
-		if ( $feedback->has_field_type( 'consent' ) && ! $feedback->has_consent() ) {
-			return;
+		$post       = get_post( $post_id );
+		$is_v2_data = ( $post && $post->post_mime_type === 'v2' );
+
+		if ( $is_v2_data ) {
+			if ( $feedback->has_field_type( 'consent' ) && ! $feedback->has_consent() ) {
+				return;
+			}
+		} else {
+			$consent_field = null;
+			if ( is_array( $form->fields ) ) {
+				foreach ( $form->fields as $form_field ) {
+					if ( 'consent' === $form_field->get_attribute( 'type' ) ) {
+						$consent_field = $form_field;
+						break;
+					}
+				}
+			}
+			if ( $consent_field ) {
+				$consent_type = strtolower( (string) $consent_field->get_attribute( 'consenttype' ) );
+				if ( 'explicit' === $consent_type && ! $consent_field->value ) {
+					return;
+				}
+			}
 		}
 
 		$mailpoet_api = self::get_api();
@@ -203,7 +266,7 @@ class MailPoet_Integration {
 			return;
 		}
 
-		$subscriber_data = self::get_subscriber_data( $feedback );
+		$subscriber_data = $is_v2_data ? self::get_subscriber_data( $feedback ) : self::get_subscriber_data_from_fields( $fields );
 		if ( empty( $subscriber_data ) ) {
 			// Email is required for MailPoet subscribers.
 			return;

--- a/projects/plugins/jetpack/changelog/update-forms-mailpoet-alternative-methods
+++ b/projects/plugins/jetpack/changelog/update-forms-mailpoet-alternative-methods
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: Let MailPoet handle old/new form data.


### PR DESCRIPTION
## Proposed changes:

There has been recent work to update how form data is structured and saved. We pushed a PR to update form saving to use new data, but then [reverted it](https://github.com/Automattic/jetpack/pull/44924) due to some issues. I had also updated MailPoet to use the new format [here](https://github.com/Automattic/jetpack/pull/44852). 

To avoid issues, I'm updating the MailPoet code to handle both cases. To know which we're dealing with, I check for post_mime_type === v2, which we set in the new code [here](https://github.com/Automattic/jetpack/blob/8e6d86baa6aa887af0fe7564694ec1a071ab2eed/projects/packages/forms/src/contact-form/class-feedback.php#L771). 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Slack: p1755929367710519-slack-C02FMH4G8

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

This is a refactor, so the behavior should be the same before and after. 

* **Prep:** If you've tested this before, be sure to remove the MailPoet feature flag. You no longer need to add a MailPoet key to start adding contacts to your lists.
**Add a form to a page or post.** 
   - Required fields: Your form must have an email field. If you include a name field with 'First Name' label or 'firstname' id, that will be added to your lists. If you include a name field with 'Last Name' label or 'lastname' id, that will be added to your lists.
   - Enable MailPoet: Open the integration modal and install/activate MailPoet if needed. Complete MailPoet setup if prompted. Enable the MailPoet toggle, select a MailPoet list, and choose if you want consent field or not. 
* **Test frontend submission:** Go to frontend, submit, and confirm subscriber was added to MailPoet list.
* **Test consent:** Test different consent states. 
   - No consent field: contact will be added to MailPoet
   - Consent field with no checkbox: contact will be added to MailPoet
   - Consent field with 'checked' checkbox: contact will be added to MailPoet
   - Consent field with 'unchecked' checkbox: contact will not be added to MailPoet