### PR TITLE
Add product sync checksum support

### DIFF
--- a/projects/packages/sync/changelog/update-wc-product-sync-checksum
+++ b/projects/packages/sync/changelog/update-wc-product-sync-checksum
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Add product sync checksum support and include trash/auto-draft post statuses in queries

--- a/projects/packages/sync/src/modules/class-woocommerce-products.php
+++ b/projects/packages/sync/src/modules/class-woocommerce-products.php
@@ -406,7 +406,7 @@ class WooCommerce_Products extends Module {
 				'include'     => $ids,
 				'order'       => $order,
 				'post_type'   => array( 'product', 'product_variation' ),
-				'post_status' => 'any',
+				'post_status' => array( 'any', 'trash', 'auto-draft' ),
 				'numberposts' => -1, // Get all posts.
 			)
 		);

--- a/projects/packages/sync/src/modules/class-woocommerce-products.php
+++ b/projects/packages/sync/src/modules/class-woocommerce-products.php
@@ -263,6 +263,7 @@ class WooCommerce_Products extends Module {
 		// Build base product data from posts.
 		foreach ( $posts as $post ) {
 			$products[ $post->ID ] = array(
+				'product_id'    => $post->ID,
 				'title'         => $post->post_title,
 				'post_status'   => $post->post_status,
 				'slug'          => $post->post_name,

--- a/projects/packages/sync/src/replicastore/class-table-checksum.php
+++ b/projects/packages/sync/src/replicastore/class-table-checksum.php
@@ -289,6 +289,21 @@ class Table_Checksum {
 			),
 			'links'                      => $wpdb->links, // TODO describe in the array format or add exceptions.
 			'options'                    => $wpdb->options, // TODO describe in the array format or add exceptions.
+			'woocommerce_products'       => array(
+				'table'                     => $wpdb->posts,
+				'range_field'               => 'ID',
+				'key_fields'                => array( 'ID' ),
+				'checksum_fields'           => array( 'post_modified_gmt' ),
+				'filter_values'             => array(
+					'post_type' => array(
+						'operator' => 'IN',
+						'values'   => array( 'product', 'product_variation' ),
+					),
+				),
+				'is_table_enabled_callback' => function () {
+					return false !== Sync\Modules::get_module( 'woocommerce_products' );
+				},
+			),
 			'woocommerce_order_items'    => array(
 				'table'                     => "{$wpdb->prefix}woocommerce_order_items",
 				'range_field'               => 'order_item_id',

--- a/projects/packages/sync/src/replicastore/class-table-checksum.php
+++ b/projects/packages/sync/src/replicastore/class-table-checksum.php
@@ -289,7 +289,7 @@ class Table_Checksum {
 			),
 			'links'                      => $wpdb->links, // TODO describe in the array format or add exceptions.
 			'options'                    => $wpdb->options, // TODO describe in the array format or add exceptions.
-			'woocommerce_products'       => array(
+			'wc_product_lookup'          => array( // wc_product_lookup is a table in the cache database
 				'table'                     => $wpdb->posts,
 				'range_field'               => 'ID',
 				'key_fields'                => array( 'ID' ),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to WOOA7S-378

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

* Add WooCommerce products to the `Table_Checksum` class for data integrity verification, enabling checksum support
* Fix `get_posts` queries to include 'trash' and 'auto-draft' post statuses.  

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No, this PR does not change what data or activity we track. It only enhances the synchronization mechanism for existing WooCommerce product data.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Follow testing instructions in 191325-ghe-Automattic/wpcom
