### PR TITLE
Tiled gallery block: Add email rendering

### DIFF
--- a/projects/plugins/jetpack/changelog/add-tiled-gallery-email-rendering
+++ b/projects/plugins/jetpack/changelog/add-tiled-gallery-email-rendering
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Tiled gallery block: add email rendering.

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/tiled-gallery.php
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/tiled-gallery.php
@@ -705,62 +705,70 @@ class Tiled_Gallery {
 	 * @return string HTML content.
 	 */
 	private static function build_mosaic_layout_content( $images, $cell_padding, $border_radius = 0, $attr = array() ) {
-		$content_parts       = array();
 		$border_radius_style = self::generate_border_radius_style( '', $border_radius );
 
 		// Generate mosaic layout rows
 		$rows = self::generate_mosaic_rows( $images );
 
+		// Determine the maximum number of columns to ensure consistent layout
+		$max_columns = 0;
 		foreach ( $rows as $row ) {
-			$images_in_row      = count( $row );
+			$max_columns = max( $max_columns, count( $row ) );
+		}
+
+		// Build each row as a separate table to match flexbox behavior
+		$content_parts = array();
+		foreach ( $rows as $row ) {
+			$images_in_row = count( $row );
+
+			// Calculate width for each cell in this row (like flexbox)
 			$cell_width_percent = ( 100 / $images_in_row );
 
 			// Build table cells for this row
 			$row_cells = '';
 			foreach ( $row as $image_index => $image ) {
-				// Calculate cell attributes
-				$cell_attrs = array(
-					'style' => sprintf(
-						'width: %s%%; padding: %dpx; vertical-align: top; text-align: center;',
-						$cell_width_percent,
-						$cell_padding
-					),
+				$cell_style = sprintf(
+					'width: %s%%; padding: %dpx; vertical-align: top; text-align: center;',
+					$cell_width_percent,
+					$cell_padding
 				);
 
-				// Add right padding to all but last cell
+				// Add right padding to all but last cell in the actual row
 				if ( $image_index < $images_in_row - 1 ) {
-					$cell_attrs['style'] .= 'padding-right: ' . ( $cell_padding * 2 ) . 'px;';
+					$cell_style .= 'padding-right: ' . ( $cell_padding * 2 ) . 'px;';
 				}
 
-				$image_styles = 'margin: 0; width: 100%; max-width: 100%; height: auto; display: block;';
+				// Set consistent height for all images in this row to ensure alignment
+				// Use progressive enhancement: object-fit for supported clients, natural layout for others
+				$image_styles = 'margin: 0; width: 100%; max-width: 100%; height: 200px; display: block; object-fit: cover; object-position: center;';
 
 				$cell_content = self::generate_image_html( $image, $image_styles, $border_radius_style, $attr );
 
-				$row_cells .= \Automattic\WooCommerce\EmailEditor\Integrations\Utils\Table_Wrapper_Helper::render_table_cell(
-					$cell_content,
-					$cell_attrs
+				$row_cells .= sprintf(
+					'<td style="%s">%s</td>',
+					esc_attr( $cell_style ),
+					$cell_content
 				);
 			}
 
-			// Use Table_Wrapper_Helper for email-compatible table rendering
-			$table_attrs = array(
-				'style' => 'width: 100%; border-collapse: collapse;',
+			// Create a separate table for each row with flexible height for alignment
+			$row_table = sprintf(
+				'<table role="presentation" style="width: 100%%; border-collapse: collapse; margin-bottom: %dpx; table-layout: fixed;"><tr>%s</tr></table>',
+				$cell_padding,
+				$row_cells
 			);
 
-			$content_parts[] = \Automattic\WooCommerce\EmailEditor\Integrations\Utils\Table_Wrapper_Helper::render_table_wrapper(
-				$row_cells,
-				$table_attrs
-			);
+			$content_parts[] = $row_table;
 		}
 
-		// Use Table_Wrapper_Helper for consistent email rendering
-		$wrapper_attrs = array(
+		// Use Table_Wrapper_Helper for the main container
+		$table_attrs = array(
 			'style' => 'width: 100%; border-collapse: collapse;',
 		);
 
 		return \Automattic\WooCommerce\EmailEditor\Integrations\Utils\Table_Wrapper_Helper::render_table_wrapper(
 			implode( '', $content_parts ),
-			$wrapper_attrs
+			$table_attrs
 		);
 	}
 

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/tiled-gallery.php
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/tiled-gallery.php
@@ -555,8 +555,7 @@ class Tiled_Gallery {
 				}
 			}
 
-			$content_parts[] = '</div>'; // Close clear:both container
-			$content_parts[] = '</div>'; // Close column
+			$content_parts[] = '</div></div>'; // Close clear:both container and column container
 		}
 
 		$content_parts[] = '</div>'; // Close main flex container
@@ -634,7 +633,7 @@ class Tiled_Gallery {
 				9 => array( 3, 3, 3 ),   // 9 images: 3 + 3 + 3
 			);
 
-			$pattern     = isset( $patterns[ $image_count ] ) ? $patterns[ $image_count ] : array( 3, 3, 3 );
+			$pattern     = $patterns[ $image_count ] ?? array( 3, 3, 3 );
 			$image_index = 0;
 
 			foreach ( $pattern as $images_in_row ) {

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/tiled-gallery.php
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/tiled-gallery.php
@@ -554,8 +554,8 @@ class Tiled_Gallery {
 
 			// Build table cells for this row
 			$row_cells = '';
-			foreach ( $row_images as $image_index => $image ) {
-				// Calculate cell attributes
+			foreach ( $row_images as $image ) {
+				// Calculate cell attributes with consistent padding
 				$cell_attrs = array(
 					'style' => sprintf(
 						'width: %s%%; padding: %dpx; vertical-align: top; text-align: center;',
@@ -563,11 +563,6 @@ class Tiled_Gallery {
 						$cell_padding
 					),
 				);
-
-				// Add right padding to all but last cell
-				if ( $image_index < $images_in_row - 1 ) {
-					$cell_attrs['style'] .= 'padding-right: ' . ( $cell_padding * 2 ) . 'px;';
-				}
 
 				$image_styles = 'margin: 0; width: 100%; max-width: 100%; height: auto; display: block;';
 

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/tiled-gallery.php
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/tiled-gallery.php
@@ -374,12 +374,13 @@ class Tiled_Gallery {
 	 * Get layout style and columns from block attributes.
 	 *
 	 * @param array $attr Block attributes.
-	 * @return array Array with 'style' and 'columns' keys.
+	 * @return array Array with 'style', 'columns', and 'border_radius' keys.
 	 */
 	private static function get_layout_style_from_attributes( $attr ) {
 		$layout_info = array(
-			'style'   => 'rectangular', // Default to rectangular/mosaic layout
-			'columns' => 3, // Default to 3 columns
+			'style'         => 'rectangular', // Default to rectangular/mosaic layout
+			'columns'       => 3, // Default to 3 columns
+			'border_radius' => 0, // Default to no border radius
 		);
 
 		// Get number of columns from attributes
@@ -387,7 +388,14 @@ class Tiled_Gallery {
 			$layout_info['columns'] = absint( $attr['columns'] );
 		}
 
-		// Get layout style from className
+		// Get border radius from roundedCorners attribute (preferred method)
+		if ( ! empty( $attr['roundedCorners'] ) && is_numeric( $attr['roundedCorners'] ) ) {
+			$border_radius_value = absint( $attr['roundedCorners'] );
+			// Clamp value between 0 and 20
+			$layout_info['border_radius'] = max( 0, min( 20, $border_radius_value ) );
+		}
+
+		// Get layout style and border radius from className
 		if ( ! empty( $attr['className'] ) ) {
 			if ( str_contains( $attr['className'], 'is-style-square' ) ) {
 				$layout_info['style'] = 'square';
@@ -395,6 +403,13 @@ class Tiled_Gallery {
 				$layout_info['style'] = 'circle';
 			} elseif ( str_contains( $attr['className'], 'is-style-columns' ) ) {
 				$layout_info['style'] = 'columns';
+			}
+
+			// Extract border radius from has-rounded-corners-{value} class (fallback method)
+			if ( $layout_info['border_radius'] === 0 && preg_match( '/has-rounded-corners-(\d+)/', $attr['className'], $matches ) ) {
+				$border_radius_value = absint( $matches[1] );
+				// Clamp value between 0 and 20
+				$layout_info['border_radius'] = max( 0, min( 20, $border_radius_value ) );
 			}
 		}
 
@@ -411,19 +426,20 @@ class Tiled_Gallery {
 	 * @return string HTML content.
 	 */
 	private static function build_email_layout_content( $images, $layout_info, $target_width, $cell_padding ) {
-		$layout_style = $layout_info['style'];
-		$columns      = $layout_info['columns'];
+		$layout_style  = $layout_info['style'];
+		$columns       = $layout_info['columns'];
+		$border_radius = $layout_info['border_radius'];
 
 		switch ( $layout_style ) {
 			case 'square':
-				return self::build_square_layout_content( $images, $target_width, $cell_padding, $columns, 'square' );
+				return self::build_square_layout_content( $images, $target_width, $cell_padding, $columns, 'square', $border_radius );
 			case 'circle':
-				return self::build_square_layout_content( $images, $target_width, $cell_padding, $columns, 'circle' );
+				return self::build_square_layout_content( $images, $target_width, $cell_padding, $columns, 'circle', $border_radius );
 			case 'columns':
-				return self::build_columns_layout_content( $images, $target_width, $cell_padding, $columns );
+				return self::build_columns_layout_content( $images, $target_width, $cell_padding, $columns, $border_radius );
 			case 'rectangular':
 			default:
-				return self::build_mosaic_layout_content( $images, $target_width, $cell_padding );
+				return self::build_mosaic_layout_content( $images, $target_width, $cell_padding, $border_radius );
 		}
 	}
 
@@ -435,9 +451,10 @@ class Tiled_Gallery {
 	 * @param int    $cell_padding Cell padding.
 	 * @param int    $columns Number of columns for the layout.
 	 * @param string $style Layout style (square or circle).
+	 * @param int    $border_radius Border radius value (0-20).
 	 * @return string HTML content.
 	 */
-	private static function build_square_layout_content( $images, $target_width, $cell_padding, $columns, $style = 'square' ) {
+	private static function build_square_layout_content( $images, $target_width, $cell_padding, $columns, $style = 'square', $border_radius = 0 ) {
 
 		$grid_content  = '<div style="margin-bottom:24px;clear:both;text-align:center;margin:0 auto;padding:4px;background-color:white">';
 		$grid_content .= '<div style="margin-bottom:24px">';
@@ -470,8 +487,13 @@ class Tiled_Gallery {
 				// Add margin-right to all but last image in row
 				$margin_right = ( $image_index < count( $row_images ) - 1 ) ? 'margin-right:' . $cell_padding . 'px;' : '';
 
-				// Add border-radius for circle style
-				$border_radius = ( $style === 'circle' ) ? 'border-radius:50%' : '';
+				// Add border-radius for circle style or rounded corners
+				$border_radius_style = '';
+				if ( $style === 'circle' ) {
+					$border_radius_style = 'border-radius:50%';
+				} elseif ( $border_radius > 0 ) {
+					$border_radius_style = 'border-radius:' . $border_radius . 'px';
+				}
 
 				// Use simple structure - images are pre-cropped to squares for square/circle styles
 				$grid_content .= '<div style="margin-bottom:24px;display:flex;margin:0;' . $width_style . ';' . $margin_right . '">';
@@ -484,7 +506,7 @@ class Tiled_Gallery {
 						'<img alt="%s" src="%s" style="border:none;margin-bottom:24px;background-color:#0000001a;display:block;height:auto;margin:0 auto;max-width:100%%;object-fit:cover;object-position:center;padding:0;width:auto;%s" />',
 						esc_attr( $image['alt'] ),
 						esc_url( $image['url'] ),
-						$border_radius
+						$border_radius_style
 					);
 				} else {
 					// Multiple images - fill container width
@@ -492,7 +514,7 @@ class Tiled_Gallery {
 						'<img alt="%s" src="%s" style="border:none;margin-bottom:24px;background-color:#0000001a;display:block;height:auto;margin:0;max-width:100%%;object-fit:cover;object-position:center;padding:0;width:100%%;%s" />',
 						esc_attr( $image['alt'] ),
 						esc_url( $image['url'] ),
-						$border_radius
+						$border_radius_style
 					);
 				}
 
@@ -509,53 +531,83 @@ class Tiled_Gallery {
 	}
 
 	/**
-	 * Build columns layout content.
+	 * Build columns layout content using mosaic logic organized into columns.
 	 *
 	 * @param array $images Array of image data.
 	 * @param int   $target_width Target width for email.
 	 * @param int   $cell_padding Cell padding.
 	 * @param int   $columns Number of columns for the layout.
+	 * @param int   $border_radius Border radius value (0-20).
 	 * @return string HTML content.
 	 */
-	private static function build_columns_layout_content( $images, $target_width, $cell_padding, $columns ) {
+	private static function build_columns_layout_content( $images, $target_width, $cell_padding, $columns, $border_radius = 0 ) {
 
 		$grid_content  = '<div style="margin-bottom:24px;clear:both;text-align:center;margin:0 auto;padding:4px;background-color:white">';
 		$grid_content .= '<div style="margin-bottom:24px">';
 		$grid_content .= '<div style="margin-bottom:24px;padding:0;width:100%;display:block">';
 
-		// Create rows of images
-		$image_chunks = array_chunk( $images, $columns );
+		// Use simple div approach with display:flex for horizontal layout
+		$grid_content .= '<div style="margin-bottom:24px;display:flex;margin:0;width:100%">';
 
-		foreach ( $image_chunks as $index => $row_images ) {
-			$margin_bottom = ( $index < count( $image_chunks ) - 1 ) ? $cell_padding : '0';
-			$grid_content .= '<div style="margin-bottom:' . $margin_bottom . 'px;display:flex;margin:0;width:100%;max-width:100%;box-sizing:border-box">';
-
-			foreach ( $row_images as $image_index => $image ) {
-				$margin_right = ( $image_index < count( $row_images ) - 1 ) ? $cell_padding : '0';
-
-				// Calculate explicit width to ensure proper layout in email clients
-				$images_in_row       = count( $row_images );
-				$total_margin_width  = ( $images_in_row - 1 ) * $cell_padding;
-				$image_width_percent = ( 100 / $images_in_row );
-				$width_style         = 'width:calc(' . $image_width_percent . '% - ' . ( $total_margin_width / $images_in_row ) . 'px);';
-
-				$grid_content .= '<div style="margin:0;margin-right:' . $margin_right . 'px;' . $width_style . 'display:flex;min-width:0;box-sizing:border-box">';
-				$grid_content .= '<figure style="margin:0;overflow:hidden;padding:0;display:flex;width:100%;box-sizing:border-box">';
-
-				// Build individual image content
-				$grid_content .= sprintf(
-					'<img src="%s" alt="%s" style="border:none;background-color:#0000001a;display:block;height:auto;margin:0;max-width:100%%;object-fit:cover;object-position:center;padding:0;width:100%%;box-sizing:border-box" />',
-					esc_url( $image['url'] ),
-					esc_attr( $image['alt'] )
-				);
-
-				$grid_content .= '</figure>';
-				$grid_content .= '</div>';
-			}
-
-			$grid_content .= '</div>';
+		// Distribute images across columns using round-robin approach for better balance
+		$column_arrays = array_fill( 0, $columns, array() );
+		foreach ( $images as $index => $image ) {
+			$column_index                     = $index % $columns;
+			$column_arrays[ $column_index ][] = $image;
 		}
 
+		// Prepare border radius style
+		$border_radius_style = $border_radius > 0 ? 'border-radius:' . $border_radius . 'px;' : '';
+
+		foreach ( $column_arrays as $col_index => $column_images ) {
+			if ( empty( $column_images ) ) {
+				continue;
+			}
+
+			// Add margin-right to all columns except the last
+			$column_margin = ( $col_index < $columns - 1 ) ? 'margin-right:' . $cell_padding . 'px;' : '';
+
+			// Create column container using display:flex for the outer horizontal layout
+			$grid_content .= '<div style="margin-bottom:24px;display:flex;margin:0;' . $column_margin . '">';
+			$grid_content .= '<div style="margin-bottom:24px;clear:both">';
+
+			// Generate mosaic-style groupings within this column
+			$column_rows = self::generate_column_mosaic_rows( $column_images );
+
+			foreach ( $column_rows as $row_index => $row_images ) {
+				// Add margin-top for spacing between images in the column (except first)
+				$margin_top_style = ( $row_index > 0 ) ? 'margin-top:' . $cell_padding . 'px;' : '';
+
+				if ( count( $row_images ) === 1 ) {
+					// Single image - use clear:both for vertical stacking
+					$grid_content .= '<figure style="margin:0;overflow:hidden;padding:0;display:flex;' . $margin_top_style . '">';
+					$grid_content .= sprintf(
+						'<img src="%s" alt="%s" style="border:none;margin-bottom:24px;background-color:#0000001a;display:block;height:auto;margin:0;max-width:100%%;object-fit:cover;object-position:center;padding:0;width:100%%;%s" />',
+						esc_url( $row_images[0]['url'] ),
+						esc_attr( $row_images[0]['alt'] ),
+						$border_radius_style
+					);
+					$grid_content .= '</figure>';
+				} else {
+					// Multiple images in a horizontal row - not typical for columns layout but handle it
+					foreach ( $row_images as $image ) {
+						$grid_content .= '<figure style="margin:0;overflow:hidden;padding:0;display:flex;' . $margin_top_style . '">';
+						$grid_content .= sprintf(
+							'<img src="%s" alt="%s" style="border:none;margin-bottom:24px;background-color:#0000001a;display:block;height:auto;margin:0;max-width:100%%;object-fit:cover;object-position:center;padding:0;width:100%%;%s" />',
+							esc_url( $image['url'] ),
+							esc_attr( $image['alt'] ),
+							$border_radius_style
+						);
+						$grid_content .= '</figure>';
+					}
+				}
+			}
+
+			$grid_content .= '</div>'; // Close clear:both container
+			$grid_content .= '</div>'; // Close column
+		}
+
+		$grid_content .= '</div>'; // Close main flex container
 		$grid_content .= '</div>';
 		$grid_content .= '</div>';
 		$grid_content .= '</div>';
@@ -569,12 +621,16 @@ class Tiled_Gallery {
 	 * @param array $images Array of image data.
 	 * @param int   $target_width Target width for email.
 	 * @param int   $cell_padding Cell padding.
+	 * @param int   $border_radius Border radius value (0-20).
 	 * @return string HTML content.
 	 */
-	private static function build_mosaic_layout_content( $images, $target_width, $cell_padding ) {
+	private static function build_mosaic_layout_content( $images, $target_width, $cell_padding, $border_radius = 0 ) {
 		$grid_content  = '<div style="margin-bottom:24px;clear:both;text-align:center;margin:0 auto;padding:4px;background-color:white">';
 		$grid_content .= '<div style="margin-bottom:24px">';
 		$grid_content .= '<div style="margin-bottom:24px;padding:0;width:100%;display:block">';
+
+		// Prepare border radius style
+		$border_radius_style = $border_radius > 0 ? 'border-radius:' . $border_radius . 'px;' : '';
 
 		// Generate mosaic layout rows
 		$rows = self::generate_mosaic_rows( $images, $target_width, $cell_padding );
@@ -601,9 +657,10 @@ class Tiled_Gallery {
 
 				// Build individual image content
 				$grid_content .= sprintf(
-					'<img alt="%s" src="%s" style="border:none;background-color:#0000001a;display:block;height:auto;margin:0;max-width:100%%;object-fit:cover;object-position:center;padding:0;width:100%%;box-sizing:border-box" />',
+					'<img alt="%s" src="%s" style="border:none;background-color:#0000001a;display:block;height:auto;margin:0;max-width:100%%;object-fit:cover;object-position:center;padding:0;width:100%%;box-sizing:border-box;%s" />',
 					esc_attr( $image['alt'] ),
-					esc_url( $image['url'] )
+					esc_url( $image['url'] ),
+					$border_radius_style
 				);
 
 				$grid_content .= '</figure>';
@@ -665,6 +722,58 @@ class Tiled_Gallery {
 				$remaining = array_slice( $images, $image_index );
 				if ( ! empty( $remaining ) ) {
 					$rows[] = $remaining;
+				}
+			}
+		}
+
+		return $rows;
+	}
+
+	/**
+	 * Generate mosaic-style rows within a single column for columns layout.
+	 *
+	 * @param array $images Array of image data for this column.
+	 * @return array Array of rows, each containing 1-2 images for variety.
+	 */
+	private static function generate_column_mosaic_rows( $images ) {
+		$rows        = array();
+		$image_count = count( $images );
+
+		if ( $image_count <= 2 ) {
+			// For 2 or fewer images, each gets its own row
+			foreach ( $images as $image ) {
+				$rows[] = array( $image );
+			}
+		} else {
+			// Create varied patterns: mix of single and paired images
+			$image_index = 0;
+
+			while ( $image_index < $image_count ) {
+				$remaining = $image_count - $image_index;
+
+				if ( $remaining === 1 ) {
+					// Last image - single row
+					$rows[] = array( $images[ $image_index ] );
+					++$image_index;
+				} elseif ( $remaining === 3 ) {
+					// 3 remaining - do 1 + 2 for better balance
+					$rows[] = array( $images[ $image_index ] );
+					++$image_index;
+					$rows[]       = array( $images[ $image_index ], $images[ $image_index + 1 ] );
+					$image_index += 2;
+				} else {
+					// 2 or more remaining - alternate between single and pairs
+					$use_pair = ( count( $rows ) % 2 === 1 ); // Alternate pattern
+
+					if ( $use_pair && $remaining >= 2 ) {
+						// Create a pair
+						$rows[]       = array( $images[ $image_index ], $images[ $image_index + 1 ] );
+						$image_index += 2;
+					} else {
+						// Single image
+						$rows[] = array( $images[ $image_index ] );
+						++$image_index;
+					}
 				}
 			}
 		}

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/tiled-gallery.php
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/tiled-gallery.php
@@ -235,7 +235,7 @@ class Tiled_Gallery {
 
 		// Email rendering configuration
 		$email_common_margin = 16; // Common margin/padding value used multiple times
-		$email_cell_padding  = 4; // Cell padding used in multiple places
+		$email_cell_padding  = 4;  // Cell padding used in multiple places
 
 		$attr = $parsed_block['attrs'];
 
@@ -300,19 +300,21 @@ class Tiled_Gallery {
 	private static function process_tiled_gallery_images_for_email( $attr ) {
 		$images = array();
 
+		// Determine if this is a squareish layout once
+		$layout_info  = self::get_layout_style_from_attributes( $attr );
+		$is_squareish = self::is_squareish_layout_style( $layout_info['style'] );
+
 		// Get images from IDs (primary data source)
 		if ( ! empty( $attr['ids'] ) && is_array( $attr['ids'] ) ) {
 			foreach ( $attr['ids'] as $id ) {
-				// Validate ID is a positive integer
+				// Validate ID is a positive integer and attachment exists
 				$id = absint( $id );
-				if ( ! $id ) {
+				if ( ! $id || ! wp_attachment_is_image( $id ) ) {
 					continue;
 				}
 
 				// For square/circle layouts, get a high-quality square crop
-				if ( isset( $attr['className'] ) &&
-					( str_contains( $attr['className'], 'is-style-square' ) ||
-						str_contains( $attr['className'], 'is-style-circle' ) ) ) {
+				if ( $is_squareish ) {
 					// Start with full size image for better quality when resizing
 					$image_url = wp_get_attachment_image_url( $id, 'full' );
 
@@ -320,7 +322,7 @@ class Tiled_Gallery {
 					if ( function_exists( 'jetpack_photon_url' ) && $image_url ) {
 						$image_url = add_query_arg(
 							array(
-								'resize' => '1300,1300',
+								'resize' => '1300,1300', // High-quality square crop for email
 								'crop'   => '1',
 							),
 							$image_url
@@ -383,9 +385,11 @@ class Tiled_Gallery {
 			'border_radius' => 0, // Default to no border radius
 		);
 
-		// Get number of columns from attributes
+		// Get number of columns from attributes with validation
 		if ( ! empty( $attr['columns'] ) && is_numeric( $attr['columns'] ) ) {
-			$layout_info['columns'] = absint( $attr['columns'] );
+			$columns = absint( $attr['columns'] );
+			// Clamp columns between 1 and 6 for reasonable layouts
+			$layout_info['columns'] = max( 1, min( 6, $columns ) );
 		}
 
 		// Get border radius from roundedCorners attribute (preferred method)
@@ -408,7 +412,7 @@ class Tiled_Gallery {
 			// Extract border radius from has-rounded-corners-{value} class (fallback method)
 			if ( $layout_info['border_radius'] === 0 && preg_match( '/has-rounded-corners-(\d+)/', $attr['className'], $matches ) ) {
 				$border_radius_value = absint( $matches[1] );
-				// Clamp value between 0 and 20
+					// Clamp value between 0 and 20
 				$layout_info['border_radius'] = max( 0, min( 20, $border_radius_value ) );
 			}
 		}
@@ -455,21 +459,18 @@ class Tiled_Gallery {
 	 * @return string HTML content.
 	 */
 	private static function build_square_layout_content( $images, $target_width, $cell_padding, $columns, $style = 'square', $border_radius = 0 ) {
-
-		$grid_content  = '<div style="margin-bottom:24px;clear:both;text-align:center;margin:0 auto;padding:4px;background-color:white">';
-		$grid_content .= '<div style="margin-bottom:24px">';
-		$grid_content .= '<div style="margin-bottom:24px;padding:0;width:100%;display:block">';
+		$content_parts = array();
 
 		// Create rows of images with special handling for square/circle layouts
-		if ( $style === 'square' || $style === 'circle' ) {
-			$image_chunks = self::create_hierarchical_chunks( $images, $columns );
-		} else {
-			$image_chunks = array_chunk( $images, $columns );
-		}
+		$image_chunks = self::is_squareish_layout_style( $style )
+			? self::create_hierarchical_chunks( $images, $columns )
+			: array_chunk( $images, $columns );
+
+		$border_radius_style = self::generate_border_radius_style( $style, $border_radius );
 
 		foreach ( $image_chunks as $row_images ) {
-			// Create row container (like the working HTML)
-			$grid_content .= '<div style="margin-bottom:' . $cell_padding . 'px;display:flex;width:100%">';
+			// Create row container
+			$content_parts[] = '<div style="margin-bottom:' . $cell_padding . 'px;display:flex;width:100%">';
 
 			foreach ( $row_images as $image_index => $image ) {
 				// Calculate explicit width to ensure proper layout in email clients
@@ -477,57 +478,30 @@ class Tiled_Gallery {
 
 				if ( $images_in_row === 1 ) {
 					// Single image takes full width
-					$width_style = 'width:100%';
+					$width_style  = 'width:100%';
+					$image_styles = 'margin-bottom:24px;margin:0 auto;width:auto;';
 				} else {
 					$total_margin_width  = ( $images_in_row - 1 ) * $cell_padding;
 					$image_width_percent = ( 100 / $images_in_row );
 					$width_style         = 'width:calc(' . $image_width_percent . '% - ' . ( $total_margin_width / $images_in_row ) . 'px)';
+					$image_styles        = 'margin-bottom:24px;margin:0;width:100%;';
 				}
 
 				// Add margin-right to all but last image in row
 				$margin_right = ( $image_index < count( $row_images ) - 1 ) ? 'margin-right:' . $cell_padding . 'px;' : '';
 
-				// Add border-radius for circle style or rounded corners
-				$border_radius_style = '';
-				if ( $style === 'circle' ) {
-					$border_radius_style = 'border-radius:50%';
-				} elseif ( $border_radius > 0 ) {
-					$border_radius_style = 'border-radius:' . $border_radius . 'px';
-				}
-
 				// Use simple structure - images are pre-cropped to squares for square/circle styles
-				$grid_content .= '<div style="margin-bottom:24px;display:flex;margin:0;' . $width_style . ';' . $margin_right . '">';
-				$grid_content .= '<figure style="margin:0;overflow:hidden;padding:0">';
-
-				// Build individual image content with conditional styling for single vs multiple
-				if ( $images_in_row === 1 ) {
-					// Single image - centered with natural sizing
-					$grid_content .= sprintf(
-						'<img alt="%s" src="%s" style="border:none;margin-bottom:24px;background-color:#0000001a;display:block;height:auto;margin:0 auto;max-width:100%%;object-fit:cover;object-position:center;padding:0;width:auto;%s" />',
-						esc_attr( $image['alt'] ),
-						esc_url( $image['url'] ),
-						$border_radius_style
-					);
-				} else {
-					// Multiple images - fill container width
-					$grid_content .= sprintf(
-						'<img alt="%s" src="%s" style="border:none;margin-bottom:24px;background-color:#0000001a;display:block;height:auto;margin:0;max-width:100%%;object-fit:cover;object-position:center;padding:0;width:100%%;%s" />',
-						esc_attr( $image['alt'] ),
-						esc_url( $image['url'] ),
-						$border_radius_style
-					);
-				}
-
-				$grid_content .= '</figure>';
-				$grid_content .= '</div>';
+				$content_parts[] = '<div style="margin-bottom:24px;display:flex;margin:0;' . $width_style . ';' . $margin_right . '">';
+				$content_parts[] = '<figure style="margin:0;overflow:hidden;padding:0">';
+				$content_parts[] = self::generate_image_html( $image, $image_styles, $border_radius_style );
+				$content_parts[] = '</figure>';
+				$content_parts[] = '</div>';
 			}
 
-			$grid_content .= '</div>'; // Close row container
+			$content_parts[] = '</div>'; // Close row container
 		}
-		$grid_content .= '</div>';
-		$grid_content .= '</div>';
 
-		return $grid_content;
+		return self::generate_email_wrapper( implode( '', $content_parts ) );
 	}
 
 	/**
@@ -541,13 +515,11 @@ class Tiled_Gallery {
 	 * @return string HTML content.
 	 */
 	private static function build_columns_layout_content( $images, $target_width, $cell_padding, $columns, $border_radius = 0 ) {
-
-		$grid_content  = '<div style="margin-bottom:24px;clear:both;text-align:center;margin:0 auto;padding:4px;background-color:white">';
-		$grid_content .= '<div style="margin-bottom:24px">';
-		$grid_content .= '<div style="margin-bottom:24px;padding:0;width:100%;display:block">';
+		$content_parts       = array();
+		$border_radius_style = self::generate_border_radius_style( '', $border_radius );
 
 		// Use simple div approach with display:flex for horizontal layout
-		$grid_content .= '<div style="margin-bottom:24px;display:flex;margin:0;width:100%">';
+		$content_parts[] = '<div style="margin-bottom:24px;display:flex;margin:0;width:100%">';
 
 		// Distribute images across columns using round-robin approach for better balance
 		$column_arrays = array_fill( 0, $columns, array() );
@@ -555,9 +527,6 @@ class Tiled_Gallery {
 			$column_index                     = $index % $columns;
 			$column_arrays[ $column_index ][] = $image;
 		}
-
-		// Prepare border radius style
-		$border_radius_style = $border_radius > 0 ? 'border-radius:' . $border_radius . 'px;' : '';
 
 		foreach ( $column_arrays as $col_index => $column_images ) {
 			if ( empty( $column_images ) ) {
@@ -568,8 +537,8 @@ class Tiled_Gallery {
 			$column_margin = ( $col_index < $columns - 1 ) ? 'margin-right:' . $cell_padding . 'px;' : '';
 
 			// Create column container using display:flex for the outer horizontal layout
-			$grid_content .= '<div style="margin-bottom:24px;display:flex;margin:0;' . $column_margin . '">';
-			$grid_content .= '<div style="margin-bottom:24px;clear:both">';
+			$content_parts[] = '<div style="margin-bottom:24px;display:flex;margin:0;' . $column_margin . '">';
+			$content_parts[] = '<div style="margin-bottom:24px;clear:both">';
 
 			// Generate mosaic-style groupings within this column
 			$column_rows = self::generate_column_mosaic_rows( $column_images );
@@ -577,42 +546,22 @@ class Tiled_Gallery {
 			foreach ( $column_rows as $row_index => $row_images ) {
 				// Add margin-top for spacing between images in the column (except first)
 				$margin_top_style = ( $row_index > 0 ) ? 'margin-top:' . $cell_padding . 'px;' : '';
+				$image_styles     = 'margin-bottom:24px;margin:0;width:100%;';
 
-				if ( count( $row_images ) === 1 ) {
-					// Single image - use clear:both for vertical stacking
-					$grid_content .= '<figure style="margin:0;overflow:hidden;padding:0;display:flex;' . $margin_top_style . '">';
-					$grid_content .= sprintf(
-						'<img src="%s" alt="%s" style="border:none;margin-bottom:24px;background-color:#0000001a;display:block;height:auto;margin:0;max-width:100%%;object-fit:cover;object-position:center;padding:0;width:100%%;%s" />',
-						esc_url( $row_images[0]['url'] ),
-						esc_attr( $row_images[0]['alt'] ),
-						$border_radius_style
-					);
-					$grid_content .= '</figure>';
-				} else {
-					// Multiple images in a horizontal row - not typical for columns layout but handle it
-					foreach ( $row_images as $image ) {
-						$grid_content .= '<figure style="margin:0;overflow:hidden;padding:0;display:flex;' . $margin_top_style . '">';
-						$grid_content .= sprintf(
-							'<img src="%s" alt="%s" style="border:none;margin-bottom:24px;background-color:#0000001a;display:block;height:auto;margin:0;max-width:100%%;object-fit:cover;object-position:center;padding:0;width:100%%;%s" />',
-							esc_url( $image['url'] ),
-							esc_attr( $image['alt'] ),
-							$border_radius_style
-						);
-						$grid_content .= '</figure>';
-					}
+				foreach ( $row_images as $image ) {
+					$content_parts[] = '<figure style="margin:0;overflow:hidden;padding:0;display:flex;' . $margin_top_style . '">';
+					$content_parts[] = self::generate_image_html( $image, $image_styles, $border_radius_style );
+					$content_parts[] = '</figure>';
 				}
 			}
 
-			$grid_content .= '</div>'; // Close clear:both container
-			$grid_content .= '</div>'; // Close column
+			$content_parts[] = '</div>'; // Close clear:both container
+			$content_parts[] = '</div>'; // Close column
 		}
 
-		$grid_content .= '</div>'; // Close main flex container
-		$grid_content .= '</div>';
-		$grid_content .= '</div>';
-		$grid_content .= '</div>';
+		$content_parts[] = '</div>'; // Close main flex container
 
-		return $grid_content;
+		return self::generate_email_wrapper( implode( '', $content_parts ) );
 	}
 
 	/**
@@ -625,67 +574,49 @@ class Tiled_Gallery {
 	 * @return string HTML content.
 	 */
 	private static function build_mosaic_layout_content( $images, $target_width, $cell_padding, $border_radius = 0 ) {
-		$grid_content  = '<div style="margin-bottom:24px;clear:both;text-align:center;margin:0 auto;padding:4px;background-color:white">';
-		$grid_content .= '<div style="margin-bottom:24px">';
-		$grid_content .= '<div style="margin-bottom:24px;padding:0;width:100%;display:block">';
-
-		// Prepare border radius style
-		$border_radius_style = $border_radius > 0 ? 'border-radius:' . $border_radius . 'px;' : '';
+		$content_parts       = array();
+		$border_radius_style = self::generate_border_radius_style( '', $border_radius );
 
 		// Generate mosaic layout rows
-		$rows = self::generate_mosaic_rows( $images, $target_width, $cell_padding );
+		$rows = self::generate_mosaic_rows( $images );
 
 		foreach ( $rows as $index => $row ) {
-			// Debug: Check if this is the last row
+			// Check if this is the last row
 			$is_last_row   = ( $index === count( $rows ) - 1 );
 			$margin_bottom = $is_last_row ? '0' : $cell_padding;
 
-			$grid_content .= '<div style="margin-bottom:' . $margin_bottom . 'px;display:flex;width:100%;max-width:100%;box-sizing:border-box">';
+			$content_parts[] = '<div style="margin-bottom:' . $margin_bottom . 'px;display:flex;width:100%;max-width:100%;box-sizing:border-box">';
 
 			// Calculate width for each image in this row
-			$images_in_row           = count( $row );
-			$total_margin_width      = ( $images_in_row - 1 ) * $cell_padding;
-			$available_width_percent = 100;
-			$image_width_percent     = ( $available_width_percent / $images_in_row );
+			$images_in_row       = count( $row );
+			$total_margin_width  = ( $images_in_row - 1 ) * $cell_padding;
+			$image_width_percent = ( 100 / $images_in_row );
 
 			foreach ( $row as $image_index => $image ) {
 				$margin_right = ( $image_index < count( $row ) - 1 ) ? $cell_padding : '0';
 				$width_style  = 'width:calc(' . $image_width_percent . '% - ' . ( $total_margin_width / $images_in_row ) . 'px);';
+				$image_styles = 'margin:0;width:100%;box-sizing:border-box;';
 
-				$grid_content .= '<div style="margin:0;margin-right:' . $margin_right . 'px;' . $width_style . 'display:flex;min-width:0;box-sizing:border-box">';
-				$grid_content .= '<figure style="margin:0;overflow:hidden;padding:0;display:flex;width:100%;box-sizing:border-box">';
-
-				// Build individual image content
-				$grid_content .= sprintf(
-					'<img alt="%s" src="%s" style="border:none;background-color:#0000001a;display:block;height:auto;margin:0;max-width:100%%;object-fit:cover;object-position:center;padding:0;width:100%%;box-sizing:border-box;%s" />',
-					esc_attr( $image['alt'] ),
-					esc_url( $image['url'] ),
-					$border_radius_style
-				);
-
-				$grid_content .= '</figure>';
-				$grid_content .= '</div>';
+				$content_parts[] = '<div style="margin:0;margin-right:' . $margin_right . 'px;' . $width_style . 'display:flex;min-width:0;box-sizing:border-box">';
+				$content_parts[] = '<figure style="margin:0;overflow:hidden;padding:0;display:flex;width:100%;box-sizing:border-box">';
+				$content_parts[] = self::generate_image_html( $image, $image_styles, $border_radius_style );
+				$content_parts[] = '</figure>';
+				$content_parts[] = '</div>';
 			}
 
-			$grid_content .= '</div>';
+			$content_parts[] = '</div>';
 		}
 
-		$grid_content .= '</div>';
-		$grid_content .= '</div>';
-		$grid_content .= '</div>';
-
-		return $grid_content;
+		return self::generate_email_wrapper( implode( '', $content_parts ) );
 	}
 
 	/**
-	 * Generate mosaic layout rows based on image count and available width.
+	 * Generate mosaic layout rows based on image count.
 	 *
 	 * @param array $images Array of image data.
-	 * @param int   $target_width Target width for email.
-	 * @param int   $cell_padding Cell padding.
 	 * @return array Array of rows, each containing images.
 	 */
-	private static function generate_mosaic_rows( $images, $target_width, $cell_padding ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+	private static function generate_mosaic_rows( $images ) {
 		$rows        = array();
 		$image_count = count( $images );
 
@@ -779,6 +710,66 @@ class Tiled_Gallery {
 		}
 
 		return $rows;
+	}
+
+	/**
+	 * Generate common HTML wrapper for email layouts.
+	 *
+	 * @param string $content Inner HTML content.
+	 * @return string Wrapped HTML content.
+	 */
+	private static function generate_email_wrapper( $content ) {
+		return '<div style="margin-bottom:24px;clear:both;text-align:center;margin:0 auto;padding:4px;background-color:white">' .
+			'<div style="margin-bottom:24px">' .
+			'<div style="margin-bottom:24px;padding:0;width:100%;display:block">' .
+			$content .
+			'</div></div></div>';
+	}
+
+	/**
+	 * Generate border radius style based on layout style and border radius value.
+	 *
+	 * @param string $style Layout style (square, circle, etc.).
+	 * @param int    $border_radius Border radius value.
+	 * @return string CSS border-radius style.
+	 */
+	private static function generate_border_radius_style( $style, $border_radius ) {
+		if ( 'circle' === $style ) {
+			return 'border-radius:50%;';
+		} elseif ( $border_radius > 0 ) {
+			return 'border-radius:' . $border_radius . 'px;';
+		}
+		return '';
+	}
+
+	/**
+	 * Generate image HTML with consistent styling.
+	 *
+	 * @param array  $image Image data array.
+	 * @param string $additional_styles Additional CSS styles.
+	 * @param string $border_radius_style Border radius CSS.
+	 * @return string Image HTML.
+	 */
+	private static function generate_image_html( $image, $additional_styles = '', $border_radius_style = '' ) {
+		$base_styles     = 'border:none;background-color:#0000001a;display:block;height:auto;max-width:100%;object-fit:cover;object-position:center;padding:0;';
+		$combined_styles = $base_styles . $additional_styles . $border_radius_style;
+
+		return sprintf(
+			'<img alt="%s" src="%s" style="%s" />',
+			esc_attr( $image['alt'] ),
+			esc_url( $image['url'] ),
+			$combined_styles
+		);
+	}
+
+	/**
+	 * Check if layout style is square or circle (squareish).
+	 *
+	 * @param string $layout_style The layout style.
+	 * @return bool True if squareish layout.
+	 */
+	private static function is_squareish_layout_style( $layout_style ) {
+		return in_array( $layout_style, array( 'square', 'circle' ), true );
 	}
 
 	/**

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/tiled-gallery.php
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/tiled-gallery.php
@@ -39,7 +39,10 @@ class Tiled_Gallery {
 		) {
 			Blocks::jetpack_register_block(
 				__DIR__,
-				array( 'render_callback' => array( __CLASS__, 'render' ) )
+				array(
+					'render_callback'       => array( __CLASS__, 'render' ),
+					'render_email_callback' => array( __CLASS__, 'render_email' ),
+				)
 			);
 		}
 	}
@@ -209,6 +212,391 @@ class Tiled_Gallery {
 				'is-style-square' === $attr['className']
 				|| 'is-style-circle' === $attr['className']
 			);
+	}
+
+	/**
+	 * Render tiled gallery block for email.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param string $block_content     The original block HTML content.
+	 * @param array  $parsed_block      The parsed block data including attributes.
+	 * @param object $rendering_context Email rendering context.
+	 *
+	 * @return string
+	 */
+	public static function render_email( $block_content, array $parsed_block, $rendering_context ) {
+		// Validate input parameters and required dependencies
+		if ( ! isset( $parsed_block['attrs'] ) || ! is_array( $parsed_block['attrs'] ) ||
+			! class_exists( '\Automattic\WooCommerce\EmailEditor\Integrations\Utils\Styles_Helper' ) ||
+			! class_exists( '\Automattic\WooCommerce\EmailEditor\Integrations\Utils\Table_Wrapper_Helper' ) ) {
+			return '';
+		}
+
+		// Email rendering configuration
+		$email_common_margin = 16; // Common margin/padding value used multiple times
+		$email_cell_padding  = 4; // Cell padding used in multiple places
+
+		$attr = $parsed_block['attrs'];
+
+		// Process images for email rendering
+		$images = self::process_tiled_gallery_images_for_email( $attr );
+
+		if ( empty( $images ) ) {
+			return '';
+		}
+
+		// Determine target width from the email layout if available
+		$target_width = self::get_email_target_width( $rendering_context );
+
+		// Determine layout style from className
+		$layout_style = self::get_layout_style_from_attributes( $attr );
+
+		// Build layout content based on style
+		$grid_content = self::build_email_layout_content( $images, $layout_style, $target_width, $email_cell_padding );
+
+		// Use Table_Wrapper_Helper for consistent email rendering
+		$image_table_attrs = array(
+			'style' => 'margin: ' . $email_common_margin . 'px 0; padding: 0; border-collapse: collapse;',
+			'width' => $target_width,
+		);
+
+		$html = \Automattic\WooCommerce\EmailEditor\Integrations\Utils\Table_Wrapper_Helper::render_table_wrapper( $grid_content, $image_table_attrs );
+
+		// Add margin below the block
+		$html .= '<div style="margin-bottom: 2em;"></div>';
+
+		return $html;
+	}
+
+	/**
+	 * Get target width for email rendering.
+	 *
+	 * @param object $rendering_context Email rendering context.
+	 * @return int Target width in pixels.
+	 */
+	private static function get_email_target_width( $rendering_context ) {
+		$target_width = 600; // Default
+
+		if ( ! empty( $rendering_context ) && is_object( $rendering_context ) && method_exists( $rendering_context, 'get_layout_width_without_padding' ) ) {
+			$layout_width_px = $rendering_context->get_layout_width_without_padding();
+			if ( is_string( $layout_width_px ) ) {
+				$parsed_width = \Automattic\WooCommerce\EmailEditor\Integrations\Utils\Styles_Helper::parse_value( $layout_width_px );
+				if ( $parsed_width > 0 ) {
+					$target_width = $parsed_width;
+				}
+			}
+		}
+
+		return $target_width;
+	}
+
+	/**
+	 * Process tiled gallery images for email rendering.
+	 *
+	 * @param array $attr Block attributes containing image data.
+	 * @return array Processed image data for email rendering.
+	 */
+	private static function process_tiled_gallery_images_for_email( $attr ) {
+		$images = array();
+
+		// Get images from IDs (primary data source)
+		if ( ! empty( $attr['ids'] ) && is_array( $attr['ids'] ) ) {
+			foreach ( $attr['ids'] as $id ) {
+				// Validate ID is a positive integer
+				$id = absint( $id );
+				if ( ! $id ) {
+					continue;
+				}
+
+				$image_url = wp_get_attachment_image_url( $id, 'medium' );
+
+				// Sanitize alt text from post meta
+				$alt_text = get_post_meta( $id, '_wp_attachment_image_alt', true );
+				$alt_text = sanitize_text_field( $alt_text );
+
+				if ( $image_url ) {
+					$images[] = array(
+						'url' => $image_url,
+						'alt' => $alt_text,
+						'id'  => $id,
+					);
+				}
+			}
+		} elseif ( ! empty( $attr['images'] ) && is_array( $attr['images'] ) ) {
+			// Fall back to images array if IDs aren't available
+			foreach ( $attr['images'] as $image_data ) {
+				if ( ! empty( $image_data['url'] ) ) {
+					// Validate and sanitize URL
+					$url = esc_url_raw( $image_data['url'] );
+					if ( ! $url || ! wp_http_validate_url( $url ) ) {
+						continue;
+					}
+
+					// Sanitize alt text
+					$alt_text = ! empty( $image_data['alt'] ) ? sanitize_text_field( $image_data['alt'] ) : '';
+
+					// Validate ID if present
+					$id = ! empty( $image_data['id'] ) ? absint( $image_data['id'] ) : 0;
+
+					$images[] = array(
+						'url' => $url,
+						'alt' => $alt_text,
+						'id'  => $id,
+					);
+				}
+			}
+		}
+
+		return $images;
+	}
+
+	/**
+	 * Get layout style from block attributes.
+	 *
+	 * @param array $attr Block attributes.
+	 * @return string Layout style.
+	 */
+	private static function get_layout_style_from_attributes( $attr ) {
+		if ( ! empty( $attr['className'] ) ) {
+			if ( str_contains( $attr['className'], 'is-style-square' ) ) {
+				return 'square';
+			} elseif ( str_contains( $attr['className'], 'is-style-circle' ) ) {
+				return 'circle';
+			} elseif ( str_contains( $attr['className'], 'is-style-columns' ) ) {
+				return 'columns';
+			}
+		}
+		return 'rectangular'; // Default to rectangular/mosaic layout
+	}
+
+	/**
+	 * Build email layout content based on layout style.
+	 *
+	 * @param array  $images Array of image data.
+	 * @param string $layout_style Layout style (rectangular, square, circle, columns).
+	 * @param int    $target_width Target width for email.
+	 * @param int    $cell_padding Cell padding.
+	 * @return string HTML content.
+	 */
+	private static function build_email_layout_content( $images, $layout_style, $target_width, $cell_padding ) {
+		switch ( $layout_style ) {
+			case 'square':
+			case 'circle':
+				return self::build_square_layout_content( $images, $target_width, $cell_padding );
+			case 'columns':
+				return self::build_columns_layout_content( $images, $target_width, $cell_padding );
+			case 'rectangular':
+			default:
+				return self::build_mosaic_layout_content( $images, $target_width, $cell_padding );
+		}
+	}
+
+	/**
+	 * Build square/circle layout content.
+	 *
+	 * @param array $images Array of image data.
+	 * @param int   $target_width Target width for email.
+	 * @param int   $cell_padding Cell padding.
+	 * @return string HTML content.
+	 */
+	private static function build_square_layout_content( $images, $target_width, $cell_padding ) {
+		$columns = 3; // Default to 3 columns for square layout
+
+		$grid_content  = '<div style="margin-bottom:24px;clear:both;text-align:center;margin:0 auto;padding:4px;background-color:white">';
+		$grid_content .= '<div style="margin-bottom:24px">';
+		$grid_content .= '<div style="margin-bottom:24px;padding:0;width:100%;display:block">';
+
+		// Create rows of images
+		$image_chunks = array_chunk( $images, $columns );
+
+		foreach ( $image_chunks as $index => $row_images ) {
+			$margin_bottom = ( $index < count( $image_chunks ) - 1 ) ? $cell_padding : '0';
+			$grid_content .= '<div style="margin-bottom:' . $margin_bottom . 'px;display:flex;margin:0;width:100%;max-width:100%;box-sizing:border-box">';
+
+			foreach ( $row_images as $image_index => $image ) {
+				$margin_right  = ( $image_index < count( $row_images ) - 1 ) ? $cell_padding : '0';
+				$flex_basis    = ( 100 / $columns ) . '%';
+				$grid_content .= '<div style="margin:0;margin-right:' . $margin_right . 'px;flex:0 0 ' . $flex_basis . ';display:flex;max-width:' . $flex_basis . ';box-sizing:border-box">';
+				$grid_content .= '<figure style="margin:0;overflow:hidden;padding:0;display:flex;width:100%;aspect-ratio:1;box-sizing:border-box">';
+
+				// Build individual image content
+				$grid_content .= sprintf(
+					'<img src="%s" alt="%s" style="border:none;background-color:#0000001a;display:block;height:auto;margin:0;max-width:100%%;object-fit:cover;object-position:center;padding:0;width:100%%;box-sizing:border-box" />',
+					esc_url( $image['url'] ),
+					esc_attr( $image['alt'] )
+				);
+
+				$grid_content .= '</figure>';
+				$grid_content .= '</div>';
+			}
+
+			$grid_content .= '</div>';
+		}
+
+		$grid_content .= '</div>';
+		$grid_content .= '</div>';
+		$grid_content .= '</div>';
+
+		return $grid_content;
+	}
+
+	/**
+	 * Build columns layout content.
+	 *
+	 * @param array $images Array of image data.
+	 * @param int   $target_width Target width for email.
+	 * @param int   $cell_padding Cell padding.
+	 * @return string HTML content.
+	 */
+	private static function build_columns_layout_content( $images, $target_width, $cell_padding ) {
+		$columns = 3; // Default to 3 columns
+
+		$grid_content  = '<div style="margin-bottom:24px;clear:both;text-align:center;margin:0 auto;padding:4px;background-color:white">';
+		$grid_content .= '<div style="margin-bottom:24px">';
+		$grid_content .= '<div style="margin-bottom:24px;padding:0;width:100%;display:block">';
+
+		// Create rows of images
+		$image_chunks = array_chunk( $images, $columns );
+
+		foreach ( $image_chunks as $index => $row_images ) {
+			$margin_bottom = ( $index < count( $image_chunks ) - 1 ) ? $cell_padding : '0';
+			$grid_content .= '<div style="margin-bottom:' . $margin_bottom . 'px;display:flex;margin:0;width:100%;max-width:100%;box-sizing:border-box">';
+
+			foreach ( $row_images as $image_index => $image ) {
+				$margin_right  = ( $image_index < count( $row_images ) - 1 ) ? $cell_padding : '0';
+				$flex_basis    = ( 100 / $columns ) . '%';
+				$grid_content .= '<div style="margin:0;margin-right:' . $margin_right . 'px;flex:0 0 ' . $flex_basis . ';display:flex;max-width:' . $flex_basis . ';box-sizing:border-box">';
+				$grid_content .= '<figure style="margin:0;overflow:hidden;padding:0;display:flex;width:100%;box-sizing:border-box">';
+
+				// Build individual image content
+				$grid_content .= sprintf(
+					'<img src="%s" alt="%s" style="border:none;background-color:#0000001a;display:block;height:auto;margin:0;max-width:100%%;object-fit:cover;object-position:center;padding:0;width:100%%;box-sizing:border-box" />',
+					esc_url( $image['url'] ),
+					esc_attr( $image['alt'] )
+				);
+
+				$grid_content .= '</figure>';
+				$grid_content .= '</div>';
+			}
+
+			$grid_content .= '</div>';
+		}
+
+		$grid_content .= '</div>';
+		$grid_content .= '</div>';
+		$grid_content .= '</div>';
+
+		return $grid_content;
+	}
+
+	/**
+	 * Build mosaic layout content with flexible row/column structure.
+	 *
+	 * @param array $images Array of image data.
+	 * @param int   $target_width Target width for email.
+	 * @param int   $cell_padding Cell padding.
+	 * @return string HTML content.
+	 */
+	private static function build_mosaic_layout_content( $images, $target_width, $cell_padding ) {
+		$grid_content  = '<div style="margin-bottom:24px;clear:both;text-align:center;margin:0 auto;padding:4px;background-color:white">';
+		$grid_content .= '<div style="margin-bottom:24px">';
+		$grid_content .= '<div style="margin-bottom:24px;padding:0;width:100%;display:block">';
+
+		// Generate mosaic layout rows
+		$rows = self::generate_mosaic_rows( $images, $target_width, $cell_padding );
+
+		foreach ( $rows as $index => $row ) {
+			// Debug: Check if this is the last row
+			$is_last_row   = ( $index === count( $rows ) - 1 );
+			$margin_bottom = $is_last_row ? '0' : $cell_padding;
+
+			$grid_content .= '<div style="margin-bottom:' . $margin_bottom . 'px;display:flex;width:100%;max-width:100%;box-sizing:border-box">';
+
+			// Calculate width for each image in this row
+			$images_in_row           = count( $row );
+			$total_margin_width      = ( $images_in_row - 1 ) * $cell_padding;
+			$available_width_percent = 100;
+			$image_width_percent     = ( $available_width_percent / $images_in_row );
+
+			foreach ( $row as $image_index => $image ) {
+				$margin_right = ( $image_index < count( $row ) - 1 ) ? $cell_padding : '0';
+				$width_style  = 'width:calc(' . $image_width_percent . '% - ' . ( $total_margin_width / $images_in_row ) . 'px);';
+
+				$grid_content .= '<div style="margin:0;margin-right:' . $margin_right . 'px;' . $width_style . 'display:flex;min-width:0;box-sizing:border-box">';
+				$grid_content .= '<figure style="margin:0;overflow:hidden;padding:0;display:flex;width:100%;box-sizing:border-box">';
+
+				// Build individual image content
+				$grid_content .= sprintf(
+					'<img alt="%s" src="%s" style="border:none;background-color:#0000001a;display:block;height:auto;margin:0;max-width:100%%;object-fit:cover;object-position:center;padding:0;width:100%%;box-sizing:border-box" />',
+					esc_attr( $image['alt'] ),
+					esc_url( $image['url'] )
+				);
+
+				$grid_content .= '</figure>';
+				$grid_content .= '</div>';
+			}
+
+			$grid_content .= '</div>';
+		}
+
+		$grid_content .= '</div>';
+		$grid_content .= '</div>';
+		$grid_content .= '</div>';
+
+		return $grid_content;
+	}
+
+	/**
+	 * Generate mosaic layout rows based on image count and available width.
+	 *
+	 * @param array $images Array of image data.
+	 * @param int   $target_width Target width for email.
+	 * @param int   $cell_padding Cell padding.
+	 * @return array Array of rows, each containing images.
+	 */
+	private static function generate_mosaic_rows( $images, $target_width, $cell_padding ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		$rows        = array();
+		$image_count = count( $images );
+
+		// More sophisticated mosaic algorithm based on image count
+		if ( $image_count <= 3 ) {
+			// For 3 or fewer images, use simple layout
+			$rows[] = $images;
+		} else {
+			// For more images, create varied row patterns
+			$patterns = array(
+				5 => array( 2, 3 ),      // 5 images: 2 + 3
+				6 => array( 3, 3 ),      // 6 images: 3 + 3
+				7 => array( 3, 2, 2 ),   // 7 images: 3 + 2 + 2
+				8 => array( 3, 3, 2 ),   // 8 images: 3 + 3 + 2
+				9 => array( 3, 3, 3 ),   // 9 images: 3 + 3 + 3
+			);
+
+			$pattern     = isset( $patterns[ $image_count ] ) ? $patterns[ $image_count ] : array( 3, 3, 3 );
+			$image_index = 0;
+
+			foreach ( $pattern as $images_in_row ) {
+				$row = array();
+				for ( $i = 0; $i < $images_in_row && $image_index < $image_count; $i++ ) {
+					$row[] = $images[ $image_index ];
+					++$image_index;
+				}
+				if ( ! empty( $row ) ) {
+					$rows[] = $row;
+				}
+			}
+
+			// Add any remaining images to the last row
+			if ( $image_index < $image_count ) {
+				$remaining = array_slice( $images, $image_index );
+				if ( ! empty( $remaining ) ) {
+					$rows[] = $remaining;
+				}
+			}
+		}
+
+		return $rows;
 	}
 }
 

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/tiled-gallery.php
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/tiled-gallery.php
@@ -234,7 +234,7 @@ class Tiled_Gallery {
 		}
 
 		// Get spacing from email_attrs for better consistency with core blocks
-		$email_attrs        = isset( $parsed_block['email_attrs'] ) ? $parsed_block['email_attrs'] : array();
+		$email_attrs        = $parsed_block['email_attrs'] ?? array();
 		$table_margin_style = '';
 
 		if ( ! empty( $email_attrs ) && class_exists( '\WP_Style_Engine' ) ) {

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/tiled-gallery.php
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/tiled-gallery.php
@@ -249,11 +249,11 @@ class Tiled_Gallery {
 		// Determine target width from the email layout if available
 		$target_width = self::get_email_target_width( $rendering_context );
 
-		// Determine layout style from className
-		$layout_style = self::get_layout_style_from_attributes( $attr );
+		// Determine layout style and columns from attributes
+		$layout_info = self::get_layout_style_from_attributes( $attr );
 
-		// Build layout content based on style
-		$grid_content = self::build_email_layout_content( $images, $layout_style, $target_width, $email_cell_padding );
+		// Build layout content based on style and columns
+		$grid_content = self::build_email_layout_content( $images, $layout_info, $target_width, $email_cell_padding );
 
 		// Use Table_Wrapper_Helper for consistent email rendering
 		$image_table_attrs = array(
@@ -309,7 +309,26 @@ class Tiled_Gallery {
 					continue;
 				}
 
-				$image_url = wp_get_attachment_image_url( $id, 'medium' );
+				// For square/circle layouts, get a high-quality square crop
+				if ( isset( $attr['className'] ) &&
+					( str_contains( $attr['className'], 'is-style-square' ) ||
+						str_contains( $attr['className'], 'is-style-circle' ) ) ) {
+					// Start with full size image for better quality when resizing
+					$image_url = wp_get_attachment_image_url( $id, 'full' );
+
+					// If we have Photon/Jetpack image processing, request high-quality square crop
+					if ( function_exists( 'jetpack_photon_url' ) && $image_url ) {
+						$image_url = add_query_arg(
+							array(
+								'resize' => '1300,1300',
+								'crop'   => '1',
+							),
+							$image_url
+						);
+					}
+				} else {
+					$image_url = wp_get_attachment_image_url( $id, 'large' );
+				}
 
 				// Sanitize alt text from post meta
 				$alt_text = get_post_meta( $id, '_wp_attachment_image_alt', true );
@@ -352,40 +371,56 @@ class Tiled_Gallery {
 	}
 
 	/**
-	 * Get layout style from block attributes.
+	 * Get layout style and columns from block attributes.
 	 *
 	 * @param array $attr Block attributes.
-	 * @return string Layout style.
+	 * @return array Array with 'style' and 'columns' keys.
 	 */
 	private static function get_layout_style_from_attributes( $attr ) {
+		$layout_info = array(
+			'style'   => 'rectangular', // Default to rectangular/mosaic layout
+			'columns' => 3, // Default to 3 columns
+		);
+
+		// Get number of columns from attributes
+		if ( ! empty( $attr['columns'] ) && is_numeric( $attr['columns'] ) ) {
+			$layout_info['columns'] = absint( $attr['columns'] );
+		}
+
+		// Get layout style from className
 		if ( ! empty( $attr['className'] ) ) {
 			if ( str_contains( $attr['className'], 'is-style-square' ) ) {
-				return 'square';
+				$layout_info['style'] = 'square';
 			} elseif ( str_contains( $attr['className'], 'is-style-circle' ) ) {
-				return 'circle';
+				$layout_info['style'] = 'circle';
 			} elseif ( str_contains( $attr['className'], 'is-style-columns' ) ) {
-				return 'columns';
+				$layout_info['style'] = 'columns';
 			}
 		}
-		return 'rectangular'; // Default to rectangular/mosaic layout
+
+		return $layout_info;
 	}
 
 	/**
-	 * Build email layout content based on layout style.
+	 * Build email layout content based on layout style and columns.
 	 *
-	 * @param array  $images Array of image data.
-	 * @param string $layout_style Layout style (rectangular, square, circle, columns).
-	 * @param int    $target_width Target width for email.
-	 * @param int    $cell_padding Cell padding.
+	 * @param array $images Array of image data.
+	 * @param array $layout_info Array with 'style' and 'columns' keys.
+	 * @param int   $target_width Target width for email.
+	 * @param int   $cell_padding Cell padding.
 	 * @return string HTML content.
 	 */
-	private static function build_email_layout_content( $images, $layout_style, $target_width, $cell_padding ) {
+	private static function build_email_layout_content( $images, $layout_info, $target_width, $cell_padding ) {
+		$layout_style = $layout_info['style'];
+		$columns      = $layout_info['columns'];
+
 		switch ( $layout_style ) {
 			case 'square':
+				return self::build_square_layout_content( $images, $target_width, $cell_padding, $columns, 'square' );
 			case 'circle':
-				return self::build_square_layout_content( $images, $target_width, $cell_padding );
+				return self::build_square_layout_content( $images, $target_width, $cell_padding, $columns, 'circle' );
 			case 'columns':
-				return self::build_columns_layout_content( $images, $target_width, $cell_padding );
+				return self::build_columns_layout_content( $images, $target_width, $cell_padding, $columns );
 			case 'rectangular':
 			default:
 				return self::build_mosaic_layout_content( $images, $target_width, $cell_padding );
@@ -395,46 +430,78 @@ class Tiled_Gallery {
 	/**
 	 * Build square/circle layout content.
 	 *
-	 * @param array $images Array of image data.
-	 * @param int   $target_width Target width for email.
-	 * @param int   $cell_padding Cell padding.
+	 * @param array  $images Array of image data.
+	 * @param int    $target_width Target width for email.
+	 * @param int    $cell_padding Cell padding.
+	 * @param int    $columns Number of columns for the layout.
+	 * @param string $style Layout style (square or circle).
 	 * @return string HTML content.
 	 */
-	private static function build_square_layout_content( $images, $target_width, $cell_padding ) {
-		$columns = 3; // Default to 3 columns for square layout
+	private static function build_square_layout_content( $images, $target_width, $cell_padding, $columns, $style = 'square' ) {
 
 		$grid_content  = '<div style="margin-bottom:24px;clear:both;text-align:center;margin:0 auto;padding:4px;background-color:white">';
 		$grid_content .= '<div style="margin-bottom:24px">';
 		$grid_content .= '<div style="margin-bottom:24px;padding:0;width:100%;display:block">';
 
-		// Create rows of images
-		$image_chunks = array_chunk( $images, $columns );
+		// Create rows of images with special handling for square/circle layouts
+		if ( $style === 'square' || $style === 'circle' ) {
+			$image_chunks = self::create_hierarchical_chunks( $images, $columns );
+		} else {
+			$image_chunks = array_chunk( $images, $columns );
+		}
 
-		foreach ( $image_chunks as $index => $row_images ) {
-			$margin_bottom = ( $index < count( $image_chunks ) - 1 ) ? $cell_padding : '0';
-			$grid_content .= '<div style="margin-bottom:' . $margin_bottom . 'px;display:flex;margin:0;width:100%;max-width:100%;box-sizing:border-box">';
+		foreach ( $image_chunks as $row_images ) {
+			// Create row container (like the working HTML)
+			$grid_content .= '<div style="margin-bottom:' . $cell_padding . 'px;display:flex;width:100%">';
 
 			foreach ( $row_images as $image_index => $image ) {
-				$margin_right  = ( $image_index < count( $row_images ) - 1 ) ? $cell_padding : '0';
-				$flex_basis    = ( 100 / $columns ) . '%';
-				$grid_content .= '<div style="margin:0;margin-right:' . $margin_right . 'px;flex:0 0 ' . $flex_basis . ';display:flex;max-width:' . $flex_basis . ';box-sizing:border-box">';
-				$grid_content .= '<figure style="margin:0;overflow:hidden;padding:0;display:flex;width:100%;aspect-ratio:1;box-sizing:border-box">';
+				// Calculate explicit width to ensure proper layout in email clients
+				$images_in_row = count( $row_images );
 
-				// Build individual image content
-				$grid_content .= sprintf(
-					'<img src="%s" alt="%s" style="border:none;background-color:#0000001a;display:block;height:auto;margin:0;max-width:100%%;object-fit:cover;object-position:center;padding:0;width:100%%;box-sizing:border-box" />',
-					esc_url( $image['url'] ),
-					esc_attr( $image['alt'] )
-				);
+				if ( $images_in_row === 1 ) {
+					// Single image takes full width
+					$width_style = 'width:100%';
+				} else {
+					$total_margin_width  = ( $images_in_row - 1 ) * $cell_padding;
+					$image_width_percent = ( 100 / $images_in_row );
+					$width_style         = 'width:calc(' . $image_width_percent . '% - ' . ( $total_margin_width / $images_in_row ) . 'px)';
+				}
+
+				// Add margin-right to all but last image in row
+				$margin_right = ( $image_index < count( $row_images ) - 1 ) ? 'margin-right:' . $cell_padding . 'px;' : '';
+
+				// Add border-radius for circle style
+				$border_radius = ( $style === 'circle' ) ? 'border-radius:50%' : '';
+
+				// Use simple structure - images are pre-cropped to squares for square/circle styles
+				$grid_content .= '<div style="margin-bottom:24px;display:flex;margin:0;' . $width_style . ';' . $margin_right . '">';
+				$grid_content .= '<figure style="margin:0;overflow:hidden;padding:0">';
+
+				// Build individual image content with conditional styling for single vs multiple
+				if ( $images_in_row === 1 ) {
+					// Single image - centered with natural sizing
+					$grid_content .= sprintf(
+						'<img alt="%s" src="%s" style="border:none;margin-bottom:24px;background-color:#0000001a;display:block;height:auto;margin:0 auto;max-width:100%%;object-fit:cover;object-position:center;padding:0;width:auto;%s" />',
+						esc_attr( $image['alt'] ),
+						esc_url( $image['url'] ),
+						$border_radius
+					);
+				} else {
+					// Multiple images - fill container width
+					$grid_content .= sprintf(
+						'<img alt="%s" src="%s" style="border:none;margin-bottom:24px;background-color:#0000001a;display:block;height:auto;margin:0;max-width:100%%;object-fit:cover;object-position:center;padding:0;width:100%%;%s" />',
+						esc_attr( $image['alt'] ),
+						esc_url( $image['url'] ),
+						$border_radius
+					);
+				}
 
 				$grid_content .= '</figure>';
 				$grid_content .= '</div>';
 			}
 
-			$grid_content .= '</div>';
+			$grid_content .= '</div>'; // Close row container
 		}
-
-		$grid_content .= '</div>';
 		$grid_content .= '</div>';
 		$grid_content .= '</div>';
 
@@ -447,10 +514,10 @@ class Tiled_Gallery {
 	 * @param array $images Array of image data.
 	 * @param int   $target_width Target width for email.
 	 * @param int   $cell_padding Cell padding.
+	 * @param int   $columns Number of columns for the layout.
 	 * @return string HTML content.
 	 */
-	private static function build_columns_layout_content( $images, $target_width, $cell_padding ) {
-		$columns = 3; // Default to 3 columns
+	private static function build_columns_layout_content( $images, $target_width, $cell_padding, $columns ) {
 
 		$grid_content  = '<div style="margin-bottom:24px;clear:both;text-align:center;margin:0 auto;padding:4px;background-color:white">';
 		$grid_content .= '<div style="margin-bottom:24px">';
@@ -464,9 +531,15 @@ class Tiled_Gallery {
 			$grid_content .= '<div style="margin-bottom:' . $margin_bottom . 'px;display:flex;margin:0;width:100%;max-width:100%;box-sizing:border-box">';
 
 			foreach ( $row_images as $image_index => $image ) {
-				$margin_right  = ( $image_index < count( $row_images ) - 1 ) ? $cell_padding : '0';
-				$flex_basis    = ( 100 / $columns ) . '%';
-				$grid_content .= '<div style="margin:0;margin-right:' . $margin_right . 'px;flex:0 0 ' . $flex_basis . ';display:flex;max-width:' . $flex_basis . ';box-sizing:border-box">';
+				$margin_right = ( $image_index < count( $row_images ) - 1 ) ? $cell_padding : '0';
+
+				// Calculate explicit width to ensure proper layout in email clients
+				$images_in_row       = count( $row_images );
+				$total_margin_width  = ( $images_in_row - 1 ) * $cell_padding;
+				$image_width_percent = ( 100 / $images_in_row );
+				$width_style         = 'width:calc(' . $image_width_percent . '% - ' . ( $total_margin_width / $images_in_row ) . 'px);';
+
+				$grid_content .= '<div style="margin:0;margin-right:' . $margin_right . 'px;' . $width_style . 'display:flex;min-width:0;box-sizing:border-box">';
 				$grid_content .= '<figure style="margin:0;overflow:hidden;padding:0;display:flex;width:100%;box-sizing:border-box">';
 
 				// Build individual image content
@@ -597,6 +670,45 @@ class Tiled_Gallery {
 		}
 
 		return $rows;
+	}
+
+	/**
+	 * Create hierarchical chunks for square/circle layouts with larger items first.
+	 *
+	 * @param array $images Array of image data.
+	 * @param int   $columns Number of columns for the layout.
+	 * @return array Array of rows with different sized chunks.
+	 */
+	private static function create_hierarchical_chunks( $images, $columns ) {
+		$image_count = count( $images );
+		$chunks      = array();
+
+		if ( $image_count <= $columns ) {
+			// For column count or fewer, single row
+			$chunks[] = $images;
+		} else {
+			// Calculate remainder when dividing by columns
+			$remainder   = $image_count % $columns;
+			$start_index = 0;
+
+			if ( $remainder === 1 ) {
+				// 1 extra: 1 large image on top
+				$chunks[]    = array_slice( $images, 0, 1 );
+				$start_index = 1;
+			} elseif ( $remainder === 2 ) {
+				// 2 extra: 2 medium images on top
+				$chunks[]    = array_slice( $images, 0, 2 );
+				$start_index = 2;
+			}
+			// If remainder === 0, start_index stays 0
+
+			// Rest in groups of $columns
+			$remaining        = array_slice( $images, $start_index );
+			$remaining_chunks = array_chunk( $remaining, $columns );
+			$chunks           = array_merge( $chunks, $remaining_chunks );
+		}
+
+		return $chunks;
 	}
 }
 

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/tiled-gallery.php
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/tiled-gallery.php
@@ -287,7 +287,24 @@ class Tiled_Gallery {
 			return '';
 		}
 
-		// Email rendering configuration
+		// Get spacing from email_attrs for better consistency with core blocks
+		$email_attrs        = isset( $parsed_block['email_attrs'] ) ? $parsed_block['email_attrs'] : array();
+		$gap_style          = '';
+		$table_margin_style = '';
+		$cell_padding_style = '';
+
+		if ( ! empty( $email_attrs ) && class_exists( '\WP_Style_Engine' ) ) {
+			// Get margin-top for gap spacing
+			$gap_style = \WP_Style_Engine::compile_css( array_intersect_key( $email_attrs, array_flip( array( 'margin-top' ) ) ), '' ) ?? '';
+
+			// Get margin for table styling
+			$table_margin_style = \WP_Style_Engine::compile_css( array_intersect_key( $email_attrs, array_flip( array( 'margin' ) ) ), '' ) ?? '';
+
+			// Get padding for cell spacing
+			$cell_padding_style = \WP_Style_Engine::compile_css( array_intersect_key( $email_attrs, array_flip( array( 'padding' ) ) ), '' ) ?? '';
+		}
+
+		// Email rendering configuration - use computed values or fallbacks
 		$email_common_margin = 16; // Common margin/padding value used multiple times
 		$email_cell_padding  = 4;  // Cell padding used in multiple places
 
@@ -307,18 +324,29 @@ class Tiled_Gallery {
 		$layout_info = self::get_layout_style_from_attributes( $attr );
 
 		// Build layout content based on style and columns
-		$grid_content = self::build_email_layout_content( $images, $layout_info, $target_width, $email_cell_padding, $attr );
+		$grid_content = self::build_email_layout_content( $images, $layout_info, $email_cell_padding, $attr, $cell_padding_style );
 
 		// Use Table_Wrapper_Helper for consistent email rendering
+		$table_style = 'padding: 0; border-collapse: collapse;';
+		if ( ! empty( $table_margin_style ) ) {
+			$table_style = $table_margin_style . '; ' . $table_style;
+		} else {
+			$table_style = 'margin: ' . $email_common_margin . 'px 0; ' . $table_style;
+		}
+
 		$image_table_attrs = array(
-			'style' => 'margin: ' . $email_common_margin . 'px 0; padding: 0; border-collapse: collapse;',
+			'style' => $table_style,
 			'width' => $target_width,
 		);
 
 		$html = \Automattic\WooCommerce\EmailEditor\Integrations\Utils\Table_Wrapper_Helper::render_table_wrapper( $grid_content, $image_table_attrs );
 
-		// Add margin below the block
-		$html .= '<div style="margin-bottom: 2em;"></div>';
+		// Add margin below the block using gap_style if available, otherwise use default
+		if ( ! empty( $gap_style ) ) {
+			$html .= '<div style="' . $gap_style . '"></div>';
+		} else {
+			$html .= '<div style="margin-bottom: 32px;"></div>';
+		}
 
 		return $html;
 	}
@@ -479,26 +507,25 @@ class Tiled_Gallery {
 	 *
 	 * @param array $images Array of image data.
 	 * @param array $layout_info Array with 'style' and 'columns' keys.
-	 * @param int   $target_width Target width for email.
 	 * @param int   $cell_padding Cell padding.
 	 * @param array $attr Block attributes.
 	 * @return string HTML content.
 	 */
-	private static function build_email_layout_content( $images, $layout_info, $target_width, $cell_padding, $attr ) {
+	private static function build_email_layout_content( $images, $layout_info, $cell_padding, $attr ) {
 		$layout_style  = $layout_info['style'];
 		$columns       = $layout_info['columns'];
 		$border_radius = $layout_info['border_radius'];
 
 		switch ( $layout_style ) {
 			case 'square':
-				return self::build_square_layout_content( $images, $target_width, $cell_padding, $columns, 'square', $border_radius, $attr );
+				return self::build_square_layout_content( $images, $cell_padding, $columns, 'square', $border_radius, $attr );
 			case 'circle':
-				return self::build_square_layout_content( $images, $target_width, $cell_padding, $columns, 'circle', $border_radius, $attr );
+				return self::build_square_layout_content( $images, $cell_padding, $columns, 'circle', $border_radius, $attr );
 			case 'columns':
-				return self::build_columns_layout_content( $images, $target_width, $cell_padding, $columns, $border_radius, $attr );
+				return self::build_columns_layout_content( $images, $cell_padding, $columns, $border_radius, $attr );
 			case 'rectangular':
 			default:
-				return self::build_mosaic_layout_content( $images, $target_width, $cell_padding, $border_radius, $attr );
+				return self::build_mosaic_layout_content( $images, $cell_padding, $border_radius, $attr );
 		}
 	}
 
@@ -506,7 +533,6 @@ class Tiled_Gallery {
 	 * Build square/circle layout content.
 	 *
 	 * @param array  $images Array of image data.
-	 * @param int    $target_width Target width for email.
 	 * @param int    $cell_padding Cell padding.
 	 * @param int    $columns Number of columns for the layout.
 	 * @param string $style Layout style (square or circle).
@@ -514,69 +540,80 @@ class Tiled_Gallery {
 	 * @param array  $attr Block attributes.
 	 * @return string HTML content.
 	 */
-	private static function build_square_layout_content( $images, $target_width, $cell_padding, $columns, $style = 'square', $border_radius = 0, $attr = array() ) {
+	private static function build_square_layout_content( $images, $cell_padding, $columns, $style = 'square', $border_radius = 0, $attr = array() ) {
 		$content_parts = array();
 
-		// Create rows of images with special handling for square/circle layouts
-		$image_chunks = self::is_squareish_layout_style( $style )
-			? self::create_hierarchical_chunks( $images, $columns )
-			: array_chunk( $images, $columns );
+		// Create rows of images with hierarchical chunks for square/circle layouts
+		$image_chunks = self::create_hierarchical_chunks( $images, $columns );
 
 		$border_radius_style = self::generate_border_radius_style( $style, $border_radius );
 
 		foreach ( $image_chunks as $row_images ) {
-			// Create row container
-			$content_parts[] = '<div style="margin-bottom:' . $cell_padding . 'px;display:flex;width:100%">';
+			$images_in_row      = count( $row_images );
+			$cell_width_percent = ( 100 / $images_in_row );
 
+			// Build table cells for this row
+			$row_cells = '';
 			foreach ( $row_images as $image_index => $image ) {
-				// Calculate explicit width to ensure proper layout in email clients
-				$images_in_row = count( $row_images );
+				// Calculate cell attributes
+				$cell_attrs = array(
+					'style' => sprintf(
+						'width: %s%%; padding: %dpx; vertical-align: top; text-align: center;',
+						$cell_width_percent,
+						$cell_padding
+					),
+				);
 
-				if ( $images_in_row === 1 ) {
-					// Single image takes full width
-					$width_style  = 'width:100%';
-					$image_styles = 'margin-bottom:24px;margin:0 auto;width:auto;';
-				} else {
-					$total_margin_width  = ( $images_in_row - 1 ) * $cell_padding;
-					$image_width_percent = ( 100 / $images_in_row );
-					$width_style         = 'width:calc(' . $image_width_percent . '% - ' . ( $total_margin_width / $images_in_row ) . 'px)';
-					$image_styles        = 'margin-bottom:24px;margin:0;width:100%;';
+				// Add right padding to all but last cell
+				if ( $image_index < $images_in_row - 1 ) {
+					$cell_attrs['style'] .= 'padding-right: ' . ( $cell_padding * 2 ) . 'px;';
 				}
 
-				// Add margin-right to all but last image in row
-				$margin_right = ( $image_index < count( $row_images ) - 1 ) ? 'margin-right:' . $cell_padding . 'px;' : '';
+				$image_styles = 'margin: 0; width: 100%; max-width: 100%; height: auto; display: block;';
 
-				// Use simple structure - images are pre-cropped to squares for square/circle styles
-				$content_parts[] = '<div style="margin-bottom:24px;display:flex;margin:0;' . $width_style . ';' . $margin_right . '">';
-				$content_parts[] = '<figure style="margin:0;overflow:hidden;padding:0">';
-				$content_parts[] = self::generate_image_html( $image, $image_styles, $border_radius_style, $attr );
-				$content_parts[] = '</figure>';
-				$content_parts[] = '</div>';
+				$cell_content = self::generate_image_html( $image, $image_styles, $border_radius_style, $attr );
+
+				$row_cells .= \Automattic\WooCommerce\EmailEditor\Integrations\Utils\Table_Wrapper_Helper::render_table_cell(
+					$cell_content,
+					$cell_attrs
+				);
 			}
 
-			$content_parts[] = '</div>'; // Close row container
+			// Use Table_Wrapper_Helper for email-compatible table rendering
+			$table_attrs = array(
+				'style' => 'width: 100%; border-collapse: collapse;',
+			);
+
+			$content_parts[] = \Automattic\WooCommerce\EmailEditor\Integrations\Utils\Table_Wrapper_Helper::render_table_wrapper(
+				$row_cells,
+				$table_attrs
+			);
 		}
 
-		return self::generate_email_wrapper( implode( '', $content_parts ) );
+		// Use Table_Wrapper_Helper for consistent email rendering
+		$wrapper_attrs = array(
+			'style' => 'width: 100%; border-collapse: collapse;',
+		);
+
+		return \Automattic\WooCommerce\EmailEditor\Integrations\Utils\Table_Wrapper_Helper::render_table_wrapper(
+			implode( '', $content_parts ),
+			$wrapper_attrs
+		);
 	}
 
 	/**
 	 * Build columns layout content using mosaic logic organized into columns.
 	 *
 	 * @param array $images Array of image data.
-	 * @param int   $target_width Target width for email.
 	 * @param int   $cell_padding Cell padding.
 	 * @param int   $columns Number of columns for the layout.
 	 * @param int   $border_radius Border radius value (0-20).
 	 * @param array $attr Block attributes.
 	 * @return string HTML content.
 	 */
-	private static function build_columns_layout_content( $images, $target_width, $cell_padding, $columns, $border_radius = 0, $attr = array() ) {
+	private static function build_columns_layout_content( $images, $cell_padding, $columns, $border_radius = 0, $attr = array() ) {
 		$content_parts       = array();
 		$border_radius_style = self::generate_border_radius_style( '', $border_radius );
-
-		// Use simple div approach with display:flex for horizontal layout
-		$content_parts[] = '<div style="margin-bottom:24px;display:flex;margin:0;width:100%">';
 
 		// Distribute images across columns using round-robin approach for better balance
 		$column_arrays = array_fill( 0, $columns, array() );
@@ -585,86 +622,146 @@ class Tiled_Gallery {
 			$column_arrays[ $column_index ][] = $image;
 		}
 
+		// Build table cells for columns layout
+		$row_cells = '';
 		foreach ( $column_arrays as $col_index => $column_images ) {
 			if ( empty( $column_images ) ) {
+				// Add empty cell for balance
+				$cell_attrs = array(
+					'style' => sprintf(
+						'width: %s%%; padding: %dpx; vertical-align: top;',
+						( 100 / $columns ),
+						$cell_padding
+					),
+				);
+				$row_cells .= \Automattic\WooCommerce\EmailEditor\Integrations\Utils\Table_Wrapper_Helper::render_table_cell(
+					'',
+					$cell_attrs
+				);
 				continue;
 			}
 
-			// Add margin-right to all columns except the last
-			$column_margin = ( $col_index < $columns - 1 ) ? 'margin-right:' . $cell_padding . 'px;' : '';
+			// Calculate cell attributes
+			$cell_width_percent = ( 100 / $columns );
+			$cell_attrs         = array(
+				'style' => sprintf(
+					'width: %s%%; padding: %dpx; vertical-align: top;',
+					$cell_width_percent,
+					$cell_padding
+				),
+			);
 
-			// Create column container using display:flex for the outer horizontal layout
-			$content_parts[] = '<div style="margin-bottom:24px;display:flex;margin:0;' . $column_margin . '">';
-			$content_parts[] = '<div style="margin-bottom:24px;clear:both">';
+			// Add right padding to all but last cell
+			if ( $col_index < $columns - 1 ) {
+				$cell_attrs['style'] .= 'padding-right: ' . ( $cell_padding * 2 ) . 'px;';
+			}
 
 			// Generate mosaic-style groupings within this column
 			$column_rows = self::generate_column_mosaic_rows( $column_images );
 
-			foreach ( $column_rows as $row_index => $row_images ) {
-				// Add margin-top for spacing between images in the column (except first)
-				$margin_top_style = ( $row_index > 0 ) ? 'margin-top:' . $cell_padding . 'px;' : '';
-				$image_styles     = 'margin-bottom:24px;margin:0;width:100%;';
-
+			$cell_content = '';
+			foreach ( $column_rows as $row_images ) {
 				foreach ( $row_images as $image ) {
-					$content_parts[] = '<figure style="margin:0;overflow:hidden;padding:0;display:flex;' . $margin_top_style . '">';
-					$content_parts[] = self::generate_image_html( $image, $image_styles, $border_radius_style, $attr );
-					$content_parts[] = '</figure>';
+					$image_styles = 'margin: 0; width: 100%; max-width: 100%; height: auto; display: block;';
+
+					$cell_content .= self::generate_image_html( $image, $image_styles, $border_radius_style, $attr );
 				}
 			}
 
-			$content_parts[] = '</div></div>'; // Close clear:both container and column container
+			$row_cells .= \Automattic\WooCommerce\EmailEditor\Integrations\Utils\Table_Wrapper_Helper::render_table_cell(
+				$cell_content,
+				$cell_attrs
+			);
 		}
 
-		$content_parts[] = '</div>'; // Close main flex container
+		// Use Table_Wrapper_Helper for email-compatible table rendering
+		$table_attrs = array(
+			'style' => 'width: 100%; border-collapse: collapse;',
+		);
 
-		return self::generate_email_wrapper( implode( '', $content_parts ) );
+		$content_parts[] = \Automattic\WooCommerce\EmailEditor\Integrations\Utils\Table_Wrapper_Helper::render_table_wrapper(
+			$row_cells,
+			$table_attrs
+		);
+
+		// Use Table_Wrapper_Helper for consistent email rendering
+		$wrapper_attrs = array(
+			'style' => 'width: 100%; border-collapse: collapse;',
+		);
+
+		return \Automattic\WooCommerce\EmailEditor\Integrations\Utils\Table_Wrapper_Helper::render_table_wrapper(
+			implode( '', $content_parts ),
+			$wrapper_attrs
+		);
 	}
 
 	/**
 	 * Build mosaic layout content with flexible row/column structure.
 	 *
 	 * @param array $images Array of image data.
-	 * @param int   $target_width Target width for email.
 	 * @param int   $cell_padding Cell padding.
 	 * @param int   $border_radius Border radius value (0-20).
 	 * @param array $attr Block attributes.
 	 * @return string HTML content.
 	 */
-	private static function build_mosaic_layout_content( $images, $target_width, $cell_padding, $border_radius = 0, $attr = array() ) {
+	private static function build_mosaic_layout_content( $images, $cell_padding, $border_radius = 0, $attr = array() ) {
 		$content_parts       = array();
 		$border_radius_style = self::generate_border_radius_style( '', $border_radius );
 
 		// Generate mosaic layout rows
 		$rows = self::generate_mosaic_rows( $images );
 
-		foreach ( $rows as $index => $row ) {
-			// Check if this is the last row
-			$is_last_row   = ( $index === count( $rows ) - 1 );
-			$margin_bottom = $is_last_row ? '0' : $cell_padding;
+		foreach ( $rows as $row ) {
+			$images_in_row      = count( $row );
+			$cell_width_percent = ( 100 / $images_in_row );
 
-			$content_parts[] = '<div style="margin-bottom:' . $margin_bottom . 'px;display:flex;width:100%;max-width:100%;box-sizing:border-box">';
-
-			// Calculate width for each image in this row
-			$images_in_row       = count( $row );
-			$total_margin_width  = ( $images_in_row - 1 ) * $cell_padding;
-			$image_width_percent = ( 100 / $images_in_row );
-
+			// Build table cells for this row
+			$row_cells = '';
 			foreach ( $row as $image_index => $image ) {
-				$margin_right = ( $image_index < count( $row ) - 1 ) ? $cell_padding : '0';
-				$width_style  = 'width:calc(' . $image_width_percent . '% - ' . ( $total_margin_width / $images_in_row ) . 'px);';
-				$image_styles = 'margin:0;width:100%;box-sizing:border-box;';
+				// Calculate cell attributes
+				$cell_attrs = array(
+					'style' => sprintf(
+						'width: %s%%; padding: %dpx; vertical-align: top; text-align: center;',
+						$cell_width_percent,
+						$cell_padding
+					),
+				);
 
-				$content_parts[] = '<div style="margin:0;margin-right:' . $margin_right . 'px;' . $width_style . 'display:flex;min-width:0;box-sizing:border-box">';
-				$content_parts[] = '<figure style="margin:0;overflow:hidden;padding:0;display:flex;width:100%;box-sizing:border-box">';
-				$content_parts[] = self::generate_image_html( $image, $image_styles, $border_radius_style, $attr );
-				$content_parts[] = '</figure>';
-				$content_parts[] = '</div>';
+				// Add right padding to all but last cell
+				if ( $image_index < $images_in_row - 1 ) {
+					$cell_attrs['style'] .= 'padding-right: ' . ( $cell_padding * 2 ) . 'px;';
+				}
+
+				$image_styles = 'margin: 0; width: 100%; max-width: 100%; height: auto; display: block;';
+
+				$cell_content = self::generate_image_html( $image, $image_styles, $border_radius_style, $attr );
+
+				$row_cells .= \Automattic\WooCommerce\EmailEditor\Integrations\Utils\Table_Wrapper_Helper::render_table_cell(
+					$cell_content,
+					$cell_attrs
+				);
 			}
 
-			$content_parts[] = '</div>';
+			// Use Table_Wrapper_Helper for email-compatible table rendering
+			$table_attrs = array(
+				'style' => 'width: 100%; border-collapse: collapse;',
+			);
+
+			$content_parts[] = \Automattic\WooCommerce\EmailEditor\Integrations\Utils\Table_Wrapper_Helper::render_table_wrapper(
+				$row_cells,
+				$table_attrs
+			);
 		}
 
-		return self::generate_email_wrapper( implode( '', $content_parts ) );
+		// Use Table_Wrapper_Helper for consistent email rendering
+		$wrapper_attrs = array(
+			'style' => 'width: 100%; border-collapse: collapse;',
+		);
+
+		return \Automattic\WooCommerce\EmailEditor\Integrations\Utils\Table_Wrapper_Helper::render_table_wrapper(
+			implode( '', $content_parts ),
+			$wrapper_attrs
+		);
 	}
 
 	/**
@@ -684,6 +781,7 @@ class Tiled_Gallery {
 		} else {
 			// For more images, create varied row patterns
 			$patterns = array(
+				4 => array( 2, 2 ),      // 4 images: 2 + 2
 				5 => array( 2, 3 ),      // 5 images: 2 + 3
 				6 => array( 3, 3 ),      // 6 images: 3 + 3
 				7 => array( 3, 2, 2 ),   // 7 images: 3 + 2 + 2
@@ -691,25 +789,40 @@ class Tiled_Gallery {
 				9 => array( 3, 3, 3 ),   // 9 images: 3 + 3 + 3
 			);
 
-			$pattern     = $patterns[ $image_count ] ?? array( 3, 3, 3 );
-			$image_index = 0;
+			if ( isset( $patterns[ $image_count ] ) ) {
+				// Use predefined pattern for 4-9 images
+				$pattern     = $patterns[ $image_count ];
+				$image_index = 0;
 
-			foreach ( $pattern as $images_in_row ) {
-				$row = array();
-				for ( $i = 0; $i < $images_in_row && $image_index < $image_count; $i++ ) {
-					$row[] = $images[ $image_index ];
-					++$image_index;
-				}
-				if ( ! empty( $row ) ) {
+				foreach ( $pattern as $images_in_row ) {
+					$row = array();
+					for ( $i = 0; $i < $images_in_row; $i++ ) {
+						$row[] = $images[ $image_index ];
+						++$image_index;
+					}
 					$rows[] = $row;
 				}
-			}
+			} else {
+				// For 10+ images, create rows of 3 with remainder handling
+				$full_rows = intval( $image_count / 3 );
+				$remainder = $image_count % 3;
 
-			// Add any remaining images to the last row
-			if ( $image_index < $image_count ) {
-				$remaining = array_slice( $images, $image_index );
-				if ( ! empty( $remaining ) ) {
-					$rows[] = $remaining;
+				$image_index = 0;
+
+				// Create full rows of 3
+				for ( $row = 0; $row < $full_rows; $row++ ) {
+					$rows[]       = array(
+						$images[ $image_index ],
+						$images[ $image_index + 1 ],
+						$images[ $image_index + 2 ],
+					);
+					$image_index += 3;
+				}
+
+				// Handle remainder
+				if ( $remainder > 0 ) {
+					$remaining = array_slice( $images, $image_index );
+					$rows[]    = $remaining;
 				}
 			}
 		}
@@ -770,20 +883,6 @@ class Tiled_Gallery {
 	}
 
 	/**
-	 * Generate common HTML wrapper for email layouts.
-	 *
-	 * @param string $content Inner HTML content.
-	 * @return string Wrapped HTML content.
-	 */
-	private static function generate_email_wrapper( $content ) {
-		return '<div style="margin-bottom:24px;clear:both;text-align:center;margin:0 auto;padding:4px;background-color:white">' .
-			'<div style="margin-bottom:24px">' .
-			'<div style="margin-bottom:24px;padding:0;width:100%;display:block">' .
-			$content .
-			'</div></div></div>';
-	}
-
-	/**
 	 * Generate border radius style based on layout style and border radius value.
 	 *
 	 * @param string $style Layout style (square, circle, etc.).
@@ -809,7 +908,7 @@ class Tiled_Gallery {
 	 * @return string Image HTML.
 	 */
 	private static function generate_image_html( $image, $additional_styles = '', $border_radius_style = '', $attr = array() ) {
-		$base_styles     = 'border:none;background-color:#0000001a;display:block;height:auto;max-width:100%;object-fit:cover;object-position:center;padding:0;';
+		$base_styles     = 'border:none;background-color:#0000001a;display:block;height:auto;max-width:100%;padding:0;';
 		$combined_styles = $base_styles . $additional_styles . $border_radius_style;
 
 		$img_html = sprintf(
@@ -887,14 +986,11 @@ class Tiled_Gallery {
 			$remainder   = $image_count % $columns;
 			$start_index = 0;
 
-			if ( $remainder === 1 ) {
-				// 1 extra: 1 large image on top
-				$chunks[]    = array_slice( $images, 0, 1 );
-				$start_index = 1;
-			} elseif ( $remainder === 2 ) {
-				// 2 extra: 2 medium images on top
-				$chunks[]    = array_slice( $images, 0, 2 );
-				$start_index = 2;
+			// Handle all remainder cases to create proper hierarchy
+			if ( $remainder > 0 ) {
+				// Create a row with the remainder images (larger items first)
+				$chunks[]    = array_slice( $images, 0, $remainder );
+				$start_index = $remainder;
 			}
 			// If remainder === 0, start_index stays 0
 

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/tiled-gallery.php
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/tiled-gallery.php
@@ -64,6 +64,9 @@ class Tiled_Gallery {
 		$jetpack_plan = Jetpack_Plan::get();
 		wp_localize_script( 'jetpack-gallery-settings', 'jetpack_plan', array( 'data' => $jetpack_plan['product_slug'] ) );
 
+		// Get link settings from attributes
+		$link_to = ! empty( $attr['linkTo'] ) ? $attr['linkTo'] : 'none';
+
 		if ( preg_match_all( '/<img [^>]+>/', $content, $images ) ) {
 			/**
 			 * This block processes all of the images that are found and builds $find and $replace.
@@ -147,8 +150,14 @@ class Tiled_Gallery {
 					if ( ! empty( $srcset_parts ) ) {
 						$srcset = 'srcset="' . esc_attr( implode( ',', $srcset_parts ) ) . '"';
 
+						// Process the image with srcset
+						$processed_img = str_replace( '<img', $img_element . $srcset, $image_html );
+
+						// Handle link settings
+						$final_img = self::process_image_link( $processed_img, $attr, $link_to );
+
 						$find[]    = $image_html;
-						$replace[] = str_replace( '<img', $img_element . $srcset, $image_html );
+						$replace[] = $final_img;
 					}
 				}
 			}
@@ -168,6 +177,51 @@ class Tiled_Gallery {
 		 * @param string $content Tiled Gallery block content.
 		 */
 		return apply_filters( 'jetpack_tiled_galleries_block_content', $content );
+	}
+
+	/**
+	 * Process image link based on linkTo setting.
+	 * Excludes custom links which email clients will replace with the image.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param string $image_html The processed image HTML.
+	 * @param array  $attr       Block attributes.
+	 * @param string $link_to    Link setting (none, attachment, media, custom).
+	 * @return string The image HTML with or without link wrapper.
+	 */
+	private static function process_image_link( $image_html, $attr, $link_to ) {
+		// If linkTo is 'none' or empty, return image as-is
+		if ( 'none' === $link_to || empty( $link_to ) ) {
+			return $image_html;
+		}
+
+		// Extract image data attributes needed for link generation
+		$href = '';
+
+		switch ( $link_to ) {
+			case 'media':
+				// Link to media file - extract from data-url attribute
+				if ( preg_match( '/data-url="([^"]+)"/', $image_html, $data_url_match ) ) {
+					$href = esc_url( $data_url_match[1] );
+				}
+				break;
+
+			case 'attachment':
+				// Link to attachment page - extract from data-link attribute
+				if ( preg_match( '/data-link="([^"]+)"/', $image_html, $data_link_match ) ) {
+					$href = esc_url( $data_link_match[1] );
+				}
+				break;
+		}
+
+		// If we have a valid href, wrap the image in a link
+		if ( ! empty( $href ) ) {
+			return '<a href="' . $href . '">' . $image_html . '</a>';
+		}
+
+		// Fallback: return image without link
+		return $image_html;
 	}
 
 	/**
@@ -253,7 +307,7 @@ class Tiled_Gallery {
 		$layout_info = self::get_layout_style_from_attributes( $attr );
 
 		// Build layout content based on style and columns
-		$grid_content = self::build_email_layout_content( $images, $layout_info, $target_width, $email_cell_padding );
+		$grid_content = self::build_email_layout_content( $images, $layout_info, $target_width, $email_cell_padding, $attr );
 
 		// Use Table_Wrapper_Helper for consistent email rendering
 		$image_table_attrs = array(
@@ -427,23 +481,24 @@ class Tiled_Gallery {
 	 * @param array $layout_info Array with 'style' and 'columns' keys.
 	 * @param int   $target_width Target width for email.
 	 * @param int   $cell_padding Cell padding.
+	 * @param array $attr Block attributes.
 	 * @return string HTML content.
 	 */
-	private static function build_email_layout_content( $images, $layout_info, $target_width, $cell_padding ) {
+	private static function build_email_layout_content( $images, $layout_info, $target_width, $cell_padding, $attr ) {
 		$layout_style  = $layout_info['style'];
 		$columns       = $layout_info['columns'];
 		$border_radius = $layout_info['border_radius'];
 
 		switch ( $layout_style ) {
 			case 'square':
-				return self::build_square_layout_content( $images, $target_width, $cell_padding, $columns, 'square', $border_radius );
+				return self::build_square_layout_content( $images, $target_width, $cell_padding, $columns, 'square', $border_radius, $attr );
 			case 'circle':
-				return self::build_square_layout_content( $images, $target_width, $cell_padding, $columns, 'circle', $border_radius );
+				return self::build_square_layout_content( $images, $target_width, $cell_padding, $columns, 'circle', $border_radius, $attr );
 			case 'columns':
-				return self::build_columns_layout_content( $images, $target_width, $cell_padding, $columns, $border_radius );
+				return self::build_columns_layout_content( $images, $target_width, $cell_padding, $columns, $border_radius, $attr );
 			case 'rectangular':
 			default:
-				return self::build_mosaic_layout_content( $images, $target_width, $cell_padding, $border_radius );
+				return self::build_mosaic_layout_content( $images, $target_width, $cell_padding, $border_radius, $attr );
 		}
 	}
 
@@ -456,9 +511,10 @@ class Tiled_Gallery {
 	 * @param int    $columns Number of columns for the layout.
 	 * @param string $style Layout style (square or circle).
 	 * @param int    $border_radius Border radius value (0-20).
+	 * @param array  $attr Block attributes.
 	 * @return string HTML content.
 	 */
-	private static function build_square_layout_content( $images, $target_width, $cell_padding, $columns, $style = 'square', $border_radius = 0 ) {
+	private static function build_square_layout_content( $images, $target_width, $cell_padding, $columns, $style = 'square', $border_radius = 0, $attr = array() ) {
 		$content_parts = array();
 
 		// Create rows of images with special handling for square/circle layouts
@@ -493,7 +549,7 @@ class Tiled_Gallery {
 				// Use simple structure - images are pre-cropped to squares for square/circle styles
 				$content_parts[] = '<div style="margin-bottom:24px;display:flex;margin:0;' . $width_style . ';' . $margin_right . '">';
 				$content_parts[] = '<figure style="margin:0;overflow:hidden;padding:0">';
-				$content_parts[] = self::generate_image_html( $image, $image_styles, $border_radius_style );
+				$content_parts[] = self::generate_image_html( $image, $image_styles, $border_radius_style, $attr );
 				$content_parts[] = '</figure>';
 				$content_parts[] = '</div>';
 			}
@@ -512,9 +568,10 @@ class Tiled_Gallery {
 	 * @param int   $cell_padding Cell padding.
 	 * @param int   $columns Number of columns for the layout.
 	 * @param int   $border_radius Border radius value (0-20).
+	 * @param array $attr Block attributes.
 	 * @return string HTML content.
 	 */
-	private static function build_columns_layout_content( $images, $target_width, $cell_padding, $columns, $border_radius = 0 ) {
+	private static function build_columns_layout_content( $images, $target_width, $cell_padding, $columns, $border_radius = 0, $attr = array() ) {
 		$content_parts       = array();
 		$border_radius_style = self::generate_border_radius_style( '', $border_radius );
 
@@ -550,7 +607,7 @@ class Tiled_Gallery {
 
 				foreach ( $row_images as $image ) {
 					$content_parts[] = '<figure style="margin:0;overflow:hidden;padding:0;display:flex;' . $margin_top_style . '">';
-					$content_parts[] = self::generate_image_html( $image, $image_styles, $border_radius_style );
+					$content_parts[] = self::generate_image_html( $image, $image_styles, $border_radius_style, $attr );
 					$content_parts[] = '</figure>';
 				}
 			}
@@ -570,9 +627,10 @@ class Tiled_Gallery {
 	 * @param int   $target_width Target width for email.
 	 * @param int   $cell_padding Cell padding.
 	 * @param int   $border_radius Border radius value (0-20).
+	 * @param array $attr Block attributes.
 	 * @return string HTML content.
 	 */
-	private static function build_mosaic_layout_content( $images, $target_width, $cell_padding, $border_radius = 0 ) {
+	private static function build_mosaic_layout_content( $images, $target_width, $cell_padding, $border_radius = 0, $attr = array() ) {
 		$content_parts       = array();
 		$border_radius_style = self::generate_border_radius_style( '', $border_radius );
 
@@ -598,7 +656,7 @@ class Tiled_Gallery {
 
 				$content_parts[] = '<div style="margin:0;margin-right:' . $margin_right . 'px;' . $width_style . 'display:flex;min-width:0;box-sizing:border-box">';
 				$content_parts[] = '<figure style="margin:0;overflow:hidden;padding:0;display:flex;width:100%;box-sizing:border-box">';
-				$content_parts[] = self::generate_image_html( $image, $image_styles, $border_radius_style );
+				$content_parts[] = self::generate_image_html( $image, $image_styles, $border_radius_style, $attr );
 				$content_parts[] = '</figure>';
 				$content_parts[] = '</div>';
 			}
@@ -747,18 +805,57 @@ class Tiled_Gallery {
 	 * @param array  $image Image data array.
 	 * @param string $additional_styles Additional CSS styles.
 	 * @param string $border_radius_style Border radius CSS.
+	 * @param array  $attr Block attributes (optional, for link processing).
 	 * @return string Image HTML.
 	 */
-	private static function generate_image_html( $image, $additional_styles = '', $border_radius_style = '' ) {
+	private static function generate_image_html( $image, $additional_styles = '', $border_radius_style = '', $attr = array() ) {
 		$base_styles     = 'border:none;background-color:#0000001a;display:block;height:auto;max-width:100%;object-fit:cover;object-position:center;padding:0;';
 		$combined_styles = $base_styles . $additional_styles . $border_radius_style;
 
-		return sprintf(
+		$img_html = sprintf(
 			'<img alt="%s" src="%s" style="%s" />',
 			esc_attr( $image['alt'] ),
 			esc_url( $image['url'] ),
 			$combined_styles
 		);
+
+		// Handle link settings for email
+		$link_to = ! empty( $attr['linkTo'] ) ? $attr['linkTo'] : 'none';
+		$href    = self::get_image_link_href( $image, $attr, $link_to );
+
+		if ( ! empty( $href ) ) {
+			return sprintf( '<a href="%s">%s</a>', esc_url( $href ), $img_html );
+		}
+
+		return $img_html;
+	}
+
+	/**
+	 * Get the href for an image based on link settings (used for email rendering).
+	 * Excludes custom links which email clients will replace with the image.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array  $image Image data array.
+	 * @param array  $attr Block attributes.
+	 * @param string $link_to Link setting.
+	 * @return string The href URL or empty string.
+	 */
+	private static function get_image_link_href( $image, $attr, $link_to ) {
+		switch ( $link_to ) {
+			case 'media':
+				return ! empty( $image['url'] ) ? $image['url'] : '';
+
+			case 'attachment':
+				// For email, we need to generate the attachment page URL from the image ID
+				if ( ! empty( $image['id'] ) ) {
+					$attachment_url = get_permalink( $image['id'] );
+					return $attachment_url ? $attachment_url : '';
+				}
+				return '';
+			default:
+				return '';
+		}
 	}
 
 	/**

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/tiled-gallery.php
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/tiled-gallery.php
@@ -64,9 +64,6 @@ class Tiled_Gallery {
 		$jetpack_plan = Jetpack_Plan::get();
 		wp_localize_script( 'jetpack-gallery-settings', 'jetpack_plan', array( 'data' => $jetpack_plan['product_slug'] ) );
 
-		// Get link settings from attributes
-		$link_to = ! empty( $attr['linkTo'] ) ? $attr['linkTo'] : 'none';
-
 		if ( preg_match_all( '/<img [^>]+>/', $content, $images ) ) {
 			/**
 			 * This block processes all of the images that are found and builds $find and $replace.
@@ -150,14 +147,8 @@ class Tiled_Gallery {
 					if ( ! empty( $srcset_parts ) ) {
 						$srcset = 'srcset="' . esc_attr( implode( ',', $srcset_parts ) ) . '"';
 
-						// Process the image with srcset
-						$processed_img = str_replace( '<img', $img_element . $srcset, $image_html );
-
-						// Handle link settings
-						$final_img = self::process_image_link( $processed_img, $attr, $link_to );
-
 						$find[]    = $image_html;
-						$replace[] = $final_img;
+						$replace[] = str_replace( '<img', $img_element . $srcset, $image_html );
 					}
 				}
 			}
@@ -177,51 +168,6 @@ class Tiled_Gallery {
 		 * @param string $content Tiled Gallery block content.
 		 */
 		return apply_filters( 'jetpack_tiled_galleries_block_content', $content );
-	}
-
-	/**
-	 * Process image link based on linkTo setting.
-	 * Excludes custom links which email clients will replace with the image.
-	 *
-	 * @since $$next-version$$
-	 *
-	 * @param string $image_html The processed image HTML.
-	 * @param array  $attr       Block attributes.
-	 * @param string $link_to    Link setting (none, attachment, media, custom).
-	 * @return string The image HTML with or without link wrapper.
-	 */
-	private static function process_image_link( $image_html, $attr, $link_to ) {
-		// If linkTo is 'none' or empty, return image as-is
-		if ( 'none' === $link_to || empty( $link_to ) ) {
-			return $image_html;
-		}
-
-		// Extract image data attributes needed for link generation
-		$href = '';
-
-		switch ( $link_to ) {
-			case 'media':
-				// Link to media file - extract from data-url attribute
-				if ( preg_match( '/data-url="([^"]+)"/', $image_html, $data_url_match ) ) {
-					$href = esc_url( $data_url_match[1] );
-				}
-				break;
-
-			case 'attachment':
-				// Link to attachment page - extract from data-link attribute
-				if ( preg_match( '/data-link="([^"]+)"/', $image_html, $data_link_match ) ) {
-					$href = esc_url( $data_link_match[1] );
-				}
-				break;
-		}
-
-		// If we have a valid href, wrap the image in a link
-		if ( ! empty( $href ) ) {
-			return '<a href="' . $href . '">' . $image_html . '</a>';
-		}
-
-		// Fallback: return image without link
-		return $image_html;
 	}
 
 	/**
@@ -289,29 +235,23 @@ class Tiled_Gallery {
 
 		// Get spacing from email_attrs for better consistency with core blocks
 		$email_attrs        = isset( $parsed_block['email_attrs'] ) ? $parsed_block['email_attrs'] : array();
-		$gap_style          = '';
 		$table_margin_style = '';
-		$cell_padding_style = '';
 
 		if ( ! empty( $email_attrs ) && class_exists( '\WP_Style_Engine' ) ) {
-			// Get margin-top for gap spacing
-			$gap_style = \WP_Style_Engine::compile_css( array_intersect_key( $email_attrs, array_flip( array( 'margin-top' ) ) ), '' ) ?? '';
-
 			// Get margin for table styling
 			$table_margin_style = \WP_Style_Engine::compile_css( array_intersect_key( $email_attrs, array_flip( array( 'margin' ) ) ), '' ) ?? '';
-
-			// Get padding for cell spacing
-			$cell_padding_style = \WP_Style_Engine::compile_css( array_intersect_key( $email_attrs, array_flip( array( 'padding' ) ) ), '' ) ?? '';
 		}
 
-		// Email rendering configuration - use computed values or fallbacks
-		$email_common_margin = 16; // Common margin/padding value used multiple times
-		$email_cell_padding  = 4;  // Cell padding used in multiple places
+		// Email cell padding
+		$email_cell_padding = 2;  // Cell padding
 
 		$attr = $parsed_block['attrs'];
 
+		// Determine layout style and columns from attributes (needed for both image processing and layout building)
+		$layout_info = self::get_layout_style_from_attributes( $attr );
+
 		// Process images for email rendering
-		$images = self::process_tiled_gallery_images_for_email( $attr );
+		$images = self::process_tiled_gallery_images_for_email( $attr, $layout_info );
 
 		if ( empty( $images ) ) {
 			return '';
@@ -320,33 +260,22 @@ class Tiled_Gallery {
 		// Determine target width from the email layout if available
 		$target_width = self::get_email_target_width( $rendering_context );
 
-		// Determine layout style and columns from attributes
-		$layout_info = self::get_layout_style_from_attributes( $attr );
-
 		// Build layout content based on style and columns
-		$grid_content = self::build_email_layout_content( $images, $layout_info, $email_cell_padding, $attr, $cell_padding_style );
+		$grid_content = self::build_email_layout_content( $images, $layout_info, $email_cell_padding, $attr );
 
 		// Use Table_Wrapper_Helper for consistent email rendering
-		$table_style = 'padding: 0; border-collapse: collapse;';
+		$table_style = sprintf( 'width: 100%%; max-width: %dpx; padding: 0; border-collapse: collapse;', $target_width );
 		if ( ! empty( $table_margin_style ) ) {
 			$table_style = $table_margin_style . '; ' . $table_style;
 		} else {
-			$table_style = 'margin: ' . $email_common_margin . 'px 0; ' . $table_style;
+			$table_style = 'margin: 16px 0; ' . $table_style;
 		}
 
 		$image_table_attrs = array(
 			'style' => $table_style,
-			'width' => $target_width,
 		);
 
 		$html = \Automattic\WooCommerce\EmailEditor\Integrations\Utils\Table_Wrapper_Helper::render_table_wrapper( $grid_content, $image_table_attrs );
-
-		// Add margin below the block using gap_style if available, otherwise use default
-		if ( ! empty( $gap_style ) ) {
-			$html .= '<div style="' . $gap_style . '"></div>';
-		} else {
-			$html .= '<div style="margin-bottom: 32px;"></div>';
-		}
 
 		return $html;
 	}
@@ -377,14 +306,14 @@ class Tiled_Gallery {
 	 * Process tiled gallery images for email rendering.
 	 *
 	 * @param array $attr Block attributes containing image data.
+	 * @param array $layout_info Layout information from get_layout_style_from_attributes.
 	 * @return array Processed image data for email rendering.
 	 */
-	private static function process_tiled_gallery_images_for_email( $attr ) {
+	private static function process_tiled_gallery_images_for_email( $attr, $layout_info ) {
 		$images = array();
 
-		// Determine if this is a squareish layout once
-		$layout_info  = self::get_layout_style_from_attributes( $attr );
-		$is_squareish = self::is_squareish_layout_style( $layout_info['style'] );
+		// Determine if this is a squareish layout
+		$is_squareish = in_array( $layout_info['style'], array( 'square', 'circle' ), true );
 
 		// Get images from IDs (primary data source)
 		if ( ! empty( $attr['ids'] ) && is_array( $attr['ids'] ) ) {
@@ -564,7 +493,7 @@ class Tiled_Gallery {
 					),
 				);
 
-				$image_styles = 'margin: 0; width: 100%; max-width: 100%; height: auto; display: block;';
+				$image_styles = self::generate_image_styles( false );
 
 				$cell_content = self::generate_image_html( $image, $image_styles, $border_radius_style, $attr );
 
@@ -619,7 +548,7 @@ class Tiled_Gallery {
 
 		// Build table cells for columns layout
 		$row_cells = '';
-		foreach ( $column_arrays as $col_index => $column_images ) {
+		foreach ( $column_arrays as $column_images ) {
 			if ( empty( $column_images ) ) {
 				// Add empty cell for balance
 				$cell_attrs = array(
@@ -646,18 +575,18 @@ class Tiled_Gallery {
 				),
 			);
 
-			// Add right padding to all but last cell
-			if ( $col_index < $columns - 1 ) {
-				$cell_attrs['style'] .= 'padding-right: ' . ( $cell_padding * 2 ) . 'px;';
-			}
-
 			// Generate mosaic-style groupings within this column
 			$column_rows = self::generate_column_mosaic_rows( $column_images );
 
 			$cell_content = '';
-			foreach ( $column_rows as $row_images ) {
+			foreach ( $column_rows as $row_index => $row_images ) {
 				foreach ( $row_images as $image ) {
-					$image_styles = 'margin: 0; width: 100%; max-width: 100%; height: auto; display: block;';
+					$image_styles = self::generate_image_styles( false );
+
+					// Add top margin to all images except the first one in the column
+					if ( $row_index > 0 || $cell_content !== '' ) {
+						$image_styles .= ' margin-top: ' . ( $cell_padding * 2 ) . 'px;';
+					}
 
 					$cell_content .= self::generate_image_html( $image, $image_styles, $border_radius_style, $attr );
 				}
@@ -721,21 +650,16 @@ class Tiled_Gallery {
 
 			// Build table cells for this row
 			$row_cells = '';
-			foreach ( $row as $image_index => $image ) {
+			foreach ( $row as $image ) {
 				$cell_style = sprintf(
 					'width: %s%%; padding: %dpx; vertical-align: top; text-align: center;',
 					$cell_width_percent,
 					$cell_padding
 				);
 
-				// Add right padding to all but last cell in the actual row
-				if ( $image_index < $images_in_row - 1 ) {
-					$cell_style .= 'padding-right: ' . ( $cell_padding * 2 ) . 'px;';
-				}
-
 				// Set consistent height for all images in this row to ensure alignment
 				// Use progressive enhancement: object-fit for supported clients, natural layout for others
-				$image_styles = 'margin: 0; width: 100%; max-width: 100%; height: 200px; display: block; object-fit: cover; object-position: center;';
+				$image_styles = self::generate_image_styles( true );
 
 				$cell_content = self::generate_image_html( $image, $image_styles, $border_radius_style, $attr );
 
@@ -748,8 +672,7 @@ class Tiled_Gallery {
 
 			// Create a separate table for each row with flexible height for alignment
 			$row_table = sprintf(
-				'<table role="presentation" style="width: 100%%; border-collapse: collapse; margin-bottom: %dpx; table-layout: fixed;"><tr>%s</tr></table>',
-				$cell_padding,
+				'<table role="presentation" style="width: 100%%; border-collapse: collapse; table-layout: fixed;"><tr>%s</tr></table>',
 				$row_cells
 			);
 
@@ -902,6 +825,22 @@ class Tiled_Gallery {
 	}
 
 	/**
+	 * Generate image styles for email rendering.
+	 *
+	 * @param bool $use_fixed_height Whether to use fixed height with object-fit.
+	 * @return string CSS style string.
+	 */
+	private static function generate_image_styles( $use_fixed_height = false ) {
+		$base_styles = 'margin: 0; width: 100%; max-width: 100%; display: block;';
+
+		if ( $use_fixed_height ) {
+			return $base_styles . ' height: 200px; object-fit: cover; object-position: center;';
+		}
+
+		return $base_styles . ' height: auto;';
+	}
+
+	/**
 	 * Generate image HTML with consistent styling.
 	 *
 	 * @param array  $image Image data array.
@@ -958,16 +897,6 @@ class Tiled_Gallery {
 			default:
 				return '';
 		}
-	}
-
-	/**
-	 * Check if layout style is square or circle (squareish).
-	 *
-	 * @param string $layout_style The layout style.
-	 * @return bool True if squareish layout.
-	 */
-	private static function is_squareish_layout_style( $layout_style ) {
-		return in_array( $layout_style, array( 'square', 'circle' ), true );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/Tiled_Gallery_Block_Email_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/Tiled_Gallery_Block_Email_Test.php
@@ -93,8 +93,8 @@ class Tiled_Gallery_Block_Email_Test extends WP_UnitTestCase {
 		// Should contain table-based layout for email compatibility
 		$this->assertStringContainsString( 'border-collapse: collapse', $result );
 
-		// Should contain margin below block
-		$this->assertStringContainsString( 'margin-bottom: 32px', $result );
+		// Should contain margin styling for email spacing
+		$this->assertStringContainsString( 'margin: 16px 0', $result );
 	}
 
 	/**
@@ -388,93 +388,5 @@ class Tiled_Gallery_Block_Email_Test extends WP_UnitTestCase {
 		$this->assertNotEmpty( $result );
 		$this->assertStringContainsString( '<img', $result );
 		$this->assertStringNotContainsString( '<a href=', $result );
-	}
-
-	/**
-	 * Test front-end render method with media links.
-	 */
-	public function test_render_frontend_with_media_links() {
-		// Sample HTML content with tiled gallery images
-		$content = '<div class="wp-block-jetpack-tiled-gallery">
-			<div class="tiled-gallery__gallery">
-				<div class="tiled-gallery__row">
-					<div class="tiled-gallery__col">
-						<figure class="tiled-gallery__item">
-							<img alt="Test Image 1" data-height="1254" data-id="1" data-link="https://example.com/?attachment_id=1" data-url="https://example.com/image1.jpg" data-width="1880" src="https://example.com/image1.jpg" />
-						</figure>
-					</div>
-					<div class="tiled-gallery__col">
-						<figure class="tiled-gallery__item">
-							<img alt="Test Image 2" data-height="1254" data-id="2" data-link="https://example.com/?attachment_id=2" data-url="https://example.com/image2.jpg" data-width="1880" src="https://example.com/image2.jpg" />
-						</figure>
-					</div>
-				</div>
-			</div>
-		</div>';
-
-		$attr = array(
-			'linkTo' => 'media',
-		);
-
-		$result = \Automattic\Jetpack\Extensions\Tiled_Gallery::render( $attr, $content );
-
-		// Should wrap images in media file links
-		$this->assertStringContainsString( '<a href="https://example.com/image1.jpg">', $result );
-		$this->assertStringContainsString( '<a href="https://example.com/image2.jpg">', $result );
-	}
-
-	/**
-	 * Test front-end render method with attachment links.
-	 */
-	public function test_render_frontend_with_attachment_links() {
-		// Sample HTML content with tiled gallery images
-		$content = '<div class="wp-block-jetpack-tiled-gallery">
-			<div class="tiled-gallery__gallery">
-				<div class="tiled-gallery__row">
-					<div class="tiled-gallery__col">
-						<figure class="tiled-gallery__item">
-							<img alt="Test Image 1" data-height="1254" data-id="1" data-link="https://example.com/?attachment_id=1" data-url="https://example.com/image1.jpg" data-width="1880" src="https://example.com/image1.jpg" />
-						</figure>
-					</div>
-				</div>
-			</div>
-		</div>';
-
-		$attr = array(
-			'linkTo' => 'attachment',
-		);
-
-		$result = \Automattic\Jetpack\Extensions\Tiled_Gallery::render( $attr, $content );
-
-		// Should wrap images in attachment page links
-		$this->assertStringContainsString( '<a href="https://example.com/?attachment_id=1">', $result );
-	}
-
-	/**
-	 * Test front-end render method with no links (default).
-	 */
-	public function test_render_frontend_with_no_links() {
-		// Sample HTML content with tiled gallery images
-		$content = '<div class="wp-block-jetpack-tiled-gallery">
-			<div class="tiled-gallery__gallery">
-				<div class="tiled-gallery__row">
-					<div class="tiled-gallery__col">
-						<figure class="tiled-gallery__item">
-							<img alt="Test Image 1" data-height="1254" data-id="1" data-link="https://example.com/?attachment_id=1" data-url="https://example.com/image1.jpg" data-width="1880" src="https://example.com/image1.jpg" />
-						</figure>
-					</div>
-				</div>
-			</div>
-		</div>';
-
-		$attr = array(
-			'linkTo' => 'none',
-		);
-
-		$result = \Automattic\Jetpack\Extensions\Tiled_Gallery::render( $attr, $content );
-
-		// Should not wrap images in any links
-		$this->assertStringNotContainsString( '<a href=', $result );
-		$this->assertStringContainsString( '<img', $result );
 	}
 }

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/Tiled_Gallery_Block_Email_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/Tiled_Gallery_Block_Email_Test.php
@@ -280,4 +280,201 @@ class Tiled_Gallery_Block_Email_Test extends WP_UnitTestCase {
 		$this->assertTrue( $styles_helper_exists, 'Styles_Helper class should be mocked and available' );
 		$this->assertTrue( $table_helper_exists, 'Table_Wrapper_Helper class should be mocked and available' );
 	}
+
+	/**
+	 * Test render_email with no link setting (default: none).
+	 */
+	public function test_render_email_with_no_link() {
+		$parsed_block = $this->create_parsed_block_with_attrs(
+			array(
+				'linkTo' => 'none',
+			)
+		);
+		$mock_context = $this->create_rendering_context_mock();
+		$result       = \Automattic\Jetpack\Extensions\Tiled_Gallery::render_email( '', $parsed_block, $mock_context );
+
+		// Should return HTML content without any links
+		$this->assertNotEmpty( $result );
+		$this->assertStringContainsString( '<img', $result );
+		$this->assertStringNotContainsString( '<a href=', $result );
+	}
+
+	/**
+	 * Test render_email with media file links.
+	 */
+	public function test_render_email_with_media_links() {
+		$parsed_block = $this->create_parsed_block_with_attrs(
+			array(
+				'linkTo' => 'media',
+			)
+		);
+		$mock_context = $this->create_rendering_context_mock();
+		$result       = \Automattic\Jetpack\Extensions\Tiled_Gallery::render_email( '', $parsed_block, $mock_context );
+
+		// Should return HTML content with media file links
+		$this->assertNotEmpty( $result );
+		$this->assertStringContainsString( '<a href="http://example.com/test-image-1.jpg">', $result );
+		$this->assertStringContainsString( '<a href="http://example.com/test-image-2.jpg">', $result );
+		$this->assertStringContainsString( '<a href="http://example.com/test-image-3.jpg">', $result );
+	}
+
+	/**
+	 * Test render_email with attachment page links.
+	 */
+	public function test_render_email_with_attachment_links() {
+		// Create test attachments
+		$attachment_id_1 = $this->factory->attachment->create();
+		$attachment_id_2 = $this->factory->attachment->create();
+		$attachment_id_3 = $this->factory->attachment->create();
+
+		$parsed_block = $this->create_parsed_block_with_attrs(
+			array(
+				'linkTo' => 'attachment',
+				'images' => array(
+					array(
+						'url' => 'http://example.com/test-image-1.jpg',
+						'alt' => 'Test Alt Text 1',
+						'id'  => $attachment_id_1,
+					),
+					array(
+						'url' => 'http://example.com/test-image-2.jpg',
+						'alt' => 'Test Alt Text 2',
+						'id'  => $attachment_id_2,
+					),
+					array(
+						'url' => 'http://example.com/test-image-3.jpg',
+						'alt' => 'Test Alt Text 3',
+						'id'  => $attachment_id_3,
+					),
+				),
+			)
+		);
+		$mock_context = $this->create_rendering_context_mock();
+		$result       = \Automattic\Jetpack\Extensions\Tiled_Gallery::render_email( '', $parsed_block, $mock_context );
+
+		// Should return HTML content with attachment page links
+		$this->assertNotEmpty( $result );
+		$this->assertStringContainsString( '<a href=', $result );
+
+		// Check that links contain attachment URLs
+		$expected_url_1 = get_permalink( $attachment_id_1 );
+		$expected_url_2 = get_permalink( $attachment_id_2 );
+		$expected_url_3 = get_permalink( $attachment_id_3 );
+
+		if ( $expected_url_1 ) {
+			$this->assertStringContainsString( 'href="' . esc_url( $expected_url_1 ) . '"', $result );
+		}
+		if ( $expected_url_2 ) {
+			$this->assertStringContainsString( 'href="' . esc_url( $expected_url_2 ) . '"', $result );
+		}
+		if ( $expected_url_3 ) {
+			$this->assertStringContainsString( 'href="' . esc_url( $expected_url_3 ) . '"', $result );
+		}
+	}
+
+	/**
+	 * Test render_email with invalid linkTo setting.
+	 */
+	public function test_render_email_with_invalid_link_setting() {
+		$parsed_block = $this->create_parsed_block_with_attrs(
+			array(
+				'linkTo' => 'invalid-setting',
+			)
+		);
+		$mock_context = $this->create_rendering_context_mock();
+		$result       = \Automattic\Jetpack\Extensions\Tiled_Gallery::render_email( '', $parsed_block, $mock_context );
+
+		// Should return HTML content without any links (fallback to no links)
+		$this->assertNotEmpty( $result );
+		$this->assertStringContainsString( '<img', $result );
+		$this->assertStringNotContainsString( '<a href=', $result );
+	}
+
+	/**
+	 * Test front-end render method with media links.
+	 */
+	public function test_render_frontend_with_media_links() {
+		// Sample HTML content with tiled gallery images
+		$content = '<div class="wp-block-jetpack-tiled-gallery">
+			<div class="tiled-gallery__gallery">
+				<div class="tiled-gallery__row">
+					<div class="tiled-gallery__col">
+						<figure class="tiled-gallery__item">
+							<img alt="Test Image 1" data-height="1254" data-id="1" data-link="https://example.com/?attachment_id=1" data-url="https://example.com/image1.jpg" data-width="1880" src="https://example.com/image1.jpg" />
+						</figure>
+					</div>
+					<div class="tiled-gallery__col">
+						<figure class="tiled-gallery__item">
+							<img alt="Test Image 2" data-height="1254" data-id="2" data-link="https://example.com/?attachment_id=2" data-url="https://example.com/image2.jpg" data-width="1880" src="https://example.com/image2.jpg" />
+						</figure>
+					</div>
+				</div>
+			</div>
+		</div>';
+
+		$attr = array(
+			'linkTo' => 'media',
+		);
+
+		$result = \Automattic\Jetpack\Extensions\Tiled_Gallery::render( $attr, $content );
+
+		// Should wrap images in media file links
+		$this->assertStringContainsString( '<a href="https://example.com/image1.jpg">', $result );
+		$this->assertStringContainsString( '<a href="https://example.com/image2.jpg">', $result );
+	}
+
+	/**
+	 * Test front-end render method with attachment links.
+	 */
+	public function test_render_frontend_with_attachment_links() {
+		// Sample HTML content with tiled gallery images
+		$content = '<div class="wp-block-jetpack-tiled-gallery">
+			<div class="tiled-gallery__gallery">
+				<div class="tiled-gallery__row">
+					<div class="tiled-gallery__col">
+						<figure class="tiled-gallery__item">
+							<img alt="Test Image 1" data-height="1254" data-id="1" data-link="https://example.com/?attachment_id=1" data-url="https://example.com/image1.jpg" data-width="1880" src="https://example.com/image1.jpg" />
+						</figure>
+					</div>
+				</div>
+			</div>
+		</div>';
+
+		$attr = array(
+			'linkTo' => 'attachment',
+		);
+
+		$result = \Automattic\Jetpack\Extensions\Tiled_Gallery::render( $attr, $content );
+
+		// Should wrap images in attachment page links
+		$this->assertStringContainsString( '<a href="https://example.com/?attachment_id=1">', $result );
+	}
+
+	/**
+	 * Test front-end render method with no links (default).
+	 */
+	public function test_render_frontend_with_no_links() {
+		// Sample HTML content with tiled gallery images
+		$content = '<div class="wp-block-jetpack-tiled-gallery">
+			<div class="tiled-gallery__gallery">
+				<div class="tiled-gallery__row">
+					<div class="tiled-gallery__col">
+						<figure class="tiled-gallery__item">
+							<img alt="Test Image 1" data-height="1254" data-id="1" data-link="https://example.com/?attachment_id=1" data-url="https://example.com/image1.jpg" data-width="1880" src="https://example.com/image1.jpg" />
+						</figure>
+					</div>
+				</div>
+			</div>
+		</div>';
+
+		$attr = array(
+			'linkTo' => 'none',
+		);
+
+		$result = \Automattic\Jetpack\Extensions\Tiled_Gallery::render( $attr, $content );
+
+		// Should not wrap images in any links
+		$this->assertStringNotContainsString( '<a href=', $result );
+		$this->assertStringContainsString( '<img', $result );
+	}
 }

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/Tiled_Gallery_Block_Email_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/Tiled_Gallery_Block_Email_Test.php
@@ -90,11 +90,11 @@ class Tiled_Gallery_Block_Email_Test extends WP_UnitTestCase {
 		$this->assertStringContainsString( '<table', $result );
 		$this->assertStringContainsString( '<img', $result );
 
-		// Should contain flexbox layout
-		$this->assertStringContainsString( 'display:flex', $result );
+		// Should contain table-based layout for email compatibility
+		$this->assertStringContainsString( 'border-collapse: collapse', $result );
 
 		// Should contain margin below block
-		$this->assertStringContainsString( 'margin-bottom: 2em', $result );
+		$this->assertStringContainsString( 'margin-bottom: 32px', $result );
 	}
 
 	/**
@@ -115,8 +115,8 @@ class Tiled_Gallery_Block_Email_Test extends WP_UnitTestCase {
 		$this->assertStringContainsString( '<table', $result );
 		$this->assertStringContainsString( '<img', $result );
 
-		// Should contain flexbox layout
-		$this->assertStringContainsString( 'display:flex', $result );
+		// Should contain table-based layout for email compatibility
+		$this->assertStringContainsString( 'border-collapse: collapse', $result );
 	}
 
 	/**
@@ -152,7 +152,7 @@ class Tiled_Gallery_Block_Email_Test extends WP_UnitTestCase {
 
 		// Should return HTML content with columns layout
 		$this->assertNotEmpty( $result );
-		$this->assertStringContainsString( 'clear:both', $result );
+		$this->assertStringContainsString( 'border-collapse: collapse', $result );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/Tiled_Gallery_Block_Email_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/Tiled_Gallery_Block_Email_Test.php
@@ -1,0 +1,283 @@
+<?php
+/**
+ * Tiled Gallery Block Email Rendering tests
+ *
+ * @package automattic/jetpack
+ */
+
+require_once JETPACK__PLUGIN_DIR . 'extensions/blocks/tiled-gallery/tiled-gallery.php';
+
+// Include mock classes for WooCommerce Email Editor helpers
+require_once __DIR__ . '/class-mock-styles-helper.php';
+require_once __DIR__ . '/class-mock-table-wrapper-helper.php';
+
+use PHPUnit\Framework\Attributes\CoversMethod;
+
+/**
+ * Tiled Gallery Block Email Rendering tests.
+ *
+ * These tests verify the render_email function works correctly for various scenarios
+ * including valid inputs, security validation, layout styles, and grid generation.
+ *
+ * @covers Automattic\Jetpack\Extensions\Tiled_Gallery::render_email
+ */
+#[CoversMethod( Automattic\Jetpack\Extensions\Tiled_Gallery::class, 'render_email' )]
+class Tiled_Gallery_Block_Email_Test extends WP_UnitTestCase {
+	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
+
+	/**
+	 * Helper to create a parsed block with test images.
+	 *
+	 * @param array $attrs Optional custom attributes.
+	 * @return array Parsed block structure.
+	 */
+	private function create_parsed_block_with_attrs( $attrs = array() ) {
+		$default_attrs = array(
+			'images' => array(
+				array(
+					'url' => 'http://example.com/test-image-1.jpg',
+					'alt' => 'Test Alt Text 1',
+					'id'  => 1,
+				),
+				array(
+					'url' => 'http://example.com/test-image-2.jpg',
+					'alt' => 'Test Alt Text 2',
+					'id'  => 2,
+				),
+				array(
+					'url' => 'http://example.com/test-image-3.jpg',
+					'alt' => 'Test Alt Text 3',
+					'id'  => 3,
+				),
+			),
+		);
+
+		return array(
+			'attrs' => array_merge( $default_attrs, $attrs ),
+		);
+	}
+
+	/**
+	 * Helper to create a rendering context mock.
+	 *
+	 * @param string $width The width to return from get_layout_width_without_padding.
+	 * @return object Mock rendering context.
+	 */
+	private function create_rendering_context_mock( $width = '600px' ) {
+		return new class( $width ) {
+			private $width;
+
+			public function __construct( $width ) {
+				$this->width = $width;
+			}
+
+			public function get_layout_width_without_padding() {
+				return $this->width;
+			}
+		};
+	}
+
+	/**
+	 * Test render_email with valid images - mosaic layout.
+	 */
+	public function test_render_email_with_valid_images_mosaic() {
+		$parsed_block = $this->create_parsed_block_with_attrs();
+		$mock_context = $this->create_rendering_context_mock();
+		$result       = \Automattic\Jetpack\Extensions\Tiled_Gallery::render_email( '', $parsed_block, $mock_context );
+
+		// Should return HTML content
+		$this->assertNotEmpty( $result );
+		$this->assertStringContainsString( '<table', $result );
+		$this->assertStringContainsString( '<img', $result );
+
+		// Should contain flexbox layout
+		$this->assertStringContainsString( 'display:flex', $result );
+
+		// Should contain margin below block
+		$this->assertStringContainsString( 'margin-bottom: 2em', $result );
+	}
+
+	/**
+	 * Test render_email with square layout style.
+	 */
+	public function test_render_email_with_square_layout() {
+		$parsed_block = $this->create_parsed_block_with_attrs(
+			array(
+				'className' => 'is-style-square',
+				'columns'   => 2,
+			)
+		);
+		$mock_context = $this->create_rendering_context_mock();
+		$result       = \Automattic\Jetpack\Extensions\Tiled_Gallery::render_email( '', $parsed_block, $mock_context );
+
+		// Should return HTML content with square layout
+		$this->assertNotEmpty( $result );
+		$this->assertStringContainsString( '<table', $result );
+		$this->assertStringContainsString( '<img', $result );
+
+		// Should contain flexbox layout
+		$this->assertStringContainsString( 'display:flex', $result );
+	}
+
+	/**
+	 * Test render_email with circle layout style.
+	 */
+	public function test_render_email_with_circle_layout() {
+		$parsed_block = $this->create_parsed_block_with_attrs(
+			array(
+				'className' => 'is-style-circle',
+				'columns'   => 3,
+			)
+		);
+		$mock_context = $this->create_rendering_context_mock();
+		$result       = \Automattic\Jetpack\Extensions\Tiled_Gallery::render_email( '', $parsed_block, $mock_context );
+
+		// Should return HTML content with circle styling
+		$this->assertNotEmpty( $result );
+		$this->assertStringContainsString( 'border-radius:50%', $result );
+	}
+
+	/**
+	 * Test render_email with columns layout style.
+	 */
+	public function test_render_email_with_columns_layout() {
+		$parsed_block = $this->create_parsed_block_with_attrs(
+			array(
+				'className' => 'is-style-columns',
+				'columns'   => 2,
+			)
+		);
+		$mock_context = $this->create_rendering_context_mock();
+		$result       = \Automattic\Jetpack\Extensions\Tiled_Gallery::render_email( '', $parsed_block, $mock_context );
+
+		// Should return HTML content with columns layout
+		$this->assertNotEmpty( $result );
+		$this->assertStringContainsString( 'clear:both', $result );
+	}
+
+	/**
+	 * Test render_email with rounded corners.
+	 */
+	public function test_render_email_with_rounded_corners() {
+		$parsed_block = $this->create_parsed_block_with_attrs(
+			array(
+				'roundedCorners' => 10,
+			)
+		);
+		$mock_context = $this->create_rendering_context_mock();
+		$result       = \Automattic\Jetpack\Extensions\Tiled_Gallery::render_email( '', $parsed_block, $mock_context );
+
+		// Should contain border radius styling
+		$this->assertNotEmpty( $result );
+		$this->assertStringContainsString( 'border-radius:10px', $result );
+	}
+
+	/**
+	 * Test render_email with missing attrs.
+	 */
+	public function test_render_email_with_missing_attrs() {
+		$mock_context = $this->create_rendering_context_mock();
+
+		// Test with missing attrs
+		$result = \Automattic\Jetpack\Extensions\Tiled_Gallery::render_email( '', array( 'not-attrs' => array() ), $mock_context );
+		$this->assertSame( '', $result );
+
+		// Test with empty attrs
+		$result = \Automattic\Jetpack\Extensions\Tiled_Gallery::render_email( '', array( 'attrs' => array() ), $mock_context );
+		$this->assertSame( '', $result );
+	}
+
+	/**
+	 * Test render_email with invalid attachment IDs.
+	 */
+	public function test_render_email_with_invalid_attachment_ids() {
+		$parsed_block = array(
+			'attrs' => array(
+				'ids' => array( 99999, 99998 ), // Non-existent IDs
+			),
+		);
+
+		$mock_context = $this->create_rendering_context_mock();
+		$result       = \Automattic\Jetpack\Extensions\Tiled_Gallery::render_email( '', $parsed_block, $mock_context );
+
+		// Should return empty string when no valid images
+		$this->assertSame( '', $result );
+	}
+
+	/**
+	 * Test render_email with invalid images array.
+	 */
+	public function test_render_email_with_invalid_images() {
+		$parsed_block = array(
+			'attrs' => array(
+				'images' => array(
+					array(
+						'url' => '', // Invalid/empty URL
+						'alt' => 'Test Alt Text',
+						'id'  => 1,
+					),
+				),
+			),
+		);
+
+		$mock_context = $this->create_rendering_context_mock();
+		$result       = \Automattic\Jetpack\Extensions\Tiled_Gallery::render_email( '', $parsed_block, $mock_context );
+
+		// Should return empty string when no valid images
+		$this->assertSame( '', $result );
+	}
+
+	/**
+	 * Test render_email security - column validation.
+	 */
+	public function test_render_email_security_column_validation() {
+		$parsed_block = $this->create_parsed_block_with_attrs(
+			array(
+				'columns' => 50, // Excessive number of columns
+			)
+		);
+		$mock_context = $this->create_rendering_context_mock();
+		$result       = \Automattic\Jetpack\Extensions\Tiled_Gallery::render_email( '', $parsed_block, $mock_context );
+
+		// Should still render (columns should be clamped to max 6)
+		$this->assertNotEmpty( $result );
+	}
+
+	/**
+	 * Test render_email security - border radius validation.
+	 */
+	public function test_render_email_security_border_radius_validation() {
+		$parsed_block = $this->create_parsed_block_with_attrs(
+			array(
+				'roundedCorners' => 100, // Excessive border radius
+			)
+		);
+		$mock_context = $this->create_rendering_context_mock();
+		$result       = \Automattic\Jetpack\Extensions\Tiled_Gallery::render_email( '', $parsed_block, $mock_context );
+
+		// Should render with clamped border radius (max 20px)
+		$this->assertNotEmpty( $result );
+		$this->assertStringContainsString( 'border-radius:20px', $result );
+		$this->assertStringNotContainsString( 'border-radius:100px', $result );
+	}
+
+	/**
+	 * Test render_email returns empty when WooCommerce Email Editor helper classes are missing.
+	 */
+	public function test_render_email_returns_empty_when_helpers_missing() {
+		$parsed_block = $this->create_parsed_block_with_attrs();
+		$mock_context = $this->create_rendering_context_mock();
+
+		// Verify that with mocked classes, the function works
+		$result_with_mocks = \Automattic\Jetpack\Extensions\Tiled_Gallery::render_email( '', $parsed_block, $mock_context );
+		$this->assertNotEmpty( $result_with_mocks );
+
+		// Test the class existence check logic directly
+		$styles_helper_exists = class_exists( '\Automattic\WooCommerce\EmailEditor\Integrations\Utils\Styles_Helper' );
+		$table_helper_exists  = class_exists( '\Automattic\WooCommerce\EmailEditor\Integrations\Utils\Table_Wrapper_Helper' );
+
+		// Both classes should exist due to our mocks
+		$this->assertTrue( $styles_helper_exists, 'Styles_Helper class should be mocked and available' );
+		$this->assertTrue( $table_helper_exists, 'Table_Wrapper_Helper class should be mocked and available' );
+	}
+}

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/Tiled_Gallery_Block_Email_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/Tiled_Gallery_Block_Email_Test.php
@@ -323,9 +323,9 @@ class Tiled_Gallery_Block_Email_Test extends WP_UnitTestCase {
 	 */
 	public function test_render_email_with_attachment_links() {
 		// Create test attachments
-		$attachment_id_1 = $this->factory->attachment->create();
-		$attachment_id_2 = $this->factory->attachment->create();
-		$attachment_id_3 = $this->factory->attachment->create();
+		$attachment_id_1 = $this->factory()->attachment->create();
+		$attachment_id_2 = $this->factory()->attachment->create();
+		$attachment_id_3 = $this->factory()->attachment->create();
 
 		$parsed_block = $this->create_parsed_block_with_attrs(
 			array(

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/class-mock-table-wrapper-helper.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/class-mock-table-wrapper-helper.php
@@ -29,6 +29,24 @@ if ( ! class_exists( '\Automattic\WooCommerce\EmailEditor\Integrations\Utils\Tab
 				$style
 			) . '<tr><td style="padding: 0; font-family: Arial, sans-serif;">' . $content . '</td></tr></table>';
 		}
+
+		/**
+		 * Mock render_table_cell method
+		 *
+		 * @param string $content    The content to wrap in a cell.
+		 * @param array  $attributes The cell attributes.
+		 * @return string The wrapped cell HTML.
+		 */
+		public static function render_table_cell( $content, $attributes ) {
+			// Simple mock that wraps content in a table cell
+			$style = $attributes['style'] ?? '';
+
+			return sprintf(
+				'<td style="%s">%s</td>',
+				$style,
+				$content
+			);
+		}
 	}
 	class_alias( 'Mock_Table_Wrapper_Helper', '\Automattic\WooCommerce\EmailEditor\Integrations\Utils\Table_Wrapper_Helper' );
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://linear.app/a8c/issue/CML-820/add-email-rendering-for-tiled-gallery-blocks
Fixes https://linear.app/a8c/issue/CML-833/fix-tiled-gallery-block-rendering

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add email renderer for tiled gallery block.
* Add tests.

<img width="687" height="458" alt="Screenshot 2025-08-25 at 2 52 56 PM" src="https://github.com/user-attachments/assets/7742c6a9-1fd3-4661-bd58-50cd06251891" />
<img width="682" height="247" alt="Screenshot 2025-08-25 at 2 52 44 PM" src="https://github.com/user-attachments/assets/2f5c0dfd-e802-49f5-b87c-ba5db0a71714" />
<img width="686" height="133" alt="Screenshot 2025-08-25 at 2 52 38 PM" src="https://github.com/user-attachments/assets/2da8e01c-8aa9-465f-9575-7b4f60957ef5" />
<img width="769" height="584" alt="Screenshot 2025-08-25 at 2 52 32 PM" src="https://github.com/user-attachments/assets/53b51a08-951f-4e7d-b041-aa9f42a32453" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

pe7F0s-33D-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

N/A

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply these changes to your sandbox using `bin/jetpack-downloader test jetpack add/tiled-gallery-email-rendering`.
* Sandbox the API and turn on write access.
* Add the `wc-email-editor` sticker to a test site. See PCYsg-eQj-p2 or I can add you to my test site.
* Create a post with a tiled gallery block.
* Send yourself a test email.
* Try out different tiled gallery styles and settings. 

Notes:
- To test with a WoA dev or self-hosted site you'll need to set it up to connect to your sandbox.
- The columns style doesn't match the web version exactly, which is currently the case. No JS and limited CSS support makes it difficult to support the same masonry column layout.
- Backgrounds and custom links aren't supported, which is currently the case.