### PR TITLE
CHARTS-93: Refactor leaderboard chart to remove progressbar component.

### DIFF
--- a/projects/js-packages/charts/changelog/update_CHARTS-93-refactor-leaderboard-chart-to-remove-progressbar
+++ b/projects/js-packages/charts/changelog/update_CHARTS-93-refactor-leaderboard-chart-to-remove-progressbar
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Refactored leaderboard chart to remove progressbar.

--- a/projects/js-packages/charts/src/components/leaderboard-chart/leaderboard-chart.module.scss
+++ b/projects/js-packages/charts/src/components/leaderboard-chart/leaderboard-chart.module.scss
@@ -6,18 +6,29 @@
 	}
 }
 
-.progressContainerWithOverlayLabel {
+.barWithLabelContainer {
 	display: grid;
-	grid-template: "overlap" 1fr / 1fr; /* contains a single cell callded 'overlap' */
 	align-items: center;
+	grid-template-columns: 1fr;
+	row-gap: 6px;
 
-	> * {
-		grid-area: overlap;
+	&.is-overlay {
+		grid-template: "overlap" 1fr / 1fr; /* contains a single cell callded 'overlap' */
+
+		> * {
+			grid-area: overlap;
+		}
+
+		.label {
+			padding-left: 8px;
+		}
 	}
 
-	.progressBar {
+	.bar {
 		height: 100%;
-		background-color: var(--primary-color, #3858e9);
+		min-height: 6px;
+
+		background-color: var(--bar-color, #3858e9);
 
 		border-radius: var(--bar-border, 9999px);
 		z-index: -1; /* places it behind the label */
@@ -25,36 +36,12 @@
 		transition: width 0.3s ease-in-out;
 	}
 
-	.progressBarLabel {
-		padding-left: 8px;
-	}
-}
-
-.progressContainer {
-	display: flex;
-	flex-direction: column;
-	gap: 6px;
-
-	.progressBar {
-		width: 100%;
-		height: 6px;
-		border-radius: 2px;
-		background-color: transparent;
-		overflow: hidden;
-		transition: width 0.3s ease-in-out;
-
-		> div {
-			background-color: var(--progress-color, #3858e9);
-			border-radius: var(--bar-border, 9999px);
-		}
-	}
-
 	.primaryBar {
-		--progress-color: var(--primary-color, #3858e9);
+		--bar-color: var(--primary-color, #3858e9);
 	}
 
 	.secondaryBar {
-		--progress-color: var(--secondary-color, #66bdff);
+		--bar-color: var(--secondary-color, #66bdff);
 	}
 }
 

--- a/projects/js-packages/charts/src/components/leaderboard-chart/leaderboard-chart.tsx
+++ b/projects/js-packages/charts/src/components/leaderboard-chart/leaderboard-chart.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable @wordpress/no-unsafe-wp-apis */
 import {
-	ProgressBar,
 	__experimentalVStack as VStack,
 	__experimentalGrid as Grid,
 	__experimentalText as Text,
@@ -147,42 +146,38 @@ const defaultDeltaFormatter = ( value: number ): string => {
 	} );
 };
 
-const ProgressBarWithOverlayLabel = ( { entry }: { entry: LeaderboardEntry } ) => (
-	<div className={ styles.progressContainerWithOverlayLabel }>
-		{ typeof entry.label === 'string' ? (
-			<Text className={ styles.progressBarLabel }>{ entry.label }</Text>
-		) : (
-			entry.label
-		) }
-
-		<div className={ styles.progressBar } style={ { width: entry.currentShare + '%' } }></div>
-	</div>
+const BarLabel = ( { label }: { label: string | JSX.Element } ) => (
+	<>{ typeof label === 'string' ? <Text className={ styles.label }>{ label }</Text> : label }</>
 );
 
-const ProgressBarWithLabel = ( {
+const BarWithLabel = ( {
 	entry,
 	withComparison,
+	withOverlayLabel,
 }: {
 	entry: LeaderboardEntry;
 	withComparison?: boolean;
+	withOverlayLabel?: boolean;
 } ) => (
-	<>
-		{ typeof entry.label === 'string' ? <Text>{ entry.label }</Text> : entry.label }
+	<div
+		className={ clsx( styles.barWithLabelContainer, {
+			[ styles[ 'is-overlay' ] ]: withOverlayLabel,
+		} ) }
+	>
+		<BarLabel label={ entry.label } />
 
-		<div className={ styles.progressContainer }>
-			<ProgressBar
-				value={ entry.currentShare }
-				className={ clsx( styles.progressBar, styles.primaryBar ) }
-			/>
+		<div
+			className={ clsx( styles.bar, styles.primaryBar ) }
+			style={ { width: entry.currentShare + '%' } }
+		></div>
 
-			{ withComparison && (
-				<ProgressBar
-					value={ entry.previousShare }
-					className={ clsx( styles.progressBar, styles.secondaryBar ) }
-				/>
-			) }
-		</div>
-	</>
+		{ withComparison && ! withOverlayLabel && (
+			<div
+				className={ clsx( styles.bar, styles.secondaryBar ) }
+				style={ { width: entry.previousShare + '%' } }
+			></div>
+		) }
+	</div>
 );
 
 /**
@@ -267,11 +262,11 @@ export const LeaderboardChart: FC< LeaderboardChartProps > = ( {
 				return (
 					<Fragment key={ entry.id }>
 						<VStack spacing={ labelSpacing }>
-							{ withOverlayLabel ? (
-								<ProgressBarWithOverlayLabel entry={ entry } />
-							) : (
-								<ProgressBarWithLabel entry={ entry } withComparison={ withComparison } />
-							) }
+							<BarWithLabel
+								entry={ entry }
+								withComparison={ withComparison }
+								withOverlayLabel={ withOverlayLabel }
+							/>
 						</VStack>
 
 						<div


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #[CHARTS-81](https://linear.app/a8c/issue/CHARTS-81)

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Removed the progress bar component and repurpose the newly added `BarWithLabel` component.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Launch the storybook for chart.
* Visit http://localhost:50240/?path=/story/js-packages-charts-types-leaderboard-chart--custom-label
* There should be no difference with https://automattic.github.io/jetpack-storybook/?path=/story/js-packages-charts-types-leaderboard-chart--custom-label
* Test other leaderboard chart examples too.

