### PR TITLE
Boost: Fix page cache error on multisite when updating a page

### DIFF
--- a/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/class-boost-cache.php
+++ b/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/class-boost-cache.php
@@ -12,6 +12,10 @@ use WP_Post;
  * Require all pre-wordpress files here. These files aren't autoloaded as they are loaded before WordPress is fully initialized.
  * pre-wordpress files assume all other pre-wordpress files are loaded here.
  */
+require_once __DIR__ . '/path-actions/interface-path-action.php';
+require_once __DIR__ . '/path-actions/class-filter-older.php';
+require_once __DIR__ . '/path-actions/class-rebuild-file.php';
+require_once __DIR__ . '/path-actions/class-simple-delete.php';
 require_once __DIR__ . '/boost-cache-actions.php';
 require_once __DIR__ . '/class-boost-cache-error.php';
 require_once __DIR__ . '/class-boost-cache-settings.php';

--- a/projects/plugins/boost/changelog/fix-page-cache-multisite-update-page-fatal-hog-325
+++ b/projects/plugins/boost/changelog/fix-page-cache-multisite-update-page-fatal-hog-325
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Page Cache: Fix fatal error when updating a page on multisite.


### PR DESCRIPTION
Fixes HOG-325, related to #45008

## Proposed changes:

* Add missing includes in pre-wordpress part of Boost.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

HOG-325

## Does this pull request change what data or activity we track or use?

no

## Testing instructions:

**Pre-requisites**

- You'll need to test this on a multisite with 2 sites. I'll call these site A, and B. I used [Local](https://localwp.com/) to setup one (Jurassic Ninja might work as well, but I didn't use it);
- Install Jetpack Beta as a network plugin so you can easily switch the Boost version;

### Test that it breaks

- From Jetpack Beta, make sure you're on the trunk or the production version of Boost;
- On site A, activate Jetpack Boost and Page Cache. Make sure page cache works as expected;
- On site B, make sure Jetpack Boost is disabled. Try editing a page and you should see an error.

### Test that it breaks

- Keep the same setup as above, but switch to (`fix/boost/page-cache/multisite-update-page-fatal-hog-325`) from Jetpack Beta;
- On site B, try editing a page and it should work without a problem.