### PR TITLE
Forms: fix warning when more tag is missing in submission

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-warning-more-tag-missing
+++ b/projects/packages/forms/changelog/fix-forms-warning-more-tag-missing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: fix warning when more tag is missing in submission

--- a/projects/packages/forms/src/contact-form/class-admin.php
+++ b/projects/packages/forms/src/contact-form/class-admin.php
@@ -676,9 +676,10 @@ class Admin {
 	public function grunion_manage_post_column_response( $post ) {
 
 		$post_content = get_post_field( 'post_content', $post->ID );
-		$content      = explode( '<!--more-->', $post_content );
-		$content      = str_ireplace( array( '<br />', ')</p>' ), '', $content[1] );
-		$chunks       = explode( "\nJSON_DATA", $content );
+		$parts        = explode( '<!--more-->', $post_content );
+		$content_body = isset( $parts[1] ) ? $parts[1] : $post_content;
+		$content_body = str_ireplace( array( '<br />', ')</p>' ), '', $content_body );
+		$chunks       = explode( "\nJSON_DATA", $content_body );
 		// Get content fields.
 		$content_fields = Contact_Form_Plugin::parse_fields_from_content( $post->ID );
 
@@ -686,7 +687,7 @@ class Admin {
 			return;
 		}
 
-		$chunks = explode( "\nArray", $content );
+		$chunks = explode( "\nArray", $content_body );
 		if ( ! empty( $chunks[1] ) ) {
 			// re-construct the array string
 			$array = 'Array' . $chunks[1];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes PHP warning:

```
Warning: Undefined array key 1 in ...src/contact-form/class-admin.php on line 680 
```

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Guard against more tag missing

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

