### PR TITLE
Charts: Add legendValueDisplay prop to control legend value format in PieChart

### DIFF
--- a/projects/js-packages/charts/changelog/charts-101-add-ability-to-control-percentage-vs-value-display
+++ b/projects/js-packages/charts/changelog/charts-101-add-ability-to-control-percentage-vs-value-display
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Charts: adds ability to control percentage vs value display

--- a/projects/js-packages/charts/src/components/legend/hooks/use-chart-legend-items.ts
+++ b/projects/js-packages/charts/src/components/legend/hooks/use-chart-legend-items.ts
@@ -7,30 +7,49 @@ import type { LegendShape } from '@visx/legend/lib/types';
 import type { GlyphProps } from '@visx/xychart';
 import type { ReactNode } from 'react';
 
+export type LegendValueDisplay = 'percentage' | 'value' | 'valueDisplay' | 'none';
+
 export interface ChartLegendOptions {
 	withGlyph?: boolean;
 	glyphSize?: number;
 	renderGlyph?: < Datum extends object >( props: GlyphProps< Datum > ) => ReactNode;
 	showValues?: boolean;
+	legendValueDisplay?: LegendValueDisplay;
 }
 
 /**
- * Formats the value for a data point based on its type
- * @param point      - The data point to format
- * @param showValues - Whether to show values or return empty string
+ * Formats the value for a data point based on its type and display preference
+ * @param point              - The data point to format
+ * @param showValues         - Whether to show values or return empty string
+ * @param legendValueDisplay - What type of value to display
  * @return Formatted value string
  */
 function formatPointValue(
 	point: DataPointDate | DataPointPercentage,
-	showValues: boolean
+	showValues: boolean,
+	legendValueDisplay: LegendValueDisplay = 'percentage'
 ): string {
-	if ( ! showValues ) {
+	if ( ! showValues || legendValueDisplay === 'none' ) {
 		return '';
 	}
 
+	// Handle DataPointPercentage (pie chart data)
 	if ( 'percentage' in point ) {
-		return formatPercentage( point.percentage );
-	} else if ( 'value' in point ) {
+		const percentagePoint = point as DataPointPercentage;
+		switch ( legendValueDisplay ) {
+			case 'percentage':
+				return formatPercentage( percentagePoint.percentage );
+			case 'value':
+				return percentagePoint.value.toString();
+			case 'valueDisplay':
+				return percentagePoint.valueDisplay || percentagePoint.value.toString();
+			default:
+				return '';
+		}
+	}
+
+	// Handle DataPointDate (time series data)
+	if ( 'value' in point ) {
 		return point.value.toString();
 	}
 
@@ -85,18 +104,20 @@ function processSeriesData(
 
 /**
  * Processes point data into legend items
- * @param pointData   - The point data to process
- * @param theme       - The chart theme for colors
- * @param showValues  - Whether to show values in legend
- * @param withGlyph   - Whether to include glyph rendering
- * @param glyphSize   - Size of the glyph
- * @param renderGlyph - Component to render the glyph
+ * @param pointData          - The point data to process
+ * @param theme              - The chart theme for colors
+ * @param showValues         - Whether to show values in legend
+ * @param legendValueDisplay - What type of value to display
+ * @param withGlyph          - Whether to include glyph rendering
+ * @param glyphSize          - Size of the glyph
+ * @param renderGlyph        - Component to render the glyph
  * @return Array of processed legend items
  */
 function processPointData(
 	pointData: ( DataPointDate | DataPointPercentage )[],
 	theme: ChartTheme,
 	showValues: boolean,
+	legendValueDisplay: LegendValueDisplay,
 	withGlyph: boolean,
 	glyphSize: number,
 	renderGlyph?: < Datum extends object >( props: GlyphProps< Datum > ) => ReactNode
@@ -104,7 +125,7 @@ function processPointData(
 	const mapper = ( point: DataPointDate | DataPointPercentage, index: number ) => {
 		const baseItem = {
 			label: point.label,
-			value: formatPointValue( point, showValues ),
+			value: formatPointValue( point, showValues, legendValueDisplay ),
 			color: ( point as DataPointPercentage ).color ?? theme.colors[ index % theme.colors.length ],
 			group: ( point as DataPointPercentage ).group,
 			index,
@@ -141,7 +162,13 @@ export function useChartLegendItems<
 	options: ChartLegendOptions = {},
 	legendShape?: LegendShape< SeriesData[], number >
 ): BaseLegendItem[] {
-	const { showValues = false, withGlyph = false, glyphSize = 8, renderGlyph } = options;
+	const {
+		showValues = false,
+		legendValueDisplay = 'percentage',
+		withGlyph = false,
+		glyphSize = 8,
+		renderGlyph,
+	} = options;
 	const theme = useGlobalChartsTheme();
 
 	return useMemo( () => {
@@ -167,9 +194,19 @@ export function useChartLegendItems<
 			data as ( DataPointDate | DataPointPercentage )[],
 			theme,
 			showValues,
+			legendValueDisplay,
 			withGlyph,
 			glyphSize,
 			renderGlyph
 		);
-	}, [ data, theme, showValues, withGlyph, glyphSize, renderGlyph, legendShape ] );
+	}, [
+		data,
+		theme,
+		showValues,
+		legendValueDisplay,
+		withGlyph,
+		glyphSize,
+		renderGlyph,
+		legendShape,
+	] );
 }

--- a/projects/js-packages/charts/src/components/legend/index.ts
+++ b/projects/js-packages/charts/src/components/legend/index.ts
@@ -1,4 +1,4 @@
 export { Legend } from './legend';
 export { useChartLegendItems } from './hooks/use-chart-legend-items';
 export type { LegendProps, BaseLegendProps, BaseLegendItem } from './types';
-export type { ChartLegendOptions } from './hooks/use-chart-legend-items';
+export type { ChartLegendOptions, LegendValueDisplay } from './hooks/use-chart-legend-items';

--- a/projects/js-packages/charts/src/components/pie-chart/pie-chart.tsx
+++ b/projects/js-packages/charts/src/components/pie-chart/pie-chart.tsx
@@ -233,6 +233,7 @@ const PieChartInternal = ( {
 					display: 'flex',
 					flexDirection: showLegend && legendPosition === 'top' ? 'column-reverse' : 'column',
 				} }
+				data-legend-value-display={ legendValueDisplay }
 			>
 				<svg
 					viewBox={ `0 0 ${ width } ${ adjustedHeight }` }

--- a/projects/js-packages/charts/src/components/pie-chart/pie-chart.tsx
+++ b/projects/js-packages/charts/src/components/pie-chart/pie-chart.tsx
@@ -233,7 +233,6 @@ const PieChartInternal = ( {
 					display: 'flex',
 					flexDirection: showLegend && legendPosition === 'top' ? 'column-reverse' : 'column',
 				} }
-				data-legend-value-display={ legendValueDisplay }
 			>
 				<svg
 					viewBox={ `0 0 ${ width } ${ adjustedHeight }` }

--- a/projects/js-packages/charts/src/components/pie-chart/pie-chart.tsx
+++ b/projects/js-packages/charts/src/components/pie-chart/pie-chart.tsx
@@ -20,6 +20,7 @@ import { withResponsive } from '../private/with-responsive';
 import { BaseTooltip } from '../tooltip';
 import styles from './pie-chart.module.scss';
 import type { BaseChartProps, DataPointPercentage, Optional } from '../../types';
+import type { LegendValueDisplay } from '../legend';
 import type { ChartComponentWithComposition } from '../private/chart-composition';
 import type { ResponsiveConfig } from '../private/with-responsive';
 import type { SVGProps, MouseEvent, ReactNode, FC } from 'react';
@@ -58,6 +59,15 @@ export interface PieChartProps extends BaseChartProps< DataPointPercentage[] > {
 	 * Whether to show labels on pie segments. Defaults to true.
 	 */
 	showLabels?: boolean;
+
+	/**
+	 * What type of value to display in the legend when showValues is true.
+	 * - 'percentage': Shows percentage values (e.g., "23%") [default]
+	 * - 'value': Shows raw numeric values (e.g., "30000")
+	 * - 'valueDisplay': Shows formatted values (e.g., "30K")
+	 * - 'none': Shows no values, only labels
+	 */
+	legendValueDisplay?: LegendValueDisplay;
 
 	/**
 	 * Use the children prop to render additional elements on the chart.
@@ -122,6 +132,7 @@ const PieChartInternal = ( {
 	gapScale = 0,
 	cornerScale = 0,
 	showLabels = true,
+	legendValueDisplay = 'percentage',
 	children = null,
 }: PieChartProps ) => {
 	const providerTheme = useGlobalChartsTheme();
@@ -133,7 +144,10 @@ const PieChartInternal = ( {
 		} );
 
 	// Memoize legend options to prevent unnecessary re-calculations
-	const legendOptions = useMemo( () => ( { showValues: true } ), [] );
+	const legendOptions = useMemo(
+		() => ( { showValues: true, legendValueDisplay } ),
+		[ legendValueDisplay ]
+	);
 
 	// Create legend items using the reusable hook
 	const legendItems = useChartLegendItems( data, legendOptions );

--- a/projects/js-packages/charts/src/components/pie-chart/stories/donut.stories.tsx
+++ b/projects/js-packages/charts/src/components/pie-chart/stories/donut.stories.tsx
@@ -201,7 +201,7 @@ export const WithLegend: Story = {
 };
 
 export const WithCompositionLegend: Story = {
-	render: () => (
+	render: args => (
 		<div
 			style={ {
 				display: 'grid',
@@ -214,11 +214,12 @@ export const WithCompositionLegend: Story = {
 				<h3>Traditional Props-based</h3>
 				<PieChart
 					size={ 300 }
-					data={ data }
+					data={ args.data }
 					thickness={ 0.5 }
 					showLegend={ true }
 					legendPosition="bottom"
 					legendOrientation="horizontal"
+					legendValueDisplay={ args.legendValueDisplay }
 				>
 					<Group>
 						<Text textAnchor="middle" verticalAnchor="middle" fontSize={ 16 } y={ -8 }>
@@ -232,7 +233,12 @@ export const WithCompositionLegend: Story = {
 			</div>
 			<div>
 				<h3>Composition API</h3>
-				<PieChart size={ 300 } data={ data } thickness={ 0.5 }>
+				<PieChart
+					size={ 300 }
+					data={ args.data }
+					thickness={ 0.5 }
+					legendValueDisplay={ args.legendValueDisplay }
+				>
 					<Group>
 						<Text textAnchor="middle" verticalAnchor="middle" fontSize={ 16 } y={ -8 }>
 							User Stats
@@ -246,6 +252,10 @@ export const WithCompositionLegend: Story = {
 			</div>
 		</div>
 	),
+	args: {
+		data,
+		thickness: 0.5,
+	},
 	parameters: {
 		docs: {
 			description: {

--- a/projects/js-packages/charts/src/components/pie-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/components/pie-chart/stories/index.stories.tsx
@@ -85,7 +85,8 @@ const meta: Meta< StoryArgs > = {
 				type: 'select',
 				options: [ 'percentage', 'value', 'valueDisplay', 'none' ],
 			},
-			description: 'What type of value to display in the legend when showValues is true',
+			description:
+				'What type of value to display in the legend when showValues is true. Note: Enable "showLegend" to see the effect of this control.',
 		},
 	},
 	render: ( { labelTextColor, labelBackgroundColor, ...chartProps } ) => {
@@ -144,6 +145,7 @@ export const WithLegend: Story = {
 	args: {
 		...Default.args,
 		showLegend: true,
+		legendValueDisplay: 'percentage', // Default value to show in controls
 	},
 };
 
@@ -371,6 +373,45 @@ export const CustomLabelColors: Story = {
 - **Opt-in enhancement**: Backgrounds only appear when explicitly set
 
 Use the Storybook controls to experiment with different combinations. Try setting labelBackgroundColor to \`transparent\` to see the default behavior.`,
+			},
+		},
+	},
+};
+
+export const LegendValueDisplayOptions: Story = {
+	args: {
+		...Default.args,
+		showLegend: true,
+		data: [
+			{
+				label: 'Chrome',
+				value: 80000,
+				valueDisplay: '80K',
+				percentage: 60,
+			},
+			{
+				label: 'Firefox',
+				value: 30000,
+				valueDisplay: '30K',
+				percentage: 23,
+			},
+			{
+				label: 'Safari',
+				value: 22000,
+				valueDisplay: '22K',
+				percentage: 17,
+			},
+		],
+		legendValueDisplay: 'percentage', // Try changing this control
+	},
+	parameters: {
+		docs: {
+			description: {
+				story: `Demonstrates the legendValueDisplay prop options. Enable showLegend and try different values:
+- **percentage**: Shows "60%", "23%", "17%" (default)
+- **value**: Shows raw numbers "80000", "30000", "22000"
+- **valueDisplay**: Shows formatted values "80K", "30K", "22K"
+- **none**: Shows only labels without values`,
 			},
 		},
 	},

--- a/projects/js-packages/charts/src/components/pie-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/components/pie-chart/stories/index.stories.tsx
@@ -141,7 +141,7 @@ export const WithLegend: Story = {
 };
 
 export const WithCompositionLegend: Story = {
-	render: () => (
+	render: args => (
 		<div
 			style={ {
 				display: 'grid',
@@ -154,20 +154,24 @@ export const WithCompositionLegend: Story = {
 				<h3>Traditional Props-based Legend</h3>
 				<PieChart
 					size={ 300 }
-					data={ data }
+					data={ args.data }
 					showLegend={ true }
 					legendPosition="bottom"
 					legendOrientation="horizontal"
+					legendValueDisplay={ args.legendValueDisplay }
 				/>
 			</div>
 			<div>
 				<h3>Composition API with Legend Component</h3>
-				<PieChart size={ 300 } data={ data }>
+				<PieChart size={ 300 } data={ args.data } legendValueDisplay={ args.legendValueDisplay }>
 					<PieChart.Legend position="bottom" orientation="horizontal" alignment="center" />
 				</PieChart>
 			</div>
 		</div>
 	),
+	args: {
+		data,
+	},
 	parameters: {
 		docs: {
 			description: {
@@ -239,8 +243,8 @@ export const Responsiveness: Story = {
 };
 
 export const CompositionAPI: Story = {
-	render: () => {
-		const chartData = [
+	render: args => {
+		const chartData = args.data || [
 			{ label: 'Desktop', value: 45, percentage: 45 },
 			{ label: 'Mobile', value: 30, percentage: 30 },
 			{ label: 'Tablet', value: 25, percentage: 25 },
@@ -253,6 +257,7 @@ export const CompositionAPI: Story = {
 					size={ 400 }
 					withTooltips={ true }
 					thickness={ 0.7 }
+					legendValueDisplay={ args.legendValueDisplay || 'value' }
 				>
 					<PieChartUnresponsive.HTML>
 						<h3 style={ { textAlign: 'center', marginBottom: '20px' } }>
@@ -303,6 +308,9 @@ export const CompositionAPI: Story = {
 				</PieChartUnresponsive>
 			</div>
 		);
+	},
+	args: {
+		data,
 	},
 	parameters: {
 		docs: {

--- a/projects/js-packages/charts/src/components/pie-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/components/pie-chart/stories/index.stories.tsx
@@ -80,6 +80,13 @@ const meta: Meta< StoryArgs > = {
 			control: 'boolean',
 			description: 'Show or hide labels on pie segments',
 		},
+		legendValueDisplay: {
+			control: {
+				type: 'select',
+				options: [ 'percentage', 'value', 'valueDisplay', 'none' ],
+			},
+			description: 'What type of value to display in the legend when showValues is true',
+		},
 	},
 	render: ( { labelTextColor, labelBackgroundColor, ...chartProps } ) => {
 		const ChartComponent = <PieChart { ...chartProps } />;

--- a/projects/js-packages/charts/src/components/pie-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/components/pie-chart/stories/index.stories.tsx
@@ -9,11 +9,13 @@ import { osUsageData as data } from '../../../stories/sample-data';
 import { themeArgTypes } from '../../../stories/theme-config';
 import { PieChart } from '../index';
 import { PieChartUnresponsive } from '../pie-chart';
+import type { LegendValueDisplay } from '../../legend';
 import type { Meta, StoryObj } from '@storybook/react';
 
 type StoryArgs = ChartStoryArgs< React.ComponentProps< typeof PieChart > > & {
 	labelTextColor?: string;
 	labelBackgroundColor?: string;
+	legendValueDisplay?: LegendValueDisplay;
 };
 
 const meta: Meta< StoryArgs > = {

--- a/projects/js-packages/charts/src/components/pie-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/components/pie-chart/stories/index.stories.tsx
@@ -80,9 +80,15 @@ const meta: Meta< StoryArgs > = {
 			control: 'boolean',
 			description: 'Show or hide labels on pie segments',
 		},
-		// Explicitly override the legendValueDisplay control to ensure it works
+		// Explicitly define the legendValueDisplay control
 		legendValueDisplay: {
-			...legendArgTypes.legendValueDisplay,
+			control: {
+				type: 'select',
+				options: [ 'percentage', 'value', 'valueDisplay', 'none' ],
+			},
+			table: { category: 'Legend' },
+			description:
+				'What type of value to display in the legend when showValues is true. Note: Enable "showLegend" to see the effect of this control.',
 		},
 	},
 	render: ( { labelTextColor, labelBackgroundColor, ...chartProps } ) => {

--- a/projects/js-packages/charts/src/components/pie-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/components/pie-chart/stories/index.stories.tsx
@@ -80,6 +80,10 @@ const meta: Meta< StoryArgs > = {
 			control: 'boolean',
 			description: 'Show or hide labels on pie segments',
 		},
+		// Explicitly override the legendValueDisplay control to ensure it works
+		legendValueDisplay: {
+			...legendArgTypes.legendValueDisplay,
+		},
 	},
 	render: ( { labelTextColor, labelBackgroundColor, ...chartProps } ) => {
 		const ChartComponent = <PieChart { ...chartProps } />;

--- a/projects/js-packages/charts/src/components/pie-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/components/pie-chart/stories/index.stories.tsx
@@ -9,13 +9,11 @@ import { osUsageData as data } from '../../../stories/sample-data';
 import { themeArgTypes } from '../../../stories/theme-config';
 import { PieChart } from '../index';
 import { PieChartUnresponsive } from '../pie-chart';
-import type { LegendValueDisplay } from '../../legend';
 import type { Meta, StoryObj } from '@storybook/react';
 
 type StoryArgs = ChartStoryArgs< React.ComponentProps< typeof PieChart > > & {
 	labelTextColor?: string;
 	labelBackgroundColor?: string;
-	legendValueDisplay?: LegendValueDisplay;
 };
 
 const meta: Meta< StoryArgs > = {
@@ -82,14 +80,6 @@ const meta: Meta< StoryArgs > = {
 			control: 'boolean',
 			description: 'Show or hide labels on pie segments',
 		},
-		legendValueDisplay: {
-			control: {
-				type: 'select',
-				options: [ 'percentage', 'value', 'valueDisplay', 'none' ],
-			},
-			description:
-				'What type of value to display in the legend when showValues is true. Note: Enable "showLegend" to see the effect of this control.',
-		},
 	},
 	render: ( { labelTextColor, labelBackgroundColor, ...chartProps } ) => {
 		const ChartComponent = <PieChart { ...chartProps } />;
@@ -147,7 +137,6 @@ export const WithLegend: Story = {
 	args: {
 		...Default.args,
 		showLegend: true,
-		legendValueDisplay: 'percentage', // Default value to show in controls
 	},
 };
 
@@ -375,45 +364,6 @@ export const CustomLabelColors: Story = {
 - **Opt-in enhancement**: Backgrounds only appear when explicitly set
 
 Use the Storybook controls to experiment with different combinations. Try setting labelBackgroundColor to \`transparent\` to see the default behavior.`,
-			},
-		},
-	},
-};
-
-export const LegendValueDisplayOptions: Story = {
-	args: {
-		...Default.args,
-		showLegend: true,
-		data: [
-			{
-				label: 'Chrome',
-				value: 80000,
-				valueDisplay: '80K',
-				percentage: 60,
-			},
-			{
-				label: 'Firefox',
-				value: 30000,
-				valueDisplay: '30K',
-				percentage: 23,
-			},
-			{
-				label: 'Safari',
-				value: 22000,
-				valueDisplay: '22K',
-				percentage: 17,
-			},
-		],
-		legendValueDisplay: 'percentage', // Try changing this control
-	},
-	parameters: {
-		docs: {
-			description: {
-				story: `Demonstrates the legendValueDisplay prop options. Enable showLegend and try different values:
-- **percentage**: Shows "60%", "23%", "17%" (default)
-- **value**: Shows raw numbers "80000", "30000", "22000"
-- **valueDisplay**: Shows formatted values "80K", "30K", "22K"
-- **none**: Shows only labels without values`,
 			},
 		},
 	},

--- a/projects/js-packages/charts/src/components/pie-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/components/pie-chart/stories/index.stories.tsx
@@ -80,16 +80,6 @@ const meta: Meta< StoryArgs > = {
 			control: 'boolean',
 			description: 'Show or hide labels on pie segments',
 		},
-		// Explicitly define the legendValueDisplay control
-		legendValueDisplay: {
-			control: {
-				type: 'select',
-				options: [ 'percentage', 'value', 'valueDisplay', 'none' ],
-			},
-			table: { category: 'Legend' },
-			description:
-				'What type of value to display in the legend when showValues is true. Note: Enable "showLegend" to see the effect of this control.',
-		},
 	},
 	render: ( { labelTextColor, labelBackgroundColor, ...chartProps } ) => {
 		const ChartComponent = <PieChart { ...chartProps } />;

--- a/projects/js-packages/charts/src/components/pie-chart/test/pie-chart.test.tsx
+++ b/projects/js-packages/charts/src/components/pie-chart/test/pie-chart.test.tsx
@@ -158,4 +158,69 @@ describe( 'PieChart', () => {
 			expect( labels.length ).toBeGreaterThan( 0 );
 		} );
 	} );
+
+	describe( 'Legend Value Display', () => {
+		const testData = [
+			{ label: 'Windows', value: 80000, valueDisplay: '80K', percentage: 60 },
+			{ label: 'MacOS', value: 30000, valueDisplay: '30K', percentage: 23 },
+			{ label: 'Linux', value: 22000, valueDisplay: '22K', percentage: 17 },
+		];
+
+		test( 'shows percentage values by default when showLegend and showValues are enabled', () => {
+			renderWithTheme( {
+				data: testData,
+				showLegend: true,
+				// legendValueDisplay defaults to 'percentage'
+			} );
+
+			// Should display percentage values (using formatPercentage which shows "60%", "23%", "17%")
+			expect( screen.getByText( '60%' ) ).toBeInTheDocument();
+			expect( screen.getByText( '23%' ) ).toBeInTheDocument();
+			expect( screen.getByText( '17%' ) ).toBeInTheDocument();
+		} );
+
+		test( 'shows raw values when legendValueDisplay is set to "value"', () => {
+			renderWithTheme( {
+				data: testData,
+				showLegend: true,
+				legendValueDisplay: 'value',
+			} );
+
+			// Should display raw numeric values
+			expect( screen.getByText( '80000' ) ).toBeInTheDocument();
+			expect( screen.getByText( '30000' ) ).toBeInTheDocument();
+			expect( screen.getByText( '22000' ) ).toBeInTheDocument();
+		} );
+
+		test( 'shows formatted values when legendValueDisplay is set to "valueDisplay"', () => {
+			renderWithTheme( {
+				data: testData,
+				showLegend: true,
+				legendValueDisplay: 'valueDisplay',
+			} );
+
+			// Should display formatted values (valueDisplay field)
+			expect( screen.getByText( '80K' ) ).toBeInTheDocument();
+			expect( screen.getByText( '30K' ) ).toBeInTheDocument();
+			expect( screen.getByText( '22K' ) ).toBeInTheDocument();
+		} );
+
+		test( 'shows no values when legendValueDisplay is set to "none"', () => {
+			renderWithTheme( {
+				data: testData,
+				showLegend: true,
+				showLabels: false, // Disable pie slice labels to avoid confusion
+				legendValueDisplay: 'none',
+			} );
+
+			// Should not display any values in legend
+			expect( screen.queryByText( '60%' ) ).not.toBeInTheDocument();
+			expect( screen.queryByText( '80000' ) ).not.toBeInTheDocument();
+			expect( screen.queryByText( '80K' ) ).not.toBeInTheDocument();
+
+			// Legend should have the correct number of items (labels only, no values)
+			const legendItems = screen.getAllByTestId( 'legend-item' );
+			expect( legendItems ).toHaveLength( 3 );
+		} );
+	} );
 } );

--- a/projects/js-packages/charts/src/components/pie-semi-circle-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/components/pie-semi-circle-chart/stories/index.stories.tsx
@@ -81,7 +81,7 @@ export const WithLegend: Story = {
 };
 
 export const WithCompositionLegend: Story = {
-	render: () => (
+	render: args => (
 		<div
 			style={ {
 				display: 'grid',
@@ -94,21 +94,23 @@ export const WithCompositionLegend: Story = {
 				<h3>Traditional Props-based Legend</h3>
 				<PieSemiCircleChart
 					width={ 400 }
-					data={ data }
+					data={ args.data }
 					label="Performance Metrics"
 					note="Q4 2023 Results"
 					showLegend={ true }
 					legendPosition="bottom"
 					legendOrientation="horizontal"
+					legendValueDisplay={ args.legendValueDisplay }
 				/>
 			</div>
 			<div>
 				<h3>Composition API with Legend Component</h3>
 				<PieSemiCircleChart
 					width={ 400 }
-					data={ data }
+					data={ args.data }
 					label="Performance Metrics"
 					note="Q4 2023 Results"
+					legendValueDisplay={ args.legendValueDisplay }
 				>
 					<PieSemiCircleChart.Legend
 						position="bottom"
@@ -119,6 +121,9 @@ export const WithCompositionLegend: Story = {
 			</div>
 		</div>
 	),
+	args: {
+		data,
+	},
 	parameters: {
 		docs: {
 			description: {
@@ -238,7 +243,7 @@ export const ErrorStates: Story = {
 };
 
 export const CompositionAPI: Story = {
-	render: () => (
+	render: args => (
 		<div style={ { padding: '2rem' } }>
 			<h2>PieSemiCircleChart Composition API</h2>
 			<p>Demonstrates the flexible composition API with SVG and HTML compound components.</p>
@@ -255,10 +260,11 @@ export const CompositionAPI: Story = {
 					<h3>With Custom SVG Elements</h3>
 					<PieSemiCircleChart
 						width={ 400 }
-						data={ data }
+						data={ args.data }
 						label="OS Usage"
 						note="Q4 2023"
 						withTooltips={ true }
+						legendValueDisplay={ args.legendValueDisplay }
 					>
 						<PieSemiCircleChart.SVG>
 							<Group>
@@ -292,7 +298,13 @@ export const CompositionAPI: Story = {
 
 				<div>
 					<h3>With Custom Legend and HTML Content</h3>
-					<PieSemiCircleChart width={ 400 } data={ data } label="Performance" note="Latest Results">
+					<PieSemiCircleChart
+						width={ 400 }
+						data={ args.data }
+						label="Performance"
+						note="Latest Results"
+						legendValueDisplay={ args.legendValueDisplay }
+					>
 						<PieSemiCircleChart.HTML>
 							<div
 								style={ {
@@ -341,7 +353,13 @@ export const CompositionAPI: Story = {
 				<p style={ { fontSize: '14px', color: '#666', marginBottom: '1rem' } }>
 					For backward compatibility, Group components are still supported directly:
 				</p>
-				<PieSemiCircleChart width={ 400 } data={ data } label="Legacy Mode" note="Still works!">
+				<PieSemiCircleChart
+					width={ 400 }
+					data={ args.data }
+					label="Legacy Mode"
+					note="Still works!"
+					legendValueDisplay={ args.legendValueDisplay }
+				>
 					<Group>
 						<Text x={ 0 } y={ -70 } textAnchor="middle" fontSize={ 12 } fill="#999">
 							Direct Group usage
@@ -352,6 +370,9 @@ export const CompositionAPI: Story = {
 			</div>
 		</div>
 	),
+	args: {
+		data,
+	},
 	parameters: {
 		layout: 'fullscreen',
 		docs: {

--- a/projects/js-packages/charts/src/index.ts
+++ b/projects/js-packages/charts/src/index.ts
@@ -10,6 +10,7 @@ export { ConversionFunnelChart } from './components/conversion-funnel-chart';
 // Chart components
 export { BaseTooltip } from './components/tooltip';
 export { Legend, useChartLegendItems } from './components/legend';
+export type { LegendValueDisplay } from './components/legend';
 
 // Visx components
 export { Text, getStringWidth, useText } from './visx/text';

--- a/projects/js-packages/charts/src/index.ts
+++ b/projects/js-packages/charts/src/index.ts
@@ -24,5 +24,6 @@ export { defaultTheme, jetpackTheme, wooTheme } from './providers/theme/themes';
 // Types
 export type * from './types';
 export type * from './visx/types';
+export type { PieChartProps } from './components/pie-chart';
 
 export type { LineStyles, GridStyles, EventHandlerParams } from '@visx/xychart';

--- a/projects/js-packages/charts/src/stories/legend-config.tsx
+++ b/projects/js-packages/charts/src/stories/legend-config.tsx
@@ -32,4 +32,13 @@ export const legendArgTypes = {
 		table: { category: 'Legend' },
 		description: 'Show glyphs in legend (Line charts only)',
 	},
+	legendValueDisplay: {
+		control: {
+			type: 'select' as const,
+			options: [ 'percentage', 'value', 'valueDisplay', 'none' ],
+		},
+		table: { category: 'Legend' },
+		description:
+			'What type of value to display in the legend when showValues is true. Note: Enable "showLegend" to see the effect of this control.',
+	},
 };

--- a/projects/js-packages/charts/src/stories/legend-config.tsx
+++ b/projects/js-packages/charts/src/stories/legend-config.tsx
@@ -33,10 +33,8 @@ export const legendArgTypes = {
 		description: 'Show glyphs in legend (Line charts only)',
 	},
 	legendValueDisplay: {
-		control: {
-			type: 'select' as const,
-			options: [ 'percentage', 'value', 'valueDisplay', 'none' ],
-		},
+		control: { type: 'select' as const },
+		options: [ 'percentage', 'value', 'valueDisplay', 'none' ],
 		table: { category: 'Legend' },
 		description:
 			'What type of value to display in the legend when showValues is true. Note: Enable "showLegend" to see the effect of this control.',


### PR DESCRIPTION
fixes: [#charts-101](https://linear.app/a8c/issue/CHARTS-101/add-ability-to-control-percentage-vs-value-display)

## Proposed changes:
* Add `legendValueDisplay` prop to PieChart component with four display options: 'percentage', 'value', 'valueDisplay', and 'none'
* Implement core legend value formatting logic in `formatPointValue` function to handle different display modes
* Export `LegendValueDisplay` type from both legend module and main package index for external consumption
* Add comprehensive JSDoc documentation explaining each display option with examples
* Maintain backward compatibility with default 'percentage' display mode
* Add Storybook control for interactive testing of legend value display options
* Implement comprehensive test coverage for all legend value display modes including edge cases

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?

No, it does not.

## Testing instructions:

* Go to Storybook -> Charts -> Types -> Pie Chart
* Use the `legendValueDisplay` control to test all four options:
  - `percentage`: Should display "60%", "23%", "17%" format
  - `value`: Should display raw numbers like "80000", "30000", "22000"
  - `valueDisplay`: Should display formatted values like "80K", "30K", "22K"
  - `none`: Should display only labels without any values
* Enable "showLegend" to see the legend value changes
* Verify that percentage display is used by default (backward compatibility)
* Test with different data sets to ensure proper value formatting
* Verify that the feature works with both regular PieChart and composition API usage
* Ensure no visual regressions in chart rendering, tooltips, or other legend functionality