### PR TITLE
e2e tests: remove REST API check from environment readiness suite

### DIFF
--- a/tools/e2e-commons/setup-specs/env-check.setup.ts
+++ b/tools/e2e-commons/setup-specs/env-check.setup.ts
@@ -30,7 +30,7 @@ async function retry(
 	await setup.step( successMsg, async () => {} );
 }
 
-setup( 'verify environment readiness', async ( { baseURL, request, testUtils } ) => {
+setup( 'verify environment readiness', async ( { baseURL, request } ) => {
 	// Skip connectivity checks for localhost URLs
 	if ( baseURL.includes( 'localhost' ) || baseURL.includes( '127.0.0.1' ) ) {
 		await setup.step( 'skip - localhost environment', async () => {

--- a/tools/e2e-commons/setup-specs/env-check.setup.ts
+++ b/tools/e2e-commons/setup-specs/env-check.setup.ts
@@ -45,7 +45,6 @@ setup( 'verify environment readiness', async ( { baseURL, request, testUtils } )
 
 		await retry( 'DNS resolution', async () => {
 			await dns.resolve4( hostname );
-			logger.debug( `DNS resolved` );
 		} );
 	} );
 
@@ -54,17 +53,7 @@ setup( 'verify environment readiness', async ( { baseURL, request, testUtils } )
 
 		await retry( 'HTTP connectivity', async () => {
 			const response = await request.get( baseURL );
-			logger.debug( `HTTP response status: ${ response.status() }` );
-			expect( response.status() ).toBe( 200 );
-		} );
-	} );
-
-	await setup.step( 'verify REST API', async ( {} ) => {
-		logger.debug( `Checking REST API for ${ baseURL }` );
-
-		await retry( 'REST API', async () => {
-			const r = await testUtils.requestUtils.rest( { path: '/jetpack/v4/connection/test' } );
-			logger.debug( `Response: ${ JSON.stringify( r ) }` );
+			expect( response.status(), `Unexpected HTTP status` ).toBe( 200 );
 		} );
 	} );
 } );


### PR DESCRIPTION

## Proposed changes:

Remove the 'verify REST API' step from the environment readiness check. It's redundant, the previous HTTP check should be enough to validate the environment being ready.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
* e2e tests should pass in CI

