### PR TITLE
Forms: Fix slider field clickable area

### DIFF
--- a/projects/packages/forms/changelog/fix-slider-slide-area
+++ b/projects/packages/forms/changelog/fix-slider-slide-area
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: improve slider range touch area

--- a/projects/packages/forms/src/blocks/input-range/style.scss
+++ b/projects/packages/forms/src/blocks/input-range/style.scss
@@ -13,6 +13,7 @@
 		flex: 1 1 auto;
 		min-width: 0;
 		position: relative;
+		min-height: 36px;
 
 		&::before {
 			content: "";
@@ -25,13 +26,17 @@
 			width: 100%;
 			background: var(--jetpack--contact-form--button-primary--background-color);
 			z-index: 0;
+			pointer-events: none;
+			border-radius: 2px;
 		}
 	}
 
 	&__range {
 		-webkit-appearance: none;
 		appearance: none;
-		height: 100%;
+		-moz-appearance: none;
+		height: 4px; /* visual track height */
+		padding: 18px 0 16px; /* enlarge hit area without moving track */
 		background: transparent;
 		outline: none;
 		border-radius: 2px;
@@ -39,6 +44,27 @@
 		width: 100%;
 		box-sizing: border-box;
 		z-index: 1;
+		cursor: pointer;
+
+		/* Hide native tracks to prevent double-track rendering */
+		&::-webkit-slider-runnable-track,
+		&::-moz-range-track,
+		&::-ms-track,
+		&::-moz-range-progress {
+			background: transparent;
+			border-color: transparent;
+			color: transparent;
+			height: 4px;
+		}
+
+		&::-moz-range-progress {
+			border: 0;
+		}
+
+		/* Remove extra focus ring gap in Firefox */
+		&::-moz-focus-outer {
+			border: 0;
+		}
 
 		&:focus {
 			outline: none;
@@ -48,8 +74,8 @@
 		&::-webkit-slider-thumb {
 			-webkit-appearance: none;
 			appearance: none;
-			width: 16px;
-			height: 16px;
+			width: 18px;
+			height: 18px;
 			background: var(--jetpack--contact-form--button-primary--background-color);
 			border-radius: 50%;
 			cursor: pointer;
@@ -57,14 +83,29 @@
 			box-shadow: 0 0 2px rgba(0, 0, 0, 0.2);
 		}
 
-		&::-moz-range-thumb,
-		&::-ms-thumb {
-			width: 16px;
-			height: 16px;
+		&::-moz-range-thumb {
+			appearance: none !important;
+			-moz-appearance: none !important;
+			width: 18px;
+			height: 18px;
 			background: var(--jetpack--contact-form--button-primary--background-color);
 			border-radius: 50%;
 			cursor: pointer;
 			transition: background 0.3s;
+			border: none;
+			box-shadow: 0 0 2px rgba(0, 0, 0, 0.2);
+		}
+
+		&::-ms-thumb {
+			appearance: none !important;
+			width: 18px;
+			height: 18px;
+			background: var(--jetpack--contact-form--button-primary--background-color);
+			border-radius: 50%;
+			cursor: pointer;
+			transition: background 0.3s;
+			border: none;
+			box-shadow: 0 0 2px rgba(0, 0, 0, 0.2);
 		}
 
 		&:focus::-webkit-slider-thumb,
@@ -80,8 +121,7 @@
 	&__value-indicator {
 		position: absolute;
 		left: 0;
-		bottom: calc(100% + 0.7em);
-		bottom: calc(100% + clamp(10px, 0.7em, 14px));
+		bottom: 100%;
 		transform: translateX(-50%);
 		background: var(--jetpack--contact-form--button-primary--background-color);
 		color: var(--jetpack--contact-form--button-primary--color);

--- a/projects/packages/forms/src/blocks/input-range/style.scss
+++ b/projects/packages/forms/src/blocks/input-range/style.scss
@@ -13,18 +13,32 @@
 		flex: 1 1 auto;
 		min-width: 0;
 		position: relative;
+
+		&::before {
+			content: "";
+			position: absolute;
+			left: 0;
+			right: 0;
+			top: 50%;
+			transform: translateY(-50%);
+			height: 4px;
+			width: 100%;
+			background: var(--jetpack--contact-form--button-primary--background-color);
+			z-index: 0;
+		}
 	}
 
 	&__range {
 		-webkit-appearance: none;
 		appearance: none;
-		height: 4px;
-		background: var(--jetpack--contact-form--button-primary--background-color);
+		height: 100%;
+		background: transparent;
 		outline: none;
 		border-radius: 2px;
 		transition: background 0.3s;
 		width: 100%;
 		box-sizing: border-box;
+		z-index: 1;
 
 		&:focus {
 			outline: none;


### PR DESCRIPTION
This PR increases the touch area for the slider range. So that the sliders is easer to move to the correct place. 

## Proposed changes:
* This PR adds a background element that shows the slider bar.
* And increase the height of the range input so that the user can more easliy slide the input via touch. 

Editor:
<img width="1730" height="378" alt="Screenshot 2025-08-27 at 3 42 34 PM" src="https://github.com/user-attachments/assets/0fcd49f6-622a-40b7-9b25-da3c31df94b4" />

Web:
<img width="2396" height="222" alt="Screenshot 2025-08-27 at 3 42 44 PM" src="https://github.com/user-attachments/assets/e0d98e80-1bd5-40b9-846a-36a2e178d3da" />



### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
Does it still look like before? 
Are you able to more easily select the correct range. 
