### PR TITLE
Forms: Make rating and slider fields also available as beta blocks

### DIFF
--- a/projects/packages/forms/changelog/update-forms-experimental-beta-blocks
+++ b/projects/packages/forms/changelog/update-forms-experimental-beta-blocks
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Making some Form fields that are available as experimental blocks to beta as well. Should not have any effect for normal users
+
+

--- a/projects/packages/forms/src/blocks/contact-form/child-blocks.js
+++ b/projects/packages/forms/src/blocks/contact-form/child-blocks.js
@@ -60,7 +60,7 @@ export const childBlocks = [
 	JetpackTelephoneField,
 	JetpackTextareaField,
 	JetpackFieldFile,
-	...( getJetpackBlocksVariation() === 'experimental'
+	...( [ 'experimental', 'beta' ].includes( getJetpackBlocksVariation() )
 		? [ JetpackRatingField, JetpackRatingInput, JetpackFieldSlider, JetpackSliderInput ]
 		: [] ),
 	...( getJetpackBlocksVariation() === 'beta' ? [ JetpackTimeField, JetpackHiddenField ] : [] ),

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -262,7 +262,7 @@ class Contact_Form_Block {
 			)
 		);
 
-		if ( Blocks::get_variation() === 'experimental' ) {
+		if ( Blocks::get_variation() === 'experimental' || Blocks::get_variation() === 'beta' ) {
 			Blocks::jetpack_register_block(
 				'jetpack/input-rating',
 				array(
@@ -454,7 +454,7 @@ class Contact_Form_Block {
 			);
 		}
 
-		if ( Blocks::get_variation() === 'experimental' ) {
+		if ( Blocks::get_variation() === 'experimental' || Blocks::get_variation() === 'beta' ) {
 			Blocks::jetpack_register_block(
 				'jetpack/field-rating',
 				array(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Follow-up to #44998

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Enables the block for experimental AND beta blocks variation

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Enable beta blocks
* Check that you can add and use the Rating and Slider fields
* Enable experimental blocks
* Check that you can add and use the Rating and Slider fields
* Enable production blocks
* Check that you cannot add and use the Rating and Slider fields
