### PR TITLE
Untangling: Update the WordPress importer link for Simple Sites

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-wp-importer-link-simple-sites
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-wp-importer-link-simple-sites
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update the WordPress importer link for Simple Sites.
+
+

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-imports/wpcom-imports.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-imports/wpcom-imports.php
@@ -83,3 +83,27 @@ add_action(
 		exit();
 	}
 );
+
+/**
+ * Update the WordPress importer URL to point to the Calypso Stepper importer.
+ *
+ * @param string $url the Importer URL.
+ * @param string $importer_type The type of the importer (e.g. WordPress).
+ *
+ * @return string
+ */
+function wpcom_import_update_wordpress_url_on_simple( $url, $importer_type ) {
+	// @phpcs:ignore WordPress.WP.CapitalPDangit.MisspelledInText
+	if ( 'wordpress' !== $importer_type ) {
+		return $url;
+	}
+
+	$domain = wp_parse_url( home_url(), PHP_URL_HOST );
+
+	return 'https://wordpress.com/setup/site-setup/importerWordpress?ref=wp-admin-importers-list-direct-importer&siteSlug=' . $domain;
+}
+
+/**
+ * Although the hook is prefixed with wp_*, it's actually a custom WPCOM one that's only executed on Simple Sites.
+ */
+add_action( 'wp_import_run_import_url_filter', 'wpcom_import_update_wordpress_url_on_simple', 11, 2 );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #DOTCOM-14233

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Update the WordPress importer link to point to the Calypso Stepper (only for Simple Sites)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this PR on your sandbox
* Go to /wp-admin/import.php on a Simple Site
* Notice that the "WordPress" importer now points to the stepper
* Click on it and you should be redirected to the Calypso Stepper page

