### PR TITLE
Image CDN: Add compatibility with Breakdance editor

### DIFF
--- a/projects/packages/image-cdn/changelog/add-breakdance-compatibility
+++ b/projects/packages/image-cdn/changelog/add-breakdance-compatibility
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Add support for images added via Breakdance blocks.

--- a/projects/packages/image-cdn/src/class-image-cdn-core.php
+++ b/projects/packages/image-cdn/src/class-image-cdn-core.php
@@ -26,6 +26,9 @@ class Image_CDN_Core {
 		// Add ActivityPub compatibility.
 		require_once __DIR__ . '/compatibility/activitypub.php';
 
+		// Add Breakdance compatibility.
+		require_once __DIR__ . '/compatibility/breakdance.php';
+
 		/**
 		 * Add an easy way to photon-ize a URL that is safe to call even if Jetpack isn't active.
 		 *

--- a/projects/packages/image-cdn/src/compatibility/breakdance.php
+++ b/projects/packages/image-cdn/src/compatibility/breakdance.php
@@ -12,9 +12,23 @@ namespace Automattic\Jetpack\Image_CDN\Compatibility;
 use Automattic\Jetpack\Image_CDN\Image_CDN;
 
 /**
+ * Hook the compatibility functions into Breakdance filters.
+ *
+ * @since $$next-version$$
+ *
+ * @return void
+ */
+function load_breakdance_compat() {
+	add_filter( 'breakdance_singular_content', __NAMESPACE__ . '\use_image_cdn' );
+}
+add_action( 'plugins_loaded', __NAMESPACE__ . '\load_breakdance_compat' );
+
+/**
  * Unless the 'Apply the_content filter to Breakdance content' option is enabled
  * in the Breakdance settings, the content will not be filtered by the_content filter.
  * This ensures that images are passed through Image CDN when it's enabled.
+ *
+ * @since $$next-version$$
  *
  * @param string $content The content to filter.
  * @return string The filtered content.
@@ -26,4 +40,3 @@ function use_image_cdn( $content ) {
 
 	return $content;
 }
-add_filter( 'breakdance_singular_content', __NAMESPACE__ . '\use_image_cdn' );

--- a/projects/packages/image-cdn/src/compatibility/breakdance.php
+++ b/projects/packages/image-cdn/src/compatibility/breakdance.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Compatibility functions for the Breakdance plugin.
+ *
+ * @since $$next-version$$
+ *
+ * @package automattic/jetpack-image-cdn
+ */
+
+namespace Automattic\Jetpack\Image_CDN\Compatibility;
+
+use Automattic\Jetpack\Image_CDN\Image_CDN;
+
+/**
+ * Unless the 'Apply the_content filter to Breakdance content' option is enabled
+ * in the Breakdance settings, the content will not be filtered by the_content filter.
+ * This ensures that images are passed through Image CDN when it's enabled.
+ *
+ * @param string $content The content to filter.
+ * @return string The filtered content.
+ */
+function use_image_cdn( $content ) {
+	if ( Image_CDN::is_enabled() ) {
+		$content = Image_CDN::filter_the_content( $content );
+	}
+
+	return $content;
+}
+add_filter( 'breakdance_singular_content', __NAMESPACE__ . '\use_image_cdn' );

--- a/projects/packages/image-cdn/tests/php/Breakdance_Compat_Test.php
+++ b/projects/packages/image-cdn/tests/php/Breakdance_Compat_Test.php
@@ -17,11 +17,11 @@ require __DIR__ . '/../../src/compatibility/breakdance.php';
 #[CoversFunction( '\\Automattic\\Jetpack\\Image_CDN\\Compatibility\\load_breakdance_compat' )]
 class Breakdance_Compat_Test extends BaseTestCase {
 	/**
-	 * Test that we do not disable CDN for Breakdance requests by default.
+	 * Test that CDN is enabled for Breakdance content by default.
 	 */
 	public function test_load_breakdance_compat_default() {
 		\Automattic\Jetpack\Image_CDN\Compatibility\load_breakdance_compat();
-		// By default we should not hook into the Breakdance filters.
-		$this->assertFalse( has_action( 'breakdance_singular_content' ) );
+		// By default we should hook into the Breakdance filters.
+		$this->assertTrue( has_filter( 'breakdance_singular_content' ) );
 	}
 }

--- a/projects/packages/image-cdn/tests/php/Breakdance_Compat_Test.php
+++ b/projects/packages/image-cdn/tests/php/Breakdance_Compat_Test.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * This file contains PHPUnit tests for the Breakdance compatibility functions.
+ * To run the package unit tests, run jetpack test php packages/image-cdn
+ *
+ * @package automattic/jetpack-image-cdn
+ */
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use WorDBless\BaseTestCase;
+
+require __DIR__ . '/../../src/compatibility/breakdance.php';
+
+/**
+ * @covers ::\Automattic\Jetpack\Image_CDN\Compatibility\load_breakdance_compat
+ */
+#[CoversFunction( '\\Automattic\\Jetpack\\Image_CDN\\Compatibility\\load_breakdance_compat' )]
+class Breakdance_Compat_Test extends BaseTestCase {
+	/**
+	 * Test that we do not disable CDN for Breakdance requests by default.
+	 */
+	public function test_load_breakdance_compat_default() {
+		\Automattic\Jetpack\Image_CDN\Compatibility\load_breakdance_compat();
+		// By default we should not hook into the Breakdance filters.
+		$this->assertFalse( has_action( 'breakdance_singular_content' ) );
+	}
+}

--- a/projects/packages/image-cdn/tests/php/Breakdance_Compat_Test.php
+++ b/projects/packages/image-cdn/tests/php/Breakdance_Compat_Test.php
@@ -6,6 +6,7 @@
  * @package automattic/jetpack-image-cdn
  */
 
+use Automattic\Jetpack\Image_CDN\Image_CDN;
 use PHPUnit\Framework\Attributes\CoversFunction;
 use WorDBless\BaseTestCase;
 
@@ -23,5 +24,82 @@ class Breakdance_Compat_Test extends BaseTestCase {
 		\Automattic\Jetpack\Image_CDN\Compatibility\load_breakdance_compat();
 		// By default we should hook into the Breakdance filters.
 		$this->assertTrue( has_filter( 'breakdance_singular_content' ) );
+	}
+
+	/**
+	 * Test that the plugins_loaded action is properly hooked.
+	 */
+	public function test_plugins_loaded_action_is_hooked() {
+		// Verify that the action is registered
+		$this->assertTrue( has_action( 'plugins_loaded' ) );
+	}
+
+	/**
+	 * Test use_image_cdn function when Image CDN is enabled.
+	 */
+	public function test_use_image_cdn_when_enabled() {
+		// Initialize Image CDN to enable it
+		Image_CDN::instance();
+
+		$sample_content = '<p>Test content with <img src="http://example.com/image.jpg" alt="test"> image</p>';
+
+		$result = \Automattic\Jetpack\Image_CDN\Compatibility\use_image_cdn( $sample_content );
+
+		// The content should be processed by filter_the_content when CDN is enabled
+		$this->assertIsString( $result );
+		$this->assertNotEmpty( $result );
+	}
+
+	/**
+	 * Test use_image_cdn function when Image CDN is disabled.
+	 */
+	public function test_use_image_cdn_when_disabled() {
+		// Reset the Image CDN instance to ensure it's disabled
+		$reflection        = new \ReflectionClass( Image_CDN::class );
+		$instance_property = $reflection->getProperty( 'instance' );
+		$instance_property->setAccessible( true );
+		$instance_property->setValue( null );
+
+		$enabled_property = $reflection->getProperty( 'is_enabled' );
+		$enabled_property->setAccessible( true );
+		$enabled_property->setValue( false );
+
+		$sample_content = '<p>Test content with <img src="http://example.com/image.jpg" alt="test"> image</p>';
+
+		$result = \Automattic\Jetpack\Image_CDN\Compatibility\use_image_cdn( $sample_content );
+
+		// When CDN is disabled, content should be returned unchanged
+		$this->assertEquals( $sample_content, $result );
+	}
+
+	/**
+	 * Test use_image_cdn function with empty content.
+	 */
+	public function test_use_image_cdn_with_empty_content() {
+		// Initialize Image CDN to enable it
+		Image_CDN::instance();
+
+		$empty_content = '';
+
+		$result = \Automattic\Jetpack\Image_CDN\Compatibility\use_image_cdn( $empty_content );
+
+		// Empty content should remain empty
+		$this->assertSame( '', $result );
+	}
+
+	/**
+	 * Test use_image_cdn function with content containing no images.
+	 */
+	public function test_use_image_cdn_with_no_images() {
+		// Initialize Image CDN to enable it
+		Image_CDN::instance();
+
+		$content_no_images = '<p>This is just text content without any images.</p>';
+
+		$result = \Automattic\Jetpack\Image_CDN\Compatibility\use_image_cdn( $content_no_images );
+
+		// Content without images should be processed but essentially unchanged
+		$this->assertIsString( $result );
+		$this->assertStringContainsString( 'This is just text content', $result );
 	}
 }

--- a/projects/packages/image-cdn/tests/php/Breakdance_Compat_Test.php
+++ b/projects/packages/image-cdn/tests/php/Breakdance_Compat_Test.php
@@ -14,8 +14,10 @@ require __DIR__ . '/../../src/compatibility/breakdance.php';
 
 /**
  * @covers ::\Automattic\Jetpack\Image_CDN\Compatibility\load_breakdance_compat
+ * @covers ::\Automattic\Jetpack\Image_CDN\Compatibility\use_image_cdn
  */
 #[CoversFunction( '\\Automattic\\Jetpack\\Image_CDN\\Compatibility\\load_breakdance_compat' )]
+#[CoversFunction( '\\Automattic\\Jetpack\\Image_CDN\\Compatibility\\use_image_cdn' )]
 class Breakdance_Compat_Test extends BaseTestCase {
 	/**
 	 * Test that CDN is enabled for Breakdance content by default.
@@ -27,11 +29,14 @@ class Breakdance_Compat_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Test that the plugins_loaded action is properly hooked.
+	 * Test that the plugins_loaded action hook is properly registered.
 	 */
-	public function test_plugins_loaded_action_is_hooked() {
-		// Verify that the action is registered
-		$this->assertTrue( has_action( 'plugins_loaded' ) );
+	public function test_plugins_loaded_action_registered() {
+		// The action should be registered when the file is loaded
+		$this->assertNotFalse(
+			has_action( 'plugins_loaded', 'Automattic\\Jetpack\\Image_CDN\\Compatibility\\load_breakdance_compat' ),
+			'The plugins_loaded action should be registered'
+		);
 	}
 
 	/**

--- a/projects/packages/image-cdn/tests/php/Breakdance_Compat_Test.php
+++ b/projects/packages/image-cdn/tests/php/Breakdance_Compat_Test.php
@@ -58,11 +58,11 @@ class Breakdance_Compat_Test extends BaseTestCase {
 		$reflection        = new \ReflectionClass( Image_CDN::class );
 		$instance_property = $reflection->getProperty( 'instance' );
 		$instance_property->setAccessible( true );
-		$instance_property->setValue( null );
+		$instance_property->setValue( null, null );
 
 		$enabled_property = $reflection->getProperty( 'is_enabled' );
 		$enabled_property->setAccessible( true );
-		$enabled_property->setValue( false );
+		$enabled_property->setValue( null, false );
 
 		$sample_content = '<p>Test content with <img src="http://example.com/image.jpg" alt="test"> image</p>';
 

--- a/projects/plugins/boost/changelog/add-image-cdn-breakdance-compatibility
+++ b/projects/plugins/boost/changelog/add-image-cdn-breakdance-compatibility
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Image CDN: Add support for images added via Breakdance blocks.

--- a/projects/plugins/jetpack/changelog/add-image-cdn-breakdance-compatibility
+++ b/projects/plugins/jetpack/changelog/add-image-cdn-breakdance-compatibility
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Site Accelerator (Image CDN): Add support for images added via Breakdance blocks.


### PR DESCRIPTION
Fixes HOG-333

## Proposed changes:

* Fix images added via blocks from the Breakdance editor not being served through CDN.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

HOG-333

## Does this pull request change what data or activity we track or use?

no

## Testing instructions:

- You need Breakdance from https://breakdance.com/ and Boost (free works) or Jetpack on a website that can run Image CDN. You'll have to sign up to breakdance to download the free version.
- After setting up Breakdance, make sure Image CDN is enabled either via the Boost settings or via Jetpack's Performance tab (Site accelerator), or via the Jetpack Modules page;
- Edit a page using the Breakdance editor and add an Image block (it might take a while for the blocks to load);

<img width="912" height="400" alt="CleanShot 2025-09-03 at 16 50 12@2x" src="https://github.com/user-attachments/assets/8a207323-d78f-4de8-b347-6f9be7aa0e61" />

<img width="1512" height="860" alt="CleanShot 2025-09-03 at 16 50 22@2x" src="https://github.com/user-attachments/assets/02d82182-556c-4f38-8c5b-1cb248511178" />

- Visit the page in the front-end and check the image URL - it should be served via CDN:

<img width="863" height="222" alt="CleanShot 2025-09-03 at 16 51 27@2x" src="https://github.com/user-attachments/assets/6894b3cd-b35c-4e13-b91f-7612b1aa6cbb" />
