### PR TITLE
Fix missing legendValueDisplay prop in PieSemiCircleChart

### DIFF
--- a/projects/js-packages/charts/changelog/fix-pie-semi-circle-chart-legend-value-display-prop
+++ b/projects/js-packages/charts/changelog/fix-pie-semi-circle-chart-legend-value-display-prop
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Charts: fix Type error with legendValueDisplay

--- a/projects/js-packages/charts/src/components/pie-semi-circle-chart/pie-semi-circle-chart.tsx
+++ b/projects/js-packages/charts/src/components/pie-semi-circle-chart/pie-semi-circle-chart.tsx
@@ -21,6 +21,7 @@ import { withResponsive } from '../private/with-responsive';
 import { BaseTooltip } from '../tooltip';
 import styles from './pie-semi-circle-chart.module.scss';
 import type { BaseChartProps, DataPointPercentage, Optional } from '../../types';
+import type { LegendValueDisplay } from '../legend';
 import type { ChartComponentWithComposition } from '../private/chart-composition';
 import type { ResponsiveConfig } from '../private/with-responsive';
 import type { PieArcDatum } from '@visx/shape/lib/shapes/Pie';
@@ -59,6 +60,15 @@ export interface PieSemiCircleChartProps extends BaseChartProps< DataPointPercen
 	 * Use the children prop to render additional elements on the chart.
 	 */
 	children?: ReactNode;
+
+	/**
+	 * What type of value to display in the legend when showValues is true.
+	 * - 'percentage': Shows percentage values (e.g., "23%") [default]
+	 * - 'value': Shows raw numeric values (e.g., "30000")
+	 * - 'valueDisplay': Shows formatted values (e.g., "30K")
+	 * - 'none': Shows no values, only labels
+	 */
+	legendValueDisplay?: LegendValueDisplay;
 }
 
 // Base props type with optional responsive properties
@@ -109,6 +119,7 @@ const PieSemiCircleChartInternal: FC< PieSemiCircleChartProps > = ( {
 	legendPosition = 'bottom',
 	legendAlignment = 'center',
 	legendShape = 'circle',
+	legendValueDisplay = 'percentage',
 	label,
 	note,
 	className,
@@ -164,7 +175,10 @@ const PieSemiCircleChartInternal: FC< PieSemiCircleChartProps > = ( {
 	);
 
 	// Memoize legend options to prevent unnecessary re-calculations
-	const legendOptions = useMemo( () => ( { showValues: true } ), [] );
+	const legendOptions = useMemo(
+		() => ( { showValues: true, legendValueDisplay } ),
+		[ legendValueDisplay ]
+	);
 
 	// Create legend items using the reusable hook
 	const legendItems = useChartLegendItems( data, legendOptions );


### PR DESCRIPTION
## Proposed changes:
* Add `legendValueDisplay` prop to PieSemiCircleChart component to match PieChart implementation
* Import the `LegendValueDisplay` type from the legend module
* Add comprehensive JSDoc documentation explaining each display option ('percentage', 'value', 'valueDisplay', 'none')
* Set default value to 'percentage' to maintain backward compatibility
* Pass the prop through to the `useChartLegendItems` hook via `legendOptions`
* Update the component's TypeScript interface to include the new prop

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?

No, it does not.

## Testing instructions:

* Go to Storybook -> Charts -> Types -> Pie Semi Circle Chart
* Use the `legendValueDisplay` control to test all four options:
  - `percentage`: Should display "60%", "23%", "17%" format (default)
  - `value`: Should display raw numbers like "80000", "30000", "22000"
  - `valueDisplay`: Should display formatted values like "80K", "30K", "22K"
  - `none`: Should display only labels without any values
* Enable "showLegend" to see the legend value changes
* Verify that percentage display is used by default (backward compatibility)
* Test with different data sets to ensure proper value formatting
* Ensure the PieSemiCircleChart now has the same legend value display capabilities as PieChart
* Verify no TypeScript errors in the stories file
* Confirm no visual regressions in chart rendering, tooltips, or other legend functionality