### PR TITLE
Related Posts block: Update Related Posts placeholder information

### DIFF
--- a/projects/plugins/jetpack/changelog/update-related-posts-placeholder-info
+++ b/projects/plugins/jetpack/changelog/update-related-posts-placeholder-info
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Related Posts block: Update placeholder text for the site editor, and update the demo date.

--- a/projects/plugins/jetpack/extensions/blocks/related-posts/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/related-posts/edit.js
@@ -7,9 +7,9 @@ import {
 } from '@wordpress/block-editor';
 import { Path, SVG } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
-import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { LoadingPostsGrid } from '../../shared/components/loading-posts-grid';
+import { getEditorType, SITE_EDITOR } from '../../shared/get-editor-type';
 import metadata from './block.json';
 import { RelatedPostsBlockControls, RelatedPostsInspectorControls } from './controls';
 import { useRelatedPosts } from './hooks/use-related-posts';
@@ -187,7 +187,7 @@ export default function RelatedPostsEdit( { attributes, setAttributes } ) {
 
 	const { posts, isLoading: isLoadingRelatedPosts } = useRelatedPosts( isEnabled );
 
-	const isInSiteEditor = useSelect( select => !! select( 'core/edit-site' ), [] );
+	const isInSiteEditor = SITE_EDITOR === getEditorType();
 
 	const { instanceId } = useInstanceId( RelatedPostsEdit );
 

--- a/projects/plugins/jetpack/extensions/blocks/related-posts/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/related-posts/edit.js
@@ -8,7 +8,6 @@ import {
 import { Path, SVG } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
 import { useSelect } from '@wordpress/data';
-import { store as editorStore } from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
 import { LoadingPostsGrid } from '../../shared/components/loading-posts-grid';
 import metadata from './block.json';
@@ -31,7 +30,10 @@ function PlaceholderPostEdit( props ) {
 		>
 			<strong id={ props.id + '-heading' } className="jp-related-posts-i2__post-link">
 				{ props.isInSiteEditor
-					? __( 'Preview unavailable in site editor.', 'jetpack' )
+					? __(
+							'Preview unavailable in site editor. The post title will appear normally on your site.',
+							'jetpack'
+					  )
 					: __(
 							"Preview unavailable: you haven't published enough posts with similar content.",
 							'jetpack'
@@ -68,7 +70,7 @@ function PlaceholderPostEdit( props ) {
 
 			{ props.displayDate && (
 				<div className="jp-related-posts-i2__post-date has-small-font-size">
-					{ __( 'August 3, 2018', 'jetpack' ) }
+					{ __( 'August 3, 2025', 'jetpack' ) }
 				</div>
 			) }
 			{ props.displayAuthor && (
@@ -185,12 +187,7 @@ export default function RelatedPostsEdit( { attributes, setAttributes } ) {
 
 	const { posts, isLoading: isLoadingRelatedPosts } = useRelatedPosts( isEnabled );
 
-	const { isInSiteEditor } = useSelect( select => {
-		const currentPost = select( editorStore ).getCurrentPost();
-		return {
-			isInSiteEditor: ! currentPost || Object.keys( currentPost ).length === 0,
-		};
-	} );
+	const isInSiteEditor = useSelect( select => !! select( 'core/edit-site' ), [] );
 
 	const { instanceId } = useInstanceId( RelatedPostsEdit );
 

--- a/projects/plugins/jetpack/extensions/blocks/related-posts/test/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/related-posts/test/edit.js
@@ -73,13 +73,19 @@ jest.mock( '@automattic/jetpack-shared-extension-utils', () => ( {
 jest.mock( '../hooks/use-status-toggle' );
 
 jest.mock( '@wordpress/data/build/components/use-select', () => jest.fn() );
-useSelect.mockImplementation( cb => {
-	return cb( () => ( {
-		getCurrentPost: jest.fn().mockReturnValueOnce( currentPost ),
-		isFirstMultiSelectedBlock: jest.fn().mockReturnValueOnce( true ),
-		getMultiSelectedBlockClientIds: () => [],
-	} ) );
-} );
+
+const makeSelect =
+	( { inSiteEditor } = { inSiteEditor: false } ) =>
+	store => {
+		if ( store === 'core/edit-site' ) {
+			return inSiteEditor ? {} : undefined;
+		}
+		return {
+			getCurrentPost: jest.fn().mockReturnValue( currentPost ),
+			isFirstMultiSelectedBlock: jest.fn().mockReturnValue( true ),
+			getMultiSelectedBlockClientIds: () => [],
+		};
+	};
 
 jest.mock( '@wordpress/block-editor', () => ( {
 	...jest.requireActual( '@wordpress/block-editor' ),
@@ -125,6 +131,8 @@ beforeEach( () => {
 		isFetchingStatus: false,
 		isUpdatingStatus: false,
 	} );
+
+	useSelect.mockImplementation( cb => cb( makeSelect( { inSiteEditor: false } ) ) );
 } );
 
 describe( 'RelatedPostsEdit', () => {
@@ -168,6 +176,18 @@ describe( 'RelatedPostsEdit', () => {
 			expect(
 				screen.getByText(
 					"Preview unavailable: you haven't published enough posts with similar content."
+				)
+			).toBeInTheDocument();
+		} );
+		test( 'loads and displays placeholder when there are not enough related posts within Site Editor context', () => {
+			useSelect.mockImplementation( cb => cb( makeSelect( { inSiteEditor: true } ) ) );
+			renderRelatedPosts( { postsToShow: 3 } );
+
+			expect( screen.getByText( 'Test Post One' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Test Post Two' ) ).toBeInTheDocument();
+			expect(
+				screen.getByText(
+					'Preview unavailable in site editor. The post title will appear normally on your site.'
 				)
 			).toBeInTheDocument();
 		} );

--- a/projects/plugins/jetpack/extensions/blocks/related-posts/test/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/related-posts/test/edit.js
@@ -1,6 +1,7 @@
 import { useModuleStatus } from '@automattic/jetpack-shared-extension-utils';
 import { render, screen } from '@testing-library/react';
 import { useSelect } from '@wordpress/data';
+import { getEditorType, SITE_EDITOR } from '../../../shared/get-editor-type';
 import RelatedPostsEdit from '../edit';
 import { useRelatedPostsStatus } from '../hooks/use-status-toggle';
 
@@ -74,18 +75,23 @@ jest.mock( '../hooks/use-status-toggle' );
 
 jest.mock( '@wordpress/data/build/components/use-select', () => jest.fn() );
 
-const makeSelect =
-	( { inSiteEditor } = { inSiteEditor: false } ) =>
-	store => {
-		if ( store === 'core/edit-site' ) {
-			return inSiteEditor ? {} : undefined;
-		}
-		return {
-			getCurrentPost: jest.fn().mockReturnValue( currentPost ),
-			isFirstMultiSelectedBlock: jest.fn().mockReturnValue( true ),
-			getMultiSelectedBlockClientIds: () => [],
-		};
+useSelect.mockImplementation( cb => {
+	return cb( () => ( {
+		getCurrentPost: jest.fn().mockReturnValueOnce( currentPost ),
+		isFirstMultiSelectedBlock: jest.fn().mockReturnValueOnce( true ),
+		getMultiSelectedBlockClientIds: () => [],
+	} ) );
+} );
+
+jest.mock( '../../../shared/get-editor-type', () => {
+	// eslint-disable-next-line no-shadow
+	const SITE_EDITOR = 'site-editor';
+	return {
+		__esModule: true,
+		SITE_EDITOR,
+		getEditorType: jest.fn( () => 'post-editor' ),
 	};
+} );
 
 jest.mock( '@wordpress/block-editor', () => ( {
 	...jest.requireActual( '@wordpress/block-editor' ),
@@ -132,7 +138,7 @@ beforeEach( () => {
 		isUpdatingStatus: false,
 	} );
 
-	useSelect.mockImplementation( cb => cb( makeSelect( { inSiteEditor: false } ) ) );
+	getEditorType.mockReturnValue( 'post-editor' );
 } );
 
 describe( 'RelatedPostsEdit', () => {
@@ -180,7 +186,7 @@ describe( 'RelatedPostsEdit', () => {
 			).toBeInTheDocument();
 		} );
 		test( 'loads and displays placeholder when there are not enough related posts within Site Editor context', () => {
-			useSelect.mockImplementation( cb => cb( makeSelect( { inSiteEditor: true } ) ) );
+			getEditorType.mockReturnValue( SITE_EDITOR );
 			renderRelatedPosts( { postsToShow: 3 } );
 
 			expect( screen.getByText( 'Test Post One' ) ).toBeInTheDocument();


### PR DESCRIPTION
Fixes VULCAN-294

## Proposed changes:

* This PR updates the logic that checks if we're in the site editor when showing the Related Posts block placeholder, making sure we show text relevant for the site editor in that case. It also updates the demo date provided in the placeholder as well (from 2018 to 2025).
* This PR also updates test to consider (and test) the new functionality.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

See Linear link above.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

To test the new text, on a self hosted site using Jetpack, apply this PR if testing locally, or using the Jetpack Beta tester plugin. Also applicable for WoA. On Simple, apply the PR by using the command in the generated comment below, for a sandboxed Simple site.

* On your test site, add a block theme such as Twenty Twenty Five. Open up the site editor and a template such as the index template, which would ordinarily use the query loop to show posts.
* Add a Related Posts block. The text in the placeholder should be as shown below.
* If you have a limited number of posts on your test site, add a Related Posts block within a post to confirm that the placeholder mentions that 'you haven't published enough posts with similar content'.

<img width="1237" height="172" alt="Screenshot 2025-08-25 at 11 12 40" src="https://github.com/user-attachments/assets/af1f1965-1d54-4c5c-b703-357c36259bc2" />

