### PR TITLE
Fix WooCommerce product sync to handle trashed products

### DIFF
--- a/projects/packages/sync/changelog/fix-wc-product-trash-sync
+++ b/projects/packages/sync/changelog/fix-wc-product-trash-sync
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix WooCommerce product sync to handle trashed products

--- a/projects/packages/sync/src/modules/class-woocommerce-products.php
+++ b/projects/packages/sync/src/modules/class-woocommerce-products.php
@@ -18,12 +18,16 @@ use WP_Error;
  * Note: This module is currently used for analytics purposes only.
  */
 class WooCommerce_Products extends Module {
+
+	const PRODUCT_POST_TYPES = array( 'product', 'product_variation' );
+
 	/**
 	 * Constructor.
 	 */
 	public function __construct() {
 		// Preprocess action to be sent by Jetpack sync for wp_delete_post.
 		add_action( 'delete_post', array( $this, 'action_wp_delete_post' ), 10, 1 );
+		add_action( 'trashed_post', array( $this, 'action_wp_trash_post' ), 10, 1 );
 	}
 
 	/**
@@ -90,6 +94,9 @@ class WooCommerce_Products extends Module {
 		// Listen to specific stock update.
 		add_action( 'woocommerce_updated_product_stock', $callable, 10, 1 );
 
+		// Listen to product trashed.
+		add_action( 'jetpack_sync_woocommerce_product_trashed', $callable, 10, 1 );
+
 		// Listen to product deletion via wp_delete_post (more reliable than WC hooks)
 		add_action( 'jetpack_sync_woocommerce_product_deleted', $callable, 10, 1 );
 
@@ -100,6 +107,7 @@ class WooCommerce_Products extends Module {
 		add_filter( 'jetpack_sync_before_enqueue_woocommerce_update_product_variation', array( $this, 'expand_product_data' ) );
 		add_filter( 'jetpack_sync_before_enqueue_woocommerce_updated_product_stock', array( $this, 'expand_product_data' ) );
 		add_filter( 'jetpack_sync_before_enqueue_jetpack_sync_woocommerce_product_deleted', array( $this, 'expand_product_data' ) );
+		add_filter( 'jetpack_sync_before_enqueue_jetpack_sync_woocommerce_product_trashed', array( $this, 'expand_product_data' ) );
 	}
 
 	/**
@@ -140,16 +148,29 @@ class WooCommerce_Products extends Module {
 	 * @param int $post_id The post ID being deleted.
 	 */
 	public function action_wp_delete_post( $post_id ) {
-		$post_type = get_post_type( $post_id );
-
-		// Only process WooCommerce product and product variation post types
-		if ( in_array( $post_type, array( 'product', 'product_variation' ), true ) ) {
+		if ( $this->is_a_product_post( $post_id ) ) {
 			/**
 			 * Fires when a WooCommerce product is deleted via wp_delete_post.
 			 *
 			 * @param int $post_id The product ID being deleted.
 			 */
 			do_action( 'jetpack_sync_woocommerce_product_deleted', $post_id );
+		}
+	}
+
+	/**
+	 * Handle wp_trash_post action and trigger custom product trashed sync for WooCommerce products.
+	 *
+	 * @param int $post_id The post ID being trashed.
+	 */
+	public function action_wp_trash_post( $post_id ) {
+		if ( $this->is_a_product_post( $post_id ) ) {
+			/**
+			 * Fires when a WooCommerce product is trashed via wp_trash_post.
+			 *
+			 * @param int $post_id The product ID being trashed.
+			 */
+			do_action( 'jetpack_sync_woocommerce_product_trashed', $post_id );
 		}
 	}
 
@@ -529,5 +550,16 @@ class WooCommerce_Products extends Module {
 		}
 
 		return null;
+	}
+
+	/**
+	 * Check if the post is a product post.
+	 *
+	 * @param int $post_id The post ID to check.
+	 * @return bool True if the post is a product post, false otherwise.
+	 */
+	private function is_a_product_post( $post_id ) {
+		$post_type = get_post_type( $post_id );
+		return in_array( $post_type, self::PRODUCT_POST_TYPES, true );
 	}
 }

--- a/projects/packages/sync/src/modules/class-woocommerce-products.php
+++ b/projects/packages/sync/src/modules/class-woocommerce-products.php
@@ -427,7 +427,7 @@ class WooCommerce_Products extends Module {
 			array(
 				'include'     => $ids,
 				'order'       => $order,
-				'post_type'   => array( 'product', 'product_variation' ),
+				'post_type'   => self::PRODUCT_POST_TYPES,
 				'post_status' => array( 'any', 'trash', 'auto-draft' ),
 				'numberposts' => -1, // Get all posts.
 			)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

Previously, moving a product to the bin did not trigger a status sync with WPCOM. This PR resolves the issue by adding a new action listener to ensure trashed products are handled correctly.

### Key changes:

* Fix WooCommerce product sync to properly handle trashed products by listening to `trashed_post ` hook
* Refactor duplicate code by extracting `is_a_product_post()` helper method

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

Nope

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->

Follow the testing instructions in 191496-ghe-Automattic/wpcom
 