### PR TITLE
Subscribers Dashboard: Restore @types/jest dependency

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3702,6 +3702,9 @@ importers:
       '@testing-library/react':
         specifier: 16.3.0
         version: 16.3.0(@testing-library/dom@10.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@types/jest':
+        specifier: 30.0.0
+        version: 30.0.0
       concurrently:
         specifier: 7.6.0
         version: 7.6.0
@@ -18723,7 +18726,7 @@ snapshots:
       '@jest/schemas': 30.0.5
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 20.19.10
+      '@types/node': 22.17.1
       '@types/yargs': 17.0.33
       chalk: 4.1.2
 
@@ -27137,7 +27140,7 @@ snapshots:
   jest-mock@30.0.5:
     dependencies:
       '@jest/types': 30.0.5
-      '@types/node': 20.19.10
+      '@types/node': 22.17.1
       jest-util: 30.0.5
 
   jest-playwright-preset@4.0.0(jest-circus@30.0.5)(jest-environment-node@30.0.5)(jest-runner@30.0.5)(jest@30.0.4):
@@ -27407,7 +27410,7 @@ snapshots:
   jest-util@30.0.5:
     dependencies:
       '@jest/types': 30.0.5
-      '@types/node': 20.19.10
+      '@types/node': 22.17.1
       chalk: 4.1.2
       ci-info: 4.3.0
       graceful-fs: 4.2.11

--- a/projects/packages/subscribers-dashboard/changelog/fix-subscribers-dashboard-overpruned_dependencies
+++ b/projects/packages/subscribers-dashboard/changelog/fix-subscribers-dashboard-overpruned_dependencies
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Restore dependency removed in #44813.

--- a/projects/packages/subscribers-dashboard/package.json
+++ b/projects/packages/subscribers-dashboard/package.json
@@ -49,6 +49,7 @@
 		"@testing-library/dom": "10.4.0",
 		"@testing-library/jest-dom": "6.6.3",
 		"@testing-library/react": "16.3.0",
+		"@types/jest": "30.0.0",
 		"concurrently": "7.6.0",
 		"jest": "30.0.4",
 		"react": "18.3.1",


### PR DESCRIPTION
Closes MONOREP-84

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

In #44813 I removed some unneeded dependencies, but apparently one too many slipped through. This restores the `@types/jest` dev dependency.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Is CI happy?
