### PR TITLE
Prevent PHP error on invalid excluded extensions check

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-fatal_on_invalid_excluded_extensions
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-fatal_on_invalid_excluded_extensions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Prevent PHP error when checking for available Gutenberg extensions.

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -328,6 +328,11 @@ class Jetpack_Gutenberg {
 		$exclusions         = get_option( 'jetpack_excluded_extensions', array() );
 		$allowed_extensions = $allowed_extensions === null ? self::get_jetpack_gutenberg_extensions_allowed_list() : $allowed_extensions;
 
+		// Avoid errors if option data is not as expected.
+		if ( ! is_array( $exclusions ) ) {
+			$exclusions = array();
+		}
+
 		return array_diff( $allowed_extensions, $exclusions );
 	}
 


### PR DESCRIPTION
Closes MONOREP-95

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

We had a spike of these:
```
PHP Fatal error: Uncaught TypeError: array_diff(): Argument #2 must be of type array, string given in /wordpress/plugins/jetpack/15.0-a.7/class.jetpack-gutenberg.php:331
```

This PR adds a check to verify the option returned is an array.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

