### PR TITLE
Forms: Add integrations feature flag

### DIFF
--- a/projects/packages/forms/changelog/add-form-show-integrations-filter
+++ b/projects/packages/forms/changelog/add-form-show-integrations-filter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: Add integrations feature flag.

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -66,9 +66,6 @@ class Contact_Form_Block {
 		// Features that are only available to users with a paid plan.
 		$features['multistep-form'] = Current_Plan::supports( 'multistep-form' );
 
-		// Whether to show integrations in the editor UI.
-		$features['forms_integrations_enabled'] = Jetpack_Forms::is_integrations_enabled();
-
 		return $features;
 	}
 

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -67,7 +67,7 @@ class Contact_Form_Block {
 		$features['multistep-form'] = Current_Plan::supports( 'multistep-form' );
 
 		// Whether to show integrations in the editor UI.
-		$features['forms_enable_integrations'] = Jetpack_Forms::enable_integrations();
+		$features['forms_integrations_enabled'] = Jetpack_Forms::is_integrations_enabled();
 
 		return $features;
 	}

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -67,7 +67,7 @@ class Contact_Form_Block {
 		$features['multistep-form'] = Current_Plan::supports( 'multistep-form' );
 
 		// Whether to show integrations in the editor UI.
-		$features['forms_show_integrations'] = Jetpack_Forms::is_integrations_enabled();
+		$features['forms_enable_integrations'] = Jetpack_Forms::enable_integrations();
 
 		return $features;
 	}

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -66,6 +66,9 @@ class Contact_Form_Block {
 		// Features that are only available to users with a paid plan.
 		$features['multistep-form'] = Current_Plan::supports( 'multistep-form' );
 
+		// Whether to show integrations in the editor UI.
+		$features['forms_show_integrations'] = Jetpack_Forms::should_show_integrations();
+
 		return $features;
 	}
 

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -67,7 +67,7 @@ class Contact_Form_Block {
 		$features['multistep-form'] = Current_Plan::supports( 'multistep-form' );
 
 		// Whether to show integrations in the editor UI.
-		$features['forms_show_integrations'] = Jetpack_Forms::should_show_integrations();
+		$features['forms_show_integrations'] = Jetpack_Forms::is_integrations_enabled();
 
 		return $features;
 	}

--- a/projects/packages/forms/src/blocks/contact-form/edit.js
+++ b/projects/packages/forms/src/blocks/contact-form/edit.js
@@ -98,7 +98,7 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 		formTitle,
 		variationName,
 	} = attributes;
-	const showFormIntegrations = hasFeatureFlag( 'forms_enable_integrations' );
+	const showFormIntegrations = hasFeatureFlag( 'forms_integrations_enabled' );
 	const instanceId = useInstanceId( JetpackContactFormEdit );
 
 	const steps = useFormSteps( clientId );

--- a/projects/packages/forms/src/blocks/contact-form/edit.js
+++ b/projects/packages/forms/src/blocks/contact-form/edit.js
@@ -1,5 +1,5 @@
 import { ThemeProvider } from '@automattic/jetpack-components';
-import { useModuleStatus, hasFeatureFlag } from '@automattic/jetpack-shared-extension-utils';
+import { useModuleStatus } from '@automattic/jetpack-shared-extension-utils';
 import {
 	URLInput,
 	InspectorAdvancedControls,
@@ -26,6 +26,7 @@ import { store as editorStore } from '@wordpress/editor';
 import { useRef, useEffect, useCallback, lazy, Suspense } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
+import useFormsConfig from '../../hooks/use-forms-config';
 import { store as singleStepStore } from '../../store/form-step-preview';
 import {
 	PREVIOUS_BUTTON_TEMPLATE,
@@ -98,7 +99,8 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 		formTitle,
 		variationName,
 	} = attributes;
-	const showFormIntegrations = hasFeatureFlag( 'forms_integrations_enabled' );
+	const formsConfig = useFormsConfig();
+	const showFormIntegrations = Boolean( formsConfig?.isIntegrationsEnabled );
 	const instanceId = useInstanceId( JetpackContactFormEdit );
 
 	const steps = useFormSteps( clientId );

--- a/projects/packages/forms/src/blocks/contact-form/edit.js
+++ b/projects/packages/forms/src/blocks/contact-form/edit.js
@@ -98,7 +98,7 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 		formTitle,
 		variationName,
 	} = attributes;
-	const showFormIntegrations = hasFeatureFlag( 'forms_show_integrations' );
+	const showFormIntegrations = hasFeatureFlag( 'forms_enable_integrations' );
 	const instanceId = useInstanceId( JetpackContactFormEdit );
 
 	const steps = useFormSteps( clientId );

--- a/projects/packages/forms/src/blocks/contact-form/edit.js
+++ b/projects/packages/forms/src/blocks/contact-form/edit.js
@@ -1,6 +1,5 @@
 import { ThemeProvider } from '@automattic/jetpack-components';
-import { isSimpleSite } from '@automattic/jetpack-script-data';
-import { useModuleStatus } from '@automattic/jetpack-shared-extension-utils';
+import { useModuleStatus, hasFeatureFlag } from '@automattic/jetpack-shared-extension-utils';
 import {
 	URLInput,
 	InspectorAdvancedControls,
@@ -99,6 +98,7 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 		formTitle,
 		variationName,
 	} = attributes;
+	const showFormIntegrations = hasFeatureFlag( 'forms_show_integrations' );
 	const instanceId = useInstanceId( JetpackContactFormEdit );
 
 	const steps = useFormSteps( clientId );
@@ -114,48 +114,42 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 		block => block.name === 'jetpack/button'
 	);
 
-	const {
-		postTitle,
-		canUserInstallPlugins,
-		hasAnyInnerBlocks,
-		postAuthorEmail,
-		selectedBlockClientId,
-		onlySubmitBlock,
-	} = useSelect(
-		select => {
-			const { getBlocks, getBlock, getSelectedBlockClientId, getBlockParentsByBlockName } =
-				select( blockEditorStore );
-			const { getEditedPostAttribute } = select( editorStore );
-			const selectedBlockId = getSelectedBlockClientId();
-			const selectedBlock = getBlock( selectedBlockId );
-			let selectedStepBlockId = selectedBlockId;
+	const { postTitle, hasAnyInnerBlocks, postAuthorEmail, selectedBlockClientId, onlySubmitBlock } =
+		useSelect(
+			select => {
+				const { getBlocks, getBlock, getSelectedBlockClientId, getBlockParentsByBlockName } =
+					select( blockEditorStore );
+				const { getEditedPostAttribute } = select( editorStore );
+				const selectedBlockId = getSelectedBlockClientId();
+				const selectedBlock = getBlock( selectedBlockId );
+				let selectedStepBlockId = selectedBlockId;
 
-			if ( selectedBlock && selectedBlock.name !== 'jetpack/form-step' ) {
-				selectedStepBlockId = getBlockParentsByBlockName(
-					selectedBlockId,
-					'jetpack/form-step'
-				)[ 0 ];
-			}
+				if ( selectedBlock && selectedBlock.name !== 'jetpack/form-step' ) {
+					selectedStepBlockId = getBlockParentsByBlockName(
+						selectedBlockId,
+						'jetpack/form-step'
+					)[ 0 ];
+				}
 
-			const { getUser, canUser } = select( coreStore );
-			const innerBlocksData = getBlocks( clientId );
+				const { getUser, canUser } = select( coreStore );
+				const innerBlocksData = getBlocks( clientId );
 
-			const title = getEditedPostAttribute( 'title' );
-			const authorId = getEditedPostAttribute( 'author' );
-			const authorEmail = authorId && getUser( authorId )?.email;
+				const title = getEditedPostAttribute( 'title' );
+				const authorId = getEditedPostAttribute( 'author' );
+				const authorEmail = authorId && getUser( authorId )?.email;
 
-			return {
-				postTitle: title,
-				canUserInstallPlugins: canUser( 'create', 'plugins' ),
-				hasAnyInnerBlocks: innerBlocksData.length > 0,
-				postAuthorEmail: authorEmail,
-				selectedBlockClientId: selectedStepBlockId,
-				onlySubmitBlock:
-					innerBlocksData.length === 1 && innerBlocksData[ 0 ].name === 'jetpack/button',
-			};
-		},
-		[ clientId ]
-	);
+				return {
+					postTitle: title,
+					canUserInstallPlugins: canUser( 'create', 'plugins' ),
+					hasAnyInnerBlocks: innerBlocksData.length > 0,
+					postAuthorEmail: authorEmail,
+					selectedBlockClientId: selectedStepBlockId,
+					onlySubmitBlock:
+						innerBlocksData.length === 1 && innerBlocksData[ 0 ].name === 'jetpack/button',
+				};
+			},
+			[ clientId ]
+		);
 
 	useEffect( () => {
 		if ( submitButton && ! submitButton.attributes.lock ) {
@@ -754,8 +748,7 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 							setAttributes={ setAttributes }
 						/>
 					</PanelBody>
-
-					{ ! isSimpleSite() && canUserInstallPlugins && (
+					{ showFormIntegrations && (
 						<Suspense fallback={ <div /> }>
 							<IntegrationControls attributes={ attributes } setAttributes={ setAttributes } />
 						</Suspense>

--- a/projects/packages/forms/src/blocks/contact-form/edit.js
+++ b/projects/packages/forms/src/blocks/contact-form/edit.js
@@ -131,7 +131,7 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 					)[ 0 ];
 				}
 
-				const { getUser, canUser } = select( coreStore );
+				const { getUser } = select( coreStore );
 				const innerBlocksData = getBlocks( clientId );
 
 				const title = getEditedPostAttribute( 'title' );
@@ -140,7 +140,6 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 
 				return {
 					postTitle: title,
-					canUserInstallPlugins: canUser( 'create', 'plugins' ),
 					hasAnyInnerBlocks: innerBlocksData.length > 0,
 					postAuthorEmail: authorEmail,
 					selectedBlockClientId: selectedStepBlockId,

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -95,16 +95,16 @@ class Jetpack_Forms {
 	}
 
 	/**
-	 * Returns true if the Integrations UI is enabled in the editor.
+	 * Returns true if the Integrations UI should be enabled.
 	 *
 	 * @return boolean
 	 */
-	public static function is_integrations_enabled() {
+	public static function enable_integrations() {
 		/**
-		 * Whether to enable the Integrations UI in the editor.
+		 * Whether to enable the Integrations UI.
 		 *
 		 * @param bool true Whether to enable the Integrations UI. Default true.
 		 */
-		return apply_filters( 'jetpack_forms_is_integrations_enabled', true );
+		return apply_filters( 'jetpack_forms_enable_integrations', true );
 	}
 }

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -93,4 +93,18 @@ class Jetpack_Forms {
 		 */
 		return apply_filters( 'jetpack_forms_mailpoet_enable', true );
 	}
+
+	/**
+	 * Returns true if Integrations UI should be shown in the editor.
+	 *
+	 * @return boolean
+	 */
+	public static function should_show_integrations() {
+		/**
+		 * Show Integrations UI in the editor.
+		 *
+		 * @param bool true Whether to show the Integrations UI. Default true.
+		 */
+		return apply_filters( 'jetpack_forms_show_integrations', true );
+	}
 }

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -99,12 +99,12 @@ class Jetpack_Forms {
 	 *
 	 * @return boolean
 	 */
-	public static function enable_integrations() {
+	public static function is_integrations_enabled() {
 		/**
 		 * Whether to enable the Integrations UI.
 		 *
 		 * @param bool true Whether to enable the Integrations UI. Default true.
 		 */
-		return apply_filters( 'jetpack_forms_enable_integrations', true );
+		return apply_filters( 'jetpack_forms_is_integrations_enabled', true );
 	}
 }

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -95,16 +95,16 @@ class Jetpack_Forms {
 	}
 
 	/**
-	 * Returns true if Integrations UI should be shown in the editor.
+	 * Returns true if the Integrations UI is enabled in the editor.
 	 *
 	 * @return boolean
 	 */
-	public static function should_show_integrations() {
+	public static function is_integrations_enabled() {
 		/**
-		 * Show Integrations UI in the editor.
+		 * Whether to enable the Integrations UI in the editor.
 		 *
-		 * @param bool true Whether to show the Integrations UI. Default true.
+		 * @param bool true Whether to enable the Integrations UI. Default true.
 		 */
-		return apply_filters( 'jetpack_forms_show_integrations', true );
+		return apply_filters( 'jetpack_forms_is_integrations_enabled', true );
 	}
 }

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -1028,7 +1028,7 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 			'siteURL'                 => ( new Status() )->get_site_suffix(),
 			'hasFeedback'             => ( new Forms_Dashboard() )->has_feedback(),
 			'hasAI'                   => $has_ai,
-			'enableIntegrationsTab'   => apply_filters( 'jetpack_forms_enable_integrations_tab', true ),
+			'isIntegrationsEnabled'   => Jetpack_Forms::is_integrations_enabled(),
 			'renderMigrationPage'     => $switch->is_jetpack_forms_announcing_new_menu(),
 			'dashboardURL'            => add_query_arg( 'jetpack_forms_migration_announcement_seen', 'yes', $switch->get_forms_admin_url() ),
 			// New data.

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -43,13 +43,6 @@ class Dashboard {
 	const MENU_PRIORITY = 999;
 
 	/**
-	 * Whether the integrations tab is enabled.
-	 *
-	 * @var bool
-	 */
-	public static $show_integrations = false;
-
-	/**
 	 * Dashboard_View_Switch instance
 	 *
 	 * @var Dashboard_View_Switch
@@ -63,9 +56,6 @@ class Dashboard {
 	 */
 	public function __construct( ?Dashboard_View_Switch $switch = null ) {
 		$this->switch = $switch ?? new Dashboard_View_Switch();
-
-		// Set the integrations tab feature flag
-		self::$show_integrations = apply_filters( 'jetpack_forms_enable_integrations_tab', true );
 	}
 
 	/**
@@ -226,7 +216,7 @@ class Dashboard {
 			'siteURL'                 => ( new Status() )->get_site_suffix(),
 			'hasFeedback'             => $this->has_feedback(),
 			'hasAI'                   => $has_ai,
-			'enableIntegrationsTab'   => self::$show_integrations,
+			'enableIntegrationsTab'   => Jetpack_Forms::should_show_integrations(),
 			'renderMigrationPage'     => $this->switch->is_jetpack_forms_announcing_new_menu(),
 			'dashboardURL'            => add_query_arg( 'jetpack_forms_migration_announcement_seen', 'yes', $this->switch->get_forms_admin_url() ),
 			'isMailpoetEnabled'       => Jetpack_Forms::is_mailpoet_enabled(),

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -216,7 +216,7 @@ class Dashboard {
 			'siteURL'                 => ( new Status() )->get_site_suffix(),
 			'hasFeedback'             => $this->has_feedback(),
 			'hasAI'                   => $has_ai,
-			'enableIntegrationsTab'   => Jetpack_Forms::should_show_integrations(),
+			'enableIntegrationsTab'   => Jetpack_Forms::is_integrations_enabled(),
 			'renderMigrationPage'     => $this->switch->is_jetpack_forms_announcing_new_menu(),
 			'dashboardURL'            => add_query_arg( 'jetpack_forms_migration_announcement_seen', 'yes', $this->switch->get_forms_admin_url() ),
 			'isMailpoetEnabled'       => Jetpack_Forms::is_mailpoet_enabled(),

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -216,7 +216,7 @@ class Dashboard {
 			'siteURL'                 => ( new Status() )->get_site_suffix(),
 			'hasFeedback'             => $this->has_feedback(),
 			'hasAI'                   => $has_ai,
-			'enableIntegrationsTab'   => Jetpack_Forms::enable_integrations(),
+			'enableIntegrationsTab'   => Jetpack_Forms::is_integrations_enabled(),
 			'renderMigrationPage'     => $this->switch->is_jetpack_forms_announcing_new_menu(),
 			'dashboardURL'            => add_query_arg( 'jetpack_forms_migration_announcement_seen', 'yes', $this->switch->get_forms_admin_url() ),
 			'isMailpoetEnabled'       => Jetpack_Forms::is_mailpoet_enabled(),

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -216,7 +216,7 @@ class Dashboard {
 			'siteURL'                 => ( new Status() )->get_site_suffix(),
 			'hasFeedback'             => $this->has_feedback(),
 			'hasAI'                   => $has_ai,
-			'enableIntegrationsTab'   => Jetpack_Forms::is_integrations_enabled(),
+			'enableIntegrationsTab'   => Jetpack_Forms::enable_integrations(),
 			'renderMigrationPage'     => $this->switch->is_jetpack_forms_announcing_new_menu(),
 			'dashboardURL'            => add_query_arg( 'jetpack_forms_migration_announcement_seen', 'yes', $this->switch->get_forms_admin_url() ),
 			'isMailpoetEnabled'       => Jetpack_Forms::is_mailpoet_enabled(),

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -216,7 +216,6 @@ class Dashboard {
 			'siteURL'                 => ( new Status() )->get_site_suffix(),
 			'hasFeedback'             => $this->has_feedback(),
 			'hasAI'                   => $has_ai,
-			'enableIntegrationsTab'   => Jetpack_Forms::is_integrations_enabled(),
 			'renderMigrationPage'     => $this->switch->is_jetpack_forms_announcing_new_menu(),
 			'dashboardURL'            => add_query_arg( 'jetpack_forms_migration_announcement_seen', 'yes', $this->switch->get_forms_admin_url() ),
 			'isMailpoetEnabled'       => Jetpack_Forms::is_mailpoet_enabled(),

--- a/projects/packages/forms/src/dashboard/components/layout/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/layout/index.tsx
@@ -11,6 +11,7 @@ import { Outlet, useLocation, useNavigate } from 'react-router';
 /**
  * Internal dependencies
  */
+import useFormsConfig from '../../../hooks/use-forms-config';
 import EmptySpamButton from '../../components/empty-spam-button';
 import EmptyTrashButton from '../../components/empty-trash-button';
 import ExportResponsesButton from '../../inbox/export-responses';
@@ -26,8 +27,9 @@ const Layout = () => {
 	const location = useLocation();
 	const navigate = useNavigate();
 	const [ isSm ] = useBreakpointMatch( 'sm' );
+	const formsConfig = useFormsConfig();
 
-	const enableIntegrationsTab = config( 'enableIntegrationsTab' );
+	const enableIntegrationsTab = Boolean( formsConfig?.isIntegrationsEnabled );
 
 	const { currentStatus } = useSelect(
 		select => ( {

--- a/projects/packages/forms/src/dashboard/index.tsx
+++ b/projects/packages/forms/src/dashboard/index.tsx
@@ -49,14 +49,10 @@ window.addEventListener( 'load', () => {
 					path: 'responses',
 					element: <Inbox />,
 				},
-				...( config( 'enableIntegrationsTab' )
-					? [
-							{
-								path: 'integrations',
-								element: <Integrations />,
-							},
-					  ]
-					: [] ),
+				{
+					path: 'integrations',
+					element: <Integrations />,
+				},
 				{
 					path: 'about',
 					element: <About />,

--- a/projects/packages/forms/src/types/index.ts
+++ b/projects/packages/forms/src/types/index.ts
@@ -202,12 +202,12 @@ export type BlockEditorStoreSelect = {
 export interface FormsConfigData {
 	/** Whether MailPoet integration is enabled across contexts. */
 	isMailPoetEnabled?: boolean;
+	/** Whether integrations UI is enabled (feature-flagged). */
+	isIntegrationsEnabled?: boolean;
 	/** Whether the current user can install plugins (install_plugins). */
 	canInstallPlugins?: boolean;
 	/** Whether the current user can activate plugins (activate_plugins). */
 	canActivatePlugins?: boolean;
-	/** Whether to show the Integrations tab in the dashboard UI. */
-	enableIntegrationsTab?: boolean;
 	/** Whether to render the migration/announcement page instead of the main dashboard. */
 	renderMigrationPage?: boolean;
 	/** Whether there are any feedback (form response) posts on the site. */

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Endpoint_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Endpoint_Test.php
@@ -424,7 +424,7 @@ class Contact_Form_Endpoint_Test extends TestCase {
 			'siteURL',
 			'hasFeedback',
 			'hasAI',
-			'enableIntegrationsTab',
+			'isIntegrationsEnabled',
 			'renderMigrationPage',
 			'dashboardURL',
 			'canInstallPlugins',

--- a/projects/plugins/jetpack/changelog/add-form-show-integrations-filter
+++ b/projects/plugins/jetpack/changelog/add-form-show-integrations-filter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: compat
+
+Forms: Add integrations feature flag.


### PR DESCRIPTION
## Proposed changes:

Introduces a general-purpose feature flag to show or hide integrations UI for Jetpack Forms. 

Specific changes:
* Adds filter-based feature flag `jetpack_forms_is_integrations_enabled`. This defaults to true. 
   - Going forward, if any environment (like WordPress.com or VIP, CIAB) wants to hide integrations, they can use: `add_filter( 'jetpack_forms_is_integrations_enabled', '__return_false' );`
* Adds `Jetpack_Forms::is_integrations_enabled()` method that wraps the feature flag. 
* Adds `isIntegrationsEnabled` property to the forms config endpoint. This is a new endpoint, and allows to have a single source of truth in our frontend code for whether integrations are enabled. 
* Removes the `enableIntegrationsTab` property from the `config` object that we pass from PHP to JS for the dashboard. We're not using the config endpoint. 
* Finally and most important, conditionally hide the Integrations menu on the forms dashboard, and the integrations modal in the block editor, if the new filter is set to false. 
* Updated tests.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Without any custom code for the feature flag, confirm integrations show in the forms dashboard and form block modal as usual. 
* Turn off integrations with `add_filter( 'jetpack_forms_is_integrations_enabled', '__return_false' );` 
* Confirm you no longer see our integrations interface in the forms dashboard or form block.
* Tests were updated, so confirm they still pass.