### PR TITLE
Forms: Fix checkbox validation for older forms

### DIFF
--- a/projects/packages/forms/changelog/fix-checkbox-validation-forms
+++ b/projects/packages/forms/changelog/fix-checkbox-validation-forms
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: improve checkbox validation for older checkboxes

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -343,7 +343,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 					$possible_values = array();
 					if ( ! empty( $options_data ) ) {
 						foreach ( $options_data as $option_index => $option ) {
-							$option_label = Contact_Form_Plugin::strip_tags( $option['label'] );
+							$option_label = isset( $option['label'] ) ? Contact_Form_Plugin::strip_tags( $option['label'] ) : '';
 							if ( is_string( $option_label ) && '' !== $option_label ) {
 								$possible_values[] = $this->get_option_value( $this->get_attribute( 'values' ), $option_index, $option_label );
 							}

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -338,27 +338,26 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 					/* translators: %s is the name of a form field */
 					$this->add_error( sprintf( __( '%s requires at least one selection.', 'jetpack-forms' ), $field_label ) );
 				} else {
-					// Check that the selected options are valid
-					$options      = (array) $this->get_attribute( 'options' );
-					$options_data = (array) $this->get_attribute( 'optionsdata' );
 
+					$options_data    = (array) $this->get_attribute( 'optionsdata' );
+					$possible_values = array();
 					if ( ! empty( $options_data ) ) {
-						$options = array_map(
-							function ( $option ) {
-								return $this->sanitize_text_field( trim( $option['label'] ) );
-							},
-							$options_data
-						);
+						foreach ( $options_data as $option_index => $option ) {
+							$option_label = Contact_Form_Plugin::strip_tags( $option['label'] );
+							if ( is_string( $option_label ) && '' !== $option_label ) {
+								$possible_values[] = $this->get_option_value( $this->get_attribute( 'values' ), $option_index, $option_label );
+							}
+						}
 					} else {
-						$options = array_map( array( $this, 'sanitize_text_field' ), $options );
+						foreach ( (array) $this->get_attribute( 'options' ) as $option_index => $option ) {
+							$option = Contact_Form_Plugin::strip_tags( $option );
+							if ( is_string( $option ) && '' !== $option ) {
+								$possible_values[] = $this->get_option_value( $this->get_attribute( 'values' ), $option_index, $option );
+							}
+						}
 					}
 
-					$non_empty_options = array_filter(
-						$options,
-						function ( $option ) {
-							return $option !== '';
-						}
-					);
+					$non_empty_options = array_map( array( $this, 'sanitize_text_field' ), $possible_values );
 
 					foreach ( $field_value  as $field_value_item ) {
 						if ( ! in_array( $field_value_item, $non_empty_options, true ) ) {

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -3092,6 +3092,7 @@ EOT;
 				'radioempty'     => '',
 				'radioemptydata' => '',
 				'pick'           => $pick,
+				'pickvalue'      => array( 'truth' ), // a value but not a part of the values array.
 			),
 			'g' . $form_id
 		);
@@ -3109,7 +3110,8 @@ EOT;
 			[contact-field label='Choose Radio' type='radio' options='truth,dare' required='1'/]
 			[contact-field label='Choose Empty' type='radio' options='truth,dare' required='1'/]
 			[contact-field label='Choose Empty Data' type='radio' options='truth,dare' optionsdata='&#091;{&quot;label&quot;:&quot;hello  there&quot;&#044;&quot;class&quot;:&quot;wp-block-jetpack-option&quot;}&#044;{&quot;label&quot;:&quot;option 1&quot;&#044;&quot;class&quot;:&quot;wp-block-jetpack-option&quot;}&#044;{&quot;label&quot;:&quot;option 2&quot;&#044;&quot;class&quot;:&quot;wp-block-jetpack-option&quot;}&#093;' required='1'/]
-			[contact-field label='Pick' type='checkbox-multiple' options='truth,dare' required='1'/]"
+			[contact-field label='Pick' type='checkbox-multiple' options='truth,dare' required='1'/]
+			[contact-field label='Pick Value' type='checkbox-multiple' options='truth,dare' values='one,two' required='1'/]"
 		);
 		$form->validate();
 		unset( $_POST ); // Clean up the global $_POST variable after the test.
@@ -3126,6 +3128,7 @@ EOT;
 				'Choose Empty requires at least one selection.',
 				'Choose Empty Data requires at least one selection.',
 				'Pick requires at least one selection.',
+				'Pick Value requires at least one selection.',
 			),
 			$form->get_error_messages()
 		);
@@ -3176,19 +3179,18 @@ EOT;
 	}
 
 	public function test_validate_checkboxes_form() {
-		$name    = '';
-		$email   = '';
 		$form_id = Utility::get_form_id();
 
 		// Create a form submission
 		$_POST = Utility::get_post_request(
 			array(
-				'name'                        => $name,
-				'email'                       => $email,
-				'choose'                      => array( 'truth' ),
+
+				'choose'                      => array( 'truth 🙈 ' ),
 				'chooseoptions'               => array( 'hello  there' ),
 				'chooseseveraloptions'        => array( 'hello, there' ),
 				'chooseseveraloptionsspecial' => array( 'hello, world' ),
+				'chooseseveraloptionsvalues'  => array( 'one' ),
+				'choosevalueoptionsdata'      => array( 'one' ),
 
 			),
 			'g' . $form_id
@@ -3199,23 +3201,23 @@ EOT;
 				'title'       => 'Test Form',
 				'description' => 'This is a test form.',
 			),
-			'[contact-field label="Name" type="name" /][contact-field label="Email" type="email" /][contact-field label="Choose" type="checkbox-multiple" options="truth,dare" /][contact-field type="checkbox-multiple" label="Choose options" labelclasses="wp-block-jetpack-label" optionsclasses="wp-block-jetpack-options" options="hello  there,option 1,option 2" optionsdata="&#091;{&quot;label&quot;:&quot;hello  there&quot;&#044;&quot;class&quot;:&quot;wp-block-jetpack-option&quot;}&#044;{&quot;label&quot;:&quot;option 1&quot;&#044;&quot;class&quot;:&quot;wp-block-jetpack-option&quot;}&#044;{&quot;label&quot;:&quot;option 2&quot;&#044;&quot;class&quot;:&quot;wp-block-jetpack-option&quot;}&#093;" stylevariationattributes="" stylevariationclasses="" stylevariationstyles="" fieldwrapperclasses="wp-block-jetpack-field-checkbox-multiple"]&lt;div&gt;
-
-
+			'
+			[contact-field label="Choose" type="checkbox-multiple" options="truth 🙈 , dare" ]
+			[contact-field type="checkbox-multiple" label="Choose options" labelclasses="wp-block-jetpack-label" optionsclasses="wp-block-jetpack-options" options="hello  there,option 1,option 2" optionsdata="&#091;{&quot;label&quot;:&quot;hello  there&quot;&#044;&quot;class&quot;:&quot;wp-block-jetpack-option&quot;}&#044;{&quot;label&quot;:&quot;option 1&quot;&#044;&quot;class&quot;:&quot;wp-block-jetpack-option&quot;}&#044;{&quot;label&quot;:&quot;option 2&quot;&#044;&quot;class&quot;:&quot;wp-block-jetpack-option&quot;}&#093;" stylevariationattributes="" stylevariationclasses="" stylevariationstyles="" fieldwrapperclasses="wp-block-jetpack-field-checkbox-multiple"]&lt;div&gt;
 &lt;ul class=&quot;wp-block-jetpack-options&quot;&gt;
-
-
-
 &lt;/ul&gt;
-&lt;/div&gt;[/contact-field][contact-field type="checkbox-multiple" label="Choose several options" labelclasses="wp-block-jetpack-label" optionsclasses="wp-block-jetpack-options" options="hello, there,option 1,option 2" optionsdata="&#091;{&quot;label&quot;:&quot;hello&#044; there&quot;&#044;&quot;class&quot;:&quot;wp-block-jetpack-option&quot;}&#044;{&quot;label&quot;:&quot;option 1&quot;&#044;&quot;class&quot;:&quot;wp-block-jetpack-option&quot;}&#044;{&quot;label&quot;:&quot;option 2&quot;&#044;&quot;class&quot;:&quot;wp-block-jetpack-option&quot;}&#093;" stylevariationattributes="" stylevariationclasses="" stylevariationstyles="" fieldwrapperclasses="wp-block-jetpack-field-checkbox-multiple"]&lt;div&gt;
-
-
+&lt;/div&gt;[/contact-field]
+[contact-field type="checkbox-multiple" label="Choose several options" labelclasses="wp-block-jetpack-label" optionsclasses="wp-block-jetpack-options" options="hello, there,option 1,option 2" optionsdata="&#091;{&quot;label&quot;:&quot;hello&#044; there&quot;&#044;&quot;class&quot;:&quot;wp-block-jetpack-option&quot;}&#044;{&quot;label&quot;:&quot;option 1&quot;&#044;&quot;class&quot;:&quot;wp-block-jetpack-option&quot;}&#044;{&quot;label&quot;:&quot;option 2&quot;&#044;&quot;class&quot;:&quot;wp-block-jetpack-option&quot;}&#093;" stylevariationattributes="" stylevariationclasses="" stylevariationstyles="" fieldwrapperclasses="wp-block-jetpack-field-checkbox-multiple"]&lt;div&gt;
 &lt;ul class=&quot;wp-block-jetpack-options&quot;&gt;
-
-
-
 &lt;/ul&gt;
-&lt;/div&gt;[/contact-field][contact-field label="Choose several options special" type="checkbox-multiple" options="hello&#044; world,dare" /]'
+&lt;/div&gt;[/contact-field]
+[contact-field label="Choose several options special" type="checkbox-multiple" options="hello&#044; world,dare" /]
+[contact-field label="Choose several options  values" type="checkbox-multiple" options="hello world,dare" values="one,two" /]
+[contact-field type="checkbox-multiple" label="Choose value options data" labelclasses="wp-block-jetpack-label" optionsclasses="wp-block-jetpack-options" options="hello, there,option 1,option 2" values="one,two" optionsdata="&#091;{&quot;label&quot;:&quot;hello&#044; there&quot;&#044;&quot;class&quot;:&quot;wp-block-jetpack-option&quot;}&#044;{&quot;label&quot;:&quot;option 1&quot;&#044;&quot;class&quot;:&quot;wp-block-jetpack-option&quot;}&#044;{&quot;label&quot;:&quot;option 2&quot;&#044;&quot;class&quot;:&quot;wp-block-jetpack-option&quot;}&#093;" stylevariationattributes="" stylevariationclasses="" stylevariationstyles="" fieldwrapperclasses="wp-block-jetpack-field-checkbox-multiple"]&lt;div&gt;
+&lt;ul class=&quot;wp-block-jetpack-options&quot;&gt;
+&lt;/ul&gt;
+&lt;/div&gt;[/contact-field]
+'
 		);
 		$form->validate();
 		unset( $_POST ); // Clean up the global $_POST variable after the test.

--- a/projects/plugins/jetpack/changelog/fix-checkbox-validation-forms
+++ b/projects/plugins/jetpack/changelog/fix-checkbox-validation-forms
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: improve checkbox validation for older checkboxes


### PR DESCRIPTION
Improve checkbox validation for older checkbox formats. 

This PR improved checkbox validation for older forms that used the `values` attribute to in shortcodes. 

## Proposed changes:
* This PR takes into account the values array. That can be passed in via shortcodes. 
* It generates the possible values array the same way as the form generates the values for the form. 
* It passes the values though the same filters. 
* Adds tests to make sure it works. Covers both failures and success.  

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1756065784341329/1755930976.939539-slack-C086RGTJT1D

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Do the tests pass? 

Create a form. Which checkboxes. Does the form submit as expected? 
Create an older form with previous values. ( before the global styles refactor ) 
```
<!-- wp:group {"className":"is-style-outline","style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|50","right":"var:preset|spacing|50"}}},"layout":{"type":"constrained","contentSize":"660px","wideSize":"1060px"}} -->
<div class="wp-block-group is-style-outline" style="padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--50)"><!-- wp:jetpack/contact-form {"style":{"spacing":{"padding":{"top":"16px","right":"16px","bottom":"16px","left":"16px"}}}} -->
<div class="wp-block-jetpack-contact-form" style="padding-top:16px;padding-right:16px;padding-bottom:16px;padding-left:16px"><!-- wp:jetpack/field-name {"required":true,"requiredText":"(required)","borderRadius":0,"lineHeight":1.5} /-->

<!-- wp:jetpack/field-checkbox-multiple {"label":"Availability (please check all times you are generally available to work)","borderRadius":0,"lineHeight":1.5} -->
<div class="wp-block-jetpack-field-checkbox-multiple"><!-- wp:jetpack/field-option-checkbox {"label":"Monday  (10AM - 4PM)"} /-->

<!-- wp:jetpack/field-option-checkbox {"label":"Monday  (4PM - 10PM) "} /-->

<!-- /wp:jetpack/field-checkbox-multiple -->

<!-- wp:jetpack/button {"element":"button","text":"Apply Now","lock":{"remove":true}} /--></div>
<!-- /wp:jetpack/contact-form --></div>
<!-- /wp:group -->
```
Create a form with shortcode and values

```
[contact-form]
[contact-field label="Choose" type="checkbox-multiple" options="truth,dare" values="one,two" /]
[/contact-form]
```
Submitting the form shouldn't return any 400 errors. 

