### PR TITLE
Forms: release hidden field

### DIFF
--- a/projects/packages/forms/changelog/update-forms-release-hidden-field
+++ b/projects/packages/forms/changelog/update-forms-release-hidden-field
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: add hidden field

--- a/projects/packages/forms/src/blocks/contact-form/child-blocks.js
+++ b/projects/packages/forms/src/blocks/contact-form/child-blocks.js
@@ -49,6 +49,7 @@ export const childBlocks = [
 	JetpackConsentField,
 	JetpackDateField,
 	JetpackDropdownField,
+	JetpackHiddenField,
 	JetpackEmailField,
 	JetpackMultipleChoiceField,
 	JetpackNameField,
@@ -67,7 +68,6 @@ export const childBlocks = [
 	...( getJetpackBlocksVariation() === 'beta'
 		? [
 				JetpackTimeField,
-				JetpackHiddenField,
 				JetpackImageSelectField,
 				JetpackImageOptionsFieldset,
 				JetpackImageOptionInput,

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -443,14 +443,12 @@ class Contact_Form_Block {
 			)
 		);
 
-		if ( Blocks::get_variation() === 'beta' ) {
-			Blocks::jetpack_register_block(
-				'jetpack/field-hidden',
-				array(
-					'render_callback' => array( Contact_Form_Plugin::class, 'gutenblock_render_field_hidden' ),
-				)
-			);
-		}
+		Blocks::jetpack_register_block(
+			'jetpack/field-hidden',
+			array(
+				'render_callback' => array( Contact_Form_Plugin::class, 'gutenblock_render_field_hidden' ),
+			)
+		);
 
 		Blocks::jetpack_register_block(
 			'jetpack/field-rating',

--- a/projects/plugins/jetpack/changelog/update-forms-release-hidden-field
+++ b/projects/plugins/jetpack/changelog/update-forms-release-hidden-field
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: add hidden field


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Follow up to https://github.com/Automattic/jetpack/pull/44079



## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Releases hidden field to Jetpack and WP.com customers

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

