### PR TITLE
i18n + webpack + dataviews + forms: generate function variants programmatically

### DIFF
--- a/projects/packages/forms/changelog/fix-i18n-webpack_and_dataviews_function_variants
+++ b/projects/packages/forms/changelog/fix-i18n-webpack_and_dataviews_function_variants
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Tooling: Generate i18n function variants programmatically.

--- a/projects/packages/forms/tools/webpack.config.dashboard.js
+++ b/projects/packages/forms/tools/webpack.config.dashboard.js
@@ -5,6 +5,25 @@
 const path = require( 'path' );
 const jetpackWebpackConfig = require( '@automattic/jetpack-webpack-config/webpack' );
 
+/**
+ * Generate i18n function variants for @automattic/babel-plugin-replace-textdomain.
+ *
+ * The @wordpress/dataviews currently uses the i18n functions under a variety of aliases,
+ * which makes it a pain to add the proper textdomain. This function generates an object
+ * with the base function and 99 more variants as keys.
+ *
+ * @param {string} baseFn - Base function name (e.g., '__', '_x', '_n')
+ * @param {number} value  - Textdomain argument position (1-based index)
+ * @return {object} Object mapping function names to textdomain positions
+ */
+const generateI18nVariants = ( baseFn, value ) =>
+	Object.fromEntries(
+		Array.from( { length: 100 }, ( _, i ) => [
+			`${ baseFn }${ i || '' }`, // empty suffix for 0
+			value,
+		] )
+	);
+
 module.exports = {
 	mode: jetpackWebpackConfig.mode,
 	entry: {
@@ -58,47 +77,9 @@ module.exports = {
 							{
 								textdomain: 'jetpack-forms',
 								functions: {
-									__: 1,
-									__1: 1,
-									__2: 1,
-									__3: 1,
-									__4: 1,
-									__5: 1,
-									__6: 1,
-									__7: 1,
-									__8: 1,
-									__9: 1,
-									__10: 1,
-									__11: 1,
-									__12: 1,
-									__13: 1,
-									__14: 1,
-									__15: 1,
-									__16: 1,
-									__17: 1,
-									__18: 1,
-									__19: 1,
-									__20: 1,
-									__21: 1,
-									__22: 1,
-									__23: 1,
-									__24: 1,
-									__25: 1,
-									__26: 1,
-									__27: 1,
-									__28: 1,
-									__29: 1,
-									__30: 1,
-									__31: 1,
-									__32: 1,
-									__33: 1,
-									_x: 2,
-									_x1: 2,
-									_x2: 2,
-									_x3: 2,
-									_x4: 2,
-									_x5: 2,
-									_n: 3,
+									...generateI18nVariants( '__', 1 ),
+									...generateI18nVariants( '_x', 2 ),
+									...generateI18nVariants( '_n', 3 ),
 								},
 							},
 						],


### PR DESCRIPTION
Closes MONOREP-90

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

I noticed that with the DataViews update PR (#45012) it was yet again failing due to i18n textdomain errors:

```domain argument (index 2) is missing```

This affects Forms in particular, and the fix has typically been to add additional function variants to the webpack file (e.g. https://github.com/Automattic/jetpack/pull/44376#issuecomment-3089756647). However, the recent update bumped that to 52 variants, so it's time to add them programmatically, which is what this PR does.

It's currently passing more functions than it needs. As of this writing `@wordpress/dataviews` v7.0.0 uses these variants:
* `__()` through `__52()`
* `_x()` through `_x6()`
* `_n()` and `_n2()` (`_n1()` is skipped for some reason)

I considered hard-coding the first and last variant number as params in the function, but opted to just generate the base and 99 more (100 total), which should prevent us from needing to change the numbers again anytime soon, with the tiny possibility that some conflict could arise if that package introduced a non-i18n function with one of those names.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Do things still build?