### PR TITLE
Forms: save submissions toggle

### DIFF
--- a/projects/packages/forms/changelog/add-forms-store-submissions-toggle
+++ b/projects/packages/forms/changelog/add-forms-store-submissions-toggle
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: added new block toggle to skip saving form submisions on wp-admin

--- a/projects/packages/forms/src/blocks/contact-form/attributes.js
+++ b/projects/packages/forms/src/blocks/contact-form/attributes.js
@@ -52,4 +52,8 @@ export default {
 			listName: null,
 		},
 	},
+	saveResponses: {
+		type: 'boolean',
+		default: true,
+	},
 };

--- a/projects/packages/forms/src/blocks/contact-form/attributes.js
+++ b/projects/packages/forms/src/blocks/contact-form/attributes.js
@@ -53,7 +53,7 @@ export default {
 		},
 	},
 	saveResponses: {
-		type: 'string',
-		default: 'yes',
+		type: 'boolean',
+		default: true,
 	},
 };

--- a/projects/packages/forms/src/blocks/contact-form/attributes.js
+++ b/projects/packages/forms/src/blocks/contact-form/attributes.js
@@ -53,7 +53,7 @@ export default {
 		},
 	},
 	saveResponses: {
-		type: 'boolean',
-		default: true,
+		type: 'string',
+		default: 'yes',
 	},
 };

--- a/projects/packages/forms/src/blocks/contact-form/edit.js
+++ b/projects/packages/forms/src/blocks/contact-form/edit.js
@@ -686,7 +686,10 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 						className="jetpack-contact-form__manage-responses-panel"
 						initialOpen={ false }
 					>
-						<JetpackManageResponsesSettings setAttributes={ setAttributes } />
+						<JetpackManageResponsesSettings
+							attributes={ attributes }
+							setAttributes={ setAttributes }
+						/>
 					</PanelBody>
 					<PanelBody title={ __( 'Action after submit', 'jetpack-forms' ) } initialOpen={ false }>
 						<InspectorHint>

--- a/projects/packages/forms/src/blocks/shared/components/jetpack-manage-responses-settings.js
+++ b/projects/packages/forms/src/blocks/shared/components/jetpack-manage-responses-settings.js
@@ -4,7 +4,7 @@ import { FULL_RESPONSES_PATH } from '../../../util/get-preferred-responses-view'
 import InspectorHint from './inspector-hint';
 
 const JetpackManageResponsesSettings = ( { attributes, setAttributes } ) => {
-	const { saveResponses = 'yes' } = attributes;
+	const { saveResponses = true } = attributes;
 
 	return (
 		<>
@@ -14,8 +14,8 @@ const JetpackManageResponsesSettings = ( { attributes, setAttributes } ) => {
 					'Store form submissions in your WordPress admin for review and export.',
 					'jetpack-forms'
 				) }
-				checked={ saveResponses === 'yes' }
-				onChange={ value => setAttributes( { saveResponses: value ? 'yes' : 'no' } ) }
+				checked={ saveResponses }
+				onChange={ value => setAttributes( { saveResponses: value } ) }
 				__nextHasNoMarginBottom={ true }
 			/>
 			<InspectorHint>

--- a/projects/packages/forms/src/blocks/shared/components/jetpack-manage-responses-settings.js
+++ b/projects/packages/forms/src/blocks/shared/components/jetpack-manage-responses-settings.js
@@ -1,11 +1,23 @@
-import { Button } from '@wordpress/components';
+import { Button, ToggleControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { FULL_RESPONSES_PATH } from '../../../util/get-preferred-responses-view';
 import InspectorHint from './inspector-hint';
 
-const JetpackManageResponsesSettings = () => {
+const JetpackManageResponsesSettings = ( { attributes, setAttributes } ) => {
+	const { saveResponses = true } = attributes;
+
 	return (
 		<>
+			<ToggleControl
+				label={ __( 'Save responses', 'jetpack-forms' ) }
+				help={ __(
+					'Store form submissions in your WordPress admin for review and export.',
+					'jetpack-forms'
+				) }
+				checked={ saveResponses }
+				onChange={ value => setAttributes( { saveResponses: value } ) }
+				__nextHasNoMarginBottom={ true }
+			/>
 			<InspectorHint>
 				{ __( 'Manage and export your form responses in WPAdmin:', 'jetpack-forms' ) }
 			</InspectorHint>

--- a/projects/packages/forms/src/blocks/shared/components/jetpack-manage-responses-settings.js
+++ b/projects/packages/forms/src/blocks/shared/components/jetpack-manage-responses-settings.js
@@ -4,7 +4,7 @@ import { FULL_RESPONSES_PATH } from '../../../util/get-preferred-responses-view'
 import InspectorHint from './inspector-hint';
 
 const JetpackManageResponsesSettings = ( { attributes, setAttributes } ) => {
-	const { saveResponses = true } = attributes;
+	const { saveResponses = 'yes' } = attributes;
 
 	return (
 		<>
@@ -14,8 +14,8 @@ const JetpackManageResponsesSettings = ( { attributes, setAttributes } ) => {
 					'Store form submissions in your WordPress admin for review and export.',
 					'jetpack-forms'
 				) }
-				checked={ saveResponses }
-				onChange={ value => setAttributes( { saveResponses: value } ) }
+				checked={ saveResponses === 'yes' }
+				onChange={ value => setAttributes( { saveResponses: value ? 'yes' : 'no' } ) }
 				__nextHasNoMarginBottom={ true }
 			/>
 			<InspectorHint>

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -285,10 +285,10 @@ class Contact_Form_Plugin {
 			array(
 				'label'                  => 'Temporary',
 				'public'                 => false,
+				'internal'               => true,
 				'exclude_from_search'    => true,
 				'show_in_admin_all_list' => false,
 				// translators: The temporary count.
-				'label_count'            => _n_noop( 'Temporary <span class="count">(%s)</span>', 'Temporary <span class="count">(%s)</span>', 'jetpack-forms' ),
 				'protected'              => true,
 				'_builtin'               => false,
 			)

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -279,6 +279,21 @@ class Contact_Form_Plugin {
 			)
 		);
 
+		// Add "temp" as a post status for temporary storage when saveResponses is 'no'
+		register_post_status(
+			'temp',
+			array(
+				'label'                  => 'Temporary',
+				'public'                 => false,
+				'exclude_from_search'    => true,
+				'show_in_admin_all_list' => false,
+				// translators: The temporary count.
+				'label_count'            => _n_noop( 'Temporary <span class="count">(%s)</span>', 'Temporary <span class="count">(%s)</span>', 'jetpack-forms' ),
+				'protected'              => true,
+				'_builtin'               => false,
+			)
+		);
+
 		// POST handler
 		if (
 			isset( $_SERVER['REQUEST_METHOD'] ) && 'POST' === strtoupper( sanitize_text_field( wp_unslash( $_SERVER['REQUEST_METHOD'] ) ) )

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -279,16 +279,17 @@ class Contact_Form_Plugin {
 			)
 		);
 
-		// Add "temp" as a post status for temporary storage when saveResponses is 'no'
+		// Add "jp-temp-feedback" as a post status for temporary storage when saveResponses is 'no'.
+		// We want these responses skip the inbox but we still need to keep them in the database so that
+		// filters and integrations continue to work.
 		register_post_status(
-			'jetpack-temp-feedback',
+			'jp-temp-feedback',
 			array(
-				'label'                  => 'Temporary',
+				'label'                  => 'Temporary Feedback Status',
 				'public'                 => false,
 				'internal'               => true,
 				'exclude_from_search'    => true,
 				'show_in_admin_all_list' => false,
-				// translators: The temporary count.
 				'protected'              => true,
 				'_builtin'               => false,
 			)

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -281,7 +281,7 @@ class Contact_Form_Plugin {
 
 		// Add "temp" as a post status for temporary storage when saveResponses is 'no'
 		register_post_status(
-			'temp',
+			'jetpack-temp-feedback',
 			array(
 				'label'                  => 'Temporary',
 				'public'                 => false,

--- a/projects/packages/forms/src/contact-form/class-contact-form-shortcode.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-shortcode.php
@@ -168,7 +168,6 @@ class Contact_Form_Shortcode {
 	 */
 	public function __toString() {
 		$r = "[{$this->shortcode_name} ";
-
 		foreach ( $this->attributes as $key => $value ) {
 			if ( ! $value ) {
 				continue;

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -186,6 +186,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 			'salesforceData'         => null,
 			'hiddenFields'           => null,
 			'stepTransition'         => 'fade-slide', // The transition style for multi-step forms. Options: none, fade, slide, fade-slide
+			'saveResponses'          => true,
 		);
 
 		$attributes = shortcode_atts( $this->defaults, $attributes, 'contact-form' );
@@ -1885,15 +1886,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 		// once insert has finished we don't need this filter any more
 		remove_filter( 'wp_insert_post_data', array( $plugin, 'insert_feedback_filter' ), 10 );
 
-		update_post_meta( $post_id, '_feedback_extra_fields', $this->addslashes_deep( $extra_values ) );
-
-		if ( 'publish' === $feedback_status ) {
-			// Increase count of unread feedback.
-			$unread = (int) get_option( 'feedback_unread_count', 0 ) + 1;
-			update_option( 'feedback_unread_count', $unread );
-		}
-
-		if ( defined( 'AKISMET_VERSION' ) ) {
+		if ( defined( 'AKISMET_VERSION' ) && $post_id ) {
 			update_post_meta( $post_id, '_feedback_akismet_values', $this->addslashes_deep( $akismet_values ) );
 		}
 
@@ -1957,15 +1950,18 @@ class Contact_Form extends Contact_Form_Shortcode {
 		$status = $is_spam ? 'spam' : 'inbox';
 
 		// Build the dashboard URL with the status and the feedback's post id
-		$dashboard_url = ( new Dashboard_View_Switch() )->get_forms_admin_url( $status, true ) . '&r=' . $post_id;
+		$dashboard_url = ( new Dashboard_View_Switch() )->get_forms_admin_url( $status, true );
+		if ( $post_id ) {
+			$dashboard_url .= '&r=' . $post_id;
+		}
 
 		$mark_as_spam_url = $dashboard_url . '&mark_as_spam';
 
-		$footer_mark_as_spam_url = sprintf(
+		$footer_mark_as_spam_url = $post_id ? sprintf(
 			'<a href="%1$s">%2$s</a>',
 			esc_url( $mark_as_spam_url ),
 			__( 'Mark as spam', 'jetpack-forms' )
-		);
+		) : '';
 
 		$footer = implode(
 			'',
@@ -1980,14 +1976,16 @@ class Contact_Form extends Contact_Form_Shortcode {
 			 */
 			apply_filters(
 				'jetpack_forms_response_email_footer',
-				array(
-					'<span style="font-size: 12px">',
-					$footer_time . '<br />',
-					$footer_ip ? $footer_ip . '<br />' : null,
-					$footer_url . '<br /><br />',
-					$footer_mark_as_spam_url . '<br />',
-					$sent_by_text,
-					'</span>',
+				array_filter(
+					array(
+						'<span style="font-size: 12px">',
+						$footer_time . '<br />',
+						$footer_ip ? $footer_ip . '<br />' : null,
+						$footer_url . '<br /><br />',
+						$footer_mark_as_spam_url ? $footer_mark_as_spam_url . '<br />' : null,
+						$sent_by_text,
+						'</span>',
+					)
 				)
 			)
 		);

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1138,12 +1138,15 @@ class Contact_Form extends Contact_Form_Shortcode {
 	 *
 	 * @param int          $feedback_id - the feedback ID.
 	 * @param Contact_Form $form - the form.
+	 * @param Feedback     $response - the response.
 	 *
 	 * @return array $lines
 	 */
-	public static function get_compiled_form_for_email( $feedback_id, $form ) {
+	public static function get_compiled_form_for_email( $feedback_id, $form, $response = null ) {
 		$compiled_form = array();
-		$response      = Feedback::get( $feedback_id );
+		if ( ! $response ) {
+			$response = Feedback::get( $feedback_id );
+		}
 
 		if ( $response instanceof Feedback ) {
 			// If the response is an instance of Feedback, we can use its method to get compiled fields.
@@ -1914,7 +1917,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 		 * @param string the title of the email
 		 */
 		$title   = (string) apply_filters( 'jetpack_forms_response_email_title', '' );
-		$message = self::get_compiled_form_for_email( $post_id, $this );
+		$message = self::get_compiled_form_for_email( $post_id, $this, $response );
 
 		if ( is_user_logged_in() ) {
 			$sent_by_text = sprintf(
@@ -1949,19 +1952,18 @@ class Contact_Form extends Contact_Form_Shortcode {
 		// Get the status of the feedback
 		$status = $is_spam ? 'spam' : 'inbox';
 
-		// Build the dashboard URL with the status and the feedback's post id
-		$dashboard_url = ( new Dashboard_View_Switch() )->get_forms_admin_url( $status, true );
+		// Build the dashboard URL with the status and the feedback's post id if we have a post id
+		$dashboard_url           = '';
+		$footer_mark_as_spam_url = '';
 		if ( $post_id ) {
-			$dashboard_url .= '&r=' . $post_id;
+			$dashboard_url           = ( new Dashboard_View_Switch() )->get_forms_admin_url( $status, true ) . '&r=' . $post_id;
+			$mark_as_spam_url        = $dashboard_url . '&mark_as_spam';
+			$footer_mark_as_spam_url = sprintf(
+				'<a href="%1$s">%2$s</a>',
+				esc_url( $mark_as_spam_url ),
+				__( 'Mark as spam', 'jetpack-forms' )
+			);
 		}
-
-		$mark_as_spam_url = $dashboard_url . '&mark_as_spam';
-
-		$footer_mark_as_spam_url = $post_id ? sprintf(
-			'<a href="%1$s">%2$s</a>',
-			esc_url( $mark_as_spam_url ),
-			__( 'Mark as spam', 'jetpack-forms' )
-		) : '';
 
 		$footer = implode(
 			'',
@@ -1990,25 +1992,29 @@ class Contact_Form extends Contact_Form_Shortcode {
 			)
 		);
 
-		$actions = sprintf(
-			'<table class="button_block" border="0" cellpadding="0" cellspacing="0" role="presentation">
-				<tr>
-					<td class="pad" align="center">
-						<a rel="noopener" target="_blank" href="%1$s" data-tracks-link-desc="">
-							<!--[if mso]>
-							<i style="mso-text-raise: 30pt;">&nbsp;</i>
-							<![endif]-->
-							<span>%2$s</span>
-							<!--[if mso]>
-							<i>&nbsp;</i>
-							<![endif]-->
-						</a>
-					</td>
-				</tr>
-			</table>',
-			esc_url( $dashboard_url ),
-			__( 'View in dashboard', 'jetpack-forms' )
-		);
+		// Build the actions url if we have a dashboard url
+		$actions = '';
+		if ( $dashboard_url ) {
+			$actions = sprintf(
+				'<table class="button_block" border="0" cellpadding="0" cellspacing="0" role="presentation">
+					<tr>
+						<td class="pad" align="center">
+							<a rel="noopener" target="_blank" href="%1$s" data-tracks-link-desc="">
+								<!--[if mso]>
+								<i style="mso-text-raise: 30pt;">&nbsp;</i>
+								<![endif]-->
+								<span>%2$s</span>
+								<!--[if mso]>
+								<i>&nbsp;</i>
+								<![endif]-->
+							</a>
+						</td>
+					</tr>
+				</table>',
+				esc_url( $dashboard_url ),
+				__( 'View in dashboard', 'jetpack-forms' )
+			);
+		}
 
 		/**
 		 * Filters the message sent via email after a successful form submission.
@@ -2025,7 +2031,9 @@ class Contact_Form extends Contact_Form_Shortcode {
 		// This is called after `contact_form_message`, in order to preserve back-compat
 		$message = self::wrap_message_in_html_tags( $title, $message, $footer, $actions );
 
-		update_post_meta( $post_id, '_feedback_email', $this->addslashes_deep( compact( 'to', 'message' ) ) );
+		if ( $post_id ) {
+			update_post_meta( $post_id, '_feedback_email', $this->addslashes_deep( compact( 'to', 'message' ) ) );
+		}
 
 		/**
 		 * Fires right before the contact form message is sent via email to
@@ -2098,15 +2106,14 @@ class Contact_Form extends Contact_Form_Shortcode {
 			'contact-form-id'   => $id,
 			'contact-form-sent' => $post_id,
 			'contact-form-hash' => $this->hash,
-			'_wpnonce'          => wp_create_nonce( "contact-form-sent-{$post_id}" ), // wp_nonce_url HTMLencodes :( .
+			'_wpnonce'          => $post_id ? wp_create_nonce( "contact-form-sent-{$post_id}" ) : '', // wp_nonce_url HTMLencodes :( .
 		);
 
 		// If the request accepts JSON, return a JSON response instead of redirecting
 		$accepts_json = isset( $_SERVER['HTTP_ACCEPT'] ) && false !== strpos( strtolower( sanitize_text_field( wp_unslash( $_SERVER['HTTP_ACCEPT'] ) ) ), 'application/json' );
 
 		if ( $this->is_response_without_reload_enabled && $accepts_json ) {
-			$data     = array();
-			$response = Feedback::get( $post_id );
+			$data = array();
 			if ( $response instanceof Feedback ) {
 				$data = $response->get_compiled_fields( 'ajax', 'label|value' );
 			}

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -2046,9 +2046,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 		// This is called after `contact_form_message`, in order to preserve back-compat
 		$message = self::wrap_message_in_html_tags( $title, $message, $footer, $actions );
 
-		if ( $post_id ) {
-			update_post_meta( $post_id, '_feedback_email', $this->addslashes_deep( compact( 'to', 'message' ) ) );
-		}
+		update_post_meta( $post_id, '_feedback_email', $this->addslashes_deep( compact( 'to', 'message' ) ) );
 
 		/**
 		 * Fires right before the contact form message is sent via email to
@@ -2121,7 +2119,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 			'contact-form-id'   => $id,
 			'contact-form-sent' => $post_id,
 			'contact-form-hash' => $this->hash,
-			'_wpnonce'          => $post_id ? wp_create_nonce( "contact-form-sent-{$post_id}" ) : '', // wp_nonce_url HTMLencodes :( .
+			'_wpnonce'          => wp_create_nonce( "contact-form-sent-{$post_id}" ), // wp_nonce_url HTMLencodes :( .
 		);
 
 		// If the request accepts JSON, return a JSON response instead of redirecting

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1143,15 +1143,12 @@ class Contact_Form extends Contact_Form_Shortcode {
 	 *
 	 * @param int          $feedback_id - the feedback ID.
 	 * @param Contact_Form $form - the form.
-	 * @param Feedback     $response - the response.
 	 *
 	 * @return array $lines
 	 */
-	public static function get_compiled_form_for_email( $feedback_id, $form, $response = null ) {
+	public static function get_compiled_form_for_email( $feedback_id, $form ) {
 		$compiled_form = array();
-		if ( ! $response ) {
-			$response = Feedback::get( $feedback_id );
-		}
+		$response      = Feedback::get( $feedback_id );
 
 		if ( $response instanceof Feedback ) {
 			// If the response is an instance of Feedback, we can use its method to get compiled fields.
@@ -1840,7 +1837,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 		} elseif ( $is_spam ) {
 			$feedback_status = 'spam';
 		} elseif ( 'no' === $this->get_attribute( 'saveResponses' ) ) {
-			$feedback_status = 'jetpack-temp-feedback';
+			$feedback_status = 'jp-temp-feedback';
 		} else {
 			$feedback_status = 'publish';
 		}
@@ -1932,7 +1929,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 		 * @param string the title of the email
 		 */
 		$title   = (string) apply_filters( 'jetpack_forms_response_email_title', '' );
-		$message = self::get_compiled_form_for_email( $post_id, $this, $response );
+		$message = self::get_compiled_form_for_email( $post_id, $this );
 
 		if ( is_user_logged_in() ) {
 			$sent_by_text = sprintf(
@@ -1970,7 +1967,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 		// Build the dashboard URL with the status and the feedback's post id if we have a post id
 		$dashboard_url           = '';
 		$footer_mark_as_spam_url = '';
-		if ( $feedback_status !== 'jetpack-temp-feedback' ) {
+		if ( $feedback_status !== 'jp-temp-feedback' ) {
 			$dashboard_url           = ( new Dashboard_View_Switch() )->get_forms_admin_url( $status, true ) . '&r=' . $post_id;
 			$mark_as_spam_url        = $dashboard_url . '&mark_as_spam';
 			$footer_mark_as_spam_url = sprintf(

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1889,6 +1889,16 @@ class Contact_Form extends Contact_Form_Shortcode {
 		// once insert has finished we don't need this filter any more
 		remove_filter( 'wp_insert_post_data', array( $plugin, 'insert_feedback_filter' ), 10 );
 
+		if ( $post_id ) {
+			update_post_meta( $post_id, '_feedback_extra_fields', $this->addslashes_deep( $extra_values ) );
+		}
+
+		if ( 'publish' === $feedback_status && $post_id ) {
+			// Increase count of unread feedback.
+			$unread = (int) get_option( 'feedback_unread_count', 0 ) + 1;
+			update_option( 'feedback_unread_count', $unread );
+		}
+
 		if ( defined( 'AKISMET_VERSION' ) && $post_id ) {
 			update_post_meta( $post_id, '_feedback_akismet_values', $this->addslashes_deep( $akismet_values ) );
 		}

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -186,7 +186,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 			'salesforceData'         => null,
 			'hiddenFields'           => null,
 			'stepTransition'         => 'fade-slide', // The transition style for multi-step forms. Options: none, fade, slide, fade-slide
-			'saveResponses'          => true,
+			'saveResponses'          => 'yes',
 		);
 
 		$attributes = shortcode_atts( $this->defaults, $attributes, 'contact-form' );

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1896,9 +1896,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 		// once insert has finished we don't need this filter any more
 		remove_filter( 'wp_insert_post_data', array( $plugin, 'insert_feedback_filter' ), 10 );
 
-		if ( $post_id ) {
-			update_post_meta( $post_id, '_feedback_extra_fields', $this->addslashes_deep( $extra_values ) );
-		}
+		update_post_meta( $post_id, '_feedback_extra_fields', $this->addslashes_deep( $extra_values ) );
 
 		if ( 'publish' === $feedback_status ) {
 			// Increase count of unread feedback.
@@ -1906,7 +1904,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 			update_option( 'feedback_unread_count', $unread );
 		}
 
-		if ( defined( 'AKISMET_VERSION' ) && $post_id ) {
+		if ( defined( 'AKISMET_VERSION' ) ) {
 			update_post_meta( $post_id, '_feedback_akismet_values', $this->addslashes_deep( $akismet_values ) );
 		}
 

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -191,6 +191,11 @@ class Contact_Form extends Contact_Form_Shortcode {
 
 		$attributes = shortcode_atts( $this->defaults, $attributes, 'contact-form' );
 
+		// Transform boolean saveResponses to string for backend compatibility
+		if ( isset( $attributes['saveResponses'] ) && is_bool( $attributes['saveResponses'] ) ) {
+			$attributes['saveResponses'] = $attributes['saveResponses'] ? 'yes' : 'no';
+		}
+
 		// We only enable the contact-field shortcode temporarily while processing the contact-form shortcode.
 		Contact_Form_Plugin::$using_contact_form_field = true;
 

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1895,7 +1895,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 			update_post_meta( $post_id, '_feedback_extra_fields', $this->addslashes_deep( $extra_values ) );
 		}
 
-		if ( 'publish' === $feedback_status && $post_id ) {
+		if ( 'publish' === $feedback_status ) {
 			// Increase count of unread feedback.
 			$unread = (int) get_option( 'feedback_unread_count', 0 ) + 1;
 			update_option( 'feedback_unread_count', $unread );
@@ -1967,7 +1967,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 		// Build the dashboard URL with the status and the feedback's post id if we have a post id
 		$dashboard_url           = '';
 		$footer_mark_as_spam_url = '';
-		if ( $post_id ) {
+		if ( $feedback_status !== 'temp' ) {
 			$dashboard_url           = ( new Dashboard_View_Switch() )->get_forms_admin_url( $status, true ) . '&r=' . $post_id;
 			$mark_as_spam_url        = $dashboard_url . '&mark_as_spam';
 			$footer_mark_as_spam_url = sprintf(

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1834,6 +1834,8 @@ class Contact_Form extends Contact_Form_Shortcode {
 			$feedback_status = 'trash';
 		} elseif ( $is_spam ) {
 			$feedback_status = 'spam';
+		} elseif ( 'no' === $this->get_attribute( 'saveResponses' ) ) {
+			$feedback_status = 'temp';
 		} else {
 			$feedback_status = 'publish';
 		}

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1840,7 +1840,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 		} elseif ( $is_spam ) {
 			$feedback_status = 'spam';
 		} elseif ( 'no' === $this->get_attribute( 'saveResponses' ) ) {
-			$feedback_status = 'temp';
+			$feedback_status = 'jetpack-temp-feedback';
 		} else {
 			$feedback_status = 'publish';
 		}
@@ -1970,7 +1970,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 		// Build the dashboard URL with the status and the feedback's post id if we have a post id
 		$dashboard_url           = '';
 		$footer_mark_as_spam_url = '';
-		if ( $feedback_status !== 'temp' ) {
+		if ( $feedback_status !== 'jetpack-temp-feedback' ) {
 			$dashboard_url           = ( new Dashboard_View_Switch() )->get_forms_admin_url( $status, true ) . '&r=' . $post_id;
 			$mark_as_spam_url        = $dashboard_url . '&mark_as_spam';
 			$footer_mark_as_spam_url = sprintf(

--- a/projects/packages/forms/src/contact-form/class-feedback.php
+++ b/projects/packages/forms/src/contact-form/class-feedback.php
@@ -815,7 +815,7 @@ class Feedback {
 		// Check if responses should be saved to the database
 		if ( $this->form && method_exists( $this->form, 'get_attribute' ) ) {
 			$save_responses = $this->form->get_attribute( 'saveResponses' );
-			if ( '' === $save_responses ) {
+			if ( 'no' === $save_responses ) {
 				return 0; // Don't save the response
 			}
 		}

--- a/projects/packages/forms/src/contact-form/class-feedback.php
+++ b/projects/packages/forms/src/contact-form/class-feedback.php
@@ -121,6 +121,13 @@ class Feedback {
 	protected $source;
 
 	/**
+	 * The Contact_Form object that this feedback was submitted from.
+	 *
+	 * @var Contact_Form|null
+	 */
+	protected $form;
+
+	/**
 	 * Create a response object from a feedback post ID.
 	 *
 	 * @param int $feedback_post_id The ID of the feedback post.
@@ -204,6 +211,7 @@ class Feedback {
 	 */
 	private function load_from_submission( $post_data, $form, $current_post = null, $current_page_number = 1 ) {
 
+		$this->form   = $form;
 		$this->source = Feedback_Source::from_submission( $current_post, $current_page_number );
 		// If post_data is provided, use it to populate fields.
 		$this->fields          = $this->get_computed_fields( $post_data, $form );
@@ -804,6 +812,14 @@ class Feedback {
 	 * @return int
 	 */
 	public function save() {
+		// Check if responses should be saved to the database
+		if ( $this->form && method_exists( $this->form, 'get_attribute' ) ) {
+			$save_responses = $this->form->get_attribute( 'saveResponses' );
+			if ( '' === $save_responses ) {
+				return 0; // Don't save the response
+			}
+		}
+
 		$post_id = wp_insert_post(
 			array(
 				'post_type'      => self::POST_TYPE,

--- a/projects/packages/forms/src/contact-form/class-feedback.php
+++ b/projects/packages/forms/src/contact-form/class-feedback.php
@@ -121,13 +121,6 @@ class Feedback {
 	protected $source;
 
 	/**
-	 * The Contact_Form object that this feedback was submitted from.
-	 *
-	 * @var Contact_Form|null
-	 */
-	protected $form;
-
-	/**
 	 * Create a response object from a feedback post ID.
 	 *
 	 * @param int $feedback_post_id The ID of the feedback post.
@@ -211,7 +204,6 @@ class Feedback {
 	 */
 	private function load_from_submission( $post_data, $form, $current_post = null, $current_page_number = 1 ) {
 
-		$this->form   = $form;
 		$this->source = Feedback_Source::from_submission( $current_post, $current_page_number );
 		// If post_data is provided, use it to populate fields.
 		$this->fields          = $this->get_computed_fields( $post_data, $form );
@@ -812,14 +804,6 @@ class Feedback {
 	 * @return int
 	 */
 	public function save() {
-		// Check if responses should be saved to the database
-		if ( $this->form && method_exists( $this->form, 'get_attribute' ) ) {
-			$save_responses = $this->form->get_attribute( 'saveResponses' );
-			if ( 'no' === $save_responses ) {
-				return 0; // Don't save the response
-			}
-		}
-
 		$post_id = wp_insert_post(
 			array(
 				'post_type'      => self::POST_TYPE,

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -2591,6 +2591,7 @@ EOT;
 		$expected_attributes['block_template']      = '';
 		$expected_attributes['block_template_part'] = '';
 		$expected_attributes['id']                  = 'widget-string';
+		$expected_attributes['saveResponses']       = 'yes';
 
 		$form = new Contact_Form(
 			$attributes,

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -85,7 +85,7 @@ class Contact_Form_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Test that form submissions are stored with 'jetpack-temp-feedback' status when saveResponses is 'no'
+	 * Test that form submissions are stored with 'jp-temp-feedback' status when saveResponses is 'no'
 	 */
 	public function test_process_submission_does_not_store_feedback_when_save_responses_no() {
 		// Fill field values
@@ -124,7 +124,7 @@ class Contact_Form_Test extends BaseTestCase {
 		$new_post = end( $final_posts );
 		$this->assertInstanceOf( 'stdClass', $new_post, 'The new post should be a stdClass instance' );
 		$this->assertEquals( 'feedback', $new_post->post_type, 'The new post should be of type feedback' );
-		$this->assertEquals( 'jetpack-temp-feedback', $new_post->post_status, 'The new post should have jetpack-temp-feedback status when saveResponses is no' );
+		$this->assertEquals( 'jp-temp-feedback', $new_post->post_status, 'The new post should have jp-temp-feedback status when saveResponses is no' );
 
 		// Verify the form attribute is correctly set
 		$this->assertEquals( 'no', $form->get_attribute( 'saveResponses' ), 'Form should have saveResponses set to no' );

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -40,6 +40,134 @@ class Contact_Form_Test extends BaseTestCase {
 	private $plugin;
 
 	/**
+	 * Test that form submissions are stored in database when saveResponses is 'yes' (default)
+	 */
+	public function test_process_submission_stores_feedback_when_save_responses_yes() {
+		// Fill field values
+		$this->add_field_values(
+			array(
+				'name'    => 'John Doe',
+				'email'   => 'john@example.com',
+				'message' => 'Test message',
+			)
+		);
+
+		// Create form with saveResponses explicitly set to 'yes'
+		$form = new Contact_Form(
+			array(
+				'saveResponses' => 'yes',
+			),
+			"[contact-field label='Name' type='name' required='1'/][contact-field label='Email' type='email' required='1'/][contact-field label='Message' type='textarea' required='1'/]"
+		);
+
+		// Get initial post count
+		$initial_posts = Posts::init()->posts;
+		$initial_count = count( $initial_posts );
+
+		// Process the submission
+		$result = $form->process_submission();
+
+		// Processing should be successful
+		$this->assertTrue( is_string( $result ), 'Form submission should be successful' );
+
+		// Check that a new feedback post was created
+		$final_posts = Posts::init()->posts;
+		$final_count = count( $final_posts );
+		$this->assertEquals( $initial_count + 1, $final_count, 'A new feedback post should be created when saveResponses is yes' );
+
+		// Verify the feedback post was created with correct type
+		$feedback_id = end( $final_posts )->ID;
+		$submission  = get_post( $feedback_id );
+		$this->assertEquals( 'feedback', $submission->post_type, 'Post type should be feedback' );
+
+		// Verify the form attribute is correctly set
+		$this->assertEquals( 'yes', $form->get_attribute( 'saveResponses' ), 'Form should have saveResponses set to yes' );
+	}
+
+	/**
+	 * Test that form submissions are NOT stored in database when saveResponses is 'no'
+	 */
+	public function test_process_submission_does_not_store_feedback_when_save_responses_no() {
+		// Fill field values
+		$this->add_field_values(
+			array(
+				'name'    => 'Jane Doe',
+				'email'   => 'jane@example.com',
+				'message' => 'Test message for no save',
+			)
+		);
+
+		// Create form with saveResponses set to 'no'
+		$form = new Contact_Form(
+			array(
+				'saveResponses' => 'no',
+			),
+			"[contact-field label='Name' type='name' required='1'/][contact-field label='Email' type='email' required='1'/][contact-field label='Message' type='textarea' required='1'/]"
+		);
+
+		// Get initial post count
+		$initial_posts = Posts::init()->posts;
+		$initial_count = count( $initial_posts );
+
+		// Process the submission
+		$result = $form->process_submission();
+
+		// Processing should still be successful (email should still be sent)
+		$this->assertTrue( is_string( $result ), 'Form submission should be successful even when not saving responses' );
+
+		// Check that NO new feedback post was created
+		$final_posts = Posts::init()->posts;
+		$final_count = count( $final_posts );
+		$this->assertEquals( $initial_count, $final_count, 'No new feedback post should be created when saveResponses is no' );
+
+		// Verify the form attribute is correctly set
+		$this->assertEquals( 'no', $form->get_attribute( 'saveResponses' ), 'Form should have saveResponses set to no' );
+	}
+
+	/**
+	 * Test that form submissions are stored in database when saveResponses is not specified (defaults to 'yes')
+	 */
+	public function test_process_submission_stores_feedback_when_save_responses_default() {
+		// Fill field values
+		$this->add_field_values(
+			array(
+				'name'    => 'Default User',
+				'email'   => 'default@example.com',
+				'message' => 'Test message for default behavior',
+			)
+		);
+
+		// Create form without specifying saveResponses (should default to 'yes')
+		$form = new Contact_Form(
+			array(),
+			"[contact-field label='Name' type='name' required='1'/][contact-field label='Email' type='email' required='1'/][contact-field label='Message' type='textarea' required='1'/]"
+		);
+
+		// Get initial post count
+		$initial_posts = Posts::init()->posts;
+		$initial_count = count( $initial_posts );
+
+		// Process the submission
+		$result = $form->process_submission();
+
+		// Processing should be successful
+		$this->assertTrue( is_string( $result ), 'Form submission should be successful' );
+
+		// Check that a new feedback post was created (default behavior)
+		$final_posts = Posts::init()->posts;
+		$final_count = count( $final_posts );
+		$this->assertEquals( $initial_count + 1, $final_count, 'A new feedback post should be created by default' );
+
+		// Verify the feedback post was created with correct type
+		$feedback_id = end( $final_posts )->ID;
+		$submission  = get_post( $feedback_id );
+		$this->assertEquals( 'feedback', $submission->post_type, 'Post type should be feedback' );
+
+		// Verify the form attribute defaults to 'yes'
+		$this->assertEquals( 'yes', $form->get_attribute( 'saveResponses' ), 'Form should default saveResponses to yes' );
+	}
+
+	/**
 	 * Test the esc_shortcode_val method with various input types
 	 */
 	public function test_esc_shortcode_val() {

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -85,7 +85,7 @@ class Contact_Form_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Test that form submissions are NOT stored in database when saveResponses is 'no'
+	 * Test that form submissions are stored with 'temp' status when saveResponses is 'no'
 	 */
 	public function test_process_submission_does_not_store_feedback_when_save_responses_no() {
 		// Fill field values
@@ -115,10 +115,16 @@ class Contact_Form_Test extends BaseTestCase {
 		// Processing should still be successful (email should still be sent)
 		$this->assertTrue( is_string( $result ), 'Form submission should be successful even when not saving responses' );
 
-		// Check that NO new feedback post was created
+		// Check that a new feedback post was created
 		$final_posts = Posts::init()->posts;
 		$final_count = count( $final_posts );
-		$this->assertEquals( $initial_count, $final_count, 'No new feedback post should be created when saveResponses is no' );
+		$this->assertEquals( $initial_count + 1, $final_count, 'A new feedback post should be created when saveResponses is no' );
+
+		// Get the newly created post
+		$new_post = end( $final_posts );
+		$this->assertInstanceOf( 'stdClass', $new_post, 'The new post should be a stdClass instance' );
+		$this->assertEquals( 'feedback', $new_post->post_type, 'The new post should be of type feedback' );
+		$this->assertEquals( 'temp', $new_post->post_status, 'The new post should have temp status when saveResponses is no' );
 
 		// Verify the form attribute is correctly set
 		$this->assertEquals( 'no', $form->get_attribute( 'saveResponses' ), 'Form should have saveResponses set to no' );

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -85,7 +85,7 @@ class Contact_Form_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Test that form submissions are stored with 'temp' status when saveResponses is 'no'
+	 * Test that form submissions are stored with 'jetpack-temp-feedback' status when saveResponses is 'no'
 	 */
 	public function test_process_submission_does_not_store_feedback_when_save_responses_no() {
 		// Fill field values
@@ -124,7 +124,7 @@ class Contact_Form_Test extends BaseTestCase {
 		$new_post = end( $final_posts );
 		$this->assertInstanceOf( 'stdClass', $new_post, 'The new post should be a stdClass instance' );
 		$this->assertEquals( 'feedback', $new_post->post_type, 'The new post should be of type feedback' );
-		$this->assertEquals( 'temp', $new_post->post_status, 'The new post should have temp status when saveResponses is no' );
+		$this->assertEquals( 'jetpack-temp-feedback', $new_post->post_status, 'The new post should have jetpack-temp-feedback status when saveResponses is no' );
 
 		// Verify the form attribute is correctly set
 		$this->assertEquals( 'no', $form->get_attribute( 'saveResponses' ), 'Form should have saveResponses set to no' );

--- a/projects/plugins/jetpack/changelog/add-forms-store-submissions-toggle
+++ b/projects/plugins/jetpack/changelog/add-forms-store-submissions-toggle
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: added new block toggle to skip saving form submisions on wp-admin


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes FORMS-247

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* I've added a toggle in the form's block panel to allow users to not save form submissions in wp-admin. The toggle is on by default.
<img width="626" height="556" alt="Screenshot 2025-09-04 at 16 53 47" src="https://github.com/user-attachments/assets/9198599a-bbcc-4860-95c8-9a40cabd8c70" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add a form to a post or page.
* Go to the forms block settings' `Manage responses` panel and set the `Save response` toggle off.
* Publish the post/page and then submit a form response.
* The post-submission page will show the form submission data. Also, check that after a page refresh, the form submission is still present.
<img width="1316" height="934" alt="Screenshot 2025-09-08 at 11 54 28" src="https://github.com/user-attachments/assets/2664ea49-ed3d-4d7b-88ff-2ad63b1cef64" />
* Go to the Jetpack Forms responses page in wp-admin and check that the response you submitted doesn't show up there.
* Check that you've received an email with the form submission data. The email shouldn't have the `View in dashboard` button and the `Mark as spam` link.
<img width="1362" height="1124" alt="Screenshot 2025-09-08 at 11 50 07" src="https://github.com/user-attachments/assets/343e9b4e-cd5c-42b0-8375-fe262d824ded" />
* Go back to edit the post/page you've created and now set the `Save responses` toggle on.
* Check that now the responses show up in the Jetpack forms responses page in wp-admin.
* Check that on the post-submission page, the form submission data appears after page refresh.
* Check that the form submission email shows the `View in Dashboard` button and `Mark as spam` link.
<img width="1342" height="1286" alt="Screenshot 2025-09-08 at 11 50 15" src="https://github.com/user-attachments/assets/72edb738-1f86-4910-b3a7-d931c404d833" />
* Set up a form integration, such as MailPoet, and check that the integration continues to work with the `Save response` toggle on and off.


