### PR TITLE
WAF: Fix emitting PHP warnings when the BFP transient is not set, or when the hook data for the WAF update flag is not as expected.

### DIFF
--- a/projects/packages/waf/changelog/waf-fix-warnings
+++ b/projects/packages/waf/changelog/waf-fix-warnings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+WAF: Fix emitting PHP warnings when the BFP transient is not set, or when the hook data for the WAF update flag is not as expected.

--- a/projects/packages/waf/src/class-brute-force-protection.php
+++ b/projects/packages/waf/src/class-brute-force-protection.php
@@ -551,7 +551,7 @@ class Brute_Force_Protection {
 				--$transient;
 			}
 
-			if ( ! $transient || ! is_int( $transient ) || $transient < 1 ) {
+			if ( ! is_int( $transient ) || $transient < 1 ) {
 				$this->delete_transient( 'jpp_math_pass_' . sanitize_key( $_COOKIE['jpp_math_pass'] ) );
 				// This is a cop out for the tests on some PHP versions
 				if ( ! headers_sent() ) {

--- a/projects/packages/waf/src/class-brute-force-protection.php
+++ b/projects/packages/waf/src/class-brute-force-protection.php
@@ -547,7 +547,9 @@ class Brute_Force_Protection {
 		if ( isset( $_COOKIE['jpp_math_pass'] ) ) {
 
 			$transient = $this->get_transient( 'jpp_math_pass_' . sanitize_key( $_COOKIE['jpp_math_pass'] ) );
-			--$transient;
+			if ( $transient ) {
+				--$transient;
+			}
 
 			if ( ! $transient || $transient < 1 ) {
 				$this->delete_transient( 'jpp_math_pass_' . sanitize_key( $_COOKIE['jpp_math_pass'] ) );

--- a/projects/packages/waf/src/class-brute-force-protection.php
+++ b/projects/packages/waf/src/class-brute-force-protection.php
@@ -553,7 +553,10 @@ class Brute_Force_Protection {
 
 			if ( ! $transient || $transient < 1 ) {
 				$this->delete_transient( 'jpp_math_pass_' . sanitize_key( $_COOKIE['jpp_math_pass'] ) );
-				setcookie( 'jpp_math_pass', '0', time() - DAY_IN_SECONDS, COOKIEPATH, COOKIE_DOMAIN, false, true );
+				// This is a cop out for the tests on some PHP versions
+				if ( ! headers_sent() ) {
+					setcookie( 'jpp_math_pass', '0', time() - DAY_IN_SECONDS, COOKIEPATH, COOKIE_DOMAIN, false, true );
+				}
 			} else {
 				$this->set_transient( 'jpp_math_pass_' . sanitize_key( $_COOKIE['jpp_math_pass'] ), $transient, DAY_IN_SECONDS );
 			}

--- a/projects/packages/waf/src/class-brute-force-protection.php
+++ b/projects/packages/waf/src/class-brute-force-protection.php
@@ -547,11 +547,11 @@ class Brute_Force_Protection {
 		if ( isset( $_COOKIE['jpp_math_pass'] ) ) {
 
 			$transient = $this->get_transient( 'jpp_math_pass_' . sanitize_key( $_COOKIE['jpp_math_pass'] ) );
-			if ( $transient ) {
+			if ( is_int( $transient ) ) {
 				--$transient;
 			}
 
-			if ( ! $transient || $transient < 1 ) {
+			if ( ! $transient || ! is_int( $transient ) || $transient < 1 ) {
 				$this->delete_transient( 'jpp_math_pass_' . sanitize_key( $_COOKIE['jpp_math_pass'] ) );
 				// This is a cop out for the tests on some PHP versions
 				if ( ! headers_sent() ) {

--- a/projects/packages/waf/src/class-waf-initializer.php
+++ b/projects/packages/waf/src/class-waf-initializer.php
@@ -17,7 +17,7 @@ use WP_Upgrader;
 class Waf_Initializer {
 
 	/**
-	 * Option for storing whether or not the WAF files are potentially out of date.
+	 * Option for storing whether the WAF files are potentially out of date.
 	 *
 	 * @var string NEEDS_UPDATE_OPTION_NAME
 	 */
@@ -132,6 +132,10 @@ class Waf_Initializer {
 		$jetpack_text_domains_with_waf = array( 'jetpack', 'jetpack-protect' );
 		$jetpack_plugins_with_waf      = array( 'jetpack/jetpack.php', 'jetpack-protect/jetpack-protect.php' );
 
+		$hook_extra['type']    = $hook_extra['type'] ?? null;
+		$hook_extra['action']  = $hook_extra['action'] ?? null;
+		$hook_extra['plugins'] = $hook_extra['plugins'] ?? array();
+
 		// Only run on upgrades affecting plugins
 		if ( 'plugin' !== $hook_extra['type'] ) {
 			return;
@@ -151,7 +155,7 @@ class Waf_Initializer {
 		}
 		if ( 'install' === $hook_extra['action'] &&
 			! empty( $upgrader->new_plugin_data['TextDomain'] ) &&
-			empty( in_array( $upgrader->new_plugin_data['TextDomain'], $jetpack_text_domains_with_waf, true ) )
+			empty( in_array( $upgrader->new_plugin_data['TextDomain'] ?? null, $jetpack_text_domains_with_waf, true ) )
 		) {
 			return;
 		}

--- a/projects/packages/waf/tests/php/integration/BruteForceProtectionTest.php
+++ b/projects/packages/waf/tests/php/integration/BruteForceProtectionTest.php
@@ -101,4 +101,29 @@ class BruteForceProtectionTest extends WorDBless\BaseTestCase {
 		$this->assertIsString( $result );
 		$this->assertNotEmpty( $result );
 	}
+
+	/**
+	 * Verifies that the transient value is not acted upon (decremented) if the transient value was indeed not set.
+	 *
+	 * @backupGlobals enabled
+	 */
+	#[BackupGlobals( true )]
+	public function test_log_failed_attempt_does_not_emit_warning_when_transient_not_set() {
+		$error = new WP_Error( 'incorrect_password', 'Incorrect password' );
+
+		$this->instance = $this->getMockBuilder( Brute_Force_Protection::class )
+			->disableOriginalConstructor()
+			->onlyMethods( array( 'protect_call', 'get_transient' ) )
+			->getMock();
+
+		$this->instance->method( 'protect_call' )->willReturn( array() );
+		$this->instance->method( 'get_transient' )->willReturn( false );
+
+		$this->instance->expects( $this->once() )
+			->method( 'protect_call' )
+			->with( 'failed_attempt' );
+
+		$_COOKIE['jpp_math_pass'] = 1;
+		$this->instance->log_failed_attempt( 'username', $error );
+	}
 }

--- a/projects/packages/waf/tests/php/integration/BruteForceProtectionTest.php
+++ b/projects/packages/waf/tests/php/integration/BruteForceProtectionTest.php
@@ -7,6 +7,7 @@
 
 use Automattic\Jetpack\Waf\Brute_Force_Protection\Brute_Force_Protection;
 use PHPUnit\Framework\Attributes\BackupGlobals;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Brute Force Protection test case.
@@ -125,5 +126,43 @@ class BruteForceProtectionTest extends WorDBless\BaseTestCase {
 
 		$_COOKIE['jpp_math_pass'] = 1;
 		$this->instance->log_failed_attempt( 'username', $error );
+	}
+
+	/**
+	 * Verifies that the transient value is not acted upon (decremented) if the transient value was not an integer.
+	 *
+	 * @backupGlobals enabled
+	 * @dataProvider non_integer_data_provider
+	 */
+	#[BackupGlobals( true )]
+	#[DataProvider( 'non_integer_data_provider' )]
+	public function test_log_failed_attempt_does_not_emit_warning_when_transient_not_integer( $non_integer ) {
+		$error = new WP_Error( 'incorrect_password', 'Incorrect password' );
+
+		$this->instance = $this->getMockBuilder( Brute_Force_Protection::class )
+			->disableOriginalConstructor()
+			->onlyMethods( array( 'protect_call', 'get_transient' ) )
+			->getMock();
+
+		$this->instance->method( 'protect_call' )->willReturn( array() );
+		$this->instance->method( 'get_transient' )->willReturn( $non_integer );
+
+		$this->instance->expects( $this->once() )
+			->method( 'protect_call' )
+			->with( 'failed_attempt' );
+
+		$_COOKIE['jpp_math_pass'] = 1;
+		$this->instance->log_failed_attempt( 'username', $error );
+	}
+
+	public static function non_integer_data_provider(): array {
+		return array(
+			array( true ),
+			array( null ),
+			array( 3.14 ),
+			array( array( 'hello' ) ),
+			array( 'some-string' ),
+			array( (object) array() ),
+		);
 	}
 }

--- a/projects/packages/waf/tests/php/integration/WafUpdateTest.php
+++ b/projects/packages/waf/tests/php/integration/WafUpdateTest.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Update tests.
+ *
+ * @package automattic/jetpack-waf
+ */
+
+use Automattic\Jetpack\Waf\Waf_Initializer;
+
+/**
+ * Integration tests for the firewall update process.
+ */
+final class WafUpdateTest extends WorDBless\BaseTestCase {
+
+	/**
+	 * This test ensures that when the update function is called with empty fields,
+	 * it does not emit warnings or update the option indicating an update is needed.
+	 */
+	public function test_update_waf_after_plugin_upgrade_does_not_emit_warnings_or_update_option_when_fields_are_empty() {
+		// WorDBless apparently has an issue with me storing false, so I'll just use a string instead to make sure this works and the option is not updated.
+		$broken_value = 'something-broken';
+		update_option( Waf_Initializer::NEEDS_UPDATE_OPTION_NAME, $broken_value );
+
+		Waf_Initializer::update_waf_after_plugin_upgrade( new stdClass(), null );
+		$this->assertSame( $broken_value, get_option( Waf_Initializer::NEEDS_UPDATE_OPTION_NAME, null ), 'The update need option should still be the broken value.' );
+	}
+}

--- a/projects/packages/waf/tests/php/integration/WafUpdateTest.php
+++ b/projects/packages/waf/tests/php/integration/WafUpdateTest.php
@@ -7,6 +7,10 @@
 
 use Automattic\Jetpack\Waf\Waf_Initializer;
 
+if ( ! class_exists( 'WP_Upgrader' ) ) {
+	require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
+}
+
 /**
  * Integration tests for the firewall update process.
  */
@@ -21,7 +25,7 @@ final class WafUpdateTest extends WorDBless\BaseTestCase {
 		$broken_value = 'something-broken';
 		update_option( Waf_Initializer::NEEDS_UPDATE_OPTION_NAME, $broken_value );
 
-		Waf_Initializer::update_waf_after_plugin_upgrade( new stdClass(), null );
+		Waf_Initializer::update_waf_after_plugin_upgrade( $this->createMock( 'WP_Upgrader' ), array() );
 		$this->assertSame( $broken_value, get_option( Waf_Initializer::NEEDS_UPDATE_OPTION_NAME, null ), 'The update need option should still be the broken value.' );
 	}
 }


### PR DESCRIPTION
Ticket: https://linear.app/a8c/issue/PROTECT-121

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes two warnings related to data that is not always passed as expected into these functions:

> PHP Warning: Decrement on type bool has no effect, this will change in the next major version of PHP in /wordpress/plugins/jetpack/15.0-a.3/jetpack_vendor/automattic/jetpack-waf/src/class-brute-force-protection.php on line 550

and

> PHP Warning: Undefined array key "type" in /wordpress/plugins/jetpack/15.0-a.3/jetpack_vendor/automattic/jetpack-waf/src/class-waf-initializer.php on line 136

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Ensure the warnings are not caused anymore.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

I am not entirely sure in which circumstances this may occasionally happen, so I made the code more defensive to ensure it does not break. 

If you like, you can remove the defensive code I added and then run `composer phpunit` from within `projects/jetpack/projects/packages/waf` which will demonstrate that the tests fail in these cases. Then, add the code again, and the tests should be green. (Of course CI is running the tests as well).

