### PR TITLE
Do not force CRM installation for Complete plan users

### DIFF
--- a/projects/packages/my-jetpack/changelog/update-do-not-force-install-crm-on-complete
+++ b/projects/packages/my-jetpack/changelog/update-do-not-force-install-crm-on-complete
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Do not force CRM installation for Complete plan users

--- a/projects/packages/my-jetpack/src/class-red-bubble-notifications.php
+++ b/projects/packages/my-jetpack/src/class-red-bubble-notifications.php
@@ -75,6 +75,10 @@ class Red_Bubble_Notifications {
 			if ( in_array( $slug, Products::get_not_shown_products(), true ) ) {
 				continue;
 			}
+			// Skip CRM from installation requirements - e.g. don't enforce installation for Complete plan users
+			if ( $slug === 'crm' ) {
+				continue;
+			}
 			if ( ! $product_class::has_paid_plan_for_product() ) {
 				continue;
 			}

--- a/projects/plugins/backup/changelog/update-do-not-force-install-crm-on-complete
+++ b/projects/plugins/backup/changelog/update-do-not-force-install-crm-on-complete
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Do not force CRM installation for Complete plan users

--- a/projects/plugins/boost/changelog/update-do-not-force-install-crm-on-complete
+++ b/projects/plugins/boost/changelog/update-do-not-force-install-crm-on-complete
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Do not force CRM installation for Complete plan users

--- a/projects/plugins/jetpack/changelog/update-do-not-force-install-crm-on-complete
+++ b/projects/plugins/jetpack/changelog/update-do-not-force-install-crm-on-complete
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Do not force CRM installation for Complete plan users

--- a/projects/plugins/protect/changelog/update-do-not-force-install-crm-on-complete
+++ b/projects/plugins/protect/changelog/update-do-not-force-install-crm-on-complete
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Do not force CRM installation for Complete plan users

--- a/projects/plugins/search/changelog/update-do-not-force-install-crm-on-complete
+++ b/projects/plugins/search/changelog/update-do-not-force-install-crm-on-complete
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Do not force CRM installation for Complete plan users

--- a/projects/plugins/social/changelog/update-do-not-force-install-crm-on-complete
+++ b/projects/plugins/social/changelog/update-do-not-force-install-crm-on-complete
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Do not force CRM installation for Complete plan users

--- a/projects/plugins/starter-plugin/changelog/update-do-not-force-install-crm-on-complete
+++ b/projects/plugins/starter-plugin/changelog/update-do-not-force-install-crm-on-complete
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Do not force CRM installation for Complete plan users

--- a/projects/plugins/videopress/changelog/update-do-not-force-install-crm-on-complete
+++ b/projects/plugins/videopress/changelog/update-do-not-force-install-crm-on-complete
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Do not force CRM installation for Complete plan users


### PR DESCRIPTION
Fixes MYJP-264

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* We don't want to display installation of CRM as an actionable step for Complete plan users - making it more optional

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
- Create JN site and purchase Complete plan for it
- Make sure CRM is not installed
- The "red dot" should not be displayed, and there shouldn't be "Some plugins need to be installed" notification in My Jetpack

<img width="2880" height="1418" alt="image" src="https://github.com/user-attachments/assets/13dccf02-6079-475e-b8b2-1a9e3c383543" />


