### PR TITLE
Forms: Fix error wrapper inline error

### DIFF
--- a/projects/packages/forms/changelog/fix-form-error-wrapper-inline-error
+++ b/projects/packages/forms/changelog/fix-form-error-wrapper-inline-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: improve the showing of the error div to display correctly across themes. 

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -1118,7 +1118,7 @@ on production builds, the attributes are being reordered, causing side-effects
 }
 
 .contact-form__error.show-errors {
-	display: inline;
+	display: inline-block;
 	min-width: 100%;
 	box-sizing: inherit;
 }

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -1121,6 +1121,7 @@ on production builds, the attributes are being reordered, causing side-effects
 	display: inline-block;
 	min-width: 100%;
 	box-sizing: inherit;
+	margin-block-end: 0.5em;
 }
 
 .contact-form__error ul {

--- a/projects/plugins/jetpack/changelog/fix-form-error-wrapper-inline-error
+++ b/projects/plugins/jetpack/changelog/fix-form-error-wrapper-inline-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: error wrapper, make it possible to place the button inside a group block


### PR DESCRIPTION
Fixes [FORMS-273](https://linear.app/a8c/issue/FORMS-273/error-message-not-displaying-correctly-in-form-block)

When placing a button block inside a group block or when using the default block the error message is not displaying as expected. 

Before:
<img width="2382" height="1252" alt="Screenshot 2025-08-25 at 5 44 59 AM" src="https://github.com/user-attachments/assets/24587247-8208-4cba-a6d0-4499b945afb8" />

After:
<img width="1164" height="1234" alt="Screenshot 2025-08-25 at 5 38 43 AM" src="https://github.com/user-attachments/assets/cbe542fa-07f3-4db7-b313-c973071dcc67" />

## Proposed changes:
* Add an inline-block for width and height control and margin at the bottom for spacing. 

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1755832203584319-slack-C03TY6J1A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Add a form block. ( without selecting a type )
Click the submit botton. Notice that the error looks like you would expect.