### PR TITLE
Forms: Fix slider css theme conflicts

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-slider-theme-conflicts
+++ b/projects/packages/forms/changelog/fix-forms-slider-theme-conflicts
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Fix slider css theme conflicts.

--- a/projects/packages/forms/src/blocks/input-range/style.scss
+++ b/projects/packages/forms/src/blocks/input-range/style.scss
@@ -1,6 +1,6 @@
-.jetpack-field-slider {
+.wp-block-jetpack-field-slider {
 
-	&__input-row {
+	.jetpack-field-slider__input-row {
 		display: flex;
 		align-items: center;
 		width: 100%;
@@ -8,7 +8,7 @@
 		margin-top: 30px;
 	}
 
-	&__input-container {
+	.jetpack-field-slider__input-container {
 		display: flex;
 		flex: 1 1 auto;
 		min-width: 0;
@@ -24,14 +24,14 @@
 			transform: translateY(-50%);
 			height: 4px;
 			width: 100%;
-			background: var(--jetpack--contact-form--button-primary--background-color);
+			background: var(--jetpack--contact-form--text-color);
 			z-index: 0;
 			pointer-events: none;
 			border-radius: 2px;
 		}
 	}
 
-	&__range {
+	.jetpack-field-slider__range[type="range"] {
 		-webkit-appearance: none;
 		appearance: none;
 		-moz-appearance: none;
@@ -39,10 +39,12 @@
 		padding: 18px 0 16px; /* enlarge hit area without moving track */
 		background: transparent;
 		outline: none;
+		border: none;
 		border-radius: 2px;
 		transition: background 0.3s;
 		width: 100%;
 		box-sizing: border-box;
+		box-shadow: none;
 		z-index: 1;
 		cursor: pointer;
 
@@ -76,7 +78,7 @@
 			appearance: none;
 			width: 18px;
 			height: 18px;
-			background: var(--jetpack--contact-form--button-primary--background-color);
+			background: var(--jetpack--contact-form--text-color);
 			border-radius: 50%;
 			cursor: pointer;
 			transition: background 0.3s;
@@ -88,7 +90,7 @@
 			-moz-appearance: none !important;
 			width: 18px;
 			height: 18px;
-			background: var(--jetpack--contact-form--button-primary--background-color);
+			background: var(--jetpack--contact-form--text-color);
 			border-radius: 50%;
 			cursor: pointer;
 			transition: background 0.3s;
@@ -100,7 +102,7 @@
 			appearance: none !important;
 			width: 18px;
 			height: 18px;
-			background: var(--jetpack--contact-form--button-primary--background-color);
+			background: var(--jetpack--contact-form--text-color);
 			border-radius: 50%;
 			cursor: pointer;
 			transition: background 0.3s;
@@ -114,17 +116,17 @@
 		&::-ms-fill-upper,
 		&:focus::-ms-fill-lower,
 		&:focus::-ms-fill-upper {
-			background: var(--jetpack--contact-form--button-primary--background-color);
+			background: var(--jetpack--contact-form--text-color);
 		}
 	}
 
-	&__value-indicator {
+	.jetpack-field-slider__value-indicator {
 		position: absolute;
 		left: 0;
 		bottom: 100%;
 		transform: translateX(-50%);
-		background: var(--jetpack--contact-form--button-primary--background-color);
-		color: var(--jetpack--contact-form--button-primary--color);
+		background: var(--jetpack--contact-form--text-color);
+		color: var(--jetpack--contact-form--background-color);
 		border-radius: 8px;
 		padding: 2px 8px;
 		font-size: 0.7em;
@@ -132,24 +134,24 @@
 		text-wrap: nowrap;
 	}
 
-	&__min-label,
-	&__max-label {
+	.jetpack-field-slider__min-label,
+	.jetpack-field-slider__max-label {
 		font-size: 0.9em;
 		text-align: center;
 	}
 
-	&__text-labels {
+	.jetpack-field-slider__text-labels {
 		display: flex;
 		justify-content: space-between;
 		margin-top: 6px;
 		font-size: 0.9em;
 	}
 
-	&__min-text-label {
+	.jetpack-field-slider__min-text-label {
 		text-align: left;
 	}
 
-	&__max-text-label {
+	.jetpack-field-slider__max-text-label {
 		text-align: right;
 	}
 }


### PR DESCRIPTION
## Proposed changes:

I went through and tested the new slider field against many different themes and fixed conflicts. Fixes involved:
* Nested our slider CSS selectors .wp-block-jetpack-field-slider to add extra specificity
* Overriding some specific rules (ie, border, box shadows, etc, that themes apply to the slider that look broken)
* I had to update the slider to use text color (`--jetpack--contact-form--text-color`) by default rather than button background color (`--jetpack--contact-form--button-primary--background-color`). In at least one case, button background color was transparent, which meant the track and bullet were transparent. Text color is safer across and always has contrast with the page background.

**No conflicts.** These themes were already good with no conflicts, and still look good with the changes: 
- Elementor, Hestia, Blocksy, GeneratePress, OceanWP, 2010, 2011, 2016 (background vs text is not the best), 2020, 2021, 2022, 2023, 2024, 2025

**Conflicts.** These themes had conflicts, and are now looking good with the latest changes: 
- Go, Kadence, 2012, 2013, 2014, 2015, 2017, 2019, 2021

**To do.** Still needs fix.
- Astra

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a form with a slider.
* Test it against multiple themes and confirm the styling always looks roughly like expected. You can do this manually by activating each theme, or in a group using https://wordpress.org/plugins/back-to-the-theme/

