### PR TITLE
Fix PHP fatal when running WP-CLI

### DIFF
--- a/projects/packages/my-jetpack/changelog/try-fix_WP-CLI_fatal
+++ b/projects/packages/my-jetpack/changelog/try-fix_WP-CLI_fatal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Prevent PHP fatal when using WP-CLI.

--- a/projects/packages/my-jetpack/src/class-rest-products.php
+++ b/projects/packages/my-jetpack/src/class-rest-products.php
@@ -32,7 +32,7 @@ class REST_Products {
 					'permission_callback' => __CLASS__ . '::view_products_permissions_callback',
 					'args'                => array(
 						'products' => array(
-							'description'       => __( 'Comma seperated list of product slugs that should be retrieved.', 'jetpack-my-jetpack' ),
+							'description'       => __( 'Comma-separated list of product slugs that should be retrieved.', 'jetpack-my-jetpack' ),
 							'type'              => 'string',
 							'required'          => false,
 							'validate_callback' => __CLASS__ . '::check_products_string',
@@ -113,24 +113,7 @@ class REST_Products {
 						),
 					),
 				),
-				'schema' => array(
-					'$schema'    => 'http://json-schema.org/draft-04/schema#',
-					'title'      => 'Products interstitials',
-					'type'       => 'object',
-					'properties' => array(
-						'products' => array(
-							'type'        => 'object',
-							'description' => __( 'Key-value pairs of product slugs and their interstitial states.', 'jetpack-my-jetpack' ),
-							'properties'  => array_fill_keys(
-								Products::get_products_slugs(),
-								array(
-									'description' => __( 'Interstitial state for the product. True means that the user has seen the interstitial for the product.', 'jetpack-my-jetpack' ),
-									'type'        => 'boolean',
-								)
-							),
-						),
-					),
-				),
+				'schema' => array( self::class, 'get_interstitials_schema' ),
 			)
 		);
 
@@ -173,6 +156,32 @@ class REST_Products {
 			'title'      => 'products',
 			'type'       => 'object',
 			'properties' => Products::get_product_data_schema(),
+		);
+	}
+
+	/**
+	 * Get the schema for the interstitials endpoint
+	 *
+	 * @return array
+	 */
+	public static function get_interstitials_schema() {
+		return array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'Products interstitials',
+			'type'       => 'object',
+			'properties' => array(
+				'products' => array(
+					'type'        => 'object',
+					'description' => __( 'Key-value pairs of product slugs and their interstitial states.', 'jetpack-my-jetpack' ),
+					'properties'  => array_fill_keys(
+						Products::get_products_slugs(),
+						array(
+							'description' => __( 'Interstitial state for the product. True means that the user has seen the interstitial for the product.', 'jetpack-my-jetpack' ),
+							'type'        => 'boolean',
+						)
+					),
+				),
+			),
 		);
 	}
 

--- a/projects/plugins/jetpack/changelog/try-fix_WP-CLI_fatal
+++ b/projects/plugins/jetpack/changelog/try-fix_WP-CLI_fatal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+My Jetpack: Prevent PHP error when using WP-CLI.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

When running something like `wp site empty` on WP Cloud sites, it gives a PHP fatal.

This seems to have been introduced in 123e2a0e4d94e703b9c4c31a5d9c6e5cb0e6038c (see #44772).

After much trial and error, I found that deferring the schema generation to a callback seems to work fine, but I'm not familiar with endpoints or the implications of making this change, and have no idea why it works, particularly because effectively the exact same thing happens in the `args` key.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

`wp site empty` should work fine with this branch, but I'm not sure how to test for regressions.