### PR TITLE
Forms: use hidden input for implicit consent

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-implicit-consent-toggling
+++ b/projects/packages/forms/changelog/fix-forms-implicit-consent-toggling
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Forms: render implicit consent as hidden field instead of a DOM hidden checkbox

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -1318,7 +1318,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		$field = "<label class='" . esc_attr( $label_class ) . "' style='" . esc_attr( $this->label_styles ) . ( $has_inner_block_option_styles ? esc_attr( $this->option_styles ) : '' ) . "'>";
 
 		if ( 'implicit' === $consent_type ) {
-			$field .= "\t\t<input aria-hidden='true' type='checkbox' checked name='" . esc_attr( $id ) . "' value='" . esc_attr__( 'Yes', 'jetpack-forms' ) . "' style='display:none;' /> \n";
+			$field .= "\t\t<input type='hidden' name='" . esc_attr( $id ) . "' value='" . esc_attr__( 'Yes', 'jetpack-forms' ) . "' /> \n";
 		} else {
 			$field .= "\t\t<input type='checkbox' name='" . esc_attr( $id ) . "' value='" . esc_attr__( 'Yes', 'jetpack-forms' ) . "' " . $class . "/> \n";
 		}

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Field_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Field_Test.php
@@ -67,7 +67,8 @@ class Contact_Form_Field_Test extends BaseTestCase {
 			'default' => 'default',
 		);
 
-		return new Contact_Form_Field( wp_parse_args( $attributes, $defaults ) );
+		$form = new Contact_Form( array() );
+		return new Contact_Form_Field( wp_parse_args( $attributes, $defaults ), '', $form );
 	}
 
 	/**
@@ -178,5 +179,68 @@ class Contact_Form_Field_Test extends BaseTestCase {
 
 		$unsanitized_value = 'hello&#044; world';
 		$this->assertEquals( sanitize_text_field( html_entity_decode( $unsanitized_value, ENT_QUOTES ) ), $field->sanitize_text_field( $unsanitized_value ) );
+	}
+
+	/**
+	 * Test consent field renders as hidden input when consent type is implicit.
+	 */
+	public function test_render_consent_field_implicit_type() {
+		$field = $this->get_new_field_instance(
+			array(
+				'type'                   => 'consent',
+				'id'                     => 'test_consent',
+				'consenttype'            => 'implicit',
+				'implicitconsentmessage' => 'By submitting this form, you agree to our terms.',
+			)
+		);
+
+		$html = $field->render();
+
+		// Should contain a hidden input field
+		$this->assertStringContainsString( 'type=\'hidden\'', $html );
+		$this->assertStringContainsString( 'value=\'Yes\'', $html );
+		$this->assertStringContainsString( 'consent-implicit', $html );
+		$this->assertStringContainsString( 'By submitting this form, you agree to our terms.', $html );
+	}
+
+	/**
+	 * Test consent field renders as checkbox when consent type is explicit.
+	 */
+	public function test_render_consent_field_explicit_type() {
+		$field = $this->get_new_field_instance(
+			array(
+				'type'                   => 'consent',
+				'id'                     => 'test_consent',
+				'consenttype'            => 'explicit',
+				'explicitconsentmessage' => 'I agree to the terms and conditions.',
+			)
+		);
+
+		$html = $field->render();
+
+		// Should contain a checkbox input field
+		$this->assertStringContainsString( 'type=\'checkbox\'', $html );
+		$this->assertStringContainsString( 'value=\'Yes\'', $html );
+		$this->assertStringContainsString( 'consent-explicit', $html );
+		$this->assertStringContainsString( 'I agree to the terms and conditions.', $html );
+	}
+
+	/**
+	 * Test consent field defaults to implicit when no consent type is specified.
+	 */
+	public function test_render_consent_field_default_implicit() {
+		$field = $this->get_new_field_instance(
+			array(
+				'type'                   => 'consent',
+				'id'                     => 'test_consent',
+				'implicitconsentmessage' => 'Default implicit consent message.',
+			)
+		);
+
+		$html = $field->render();
+
+		// Should default to implicit (hidden field)
+		$this->assertStringContainsString( 'type=\'hidden\'', $html );
+		$this->assertStringContainsString( 'consent-implicit', $html );
 	}
 } // end class

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Test.php
@@ -866,7 +866,7 @@ class Feedback_Test extends BaseTestCase {
 				'title'       => 'Test Form',
 				'description' => 'This is a test form.',
 			),
-			"[contact-field label='Email' type='email' required='1'/][contact-field label='Consent' type='consent' required='1'/]"
+			"[contact-field label='Email' type='email' required='1'/][contact-field label='Consent' type='consent' consenttype='explicit' required='1'/]"
 		);
 
 		$response         = Feedback::from_submission( $_post_data, $form );
@@ -874,6 +874,70 @@ class Feedback_Test extends BaseTestCase {
 		$saved_response   = Feedback::get( $feedback_post_id );
 		$this->assertFalse( $response->has_consent(), 'Has consent should match the form submission' );
 		$this->assertFalse( $saved_response->has_consent(), 'Has consent should match the saved form submission' );
+	}
+
+	public function test_implicit_consent_submits_yes() {
+		$form_id = Utility::get_form_id();
+
+		// Create a form submission with implicit consent field
+		// Since implicit consent renders as hidden input with value="Yes",
+		// a real form submission would always post "Yes"
+		$_post_data = Utility::get_post_request(
+			array(
+				'email'   => 'email@example.com',
+				'consent' => 'Yes', // This is what the hidden input would submit
+			),
+			'g' . $form_id
+		);
+
+		$form = new Contact_Form(
+			array(
+				'title'       => 'Test Form',
+				'description' => 'This is a test form.',
+			),
+			"[contact-field label='Email' type='email' required='1'/][contact-field label='Consent' type='consent' consenttype='implicit' required='1'/]"
+		);
+
+		$response         = Feedback::from_submission( $_post_data, $form );
+		$feedback_post_id = $response->save();
+		$saved_response   = Feedback::get( $feedback_post_id );
+
+		// Implicit consent should be granted when "Yes" is posted
+		$this->assertTrue( $response->has_consent(), 'Implicit consent should be granted' );
+		$this->assertTrue( $saved_response->has_consent(), 'Saved implicit consent should be granted' );
+
+		// Check that the field value is 'Yes'
+		$this->assertEquals( 'Yes', $response->get_field_value_by_label( 'Consent' ), 'Implicit consent field value should be Yes' );
+		$this->assertEquals( 'Yes', $saved_response->get_field_value_by_label( 'Consent' ), 'Saved implicit consent field value should be Yes' );
+	}
+
+	public function test_explicit_consent_respects_posted_value() {
+		$form_id = Utility::get_form_id();
+
+		// Create a form submission with explicit consent field, posting empty value
+		$_post_data = Utility::get_post_request(
+			array(
+				'email'   => 'email@example.com',
+				'consent' => '', // Empty value should result in no consent for explicit consent
+			),
+			'g' . $form_id
+		);
+
+		$form = new Contact_Form(
+			array(
+				'title'       => 'Test Form',
+				'description' => 'This is a test form.',
+			),
+			"[contact-field label='Email' type='email' required='1'/][contact-field label='Consent' type='consent' consenttype='explicit' required='1'/]"
+		);
+
+		$response         = Feedback::from_submission( $_post_data, $form );
+		$feedback_post_id = $response->save();
+		$saved_response   = Feedback::get( $feedback_post_id );
+
+		// With explicit consent, should respect the posted value
+		$this->assertFalse( $response->has_consent(), 'Explicit consent should not be granted when empty value is posted' );
+		$this->assertFalse( $saved_response->has_consent(), 'Saved explicit consent should not be granted when empty value is posted' );
 	}
 
 	public function test_compute_entry_ID_legacy() {


### PR DESCRIPTION
Fixes: FORMS-286

## Proposed changes:
This PR turns the implicit consent field output into a hidden field. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1756854611926379-slack-C052XEUUBL4
p1756921200224249-slack-C08LJ97DJ6A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Run `jetpack test php packages/forms --verbose`, see that it runs without any errors.

Insert a form and add a terms and consent field, use the option to "Mention":
<img width="285" height="145" alt="image" src="https://github.com/user-attachments/assets/1534f43b-2746-4552-84a4-9396d7ba46ec" />

Visit the form and submit. Try clicking on the consent field and then submitting, its value should not have changed (always a "yes" value).