### PR TITLE
Remove unnecessary filter for deleted WooCommerce products 

### DIFF
--- a/projects/packages/sync/changelog/update-wc-product-deleted
+++ b/projects/packages/sync/changelog/update-wc-product-deleted
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Remove unnecessary filter for deleted WooCommerce products in the WooCommerce_Products module

--- a/projects/packages/sync/src/modules/class-woocommerce-products.php
+++ b/projects/packages/sync/src/modules/class-woocommerce-products.php
@@ -106,7 +106,6 @@ class WooCommerce_Products extends Module {
 		add_filter( 'jetpack_sync_before_enqueue_woocommerce_new_product_variation', array( $this, 'expand_product_data' ) );
 		add_filter( 'jetpack_sync_before_enqueue_woocommerce_update_product_variation', array( $this, 'expand_product_data' ) );
 		add_filter( 'jetpack_sync_before_enqueue_woocommerce_updated_product_stock', array( $this, 'expand_product_data' ) );
-		add_filter( 'jetpack_sync_before_enqueue_jetpack_sync_woocommerce_product_deleted', array( $this, 'expand_product_data' ) );
 		add_filter( 'jetpack_sync_before_enqueue_jetpack_sync_woocommerce_product_trashed', array( $this, 'expand_product_data' ) );
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

As pointed out in the previous PR comment https://github.com/Automattic/jetpack/pull/44993/files#r2306865435, it's not necessary to expand product data for the `jetpack_sync_woocommerce_product_deleted` action since we only need product_id to delete the product from the cache table.


## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

Nope

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Check out this branch and enable the product sync module if you don't already have it enabled
2. Create a product in WooCommerce if you don’t already have one
2. Confirm that the product exists in the cache table
3. Trash and permanently delete the product in WooCommerce
4. Confirm that the product is removed from the cache table

