### PR TITLE
Forms: release rating and slider fields for WP.com customers

### DIFF
--- a/projects/packages/forms/changelog/update-forms-release-rating-slider
+++ b/projects/packages/forms/changelog/update-forms-release-rating-slider
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: release rating and slider fields

--- a/projects/packages/forms/changelog/update-forms-release-rating-slider
+++ b/projects/packages/forms/changelog/update-forms-release-rating-slider
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Forms: release rating and slider fields
+Forms: release rating and slider fields at WP.com (not Jetpack yet)

--- a/projects/packages/forms/src/blocks/contact-form/child-blocks.js
+++ b/projects/packages/forms/src/blocks/contact-form/child-blocks.js
@@ -59,10 +59,9 @@ export const childBlocks = [
 	JetpackTelephoneField,
 	JetpackTextareaField,
 	JetpackFieldFile,
-	JetpackRatingField,
-	JetpackRatingInput,
-	JetpackFieldSlider,
-	JetpackSliderInput,
+	...( getJetpackBlocksVariation() === 'experimental'
+		? [ JetpackRatingField, JetpackRatingInput, JetpackFieldSlider, JetpackSliderInput ]
+		: [] ),
 	...( getJetpackBlocksVariation() === 'beta'
 		? [ JetpackTimeField, JetpackPhoneField, JetpackPhoneInput ]
 		: [] ),

--- a/projects/packages/forms/src/blocks/contact-form/child-blocks.js
+++ b/projects/packages/forms/src/blocks/contact-form/child-blocks.js
@@ -59,16 +59,12 @@ export const childBlocks = [
 	JetpackTelephoneField,
 	JetpackTextareaField,
 	JetpackFieldFile,
+	JetpackRatingField,
+	JetpackRatingInput,
+	JetpackFieldSlider,
+	JetpackSliderInput,
 	...( getJetpackBlocksVariation() === 'beta'
-		? [
-				JetpackRatingField,
-				JetpackRatingInput,
-				JetpackFieldSlider,
-				JetpackSliderInput,
-				JetpackTimeField,
-				JetpackPhoneField,
-				JetpackPhoneInput,
-		  ]
+		? [ JetpackTimeField, JetpackPhoneField, JetpackPhoneInput ]
 		: [] ),
 
 	// The following are required for these blocks to be parsed correctly in block

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -227,41 +227,43 @@ class Contact_Form_Block {
 			)
 		);
 
-		Blocks::jetpack_register_block(
-			'jetpack/input-rating',
-			array(
-				'supports' => array(
-					'color'      => array(
-						'text'       => true,
-						'background' => false,
+		if ( Blocks::get_variation() === 'experimental' ) {
+			Blocks::jetpack_register_block(
+				'jetpack/input-rating',
+				array(
+					'supports' => array(
+						'color'      => array(
+							'text'       => true,
+							'background' => false,
+						),
+						'typography' => array(
+							'fontSize' => true,
+						),
 					),
-					'typography' => array(
-						'fontSize' => true,
-					),
-				),
-			)
-		);
+				)
+			);
 
-		Blocks::jetpack_register_block(
-			'jetpack/input-range',
-			array(
-				'supports' => array(
-					'color'      => array(
-						'text'       => true,
-						'background' => false,
+			Blocks::jetpack_register_block(
+				'jetpack/input-range',
+				array(
+					'supports' => array(
+						'color'      => array(
+							'text'       => true,
+							'background' => false,
+						),
+						'typography' => array(
+							'fontSize'                     => true,
+							'__experimentalFontFamily'     => true,
+							'__experimentalFontWeight'     => true,
+							'__experimentalFontStyle'      => true,
+							'__experimentalTextTransform'  => true,
+							'__experimentalTextDecoration' => true,
+							'__experimentalLetterSpacing'  => true,
+						),
 					),
-					'typography' => array(
-						'fontSize'                     => true,
-						'__experimentalFontFamily'     => true,
-						'__experimentalFontWeight'     => true,
-						'__experimentalFontStyle'      => true,
-						'__experimentalTextTransform'  => true,
-						'__experimentalTextDecoration' => true,
-						'__experimentalLetterSpacing'  => true,
-					),
-				),
-			)
-		);
+				)
+			);
+		}
 
 		if ( Blocks::get_variation() === 'beta' ) {
 
@@ -429,23 +431,25 @@ class Contact_Form_Block {
 			)
 		);
 
-		Blocks::jetpack_register_block(
-			'jetpack/field-rating',
-			array(
-				'render_callback'  => array( Contact_Form_Plugin::class, 'gutenblock_render_field_rating' ),
-				'provides_context' => array(
-					'jetpack/field-required' => 'required',
-				),
-			)
-		);
+		if ( Blocks::get_variation() === 'experimental' ) {
+			Blocks::jetpack_register_block(
+				'jetpack/field-rating',
+				array(
+					'render_callback'  => array( Contact_Form_Plugin::class, 'gutenblock_render_field_rating' ),
+					'provides_context' => array(
+						'jetpack/field-required' => 'required',
+					),
+				)
+			);
 
-		Blocks::jetpack_register_block(
-			'jetpack/field-slider',
-			array(
-				'render_callback'  => array( Contact_Form_Plugin::class, 'gutenblock_render_field_slider' ),
-				'provides_context' => array( 'jetpack/field-required' => 'required' ),
-			)
-		);
+			Blocks::jetpack_register_block(
+				'jetpack/field-slider',
+				array(
+					'render_callback'  => array( Contact_Form_Plugin::class, 'gutenblock_render_field_slider' ),
+					'provides_context' => array( 'jetpack/field-required' => 'required' ),
+				)
+			);
+		}
 
 		if ( Blocks::get_variation() === 'beta' ) {
 			Blocks::jetpack_register_block(

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -227,42 +227,43 @@ class Contact_Form_Block {
 			)
 		);
 
-		if ( Blocks::get_variation() === 'beta' ) {
-			Blocks::jetpack_register_block(
-				'jetpack/input-rating',
-				array(
-					'supports' => array(
-						'color'      => array(
-							'text'       => true,
-							'background' => false,
-						),
-						'typography' => array(
-							'fontSize' => true,
-						),
+		Blocks::jetpack_register_block(
+			'jetpack/input-rating',
+			array(
+				'supports' => array(
+					'color'      => array(
+						'text'       => true,
+						'background' => false,
 					),
-				)
-			);
+					'typography' => array(
+						'fontSize' => true,
+					),
+				),
+			)
+		);
 
-			Blocks::jetpack_register_block(
-				'jetpack/input-range',
-				array(
-					'supports' => array(
-						'color'      => array(
-							'text'       => true,
-							'background' => false,
-						),
-						'typography' => array(
-							'fontSize'                     => true,
-							'__experimentalFontFamily'     => true,
-							'__experimentalFontWeight'     => true,
-							'__experimentalFontStyle'      => true,
-							'__experimentalTextTransform'  => true,
-							'__experimentalTextDecoration' => true,
-							'__experimentalLetterSpacing'  => true,
-						),
+		Blocks::jetpack_register_block(
+			'jetpack/input-range',
+			array(
+				'supports' => array(
+					'color'      => array(
+						'text'       => true,
+						'background' => false,
 					),
-				)
-			);
+					'typography' => array(
+						'fontSize'                     => true,
+						'__experimentalFontFamily'     => true,
+						'__experimentalFontWeight'     => true,
+						'__experimentalFontStyle'      => true,
+						'__experimentalTextTransform'  => true,
+						'__experimentalTextDecoration' => true,
+						'__experimentalLetterSpacing'  => true,
+					),
+				),
+			)
+		);
+
+		if ( Blocks::get_variation() === 'beta' ) {
 
 			Blocks::jetpack_register_block(
 				'jetpack/phone-input',
@@ -299,6 +300,7 @@ class Contact_Form_Block {
 				)
 			);
 		}
+
 		// Field render methods.
 		Blocks::jetpack_register_block(
 			'jetpack/field-text',
@@ -427,23 +429,25 @@ class Contact_Form_Block {
 			)
 		);
 
+		Blocks::jetpack_register_block(
+			'jetpack/field-rating',
+			array(
+				'render_callback'  => array( Contact_Form_Plugin::class, 'gutenblock_render_field_rating' ),
+				'provides_context' => array(
+					'jetpack/field-required' => 'required',
+				),
+			)
+		);
+
+		Blocks::jetpack_register_block(
+			'jetpack/field-slider',
+			array(
+				'render_callback'  => array( Contact_Form_Plugin::class, 'gutenblock_render_field_slider' ),
+				'provides_context' => array( 'jetpack/field-required' => 'required' ),
+			)
+		);
+
 		if ( Blocks::get_variation() === 'beta' ) {
-			Blocks::jetpack_register_block(
-				'jetpack/field-rating',
-				array(
-					'render_callback'  => array( Contact_Form_Plugin::class, 'gutenblock_render_field_rating' ),
-					'provides_context' => array(
-						'jetpack/field-required' => 'required',
-					),
-				)
-			);
-			Blocks::jetpack_register_block(
-				'jetpack/field-slider',
-				array(
-					'render_callback'  => array( Contact_Form_Plugin::class, 'gutenblock_render_field_slider' ),
-					'provides_context' => array( 'jetpack/field-required' => 'required' ),
-				)
-			);
 			Blocks::jetpack_register_block(
 				'jetpack/field-time',
 				array(

--- a/projects/plugins/jetpack/changelog/update-forms-release-rating-slider
+++ b/projects/plugins/jetpack/changelog/update-forms-release-rating-slider
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Forms: add new rating and slider fields

--- a/projects/plugins/jetpack/changelog/update-forms-release-rating-slider
+++ b/projects/plugins/jetpack/changelog/update-forms-release-rating-slider
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: add new rating and slider fields


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->



## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Releases new "ratings" and "slider" form fields for WP.com customer by changing them from "beta" blocks to "experimental" blocks.

https://github.com/Automattic/jetpack/blob/4ec0394cafd839daad402c80adc789428dcd08d2/projects/plugins/jetpack/extensions/README.md#L109

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Without `define('JETPACK_BLOCKS_VARIATION', 'beta');` configured, blocks should not be available on Jetpack
* At WP.com blocks should be available
* Try the slider and ratings once more

