### PR TITLE
Forms: split editor.js into two chunks to reduce loading of one big file.

### DIFF
--- a/projects/packages/forms/changelog/update-split-editor-forms
+++ b/projects/packages/forms/changelog/update-split-editor-forms
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Split editor forms functionality

--- a/projects/packages/forms/src/blocks/contact-form/edit.js
+++ b/projects/packages/forms/src/blocks/contact-form/edit.js
@@ -24,7 +24,7 @@ import { useInstanceId } from '@wordpress/compose';
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
-import { useRef, useEffect, useCallback } from '@wordpress/element';
+import { useRef, useEffect, useCallback, lazy, Suspense } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import { store as singleStepStore } from '../../store/form-step-preview';
@@ -44,7 +44,7 @@ import { childBlocks } from './child-blocks';
 import { ContactFormPlaceholder } from './components/jetpack-contact-form-placeholder';
 import ContactFormSkeletonLoader from './components/jetpack-contact-form-skeleton-loader';
 import JetpackEmailConnectionSettings from './components/jetpack-email-connection-settings';
-import IntegrationControls from './components/jetpack-integration-controls';
+const IntegrationControls = lazy( () => import( './components/jetpack-integration-controls' ) );
 import VariationPicker from './variation-picker';
 import './util/form-styles.js';
 
@@ -756,7 +756,9 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 					</PanelBody>
 
 					{ ! isSimpleSite() && canUserInstallPlugins && (
-						<IntegrationControls attributes={ attributes } setAttributes={ setAttributes } />
+						<Suspense fallback={ <div /> }>
+							<IntegrationControls attributes={ attributes } setAttributes={ setAttributes } />
+						</Suspense>
 					) }
 				</InspectorControls>
 				<InspectorAdvancedControls>


### PR DESCRIPTION
Load the JS for the editor faster by splitting it up. 
The main chunk is from the interpretation panel. Which is only really visible once you click into it. 
It should be lazy-loaded once the block is loaded.

This PR improves the loading of js resources. 
See 
Before:
<img width="2766" height="650" alt="Screenshot 2025-09-03 at 3 31 10 PM" src="https://github.com/user-attachments/assets/c728bb48-7510-4203-8b4b-eb4415f66def" />

After:
<img width="2710" height="578" alt="Screenshot 2025-09-03 at 3 43 09 PM" src="https://github.com/user-attachments/assets/54278bb1-633c-4f64-a1ca-a98acf8c258e" />

Notice that the editor.js file went from 1.8MB to 0.9MB ( it is a lot less when compressed). 
There is still more work to be done, but this will help a lot with the initial loading. 


## Proposed changes:
* Split the loading of the Integration panel into smaller chunks, resulting in the original loading of the editor.js file being a lot smaller. 

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1756938571668759/1756937162.561669-slack-C052XEUUBL4

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Load the editor.
Add the form block. 
Interact with the integration panel. Does it work as expected? 