### PR TITLE
Sync: Allow post meta prefix whitelist

### DIFF
--- a/projects/packages/sync/changelog/update-sync-allow-post-meta-prefix-whitelist
+++ b/projects/packages/sync/changelog/update-sync-allow-post-meta-prefix-whitelist
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Sync: Allowing post meta prefix whitelist that works for Full Sync and Checksums.

--- a/projects/packages/sync/src/class-defaults.php
+++ b/projects/packages/sync/src/class-defaults.php
@@ -812,6 +812,33 @@ class Defaults {
 	}
 
 	/**
+	 * Array of post meta key prefixes whitelisted (wildcard match).
+	 *
+	 * @var array Post meta prefix whitelist.
+	 */
+	public static $post_meta_prefix_whitelist = array(
+		'_wpas_skip_',
+	);
+
+	/**
+	 * Get the post meta key prefix whitelist (wildcard match).
+	 *
+	 * @return array Post meta prefix whitelist.
+	 */
+	public static function get_post_meta_prefix_whitelist() {
+		/**
+		 * Filter the list of post meta key prefixes (wildcards) that are manageable via the JSON API.
+		 *
+		 * @module sync
+		 *
+		 * @since $$next_version
+		 *
+		 * @param array The default list of meta key prefixes.
+		 */
+		return apply_filters( 'jetpack_sync_post_meta_prefix_whitelist', self::$post_meta_prefix_whitelist );
+	}
+
+	/**
 	 * Comment meta whitelist.
 	 *
 	 * @var array Comment meta whitelist.

--- a/projects/packages/sync/src/class-settings.php
+++ b/projects/packages/sync/src/class-settings.php
@@ -425,8 +425,17 @@ class Settings {
 	public static function get_allowed_post_meta_structured() {
 		return array(
 			'meta_key' => array(
-				'operator' => 'IN',
-				'values'   => array_map( 'esc_sql', static::get_setting( 'post_meta_whitelist' ) ),
+				'group_operator' => 'OR',
+				'filters'        => array(
+					array(
+						'operator' => 'IN',
+						'values'   => array_map( 'esc_sql', static::get_setting( 'post_meta_whitelist' ) ),
+					),
+					array(
+						'operator' => 'LIKE',
+						'values'   => array_map( 'esc_sql', Defaults::get_post_meta_prefix_whitelist() ),
+					),
+				),
 			),
 		);
 	}

--- a/projects/packages/sync/src/modules/class-module.php
+++ b/projects/packages/sync/src/modules/class-module.php
@@ -584,12 +584,13 @@ abstract class Module {
 	 *
 	 * @todo Refactor to use $wpdb->prepare() on the SQL query.
 	 *
-	 * @param array  $ids                Object IDs.
-	 * @param string $meta_type          Meta type.
-	 * @param array  $meta_key_whitelist Meta key whitelist.
+	 * @param array  $ids                     Object IDs.
+	 * @param string $meta_type               Meta type.
+	 * @param array  $meta_key_whitelist      Exact meta keys to allow.
+	 * @param array  $meta_key_prefix_filters Optional. Prefixes of meta keys to allow.
 	 * @return array Unserialized meta values.
 	 */
-	protected function get_metadata( $ids, $meta_type, $meta_key_whitelist ) {
+	protected function get_metadata( $ids, $meta_type, $meta_key_whitelist, $meta_key_prefix_filters = array() ) {
 		global $wpdb;
 		$table = _get_meta_table( $meta_type );
 		$id    = $meta_type . '_id';
@@ -597,18 +598,33 @@ abstract class Module {
 			return array();
 		}
 
-		$private_meta_whitelist_sql = "'" . implode( "','", array_map( 'esc_sql', $meta_key_whitelist ) ) . "'";
+		$meta_key_conditions = array();
 
-		return array_map(
-			array( $this, 'unserialize_meta' ),
-			$wpdb->get_results(
-				// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared
-				"SELECT $id, meta_key, meta_value, meta_id FROM $table WHERE $id IN ( " . implode( ',', wp_parse_id_list( $ids ) ) . ' )' .
-				" AND meta_key IN ( $private_meta_whitelist_sql ) ",
-				// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared
-				OBJECT
-			)
+		if ( ! empty( $meta_key_whitelist ) ) {
+			$escaped_keys          = implode( "','", array_map( 'esc_sql', $meta_key_whitelist ) );
+			$meta_key_conditions[] = "meta_key IN ( '$escaped_keys' )";
+		}
+
+		foreach ( $meta_key_prefix_filters as $prefix ) {
+			$meta_key_conditions[] = $wpdb->prepare( 'meta_key LIKE %s', esc_sql( $prefix ) . '%' );
+		}
+
+		if ( empty( $meta_key_conditions ) ) {
+			return array(); // No whitelist or wildcard = deny all
+		}
+
+		$ids_sql   = implode( ',', wp_parse_id_list( $ids ) );
+		$where_sql = implode( ' OR ', $meta_key_conditions );
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
+		$results = $wpdb->get_results(
+			"SELECT $id, meta_key, meta_value, meta_id
+			FROM $table
+			WHERE $id IN ( $ids_sql )
+			AND ( $where_sql )",
+			// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
+			OBJECT
 		);
+		return array_map( array( $this, 'unserialize_meta' ), $results );
 	}
 
 	/**

--- a/projects/packages/sync/src/modules/class-posts.php
+++ b/projects/packages/sync/src/modules/class-posts.php
@@ -9,6 +9,7 @@ namespace Automattic\Jetpack\Sync\Modules;
 
 use Automattic\Jetpack\Constants as Jetpack_Constants;
 use Automattic\Jetpack\Roles;
+use Automattic\Jetpack\Sync\Defaults;
 use Automattic\Jetpack\Sync\Modules;
 use Automattic\Jetpack\Sync\Settings;
 
@@ -397,11 +398,23 @@ class Posts extends Module {
 	 * Whether a post meta key is whitelisted.
 	 *
 	 * @param string $meta_key Meta key.
-	 * @return boolean Whether the post meta key is whitelisted.
+	 * @return bool Whether the post meta key is whitelisted.
 	 */
 	public function is_whitelisted_post_meta( $meta_key ) {
-		// The _wpas_skip_ meta key is used by Publicize.
-		return in_array( $meta_key, Settings::get_setting( 'post_meta_whitelist' ), true ) || str_starts_with( $meta_key, '_wpas_skip_' );
+		$whitelist        = Settings::get_setting( 'post_meta_whitelist' );
+		$prefix_whitelist = Defaults::get_post_meta_prefix_whitelist();
+
+		if ( in_array( $meta_key, $whitelist, true ) ) {
+			return true;
+		}
+
+		foreach ( $prefix_whitelist as $prefix ) {
+			if ( str_starts_with( $meta_key, $prefix ) ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**
@@ -843,7 +856,7 @@ class Posts extends Module {
 		list( $post_ids, $previous_interval_end ) = $args;
 
 		$posts              = $this->expand_posts( $post_ids );
-		$posts_metadata     = $this->get_metadata( $post_ids, 'post', Settings::get_setting( 'post_meta_whitelist' ) );
+		$posts_metadata     = $this->get_metadata( $post_ids, 'post', Settings::get_setting( 'post_meta_whitelist' ), Defaults::get_post_meta_prefix_whitelist() );
 		$term_relationships = $this->get_term_relationships( $post_ids );
 
 		return array(
@@ -898,7 +911,7 @@ class Posts extends Module {
 		}
 		// Get the post IDs from the posts that were fetched.
 		$fetched_post_ids = wp_list_pluck( $posts, 'ID' );
-		$metadata         = $this->get_metadata( $fetched_post_ids, 'post', Settings::get_setting( 'post_meta_whitelist' ) );
+		$metadata         = $this->get_metadata( $fetched_post_ids, 'post', Settings::get_setting( 'post_meta_whitelist' ), Defaults::get_post_meta_prefix_whitelist() );
 
 		// Filter the posts and metadata based on the maximum size constraints.
 		list( $filtered_post_ids, $filtered_posts, $filtered_posts_metadata ) = $this->filter_objects_and_metadata_by_size(

--- a/projects/packages/sync/src/modules/class-woocommerce-hpos-orders.php
+++ b/projects/packages/sync/src/modules/class-woocommerce-hpos-orders.php
@@ -471,10 +471,11 @@ class WooCommerce_HPOS_Orders extends Module {
 	 * @param array  $ids List of order IDs.
 	 * @param string $meta_type Meta type.
 	 * @param array  $meta_key_whitelist List of allowed meta keys.
+	 * @param array  $meta_key_prefix_filters Optional. Prefixes of meta keys to allow.
 	 *
 	 * @return array Filtered order metadata.
 	 */
-	protected function get_metadata( $ids, $meta_type, $meta_key_whitelist ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- returning empty meta is intentional.
+	protected function get_metadata( $ids, $meta_type, $meta_key_whitelist, $meta_key_prefix_filters = array() ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- returning empty meta is intentional.
 		return array(); // don't sync metadata, all allow-listed core data is available in the order object.
 	}
 

--- a/projects/packages/sync/src/replicastore/class-table-checksum.php
+++ b/projects/packages/sync/src/replicastore/class-table-checksum.php
@@ -521,21 +521,42 @@ class Table_Checksum {
 
 		$result = array();
 
-		foreach ( $filter_values as $field => $filter ) {
+		foreach ( $filter_values as $field => $filters ) {
 			$key = ( ! empty( $table_prefix ) ? $table_prefix : $this->table ) . '.' . $field;
 
-			switch ( $filter['operator'] ) {
-				case 'IN':
-				case 'NOT IN':
-					$filter_values_count = is_countable( $filter['values'] ) ? count( $filter['values'] ) : 0;
-					$values_placeholders = implode( ',', array_fill( 0, $filter_values_count, '%s' ) );
-					$statement           = "{$key} {$filter['operator']} ( $values_placeholders )";
+			$group_operator = $filters['group_operator'] ?? 'AND'; // Default to AND if not specified.
+			// If filters is explicitly provided, separate it out
+			if ( isset( $filters['filters'] ) ) {
+				$filters = $filters['filters'];
+			} else {
+				$filters = array( $filters );
+			}
 
-					// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
-					$prepared_statement = $wpdb->prepare( $statement, $filter['values'] );
+			$group_clauses = array();
 
-					$result[] = $prepared_statement;
-					break;
+			foreach ( $filters as $filter ) {
+				switch ( $filter['operator'] ) {
+					case 'IN':
+					case 'NOT IN':
+						$filter_values_count = is_countable( $filter['values'] ) ? count( $filter['values'] ) : 0;
+						$values_placeholders = implode( ',', array_fill( 0, $filter_values_count, '%s' ) );
+						$statement           = "{$key} {$filter['operator']} ( $values_placeholders )";
+
+						// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+						$group_clauses[] = $wpdb->prepare( $statement, $filter['values'] );
+						break;
+
+					case 'LIKE':
+						foreach ( $filter['values'] as $wildcard ) {
+							// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+							$group_clauses[] = $wpdb->prepare( "{$key} LIKE %s", $wildcard . '%' );
+						}
+						break;
+				}
+			}
+
+			if ( ! empty( $group_clauses ) ) {
+				$result[] = '( ' . implode( " {$group_operator} ", $group_clauses ) . ' )';
 			}
 		}
 

--- a/projects/plugins/automattic-for-agencies-client/changelog/update-sync-allow-post-meta-prefix-whitelist
+++ b/projects/plugins/automattic-for-agencies-client/changelog/update-sync-allow-post-meta-prefix-whitelist
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Sync: Allowing post meta prefix whitelist that works for Full Sync and Checksums.

--- a/projects/plugins/backup/changelog/update-sync-allow-post-meta-prefix-whitelist
+++ b/projects/plugins/backup/changelog/update-sync-allow-post-meta-prefix-whitelist
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Sync: Allowing post meta prefix whitelist that works for Full Sync and Checksums.

--- a/projects/plugins/boost/changelog/update-sync-allow-post-meta-prefix-whitelist
+++ b/projects/plugins/boost/changelog/update-sync-allow-post-meta-prefix-whitelist
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Sync: Allowing post meta prefix whitelist that works for Full Sync and Checksums.

--- a/projects/plugins/jetpack/changelog/update-sync-allow-post-meta-prefix-whitelist
+++ b/projects/plugins/jetpack/changelog/update-sync-allow-post-meta-prefix-whitelist
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Sync: Allowing post meta prefix whitelist that works for Full Sync and Checksums.

--- a/projects/plugins/mu-wpcom-plugin/changelog/update-sync-allow-post-meta-prefix-whitelist
+++ b/projects/plugins/mu-wpcom-plugin/changelog/update-sync-allow-post-meta-prefix-whitelist
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Sync: Allowing post meta prefix whitelist that works for Full Sync and Checksums.

--- a/projects/plugins/protect/changelog/update-sync-allow-post-meta-prefix-whitelist
+++ b/projects/plugins/protect/changelog/update-sync-allow-post-meta-prefix-whitelist
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Sync: Allowing post meta prefix whitelist that works for Full Sync and Checksums.

--- a/projects/plugins/search/changelog/update-sync-allow-post-meta-prefix-whitelist
+++ b/projects/plugins/search/changelog/update-sync-allow-post-meta-prefix-whitelist
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Sync: Allowing post meta prefix whitelist that works for Full Sync and Checksums.

--- a/projects/plugins/social/changelog/update-sync-allow-post-meta-prefix-whitelist
+++ b/projects/plugins/social/changelog/update-sync-allow-post-meta-prefix-whitelist
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Sync: Allowing post meta prefix whitelist that works for Full Sync and Checksums.

--- a/projects/plugins/starter-plugin/changelog/update-sync-allow-post-meta-prefix-whitelist
+++ b/projects/plugins/starter-plugin/changelog/update-sync-allow-post-meta-prefix-whitelist
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Sync: Allowing post meta prefix whitelist that works for Full Sync and Checksums.

--- a/projects/plugins/videopress/changelog/update-sync-allow-post-meta-prefix-whitelist
+++ b/projects/plugins/videopress/changelog/update-sync-allow-post-meta-prefix-whitelist
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Sync: Allowing post meta prefix whitelist that works for Full Sync and Checksums.

--- a/projects/plugins/wpcomsh/changelog/update-sync-allow-post-meta-prefix-whitelist
+++ b/projects/plugins/wpcomsh/changelog/update-sync-allow-post-meta-prefix-whitelist
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Sync: Allowing post meta prefix whitelist that works for Full Sync and Checksums.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/Automattic/jetpack/pull/43933
Fixes [SYNC-30](https://linear.app/a8c/issue/SYNC-30/wildcards-like-wpas-skip-not-considered-in-full-sync-or-checksums)

Wildcard post meta whitelist `_wpas_skip ` used in incremental Sync [here](https://github.com/Automattic/jetpack/blob/trunk/projects/packages/sync/src/modules/class-posts.php), doesn't seem to have an alternative in Full Syncs or Checksums.

Checksums will consider the post_meta_whitelist settings [here](https://github.com/Automattic/jetpack/blob/trunk/projects/packages/sync/src/class-settings.php#L429)

Full Syncs will do similarly [here](https://github.com/Automattic/jetpack/blob/trunk/projects/packages/sync/src/modules/class-posts.php#L891)

**Note:** Needs a WPCOM counterpart  191898-ghe-Automattic/wpcom

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
- Added a default `post_meta_prefix_whitelist` (Did not add a Setting to not overcomplicate things, but maybe we want to)
- Updated checksum logic to allow LIKE as the operator in the SQL, and to allow a group operator (defaults to AND).
- Leveraged checksum logic to update `get_allowed_post_meta_structured` with a group operator that checks for metas in `post_meta_whitelist`  OR metas starting with wildcards in `post_meta_prefix_whitelist`.
- Updated how to get metadata that have `meta_key_prefix`.
- Ensure Wildcards for post meta are considered in the Sync posts Module for Full Syncs and Checksums.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

TBD and will be shown in WPCOM counterpart, but basically we want to ensure that wildcards work for incremental, full sync and checksums.