### PR TITLE
Boost: Backport 4.3.1 changes

### DIFF
--- a/projects/plugins/boost/CHANGELOG.md
+++ b/projects/plugins/boost/CHANGELOG.md
@@ -5,11 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [4.3.1-beta] - 2025-08-21
+## [4.3.1] - 2025-08-25
 ### Changed
-- Cornerstone Pages: Update "Load default pages" to be called "Include default pages" and change the behavior to reflect the name. [#44845]
 - Cornerstone Pages: Add tooltips to "Include default pages" button to better explain behavior. [#44845]
 - Cornerstone Pages: Improve behavior when running on WordPress MU installations. [#44824]
+- Cornerstone Pages: Update "Load default pages" to be called "Include default pages" and change the behavior to reflect the name. [#44845]
 - My Jetpack: Fixed multisite availability check for restricted products and modules. [#44710]
 - Update package dependencies. [#44677] [#44701] [#44725]
 
@@ -804,7 +804,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - First public alpha release
 
-[4.3.1-beta]: https://github.com/Automattic/jetpack-boost-production/compare/4.3.0...4.3.1-beta
+[4.3.1]: https://github.com/Automattic/jetpack-boost-production/compare/4.3.0...4.3.1
 [4.3.0]: https://github.com/Automattic/jetpack-boost-production/compare/4.2.1...4.3.0
 [4.2.1]: https://github.com/Automattic/jetpack-boost-production/compare/4.2.0...4.2.1
 [4.2.0]: https://github.com/Automattic/jetpack-boost-production/compare/4.1.2...4.2.0

--- a/projects/plugins/boost/changelog/update-boost-backport-4.3.1-changes
+++ b/projects/plugins/boost/changelog/update-boost-backport-4.3.1-changes
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Backport 4.3.1 release changes.
+
+

--- a/projects/plugins/boost/changelog/update-boost-changelog-readme
+++ b/projects/plugins/boost/changelog/update-boost-changelog-readme
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Clean up readme/changelog since entries are not user facing.
-
-

--- a/projects/plugins/boost/composer.json
+++ b/projects/plugins/boost/composer.json
@@ -3,7 +3,7 @@
 	"description": "Boost your WordPress site's performance, from the creators of Jetpack",
 	"type": "library",
 	"license": "GPL-2.0-or-later",
-	"version": "4.3.1-beta",
+	"version": "4.3.1",
 	"authors": [
 		{
 			"name": "Automattic, Inc.",
@@ -77,7 +77,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "b1e77e6231d50e7663f84529b6a3dfda_jetpack_boostⓥ4_3_1_beta",
+		"autoloader-suffix": "b1e77e6231d50e7663f84529b6a3dfda_jetpack_boostⓥ4_3_1",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4354d189d22bc58a61a2c4e39dfea8b8",
+    "content-hash": "9102e2872ace982f6473281700baed79",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",

--- a/projects/plugins/boost/jetpack-boost.php
+++ b/projects/plugins/boost/jetpack-boost.php
@@ -9,7 +9,7 @@
  * Plugin Name:       Jetpack Boost
  * Plugin URI:        https://jetpack.com/boost
  * Description:       Boost your WordPress site's performance, from the creators of Jetpack
- * Version: 4.3.1-beta
+ * Version: 4.3.1
  * Author:            Automattic - Jetpack Site Speed team
  * Author URI:        https://jetpack.com/boost/
  * License:           GPL-2.0+
@@ -29,7 +29,7 @@ if ( ! defined( 'WPINC' ) ) {
 	die( 0 );
 }
 
-define( 'JETPACK_BOOST_VERSION', '4.3.1-beta' );
+define( 'JETPACK_BOOST_VERSION', '4.3.1' );
 define( 'JETPACK_BOOST_SLUG', 'jetpack-boost' );
 
 if ( ! defined( 'JETPACK_BOOST_CLIENT_NAME' ) ) {

--- a/projects/plugins/boost/readme.txt
+++ b/projects/plugins/boost/readme.txt
@@ -183,11 +183,11 @@ If you run into compatibility issues, please do let us know. You can drop us a l
 2. Jetpack Boost Speed Improvement
 
 == Changelog ==
-### 4.3.1-beta - 2025-08-21
+### 4.3.1 - 2025-08-25
 #### Changed
-- Cornerstone Pages: Update "Load default pages" to be called "Include default pages" and change the behavior to reflect the name.
 - Cornerstone Pages: Add tooltips to "Include default pages" button to better explain behavior.
 - Cornerstone Pages: Improve behavior when running on WordPress MU installations.
+- Cornerstone Pages: Update "Load default pages" to be called "Include default pages" and change the behavior to reflect the name.
 - My Jetpack: Fixed multisite availability check for restricted products and modules.
 - Update package dependencies.
 

--- a/projects/plugins/boost/readme.txt
+++ b/projects/plugins/boost/readme.txt
@@ -5,7 +5,7 @@ Tags: performance, speed, web vitals, critical css, cache
 Requires at least: 6.7
 Tested up to: 6.8
 Requires PHP: 7.2
-Stable tag: 4.3.0
+Stable tag: 4.3.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
Fixes HOG-305

## Proposed changes:

* Backport changelog/readme changes from 4.3.1 release;
* Update stable tag in readme to 4.3.1.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

HOG-305

## Does this pull request change what data or activity we track or use?

n/a

## Testing instructions:

- Proof read changes and make sure they make sense.