### PR TITLE
Forms: add forms related command palette commands

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -481,7 +481,7 @@ importers:
         version: 5.0.3(jest@30.0.4)
       mini-css-extract-plugin:
         specifier: ^2.7.0
-        version: 2.9.4(webpack@5.101.3)
+        version: 2.9.1(webpack@5.101.3)
       postcss:
         specifier: 8.5.6
         version: 8.5.6
@@ -1144,7 +1144,7 @@ importers:
         version: 4.4.3
       tslib:
         specifier: ^2.5.0
-        version: 2.8.1
+        version: 2.5.0
     devDependencies:
       '@babel/core':
         specifier: 7.28.4
@@ -2515,6 +2515,9 @@ importers:
       '@wordpress/blocks':
         specifier: 15.4.0
         version: 15.4.0(react@18.3.1)
+      '@wordpress/commands':
+        specifier: 1.28.0
+        version: 1.28.0(@types/react-dom@18.3.7(@types/react@18.3.25))(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/components':
         specifier: 30.4.0
         version: 30.4.0(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -9655,6 +9658,13 @@ packages:
     resolution: {integrity: sha512-8NemosyPrey1yswd6LH8vX9mcRF6Xmqt2mKUCspnmEX4KvayyezmtJPh2EQo3GfySVHGWePzb0yfMYEqDdsC0Q==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
+  '@wordpress/commands@1.28.0':
+    resolution: {integrity: sha512-iokqHdXs9WrFw7Rf9MVJSW3+Z8aJbpUDkLQpIYbL/PX3WTz05nEIUI/p45fH3vPoOeoJqVZ8YwC6uvnoUxy9Cw==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
+
   '@wordpress/commands@1.31.0':
     resolution: {integrity: sha512-PaBQVIHNGBn2sMxPj5ILJPAe4h79MvUcb5DzgiXA+H+0nNHLsQxg2u8Cfm2spct37dqOLMnQ6PVMRS+SwCLESQ==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -14077,6 +14087,12 @@ packages:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
 
+  mini-css-extract-plugin@2.9.1:
+    resolution: {integrity: sha512-+Vyi+GCCOHnrJ2VPS+6aPoXN2k2jgUzDRhTFLjjTBn23qyXJXkjUWQgTL+mXpF5/A8ixLdCc6kWsoeOjKGejKQ==}
+    engines: {node: '>= 12.13.0'}
+    peerDependencies:
+      webpack: ^5.0.0
+
   mini-css-extract-plugin@2.9.4:
     resolution: {integrity: sha512-ZWYT7ln73Hptxqxk2DxPU9MmapXRhxkJD6tkSR04dnQxm8BGu2hzgKLugK5yySD97u/8yy7Ma7E76k9ZdvtjkQ==}
     engines: {node: '>= 12.13.0'}
@@ -16573,6 +16589,9 @@ packages:
 
   tslib@1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
+
+  tslib@2.5.0:
+    resolution: {integrity: sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -22861,6 +22880,26 @@ snapshots:
   '@wordpress/browserslist-config@6.31.0': {}
 
   '@wordpress/browserslist-config@6.32.0': {}
+
+  '@wordpress/commands@1.28.0(@types/react-dom@18.3.7(@types/react@18.3.25))(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.28.4
+      '@wordpress/components': 30.4.0(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/data': 10.31.0(react@18.3.1)
+      '@wordpress/element': 6.31.0
+      '@wordpress/i18n': 6.4.0
+      '@wordpress/icons': 10.31.0(react@18.3.1)
+      '@wordpress/keyboard-shortcuts': 5.32.0(react@18.3.1)
+      '@wordpress/private-apis': 1.32.0
+      clsx: 2.1.1
+      cmdk: 1.1.1(@types/react-dom@18.3.7(@types/react@18.3.25))(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    transitivePeerDependencies:
+      - '@emotion/is-prop-valid'
+      - '@types/react'
+      - '@types/react-dom'
+      - supports-color
 
   '@wordpress/commands@1.31.0(@types/react-dom@18.3.7(@types/react@18.3.25))(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -29981,11 +30020,17 @@ snapshots:
 
   min-indent@1.0.1: {}
 
-  mini-css-extract-plugin@2.9.4(webpack@5.101.3):
+  mini-css-extract-plugin@2.9.1(webpack@5.101.3):
     dependencies:
       schema-utils: 4.3.3
       tapable: 2.3.0
       webpack: 5.101.3(esbuild@0.25.9)(webpack-cli@6.0.1)
+
+  mini-css-extract-plugin@2.9.4(webpack@5.101.3):
+    dependencies:
+      schema-utils: 4.3.3
+      tapable: 2.3.0
+      webpack: 5.101.3(webpack-cli@6.0.1)
 
   minimalistic-assert@1.0.1: {}
 
@@ -32733,6 +32778,8 @@ snapshots:
       strip-bom: 3.0.0
 
   tslib@1.14.1: {}
+
+  tslib@2.5.0: {}
 
   tslib@2.8.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -481,7 +481,7 @@ importers:
         version: 5.0.3(jest@30.0.4)
       mini-css-extract-plugin:
         specifier: ^2.7.0
-        version: 2.9.1(webpack@5.101.3)
+        version: 2.9.4(webpack@5.101.3)
       postcss:
         specifier: 8.5.6
         version: 8.5.6
@@ -1144,7 +1144,7 @@ importers:
         version: 4.4.3
       tslib:
         specifier: ^2.5.0
-        version: 2.5.0
+        version: 2.8.1
     devDependencies:
       '@babel/core':
         specifier: 7.28.4
@@ -2516,8 +2516,8 @@ importers:
         specifier: 15.4.0
         version: 15.4.0(react@18.3.1)
       '@wordpress/commands':
-        specifier: 1.28.0
-        version: 1.28.0(@types/react-dom@18.3.7(@types/react@18.3.25))(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 1.33.0
+        version: 1.33.0(@types/react-dom@18.3.7(@types/react@18.3.25))(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/components':
         specifier: 30.4.0
         version: 30.4.0(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -2859,7 +2859,7 @@ importers:
         version: 4.31.0(react@18.3.1)
       '@wordpress/private-apis':
         specifier: ^1.8.1
-        version: 1.33.0
+        version: 1.32.0
       '@wordpress/router':
         specifier: ^1.8.11
         version: 1.32.0(react@18.3.1)
@@ -9553,6 +9553,10 @@ packages:
     resolution: {integrity: sha512-LU2Ea+RRaqe1Q8u15Y1dBxXfGwPsOtqXLZR7Bfk7y9yMsJnKqymovR7yvoPYe/4dWXy0B9sK1jUJtPAMUFfOng==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
+  '@wordpress/a11y@4.32.0':
+    resolution: {integrity: sha512-FNoyQUO1wAf768MX2vMNNk1Il3bi/A7c1s9WKSaufwEZEViXjWeqqb9GO6stWkur4UP9MRcv8IpWoLXi1BePHA==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
   '@wordpress/a11y@4.33.0':
     resolution: {integrity: sha512-LUFmuDkwKS15XkV8ziR2isSMvgLZjyRg0EQD4lfCywS9ycQzuzGFHDzUxpg0ECjYQfRrGDzMcPQe5ts8HuklOA==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -9595,6 +9599,10 @@ packages:
 
   '@wordpress/base-styles@6.7.0':
     resolution: {integrity: sha512-Ob2+lGMFJnPZE5OQLEsdvs2Rp1RxemqHufJFg00c5mWCXokKPaDBIa/EcS/O3nsQGA3qYHciUSM1uIYLOUdbzA==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
+  '@wordpress/base-styles@6.8.0':
+    resolution: {integrity: sha512-x3LCQ4DuIOg58LyQRZtI6shmNKCk2zuKGwIEMH7h7MMri/Q95ehR6Sub8dKiUL4AHktdlweouJwbHaqrXPkd0Q==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/base-styles@6.9.0':
@@ -9658,13 +9666,6 @@ packages:
     resolution: {integrity: sha512-8NemosyPrey1yswd6LH8vX9mcRF6Xmqt2mKUCspnmEX4KvayyezmtJPh2EQo3GfySVHGWePzb0yfMYEqDdsC0Q==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
-  '@wordpress/commands@1.28.0':
-    resolution: {integrity: sha512-iokqHdXs9WrFw7Rf9MVJSW3+Z8aJbpUDkLQpIYbL/PX3WTz05nEIUI/p45fH3vPoOeoJqVZ8YwC6uvnoUxy9Cw==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-    peerDependencies:
-      react: ^18.0.0
-      react-dom: ^18.0.0
-
   '@wordpress/commands@1.31.0':
     resolution: {integrity: sha512-PaBQVIHNGBn2sMxPj5ILJPAe4h79MvUcb5DzgiXA+H+0nNHLsQxg2u8Cfm2spct37dqOLMnQ6PVMRS+SwCLESQ==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -9672,8 +9673,8 @@ packages:
       react: ^18.0.0
       react-dom: ^18.0.0
 
-  '@wordpress/commands@1.32.0':
-    resolution: {integrity: sha512-csVqkLoGw73i4plSMVx1t5pXFdFk8D9vJQJRzJWtdWiy8aMM+/1Yx3YetTAY/YD62mYOGk4FtkkhF/3ijaQUqQ==}
+  '@wordpress/commands@1.33.0':
+    resolution: {integrity: sha512-EJM2QdC0xQp6lVaCybbCQhkaX7/it5cEvYXvLtSSRMbCreu8OhCBvd2IruT8+5QIgnAgBHQkc589SsdW3DNsaA==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     peerDependencies:
       react: ^18.0.0
@@ -9681,6 +9682,13 @@ packages:
 
   '@wordpress/components@30.4.0':
     resolution: {integrity: sha512-PrZ8+VMCciVkWna//AH55Xg+TALw/E67358B5w/qiBohZ0CaoL1z4UcltkO+Gd5BJ1E14HbD8vC/6ao8dMXEJg==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
+
+  '@wordpress/components@30.5.0':
+    resolution: {integrity: sha512-LIu96PI14RpwABd5iDyTI8OxlDVEbDfX/6UUctTKsSqfJWTAynIL/K/JIHhxxI2wYbtut9yu8nugwFCPdconvA==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     peerDependencies:
       react: ^18.0.0
@@ -9701,6 +9709,12 @@ packages:
 
   '@wordpress/compose@7.31.0':
     resolution: {integrity: sha512-kxb1qHhiFwUDifBM9r4JZ3gYC1ZUvck5tgjmaWeg8EqIEnVn+Z7C+ntNA9ySLWrmDYc4Gki7YJZbfVHzrtcDLg==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
+
+  '@wordpress/compose@7.32.0':
+    resolution: {integrity: sha512-y4StIlClJiijBHduZ6Bx0tfFarsNi6hc+mvPk2ENIfNNLHf0P90f97XjbvUUr0U1J92x7silHliQfdF0ygbFQg==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     peerDependencies:
       react: ^18.0.0
@@ -9737,6 +9751,12 @@ packages:
     peerDependencies:
       react: ^18.0.0
 
+  '@wordpress/data@10.32.0':
+    resolution: {integrity: sha512-7lReC2/qVxlQVYVlqIYfZ9Irbzo6W30iuiD67xaXqVxiD9BA8CePY2dTBpCsykBkczoT0ryerVp648SvY82R9Q==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
+
   '@wordpress/data@10.33.0':
     resolution: {integrity: sha512-05USk5y+UoGBW5xEVLWLUJOZsMTMmFRagsdgijV+RETzRj1qTw0Vj3y/mhH49EQ16s7fkPMmcCbZnSiGvATD7g==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -9759,6 +9779,10 @@ packages:
     resolution: {integrity: sha512-xqKytkb60N9i+ETqTI+Asgb1myZIgnUne8zsGaYQU+B7H1M3ELw4lmc+ptDXjXrpI1Yb6BGUad4EIHBGVk+mog==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
+  '@wordpress/date@5.32.0':
+    resolution: {integrity: sha512-hWmsDHzzmhbWAwWzBM042eItGor1up9tV0nEvjn1qdERoI/MS3+78d8vF40sMdWnXLNcPTCR+JHjD6kqJVmuXQ==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
   '@wordpress/date@5.33.0':
     resolution: {integrity: sha512-pcZjaytspcLLQIN2cnrK51Zgv4lm/s1qLu/tLEmNg9DeVL3mKsWNBE6JFSmSJzPLQUHtH7k174RwY8g1bBDTbA==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -9769,6 +9793,10 @@ packages:
     peerDependencies:
       webpack: ^5.0.0
 
+  '@wordpress/deprecated@4.32.0':
+    resolution: {integrity: sha512-HfHXUWfe/lyXTvJLWjpMJ90+XzmC2l/9vcp05n2tD+nsxwF5nS0Hjf+38pQtFPBcw3d1bbzMTNahDjtNBLvKTQ==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
   '@wordpress/deprecated@4.33.0':
     resolution: {integrity: sha512-+9RD5oAAH+HGh6YwRJui0mj/WOfxSZi1/0l2YdgKuQsY2DhnJbEscc/86IxSR44IEMItKjIoJO3k9CdeyFyRig==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -9777,12 +9805,20 @@ packages:
     resolution: {integrity: sha512-aRM4l5wzkrqAU686s4fz1bb+/7/BOFp+sXB0kx1vkiXl3ocfmHAr3jwEYU+OH/sX6Is3Ntkfh0uZe3EJLsqHTQ==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
+  '@wordpress/dom-ready@4.32.0':
+    resolution: {integrity: sha512-Ru+gF3J37wiz33yqVoSmwPmc5afvGyujxyLvkGI0N4Y6EBMUmEJbC6QUbTOVld8RANQ0Bqu1btXMZfFYEY9PIQ==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
   '@wordpress/dom-ready@4.33.0':
     resolution: {integrity: sha512-NDmtk+n0ZoWW0KzPHNSGYfKB/NM2EVxP2HwkBE8tN3+G7Z/hktdcpFiRTPhYoDg2KIAZMngBOzckgGtcIJ3z3A==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/dom@4.31.0':
     resolution: {integrity: sha512-5/RBy9OreQktnBE75cB3R6Lva5c6hUlXvPo1NFfAebLeXX+7swZBmLYZnyf7dZbARRdqSwkundHZoKLcHa+20A==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
+  '@wordpress/dom@4.32.0':
+    resolution: {integrity: sha512-TphAq3bE34R5O0qW2q1SSBGdqfjTtHQSxzjKc0ufvTJf1nVZkJpCOqAP0Bue48AwfFYQSagdD3RgqYjcPPEMYg==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/dom@4.33.0':
@@ -9813,12 +9849,20 @@ packages:
     resolution: {integrity: sha512-KOier6Y4b4Y5yEV1GYen81R9gCEOvJT6eVbsc93w2fFEKi2FK/oI7IKzGv9GeJMkoCWvTSX6C/ZYTWk6fCUfeA==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
+  '@wordpress/element@6.32.0':
+    resolution: {integrity: sha512-W/Bw6HXzRBJgYYUdoUBUvtjXNWh8dVK8aqFsqpnEJTAiXdU8Ii0wBQ+E49bI/08yGCwsaXrLbQLXqtAiV6leMw==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
   '@wordpress/element@6.33.0':
     resolution: {integrity: sha512-vUcH12viRpHkqZ1j3kEqE3bnCvl0tsvUUgp9USgeqRx9YE+8XAn6MdghvwF65/R2It66vqogJlKnbO4wfXehTA==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/escape-html@3.31.0':
     resolution: {integrity: sha512-9g9qd7Q16PWDeYEa2dU+84d1SvjP4LfS7n7AuXkwl5+F7KfL2nZTmDTHWutw9jVjdDAGmjm1VNIj4ydQk9vaLA==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
+  '@wordpress/escape-html@3.32.0':
+    resolution: {integrity: sha512-pT5wZmg9ob/u8RuSXgfZv8Kfd8zpvtBcCdcFE/UHasjtxJSecxDHFb0uI4eXQrSiTrsthbDZDlK/GIAagmt75Q==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/escape-html@3.33.0':
@@ -9871,12 +9915,20 @@ packages:
     resolution: {integrity: sha512-8YOftWP54V4hvO46/FgXnpiB/fAC72CWD/F1JYtcfZcrWgbR96MGZxKXNvn5BgLx6juO36QQuFhJ5y2ZUEulkw==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
+  '@wordpress/hooks@4.32.0':
+    resolution: {integrity: sha512-aXCLsuOQJiVJDrVKV4MjGYeU2Nv8+pg2KSAzANs7OGXIl714Q968t5qODJiJ6ADsng3FnQ0pATVYBGBTGlW6Gg==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
   '@wordpress/hooks@4.33.0':
     resolution: {integrity: sha512-UwYLO+d3B2a9YtyiKTKjpE+j+eXI1pgySUutD8DL9DnHZMKX/TY4pBdSH4tyNMYxA2Jx0HBDhxBWVkE6e2KB6A==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/html-entities@4.31.0':
     resolution: {integrity: sha512-5dk9h16jSXDTSdk0HnyXEOgZd7VSsMtr3YCSUQvzIYOFkpW2q1eB10coXHiuz0Z5ArlTuNYSfBd2J02xnG+a8g==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
+  '@wordpress/html-entities@4.32.0':
+    resolution: {integrity: sha512-IHHxBeMIQR7/+Fq27eWEzOuBi10guTRBNVZUrdk32ZyJL2ISpVYwMiHOwKBH6J/67ayBSon23gUEWBqUE6bC9g==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/html-entities@4.33.0':
@@ -9890,6 +9942,11 @@ packages:
 
   '@wordpress/i18n@6.4.0':
     resolution: {integrity: sha512-tLTjdLw8H778K4fmEo5NDLYJOAgvHxgfLU5N7lPuBy2TKi8tQl24xgmJOlDLiMzbmbSEwvUBZ/4xWJsGq9ITDQ==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    hasBin: true
+
+  '@wordpress/i18n@6.5.0':
+    resolution: {integrity: sha512-VJ4QwkgKaVBk2+u6NYTMJ4jc/fave0Q2DAmoTN1AoSaHnK1Yuq9qJtBHAdkLUo7bBpRORBTl8OFFJTFLxgc9eA==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     hasBin: true
 
@@ -9935,6 +9992,10 @@ packages:
       react: ^18.0.0
       react-dom: ^18.0.0
 
+  '@wordpress/is-shallow-equal@5.32.0':
+    resolution: {integrity: sha512-YabJ43zv30CU8kPhTrWQZhlatwO/fBo78/HvEU40CSGCRf+j9XKu9ZUidj3xDKgzLEkDCOKmj0vUY0+NyBbKzA==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
   '@wordpress/is-shallow-equal@5.33.0':
     resolution: {integrity: sha512-nd8yAVFXnPw4V91MjHQ58eEc/wiDHh4KplUfWzfLd2EesLbRlrtFcZyXe4NkeMlGk+Prfy7wJyNNrax17sBCBQ==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -9951,8 +10012,18 @@ packages:
     peerDependencies:
       react: ^18.0.0
 
+  '@wordpress/keyboard-shortcuts@5.33.0':
+    resolution: {integrity: sha512-hFCHRlhPUOlpoXB6R2Wt3QPFJnqN6GutVjMAXnbduWk9m9KCfRiGs/K7N718PtHjX90COrODoumr3/ybHs1iGQ==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
+
   '@wordpress/keycodes@4.31.0':
     resolution: {integrity: sha512-TmweVWZKUu3DreU9SAX69h7wGNnsl5cnN5S3RTVK3aMNOGhJabC7j7rueCmBgqgOFvzNEXeIL+SuYtWpIyEVsA==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
+  '@wordpress/keycodes@4.32.0':
+    resolution: {integrity: sha512-XzSc3uT+viVCdycT2W6/wu+d8NZaS2y0sdHZbPXIJ6hEbyyG7ncG+XDFhXckFggqXuajxkPTEJDwOtrSTxLYqw==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/keycodes@4.33.0':
@@ -10014,14 +10085,28 @@ packages:
     peerDependencies:
       react: ^18.0.0
 
+  '@wordpress/primitives@4.32.0':
+    resolution: {integrity: sha512-pf46CU5qQaGOULlAMNQTi+Jkwf1vwfrGYmkRtuTP68/Y8yOI19v5JZg/Vwq5nCHOs/L750mX1wMp4WvGWoPhFg==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
+
   '@wordpress/primitives@4.33.0':
     resolution: {integrity: sha512-gK5/L+Yz5JmsJBwFd/pMb4zQoOYkhNkMAdhFCm9akn/qG/zrP+UlligxNYVbC+HhgOT6Jg932gcu2KqWkEYoSw==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     peerDependencies:
       react: ^18.0.0
 
+  '@wordpress/priority-queue@3.32.0':
+    resolution: {integrity: sha512-LXlkiXxRSv35FBvjfAqn+rHH7KF4mw2wVl57SVzWglZAUdfvrcjrinRlEsqgMZxeAVeLPiutRV1qlkueZl7E8w==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
   '@wordpress/priority-queue@3.33.0':
     resolution: {integrity: sha512-/tfjwy1IdjS7JGb5OMvkbkToXURmfDGwp/FZhenCMZfQFZqiriA1KjYCKLeMQgjsJ5ezf/2lq/KF6wdr0sYg4w==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
+  '@wordpress/private-apis@1.32.0':
+    resolution: {integrity: sha512-xmc+U8tve6QmGKiYTwVutkPkqqJkvB2fvrimjMkw8TGpnzBcmSlCtwIoLwJOBesD6liDdRFtBPpf6PM0jIRcIA==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/private-apis@1.33.0':
@@ -10031,6 +10116,12 @@ packages:
   '@wordpress/react-i18n@4.32.0':
     resolution: {integrity: sha512-037c2RePQbTtXXQhgopBssOsrVw4dZJe2y5JTp7qh+Yoi6qeO43j0KWlRkXJnqgbsigvddTtWF/kw4VAHMWQHQ==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
+  '@wordpress/redux-routine@5.32.0':
+    resolution: {integrity: sha512-DE/UCpBF7PxznAOOlf2/Tq1aQKvqU07aaFhgGaCBd7sBn6QtBjA5SvtOvKcpr+09awdcS1AeLl2DdPGnRUZkog==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      redux: '>=4'
 
   '@wordpress/redux-routine@5.33.0':
     resolution: {integrity: sha512-I3VWtOdiXsQqQZIt8aCIe3qaYxZfQJo1DBdQKscxxWOF/J5OLDfM3psKsTD0fs6g4rulCbDgFfIxI7bOxdXSoQ==}
@@ -10047,6 +10138,12 @@ packages:
 
   '@wordpress/rich-text@7.31.0':
     resolution: {integrity: sha512-s1CHb9vFYxa/fOPXSMn8GauOYb+gSVczHHx06Hj86JilGNAKmALADqzR+6D6ACKjahQypduYsF9P669PY7+PrQ==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
+
+  '@wordpress/rich-text@7.32.0':
+    resolution: {integrity: sha512-CUiKYCkuoAqfyMPkw4HRcWcK8bKdOCfMiHUfZvAaapjWB6qGhSsL4MRlmQV8IGtbHj5tUVkBAzTm5V5tIV2/yQ==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     peerDependencies:
       react: ^18.0.0
@@ -10097,6 +10194,10 @@ packages:
     resolution: {integrity: sha512-FgA06HzE0dESSXAQIgzKfLa9Z2Qv1Gv4Blcskyko7wNTcQfPq53oByvCiA0aMFh/LmKHNIa2FR1vn3Y3ck/Ewg==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
+  '@wordpress/undo-manager@1.32.0':
+    resolution: {integrity: sha512-pEnsf9zvk61ijX28wmJ7HM2Xb2Dbdg80feF0QVFAsngFiS34r9/K1JE+y56OdyYY20ZGPbmbHLpIHX0ghjhpoQ==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
   '@wordpress/undo-manager@1.33.0':
     resolution: {integrity: sha512-0QU8ElPAf50mEp95dnqQfUnby0ybxNs5Ukd3OYoxal5+lvGCOpBMf+L4zWLp8VGr5uLPL8ER12DdaBczXfXfPg==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -10119,6 +10220,10 @@ packages:
     resolution: {integrity: sha512-fI0TK7WsGB3hgal/3PuoSN8zrato1hJz0r2xZQTe7+DWgrO3R8zlsoKhtOGzLL/zTNM5Auw22EPvRxGcwGT5zA==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
+  '@wordpress/url@4.32.0':
+    resolution: {integrity: sha512-B7Q6sKzBqSLUdQiW8oL69LFuky/IRrXDbBhPpOJruwV4l6eH6UhTlnY4QZYi1Ke91c/VJZRjUKx1fNWPJx5d9w==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
   '@wordpress/url@4.33.0':
     resolution: {integrity: sha512-RKBrMc4bXfJDu5l9Ry2kTOtq83Y/EbGn+AMBrqhbDdRI7xxK3XuCmAbaC/vhjC7dWfdwzs7m16knFGeG87BKYw==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -10128,6 +10233,10 @@ packages:
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     peerDependencies:
       react: ^18.0.0
+
+  '@wordpress/warning@3.32.0':
+    resolution: {integrity: sha512-6dPNKfJAOXijIMi9k/QdS/IQvHXcl5ErNM10y5dIhhLDuGmsZlQER06VrVmQIVAkbsmL49OfrqkqMOQidp61JA==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/warning@3.33.0':
     resolution: {integrity: sha512-LzYgKfxgK5YEpTu4zHPCDzw+kH5hYCrKRK/joK8S9booy5ERvzRCPrISMwrmAKTD9esYF82+IEHhW0/qsjxPsw==}
@@ -14087,12 +14196,6 @@ packages:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
 
-  mini-css-extract-plugin@2.9.1:
-    resolution: {integrity: sha512-+Vyi+GCCOHnrJ2VPS+6aPoXN2k2jgUzDRhTFLjjTBn23qyXJXkjUWQgTL+mXpF5/A8ixLdCc6kWsoeOjKGejKQ==}
-    engines: {node: '>= 12.13.0'}
-    peerDependencies:
-      webpack: ^5.0.0
-
   mini-css-extract-plugin@2.9.4:
     resolution: {integrity: sha512-ZWYT7ln73Hptxqxk2DxPU9MmapXRhxkJD6tkSR04dnQxm8BGu2hzgKLugK5yySD97u/8yy7Ma7E76k9ZdvtjkQ==}
     engines: {node: '>= 12.13.0'}
@@ -16590,9 +16693,6 @@ packages:
   tslib@1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
 
-  tslib@2.5.0:
-    resolution: {integrity: sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==}
-
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -17445,7 +17545,7 @@ snapshots:
       '@wordpress/api-fetch': 7.31.0
       '@wordpress/data': 10.31.0(react@18.3.1)
       '@wordpress/data-controls': 4.31.0(react@18.3.1)
-      '@wordpress/deprecated': 4.33.0
+      '@wordpress/deprecated': 4.32.0
       '@wordpress/element': 6.31.0
       '@wordpress/i18n': 5.26.0
       '@wordpress/primitives': 4.31.0(react@18.3.1)
@@ -22204,6 +22304,12 @@ snapshots:
       '@wordpress/dom-ready': 4.31.0
       '@wordpress/i18n': 6.4.0
 
+  '@wordpress/a11y@4.32.0':
+    dependencies:
+      '@babel/runtime': 7.28.4
+      '@wordpress/dom-ready': 4.32.0
+      '@wordpress/i18n': 6.5.0
+
   '@wordpress/a11y@4.33.0':
     dependencies:
       '@wordpress/dom-ready': 4.33.0
@@ -22241,8 +22347,8 @@ snapshots:
   '@wordpress/api-fetch@7.32.0':
     dependencies:
       '@babel/runtime': 7.28.4
-      '@wordpress/i18n': 6.6.0
-      '@wordpress/url': 4.33.0
+      '@wordpress/i18n': 6.5.0
+      '@wordpress/url': 4.32.0
 
   '@wordpress/autop@4.32.0':
     dependencies:
@@ -22261,7 +22367,7 @@ snapshots:
       '@babel/preset-typescript': 7.27.1(@babel/core@7.28.4)
       '@babel/runtime': 7.28.4
       '@wordpress/browserslist-config': 6.32.0
-      '@wordpress/warning': 3.33.0
+      '@wordpress/warning': 3.32.0
       browserslist: 4.24.5
       core-js: 3.38.1
       react: 18.3.1
@@ -22271,6 +22377,8 @@ snapshots:
   '@wordpress/base-styles@5.23.0': {}
 
   '@wordpress/base-styles@6.7.0': {}
+
+  '@wordpress/base-styles@6.8.0': {}
 
   '@wordpress/base-styles@6.9.0': {}
 
@@ -22298,7 +22406,7 @@ snapshots:
       '@wordpress/compose': 7.31.0(react@18.3.1)
       '@wordpress/data': 10.31.0(react@18.3.1)
       '@wordpress/date': 5.31.0
-      '@wordpress/deprecated': 4.33.0
+      '@wordpress/deprecated': 4.32.0
       '@wordpress/dom': 4.31.0
       '@wordpress/element': 6.31.0
       '@wordpress/escape-html': 3.31.0
@@ -22306,19 +22414,19 @@ snapshots:
       '@wordpress/html-entities': 4.31.0
       '@wordpress/i18n': 6.4.0
       '@wordpress/icons': 10.31.0(react@18.3.1)
-      '@wordpress/is-shallow-equal': 5.33.0
+      '@wordpress/is-shallow-equal': 5.32.0
       '@wordpress/keyboard-shortcuts': 5.32.0(react@18.3.1)
       '@wordpress/keycodes': 4.31.0
       '@wordpress/notices': 5.31.0(react@18.3.1)
       '@wordpress/preferences': 4.32.0(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/priority-queue': 3.33.0
-      '@wordpress/private-apis': 1.33.0
+      '@wordpress/priority-queue': 3.32.0
+      '@wordpress/private-apis': 1.32.0
       '@wordpress/rich-text': 7.31.0(react@18.3.1)
       '@wordpress/style-engine': 2.32.0
       '@wordpress/token-list': 3.31.0
       '@wordpress/upload-media': 0.16.0(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/url': 4.31.0
-      '@wordpress/warning': 3.33.0
+      '@wordpress/warning': 3.32.0
       '@wordpress/wordcount': 4.31.0
       change-case: 4.1.2
       clsx: 2.1.1
@@ -22358,7 +22466,7 @@ snapshots:
       '@wordpress/compose': 7.31.0(react@18.3.1)
       '@wordpress/data': 10.31.0(react@18.3.1)
       '@wordpress/date': 5.31.0
-      '@wordpress/deprecated': 4.33.0
+      '@wordpress/deprecated': 4.32.0
       '@wordpress/dom': 4.31.0
       '@wordpress/element': 6.31.0
       '@wordpress/escape-html': 3.31.0
@@ -22366,19 +22474,19 @@ snapshots:
       '@wordpress/html-entities': 4.31.0
       '@wordpress/i18n': 6.4.0
       '@wordpress/icons': 10.31.0(react@18.3.1)
-      '@wordpress/is-shallow-equal': 5.33.0
+      '@wordpress/is-shallow-equal': 5.32.0
       '@wordpress/keyboard-shortcuts': 5.32.0(react@18.3.1)
       '@wordpress/keycodes': 4.31.0
       '@wordpress/notices': 5.31.0(react@18.3.1)
       '@wordpress/preferences': 4.32.0(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/priority-queue': 3.33.0
-      '@wordpress/private-apis': 1.33.0
+      '@wordpress/priority-queue': 3.32.0
+      '@wordpress/private-apis': 1.32.0
       '@wordpress/rich-text': 7.31.0(react@18.3.1)
       '@wordpress/style-engine': 2.32.0
       '@wordpress/token-list': 3.31.0
       '@wordpress/upload-media': 0.16.0(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/url': 4.31.0
-      '@wordpress/warning': 3.33.0
+      '@wordpress/warning': 3.32.0
       '@wordpress/wordcount': 4.31.0
       change-case: 4.1.2
       clsx: 2.1.1
@@ -22418,7 +22526,7 @@ snapshots:
       '@wordpress/compose': 7.31.0(react@18.3.1)
       '@wordpress/data': 10.31.0(react@18.3.1)
       '@wordpress/date': 5.31.0
-      '@wordpress/deprecated': 4.33.0
+      '@wordpress/deprecated': 4.32.0
       '@wordpress/dom': 4.31.0
       '@wordpress/element': 6.31.0
       '@wordpress/escape-html': 3.31.0
@@ -22426,19 +22534,19 @@ snapshots:
       '@wordpress/html-entities': 4.31.0
       '@wordpress/i18n': 6.4.0
       '@wordpress/icons': 10.31.0(react@18.3.1)
-      '@wordpress/is-shallow-equal': 5.33.0
+      '@wordpress/is-shallow-equal': 5.32.0
       '@wordpress/keyboard-shortcuts': 5.32.0(react@18.3.1)
       '@wordpress/keycodes': 4.31.0
       '@wordpress/notices': 5.31.0(react@18.3.1)
       '@wordpress/preferences': 4.32.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/priority-queue': 3.33.0
-      '@wordpress/private-apis': 1.33.0
+      '@wordpress/priority-queue': 3.32.0
+      '@wordpress/private-apis': 1.32.0
       '@wordpress/rich-text': 7.31.0(react@18.3.1)
       '@wordpress/style-engine': 2.32.0
       '@wordpress/token-list': 3.31.0
       '@wordpress/upload-media': 0.16.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/url': 4.31.0
-      '@wordpress/warning': 3.33.0
+      '@wordpress/warning': 3.32.0
       '@wordpress/wordcount': 4.31.0
       change-case: 4.1.2
       clsx: 2.1.1
@@ -22468,37 +22576,37 @@ snapshots:
       '@emotion/react': 11.14.0(@types/react@18.3.25)(react@18.3.1)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@18.3.25)(react@18.3.1))(@types/react@18.3.25)(react@18.3.1)
       '@react-spring/web': 9.7.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/a11y': 4.33.0
+      '@wordpress/a11y': 4.32.0
       '@wordpress/api-fetch': 7.32.0
       '@wordpress/blob': 4.32.0
       '@wordpress/block-serialization-default-parser': 5.32.0
       '@wordpress/blocks': 15.5.0(react@18.3.1)
-      '@wordpress/commands': 1.32.0(@types/react-dom@18.3.7(@types/react@18.3.25))(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/components': 30.6.0(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/compose': 7.33.0(react@18.3.1)
-      '@wordpress/data': 10.33.0(react@18.3.1)
-      '@wordpress/date': 5.33.0
-      '@wordpress/deprecated': 4.33.0
-      '@wordpress/dom': 4.33.0
-      '@wordpress/element': 6.33.0
-      '@wordpress/escape-html': 3.33.0
-      '@wordpress/hooks': 4.33.0
-      '@wordpress/html-entities': 4.33.0
-      '@wordpress/i18n': 6.6.0
+      '@wordpress/commands': 1.33.0(@types/react-dom@18.3.7(@types/react@18.3.25))(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/components': 30.5.0(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/compose': 7.32.0(react@18.3.1)
+      '@wordpress/data': 10.32.0(react@18.3.1)
+      '@wordpress/date': 5.32.0
+      '@wordpress/deprecated': 4.32.0
+      '@wordpress/dom': 4.32.0
+      '@wordpress/element': 6.32.0
+      '@wordpress/escape-html': 3.32.0
+      '@wordpress/hooks': 4.32.0
+      '@wordpress/html-entities': 4.32.0
+      '@wordpress/i18n': 6.5.0
       '@wordpress/icons': 10.32.0(react@18.3.1)
-      '@wordpress/is-shallow-equal': 5.33.0
+      '@wordpress/is-shallow-equal': 5.32.0
       '@wordpress/keyboard-shortcuts': 5.32.0(react@18.3.1)
-      '@wordpress/keycodes': 4.33.0
+      '@wordpress/keycodes': 4.32.0
       '@wordpress/notices': 5.32.0(react@18.3.1)
       '@wordpress/preferences': 4.32.0(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/priority-queue': 3.33.0
-      '@wordpress/private-apis': 1.33.0
-      '@wordpress/rich-text': 7.33.0(react@18.3.1)
+      '@wordpress/priority-queue': 3.32.0
+      '@wordpress/private-apis': 1.32.0
+      '@wordpress/rich-text': 7.32.0(react@18.3.1)
       '@wordpress/style-engine': 2.32.0
       '@wordpress/token-list': 3.32.0
       '@wordpress/upload-media': 0.17.0(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/url': 4.33.0
-      '@wordpress/warning': 3.33.0
+      '@wordpress/url': 4.32.0
+      '@wordpress/warning': 3.32.0
       '@wordpress/wordcount': 4.32.0
       change-case: 4.1.2
       clsx: 2.1.1
@@ -22528,37 +22636,37 @@ snapshots:
       '@emotion/react': 11.14.0(@types/react@18.3.25)(react@18.3.1)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@18.3.25)(react@18.3.1))(@types/react@18.3.25)(react@18.3.1)
       '@react-spring/web': 9.7.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/a11y': 4.33.0
+      '@wordpress/a11y': 4.32.0
       '@wordpress/api-fetch': 7.32.0
       '@wordpress/blob': 4.32.0
       '@wordpress/block-serialization-default-parser': 5.32.0
       '@wordpress/blocks': 15.5.0(react@18.3.1)
-      '@wordpress/commands': 1.32.0(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/components': 30.6.0(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/compose': 7.33.0(react@18.3.1)
-      '@wordpress/data': 10.33.0(react@18.3.1)
-      '@wordpress/date': 5.33.0
-      '@wordpress/deprecated': 4.33.0
-      '@wordpress/dom': 4.33.0
-      '@wordpress/element': 6.33.0
-      '@wordpress/escape-html': 3.33.0
-      '@wordpress/hooks': 4.33.0
-      '@wordpress/html-entities': 4.33.0
-      '@wordpress/i18n': 6.6.0
+      '@wordpress/commands': 1.33.0(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/components': 30.5.0(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/compose': 7.32.0(react@18.3.1)
+      '@wordpress/data': 10.32.0(react@18.3.1)
+      '@wordpress/date': 5.32.0
+      '@wordpress/deprecated': 4.32.0
+      '@wordpress/dom': 4.32.0
+      '@wordpress/element': 6.32.0
+      '@wordpress/escape-html': 3.32.0
+      '@wordpress/hooks': 4.32.0
+      '@wordpress/html-entities': 4.32.0
+      '@wordpress/i18n': 6.5.0
       '@wordpress/icons': 10.32.0(react@18.3.1)
-      '@wordpress/is-shallow-equal': 5.33.0
+      '@wordpress/is-shallow-equal': 5.32.0
       '@wordpress/keyboard-shortcuts': 5.32.0(react@18.3.1)
-      '@wordpress/keycodes': 4.33.0
+      '@wordpress/keycodes': 4.32.0
       '@wordpress/notices': 5.32.0(react@18.3.1)
       '@wordpress/preferences': 4.32.0(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/priority-queue': 3.33.0
-      '@wordpress/private-apis': 1.33.0
-      '@wordpress/rich-text': 7.33.0(react@18.3.1)
+      '@wordpress/priority-queue': 3.32.0
+      '@wordpress/private-apis': 1.32.0
+      '@wordpress/rich-text': 7.32.0(react@18.3.1)
       '@wordpress/style-engine': 2.32.0
       '@wordpress/token-list': 3.32.0
       '@wordpress/upload-media': 0.17.0(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/url': 4.33.0
-      '@wordpress/warning': 3.33.0
+      '@wordpress/url': 4.32.0
+      '@wordpress/warning': 3.32.0
       '@wordpress/wordcount': 4.32.0
       change-case: 4.1.2
       clsx: 2.1.1
@@ -22588,37 +22696,37 @@ snapshots:
       '@emotion/react': 11.14.0(react@18.3.1)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(react@18.3.1))(react@18.3.1)
       '@react-spring/web': 9.7.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/a11y': 4.33.0
+      '@wordpress/a11y': 4.32.0
       '@wordpress/api-fetch': 7.32.0
       '@wordpress/blob': 4.32.0
       '@wordpress/block-serialization-default-parser': 5.32.0
       '@wordpress/blocks': 15.5.0(react@18.3.1)
-      '@wordpress/commands': 1.32.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/components': 30.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/compose': 7.33.0(react@18.3.1)
-      '@wordpress/data': 10.33.0(react@18.3.1)
-      '@wordpress/date': 5.33.0
-      '@wordpress/deprecated': 4.33.0
-      '@wordpress/dom': 4.33.0
-      '@wordpress/element': 6.33.0
-      '@wordpress/escape-html': 3.33.0
-      '@wordpress/hooks': 4.33.0
-      '@wordpress/html-entities': 4.33.0
-      '@wordpress/i18n': 6.6.0
+      '@wordpress/commands': 1.33.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/components': 30.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/compose': 7.32.0(react@18.3.1)
+      '@wordpress/data': 10.32.0(react@18.3.1)
+      '@wordpress/date': 5.32.0
+      '@wordpress/deprecated': 4.32.0
+      '@wordpress/dom': 4.32.0
+      '@wordpress/element': 6.32.0
+      '@wordpress/escape-html': 3.32.0
+      '@wordpress/hooks': 4.32.0
+      '@wordpress/html-entities': 4.32.0
+      '@wordpress/i18n': 6.5.0
       '@wordpress/icons': 10.32.0(react@18.3.1)
-      '@wordpress/is-shallow-equal': 5.33.0
+      '@wordpress/is-shallow-equal': 5.32.0
       '@wordpress/keyboard-shortcuts': 5.32.0(react@18.3.1)
-      '@wordpress/keycodes': 4.33.0
+      '@wordpress/keycodes': 4.32.0
       '@wordpress/notices': 5.32.0(react@18.3.1)
       '@wordpress/preferences': 4.32.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/priority-queue': 3.33.0
-      '@wordpress/private-apis': 1.33.0
-      '@wordpress/rich-text': 7.33.0(react@18.3.1)
+      '@wordpress/priority-queue': 3.32.0
+      '@wordpress/private-apis': 1.32.0
+      '@wordpress/rich-text': 7.32.0(react@18.3.1)
       '@wordpress/style-engine': 2.32.0
       '@wordpress/token-list': 3.32.0
       '@wordpress/upload-media': 0.17.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/url': 4.33.0
-      '@wordpress/warning': 3.33.0
+      '@wordpress/url': 4.32.0
+      '@wordpress/warning': 3.32.0
       '@wordpress/wordcount': 4.32.0
       change-case: 4.1.2
       clsx: 2.1.1
@@ -22656,7 +22764,7 @@ snapshots:
       '@wordpress/core-data': 7.31.0(@types/react-dom@18.3.7(@types/react@18.3.25))(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/data': 10.31.0(react@18.3.1)
       '@wordpress/date': 5.31.0
-      '@wordpress/deprecated': 4.33.0
+      '@wordpress/deprecated': 4.32.0
       '@wordpress/dom': 4.31.0
       '@wordpress/element': 6.31.0
       '@wordpress/escape-html': 3.31.0
@@ -22671,7 +22779,7 @@ snapshots:
       '@wordpress/notices': 5.31.0(react@18.3.1)
       '@wordpress/patterns': 2.32.0(@types/react-dom@18.3.7(@types/react@18.3.25))(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/primitives': 4.31.0(react@18.3.1)
-      '@wordpress/private-apis': 1.33.0
+      '@wordpress/private-apis': 1.32.0
       '@wordpress/reusable-blocks': 5.32.0(@types/react-dom@18.3.7(@types/react@18.3.25))(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/rich-text': 7.31.0(react@18.3.1)
       '@wordpress/server-side-render': 6.8.0(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -22711,7 +22819,7 @@ snapshots:
       '@wordpress/core-data': 7.31.0(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/data': 10.31.0(react@18.3.1)
       '@wordpress/date': 5.31.0
-      '@wordpress/deprecated': 4.33.0
+      '@wordpress/deprecated': 4.32.0
       '@wordpress/dom': 4.31.0
       '@wordpress/element': 6.31.0
       '@wordpress/escape-html': 3.31.0
@@ -22726,7 +22834,7 @@ snapshots:
       '@wordpress/notices': 5.31.0(react@18.3.1)
       '@wordpress/patterns': 2.32.0(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/primitives': 4.31.0(react@18.3.1)
-      '@wordpress/private-apis': 1.33.0
+      '@wordpress/private-apis': 1.32.0
       '@wordpress/reusable-blocks': 5.32.0(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/rich-text': 7.31.0(react@18.3.1)
       '@wordpress/server-side-render': 6.8.0(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -22766,7 +22874,7 @@ snapshots:
       '@wordpress/core-data': 7.31.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/data': 10.31.0(react@18.3.1)
       '@wordpress/date': 5.31.0
-      '@wordpress/deprecated': 4.33.0
+      '@wordpress/deprecated': 4.32.0
       '@wordpress/dom': 4.31.0
       '@wordpress/element': 6.31.0
       '@wordpress/escape-html': 3.31.0
@@ -22781,7 +22889,7 @@ snapshots:
       '@wordpress/notices': 5.31.0(react@18.3.1)
       '@wordpress/patterns': 2.32.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/primitives': 4.31.0(react@18.3.1)
-      '@wordpress/private-apis': 1.33.0
+      '@wordpress/private-apis': 1.32.0
       '@wordpress/reusable-blocks': 5.32.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/rich-text': 7.31.0(react@18.3.1)
       '@wordpress/server-side-render': 6.8.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -22822,17 +22930,17 @@ snapshots:
       '@wordpress/blob': 4.31.0
       '@wordpress/block-serialization-default-parser': 5.31.0
       '@wordpress/data': 10.31.0(react@18.3.1)
-      '@wordpress/deprecated': 4.33.0
+      '@wordpress/deprecated': 4.32.0
       '@wordpress/dom': 4.31.0
       '@wordpress/element': 6.31.0
       '@wordpress/hooks': 4.31.0
       '@wordpress/html-entities': 4.31.0
       '@wordpress/i18n': 6.4.0
-      '@wordpress/is-shallow-equal': 5.33.0
-      '@wordpress/private-apis': 1.33.0
+      '@wordpress/is-shallow-equal': 5.32.0
+      '@wordpress/private-apis': 1.32.0
       '@wordpress/rich-text': 7.31.0(react@18.3.1)
       '@wordpress/shortcode': 4.32.0
-      '@wordpress/warning': 3.33.0
+      '@wordpress/warning': 3.32.0
       change-case: 4.1.2
       colord: 2.9.3
       fast-deep-equal: 3.1.3
@@ -22852,18 +22960,18 @@ snapshots:
       '@wordpress/autop': 4.32.0
       '@wordpress/blob': 4.32.0
       '@wordpress/block-serialization-default-parser': 5.32.0
-      '@wordpress/data': 10.33.0(react@18.3.1)
-      '@wordpress/deprecated': 4.33.0
-      '@wordpress/dom': 4.33.0
-      '@wordpress/element': 6.33.0
-      '@wordpress/hooks': 4.33.0
-      '@wordpress/html-entities': 4.33.0
-      '@wordpress/i18n': 6.6.0
-      '@wordpress/is-shallow-equal': 5.33.0
-      '@wordpress/private-apis': 1.33.0
-      '@wordpress/rich-text': 7.33.0(react@18.3.1)
+      '@wordpress/data': 10.32.0(react@18.3.1)
+      '@wordpress/deprecated': 4.32.0
+      '@wordpress/dom': 4.32.0
+      '@wordpress/element': 6.32.0
+      '@wordpress/hooks': 4.32.0
+      '@wordpress/html-entities': 4.32.0
+      '@wordpress/i18n': 6.5.0
+      '@wordpress/is-shallow-equal': 5.32.0
+      '@wordpress/private-apis': 1.32.0
+      '@wordpress/rich-text': 7.32.0(react@18.3.1)
       '@wordpress/shortcode': 4.32.0
-      '@wordpress/warning': 3.33.0
+      '@wordpress/warning': 3.32.0
       change-case: 4.1.2
       colord: 2.9.3
       fast-deep-equal: 3.1.3
@@ -22881,7 +22989,7 @@ snapshots:
 
   '@wordpress/browserslist-config@6.32.0': {}
 
-  '@wordpress/commands@1.28.0(@types/react-dom@18.3.7(@types/react@18.3.25))(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@wordpress/commands@1.31.0(@types/react-dom@18.3.7(@types/react@18.3.25))(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.28.4
       '@wordpress/components': 30.4.0(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -22901,26 +23009,6 @@ snapshots:
       - '@types/react-dom'
       - supports-color
 
-  '@wordpress/commands@1.31.0(@types/react-dom@18.3.7(@types/react@18.3.25))(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@babel/runtime': 7.28.4
-      '@wordpress/components': 30.4.0(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/data': 10.31.0(react@18.3.1)
-      '@wordpress/element': 6.31.0
-      '@wordpress/i18n': 6.4.0
-      '@wordpress/icons': 10.31.0(react@18.3.1)
-      '@wordpress/keyboard-shortcuts': 5.32.0(react@18.3.1)
-      '@wordpress/private-apis': 1.33.0
-      clsx: 2.1.1
-      cmdk: 1.1.1(@types/react-dom@18.3.7(@types/react@18.3.25))(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-    transitivePeerDependencies:
-      - '@emotion/is-prop-valid'
-      - '@types/react'
-      - '@types/react-dom'
-      - supports-color
-
   '@wordpress/commands@1.31.0(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.28.4
@@ -22930,7 +23018,7 @@ snapshots:
       '@wordpress/i18n': 6.4.0
       '@wordpress/icons': 10.31.0(react@18.3.1)
       '@wordpress/keyboard-shortcuts': 5.32.0(react@18.3.1)
-      '@wordpress/private-apis': 1.33.0
+      '@wordpress/private-apis': 1.32.0
       clsx: 2.1.1
       cmdk: 1.1.1(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
@@ -22950,7 +23038,7 @@ snapshots:
       '@wordpress/i18n': 6.4.0
       '@wordpress/icons': 10.31.0(react@18.3.1)
       '@wordpress/keyboard-shortcuts': 5.32.0(react@18.3.1)
-      '@wordpress/private-apis': 1.33.0
+      '@wordpress/private-apis': 1.32.0
       clsx: 2.1.1
       cmdk: 1.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
@@ -22961,15 +23049,15 @@ snapshots:
       - '@types/react-dom'
       - supports-color
 
-  '@wordpress/commands@1.32.0(@types/react-dom@18.3.7(@types/react@18.3.25))(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@wordpress/commands@1.33.0(@types/react-dom@18.3.7(@types/react@18.3.25))(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.28.4
+      '@wordpress/base-styles': 6.9.0
       '@wordpress/components': 30.6.0(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/data': 10.33.0(react@18.3.1)
       '@wordpress/element': 6.33.0
       '@wordpress/i18n': 6.6.0
-      '@wordpress/icons': 10.32.0(react@18.3.1)
-      '@wordpress/keyboard-shortcuts': 5.32.0(react@18.3.1)
+      '@wordpress/icons': 11.0.0(react@18.3.1)
+      '@wordpress/keyboard-shortcuts': 5.33.0(react@18.3.1)
       '@wordpress/private-apis': 1.33.0
       clsx: 2.1.1
       cmdk: 1.1.1(@types/react-dom@18.3.7(@types/react@18.3.25))(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -22981,15 +23069,15 @@ snapshots:
       - '@types/react-dom'
       - supports-color
 
-  '@wordpress/commands@1.32.0(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@wordpress/commands@1.33.0(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.28.4
+      '@wordpress/base-styles': 6.9.0
       '@wordpress/components': 30.6.0(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/data': 10.33.0(react@18.3.1)
       '@wordpress/element': 6.33.0
       '@wordpress/i18n': 6.6.0
-      '@wordpress/icons': 10.32.0(react@18.3.1)
-      '@wordpress/keyboard-shortcuts': 5.32.0(react@18.3.1)
+      '@wordpress/icons': 11.0.0(react@18.3.1)
+      '@wordpress/keyboard-shortcuts': 5.33.0(react@18.3.1)
       '@wordpress/private-apis': 1.33.0
       clsx: 2.1.1
       cmdk: 1.1.1(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -23001,15 +23089,15 @@ snapshots:
       - '@types/react-dom'
       - supports-color
 
-  '@wordpress/commands@1.32.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@wordpress/commands@1.33.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.28.4
+      '@wordpress/base-styles': 6.9.0
       '@wordpress/components': 30.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/data': 10.33.0(react@18.3.1)
       '@wordpress/element': 6.33.0
       '@wordpress/i18n': 6.6.0
-      '@wordpress/icons': 10.32.0(react@18.3.1)
-      '@wordpress/keyboard-shortcuts': 5.32.0(react@18.3.1)
+      '@wordpress/icons': 11.0.0(react@18.3.1)
+      '@wordpress/keyboard-shortcuts': 5.33.0(react@18.3.1)
       '@wordpress/private-apis': 1.33.0
       clsx: 2.1.1
       cmdk: 1.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -23038,7 +23126,7 @@ snapshots:
       '@wordpress/a11y': 4.31.0
       '@wordpress/compose': 7.31.0(react@18.3.1)
       '@wordpress/date': 5.31.0
-      '@wordpress/deprecated': 4.33.0
+      '@wordpress/deprecated': 4.32.0
       '@wordpress/dom': 4.31.0
       '@wordpress/element': 6.31.0
       '@wordpress/escape-html': 3.31.0
@@ -23046,12 +23134,12 @@ snapshots:
       '@wordpress/html-entities': 4.31.0
       '@wordpress/i18n': 6.4.0
       '@wordpress/icons': 10.31.0(react@18.3.1)
-      '@wordpress/is-shallow-equal': 5.33.0
+      '@wordpress/is-shallow-equal': 5.32.0
       '@wordpress/keycodes': 4.31.0
       '@wordpress/primitives': 4.31.0(react@18.3.1)
-      '@wordpress/private-apis': 1.33.0
+      '@wordpress/private-apis': 1.32.0
       '@wordpress/rich-text': 7.31.0(react@18.3.1)
-      '@wordpress/warning': 3.33.0
+      '@wordpress/warning': 3.32.0
       change-case: 4.1.2
       clsx: 2.1.1
       colord: 2.9.3
@@ -23093,7 +23181,7 @@ snapshots:
       '@wordpress/a11y': 4.31.0
       '@wordpress/compose': 7.31.0(react@18.3.1)
       '@wordpress/date': 5.31.0
-      '@wordpress/deprecated': 4.33.0
+      '@wordpress/deprecated': 4.32.0
       '@wordpress/dom': 4.31.0
       '@wordpress/element': 6.31.0
       '@wordpress/escape-html': 3.31.0
@@ -23101,12 +23189,122 @@ snapshots:
       '@wordpress/html-entities': 4.31.0
       '@wordpress/i18n': 6.4.0
       '@wordpress/icons': 10.31.0(react@18.3.1)
-      '@wordpress/is-shallow-equal': 5.33.0
+      '@wordpress/is-shallow-equal': 5.32.0
       '@wordpress/keycodes': 4.31.0
       '@wordpress/primitives': 4.31.0(react@18.3.1)
-      '@wordpress/private-apis': 1.33.0
+      '@wordpress/private-apis': 1.32.0
       '@wordpress/rich-text': 7.31.0(react@18.3.1)
-      '@wordpress/warning': 3.33.0
+      '@wordpress/warning': 3.32.0
+      change-case: 4.1.2
+      clsx: 2.1.1
+      colord: 2.9.3
+      date-fns: 3.6.0
+      deepmerge: 4.3.1
+      fast-deep-equal: 3.1.3
+      framer-motion: 11.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      gradient-parser: 1.1.1
+      highlight-words-core: 1.2.3
+      is-plain-object: 5.0.0
+      memize: 2.1.1
+      path-to-regexp: 6.3.0
+      re-resizable: 6.11.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-colorful: 5.6.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-day-picker: 9.11.1(react@18.3.1)
+      react-dom: 18.3.1(react@18.3.1)
+      remove-accents: 0.5.0
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - '@emotion/is-prop-valid'
+      - '@types/react'
+      - supports-color
+
+  '@wordpress/components@30.5.0(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@ariakit/react': 0.4.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@babel/runtime': 7.28.4
+      '@emotion/cache': 11.14.0
+      '@emotion/css': 11.13.5
+      '@emotion/react': 11.14.0(@types/react@18.3.25)(react@18.3.1)
+      '@emotion/serialize': 1.3.3
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@18.3.25)(react@18.3.1))(@types/react@18.3.25)(react@18.3.1)
+      '@emotion/utils': 1.4.2
+      '@floating-ui/react-dom': 2.0.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@types/gradient-parser': 1.1.0
+      '@types/highlight-words-core': 1.2.1
+      '@use-gesture/react': 10.3.1(react@18.3.1)
+      '@wordpress/a11y': 4.32.0
+      '@wordpress/compose': 7.32.0(react@18.3.1)
+      '@wordpress/date': 5.32.0
+      '@wordpress/deprecated': 4.32.0
+      '@wordpress/dom': 4.32.0
+      '@wordpress/element': 6.32.0
+      '@wordpress/escape-html': 3.32.0
+      '@wordpress/hooks': 4.32.0
+      '@wordpress/html-entities': 4.32.0
+      '@wordpress/i18n': 6.5.0
+      '@wordpress/icons': 10.32.0(react@18.3.1)
+      '@wordpress/is-shallow-equal': 5.32.0
+      '@wordpress/keycodes': 4.32.0
+      '@wordpress/primitives': 4.32.0(react@18.3.1)
+      '@wordpress/private-apis': 1.32.0
+      '@wordpress/rich-text': 7.32.0(react@18.3.1)
+      '@wordpress/warning': 3.32.0
+      change-case: 4.1.2
+      clsx: 2.1.1
+      colord: 2.9.3
+      date-fns: 3.6.0
+      deepmerge: 4.3.1
+      fast-deep-equal: 3.1.3
+      framer-motion: 11.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      gradient-parser: 1.1.1
+      highlight-words-core: 1.2.3
+      is-plain-object: 5.0.0
+      memize: 2.1.1
+      path-to-regexp: 6.3.0
+      re-resizable: 6.11.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-colorful: 5.6.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-day-picker: 9.11.1(react@18.3.1)
+      react-dom: 18.3.1(react@18.3.1)
+      remove-accents: 0.5.0
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - '@emotion/is-prop-valid'
+      - '@types/react'
+      - supports-color
+
+  '@wordpress/components@30.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@ariakit/react': 0.4.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@babel/runtime': 7.28.4
+      '@emotion/cache': 11.14.0
+      '@emotion/css': 11.13.5
+      '@emotion/react': 11.14.0(react@18.3.1)
+      '@emotion/serialize': 1.3.3
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(react@18.3.1))(react@18.3.1)
+      '@emotion/utils': 1.4.2
+      '@floating-ui/react-dom': 2.0.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@types/gradient-parser': 1.1.0
+      '@types/highlight-words-core': 1.2.1
+      '@use-gesture/react': 10.3.1(react@18.3.1)
+      '@wordpress/a11y': 4.32.0
+      '@wordpress/compose': 7.32.0(react@18.3.1)
+      '@wordpress/date': 5.32.0
+      '@wordpress/deprecated': 4.32.0
+      '@wordpress/dom': 4.32.0
+      '@wordpress/element': 6.32.0
+      '@wordpress/escape-html': 3.32.0
+      '@wordpress/hooks': 4.32.0
+      '@wordpress/html-entities': 4.32.0
+      '@wordpress/i18n': 6.5.0
+      '@wordpress/icons': 10.32.0(react@18.3.1)
+      '@wordpress/is-shallow-equal': 5.32.0
+      '@wordpress/keycodes': 4.32.0
+      '@wordpress/primitives': 4.32.0(react@18.3.1)
+      '@wordpress/private-apis': 1.32.0
+      '@wordpress/rich-text': 7.32.0(react@18.3.1)
+      '@wordpress/warning': 3.32.0
       change-case: 4.1.2
       clsx: 2.1.1
       colord: 2.9.3
@@ -23245,13 +23443,13 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.28.4
       '@types/mousetrap': 1.6.15
-      '@wordpress/deprecated': 4.33.0
+      '@wordpress/deprecated': 4.32.0
       '@wordpress/dom': 4.31.0
       '@wordpress/element': 6.31.0
-      '@wordpress/is-shallow-equal': 5.33.0
+      '@wordpress/is-shallow-equal': 5.32.0
       '@wordpress/keycodes': 4.31.0
-      '@wordpress/priority-queue': 3.33.0
-      '@wordpress/undo-manager': 1.33.0
+      '@wordpress/priority-queue': 3.32.0
+      '@wordpress/undo-manager': 1.32.0
       change-case: 4.1.2
       clipboard: 2.0.11
       mousetrap: 1.6.5
@@ -23262,13 +23460,30 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.28.4
       '@types/mousetrap': 1.6.15
-      '@wordpress/deprecated': 4.33.0
+      '@wordpress/deprecated': 4.32.0
       '@wordpress/dom': 4.31.0
       '@wordpress/element': 6.31.0
-      '@wordpress/is-shallow-equal': 5.33.0
+      '@wordpress/is-shallow-equal': 5.32.0
       '@wordpress/keycodes': 4.31.0
-      '@wordpress/priority-queue': 3.33.0
-      '@wordpress/undo-manager': 1.33.0
+      '@wordpress/priority-queue': 3.32.0
+      '@wordpress/undo-manager': 1.32.0
+      change-case: 4.1.2
+      clipboard: 2.0.11
+      mousetrap: 1.6.5
+      react: 18.3.1
+      use-memo-one: 1.1.3(react@18.3.1)
+
+  '@wordpress/compose@7.32.0(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.28.4
+      '@types/mousetrap': 1.6.15
+      '@wordpress/deprecated': 4.32.0
+      '@wordpress/dom': 4.32.0
+      '@wordpress/element': 6.32.0
+      '@wordpress/is-shallow-equal': 5.32.0
+      '@wordpress/keycodes': 4.32.0
+      '@wordpress/priority-queue': 3.32.0
+      '@wordpress/undo-manager': 1.32.0
       change-case: 4.1.2
       clipboard: 2.0.11
       mousetrap: 1.6.5
@@ -23299,17 +23514,17 @@ snapshots:
       '@wordpress/blocks': 15.4.0(react@18.3.1)
       '@wordpress/compose': 7.31.0(react@18.3.1)
       '@wordpress/data': 10.31.0(react@18.3.1)
-      '@wordpress/deprecated': 4.33.0
+      '@wordpress/deprecated': 4.32.0
       '@wordpress/element': 6.31.0
       '@wordpress/html-entities': 4.31.0
       '@wordpress/i18n': 6.4.0
-      '@wordpress/is-shallow-equal': 5.33.0
-      '@wordpress/private-apis': 1.33.0
+      '@wordpress/is-shallow-equal': 5.32.0
+      '@wordpress/private-apis': 1.32.0
       '@wordpress/rich-text': 7.31.0(react@18.3.1)
       '@wordpress/sync': 1.32.0
-      '@wordpress/undo-manager': 1.33.0
+      '@wordpress/undo-manager': 1.32.0
       '@wordpress/url': 4.31.0
-      '@wordpress/warning': 3.33.0
+      '@wordpress/warning': 3.32.0
       change-case: 4.1.2
       equivalent-key-map: 0.2.2
       fast-deep-equal: 3.1.3
@@ -23333,17 +23548,17 @@ snapshots:
       '@wordpress/blocks': 15.4.0(react@18.3.1)
       '@wordpress/compose': 7.31.0(react@18.3.1)
       '@wordpress/data': 10.31.0(react@18.3.1)
-      '@wordpress/deprecated': 4.33.0
+      '@wordpress/deprecated': 4.32.0
       '@wordpress/element': 6.31.0
       '@wordpress/html-entities': 4.31.0
       '@wordpress/i18n': 6.4.0
-      '@wordpress/is-shallow-equal': 5.33.0
-      '@wordpress/private-apis': 1.33.0
+      '@wordpress/is-shallow-equal': 5.32.0
+      '@wordpress/private-apis': 1.32.0
       '@wordpress/rich-text': 7.31.0(react@18.3.1)
       '@wordpress/sync': 1.32.0
-      '@wordpress/undo-manager': 1.33.0
+      '@wordpress/undo-manager': 1.32.0
       '@wordpress/url': 4.31.0
-      '@wordpress/warning': 3.33.0
+      '@wordpress/warning': 3.32.0
       change-case: 4.1.2
       equivalent-key-map: 0.2.2
       fast-deep-equal: 3.1.3
@@ -23367,17 +23582,17 @@ snapshots:
       '@wordpress/blocks': 15.4.0(react@18.3.1)
       '@wordpress/compose': 7.31.0(react@18.3.1)
       '@wordpress/data': 10.31.0(react@18.3.1)
-      '@wordpress/deprecated': 4.33.0
+      '@wordpress/deprecated': 4.32.0
       '@wordpress/element': 6.31.0
       '@wordpress/html-entities': 4.31.0
       '@wordpress/i18n': 6.4.0
-      '@wordpress/is-shallow-equal': 5.33.0
-      '@wordpress/private-apis': 1.33.0
+      '@wordpress/is-shallow-equal': 5.32.0
+      '@wordpress/private-apis': 1.32.0
       '@wordpress/rich-text': 7.31.0(react@18.3.1)
       '@wordpress/sync': 1.32.0
-      '@wordpress/undo-manager': 1.33.0
+      '@wordpress/undo-manager': 1.32.0
       '@wordpress/url': 4.31.0
-      '@wordpress/warning': 3.33.0
+      '@wordpress/warning': 3.32.0
       change-case: 4.1.2
       equivalent-key-map: 0.2.2
       fast-deep-equal: 3.1.3
@@ -23399,19 +23614,19 @@ snapshots:
       '@wordpress/api-fetch': 7.32.0
       '@wordpress/block-editor': 15.5.0(@types/react-dom@18.3.7(@types/react@18.3.25))(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/blocks': 15.5.0(react@18.3.1)
-      '@wordpress/compose': 7.33.0(react@18.3.1)
-      '@wordpress/data': 10.33.0(react@18.3.1)
-      '@wordpress/deprecated': 4.33.0
-      '@wordpress/element': 6.33.0
-      '@wordpress/html-entities': 4.33.0
-      '@wordpress/i18n': 6.6.0
-      '@wordpress/is-shallow-equal': 5.33.0
-      '@wordpress/private-apis': 1.33.0
-      '@wordpress/rich-text': 7.33.0(react@18.3.1)
+      '@wordpress/compose': 7.32.0(react@18.3.1)
+      '@wordpress/data': 10.32.0(react@18.3.1)
+      '@wordpress/deprecated': 4.32.0
+      '@wordpress/element': 6.32.0
+      '@wordpress/html-entities': 4.32.0
+      '@wordpress/i18n': 6.5.0
+      '@wordpress/is-shallow-equal': 5.32.0
+      '@wordpress/private-apis': 1.32.0
+      '@wordpress/rich-text': 7.32.0(react@18.3.1)
       '@wordpress/sync': 1.32.0
-      '@wordpress/undo-manager': 1.33.0
-      '@wordpress/url': 4.33.0
-      '@wordpress/warning': 3.33.0
+      '@wordpress/undo-manager': 1.32.0
+      '@wordpress/url': 4.32.0
+      '@wordpress/warning': 3.32.0
       change-case: 4.1.2
       equivalent-key-map: 0.2.2
       fast-deep-equal: 3.1.3
@@ -23433,19 +23648,19 @@ snapshots:
       '@wordpress/api-fetch': 7.32.0
       '@wordpress/block-editor': 15.5.0(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/blocks': 15.5.0(react@18.3.1)
-      '@wordpress/compose': 7.33.0(react@18.3.1)
-      '@wordpress/data': 10.33.0(react@18.3.1)
-      '@wordpress/deprecated': 4.33.0
-      '@wordpress/element': 6.33.0
-      '@wordpress/html-entities': 4.33.0
-      '@wordpress/i18n': 6.6.0
-      '@wordpress/is-shallow-equal': 5.33.0
-      '@wordpress/private-apis': 1.33.0
-      '@wordpress/rich-text': 7.33.0(react@18.3.1)
+      '@wordpress/compose': 7.32.0(react@18.3.1)
+      '@wordpress/data': 10.32.0(react@18.3.1)
+      '@wordpress/deprecated': 4.32.0
+      '@wordpress/element': 6.32.0
+      '@wordpress/html-entities': 4.32.0
+      '@wordpress/i18n': 6.5.0
+      '@wordpress/is-shallow-equal': 5.32.0
+      '@wordpress/private-apis': 1.32.0
+      '@wordpress/rich-text': 7.32.0(react@18.3.1)
       '@wordpress/sync': 1.32.0
-      '@wordpress/undo-manager': 1.33.0
-      '@wordpress/url': 4.33.0
-      '@wordpress/warning': 3.33.0
+      '@wordpress/undo-manager': 1.32.0
+      '@wordpress/url': 4.32.0
+      '@wordpress/warning': 3.32.0
       change-case: 4.1.2
       equivalent-key-map: 0.2.2
       fast-deep-equal: 3.1.3
@@ -23467,19 +23682,19 @@ snapshots:
       '@wordpress/api-fetch': 7.32.0
       '@wordpress/block-editor': 15.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/blocks': 15.5.0(react@18.3.1)
-      '@wordpress/compose': 7.33.0(react@18.3.1)
-      '@wordpress/data': 10.33.0(react@18.3.1)
-      '@wordpress/deprecated': 4.33.0
-      '@wordpress/element': 6.33.0
-      '@wordpress/html-entities': 4.33.0
-      '@wordpress/i18n': 6.6.0
-      '@wordpress/is-shallow-equal': 5.33.0
-      '@wordpress/private-apis': 1.33.0
-      '@wordpress/rich-text': 7.33.0(react@18.3.1)
+      '@wordpress/compose': 7.32.0(react@18.3.1)
+      '@wordpress/data': 10.32.0(react@18.3.1)
+      '@wordpress/deprecated': 4.32.0
+      '@wordpress/element': 6.32.0
+      '@wordpress/html-entities': 4.32.0
+      '@wordpress/i18n': 6.5.0
+      '@wordpress/is-shallow-equal': 5.32.0
+      '@wordpress/private-apis': 1.32.0
+      '@wordpress/rich-text': 7.32.0(react@18.3.1)
       '@wordpress/sync': 1.32.0
-      '@wordpress/undo-manager': 1.33.0
-      '@wordpress/url': 4.33.0
-      '@wordpress/warning': 3.33.0
+      '@wordpress/undo-manager': 1.32.0
+      '@wordpress/url': 4.32.0
+      '@wordpress/warning': 3.32.0
       change-case: 4.1.2
       equivalent-key-map: 0.2.2
       fast-deep-equal: 3.1.3
@@ -23500,19 +23715,38 @@ snapshots:
       '@babel/runtime': 7.28.4
       '@wordpress/api-fetch': 7.31.0
       '@wordpress/data': 10.31.0(react@18.3.1)
-      '@wordpress/deprecated': 4.33.0
+      '@wordpress/deprecated': 4.32.0
       react: 18.3.1
 
   '@wordpress/data@10.31.0(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.28.4
       '@wordpress/compose': 7.31.0(react@18.3.1)
-      '@wordpress/deprecated': 4.33.0
+      '@wordpress/deprecated': 4.32.0
       '@wordpress/element': 6.31.0
-      '@wordpress/is-shallow-equal': 5.33.0
-      '@wordpress/priority-queue': 3.33.0
-      '@wordpress/private-apis': 1.33.0
-      '@wordpress/redux-routine': 5.33.0(redux@5.0.1)
+      '@wordpress/is-shallow-equal': 5.32.0
+      '@wordpress/priority-queue': 3.32.0
+      '@wordpress/private-apis': 1.32.0
+      '@wordpress/redux-routine': 5.32.0(redux@5.0.1)
+      deepmerge: 4.3.1
+      equivalent-key-map: 0.2.2
+      is-plain-object: 5.0.0
+      is-promise: 4.0.0
+      react: 18.3.1
+      redux: 5.0.1
+      rememo: 4.0.2
+      use-memo-one: 1.1.3(react@18.3.1)
+
+  '@wordpress/data@10.32.0(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.28.4
+      '@wordpress/compose': 7.32.0(react@18.3.1)
+      '@wordpress/deprecated': 4.32.0
+      '@wordpress/element': 6.32.0
+      '@wordpress/is-shallow-equal': 5.32.0
+      '@wordpress/priority-queue': 3.32.0
+      '@wordpress/private-apis': 1.32.0
+      '@wordpress/redux-routine': 5.32.0(redux@5.0.1)
       deepmerge: 4.3.1
       equivalent-key-map: 0.2.2
       is-plain-object: 5.0.0
@@ -23638,18 +23872,18 @@ snapshots:
     dependencies:
       '@ariakit/react': 0.4.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@babel/runtime': 7.28.4
-      '@wordpress/base-styles': 6.9.0
-      '@wordpress/components': 30.6.0(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/compose': 7.33.0(react@18.3.1)
-      '@wordpress/data': 10.33.0(react@18.3.1)
-      '@wordpress/element': 6.33.0
-      '@wordpress/i18n': 6.6.0
+      '@wordpress/base-styles': 6.8.0
+      '@wordpress/components': 30.5.0(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/compose': 7.32.0(react@18.3.1)
+      '@wordpress/data': 10.32.0(react@18.3.1)
+      '@wordpress/element': 6.32.0
+      '@wordpress/i18n': 6.5.0
       '@wordpress/icons': 10.32.0(react@18.3.1)
-      '@wordpress/keycodes': 4.33.0
-      '@wordpress/primitives': 4.33.0(react@18.3.1)
-      '@wordpress/private-apis': 1.33.0
-      '@wordpress/url': 4.33.0
-      '@wordpress/warning': 3.33.0
+      '@wordpress/keycodes': 4.32.0
+      '@wordpress/primitives': 4.32.0(react@18.3.1)
+      '@wordpress/private-apis': 1.32.0
+      '@wordpress/url': 4.32.0
+      '@wordpress/warning': 3.32.0
       clsx: 2.1.1
       react: 18.3.1
       remove-accents: 0.5.0
@@ -23661,8 +23895,8 @@ snapshots:
       '@emotion/utils': 1.4.2
       '@floating-ui/react-dom': 2.0.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@use-gesture/react': 10.3.1(react@18.3.1)
-      '@wordpress/date': 5.33.0
-      '@wordpress/hooks': 4.33.0
+      '@wordpress/date': 5.32.0
+      '@wordpress/hooks': 4.32.0
       change-case: 4.1.2
       colord: 2.9.3
       date-fns: 4.1.0
@@ -23686,18 +23920,18 @@ snapshots:
     dependencies:
       '@ariakit/react': 0.4.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@babel/runtime': 7.28.4
-      '@wordpress/base-styles': 6.9.0
-      '@wordpress/components': 30.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/compose': 7.33.0(react@18.3.1)
-      '@wordpress/data': 10.33.0(react@18.3.1)
-      '@wordpress/element': 6.33.0
-      '@wordpress/i18n': 6.6.0
+      '@wordpress/base-styles': 6.8.0
+      '@wordpress/components': 30.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/compose': 7.32.0(react@18.3.1)
+      '@wordpress/data': 10.32.0(react@18.3.1)
+      '@wordpress/element': 6.32.0
+      '@wordpress/i18n': 6.5.0
       '@wordpress/icons': 10.32.0(react@18.3.1)
-      '@wordpress/keycodes': 4.33.0
-      '@wordpress/primitives': 4.33.0(react@18.3.1)
-      '@wordpress/private-apis': 1.33.0
-      '@wordpress/url': 4.33.0
-      '@wordpress/warning': 3.33.0
+      '@wordpress/keycodes': 4.32.0
+      '@wordpress/primitives': 4.32.0(react@18.3.1)
+      '@wordpress/private-apis': 1.32.0
+      '@wordpress/url': 4.32.0
+      '@wordpress/warning': 3.32.0
       clsx: 2.1.1
       react: 18.3.1
       remove-accents: 0.5.0
@@ -23709,8 +23943,8 @@ snapshots:
       '@emotion/utils': 1.4.2
       '@floating-ui/react-dom': 2.0.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@use-gesture/react': 10.3.1(react@18.3.1)
-      '@wordpress/date': 5.33.0
-      '@wordpress/hooks': 4.33.0
+      '@wordpress/date': 5.32.0
+      '@wordpress/hooks': 4.32.0
       change-case: 4.1.2
       colord: 2.9.3
       date-fns: 4.1.0
@@ -23733,7 +23967,14 @@ snapshots:
   '@wordpress/date@5.31.0':
     dependencies:
       '@babel/runtime': 7.28.4
-      '@wordpress/deprecated': 4.33.0
+      '@wordpress/deprecated': 4.32.0
+      moment: 2.30.1
+      moment-timezone: 0.5.48
+
+  '@wordpress/date@5.32.0':
+    dependencies:
+      '@babel/runtime': 7.28.4
+      '@wordpress/deprecated': 4.32.0
       moment: 2.30.1
       moment-timezone: 0.5.48
 
@@ -23748,6 +23989,11 @@ snapshots:
       json2php: 0.0.7
       webpack: 5.101.3(webpack-cli@6.0.1)
 
+  '@wordpress/deprecated@4.32.0':
+    dependencies:
+      '@babel/runtime': 7.28.4
+      '@wordpress/hooks': 4.32.0
+
   '@wordpress/deprecated@4.33.0':
     dependencies:
       '@wordpress/hooks': 4.33.0
@@ -23756,12 +24002,21 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.28.4
 
+  '@wordpress/dom-ready@4.32.0':
+    dependencies:
+      '@babel/runtime': 7.28.4
+
   '@wordpress/dom-ready@4.33.0': {}
 
   '@wordpress/dom@4.31.0':
     dependencies:
       '@babel/runtime': 7.28.4
-      '@wordpress/deprecated': 4.33.0
+      '@wordpress/deprecated': 4.32.0
+
+  '@wordpress/dom@4.32.0':
+    dependencies:
+      '@babel/runtime': 7.28.4
+      '@wordpress/deprecated': 4.32.0
 
   '@wordpress/dom@4.33.0':
     dependencies:
@@ -23797,7 +24052,7 @@ snapshots:
       '@wordpress/compose': 7.31.0(react@18.3.1)
       '@wordpress/core-data': 7.31.0(@types/react-dom@18.3.7(@types/react@18.3.25))(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/data': 10.31.0(react@18.3.1)
-      '@wordpress/deprecated': 4.33.0
+      '@wordpress/deprecated': 4.32.0
       '@wordpress/dom': 4.31.0
       '@wordpress/editor': 14.31.0(@types/react-dom@18.3.7(@types/react@18.3.25))(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/element': 6.31.0
@@ -23810,10 +24065,10 @@ snapshots:
       '@wordpress/notices': 5.31.0(react@18.3.1)
       '@wordpress/plugins': 7.31.0(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/preferences': 4.32.0(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/private-apis': 1.33.0
+      '@wordpress/private-apis': 1.32.0
       '@wordpress/url': 4.31.0
       '@wordpress/viewport': 6.31.0(react@18.3.1)
-      '@wordpress/warning': 3.33.0
+      '@wordpress/warning': 3.32.0
       '@wordpress/widgets': 4.31.0(@types/react-dom@18.3.7(@types/react@18.3.25))(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       clsx: 2.1.1
       memize: 2.1.1
@@ -23840,7 +24095,7 @@ snapshots:
       '@wordpress/compose': 7.31.0(react@18.3.1)
       '@wordpress/core-data': 7.31.0(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/data': 10.31.0(react@18.3.1)
-      '@wordpress/deprecated': 4.33.0
+      '@wordpress/deprecated': 4.32.0
       '@wordpress/dom': 4.31.0
       '@wordpress/editor': 14.31.0(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/element': 6.31.0
@@ -23853,10 +24108,10 @@ snapshots:
       '@wordpress/notices': 5.31.0(react@18.3.1)
       '@wordpress/plugins': 7.31.0(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/preferences': 4.32.0(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/private-apis': 1.33.0
+      '@wordpress/private-apis': 1.32.0
       '@wordpress/url': 4.31.0
       '@wordpress/viewport': 6.31.0(react@18.3.1)
-      '@wordpress/warning': 3.33.0
+      '@wordpress/warning': 3.32.0
       '@wordpress/widgets': 4.31.0(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       clsx: 2.1.1
       memize: 2.1.1
@@ -23883,7 +24138,7 @@ snapshots:
       '@wordpress/compose': 7.31.0(react@18.3.1)
       '@wordpress/core-data': 7.31.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/data': 10.31.0(react@18.3.1)
-      '@wordpress/deprecated': 4.33.0
+      '@wordpress/deprecated': 4.32.0
       '@wordpress/dom': 4.31.0
       '@wordpress/editor': 14.31.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/element': 6.31.0
@@ -23896,10 +24151,10 @@ snapshots:
       '@wordpress/notices': 5.31.0(react@18.3.1)
       '@wordpress/plugins': 7.31.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/preferences': 4.32.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/private-apis': 1.33.0
+      '@wordpress/private-apis': 1.32.0
       '@wordpress/url': 4.31.0
       '@wordpress/viewport': 6.31.0(react@18.3.1)
-      '@wordpress/warning': 3.33.0
+      '@wordpress/warning': 3.32.0
       '@wordpress/widgets': 4.31.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       clsx: 2.1.1
       memize: 2.1.1
@@ -23928,7 +24183,7 @@ snapshots:
       '@wordpress/data': 10.31.0(react@18.3.1)
       '@wordpress/dataviews': 9.1.0(patch_hash=9971bdb899e2fb0a4421ab8b7f0a54a41f03b10ef1b51d72946e94f4279e05c1)(@types/react@18.3.25)(react@18.3.1)
       '@wordpress/date': 5.31.0
-      '@wordpress/deprecated': 4.33.0
+      '@wordpress/deprecated': 4.32.0
       '@wordpress/dom': 4.31.0
       '@wordpress/element': 6.31.0
       '@wordpress/fields': 0.23.0(@types/react-dom@18.3.7(@types/react@18.3.25))(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -23944,12 +24199,12 @@ snapshots:
       '@wordpress/patterns': 2.32.0(@types/react-dom@18.3.7(@types/react@18.3.25))(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/plugins': 7.31.0(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/preferences': 4.32.0(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/private-apis': 1.33.0
+      '@wordpress/private-apis': 1.32.0
       '@wordpress/reusable-blocks': 5.32.0(@types/react-dom@18.3.7(@types/react@18.3.25))(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/rich-text': 7.31.0(react@18.3.1)
       '@wordpress/server-side-render': 6.8.0(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/url': 4.31.0
-      '@wordpress/warning': 3.33.0
+      '@wordpress/warning': 3.32.0
       '@wordpress/wordcount': 4.31.0
       change-case: 4.1.2
       client-zip: 2.5.0
@@ -23987,7 +24242,7 @@ snapshots:
       '@wordpress/data': 10.31.0(react@18.3.1)
       '@wordpress/dataviews': 9.1.0(patch_hash=9971bdb899e2fb0a4421ab8b7f0a54a41f03b10ef1b51d72946e94f4279e05c1)(@types/react@18.3.25)(react@18.3.1)
       '@wordpress/date': 5.31.0
-      '@wordpress/deprecated': 4.33.0
+      '@wordpress/deprecated': 4.32.0
       '@wordpress/dom': 4.31.0
       '@wordpress/element': 6.31.0
       '@wordpress/fields': 0.23.0(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -24003,12 +24258,12 @@ snapshots:
       '@wordpress/patterns': 2.32.0(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/plugins': 7.31.0(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/preferences': 4.32.0(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/private-apis': 1.33.0
+      '@wordpress/private-apis': 1.32.0
       '@wordpress/reusable-blocks': 5.32.0(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/rich-text': 7.31.0(react@18.3.1)
       '@wordpress/server-side-render': 6.8.0(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/url': 4.31.0
-      '@wordpress/warning': 3.33.0
+      '@wordpress/warning': 3.32.0
       '@wordpress/wordcount': 4.31.0
       change-case: 4.1.2
       client-zip: 2.5.0
@@ -24046,7 +24301,7 @@ snapshots:
       '@wordpress/data': 10.31.0(react@18.3.1)
       '@wordpress/dataviews': 9.1.0(patch_hash=9971bdb899e2fb0a4421ab8b7f0a54a41f03b10ef1b51d72946e94f4279e05c1)(react@18.3.1)
       '@wordpress/date': 5.31.0
-      '@wordpress/deprecated': 4.33.0
+      '@wordpress/deprecated': 4.32.0
       '@wordpress/dom': 4.31.0
       '@wordpress/element': 6.31.0
       '@wordpress/fields': 0.23.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -24062,12 +24317,12 @@ snapshots:
       '@wordpress/patterns': 2.32.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/plugins': 7.31.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/preferences': 4.32.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/private-apis': 1.33.0
+      '@wordpress/private-apis': 1.32.0
       '@wordpress/reusable-blocks': 5.32.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/rich-text': 7.31.0(react@18.3.1)
       '@wordpress/server-side-render': 6.8.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/url': 4.31.0
-      '@wordpress/warning': 3.33.0
+      '@wordpress/warning': 3.32.0
       '@wordpress/wordcount': 4.31.0
       change-case: 4.1.2
       client-zip: 2.5.0
@@ -24101,6 +24356,17 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
+  '@wordpress/element@6.32.0':
+    dependencies:
+      '@babel/runtime': 7.28.4
+      '@types/react': 18.3.25
+      '@types/react-dom': 18.3.7(@types/react@18.3.25)
+      '@wordpress/escape-html': 3.32.0
+      change-case: 4.1.2
+      is-plain-object: 5.0.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
   '@wordpress/element@6.33.0':
     dependencies:
       '@types/react': 18.3.25
@@ -24112,6 +24378,10 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
 
   '@wordpress/escape-html@3.31.0':
+    dependencies:
+      '@babel/runtime': 7.28.4
+
+  '@wordpress/escape-html@3.32.0':
     dependencies:
       '@babel/runtime': 7.28.4
 
@@ -24164,10 +24434,10 @@ snapshots:
       '@wordpress/notices': 5.31.0(react@18.3.1)
       '@wordpress/patterns': 2.32.0(@types/react-dom@18.3.7(@types/react@18.3.25))(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/primitives': 4.31.0(react@18.3.1)
-      '@wordpress/private-apis': 1.33.0
+      '@wordpress/private-apis': 1.32.0
       '@wordpress/router': 1.32.0(react@18.3.1)
       '@wordpress/url': 4.31.0
-      '@wordpress/warning': 3.33.0
+      '@wordpress/warning': 3.32.0
       change-case: 4.1.2
       client-zip: 2.5.0
       clsx: 2.1.1
@@ -24204,10 +24474,10 @@ snapshots:
       '@wordpress/notices': 5.31.0(react@18.3.1)
       '@wordpress/patterns': 2.32.0(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/primitives': 4.31.0(react@18.3.1)
-      '@wordpress/private-apis': 1.33.0
+      '@wordpress/private-apis': 1.32.0
       '@wordpress/router': 1.32.0(react@18.3.1)
       '@wordpress/url': 4.31.0
-      '@wordpress/warning': 3.33.0
+      '@wordpress/warning': 3.32.0
       change-case: 4.1.2
       client-zip: 2.5.0
       clsx: 2.1.1
@@ -24244,10 +24514,10 @@ snapshots:
       '@wordpress/notices': 5.31.0(react@18.3.1)
       '@wordpress/patterns': 2.32.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/primitives': 4.31.0(react@18.3.1)
-      '@wordpress/private-apis': 1.33.0
+      '@wordpress/private-apis': 1.32.0
       '@wordpress/router': 1.32.0(react@18.3.1)
       '@wordpress/url': 4.31.0
-      '@wordpress/warning': 3.33.0
+      '@wordpress/warning': 3.32.0
       change-case: 4.1.2
       client-zip: 2.5.0
       clsx: 2.1.1
@@ -24274,7 +24544,7 @@ snapshots:
       '@wordpress/html-entities': 4.31.0
       '@wordpress/i18n': 6.4.0
       '@wordpress/icons': 10.31.0(react@18.3.1)
-      '@wordpress/private-apis': 1.33.0
+      '@wordpress/private-apis': 1.32.0
       '@wordpress/rich-text': 7.31.0(react@18.3.1)
       '@wordpress/url': 4.31.0
       react: 18.3.1
@@ -24289,9 +24559,17 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.28.4
 
+  '@wordpress/hooks@4.32.0':
+    dependencies:
+      '@babel/runtime': 7.28.4
+
   '@wordpress/hooks@4.33.0': {}
 
   '@wordpress/html-entities@4.31.0':
+    dependencies:
+      '@babel/runtime': 7.28.4
+
+  '@wordpress/html-entities@4.32.0':
     dependencies:
       '@babel/runtime': 7.28.4
 
@@ -24315,6 +24593,15 @@ snapshots:
       memize: 2.1.1
       tannin: 1.2.0
 
+  '@wordpress/i18n@6.5.0':
+    dependencies:
+      '@babel/runtime': 7.28.4
+      '@tannin/sprintf': 1.3.3
+      '@wordpress/hooks': 4.32.0
+      gettext-parser: 1.4.0
+      memize: 2.1.1
+      tannin: 1.2.0
+
   '@wordpress/i18n@6.6.0':
     dependencies:
       '@tannin/sprintf': 1.3.3
@@ -24333,8 +24620,8 @@ snapshots:
   '@wordpress/icons@10.32.0(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.28.4
-      '@wordpress/element': 6.33.0
-      '@wordpress/primitives': 4.33.0(react@18.3.1)
+      '@wordpress/element': 6.32.0
+      '@wordpress/primitives': 4.32.0(react@18.3.1)
       react: 18.3.1
 
   '@wordpress/icons@11.0.0(react@18.3.1)':
@@ -24345,7 +24632,7 @@ snapshots:
 
   '@wordpress/interactivity-router@2.32.0':
     dependencies:
-      '@wordpress/a11y': 4.33.0
+      '@wordpress/a11y': 4.32.0
       '@wordpress/interactivity': 6.32.0
       es-module-lexer: 1.7.0
 
@@ -24366,7 +24653,7 @@ snapshots:
       '@wordpress/components': 30.4.0(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/compose': 7.31.0(react@18.3.1)
       '@wordpress/data': 10.31.0(react@18.3.1)
-      '@wordpress/deprecated': 4.33.0
+      '@wordpress/deprecated': 4.32.0
       '@wordpress/element': 6.31.0
       '@wordpress/i18n': 6.4.0
       '@wordpress/icons': 10.31.0(react@18.3.1)
@@ -24388,7 +24675,7 @@ snapshots:
       '@wordpress/components': 30.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/compose': 7.31.0(react@18.3.1)
       '@wordpress/data': 10.31.0(react@18.3.1)
-      '@wordpress/deprecated': 4.33.0
+      '@wordpress/deprecated': 4.32.0
       '@wordpress/element': 6.31.0
       '@wordpress/i18n': 6.4.0
       '@wordpress/icons': 10.31.0(react@18.3.1)
@@ -24403,6 +24690,10 @@ snapshots:
       - '@types/react'
       - supports-color
 
+  '@wordpress/is-shallow-equal@5.32.0':
+    dependencies:
+      '@babel/runtime': 7.28.4
+
   '@wordpress/is-shallow-equal@5.33.0': {}
 
   '@wordpress/jest-console@8.31.0(jest@30.0.4)':
@@ -24414,6 +24705,13 @@ snapshots:
   '@wordpress/keyboard-shortcuts@5.32.0(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.28.4
+      '@wordpress/data': 10.32.0(react@18.3.1)
+      '@wordpress/element': 6.32.0
+      '@wordpress/keycodes': 4.32.0
+      react: 18.3.1
+
+  '@wordpress/keyboard-shortcuts@5.33.0(react@18.3.1)':
+    dependencies:
       '@wordpress/data': 10.33.0(react@18.3.1)
       '@wordpress/element': 6.33.0
       '@wordpress/keycodes': 4.33.0
@@ -24423,6 +24721,11 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.28.4
       '@wordpress/i18n': 6.4.0
+
+  '@wordpress/keycodes@4.32.0':
+    dependencies:
+      '@babel/runtime': 7.28.4
+      '@wordpress/i18n': 6.5.0
 
   '@wordpress/keycodes@4.33.0':
     dependencies:
@@ -24435,7 +24738,7 @@ snapshots:
       '@wordpress/blob': 4.31.0
       '@wordpress/element': 6.31.0
       '@wordpress/i18n': 6.4.0
-      '@wordpress/private-apis': 1.33.0
+      '@wordpress/private-apis': 1.32.0
 
   '@wordpress/notices@5.31.0(react@18.3.1)':
     dependencies:
@@ -24447,27 +24750,27 @@ snapshots:
   '@wordpress/notices@5.32.0(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.28.4
-      '@wordpress/a11y': 4.33.0
-      '@wordpress/data': 10.33.0(react@18.3.1)
+      '@wordpress/a11y': 4.32.0
+      '@wordpress/data': 10.32.0(react@18.3.1)
       react: 18.3.1
 
   '@wordpress/patterns@2.32.0(@types/react-dom@18.3.7(@types/react@18.3.25))(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.28.4
-      '@wordpress/a11y': 4.33.0
+      '@wordpress/a11y': 4.32.0
       '@wordpress/block-editor': 15.5.0(@types/react-dom@18.3.7(@types/react@18.3.25))(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/blocks': 15.5.0(react@18.3.1)
-      '@wordpress/components': 30.6.0(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/compose': 7.33.0(react@18.3.1)
+      '@wordpress/components': 30.5.0(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/compose': 7.32.0(react@18.3.1)
       '@wordpress/core-data': 7.32.0(@types/react-dom@18.3.7(@types/react@18.3.25))(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/data': 10.33.0(react@18.3.1)
-      '@wordpress/element': 6.33.0
-      '@wordpress/html-entities': 4.33.0
-      '@wordpress/i18n': 6.6.0
+      '@wordpress/data': 10.32.0(react@18.3.1)
+      '@wordpress/element': 6.32.0
+      '@wordpress/html-entities': 4.32.0
+      '@wordpress/i18n': 6.5.0
       '@wordpress/icons': 10.32.0(react@18.3.1)
       '@wordpress/notices': 5.32.0(react@18.3.1)
-      '@wordpress/private-apis': 1.33.0
-      '@wordpress/url': 4.33.0
+      '@wordpress/private-apis': 1.32.0
+      '@wordpress/url': 4.32.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     transitivePeerDependencies:
@@ -24481,20 +24784,20 @@ snapshots:
   '@wordpress/patterns@2.32.0(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.28.4
-      '@wordpress/a11y': 4.33.0
+      '@wordpress/a11y': 4.32.0
       '@wordpress/block-editor': 15.5.0(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/blocks': 15.5.0(react@18.3.1)
-      '@wordpress/components': 30.6.0(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/compose': 7.33.0(react@18.3.1)
+      '@wordpress/components': 30.5.0(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/compose': 7.32.0(react@18.3.1)
       '@wordpress/core-data': 7.32.0(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/data': 10.33.0(react@18.3.1)
-      '@wordpress/element': 6.33.0
-      '@wordpress/html-entities': 4.33.0
-      '@wordpress/i18n': 6.6.0
+      '@wordpress/data': 10.32.0(react@18.3.1)
+      '@wordpress/element': 6.32.0
+      '@wordpress/html-entities': 4.32.0
+      '@wordpress/i18n': 6.5.0
       '@wordpress/icons': 10.32.0(react@18.3.1)
       '@wordpress/notices': 5.32.0(react@18.3.1)
-      '@wordpress/private-apis': 1.33.0
-      '@wordpress/url': 4.33.0
+      '@wordpress/private-apis': 1.32.0
+      '@wordpress/url': 4.32.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     transitivePeerDependencies:
@@ -24508,20 +24811,20 @@ snapshots:
   '@wordpress/patterns@2.32.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.28.4
-      '@wordpress/a11y': 4.33.0
+      '@wordpress/a11y': 4.32.0
       '@wordpress/block-editor': 15.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/blocks': 15.5.0(react@18.3.1)
-      '@wordpress/components': 30.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/compose': 7.33.0(react@18.3.1)
+      '@wordpress/components': 30.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/compose': 7.32.0(react@18.3.1)
       '@wordpress/core-data': 7.32.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/data': 10.33.0(react@18.3.1)
-      '@wordpress/element': 6.33.0
-      '@wordpress/html-entities': 4.33.0
-      '@wordpress/i18n': 6.6.0
+      '@wordpress/data': 10.32.0(react@18.3.1)
+      '@wordpress/element': 6.32.0
+      '@wordpress/html-entities': 4.32.0
+      '@wordpress/i18n': 6.5.0
       '@wordpress/icons': 10.32.0(react@18.3.1)
       '@wordpress/notices': 5.32.0(react@18.3.1)
-      '@wordpress/private-apis': 1.33.0
-      '@wordpress/url': 4.33.0
+      '@wordpress/private-apis': 1.32.0
+      '@wordpress/url': 4.32.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     transitivePeerDependencies:
@@ -24537,11 +24840,11 @@ snapshots:
       '@babel/runtime': 7.28.4
       '@wordpress/components': 30.4.0(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/compose': 7.31.0(react@18.3.1)
-      '@wordpress/deprecated': 4.33.0
+      '@wordpress/deprecated': 4.32.0
       '@wordpress/element': 6.31.0
       '@wordpress/hooks': 4.31.0
       '@wordpress/icons': 10.31.0(react@18.3.1)
-      '@wordpress/is-shallow-equal': 5.33.0
+      '@wordpress/is-shallow-equal': 5.32.0
       memize: 2.1.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -24555,11 +24858,11 @@ snapshots:
       '@babel/runtime': 7.28.4
       '@wordpress/components': 30.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/compose': 7.31.0(react@18.3.1)
-      '@wordpress/deprecated': 4.33.0
+      '@wordpress/deprecated': 4.32.0
       '@wordpress/element': 6.31.0
       '@wordpress/hooks': 4.31.0
       '@wordpress/icons': 10.31.0(react@18.3.1)
-      '@wordpress/is-shallow-equal': 5.33.0
+      '@wordpress/is-shallow-equal': 5.32.0
       memize: 2.1.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -24577,15 +24880,15 @@ snapshots:
   '@wordpress/preferences@4.32.0(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.28.4
-      '@wordpress/a11y': 4.33.0
-      '@wordpress/components': 30.6.0(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/compose': 7.33.0(react@18.3.1)
-      '@wordpress/data': 10.33.0(react@18.3.1)
-      '@wordpress/deprecated': 4.33.0
-      '@wordpress/element': 6.33.0
-      '@wordpress/i18n': 6.6.0
+      '@wordpress/a11y': 4.32.0
+      '@wordpress/components': 30.5.0(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/compose': 7.32.0(react@18.3.1)
+      '@wordpress/data': 10.32.0(react@18.3.1)
+      '@wordpress/deprecated': 4.32.0
+      '@wordpress/element': 6.32.0
+      '@wordpress/i18n': 6.5.0
       '@wordpress/icons': 10.32.0(react@18.3.1)
-      '@wordpress/private-apis': 1.33.0
+      '@wordpress/private-apis': 1.32.0
       clsx: 2.1.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -24597,15 +24900,15 @@ snapshots:
   '@wordpress/preferences@4.32.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.28.4
-      '@wordpress/a11y': 4.33.0
-      '@wordpress/components': 30.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/compose': 7.33.0(react@18.3.1)
-      '@wordpress/data': 10.33.0(react@18.3.1)
-      '@wordpress/deprecated': 4.33.0
-      '@wordpress/element': 6.33.0
-      '@wordpress/i18n': 6.6.0
+      '@wordpress/a11y': 4.32.0
+      '@wordpress/components': 30.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/compose': 7.32.0(react@18.3.1)
+      '@wordpress/data': 10.32.0(react@18.3.1)
+      '@wordpress/deprecated': 4.32.0
+      '@wordpress/element': 6.32.0
+      '@wordpress/i18n': 6.5.0
       '@wordpress/icons': 10.32.0(react@18.3.1)
-      '@wordpress/private-apis': 1.33.0
+      '@wordpress/private-apis': 1.32.0
       clsx: 2.1.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -24625,24 +24928,48 @@ snapshots:
       clsx: 2.1.1
       react: 18.3.1
 
+  '@wordpress/primitives@4.32.0(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.28.4
+      '@wordpress/element': 6.32.0
+      clsx: 2.1.1
+      react: 18.3.1
+
   '@wordpress/primitives@4.33.0(react@18.3.1)':
     dependencies:
       '@wordpress/element': 6.33.0
       clsx: 2.1.1
       react: 18.3.1
 
+  '@wordpress/priority-queue@3.32.0':
+    dependencies:
+      '@babel/runtime': 7.28.4
+      requestidlecallback: 0.3.0
+
   '@wordpress/priority-queue@3.33.0':
     dependencies:
       requestidlecallback: 0.3.0
+
+  '@wordpress/private-apis@1.32.0':
+    dependencies:
+      '@babel/runtime': 7.28.4
 
   '@wordpress/private-apis@1.33.0': {}
 
   '@wordpress/react-i18n@4.32.0':
     dependencies:
       '@babel/runtime': 7.28.4
-      '@wordpress/element': 6.33.0
-      '@wordpress/i18n': 6.6.0
+      '@wordpress/element': 6.32.0
+      '@wordpress/i18n': 6.5.0
       utility-types: 3.11.0
+
+  '@wordpress/redux-routine@5.32.0(redux@5.0.1)':
+    dependencies:
+      '@babel/runtime': 7.28.4
+      is-plain-object: 5.0.0
+      is-promise: 4.0.0
+      redux: 5.0.1
+      rungen: 0.3.2
 
   '@wordpress/redux-routine@5.33.0(redux@5.0.1)':
     dependencies:
@@ -24656,15 +24983,15 @@ snapshots:
       '@babel/runtime': 7.28.4
       '@wordpress/block-editor': 15.5.0(@types/react-dom@18.3.7(@types/react@18.3.25))(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/blocks': 15.5.0(react@18.3.1)
-      '@wordpress/components': 30.6.0(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/components': 30.5.0(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/core-data': 7.32.0(@types/react-dom@18.3.7(@types/react@18.3.25))(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/data': 10.33.0(react@18.3.1)
-      '@wordpress/element': 6.33.0
-      '@wordpress/i18n': 6.6.0
+      '@wordpress/data': 10.32.0(react@18.3.1)
+      '@wordpress/element': 6.32.0
+      '@wordpress/i18n': 6.5.0
       '@wordpress/icons': 10.32.0(react@18.3.1)
       '@wordpress/notices': 5.32.0(react@18.3.1)
-      '@wordpress/private-apis': 1.33.0
-      '@wordpress/url': 4.33.0
+      '@wordpress/private-apis': 1.32.0
+      '@wordpress/url': 4.32.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     transitivePeerDependencies:
@@ -24680,15 +25007,15 @@ snapshots:
       '@babel/runtime': 7.28.4
       '@wordpress/block-editor': 15.5.0(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/blocks': 15.5.0(react@18.3.1)
-      '@wordpress/components': 30.6.0(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/components': 30.5.0(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/core-data': 7.32.0(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/data': 10.33.0(react@18.3.1)
-      '@wordpress/element': 6.33.0
-      '@wordpress/i18n': 6.6.0
+      '@wordpress/data': 10.32.0(react@18.3.1)
+      '@wordpress/element': 6.32.0
+      '@wordpress/i18n': 6.5.0
       '@wordpress/icons': 10.32.0(react@18.3.1)
       '@wordpress/notices': 5.32.0(react@18.3.1)
-      '@wordpress/private-apis': 1.33.0
-      '@wordpress/url': 4.33.0
+      '@wordpress/private-apis': 1.32.0
+      '@wordpress/url': 4.32.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     transitivePeerDependencies:
@@ -24704,15 +25031,15 @@ snapshots:
       '@babel/runtime': 7.28.4
       '@wordpress/block-editor': 15.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/blocks': 15.5.0(react@18.3.1)
-      '@wordpress/components': 30.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/components': 30.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/core-data': 7.32.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/data': 10.33.0(react@18.3.1)
-      '@wordpress/element': 6.33.0
-      '@wordpress/i18n': 6.6.0
+      '@wordpress/data': 10.32.0(react@18.3.1)
+      '@wordpress/element': 6.32.0
+      '@wordpress/i18n': 6.5.0
       '@wordpress/icons': 10.32.0(react@18.3.1)
       '@wordpress/notices': 5.32.0(react@18.3.1)
-      '@wordpress/private-apis': 1.33.0
-      '@wordpress/url': 4.33.0
+      '@wordpress/private-apis': 1.32.0
+      '@wordpress/url': 4.32.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     transitivePeerDependencies:
@@ -24729,11 +25056,26 @@ snapshots:
       '@wordpress/a11y': 4.31.0
       '@wordpress/compose': 7.31.0(react@18.3.1)
       '@wordpress/data': 10.31.0(react@18.3.1)
-      '@wordpress/deprecated': 4.33.0
+      '@wordpress/deprecated': 4.32.0
       '@wordpress/element': 6.31.0
       '@wordpress/escape-html': 3.31.0
       '@wordpress/i18n': 6.4.0
       '@wordpress/keycodes': 4.31.0
+      colord: 2.9.3
+      memize: 2.1.1
+      react: 18.3.1
+
+  '@wordpress/rich-text@7.32.0(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.28.4
+      '@wordpress/a11y': 4.32.0
+      '@wordpress/compose': 7.32.0(react@18.3.1)
+      '@wordpress/data': 10.32.0(react@18.3.1)
+      '@wordpress/deprecated': 4.32.0
+      '@wordpress/element': 6.32.0
+      '@wordpress/escape-html': 3.32.0
+      '@wordpress/i18n': 6.5.0
+      '@wordpress/keycodes': 4.32.0
       colord: 2.9.3
       memize: 2.1.1
       react: 18.3.1
@@ -24755,10 +25097,10 @@ snapshots:
   '@wordpress/router@1.32.0(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.28.4
-      '@wordpress/compose': 7.33.0(react@18.3.1)
-      '@wordpress/element': 6.33.0
-      '@wordpress/private-apis': 1.33.0
-      '@wordpress/url': 4.33.0
+      '@wordpress/compose': 7.32.0(react@18.3.1)
+      '@wordpress/element': 6.32.0
+      '@wordpress/private-apis': 1.32.0
+      '@wordpress/url': 4.32.0
       history: 5.3.0
       react: 18.3.1
       route-recognizer: 0.3.4
@@ -24768,13 +25110,13 @@ snapshots:
       '@babel/runtime': 7.28.4
       '@wordpress/api-fetch': 7.32.0
       '@wordpress/blocks': 15.5.0(react@18.3.1)
-      '@wordpress/components': 30.6.0(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/compose': 7.33.0(react@18.3.1)
-      '@wordpress/data': 10.33.0(react@18.3.1)
-      '@wordpress/deprecated': 4.33.0
-      '@wordpress/element': 6.33.0
-      '@wordpress/i18n': 6.6.0
-      '@wordpress/url': 4.33.0
+      '@wordpress/components': 30.5.0(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/compose': 7.32.0(react@18.3.1)
+      '@wordpress/data': 10.32.0(react@18.3.1)
+      '@wordpress/deprecated': 4.32.0
+      '@wordpress/element': 6.32.0
+      '@wordpress/i18n': 6.5.0
+      '@wordpress/url': 4.32.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     transitivePeerDependencies:
@@ -24787,13 +25129,13 @@ snapshots:
       '@babel/runtime': 7.28.4
       '@wordpress/api-fetch': 7.32.0
       '@wordpress/blocks': 15.5.0(react@18.3.1)
-      '@wordpress/components': 30.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/compose': 7.33.0(react@18.3.1)
-      '@wordpress/data': 10.33.0(react@18.3.1)
-      '@wordpress/deprecated': 4.33.0
-      '@wordpress/element': 6.33.0
-      '@wordpress/i18n': 6.6.0
-      '@wordpress/url': 4.33.0
+      '@wordpress/components': 30.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/compose': 7.32.0(react@18.3.1)
+      '@wordpress/data': 10.32.0(react@18.3.1)
+      '@wordpress/deprecated': 4.32.0
+      '@wordpress/element': 6.32.0
+      '@wordpress/i18n': 6.5.0
+      '@wordpress/url': 4.32.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     transitivePeerDependencies:
@@ -24825,7 +25167,7 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.28.4
       '@types/simple-peer': 9.11.8
-      '@wordpress/url': 4.33.0
+      '@wordpress/url': 4.32.0
       import-locals: 2.0.0
       lib0: 0.2.114
       simple-peer: 9.11.1
@@ -24846,6 +25188,11 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.28.4
 
+  '@wordpress/undo-manager@1.32.0':
+    dependencies:
+      '@babel/runtime': 7.28.4
+      '@wordpress/is-shallow-equal': 5.32.0
+
   '@wordpress/undo-manager@1.33.0':
     dependencies:
       '@wordpress/is-shallow-equal': 5.33.0
@@ -24860,7 +25207,7 @@ snapshots:
       '@wordpress/element': 6.31.0
       '@wordpress/i18n': 6.4.0
       '@wordpress/preferences': 4.32.0(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/private-apis': 1.33.0
+      '@wordpress/private-apis': 1.32.0
       '@wordpress/url': 4.31.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -24880,7 +25227,7 @@ snapshots:
       '@wordpress/element': 6.31.0
       '@wordpress/i18n': 6.4.0
       '@wordpress/preferences': 4.32.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/private-apis': 1.33.0
+      '@wordpress/private-apis': 1.32.0
       '@wordpress/url': 4.31.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -24895,13 +25242,13 @@ snapshots:
       '@babel/runtime': 7.28.4
       '@wordpress/api-fetch': 7.32.0
       '@wordpress/blob': 4.32.0
-      '@wordpress/compose': 7.33.0(react@18.3.1)
-      '@wordpress/data': 10.33.0(react@18.3.1)
-      '@wordpress/element': 6.33.0
-      '@wordpress/i18n': 6.6.0
+      '@wordpress/compose': 7.32.0(react@18.3.1)
+      '@wordpress/data': 10.32.0(react@18.3.1)
+      '@wordpress/element': 6.32.0
+      '@wordpress/i18n': 6.5.0
       '@wordpress/preferences': 4.32.0(@types/react@18.3.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/private-apis': 1.33.0
-      '@wordpress/url': 4.33.0
+      '@wordpress/private-apis': 1.32.0
+      '@wordpress/url': 4.32.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       uuid: 9.0.1
@@ -24915,13 +25262,13 @@ snapshots:
       '@babel/runtime': 7.28.4
       '@wordpress/api-fetch': 7.32.0
       '@wordpress/blob': 4.32.0
-      '@wordpress/compose': 7.33.0(react@18.3.1)
-      '@wordpress/data': 10.33.0(react@18.3.1)
-      '@wordpress/element': 6.33.0
-      '@wordpress/i18n': 6.6.0
+      '@wordpress/compose': 7.32.0(react@18.3.1)
+      '@wordpress/data': 10.32.0(react@18.3.1)
+      '@wordpress/element': 6.32.0
+      '@wordpress/i18n': 6.5.0
       '@wordpress/preferences': 4.32.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/private-apis': 1.33.0
-      '@wordpress/url': 4.33.0
+      '@wordpress/private-apis': 1.32.0
+      '@wordpress/url': 4.32.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       uuid: 9.0.1
@@ -24931,6 +25278,11 @@ snapshots:
       - supports-color
 
   '@wordpress/url@4.31.0':
+    dependencies:
+      '@babel/runtime': 7.28.4
+      remove-accents: 0.5.0
+
+  '@wordpress/url@4.32.0':
     dependencies:
       '@babel/runtime': 7.28.4
       remove-accents: 0.5.0
@@ -24946,6 +25298,8 @@ snapshots:
       '@wordpress/data': 10.31.0(react@18.3.1)
       '@wordpress/element': 6.31.0
       react: 18.3.1
+
+  '@wordpress/warning@3.32.0': {}
 
   '@wordpress/warning@3.33.0': {}
 
@@ -30020,17 +30374,11 @@ snapshots:
 
   min-indent@1.0.1: {}
 
-  mini-css-extract-plugin@2.9.1(webpack@5.101.3):
-    dependencies:
-      schema-utils: 4.3.3
-      tapable: 2.3.0
-      webpack: 5.101.3(esbuild@0.25.9)(webpack-cli@6.0.1)
-
   mini-css-extract-plugin@2.9.4(webpack@5.101.3):
     dependencies:
       schema-utils: 4.3.3
       tapable: 2.3.0
-      webpack: 5.101.3(webpack-cli@6.0.1)
+      webpack: 5.101.3(esbuild@0.25.9)(webpack-cli@6.0.1)
 
   minimalistic-assert@1.0.1: {}
 
@@ -32778,8 +33126,6 @@ snapshots:
       strip-bom: 3.0.0
 
   tslib@1.14.1: {}
-
-  tslib@2.5.0: {}
 
   tslib@2.8.1: {}
 

--- a/projects/packages/forms/changelog/update-forms-command-palette
+++ b/projects/packages/forms/changelog/update-forms-command-palette
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: add command palette commands

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -47,6 +47,7 @@
 		"@wordpress/base-styles": "6.7.0",
 		"@wordpress/block-editor": "15.4.0",
 		"@wordpress/blocks": "15.4.0",
+		"@wordpress/commands": "1.28.0",
 		"@wordpress/components": "30.4.0",
 		"@wordpress/compose": "7.31.0",
 		"@wordpress/core-data": "7.31.0",

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -47,7 +47,7 @@
 		"@wordpress/base-styles": "6.7.0",
 		"@wordpress/block-editor": "15.4.0",
 		"@wordpress/blocks": "15.4.0",
-		"@wordpress/commands": "1.28.0",
+		"@wordpress/commands": "1.33.0",
 		"@wordpress/components": "30.4.0",
 		"@wordpress/compose": "7.31.0",
 		"@wordpress/core-data": "7.31.0",

--- a/projects/packages/forms/src/blocks/contact-form/index.js
+++ b/projects/packages/forms/src/blocks/contact-form/index.js
@@ -12,7 +12,7 @@ import variations from './variations';
 
 export const name = 'contact-form';
 
-const icon = renderMaterialIcon(
+export const icon = renderMaterialIcon(
 	<>
 		<Path fillRule="evenodd" clipRule="evenodd" d="M18 9H13V7.5H18V9Z" />
 		<Path fillRule="evenodd" clipRule="evenodd" d="M18 16.5H13V15H18V16.5Z" />

--- a/projects/packages/forms/src/blocks/contact-form/index.js
+++ b/projects/packages/forms/src/blocks/contact-form/index.js
@@ -1,8 +1,7 @@
 import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
-import { Path } from '@wordpress/components';
 import { __, _x } from '@wordpress/i18n';
 import './editor.scss';
-import renderMaterialIcon from '../shared/components/render-material-icon';
+import FormsIcon from '../shared/components/forms-icon';
 import { getIconColor } from '../shared/util/block-icons';
 import defaultAttributes from './attributes';
 import deprecated from './deprecated';
@@ -12,28 +11,6 @@ import variations from './variations';
 
 export const name = 'contact-form';
 
-export const icon = renderMaterialIcon(
-	<>
-		<Path fillRule="evenodd" clipRule="evenodd" d="M18 9H13V7.5H18V9Z" />
-		<Path fillRule="evenodd" clipRule="evenodd" d="M18 16.5H13V15H18V16.5Z" />
-		<Path
-			fillRule="evenodd"
-			clipRule="evenodd"
-			d="M9.5 7.5H7.5V9.5H9.5V7.5ZM7.5 6H9.5C10.3284 6 11 6.67157 11 7.5V9.5C11 10.3284 10.3284 11 9.5 11H7.5C6.67157 11 6 10.3284 6 9.5V7.5C6 6.67157 6.67157 6 7.5 6Z"
-		/>
-		<Path
-			fillRule="evenodd"
-			clipRule="evenodd"
-			d="M9.5 14.5H7.5V16.5H9.5V14.5ZM7.5 13H9.5C10.3284 13 11 13.6716 11 14.5V16.5C11 17.3284 10.3284 18 9.5 18H7.5C6.67157 18 6 17.3284 6 16.5V14.5C6 13.6716 6.67157 13 7.5 13Z"
-		/>
-		<Path
-			fillRule="evenodd"
-			clipRule="evenodd"
-			d="M19 4.5H5C4.72386 4.5 4.5 4.72386 4.5 5V19C4.5 19.2761 4.72386 19.5 5 19.5H19C19.2761 19.5 19.5 19.2761 19.5 19V5C19.5 4.72386 19.2761 4.5 19 4.5ZM5 3C3.89543 3 3 3.89543 3 5V19C3 20.1046 3.89543 21 5 21H19C20.1046 21 21 20.1046 21 19V5C21 3.89543 20.1046 3 19 3H5Z"
-		/>
-	</>
-);
-
 export const settings = {
 	apiVersion: 3,
 	title: __( 'Form', 'jetpack-forms' ),
@@ -41,7 +18,7 @@ export const settings = {
 		'Create forms to collect data from site visitors and manage their responses.',
 		'jetpack-forms'
 	),
-	icon: { src: icon, foreground: getIconColor() },
+	icon: { src: FormsIcon, foreground: getIconColor() },
 	keywords: [
 		_x( 'email', 'block search term', 'jetpack-forms' ),
 		_x( 'feedback', 'block search term', 'jetpack-forms' ),

--- a/projects/packages/forms/src/blocks/shared/components/forms-icon.js
+++ b/projects/packages/forms/src/blocks/shared/components/forms-icon.js
@@ -1,0 +1,26 @@
+import { Path } from '@wordpress/components';
+import renderMaterialIcon from './render-material-icon';
+
+const FormsIcon = renderMaterialIcon(
+	<>
+		<Path fillRule="evenodd" clipRule="evenodd" d="M18 9H13V7.5H18V9Z" />
+		<Path fillRule="evenodd" clipRule="evenodd" d="M18 16.5H13V15H18V16.5Z" />
+		<Path
+			fillRule="evenodd"
+			clipRule="evenodd"
+			d="M9.5 7.5H7.5V9.5H9.5V7.5ZM7.5 6H9.5C10.3284 6 11 6.67157 11 7.5V9.5C11 10.3284 10.3284 11 9.5 11H7.5C6.67157 11 6 10.3284 6 9.5V7.5C6 6.67157 6.67157 6 7.5 6Z"
+		/>
+		<Path
+			fillRule="evenodd"
+			clipRule="evenodd"
+			d="M9.5 14.5H7.5V16.5H9.5V14.5ZM7.5 13H9.5C10.3284 13 11 13.6716 11 14.5V16.5C11 17.3284 10.3284 18 9.5 18H7.5C6.67157 18 6 17.3284 6 16.5V14.5C6 13.6716 6.67157 13 7.5 13Z"
+		/>
+		<Path
+			fillRule="evenodd"
+			clipRule="evenodd"
+			d="M19 4.5H5C4.72386 4.5 4.5 4.72386 4.5 5V19C4.5 19.2761 4.72386 19.5 5 19.5H19C19.2761 19.5 19.5 19.2761 19.5 19V5C19.5 4.72386 19.2761 4.5 19 4.5ZM5 3C3.89543 3 3 3.89543 3 5V19C3 20.1046 3.89543 21 5 21H19C20.1046 21 21 20.1046 21 19V5C21 3.89543 20.1046 3 19 3H5Z"
+		/>
+	</>
+);
+
+export default FormsIcon;

--- a/projects/packages/forms/src/contact-form/class-admin.php
+++ b/projects/packages/forms/src/contact-form/class-admin.php
@@ -9,6 +9,7 @@ namespace Automattic\Jetpack\Forms\ContactForm;
 
 use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
+use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Forms\Service\Google_Drive;
 use Automattic\Jetpack\Redirect;
 use Automattic\Jetpack\Tracking;
@@ -92,18 +93,17 @@ class Admin {
 	public function admin_enqueue_scripts() {
 
 		// Command palette loaded everywhere in wp-admin
-		$command_palette_handle = 'jetpack-forms-command-palette';
 		Assets::register_script(
-			$command_palette_handle,
-			'../../../dist/contact-form/js/command-palette.js',
+			'jetpack-forms-command-palette',
+			'../../dist/contact-form/js/command-palette.js',
 			__FILE__,
 			array(
+				'enqueue'    => true,
 				'in_footer'  => true,
 				'textdomain' => 'jetpack-forms',
-				'enqueue'    => true,
+				'version'    => Constants::get_constant( 'JETPACK__VERSION' ),
 			)
 		);
-		Assets::enqueue_script( $command_palette_handle );
 
 		// Page specific admin scripts
 		$current_screen = get_current_screen();

--- a/projects/packages/forms/src/contact-form/class-admin.php
+++ b/projects/packages/forms/src/contact-form/class-admin.php
@@ -90,6 +90,22 @@ class Admin {
 	 * Hook handler for admin_enqueue_scripts hook
 	 */
 	public function admin_enqueue_scripts() {
+
+		// Command palette loaded everywhere in wp-admin
+		$command_palette_handle = 'jetpack-forms-command-palette';
+		Assets::register_script(
+			$command_palette_handle,
+			'../../../dist/contact-form/js/command-palette.js',
+			__FILE__,
+			array(
+				'in_footer'  => true,
+				'textdomain' => 'jetpack-forms',
+				'enqueue'    => true,
+			)
+		);
+		Assets::enqueue_script( $command_palette_handle );
+
+		// Page specific admin scripts
 		$current_screen = get_current_screen();
 		if ( empty( $current_screen ) || ! in_array( $current_screen->id, array( 'edit-feedback', 'feedback_page_feedback-export' ), true ) ) {
 			return;

--- a/projects/packages/forms/src/contact-form/js/command-palette.js
+++ b/projects/packages/forms/src/contact-form/js/command-palette.js
@@ -17,7 +17,7 @@ const getFormsCommands = () =>
 			return [
 				{
 					icon: FormsIcon,
-					label: __( 'View form responses', 'jetpack-forms' ),
+					label: __( 'See form responses', 'jetpack-forms' ),
 					name: 'jetpack/forms-inbox',
 					callback: ( { close } ) => {
 						tracks.recordEvent( 'jetpack_command_palette_forms_inbox_open' );
@@ -27,7 +27,7 @@ const getFormsCommands = () =>
 				},
 				{
 					icon: spam,
-					label: __( 'View form spam', 'jetpack-forms' ),
+					label: __( 'Review form spam', 'jetpack-forms' ),
 					name: 'jetpack/forms-spam',
 					callback: ( { close } ) => {
 						tracks.recordEvent( 'jetpack_command_palette_forms_spam_open' );
@@ -37,7 +37,7 @@ const getFormsCommands = () =>
 				},
 				{
 					icon: trash,
-					label: __( 'View form trash', 'jetpack-forms' ),
+					label: __( 'See form trash', 'jetpack-forms' ),
 					name: 'jetpack/forms-trash',
 					callback: ( { close } ) => {
 						tracks.recordEvent( 'jetpack_command_palette_forms_trash_open' );
@@ -55,12 +55,17 @@ const getFormsCommands = () =>
 	};
 
 const JetpackFormsCommands = () => {
-	// Command palette available across WP Admin from Gutenberg v21.5 and (TBD) WP v6.9
-	// https://github.com/WordPress/gutenberg/pull/71030
 	useCommandLoader( {
 		name: 'jetpack/forms',
 		hook: getFormsCommands(),
 	} );
 };
 
-JetpackFormsCommands();
+// Command palette available across WP Admin from Gutenberg v21.5 and WordPress v6.9
+// https://github.com/WordPress/gutenberg/pull/71030
+if ( typeof useCommandLoader === 'function' ) {
+	JetpackFormsCommands();
+} else {
+	// eslint-disable-next-line no-console
+	console.info( 'Command palette not available.' );
+}

--- a/projects/packages/forms/src/contact-form/js/command-palette.js
+++ b/projects/packages/forms/src/contact-form/js/command-palette.js
@@ -2,7 +2,7 @@ import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { useCommand } from '@wordpress/commands';
 import domReady from '@wordpress/dom-ready';
 import { __ } from '@wordpress/i18n';
-import { icon } from '../../blocks/contact-form/';
+import FormsIcon from '../../blocks/shared/components/forms-icon';
 
 domReady( () => {
 	// Command palette available across WP Admin from WP 6.9
@@ -10,7 +10,7 @@ domReady( () => {
 		const { tracks } = useAnalytics();
 
 		useCommand( {
-			icon,
+			icon: FormsIcon,
 			label: __( 'View form responses', 'jetpack-forms' ),
 			name: 'jetpack/forms-inbox',
 			callback: ( { close } ) => {
@@ -20,7 +20,7 @@ domReady( () => {
 			},
 		} );
 		useCommand( {
-			icon,
+			icon: FormsIcon,
 			label: __( 'View form spam', 'jetpack-forms' ),
 			name: 'jetpack/forms-spam',
 			callback: ( { close } ) => {

--- a/projects/packages/forms/src/contact-form/js/command-palette.js
+++ b/projects/packages/forms/src/contact-form/js/command-palette.js
@@ -1,0 +1,33 @@
+import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
+import { useCommand } from '@wordpress/commands';
+import domReady from '@wordpress/dom-ready';
+import { __ } from '@wordpress/i18n';
+import { icon } from '../../blocks/contact-form/';
+
+domReady( () => {
+	// Command palette available across WP Admin from WP 6.9
+	if ( typeof useCommand === 'function' ) {
+		const { tracks } = useAnalytics();
+
+		useCommand( {
+			icon,
+			label: __( 'View form responses', 'jetpack-forms' ),
+			name: 'jetpack/forms-inbox',
+			callback: ( { close } ) => {
+				tracks.recordEvent( 'jetpack_command_palette_forms_inbox_open' );
+				document.location.href = 'admin.php?page=jetpack-forms-admin#/responses?status=inbox';
+				close();
+			},
+		} );
+		useCommand( {
+			icon,
+			label: __( 'View form spam', 'jetpack-forms' ),
+			name: 'jetpack/forms-spam',
+			callback: ( { close } ) => {
+				tracks.recordEvent( 'jetpack_command_palette_forms_spam_open' );
+				document.location.href = 'admin.php?page=jetpack-forms-admin#/responses?status=spam';
+				close();
+			},
+		} );
+	}
+} );

--- a/projects/packages/forms/src/contact-form/js/command-palette.js
+++ b/projects/packages/forms/src/contact-form/js/command-palette.js
@@ -2,7 +2,9 @@ import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { useCommand } from '@wordpress/commands';
 import domReady from '@wordpress/dom-ready';
 import { __ } from '@wordpress/i18n';
+import { trash } from '@wordpress/icons';
 import FormsIcon from '../../blocks/shared/components/forms-icon';
+import { spam } from '../../dashboard/icons';
 
 domReady( () => {
 	// Command palette available across WP Admin from WP 6.9
@@ -20,12 +22,22 @@ domReady( () => {
 			},
 		} );
 		useCommand( {
-			icon: FormsIcon,
+			icon: spam,
 			label: __( 'View form spam', 'jetpack-forms' ),
 			name: 'jetpack/forms-spam',
 			callback: ( { close } ) => {
 				tracks.recordEvent( 'jetpack_command_palette_forms_spam_open' );
 				document.location.href = 'admin.php?page=jetpack-forms-admin#/responses?status=spam';
+				close();
+			},
+		} );
+		useCommand( {
+			icon: trash,
+			label: __( 'View form trash', 'jetpack-forms' ),
+			name: 'jetpack/forms-trash',
+			callback: ( { close } ) => {
+				tracks.recordEvent( 'jetpack_command_palette_forms_trash_open' );
+				document.location.href = 'admin.php?page=jetpack-forms-admin#/responses?status=trash';
 				close();
 			},
 		} );

--- a/projects/packages/forms/src/contact-form/js/command-palette.js
+++ b/projects/packages/forms/src/contact-form/js/command-palette.js
@@ -1,45 +1,66 @@
 import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
-import { useCommand } from '@wordpress/commands';
-import domReady from '@wordpress/dom-ready';
+import { useCommandLoader } from '@wordpress/commands';
+import { useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { trash } from '@wordpress/icons';
 import FormsIcon from '../../blocks/shared/components/forms-icon';
 import { spam } from '../../dashboard/icons';
 
-domReady( () => {
-	// Command palette available across WP Admin from WP 6.9
-	if ( typeof useCommand === 'function' ) {
+const getDashboardUrl = status =>
+	`admin.php?page=jetpack-forms-admin#/responses?status=${ status }`;
+
+const getFormsCommands = () =>
+	function useFormsGlobalCommands() {
 		const { tracks } = useAnalytics();
 
-		useCommand( {
-			icon: FormsIcon,
-			label: __( 'View form responses', 'jetpack-forms' ),
-			name: 'jetpack/forms-inbox',
-			callback: ( { close } ) => {
-				tracks.recordEvent( 'jetpack_command_palette_forms_inbox_open' );
-				document.location.href = 'admin.php?page=jetpack-forms-admin#/responses?status=inbox';
-				close();
-			},
-		} );
-		useCommand( {
-			icon: spam,
-			label: __( 'View form spam', 'jetpack-forms' ),
-			name: 'jetpack/forms-spam',
-			callback: ( { close } ) => {
-				tracks.recordEvent( 'jetpack_command_palette_forms_spam_open' );
-				document.location.href = 'admin.php?page=jetpack-forms-admin#/responses?status=spam';
-				close();
-			},
-		} );
-		useCommand( {
-			icon: trash,
-			label: __( 'View form trash', 'jetpack-forms' ),
-			name: 'jetpack/forms-trash',
-			callback: ( { close } ) => {
-				tracks.recordEvent( 'jetpack_command_palette_forms_trash_open' );
-				document.location.href = 'admin.php?page=jetpack-forms-admin#/responses?status=trash';
-				close();
-			},
-		} );
-	}
-} );
+		const commands = useMemo( () => {
+			return [
+				{
+					icon: FormsIcon,
+					label: __( 'View form responses', 'jetpack-forms' ),
+					name: 'jetpack/forms-inbox',
+					callback: ( { close } ) => {
+						tracks.recordEvent( 'jetpack_command_palette_forms_inbox_open' );
+						document.location.href = getDashboardUrl( 'inbox' );
+						close();
+					},
+				},
+				{
+					icon: spam,
+					label: __( 'View form spam', 'jetpack-forms' ),
+					name: 'jetpack/forms-spam',
+					callback: ( { close } ) => {
+						tracks.recordEvent( 'jetpack_command_palette_forms_spam_open' );
+						document.location.href = getDashboardUrl( 'spam' );
+						close();
+					},
+				},
+				{
+					icon: trash,
+					label: __( 'View form trash', 'jetpack-forms' ),
+					name: 'jetpack/forms-trash',
+					callback: ( { close } ) => {
+						tracks.recordEvent( 'jetpack_command_palette_forms_trash_open' );
+						document.location.href = getDashboardUrl( 'trash' );
+						close();
+					},
+				},
+			];
+		}, [ tracks ] );
+
+		return {
+			commands,
+			isLoading: false,
+		};
+	};
+
+const JetpackFormsCommands = () => {
+	// Command palette available across WP Admin from Gutenberg v21.5 and (TBD) WP v6.9
+	// https://github.com/WordPress/gutenberg/pull/71030
+	useCommandLoader( {
+		name: 'jetpack/forms',
+		hook: getFormsCommands(),
+	} );
+};
+
+JetpackFormsCommands();

--- a/projects/packages/forms/tools/webpack.config.contact-form.js
+++ b/projects/packages/forms/tools/webpack.config.contact-form.js
@@ -68,7 +68,7 @@ const sharedWebpackConfig = {
 
 			// Leave fonts and images in place.
 			{
-				test: /\.(eot|ttf|woff|png|svg)$/i,
+				test: /\.(eot|ttf|woff|png|svg|jpg)$/i,
 				type: 'asset/resource',
 				generator: {
 					emit: false,

--- a/projects/plugins/jetpack/changelog/update-forms-command-palette
+++ b/projects/plugins/jetpack/changelog/update-forms-command-palette
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: add command palette commands


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Resolves FORMS-285

Now that the Command palette is generally [available](https://github.com/WordPress/gutenberg/pull/71030) across WP Admin pages with the Gutenberg plugin (and potentially in WP 6.9), let's add the first Forms-related commands, too.

We already [had](https://github.com/Automattic/wp-calypso/blob/ee4fafab337d419e2f31e8172887cea282fb428d/packages/command-palette/src/commands.tsx#L1069-L1081) one command available in the Calypso command palette, but that will go away with Calypso untangling efforts.

> Command Palette (Press Ctrl+K or Command+K anywhere in the dashboard to use the command palette) is available across both the Editor and the Dashboard, making navigation and actions faster and easier. Simply type in the Command Palette to search, jump to specific screens, or trigger actions directly. This also lays the groundwork for future integrations with the new Abilities API.

[via](https://make.wordpress.org/core/2025/10/21/wordpress-6-9-beta-1/)

Docs:
- https://make.wordpress.org/core/2023/07/17/introducing-the-wordpress-command-palette-api/
- https://developer.wordpress.org/block-editor/reference-guides/packages/packages-commands/

### TODO:

<img width="607" height="240" alt="image" src="https://github.com/user-attachments/assets/bd2d0a1b-1dfe-4613-8a19-8b6b0ff00022" />


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add "See form responses" command
* Add "See form spam" command
* Add "See form trash" command

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* With latest Gutenberg plugin active
* Anywhere in WP Admin, press `cmd + K` to bring up command palette
* Find "forms" commands and try them
