### PR TITLE
Untangling: Add Substack importer entry in import.php

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-substack-importer-entry
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-substack-importer-entry
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Add a Substack entry in import.php
+
+

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-imports/wpcom-imports.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-imports/wpcom-imports.php
@@ -21,7 +21,7 @@ function wpcom_imports_register_imports() {
 	$squarespace_description = __( 'Import <strong>posts, comments, images and tags</strong> from a Squarespace export file.', 'jetpack-mu-wpcom' );
 	$medium_description      = __( 'Import <strong>posts</strong> from a Medium export file.', 'jetpack-mu-wpcom' );
 	$wix_description         = __( 'Import <strong>posts, pages, and media</strong> from your Wix.com site.', 'jetpack-mu-wpcom' );
-	$substack_description    = __( 'Import <strong>posts, pages, and media</strong> from your Wix.com site.', 'jetpack-mu-wpcom' );
+	$substack_description    = __( 'Import <strong>content and subscribers</strong> from your Substack site.', 'jetpack-mu-wpcom' );
 
 	register_importer( 'wpcom-squarespace', __( 'Squarespace', 'jetpack-mu-wpcom' ), $squarespace_description, $page );
 	register_importer( 'wpcom-medium', __( 'Medium', 'jetpack-mu-wpcom' ), $medium_description, $page );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-imports/wpcom-imports.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-imports/wpcom-imports.php
@@ -21,10 +21,12 @@ function wpcom_imports_register_imports() {
 	$squarespace_description = __( 'Import <strong>posts, comments, images and tags</strong> from a Squarespace export file.', 'jetpack-mu-wpcom' );
 	$medium_description      = __( 'Import <strong>posts</strong> from a Medium export file.', 'jetpack-mu-wpcom' );
 	$wix_description         = __( 'Import <strong>posts, pages, and media</strong> from your Wix.com site.', 'jetpack-mu-wpcom' );
+	$substack_description    = __( 'Import <strong>posts, pages, and media</strong> from your Wix.com site.', 'jetpack-mu-wpcom' );
 
 	register_importer( 'wpcom-squarespace', __( 'Squarespace', 'jetpack-mu-wpcom' ), $squarespace_description, $page );
 	register_importer( 'wpcom-medium', __( 'Medium', 'jetpack-mu-wpcom' ), $medium_description, $page );
 	register_importer( 'wpcom-wix', __( 'Wix', 'jetpack-mu-wpcom' ), $wix_description, $page );
+	register_importer( 'wpcom-substack', __( 'Substack', 'jetpack-mu-wpcom' ), $substack_description, $page );
 }
 
 add_action( 'admin_init', 'wpcom_imports_register_imports' );
@@ -80,6 +82,24 @@ add_action(
 		$site_id = get_wpcom_blog_id();
 		// phpcs:ignore WordPress.Security.SafeRedirect.wp_redirect_wp_redirect
 		wp_redirect( 'https://wordpress.com/setup/site-migration/site-migration-identify?platform=wix&action=skip_platform_identification&hide_importer_link=true&siteSlug=' . $domain . '&siteId=' . $site_id );
+		exit();
+	}
+);
+
+/**
+ * Redirect to Calypso Stepper Substack importer.
+ */
+add_action(
+	'load-importer-wpcom-substack',
+	/**
+	 * Redirect to the Substack importer in the Calypso Stepper.
+	 *
+	 * @return never-return
+	 */
+	function () {
+		$domain = wp_parse_url( home_url(), PHP_URL_HOST );
+		// phpcs:ignore WordPress.Security.SafeRedirect.wp_redirect_wp_redirect
+		wp_redirect( 'https://wordpress.com/setup/site-setup/importerSubstack?ref=wp-admin-importers-list-direct-importer&siteSlug=' . $domain );
 		exit();
 	}
 );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes DOTCOM-14235

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds a "Substack importer entry on WP-Admin/import.php for Simple and Atomic sites

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this PR on your Atomic site and on your Sandbox
* Go to wp-admin/import.php
* Notice you have a new "Substack" in wp-admin/import.php that points to the Stepper Substack page

