### PR TITLE
Leaderboard chart: extend BaseChartsProps

### DIFF
--- a/projects/js-packages/charts/changelog/charts-114-leaderboard-chart-use-basechartsprops
+++ b/projects/js-packages/charts/changelog/charts-114-leaderboard-chart-use-basechartsprops
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Leaderboard chart: Extend BaseChartProps

--- a/projects/js-packages/charts/src/components/leaderboard-chart/index.ts
+++ b/projects/js-packages/charts/src/components/leaderboard-chart/index.ts
@@ -1,4 +1,5 @@
 export { default as LeaderboardChart } from './leaderboard-chart';
-export type { LeaderboardChartProps, LeaderboardEntry } from './leaderboard-chart';
+export type { LeaderboardChartProps } from './types';
+export type { LeaderboardEntry } from '../../types';
 export { formatMetricValue } from '../../utils';
 export type { MetricValueType } from '../../utils';

--- a/projects/js-packages/charts/src/components/leaderboard-chart/leaderboard-chart.tsx
+++ b/projects/js-packages/charts/src/components/leaderboard-chart/leaderboard-chart.tsx
@@ -13,10 +13,10 @@ import {
 	useGlobalChartsContext,
 	useGlobalChartsTheme,
 } from '../../providers/chart-context';
-import { LeaderboardEntry } from '../../types';
 import { formatMetricValue } from '../../utils';
 import styles from './leaderboard-chart.module.scss';
-import { LeaderboardChartProps } from './types';
+import type { LeaderboardChartProps } from './types';
+import type { LeaderboardEntry } from '../../types';
 
 /**
  * Default value formatter using formatMetricValue

--- a/projects/js-packages/charts/src/components/leaderboard-chart/leaderboard-chart.tsx
+++ b/projects/js-packages/charts/src/components/leaderboard-chart/leaderboard-chart.tsx
@@ -13,53 +13,10 @@ import {
 	useGlobalChartsContext,
 	useGlobalChartsTheme,
 } from '../../providers/chart-context';
-import { BaseChartProps, LeaderboardEntry } from '../../types';
+import { LeaderboardEntry } from '../../types';
 import { formatMetricValue } from '../../utils';
 import styles from './leaderboard-chart.module.scss';
-
-export interface LeaderboardChartProps extends BaseChartProps< LeaderboardEntry[] > {
-	/**
-	 * Whether to show comparison data
-	 */
-	withComparison?: boolean;
-
-	/**
-	 * Whether to overlay the label on top of bar
-	 */
-	withOverlayLabel?: boolean;
-
-	/**
-	 * Primary color for current period bars
-	 */
-	primaryColor?: string;
-
-	/**
-	 * Secondary color for comparison period bars
-	 */
-	secondaryColor?: string;
-
-	/**
-	 * Formatter for values
-	 */
-	valueFormatter?: ( value: number ) => string;
-
-	/**
-	 * Formatter for delta values
-	 */
-	deltaFormatter?: ( value: number ) => string;
-
-	/**
-	 * Whether the chart is in loading state
-	 */
-	loading?: boolean;
-
-	/**
-	 * Custom styling for the chart container
-	 */
-	style?: React.CSSProperties & {
-		'--a8c--charts--leaderboard--bar--border-radius'?: string;
-	};
-}
+import { LeaderboardChartProps } from './types';
 
 /**
  * Default value formatter using formatMetricValue

--- a/projects/js-packages/charts/src/components/leaderboard-chart/leaderboard-chart.tsx
+++ b/projects/js-packages/charts/src/components/leaderboard-chart/leaderboard-chart.tsx
@@ -13,57 +13,11 @@ import {
 	useGlobalChartsContext,
 	useGlobalChartsTheme,
 } from '../../providers/chart-context';
+import { BaseChartProps, LeaderboardEntry } from '../../types';
 import { formatMetricValue } from '../../utils';
 import styles from './leaderboard-chart.module.scss';
 
-export interface LeaderboardEntry {
-	/**
-	 * Unique internal key (e.g., 'key-direct')
-	 */
-	id: string;
-
-	/**
-	 * Human-readable name (e.g., 'Direct') or a JSX element (e.g., <h4>Direct</h4>)
-	 */
-	label: string | JSX.Element;
-
-	/**
-	 * Value of the entry
-	 */
-	currentValue: number;
-
-	/**
-	 * Value of the entry in the previous period
-	 */
-	previousValue: number;
-
-	/**
-	 * Width of current bar, as % of the current value
-	 */
-	currentShare: number;
-
-	/**
-	 * Width of previous bar, as % of the current value
-	 */
-	previousShare: number;
-
-	/**
-	 * Delta of the entry
-	 */
-	delta: number;
-
-	/**
-	 * Optional color for the entry's image/icon
-	 */
-	imageColor?: string;
-}
-
-export interface LeaderboardChartProps {
-	/**
-	 * Array of leaderboard entries to display
-	 */
-	data: LeaderboardEntry[];
-
+export interface LeaderboardChartProps extends BaseChartProps< LeaderboardEntry[] > {
 	/**
 	 * Whether to show comparison data
 	 */
@@ -98,11 +52,6 @@ export interface LeaderboardChartProps {
 	 * Whether the chart is in loading state
 	 */
 	loading?: boolean;
-
-	/**
-	 * Additional CSS class name for the chart container
-	 */
-	className?: string;
 
 	/**
 	 * Custom styling for the chart container

--- a/projects/js-packages/charts/src/components/leaderboard-chart/test/leaderboard-chart.test.tsx
+++ b/projects/js-packages/charts/src/components/leaderboard-chart/test/leaderboard-chart.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import LeaderboardChart from '../leaderboard-chart';
-import type { LeaderboardEntry } from '../leaderboard-chart';
+import type { LeaderboardEntry } from '../../../types';
 
 const mockData: LeaderboardEntry[] = [
 	{

--- a/projects/js-packages/charts/src/components/leaderboard-chart/types.ts
+++ b/projects/js-packages/charts/src/components/leaderboard-chart/types.ts
@@ -1,6 +1,7 @@
 import { BaseChartProps, LeaderboardEntry } from '../../types';
 
-export interface LeaderboardChartProps extends BaseChartProps< LeaderboardEntry > {
+export interface LeaderboardChartProps
+	extends Pick< BaseChartProps< LeaderboardEntry >, 'className' | 'data' > {
 	/**
 	 * Whether to show comparison data
 	 */

--- a/projects/js-packages/charts/src/components/leaderboard-chart/types.ts
+++ b/projects/js-packages/charts/src/components/leaderboard-chart/types.ts
@@ -1,6 +1,6 @@
 import { BaseChartProps, LeaderboardEntry } from '../../types';
 
-export interface LeaderboardChartProps extends BaseChartProps< LeaderboardEntry[] > {
+export interface LeaderboardChartProps extends BaseChartProps< LeaderboardEntry > {
 	/**
 	 * Whether to show comparison data
 	 */

--- a/projects/js-packages/charts/src/components/leaderboard-chart/types.ts
+++ b/projects/js-packages/charts/src/components/leaderboard-chart/types.ts
@@ -1,0 +1,45 @@
+import { BaseChartProps, LeaderboardEntry } from '../../types';
+
+export interface LeaderboardChartProps extends BaseChartProps< LeaderboardEntry[] > {
+	/**
+	 * Whether to show comparison data
+	 */
+	withComparison?: boolean;
+
+	/**
+	 * Whether to overlay the label on top of bar
+	 */
+	withOverlayLabel?: boolean;
+
+	/**
+	 * Primary color for current period bars
+	 */
+	primaryColor?: string;
+
+	/**
+	 * Secondary color for comparison period bars
+	 */
+	secondaryColor?: string;
+
+	/**
+	 * Formatter for values
+	 */
+	valueFormatter?: ( value: number ) => string;
+
+	/**
+	 * Formatter for delta values
+	 */
+	deltaFormatter?: ( value: number ) => string;
+
+	/**
+	 * Whether the chart is in loading state
+	 */
+	loading?: boolean;
+
+	/**
+	 * Custom styling for the chart container
+	 */
+	style?: React.CSSProperties & {
+		'--a8c--charts--leaderboard--bar--border-radius'?: string;
+	};
+}

--- a/projects/js-packages/charts/src/types.ts
+++ b/projects/js-packages/charts/src/types.ts
@@ -47,6 +47,48 @@ export type DataPointDate = {
 	label?: string;
 };
 
+export type LeaderboardEntry = {
+	/**
+	 * Unique internal key (e.g., 'key-direct')
+	 */
+	id: string;
+
+	/**
+	 * Human-readable name (e.g., 'Direct') or a JSX element (e.g., <h4>Direct</h4>)
+	 */
+	label: string | JSX.Element;
+
+	/**
+	 * Value of the entry
+	 */
+	currentValue: number;
+
+	/**
+	 * Value of the entry in the previous period
+	 */
+	previousValue: number;
+
+	/**
+	 * Width of current bar, as % of the current value
+	 */
+	currentShare: number;
+
+	/**
+	 * Width of previous bar, as % of the current value
+	 */
+	previousShare: number;
+
+	/**
+	 * Delta of the entry
+	 */
+	delta: number;
+
+	/**
+	 * Optional color for the entry's image/icon
+	 */
+	imageColor?: string;
+};
+
 export type SeriesDataOptions = {
 	gradient?: { from: string; to: string; fromOpacity?: number; toOpacity?: number };
 	stroke?: string;
@@ -215,11 +257,11 @@ export type ScaleOptions = {
 /**
  * Base properties shared across all chart components
  */
-export type BaseChartProps< T = DataPoint | DataPointDate > = {
+export type BaseChartProps< T = DataPoint | DataPointDate | LeaderboardEntry > = {
 	/**
 	 * Array of data points to display in the chart
 	 */
-	data: T extends DataPoint | DataPointDate ? T[] : T;
+	data: T extends DataPoint | DataPointDate | LeaderboardEntry ? T[] : T;
 	/**
 	 * Optional unique identifier for the chart (auto-generated if not provided)
 	 */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes [CHARTS-114: Leaderboard Chart: Use BaseChartsProps](https://linear.app/a8c/issue/CHARTS-114/leaderboard-chart-use-basechartsprops)

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Make Leaderboard chart props consistent with other charts by extending BaseChartProps

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* No functional change to test

