### PR TITLE
Fix forms failing file field test

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-failing-file-field-test
+++ b/projects/packages/forms/changelog/fix-forms-failing-file-field-test
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Forms: fix file field test

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Test.php
@@ -1139,7 +1139,7 @@ class Feedback_Test extends BaseTestCase {
 		);
 
 		$expected_file = array(
-			'field_id' => 'g2376-1-uploadafile',
+			'field_id' => 'g' . $form_id . '-uploadafile',
 			'files'    => array(
 				array(
 					'file_id' => 54321,


### PR DESCRIPTION
## Proposed changes:
This PR fixes a hardcoded value preventing one of the tests to run smoothly

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1756145885804539-slack-C052XEUUBL4

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Run `jetpack test php packages/forms --verbose`, see they pass