### PR TITLE
Charts: Use getStringWidth for accurate text measurement in pie chart labels

### DIFF
--- a/projects/js-packages/charts/changelog/update-charts-108-use-getstringwidth-for-labelbackgroundcolor
+++ b/projects/js-packages/charts/changelog/update-charts-108-use-getstringwidth-for-labelbackgroundcolor
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Charts: use getStringWidth for label size calculations

--- a/projects/js-packages/charts/src/components/pie-chart/pie-chart.tsx
+++ b/projects/js-packages/charts/src/components/pie-chart/pie-chart.tsx
@@ -12,6 +12,7 @@ import {
 } from '../../providers/chart-context';
 import { GlobalChartsContext } from '../../providers/chart-context/global-charts-provider';
 import { attachSubComponents } from '../../utils';
+import { getStringWidth } from '../../visx/text';
 import { Legend, useChartLegendItems } from '../legend';
 import { ChartSVG, ChartHTML, useChartChildren } from '../private/chart-composition';
 import { SingleChartContext } from '../private/single-chart-context';
@@ -247,7 +248,7 @@ const PieChartInternal = ( {
 
 									// Estimate text width more accurately for background sizing
 									const fontSize = 12;
-									const estimatedTextWidth = arc.data.label.length * fontSize * 0.6; // Rough estimate
+									const estimatedTextWidth = getStringWidth( arc.data.label, { fontSize } );
 									const labelPadding = 6;
 									const backgroundWidth = estimatedTextWidth + labelPadding * 2;
 									const backgroundHeight = fontSize + labelPadding * 2;


### PR DESCRIPTION
## Proposed changes:
* Replace manual text width estimation (`arc.data.label.length * fontSize * 0.6`) with accurate `getStringWidth()` function in pie chart label backgrounds
* This improves the accuracy of background rectangle sizing for pie chart labels

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?

No, it does not. 

## Testing instructions:

* Go to Storybook -> Charts -> PieChart 
* Verify that pie chart labels with background colors (`labelBackgroundColor` theme property) display correctly
* Compare background rectangle sizing before and after - backgrounds should now fit text more accurately
* Test with various label lengths (short labels like "A", medium labels like "Category", long labels like "Very Long Category Name")
* Ensure no visual regressions in pie chart rendering