### PR TITLE
Sharing: Fix Facebook sharing URL

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-sharing-buttons-facebook-url
+++ b/projects/plugins/jetpack/changelog/fix-sharing-buttons-facebook-url
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Sharing: Fix Facebook sharing URL.

--- a/projects/plugins/jetpack/extensions/blocks/sharing-button/class-sharing-source-block.php
+++ b/projects/plugins/jetpack/extensions/blocks/sharing-button/class-sharing-source-block.php
@@ -568,7 +568,7 @@ class Share_Facebook_Block extends Sharing_Source_Block {
 	 */
 	public function process_request( $post, array $post_data ) {
 		$post_id = $post instanceof WP_Post ? $post->ID : 0;
-		$fb_url  = $this->http() . '://www.facebook.com/sharer/sharer.php?u=' . rawurlencode( $this->get_share_url( $post_id ) ) . '&t=' . rawurlencode( $this->get_share_title( $post_id ) );
+		$fb_url  = 'https://www.facebook.com/sharer/sharer.php?u=' . rawurlencode( $this->get_share_url( $post_id ) ) . '&t=' . rawurlencode( $this->get_share_title( $post_id ) );
 
 		// Record stats
 		parent::process_request( $post, $post_data );

--- a/projects/plugins/jetpack/extensions/blocks/sharing-button/class-sharing-source-block.php
+++ b/projects/plugins/jetpack/extensions/blocks/sharing-button/class-sharing-source-block.php
@@ -568,7 +568,7 @@ class Share_Facebook_Block extends Sharing_Source_Block {
 	 */
 	public function process_request( $post, array $post_data ) {
 		$post_id = $post instanceof WP_Post ? $post->ID : 0;
-		$fb_url  = $this->http() . '://www.facebook.com/sharer.php?u=' . rawurlencode( $this->get_share_url( $post_id ) ) . '&t=' . rawurlencode( $this->get_share_title( $post_id ) );
+		$fb_url  = $this->http() . '://www.facebook.com/sharer/sharer.php?u=' . rawurlencode( $this->get_share_url( $post_id ) ) . '&t=' . rawurlencode( $this->get_share_title( $post_id ) );
 
 		// Record stats
 		parent::process_request( $post, $post_data );

--- a/projects/plugins/jetpack/modules/sharedaddy/sharing-sources.php
+++ b/projects/plugins/jetpack/modules/sharedaddy/sharing-sources.php
@@ -2004,7 +2004,7 @@ class Share_Facebook extends Sharing_Source {
 	 * @return void
 	 */
 	public function process_request( $post, array $post_data ) {
-		$fb_url = $this->http() . '://www.facebook.com/sharer/sharer.php?u=' . rawurlencode( $this->get_share_url( $post->ID ) ) . '&t=' . rawurlencode( $this->get_share_title( $post->ID ) );
+		$fb_url = 'https://www.facebook.com/sharer/sharer.php?u=' . rawurlencode( $this->get_share_url( $post->ID ) ) . '&t=' . rawurlencode( $this->get_share_title( $post->ID ) );
 
 		// Record stats
 		parent::process_request( $post, $post_data );

--- a/projects/plugins/jetpack/modules/sharedaddy/sharing-sources.php
+++ b/projects/plugins/jetpack/modules/sharedaddy/sharing-sources.php
@@ -2004,7 +2004,7 @@ class Share_Facebook extends Sharing_Source {
 	 * @return void
 	 */
 	public function process_request( $post, array $post_data ) {
-		$fb_url = $this->http() . '://www.facebook.com/sharer.php?u=' . rawurlencode( $this->get_share_url( $post->ID ) ) . '&t=' . rawurlencode( $this->get_share_title( $post->ID ) );
+		$fb_url = $this->http() . '://www.facebook.com/sharer/sharer.php?u=' . rawurlencode( $this->get_share_url( $post->ID ) ) . '&t=' . rawurlencode( $this->get_share_title( $post->ID ) );
 
 		// Record stats
 		parent::process_request( $post, $post_data );


### PR DESCRIPTION
For sharing buttons, we currently use the old sharing URLs for Facebook. [Facebook's official developer documentation recommends](https://developers.facebook.com/docs/plugins/share-button/#configurator) using `/sharer/sharer.php` rather than `/sharer.php` for long-term compatibility.

Fixes SOCIAL-143

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Update the URL for Facebook sharing buttons

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to `/wp-admin/admin.php?page=jetpack#sharing`
* Turn ON "Sharing buttons"
* Click on the "Configure your sharing buttons" link there
* Ensure that there is a sharing buttons block
* Ensure that there is a Facebook button in it
* Go to any post on the site to find the sharing buttons
* Confirm that sharing to Facebook works as expected