### PR TITLE
e2e tests: Fix Boost connection setup intermittent failures

### DIFF
--- a/projects/plugins/boost/changelog/jetpack-787-flaky-test-boost-e2e-tests-intermittent-failures-during
+++ b/projects/plugins/boost/changelog/jetpack-787-flaky-test-boost-e2e-tests-intermittent-failures-during
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+E2E tests: improved connection flow

--- a/projects/plugins/boost/tests/e2e/lib/pages/jetpack-boost-page.ts
+++ b/projects/plugins/boost/tests/e2e/lib/pages/jetpack-boost-page.ts
@@ -28,11 +28,19 @@ export default class JetpackBoostPage {
 	 * Select the free plan from getting started page.
 	 */
 	async chooseFreePlan() {
-		const button = this.page.locator( 'text=Start for free' );
-		await button.click();
+		const button = this.page.getByRole( 'button', { name: 'Start for free' } );
 
-		// We should wait a longer time to ensure the connection/plan is complete/established.
-		await this.expectScoreToBeLoading();
+		const connectionResponse = this.page.waitForResponse(
+			response => response.url().includes( '/jetpack-boost/v1/connection' ),
+			{ timeout: 60 * 1000 }
+		);
+		await button.click();
+		await connectionResponse;
+
+		await expect(
+			this.page.getByRole( 'button', { name: 'Refresh' } ),
+			'Refresh button should be visible after connection'
+		).toBeVisible();
 	}
 
 	/**


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/44981

## Proposed changes:

Address intermittent test failures during the Boost plugin connection flow.
- wait for `/jetpack-boost/v1/connection` API response after clicking "Start for free" button, with a 60s timeout
- added explicit wait for "Refresh" button visibility, which should cover both `Loading...` or scores being displayed states

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
* e2e tests should pass in CI

