### PR TITLE
Forms: add "source" to hidden field value

### DIFF
--- a/projects/packages/forms/changelog/update-hidden-field-source
+++ b/projects/packages/forms/changelog/update-hidden-field-source
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: hidden input - add source selection

--- a/projects/packages/forms/src/blocks/field-hidden/edit.js
+++ b/projects/packages/forms/src/blocks/field-hidden/edit.js
@@ -1,7 +1,16 @@
 import { useBlockProps } from '@wordpress/block-editor';
-import { Placeholder, TextControl, __experimentalHStack as HStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
+import {
+	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+	__experimentalText as Text, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+	Placeholder,
+	SelectControl,
+	TextControl,
+} from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
 import { unseen } from '@wordpress/icons';
+import { safeDecodeURIComponent } from '@wordpress/url';
 import useFormWrapper from '../shared/hooks/use-form-wrapper';
 import useInsertAfterOnEnterKeyDown from '../shared/hooks/use-insert-after-on-enter-key-down';
 import './editor.scss';
@@ -11,12 +20,31 @@ export default function HiddenFieldEdit( props ) {
 	const blockProps = useBlockProps();
 	useFormWrapper( props );
 
-	const handleLabelChange = textValue => {
-		setAttributes( { label: textValue } );
+	const { permalink, postId, postSlug, postTitle } = useSelect( select => {
+		const post = select( editorStore ).getCurrentPost();
+
+		return {
+			permalink: safeDecodeURIComponent( select( editorStore ).getPermalink() ),
+			postId: select( editorStore ).getCurrentPostId(),
+			postSlug: safeDecodeURIComponent( select( editorStore ).getEditedPostSlug() ),
+			postTitle: post.title,
+		};
+	}, [] );
+
+	const handleLabelChange = label => {
+		setAttributes( { label: label } );
 	};
 
-	const handleValueChange = textValue => {
-		setAttributes( { default: textValue } );
+	const handleValueChange = value => {
+		setAttributes( { default: value } );
+	};
+
+	const handleValueSourceChange = valueSource => {
+		setAttributes( { valueSource: valueSource } );
+	};
+
+	const handleUrlParameterChange = urlParameter => {
+		setAttributes( { urlParameter: urlParameter } );
 	};
 
 	const onKeyDown = useInsertAfterOnEnterKeyDown( clientId, true );
@@ -24,28 +52,94 @@ export default function HiddenFieldEdit( props ) {
 	return (
 		<div { ...blockProps }>
 			<Placeholder icon={ unseen } label={ __( 'Hidden field', 'jetpack-forms' ) }>
-				<HStack alignment="top" className="jetpack-form-hidden-field-inputs">
+				<HStack alignment="top" spacing="2" className="jetpack-form-hidden-field-inputs">
 					<TextControl
 						__next40pxDefaultSize
 						__nextHasNoMarginBottom
-						onChange={ handleLabelChange }
+						autoComplete="off"
 						label={ __( 'Name', 'jetpack-forms' ) }
-						value={ attributes.label }
-						help={ __(
-							'Internal name used to identify this field in form responses.',
-							'jetpack-forms'
-						) }
+						onChange={ handleLabelChange }
 						onKeyDown={ onKeyDown }
+						spellCheck="false"
+						value={ attributes.label }
 					/>
-					<TextControl
+					<SelectControl
 						__next40pxDefaultSize
 						__nextHasNoMarginBottom
-						onChange={ handleValueChange }
-						label={ __( 'Value', 'jetpack-forms' ) }
-						value={ attributes.default }
-						help={ __( 'The value that will be submitted with the form.', 'jetpack-forms' ) }
-						onKeyDown={ onKeyDown }
+						label={ __( 'Value source', 'jetpack-forms' ) }
+						onChange={ handleValueSourceChange }
+						options={ [
+							{ label: __( 'Enter manually', 'jetpack-forms' ), value: 'manual' },
+							{ label: __( 'Page/post ID', 'jetpack-forms' ), value: 'post_id' },
+							{ label: __( 'Page/post link', 'jetpack-forms' ), value: 'permalink' },
+							{ label: __( 'Page/post slug', 'jetpack-forms' ), value: 'slug' },
+							{ label: __( 'Page/post title', 'jetpack-forms' ), value: 'post_title' },
+							{ label: __( 'URL parameter', 'jetpack-forms' ), value: 'url_parameter' },
+						] }
+						value={ attributes.valueSource }
 					/>
+					{ attributes.valueSource === 'manual' && (
+						<TextControl
+							__next40pxDefaultSize
+							__nextHasNoMarginBottom
+							autoComplete="off"
+							label={ __( 'Value', 'jetpack-forms' ) }
+							onChange={ handleValueChange }
+							onKeyDown={ onKeyDown }
+							spellCheck="false"
+							value={ attributes.default }
+						/>
+					) }
+					{ attributes.valueSource === 'post_id' && (
+						<div className="jetpack-form-hidden-field-fixed-value">
+							<Text upperCase>{ __( 'Page/post ID', 'jetpack-forms' ) }</Text>
+							<Text variant="muted" as="p" lineHeight={ 3.5 } numberOfLines={ 1 }>
+								<code>{ postId }</code>
+							</Text>
+						</div>
+					) }
+					{ attributes.valueSource === 'permalink' && (
+						<div className="jetpack-form-hidden-field-fixed-value">
+							<Text upperCase>{ __( 'Page/post link', 'jetpack-forms' ) }</Text>
+							<Text
+								variant="muted"
+								as="p"
+								lineHeight={ 3.5 }
+								numberOfLines={ 1 }
+								ellipsizeMode="head"
+							>
+								{ permalink }
+							</Text>
+						</div>
+					) }
+					{ attributes.valueSource === 'slug' && (
+						<div className="jetpack-form-hidden-field-fixed-value">
+							<Text upperCase>{ __( 'Page/post slug', 'jetpack-forms' ) }</Text>
+							<Text variant="muted" as="p" lineHeight={ 3.5 } numberOfLines={ 1 }>
+								{ postSlug }
+							</Text>
+						</div>
+					) }
+					{ attributes.valueSource === 'post_title' && (
+						<div className="jetpack-form-hidden-field-fixed-value">
+							<Text upperCase>{ __( 'Post title', 'jetpack-forms' ) }</Text>
+							<Text variant="muted" as="p" lineHeight={ 3.5 } numberOfLines={ 1 }>
+								{ postTitle }
+							</Text>
+						</div>
+					) }
+					{ attributes.valueSource === 'url_parameter' && (
+						<TextControl
+							__next40pxDefaultSize
+							__nextHasNoMarginBottom
+							autoComplete="off"
+							label={ __( 'URL parameter', 'jetpack-forms' ) }
+							onChange={ handleUrlParameterChange }
+							onKeyDown={ onKeyDown }
+							spellCheck="false"
+							value={ attributes.urlParameter }
+						/>
+					) }
 				</HStack>
 			</Placeholder>
 		</div>

--- a/projects/packages/forms/src/blocks/field-hidden/editor.scss
+++ b/projects/packages/forms/src/blocks/field-hidden/editor.scss
@@ -10,3 +10,7 @@
 		flex-wrap: wrap;
 	}
 }
+
+.jetpack-form-hidden-field-fixed-value {
+	width: 100%;
+}

--- a/projects/packages/forms/src/blocks/field-hidden/index.js
+++ b/projects/packages/forms/src/blocks/field-hidden/index.js
@@ -20,13 +20,16 @@ const settings = {
 	edit,
 	save,
 	attributes: {
-		label: { type: 'string', default: '' },
 		default: { type: 'string', default: '' },
+		label: { type: 'string', default: '' },
+		urlParameter: { type: 'string', default: '' },
+		valueSource: { type: 'string', default: 'manual' },
 	},
 	example: {
 		attributes: {
 			label: __( 'Company_ID', 'jetpack-forms' ),
 			default: __( 'ACME Inc.', 'jetpack-forms' ),
+			valueSource: 'manual',
 		},
 	},
 };

--- a/projects/packages/forms/src/blocks/field-hidden/save.js
+++ b/projects/packages/forms/src/blocks/field-hidden/save.js
@@ -1,3 +1,1 @@
-export default () => {
-	return '';
-};
+export default () => null;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Adds just UI for hidden field's sources as an experiment. We likely should pick just couple to implement for ease.

A good set could be:

- Manual
- URL param
- Page/post link

<img width="665" height="226" alt="Screenshot 2025-09-08 at 18 39 52" src="https://github.com/user-attachments/assets/59df7f36-e351-42bc-8c1c-8f747607bdc9" />
<img width="672" height="230" alt="Screenshot 2025-09-08 at 18 39 48" src="https://github.com/user-attachments/assets/6cb78d81-32be-46b5-a935-4bf6c6e7a3f1" />
<img width="669" height="227" alt="Screenshot 2025-09-08 at 18 39 34" src="https://github.com/user-attachments/assets/b451450e-17c4-4178-94fa-6f6347f1df85" />
<img width="666" height="276" alt="Screenshot 2025-09-08 at 18 39 29" src="https://github.com/user-attachments/assets/c45b3fc7-0312-4104-bc7a-185689436d5b" />
<img width="672" height="272" alt="Screenshot 2025-09-08 at 18 39 03" src="https://github.com/user-attachments/assets/9d23dcf7-844e-42f9-aff9-50bc76485e23" />
<img width="669" height="226" alt="Screenshot 2025-09-08 at 18 38 49" src="https://github.com/user-attachments/assets/0fb394b2-1bbc-495a-95e3-4c074bfe5dad" />
<img width="664" height="228" alt="Screenshot 2025-09-08 at 18 38 57" src="https://github.com/user-attachments/assets/1b9312b2-2ff1-49c5-b98c-1413c537fb47" />

Needs some styling work to make line-height work.


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

