### PR TITLE
Social: Fix `default_image_id` cannot be cleared

### DIFF
--- a/projects/js-packages/publicize-components/changelog/fix-social-clearing-default-image
+++ b/projects/js-packages/publicize-components/changelog/fix-social-clearing-default-image
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixes an issue with Social where default image id could not be cleared.

--- a/projects/js-packages/publicize-components/src/components/admin-page/toggles/social-image-generator-toggle/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/admin-page/toggles/social-image-generator-toggle/index.tsx
@@ -45,7 +45,7 @@ const SocialImageGeneratorToggle: FC< SocialImageGeneratorToggleProps > = ( { di
 			updateSocialImageGeneratorConfig( {
 				enabled: isEnabled,
 				template,
-				default_image_id: imageId,
+				default_image_id: imageId || 0,
 				font,
 			} );
 		},

--- a/projects/packages/publicize/changelog/fix-social-clearing-default-image
+++ b/projects/packages/publicize/changelog/fix-social-clearing-default-image
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixes an issue with Social where default image id could not be cleared.

--- a/projects/packages/publicize/tests/php/jetpack-social-settings/Social_Image_Generator_Settings_Test.php
+++ b/projects/packages/publicize/tests/php/jetpack-social-settings/Social_Image_Generator_Settings_Test.php
@@ -110,4 +110,19 @@ class Social_Image_Generator_Settings_Test extends BaseTestCase {
 
 		$this->assertEquals( 'example_template', $sig_settings['template'] );
 	}
+
+	/**
+	 * Test that default_image_id can be set and cleared with 0.
+	 */
+	public function test_default_image_id_can_be_cleared_with_zero() {
+		// First set a default image ID
+		$this->settings->update_social_image_generator_settings( array( 'default_image_id' => 123 ) );
+		$sig_settings = $this->settings->get_settings()['socialImageGeneratorSettings'];
+		$this->assertEquals( 123, $sig_settings['default_image_id'] );
+
+		// Now clear it with 0
+		$this->settings->update_social_image_generator_settings( array( 'default_image_id' => 0 ) );
+		$sig_settings = $this->settings->get_settings()['socialImageGeneratorSettings'];
+		$this->assertSame( 0, $sig_settings['default_image_id'] );
+	}
 }

--- a/projects/plugins/jetpack/changelog/fix-social-clearing-default-image
+++ b/projects/plugins/jetpack/changelog/fix-social-clearing-default-image
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fixes an issue with Social where default image id could not be cleared.

--- a/projects/plugins/social/changelog/fix-social-clearing-default-image
+++ b/projects/plugins/social/changelog/fix-social-clearing-default-image
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixes an issue with Social where default image id could not be cleared.


### PR DESCRIPTION
Fixes SOCIAL-139

  ## Proposed changes:
  * Fixed Social Image Generator settings not saving when trying to clear the default
  image
  * Changed frontend to send `0` instead of `null` when clearing default image, following
   WordPress conventions

  ## Does this pull request change what data or activity we track or use?
  No.

  ## Testing instructions:

  ### Before the fix:
  * The default image could not be cleared - attempting to remove it would result in the
  image staying in place after refresh
  * REST API requests would fail with 400 error when trying to send `null` values to a number field

Test this locally and on JN as well

  ### Testing the fix:
  1. **Setup Social Image Generator:**
     * Go to Jetpack → Settings → Social
     * Enable "Social Image Generator"
     * Click "Change defaults"

  2. **Set a default image:**
     * In the template picker modal, click "Choose Image"
     * Select any image from the media library
     * Save the settings
     * Verify the image appears as the default and refresh the page

  3. **Clear the default image:**
     * Click "Change defaults" again
     * Click "Remove" or the X button on the selected image
     * Save the settings
     * **Expected result:** The default image should be cleared and no longer appear

  4. **Verify the setting persists:**
     * Refresh the page
     * Click "Change defaults"
     * **Expected result:** No default image should be selected (shows "Choose Image"
  button)