### PR TITLE
Forms: Fix range scroll forms

### DIFF
--- a/projects/packages/forms/changelog/fix-range-scroll-forms
+++ b/projects/packages/forms/changelog/fix-range-scroll-forms
@@ -1,0 +1,4 @@
+Significance: major
+Type: fixed
+
+Forms: fix range slider mobile input

--- a/projects/packages/forms/src/blocks/input-range/style.scss
+++ b/projects/packages/forms/src/blocks/input-range/style.scss
@@ -12,6 +12,7 @@
 		display: flex;
 		flex: 1 1 auto;
 		min-width: 0;
+		padding: 0;
 		position: relative;
 		min-height: 36px;
 		touch-action: pan-x;
@@ -19,12 +20,12 @@
 		&::before {
 			content: "";
 			position: absolute;
-			left: 0;
-			right: 0;
+			left: 8px;
+			right: 8px;
 			top: 50%;
 			transform: translateY(-50%);
 			height: 4px; /* visual track height */
-			width: 100%;
+			width: auto;
 			background: var(--jetpack--contact-form--button-primary--background-color);
 			z-index: 0;
 			pointer-events: none;
@@ -38,7 +39,9 @@
 		-moz-appearance: none;
 		height: 100%;
 		min-height: 36px;
-		padding: 0; /* enlarge hit area without moving track */
+
+		margin: 0; /* enlarge hit area without moving track */
+		padding: 0;
 		background: transparent;
 		outline: none;
 		border: none;
@@ -78,9 +81,7 @@
 			width: 32px;
 			height: 32px;
 			background: radial-gradient(circle at center, var(--jetpack--contact-form--button-primary--background-color) 0%, var(--jetpack--contact-form--button-primary--background-color) 40%, transparent 40%);
-			border-radius: 50%;
 			cursor: pointer;
-			transition: background 0.3s;
 			box-shadow: none;
 		}
 
@@ -90,9 +91,7 @@
 			width: 32px;
 			height: 32px;
 			background: radial-gradient(circle at center, var(--jetpack--contact-form--button-primary--background-color) 0%, var(--jetpack--contact-form--button-primary--background-color) 40%, transparent 40%);
-			border-radius: 50%;
 			cursor: pointer;
-			transition: background 0.3s;
 			border: none;
 			box-shadow: none;
 		}
@@ -102,9 +101,7 @@
 			width: 32px;
 			height: 32px;
 			background: radial-gradient(circle at center, var(--jetpack--contact-form--button-primary--background-color) 0%, var(--jetpack--contact-form--button-primary--background-color) 40%, transparent 40%);
-			border-radius: 50%;
 			cursor: pointer;
-			transition: background 0.3s;
 			border: none;
 			box-shadow: none;
 		}

--- a/projects/packages/forms/src/blocks/input-range/style.scss
+++ b/projects/packages/forms/src/blocks/input-range/style.scss
@@ -14,6 +14,7 @@
 		min-width: 0;
 		position: relative;
 		min-height: 36px;
+		touch-action: pan-x;
 
 		&::before {
 			content: "";
@@ -22,7 +23,7 @@
 			right: 0;
 			top: 50%;
 			transform: translateY(-50%);
-			height: 4px;
+			height: 4px; /* visual track height */
 			width: 100%;
 			background: var(--jetpack--contact-form--button-primary--background-color);
 			z-index: 0;
@@ -31,14 +32,16 @@
 		}
 	}
 
-	&__range {
+	&__range.jetpack-field-slider__range {
 		-webkit-appearance: none;
 		appearance: none;
 		-moz-appearance: none;
-		height: 4px; /* visual track height */
-		padding: 18px 0 16px; /* enlarge hit area without moving track */
+		height: 100%;
+		min-height: 36px;
+		padding: 0; /* enlarge hit area without moving track */
 		background: transparent;
 		outline: none;
+		border: none;
 		border-radius: 2px;
 		transition: background 0.3s;
 		width: 100%;

--- a/projects/packages/forms/src/blocks/input-range/style.scss
+++ b/projects/packages/forms/src/blocks/input-range/style.scss
@@ -42,8 +42,6 @@
 		background: transparent;
 		outline: none;
 		border: none;
-		border-radius: 2px;
-		transition: background 0.3s;
 		width: 100%;
 		box-sizing: border-box;
 		z-index: 1;

--- a/projects/packages/forms/src/blocks/input-range/style.scss
+++ b/projects/packages/forms/src/blocks/input-range/style.scss
@@ -75,38 +75,38 @@
 		&::-webkit-slider-thumb {
 			-webkit-appearance: none;
 			appearance: none;
-			width: 18px;
-			height: 18px;
-			background: var(--jetpack--contact-form--button-primary--background-color);
+			width: 32px;
+			height: 32px;
+			background: radial-gradient(circle at center, var(--jetpack--contact-form--button-primary--background-color) 0%, var(--jetpack--contact-form--button-primary--background-color) 40%, transparent 40%);
 			border-radius: 50%;
 			cursor: pointer;
 			transition: background 0.3s;
-			box-shadow: 0 0 2px rgba(0, 0, 0, 0.2);
+			box-shadow: none;
 		}
 
 		&::-moz-range-thumb {
 			appearance: none !important;
 			-moz-appearance: none !important;
-			width: 18px;
-			height: 18px;
-			background: var(--jetpack--contact-form--button-primary--background-color);
+			width: 32px;
+			height: 32px;
+			background: radial-gradient(circle at center, var(--jetpack--contact-form--button-primary--background-color) 0%, var(--jetpack--contact-form--button-primary--background-color) 40%, transparent 40%);
 			border-radius: 50%;
 			cursor: pointer;
 			transition: background 0.3s;
 			border: none;
-			box-shadow: 0 0 2px rgba(0, 0, 0, 0.2);
+			box-shadow: none;
 		}
 
 		&::-ms-thumb {
 			appearance: none !important;
-			width: 18px;
-			height: 18px;
-			background: var(--jetpack--contact-form--button-primary--background-color);
+			width: 32px;
+			height: 32px;
+			background: radial-gradient(circle at center, var(--jetpack--contact-form--button-primary--background-color) 0%, var(--jetpack--contact-form--button-primary--background-color) 40%, transparent 40%);
 			border-radius: 50%;
 			cursor: pointer;
 			transition: background 0.3s;
 			border: none;
-			box-shadow: 0 0 2px rgba(0, 0, 0, 0.2);
+			box-shadow: none;
 		}
 
 		&:focus::-webkit-slider-thumb,

--- a/projects/packages/forms/src/modules/slider-field/view.js
+++ b/projects/packages/forms/src/modules/slider-field/view.js
@@ -31,7 +31,7 @@ store( NAMESPACE, {
 			const percent = ( ( value - min ) * 100 ) / ( max - min );
 
 			// Magic numbers: 8px base offset, 0.15px per percent
-			return `calc(${ percent }% + (${ 8 - percent * 0.15 }px))`;
+			return `calc(${ percent }% + (${ 16 - percent * 0.32 }px))`;
 		},
 	},
 	actions: {


### PR DESCRIPTION
The current range slider doesn't have a good experience on iPad deviceds. 
The hit area is too small and vertical scrolling is also possible when you are doing the horizonal sliding. 

## Proposed changes:
* We add a touch-action: pan-x; to the div above the range so that vertical panning is not possible. 
* We increase the hit area so that it is easier for users to select the field on mobile devices. 

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?


## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Test the slider input using xcode Simulator does it work much better then before? 

