### PR TITLE
Widget Visibility: Fix thrown PHP error under specific block conditions

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-widget-visibility-array-string-conversion-error-hog-336
+++ b/projects/plugins/jetpack/changelog/fix-widget-visibility-array-string-conversion-error-hog-336
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Widget Visibility: Fix thrown PHP error under specific block conditions

--- a/projects/plugins/jetpack/modules/widget-visibility/widget-conditions.php
+++ b/projects/plugins/jetpack/modules/widget-visibility/widget-conditions.php
@@ -826,57 +826,59 @@ class Jetpack_Widget_Conditions {
 				return $instance;
 			}
 			return false;
-		} elseif ( ! empty( $instance['content'] ) ) {
-			$content = $instance['content'];
+		}
 
-			// Normalize content to a string before checking for blocks.
-			if ( is_array( $content ) ) {
-				// Content may be provided as an array shape.
-				if ( isset( $content['content'] ) && is_string( $content['content'] ) ) {
-					$content = $content['content'];
-				} elseif ( ! empty( $content ) && isset( $content[0] ) && is_array( $content[0] ) && isset( $content[0]['blockName'] ) ) {
-					// Looks like a parsed blocks array.
-					$content = serialize_blocks( $content );
-				} else {
-					// Unknown array shape: treat as no visibility rules.
-					return $instance;
-				}
-			}
+		if ( empty( $instance['content'] ) ) {
+			return $instance;
+		}
+		$content = $instance['content'];
 
-			if ( empty( $content ) || ! is_string( $content ) || ! has_blocks( $content ) ) {
-				// No visibility found.
+		// Normalize content to a string before checking for blocks.
+		if ( is_array( $content ) ) {
+			// Content may be provided as an array shape.
+			if ( isset( $content['content'] ) && is_string( $content['content'] ) ) {
+				$content = $content['content'];
+			} elseif ( ! empty( $content ) && isset( $content[0] ) && is_array( $content[0] ) && isset( $content[0]['blockName'] ) ) {
+				// Looks like a parsed blocks array.
+				$content = serialize_blocks( $content );
+			} else {
+				// Unknown array shape: treat as no visibility rules.
 				return $instance;
 			}
+		}
 
-			$scanner = Block_Scanner::create( $content );
-			if ( ! $scanner ) {
+		if ( empty( $content ) || ! is_string( $content ) || ! has_blocks( $content ) ) {
+			// No visibility found.
+			return $instance;
+		}
+
+		$scanner = Block_Scanner::create( $content );
+		if ( ! $scanner ) {
+			// No Rules: Display widget.
+			return $instance;
+		}
+
+		// Find the first block that opens
+		while ( $scanner->next_delimiter() ) {
+			if ( ! $scanner->opens_block() ) {
+				continue;
+			}
+
+			$attributes = $scanner->allocate_and_return_parsed_attributes();
+
+			if ( ! is_array( $attributes ) || empty( $attributes['conditions']['rules'] ) ) {
 				// No Rules: Display widget.
 				return $instance;
 			}
 
-			// Find the first block that opens
-			while ( $scanner->next_delimiter() ) {
-				if ( ! $scanner->opens_block() ) {
-					continue;
-				}
-
-				$attributes = $scanner->allocate_and_return_parsed_attributes();
-
-				if ( ! is_array( $attributes ) || empty( $attributes['conditions']['rules'] ) ) {
-					// No Rules: Display widget.
-					return $instance;
-				}
-
-				if ( self::filter_widget_check_conditions( $attributes['conditions'] ) ) {
-					// Rules passed checks: Display widget.
-					return $instance;
-				}
-
-				// Rules failed checks: Hide widget.
-				return false;
+			if ( self::filter_widget_check_conditions( $attributes['conditions'] ) ) {
+				// Rules passed checks: Display widget.
+				return $instance;
 			}
-		}
 
+			// Rules failed checks: Hide widget.
+			return false;
+		}
 		// No visibility found.
 		return $instance;
 	}

--- a/projects/plugins/jetpack/modules/widget-visibility/widget-conditions.php
+++ b/projects/plugins/jetpack/modules/widget-visibility/widget-conditions.php
@@ -816,20 +816,20 @@ class Jetpack_Widget_Conditions {
 			return $content;
 		}
 
-		if ( is_array( $content ) ) {
-			if ( isset( $content['content'] ) && is_string( $content['content'] ) ) {
-				return $content['content'];
-			}
-
-			if ( ! empty( $content ) && isset( $content[0] ) && is_array( $content[0] ) && isset( $content[0]['blockName'] ) ) {
-				// Looks like a parsed blocks array.
-				return serialize_blocks( $content );
-			}
-
-			// Unknown array shape: treat as no visibility rules.
+		if ( ! is_array( $content ) ) {
 			return false;
 		}
 
+		if ( isset( $content['content'] ) && is_string( $content['content'] ) ) {
+			return $content['content'];
+		}
+
+		if ( isset( $content[0] ) && is_array( $content[0] ) && isset( $content[0]['blockName'] ) ) {
+			// Looks like a parsed blocks array.
+			return serialize_blocks( $content );
+		}
+
+		// Unknown array shape: treat as no visibility rules.
 		return false;
 	}
 

--- a/projects/plugins/jetpack/modules/widget-visibility/widget-conditions.php
+++ b/projects/plugins/jetpack/modules/widget-visibility/widget-conditions.php
@@ -826,24 +826,25 @@ class Jetpack_Widget_Conditions {
 				return $instance;
 			}
 			return false;
-		} elseif ( ! empty( $instance['content'] ) && has_blocks( $instance['content'] ) ) {
+		} elseif ( ! empty( $instance['content'] ) ) {
 			$content = $instance['content'];
+
+			// Normalize content to a string before checking for blocks.
 			if ( is_array( $content ) ) {
-				// Handle case where $instance['content'] might be an array instead of string
+				// Content may be provided as an array shape.
 				if ( isset( $content['content'] ) && is_string( $content['content'] ) ) {
-					// Content is nested in array structure
 					$content = $content['content'];
-				} elseif ( ! empty( $content ) ) {
-					// Try to convert array of blocks back to string using serialize_blocks
+				} elseif ( ! empty( $content ) && isset( $content[0] ) && is_array( $content[0] ) && isset( $content[0]['blockName'] ) ) {
+					// Looks like a parsed blocks array.
 					$content = serialize_blocks( $content );
 				} else {
-					// Empty or invalid array, treat as no blocks
+					// Unknown array shape: treat as no visibility rules.
 					return $instance;
 				}
 			}
 
-			// Ensure content is still a string after processing
-			if ( ! is_string( $content ) || empty( $content ) ) {
+			if ( ! is_string( $content ) || '' === $content || ! has_blocks( $content ) ) {
+				// No visibility found.
 				return $instance;
 			}
 

--- a/projects/plugins/jetpack/modules/widget-visibility/widget-conditions.php
+++ b/projects/plugins/jetpack/modules/widget-visibility/widget-conditions.php
@@ -827,7 +827,27 @@ class Jetpack_Widget_Conditions {
 			}
 			return false;
 		} elseif ( ! empty( $instance['content'] ) && has_blocks( $instance['content'] ) ) {
-			$scanner = Block_Scanner::create( $instance['content'] );
+			$content = $instance['content'];
+			if ( is_array( $content ) ) {
+				// Handle case where $instance['content'] might be an array instead of string
+				if ( isset( $content['content'] ) && is_string( $content['content'] ) ) {
+					// Content is nested in array structure
+					$content = $content['content'];
+				} elseif ( ! empty( $content ) ) {
+					// Try to convert array of blocks back to string using serialize_blocks
+					$content = serialize_blocks( $content );
+				} else {
+					// Empty or invalid array, treat as no blocks
+					return $instance;
+				}
+			}
+
+			// Ensure content is still a string after processing
+			if ( ! is_string( $content ) || empty( $content ) ) {
+				return $instance;
+			}
+
+			$scanner = Block_Scanner::create( $content );
 			if ( ! $scanner ) {
 				// No Rules: Display widget.
 				return $instance;

--- a/projects/plugins/jetpack/modules/widget-visibility/widget-conditions.php
+++ b/projects/plugins/jetpack/modules/widget-visibility/widget-conditions.php
@@ -843,7 +843,7 @@ class Jetpack_Widget_Conditions {
 				}
 			}
 
-			if ( ! is_string( $content ) || '' === $content || ! has_blocks( $content ) ) {
+			if ( empty( $content ) || ! is_string( $content ) || ! has_blocks( $content ) ) {
 				// No visibility found.
 				return $instance;
 			}

--- a/projects/plugins/jetpack/modules/widget-visibility/widget-conditions.php
+++ b/projects/plugins/jetpack/modules/widget-visibility/widget-conditions.php
@@ -800,6 +800,40 @@ class Jetpack_Widget_Conditions {
 	}
 
 	/**
+	 * Normalize widget `content` into a string suitable for block scanning.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param mixed $content The widget instance 'content' value.
+	 * @return string|false Normalized string content or false if none.
+	 */
+	private static function normalize_widget_content( $content ) {
+		if ( empty( $content ) ) {
+			return false;
+		}
+
+		if ( is_string( $content ) ) {
+			return $content;
+		}
+
+		if ( is_array( $content ) ) {
+			if ( isset( $content['content'] ) && is_string( $content['content'] ) ) {
+				return $content['content'];
+			}
+
+			if ( ! empty( $content ) && isset( $content[0] ) && is_array( $content[0] ) && isset( $content[0]['blockName'] ) ) {
+				// Looks like a parsed blocks array.
+				return serialize_blocks( $content );
+			}
+
+			// Unknown array shape: treat as no visibility rules.
+			return false;
+		}
+
+		return false;
+	}
+
+	/**
 	 * Determine whether the widget should be displayed based on conditions set by the user.
 	 *
 	 * @param array $instance The widget settings.
@@ -831,23 +865,9 @@ class Jetpack_Widget_Conditions {
 		if ( empty( $instance['content'] ) ) {
 			return $instance;
 		}
-		$content = $instance['content'];
+		$content = self::normalize_widget_content( isset( $instance['content'] ) ? $instance['content'] : null );
 
-		// Normalize content to a string before checking for blocks.
-		if ( is_array( $content ) ) {
-			// Content may be provided as an array shape.
-			if ( isset( $content['content'] ) && is_string( $content['content'] ) ) {
-				$content = $content['content'];
-			} elseif ( ! empty( $content ) && isset( $content[0] ) && is_array( $content[0] ) && isset( $content[0]['blockName'] ) ) {
-				// Looks like a parsed blocks array.
-				$content = serialize_blocks( $content );
-			} else {
-				// Unknown array shape: treat as no visibility rules.
-				return $instance;
-			}
-		}
-
-		if ( empty( $content ) || ! is_string( $content ) || ! has_blocks( $content ) ) {
+		if ( false === $content || ! has_blocks( $content ) ) {
 			// No visibility found.
 			return $instance;
 		}

--- a/projects/plugins/jetpack/tests/php/modules/widget-visibility/Jetpack_Widget_Conditions_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/widget-visibility/Jetpack_Widget_Conditions_Test.php
@@ -1,5 +1,6 @@
 <?php
 
+use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 require_once JETPACK__PLUGIN_DIR . 'modules/widget-visibility/widget-conditions.php';
@@ -37,7 +38,7 @@ class Jetpack_Widget_Conditions_Test extends WP_UnitTestCase {
 		// Expect to see the same block. Clone it, just in case the function modifies its parameters.
 		$expected   = unserialize( serialize( $block ) );
 		$return_val = Jetpack_Widget_Conditions::filter_widget( $block );
-		$this->assertSame( $expected, $return_val );
+		Assert::assertSame( $expected, $return_val );
 
 		// Block with rule for "Display only when logged in" (Will fail during unit tests).
 		// Expect to see: False ("Not allowed to display").
@@ -47,7 +48,7 @@ class Jetpack_Widget_Conditions_Test extends WP_UnitTestCase {
 		$block         = array( 'content' => $block_content );
 		$expected      = false;
 		$return_val    = Jetpack_Widget_Conditions::filter_widget( $block );
-		$this->assertSame( $expected, $return_val );
+		Assert::assertSame( $expected, $return_val );
 
 		// Block with no rules:.
 		$block_content = '<!-- wp:paragraph -->'
@@ -57,6 +58,51 @@ class Jetpack_Widget_Conditions_Test extends WP_UnitTestCase {
 		// Expect to see the same block. Clone it, just in case the function modifies its parameters.
 		$expected   = unserialize( serialize( $block ) );
 		$return_val = Jetpack_Widget_Conditions::filter_widget( $block );
-		$this->assertSame( $expected, $return_val );
+		Assert::assertSame( $expected, $return_val );
+	}
+
+	/**
+	 * Verifies that filter_widget handles parsed blocks arrays (output of parse_blocks)
+	 * and respects visibility rules without throwing errors.
+	 */
+	public function test_filter_widget_with_parsed_blocks_array() {
+		// Block with rule for "Display only when logged out" (Will pass during unit tests).
+		$block_content = '<!-- wp:paragraph {"conditions":{"action":"show","rules":[{"major":"loggedin","minor":"loggedout"}],"match_all":0}} -->'
+			. "\n" . '<p>Test Paragraph</p>'
+			. "\n" . '<!-- /wp:paragraph -->';
+		$parsed_blocks = parse_blocks( $block_content );
+		$block         = array( 'content' => $parsed_blocks );
+		$expected      = unserialize( serialize( $block ) );
+		$return_val    = Jetpack_Widget_Conditions::filter_widget( $block );
+		Assert::assertSame( $expected, $return_val );
+
+		// Block with rule for "Display only when logged in" (Will fail during unit tests).
+		$block_content = '<!-- wp:paragraph {"conditions":{"action":"show","rules":[{"major":"loggedin","minor":"loggedin"}],"match_all":0}} -->'
+			. "\n" . '<p>Test Paragraph</p>'
+			. "\n" . '<!-- /wp:paragraph -->';
+		$parsed_blocks = parse_blocks( $block_content );
+		$block         = array( 'content' => $parsed_blocks );
+		$expected      = false;
+		$return_val    = Jetpack_Widget_Conditions::filter_widget( $block );
+		Assert::assertSame( $expected, $return_val );
+	}
+
+	/**
+	 * Verifies that filter_widget safely bails and returns the instance when content
+	 * is an unknown array shape that cannot be normalized.
+	 */
+	public function test_filter_widget_with_unknown_array_shape() {
+		$block    = array( 'content' => array( 'foo' => 'bar' ) );
+		$expected = unserialize( serialize( $block ) );
+		Assert::assertSame( $expected, Jetpack_Widget_Conditions::filter_widget( $block ) );
+	}
+
+	/**
+	 * Verifies that filter_widget safely returns the instance when content is an empty array.
+	 */
+	public function test_filter_widget_with_empty_array_content() {
+		$block    = array( 'content' => array() );
+		$expected = unserialize( serialize( $block ) );
+		Assert::assertSame( $expected, Jetpack_Widget_Conditions::filter_widget( $block ) );
 	}
 }

--- a/projects/plugins/jetpack/tests/php/modules/widget-visibility/Jetpack_Widget_Conditions_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/widget-visibility/Jetpack_Widget_Conditions_Test.php
@@ -1,6 +1,5 @@
 <?php
 
-use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 require_once JETPACK__PLUGIN_DIR . 'modules/widget-visibility/widget-conditions.php';
@@ -38,7 +37,7 @@ class Jetpack_Widget_Conditions_Test extends WP_UnitTestCase {
 		// Expect to see the same block. Clone it, just in case the function modifies its parameters.
 		$expected   = unserialize( serialize( $block ) );
 		$return_val = Jetpack_Widget_Conditions::filter_widget( $block );
-		Assert::assertSame( $expected, $return_val );
+		$this->assertSame( $expected, $return_val );
 
 		// Block with rule for "Display only when logged in" (Will fail during unit tests).
 		// Expect to see: False ("Not allowed to display").
@@ -48,7 +47,7 @@ class Jetpack_Widget_Conditions_Test extends WP_UnitTestCase {
 		$block         = array( 'content' => $block_content );
 		$expected      = false;
 		$return_val    = Jetpack_Widget_Conditions::filter_widget( $block );
-		Assert::assertSame( $expected, $return_val );
+		$this->assertSame( $expected, $return_val );
 
 		// Block with no rules:.
 		$block_content = '<!-- wp:paragraph -->'
@@ -58,7 +57,7 @@ class Jetpack_Widget_Conditions_Test extends WP_UnitTestCase {
 		// Expect to see the same block. Clone it, just in case the function modifies its parameters.
 		$expected   = unserialize( serialize( $block ) );
 		$return_val = Jetpack_Widget_Conditions::filter_widget( $block );
-		Assert::assertSame( $expected, $return_val );
+		$this->assertSame( $expected, $return_val );
 	}
 
 	/**
@@ -74,7 +73,7 @@ class Jetpack_Widget_Conditions_Test extends WP_UnitTestCase {
 		$block         = array( 'content' => $parsed_blocks );
 		$expected      = unserialize( serialize( $block ) );
 		$return_val    = Jetpack_Widget_Conditions::filter_widget( $block );
-		Assert::assertSame( $expected, $return_val );
+		$this->assertSame( $expected, $return_val );
 
 		// Block with rule for "Display only when logged in" (Will fail during unit tests).
 		$block_content = '<!-- wp:paragraph {"conditions":{"action":"show","rules":[{"major":"loggedin","minor":"loggedin"}],"match_all":0}} -->'
@@ -84,7 +83,7 @@ class Jetpack_Widget_Conditions_Test extends WP_UnitTestCase {
 		$block         = array( 'content' => $parsed_blocks );
 		$expected      = false;
 		$return_val    = Jetpack_Widget_Conditions::filter_widget( $block );
-		Assert::assertSame( $expected, $return_val );
+		$this->assertSame( $expected, $return_val );
 	}
 
 	/**
@@ -94,7 +93,7 @@ class Jetpack_Widget_Conditions_Test extends WP_UnitTestCase {
 	public function test_filter_widget_with_unknown_array_shape() {
 		$block    = array( 'content' => array( 'foo' => 'bar' ) );
 		$expected = unserialize( serialize( $block ) );
-		Assert::assertSame( $expected, Jetpack_Widget_Conditions::filter_widget( $block ) );
+		$this->assertSame( $expected, Jetpack_Widget_Conditions::filter_widget( $block ) );
 	}
 
 	/**
@@ -103,6 +102,6 @@ class Jetpack_Widget_Conditions_Test extends WP_UnitTestCase {
 	public function test_filter_widget_with_empty_array_content() {
 		$block    = array( 'content' => array() );
 		$expected = unserialize( serialize( $block ) );
-		Assert::assertSame( $expected, Jetpack_Widget_Conditions::filter_widget( $block ) );
+		$this->assertSame( $expected, Jetpack_Widget_Conditions::filter_widget( $block ) );
 	}
 }


### PR DESCRIPTION
Fixes [HOG-336: Block Scanner: PHP Fatal TypeError in Widget Visibility Conditions](https://linear.app/a8c/issue/HOG-336/block-scanner-php-fatal-typeerror-in-widget-visibility-conditions)

## Proposed changes:
- Normalize `$instance['content']` to a string before calling `has_blocks()` in `Jetpack_Widget_Conditions::filter_widget`.
- Guard `serialize_blocks()` to only run on parsed block arrays (checks for `blockName`), and bail safely on unknown/empty array shapes.
- Avoids a PHP 8+ TypeError when `has_blocks()` is invoked with an array.


## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
N/A

## Testing instructions:
- Prereqs:
  - PHP 8.1+ recommended.
  - Jetpack active with this branch installed.
  - Enable logging in `wp-config.php` if not already:
    - `define( 'WP_DEBUG', true );`
    - `define( 'WP_DEBUG_LOG', true );`
    - `define( 'WP_DEBUG_DISPLAY', false );`
  - Tail `wp-content/debug.log` while testing.

- Manual verification:
  - Activate a classic theme that uses legacy widgets (e.g., Twenty Twenty or Twenty Twenty-One). This functionality does not apply to block-based themes.
  - Ensure the **Widget Visibility** module is active in Jetpack settings.
  - Navigate to **Appearance > Widgets**.
  - Add a block-based widget (e.g., “Latest Posts”) to a sidebar.
  - In the block controls → Advanced, set Widget Visibility to “Show if” → “Page” → “Front page”.
  - Visit:
    - Front page: widget is visible.
    - Another page/post: widget is hidden.
  - Confirm no errors in `wp-content/debug.log`.

- Simulate "array content" code paths using a temporary MU plugin:
  - Create `wp-content/mu-plugins/test-widget-visibility-content-shapes.php`, or use an existing `01-snippets.php`:
```php
<?php
add_filter(
	'widget_display_callback',
	function ( $instance, $widget, $args ) {
		static $originals = array();

		// Only run when requested.
		$force_parsed_blocks = isset( $_GET['force_arr_content'] );
		$force_nested        = isset( $_GET['force_nested_content'] );

		if ( ! ( $force_parsed_blocks || $force_nested ) ) {
			return $instance;
		}

		// Only act on Block Widget instances, which carry block content.
		if ( ! ( $widget instanceof \WP_Widget_Block ) ) {
			return $instance;
		}

		// Must have string content to start with, or nothing to do.
		if ( empty( $instance['content'] ) || ! is_string( $instance['content'] ) ) {
			return $instance;
		}

		$widget_id = isset( $args['widget_id'] ) ? $args['widget_id'] : null;
		if ( ! $widget_id ) {
			return $instance;
		}

		// Store original string to restore at priority 11.
		$originals[ $widget_id ] = $instance['content'];

		// Present array shapes to Jetpack at priority 10.
		if ( $force_parsed_blocks ) {
			$blocks = parse_blocks( $instance['content'] );
			if ( is_array( $blocks ) && ! empty( $blocks ) ) {
				$instance['content'] = $blocks;
			}
		} elseif ( $force_nested ) {
			$instance['content'] = array( 'content' => $instance['content'] );
		}

		// Register a restoration callback once to revert to the original string after Jetpack runs.
		static $restorer_added = false;
		if ( ! $restorer_added ) {
			add_filter(
				'widget_display_callback',
				function ( $inst, $w, $a ) use ( &$originals ) {
					$wid = isset( $a['widget_id'] ) ? $a['widget_id'] : null;
					if ( $wid && isset( $originals[ $wid ] ) ) {
						$inst['content'] = $originals[ $wid ];
						unset( $originals[ $wid ] );
					}
					return $inst;
				},
				11,
				3
			);
			$restorer_added = true;
		}

		return $instance;
	},
	9,
	3
);
```
  - With your test widget in place:
    - Visit the front page with `?force_arr_content=1` → no errors; visibility rules respected.
    - Visit with `?force_nested_content=1` → no errors; visibility rules respected.
    - Visit with `?force_unknown_shape=1` → no errors; widget displays (safe fallback).
  - Check `wp-content/debug.log` for any TypeErrors/notices; expect none.

- Unit tests:
  - Run, and verify all have passed.
```bash
jetpack docker phpunit jetpack -- --filter=Jetpack_Widget_Conditions_Test
```

Before / After:
- Before: `has_blocks()` could be called with an array, causing a fatal error on PHP 8+ under certain block conditions.
- After: `content` is normalized first; `has_blocks()` only receives strings; array shapes are handled safely or bailed out conservatively.
