### PR TITLE
Forms: Add logging for form validation errors. To help us debug the issues. 

### DIFF
--- a/projects/packages/forms/changelog/add-logging-for-form-validation
+++ b/projects/packages/forms/changelog/add-logging-for-form-validation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Forms: track form submission failure

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -1680,7 +1680,7 @@ class Contact_Form_Plugin {
 			echo '<div class="form-error"><ul class="form-errors"><li class="form-error-message">';
 			esc_html_e( 'An error occurred. Please try again later.', 'jetpack-forms' );
 			echo '</li></ul></div>';
-			$this->record_tracks_event( 'forms_submission_has_errors', array( 'errors' => 'is false' ) );
+			$this->record_tracks_event( 'forms_submission_has_errors', array( 'errors' => 'submission_failed' ) );
 		} elseif ( is_wp_error( $submission_result ) ) {
 			header( 'HTTP/1.1 400 Bad Request', true, 403 );
 			echo '<div class="form-error"><ul class="form-errors"><li class="form-error-message">';

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -1663,6 +1663,23 @@ class Contact_Form_Plugin {
 		// Process the form
 		return $form->process_submission();
 	}
+	/**
+	 * Get the keys from $_POST that have non-empty values.
+	 *
+	 * @return array The keys from $_POST that have non-empty values.
+	 */
+	private function non_empty_post_data_keys() {
+		$post_data = isset( $_POST ) ? wp_unslash( $_POST ) : array(); // phpcs:ignore WordPress.Security.NonceVerification.Missing
+		unset( $post_data['contact-form-hash'], $post_data['action'], $post_data['_wpnonce'], $post_data['jetpack_contact_form_jwt'] );
+
+		$log_non_empty_post_data_keys = array();
+		foreach ( $post_data as $key => $value ) {
+			if ( ! empty( $value ) ) {
+				$log_non_empty_post_data_keys[] = $key;
+			}
+		}
+		return $log_non_empty_post_data_keys;
+	}
 
 	/**
 	 * Handle the ajax request.
@@ -1672,15 +1689,19 @@ class Contact_Form_Plugin {
 	public function ajax_request() {
 		$submission_result = self::process_form_submission();
 
-		$post_data = isset( $_POST ) ? wp_unslash( $_POST ) : array(); // phpcs:ignore WordPress.Security.NonceVerification.Missing
-		unset( $post_data['contact-form-hash'], $post_data['action'], $post_data['_wpnonce'], $post_data['jetpack_contact_form_jwt'] );
-
 		if ( ! $submission_result ) {
 			header( 'HTTP/1.1 500 Server Error', true, 500 );
 			echo '<div class="form-error"><ul class="form-errors"><li class="form-error-message">';
 			esc_html_e( 'An error occurred. Please try again later.', 'jetpack-forms' );
 			echo '</li></ul></div>';
-			$this->log_to_logstash( 'forms_submission_has_errors', array( 'errors' => 'submission_failed' ) );
+
+			$this->log_to_logstash(
+				'forms_submission_has_errors',
+				array(
+					'errors' => 'submission_failed',
+					'post'   => $this->non_empty_post_data_keys(),
+				)
+			);
 		} elseif ( is_wp_error( $submission_result ) ) {
 			header( 'HTTP/1.1 400 Bad Request', true, 403 );
 			echo '<div class="form-error"><ul class="form-errors"><li class="form-error-message">';
@@ -1691,7 +1712,7 @@ class Contact_Form_Plugin {
 				'forms_submission_has_errors',
 				array(
 					'errors' => $submission_result->get_error_message(),
-					'post'   => $post_data,
+					'post'   => $this->non_empty_post_data_keys(),
 				)
 			);
 		} else {

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -962,9 +962,9 @@ class Contact_Form_Plugin {
 				<?php if ( $is_dots_style ) : ?>
 					<?php for ( $i = 0; $i < $max_steps; $i++ ) : ?>
 						<?php $step_context = array( 'stepIndex' => $i ); ?>
-						<div class="jetpack-form-progress-indicator-step" 
-							data-wp-class--is-active="state.isStepActive" 
-							data-wp-class--is-completed="state.isStepCompleted" 
+						<div class="jetpack-form-progress-indicator-step"
+							data-wp-class--is-active="state.isStepActive"
+							data-wp-class--is-completed="state.isStepCompleted"
 							data-wp-context='<?php echo wp_json_encode( $step_context ); ?>'>
 							<div class="jetpack-form-progress-indicator-line"></div>
 							<div class="jetpack-form-progress-indicator-dot">
@@ -980,7 +980,7 @@ class Contact_Form_Plugin {
 						</div>
 					<?php endfor; ?>
 				<?php endif; ?>
-				<div class="jetpack-form-progress-indicator-progress" 
+				<div class="jetpack-form-progress-indicator-progress"
 					data-wp-style--width="<?php echo esc_attr( $progress_state ); ?>"></div>
 			</div>
 		</div>
@@ -1672,17 +1672,28 @@ class Contact_Form_Plugin {
 	public function ajax_request() {
 		$submission_result = self::process_form_submission();
 
+		$post_data = isset( $_POST ) ? wp_unslash( $_POST ) : array(); // phpcs:ignore WordPress.Security.NonceVerification.Missing
+		unset( $post_data['contact-form-hash'], $post_data['action'], $post_data['_wpnonce'], $post_data['jetpack_contact_form_jwt'] );
+
 		if ( ! $submission_result ) {
 			header( 'HTTP/1.1 500 Server Error', true, 500 );
 			echo '<div class="form-error"><ul class="form-errors"><li class="form-error-message">';
 			esc_html_e( 'An error occurred. Please try again later.', 'jetpack-forms' );
 			echo '</li></ul></div>';
+			$this->record_tracks_event( 'forms_submission_has_errors', array( 'errors' => 'is false' ) );
 		} elseif ( is_wp_error( $submission_result ) ) {
 			header( 'HTTP/1.1 400 Bad Request', true, 403 );
 			echo '<div class="form-error"><ul class="form-errors"><li class="form-error-message">';
 			echo esc_html( $submission_result->get_error_message() );
 			echo '</li></ul></div>';
-			$this->record_tracks_event( 'forms_submission_has_errors', array( 'errors' => $submission_result->get_error_message() ) );
+
+			$this->record_tracks_event(
+				'forms_submission_has_errors',
+				array(
+					'errors' => $submission_result->get_error_message(),
+					'post'   => $post_data,
+				)
+			);
 		} else {
 			echo '<h4>' . esc_html__( 'Your message has been sent', 'jetpack-forms' ) . '</h4>' . wp_kses(
 				$submission_result,

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -1682,6 +1682,7 @@ class Contact_Form_Plugin {
 			echo '<div class="form-error"><ul class="form-errors"><li class="form-error-message">';
 			echo esc_html( $submission_result->get_error_message() );
 			echo '</li></ul></div>';
+			$this->record_tracks_event( 'forms_submission_has_errors', array( 'errors' => $submission_result->get_error_message() ) );
 		} else {
 			echo '<h4>' . esc_html__( 'Your message has been sent', 'jetpack-forms' ) . '</h4>' . wp_kses(
 				$submission_result,

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -1678,6 +1678,13 @@ class Contact_Form_Plugin {
 			esc_html_e( 'An error occurred. Please try again later.', 'jetpack-forms' );
 			echo '</li></ul></div>';
 
+			/**
+			 * Action when we want to log a jetpack_forms event.
+			 *
+			 * @since $$next-version$$
+			 *
+			 * @param string $log_message The log message.
+			 */
 			do_action( 'jetpack_forms_log', 'submission_failed' );
 		} elseif ( is_wp_error( $submission_result ) ) {
 			header( 'HTTP/1.1 400 Bad Request', true, 403 );

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -1680,14 +1680,14 @@ class Contact_Form_Plugin {
 			echo '<div class="form-error"><ul class="form-errors"><li class="form-error-message">';
 			esc_html_e( 'An error occurred. Please try again later.', 'jetpack-forms' );
 			echo '</li></ul></div>';
-			$this->record_tracks_event( 'forms_submission_has_errors', array( 'errors' => 'submission_failed' ) );
+			$this->log_to_logstash( 'forms_submission_has_errors', array( 'errors' => 'submission_failed' ) );
 		} elseif ( is_wp_error( $submission_result ) ) {
 			header( 'HTTP/1.1 400 Bad Request', true, 403 );
 			echo '<div class="form-error"><ul class="form-errors"><li class="form-error-message">';
 			echo esc_html( $submission_result->get_error_message() );
 			echo '</li></ul></div>';
 
-			$this->record_tracks_event(
+			$this->log_to_logstash(
 				'forms_submission_has_errors',
 				array(
 					'errors' => $submission_result->get_error_message(),
@@ -2893,6 +2893,28 @@ class Contact_Form_Plugin {
 
 			$tracking = new Tracking();
 			$tracking->record_user_event( $event_name, $event_props, $event_user );
+		}
+	}
+
+	/**
+	 * Send an event to Logstash
+	 *
+	 * @param string $message - the message to log.
+	 * @param array  $data - data to send.
+	 *
+	 * @return null|void
+	 */
+	public function log_to_logstash( $message, $data = array() ) {
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+			require_once WP_CONTENT_DIR . '/lib/log2logstash/log2logstash.php';
+			log2logstash(
+				array(
+					'blog_id' => get_current_blog_id(),
+					'feature' => 'jetpack-forms',
+					'message' => $message,
+					'extra'   => wp_json_encode( $data ),
+				)
+			);
 		}
 	}
 

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -1663,23 +1663,6 @@ class Contact_Form_Plugin {
 		// Process the form
 		return $form->process_submission();
 	}
-	/**
-	 * Get the keys from $_POST that have non-empty values.
-	 *
-	 * @return array The keys from $_POST that have non-empty values.
-	 */
-	private function non_empty_post_data_keys() {
-		$post_data = isset( $_POST ) ? wp_unslash( $_POST ) : array(); // phpcs:ignore WordPress.Security.NonceVerification.Missing
-		unset( $post_data['contact-form-hash'], $post_data['action'], $post_data['_wpnonce'], $post_data['jetpack_contact_form_jwt'] );
-
-		$log_non_empty_post_data_keys = array();
-		foreach ( $post_data as $key => $value ) {
-			if ( ! empty( $value ) ) {
-				$log_non_empty_post_data_keys[] = $key;
-			}
-		}
-		return $log_non_empty_post_data_keys;
-	}
 
 	/**
 	 * Handle the ajax request.
@@ -1695,26 +1678,14 @@ class Contact_Form_Plugin {
 			esc_html_e( 'An error occurred. Please try again later.', 'jetpack-forms' );
 			echo '</li></ul></div>';
 
-			$this->log_to_logstash(
-				'forms_submission_has_errors',
-				array(
-					'errors' => 'submission_failed',
-					'post'   => $this->non_empty_post_data_keys(),
-				)
-			);
+			do_action( 'jetpack_forms_log', 'submission_failed' );
 		} elseif ( is_wp_error( $submission_result ) ) {
 			header( 'HTTP/1.1 400 Bad Request', true, 403 );
 			echo '<div class="form-error"><ul class="form-errors"><li class="form-error-message">';
 			echo esc_html( $submission_result->get_error_message() );
 			echo '</li></ul></div>';
 
-			$this->log_to_logstash(
-				'forms_submission_has_errors',
-				array(
-					'errors' => $submission_result->get_error_message(),
-					'post'   => $this->non_empty_post_data_keys(),
-				)
-			);
+			do_action( 'jetpack_forms_log', $submission_result->get_error_message() );
 		} else {
 			echo '<h4>' . esc_html__( 'Your message has been sent', 'jetpack-forms' ) . '</h4>' . wp_kses(
 				$submission_result,
@@ -2914,28 +2885,6 @@ class Contact_Form_Plugin {
 
 			$tracking = new Tracking();
 			$tracking->record_user_event( $event_name, $event_props, $event_user );
-		}
-	}
-
-	/**
-	 * Send an event to Logstash
-	 *
-	 * @param string $message - the message to log.
-	 * @param array  $data - data to send.
-	 *
-	 * @return null|void
-	 */
-	public function log_to_logstash( $message, $data = array() ) {
-		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-			require_once WP_CONTENT_DIR . '/lib/log2logstash/log2logstash.php';
-			log2logstash(
-				array(
-					'blog_id' => get_current_blog_id(),
-					'feature' => 'jetpack-forms',
-					'message' => $message,
-					'extra'   => wp_json_encode( $data ),
-				)
-			);
 		}
 	}
 

--- a/projects/plugins/jetpack/changelog/add-logging-for-form-validation
+++ b/projects/plugins/jetpack/changelog/add-logging-for-form-validation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Forms: track form submission failure


### PR DESCRIPTION
This Pr adds logging so that we can debug issues with forms more. 

## Proposed changes:
* Add logstash just before we display errors. So that we can know when a user submits a form. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1757088621320979/1755110667.244879-slack-C052XEUUBL4

## Does this pull request change what data or activity we track or use?
yes. We track validation errors and the post data that gets submitted. 

## Testing instructions:
Add a form. 
Submit the form with validation errors. 
Notice that now you can see the errors in logstash as expected. 
