### PR TITLE
Charts: Fix the "conversion-funnel-chart" component exportation

### DIFF
--- a/projects/js-packages/charts/changelog/update-fix_conversion-funnel-chart_exportation
+++ b/projects/js-packages/charts/changelog/update-fix_conversion-funnel-chart_exportation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Fix the conversion-funnel-chart component exportation

--- a/projects/js-packages/charts/src/components/conversion-funnel-chart/index.ts
+++ b/projects/js-packages/charts/src/components/conversion-funnel-chart/index.ts
@@ -1,8 +1,9 @@
-export {
-	ConversionFunnelChart,
-	type ConversionFunnelChartProps,
-	type FunnelStep,
-	type StepLabelRenderProps,
-	type StepRateRenderProps,
-	type MainMetricRenderProps,
+export { default as ConversionFunnelChart } from './conversion-funnel-chart';
+export type {
+	ConversionFunnelChartProps,
+	FunnelStep,
+	StepLabelRenderProps,
+	StepRateRenderProps,
+	MainMetricRenderProps,
+	TooltipRenderProps,
 } from './conversion-funnel-chart';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Follow up of https://github.com/Automattic/jetpack/pull/45019#discussion_r2312628275.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fix the `conversion-funnel-chart` component exportation with interfaces.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

