### PR TITLE
WooCommerce Analytics: Fix duplicate product purchase events

### DIFF
--- a/projects/packages/woocommerce-analytics/changelog/fix-woo-analytics-product-purchase-event
+++ b/projects/packages/woocommerce-analytics/changelog/fix-woo-analytics-product-purchase-event
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix duplicate product purchase events on order confirmation page

--- a/projects/packages/woocommerce-analytics/src/class-universal.php
+++ b/projects/packages/woocommerce-analytics/src/class-universal.php
@@ -50,8 +50,9 @@ class Universal {
 		// Send events after checkout block.
 		add_action( 'woocommerce_blocks_enqueue_checkout_block_scripts_after', array( $this, 'checkout_process' ) );
 
-		// order confirmed.
-		add_action( 'woocommerce_thankyou', array( $this, 'order_process' ), 10, 1 );
+		// order processed.
+		add_action( 'woocommerce_checkout_order_processed', array( $this, 'order_process' ), 10, 1 );
+		add_action( 'woocommerce_store_api_checkout_order_processed', array( $this, 'order_process' ), 10, 1 );
 
 		add_filter( 'woocommerce_checkout_posted_data', array( $this, 'save_checkout_post_data' ), 10, 1 );
 
@@ -153,7 +154,7 @@ class Universal {
 	 */
 	public function capture_remove_from_cart( $cart_item_key, $cart ) {
 		$item = $cart->removed_cart_contents[ $cart_item_key ] ?? null;
-		$this->capture_event_in_session_data( (int) $item['product_id'], (int) $item['quantity'], 'woocommerceanalytics_remove_from_cart' );
+		$this->capture_event_in_session_data( 'woocommerceanalytics_remove_from_cart', (int) $item['product_id'], (int) $item['quantity'] );
 	}
 
 	/**
@@ -169,13 +170,13 @@ class Universal {
 	public function capture_cart_quantity_update( $cart_item_key, $quantity, $old_quantity, $cart ) {
 		$product_id = $cart->cart_contents[ $cart_item_key ]['product_id'];
 		if ( $quantity > $old_quantity ) {
-			$this->capture_event_in_session_data( $product_id, $quantity, 'woocommerceanalytics_add_to_cart' );
+			$this->capture_event_in_session_data( 'woocommerceanalytics_add_to_cart', $product_id, $quantity );
 			$this->lock_add_to_cart_events = true;
 			return;
 		}
 
 		if ( $quantity < $old_quantity ) {
-			$this->capture_event_in_session_data( $product_id, $quantity, 'woocommerceanalytics_remove_from_cart' );
+			$this->capture_event_in_session_data( 'woocommerceanalytics_remove_from_cart', $product_id, $quantity );
 			return;
 		}
 	}
@@ -291,12 +292,16 @@ class Universal {
 	}
 
 	/**
-	 * After the checkout process, fire an event for each item in the order
+	 * After the order processed, fire an event for each item in the order
 	 *
-	 * @param string $order_id Order Id.
+	 * @param string|WC_Order $order_id_or_order Order Id or Order object.
 	 */
-	public function order_process( $order_id ) {
-		$order = wc_get_order( $order_id );
+	public function order_process( $order_id_or_order ) {
+		if ( is_string( $order_id_or_order ) ) {
+			$order = wc_get_order( $order_id_or_order );
+		} else {
+			$order = $order_id_or_order;
+		}
 
 		if (
 			! $order
@@ -359,8 +364,11 @@ class Universal {
 			if ( is_array( $order_coupons ) ) {
 				$order_coupons_count = count( $order_coupons );
 			}
-			$this->record_event(
+
+			$this->capture_event_in_session_data(
 				'woocommerceanalytics_product_purchase',
+				$product_id,
+				$order_item->get_quantity(),
 				array(
 					'oi'                       => $order->get_order_number(),
 					'pq'                       => $order_item->get_quantity(),
@@ -379,8 +387,7 @@ class Universal {
 					'from_checkout'            => $checkout_page_used,
 					'checkout_page_contains_checkout_block' => $checkout_page_contains_checkout_block,
 					'checkout_page_contains_checkout_shortcode' => $checkout_page_contains_checkout_shortcode,
-				),
-				$product_id
+				)
 			);
 		}
 	}
@@ -455,23 +462,23 @@ class Universal {
 		if ( $this->lock_add_to_cart_events ) {
 			return;
 		}
-		$this->capture_event_in_session_data( $product_id, $quantity, 'woocommerceanalytics_add_to_cart' );
+		$this->capture_event_in_session_data( 'woocommerceanalytics_add_to_cart', $product_id, $quantity );
 	}
 
 	/**
 	 * Track in-session data.
 	 *
+	 * @param string $event Fired event.
 	 * @param int    $product_id Product ID.
 	 * @param int    $quantity Quantity.
-	 * @param string $event Fired event.
+	 * @param array  $properties Event properties.
 	 */
-	public function capture_event_in_session_data( $product_id, $quantity, $event ) {
+	public function capture_event_in_session_data( $event, $product_id, $quantity, $properties = array() ) {
 
 		$product = wc_get_product( $product_id );
 		if ( ! $product instanceof WC_Product ) {
 			return;
 		}
-
 		$quantity = ( 0 === $quantity ) ? 1 : $quantity;
 
 		// check for existing data.
@@ -484,14 +491,21 @@ class Universal {
 			$data = array();
 		}
 
+		$event_properties = array_merge(
+			array(
+				'quantity'     => (string) $quantity,
+				'session_id'   => $this->get_session_id(),
+				'landing_page' => $this->get_landing_page(),
+				'is_engaged'   => $this->is_engaged_session(),
+			),
+			$properties
+		);
+
 		// extract new event data.
 		$new_data = array(
-			'event'        => $event,
-			'product_id'   => (string) $product_id,
-			'quantity'     => (string) $quantity,
-			'session_id'   => $this->get_session_id(),
-			'landing_page' => $this->get_landing_page(),
-			'is_engaged'   => $this->is_engaged_session(),
+			'event'      => $event,
+			'product_id' => (string) $product_id,
+			'properties' => $event_properties,
 		);
 
 		// append new data.


### PR DESCRIPTION
## Proposed changes:

### Problem:

The `woocommerceanalytics_product_purchase` event is currently triggered every time a user refreshes the order confirmation page, due to its reliance on the `woocommerce_thankyou` hook. This causes duplicate events, which is problematic, especially when users open the order confirmation page in another device/browser since we use this event to track completed checkouts and calculate conversion rates accurately.

### Solution:

This update resolves the issue by switching from the `woocommerce_thankyou` hook to the `woocommerce_checkout_order_processed` and `woocommerce_store_api_checkout_order_processed` hooks. These order processed hooks are triggered only once when the order is completed, ensuring the event is not duplicated on page refreshes.

Additionally, I have modified the `capture_event_in_session_data` method to accept event properties and to standardize the order of its parameters.


### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No, this PR does not change what data we track. It only fixes the timing and frequency of when the existing `woocommerceanalytics_product_purchase` events are triggered to prevent duplicates.

## Testing instructions:

* Set up a WooCommerce store with Jetpack WooCommerce Analytics enabled
* In your WooCommerce admin, set up store so it's ready to accept orders
* Open your browser’s developer tools and go to the "Network" tab.
* Add products to cart and complete a purchase
* After completing the purchase, verify that the `woocommerceanalytics_product_purchase` event is recorded in the Network tab
* Refresh the order confirmation/thank you page multiple times
* Verify that `woocommerceanalytics_product_purchase` events are not recorded when refreshing the page

Note: You can also check the ClickHouse table to verify that the event is not recorded more than once.

<img width="532" height="610" alt="Screenshot 2025-08-27 at 14 38 05" src="https://github.com/user-attachments/assets/8aea06c3-21f8-4d4b-8fa0-29fe45e950da" />


