### PR TITLE
Forms: Update data processing and UI for image select field

### DIFF
--- a/projects/packages/forms/changelog/update-forms-image-select-field-data-display
+++ b/projects/packages/forms/changelog/update-forms-image-select-field-data-display
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Forms: Update data processing and UI for image select field

--- a/projects/packages/forms/src/blocks/field-image-select/edit.tsx
+++ b/projects/packages/forms/src/blocks/field-image-select/edit.tsx
@@ -26,6 +26,8 @@ import './editor.scss';
  */
 import type { Block, BlockEditorStoreSelect } from '../../types';
 
+const showOtherOption = false;
+
 export default function ImageSelectFieldEdit( props ) {
 	const { attributes, clientId, isSelected, setAttributes, name } = props;
 	const { id, required, width } = attributes;
@@ -151,7 +153,7 @@ export default function ImageSelectFieldEdit( props ) {
 							/>
 						),
 					},
-					{
+					showOtherOption && {
 						index: 5,
 						element: (
 							<ToggleControl

--- a/projects/packages/forms/src/blocks/field-image-select/editor.scss
+++ b/projects/packages/forms/src/blocks/field-image-select/editor.scss
@@ -20,3 +20,7 @@
 		width: calc(( 1 / 2 ) * 100% - var(--jetpack-field-image-options-gap) * ( 1 / 2 ));
 	}
 }
+
+div.wp-block.jetpack-input-image-option.jetpack-field {
+	margin: 0;
+}

--- a/projects/packages/forms/src/blocks/field-image-select/style.scss
+++ b/projects/packages/forms/src/blocks/field-image-select/style.scss
@@ -35,6 +35,10 @@ figure.wp-block-image {
 		&.is-supersized {
 			width: calc(( 1 / 2 ) * 100% - var(--jetpack-field-image-options-gap) * ( 1 / 2 ));
 		}
+
+		.jetpack-input-image-option {
+			width: 100%;
+		}
 	}
 
 	.jetpack-input-image-option {
@@ -42,7 +46,6 @@ figure.wp-block-image {
 		display: flex;
 		flex-direction: column;
 		overflow: hidden;
-		width: 100%;
 
 		&:not(.wp-block):hover,
 		&.is-checked {
@@ -51,7 +54,6 @@ figure.wp-block-image {
 		}
 
 		.jetpack-input-image-option__wrapper {
-			height: 100%;
 			overflow: hidden;
 			position: relative;
 

--- a/projects/packages/forms/src/blocks/field-image-select/style.scss
+++ b/projects/packages/forms/src/blocks/field-image-select/style.scss
@@ -6,9 +6,12 @@
 figure.wp-block-image {
 	margin: 0 !important;
 	padding: 0 !important;
+	position: relative;
 
 	img {
 		max-width: 100% !important;
+		width: 100% !important;
+		margin: 0 !important;
 	}
 }
 
@@ -39,6 +42,7 @@ figure.wp-block-image {
 		display: flex;
 		flex-direction: column;
 		overflow: hidden;
+		width: 100%;
 
 		&:not(.wp-block):hover,
 		&.is-checked {
@@ -47,7 +51,7 @@ figure.wp-block-image {
 		}
 
 		.jetpack-input-image-option__wrapper {
-			width: 100%;
+			height: 100%;
 			overflow: hidden;
 			position: relative;
 
@@ -60,6 +64,7 @@ figure.wp-block-image {
 				color: currentColor;
 				outline-offset: 1px;
 				border-radius: 4px;
+				z-index: 1;
 
 				&:checked {
 					background-color: currentColor;
@@ -89,10 +94,6 @@ figure.wp-block-image {
 
 					@extend %visually-hidden;
 				}
-			}
-
-			figure {
-				margin: 0;
 			}
 
 			figcaption {

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -1984,8 +1984,8 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 						'perceived' => $perceived_letters[ $option_index ],
 						'selected'  => $option_letter,
 						'image'     => array(
-							'id'  => $image_block['attrs']['id'],
-							'src' => $image_src,
+							'id'  => $image_block['attrs']['id'] ?? null,
+							'src' => $image_src ?? null,
 						),
 					)
 				);

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -10,6 +10,7 @@ namespace Automattic\Jetpack\Forms\ContactForm;
 use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Forms\Jetpack_Forms;
+use DOMDocument;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit( 0 );
@@ -433,16 +434,24 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 						}
 					);
 
-					// For single selection (radio), check if the value is in the options
+					// For single selection (radio), check if the selected value is in the options
 					if ( ! $this->get_attribute( 'ismultiple' ) ) {
-						if ( ! in_array( $field_value, $non_empty_options, true ) ) {
+						// Decode the JSON response to get the selected value
+						$decoded_value  = json_decode( $field_value, true );
+						$selected_value = $decoded_value['selected'] ?? '';
+
+						if ( ! in_array( $selected_value, $non_empty_options, true ) ) {
 							/* translators: %s is the name of a form field */
 							$this->add_error( sprintf( __( '%s requires a valid selection.', 'jetpack-forms' ), $field_label ) );
 						}
 					} else {
 						// For multiple selection (checkbox), check each selected value
 						foreach ( $field_value as $field_value_item ) {
-							if ( ! in_array( $field_value_item, $non_empty_options, true ) ) {
+							// Decode the JSON response to get the selected value
+							$decoded_item   = json_decode( $field_value_item, true );
+							$selected_value = $decoded_item['selected'] ?? '';
+
+							if ( ! in_array( $selected_value, $non_empty_options, true ) ) {
 								/* translators: %s is the name of a form field */
 								$this->add_error( sprintf( __( '%s requires valid selections.', 'jetpack-forms' ), $field_label ) );
 								break;
@@ -1931,10 +1940,10 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 
 		if ( ! empty( $options_data ) ) {
 			// Create a separate array of original letters in sequence (A, B, C...)
-			$original_letters = array();
+			$perceived_letters = array();
 
 			foreach ( $options_data as $option ) {
-				$original_letters[] = Contact_Form_Plugin::strip_tags( $option['letter'] );
+				$perceived_letters[] = Contact_Form_Plugin::strip_tags( $option['letter'] );
 			}
 
 			// Create a working copy of options for potential randomization
@@ -1946,11 +1955,39 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 			}
 
 			foreach ( $working_options as $option_index => $option ) {
-				$option_label                = Contact_Form_Plugin::strip_tags( $option['label'] );
-				$option_letter               = Contact_Form_Plugin::strip_tags( $option['letter'] );
-				$option_value                = $this->get_option_value( $this->get_attribute( 'values' ), $option_index, $option_letter );
-				$image_block                 = $option['image'];
-				$option_id                   = $id . '-' . sanitize_html_class( $option_value );
+				$option_label  = Contact_Form_Plugin::strip_tags( $option['label'] );
+				$option_letter = Contact_Form_Plugin::strip_tags( $option['letter'] );
+				$image_block   = $option['image'];
+
+				// Extract image src from rendered block
+				$rendered_block = render_block( $image_block );
+				$image_src      = '';
+
+				if ( ! empty( $rendered_block ) ) {
+					// Use DOMDocument to parse the HTML and extract src reliably
+					$dom = new DOMDocument();
+					libxml_use_internal_errors( true ); // Suppress HTML parsing warnings
+					$dom->loadHTML( '<?xml encoding="utf-8" ?>' . $rendered_block );
+					libxml_clear_errors();
+
+					$images = $dom->getElementsByTagName( 'img' );
+
+					if ( $images->length > 0 ) {
+						$image_src = $images->item( 0 )->getAttribute( 'src' );
+					}
+				}
+
+				$option_value                = wp_json_encode(
+					array(
+						'perceived' => $perceived_letters[ $option_index ],
+						'selected'  => $option_letter,
+						'image'     => array(
+							'id'  => $image_block['attrs']['id'],
+							'src' => $image_src,
+						),
+					)
+				);
+				$option_id                   = $id . '-' . $option_letter;
 				$used_html_ids[ $option_id ] = true;
 
 				// To be able to apply the backdrop-filter for the hover effect, we need to separate the background into an outer div.
@@ -2002,11 +2039,11 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 				. ( $required ? "required aria-required='true'" : '' )
 				. '/> ';
 
-				$field .= render_block( $image_block );
+				$field .= $rendered_block;
 				$field .= '</div>';
 
 				$field .= "<div class='jetpack-input-image-option__label-wrapper'>";
-				$field .= "<div class='jetpack-input-image-option__label-code'>" . esc_html( $original_letters[ $option_index ] ) . '</div>';
+				$field .= "<div class='jetpack-input-image-option__label-code'>" . esc_html( $perceived_letters[ $option_index ] ) . '</div>';
 
 				$label_classes  = 'jetpack-input-image-option__label';
 				$label_classes .= $show_labels ? '' : ' visually-hidden';

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -1960,14 +1960,14 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 				$image_block   = $option['image'];
 
 				// Extract image src from rendered block
-				$rendered_block = render_block( $image_block );
-				$image_src      = '';
+				$rendered_image_block = render_block( $image_block );
+				$image_src            = '';
 
-				if ( ! empty( $rendered_block ) ) {
+				if ( ! empty( $rendered_image_block ) ) {
 					// Use DOMDocument to parse the HTML and extract src reliably
 					$dom = new DOMDocument();
 					libxml_use_internal_errors( true ); // Suppress HTML parsing warnings
-					$dom->loadHTML( '<?xml encoding="utf-8" ?>' . $rendered_block );
+					$dom->loadHTML( '<?xml encoding="utf-8" ?>' . $rendered_image_block );
 					libxml_clear_errors();
 
 					$images = $dom->getElementsByTagName( 'img' );
@@ -1975,6 +1975,8 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 					if ( $images->length > 0 ) {
 						$image_src = $images->item( 0 )->getAttribute( 'src' );
 					}
+				} else {
+					$rendered_image_block = '<figure class="wp-block-image"><img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=" alt="" style="aspect-ratio:1;object-fit:cover"/></figure>';
 				}
 
 				$option_value                = wp_json_encode(
@@ -2039,7 +2041,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 				. ( $required ? "required aria-required='true'" : '' )
 				. '/> ';
 
-				$field .= $rendered_block;
+				$field .= $rendered_image_block;
 				$field .= '</div>';
 
 				$field .= "<div class='jetpack-input-image-option__label-wrapper'>";

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -10,7 +10,6 @@ namespace Automattic\Jetpack\Forms\ContactForm;
 use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Forms\Jetpack_Forms;
-use DOMDocument;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit( 0 );
@@ -1964,16 +1963,12 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 				$image_src            = '';
 
 				if ( ! empty( $rendered_image_block ) ) {
-					// Use DOMDocument to parse the HTML and extract src reliably
-					$dom = new DOMDocument();
-					libxml_use_internal_errors( true ); // Suppress HTML parsing warnings
-					$dom->loadHTML( '<?xml encoding="utf-8" ?>' . $rendered_image_block );
-					libxml_clear_errors();
+					if ( preg_match( '/<img[^>]+src=["\']([^"\']+)["\'][^>]*>/i', $rendered_image_block, $matches ) ) {
+						$extracted_src = $matches[1];
 
-					$images = $dom->getElementsByTagName( 'img' );
-
-					if ( $images->length > 0 ) {
-						$image_src = $images->item( 0 )->getAttribute( 'src' );
+						if ( filter_var( $extracted_src, FILTER_VALIDATE_URL ) || str_starts_with( $extracted_src, 'data:' ) ) {
+							$image_src = $extracted_src;
+						}
 					}
 				} else {
 					$rendered_image_block = '<figure class="wp-block-image"><img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=" alt="" style="aspect-ratio:1;object-fit:cover"/></figure>';

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -896,8 +896,9 @@ class Contact_Form extends Contact_Form_Shortcode {
 
 		foreach ( $data as $field_data ) {
 			$formatted_submission_data[] = array(
-				'label' => self::maybe_add_colon_to_label( $field_data['label'] ),
-				'value' => self::maybe_transform_value( $field_data['value'] ),
+				'label'  => self::maybe_add_colon_to_label( $field_data['label'] ),
+				'value'  => self::maybe_transform_value( $field_data['value'] ),
+				'images' => self::get_images( $field_data['value'] ),
 			);
 		}
 
@@ -969,6 +970,11 @@ class Contact_Form extends Contact_Form_Shortcode {
 				<div>
 					<div class="field-name" data-wp-text="context.submission.label" data-wp-bind--hidden="!context.submission.label"></div>
 					<div class="field-value" data-wp-text="context.submission.value"></div>
+					<div class="field-images" data-wp-bind--hidden="!context.submission.images">
+						<template data-wp-each--image="context.submission.images">
+							<img class="field-image" data-wp-bind--src="context.image" />
+						</template>
+					</div>
 				</div>
 			</template>';
 
@@ -977,7 +983,17 @@ class Contact_Form extends Contact_Form_Shortcode {
 				$html .= '<div data-wp-each-child>
 					<div class="field-name" data-wp-text="context.submission.label" data-wp-bind--hidden="!context.submission.label">' . $submission['label'] . '</div>
 					<div class="field-value" data-wp-text="context.submission.value">' . $submission['value'] . '</div>
-				</div>';
+					<div class="field-images" data-wp-bind--hidden="!context.submission.images">';
+
+				if ( $submission['images'] ) {
+					foreach ( $submission['images'] ?? array() as $image ) {
+						$html .= '<img data-wp-each-child class="field-image" data-wp-bind--src="context.image" src="' . $image . '" />';
+					}
+				} else {
+					$html .= '<template data-wp-each--image="context.submission.images"></template>';
+				}
+
+				$html .= '</div></div>';
 			}
 		}
 
@@ -1466,6 +1482,9 @@ class Contact_Form extends Contact_Form_Shortcode {
 				break;
 			case 'time':
 				$str = __( 'Time', 'jetpack-forms' );
+				break;
+			case 'image-select':
+				$str = __( 'Select an image', 'jetpack-forms' );
 				break;
 			default:
 				$str = null;
@@ -2454,6 +2473,18 @@ class Contact_Form extends Contact_Form_Shortcode {
 	 * @return mixed The transformed value.
 	 */
 	private static function maybe_transform_value( $value ) {
+		if ( is_array( $value ) && isset( $value['type'] ) && $value['type'] === 'image-select' ) {
+			return implode(
+				', ',
+				array_map(
+					function ( $choice ) {
+						return $choice['perceived'];
+					},
+					$value['choices']
+				)
+			);
+		}
+
 		// For file upload fields, we want to show the file name and size
 		if ( is_array( $value ) && isset( $value['name'] ) && isset( $value['size'] ) ) {
 			$file_name = $value['name'];
@@ -2462,6 +2493,27 @@ class Contact_Form extends Contact_Form_Shortcode {
 		}
 
 		return $value;
+	}
+
+	/**
+	 * Helper method to get the images from an image select field.
+	 *
+	 * @param array $value The value to get the images from.
+	 * @return array The images.
+	 */
+	private static function get_images( $value ) {
+		if ( is_array( $value ) && isset( $value['type'] ) && $value['type'] === 'image-select' ) {
+			return array_map(
+				function ( $choice ) {
+					$src = $choice['image']['src'] ?? '';
+
+					return empty( $src ) ? 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=' : $src;
+				},
+				$value['choices']
+			);
+		}
+
+		return null;
 	}
 
 	/**

--- a/projects/packages/forms/src/contact-form/class-feedback-field.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-field.php
@@ -142,10 +142,27 @@ class Feedback_Field {
 				return $this->get_render_submit_value();
 			case 'api':
 				return $this->get_render_api_value();
+			case 'web': // For the post-submission page screen.
+				return $this->get_render_web_value();
+			case 'ajax':
+				return $this->get_render_web_value(); // For now, we use the same value for ajax and web.
 			case 'default':
 			default:
 				return $this->get_render_default_value();
 		}
+	}
+
+	/**
+	 * Get the value of the field for rendering the post-submission page.
+	 *
+	 * @return string
+	 */
+	private function get_render_web_value() {
+		if ( $this->is_of_type( 'image-select' ) ) {
+			return $this->value;
+		}
+
+		return $this->get_render_default_value();
 	}
 
 	/**
@@ -168,6 +185,11 @@ class Feedback_Field {
 			return implode( ', ', $files );
 		}
 
+		if ( $this->is_of_type( 'image-select' ) ) {
+			// Return the array as is.
+			return $this->value;
+		}
+
 		if ( is_array( $this->value ) ) {
 			return implode( ', ', $this->value );
 		}
@@ -181,7 +203,6 @@ class Feedback_Field {
 	 * @return string
 	 */
 	private function get_render_api_value() {
-
 		if ( $this->is_of_type( 'file' ) ) {
 			$files = array();
 			foreach ( $this->value['files'] as &$file ) {
@@ -197,6 +218,11 @@ class Feedback_Field {
 				$files[]                = $file;
 			}
 			$this->value['files'] = $files;
+			return $this->value;
+		}
+
+		if ( $this->is_of_type( 'image-select' ) ) {
+			// Return the array as is.
 			return $this->value;
 		}
 

--- a/projects/packages/forms/src/contact-form/class-feedback-field.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-field.php
@@ -148,10 +148,33 @@ class Feedback_Field {
 				return $this->get_render_email_value();
 			case 'ajax':
 				return $this->get_render_web_value(); // For now, we use the same value for ajax and web.
+			case 'csv':
+				return $this->get_render_csv_value();
 			case 'default':
 			default:
 				return $this->get_render_default_value();
 		}
+	}
+
+	/**
+	 * Get the value of the field for rendering the CSV.
+	 *
+	 * @return string
+	 */
+	private function get_render_csv_value() {
+		if ( $this->is_of_type( 'image-select' ) ) {
+			return implode(
+				', ',
+				array_map(
+					function ( $choice ) {
+						return $choice['selected'];
+					},
+					$this->value['choices']
+				)
+			);
+		}
+
+		return $this->get_render_default_value();
 	}
 
 	/**

--- a/projects/packages/forms/src/contact-form/class-feedback-field.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-field.php
@@ -144,6 +144,8 @@ class Feedback_Field {
 				return $this->get_render_api_value();
 			case 'web': // For the post-submission page screen.
 				return $this->get_render_web_value();
+			case 'email':
+				return $this->get_render_email_value();
 			case 'ajax':
 				return $this->get_render_web_value(); // For now, we use the same value for ajax and web.
 			case 'default':
@@ -160,6 +162,26 @@ class Feedback_Field {
 	private function get_render_web_value() {
 		if ( $this->is_of_type( 'image-select' ) ) {
 			return $this->value;
+		}
+
+		return $this->get_render_default_value();
+	}
+
+	/**
+	 * Get the value of the field for rendering the email.
+	 *
+	 * @return string
+	 */
+	private function get_render_email_value() {
+		if ( $this->is_of_type( 'image-select' ) ) {
+			$choices = array();
+
+			foreach ( $this->value['choices'] as $choice ) {
+				// On the email, we want to show the actual selected value, not the perceived value, as the options can be shuffled.
+				$choices[] = $choice['selected'];
+			}
+
+			return implode( ', ', $choices );
 		}
 
 		return $this->get_render_default_value();

--- a/projects/packages/forms/src/contact-form/class-feedback.php
+++ b/projects/packages/forms/src/contact-form/class-feedback.php
@@ -555,7 +555,7 @@ class Feedback {
 
 			// Skip any fields that are just a choice from a pre-defined list. They wouldn't have any value
 			// from a spam-filtering point of view.
-			if ( in_array( $field->get_type(), array( 'select', 'checkbox', 'checkbox-multiple', 'radio', 'file' ), true ) ) {
+			if ( in_array( $field->get_type(), array( 'select', 'checkbox', 'checkbox-multiple', 'radio', 'file', 'image-select' ), true ) ) {
 				continue;
 			}
 

--- a/projects/packages/forms/src/contact-form/class-feedback.php
+++ b/projects/packages/forms/src/contact-form/class-feedback.php
@@ -234,6 +234,15 @@ class Feedback {
 			}
 			return array( 'files' => array() );
 		}
+
+		if ( $type === 'image-select' ) {
+			if ( isset( $post_data[ $key ] ) ) {
+				return self::process_image_select_field_value( $post_data[ $key ] );
+			}
+
+			return array( 'choices' => array() );
+		}
+
 		if ( isset( $post_data[ $key ] ) ) {
 			if ( is_array( $post_data[ $key ] ) ) {
 				return array_map( 'sanitize_textarea_field', wp_unslash( $post_data[ $key ] ) );
@@ -275,6 +284,34 @@ class Feedback {
 		return array(
 			'files' => $file_data_array,
 		);
+	}
+
+	/**
+	 * Process the image select field value.
+	 *
+	 * @param array $raw_data The raw post data from the image select field.
+	 *
+	 * @return array The processed image select data.
+	 */
+	public static function process_image_select_field_value( $raw_data ) {
+		$value = array(
+			'type'    => 'image-select',
+			'choices' => array(),
+		);
+
+		$selection_data_array = is_array( $raw_data )
+			? array_map(
+				function ( $json_str ) {
+					return json_decode( stripslashes( $json_str ), true );
+				},
+				$raw_data
+			) : array( json_decode( stripslashes( $raw_data ), true ) );
+
+		if ( ! empty( $selection_data_array ) ) {
+			$value['choices'] = $selection_data_array;
+		}
+
+		return $value;
 	}
 
 	/**

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -247,6 +247,23 @@ that needs to mimic the input element styles */
 	font-weight: 200;
 }
 
+.contact-form-submission .field-images {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 16px;
+	margin-bottom: 20px;
+
+	&[hidden] {
+		display: none;
+	}
+
+	.field-image {
+		width: 200px;
+		aspect-ratio: 1/1;
+		object-fit: cover;
+	}
+}
+
 .contact-form-submission .field-value {
 	margin-bottom: 20px;
 	font-weight: 600;

--- a/projects/packages/forms/src/dashboard/inbox/response.js
+++ b/projects/packages/forms/src/dashboard/inbox/response.js
@@ -36,6 +36,10 @@ const isFileUploadField = value => {
 	return value && typeof value === 'object' && 'files' in value;
 };
 
+const isImageSelectField = value => {
+	return value?.type === 'image-select';
+};
+
 const isLikelyPhoneNumber = value => {
 	// Only operate on strings to avoid coercing numbers (e.g., 2024) into strings that could match
 	if ( typeof value !== 'string' ) {
@@ -205,6 +209,35 @@ const InboxResponse = ( { response, loading, onModalStateChange } ) => {
 	}, [ onModalStateChange, setIsPreviewModalOpen, setIsImageLoading ] );
 
 	const renderFieldValue = value => {
+		if ( isImageSelectField( value ) ) {
+			return (
+				<div className="image-select-field">
+					{ ( value.choices?.length ?? 0 ) === 0 && '-' }
+					{ ( value.choices?.length ?? 0 ) > 0 && (
+						<>
+							<div className="image-select-field-choices">
+								{ value.choices.map( choice => choice.selected ).join( ', ' ) }
+							</div>
+							<div className="image-select-field-images">
+								{ value.choices.map( choice => {
+									return (
+										<img
+											key={ choice.selected }
+											className="image-select-field-image"
+											src={
+												choice.image.src ||
+												'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs='
+											}
+											alt={ choice.selected }
+										/>
+									);
+								} ) }
+							</div>
+						</>
+					) }
+				</div>
+			);
+		}
 		if ( isFileUploadField( value ) ) {
 			return (
 				<div className="file-field">

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -259,7 +259,21 @@
 		flex-direction: row;
 		gap: 12px;
 	}
+}
 
+.jp-forms__inbox-response-data-value .image-select-field {
+
+	.image-select-field-images {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 16px;
+	}
+
+	.image-select-field-image {
+		width: 200px;
+		aspect-ratio: 1/1;
+		object-fit: cover;
+	}
 }
 
 .jp-forms__header-subtext {

--- a/projects/packages/forms/src/modules/form/view.js
+++ b/projects/packages/forms/src/modules/form/view.js
@@ -51,6 +51,7 @@ const setSubmissionData = ( data = [] ) => {
 	context.formattedSubmissionData = data.map( item => ( {
 		label: maybeAddColonToLabel( item.label ),
 		value: maybeTransformValue( item.value ),
+		images: getImages( item.value ),
 	} ) );
 };
 
@@ -103,12 +104,27 @@ const maybeAddColonToLabel = label => {
 };
 
 const maybeTransformValue = value => {
+	// For image select fields, we want to show the perceived values, as the choices can be shuffled.
+	if ( value?.type === 'image-select' ) {
+		return value.choices.map( choice => choice.perceived ).join( ', ' );
+	}
+
 	// For file upload fields, we want to show the file name and size
 	if ( value?.name && value?.size ) {
 		return value.name + ' (' + value.size + ')';
 	}
 
 	return value;
+};
+
+const getImages = value => {
+	if ( value?.type === 'image-select' ) {
+		return value.choices.map(
+			choice => choice.image?.src || 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs='
+		);
+	}
+
+	return null;
 };
 
 const { state, actions } = store( NAMESPACE, {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of FORMS-60

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fixes some issues with the images
* Changes the way the values are saved, so each place the information is displayed can have its own rendering method

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Delete all submissions with image select blocks in them, as this is a breaking change
* Enable the forms-alpha flag
* Make a form with one or more image select fields (and other fields as well), enabling randomization on one of them
* Publish it and submit the form
* Check that the post-publish screen is displayed with the letter you see when you selected the image (which can be different from the one in the editor if randomization is enabled) and the images
* Reload the page
* Check that the post-publish screen is still rendered correctly
* Check the email you received. You should see the letters as they are in the editor, pre-randomization
* Check the dashboard. You should see the letters as they are in the editor, pre-randomization, and the selected images
* Export the submission. You should see the pre-randomization letters separated by comma

Editor:
<img width="1244" height="1171" alt="Screenshot from 2025-09-04 22-47-03" src="https://github.com/user-attachments/assets/db52b5c0-1070-4923-8a9c-6ebda3b14d94" />

Frontend (option A got randomized to B):
<img width="683" height="1171" alt="Screenshot from 2025-09-04 22-49-35" src="https://github.com/user-attachments/assets/c7830603-74be-47e3-8c9a-a9ab0bd70a45" />

Post-submission screen (user sees the choice from their point of view: B):
<img width="459" height="824" alt="Screenshot from 2025-09-04 22-44-39" src="https://github.com/user-attachments/assets/d828d5b5-d705-444e-b1a6-ec5a21bf7d0a" />

Email (admin's point of view from now on: A):
<img width="370" height="309" alt="Screenshot from 2025-09-04 22-44-49" src="https://github.com/user-attachments/assets/c56e202e-aae1-4fcb-8449-8c4b9e45a6cc" />

Dashboard:
<img width="677" height="841" alt="2025-09-04_22-45" src="https://github.com/user-attachments/assets/f4d3886a-8822-492a-acef-145883601ab7" />

Export:
<img width="975" height="154" alt="2025-09-04_22-46" src="https://github.com/user-attachments/assets/c5088673-911f-45ee-b5bc-acef93c0e2b0" />
