### PR TITLE
Forms: Improve passing PHP data to Javascript

### DIFF
--- a/projects/packages/forms/changelog/update-forms-admin-script-data
+++ b/projects/packages/forms/changelog/update-forms-admin-script-data
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: Consolidate data to frontend.

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -16,7 +16,6 @@ use Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch;
 use Automattic\Jetpack\Forms\Jetpack_Forms;
 use Automattic\Jetpack\Modules;
 use Automattic\Jetpack\Status\Request;
-use Jetpack;
 
 /**
  * Contact Form block render callback.
@@ -772,22 +771,17 @@ class Contact_Form_Block {
 		);
 
 		// Create a Contact_Form instance to get the default values
-		$dashboard_view_switch   = new Dashboard_View_Switch();
-		$form_responses_url      = $dashboard_view_switch->get_forms_admin_url();
-		$akismet_active_with_key = Jetpack::is_akismet_active();
-		$akismet_key_url         = admin_url( 'admin.php?page=akismet-key-config' );
-		$preferred_view          = $dashboard_view_switch->get_preferred_view();
+		$dashboard_view_switch = new Dashboard_View_Switch();
+		$form_responses_url    = $dashboard_view_switch->get_forms_admin_url();
+		$preferred_view        = $dashboard_view_switch->get_preferred_view();
 
 		$data = array(
 			'defaults' => array(
-				'to'                   => Contact_Form::get_default_to( $post ? Contact_Form::get_post_property( $post, 'post_author' ) : null ),
-				'subject'              => Contact_Form::get_default_subject( array() ),
-				'formsResponsesUrl'    => $form_responses_url,
-				'akismetActiveWithKey' => $akismet_active_with_key,
-				'akismetUrl'           => $akismet_key_url,
-				'assetsUrl'            => Jetpack_Forms::assets_url(),
-				'preferredView'        => $preferred_view,
-				'isMailPoetEnabled'    => Jetpack_Forms::is_mailpoet_enabled(),
+				'to'                => Contact_Form::get_default_to( $post ? Contact_Form::get_post_property( $post, 'post_author' ) : null ),
+				'subject'           => Contact_Form::get_default_subject( array() ),
+				'formsResponsesUrl' => $form_responses_url,
+				'preferredView'     => $preferred_view,
+				'isMailPoetEnabled' => Jetpack_Forms::is_mailpoet_enabled(),
 			),
 		);
 

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/index.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/index.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import jetpackAnalytics from '@automattic/jetpack-analytics';
+import { getScriptData } from '@automattic/jetpack-script-data';
 import { Modal, __experimentalVStack as VStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -20,7 +21,7 @@ import './style.scss';
  */
 import type { Integration } from '../../../../types';
 
-const isMailPoetEnabled: boolean = !! window?.jpFormsBlocks?.defaults?.isMailPoetEnabled;
+const isMailPoetEnabled = Boolean( getScriptData()?.forms?.isMailPoetEnabled );
 
 const IntegrationsModal = ( {
 	isOpen,

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -102,6 +102,9 @@ class Contact_Form_Plugin {
 
 			// Schedule our daily cleanup
 			add_action( 'wp_scheduled_delete', array( $instance, 'daily_akismet_meta_cleanup' ) );
+
+			// Provide consolidated Forms script data to both editor and admin via JetpackScriptData.
+			add_filter( 'jetpack_admin_js_script_data', array( __CLASS__, 'add_forms_script_data' ), 10, 1 );
 		}
 
 		return $instance;
@@ -3378,5 +3381,67 @@ class Contact_Form_Plugin {
 		// Use wp_safe_redirect to ensure we're redirecting to a safe location
 		wp_safe_redirect( $redirect_url );
 		exit;
+	}
+
+	/**
+	 * Add Forms script data to the global JetpackScriptData object for use across admin and editor.
+	 *
+	 * All Forms-related data (including capabilities used by Forms UIs) is nested under the 'forms' key.
+	 *
+	 * @param array $data Existing script data.
+	 * @return array Modified script data including Forms data.
+	 */
+	public static function add_forms_script_data( $data ) {
+		if ( ! is_array( $data ) ) {
+			$data = array();
+		}
+
+		$forms = isset( $data['forms'] ) && is_array( $data['forms'] ) ? $data['forms'] : array();
+
+		// Capabilities relevant to Forms UIs.
+		$forms['capabilities'] = array(
+			'install_plugins'  => current_user_can( 'install_plugins' ),
+			'activate_plugins' => current_user_can( 'activate_plugins' ),
+		);
+
+		// Editor defaults formerly passed via window.jpFormsBlocks.defaults.
+		$dashboard_view_switch = new \Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch();
+		$forms['defaults']     = array(
+			'formsResponsesUrl'    => $dashboard_view_switch->get_forms_admin_url(),
+			'akismetActiveWithKey' => \Jetpack::is_akismet_active(),
+			'akismetUrl'           => admin_url( 'admin.php?page=akismet-key-config' ),
+			'assetsUrl'            => \Automattic\Jetpack\Forms\Jetpack_Forms::assets_url(),
+			'preferredView'        => $dashboard_view_switch->get_preferred_view(),
+			'isMailPoetEnabled'    => \Automattic\Jetpack\Forms\Jetpack_Forms::is_mailpoet_enabled(),
+		);
+
+		// Dashboard-specific data formerly passed via the dashboard config and inline apiRoot.
+		$forms['dashboard'] = array(
+			'blogId'                  => get_current_blog_id(),
+			'exportNonce'             => wp_create_nonce( 'feedback_export' ),
+			'newFormNonce'            => wp_create_nonce( 'create_new_form' ),
+			'checkForSpamNonce'       => wp_create_nonce( 'grunion_recheck_queue' ),
+			'gdriveConnectSupportURL' => esc_url( \Automattic\Jetpack\Redirect::get_url( 'jetpack-support-contact-form-export' ) ),
+			'pluginAssetsURL'         => \Automattic\Jetpack\Forms\Jetpack_Forms::assets_url(),
+			'siteURL'                 => ( new \Automattic\Jetpack\Status() )->get_site_suffix(),
+			'enableIntegrationsTab'   => apply_filters( 'jetpack_forms_enable_integrations_tab', true ),
+			'dashboardURL'            => add_query_arg( 'jetpack_forms_migration_announcement_seen', 'yes', $dashboard_view_switch->get_forms_admin_url() ),
+			'isMailpoetEnabled'       => \Automattic\Jetpack\Forms\Jetpack_Forms::is_mailpoet_enabled(),
+			'apiRoot'                 => ( defined( 'IS_WPCOM' ) && IS_WPCOM )
+				? sprintf( '/wpcom/v2/sites/%s/', esc_url_raw( rest_url() ) )
+				: '/wp-json/wpcom/v2/',
+		);
+
+		// Optionally include AI flag mirroring the dashboard behavior.
+		$forms['dashboard']['hasAI'] = ( function () {
+			if ( ! class_exists( 'Jetpack_AI_Helper' ) ) {
+				require_once JETPACK__PLUGIN_DIR . '_inc/lib/class-jetpack-ai-helper.php';
+			}
+			$feature = \Jetpack_AI_Helper::get_ai_assistance_feature();
+			return ! is_wp_error( $feature ) ? ( $feature['has-feature'] ?? false ) : false;
+		} )();
+
+		$data['forms'] = $forms;
+		return $data;
 	}
 }

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -10,12 +10,16 @@ namespace Automattic\Jetpack\Forms\ContactForm;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Extensions\Contact_Form\Contact_Form_Block;
+use Automattic\Jetpack\Forms\Dashboard\Dashboard as Forms_Dashboard;
+use Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch;
 use Automattic\Jetpack\Forms\Jetpack_Forms;
 use Automattic\Jetpack\Forms\Service\MailPoet_Integration;
 use Automattic\Jetpack\Forms\Service\Post_To_Url;
+use Automattic\Jetpack\Redirect;
 use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Terms_Of_Service;
 use Automattic\Jetpack\Tracking;
+use Jetpack_AI_Helper;
 use Jetpack_Options;
 use WP_Block;
 use WP_Block_Patterns_Registry;
@@ -3396,50 +3400,34 @@ class Contact_Form_Plugin {
 			$data = array();
 		}
 
-		$forms = isset( $data['forms'] ) && is_array( $data['forms'] ) ? $data['forms'] : array();
+		$forms                 = isset( $data['forms'] ) && is_array( $data['forms'] ) ? $data['forms'] : array();
+		$dashboard_view_switch = new Dashboard_View_Switch();
+		$ai_feature            = Jetpack_AI_Helper::get_ai_assistance_feature();
+		$has_ai                = ! is_wp_error( $ai_feature ) ? $ai_feature['has-feature'] : false;
 
-		// Capabilities relevant to Forms UIs.
-		$forms['capabilities'] = array(
-			'install_plugins'  => current_user_can( 'install_plugins' ),
-			'activate_plugins' => current_user_can( 'activate_plugins' ),
-		);
+		// From jpFormsBlocks in class-contact-form-block.php.
+		$forms['formsResponsesUrl'] = $dashboard_view_switch->get_forms_admin_url();
+		$forms['preferredView']     = $dashboard_view_switch->get_preferred_view();
+		$forms['isMailPoetEnabled'] = Jetpack_Forms::is_mailpoet_enabled();
+		// From config in class-dashboard.php.
+		$forms['blogId']                  = get_current_blog_id();
+		$forms['gdriveConnectSupportURL'] = esc_url( Redirect::get_url( 'jetpack-support-contact-form-export' ) );
+		$forms['pluginAssetsURL']         = Jetpack_Forms::assets_url();
+		$forms['siteURL']                 = ( new Status() )->get_site_suffix();
+		$forms['hasFeedback']             = ( new Forms_Dashboard() )->has_feedback();
+		$forms['hasAI']                   = $has_ai;
+		$forms['enableIntegrationsTab']   = apply_filters( 'jetpack_forms_enable_integrations_tab', true );
+		$forms['renderMigrationPage']     = $dashboard_view_switch->is_jetpack_forms_announcing_new_menu();
+		$forms['dashboardURL']            = add_query_arg( 'jetpack_forms_migration_announcement_seen', 'yes', $dashboard_view_switch->get_forms_admin_url() );
+		// New data.
+		$forms['canInstallPlugins']  = current_user_can( 'install_plugins' );
+		$forms['canActivatePlugins'] = current_user_can( 'activate_plugins' );
 
-		// Editor defaults formerly passed via window.jpFormsBlocks.defaults.
-		$dashboard_view_switch = new \Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch();
-		$forms['defaults']     = array(
-			'formsResponsesUrl'    => $dashboard_view_switch->get_forms_admin_url(),
-			'akismetActiveWithKey' => \Jetpack::is_akismet_active(),
-			'akismetUrl'           => admin_url( 'admin.php?page=akismet-key-config' ),
-			'assetsUrl'            => \Automattic\Jetpack\Forms\Jetpack_Forms::assets_url(),
-			'preferredView'        => $dashboard_view_switch->get_preferred_view(),
-			'isMailPoetEnabled'    => \Automattic\Jetpack\Forms\Jetpack_Forms::is_mailpoet_enabled(),
-		);
-
-		// Dashboard-specific data formerly passed via the dashboard config and inline apiRoot.
-		$forms['dashboard'] = array(
-			'blogId'                  => get_current_blog_id(),
-			'exportNonce'             => wp_create_nonce( 'feedback_export' ),
-			'newFormNonce'            => wp_create_nonce( 'create_new_form' ),
-			'checkForSpamNonce'       => wp_create_nonce( 'grunion_recheck_queue' ),
-			'gdriveConnectSupportURL' => esc_url( \Automattic\Jetpack\Redirect::get_url( 'jetpack-support-contact-form-export' ) ),
-			'pluginAssetsURL'         => \Automattic\Jetpack\Forms\Jetpack_Forms::assets_url(),
-			'siteURL'                 => ( new \Automattic\Jetpack\Status() )->get_site_suffix(),
-			'enableIntegrationsTab'   => apply_filters( 'jetpack_forms_enable_integrations_tab', true ),
-			'dashboardURL'            => add_query_arg( 'jetpack_forms_migration_announcement_seen', 'yes', $dashboard_view_switch->get_forms_admin_url() ),
-			'isMailpoetEnabled'       => \Automattic\Jetpack\Forms\Jetpack_Forms::is_mailpoet_enabled(),
-			'apiRoot'                 => ( defined( 'IS_WPCOM' ) && IS_WPCOM )
-				? sprintf( '/wpcom/v2/sites/%s/', esc_url_raw( rest_url() ) )
-				: '/wp-json/wpcom/v2/',
-		);
-
-		// Optionally include AI flag mirroring the dashboard behavior.
-		$forms['dashboard']['hasAI'] = ( function () {
-			if ( ! class_exists( 'Jetpack_AI_Helper' ) ) {
-				require_once JETPACK__PLUGIN_DIR . '_inc/lib/class-jetpack-ai-helper.php';
-			}
-			$feature = \Jetpack_AI_Helper::get_ai_assistance_feature();
-			return ! is_wp_error( $feature ) ? ( $feature['has-feature'] ?? false ) : false;
-		} )();
+		// Include nonces only on the Forms dashboard screen to avoid leaking tokens elsewhere.
+		if ( is_admin() && isset( $_GET['page'] ) && 'jetpack-forms-admin' === $_GET['page'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- read-only context
+			$forms['exportNonce']  = wp_create_nonce( 'feedback_export' );
+			$forms['newFormNonce'] = wp_create_nonce( 'create_new_form' );
+		}
 
 		$data['forms'] = $forms;
 		return $data;

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -220,7 +220,6 @@ class Dashboard {
 			'enableIntegrationsTab'   => self::$show_integrations,
 			'renderMigrationPage'     => $this->switch->is_jetpack_forms_announcing_new_menu(),
 			'dashboardURL'            => add_query_arg( 'jetpack_forms_migration_announcement_seen', 'yes', $this->switch->get_forms_admin_url() ),
-			'isMailPoetEnabled'       => Jetpack_Forms::is_mailpoet_enabled(),
 		);
 
 		if ( ! empty( $extra_config ) ) {

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -111,16 +111,6 @@ class Dashboard {
 
 		// Adds Connection package initial state.
 		Connection_Initial_State::render_script( self::SCRIPT_HANDLE );
-
-		$api_root = defined( 'IS_WPCOM' ) && IS_WPCOM
-			? sprintf( '/wpcom/v2/sites/%s/', esc_url_raw( rest_url() ) )
-			: '/wp-json/wpcom/v2/';
-
-		wp_add_inline_script(
-			self::SCRIPT_HANDLE,
-			'window.jetpackFormsData = ' . wp_json_encode( array( 'apiRoot' => $api_root ) ) . ';',
-			'before'
-		);
 	}
 
 	/**
@@ -230,7 +220,7 @@ class Dashboard {
 			'enableIntegrationsTab'   => self::$show_integrations,
 			'renderMigrationPage'     => $this->switch->is_jetpack_forms_announcing_new_menu(),
 			'dashboardURL'            => add_query_arg( 'jetpack_forms_migration_announcement_seen', 'yes', $this->switch->get_forms_admin_url() ),
-			'isMailpoetEnabled'       => Jetpack_Forms::is_mailpoet_enabled(),
+			'isMailPoetEnabled'       => Jetpack_Forms::is_mailpoet_enabled(),
 		);
 
 		if ( ! empty( $extra_config ) ) {
@@ -246,7 +236,7 @@ class Dashboard {
 	 *
 	 * @return boolean
 	 */
-	private function has_feedback() {
+	public function has_feedback() {
 		$posts = new \WP_Query(
 			array(
 				'post_type'   => 'feedback',

--- a/projects/packages/forms/src/dashboard/integrations/index.tsx
+++ b/projects/packages/forms/src/dashboard/integrations/index.tsx
@@ -2,13 +2,13 @@
  * External dependencies
  */
 import jetpackAnalytics from '@automattic/jetpack-analytics';
+import { getScriptData } from '@automattic/jetpack-script-data';
 import { __ } from '@wordpress/i18n';
 import { useState, useCallback } from 'react';
 /**
  * Internal dependencies
  */
 import { useIntegrationsStatus } from '../../blocks/contact-form/components/jetpack-integrations-modal/hooks/use-integrations-status';
-import { config } from '../index';
 import AkismetDashboardCard from './akismet-card';
 import CreativeMailDashboardCard from './creative-mail-card';
 import GoogleSheetsDashboardCard from './google-sheets-card';
@@ -32,7 +32,7 @@ const Integrations = () => {
 		mailpoet: false,
 	} );
 
-	const isMailpoetEnabled = config( 'isMailpoetEnabled' );
+	const isMailpoetEnabled = Boolean( getScriptData()?.forms?.isMailPoetEnabled );
 
 	const toggleCard = useCallback( ( cardId: keyof typeof expandedCards ) => {
 		setExpandedCards( prev => {

--- a/projects/packages/forms/src/types/index.ts
+++ b/projects/packages/forms/src/types/index.ts
@@ -107,6 +107,48 @@ export interface JPFormsBlocksDefaults {
 }
 
 /**
+ * Forms script data exposed via JetpackScriptData.forms
+ */
+export interface FormsScriptData {
+	/** Whether MailPoet integration is enabled across contexts. */
+	isMailPoetEnabled?: boolean;
+	/** Whether the current user can install plugins (install_plugins). */
+	canInstallPlugins?: boolean;
+	/** Whether the current user can activate plugins (activate_plugins). */
+	canActivatePlugins?: boolean;
+	/** Whether to show the Integrations tab in the dashboard UI. */
+	enableIntegrationsTab?: boolean;
+	/** Whether to render the migration/announcement page instead of the main dashboard. */
+	renderMigrationPage?: boolean;
+	/** Whether there are any feedback (form response) posts on the site. */
+	hasFeedback?: boolean;
+	/** Whether AI Assist features are available for the site/user. */
+	hasAI?: boolean;
+	/** The URL of the Forms responses list in wp-admin. */
+	formsResponsesUrl?: string;
+	/** Current site blog ID. */
+	blogId?: number;
+	/** Support URL for Google Drive connect guidance. */
+	gdriveConnectSupportURL?: string;
+	/** Base URL to static/assets for the Forms package. */
+	pluginAssetsURL?: string;
+	/** The site suffix/fragment for building admin links. */
+	siteURL?: string;
+	/** The dashboard URL with migration acknowledgement parameter. */
+	dashboardURL?: string;
+	/** Nonce for exporting feedback responses (dashboard-only). */
+	exportNonce?: string;
+	/** Nonce for creating a new form (dashboard-only). */
+	newFormNonce?: string;
+}
+
+declare module '@automattic/jetpack-script-data' {
+	interface JetpackScriptData {
+		forms?: FormsScriptData;
+	}
+}
+
+/**
  * Augments the global Window interface to include Jetpack Forms block defaults.
  */
 declare global {

--- a/projects/plugins/jetpack/changelog/update-forms-admin-script-data
+++ b/projects/plugins/jetpack/changelog/update-forms-admin-script-data
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: Consolidate data to frontend.


### PR DESCRIPTION
## Proposed changes:

**Context** I've long been bothered by the fact that we have several different methods of passing data from PHP to our frontend JavaScript. 
* For the dashboard, we create a [config](https://github.com/Automattic/jetpack/blob/6acf8539a548793fa2930c3cc1cae6ba0b1e0d6d/projects/packages/forms/src/dashboard/class-dashboard.php#L220) object and define a [config()](https://github.com/Automattic/jetpack/blob/eb675ce01efb863d055e139f36d7f122dc3a8057/projects/packages/forms/src/dashboard/index.tsx#L21) method for accessing the object.
   - As a side problem, because the config method is defined in the root file where we mount the dashboard, if you import that config method elsewhere in the codebase, webpack imports the entire dependency tree for the dashboard. This creates other problems, see below. 
* For the dashboard, we also create a [jetpackFormsData](https://github.com/Automattic/jetpack/blob/eb675ce01efb863d055e139f36d7f122dc3a8057/projects/packages/forms/src/dashboard/class-dashboard.php#L121) object.
* For the editor, we create a [jpFormsBlocks](https://github.com/Automattic/jetpack/blob/eb675ce01efb863d055e139f36d7f122dc3a8057/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php#L781) object.
* In some cases, we need to pass the same data in multiple places if its needed in both editor and dashboard. 

**Immediate problem.** This came to a head in [this PR](https://github.com/Automattic/jetpack/pull/45063) where I wanted to pass permission checks for integrations. I had to add the permissions checks in both config and jpFormsBlocks, because the relevant component is loaded in both dashboard and editor. I had to update the component to check both config and jpFormsBlocks. And because I had to import the 'config' method from the dashboard, webpack imported the entire dashboard, **which caused a build failure because of bundle size.** 

**Solution.** In this PR I propose we leverage Jetpack's built-in getScriptsData method to pass all data to the frontend. To demo it, I've done the following:
- Add `add_forms_script_data()` method that collects all the same data as all our other approaches, and attaches it to Jetpack's script data via hook. If adopted, this would be the default way we pass all data to the frontend going forward, and it will replace the config object and the jpFormsBlocks object. 
- Updated MailPoet checks in both the dashboard and the editor to show what it would look like to use the getScriptsData rather than our current approaches in both places. 

**Follow ups.** If we adopt this approach, I'd recommend we update uses of config/jpFormsBlocks to the new approach incrementally. In particular, I tried doing all of the config changes as part of this PR, and it triggered too many code changes. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Right now, the only place I'm using the updated method is the MailPoet check. To confirm it works in both dashboard and editor, you can...
* Add this filter to your site: `add_filter( 'jetpack_forms_mailpoet_enable', '__return_false' );`
* Confirm that the MailPoet card does not show in the integrations dashboard or block modal.
* Remove the filter or update it to return true.
* Confirm that the MailPoet card does show. 
* You can also try consoling out the value of getScriptsData() in the two places where I update the MailPoet code to see what the script data is now returning. 

