### PR TITLE
PHPCS: Use wp_rand() instead of rand() and mt_rand()

### DIFF
--- a/projects/plugins/crm/changelog/update-rand_and_mt_rand_to_wp_rand
+++ b/projects/plugins/crm/changelog/update-rand_and_mt_rand_to_wp_rand
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Use wp_rand() instead of rand() and mt_rand().

--- a/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Helpers.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Helpers.php
@@ -676,18 +676,18 @@ function zeroBS_getDemoCustomer(){
 
 	);
 
-	foreach ($zbsCustomerFields as $fK => $fV){
-
-		$ret[$fK] = '';
-		if (isset($demoData[$fK])) $ret[$fK] = $demoData[$fK][mt_rand(0, count($demoData[$fK]) - 1)];
-
+	foreach ( $zbsCustomerFields as $key => $value ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+		$ret[ $key ] = '';
+		if ( isset( $demoData[ $key ] ) ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+			$ret[ $key ] = $demoData[ $key ][ wp_rand( 0, count( $demoData[ $key ] ) - 1 ) ]; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+		}
 	}
 
 	// add fullname
-	$ret['fullname'] = $demoData['fullname'][mt_rand(0, count($demoData['fullname']) - 1)];
+	$ret['fullname'] = $demoData['fullname'][ wp_rand( 0, count( $demoData['fullname'] ) - 1 ) ]; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 
 	// fill in some randoms
-	$ret['status'] = $demoData['status'][mt_rand(0, count($demoData['status']) - 1)];
+	$ret['status'] = $demoData['status'][ wp_rand( 0, count( $demoData['status'] ) - 1 ) ]; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 
 	return $ret;
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.MailTracking.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.MailTracking.php
@@ -183,6 +183,7 @@ function zeroBSCRM_mailTracking_logEmail($emailTypeID=-1, $targetObjID=-1, $send
 	global $wpdb, $ZBSCRM_t;
 
 	// MAKE A HASH - this isn't particularly legitimate, #torethink
+	 // phpcs:ignore WordPress.WP.AlternativeFunctions.rand_rand
 	$hash = sha1(time().$emailTypeID.$associatedObjID.$senderEmailAddress.$emailSubject.$senderWPID.rand(0,99999).$targetObjID);
 
 	if($thread == -1){

--- a/projects/plugins/jetpack/changelog/update-rand_and_mt_rand_to_wp_rand
+++ b/projects/plugins/jetpack/changelog/update-rand_and_mt_rand_to_wp_rand
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Use wp_rand() instead of rand() and mt_rand().

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Sender_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Sender_Test.php
@@ -192,7 +192,7 @@ class Jetpack_Sync_Sender_Test extends Jetpack_Sync_TestBase {
 		$characters_length = strlen( $characters );
 		$random_string     = '';
 		for ( $i = 0; $i < 2000; $i++ ) {
-			$random_string .= $characters[ rand( 0, $characters_length - 1 ) ];
+			$random_string .= $characters[ wp_rand( 0, $characters_length - 1 ) ];
 		}
 
 		return $random_string;

--- a/projects/plugins/jetpack/tests/php/sync/Z_IJetpack_Sync_Replicastore_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Z_IJetpack_Sync_Replicastore_Test.php
@@ -560,7 +560,7 @@ class Z_IJetpack_Sync_Replicastore_Test extends TestCase {
 	#[DataProvider( 'store_provider' )]
 	public function test_replica_update_option( $store ) {
 		$option_name  = 'blogdescription';
-		$option_value = (string) rand();
+		$option_value = (string) wp_rand();
 		$store->update_option( $option_name, $option_value );
 		$replica_option_value = $store->get_option( $option_name );
 
@@ -572,8 +572,8 @@ class Z_IJetpack_Sync_Replicastore_Test extends TestCase {
 	 */
 	#[DataProvider( 'store_provider' )]
 	public function test_replica_delete_option( $store ) {
-		$option_name  = 'test_replicastore_' . rand();
-		$option_value = (string) rand();
+		$option_name  = 'test_replicastore_' . wp_rand();
+		$option_value = (string) wp_rand();
 		$store->update_option( $option_name, $option_value );
 		$store->delete_option( $option_name );
 		$replica_option_value = $store->get_option( $option_name );

--- a/projects/plugins/super-cache/changelog/update-rand_and_mt_rand_to_wp_rand
+++ b/projects/plugins/super-cache/changelog/update-rand_and_mt_rand_to_wp_rand
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Use wp_rand() instead of rand() and mt_rand().

--- a/projects/plugins/super-cache/rest/class.wp-super-cache-rest-update-settings.php
+++ b/projects/plugins/super-cache/rest/class.wp-super-cache-rest-update-settings.php
@@ -603,7 +603,7 @@ class WP_Super_Cache_Rest_Update_Settings extends WP_REST_Controller {
 
 		if ( file_exists( $wp_cache_config_file_sample ) ) {
 			copy( $wp_cache_config_file_sample, $wp_cache_config_file );
-			$cache_page_secret = md5( date( 'H:i:s' ) . mt_rand() );
+			$cache_page_secret = md5( (string) ( gmdate( 'H:i:s' ) . wp_rand() ) );
 			wp_cache_setting( 'cache_page_secret', $cache_page_secret );
 
 			if ( function_exists( "opcache_invalidate" ) ) {

--- a/projects/plugins/super-cache/rest/class.wp-super-cache-rest-update-settings.php
+++ b/projects/plugins/super-cache/rest/class.wp-super-cache-rest-update-settings.php
@@ -603,7 +603,7 @@ class WP_Super_Cache_Rest_Update_Settings extends WP_REST_Controller {
 
 		if ( file_exists( $wp_cache_config_file_sample ) ) {
 			copy( $wp_cache_config_file_sample, $wp_cache_config_file );
-			$cache_page_secret = md5( (string) ( gmdate( 'H:i:s' ) . wp_rand() ) );
+			$cache_page_secret = md5( gmdate( 'H:i:s' ) . wp_rand() );
 			wp_cache_setting( 'cache_page_secret', $cache_page_secret );
 
 			if ( function_exists( "opcache_invalidate" ) ) {

--- a/projects/plugins/super-cache/wp-cache-phase2.php
+++ b/projects/plugins/super-cache/wp-cache-phase2.php
@@ -1222,7 +1222,7 @@ function wpsc_get_protected_directories() {
 function wpsc_debug_username() {
 	global $wp_cache_debug_username;
 	if ( ! isset( $wp_cache_debug_username ) || $wp_cache_debug_username == '' ) {
-		$wp_cache_debug_username = md5( time() + mt_rand() );
+		$wp_cache_debug_username = md5( (string) ( time() + wp_rand() ) );
 		wp_cache_setting( 'wp_cache_debug_username', $wp_cache_debug_username );
 	}
 	return $wp_cache_debug_username;
@@ -1232,7 +1232,7 @@ function wpsc_create_debug_log( $filename = '', $username = '' ) {
 	if ( $filename != '' ) {
 		$wp_cache_debug_log = $filename;
 	} else {
-		$wp_cache_debug_log = md5( time() + mt_rand() ) . '.php';
+		$wp_cache_debug_log = md5( (string) ( time() + wp_rand() ) ) . '.php';
 	}
 	if ( $username != '' ) {
 		$wp_cache_debug_username = $username;
@@ -1366,9 +1366,9 @@ function is_writeable_ACLSafe( $path ) {
 	// PHP's is_writable does not work with Win32 NTFS
 
 	if ( $path[ strlen( $path ) - 1 ] == '/' ) { // recursively return a temporary file path
-		return is_writeable_ACLSafe( $path . uniqid( mt_rand() ) . '.tmp' );
+		return is_writeable_ACLSafe( $path . uniqid( (string) wp_rand() ) . '.tmp' );
 	} elseif ( is_dir( $path ) ) {
-		return is_writeable_ACLSafe( $path . '/' . uniqid( mt_rand() ) . '.tmp' );
+		return is_writeable_ACLSafe( $path . '/' . uniqid( (string) wp_rand() ) . '.tmp' );
 	}
 
 	// check tmp file for read/write capabilities
@@ -1450,7 +1450,7 @@ function wp_cache_replace_line( $old, $new, $my_file ) {
 		}
 	}
 
-	$tmp_config_filename = tempnam( $GLOBALS['cache_path'], md5( mt_rand( 0, 9999 ) ) );
+	$tmp_config_filename = tempnam( $GLOBALS['cache_path'], md5( (string) wp_rand( 0, 9999 ) ) );
 	if ( file_exists( $tmp_config_filename . '.php' ) ) {
 		unlink( $tmp_config_filename . '.php' );
 		if ( file_exists( $tmp_config_filename . '.php' ) ) {
@@ -2322,7 +2322,7 @@ function wp_cache_get_ob( &$buffer ) {
 		$super_cache_enabled = false;
 	}
 
-	$tmp_wpcache_filename = $cache_path . uniqid( mt_rand(), true ) . '.tmp';
+	$tmp_wpcache_filename = $cache_path . uniqid( (string) wp_rand(), true ) . '.tmp';
 
 	if ( defined( 'WPSC_SUPERCACHE_ONLY' ) ) {
 		$supercacheonly = true;
@@ -2398,7 +2398,7 @@ function wp_cache_get_ob( &$buffer ) {
 			)
 		) {
 			$cache_fname        = $dir . supercache_filename();
-			$tmp_cache_filename = $dir . uniqid( mt_rand(), true ) . '.tmp';
+			$tmp_cache_filename = $dir . uniqid( (string) wp_rand(), true ) . '.tmp';
 			$fr2                = @fopen( $tmp_cache_filename, 'w' );
 			if ( ! $fr2 ) {
 				wp_cache_debug( 'Error. Supercache could not write to ' . str_replace( ABSPATH, '', $tmp_cache_filename ), 1 );
@@ -2958,7 +2958,7 @@ function wp_cache_shutdown_callback() {
 		if ( wp_cache_writers_entry() ) {
 			wp_cache_debug( "Writing meta file: {$dir}meta-{$meta_file}", 2 );
 
-			$tmp_meta_filename   = $dir . uniqid( mt_rand(), true ) . '.tmp';
+			$tmp_meta_filename   = $dir . uniqid( (string) wp_rand(), true ) . '.tmp';
 			$final_meta_filename = $dir . 'meta-' . $meta_file;
 			$fr                  = @fopen( $tmp_meta_filename, 'w' );
 			if ( $fr ) {

--- a/projects/plugins/super-cache/wp-cache.php
+++ b/projects/plugins/super-cache/wp-cache.php
@@ -744,7 +744,7 @@ function wp_cache_manager_updates() {
 		return false;
 
 	if ( false == isset( $cache_page_secret ) ) {
-		$cache_page_secret = md5( date( 'H:i:s' ) . mt_rand() );
+		$cache_page_secret = md5( (string) ( gmdate( 'H:i:s' ) . wp_rand() ) );
 		wp_cache_replace_line('^ *\$cache_page_secret', "\$cache_page_secret = '" . $cache_page_secret . "';", $wp_cache_config_file);
 	}
 
@@ -4198,7 +4198,7 @@ function update_mod_rewrite_rules( $add_rules = true ) {
 		return false;
 	}
 
-	$backup_filename = $cache_path . 'htaccess.' . mt_rand() . ".php";
+	$backup_filename      = $cache_path . 'htaccess.' . wp_rand() . '.php';
 	$backup_file_contents = file_get_contents( $home_path . '.htaccess' );
 	file_put_contents( $backup_filename, "<" . "?php die(); ?" . ">" . $backup_file_contents );
 	$existing_gzip_rules = implode( "\n", extract_from_markers( $cache_path . '.htaccess', 'supercache' ) );


### PR DESCRIPTION
Closes MONOREP-81

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

To assuage PHPCS errors that complain about direct calls to those PHP functions, this updates those calls, which results in a bit more randomness and by default a slightly larger pool of numbers, but largely is a drop-in change.

The changes were for tests, demo content, and cache file generation, and have no security implications. I did not change instances that were used outside of the WP context or that were explicitly comment-ignored.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Is CI happy? Were there any typos?
