### PR TITLE
Forms: Add preloaded config endpoint

### DIFF
--- a/projects/packages/forms/changelog/add-forms-config-endpoint
+++ b/projects/packages/forms/changelog/add-forms-config-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: Add preloaded config endpoint.

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -796,6 +796,15 @@ class Contact_Form_Block {
 			),
 		);
 
+		// Preload the Forms config endpoint in the editor so apiFetch resolves synchronously.
+		add_filter(
+			'block_editor_rest_api_preload_paths',
+			static function ( $paths ) {
+				$paths[] = array( '/wp/v2/feedback/config', 'GET' );
+				return $paths;
+			}
+		);
+
 		wp_add_inline_script( $handle, 'window.jpFormsBlocks = ' . wp_json_encode( $data ) . ';', 'before' );
 	}
 

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -49,6 +49,8 @@ class Contact_Form_Block {
 		add_filter( 'render_block_core/html', array( __CLASS__, 'render_wrapped_html_block' ), 10, 2 );
 		add_filter( 'jetpack_block_editor_feature_flags', array( __CLASS__, 'register_feature' ) );
 		add_filter( 'pre_render_block', array( __CLASS__, 'pre_render_contact_form' ), 10, 3 );
+
+		add_filter( 'block_editor_rest_api_preload_paths', array( __CLASS__, 'preload_endpoints' ) );
 	}
 	/**
 	 * Register the contact form block feature flag.
@@ -796,16 +798,18 @@ class Contact_Form_Block {
 			),
 		);
 
-		// Preload the Forms config endpoint in the editor so apiFetch resolves synchronously.
-		add_filter(
-			'block_editor_rest_api_preload_paths',
-			static function ( $paths ) {
-				$paths[] = array( '/wp/v2/feedback/config', 'GET' );
-				return $paths;
-			}
-		);
-
 		wp_add_inline_script( $handle, 'window.jpFormsBlocks = ' . wp_json_encode( $data ) . ';', 'before' );
+	}
+
+	/**
+	 * Add REST API endpoints to the block editor preload list.
+	 *
+	 * @param array $paths Existing paths to preload.
+	 * @return array Updated paths to preload.
+	 */
+	public static function preload_endpoints( $paths ) {
+		$paths[] = array( '/wp/v2/feedback/config', 'GET' );
+		return $paths;
 	}
 
 	/**

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/index.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/index.tsx
@@ -8,6 +8,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import useFormsConfig from '../../../../hooks/use-forms-config';
 import AkismetCard from './akismet-card';
 import CreativeMailCard from './creative-mail-card';
 import GoogleSheetsCard from './google-sheets-card';
@@ -19,8 +20,6 @@ import './style.scss';
  * Types
  */
 import type { Integration } from '../../../../types';
-
-const isMailPoetEnabled: boolean = !! window?.jpFormsBlocks?.defaults?.isMailPoetEnabled;
 
 const IntegrationsModal = ( {
 	isOpen,
@@ -39,9 +38,13 @@ const IntegrationsModal = ( {
 		mailpoet: false,
 	} );
 
+	const config = useFormsConfig();
+
 	if ( ! isOpen ) {
 		return null;
 	}
+
+	const isMailPoetEnabled = Boolean( config?.isMailPoetEnabled );
 
 	const toggleCard = ( cardId: string ) => {
 		setExpandedCards( prev => {

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -9,11 +9,15 @@ namespace Automattic\Jetpack\Forms\ContactForm;
 
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\External_Connections;
+use Automattic\Jetpack\Forms\Dashboard\Dashboard as Forms_Dashboard;
 use Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch;
+use Automattic\Jetpack\Forms\Jetpack_Forms;
 use Automattic\Jetpack\Forms\Service\Google_Drive;
 use Automattic\Jetpack\Forms\Service\MailPoet_Integration;
 use Automattic\Jetpack\Redirect;
+use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Status\Host;
+use Jetpack_AI_Helper;
 use WP_Error;
 use WP_REST_Request;
 use WP_REST_Response;
@@ -210,6 +214,17 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 						'default'  => 'trash',
 					),
 				),
+			)
+		);
+
+		// Forms config endpoint.
+		register_rest_route(
+			$this->namespace,
+			$this->rest_base . '/config',
+			array(
+				'methods'             => \WP_REST_Server::READABLE,
+				'permission_callback' => array( $this, 'get_items_permissions_check' ),
+				'callback'            => array( $this, 'get_forms_config' ),
 			)
 		);
 	}
@@ -985,5 +1000,45 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 		}
 		$is_deleted = External_Connections::delete_connection( $slug );
 		return rest_ensure_response( array( 'deleted' => $is_deleted ) );
+	}
+
+	/**
+	 * Return consolidated Forms config payload.
+	 *
+	 * @param WP_REST_Request $request Request.
+	 * @return WP_REST_Response
+	 */
+	public function get_forms_config( WP_REST_Request $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		$switch  = new Dashboard_View_Switch();
+		$feature = Jetpack_AI_Helper::get_ai_assistance_feature();
+		$has_ai  = ! is_wp_error( $feature ) ? ( $feature['has-feature'] ?? false ) : false;
+
+		$config = array(
+			// From jpFormsBlocks in class-contact-form-block.php.
+			'formsResponsesUrl'       => $switch->get_forms_admin_url(),
+			'preferredView'           => $switch->get_preferred_view(),
+			'isMailPoetEnabled'       => Jetpack_Forms::is_mailpoet_enabled(),
+			// From config in class-dashboard.php.
+			'blogId'                  => get_current_blog_id(),
+			'gdriveConnectSupportURL' => esc_url( Redirect::get_url( 'jetpack-support-contact-form-export' ) ),
+			'pluginAssetsURL'         => Jetpack_Forms::assets_url(),
+			'siteURL'                 => ( new Status() )->get_site_suffix(),
+			'hasFeedback'             => ( new Forms_Dashboard() )->has_feedback(),
+			'hasAI'                   => $has_ai,
+			'enableIntegrationsTab'   => apply_filters( 'jetpack_forms_enable_integrations_tab', true ),
+			'renderMigrationPage'     => $switch->is_jetpack_forms_announcing_new_menu(),
+			'dashboardURL'            => add_query_arg( 'jetpack_forms_migration_announcement_seen', 'yes', $switch->get_forms_admin_url() ),
+			// New data.
+			'canInstallPlugins'       => current_user_can( 'install_plugins' ),
+			'canActivatePlugins'      => current_user_can( 'activate_plugins' ),
+		);
+
+		// Include dashboard-only nonces when in admin Forms page context.
+		if ( is_admin() && isset( $_GET['page'] ) && 'jetpack-forms-admin' === $_GET['page'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$config['exportNonce']  = wp_create_nonce( 'feedback_export' );
+			$config['newFormNonce'] = wp_create_nonce( 'create_new_form' );
+		}
+
+		return rest_ensure_response( $config );
 	}
 }

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -1031,13 +1031,9 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 			// New data.
 			'canInstallPlugins'       => current_user_can( 'install_plugins' ),
 			'canActivatePlugins'      => current_user_can( 'activate_plugins' ),
+			'exportNonce'             => wp_create_nonce( 'feedback_export' ),
+			'newFormNonce'            => wp_create_nonce( 'create_new_form' ),
 		);
-
-		// Include dashboard-only nonces when in admin Forms page context.
-		if ( is_admin() && isset( $_GET['page'] ) && 'jetpack-forms-admin' === $_GET['page'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			$config['exportNonce']  = wp_create_nonce( 'feedback_export' );
-			$config['newFormNonce'] = wp_create_nonce( 'create_new_form' );
-		}
 
 		return rest_ensure_response( $config );
 	}

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -1009,9 +1009,12 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 	 * @return WP_REST_Response
 	 */
 	public function get_forms_config( WP_REST_Request $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-		$switch  = new Dashboard_View_Switch();
-		$feature = Jetpack_AI_Helper::get_ai_assistance_feature();
-		$has_ai  = ! is_wp_error( $feature ) ? ( $feature['has-feature'] ?? false ) : false;
+		$switch = new Dashboard_View_Switch();
+		$has_ai = false;
+		if ( class_exists( 'Jetpack_AI_Helper' ) ) {
+			$feature = Jetpack_AI_Helper::get_ai_assistance_feature();
+			$has_ai  = ! is_wp_error( $feature ) ? ( $feature['has-feature'] ?? false ) : false;
+		}
 
 		$config = array(
 			// From jpFormsBlocks in class-contact-form-block.php.

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -112,13 +112,12 @@ class Dashboard {
 		// Adds Connection package initial state.
 		Connection_Initial_State::render_script( self::SCRIPT_HANDLE );
 
-		$api_root = defined( 'IS_WPCOM' ) && IS_WPCOM
-			? sprintf( '/wpcom/v2/sites/%s/', esc_url_raw( rest_url() ) )
-			: '/wp-json/wpcom/v2/';
-
+		// Preload Forms config endpoint for dashboard context.
+		$preload_paths = array( '/wp/v2/feedback/config' );
+		$preload_data  = array_reduce( $preload_paths, 'rest_preload_api_request', array() );
 		wp_add_inline_script(
 			self::SCRIPT_HANDLE,
-			'window.jetpackFormsData = ' . wp_json_encode( array( 'apiRoot' => $api_root ) ) . ';',
+			'wp.apiFetch.use( wp.apiFetch.createPreloadingMiddleware( ' . wp_json_encode( $preload_data ) . ' ) );',
 			'before'
 		);
 	}
@@ -246,7 +245,7 @@ class Dashboard {
 	 *
 	 * @return boolean
 	 */
-	private function has_feedback() {
+	public function has_feedback() {
 		$posts = new \WP_Query(
 			array(
 				'post_type'   => 'feedback',

--- a/projects/packages/forms/src/dashboard/integrations/index.tsx
+++ b/projects/packages/forms/src/dashboard/integrations/index.tsx
@@ -8,7 +8,7 @@ import { useState, useCallback } from 'react';
  * Internal dependencies
  */
 import { useIntegrationsStatus } from '../../blocks/contact-form/components/jetpack-integrations-modal/hooks/use-integrations-status';
-import { config } from '../index';
+import useFormsConfig from '../../hooks/use-forms-config';
 import AkismetDashboardCard from './akismet-card';
 import CreativeMailDashboardCard from './creative-mail-card';
 import GoogleSheetsDashboardCard from './google-sheets-card';
@@ -32,7 +32,8 @@ const Integrations = () => {
 		mailpoet: false,
 	} );
 
-	const isMailpoetEnabled = config( 'isMailpoetEnabled' );
+	const config = useFormsConfig();
+	const isMailpoetEnabled = Boolean( config?.isMailPoetEnabled );
 
 	const toggleCard = useCallback( ( cardId: keyof typeof expandedCards ) => {
 		setExpandedCards( prev => {

--- a/projects/packages/forms/src/hooks/use-forms-config.ts
+++ b/projects/packages/forms/src/hooks/use-forms-config.ts
@@ -2,6 +2,9 @@ import apiFetch from '@wordpress/api-fetch';
 import { useEffect, useState } from '@wordpress/element';
 import type { FormsConfigData } from '../types';
 
+// Minimal cache to prevent refetch across multiple instances on the same page
+let cachedFormsConfig: FormsConfigData | undefined;
+
 /**
  * Fetch the consolidated Forms config via REST.
  * @return {Promise<FormsConfigData>} Promise resolving to the consolidated forms configuration.
@@ -19,8 +22,13 @@ export default function useFormsConfig(): FormsConfigData | undefined {
 	const [ config, setConfig ] = useState< FormsConfigData | undefined >( undefined );
 
 	useEffect( () => {
+		if ( cachedFormsConfig ) {
+			setConfig( cachedFormsConfig );
+			return;
+		}
 		fetchFormsConfig()
 			.then( data => {
+				cachedFormsConfig = data;
 				setConfig( data );
 			} )
 			.catch( () => {} );

--- a/projects/packages/forms/src/hooks/use-forms-config.ts
+++ b/projects/packages/forms/src/hooks/use-forms-config.ts
@@ -1,0 +1,30 @@
+import apiFetch from '@wordpress/api-fetch';
+import { useEffect, useState } from '@wordpress/element';
+import type { FormsConfigData } from '../types';
+
+/**
+ * Fetch the consolidated Forms config via REST.
+ * @return {Promise<FormsConfigData>} Promise resolving to the consolidated forms configuration.
+ */
+export function fetchFormsConfig(): Promise< FormsConfigData > {
+	return apiFetch< FormsConfigData >( { path: '/wp/v2/feedback/config' } );
+}
+
+/**
+ * Fetch and return the consolidated Forms config.
+ * Uses the preloaded REST response in editor context; falls back to network elsewhere.
+ * @return {FormsConfigData|undefined} Consolidated forms configuration, or undefined while loading.
+ */
+export default function useFormsConfig(): FormsConfigData | undefined {
+	const [ config, setConfig ] = useState< FormsConfigData | undefined >( undefined );
+
+	useEffect( () => {
+		fetchFormsConfig()
+			.then( data => {
+				setConfig( data );
+			} )
+			.catch( () => {} );
+	}, [] );
+
+	return config;
+}

--- a/projects/packages/forms/src/types/index.ts
+++ b/projects/packages/forms/src/types/index.ts
@@ -195,3 +195,39 @@ export type BlockEditorStoreSelect = {
 	getBlockIndex: ( clientId: string ) => number;
 	getBlockParentsByBlockName: ( clientId: string, blockName: string ) => string[];
 };
+
+/**
+ * Forms script data exposed via JetpackScriptData.forms
+ */
+export interface FormsConfigData {
+	/** Whether MailPoet integration is enabled across contexts. */
+	isMailPoetEnabled?: boolean;
+	/** Whether the current user can install plugins (install_plugins). */
+	canInstallPlugins?: boolean;
+	/** Whether the current user can activate plugins (activate_plugins). */
+	canActivatePlugins?: boolean;
+	/** Whether to show the Integrations tab in the dashboard UI. */
+	enableIntegrationsTab?: boolean;
+	/** Whether to render the migration/announcement page instead of the main dashboard. */
+	renderMigrationPage?: boolean;
+	/** Whether there are any feedback (form response) posts on the site. */
+	hasFeedback?: boolean;
+	/** Whether AI Assist features are available for the site/user. */
+	hasAI?: boolean;
+	/** The URL of the Forms responses list in wp-admin. */
+	formsResponsesUrl?: string;
+	/** Current site blog ID. */
+	blogId?: number;
+	/** Support URL for Google Drive connect guidance. */
+	gdriveConnectSupportURL?: string;
+	/** Base URL to static/assets for the Forms package. */
+	pluginAssetsURL?: string;
+	/** The site suffix/fragment for building admin links. */
+	siteURL?: string;
+	/** The dashboard URL with migration acknowledgement parameter. */
+	dashboardURL?: string;
+	/** Nonce for exporting feedback responses (dashboard-only). */
+	exportNonce?: string;
+	/** Nonce for creating a new form (dashboard-only). */
+	newFormNonce?: string;
+}

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Endpoint_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Endpoint_Test.php
@@ -404,6 +404,59 @@ class Contact_Form_Endpoint_Test extends TestCase {
 	}
 
 	/**
+	 * Test GET feedback/config returns expected structure for authorized user.
+	 */
+	public function test_get_forms_config_returns_200_and_keys() {
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/feedback/config' );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+
+		$data = $response->get_data();
+
+		// Required keys
+		$expected_keys = array(
+			'formsResponsesUrl',
+			'preferredView',
+			'isMailPoetEnabled',
+			'blogId',
+			'gdriveConnectSupportURL',
+			'pluginAssetsURL',
+			'siteURL',
+			'hasFeedback',
+			'hasAI',
+			'enableIntegrationsTab',
+			'renderMigrationPage',
+			'dashboardURL',
+			'canInstallPlugins',
+			'canActivatePlugins',
+			'exportNonce',
+			'newFormNonce',
+		);
+
+		foreach ( $expected_keys as $key ) {
+			$this->assertArrayHasKey( $key, $data );
+		}
+
+		// Basic type checks for a few fields
+		$this->assertIsBool( $data['isMailPoetEnabled'] );
+		$this->assertIsInt( $data['blogId'] );
+		$this->assertIsBool( $data['canInstallPlugins'] );
+		$this->assertIsBool( $data['canActivatePlugins'] );
+		$this->assertIsString( $data['exportNonce'] );
+		$this->assertIsString( $data['newFormNonce'] );
+	}
+
+	/**
+	 * Test GET feedback/config unauthorized access.
+	 */
+	public function test_get_forms_config_returns_401_for_unauthorized() {
+		wp_set_current_user( 0 );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/feedback/config' );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 401, $response->get_status() );
+	}
+
+	/**
 	 * Test resend email functionality
 	 */
 	public function test_resend_email() {

--- a/projects/plugins/jetpack/changelog/add-forms-config-endpoint
+++ b/projects/plugins/jetpack/changelog/add-forms-config-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: Add preloaded config endpoint.


### PR DESCRIPTION
## Proposed changes:

**Context** I've long been bothered by the fact that we have several different methods of passing data from PHP to our frontend JavaScript. 
* For the dashboard, we create a [config](https://github.com/Automattic/jetpack/blob/6acf8539a548793fa2930c3cc1cae6ba0b1e0d6d/projects/packages/forms/src/dashboard/class-dashboard.php#L220) object and define a [config()](https://github.com/Automattic/jetpack/blob/eb675ce01efb863d055e139f36d7f122dc3a8057/projects/packages/forms/src/dashboard/index.tsx#L21) method for accessing the object.
   - As a side problem, because the config method is defined in the root file where we mount the dashboard, if you import that config method elsewhere in the codebase, webpack imports the entire dependency tree for the dashboard. This creates other problems, see below. 
* For the dashboard, we also create a [jetpackFormsData](https://github.com/Automattic/jetpack/blob/eb675ce01efb863d055e139f36d7f122dc3a8057/projects/packages/forms/src/dashboard/class-dashboard.php#L121) object.
* For the editor, we create a [jpFormsBlocks](https://github.com/Automattic/jetpack/blob/eb675ce01efb863d055e139f36d7f122dc3a8057/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php#L781) object.
* In some cases, we need to pass the same data in multiple places if its needed in both editor and dashboard. 

**Immediate problem.** This came to a head in [this PR](https://github.com/Automattic/jetpack/pull/45063) where I wanted to pass permission checks for integrations. I had to add the permissions checks in both config and jpFormsBlocks, because the relevant component is loaded in both dashboard and editor. I had to update the component to check both config and jpFormsBlocks. And because I had to import the 'config' method from the dashboard, webpack imported the entire dashboard, **which caused a build failure because of bundle size.** 

**Solution.** In this PR, based on a suggested by @enejb, I propose that we add a new forms 'config' endpoint, and pre-load that endpoint with the `block_editor_rest_api_preload` filter. Specific changes:
- Added new endpoint that returns all the same data as the config and jpFormsBlocks objects. 
- Preloaded the endpoint in the dashboard and editor. 
- Added custom hook to make it easy to grab the form config data from anywhere in the codebase. 
- Added a new type for the FormConfigData
- Demo: as an example of how this will work, I updated the editor and dashboard to use isMailPoetEnabled from the new endpoint rather than the old config and jpFormsBlocks objects. 

**Follow ups.** If we adopt this approach, we would update other code in the editor and dashboard to use this, and phase out the config and jpFormsBlocks method. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

There are two ways to check this. Confirm MailPoet feature flag still works. Right now, the only place I'm using the updated method is the MailPoet check. To confirm it works in both dashboard and editor, you can...
* Add this filter to your site: `add_filter( 'jetpack_forms_mailpoet_enable', '__return_false' );`
* Confirm that the MailPoet card does not show in the integrations dashboard or block modal.
* Remove the filter or update it to return true.
* Confirm that the MailPoet card does show. 

You can also confirm endpoint data is preloaded by opening the page sources or dev tools inspector on the forms dashboard and editor pages, and searching for wp.apiFetch.createPreloadingMiddleware. Confirm you see our feedback config data loaded. there. 

Finally, we added an endpoint test. So please confirm all PHP tests pass. 

