### PR TITLE
Forms: Start using the new feedback version v3

### DIFF
--- a/projects/packages/forms/changelog/update-forms-switch-to-v3
+++ b/projects/packages/forms/changelog/update-forms-switch-to-v3
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Forms: Finally store the feedback in the new format

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -421,7 +421,7 @@ class Contact_Form_Test extends BaseTestCase {
 		$response    = Feedback::get( $feedback_id );
 
 		// Default metadata should be saved.
-		$this->assertEquals( "I\'m sorry, but the party\'s over", $response->get_subject(), 'The stored subject didn\'t match the given' );
+		$this->assertEquals( "I'm sorry, but the party's over", $response->get_subject(), 'The stored subject didn\'t match the given' );
 	}
 
 	/**


### PR DESCRIPTION
Reverts https://github.com/Automattic/jetpack/pull/44925

Following https://github.com/Automattic/jetpack/pull/44927 

## Proposed changes:
* Revert saving feedback into the new V3 format. 

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?



## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

Same as https://github.com/Automattic/jetpack/pull/44889 

Add a new form. With all the fields does the data get stored in the new format?
Are you still able to see the data in the responses tab in the back end?
Are you able to see the data in export. Do you still get the email notification?
Do you notice any PHP Errors?

Test the form by submitting Unicode characters as well as new lines and notice that you see them in the backend as expected. 


