### PR TITLE
Image CDN: Prevent warning when WP global is null

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-prevent_warning_when_global_is_null
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-prevent_warning_when_global_is_null
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Image CDN: Prevent PHP warnings when handling malformed data. 

--- a/projects/plugins/jetpack/modules/photon-cdn.php
+++ b/projects/plugins/jetpack/modules/photon-cdn.php
@@ -77,30 +77,34 @@ class Jetpack_Photon_Static_Assets_CDN {
 
 		if ( self::is_public_version( $version ) ) {
 			$site_url = trailingslashit( site_url() );
-			foreach ( $wp_scripts->registered as $handle => $thing ) {
-				if ( wp_startswith( $thing->src, self::CDN ) ) {
-					continue;
-				}
-				if ( ! is_string( $thing->src ) ) {
-					continue;
-				}
-				$src = ltrim( str_replace( $site_url, '', $thing->src ), '/' );
-				if ( self::is_js_or_css_file( $src ) && in_array( substr( $src, 0, 9 ), array( 'wp-admin/', 'wp-includ' ), true ) ) {
-					$wp_scripts->registered[ $handle ]->src = sprintf( self::CDN . 'c/%1$s/%2$s', $version, $src );
-					$wp_scripts->registered[ $handle ]->ver = null;
+			if ( $wp_scripts instanceof WP_Scripts && is_array( $wp_scripts->registered ) ) {
+				foreach ( $wp_scripts->registered as $handle => $thing ) {
+					if ( wp_startswith( $thing->src, self::CDN ) ) {
+						continue;
+					}
+					if ( ! is_string( $thing->src ) ) {
+						continue;
+					}
+					$src = ltrim( str_replace( $site_url, '', $thing->src ), '/' );
+					if ( self::is_js_or_css_file( $src ) && in_array( substr( $src, 0, 9 ), array( 'wp-admin/', 'wp-includ' ), true ) ) {
+						$wp_scripts->registered[ $handle ]->src = sprintf( self::CDN . 'c/%1$s/%2$s', $version, $src );
+						$wp_scripts->registered[ $handle ]->ver = null;
+					}
 				}
 			}
-			foreach ( $wp_styles->registered as $handle => $thing ) {
-				if ( wp_startswith( $thing->src, self::CDN ) ) {
-					continue;
-				}
-				if ( ! is_string( $thing->src ) ) {
-					continue;
-				}
-				$src = ltrim( str_replace( $site_url, '', $thing->src ), '/' );
-				if ( self::is_js_or_css_file( $src ) && in_array( substr( $src, 0, 9 ), array( 'wp-admin/', 'wp-includ' ), true ) ) {
-					$wp_styles->registered[ $handle ]->src = sprintf( self::CDN . 'c/%1$s/%2$s', $version, $src );
-					$wp_styles->registered[ $handle ]->ver = null;
+			if ( $wp_styles instanceof WP_Styles && is_array( $wp_styles->registered ) ) {
+				foreach ( $wp_styles->registered as $handle => $thing ) {
+					if ( wp_startswith( $thing->src, self::CDN ) ) {
+						continue;
+					}
+					if ( ! is_string( $thing->src ) ) {
+						continue;
+					}
+					$src = ltrim( str_replace( $site_url, '', $thing->src ), '/' );
+					if ( self::is_js_or_css_file( $src ) && in_array( substr( $src, 0, 9 ), array( 'wp-admin/', 'wp-includ' ), true ) ) {
+						$wp_styles->registered[ $handle ]->src = sprintf( self::CDN . 'c/%1$s/%2$s', $version, $src );
+						$wp_styles->registered[ $handle ]->ver = null;
+					}
 				}
 			}
 		}

--- a/projects/plugins/jetpack/modules/photon-cdn.php
+++ b/projects/plugins/jetpack/modules/photon-cdn.php
@@ -199,27 +199,31 @@ class Jetpack_Photon_Static_Assets_CDN {
 			return false;
 		}
 
-		foreach ( $wp_scripts->registered as $handle => $thing ) {
-			if ( wp_startswith( $thing->src, self::CDN ) ) {
-				continue;
-			}
-			if ( wp_startswith( $thing->src, $plugin_directory_url ) ) {
-				$local_path = substr( $thing->src, strlen( $plugin_directory_url ) );
-				if ( in_array( $local_path, $assets, true ) ) {
-					$wp_scripts->registered[ $handle ]->src = sprintf( self::CDN . 'p/%1$s/%2$s/%3$s', $plugin_slug, $current_version, $local_path );
-					$wp_scripts->registered[ $handle ]->ver = null;
+		if ( $wp_scripts instanceof WP_Scripts && is_array( $wp_scripts->registered ) ) {
+			foreach ( $wp_scripts->registered as $handle => $thing ) {
+				if ( wp_startswith( $thing->src, self::CDN ) ) {
+					continue;
+				}
+				if ( wp_startswith( $thing->src, $plugin_directory_url ) ) {
+					$local_path = substr( $thing->src, strlen( $plugin_directory_url ) );
+					if ( in_array( $local_path, $assets, true ) ) {
+						$wp_scripts->registered[ $handle ]->src = sprintf( self::CDN . 'p/%1$s/%2$s/%3$s', $plugin_slug, $current_version, $local_path );
+						$wp_scripts->registered[ $handle ]->ver = null;
+					}
 				}
 			}
 		}
-		foreach ( $wp_styles->registered as $handle => $thing ) {
-			if ( wp_startswith( $thing->src, self::CDN ) ) {
-				continue;
-			}
-			if ( wp_startswith( $thing->src, $plugin_directory_url ) ) {
-				$local_path = substr( $thing->src, strlen( $plugin_directory_url ) );
-				if ( in_array( $local_path, $assets, true ) ) {
-					$wp_styles->registered[ $handle ]->src = sprintf( self::CDN . 'p/%1$s/%2$s/%3$s', $plugin_slug, $current_version, $local_path );
-					$wp_styles->registered[ $handle ]->ver = null;
+		if ( $wp_styles instanceof WP_Styles && is_array( $wp_styles->registered ) ) {
+			foreach ( $wp_styles->registered as $handle => $thing ) {
+				if ( wp_startswith( $thing->src, self::CDN ) ) {
+					continue;
+				}
+				if ( wp_startswith( $thing->src, $plugin_directory_url ) ) {
+					$local_path = substr( $thing->src, strlen( $plugin_directory_url ) );
+					if ( in_array( $local_path, $assets, true ) ) {
+						$wp_styles->registered[ $handle ]->src = sprintf( self::CDN . 'p/%1$s/%2$s/%3$s', $plugin_slug, $current_version, $local_path );
+						$wp_styles->registered[ $handle ]->ver = null;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Closes MONOREP-89

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

There are thousands of warnings generated due to `$wp_styles` being null. This isn't standard WP behavior, of course, but since it's a global, it could be set to anything by third-party code. This PR adds a defensive check for both `$wp_styles` and `$wp_scripts`.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Look at the code?