### PR TITLE
Update/mcp abilities site settings

### DIFF
--- a/projects/plugins/jetpack/changelog/update-mcp-abilities-site-settings
+++ b/projects/plugins/jetpack/changelog/update-mcp-abilities-site-settings
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Added MCP abilities title to site settings

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -686,6 +686,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 
 				$computed_abilities[ $ability_name ] = array(
 					'name'        => $ability_name,
+					'title'       => $ability_meta['title'] ?? '',
 					'description' => $ability_meta['description'] ?? '',
 					'category'    => $ability_meta['category'] ?? '',
 					'type'        => $ability_meta['type'] ?? '',

--- a/projects/plugins/jetpack/tests/php/json-api/WPCOM_JSON_API_Site_Settings_V1_4_Endpoint_Test.php
+++ b/projects/plugins/jetpack/tests/php/json-api/WPCOM_JSON_API_Site_Settings_V1_4_Endpoint_Test.php
@@ -352,7 +352,7 @@ class WPCOM_JSON_API_Site_Settings_V1_4_Endpoint_Test extends WP_UnitTestCase {
 				array(
 					'wpcom-mcp/posts-search' => array(
 						'name'        => 'wpcom-mcp/posts-search',
-						'title'       => 'Posts Search',
+						'title'       => 'Posts search',
 						'description' => 'Search posts',
 						'category'    => 'search',
 						'type'        => 'tool',
@@ -360,7 +360,7 @@ class WPCOM_JSON_API_Site_Settings_V1_4_Endpoint_Test extends WP_UnitTestCase {
 					),
 					'wpcom-mcp/user-sites'   => array(
 						'name'        => 'wpcom-mcp/user-sites',
-						'title'       => 'User Sites',
+						'title'       => 'User sites',
 						'description' => 'Access user sites',
 						'category'    => 'user',
 						'type'        => 'resource',
@@ -391,7 +391,7 @@ class WPCOM_JSON_API_Site_Settings_V1_4_Endpoint_Test extends WP_UnitTestCase {
 				array(
 					'wpcom-mcp/posts-search' => array(
 						'name'        => 'wpcom-mcp/posts-search',
-						'title'       => 'Posts Search',
+						'title'       => 'Posts search',
 						'description' => 'Search posts',
 						'category'    => 'search',
 						'type'        => 'tool',
@@ -399,7 +399,7 @@ class WPCOM_JSON_API_Site_Settings_V1_4_Endpoint_Test extends WP_UnitTestCase {
 					),
 					'wpcom-mcp/user-sites'   => array(
 						'name'        => 'wpcom-mcp/user-sites',
-						'title'       => 'User Sites',
+						'title'       => 'User sites',
 						'description' => 'Access user sites',
 						'category'    => 'user',
 						'type'        => 'resource',
@@ -450,6 +450,7 @@ class WPCOM_JSON_API_Site_Settings_V1_4_Endpoint_Test extends WP_UnitTestCase {
 				array(
 					'wpcom-mcp/posts-search' => array(
 						'name'        => 'wpcom-mcp/posts-search',
+						'title'       => 'Posts search',
 						'description' => 'Search posts',
 						'category'    => 'search',
 						'type'        => 'tool',
@@ -457,6 +458,7 @@ class WPCOM_JSON_API_Site_Settings_V1_4_Endpoint_Test extends WP_UnitTestCase {
 					),
 					'wpcom-mcp/user-sites'   => array(
 						'name'        => 'wpcom-mcp/user-sites',
+						'title'       => 'User sites',
 						'description' => 'Access user sites',
 						'category'    => 'user',
 						'type'        => 'resource',

--- a/projects/plugins/jetpack/tests/php/json-api/WPCOM_JSON_API_Site_Settings_V1_4_Endpoint_Test.php
+++ b/projects/plugins/jetpack/tests/php/json-api/WPCOM_JSON_API_Site_Settings_V1_4_Endpoint_Test.php
@@ -89,12 +89,14 @@ class WPCOM_JSON_API_Site_Settings_V1_4_Endpoint_Test extends WP_UnitTestCase {
 			function ( $ability_meta, $ability_name ) {
 				$test_metadata = array(
 					'wpcom-mcp/posts-search' => array(
+						'title'       => 'Posts search',
 						'description' => 'Search posts',
 						'category'    => 'search',
 						'type'        => 'tool',
 						'enabled'     => true,
 					),
 					'wpcom-mcp/user-sites'   => array(
+						'title'       => 'User sites',
 						'description' => 'Access user sites',
 						'category'    => 'user',
 						'type'        => 'resource',
@@ -350,6 +352,7 @@ class WPCOM_JSON_API_Site_Settings_V1_4_Endpoint_Test extends WP_UnitTestCase {
 				array(
 					'wpcom-mcp/posts-search' => array(
 						'name'        => 'wpcom-mcp/posts-search',
+						'title'       => 'Posts Search',
 						'description' => 'Search posts',
 						'category'    => 'search',
 						'type'        => 'tool',
@@ -357,6 +360,7 @@ class WPCOM_JSON_API_Site_Settings_V1_4_Endpoint_Test extends WP_UnitTestCase {
 					),
 					'wpcom-mcp/user-sites'   => array(
 						'name'        => 'wpcom-mcp/user-sites',
+						'title'       => 'User Sites',
 						'description' => 'Access user sites',
 						'category'    => 'user',
 						'type'        => 'resource',
@@ -387,6 +391,7 @@ class WPCOM_JSON_API_Site_Settings_V1_4_Endpoint_Test extends WP_UnitTestCase {
 				array(
 					'wpcom-mcp/posts-search' => array(
 						'name'        => 'wpcom-mcp/posts-search',
+						'title'       => 'Posts Search',
 						'description' => 'Search posts',
 						'category'    => 'search',
 						'type'        => 'tool',
@@ -394,6 +399,7 @@ class WPCOM_JSON_API_Site_Settings_V1_4_Endpoint_Test extends WP_UnitTestCase {
 					),
 					'wpcom-mcp/user-sites'   => array(
 						'name'        => 'wpcom-mcp/user-sites',
+						'title'       => 'User Sites',
 						'description' => 'Access user sites',
 						'category'    => 'user',
 						'type'        => 'resource',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Follow up to https://github.com/Automattic/jetpack/pull/44921/

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Updates site settings `mcp_abilities` to include ability title - this is the translated text for a particular ability.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

