### PR TITLE
Freshly Pressed: fix PHP warning in legacy widget

### DIFF
--- a/projects/plugins/wpcomsh/changelog/fix-freshly-pressed-widget-warning
+++ b/projects/plugins/wpcomsh/changelog/fix-freshly-pressed-widget-warning
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Freshly Pressed widget: fix PHP warning.

--- a/projects/plugins/wpcomsh/widgets/class-wpcom-freshly-pressed-widget.php
+++ b/projects/plugins/wpcomsh/widgets/class-wpcom-freshly-pressed-widget.php
@@ -39,7 +39,13 @@ class WPCOM_Freshly_Pressed_Widget extends WP_Widget {
 
 		$badge_size = $this->get_badge_size( $instance['badge'] );
 
-		echo '<a href="http://discover.wordpress.com/" title="Featured on Freshly Pressed"><img src="' . esc_url( $this->get_badge_url( $instance['badge'] ) ) . '" width="' . (int) $badge_size['width'] . 'px" height="' . (int) $badge_size['height'] . 'px" /></a>';
+		printf(
+			'<a href="https://wordpress.com/discover/" title="%1$s"><img src="%2$s" width="%3$dpx" height="%4$dpx" /></a>',
+			esc_attr__( 'Featured on Freshly Pressed', 'wpcomsh' ),
+			esc_url( $this->get_badge_url( $instance['badge'] ) ),
+			(int) $badge_size['width'],
+			(int) $badge_size['height']
+		);
 
 		echo "\n" . $args['after_widget']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
@@ -128,6 +134,8 @@ class WPCOM_Freshly_Pressed_Widget extends WP_Widget {
 	 */
 	public function get_badge_size( $badge ) {
 		$badges = $this->badges();
+
+		$badge = isset( $badges[ $badge ] ) ? $badge : 'rectangle';
 
 		return $badges[ $badge ];
 	}


### PR DESCRIPTION
## Proposed changes:

See CML-836

wpcom counterpart: 191358-ghe-Automattic/wpcom/

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

Not much to test here, the widget isn't really used anymore. It's only bringing changes over to keep the 2 codebases in sync.
