### PR TITLE
Docker: Add plugin to allow sending from localhost

### DIFF
--- a/tools/docker/mu-plugins/allow_emails_from_localhost.php
+++ b/tools/docker/mu-plugins/allow_emails_from_localhost.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Plugin Name: Allow Emails from localhost
+ * Description: WordPress doesn't allow emails from localhost so we changes the hostname when sending.
+ * Version: 1.0
+ * Author: Automattic
+ * Author URI: https://automattic.com/
+ * Text Domain: jetpack
+ *
+ * @package automattic/jetpack
+ */
+
+namespace Jetpack\Docker\MuPlugin\AllowEmailsFromLocalhost;
+
+/**
+ * Allow sending emails from the Docker dev environment.
+ * WordPress relies on PHPMailer, which throws an exception when
+ * using localhost as the server name. This mocks a different
+ * email when needed.
+ *
+ * @param string $from_email Email address to send from.
+ *
+ * @return string Filtered email address to send from.
+ */
+function jetpack_allow_emails_from_localhost( $from_email ) {
+	if ( str_ends_with( $from_email, '@localhost' ) ) {
+		return 'wordpress@jetpack.docker';
+	}
+	return $from_email;
+}
+add_filter( 'wp_mail_from', __NAMESPACE__ . '\jetpack_allow_emails_from_localhost', 1, 3 );

--- a/tools/docker/mu-plugins/allow_emails_from_localhost.php
+++ b/tools/docker/mu-plugins/allow_emails_from_localhost.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: Allow Emails from localhost
- * Description: WordPress doesn't allow emails from localhost so we changes the hostname when sending.
+ * Description: WordPress doesn't allow emails from localhost so we change the hostname when sending.
  * Version: 1.0
  * Author: Automattic
  * Author URI: https://automattic.com/

--- a/tools/docker/mu-plugins/allow_emails_from_localhost.php
+++ b/tools/docker/mu-plugins/allow_emails_from_localhost.php
@@ -23,8 +23,9 @@ namespace Jetpack\Docker\MuPlugin\AllowEmailsFromLocalhost;
  * @return string Filtered email address to send from.
  */
 function jetpack_allow_emails_from_localhost( $from_email ) {
-	if ( str_ends_with( $from_email, '@localhost' ) ) {
+	if ( $from_email === 'wordpress@localhost' ) {
 		return 'wordpress@jetpack.docker';
+
 	}
 	return $from_email;
 }


### PR DESCRIPTION
Closes MONOREP-85
Closes MONOREP-83

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

In the default Docker environment WP detects the host as `localhost` and tries to send emails as `wordpress@localhost`. However, this causes PHPMailer to throw an exception (see PHPMailer/PHPMailer#1211).

The easiest workaround is to change the `From` address to something that looks more valid using the `wp_mail_from` WP filter. Note that this only changes the specific `wordpress@localhost` from address.

Reported here: p1756232087844869-slack-C05Q5HSS013

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Go to the Users page: `/wp-admin/users.php`
2. Send a password reset.
3. Check for an email in MailDev: http://localhost:1080/

With `trunk` no email will come through if your site's host is localhost. It will show up if you're using a different domain.

In the `fix/docker/allow_emails_sent_from_localhost` branch, the email will show up in both scenarios.