### PR TITLE
Forms: Fix dataview footer width and reset page on status change

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-dashboard-ux
+++ b/projects/packages/forms/changelog/fix-forms-dashboard-ux
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Fix dataview footer width and reset page on status change

--- a/projects/packages/forms/src/dashboard/components/inbox-status-toggle/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/inbox-status-toggle/index.tsx
@@ -29,12 +29,17 @@ function getTabLabel( label: string, count: number ): string {
 	return sprintf( __( '%1$s (%2$d)', 'jetpack-forms' ), label, count || 0 );
 }
 
+type InboxStatusToggleProps = {
+	onChange: ( status: string ) => void;
+};
+
 /**
  * Renders the status toggle for the inbox view.
  *
+ * @param {Function} onChange - The function to call when the status changes.
  * @return {JSX.Element} The status toggle component.
  */
-export default function InboxStatusToggle(): JSX.Element {
+export default function InboxStatusToggle( { onChange }: InboxStatusToggleProps ): JSX.Element {
 	const [ searchParams, setSearchParams ] = useSearchParams();
 	const status = searchParams.get( 'status' ) || 'inbox';
 	const [ isSm ] = useBreakpointMatch( 'sm' );
@@ -61,11 +66,12 @@ export default function InboxStatusToggle(): JSX.Element {
 			setSearchParams( prev => {
 				const params = new URLSearchParams( prev );
 				params.set( 'status', newStatus );
+				onChange( newStatus );
 
 				return params;
 			} );
 		},
-		[ setSearchParams, status, isSm ]
+		[ isSm, status, setSearchParams, onChange ]
 	);
 
 	return (

--- a/projects/packages/forms/src/dashboard/components/inbox-status-toggle/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/inbox-status-toggle/index.tsx
@@ -66,10 +66,11 @@ export default function InboxStatusToggle( { onChange }: InboxStatusToggleProps 
 			setSearchParams( prev => {
 				const params = new URLSearchParams( prev );
 				params.set( 'status', newStatus );
-				onChange( newStatus );
 
 				return params;
 			} );
+
+			onChange( newStatus );
 		},
 		[ isSm, status, setSearchParams, onChange ]
 	);

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
@@ -56,6 +56,35 @@ const formatFieldValue = fieldValue => {
 	return fieldValue;
 };
 
+const updateSidebarWidth = () => {
+	const wrapper = document.querySelector( '.dataviews-wrapper' );
+
+	if ( wrapper ) {
+		const left = wrapper.getBoundingClientRect().left;
+		wrapper.style.setProperty( '--forms-admin-sidebar-width', `${ left }px` );
+	}
+};
+
+const setupSidebarWidthObserver = () => {
+	const wrapper = document.querySelector( '.dataviews-wrapper' );
+
+	if ( ! wrapper ) {
+		return () => {};
+	}
+
+	updateSidebarWidth();
+
+	const resizeObserver = new ResizeObserver( () => {
+		requestAnimationFrame( updateSidebarWidth );
+	} );
+
+	resizeObserver.observe( wrapper );
+
+	return () => {
+		resizeObserver.disconnect();
+	};
+};
+
 /**
  * The DataViews implementation.
  *
@@ -76,6 +105,10 @@ export default function InboxView() {
 	);
 	const isMobile = containerWidth <= MOBILE_BREAKPOINT;
 	const selectedResponses = searchParams.get( 'r' );
+
+	useEffect( () => {
+		return setupSidebarWidthObserver();
+	}, [] );
 
 	const {
 		setCurrentQuery,

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
@@ -35,7 +35,6 @@ import {
 import { useView, defaultLayouts } from './views';
 
 const EMPTY_ARRAY = [];
-const EMPTY_OBJECT = {};
 const MOBILE_BREAKPOINT = 780;
 const getItemId = item => item.id.toString();
 
@@ -94,7 +93,6 @@ export default function InboxView() {
 	const [ view, setView ] = useView();
 	const [ searchParams, setSearchParams ] = useSearchParams();
 	const [ containerWidth, setContainerWidth ] = useState( 0 );
-	const [ queryArgs, setQueryArgs ] = useState( EMPTY_OBJECT );
 
 	const dateSettings = getDateSettings();
 	const containerRef = useResizeObserver(
@@ -146,12 +144,6 @@ export default function InboxView() {
 		// We need to keep the current query args in the store to be used in `export`
 		// and for getting the total records per `status`.
 		setCurrentQuery( _queryArgs );
-		// We also need to keep the args in local state and update it inside `useEffect`
-		// to run after the component mounts. This is because the `status` filter is retrieved
-		// from URL and can be changed through the parent components (Tabs), and if we'd used
-		// `useMemo` it would run during rendering and would update the component while also
-		// rendering different ones.
-		setQueryArgs( _queryArgs );
 	}, [ view, statusFilter, setCurrentQuery ] );
 	const data = useMemo(
 		() =>
@@ -310,6 +302,10 @@ export default function InboxView() {
 		return _actions;
 	}, [ isMobile, onChangeSelection, selection ] );
 
+	const resetPage = useCallback( () => {
+		view.page = 1;
+	}, [ view ] );
+
 	return (
 		<HStack
 			spacing={ 0 }
@@ -331,7 +327,7 @@ export default function InboxView() {
 					onChangeSelection={ onChangeSelection }
 					getItemId={ getItemId }
 					defaultLayouts={ defaultLayouts }
-					header={ <InboxStatusToggle currentQuery={ queryArgs } /> }
+					header={ <InboxStatusToggle onChange={ resetPage } /> }
 				/>
 			</div>
 			<SingleResponse

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -328,8 +328,8 @@
 		width: 100%;
 
 		@media (min-width: #{ (breakpoints.$break-medium + 1) }) {
-			left: variables.$admin-sidebar-width;
-			width: calc(100% - variables.$admin-sidebar-width);
+			left: var(--forms-admin-sidebar-width, variables.$admin-sidebar-width);
+			width: calc(100% - var(--forms-admin-sidebar-width, variables.$admin-sidebar-width));
 		}
 	}
 }
@@ -342,13 +342,13 @@
 .auto-fold .jp-forms__inbox__dataviews .dataviews-footer {
 
 	@media (min-width: #{ (breakpoints.$break-medium + 1) }) {
-		left: variables.$admin-sidebar-width-collapsed;
-		width: calc(100% - variables.$admin-sidebar-width-collapsed);
+		left: var(--forms-admin-sidebar-width, variables.$admin-sidebar-width-collapsed);
+		width: calc(100% - var(--forms-admin-sidebar-width, variables.$admin-sidebar-width-collapsed));
 	}
 
 	@media (min-width: #{ (breakpoints.$break-large + 1) }) {
-		left: variables.$admin-sidebar-width;
-		width: calc(100% - variables.$admin-sidebar-width);
+		left: var(--forms-admin-sidebar-width, variables.$admin-sidebar-width);
+		width: calc(100% - var(--forms-admin-sidebar-width, variables.$admin-sidebar-width));
 	}
 }
 
@@ -361,8 +361,8 @@
 	left: 0;
 
 	@media (min-width: #{ (breakpoints.$break-medium + 1) }) {
-		left: variables.$admin-sidebar-width-collapsed;
-		width: calc(100% - variables.$admin-sidebar-width-collapsed);
+		left: var(--forms-admin-sidebar-width, variables.$admin-sidebar-width-collapsed);
+		width: calc(100% - var(--forms-admin-sidebar-width, variables.$admin-sidebar-width-collapsed));
 	}
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes [FORMS-282](https://linear.app/a8c/issue/FORMS-282/dataview-footer-width-issue-and-page-reset-on-status-change)

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Sets the sidebar width dynamically via a CSS variable to fix the dataview footer positioning
* Resets the page when changing status, avoiding a state where there are results, but not on the current page

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Sandbox a simple site and navigate to the dashboard
* Check that the dataview footer is working as expected
* Test locally as well
* Go to a page other than 1 on any status (inbox, spam, trash)
* Go to another status
* Check that the page is reset to 1

Before:
<img width="1661" height="77" alt="Screenshot from 2025-08-29 15-01-17" src="https://github.com/user-attachments/assets/f1e3cb9d-399d-4bc5-8aaa-92ae5000289e" />
After:
<img width="1661" height="77" alt="Screenshot from 2025-08-29 15-00-36" src="https://github.com/user-attachments/assets/62a2e7f9-f1c1-4f63-9caa-59edd3912ef2" />
