### PR TITLE
Forms: Fix slider theme conflicts

### DIFF
--- a/projects/packages/forms/changelog/fix-form-slider-theme-conflicts
+++ b/projects/packages/forms/changelog/fix-form-slider-theme-conflicts
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Fix slider theme css conflicts.

--- a/projects/packages/forms/src/blocks/contact-form/util/form-styles.js
+++ b/projects/packages/forms/src/blocks/contact-form/util/form-styles.js
@@ -22,6 +22,37 @@ window.jetpackForms.getBackgroundColor = function ( backgroundColorNode ) {
 	return backgroundColor;
 };
 
+window.jetpackForms.getInverseReadableColor = function ( color ) {
+	if ( ! color ) {
+		return '#FFFFFF';
+	}
+
+	let r, g, b;
+
+	if ( color.startsWith( '#' ) ) {
+		let hex = color.slice( 1 );
+		if ( hex.length === 3 ) {
+			hex = hex
+				.split( '' )
+				.map( c => c + c )
+				.join( '' );
+		}
+		r = parseInt( hex.slice( 0, 2 ), 16 );
+		g = parseInt( hex.slice( 2, 4 ), 16 );
+		b = parseInt( hex.slice( 4, 6 ), 16 );
+	} else {
+		const match = color.match( /(\d+),\s*(\d+),\s*(\d+)/ );
+		if ( ! match ) {
+			return '#000000';
+		}
+		r = +match[ 1 ];
+		g = +match[ 2 ];
+		b = +match[ 3 ];
+	}
+	const luminance = 0.299 * r + 0.587 * g + 0.114 * b;
+	return luminance > 186 ? '#000000' : '#FFFFFF';
+};
+
 window.jetpackForms.generateStyleVariables = function ( formNode ) {
 	const STYLE_PROBE_CLASS = 'contact-form__style-probe';
 	const STYLE_PROBE_STYLE =
@@ -54,6 +85,7 @@ window.jetpackForms.generateStyleVariables = function ( formNode ) {
 
 	formNode.parentNode.appendChild( styleProbe );
 
+	const formRootNode = styleProbe.querySelector( '.contact-form' );
 	const buttonPrimaryNode = styleProbe.querySelector( '.btn-primary' );
 	const buttonOutlineNode = styleProbe.querySelector( '.btn-outline' );
 	const inputNode = styleProbe.querySelector( 'input[type="text"]' );
@@ -61,6 +93,8 @@ window.jetpackForms.generateStyleVariables = function ( formNode ) {
 	const backgroundColor = window.jetpackForms.getBackgroundColor( bodyNode );
 	const inputBackgroundFallback = window.jetpackForms.getBackgroundColor( inputNode );
 	const inputBackground = window.getComputedStyle( inputNode ).backgroundColor;
+	const bodyTextColor = window.getComputedStyle( formRootNode ).color;
+	const invertedBodyTextColor = window.jetpackForms.getInverseReadableColor( bodyTextColor );
 	const {
 		border: buttonPrimaryBorder,
 		borderColor: buttonPrimaryBorderColor,
@@ -101,6 +135,8 @@ window.jetpackForms.generateStyleVariables = function ( formNode ) {
 	return {
 		'--jetpack--contact-form--primary-color': buttonPrimaryBackgroundColor,
 		'--jetpack--contact-form--background-color': backgroundColor,
+		'--jetpack--contact-form--body-text-color': bodyTextColor,
+		'--jetpack--contact-form--inverted-body-text-color': invertedBodyTextColor,
 		'--jetpack--contact-form--text-color': textColor,
 		'--jetpack--contact-form--border': border,
 		'--jetpack--contact-form--border-color': borderColor,

--- a/projects/packages/forms/src/blocks/input-range/style.scss
+++ b/projects/packages/forms/src/blocks/input-range/style.scss
@@ -1,6 +1,6 @@
-.jetpack-field-slider {
+.wp-block-jetpack-field-slider {
 
-	&__input-row {
+	.jetpack-field-slider__input-row {
 		display: flex;
 		align-items: center;
 		width: 100%;
@@ -8,7 +8,7 @@
 		margin-top: 30px;
 	}
 
-	&__input-container {
+	.jetpack-field-slider__input-container {
 		display: flex;
 		flex: 1 1 auto;
 		min-width: 0;
@@ -26,14 +26,14 @@
 			transform: translateY(-50%);
 			height: 4px; /* visual track height */
 			width: auto;
-			background: var(--jetpack--contact-form--button-primary--background-color);
+			background: var(--jetpack--contact-form--text-color);
 			z-index: 0;
 			pointer-events: none;
 			border-radius: 2px;
 		}
 	}
 
-	&__range.jetpack-field-slider__range {
+	.jetpack-field-slider__range.jetpack-field-slider__range {
 		-webkit-appearance: none;
 		appearance: none;
 		-moz-appearance: none;
@@ -49,6 +49,7 @@
 		box-sizing: border-box;
 		z-index: 1;
 		cursor: pointer;
+		box-shadow: none;
 
 		/* Hide native tracks to prevent double-track rendering */
 		&::-webkit-slider-runnable-track,
@@ -80,9 +81,10 @@
 			appearance: none;
 			width: 32px;
 			height: 32px;
-			background: radial-gradient(circle at center, var(--jetpack--contact-form--button-primary--background-color) 0%, var(--jetpack--contact-form--button-primary--background-color) 40%, transparent 40%);
+			background: radial-gradient(circle at center, var(--jetpack--contact-form--text-color) 0%, var(--jetpack--contact-form--text-color) 40%, transparent 40%);
 			cursor: pointer;
 			box-shadow: none;
+			border: none;
 		}
 
 		&::-moz-range-thumb {
@@ -90,7 +92,7 @@
 			-moz-appearance: none !important;
 			width: 32px;
 			height: 32px;
-			background: radial-gradient(circle at center, var(--jetpack--contact-form--button-primary--background-color) 0%, var(--jetpack--contact-form--button-primary--background-color) 40%, transparent 40%);
+			background: radial-gradient(circle at center, var(--jetpack--contact-form--text-color) 0%, var(--jetpack--contact-form--text-color) 40%, transparent 40%);
 			cursor: pointer;
 			border: none;
 			box-shadow: none;
@@ -100,7 +102,7 @@
 			appearance: none !important;
 			width: 32px;
 			height: 32px;
-			background: radial-gradient(circle at center, var(--jetpack--contact-form--button-primary--background-color) 0%, var(--jetpack--contact-form--button-primary--background-color) 40%, transparent 40%);
+			background: radial-gradient(circle at center, var(--jetpack--contact-form--text-color) 0%, var(--jetpack--contact-form--text-color) 40%, transparent 40%);
 			cursor: pointer;
 			border: none;
 			box-shadow: none;
@@ -112,17 +114,17 @@
 		&::-ms-fill-upper,
 		&:focus::-ms-fill-lower,
 		&:focus::-ms-fill-upper {
-			background: var(--jetpack--contact-form--button-primary--background-color);
+			background: var(--jetpack--contact-form--text-color);
 		}
 	}
 
-	&__value-indicator {
+	.jetpack-field-slider__value-indicator {
 		position: absolute;
 		left: 0;
 		bottom: 100%;
 		transform: translateX(-50%);
-		background: var(--jetpack--contact-form--button-primary--background-color);
-		color: var(--jetpack--contact-form--button-primary--color);
+		background: var(--jetpack--contact-form--text-color);
+		color: var(--jetpack--contact-form--background-color);
 		border-radius: 8px;
 		padding: 2px 8px;
 		font-size: 0.7em;
@@ -130,24 +132,24 @@
 		text-wrap: nowrap;
 	}
 
-	&__min-label,
-	&__max-label {
+	.jetpack-field-slider__min-label,
+	.jetpack-field-slider__max-label {
 		font-size: 0.9em;
 		text-align: center;
 	}
 
-	&__text-labels {
+	.jetpack-field-slider__text-labels {
 		display: flex;
 		justify-content: space-between;
 		margin-top: 6px;
 		font-size: 0.9em;
 	}
 
-	&__min-text-label {
+	.jetpack-field-slider__min-text-label {
 		text-align: left;
 	}
 
-	&__max-text-label {
+	.jetpack-field-slider__max-text-label {
 		text-align: right;
 	}
 }

--- a/projects/packages/forms/src/blocks/input-range/style.scss
+++ b/projects/packages/forms/src/blocks/input-range/style.scss
@@ -26,7 +26,7 @@
 			transform: translateY(-50%);
 			height: 4px; /* visual track height */
 			width: auto;
-			background: var(--jetpack--contact-form--text-color);
+			background: var(--jetpack--contact-form--body-text-color);
 			z-index: 0;
 			pointer-events: none;
 			border-radius: 2px;
@@ -81,7 +81,7 @@
 			appearance: none;
 			width: 32px;
 			height: 32px;
-			background: radial-gradient(circle at center, var(--jetpack--contact-form--text-color) 0%, var(--jetpack--contact-form--text-color) 40%, transparent 40%);
+			background: radial-gradient(circle at center, var(--jetpack--contact-form--body-text-color) 0%, var(--jetpack--contact-form--body-text-color) 40%, transparent 40%);
 			cursor: pointer;
 			box-shadow: none;
 			border: none;
@@ -92,7 +92,7 @@
 			-moz-appearance: none !important;
 			width: 32px;
 			height: 32px;
-			background: radial-gradient(circle at center, var(--jetpack--contact-form--text-color) 0%, var(--jetpack--contact-form--text-color) 40%, transparent 40%);
+			background: radial-gradient(circle at center, var(--jetpack--contact-form--body-text-color) 0%, var(--jetpack--contact-form--body-text-color) 40%, transparent 40%);
 			cursor: pointer;
 			border: none;
 			box-shadow: none;
@@ -102,7 +102,7 @@
 			appearance: none !important;
 			width: 32px;
 			height: 32px;
-			background: radial-gradient(circle at center, var(--jetpack--contact-form--text-color) 0%, var(--jetpack--contact-form--text-color) 40%, transparent 40%);
+			background: radial-gradient(circle at center, var(--jetpack--contact-form--body-text-color) 0%, var(--jetpack--contact-form--body-text-color) 40%, transparent 40%);
 			cursor: pointer;
 			border: none;
 			box-shadow: none;
@@ -114,7 +114,7 @@
 		&::-ms-fill-upper,
 		&:focus::-ms-fill-lower,
 		&:focus::-ms-fill-upper {
-			background: var(--jetpack--contact-form--text-color);
+			background: var(--jetpack--contact-form--body-text-color);
 		}
 	}
 
@@ -123,8 +123,8 @@
 		left: 0;
 		bottom: 100%;
 		transform: translateX(-50%);
-		background: var(--jetpack--contact-form--text-color);
-		color: var(--jetpack--contact-form--background-color);
+		background: var(--jetpack--contact-form--body-text-color);
+		color: var(--jetpack--contact-form--inverted-body-text-color);
 		border-radius: 8px;
 		padding: 2px 8px;
 		font-size: 0.7em;


### PR DESCRIPTION
## Proposed changes:

I went through and tested the new slider field against many different themes and fixed conflicts. Fixes involved:
* Nested our slider CSS selectors .wp-block-jetpack-field-slider to add extra specificity
* Overriding some specific rules (ie, border, box shadows, etc, that themes apply to the slider that look broken)
* Added new jetpack forms CSS color variables for `--jetpack--contact-form--body-text-color` and `--jetpack--contact-form--inverted-body-text-color`, and updated the slider control and value indicator to use these rather than button colors. These colors are more consistent across diverse themes.

**No conflicts.** These themes were already good with no conflicts, and still look good with the changes: 
- Elementor
- Hestia
- Blocksy
- GeneratePress
- OceanWP
- 2010
- 2011
- 2016 (background vs text is not the best)
- 2020
- 2021
- 2022
- 2023
- 2024
- 2025

**Conflicts.** These themes had conflicts, and are now looking good with the latest changes: 
- Go
- Kadence
- Streamer
- 2012
- 2013
- 2014
- 2015
- 2017
- 2019
- 2021

**To do.** Still needs fix. Going to handle this is a separate PR.
- Astra

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a form with a slider.
* Test it against multiple themes and confirm the styling always looks roughly like expected. You can do this manually by activating each theme, or in a group using https://wordpress.org/plugins/back-to-the-theme/