### PR TITLE
Forms: fix fatal when checking for classic forms dashboard

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-missing-get-current-screen
+++ b/projects/packages/forms/changelog/fix-forms-missing-get-current-screen
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+Forms: fix fatal when checking for classic forms dashboard

--- a/projects/packages/forms/src/dashboard/class-dashboard-view-switch.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard-view-switch.php
@@ -321,6 +321,10 @@ CSS
 	 * @return boolean
 	 */
 	public function is_modern_view() {
+		if ( ! function_exists( 'get_current_screen' ) ) {
+			return false;
+		}
+
 		// The menu slug might vary depending on language, but modern view is always a jetpack-forms page.
 		// See: https://a8c.slack.com/archives/C03TY6J1A/p1747148941583849
 		$page_hook_suffix = '_page_jetpack-forms';
@@ -338,6 +342,10 @@ CSS
 	 * @return boolean
 	 */
 	public function is_jetpack_forms_admin_page() {
+		if ( ! function_exists( 'get_current_screen' ) ) {
+			return false;
+		}
+
 		$screen = get_current_screen();
 		return $screen && $screen->id === 'jetpack_page_jetpack-forms-admin';
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Came up in p1756099110645079-slack-CDLH4C1UZ


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fixes issue where in 3rd party plugin screen we check for [`get_current_screen()`](https://developer.wordpress.org/reference/functions/get_current_screen/) without it being initliazied yet, likely due to 3rd party plugin calling something too early.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*