### PR TITLE
Charts: Format percentage values with smart decimal handling

### DIFF
--- a/projects/js-packages/charts/changelog/update-charts-102-format-percentage-values-to-be-shorter
+++ b/projects/js-packages/charts/changelog/update-charts-102-format-percentage-values-to-be-shorter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Charts: format percentages values to be prettier

--- a/projects/js-packages/charts/changelog/update-charts-102-format-percentage-values-to-be-shorter
+++ b/projects/js-packages/charts/changelog/update-charts-102-format-percentage-values-to-be-shorter
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-Charts: format percentages values to be prettier
+Charts: format percentage values to be prettier

--- a/projects/js-packages/charts/src/components/conversion-funnel-chart/conversion-funnel-chart.tsx
+++ b/projects/js-packages/charts/src/components/conversion-funnel-chart/conversion-funnel-chart.tsx
@@ -3,7 +3,7 @@ import { useTooltip, useTooltipInPortal } from '@visx/tooltip';
 import clsx from 'clsx';
 import { type FC, useRef, useMemo, useEffect, useCallback } from 'react';
 import { useGlobalChartsTheme } from '../../providers/chart-context';
-import { hexToRgba } from '../../utils';
+import { hexToRgba, formatPercentage } from '../../utils';
 import styles from './conversion-funnel-chart.module.scss';
 import { useFunnelSelection } from './private';
 
@@ -306,7 +306,7 @@ export const ConversionFunnelChart: FC< ConversionFunnelChartProps > = ( {
 	// Default main metric rendering function
 	const renderDefaultMainMetric = () => (
 		<>
-			<span className={ styles[ 'main-rate' ] }>{ mainRate.toFixed( 1 ) }%</span>
+			<span className={ styles[ 'main-rate' ] }>{ formatPercentage( mainRate ) }</span>
 			{ changeIndicator && (
 				<span className={ styles[ 'change-indicator' ] }>{ changeIndicator }</span>
 			) }
@@ -318,7 +318,8 @@ export const ConversionFunnelChart: FC< ConversionFunnelChartProps > = ( {
 		<>
 			<div className={ styles[ 'tooltip-title' ] }>{ step.label }</div>
 			<div className={ styles[ 'tooltip-content' ] }>
-				{ step.rate.toFixed( 1 ) }%{ step.count && ` • ${ step.count.toLocaleString() } items` }
+				{ formatPercentage( step.rate ) }
+				{ step.count && ` • ${ step.count.toLocaleString() } items` }
 			</div>
 		</>
 	);
@@ -392,7 +393,9 @@ export const ConversionFunnelChart: FC< ConversionFunnelChartProps > = ( {
 											className: styles[ 'step-rate' ],
 										} )
 									) : (
-										<span className={ styles[ 'step-rate' ] }>{ step.rate.toFixed( 1 ) }%</span>
+										<span className={ styles[ 'step-rate' ] }>
+											{ formatPercentage( step.rate ) }
+										</span>
 									) }
 								</div>
 

--- a/projects/js-packages/charts/src/components/conversion-funnel-chart/test/conversion-funnel-chart.test.tsx
+++ b/projects/js-packages/charts/src/components/conversion-funnel-chart/test/conversion-funnel-chart.test.tsx
@@ -1,12 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { formatPercentage } from '../../../utils';
 import { ConversionFunnelChart } from '../conversion-funnel-chart';
 import type { FunnelStep } from '../conversion-funnel-chart';
-
-// Helper function to format percentage the same way the component does
-const formatPercentage = ( value: number ): string => {
-	return `${ parseFloat( value.toFixed( 2 ) ) }%`;
-};
 
 // Mock data for testing
 const mockSteps: FunnelStep[] = [

--- a/projects/js-packages/charts/src/components/conversion-funnel-chart/test/conversion-funnel-chart.test.tsx
+++ b/projects/js-packages/charts/src/components/conversion-funnel-chart/test/conversion-funnel-chart.test.tsx
@@ -1,6 +1,5 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { formatPercentage } from '../../../utils';
 import { ConversionFunnelChart } from '../conversion-funnel-chart';
 import type { FunnelStep } from '../conversion-funnel-chart';
 
@@ -48,7 +47,7 @@ describe( 'ConversionFunnelChart', () => {
 			renderWithoutTheme( <ConversionFunnelChart { ...defaultProps } /> );
 
 			// Check main rate is displayed (first occurrence)
-			expect( screen.getAllByText( formatPercentage( 10.3 ) ) ).toHaveLength( 2 ); // Main rate + Purchase step
+			expect( screen.getAllByText( '10.3%' ) ).toHaveLength( 2 ); // Main rate + Purchase step
 		} );
 
 		it( 'renders all funnel steps', () => {
@@ -57,9 +56,8 @@ describe( 'ConversionFunnelChart', () => {
 			mockSteps.forEach( step => {
 				expect( screen.getByText( step.label ) ).toBeInTheDocument();
 				// Use getAllByText since some rates might appear multiple times
-				expect(
-					screen.getAllByText( formatPercentage( step.rate ) ).length
-				).toBeGreaterThanOrEqual( 1 );
+				const expectedRate = step.rate === 100 ? '100%' : `${ step.rate }%`;
+				expect( screen.getAllByText( expectedRate ).length ).toBeGreaterThanOrEqual( 1 );
 			} );
 		} );
 
@@ -73,7 +71,7 @@ describe( 'ConversionFunnelChart', () => {
 			renderWithoutTheme( <ConversionFunnelChart { ...defaultProps } loading /> );
 
 			// Check for loading state by finding an element with loading behavior
-			expect( screen.getAllByText( formatPercentage( 10.3 ) ) ).toHaveLength( 2 );
+			expect( screen.getAllByText( '10.3%' ) ).toHaveLength( 2 );
 			// Note: Loading state affects opacity/pointer-events, visible in rendered component
 		} );
 
@@ -270,7 +268,7 @@ describe( 'ConversionFunnelChart', () => {
 			);
 
 			// Should format both main rate and step rate to 12.35% (rounded to 2 decimals, trailing zeros removed)
-			expect( screen.getAllByText( formatPercentage( 12.345 ) ) ).toHaveLength( 2 );
+			expect( screen.getAllByText( '12.35%' ) ).toHaveLength( 2 );
 		} );
 
 		it( 'renders large count numbers in component', async () => {
@@ -289,7 +287,7 @@ describe( 'ConversionFunnelChart', () => {
 			// Check that component renders correctly with large numbers
 			// After clicking, there will be multiple 'Test' texts (header + tooltip)
 			expect( screen.getAllByText( 'Test' ) ).toHaveLength( 2 );
-			expect( screen.getAllByText( formatPercentage( 50 ) ) ).toHaveLength( 2 );
+			expect( screen.getAllByText( '50%' ) ).toHaveLength( 2 );
 		} );
 
 		it( 'handles steps without count in tooltip', async () => {
@@ -302,7 +300,7 @@ describe( 'ConversionFunnelChart', () => {
 			await user.click( bar );
 
 			// Should show rate in tooltip, but we have multiple 75% (main + step)
-			expect( screen.getAllByText( formatPercentage( 75 ) ).length ).toBeGreaterThanOrEqual( 1 );
+			expect( screen.getAllByText( '75%' ).length ).toBeGreaterThanOrEqual( 1 );
 			expect( screen.queryByText( 'items' ) ).not.toBeInTheDocument();
 		} );
 	} );

--- a/projects/js-packages/charts/src/components/conversion-funnel-chart/test/conversion-funnel-chart.test.tsx
+++ b/projects/js-packages/charts/src/components/conversion-funnel-chart/test/conversion-funnel-chart.test.tsx
@@ -3,6 +3,11 @@ import userEvent from '@testing-library/user-event';
 import { ConversionFunnelChart } from '../conversion-funnel-chart';
 import type { FunnelStep } from '../conversion-funnel-chart';
 
+// Helper function to format percentage the same way the component does
+const formatPercentage = ( value: number ): string => {
+	return `${ parseFloat( value.toFixed( 2 ) ) }%`;
+};
+
 // Mock data for testing
 const mockSteps: FunnelStep[] = [
 	{
@@ -47,7 +52,7 @@ describe( 'ConversionFunnelChart', () => {
 			renderWithoutTheme( <ConversionFunnelChart { ...defaultProps } /> );
 
 			// Check main rate is displayed (first occurrence)
-			expect( screen.getAllByText( '10.3%' ) ).toHaveLength( 2 ); // Main rate + Purchase step
+			expect( screen.getAllByText( formatPercentage( 10.3 ) ) ).toHaveLength( 2 ); // Main rate + Purchase step
 		} );
 
 		it( 'renders all funnel steps', () => {
@@ -57,7 +62,7 @@ describe( 'ConversionFunnelChart', () => {
 				expect( screen.getByText( step.label ) ).toBeInTheDocument();
 				// Use getAllByText since some rates might appear multiple times
 				expect(
-					screen.getAllByText( `${ step.rate.toFixed( 1 ) }%` ).length
+					screen.getAllByText( formatPercentage( step.rate ) ).length
 				).toBeGreaterThanOrEqual( 1 );
 			} );
 		} );
@@ -72,7 +77,7 @@ describe( 'ConversionFunnelChart', () => {
 			renderWithoutTheme( <ConversionFunnelChart { ...defaultProps } loading /> );
 
 			// Check for loading state by finding an element with loading behavior
-			expect( screen.getAllByText( '10.3%' ) ).toHaveLength( 2 );
+			expect( screen.getAllByText( formatPercentage( 10.3 ) ) ).toHaveLength( 2 );
 			// Note: Loading state affects opacity/pointer-events, visible in rendered component
 		} );
 
@@ -259,7 +264,7 @@ describe( 'ConversionFunnelChart', () => {
 	} );
 
 	describe( 'Data Formatting', () => {
-		it( 'formats rates to one decimal place', () => {
+		it( 'formats rates with smart decimal handling', () => {
 			const stepsWithPreciseRates: FunnelStep[] = [
 				{ id: 'test', label: 'Test', rate: 12.345, count: 100 },
 			];
@@ -268,8 +273,8 @@ describe( 'ConversionFunnelChart', () => {
 				<ConversionFunnelChart mainRate={ 12.345 } steps={ stepsWithPreciseRates } />
 			);
 
-			// Should format both main rate and step rate to 12.3%
-			expect( screen.getAllByText( '12.3%' ) ).toHaveLength( 2 );
+			// Should format both main rate and step rate to 12.35% (rounded to 2 decimals, trailing zeros removed)
+			expect( screen.getAllByText( formatPercentage( 12.345 ) ) ).toHaveLength( 2 );
 		} );
 
 		it( 'renders large count numbers in component', async () => {
@@ -288,7 +293,7 @@ describe( 'ConversionFunnelChart', () => {
 			// Check that component renders correctly with large numbers
 			// After clicking, there will be multiple 'Test' texts (header + tooltip)
 			expect( screen.getAllByText( 'Test' ) ).toHaveLength( 2 );
-			expect( screen.getAllByText( '50.0%' ) ).toHaveLength( 2 );
+			expect( screen.getAllByText( formatPercentage( 50 ) ) ).toHaveLength( 2 );
 		} );
 
 		it( 'handles steps without count in tooltip', async () => {
@@ -300,8 +305,8 @@ describe( 'ConversionFunnelChart', () => {
 			const bar = screen.getByRole( 'button', { name: /test/i } );
 			await user.click( bar );
 
-			// Should show rate in tooltip, but we have multiple 75.0% (main + step)
-			expect( screen.getAllByText( '75.0%' ).length ).toBeGreaterThanOrEqual( 1 );
+			// Should show rate in tooltip, but we have multiple 75% (main + step)
+			expect( screen.getAllByText( formatPercentage( 75 ) ).length ).toBeGreaterThanOrEqual( 1 );
 			expect( screen.queryByText( 'items' ) ).not.toBeInTheDocument();
 		} );
 	} );

--- a/projects/js-packages/charts/src/components/legend/hooks/use-chart-legend-items.ts
+++ b/projects/js-packages/charts/src/components/legend/hooks/use-chart-legend-items.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { useGlobalChartsTheme } from '../../../providers/chart-context';
-import { getItemShapeStyles, getSeriesStroke } from '../../../utils';
+import { getItemShapeStyles, getSeriesStroke, formatPercentage } from '../../../utils';
 import type { ChartTheme, SeriesData, DataPointDate, DataPointPercentage } from '../../../types';
 import type { BaseLegendItem } from '../types';
 import type { LegendShape } from '@visx/legend/lib/types';
@@ -29,7 +29,7 @@ function formatPointValue(
 	}
 
 	if ( 'percentage' in point ) {
-		return `${ point.percentage }%`;
+		return formatPercentage( point.percentage );
 	} else if ( 'value' in point ) {
 		return point.value.toString();
 	}

--- a/projects/js-packages/charts/src/utils/format-metric-value.ts
+++ b/projects/js-packages/charts/src/utils/format-metric-value.ts
@@ -90,3 +90,15 @@ export const formatMetricValue = (
 		}
 	}
 };
+
+/**
+ * Format a percentage value with smart decimal handling.
+ * Removes unnecessary trailing zeros and caps at 2 decimal places.
+ *
+ * @param value - The percentage value (0-100 range)
+ * @return Formatted percentage string (e.g., "30%", "30.1%", "30.25%")
+ */
+export const formatPercentage = ( value: number ): string => {
+	// Round to max 2 decimal places, then remove trailing zeros
+	return `${ parseFloat( value.toFixed( 2 ) ) }%`;
+};

--- a/projects/js-packages/charts/src/utils/format-metric-value.ts
+++ b/projects/js-packages/charts/src/utils/format-metric-value.ts
@@ -90,15 +90,3 @@ export const formatMetricValue = (
 		}
 	}
 };
-
-/**
- * Format a percentage value with smart decimal handling.
- * Removes unnecessary trailing zeros and caps at 2 decimal places.
- *
- * @param value - The percentage value (0-100 range)
- * @return Formatted percentage string (e.g., "30%", "30.1%", "30.25%")
- */
-export const formatPercentage = ( value: number ): string => {
-	// Round to max 2 decimal places, then remove trailing zeros
-	return `${ parseFloat( value.toFixed( 2 ) ) }%`;
-};

--- a/projects/js-packages/charts/src/utils/format-percentage.ts
+++ b/projects/js-packages/charts/src/utils/format-percentage.ts
@@ -1,0 +1,20 @@
+import { formatNumber } from '@automattic/number-formatters';
+
+/**
+ * Format a percentage value with smart decimal handling.
+ * Uses @automattic/number-formatters for consistent formatting.
+ * Removes unnecessary trailing zeros and caps at 2 decimal places.
+ *
+ * @param value - The percentage value (0-100 range)
+ * @return Formatted percentage string (e.g., "30%", "30.1%", "30.25%")
+ */
+export const formatPercentage = ( value: number ): string => {
+	// Use formatNumber with percentage style, but convert from 0-100 range to 0-1 range
+	return formatNumber( value / 100, {
+		numberFormatOptions: {
+			style: 'percent',
+			minimumFractionDigits: 0,
+			maximumFractionDigits: 2,
+		},
+	} );
+};

--- a/projects/js-packages/charts/src/utils/index.ts
+++ b/projects/js-packages/charts/src/utils/index.ts
@@ -5,7 +5,7 @@ export { attachSubComponents } from './create-composition';
 export { parseAsLocalDate } from './date-parsing';
 
 // Number and metric formatting utilities
-export { formatMetricValue } from './format-metric-value';
+export { formatMetricValue, formatPercentage } from './format-metric-value';
 export type { MetricValueType } from './format-metric-value';
 
 // Chart measurement utilities

--- a/projects/js-packages/charts/src/utils/index.ts
+++ b/projects/js-packages/charts/src/utils/index.ts
@@ -5,8 +5,9 @@ export { attachSubComponents } from './create-composition';
 export { parseAsLocalDate } from './date-parsing';
 
 // Number and metric formatting utilities
-export { formatMetricValue, formatPercentage } from './format-metric-value';
+export { formatMetricValue } from './format-metric-value';
 export type { MetricValueType } from './format-metric-value';
+export { formatPercentage } from './format-percentage';
 
 // Chart measurement utilities
 export { getLongestTickWidth } from './get-longest-tick-width';

--- a/projects/js-packages/charts/src/utils/test/format-metric-value.test.ts
+++ b/projects/js-packages/charts/src/utils/test/format-metric-value.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Tests for formatMetricValue and formatPercentage utilities
+ */
+import { formatMetricValue, formatPercentage } from '../format-metric-value';
+
+describe( 'formatMetricValue', () => {
+	it( 'formats numbers correctly', () => {
+		expect( formatMetricValue( 1234 ) ).toBe( '1,234' );
+		expect( formatMetricValue( 1234.56, 'number', { decimals: 2 } ) ).toBe( '1,234.56' );
+	} );
+
+	it( 'formats currency correctly', () => {
+		expect( formatMetricValue( 1234.56, 'currency' ) ).toBe( '$1,234.56' );
+	} );
+
+	it( 'formats percentages correctly with average type', () => {
+		expect( formatMetricValue( 0.75, 'average' ) ).toBe( '+75%' );
+		expect( formatMetricValue( 0.751, 'average', { decimals: 1 } ) ).toBe( '+75.1%' );
+	} );
+
+	it( 'handles null and undefined values', () => {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		expect( formatMetricValue( null as any ) ).toBe( '' );
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		expect( formatMetricValue( undefined as any ) ).toBe( '' );
+	} );
+
+	it( 'handles NaN values', () => {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		expect( formatMetricValue( 'invalid' as any ) ).toBe( '' );
+	} );
+} );
+
+describe( 'formatPercentage', () => {
+	it( 'formats whole numbers without decimals', () => {
+		expect( formatPercentage( 30 ) ).toBe( '30%' );
+		expect( formatPercentage( 100 ) ).toBe( '100%' );
+		expect( formatPercentage( 0 ) ).toBe( '0%' );
+	} );
+
+	it( 'formats numbers with 1 decimal place', () => {
+		expect( formatPercentage( 30.1 ) ).toBe( '30.1%' );
+		expect( formatPercentage( 99.9 ) ).toBe( '99.9%' );
+		expect( formatPercentage( 0.5 ) ).toBe( '0.5%' );
+	} );
+
+	it( 'formats numbers with 2 decimal places', () => {
+		expect( formatPercentage( 30.25 ) ).toBe( '30.25%' );
+		expect( formatPercentage( 99.99 ) ).toBe( '99.99%' );
+		expect( formatPercentage( 0.05 ) ).toBe( '0.05%' );
+	} );
+
+	it( 'rounds numbers with more than 2 decimal places', () => {
+		expect( formatPercentage( 30.256 ) ).toBe( '30.26%' );
+		expect( formatPercentage( 30.254 ) ).toBe( '30.25%' );
+		expect( formatPercentage( 99.995 ) ).toBe( '100%' );
+	} );
+
+	it( 'removes trailing zeros', () => {
+		expect( formatPercentage( 30.0 ) ).toBe( '30%' );
+		expect( formatPercentage( 30.1 ) ).toBe( '30.1%' );
+		expect( formatPercentage( 30.2 ) ).toBe( '30.2%' );
+	} );
+
+	it( 'handles very small percentages', () => {
+		expect( formatPercentage( 0.01 ) ).toBe( '0.01%' );
+		expect( formatPercentage( 0.001 ) ).toBe( '0%' );
+		expect( formatPercentage( 0.005 ) ).toBe( '0.01%' );
+	} );
+
+	it( 'handles edge cases', () => {
+		expect( formatPercentage( 0 ) ).toBe( '0%' );
+		expect( formatPercentage( 100 ) ).toBe( '100%' );
+		expect( formatPercentage( 99.99 ) ).toBe( '99.99%' );
+		expect( formatPercentage( 0.01 ) ).toBe( '0.01%' );
+	} );
+} );

--- a/projects/js-packages/charts/src/utils/test/format-metric-value.test.ts
+++ b/projects/js-packages/charts/src/utils/test/format-metric-value.test.ts
@@ -1,7 +1,8 @@
 /**
  * Tests for formatMetricValue and formatPercentage utilities
  */
-import { formatMetricValue, formatPercentage } from '../format-metric-value';
+import { formatMetricValue } from '../format-metric-value';
+import { formatPercentage } from '../format-percentage';
 
 describe( 'formatMetricValue', () => {
 	it( 'formats numbers correctly', () => {


### PR DESCRIPTION
## Proposed changes:
* Add `formatPercentage()` utility function that intelligently formats percentages by removing trailing zeros and capping at 2 decimal places
* Update pie chart and semi-circle pie chart legends to use smart percentage formatting (e.g., "30%" instead of "30.0%")
* Update conversion funnel charts to use consistent smart percentage formatting across main rate, step rates, and tooltips
* This improves readability by showing "30%", "30.1%", "30.25%" instead of always showing one decimal place

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?

No, it does not. 

## Testing instructions:

* Go to Storybook -> Charts -> PieChart 
* Verify that pie chart legends display percentages without unnecessary decimals (e.g., "60%" not "60.0%")
* Go to Storybook -> Charts -> PieSemiCircleChart
* Verify the same smart percentage formatting in semi-circle pie chart legends
* Go to Storybook -> Charts -> ConversionFunnelChart
* Verify that funnel chart percentages display smartly: whole numbers as "100%", decimals preserved when meaningful "45.2%"
* Test edge cases: very small percentages (0.05%), large percentages (99.99%), and verify rounding works correctly
* Ensure no visual regressions in any chart rendering