### PR TITLE
Redirect to new jetpack-forms-admin

### DIFF
--- a/projects/packages/forms/changelog/add-jetpack-forms-legacy-dashboard-redirect
+++ b/projects/packages/forms/changelog/add-jetpack-forms-legacy-dashboard-redirect
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: deprecate legacy feedback page, redirect to new dashboard jetpack-forms-admin

--- a/projects/packages/forms/src/contact-form/class-admin.php
+++ b/projects/packages/forms/src/contact-form/class-admin.php
@@ -81,7 +81,6 @@ class Admin {
 
 		add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_scripts' ) );
 		add_action( 'admin_footer-edit.php', array( $this, 'print_export_modal' ) );
-		add_action( 'current_screen', array( $this, 'redirect_edit_feedback_to_jetpack_forms' ) );
 
 		add_action( 'wp_ajax_grunion_export_to_gdrive', array( $this, 'export_to_gdrive' ) );
 		add_action( 'wp_ajax_grunion_gdrive_connection', array( $this, 'test_gdrive_connection' ) );
@@ -1593,34 +1592,5 @@ class Admin {
 				'type' => 'error',
 			)
 		);
-	}
-
-	/**
-	 * Redirect users from the edit-feedback screen to the Jetpack Forms admin page.
-	 *
-	 * This method is hooked to 'current_screen' and checks if the current screen
-	 * is 'edit-feedback'. If so, it redirects the user to admin.php?page=jetpack-forms-admin.
-	 *
-	 * @since $$next-version$$
-	 */
-	public function redirect_edit_feedback_to_jetpack_forms() {
-		// Only proceed if we have a valid screen object
-		if ( ! function_exists( 'get_current_screen' ) ) {
-			return;
-		}
-
-		$screen = get_current_screen();
-
-		// Check if this is the edit-feedback screen
-		if ( ! $screen || $screen->id !== 'edit-feedback' ) {
-			return;
-		}
-
-		// Perform the redirect to the Jetpack Forms admin page
-		$redirect_url = admin_url( 'admin.php?page=jetpack-forms-admin' );
-
-		// Use wp_safe_redirect to ensure we're redirecting to a safe location
-		wp_safe_redirect( $redirect_url );
-		exit;
 	}
 }

--- a/projects/packages/forms/src/contact-form/class-admin.php
+++ b/projects/packages/forms/src/contact-form/class-admin.php
@@ -81,6 +81,7 @@ class Admin {
 
 		add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_scripts' ) );
 		add_action( 'admin_footer-edit.php', array( $this, 'print_export_modal' ) );
+		add_action( 'current_screen', array( $this, 'redirect_edit_feedback_to_jetpack_forms' ) );
 
 		add_action( 'wp_ajax_grunion_export_to_gdrive', array( $this, 'export_to_gdrive' ) );
 		add_action( 'wp_ajax_grunion_gdrive_connection', array( $this, 'test_gdrive_connection' ) );
@@ -1592,5 +1593,34 @@ class Admin {
 				'type' => 'error',
 			)
 		);
+	}
+
+	/**
+	 * Redirect users from the edit-feedback screen to the Jetpack Forms admin page.
+	 *
+	 * This method is hooked to 'current_screen' and checks if the current screen
+	 * is 'edit-feedback'. If so, it redirects the user to admin.php?page=jetpack-forms-admin.
+	 *
+	 * @since $$next-version$$
+	 */
+	public function redirect_edit_feedback_to_jetpack_forms() {
+		// Only proceed if we have a valid screen object
+		if ( ! function_exists( 'get_current_screen' ) ) {
+			return;
+		}
+
+		$screen = get_current_screen();
+
+		// Check if this is the edit-feedback screen
+		if ( ! $screen || $screen->id !== 'edit-feedback' ) {
+			return;
+		}
+
+		// Perform the redirect to the Jetpack Forms admin page
+		$redirect_url = admin_url( 'admin.php?page=jetpack-forms-admin' );
+
+		// Use wp_safe_redirect to ensure we're redirecting to a safe location
+		wp_safe_redirect( $redirect_url );
+		exit;
 	}
 }

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -218,6 +218,7 @@ class Contact_Form_Plugin {
 		}
 		add_action( 'admin_menu', array( $this, 'admin_menu' ) );
 		add_action( 'current_screen', array( $this, 'unread_count' ) );
+		add_action( 'current_screen', array( $this, 'redirect_edit_feedback_to_jetpack_forms' ) );
 
 		add_filter( 'use_block_editor_for_post_type', array( $this, 'use_block_editor_for_post_type' ), 10, 2 );
 
@@ -3260,5 +3261,34 @@ class Contact_Form_Plugin {
 
 		$atts = self::block_attributes_to_shortcode_attributes( $atts, 'slider', $block );
 		return Contact_Form::parse_contact_field( $atts, $content, $block );
+	}
+
+	/**
+	 * Redirect users from the edit-feedback screen to the Jetpack Forms admin page.
+	 *
+	 * This method is hooked to 'current_screen' and checks if the current screen
+	 * is 'edit-feedback'. If so, it redirects the user to admin.php?page=jetpack-forms-admin.
+	 *
+	 * @since $$next-version$$
+	 */
+	public function redirect_edit_feedback_to_jetpack_forms() {
+		// Only proceed if we have a valid screen object
+		if ( ! function_exists( 'get_current_screen' ) ) {
+			return;
+		}
+
+		$screen = get_current_screen();
+
+		// Check if this is the edit-feedback screen
+		if ( ! $screen || $screen->id !== 'edit-feedback' ) {
+			return;
+		}
+
+		// Perform the redirect to the Jetpack Forms admin page
+		$redirect_url = admin_url( 'admin.php?page=jetpack-forms-admin' );
+
+		// Use wp_safe_redirect to ensure we're redirecting to a safe location
+		wp_safe_redirect( $redirect_url );
+		exit;
 	}
 }


### PR DESCRIPTION
## Proposed changes:
This PR adds a redirect to new jetpack-forms-admin page, deprecating (and denying) access to old dashboard `edit.php?post_type=feedback`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1756209350854909-slack-C06QF6JJDTM

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Apply and try to access `wp-admin/edit.php?post_type=feedback`.
Test on simple sites as well.