### PR TITLE
Charts: Add showLabels prop to control pie chart label visibility

### DIFF
--- a/projects/js-packages/charts/changelog/charts-99-add-showlabels-prop-to-control-label-visibility
+++ b/projects/js-packages/charts/changelog/charts-99-add-showlabels-prop-to-control-label-visibility
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Charts: adds controls for label visibility

--- a/projects/js-packages/charts/src/components/pie-chart/pie-chart.tsx
+++ b/projects/js-packages/charts/src/components/pie-chart/pie-chart.tsx
@@ -55,6 +55,11 @@ export interface PieChartProps extends BaseChartProps< DataPointPercentage[] > {
 	cornerScale?: number;
 
 	/**
+	 * Whether to show labels on pie segments. Defaults to true.
+	 */
+	showLabels?: boolean;
+
+	/**
 	 * Use the children prop to render additional elements on the chart.
 	 */
 	children?: ReactNode;
@@ -116,6 +121,7 @@ const PieChartInternal = ( {
 	padding = 20,
 	gapScale = 0,
 	cornerScale = 0,
+	showLabels = true,
 	children = null,
 }: PieChartProps ) => {
 	const providerTheme = useGlobalChartsTheme();
@@ -256,7 +262,7 @@ const PieChartInternal = ( {
 									return (
 										<g key={ `arc-${ index }` }>
 											<path { ...pathProps } />
-											{ hasSpaceForLabel && (
+											{ showLabels && hasSpaceForLabel && (
 												<g>
 													{ providerTheme.labelBackgroundColor && (
 														<rect

--- a/projects/js-packages/charts/src/components/pie-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/components/pie-chart/stories/index.stories.tsx
@@ -76,6 +76,10 @@ const meta: Meta< StoryArgs > = {
 			control: { type: 'color' },
 			description: 'Background color for labels displayed on pie chart segments',
 		},
+		showLabels: {
+			control: 'boolean',
+			description: 'Show or hide labels on pie segments',
+		},
 	},
 	render: ( { labelTextColor, labelBackgroundColor, ...chartProps } ) => {
 		const ChartComponent = <PieChart { ...chartProps } />;

--- a/projects/js-packages/charts/src/components/pie-chart/test/pie-chart.test.tsx
+++ b/projects/js-packages/charts/src/components/pie-chart/test/pie-chart.test.tsx
@@ -112,4 +112,50 @@ describe( 'PieChart', () => {
 			expect( chartLabels.length ).toBeGreaterThanOrEqual( 2 );
 		} );
 	} );
+
+	describe( 'Label Visibility', () => {
+		test( 'shows labels by default', () => {
+			renderWithTheme();
+			// Labels should be visible by default
+			const labels = screen.getAllByText( /^[AB]$/ );
+			expect( labels.length ).toBeGreaterThanOrEqual( 2 );
+		} );
+
+		test( 'hides labels when showLabels is false', () => {
+			renderWithTheme( { showLabels: false } );
+
+			// When showLabels is false, the chart should not display the data labels
+			// We filter out measurement elements by checking that text is not inside measurement element
+			const labelElements = screen.queryAllByText( ( content, element ) => {
+				// Check if this text element is not the measurement element
+				return (
+					( content === 'A' || content === 'B' ) &&
+					element?.id !== '__react_svg_text_measurement_id'
+				);
+			} );
+
+			// Labels should not be present in the rendered output (excluding measurement text)
+			expect( labelElements ).toHaveLength( 0 );
+		} );
+
+		test( 'shows labels when showLabels is explicitly true', () => {
+			renderWithTheme( { showLabels: true } );
+			// Labels should be visible
+			const labels = screen.getAllByText( /^[AB]$/ );
+			expect( labels.length ).toBeGreaterThanOrEqual( 2 );
+		} );
+
+		test( 'shows labels for backward compatibility when prop not specified', () => {
+			// Render without showLabels prop to test backward compatibility
+			render(
+				<ThemeProvider>
+					<PieChart size={ 500 } data={ defaultProps.data } />
+				</ThemeProvider>
+			);
+
+			// Should find label text using Testing Library queries
+			const labels = screen.getAllByText( /^[AB]$/ );
+			expect( labels.length ).toBeGreaterThan( 0 );
+		} );
+	} );
 } );


### PR DESCRIPTION
fixes: [#charts-99](https://linear.app/a8c/issue/CHARTS-99/add-showlabels-prop-to-control-label-visibility)

## Proposed changes:
* Add `showLabels` prop to PieChart component interface with backward-compatible default value of `true`
* Conditionally render pie chart segment labels based on the `showLabels` prop value 
* Add comprehensive test coverage for all showLabels scenarios including default behavior, explicit enabling/disabling, and backward compatibility
* Add Storybook boolean control for interactive testing of label visibility feature
* This provides users control over pie chart label display without breaking existing implementations

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?

No, it does not.

## Testing instructions:

<img width="1826" height="906" alt="image" src="https://github.com/user-attachments/assets/28d33d8d-e943-421d-986b-c86b6db30631" />


* Go to Storybook -> Charts -> PieChart 
* Toggle the "showLabels" control and verify labels appear/disappear on pie segments
* Verify that labels are shown by default (backward compatibility)
* Test with different chart configurations (donut charts, various sizes, gap scales)
* Verify that when showLabels=false, no data labels appear on pie segments
* Verify that when showLabels=true (or unspecified), labels appear on segments with sufficient space
* Ensure label background colors and text colors work correctly when labels are enabled
* Test that tooltips and legends continue to function normally regardless of label visibility
* Ensure no visual regressions in pie chart rendering or positioning