### PR TITLE
Podcast player block: Add email rendering

### DIFF
--- a/projects/plugins/jetpack/changelog/add-podcast-player-email-rendering
+++ b/projects/plugins/jetpack/changelog/add-podcast-player-email-rendering
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Podcast player block: Add email rendering.

--- a/projects/plugins/jetpack/extensions/blocks/podcast-player/podcast-player.php
+++ b/projects/plugins/jetpack/extensions/blocks/podcast-player/podcast-player.php
@@ -26,10 +26,10 @@ function register_block() {
 	Blocks::jetpack_register_block(
 		__DIR__,
 		array(
-			'render_callback' => __NAMESPACE__ . '\render_block',
+			'render_callback'       => __NAMESPACE__ . '\render_block',
 			// Since Gutenberg #31873.
-			'style'           => 'wp-mediaelement',
-
+			'style'                 => 'wp-mediaelement',
+			'render_email_callback' => __NAMESPACE__ . '\render_email',
 		)
 	);
 }
@@ -292,4 +292,67 @@ function render( $name, $template_props = array(), $print = true ) {
 
 		return $markup;
 	}
+}
+
+/**
+ * Render podcast player block for email.
+ *
+ * @since $$next-version$$
+ *
+ * @param string $block_content     The original block HTML content.
+ * @param array  $parsed_block      The parsed block data including attributes.
+ * @param object $rendering_context Email rendering context.
+ *
+ * @return string
+ */
+function render_email( $block_content, array $parsed_block, $rendering_context ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+	// Validate input parameters and required dependencies
+	if ( ! isset( $parsed_block['attrs'] ) || ! is_array( $parsed_block['attrs'] ) ||
+		! class_exists( '\Automattic\WooCommerce\EmailEditor\Integrations\Utils\Table_Wrapper_Helper' ) ) {
+		return '';
+	}
+
+	$attr = $parsed_block['attrs'];
+
+	// Check if we have a valid podcast URL
+	if ( empty( $attr['url'] ) || ! wp_http_validate_url( $attr['url'] ) ) {
+		return '';
+	}
+
+	// Get spacing from email_attrs for better consistency with core blocks
+	$email_attrs        = $parsed_block['email_attrs'] ?? array();
+	$table_margin_style = '';
+
+	if ( ! empty( $email_attrs ) && class_exists( '\WP_Style_Engine' ) ) {
+		// Get margin for table styling
+		$table_margin_style = \WP_Style_Engine::compile_css( array_intersect_key( $email_attrs, array_flip( array( 'margin' ) ) ), '' ) ?? '';
+	}
+
+	$icon_image = 'https://s0.wp.com/i/emails/wpcom-notifications/audio-play.png';
+	$label      = __( 'Listen to the podcast', 'jetpack' );
+	$audio_url  = esc_url( $attr['url'] );
+
+	// Build the podcast player button content with Outlook 2021 compatibility
+	$button_content = sprintf(
+		'<a target="_blank" rel="noopener noreferrer" style="text-decoration: none;" href="%s"><div style="margin-bottom: 0; background-color: #f6f7f7; padding: 16px 24px; border-radius: 40px; border: 1px solid #AAA; font-size: 14px; mso-line-height-alt: 21.6px; line-height: 18px; font-weight: 400; font-family: Arial, Helvetica, sans-serif; text-align:center; letter-spacing: normal; margin-top: 0;"><div style="font-weight: 600; text-decoration: none; color: #000; line-height: 20px;"><img src="%s" style="display: inline-block; margin-right: 6px; vertical-align: middle;" width="18" height="18" /><div style="display: inline-block; vertical-align: middle;">%s</div></div></div></a>',
+		$audio_url,
+		esc_url( $icon_image ),
+		esc_html( $label )
+	);
+
+	// Use Table_Wrapper_Helper for consistent email rendering
+	$table_style = 'width: 100%; border-collapse: collapse;';
+	if ( ! empty( $table_margin_style ) ) {
+		$table_style = $table_margin_style . '; ' . $table_style;
+	} else {
+		$table_style = 'margin: 16px 0; ' . $table_style;
+	}
+
+	$table_attrs = array(
+		'style' => $table_style,
+	);
+
+	$html = \Automattic\WooCommerce\EmailEditor\Integrations\Utils\Table_Wrapper_Helper::render_table_wrapper( $button_content, $table_attrs );
+
+	return $html;
 }

--- a/projects/plugins/jetpack/extensions/blocks/podcast-player/podcast-player.php
+++ b/projects/plugins/jetpack/extensions/blocks/podcast-player/podcast-player.php
@@ -326,22 +326,65 @@ function render_email( $block_content, array $parsed_block, $rendering_context )
 	if ( ! empty( $email_attrs ) && class_exists( '\WP_Style_Engine' ) ) {
 		// Get margin for table styling
 		$table_margin_style = \WP_Style_Engine::compile_css( array_intersect_key( $email_attrs, array_flip( array( 'margin' ) ) ), '' ) ?? '';
+
+		// Validate CSS output to prevent injection
+		if ( ! empty( $table_margin_style ) && ! preg_match( '/^[a-zA-Z0-9\s:;()-]+$/', $table_margin_style ) ) {
+			$table_margin_style = '';
+		}
 	}
 
 	$icon_image = 'https://s0.wp.com/i/emails/wpcom-notifications/audio-play.png';
 	$label      = __( 'Listen to the podcast', 'jetpack' );
 	$audio_url  = esc_url( $attr['url'] );
 
-	// Build the podcast player button content with Outlook 2021 compatibility
-	$button_content = sprintf(
-		'<a target="_blank" rel="noopener noreferrer" style="text-decoration: none;" href="%s"><div style="margin-bottom: 0; background-color: #f6f7f7; padding: 16px 24px; border-radius: 40px; border: 1px solid #AAA; font-size: 14px; mso-line-height-alt: 21.6px; line-height: 18px; font-weight: 400; font-family: Arial, Helvetica, sans-serif; text-align:center; letter-spacing: normal; margin-top: 0;"><div style="font-weight: 600; text-decoration: none; color: #000; line-height: 20px;"><img src="%s" style="display: inline-block; margin-right: 6px; vertical-align: middle;" width="18" height="18" /><div style="display: inline-block; vertical-align: middle;">%s</div></div></div></a>',
-		$audio_url,
+	// Define pill-style colors and styling
+	$background_color = '#f6f7f7';
+	$border_color     = '#AAA';
+	$icon_size        = '18px';
+	$font_size        = '14px';
+
+	// Generate the icon content
+	$icon_content = sprintf(
+		'<a href="%1$s" rel="noopener nofollow" target="_blank" style="padding: 0.25em; padding-left: 17px; display: inline-block; vertical-align: middle;"><img height="%2$s" src="%3$s" style="display:block;margin-right:0;vertical-align:middle;" width="%2$s" alt="%4$s"></a>',
+		esc_url( $audio_url ),
+		esc_attr( $icon_size ),
 		esc_url( $icon_image ),
+		// translators: %s is the podcast player icon.
+		sprintf( __( '%s icon', 'jetpack' ), __( 'Podcast', 'jetpack' ) )
+	);
+	$icon_content = \Automattic\WooCommerce\EmailEditor\Integrations\Utils\Table_Wrapper_Helper::render_table_cell( $icon_content, array( 'style' => sprintf( 'vertical-align:middle;font-size:%s;', $font_size ) ) );
+
+	// Generate the label content
+	$label_content    = sprintf(
+		'<a href="%1$s" rel="noopener nofollow" target="_blank" style="text-decoration:none; padding: 0.25em; padding-right: 17px; display: inline-block;"><span style="margin-left:.5em;margin-right:.5em;font-weight:bold"> %2$s </span></a>',
+		esc_url( $audio_url ),
 		esc_html( $label )
 	);
+	$label_cell_style = sprintf(
+		'vertical-align:middle;font-size:%s;',
+		$font_size
+	);
+	$label_content    = \Automattic\WooCommerce\EmailEditor\Integrations\Utils\Table_Wrapper_Helper::render_table_cell( $label_content, array( 'style' => $label_cell_style ) );
 
-	// Use Table_Wrapper_Helper for consistent email rendering
-	$table_style = 'width: 100%; border-collapse: collapse;';
+	// Combine icon and label tables
+	$podcast_content = $icon_content . $label_content;
+
+	// Create the main pill-style table
+	$main_table_styles = sprintf(
+		'background-color: %s; border-radius: 9999px; display: inline-table; float: none; border: 1px solid %s; border-collapse: separate;',
+		$background_color,
+		$border_color
+	);
+
+	$main_table_attrs = array(
+		'align' => 'left',
+		'style' => $main_table_styles,
+	);
+
+	$main_table = \Automattic\WooCommerce\EmailEditor\Integrations\Utils\Table_Wrapper_Helper::render_table_wrapper( $podcast_content, $main_table_attrs, array(), array(), false );
+
+	// Create the main wrapper table
+	$table_style = 'width: 100%;';
 	if ( ! empty( $table_margin_style ) ) {
 		$table_style = $table_margin_style . '; ' . $table_style;
 	} else {
@@ -352,7 +395,11 @@ function render_email( $block_content, array $parsed_block, $rendering_context )
 		'style' => $table_style,
 	);
 
-	$html = \Automattic\WooCommerce\EmailEditor\Integrations\Utils\Table_Wrapper_Helper::render_table_wrapper( $button_content, $table_attrs );
+	$cell_attrs = array(
+		'style' => 'min-width: 100%; vertical-align: middle; word-break: break-word; text-align: left;',
+	);
 
-	return $html;
+	$main_wrapper = \Automattic\WooCommerce\EmailEditor\Integrations\Utils\Table_Wrapper_Helper::render_table_wrapper( $main_table, $table_attrs, $cell_attrs );
+
+	return \Automattic\WooCommerce\EmailEditor\Integrations\Utils\Table_Wrapper_Helper::render_outlook_table_wrapper( $main_wrapper, array( 'align' => 'left' ) );
 }

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/Podcast_Player_Block_Email_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/Podcast_Player_Block_Email_Test.php
@@ -11,20 +11,13 @@ require_once JETPACK__PLUGIN_DIR . 'extensions/blocks/podcast-player/podcast-pla
 require_once __DIR__ . '/class-mock-styles-helper.php';
 require_once __DIR__ . '/class-mock-table-wrapper-helper.php';
 
-use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\CoversMethod;
-
 /**
  * Podcast Player Block Email Rendering tests.
  *
  * These tests verify the render_email function works correctly for various scenarios
  * including valid inputs, security validation, and email rendering.
- *
- * @covers Automattic\Jetpack\Extensions\Podcast_Player\render_email
- * @covers \Automattic\Jetpack\Extensions\Podcast_Player::render_email
  */
-#[CoversMethod( Automattic\Jetpack\Extensions\Podcast_Player::class, 'render_email' )]
-#[CoversClass( Automattic\Jetpack\Extensions\Podcast_Player\render_email::class )]
+#[CoversFunction( 'Automattic\Jetpack\Extensions\Podcast_Player\render_email' )]
 class Podcast_Player_Block_Email_Test extends WP_UnitTestCase {
 	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
 

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/Podcast_Player_Block_Email_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/Podcast_Player_Block_Email_Test.php
@@ -1,0 +1,198 @@
+<?php
+/**
+ * Podcast Player Block Email Rendering tests
+ *
+ * @package automattic/jetpack
+ */
+
+require_once JETPACK__PLUGIN_DIR . 'extensions/blocks/podcast-player/podcast-player.php';
+
+// Include mock classes for WooCommerce Email Editor helpers
+require_once __DIR__ . '/class-mock-styles-helper.php';
+require_once __DIR__ . '/class-mock-table-wrapper-helper.php';
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversMethod;
+
+/**
+ * Podcast Player Block Email Rendering tests.
+ *
+ * These tests verify the render_email function works correctly for various scenarios
+ * including valid inputs, security validation, and email rendering.
+ *
+ * @covers Automattic\Jetpack\Extensions\Podcast_Player\render_email
+ * @covers \Automattic\Jetpack\Extensions\Podcast_Player::render_email
+ */
+#[CoversMethod( Automattic\Jetpack\Extensions\Podcast_Player::class, 'render_email' )]
+#[CoversClass( Automattic\Jetpack\Extensions\Podcast_Player\render_email::class )]
+class Podcast_Player_Block_Email_Test extends WP_UnitTestCase {
+	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
+
+	/**
+	 * Helper to create a parsed block with test podcast URL.
+	 *
+	 * @param array $attrs Optional custom attributes.
+	 * @return array Parsed block structure.
+	 */
+	private function create_parsed_block_with_attrs( $attrs = array() ) {
+		$default_attrs = array(
+			'url' => 'https://feeds.acast.com/public/shows/test-podcast',
+		);
+
+		return array(
+			'attrs' => array_merge( $default_attrs, $attrs ),
+		);
+	}
+
+	/**
+	 * Helper to create a rendering context mock.
+	 *
+	 * @param string $width The width to return from get_layout_width_without_padding.
+	 * @return object Mock rendering context.
+	 */
+	private function create_rendering_context_mock( $width = '600px' ) {
+		return new class( $width ) {
+			private $width;
+
+			public function __construct( $width ) {
+				$this->width = $width;
+			}
+
+			public function get_layout_width_without_padding() {
+				return $this->width;
+			}
+		};
+	}
+
+	/**
+	 * Test render_email with valid podcast URL.
+	 */
+	public function test_render_email_with_valid_podcast_url() {
+		$parsed_block = $this->create_parsed_block_with_attrs();
+		$mock_context = $this->create_rendering_context_mock();
+		$result       = \Automattic\Jetpack\Extensions\Podcast_Player\render_email( '', $parsed_block, $mock_context );
+
+		// Should return HTML content
+		$this->assertNotEmpty( $result );
+		$this->assertStringContainsString( '<table', $result );
+		$this->assertStringContainsString( 'href=', $result );
+		$this->assertStringContainsString( 'Listen to the podcast', $result );
+
+		// Should contain table-based layout for email compatibility
+		$this->assertStringContainsString( 'border-collapse: collapse', $result );
+
+		// Should contain margin styling for email spacing
+		$this->assertStringContainsString( 'margin: 16px 0', $result );
+	}
+
+	/**
+	 * Test render_email with missing attrs.
+	 */
+	public function test_render_email_with_missing_attrs() {
+		$mock_context = $this->create_rendering_context_mock();
+
+		// Test with missing attrs
+		$result = \Automattic\Jetpack\Extensions\Podcast_Player\render_email( '', array( 'not-attrs' => array() ), $mock_context );
+		$this->assertSame( '', $result );
+
+		// Test with empty attrs
+		$result = \Automattic\Jetpack\Extensions\Podcast_Player\render_email( '', array( 'attrs' => array() ), $mock_context );
+		$this->assertSame( '', $result );
+	}
+
+	/**
+	 * Test render_email with empty URL.
+	 */
+	public function test_render_email_with_empty_url() {
+		$parsed_block = $this->create_parsed_block_with_attrs(
+			array(
+				'url' => '',
+			)
+		);
+		$mock_context = $this->create_rendering_context_mock();
+		$result       = \Automattic\Jetpack\Extensions\Podcast_Player\render_email( '', $parsed_block, $mock_context );
+
+		// Should return empty string when no valid URL
+		$this->assertSame( '', $result );
+	}
+
+	/**
+	 * Test render_email with invalid URL.
+	 */
+	public function test_render_email_with_invalid_url() {
+		$parsed_block = $this->create_parsed_block_with_attrs(
+			array(
+				'url' => 'not-a-valid-url',
+			)
+		);
+		$mock_context = $this->create_rendering_context_mock();
+		$result       = \Automattic\Jetpack\Extensions\Podcast_Player\render_email( '', $parsed_block, $mock_context );
+
+		// Should return empty string when URL is invalid
+		$this->assertSame( '', $result );
+	}
+
+	/**
+	 * Test render_email returns empty when WooCommerce Email Editor helper classes are missing.
+	 */
+	public function test_render_email_returns_empty_when_helpers_missing() {
+		$parsed_block = $this->create_parsed_block_with_attrs();
+		$mock_context = $this->create_rendering_context_mock();
+
+		// Verify that with mocked classes, the function works
+		$result_with_mocks = \Automattic\Jetpack\Extensions\Podcast_Player\render_email( '', $parsed_block, $mock_context );
+		$this->assertNotEmpty( $result_with_mocks );
+
+		// Test the class existence check logic directly
+		$table_helper_exists = class_exists( '\Automattic\WooCommerce\EmailEditor\Integrations\Utils\Table_Wrapper_Helper' );
+
+		// Class should exist due to our mock
+		$this->assertTrue( $table_helper_exists, 'Table_Wrapper_Helper class should be mocked and available' );
+	}
+
+	/**
+	 * Test render_email security - URL validation.
+	 */
+	public function test_render_email_security_url_validation() {
+		$parsed_block = $this->create_parsed_block_with_attrs(
+			array(
+				'url' => 'https://feeds.acast.com/public/shows/test-podcast',
+			)
+		);
+		$mock_context = $this->create_rendering_context_mock();
+		$result       = \Automattic\Jetpack\Extensions\Podcast_Player\render_email( '', $parsed_block, $mock_context );
+
+		// Should render with valid URL
+		$this->assertNotEmpty( $result );
+		$this->assertStringContainsString( 'href="https://feeds.acast.com/public/shows/test-podcast"', $result );
+	}
+
+	/**
+	 * Test render_email contains proper button styling.
+	 */
+	public function test_render_email_contains_button_styling() {
+		$parsed_block = $this->create_parsed_block_with_attrs();
+		$mock_context = $this->create_rendering_context_mock();
+		$result       = \Automattic\Jetpack\Extensions\Podcast_Player\render_email( '', $parsed_block, $mock_context );
+
+		// Should contain button styling
+		$this->assertNotEmpty( $result );
+		$this->assertStringContainsString( 'background-color: #f6f7f7', $result );
+		$this->assertStringContainsString( 'border: 1px solid #AAA', $result );
+		$this->assertStringContainsString( 'border-radius: 40px', $result );
+	}
+
+	/**
+	 * Test render_email contains play icon.
+	 */
+	public function test_render_email_contains_play_icon() {
+		$parsed_block = $this->create_parsed_block_with_attrs();
+		$mock_context = $this->create_rendering_context_mock();
+		$result       = \Automattic\Jetpack\Extensions\Podcast_Player\render_email( '', $parsed_block, $mock_context );
+
+		// Should contain play icon
+		$this->assertNotEmpty( $result );
+		$this->assertStringContainsString( 'audio-play.png', $result );
+		$this->assertStringContainsString( '<img', $result );
+	}
+}

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/Podcast_Player_Block_Email_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/Podcast_Player_Block_Email_Test.php
@@ -11,11 +11,15 @@ require_once JETPACK__PLUGIN_DIR . 'extensions/blocks/podcast-player/podcast-pla
 require_once __DIR__ . '/class-mock-styles-helper.php';
 require_once __DIR__ . '/class-mock-table-wrapper-helper.php';
 
+use PHPUnit\Framework\Attributes\CoversFunction;
+
 /**
  * Podcast Player Block Email Rendering tests.
  *
  * These tests verify the render_email function works correctly for various scenarios
  * including valid inputs, security validation, and email rendering.
+ *
+ * @covers ::Automattic\Jetpack\Extensions\Podcast_Player\render_email
  */
 #[CoversFunction( 'Automattic\Jetpack\Extensions\Podcast_Player\render_email' )]
 class Podcast_Player_Block_Email_Test extends WP_UnitTestCase {

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/Podcast_Player_Block_Email_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/Podcast_Player_Block_Email_Test.php
@@ -176,7 +176,7 @@ class Podcast_Player_Block_Email_Test extends WP_UnitTestCase {
 		$this->assertNotEmpty( $result );
 		$this->assertStringContainsString( 'background-color: #f6f7f7', $result );
 		$this->assertStringContainsString( 'border: 1px solid #AAA', $result );
-		$this->assertStringContainsString( 'border-radius: 40px', $result );
+		$this->assertStringContainsString( 'border-radius: 9999px', $result );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/class-mock-table-wrapper-helper.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/class-mock-table-wrapper-helper.php
@@ -47,6 +47,25 @@ if ( ! class_exists( '\Automattic\WooCommerce\EmailEditor\Integrations\Utils\Tab
 				$content
 			);
 		}
+
+		/**
+		 * Mock render_outlook_table_wrapper method
+		 *
+		 * @param string $content    The content to wrap.
+		 * @param array  $attributes The table attributes.
+		 * @return string The wrapped table HTML.
+		 */
+		public static function render_outlook_table_wrapper( $content, $attributes ) {
+			// Simple mock that wraps content in a table for Outlook compatibility
+			$style = $attributes['style'] ?? '';
+			$align = $attributes['align'] ?? 'left';
+
+			return sprintf(
+				'<table role="presentation" style="width: 100%%; max-width: 600px; margin: 16px auto; border-collapse: collapse; padding: 0; text-align: %s; %s">',
+				$align,
+				$style
+			) . '<tr><td style="padding: 0; font-family: Arial, sans-serif;">' . $content . '</td></tr></table>';
+		}
 	}
 	class_alias( 'Mock_Table_Wrapper_Helper', '\Automattic\WooCommerce\EmailEditor\Integrations\Utils\Table_Wrapper_Helper' );
 }

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/class-mock-table-wrapper-helper.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/class-mock-table-wrapper-helper.php
@@ -14,20 +14,30 @@ if ( ! class_exists( '\Automattic\WooCommerce\EmailEditor\Integrations\Utils\Tab
 		/**
 		 * Mock render_table_wrapper method
 		 *
-		 * @param string $content    The content to wrap.
-		 * @param array  $attributes The table attributes.
+		 * @param string $content     The content to wrap.
+		 * @param array  $table_attrs Table attributes.
+		 * @param array  $cell_attrs  Cell attributes.
+		 * @param array  $row_attrs   Row attributes.
+		 * @param bool   $render_cell Whether to render the td wrapper.
 		 * @return string The wrapped table HTML.
 		 */
-		public static function render_table_wrapper( $content, $attributes ) {
+		public static function render_table_wrapper( $content, $table_attrs = array(), $cell_attrs = array(), $row_attrs = array(), $render_cell = true ) {
 			// Simple mock that wraps content in a table
-			$style = $attributes['style'] ?? '';
-			$width = $attributes['width'] ?? 600;
+			$style = $table_attrs['style'] ?? '';
+			$width = $table_attrs['width'] ?? 600;
 
-			return sprintf(
+			$table_html = sprintf(
 				'<table role="presentation" style="width: 100%%; max-width: %dpx; margin: 16px auto; border-collapse: collapse; padding: 0; %s">',
 				$width,
 				$style
-			) . '<tr><td style="padding: 0; font-family: Arial, sans-serif;">' . $content . '</td></tr></table>';
+			);
+
+			if ( $render_cell ) {
+				$cell_style = $cell_attrs['style'] ?? '';
+				$content    = '<td style="padding: 0; font-family: Arial, sans-serif; ' . $cell_style . '">' . $content . '</td>';
+			}
+
+			return $table_html . '<tr>' . $content . '</tr></table>';
 		}
 
 		/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://linear.app/a8c/issue/CML-821/add-email-rendering-for-podcast-player-blocks

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add email rendering to the podcast player block.
* Add tests.

## Email client compatibility:

Here's how it renders for me in Gmail:

<img width="730" height="427" alt="Screenshot 2025-08-29 at 1 48 48 PM" src="https://github.com/user-attachments/assets/e105db3f-86ee-4ec1-82e1-e90a5a20923c" />

That's a smaller, pill-shaped table version of the current rendering, for better email client compatibility.

In Outlook 2021:
<img width="168" height="64" alt="Screenshot 2025-08-29 at 1 37 03 PM" src="https://github.com/user-attachments/assets/a0bf5f83-c7cd-4fe3-b104-29163f3eaadf" />

Dark mode:
<img width="235" height="55" alt="Screenshot 2025-08-29 at 1 50 22 PM" src="https://github.com/user-attachments/assets/985ee7e7-2eae-4a30-bd64-e66eecc240e0" />


Mobile:
<img width="306" height="302" alt="Screenshot 2025-08-29 at 1 50 33 PM" src="https://github.com/user-attachments/assets/22dcb6f7-e6ac-4d62-bc3b-4f9111d98d60" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

https://linear.app/a8c/project/switch-to-centralized-email-rendering-solution-aacb0b060431/overview

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

N/A

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply these changes to your sandbox using `bin/jetpack-downloader test jetpack add/podcast-player-email-rendering`.
* Sandbox the API and turn on write access.
* Add the `wc-email-editor` sticker to a test site. See PCYsg-eQj-p2
* Create a post with a podcast player block. You can use https://feeds.acast.com/public/shows/67587e77c705e441797aff96
* Send yourself a test email.
* Click the podcast link in the email.

Notes:
- To test with a WoA dev or self-hosted site you'll need to set it up to connect to your sandbox.
- We don't apply any editor styles to the block (currently the case).

