### PR TITLE
Boost: Fix Cornerstone Pages validation for URLs with GET parameters

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/features/cornerstone-pages/meta/meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/cornerstone-pages/meta/meta.tsx
@@ -444,15 +444,19 @@ const List: FC< ListProps > = ( {
 				);
 			}
 
-			// Fixed multisite homepage detection
+			// Fixed multisite homepage detection - exclude URLs with query parameters
 			const resolvedPath = getResolvedPath( pathname, siteUrl );
 			if ( resolvedPath === siteUrl.pathname ) {
-				throw new Error(
-					__(
-						'The homepage does not need to be added to the list, as it is automatically included.',
-						'jetpack-boost'
-					)
-				);
+				// Only consider it homepage if it has no query parameters
+				const hasQueryParameters = url && url.search !== '';
+				if ( ! hasQueryParameters ) {
+					throw new Error(
+						__(
+							'The homepage does not need to be added to the list, as it is automatically included.',
+							'jetpack-boost'
+						)
+					);
+				}
 			}
 		}
 

--- a/projects/plugins/boost/app/assets/src/js/features/cornerstone-pages/meta/meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/cornerstone-pages/meta/meta.tsx
@@ -444,19 +444,15 @@ const List: FC< ListProps > = ( {
 				);
 			}
 
-			// Fixed multisite homepage detection - exclude URLs with query parameters
+			// Only consider it homepage if it has no query parameters
 			const resolvedPath = getResolvedPath( pathname, siteUrl );
-			if ( resolvedPath === siteUrl.pathname ) {
-				// Only consider it homepage if it has no query parameters
-				const hasQueryParameters = url && url.search !== '';
-				if ( ! hasQueryParameters ) {
-					throw new Error(
-						__(
-							'The homepage does not need to be added to the list, as it is automatically included.',
-							'jetpack-boost'
-						)
-					);
-				}
+			if ( resolvedPath === siteUrl.pathname && ! url?.search ) {
+				throw new Error(
+					__(
+						'The homepage does not need to be added to the list, as it is automatically included.',
+						'jetpack-boost'
+					)
+				);
 			}
 		}
 

--- a/projects/plugins/boost/changelog/fix-boost-cornerstone-get-params-exclusion-hog-335
+++ b/projects/plugins/boost/changelog/fix-boost-cornerstone-get-params-exclusion-hog-335
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Cornerstone Pages: Fix validation error preventing URLs with GET parameters from being added to the cornerstone pages list.


### PR DESCRIPTION
## Proposed changes:
* Fix homepage detection logic in Cornerstone Pages to properly handle URLs with GET parameters
* URLs like `/?page_id=32` were incorrectly being identified as homepage URLs, causing false validation errors
* Added query parameter check to exclude URLs with parameters from homepage validation
* Preserve existing functionality for actual homepage URLs and multisite installations

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
N/A

## Testing instructions:

### Setup
1. Navigate to Jetpack → Boost → Performance → Cornerstone Pages
2. Ensure you have a site with some pages created (or create test pages with `?page_id=X` URLs)

### Test the fix
**Before this fix:**
1. Try to add a URL like `https://yoursite.com/?page_id=123` to the Cornerstone Pages list
2. You would see the error: "The homepage does not need to be added to the list, as it is automatically included."

**After this fix:**
1. Add a URL like `https://yoursite.com/?page_id=123` to the Cornerstone Pages list
2. The URL should be accepted without the homepage validation error
3. Add a URL like `https://yoursite.com/?utm_source=test` to verify other query parameters work
4. Try to add `https://yoursite.com/` (bare homepage) - this should still show the homepage error (expected behavior)

### Additional test cases:
- `https://yoursite.com/` → Should trigger homepage error (preserve existing behavior)
- `https://yoursite.com/?page_id=32` → Should NOT trigger homepage error (fixed)
- `https://yoursite.com/?utm_source=test` → Should NOT trigger homepage error (fixed)  
- `https://yoursite.com/some-page` → Should NOT trigger homepage error (existing behavior)
- Relative URLs like `/page` → Should work as before (existing behavior)
