### PR TITLE
e2e tests: Add tunnel health check with retry

### DIFF
--- a/tools/e2e-commons/bin/cloudflaretunnel.js
+++ b/tools/e2e-commons/bin/cloudflaretunnel.js
@@ -10,6 +10,14 @@ const tunnelConfig = config.get( 'tunnel' );
 
 fs.mkdirSync( config.get( 'dirs.temp' ), { recursive: true } );
 
+/**
+ * Log a message with cloudflared manager prefix
+ * @param {...*} args - Arguments to log
+ */
+function log( ...args ) {
+	console.log( '[cloudflared manager]', ...args );
+}
+
 // eslint-disable-next-line @typescript-eslint/no-unused-expressions
 yargs( hideBin( process.argv ) )
 	.usage( 'Usage: $0 <cmd>' )
@@ -77,12 +85,18 @@ async function tunnelChild() {
 	} );
 
 	// Redirect console stuff to process.send too.
-	const wrap = func => m => {
-		func( m );
-		process.send?.( m );
-	};
-	console.log = wrap( console.log );
-	console.error = wrap( console.error );
+	const originalConsoleLog = console.log;
+	const originalConsoleError = console.error;
+
+	const wrap =
+		func =>
+		( ...args ) => {
+			const message = `[cloudflared manager] ${ args.join( ' ' ) }`;
+			func( message );
+			process.send?.( message );
+		};
+	console.log = wrap( originalConsoleLog );
+	console.error = wrap( originalConsoleError );
 
 	console.log( 'Starting cloudflared tunnel...' );
 
@@ -111,7 +125,7 @@ async function tunnelChild() {
 			const urlMatch = output.match( /https:\/\/.*\.trycloudflare\.com/ );
 			if ( urlMatch && ! resolved ) {
 				tunnelUrl = urlMatch[ 0 ];
-				console.log( `[tunnel manager] Cloudflare tunnel started: ${ tunnelUrl }` );
+				console.log( `Cloudflare tunnel started: ${ tunnelUrl }` );
 
 				// Save the tunnel URL and PID immediately
 				// The connectivity checks will be done by the Playwright test
@@ -128,24 +142,24 @@ async function tunnelChild() {
 
 		cloudflaredProcess.on( 'error', error => {
 			if ( ! resolved ) {
-				console.error( '[tunnel manager] Failed to start cloudflared tunnel:', error );
+				console.error( 'Failed to start cloudflared tunnel:', error );
 				reject( error );
 			}
 		} );
 
 		cloudflaredProcess.on( 'exit', code => {
-			console.log( `[tunnel manager] Cloudflared process exited with code ${ code }` );
+			console.log( `Cloudflared process exited with code ${ code }` );
 			if ( ! resolved && code !== 0 ) {
-				reject( new Error( `[tunnel manager] Cloudflared exited with code ${ code }` ) );
+				reject( new Error( `Cloudflared exited with code ${ code }` ) );
 			}
 		} );
 
 		// Timeout after 30 seconds
 		setTimeout( () => {
 			if ( ! resolved ) {
-				console.error( '[tunnel manager] Cloudflared tunnel startup timeout' );
+				console.error( 'Cloudflared tunnel startup timeout' );
 				cloudflaredProcess.kill();
-				reject( new Error( '[tunnel manager] Tunnel startup timeout' ) );
+				reject( new Error( 'Tunnel startup timeout' ) );
 			}
 		}, 30000 );
 	} );
@@ -157,7 +171,7 @@ async function tunnelChild() {
  * @return {Promise<void>}
  */
 async function tunnelOff() {
-	console.log( '[tunnel manager] Stopping cloudflared tunnel...' );
+	log( 'Stopping cloudflared tunnel...' );
 
 	const pidfile = config.get( 'temp.pid' );
 	if ( fs.existsSync( pidfile ) ) {
@@ -171,7 +185,7 @@ async function tunnelOff() {
 			}
 		};
 		if ( pid.match( /^\d+$/ ) && processExists( pid ) ) {
-			console.log( `[tunnel manager] Terminating cloudflared process ${ pid }` );
+			log( `Terminating cloudflared process ${ pid }` );
 			process.kill( pid );
 			await new Promise( resolve => {
 				const check = () => {
@@ -193,5 +207,5 @@ async function tunnelOff() {
 		fs.unlinkSync( cloudflaredPath );
 	}
 
-	console.log( '[tunnel manager] Cloudflare tunnel stopped' );
+	log( 'Cloudflare tunnel stopped' );
 }

--- a/tools/e2e-commons/bin/localtunnel.js
+++ b/tools/e2e-commons/bin/localtunnel.js
@@ -13,6 +13,30 @@ const tunnelConfig = config.get( 'tunnel' );
 
 fs.mkdirSync( config.get( 'dirs.temp' ), { recursive: true } );
 
+/**
+ * Log a message with localtunnel manager prefix
+ * @param {...*} args - Arguments to log
+ */
+function log( ...args ) {
+	console.log( '[localtunnel manager]', ...args );
+}
+
+/**
+ * Log an error message with localtunnel manager prefix
+ * @param {...*} args - Arguments to log
+ */
+function logError( ...args ) {
+	console.error( '[localtunnel manager]', ...args );
+}
+
+/**
+ * Log a warning message with localtunnel manager prefix
+ * @param {...*} args - Arguments to log
+ */
+function logWarn( ...args ) {
+	console.warn( '[localtunnel manager]', ...args );
+}
+
 // eslint-disable-next-line @typescript-eslint/no-unused-expressions
 yargs( hideBin( process.argv ) )
 	.usage( 'Usage: $0 <cmd>' )
@@ -49,9 +73,9 @@ export function getReusableUrlFromFile() {
 	} catch ( error ) {
 		if ( error.code === 'ENOENT' ) {
 			// We expect this, reduce noise in logs
-			console.warn( "Localtunnel file doesn't exist" );
+			logWarn( "Localtunnel file doesn't exist" );
 		} else {
-			console.error( error );
+			logError( error );
 		}
 	}
 	return urlFromFile;
@@ -127,12 +151,18 @@ async function tunnelChild() {
 	} );
 
 	// Redirect console stuff to process.send too.
-	const wrap = func => m => {
-		func( m );
-		process.send?.( m );
-	};
-	console.log = wrap( console.log );
-	console.error = wrap( console.error );
+	const originalConsoleLog = console.log;
+	const originalConsoleError = console.error;
+
+	const wrap =
+		func =>
+		( ...args ) => {
+			const message = `[localtunnel manager] ${ args.join( ' ' ) }`;
+			func( message );
+			process.send?.( message );
+		};
+	console.log = wrap( originalConsoleLog );
+	console.error = wrap( originalConsoleError );
 
 	const customTunnelUrl = getTunnelOverrideURL();
 	if ( customTunnelUrl ) {
@@ -174,7 +204,7 @@ async function tunnelOff() {
 	const subdomain = await getTunnelSubdomain();
 
 	if ( subdomain ) {
-		console.log( `Closing tunnel ${ subdomain }` );
+		log( `Closing tunnel ${ subdomain }` );
 
 		const pidfile = config.get( 'temp.pid' );
 		if ( fs.existsSync( pidfile ) ) {
@@ -188,7 +218,7 @@ async function tunnelOff() {
 				}
 			};
 			if ( pid.match( /^\d+$/ ) && processExists( pid ) ) {
-				console.log( `Terminating tunnel process ${ pid }` );
+				log( `Terminating tunnel process ${ pid }` );
 				process.kill( pid );
 				await new Promise( resolve => {
 					const check = () => {
@@ -206,9 +236,9 @@ async function tunnelOff() {
 
 		try {
 			const res = await axios.get( `${ tunnelConfig.host }/api/tunnels/${ subdomain }/delete` );
-			console.log( JSON.stringify( res.data ) );
+			log( JSON.stringify( res.data ) );
 		} catch ( error ) {
-			console.error( error.message );
+			logError( error.message );
 		}
 	}
 }

--- a/tools/e2e-commons/bin/tunnel.sh
+++ b/tools/e2e-commons/bin/tunnel.sh
@@ -68,6 +68,8 @@ function health_check() {
 	
 	echo "✗ Tunnel failed to respond with 200 or 301 after $max_attempts attempts"
 	echo "Note: This may be normal if the tunnel takes longer to become available"
+	# Return success to allow test suite to run - environment readiness checks will catch tunnel issues later. 
+	# We want tests to run so that these issues are caught in test reports.
 	return 0
 }
 

--- a/tools/e2e-commons/bin/tunnel.sh
+++ b/tools/e2e-commons/bin/tunnel.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 
-# Wrapper over tunnel.js script
+# Tunnel Manager
+#
+# Manages HTTP tunnels using either Cloudflare Tunnel or LocalTunnel
+#
+# Environment Variables:
+# - USE_CLOUDFLARE_TUNNEL: Use Cloudflare Tunnel instead of LocalTunnel
+#
 
 set -e
 
@@ -20,54 +26,61 @@ function usage() {
 BASE_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 export PATH="$BASE_DIR/../node_modules/.bin:$PATH"
 
+function log() {
+	echo "[tunnel manager] $*"
+}
+
 function health_check() {
 	local url="$1"
-	local max_attempts=30
+	local max_attempts=20
 	local attempt=1
+	local dns_wait_time=5
+	local retry_interval=3
 	
-	echo "Health checking tunnel at: $url"
+	log "Checking tunnel at: $url"
 	
-	# Check if curl is available
 	if ! command -v curl > /dev/null 2>&1; then
-		echo "Warning: curl not found, skipping health check"
+		log "Warning: curl not found, skipping health check"
 		return 0
 	fi
 	
-	# Give DNS some time to propagate
-	echo "Waiting 5 seconds for DNS propagation..."
-	sleep 5
+	# Give DNS some time to propagate, especially useful for Cloudflare Tunnel
+	log "Waiting $dns_wait_time seconds for DNS propagation..."
+	sleep $dns_wait_time
 	
 	while [ $attempt -le $max_attempts ]; do
 		local http_code curl_exit_code
 		http_code=$(curl -s -o /dev/null -w "%{http_code}" --connect-timeout 10 --max-time 15 "$url" 2>/dev/null)
 		curl_exit_code=$?
 		
-		echo "Attempt $attempt/$max_attempts: HTTP $http_code (curl exit: $curl_exit_code)"
-		
 		if [ "$http_code" = "200" ] || [ "$http_code" = "301" ]; then
-			echo "✓ Tunnel is responding with $http_code status"
+			log "✓ Tunnel is responding with $http_code status"
 			return 0
+		else
+			log "Attempt $attempt of $max_attempts failed: HTTP $http_code (curl exit: $curl_exit_code)"
+			
+			case $curl_exit_code in
+				6)
+					log "  DNS resolution failed"
+					;;
+				7)
+					log "  Connection refused"
+					;;
+				28)
+					log "  Connection timeout"
+					;;
+			esac
+			
+			if [ $attempt -lt $max_attempts ]; then
+				log "  Retrying in $retry_interval seconds..."
+				sleep $retry_interval
+			fi
 		fi
 		
-		# Handle specific curl error codes
-		case $curl_exit_code in
-			6)
-				echo "  DNS resolution failed, retrying..."
-				;;
-			7)
-				echo "  Connection refused, retrying..."
-				;;
-			28)
-				echo "  Connection timeout, retrying..."
-				;;
-		esac
-		
-		sleep 2
 		attempt=$((attempt + 1))
 	done
 	
-	echo "✗ Tunnel failed to respond with 200 or 301 after $max_attempts attempts"
-	echo "Note: This may be normal if the tunnel takes longer to become available"
+	log "✗ Tunnel failed to respond with 200 or 301 after $max_attempts attempts"
 	return 1
 }
 
@@ -77,7 +90,7 @@ function up() {
 	
 	while [ $retry_count -le $max_retries ]; do
 		if [ $retry_count -gt 0 ]; then
-			echo "Retrying tunnel setup (attempt $((retry_count + 1))/$((max_retries + 1)))..."
+			log "Retrying tunnel setup (attempt $((retry_count + 1))/$((max_retries + 1)))..."
 		fi
 		
 		down
@@ -96,17 +109,17 @@ function up() {
 		
 		if [[ -n "$tunnel_url" ]]; then
 			if health_check "$tunnel_url"; then
-				echo "Tunnel setup successful!"
+				log "Tunnel setup successful"
 				return 0
 			fi
 		else
-			echo "Warning: Could not extract tunnel URL from output for health check"
+			log "Warning: Could not extract tunnel URL from output for health check"
 		fi
 		
 		retry_count=$((retry_count + 1))
 	done
 	
-	echo "Tunnel setup completed after $((max_retries + 1)) attempts"
+	log "Tunnel setup failed after $((max_retries + 1)) attempts"
 	# Return success to allow test suite to run - environment readiness checks will catch tunnel issues later
 	return 0
 }

--- a/tools/e2e-commons/bin/tunnel.sh
+++ b/tools/e2e-commons/bin/tunnel.sh
@@ -20,12 +20,76 @@ function usage() {
 BASE_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 export PATH="$BASE_DIR/../node_modules/.bin:$PATH"
 
+function health_check() {
+	local url="$1"
+	local max_attempts=30
+	local attempt=1
+	
+	echo "Health checking tunnel at: $url"
+	
+	# Check if curl is available
+	if ! command -v curl > /dev/null 2>&1; then
+		echo "Warning: curl not found, skipping health check"
+		return 0
+	fi
+	
+	# Give DNS some time to propagate
+	echo "Waiting 5 seconds for DNS propagation..."
+	sleep 5
+	
+	while [ $attempt -le $max_attempts ]; do
+		local http_code curl_exit_code
+		http_code=$(curl -s -o /dev/null -w "%{http_code}" --connect-timeout 10 --max-time 15 "$url" 2>/dev/null)
+		curl_exit_code=$?
+		
+		echo "Attempt $attempt/$max_attempts: HTTP $http_code (curl exit: $curl_exit_code)"
+		
+		if [ "$http_code" = "200" ] || [ "$http_code" = "301" ]; then
+			echo "✓ Tunnel is responding with $http_code status"
+			return 0
+		fi
+		
+		# Handle specific curl error codes
+		case $curl_exit_code in
+			6)
+				echo "  DNS resolution failed, retrying..."
+				;;
+			7)
+				echo "  Connection refused, retrying..."
+				;;
+			28)
+				echo "  Connection timeout, retrying..."
+				;;
+		esac
+		
+		sleep 2
+		attempt=$((attempt + 1))
+	done
+	
+	echo "✗ Tunnel failed to respond with 200 or 301 after $max_attempts attempts"
+	echo "Note: This may be normal if the tunnel takes longer to become available"
+	return 0
+}
+
 function up() {
 	down
+	local tunnel_output
 	if [[ -n "${USE_CLOUDFLARE_TUNNEL}" ]]; then
-		node "$BASE_DIR"/cloudflaretunnel.js on "$@"
+		tunnel_output=$(node "$BASE_DIR"/cloudflaretunnel.js on "$@" 2>&1)
 	else
-		node "$BASE_DIR"/localtunnel.js on "$@"
+		tunnel_output=$(node "$BASE_DIR"/localtunnel.js on "$@" 2>&1)
+	fi
+	
+	echo "$tunnel_output"
+	
+	# Extract tunnel URL from the startup output
+	local tunnel_url
+	tunnel_url=$(echo "$tunnel_output" | grep -oE "https?://[^'\"[:space:]]+" | tail -1)
+	
+	if [[ -n "$tunnel_url" ]]; then
+		health_check "$tunnel_url"
+	else
+		echo "Warning: Could not extract tunnel URL from output for health check"
 	fi
 }
 

--- a/tools/e2e-commons/bin/tunnel.sh
+++ b/tools/e2e-commons/bin/tunnel.sh
@@ -68,31 +68,47 @@ function health_check() {
 	
 	echo "✗ Tunnel failed to respond with 200 or 301 after $max_attempts attempts"
 	echo "Note: This may be normal if the tunnel takes longer to become available"
-	# Return success to allow test suite to run - environment readiness checks will catch tunnel issues later. 
-	# We want tests to run so that these issues are caught in test reports.
-	return 0
+	return 1
 }
 
 function up() {
-	down
-	local tunnel_output
-	if [[ -n "${USE_CLOUDFLARE_TUNNEL}" ]]; then
-		tunnel_output=$(node "$BASE_DIR"/cloudflaretunnel.js on "$@" 2>&1)
-	else
-		tunnel_output=$(node "$BASE_DIR"/localtunnel.js on "$@" 2>&1)
-	fi
+	local retry_count=0
+	local max_retries=1
 	
-	echo "$tunnel_output"
+	while [ $retry_count -le $max_retries ]; do
+		if [ $retry_count -gt 0 ]; then
+			echo "Retrying tunnel setup (attempt $((retry_count + 1))/$((max_retries + 1)))..."
+		fi
+		
+		down
+		local tunnel_output
+		if [[ -n "${USE_CLOUDFLARE_TUNNEL}" ]]; then
+			tunnel_output=$(node "$BASE_DIR"/cloudflaretunnel.js on "$@" 2>&1)
+		else
+			tunnel_output=$(node "$BASE_DIR"/localtunnel.js on "$@" 2>&1)
+		fi
+		
+		echo "$tunnel_output"
+		
+		# Extract tunnel URL from the startup output
+		local tunnel_url
+		tunnel_url=$(echo "$tunnel_output" | grep -oE "https?://[^'\"[:space:]]+" | tail -1)
+		
+		if [[ -n "$tunnel_url" ]]; then
+			if health_check "$tunnel_url"; then
+				echo "Tunnel setup successful!"
+				return 0
+			fi
+		else
+			echo "Warning: Could not extract tunnel URL from output for health check"
+		fi
+		
+		retry_count=$((retry_count + 1))
+	done
 	
-	# Extract tunnel URL from the startup output
-	local tunnel_url
-	tunnel_url=$(echo "$tunnel_output" | grep -oE "https?://[^'\"[:space:]]+" | tail -1)
-	
-	if [[ -n "$tunnel_url" ]]; then
-		health_check "$tunnel_url"
-	else
-		echo "Warning: Could not extract tunnel URL from output for health check"
-	fi
+	echo "Tunnel setup completed after $((max_retries + 1)) attempts"
+	# Return success to allow test suite to run - environment readiness checks will catch tunnel issues later
+	return 0
 }
 
 function down() {

--- a/tools/e2e-commons/package.json
+++ b/tools/e2e-commons/package.json
@@ -24,9 +24,9 @@
 		"env:start": "./bin/e2e-env.sh start",
 		"env:stop": "./bin/e2e-env.sh stop",
 		"jetpack-connect": "node bin/e2e-jetpack-connector.js",
-		"tunnel:off": "./bin/tunnel.sh down",
-		"tunnel:on": "./bin/tunnel.sh up",
+		"tunnel:down": "./bin/tunnel.sh down",
 		"tunnel:reset": "./bin/tunnel.sh reset",
+		"tunnel:up": "./bin/tunnel.sh up",
 		"typecheck": "tsc --noEmit"
 	},
 	"browserslist": [],


### PR DESCRIPTION

Part of https://github.com/Automattic/jetpack/issues/44737

## Proposed changes:

Add a health check function and a retry mechanism in the tunnel script.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
* all e2e tests should pass in CI
* check the "Test environment set-up" step in e2e jobs
* locally, run `pnpm tunnel:up` or `pnpm tunnel:reset` in any of the e2e tests projects. make it fail (e.g. bring down the Docker environment) and check it retries.

