### PR TITLE
Boost: Make sure cron schedules register after translations

### DIFF
--- a/projects/plugins/boost/app/class-jetpack-boost.php
+++ b/projects/plugins/boost/app/class-jetpack-boost.php
@@ -124,12 +124,11 @@ class Jetpack_Boost {
 		add_action( 'admin_init', array( $this, 'schedule_version_change' ) );
 
 		add_action( 'init', array( $this, 'init_textdomain' ) );
+		add_action( 'init', array( $this, 'setup_cron_schedules' ) );
 
 		add_action( 'jetpack_boost_environment_changed', array( $this, 'handle_environment_change' ), 10, 2 );
 
 		add_action( 'jetpack_boost_handle_version_change_cron', array( $this, 'handle_version_change' ) );
-
-		add_filter( 'cron_schedules', array( $this, 'custom_cron_intervals' ) );
 
 		// Fired when plugin ready.
 		do_action( 'jetpack_boost_loaded', $this );
@@ -197,6 +196,13 @@ class Jetpack_Boost {
 			// Schedule the cronjob to preload the cache for Cornerstone Pages.
 			( new Cache_Preload() )->schedule_cornerstone_cronjob();
 		}
+	}
+
+	/**
+	 * Adds the custom cron intervals to the schedules list.
+	 */
+	public function setup_cron_schedules() {
+		add_filter( 'cron_schedules', array( $this, 'custom_cron_intervals' ) );
 	}
 
 	/**

--- a/projects/plugins/boost/changelog/fix-boost-using-translations-early
+++ b/projects/plugins/boost/changelog/fix-boost-using-translations-early
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+General: Fix translation warning when activating Boost.


### PR DESCRIPTION
Fixes HOG-326

<img width="824" height="234" alt="CleanShot 2025-09-04 at 15 59 45@2x" src="https://github.com/user-attachments/assets/a8b4d971-fc5f-4f02-a314-ed48a3702f88" />

## Proposed changes:

* Fix "doing it wrong" translation related warning when activating Boost.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

HOG-326

## Does this pull request change what data or activity we track or use?

no

## Testing instructions:

- Activate Boost;
- After being redirected to the Boost settings page, check your `debug.log` and there should be no warnings.
- To test that the warning shows up, switch to trunk, deactivate Boost and activate it - the warning should show up.