### PR TITLE
Docker: Change from MailDev to Mailpit

### DIFF
--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -7,8 +7,8 @@ ARG COMPOSER_VERSION
 ARG NODE_VERSION
 ARG PNPM_VERSION
 
-ENV LANG en_US.UTF-8
-ENV LC_ALL en_US.UTF-8
+ENV LANG=en_US.UTF-8
+ENV LC_ALL=en_US.UTF-8
 
 # Bypass WP-CLI `--allow-root` check. Reworking the container to not run as root would be a lot of work for basically no benefit.
 ENV WP_CLI_ALLOW_ROOT=1

--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -69,6 +69,7 @@ You can set the following variables on a per-command basis (`PORT_WORDPRESS=8000
 * `PORT_WORDPRESS`: (default=`80`) The port on your host machine connected to the WordPress container's HTTP server.
 * `PORT_INBOX`: (default=`1080`) The port on your host machine connected to the Mailpit container's web interface.
 * `PORT_SMTP`: (default=`25`) The port on your host machine connected to the Mailpit container's SMTP server.
+* `PORT_PHPMY`: (default=`8181`) The port on your host machine connected to the phpMyAdmin container's web interface.
 * `PORT_SFTP`: (default=`1022`) The port on your host machine connected to the SFTP container's SFTP server.
 
 ### Container Environments

--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -7,7 +7,7 @@ Unified environment for developing Jetpack using Docker containers providing fol
 * All monorepo plugins will be available as plugins within the Docker WP instance.
 * Xdebug setup.
 * WP-CLI installed.
-* MailDev to catch all the emails leaving WordPress so that you can observe them from browser.
+* Mailpit to catch all the emails leaving WordPress so that you can observe them from browser
 * phpMyAdmin to aid in viewing the database.
 * Handy shorthand commands like `jetpack docker up` and `jetpack docker phpunit` to simplify the usage.
 
@@ -67,8 +67,8 @@ You can control some of the behavior of Jetpack's Docker configuration with envi
 You can set the following variables on a per-command basis (`PORT_WORDPRESS=8000 jetpack docker up`) or, preferably, in the `tools/docker/.env` file you set up earlier.
 
 * `PORT_WORDPRESS`: (default=`80`) The port on your host machine connected to the WordPress container's HTTP server.
-* `PORT_MAILDEV`: (default=`1080`) The port on your host machine connected to the MailDev container's MailDev HTTP server.
-* `PORT_SMTP`: (default=`25`) The port on your host machine connected to the MailDev container's SMTP server.
+* `PORT_INBOX`: (default=`1080`) The port on your host machine connected to the Mailpit container's web interface.
+* `PORT_SMTP`: (default=`25`) The port on your host machine connected to the Mailpit container's SMTP server.
 * `PORT_SFTP`: (default=`1022`) The port on your host machine connected to the SFTP container's SFTP server.
 
 ### Container Environments
@@ -122,7 +122,7 @@ jetpack docker uninstall
 jetpack docker up
 ```
 
-Start the containers (WordPress, MySQL and MailDev) defined in `docker-compose.yml`.
+Start the containers (WordPress, MySQL and Mailpit) defined in `docker-compose.yml`.
 
 This command will rebuild the WordPress container if you made any changes to `docker-compose.yml`.
 
@@ -426,7 +426,7 @@ We recommend to regularly review the log to make sure performance issues don't g
 
 ### Debugging emails
 
-Emails don’t leave your WordPress and are caught by [MailDev](http://danfarrelly.nyc/MailDev/) SMTP server container instead.
+Emails don’t leave your WordPress and are caught by the [Mailpit](https://mailpit.axllent.org/) SMTP server container instead.
 
 To debug emails via web-interface, open [http://localhost:1080](http://localhost:1080)
 

--- a/tools/docker/config/ssmtp.conf
+++ b/tools/docker/config/ssmtp.conf
@@ -6,7 +6,7 @@
 root=postmaster
 
 # The place where the mail goes.
-mailhub=maildev:25
+mailhub=mailpit:1025
 #UseSTARTTLS=NO
 #AuthUser=
 #AuthPass=

--- a/tools/docker/jetpack-docker-config-default.yml
+++ b/tools/docker/jetpack-docker-config-default.yml
@@ -22,7 +22,7 @@ dev:
         links:
           - db:mysql
         ports:
-          - 8181:80
+          - '${PORT_PHPMY:-8181}:80'
         environment:
           MYSQL_USERNAME: '${MYSQL_USER:-wordpress}'
           MYSQL_ROOT_PASSWORD: '${MYSQL_ROOT_PASSWORD:-wordpress}'
@@ -39,7 +39,7 @@ dev:
           MP_SMTP_AUTH_ACCEPT_ANY: 1
           MP_SMTP_AUTH_ALLOW_INSECURE: 1
 
-      ## SFTP server running at localhost:1022
+      ## SFTP server running at localhost:1022 by default
       sftp:
         image: jmcombs/sftp:alpine
         volumes:

--- a/tools/docker/jetpack-docker-config-default.yml
+++ b/tools/docker/jetpack-docker-config-default.yml
@@ -28,16 +28,16 @@ dev:
           MYSQL_ROOT_PASSWORD: '${MYSQL_ROOT_PASSWORD:-wordpress}'
 
       ## SMTP Server + Web Interface for viewing and testing emails during development.
-      ## http://maildev.github.io/maildev/
-      maildev:
-        image: maildev/maildev
+      ## https://mailpit.axllent.org/
+      mailpit:
+        image: axllent/mailpit
+        container_name: mailpit
         ports:
-          - '${PORT_MAILDEV:-1080}:80'
-          - '${PORT_SMTP:-25}:25'
+          - '${PORT_INBOX:-1080}:8025'
+          - '${PORT_SMTP:-25}:1025'
         environment:
-          # It runs in its own container, it may as well use the standard ports instead of 1080 and 1025 so we don't have to reconfigure everything trying to send mail to it.
-          MAILDEV_WEB_PORT: 80
-          MAILDEV_SMTP_PORT: 25
+          MP_SMTP_AUTH_ACCEPT_ANY: 1
+          MP_SMTP_AUTH_ALLOW_INSECURE: 1
 
       ## SFTP server running at localhost:1022
       sftp:


### PR DESCRIPTION
Closes MONOREP-86

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This changes our use from MailDev to Mailpit.

Both are comparable, and few devs will use most of their capabilities beyond receiving email. In the end the biggest factor for me was size: Mailpit is almost 1/4 the compressed size, which makes for a quicker pull, particularly on slow connections.

Bonus:
* Two ENV vars in the Dockerfile were updated to use the modern `key=value` format instead of `key value`, which removes two deprecation notices.
* A new `PORT_PHPMY` var was added to allow people to configure the phpMyAdmin port.
* `PORT_MAILDEV` was updated to `PORT_INBOX` to make it generic. It's unlikely many (if any) use this, so rather than implementing a fallback that handles both, I just directly renamed it.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Check out the PR.
2. `jetpack docker build-image`
3. Verify `http://localhost:1080/` loads
4. Do a password reset on some WP user and verify the email comes through.