### PR TITLE
Enable scan and backup functionality for summer special sites

### DIFF
--- a/projects/plugins/wpcomsh/changelog/add-summer-special-scan-backups-features
+++ b/projects/plugins/wpcomsh/changelog/add-summer-special-scan-backups-features
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Enables Scans and Backups for sites with the summer-special-2025 blog sticker

--- a/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
+++ b/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
@@ -552,6 +552,7 @@ class WPCOM_Features {
 			self::WPCOM_BUSINESS_AND_HIGHER_PLANS,
 			self::WPCOM_PRO_PLANS,
 			self::WPCOM_STAGING_PRODUCT,
+			self::WPCOM_SUMMER_SPECIAL_2025_PLANS,
 		),
 		// BACKUPS_DAILY - Site has product that includes daily backups.
 		self::BACKUPS_DAILY                     => array(
@@ -562,6 +563,7 @@ class WPCOM_Features {
 		self::BACKUPS_RESTORE                   => array(
 			self::WPCOM_BUSINESS_AND_HIGHER_PLANS,
 			self::WPCOM_PRO_PLANS,
+			self::WPCOM_SUMMER_SPECIAL_2025_PLANS,
 		),
 
 		/*
@@ -953,6 +955,7 @@ class WPCOM_Features {
 			self::JETPACK_GOLDEN_TOKEN,
 			self::WPCOM_BUSINESS_AND_HIGHER_PLANS,
 			self::WPCOM_PRO_PLANS,
+			self::WPCOM_SUMMER_SPECIAL_2025_PLANS,
 		),
 		self::RECURRING_PAYMENTS                => array(
 			self::WPCOM_ALL_SITES,
@@ -986,6 +989,7 @@ class WPCOM_Features {
 			self::JETPACK_GOLDEN_TOKEN,
 			self::WPCOM_BUSINESS_AND_HIGHER_PLANS,
 			self::WPCOM_PRO_PLANS,
+			self::WPCOM_SUMMER_SPECIAL_2025_PLANS,
 		),
 
 		/*
@@ -995,6 +999,7 @@ class WPCOM_Features {
 		self::SCAN_MANAGED                      => array(
 			self::WPCOM_BUSINESS_AND_HIGHER_PLANS,
 			self::WPCOM_PRO_PLANS,
+			self::WPCOM_SUMMER_SPECIAL_2025_PLANS,
 		),
 
 		/*


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes [DOTOBRD-318](https://linear.app/a8c/issue/DOTOBRD-318/enable-scan-and-backup-functionality-for-summer-special-sites)

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* adds the Scans and Backups feature for the Summer Special sites

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Follow instructions from 191762-ghe-Automattic/wpcom
* Add the site to the WoA with the `Transfers to Atomic dev server pool` (needed for write permissions to change the wpcomsh files)
* Try to install a plugin (it will stall but it should trigger the atomic transfer)
* Once the plan is atomic, go to the Blog RC and enable a `Support SFTP User` 
* Use the credentials to run `pnpm jetpack rsync wpcomsh {username}@sftp.wp.com:~/htdocs/wp-content/mu-plugins`
* You should be able to use the Scan and Backups features