### PR TITLE
Fix form responses line breaks

### DIFF
--- a/projects/packages/forms/changelog/fix-form-responses-line-breaks
+++ b/projects/packages/forms/changelog/fix-form-responses-line-breaks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: fix line break stripping on response values

--- a/projects/packages/forms/src/contact-form/class-feedback.php
+++ b/projects/packages/forms/src/contact-form/class-feedback.php
@@ -236,17 +236,9 @@ class Feedback {
 		}
 		if ( isset( $post_data[ $key ] ) ) {
 			if ( is_array( $post_data[ $key ] ) ) {
-				// For textarea fields, use sanitize_textarea_field to preserve newlines
-				if ( $type === 'textarea' ) {
-					return array_map( 'sanitize_textarea_field', wp_unslash( $post_data[ $key ] ) );
-				}
-				return array_map( 'sanitize_text_field', wp_unslash( $post_data[ $key ] ) );
+				return array_map( 'sanitize_textarea_field', wp_unslash( $post_data[ $key ] ) );
 			} else {
-				// For textarea fields, use sanitize_textarea_field to preserve newlines
-				if ( $type === 'textarea' ) {
-					return sanitize_textarea_field( wp_unslash( $post_data[ $key ] ) );
-				}
-				return sanitize_text_field( wp_unslash( $post_data[ $key ] ) );
+				return sanitize_textarea_field( wp_unslash( $post_data[ $key ] ) );
 			}
 		}
 		return '';

--- a/projects/packages/forms/src/contact-form/class-feedback.php
+++ b/projects/packages/forms/src/contact-form/class-feedback.php
@@ -802,13 +802,7 @@ class Feedback {
 			$fields_to_serialize['ip'] = null;
 		}
 
-		$json = wp_json_encode( $fields_to_serialize );
-
-		// WordPress strips backslashes during save/load, so we need to double-escape
-		// JSON newlines to ensure they survive the WordPress content processing
-		$json = str_replace( '\\n', '\\\\n', $json );
-
-		return $json;
+		return addslashes( wp_json_encode( $fields_to_serialize ) );
 	}
 
 	/**

--- a/projects/packages/forms/src/contact-form/class-feedback.php
+++ b/projects/packages/forms/src/contact-form/class-feedback.php
@@ -827,10 +827,7 @@ class Feedback {
 	 * @return array Parsed fields.
 	 */
 	private function parse_content_v2( $post_content = '' ) {
-		// WordPress automatically adds slashes to post content when saving
-		// We need to unslash it first before JSON parsing
-		$unslashed_content = wp_unslash( $post_content );
-		$decoded_content   = json_decode( $unslashed_content, true );
+		$decoded_content = json_decode( $post_content, true );
 		if ( $decoded_content === null ) {
 			// If JSON decoding still fails, try with stripslashes and trim as a fallback
 			// This is a workaround for some cases where the JSON data is not properly formatted

--- a/projects/packages/forms/src/contact-form/class-feedback.php
+++ b/projects/packages/forms/src/contact-form/class-feedback.php
@@ -236,8 +236,16 @@ class Feedback {
 		}
 		if ( isset( $post_data[ $key ] ) ) {
 			if ( is_array( $post_data[ $key ] ) ) {
+				// For textarea fields, use sanitize_textarea_field to preserve newlines
+				if ( $type === 'textarea' ) {
+					return array_map( 'sanitize_textarea_field', wp_unslash( $post_data[ $key ] ) );
+				}
 				return array_map( 'sanitize_text_field', wp_unslash( $post_data[ $key ] ) );
 			} else {
+				// For textarea fields, use sanitize_textarea_field to preserve newlines
+				if ( $type === 'textarea' ) {
+					return sanitize_textarea_field( wp_unslash( $post_data[ $key ] ) );
+				}
 				return sanitize_text_field( wp_unslash( $post_data[ $key ] ) );
 			}
 		}
@@ -802,7 +810,13 @@ class Feedback {
 			$fields_to_serialize['ip'] = null;
 		}
 
-		return wp_json_encode( $fields_to_serialize );
+		$json = wp_json_encode( $fields_to_serialize );
+
+		// WordPress strips backslashes during save/load, so we need to double-escape
+		// JSON newlines to ensure they survive the WordPress content processing
+		$json = str_replace( '\\n', '\\\\n', $json );
+
+		return $json;
 	}
 
 	/**
@@ -827,10 +841,13 @@ class Feedback {
 	 * @return array Parsed fields.
 	 */
 	private function parse_content_v2( $post_content = '' ) {
-		$decoded_content = json_decode( $post_content, true );
+		// WordPress automatically adds slashes to post content when saving
+		// We need to unslash it first before JSON parsing
+		$unslashed_content = wp_unslash( $post_content );
+		$decoded_content   = json_decode( $unslashed_content, true );
 		if ( $decoded_content === null ) {
-			// If JSON decoding fails, try to decode the second try with stripslashes and trim.
-			// This is a workaround for some cases where the JSON data is not properly formatted.
+			// If JSON decoding still fails, try with stripslashes and trim as a fallback
+			// This is a workaround for some cases where the JSON data is not properly formatted
 			$decoded_content = json_decode( stripslashes( trim( $post_content ) ), true );
 		}
 

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -249,6 +249,7 @@ that needs to mimic the input element styles */
 .contact-form-submission .field-value {
 	margin-bottom: 20px;
 	font-weight: 600;
+	white-space: pre-wrap;
 }
 
 .form-errors .form-error-message {

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Test.php
@@ -2100,4 +2100,35 @@ class Feedback_Test extends BaseTestCase {
 		$response = Feedback::get( $post_id );
 		$this->assertInstanceOf( Feedback::class, $response );
 	}
+
+	/**
+	 * Test that new lines are not stripped from the field value.
+	 */
+	public function test_new_lines_dont_get_stripped() {
+		$form_id = Utility::get_form_id();
+		$content = 'Hello, this is a' . PHP_EOL . ' test message from our contact form.';
+
+		// Create a form submission
+		$_post_data = Utility::get_post_request(
+			array(
+				'message' => $content,
+			),
+			'g' . $form_id
+		);
+
+		$form = new Contact_Form(
+			array(
+				'title'       => 'Test Form',
+				'description' => 'This is a test form.',
+			),
+			"[contact-field label='Message' type='textarea' required='1'/]"
+		);
+
+		$response         = Feedback::from_submission( $_post_data, $form );
+		$feedback_post_id = $response->save();
+		$saved_response   = Feedback::get( $feedback_post_id );
+
+		$this->assertEquals( $content, $response->get_field_value_by_label( 'Message' ), 'Field value should match the original content for the form submission when new lines are present' );
+		$this->assertEquals( $content, $saved_response->get_field_value_by_label( 'Message' ), 'Field value should match the original content for the saved response when new lines are present' );
+	}
 }

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Test.php
@@ -2105,8 +2105,9 @@ class Feedback_Test extends BaseTestCase {
 	 * Test that new lines are not stripped from the field value.
 	 */
 	public function test_new_lines_dont_get_stripped() {
-		$form_id = Utility::get_form_id();
-		$content = 'Hello, this is a' . PHP_EOL . ' test message from our contact form.';
+		$form_id          = Utility::get_form_id();
+		$content          = 'Hello, this is a' . PHP_EOL . ' test message from our contact form.';
+		$expected_content = $content;
 
 		// Create a form submission
 		$_post_data = Utility::get_post_request(
@@ -2128,7 +2129,41 @@ class Feedback_Test extends BaseTestCase {
 		$feedback_post_id = $response->save();
 		$saved_response   = Feedback::get( $feedback_post_id );
 
-		$this->assertEquals( $content, $response->get_field_value_by_label( 'Message' ), 'Field value should match the original content for the form submission when new lines are present' );
-		$this->assertEquals( $content, $saved_response->get_field_value_by_label( 'Message' ), 'Field value should match the original content for the saved response when new lines are present' );
+		$this->assertTrue( str_contains( get_post( $feedback_post_id )->post_content, '\\n' ) ); // Double escaped PHP_EOL
+		$this->assertEquals( $expected_content, $response->get_field_value_by_label( 'Message' ), 'Field value should match the original content for the form submission when new lines are present' );
+		$this->assertEquals( $expected_content, $saved_response->get_field_value_by_label( 'Message' ), 'Field value should match the original content for the saved response when new lines are present' );
+	}
+
+	/**
+	 * Test that new lines are not stripped from the field value.
+	 */
+	public function test_new_lines_dont_get_stripped_when_addslashes() {
+		$form_id          = Utility::get_form_id();
+		$content          = addslashes( 'Hello, this is a' . PHP_EOL . ' test message from our contact form.' );
+		$expected_content = stripslashes( $content );
+
+		// Create a form submission
+		$_post_data = Utility::get_post_request(
+			array(
+				'message' => $content,
+			),
+			'g' . $form_id
+		);
+
+		$form = new Contact_Form(
+			array(
+				'title'       => 'Test Form',
+				'description' => 'This is a test form.',
+			),
+			"[contact-field label='Message' type='textarea' required='1'/]"
+		);
+
+		$response         = Feedback::from_submission( $_post_data, $form );
+		$feedback_post_id = $response->save();
+		$saved_response   = Feedback::get( $feedback_post_id );
+
+		$this->assertTrue( str_contains( get_post( $feedback_post_id )->post_content, '\\n' ) ); // Double escaped PHP_EOL
+		$this->assertEquals( $expected_content, $response->get_field_value_by_label( 'Message' ), 'Field value should match the original content for the form submission when new lines are present' );
+		$this->assertEquals( $expected_content, $saved_response->get_field_value_by_label( 'Message' ), 'Field value should match the original content for the saved response when new lines are present' );
 	}
 }


### PR DESCRIPTION
## Proposed changes:
This PR addresses and issue with line breaks on responses due to underlying WP processes.

1. **Field Sanitization Fix** (`class-feedback.php` line 230-245):
   - Modified `get_field_value()` to use `sanitize_textarea_field()` for textarea fields instead of `sanitize_text_field()`
   - This preserves newlines during initial form processing

2. **JSON Parsing Fix** (`class-feedback.php` line 841):
   - Improved `parse_content_v2()` to properly handle WordPress content slashing with `wp_unslash()`

3. **Critical WordPress Content Processing Fix** (`class-feedback.php` line 815-817):
   - Added double-escaping for newlines in JSON serialization: `str_replace( '\\n', '\\\\n', $json )`
   - This ensures that when WordPress strips one level of backslashes, the JSON still contains proper `\n` sequences

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1756129864939349-slack-C08LJ97DJ6A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Verify the tests pass.

Build both plugins/jetpack and packages/forms.

Create a form with a textarea, visit and submit with line breaks. 

Confirm the success message shows the submitted value properly.

Visit the Forms dashboard to see the response you just submitted. It should show the line breaks properly.