### PR TITLE
 Forms: Add input styles to image select field

### DIFF
--- a/projects/packages/forms/changelog/update-forms-image-select-input-style
+++ b/projects/packages/forms/changelog/update-forms-image-select-input-style
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Forms: Add input styles to image select field

--- a/projects/packages/forms/src/blocks/field-image-select/edit.tsx
+++ b/projects/packages/forms/src/blocks/field-image-select/edit.tsx
@@ -20,6 +20,7 @@ import useAddImageOption from '../shared/hooks/use-add-image-option';
 import useFormWrapper from '../shared/hooks/use-form-wrapper';
 import useJetpackFieldStyles from '../shared/hooks/use-jetpack-field-styles';
 import './style.scss';
+import './editor.scss';
 /**
  * Types
  */

--- a/projects/packages/forms/src/blocks/field-image-select/editor.scss
+++ b/projects/packages/forms/src/blocks/field-image-select/editor.scss
@@ -1,0 +1,22 @@
+// Editor-only styles.
+
+// There is a high specificity flex rule for form fields
+// that we need to override to show the image options
+// in a grid.
+.wp-block-jetpack-contact-form
+.jetpack-contact-form
+.jetpack-fieldset-image-options__wrapper
+.jetpack-input-image-option {
+	flex-basis: unset;
+}
+
+// There is no outer block in the editor, so we apply
+// the styles directly to the input image option.
+.jetpack-input-image-option {
+	display: flex;
+	width: calc(( 1 / 4 ) * 100% - var(--jetpack-field-image-options-gap) * ( 3 / 4 ));
+
+	&.is-supersized {
+		width: calc(( 1 / 2 ) * 100% - var(--jetpack-field-image-options-gap) * ( 1 / 2 ));
+	}
+}

--- a/projects/packages/forms/src/blocks/field-image-select/style.scss
+++ b/projects/packages/forms/src/blocks/field-image-select/style.scss
@@ -1,14 +1,5 @@
 @use "../shared/styles/visually-hidden" as *;
 
-// There is a high specificity flex rule that we
-// need to override in the block editor only.
-.wp-block-jetpack-contact-form
-.jetpack-contact-form
-.jetpack-fieldset-image-options__wrapper
-.jetpack-input-image-option {
-	flex-basis: unset;
-}
-
 // Themes target the image block directly to fit their needs,
 // not expecting it to be inside an image select field.
 .wp-block-jetpack-input-image-option
@@ -33,6 +24,7 @@ figure.wp-block-image {
 	flex-wrap: wrap;
 	gap: var(--jetpack-field-image-options-gap);
 
+	// Frontend-only wrapper element for background color change on hover.
 	.jetpack-input-image-option__outer {
 		display: flex;
 		width: calc(( 1 / 4 ) * 100% - var(--jetpack-field-image-options-gap) * ( 3 / 4 ));
@@ -46,7 +38,6 @@ figure.wp-block-image {
 		box-sizing: border-box;
 		display: flex;
 		flex-direction: column;
-		width: 100%;
 		overflow: hidden;
 
 		&:not(.wp-block):hover {

--- a/projects/packages/forms/src/blocks/field-image-select/style.scss
+++ b/projects/packages/forms/src/blocks/field-image-select/style.scss
@@ -40,7 +40,8 @@ figure.wp-block-image {
 		flex-direction: column;
 		overflow: hidden;
 
-		&:not(.wp-block):hover {
+		&:not(.wp-block):hover,
+		&.is-checked {
 			backdrop-filter: contrast(0.9) saturate(1.2);
 			cursor: pointer;
 		}
@@ -49,6 +50,34 @@ figure.wp-block-image {
 			width: 100%;
 			overflow: hidden;
 			position: relative;
+
+			.jetpack-input-image-option__input[type="checkbox"],
+			.jetpack-input-image-option__input[type="radio"] {
+				font-size: inherit;
+				padding: 0;
+				appearance: none;
+				border: solid 1px currentColor;
+				color: currentColor;
+				outline-offset: 1px;
+				border-radius: 4px;
+
+				&:checked {
+					background-color: currentColor;
+				}
+
+				&::before {
+					width: 0.25em;
+					height: 0.5em;
+					content: "";
+					display: block;
+					margin-left: 50%;
+					margin-top: 50%;
+					border: solid currentColor;
+					border-width: 0 2px 2px 0;
+					transform: translate(-50%, -60%) rotate(40deg);
+					filter: invert(1) contrast(2) brightness(1.5);
+				}
+			}
 
 			.jetpack-input-image-option__input {
 				position: absolute;

--- a/projects/packages/forms/src/blocks/input-image-option/edit.tsx
+++ b/projects/packages/forms/src/blocks/input-image-option/edit.tsx
@@ -73,17 +73,12 @@ export default function ImageOptionInputEdit( props ) {
 	// Use the block's own synced attributes for styling
 	const { blockStyle } = useJetpackFieldStyles( attributes );
 
-	const outerClassName = useMemo( () => {
-		return clsx( 'jetpack-input-image-option__outer', {
-			'is-supersized': isSupersized,
-		} );
-	}, [ isSupersized ] );
-
 	const blockProps = useBlockProps( {
 		className: clsx( 'jetpack-field jetpack-input-image-option', {
 			'is-selected': isSelected || isInnerBlockSelected,
 			'has-image': !! imageBlockAttributes?.url,
 			[ `is-${ selectionType }` ]: !! selectionType,
+			'is-supersized': isSupersized,
 		} ),
 		style: blockStyle,
 	} );
@@ -116,20 +111,18 @@ export default function ImageOptionInputEdit( props ) {
 	);
 
 	return (
-		<div className={ outerClassName }>
-			<div { ...blockProps }>
-				<div { ...innerBlocksProps } />
-				<div className="jetpack-input-image-option__label-wrapper">
-					<div className="jetpack-input-image-option__label-code">{ positionLetter }</div>
-					<RichText
-						tagName="span"
-						className={ labelClassName }
-						value={ label }
-						placeholder={ __( 'Add option…', 'jetpack-forms' ) }
-						__unstableDisableFormats
-						onChange={ ( newLabel: string ) => setAttributes( { label: newLabel } ) }
-					/>
-				</div>
+		<div { ...blockProps }>
+			<div { ...innerBlocksProps } />
+			<div className="jetpack-input-image-option__label-wrapper">
+				<div className="jetpack-input-image-option__label-code">{ positionLetter }</div>
+				<RichText
+					tagName="span"
+					className={ labelClassName }
+					value={ label }
+					placeholder={ __( 'Add option…', 'jetpack-forms' ) }
+					__unstableDisableFormats
+					onChange={ ( newLabel: string ) => setAttributes( { label: newLabel } ) }
+				/>
 			</div>
 		</div>
 	);

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -1930,24 +1930,26 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 
 				// To be able to apply the backdrop-filter for the hover effect, we need to separate the background into an outer div.
 				// This outer div needs the color styles separately, and also the border radius to match the inner div without sticking out.
-				$option_outer_classes = "jetpack-input-image-option__outer {$option['classcolor']}";
+				$option_outer_classes = 'jetpack-input-image-option__outer ' . ( isset( $option['classcolor'] ) ? $option['classcolor'] : '' );
 
 				if ( $is_supersized ) {
 					$option_outer_classes .= ' is-supersized';
 				}
 
 				$border_styles = '';
-				preg_match( '/border-radius:([^;]+)/', $option['style'], $radius_match );
-				preg_match( '/border-width:([^;]+)/', $option['style'], $width_match );
+				if ( ! empty( $option['style'] ) ) {
+					preg_match( '/border-radius:([^;]+)/', $option['style'], $radius_match );
+					preg_match( '/border-width:([^;]+)/', $option['style'], $width_match );
 
-				if ( ! empty( $radius_match[1] ) ) {
-					$radius_value = trim( $radius_match[1] );
+					if ( ! empty( $radius_match[1] ) ) {
+						$radius_value = trim( $radius_match[1] );
 
-					if ( ! empty( $width_match[1] ) ) {
-							$width_value   = trim( $width_match[1] );
-							$border_styles = "border-radius:calc({$radius_value} + {$width_value});";
-					} else {
-							$border_styles = "border-radius:{$radius_value};";
+						if ( ! empty( $width_match[1] ) ) {
+								$width_value   = trim( $width_match[1] );
+								$border_styles = "border-radius:calc({$radius_value} + {$width_value});";
+						} else {
+								$border_styles = "border-radius:{$radius_value};";
+						}
 					}
 				}
 

--- a/projects/packages/forms/src/modules/form/view.js
+++ b/projects/packages/forms/src/modules/form/view.js
@@ -305,8 +305,9 @@ const { state, actions } = store( NAMESPACE, {
 		},
 
 		onImageOptionClick: event => {
-			// Find the parent container that has the data-wp-on--click attribute
+			// Find the block container
 			let target = event.target;
+
 			while ( target && ! target.classList.contains( 'jetpack-input-image-option' ) ) {
 				target = target.parentElement;
 			}
@@ -314,12 +315,25 @@ const { state, actions } = store( NAMESPACE, {
 			if ( target ) {
 				// Find the input inside this container
 				const input = target.querySelector( '.jetpack-input-image-option__input' );
+
 				if ( input ) {
-					// Toggle the input state
 					if ( input.type === 'checkbox' ) {
 						input.checked = ! input.checked;
+						target.classList.toggle( 'is-checked', input.checked );
 					} else if ( input.type === 'radio' ) {
 						input.checked = true;
+
+						// Find all image options in the same fieldset and toggle the checked class
+						const fieldset = target.closest( '.jetpack-fieldset-image-options__wrapper' );
+
+						if ( fieldset ) {
+							const imageOptions = fieldset.querySelectorAll( '.jetpack-input-image-option' );
+
+							imageOptions.forEach( imageOption => {
+								const imageOptionInput = imageOption.querySelector( 'input' );
+								imageOption.classList.toggle( 'is-checked', imageOptionInput.id === input.id );
+							} );
+						}
 					}
 
 					// Dispatch change event to trigger any change handlers


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of FORMS-60

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fixes warnings when there is no custom block styling
* Fixes the behavior of the block inserter
* Adds styling for the input on the frontend

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

For the warning fix:
* On an unsandboxed Simple site, create an image select field and add images, but do not change the default style
* Publish it and go to the frontend
* Check that there are warnings
* Sandbox your test Simple site with this PR
* Go to the published post again
* Check that the warnings are gone

For the block inserter behavior:
* Without this PR, go to the block editor and add an image select field
* Hover between two options. Check that the block inserter does not appear
* Apply this PR
* Check that the vertical block inserter is displayed now

For the frontend styles:
* Publish a form with two image select fields containing images on all options. In one of them, enable multi selection.
* Style the options as desired. Try disabling the style syncing on the image select field and then styling each option differently
* Check that the selected images have checkmarks on them, emulating the normal checkboxes

Note: Contrary to all other use cases of checkboxes and radio inputs, this one sits on top of an image, which can be difficult to see depending on the colors and the image. Also, the way used on other places to determine colors will not work on this case as each option can be styled separately, so I used filters to determine a combination of colors based on the text color as a proposal.

| Before | After |
| - | - |
| <img width="527" height="582" alt="Screenshot from 2025-08-28 21-42-26" src="https://github.com/user-attachments/assets/cd5a6dcf-959a-42fb-b1cb-367b061bc640" /> | <img width="527" height="582" alt="Screenshot from 2025-08-28 21-15-53" src="https://github.com/user-attachments/assets/80e1a2d1-5423-46ff-9f95-75082eaff124" /> |
