### PR TITLE
Related Posts: Prevent PHP warnings when tag data returns unexpected content

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-php_warnings_on_related_posts
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-php_warnings_on_related_posts
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Related Posts: Prevent PHP warnings when handling malformed data.

--- a/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
+++ b/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
@@ -1770,11 +1770,8 @@ EOT;
 		$tags = get_the_terms( $post_id, 'post_tag' );
 		if ( is_array( $tags ) ) {
 			foreach ( $tags as $tag ) {
-				if ( ! $tag instanceof WP_Term ) {
-					continue;
-				}
-				$tag_link = get_tag_link( $tag );
-				if ( '' !== trim( $tag->name ) ) {
+				if ( $tag instanceof WP_Term && '' !== trim( $tag->name ) ) {
+					$tag_link = get_tag_link( $tag );
 					return array(
 						'text' => trim( $tag->name ),
 						'link' => $tag_link,
@@ -1841,10 +1838,7 @@ EOT;
 		$tags = get_the_terms( $post_id, 'post_tag' );
 		if ( is_array( $tags ) ) {
 			foreach ( $tags as $tag ) {
-				if ( ! $tag instanceof WP_Term ) {
-					continue;
-				}
-				if ( '' !== trim( $tag->name ) ) {
+				if ( $tag instanceof WP_Term && '' !== trim( $tag->name ) ) {
 					$post_tag_context = sprintf(
 						// Translators: the category or tag name.
 						_x( 'In "%s"', 'in {category/tag name}', 'jetpack' ),

--- a/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
+++ b/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
@@ -1758,8 +1758,8 @@ EOT;
 		$categories = get_the_category( $post_id );
 		if ( is_array( $categories ) ) {
 			foreach ( $categories as $category ) {
-				$cat_link = get_category_link( $category );
-				if ( 'uncategorized' !== $category->slug && '' !== trim( $category->name ) ) {
+				if ( $category instanceof WP_Term && 'uncategorized' !== $category->slug && '' !== trim( $category->name ) ) {
+					$cat_link = get_category_link( $category );
 					return array(
 						'text' => trim( $category->name ),
 						'link' => $cat_link,
@@ -1814,7 +1814,7 @@ EOT;
 		$categories = get_the_category( $post_id );
 		if ( is_array( $categories ) ) {
 			foreach ( $categories as $category ) {
-				if ( 'uncategorized' !== $category->slug && '' !== trim( $category->name ) ) {
+				if ( $category instanceof WP_Term && 'uncategorized' !== $category->slug && '' !== trim( $category->name ) ) {
 					$post_cat_context = sprintf(
 						// Translators: The category or tag name.
 						esc_html_x( 'In "%s"', 'in {category/tag name}', 'jetpack' ),

--- a/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
+++ b/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
@@ -1770,6 +1770,9 @@ EOT;
 		$tags = get_the_terms( $post_id, 'post_tag' );
 		if ( is_array( $tags ) ) {
 			foreach ( $tags as $tag ) {
+				if ( ! $tag instanceof WP_Term ) {
+					continue;
+				}
 				$tag_link = get_tag_link( $tag );
 				if ( '' !== trim( $tag->name ) ) {
 					return array(
@@ -1838,6 +1841,9 @@ EOT;
 		$tags = get_the_terms( $post_id, 'post_tag' );
 		if ( is_array( $tags ) ) {
 			foreach ( $tags as $tag ) {
+				if ( ! $tag instanceof WP_Term ) {
+					continue;
+				}
 				if ( '' !== trim( $tag->name ) ) {
 					$post_tag_context = sprintf(
 						// Translators: the category or tag name.


### PR DESCRIPTION
Closes MONOREP-79

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR resolves the following bunch of warnings:
```
PHP Warning: Attempt to read property "slug" on null in /wordpress/plugins/jetpack/15.0-a.5/modules/related-posts/jetpack-related-posts.php on line 1762
PHP Warning: Attempt to read property "name" on null in /wordpress/plugins/jetpack/15.0-a.5/modules/related-posts/jetpack-related-posts.php on line 1762
PHP Warning: Attempt to read property "name" on null in /wordpress/plugins/jetpack/15.0-a.7/modules/related-posts/jetpack-related-posts.php on line 1774
PHP Warning: Attempt to read property "slug" on null in /wordpress/plugins/jetpack/15.0-a.5/modules/related-posts/jetpack-related-posts.php on line 1817
PHP Warning: Attempt to read property "name" on null in /wordpress/plugins/jetpack/15.0-a.5/modules/related-posts/jetpack-related-posts.php on line 1817
PHP Warning: Attempt to read property "name" on null in /wordpress/plugins/jetpack/15.0-a.7/modules/related-posts/jetpack-related-posts.php on line 1841
```

Both `get_the_category()` and `get_the_terms()` should return an array of `WP_Term` objects, but the results are filtered, so we can't trust their values (as is clear in the warnings).

Along with adding the conditions, I moved the link retrieval within the block, which would make things slightly more efficient than before when the condition fails.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Do the changes make sense?