### PR TITLE
Move MCP abilities registry in site settings

### DIFF
--- a/projects/plugins/jetpack/changelog/update-mcp-abilities-registry-loc
+++ b/projects/plugins/jetpack/changelog/update-mcp-abilities-registry-loc
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Update Abilities Registry Directory

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -628,7 +628,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 	 */
 	private function get_all_site_mcp_abilities(): array {
 		$all_abilities         = array();
-		$ability_registry_file = WP_CONTENT_DIR . '/mu-plugins/wpcom-mcp/includes/AbilitiesRegistry/Registry/AbilityRegistry.php';
+		$ability_registry_file = JETPACK_MU_WPCOM_PLUGIN_LOADER_PATH . '/jetpack_vendor/automattic/jetpack-mu-wpcom/src/features/mcp-abilities/AbilitiesRegistry/Registry/AbilityRegistry.php';
 		if ( file_exists( $ability_registry_file ) ) {
 			require_once $ability_registry_file;
 			// @phan-suppress-next-line PhanUndeclaredClassMethod
@@ -651,7 +651,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 	 */
 	private function get_mcp_abilities_metadata( string $ability_name ): array {
 		$ability_meta          = array();
-		$ability_registry_file = WP_CONTENT_DIR . '/mu-plugins/wpcom-mcp/includes/AbilitiesRegistry/Registry/AbilityRegistry.php';
+		$ability_registry_file = JETPACK_MU_WPCOM_PLUGIN_LOADER_PATH . '/jetpack_vendor/automattic/jetpack-mu-wpcom/src/features/mcp-abilities/AbilitiesRegistry/Registry/AbilityRegistry.php';
 		if ( file_exists( $ability_registry_file ) ) {
 			require_once $ability_registry_file;
 			// @phan-suppress-next-line PhanUndeclaredClassMethod

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -628,22 +628,10 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 	 */
 	private function get_all_site_mcp_abilities(): array {
 		$all_abilities         = array();
-		// Try to find the jetpack-mu-wpcom plugin directory
-		$mu_wpcom_plugin_dir = '';
-		if ( defined( 'JETPACK_MU_WPCOM_PLUGIN_LOADER_PATH' ) ) {
-			$mu_wpcom_plugin_dir = JETPACK_MU_WPCOM_PLUGIN_LOADER_PATH;
-		} else {
-			// Fallback: look for jetpack-mu-wpcom-plugin in plugins directory
-			$plugins_dir = WP_PLUGIN_DIR;
-			$mu_wpcom_plugin_dir = $plugins_dir . '/jetpack-mu-wpcom-plugin-dev';
-			if ( ! file_exists( $mu_wpcom_plugin_dir ) ) {
-				$mu_wpcom_plugin_dir = $plugins_dir . '/jetpack-mu-wpcom-plugin';
-			}
-		}
+		$mu_wpcom_plugin_dir   = defined( 'JETPACK_MU_WPCOM_PLUGIN_LOADER_PATH' ) ? JETPACK_MU_WPCOM_PLUGIN_LOADER_PATH : WP_PLUGIN_DIR . '/jetpack-mu-wpcom-plugin-dev';
 		$ability_registry_file = $mu_wpcom_plugin_dir . '/jetpack_vendor/automattic/jetpack-mu-wpcom/src/features/mcp-abilities/AbilitiesRegistry/Registry/AbilityRegistry.php';
 		if ( file_exists( $ability_registry_file ) ) {
 			require_once $ability_registry_file;
-			error_log( 'Ability registry file found: ' . $ability_registry_file );
 			// @phan-suppress-next-line PhanUndeclaredClassMethod
 			$abilities_resources = Automattic\WpcomMcp\AbilitiesRegistry\Registry\AbilityRegistry::get_resources_for_server( 'site-level' );
 			// @phan-suppress-next-line PhanUndeclaredClassMethod
@@ -651,10 +639,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 			// @phan-suppress-next-line PhanUndeclaredClassMethod
 			$abilities_prompts = Automattic\WpcomMcp\AbilitiesRegistry\Registry\AbilityRegistry::get_prompts_for_server( 'site-level' );
 			$all_abilities     = array_merge( $abilities_resources, $abilities_tools, $abilities_prompts );
-		} else {
-			error_log( 'Ability registry file not found: ' . $ability_registry_file );
 		}
-		error_log( 'All abilities: ' . print_r( $all_abilities, true ) );
 		return apply_filters( 'jetpack_site_mcp_abilities', $all_abilities );
 	}
 
@@ -667,28 +652,13 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 	 */
 	private function get_mcp_abilities_metadata( string $ability_name ): array {
 		$ability_meta          = array();
-		// Try to find the jetpack-mu-wpcom plugin directory
-		$mu_wpcom_plugin_dir = '';
-		if ( defined( 'JETPACK_MU_WPCOM_PLUGIN_LOADER_PATH' ) ) {
-			$mu_wpcom_plugin_dir = JETPACK_MU_WPCOM_PLUGIN_LOADER_PATH;
-		} else {
-			// Fallback: look for jetpack-mu-wpcom-plugin in plugins directory
-			$plugins_dir = WP_PLUGIN_DIR;
-			$mu_wpcom_plugin_dir = $plugins_dir . '/jetpack-mu-wpcom-plugin-dev';
-			if ( ! file_exists( $mu_wpcom_plugin_dir ) ) {
-				$mu_wpcom_plugin_dir = $plugins_dir . '/jetpack-mu-wpcom-plugin';
-			}
-		}
+		$mu_wpcom_plugin_dir   = defined( 'JETPACK_MU_WPCOM_PLUGIN_LOADER_PATH' ) ? JETPACK_MU_WPCOM_PLUGIN_LOADER_PATH : WP_PLUGIN_DIR . '/jetpack-mu-wpcom-plugin-dev';
 		$ability_registry_file = $mu_wpcom_plugin_dir . '/jetpack_vendor/automattic/jetpack-mu-wpcom/src/features/mcp-abilities/AbilitiesRegistry/Registry/AbilityRegistry.php';
 		if ( file_exists( $ability_registry_file ) ) {
-			error_log( 'Ability registry file found: ' . $ability_registry_file );
 			require_once $ability_registry_file;
 			// @phan-suppress-next-line PhanUndeclaredClassMethod
 			$ability_meta = Automattic\WpcomMcp\AbilitiesRegistry\Registry\AbilityRegistry::get_metadata( $ability_name );
-		} else {
-			error_log( 'Ability registry file not found: ' . $ability_registry_file );
 		}
-		error_log( 'Ability meta: ' . print_r( $ability_meta, true ) );
 		return apply_filters( 'jetpack_site_mcp_ability_meta', $ability_meta, $ability_name );
 	}
 

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -628,7 +628,19 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 	 */
 	private function get_all_site_mcp_abilities(): array {
 		$all_abilities         = array();
-		$ability_registry_file = JETPACK__PLUGIN_DIR . 'jetpack_vendor/automattic/jetpack-mu-wpcom/src/features/mcp-abilities/AbilitiesRegistry/Registry/AbilityRegistry.php';
+		// Try to find the jetpack-mu-wpcom plugin directory
+		$mu_wpcom_plugin_dir = '';
+		if ( defined( 'JETPACK_MU_WPCOM_PLUGIN_LOADER_PATH' ) ) {
+			$mu_wpcom_plugin_dir = JETPACK_MU_WPCOM_PLUGIN_LOADER_PATH;
+		} else {
+			// Fallback: look for jetpack-mu-wpcom-plugin in plugins directory
+			$plugins_dir = WP_PLUGIN_DIR;
+			$mu_wpcom_plugin_dir = $plugins_dir . '/jetpack-mu-wpcom-plugin-dev';
+			if ( ! file_exists( $mu_wpcom_plugin_dir ) ) {
+				$mu_wpcom_plugin_dir = $plugins_dir . '/jetpack-mu-wpcom-plugin';
+			}
+		}
+		$ability_registry_file = $mu_wpcom_plugin_dir . '/jetpack_vendor/automattic/jetpack-mu-wpcom/src/features/mcp-abilities/AbilitiesRegistry/Registry/AbilityRegistry.php';
 		if ( file_exists( $ability_registry_file ) ) {
 			require_once $ability_registry_file;
 			error_log( 'Ability registry file found: ' . $ability_registry_file );
@@ -655,7 +667,19 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 	 */
 	private function get_mcp_abilities_metadata( string $ability_name ): array {
 		$ability_meta          = array();
-		$ability_registry_file = JETPACK__PLUGIN_DIR . 'jetpack_vendor/automattic/jetpack-mu-wpcom/src/features/mcp-abilities/AbilitiesRegistry/Registry/AbilityRegistry.php';
+		// Try to find the jetpack-mu-wpcom plugin directory
+		$mu_wpcom_plugin_dir = '';
+		if ( defined( 'JETPACK_MU_WPCOM_PLUGIN_LOADER_PATH' ) ) {
+			$mu_wpcom_plugin_dir = JETPACK_MU_WPCOM_PLUGIN_LOADER_PATH;
+		} else {
+			// Fallback: look for jetpack-mu-wpcom-plugin in plugins directory
+			$plugins_dir = WP_PLUGIN_DIR;
+			$mu_wpcom_plugin_dir = $plugins_dir . '/jetpack-mu-wpcom-plugin-dev';
+			if ( ! file_exists( $mu_wpcom_plugin_dir ) ) {
+				$mu_wpcom_plugin_dir = $plugins_dir . '/jetpack-mu-wpcom-plugin';
+			}
+		}
+		$ability_registry_file = $mu_wpcom_plugin_dir . '/jetpack_vendor/automattic/jetpack-mu-wpcom/src/features/mcp-abilities/AbilitiesRegistry/Registry/AbilityRegistry.php';
 		if ( file_exists( $ability_registry_file ) ) {
 			error_log( 'Ability registry file found: ' . $ability_registry_file );
 			require_once $ability_registry_file;

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -628,7 +628,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 	 */
 	private function get_all_site_mcp_abilities(): array {
 		$all_abilities         = array();
-		$ability_registry_file = JETPACK_MU_WPCOM_PLUGIN_LOADER_PATH . '/jetpack_vendor/automattic/jetpack-mu-wpcom/src/features/mcp-abilities/AbilitiesRegistry/Registry/AbilityRegistry.php';
+		$ability_registry_file = Jetpack_Mu_Wpcom::BASE_DIR . '/jetpack_vendor/automattic/jetpack-mu-wpcom/src/features/mcp-abilities/AbilitiesRegistry/Registry/AbilityRegistry.php';
 		if ( file_exists( $ability_registry_file ) ) {
 			require_once $ability_registry_file;
 			// @phan-suppress-next-line PhanUndeclaredClassMethod
@@ -651,7 +651,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 	 */
 	private function get_mcp_abilities_metadata( string $ability_name ): array {
 		$ability_meta          = array();
-		$ability_registry_file = JETPACK_MU_WPCOM_PLUGIN_LOADER_PATH . '/jetpack_vendor/automattic/jetpack-mu-wpcom/src/features/mcp-abilities/AbilitiesRegistry/Registry/AbilityRegistry.php';
+		$ability_registry_file = Jetpack_Mu_Wpcom::BASE_DIR . '/jetpack_vendor/automattic/jetpack-mu-wpcom/src/features/mcp-abilities/AbilitiesRegistry/Registry/AbilityRegistry.php';
 		if ( file_exists( $ability_registry_file ) ) {
 			require_once $ability_registry_file;
 			// @phan-suppress-next-line PhanUndeclaredClassMethod

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -628,7 +628,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 	 */
 	private function get_all_site_mcp_abilities(): array {
 		$all_abilities         = array();
-		$ability_registry_file = Jetpack_Mu_Wpcom::BASE_DIR . '/jetpack_vendor/automattic/jetpack-mu-wpcom/src/features/mcp-abilities/AbilitiesRegistry/Registry/AbilityRegistry.php';
+		$ability_registry_file = JETPACK__PLUGIN_DIR . 'jetpack_vendor/automattic/jetpack-mu-wpcom/src/features/mcp-abilities/AbilitiesRegistry/Registry/AbilityRegistry.php';
 		if ( file_exists( $ability_registry_file ) ) {
 			require_once $ability_registry_file;
 			// @phan-suppress-next-line PhanUndeclaredClassMethod
@@ -651,7 +651,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 	 */
 	private function get_mcp_abilities_metadata( string $ability_name ): array {
 		$ability_meta          = array();
-		$ability_registry_file = Jetpack_Mu_Wpcom::BASE_DIR . '/jetpack_vendor/automattic/jetpack-mu-wpcom/src/features/mcp-abilities/AbilitiesRegistry/Registry/AbilityRegistry.php';
+		$ability_registry_file = JETPACK__PLUGIN_DIR . 'jetpack_vendor/automattic/jetpack-mu-wpcom/src/features/mcp-abilities/AbilitiesRegistry/Registry/AbilityRegistry.php';
 		if ( file_exists( $ability_registry_file ) ) {
 			require_once $ability_registry_file;
 			// @phan-suppress-next-line PhanUndeclaredClassMethod

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -631,6 +631,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 		$ability_registry_file = JETPACK__PLUGIN_DIR . 'jetpack_vendor/automattic/jetpack-mu-wpcom/src/features/mcp-abilities/AbilitiesRegistry/Registry/AbilityRegistry.php';
 		if ( file_exists( $ability_registry_file ) ) {
 			require_once $ability_registry_file;
+			error_log( 'Ability registry file found: ' . $ability_registry_file );
 			// @phan-suppress-next-line PhanUndeclaredClassMethod
 			$abilities_resources = Automattic\WpcomMcp\AbilitiesRegistry\Registry\AbilityRegistry::get_resources_for_server( 'site-level' );
 			// @phan-suppress-next-line PhanUndeclaredClassMethod
@@ -638,7 +639,10 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 			// @phan-suppress-next-line PhanUndeclaredClassMethod
 			$abilities_prompts = Automattic\WpcomMcp\AbilitiesRegistry\Registry\AbilityRegistry::get_prompts_for_server( 'site-level' );
 			$all_abilities     = array_merge( $abilities_resources, $abilities_tools, $abilities_prompts );
+		} else {
+			error_log( 'Ability registry file not found: ' . $ability_registry_file );
 		}
+		error_log( 'All abilities: ' . print_r( $all_abilities, true ) );
 		return apply_filters( 'jetpack_site_mcp_abilities', $all_abilities );
 	}
 
@@ -653,10 +657,14 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 		$ability_meta          = array();
 		$ability_registry_file = JETPACK__PLUGIN_DIR . 'jetpack_vendor/automattic/jetpack-mu-wpcom/src/features/mcp-abilities/AbilitiesRegistry/Registry/AbilityRegistry.php';
 		if ( file_exists( $ability_registry_file ) ) {
+			error_log( 'Ability registry file found: ' . $ability_registry_file );
 			require_once $ability_registry_file;
 			// @phan-suppress-next-line PhanUndeclaredClassMethod
 			$ability_meta = Automattic\WpcomMcp\AbilitiesRegistry\Registry\AbilityRegistry::get_metadata( $ability_name );
+		} else {
+			error_log( 'Ability registry file not found: ' . $ability_registry_file );
 		}
+		error_log( 'Ability meta: ' . print_r( $ability_meta, true ) );
 		return apply_filters( 'jetpack_site_mcp_ability_meta', $ability_meta, $ability_name );
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://linear.app/a8c/issue/AIINT-164/mcp-abilitieis-on-atomic

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Updates the location of the Ability Registry in site settings to expect it on Jetpack
* `JETPACK_MU_WPCOM_PLUGIN_LOADER_PATH' )` is used as base directory to Jetpack on Simple sites.
* `WP_PLUGIN_DIR . '/jetpack-mu-wpcom-plugin-dev'` appears the be base directory to Jetpack on Atomic sites.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

