### PR TITLE
Sharing: fix typo in 'services' for sharing buttons wrapper element

### DIFF
--- a/projects/js-packages/publicize-components/changelog/jetpack-731-typo-in-sharing-buttons-code-serivces
+++ b/projects/js-packages/publicize-components/changelog/jetpack-731-typo-in-sharing-buttons-code-serivces
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Sharing: fix typo in 'services' for sharing buttons wrapper element

--- a/projects/js-packages/publicize-components/src/components/social-previews/modal.js
+++ b/projects/js-packages/publicize-components/src/components/social-previews/modal.js
@@ -8,12 +8,12 @@ import { Button, Modal, TabPanel } from '@wordpress/components';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __ } from '@wordpress/i18n';
 import { close } from '@wordpress/icons';
-import { useAvailableSerivces } from './use-available-services';
+import { useAvailableServices } from './use-available-services';
 import { usePostData } from './use-post-data';
 import './modal.scss';
 
 const SocialPreviewsModal = function SocialPreviewsModal( { onClose, initialTabName = null } ) {
-	const availableServices = useAvailableSerivces();
+	const availableServices = useAvailableServices();
 	const { image, media, title, description, url, excerpt } = usePostData();
 
 	return (

--- a/projects/js-packages/publicize-components/src/components/social-previews/panel.js
+++ b/projects/js-packages/publicize-components/src/components/social-previews/panel.js
@@ -6,11 +6,11 @@
 
 import { Button } from '@wordpress/components';
 import { __, _x } from '@wordpress/i18n';
-import { useAvailableSerivces } from './use-available-services';
+import { useAvailableServices } from './use-available-services';
 import './panel.scss';
 
 const SocialPreviewsPanel = ( { openModal } ) => {
-	const availableServices = useAvailableSerivces();
+	const availableServices = useAvailableServices();
 
 	return (
 		<div className="jetpack-social-previews__panel">

--- a/projects/js-packages/publicize-components/src/components/social-previews/use-available-services.js
+++ b/projects/js-packages/publicize-components/src/components/social-previews/use-available-services.js
@@ -16,7 +16,7 @@ import Twitter from './twitter';
  *
  * @return {Array<{title: string, icon: import('react').Component, name: string, preview: import('react').Component}>} The list of available services.
  */
-export function useAvailableSerivces() {
+export function useAvailableServices() {
 	return useMemo(
 		() =>
 			[

--- a/projects/plugins/jetpack/changelog/jetpack-731-typo-in-sharing-buttons-code-serivces
+++ b/projects/plugins/jetpack/changelog/jetpack-731-typo-in-sharing-buttons-code-serivces
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Minor fix
+
+

--- a/projects/plugins/jetpack/extensions/blocks/sharing-button/sharing-button.php
+++ b/projects/plugins/jetpack/extensions/blocks/sharing-button/sharing-button.php
@@ -335,7 +335,7 @@ function add_default_services_to_block( $parsed_hooked_block, $hooked_block_type
 
 	// Wrap inner blocks in our sharing buttons markup.
 	$parsed_hooked_block['innerContent'] = array(
-		'<ul class="wp-block-jetpack-sharing-buttons has-normal-icon-size jetpack-sharing-buttons__services-list" id="jetpack-sharing-serivces-list">',
+		'<ul class="wp-block-jetpack-sharing-buttons has-normal-icon-size jetpack-sharing-buttons__services-list" id="jetpack-sharing-services-list">',
 		null,
 		null,
 		null,

--- a/projects/plugins/jetpack/extensions/blocks/sharing-buttons/save.js
+++ b/projects/plugins/jetpack/extensions/blocks/sharing-buttons/save.js
@@ -4,7 +4,7 @@ import clsx from 'clsx';
 export default function save( { attributes } ) {
 	const { size } = attributes;
 	const className = clsx( size, 'jetpack-sharing-buttons__services-list' );
-	const id = 'jetpack-sharing-serivces-list';
+	const id = 'jetpack-sharing-services-list';
 	const blockProps = useBlockProps.save( { className } );
 	const innerBlocksProps = useInnerBlocksProps.save( blockProps );
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/44756

## Proposed changes:
* Rename anything with misspelling `serivces` to `services` including element IDs and JavaScript class names

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* Test Jetpack Social previews and related "Sharing Buttons" block settings to make sure existing functionality continues to work, and no regressions (see JS console)
