### PR TITLE
Forms: Fix slider tooltip wrapping

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-slider-tooltip
+++ b/projects/packages/forms/changelog/fix-forms-slider-tooltip
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: fix text wrapping in the slider tooltip

--- a/projects/packages/forms/src/blocks/input-range/style.scss
+++ b/projects/packages/forms/src/blocks/input-range/style.scss
@@ -129,6 +129,7 @@
 		padding: 2px 8px;
 		font-size: 0.7em;
 		z-index: 2;
+		text-wrap: nowrap;
 	}
 
 	&__min-label,


### PR DESCRIPTION
This PR fixes the tooltip of the slider In some cases the tooltip wraps. 

Before:
<img width="742" height="318" alt="Screenshot 2025-08-27 at 9 41 00 PM" src="https://github.com/user-attachments/assets/4518c874-75c8-467e-a9ac-085548f43349" />


After:
<img width="752" height="306" alt="Screenshot 2025-08-27 at 9 41 29 PM" src="https://github.com/user-attachments/assets/01cdfd9f-fc41-4e9b-90f8-64ec9f0c71d0" />


Fixes FORMS-NEW

## Proposed changes:
* Add css text-wrap:nowrap; property to the tool tip

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?


## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
Create a form where to tool tip seems wraps. 
Notice that with this PR the tooltop doesn't wrap any more. 

