### PR TITLE
Admin Menu: Remove "Hosting > Marketing" and "Settings > Newsletter"

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/remove-untangling-deprecated-menus
+++ b/projects/packages/jetpack-mu-wpcom/changelog/remove-untangling-deprecated-menus
@@ -1,0 +1,4 @@
+Significance: minor
+Type: removed
+
+Admin Menu: Remove Hosting > Marketing

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
@@ -172,18 +172,6 @@ function wpcom_add_hosting_menu() {
 		null // @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal
 	);
 
-	// Temporary "Hosting > Marketing" menu for existing users that shows a callout informing that the screen has moved to "Tools > Marketing".
-	if ( get_current_user_id() < 269750000 ) {
-		add_submenu_page(
-			$parent_slug,
-			esc_attr__( 'Marketing', 'jetpack-mu-wpcom' ),
-			esc_attr__( 'Marketing', 'jetpack-mu-wpcom' ),
-			'manage_options',
-			esc_url( "https://wordpress.com/marketing/tools-marketing/$domain" ),
-			null // @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal
-		);
-	}
-
 	// By default, WordPress adds a submenu item for the parent menu item, which we don't want.
 	remove_submenu_page(
 		$parent_slug,

--- a/projects/packages/masterbar/changelog/remove-untangling-deprecated-menus
+++ b/projects/packages/masterbar/changelog/remove-untangling-deprecated-menus
@@ -1,0 +1,4 @@
+Significance: minor
+Type: removed
+
+Admin Menu: Remove Settings > Newsletter

--- a/projects/packages/masterbar/src/admin-menu/class-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-admin-menu.php
@@ -32,7 +32,6 @@ class Admin_Menu extends Base_Admin_Menu {
 		$this->add_plugins_menu();
 		$this->add_users_menu();
 		$this->add_tools_menu();
-		$this->add_options_menu();
 
 		// Remove Links Manager menu since its usage is discouraged. https://github.com/Automattic/wp-calypso/issues/51188.
 		// @see https://core.trac.wordpress.org/ticket/21307#comment:73.
@@ -332,42 +331,6 @@ class Admin_Menu extends Base_Admin_Menu {
 		$this->update_submenus( 'tools.php', $submenus_to_update );
 
 		$this->hide_submenu_page( 'tools.php', 'delete-blog' );
-	}
-
-	/**
-	 * Adds Settings menu.
-	 */
-	public function add_options_menu() {
-		$submenus_to_update = array();
-
-		if ( self::DEFAULT_VIEW === $this->get_preferred_view( 'options-general.php' ) ) {
-			$this->hide_submenu_page( 'options-general.php', 'sharing' );
-		}
-
-		if ( self::DEFAULT_VIEW === $this->get_preferred_view( 'options-general.php' ) ) {
-			$submenus_to_update['options-general.php'] = 'https://wordpress.com/settings/general/' . $this->domain;
-		}
-
-		if ( self::DEFAULT_VIEW === $this->get_preferred_view( 'options-writing.php' ) ) {
-			$submenus_to_update['options-writing.php'] = 'https://wordpress.com/settings/writing/' . $this->domain;
-		}
-
-		if ( self::DEFAULT_VIEW === $this->get_preferred_view( 'options-reading.php' )
-		) {
-			$submenus_to_update['options-reading.php'] = 'https://wordpress.com/settings/reading/' . $this->domain;
-		}
-
-		if ( self::DEFAULT_VIEW === $this->get_preferred_view( 'options-discussion.php' ) ) {
-			$submenus_to_update['options-discussion.php'] = 'https://wordpress.com/settings/discussion/' . $this->domain;
-		}
-
-		$this->update_submenus( 'options-general.php', $submenus_to_update );
-
-		// Temporary "Settings > Newsletter" menu for existing users that shows a callout informing that the screen has moved to "Jetpack (> Settings) > Newsletter".
-		if ( get_current_user_id() < 269750000 ) {
-			// @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
-			add_submenu_page( 'options-general.php', esc_attr__( 'Newsletter', 'jetpack-masterbar' ), __( 'Newsletter', 'jetpack-masterbar' ), 'manage_options', 'https://wordpress.com/settings/jetpack-newsletter/' . $this->domain, null, 7 );
-		}
 	}
 
 	/**

--- a/projects/packages/masterbar/src/admin-menu/class-atomic-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-atomic-admin-menu.php
@@ -304,19 +304,6 @@ class Atomic_Admin_Menu extends Admin_Menu {
 	}
 
 	/**
-	 * Adds Settings menu.
-	 */
-	public function add_options_menu() {
-		parent::add_options_menu();
-
-		// Hide Settings > Performance when the interface is set to wp-admin.
-		// This is due to these settings are mostly also available in Jetpack > Settings, in the Performance tab.
-		if ( $this->use_wp_admin_interface() ) {
-			$this->hide_submenu_page( 'options-general.php', 'https://wordpress.com/settings/performance/' . $this->domain );
-		}
-	}
-
-	/**
 	 * Override the global submenu_file for theme-install.php page so the WP Admin menu item gets highlighted correctly.
 	 *
 	 * @param string $submenu_file The current pages $submenu_file global variable value.

--- a/projects/packages/masterbar/src/admin-menu/class-jetpack-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-jetpack-admin-menu.php
@@ -8,7 +8,6 @@
 namespace Automattic\Jetpack\Masterbar;
 
 use Automattic\Jetpack\Blaze;
-use Automattic\Jetpack\Current_Plan as Jetpack_Plan;
 use Automattic\Jetpack\Modules;
 use Automattic\Jetpack\Subscribers_Dashboard\Dashboard as Subscribers_Dashboard;
 
@@ -263,42 +262,6 @@ class Jetpack_Admin_Menu extends Admin_Menu {
 
 		// Remove the submenu auto-created by Core.
 		$this->hide_submenu_page( 'tools.php', 'tools.php' );
-	}
-
-	/**
-	 * Adds Settings menu.
-	 */
-	public function add_options_menu() {
-		$slug = 'https://wordpress.com/settings/general/' . $this->domain;
-		// @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
-		add_menu_page( esc_attr__( 'Settings', 'jetpack-masterbar' ), __( 'Settings', 'jetpack-masterbar' ), 'manage_options', $slug, null, 'dashicons-admin-settings', 80 );
-		add_submenu_page( $slug, esc_attr__( 'General', 'jetpack-masterbar' ), __( 'General', 'jetpack-masterbar' ), 'manage_options', $slug );
-		add_submenu_page( $slug, esc_attr__( 'Security', 'jetpack-masterbar' ), __( 'Security', 'jetpack-masterbar' ), 'manage_options', 'https://wordpress.com/settings/security/' . $this->domain );
-		add_submenu_page( $slug, esc_attr__( 'Performance', 'jetpack-masterbar' ), __( 'Performance', 'jetpack-masterbar' ), 'manage_options', 'https://wordpress.com/settings/performance/' . $this->domain );
-		add_submenu_page( $slug, esc_attr__( 'Writing', 'jetpack-masterbar' ), __( 'Writing', 'jetpack-masterbar' ), 'manage_options', 'https://wordpress.com/settings/writing/' . $this->domain );
-		add_submenu_page( $slug, esc_attr__( 'Reading', 'jetpack-masterbar' ), __( 'Reading', 'jetpack-masterbar' ), 'manage_options', 'https://wordpress.com/settings/reading/' . $this->domain );
-		add_submenu_page( $slug, esc_attr__( 'Discussion', 'jetpack-masterbar' ), __( 'Discussion', 'jetpack-masterbar' ), 'manage_options', 'https://wordpress.com/settings/discussion/' . $this->domain );
-		add_submenu_page( $slug, esc_attr__( 'Newsletter', 'jetpack-masterbar' ), __( 'Newsletter', 'jetpack-masterbar' ), 'manage_options', 'https://wordpress.com/settings/newsletter/' . $this->domain );
-
-		$plan_supports_scan = Jetpack_Plan::supports( 'scan' );
-		$products           = Jetpack_Plan::get_products();
-		$has_scan_product   = false;
-
-		if ( is_array( $products ) ) {
-			foreach ( $products as $product ) {
-				if ( strpos( $product['product_slug'], 'jetpack_scan' ) === 0 ) {
-					$has_scan_product = true;
-					break;
-				}
-			}
-		}
-
-		$has_scan     = $plan_supports_scan || $has_scan_product;
-		$rewind_state = get_transient( 'jetpack_rewind_state' );
-		$has_backup   = $rewind_state && in_array( $rewind_state->state, array( 'awaiting_credentials', 'provisioning', 'active' ), true );
-		if ( $has_scan || $has_backup ) {
-			add_submenu_page( $slug, esc_attr__( 'Jetpack', 'jetpack-masterbar' ), __( 'Jetpack', 'jetpack-masterbar' ), 'manage_options', 'https://wordpress.com/settings/jetpack/' . $this->domain );
-		}
 	}
 
 	/**

--- a/projects/packages/masterbar/tests/php/Admin_Menu_Test.php
+++ b/projects/packages/masterbar/tests/php/Admin_Menu_Test.php
@@ -315,17 +315,6 @@ class Admin_Menu_Test extends TestCase {
 	}
 
 	/**
-	 * Tests add_options_menu
-	 */
-	public function test_add_options_menu() {
-		global $submenu;
-
-		static::$admin_menu->add_options_menu();
-
-		$this->assertSame( 'https://wordpress.com/settings/general/' . static::$domain, $submenu['options-general.php'][0][2] );
-	}
-
-	/**
 	 * Check if the hidden menus are at the end of the submenu.
 	 */
 	public function test_if_the_hidden_menus_are_at_the_end_of_submenu() {


### PR DESCRIPTION
Part of DOTCOM-14123 and DOTCOM-14136

## Proposed changes:

Removes the "Hosting > Marketing" and "Settings > Newsletter" menus since they were scheduled to be removed now that the we deprecated them one month ago.

Before | After
--- | ---
<img width="336" height="223" alt="Screenshot 2025-09-02 at 13 06 49" src="https://github.com/user-attachments/assets/570adb34-2d06-487f-a1fe-89a13600b81c" /> | <img width="335" height="193" alt="Screenshot 2025-09-02 at 13 30 37" src="https://github.com/user-attachments/assets/df49b3fc-c7ab-42ea-844e-4905afc8c988" />
<img width="560" height="343" alt="Screenshot 2025-09-02 at 13 07 00" src="https://github.com/user-attachments/assets/ca202edf-2f65-471b-b681-87bbc3190c65" /> | <img width="560" height="341" alt="Screenshot 2025-09-02 at 13 30 27" src="https://github.com/user-attachments/assets/8edea774-9480-4af1-977c-5378428415cb" />



### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
- Apply these changes to your WP.com site
- Make sure the "Hosting > Marketing" menu is not visible on sites with the classic admin interface
- Make sure the "Settings > Newsletter" menu is not visible on sites with the default admin interface

