### PR TITLE
Backport jetpack 15.1-a.1 Changes

### DIFF
--- a/projects/js-packages/ai-client/CHANGELOG.md
+++ b/projects/js-packages/ai-client/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.33.11] - 2025-09-08
+### Changed
+- Update package dependencies. [#45027] [#45097]
+
 ## [0.33.10] - 2025-09-01
 ### Changed
 - Update dependencies. [#44940]
@@ -698,6 +702,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - AI Client: stop using smart document visibility handling on the fetchEventSource library, so it does not restart the completion when changing tabs. [#32004]
 - Updated package dependencies. [#31468] [#31659] [#31785]
 
+[0.33.11]: https://github.com/Automattic/jetpack-ai-client/compare/v0.33.10...v0.33.11
 [0.33.10]: https://github.com/Automattic/jetpack-ai-client/compare/v0.33.9...v0.33.10
 [0.33.9]: https://github.com/Automattic/jetpack-ai-client/compare/v0.33.8...v0.33.9
 [0.33.8]: https://github.com/Automattic/jetpack-ai-client/compare/v0.33.7...v0.33.8

--- a/projects/js-packages/ai-client/package.json
+++ b/projects/js-packages/ai-client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-ai-client",
-	"version": "0.33.10",
+	"version": "0.33.11",
 	"private": false,
 	"description": "A JS client for consuming Jetpack AI services",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/ai-client/#readme",

--- a/projects/js-packages/api/CHANGELOG.md
+++ b/projects/js-packages/api/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### This is a list detailing changes for the Jetpack RNA Components package releases.
 
+## [1.0.9] - 2025-09-08
+### Changed
+- Update package dependencies. [#45027]
+
 ## [1.0.8] - 2025-08-13
 ### Changed
 - Update package dependencies. [#44701]
@@ -454,6 +458,7 @@
 - Add the API methods left behind by the previous PR.
 - Initial release of jetpack-api package
 
+[1.0.9]: https://github.com/Automattic/jetpack-api/compare/v1.0.8...v1.0.9
 [1.0.8]: https://github.com/Automattic/jetpack-api/compare/v1.0.7...v1.0.8
 [1.0.7]: https://github.com/Automattic/jetpack-api/compare/v1.0.6...v1.0.7
 [1.0.6]: https://github.com/Automattic/jetpack-api/compare/v1.0.5...v1.0.6

--- a/projects/js-packages/api/package.json
+++ b/projects/js-packages/api/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-api",
-	"version": "1.0.8",
+	"version": "1.0.9",
 	"description": "Jetpack Api Package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/api/#readme",
 	"bugs": {

--- a/projects/js-packages/base-styles/CHANGELOG.md
+++ b/projects/js-packages/base-styles/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.9] - 2025-09-08
+### Changed
+- Update package dependencies. [#45027]
+
 ## [1.0.8] - 2025-08-13
 ### Changed
 - Update package dependencies. [#44701]
@@ -436,6 +440,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Use Node 16.7.0 in tooling. This shouldn't change the behavior of the code itself.
 
+[1.0.9]: https://github.com/Automattic/jetpack-base-styles/compare/1.0.8...1.0.9
 [1.0.8]: https://github.com/Automattic/jetpack-base-styles/compare/1.0.7...1.0.8
 [1.0.7]: https://github.com/Automattic/jetpack-base-styles/compare/1.0.6...1.0.7
 [1.0.6]: https://github.com/Automattic/jetpack-base-styles/compare/1.0.5...1.0.6

--- a/projects/js-packages/base-styles/package.json
+++ b/projects/js-packages/base-styles/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-base-styles",
-	"version": "1.0.8",
+	"version": "1.0.9",
 	"description": "Jetpack components base styles",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/base-styles/#readme",
 	"bugs": {

--- a/projects/js-packages/boost-score-api/CHANGELOG.md
+++ b/projects/js-packages/boost-score-api/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.13] - 2025-09-08
+### Changed
+- Update package dependencies. [#45027] [#45097]
+
 ## [1.0.12] - 2025-08-25
 ### Changed
 - Update package dependencies. [#44901]
@@ -335,6 +339,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Create package for the boost score bar API [#30781]
 
+[1.0.13]: https://github.com/Automattic/jetpack-boost-score-api/compare/v1.0.12...v1.0.13
 [1.0.12]: https://github.com/Automattic/jetpack-boost-score-api/compare/v1.0.11...v1.0.12
 [1.0.11]: https://github.com/Automattic/jetpack-boost-score-api/compare/v1.0.10...v1.0.11
 [1.0.10]: https://github.com/Automattic/jetpack-boost-score-api/compare/v1.0.9...v1.0.10

--- a/projects/js-packages/boost-score-api/package.json
+++ b/projects/js-packages/boost-score-api/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-boost-score-api",
-	"version": "1.0.12",
+	"version": "1.0.13",
 	"description": "A package to get the Jetpack Boost score of a site",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/boost-score-api/#readme",
 	"bugs": {

--- a/projects/js-packages/charts/CHANGELOG.md
+++ b/projects/js-packages/charts/CHANGELOG.md
@@ -5,18 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.32.0] - 2025-09-02
+## [0.33.0] - 2025-09-08
 ### Added
-- Charts: adds controls for label visibility [#45040]
+- Add ability to control percentage vs. value display. [#45052]
 
 ### Changed
-- Charts: format percentage values to be prettier [#45032]
-- Charts: Use a global context provider for theme configuration in all stories [#45028]
-- Charts: use getStringWidth for label size calculations [#45030]
-- Fix the conversion-funnel-chart component exportation [#45033]
+- LeaderboardChart: Use GlobalContextProvider theme for colors. [#45067]
+- Update package dependencies. [#45027] [#45097]
+- Use `tsup` for builds. [#45051]
 
 ### Fixed
-- All charts were affected due to z-index. [#45043]
+- Allow type-checking of tests and stories. [#45082]
+
+## [0.32.0] - 2025-09-02
+### Added
+- Add controls for label visibility. [#45040]
+
+### Changed
+- Fix the conversion-funnel-chart component export. [#45033]
+- Format percentage values to be prettier. [#45032]
+- Use a global context provider for theme configuration in all stories. [#45028]
+- Use `getStringWidth` for label size calculations. [#45030]
+
+### Fixed
+- Prevent z-index issue across all charts. [#45043]
 
 ## [0.31.0] - 2025-09-01
 ### Added
@@ -418,6 +430,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed lints following ESLint rule changes for TS [#40584]
 - Fixing a bug in Chart storybook data. [#40640]
 
+[0.33.0]: https://github.com/Automattic/charts/compare/v0.32.0...v0.33.0
 [0.32.0]: https://github.com/Automattic/charts/compare/v0.31.0...v0.32.0
 [0.31.0]: https://github.com/Automattic/charts/compare/v0.30.0...v0.31.0
 [0.30.0]: https://github.com/Automattic/charts/compare/v0.29.0...v0.30.0

--- a/projects/js-packages/charts/changelog/charts-101-add-ability-to-control-percentage-vs-value-display
+++ b/projects/js-packages/charts/changelog/charts-101-add-ability-to-control-percentage-vs-value-display
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Charts: adds ability to control percentage vs value display

--- a/projects/js-packages/charts/changelog/charts-110-leaderboard-chart-make-theming-consistent-with-other-charts
+++ b/projects/js-packages/charts/changelog/charts-110-leaderboard-chart-make-theming-consistent-with-other-charts
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-LeaderboardChart: Use GlobalContextProvider theme for colors

--- a/projects/js-packages/charts/changelog/charts-113-remove-tsconfig-exclude-field
+++ b/projects/js-packages/charts/changelog/charts-113-remove-tsconfig-exclude-field
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Charts: Allow typechecking of tests and stories

--- a/projects/js-packages/charts/changelog/update-replace-with-global-charts-provider
+++ b/projects/js-packages/charts/changelog/update-replace-with-global-charts-provider
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Chart: use tsup for builds

--- a/projects/js-packages/charts/package.json
+++ b/projects/js-packages/charts/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/charts",
-	"version": "0.32.0",
+	"version": "0.33.0",
 	"description": "Display charts within Automattic products.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/charts/#readme",
 	"bugs": {

--- a/projects/js-packages/components/CHANGELOG.md
+++ b/projects/js-packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### This is a list detailing changes for the Jetpack RNA Components package releases.
 
+## [1.3.2] - 2025-09-08
+### Changed
+- Update package dependencies. [#45027] [#45097]
+
 ## [1.3.1] - 2025-09-01
 ### Changed
 - My Jetpack: Add product interstitials state management. [#44772]
@@ -1524,6 +1528,7 @@
 ### Changed
 - Update node version requirement to 14.16.1
 
+[1.3.2]: https://github.com/Automattic/jetpack-components/compare/1.3.1...1.3.2
 [1.3.1]: https://github.com/Automattic/jetpack-components/compare/1.3.0...1.3.1
 [1.3.0]: https://github.com/Automattic/jetpack-components/compare/1.2.2...1.3.0
 [1.2.2]: https://github.com/Automattic/jetpack-components/compare/1.2.1...1.2.2

--- a/projects/js-packages/components/changelog/fix-boost-score-graph-css-hack
+++ b/projects/js-packages/components/changelog/fix-boost-score-graph-css-hack
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Remove hacky way of loading styles.
-
-

--- a/projects/js-packages/components/changelog/renovate-typescript-5.x
+++ b/projects/js-packages/components/changelog/renovate-typescript-5.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/js-packages/components/changelog/renovate-wordpress-monorepo2
+++ b/projects/js-packages/components/changelog/renovate-wordpress-monorepo2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-components",
-	"version": "1.3.1",
+	"version": "1.3.2",
 	"description": "Jetpack Components Package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/components/#readme",
 	"bugs": {

--- a/projects/js-packages/connection/CHANGELOG.md
+++ b/projects/js-packages/connection/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### This is a list detailing changes for the Jetpack RNA Connection Component releases.
 
+## [1.4.8] - 2025-09-08
+### Changed
+- Update package dependencies. [#45027] [#45097]
+
 ## [1.4.7] - 2025-09-01
 ### Changed
 - Update dependencies.
@@ -1158,6 +1162,7 @@
 - `Main` and `ConnectUser` components added.
 - `JetpackRestApiClient` API client added.
 
+[1.4.8]: https://github.com/Automattic/jetpack-connection-js/compare/v1.4.7...v1.4.8
 [1.4.7]: https://github.com/Automattic/jetpack-connection-js/compare/v1.4.6...v1.4.7
 [1.4.6]: https://github.com/Automattic/jetpack-connection-js/compare/v1.4.5...v1.4.6
 [1.4.5]: https://github.com/Automattic/jetpack-connection-js/compare/v1.4.4...v1.4.5

--- a/projects/js-packages/connection/changelog/renovate-typescript-5.x
+++ b/projects/js-packages/connection/changelog/renovate-typescript-5.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/js-packages/connection/changelog/renovate-wordpress-monorepo2
+++ b/projects/js-packages/connection/changelog/renovate-wordpress-monorepo2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/js-packages/connection/package.json
+++ b/projects/js-packages/connection/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-connection",
-	"version": "1.4.7",
+	"version": "1.4.8",
 	"description": "Jetpack Connection Component",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/connection/#readme",
 	"bugs": {

--- a/projects/js-packages/i18n-loader-webpack-plugin/CHANGELOG.md
+++ b/projects/js-packages/i18n-loader-webpack-plugin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.84] - 2025-09-08
+### Changed
+- Update package dependencies. [#45027]
+
 ## [2.0.83] - 2025-08-13
 ### Changed
 - Update package dependencies. [#44701]
@@ -361,6 +365,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release.
 
+[2.0.84]: https://github.com/Automattic/i18n-loader-webpack-plugin/compare/v2.0.83...v2.0.84
 [2.0.83]: https://github.com/Automattic/i18n-loader-webpack-plugin/compare/v2.0.82...v2.0.83
 [2.0.82]: https://github.com/Automattic/i18n-loader-webpack-plugin/compare/v2.0.81...v2.0.82
 [2.0.81]: https://github.com/Automattic/i18n-loader-webpack-plugin/compare/v2.0.80...v2.0.81

--- a/projects/js-packages/i18n-loader-webpack-plugin/changelog/renovate-wordpress-monorepo2
+++ b/projects/js-packages/i18n-loader-webpack-plugin/changelog/renovate-wordpress-monorepo2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/js-packages/i18n-loader-webpack-plugin/package.json
+++ b/projects/js-packages/i18n-loader-webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/i18n-loader-webpack-plugin",
-	"version": "2.0.83",
+	"version": "2.0.84",
 	"description": "A Webpack plugin to load WordPress i18n when Webpack lazy-loads a bundle.",
 	"keywords": [
 		"webpack",

--- a/projects/js-packages/idc/CHANGELOG.md
+++ b/projects/js-packages/idc/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### This is a list detailing changes for the Jetpack RNA IDC package releases.
 
+## 1.0.25 - 2025-09-08
+### Changed
+- Update package dependencies. [#45027]
+
 ## 1.0.24 - 2025-09-01
 ### Changed
 - Update dependencies. [#44300]

--- a/projects/js-packages/idc/changelog/renovate-wordpress-monorepo2
+++ b/projects/js-packages/idc/changelog/renovate-wordpress-monorepo2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/js-packages/idc/package.json
+++ b/projects/js-packages/idc/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-idc",
-	"version": "1.0.24",
+	"version": "1.0.25",
 	"description": "Jetpack Connection Component",
 	"license": "GPL-2.0-or-later",
 	"author": "Automattic",

--- a/projects/js-packages/licensing/CHANGELOG.md
+++ b/projects/js-packages/licensing/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.2.5 - 2025-09-08
+### Changed
+- Update package dependencies. [#45027] [#45097]
+
 ## 1.2.4 - 2025-09-01
 ### Changed
 - Update dependencies. [#44940]

--- a/projects/js-packages/licensing/changelog/renovate-typescript-5.x
+++ b/projects/js-packages/licensing/changelog/renovate-typescript-5.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/js-packages/licensing/changelog/renovate-wordpress-monorepo2
+++ b/projects/js-packages/licensing/changelog/renovate-wordpress-monorepo2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/js-packages/licensing/package.json
+++ b/projects/js-packages/licensing/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-licensing",
-	"version": "1.2.4",
+	"version": "1.2.5",
 	"private": true,
 	"description": "Jetpack licensing flow",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/licensing/#readme",

--- a/projects/js-packages/number-formatters/CHANGELOG.md
+++ b/projects/js-packages/number-formatters/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [1.0.11] - 2025-09-08
+### Changed
+- Update package dependencies. [#45097]
+
 ## [1.0.10] - 2025-08-01
 ### Changed
 - Internal updates.
@@ -73,6 +77,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Initial release
 - Basic number formatting functionality
 
+[1.0.11]: https://github.com/Automattic/number-formatters/compare/1.0.10...1.0.11
 [1.0.10]: https://github.com/Automattic/number-formatters/compare/1.0.9...1.0.10
 [1.0.9]: https://github.com/Automattic/number-formatters/compare/1.0.8...1.0.9
 [1.0.8]: https://github.com/Automattic/number-formatters/compare/1.0.7...1.0.8

--- a/projects/js-packages/number-formatters/changelog/renovate-typescript-5.x
+++ b/projects/js-packages/number-formatters/changelog/renovate-typescript-5.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/js-packages/number-formatters/package.json
+++ b/projects/js-packages/number-formatters/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/number-formatters",
-	"version": "1.0.10",
+	"version": "1.0.11",
 	"description": "Number formatting utilities",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/number-formatters/#readme",
 	"bugs": {

--- a/projects/js-packages/partner-coupon/CHANGELOG.md
+++ b/projects/js-packages/partner-coupon/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.0.16 - 2025-09-08
+### Changed
+- Update package dependencies. [#45027]
+
 ## 1.0.15 - 2025-09-01
 ### Changed
 - Update dependencies. [#44940]

--- a/projects/js-packages/partner-coupon/changelog/renovate-wordpress-monorepo2
+++ b/projects/js-packages/partner-coupon/changelog/renovate-wordpress-monorepo2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/js-packages/partner-coupon/package.json
+++ b/projects/js-packages/partner-coupon/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-partner-coupon",
-	"version": "1.0.15",
+	"version": "1.0.16",
 	"private": true,
 	"description": "This package aims to add components to make it easier to redeem partner coupons",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/partner-coupon/#readme",

--- a/projects/js-packages/publicize-components/CHANGELOG.md
+++ b/projects/js-packages/publicize-components/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.0] - 2025-09-08
+### Changed
+- Update @wordpress/dataviews package from v5.0.0 to v7.0.0. [#45012]
+- Update package dependencies. [#45027] [#45097]
+
 ## [1.2.6] - 2025-09-01
 ### Fixed
 - Social: Allow default image to be cleared. [#44994]
@@ -1355,6 +1360,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated package dependencies. [#24470]
 
+[1.3.0]: https://github.com/Automattic/jetpack-publicize-components/compare/v1.2.6...v1.3.0
 [1.2.6]: https://github.com/Automattic/jetpack-publicize-components/compare/v1.2.5...v1.2.6
 [1.2.5]: https://github.com/Automattic/jetpack-publicize-components/compare/v1.2.4...v1.2.5
 [1.2.4]: https://github.com/Automattic/jetpack-publicize-components/compare/v1.2.3...v1.2.4

--- a/projects/js-packages/publicize-components/changelog/renovate-typescript-5.x
+++ b/projects/js-packages/publicize-components/changelog/renovate-typescript-5.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/js-packages/publicize-components/changelog/renovate-wordpress-monorepo2
+++ b/projects/js-packages/publicize-components/changelog/renovate-wordpress-monorepo2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/js-packages/publicize-components/changelog/update-dataviews-700
+++ b/projects/js-packages/publicize-components/changelog/update-dataviews-700
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Update @wordpress/dataviews package v5.0.0 → v7.0.0

--- a/projects/js-packages/publicize-components/package.json
+++ b/projects/js-packages/publicize-components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-publicize-components",
-	"version": "1.2.6",
+	"version": "1.3.0",
 	"private": true,
 	"description": "A library of JS components required by the Publicize editor plugin",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/publicize-components/#readme",

--- a/projects/js-packages/script-data/CHANGELOG.md
+++ b/projects/js-packages/script-data/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.3] - 2025-09-08
+### Changed
+- Update package dependencies. [#45097]
+
 ## [0.5.2] - 2025-08-18
 ### Added
 - Add `typecheck` script to ensure that TypeScript files are type-checked. [#44795]
@@ -93,6 +97,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added jetpack-script-data package to consolidate the logic for Jetpack Initial state [#38430]
 
+[0.5.3]: https://github.com/Automattic/jetpack-script-data/compare/v0.5.2...v0.5.3
 [0.5.2]: https://github.com/Automattic/jetpack-script-data/compare/v0.5.1...v0.5.2
 [0.5.1]: https://github.com/Automattic/jetpack-script-data/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/Automattic/jetpack-script-data/compare/v0.4.4...v0.5.0

--- a/projects/js-packages/script-data/changelog/renovate-typescript-5.x
+++ b/projects/js-packages/script-data/changelog/renovate-typescript-5.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/js-packages/script-data/package.json
+++ b/projects/js-packages/script-data/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-script-data",
-	"version": "0.5.2",
+	"version": "0.5.3",
 	"description": "A library to provide data for script handles and the corresponding utility functions for Jetpack.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/script-data/#readme",
 	"bugs": {

--- a/projects/js-packages/shared-extension-utils/CHANGELOG.md
+++ b/projects/js-packages/shared-extension-utils/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.15] - 2025-09-08
+### Changed
+- Update package dependencies. [#45027] [#45097]
+
 ## [1.3.14] - 2025-09-01
 ### Changed
 - Update dependencies. [#44940]
@@ -759,6 +763,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Core: prepare utility for release
 
+[1.3.15]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/1.3.14...1.3.15
 [1.3.14]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/1.3.13...1.3.14
 [1.3.13]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/1.3.12...1.3.13
 [1.3.12]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/1.3.11...1.3.12

--- a/projects/js-packages/shared-extension-utils/changelog/renovate-typescript-5.x
+++ b/projects/js-packages/shared-extension-utils/changelog/renovate-typescript-5.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/js-packages/shared-extension-utils/changelog/renovate-wordpress-monorepo2
+++ b/projects/js-packages/shared-extension-utils/changelog/renovate-wordpress-monorepo2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/js-packages/shared-extension-utils/package.json
+++ b/projects/js-packages/shared-extension-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-shared-extension-utils",
-	"version": "1.3.14",
+	"version": "1.3.15",
 	"description": "Utility functions used by the block editor extensions",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/shared-extension-utils/#readme",
 	"bugs": {

--- a/projects/js-packages/social-logos/CHANGELOG.md
+++ b/projects/js-packages/social-logos/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [3.2.10] - 2025-09-08
+### Changed
+- Update package dependencies. [#45097]
+
 ## [3.2.9] - 2025-08-18
 ### Added
 - Add `typecheck` script to ensure that TypeScript files are type-checked. [#44795]
@@ -256,6 +260,7 @@
 
 - Build: Refactored (aligned build system with Gridicons).
 
+[3.2.10]: https://github.com/Automattic/social-logos/compare/v3.2.9...v3.2.10
 [3.2.9]: https://github.com/Automattic/social-logos/compare/v3.2.8...v3.2.9
 [3.2.8]: https://github.com/Automattic/social-logos/compare/v3.2.7...v3.2.8
 [3.2.7]: https://github.com/Automattic/social-logos/compare/v3.2.6...v3.2.7

--- a/projects/js-packages/social-logos/changelog/renovate-typescript-5.x
+++ b/projects/js-packages/social-logos/changelog/renovate-typescript-5.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/js-packages/social-logos/package.json
+++ b/projects/js-packages/social-logos/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "social-logos",
-	"version": "3.2.9",
+	"version": "3.2.10",
 	"description": "A repository of all the social logos used on WordPress.com.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/social-logos/",
 	"bugs": {

--- a/projects/js-packages/webpack-config/CHANGELOG.md
+++ b/projects/js-packages/webpack-config/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 3.7.7 - 2025-09-08
+### Changed
+- Update package dependencies. [#45027] [#45097]
+
 ## 3.7.6 - 2025-08-13
 ### Changed
 - Update package dependencies. [#44701]

--- a/projects/js-packages/webpack-config/changelog/renovate-typescript-5.x
+++ b/projects/js-packages/webpack-config/changelog/renovate-typescript-5.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/js-packages/webpack-config/changelog/renovate-wordpress-monorepo2
+++ b/projects/js-packages/webpack-config/changelog/renovate-wordpress-monorepo2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/js-packages/webpack-config/package.json
+++ b/projects/js-packages/webpack-config/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-webpack-config",
-	"version": "3.7.6",
+	"version": "3.7.7",
 	"private": true,
 	"description": "Library of pieces for webpack config in Jetpack projects.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/webpack-config/#readme",

--- a/projects/packages/assets/CHANGELOG.md
+++ b/projects/packages/assets/CHANGELOG.md
@@ -5,14 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.3.6] - 2025-09-08
+### Changed
+- Update package dependencies. [#45027]
+
 ## [4.3.5] - 2025-08-18
 ### Changed
 - Update dependencies. [#42554]
 
 ## [4.3.4] - 2025-08-13
 ### Changed
-- Update package dependencies. [#44701]
-- Update package dependencies. [#44725]
+- Update package dependencies. [#44701] [#44725]
 
 ## [4.3.3] - 2025-08-11
 ### Changed
@@ -705,6 +708,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Statically access asset tools
 
+[4.3.6]: https://github.com/Automattic/jetpack-assets/compare/v4.3.5...v4.3.6
 [4.3.5]: https://github.com/Automattic/jetpack-assets/compare/v4.3.4...v4.3.5
 [4.3.4]: https://github.com/Automattic/jetpack-assets/compare/v4.3.3...v4.3.4
 [4.3.3]: https://github.com/Automattic/jetpack-assets/compare/v4.3.2...v4.3.3

--- a/projects/packages/assets/changelog/renovate-wordpress-monorepo2
+++ b/projects/packages/assets/changelog/renovate-wordpress-monorepo2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/backup-helper-script-manager/CHANGELOG.md
+++ b/projects/packages/backup-helper-script-manager/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.8] - 2025-09-08
+### Changed
+- Internal updates.
+
 ## [0.3.7] - 2025-04-28
 ### Changed
 - Internal updates.
@@ -80,6 +84,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Initial release (improved helper script installer logging). [#34297]
 
+[0.3.8]: https://github.com/Automattic/jetpack-backup-helper-script-manager/compare/v0.3.7...v0.3.8
 [0.3.7]: https://github.com/Automattic/jetpack-backup-helper-script-manager/compare/v0.3.6...v0.3.7
 [0.3.6]: https://github.com/Automattic/jetpack-backup-helper-script-manager/compare/v0.3.5...v0.3.6
 [0.3.5]: https://github.com/Automattic/jetpack-backup-helper-script-manager/compare/v0.3.4...v0.3.5

--- a/projects/packages/backup-helper-script-manager/changelog/fix-phan-PhanTypeMismatchArgumentInternal
+++ b/projects/packages/backup-helper-script-manager/changelog/fix-phan-PhanTypeMismatchArgumentInternal
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Fix some PhanTypeMismatchArgument violations.
-
-

--- a/projects/packages/backup/CHANGELOG.md
+++ b/projects/packages/backup/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.2.20] - 2025-09-08
+### Changed
+- Update package dependencies. [#45027] [#45097]
+
 ## [4.2.19] - 2025-09-01
 ### Changed
 - Update dependencies. [#44940]
@@ -935,6 +939,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add API endpoints and Jetpack Backup package for managing Help…
 
+[4.2.20]: https://github.com/Automattic/jetpack-backup/compare/v4.2.19...v4.2.20
 [4.2.19]: https://github.com/Automattic/jetpack-backup/compare/v4.2.18...v4.2.19
 [4.2.18]: https://github.com/Automattic/jetpack-backup/compare/v4.2.17...v4.2.18
 [4.2.17]: https://github.com/Automattic/jetpack-backup/compare/v4.2.16...v4.2.17

--- a/projects/packages/backup/changelog/renovate-typescript-5.x
+++ b/projects/packages/backup/changelog/renovate-typescript-5.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/backup/changelog/renovate-wordpress-monorepo2
+++ b/projects/packages/backup/changelog/renovate-wordpress-monorepo2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/backup/src/class-package-version.php
+++ b/projects/packages/backup/src/class-package-version.php
@@ -16,7 +16,7 @@ namespace Automattic\Jetpack\Backup;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '4.2.19';
+	const PACKAGE_VERSION = '4.2.20';
 
 	const PACKAGE_SLUG = 'backup';
 

--- a/projects/packages/blaze/CHANGELOG.md
+++ b/projects/packages/blaze/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.26.7] - 2025-09-08
+### Changed
+- Update package dependencies. [#45027]
+
 ## [0.26.6] - 2025-09-01
 ### Changed
 - Update dependencies. [#44940]
@@ -684,6 +688,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated package dependencies. [#27906]
 
+[0.26.7]: https://github.com/automattic/jetpack-blaze/compare/v0.26.6...v0.26.7
 [0.26.6]: https://github.com/automattic/jetpack-blaze/compare/v0.26.5...v0.26.6
 [0.26.5]: https://github.com/automattic/jetpack-blaze/compare/v0.26.4...v0.26.5
 [0.26.4]: https://github.com/automattic/jetpack-blaze/compare/v0.26.3...v0.26.4

--- a/projects/packages/blaze/changelog/renovate-wordpress-monorepo2
+++ b/projects/packages/blaze/changelog/renovate-wordpress-monorepo2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/blaze/package.json
+++ b/projects/packages/blaze/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-blaze",
-	"version": "0.26.6",
+	"version": "0.26.7",
 	"private": true,
 	"description": "Attract high-quality traffic to your site using Blaze. Using this service, you can advertise a post or page on some of the millions of pages across WordPress.com and Tumblr from just $5 per day.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/blaze/#readme",

--- a/projects/packages/blaze/src/class-dashboard.php
+++ b/projects/packages/blaze/src/class-dashboard.php
@@ -21,7 +21,7 @@ class Dashboard {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.26.6';
+	const PACKAGE_VERSION = '0.26.7';
 
 	/**
 	 * List of dependencies needed to render the dashboard in wp-admin.

--- a/projects/packages/boost-core/CHANGELOG.md
+++ b/projects/packages/boost-core/CHANGELOG.md
@@ -5,13 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.13] - 2025-09-08
+### Changed
+- Internal updates.
+
 ## [0.3.12] - 2025-08-04
 ### Added
 - Add helper to clear all custom transients at the same time. [#44549]
 
 ## [0.3.11] - 2025-06-23
 ### Fixed
-- General: ensure the correct home page is checked when sites are using WP in a subfolder. [#44007]
+- General: Ensure the correct home page is checked when sites are in a subfolder. [#44007]
 
 ## [0.3.10] - 2025-04-28
 ### Changed
@@ -137,6 +141,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Introduce new package. [#31163]
 
+[0.3.13]: https://github.com/Automattic/jetpack-boost-core/compare/v0.3.12...v0.3.13
 [0.3.12]: https://github.com/Automattic/jetpack-boost-core/compare/v0.3.11...v0.3.12
 [0.3.11]: https://github.com/Automattic/jetpack-boost-core/compare/v0.3.10...v0.3.11
 [0.3.10]: https://github.com/Automattic/jetpack-boost-core/compare/v0.3.9...v0.3.10

--- a/projects/packages/boost-core/changelog/fix-phan-PhanTypeMismatchArgumentInternal
+++ b/projects/packages/boost-core/changelog/fix-phan-PhanTypeMismatchArgumentInternal
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Fix some PhanTypeMismatchArgument violations.
-
-

--- a/projects/packages/boost-core/package.json
+++ b/projects/packages/boost-core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-boost-core",
-	"version": "0.3.12",
+	"version": "0.3.13",
 	"private": true,
 	"description": "Core functionality for boost and relevant packages to depend on",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/boost-core/#readme",

--- a/projects/packages/classic-theme-helper/CHANGELOG.md
+++ b/projects/packages/classic-theme-helper/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.17] - 2025-09-08
+### Changed
+- Update package dependencies. [#45027]
+
 ## [0.13.16] - 2025-08-25
 ### Changed
 - Internal updates.
@@ -364,6 +368,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Add wordpress folder on gitignore. [#37177]
 
+[0.13.17]: https://github.com/Automattic/jetpack-classic-theme-helper/compare/v0.13.16...v0.13.17
 [0.13.16]: https://github.com/Automattic/jetpack-classic-theme-helper/compare/v0.13.15...v0.13.16
 [0.13.15]: https://github.com/Automattic/jetpack-classic-theme-helper/compare/v0.13.14...v0.13.15
 [0.13.14]: https://github.com/Automattic/jetpack-classic-theme-helper/compare/v0.13.13...v0.13.14

--- a/projects/packages/classic-theme-helper/changelog/fix-phan-PhanTypeMismatchArgumentInternal
+++ b/projects/packages/classic-theme-helper/changelog/fix-phan-PhanTypeMismatchArgumentInternal
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Fix some PhanTypeMismatchArgument violations.
-
-

--- a/projects/packages/classic-theme-helper/changelog/renovate-wordpress-monorepo2
+++ b/projects/packages/classic-theme-helper/changelog/renovate-wordpress-monorepo2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/classic-theme-helper/package.json
+++ b/projects/packages/classic-theme-helper/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-classic-theme-helper",
-	"version": "0.13.16",
+	"version": "0.13.17",
 	"private": true,
 	"description": "Features used with classic themes",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/classic-theme-helper/#readme",

--- a/projects/packages/classic-theme-helper/src/class-main.php
+++ b/projects/packages/classic-theme-helper/src/class-main.php
@@ -14,7 +14,7 @@ use WP_Error;
  */
 class Main {
 
-	const PACKAGE_VERSION = '0.13.16';
+	const PACKAGE_VERSION = '0.13.17';
 
 	/**
 	 * Modules to include.

--- a/projects/packages/connection/CHANGELOG.md
+++ b/projects/packages/connection/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.18.6] - 2025-09-08
+### Changed
+- Update package dependencies. [#45027]
+
 ## [6.18.5] - 2025-09-01
 ### Changed
 - Internal updates.
@@ -1579,6 +1583,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Separate the connection library into its own package.
 
+[6.18.6]: https://github.com/Automattic/jetpack-connection/compare/v6.18.5...v6.18.6
 [6.18.5]: https://github.com/Automattic/jetpack-connection/compare/v6.18.4...v6.18.5
 [6.18.4]: https://github.com/Automattic/jetpack-connection/compare/v6.18.3...v6.18.4
 [6.18.3]: https://github.com/Automattic/jetpack-connection/compare/v6.18.2...v6.18.3

--- a/projects/packages/connection/changelog/fix-jetpack-direct_access_fatals_part_6
+++ b/projects/packages/connection/changelog/fix-jetpack-direct_access_fatals_part_6
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Prevent PHP errors by limiting direct access to files.
-
-

--- a/projects/packages/connection/changelog/fix-phan-PhanTypeMismatchArgumentInternal
+++ b/projects/packages/connection/changelog/fix-phan-PhanTypeMismatchArgumentInternal
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Fix some PhanTypeMismatchArgument violations.
-
-

--- a/projects/packages/connection/changelog/renovate-wordpress-monorepo2
+++ b/projects/packages/connection/changelog/renovate-wordpress-monorepo2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/connection/src/class-package-version.php
+++ b/projects/packages/connection/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Connection;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '6.18.5';
+	const PACKAGE_VERSION = '6.18.6';
 
 	const PACKAGE_SLUG = 'connection';
 

--- a/projects/packages/explat/CHANGELOG.md
+++ b/projects/packages/explat/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.9] - 2025-09-08
+### Changed
+- Update package dependencies. [#45027] [#45097]
+
 ## [0.3.8] - 2025-08-18
 ### Added
 - Add `typecheck` script to ensure that TypeScript files are type-checked. [#44795]
@@ -219,6 +223,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ExPlat: add condition to prevent fetching the experiment assignment if there's not anon id (meaning that Tracks is likely disabled) [#38327]
 - Updated package dependencies. [#38132]
 
+[0.3.9]: https://github.com/Automattic/jetpack-explat/compare/v0.3.8...v0.3.9
 [0.3.8]: https://github.com/Automattic/jetpack-explat/compare/v0.3.7...v0.3.8
 [0.3.7]: https://github.com/Automattic/jetpack-explat/compare/v0.3.6...v0.3.7
 [0.3.6]: https://github.com/Automattic/jetpack-explat/compare/v0.3.5...v0.3.6

--- a/projects/packages/explat/changelog/renovate-typescript-5.x
+++ b/projects/packages/explat/changelog/renovate-typescript-5.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/explat/changelog/renovate-wordpress-monorepo2
+++ b/projects/packages/explat/changelog/renovate-wordpress-monorepo2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/explat/package.json
+++ b/projects/packages/explat/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-explat",
-	"version": "0.3.8",
+	"version": "0.3.9",
 	"private": true,
 	"description": "A package for running A/B tests on the Experimentation Platform (ExPlat) in the plugin.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/explat/#readme",

--- a/projects/packages/explat/src/class-explat.php
+++ b/projects/packages/explat/src/class-explat.php
@@ -20,7 +20,7 @@ class ExPlat {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.3.8';
+	const PACKAGE_VERSION = '0.3.9';
 
 	/**
 	 * Initializer.

--- a/projects/packages/external-connections/CHANGELOG.md
+++ b/projects/packages/external-connections/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1] - 2025-09-08
+### Changed
+- Update package dependencies. [#45027]
+
 ## 0.1.0 - 2025-09-01
 ### Added
 - Initial version. [#44858]
+
+[0.1.1]: https://github.com/Automattic/jetpack-external-connections/compare/v0.1.0...v0.1.1

--- a/projects/packages/external-connections/changelog/renovate-wordpress-monorepo2
+++ b/projects/packages/external-connections/changelog/renovate-wordpress-monorepo2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/external-connections/package.json
+++ b/projects/packages/external-connections/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-external-connections",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"private": true,
 	"description": "Connect your site to external services.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/external-connections/#readme",

--- a/projects/packages/external-connections/src/class-external-connections.php
+++ b/projects/packages/external-connections/src/class-external-connections.php
@@ -16,7 +16,7 @@ use Automattic\Jetpack\Status\Host;
  */
 class External_Connections {
 
-	const PACKAGE_VERSION = '0.1.0';
+	const PACKAGE_VERSION = '0.1.1';
 	const BASE_FILE       = __FILE__;
 
 	/**

--- a/projects/packages/external-media/CHANGELOG.md
+++ b/projects/packages/external-media/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.1] - 2025-09-08
+### Changed
+- Update package dependencies. [#45027] [#45097]
+
 ## [0.5.0] - 2025-09-01
 ### Added
 - Media Settings: Add Google Photos connection. [#44825]
@@ -174,6 +178,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix the button size in the editor for Gutenberg 18 or below. [#41619]
 - Media Library: Fix the Import Media button color in some color schemes. [#41664]
 
+[0.5.1]: https://github.com/Automattic/jetpack-external-media/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/Automattic/jetpack-external-media/compare/v0.4.11...v0.5.0
 [0.4.11]: https://github.com/Automattic/jetpack-external-media/compare/v0.4.10...v0.4.11
 [0.4.10]: https://github.com/Automattic/jetpack-external-media/compare/v0.4.9...v0.4.10

--- a/projects/packages/external-media/changelog/renovate-typescript-5.x
+++ b/projects/packages/external-media/changelog/renovate-typescript-5.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/external-media/changelog/renovate-wordpress-monorepo2
+++ b/projects/packages/external-media/changelog/renovate-wordpress-monorepo2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/external-media/package.json
+++ b/projects/packages/external-media/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-external-media",
-	"version": "0.5.0",
+	"version": "0.5.1",
 	"private": true,
 	"description": "The external media feature allows users to select and import photos from external media",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/external-media/#readme",

--- a/projects/packages/external-media/src/class-external-media.php
+++ b/projects/packages/external-media/src/class-external-media.php
@@ -18,7 +18,7 @@ use Jetpack_Options;
  * Class External_Media
  */
 class External_Media {
-	const PACKAGE_VERSION = '0.5.0';
+	const PACKAGE_VERSION = '0.5.1';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;
 

--- a/projects/packages/forms/CHANGELOG.md
+++ b/projects/packages/forms/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.3.0] - 2025-09-08
+### Added
+- Add hidden input block. [#44079]
+- Make rating and slider fields available to self-hosted users. [#45094]
+- Store the feedback in the new format. [#45047]
+- Track form submission failures. [#45090]
+
+### Changed
+- Improve performance by splitting editor code into two chunks. [#45065]
+- Move all international phone code and UI back into legacy telephone field. [#45061]
+- Remove legacy menu item by defaulting the filter to true. [#44043]
+- Render implicit consent as hidden field instead of a DOM-hidden checkbox. [#45078]
+- Set button state to busy and ignore further clicks when exporting to Google Drive. [#45074]
+- Show custom messages for empty inbox/spam/trash folders. [#45013]
+- Update @wordpress/dataviews package from v5.0.0 to v7.0.0. [#45012]
+- Update package dependencies. [#45027] [#45097]
+
 ## [6.2.0] - 2025-09-03
 ### Changed
 - Use sentence case in integrations panel CTAs. [#45054]
@@ -1521,6 +1538,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a new jetpack/forms package [#28409]
 - Added a public load_contact_form method for initializing the contact form module. [#28416]
 
+[6.3.0]: https://github.com/automattic/jetpack-forms/compare/v6.2.0...v6.3.0
 [6.2.0]: https://github.com/automattic/jetpack-forms/compare/v6.1.0...v6.2.0
 [6.1.0]: https://github.com/automattic/jetpack-forms/compare/v6.0.0...v6.1.0
 [6.0.0]: https://github.com/automattic/jetpack-forms/compare/v5.5.0...v6.0.0

--- a/projects/packages/forms/changelog/add-forms-hidden-field-block
+++ b/projects/packages/forms/changelog/add-forms-hidden-field-block
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Forms: Add hidden input block  

--- a/projects/packages/forms/changelog/add-logging-for-form-validation
+++ b/projects/packages/forms/changelog/add-logging-for-form-validation
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Forms: track form submission failure

--- a/projects/packages/forms/changelog/fix-forms-export-gdrive-button-state
+++ b/projects/packages/forms/changelog/fix-forms-export-gdrive-button-state
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Forms: when exporting to gdrive set button state to busy and ignore further clicks

--- a/projects/packages/forms/changelog/fix-forms-implicit-consent-toggling
+++ b/projects/packages/forms/changelog/fix-forms-implicit-consent-toggling
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Forms: render implicit consent as hidden field instead of a DOM hidden checkbox

--- a/projects/packages/forms/changelog/fix-jetpack-direct_access_fatals_part_6
+++ b/projects/packages/forms/changelog/fix-jetpack-direct_access_fatals_part_6
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Prevent PHP errors by limiting direct access to files.
-
-

--- a/projects/packages/forms/changelog/fix-phan-PhanTypeMismatchArgumentInternal
+++ b/projects/packages/forms/changelog/fix-phan-PhanTypeMismatchArgumentInternal
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Fix some PhanTypeMismatchArgument violations.
-
-

--- a/projects/packages/forms/changelog/move-international-phone-input-to-telephone
+++ b/projects/packages/forms/changelog/move-international-phone-input-to-telephone
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Forms: move all international phone code and UI back into legacy telephone field, keep backwards compat

--- a/projects/packages/forms/changelog/remove-jetpack-forms-legacy-menu-item
+++ b/projects/packages/forms/changelog/remove-jetpack-forms-legacy-menu-item
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Forms: remove legacy menu item by defaulting the filter to true

--- a/projects/packages/forms/changelog/renovate-typescript-5.x
+++ b/projects/packages/forms/changelog/renovate-typescript-5.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/forms/changelog/renovate-wordpress-monorepo2
+++ b/projects/packages/forms/changelog/renovate-wordpress-monorepo2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/forms/changelog/update-dataviews-700
+++ b/projects/packages/forms/changelog/update-dataviews-700
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Update @wordpress/dataviews package v5.0.0 → v7.0.0

--- a/projects/packages/forms/changelog/update-forms-empty-states
+++ b/projects/packages/forms/changelog/update-forms-empty-states
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Forms: show custom messages for empty inbox/spam/trash folders.

--- a/projects/packages/forms/changelog/update-forms-experimental-beta-blocks
+++ b/projects/packages/forms/changelog/update-forms-experimental-beta-blocks
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Making some Form fields that are available as experimental blocks to beta as well. Should not have any effect for normal users
-
-

--- a/projects/packages/forms/changelog/update-forms-release-rating-slider-in-jp
+++ b/projects/packages/forms/changelog/update-forms-release-rating-slider-in-jp
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Forms: release rating and slide fields to Jetpack customers

--- a/projects/packages/forms/changelog/update-forms-switch-to-v3
+++ b/projects/packages/forms/changelog/update-forms-switch-to-v3
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Forms: Finally store the feedback in the new format

--- a/projects/packages/forms/changelog/update-split-editor-forms
+++ b/projects/packages/forms/changelog/update-split-editor-forms
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Split editor forms functionality

--- a/projects/packages/forms/composer.json
+++ b/projects/packages/forms/composer.json
@@ -71,7 +71,7 @@
 			"link-template": "https://github.com/automattic/jetpack-forms/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "6.2.x-dev"
+			"dev-trunk": "6.3.x-dev"
 		},
 		"textdomain": "jetpack-forms",
 		"version-constants": {

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-forms",
-	"version": "6.2.0",
+	"version": "6.3.0",
 	"private": true,
 	"description": "Jetpack Forms",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/forms/#readme",

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -14,7 +14,7 @@ use Automattic\Jetpack\Forms\Dashboard\Dashboard;
  */
 class Jetpack_Forms {
 
-	const PACKAGE_VERSION = '6.2.0';
+	const PACKAGE_VERSION = '6.3.0';
 
 	/**
 	 * Load the contact form module.

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -1513,7 +1513,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		 *
 		 * Filter the value of the hidden field.
 		 *
-		 * @since $$next-version$$
+		 * @since 6.3.0
 		 *
 		 * @param string $value The value of the hidden field.
 		 * @param string $label The label of the hidden field.

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -1681,7 +1681,7 @@ class Contact_Form_Plugin {
 			/**
 			 * Action when we want to log a jetpack_forms event.
 			 *
-			 * @since $$next-version$$
+			 * @since 6.3.0
 			 *
 			 * @param string $log_message The log message.
 			 */

--- a/projects/packages/image-cdn/CHANGELOG.md
+++ b/projects/packages/image-cdn/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.19] - 2025-09-08
+### Changed
+- Internal updates.
+
 ## [0.7.18] - 2025-08-25
 ### Fixed
 - Prevent an error when attempting to filter null. [#44874]
@@ -226,6 +230,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add image CDN package. [#29561]
 
+[0.7.19]: https://github.com/Automattic/jetpack-image-cdn/compare/v0.7.18...v0.7.19
 [0.7.18]: https://github.com/Automattic/jetpack-image-cdn/compare/v0.7.17...v0.7.18
 [0.7.17]: https://github.com/Automattic/jetpack-image-cdn/compare/v0.7.16...v0.7.17
 [0.7.16]: https://github.com/Automattic/jetpack-image-cdn/compare/v0.7.15...v0.7.16

--- a/projects/packages/image-cdn/changelog/fix-phan-PhanTypeMismatchArgumentInternal
+++ b/projects/packages/image-cdn/changelog/fix-phan-PhanTypeMismatchArgumentInternal
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Fix some PhanTypeMismatchArgument violations.
-
-

--- a/projects/packages/image-cdn/src/class-image-cdn.php
+++ b/projects/packages/image-cdn/src/class-image-cdn.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Image_CDN;
  */
 final class Image_CDN {
 
-	const PACKAGE_VERSION = '0.7.18';
+	const PACKAGE_VERSION = '0.7.19';
 
 	/**
 	 * Singleton.

--- a/projects/packages/ip/CHANGELOG.md
+++ b/projects/packages/ip/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.10] - 2025-09-08
+### Changed
+- Internal updates.
+
 ## [0.4.9] - 2025-04-28
 ### Changed
 - Internal updates.
@@ -102,6 +106,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add jetpack-ip package functionality [#28846]
 - Initialized the package. [#28765]
 
+[0.4.10]: https://github.com/automattic/jetpack-ip/compare/v0.4.9...v0.4.10
 [0.4.9]: https://github.com/automattic/jetpack-ip/compare/v0.4.8...v0.4.9
 [0.4.8]: https://github.com/automattic/jetpack-ip/compare/v0.4.7...v0.4.8
 [0.4.7]: https://github.com/automattic/jetpack-ip/compare/v0.4.6...v0.4.7

--- a/projects/packages/ip/changelog/fix-phan-PhanTypeMismatchArgumentInternal
+++ b/projects/packages/ip/changelog/fix-phan-PhanTypeMismatchArgumentInternal
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Fix some PhanTypeMismatchArgument violations.
-
-

--- a/projects/packages/ip/src/class-utils.php
+++ b/projects/packages/ip/src/class-utils.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\IP;
  */
 class Utils {
 
-	const PACKAGE_VERSION = '0.4.9';
+	const PACKAGE_VERSION = '0.4.10';
 
 	/**
 	 * Get the current user's IP address.

--- a/projects/packages/jitm/CHANGELOG.md
+++ b/projects/packages/jitm/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.3.4] - 2025-09-08
+### Changed
+- Update package dependencies. [#45027]
+
 ## [4.3.3] - 2025-08-14
 ### Changed
 - Update package dependencies. [#44701]
@@ -978,6 +982,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update Jetpack to use new JITM package
 
+[4.3.4]: https://github.com/Automattic/jetpack-jitm/compare/v4.3.3...v4.3.4
 [4.3.3]: https://github.com/Automattic/jetpack-jitm/compare/v4.3.2...v4.3.3
 [4.3.2]: https://github.com/Automattic/jetpack-jitm/compare/v4.3.1...v4.3.2
 [4.3.1]: https://github.com/Automattic/jetpack-jitm/compare/v4.3.0...v4.3.1

--- a/projects/packages/jitm/changelog/renovate-wordpress-monorepo2
+++ b/projects/packages/jitm/changelog/renovate-wordpress-monorepo2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/jitm/src/class-jitm.php
+++ b/projects/packages/jitm/src/class-jitm.php
@@ -25,7 +25,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class JITM {
 
-	const PACKAGE_VERSION = '4.3.3';
+	const PACKAGE_VERSION = '4.3.4';
 
 	/**
 	 * List of screen IDs where JITMs are allowed to display.

--- a/projects/packages/masterbar/CHANGELOG.md
+++ b/projects/packages/masterbar/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.22.3] - 2025-09-08
+### Changed
+- Update package dependencies. [#45027]
+
 ## [0.22.2] - 2025-09-01
 ### Changed
 - Internal updates.
@@ -426,6 +430,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Notifications: Change Icon [#37676]
 - Updated package dependencies. [#37669] [#37706]
 
+[0.22.3]: https://github.com/Automattic/jetpack-masterbar/compare/v0.22.2...v0.22.3
 [0.22.2]: https://github.com/Automattic/jetpack-masterbar/compare/v0.22.1...v0.22.2
 [0.22.1]: https://github.com/Automattic/jetpack-masterbar/compare/v0.22.0...v0.22.1
 [0.22.0]: https://github.com/Automattic/jetpack-masterbar/compare/v0.21.0...v0.22.0

--- a/projects/packages/masterbar/changelog/renovate-wordpress-monorepo2
+++ b/projects/packages/masterbar/changelog/renovate-wordpress-monorepo2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/masterbar/package.json
+++ b/projects/packages/masterbar/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-masterbar",
-	"version": "0.22.2",
+	"version": "0.22.3",
 	"private": true,
 	"description": "The WordPress.com Toolbar feature replaces the default admin bar and offers quick links to the Reader, all your sites, your WordPress.com profile, and notifications.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/masterbar/#readme",

--- a/projects/packages/masterbar/src/class-main.php
+++ b/projects/packages/masterbar/src/class-main.php
@@ -14,7 +14,7 @@ use Automattic\Jetpack\Status\Host;
  */
 class Main {
 
-	const PACKAGE_VERSION = '0.22.2';
+	const PACKAGE_VERSION = '0.22.3';
 
 	/**
 	 * Initializer.

--- a/projects/packages/my-jetpack/CHANGELOG.md
+++ b/projects/packages/my-jetpack/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.26.0] - 2025-09-08
+### Changed
+- Update @wordpress/dataviews package from v5.0.0 to v7.0.0. [#45012]
+- Update package dependencies. [#45027] [#45097]
+
 ## [5.25.2] - 2025-09-03
 ### Fixed
 - Prevent PHP error when using WP-CLI. [#45045]
@@ -2330,6 +2335,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created package
 
+[5.26.0]: https://github.com/Automattic/jetpack-my-jetpack/compare/5.25.2...5.26.0
 [5.25.2]: https://github.com/Automattic/jetpack-my-jetpack/compare/5.25.1...5.25.2
 [5.25.1]: https://github.com/Automattic/jetpack-my-jetpack/compare/5.25.0...5.25.1
 [5.25.0]: https://github.com/Automattic/jetpack-my-jetpack/compare/5.24.0...5.25.0

--- a/projects/packages/my-jetpack/changelog/fix-jetpack-direct_access_fatals_part_6
+++ b/projects/packages/my-jetpack/changelog/fix-jetpack-direct_access_fatals_part_6
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Prevent PHP errors by limiting direct access to files.
-
-

--- a/projects/packages/my-jetpack/changelog/renovate-typescript-5.x
+++ b/projects/packages/my-jetpack/changelog/renovate-typescript-5.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/my-jetpack/changelog/renovate-wordpress-monorepo2
+++ b/projects/packages/my-jetpack/changelog/renovate-wordpress-monorepo2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/my-jetpack/changelog/update-dataviews-700
+++ b/projects/packages/my-jetpack/changelog/update-dataviews-700
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Update @wordpress/dataviews package v5.0.0 → v7.0.0

--- a/projects/packages/my-jetpack/composer.json
+++ b/projects/packages/my-jetpack/composer.json
@@ -82,7 +82,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "5.25.x-dev"
+			"dev-trunk": "5.26.x-dev"
 		},
 		"version-constants": {
 			"::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "5.25.2",
+	"version": "5.26.0",
 	"private": true,
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -39,7 +39,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '5.25.2';
+	const PACKAGE_VERSION = '5.26.0';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.

--- a/projects/packages/paypal-payments/CHANGELOG.md
+++ b/projects/packages/paypal-payments/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.2] - 2025-09-08
+### Changed
+- Update package dependencies. [#45027]
+
 ## [0.5.1] - 2025-09-01
 ### Changed
 - Internal updates.
@@ -59,6 +63,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Simple Payments: Move Simple Payments block to PayPal Payments package. [#43413]
 
+[0.5.2]: https://github.com/Automattic/jetpack-paypal-payments/compare/v0.5.1...v0.5.2
 [0.5.1]: https://github.com/Automattic/jetpack-paypal-payments/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/Automattic/jetpack-paypal-payments/compare/v0.4.3...v0.5.0
 [0.4.3]: https://github.com/Automattic/jetpack-paypal-payments/compare/v0.4.2...v0.4.3

--- a/projects/packages/paypal-payments/changelog/renovate-wordpress-monorepo2
+++ b/projects/packages/paypal-payments/changelog/renovate-wordpress-monorepo2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/paypal-payments/package.json
+++ b/projects/packages/paypal-payments/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-paypal-payments",
-	"version": "0.5.1",
+	"version": "0.5.2",
 	"private": true,
 	"description": "Add PayPal, credit, and debit card payment buttons with minimal setup. Good for collecting donations or payments for products and services.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/paypal-payments/#readme",

--- a/projects/packages/paypal-payments/src/class-paypal-payments.php
+++ b/projects/packages/paypal-payments/src/class-paypal-payments.php
@@ -12,5 +12,5 @@ namespace Automattic\Jetpack;
  */
 class PayPal_Payments {
 
-	const PACKAGE_VERSION = '0.5.1';
+	const PACKAGE_VERSION = '0.5.2';
 }

--- a/projects/packages/post-list/CHANGELOG.md
+++ b/projects/packages/post-list/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.28] - 2025-09-08
+### Changed
+- Update package dependencies. [#45027]
+
 ## [0.8.27] - 2025-08-14
 ### Changed
 - Update package dependencies. [#44701]
@@ -249,6 +253,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated the default columns displayed on the post and page list screens
 - Refactored thumbnail preview to function server side. All javascript removed.
 
+[0.8.28]: https://github.com/automattic/jetpack-post-list/compare/v0.8.27...v0.8.28
 [0.8.27]: https://github.com/automattic/jetpack-post-list/compare/v0.8.26...v0.8.27
 [0.8.26]: https://github.com/automattic/jetpack-post-list/compare/v0.8.25...v0.8.26
 [0.8.25]: https://github.com/automattic/jetpack-post-list/compare/v0.8.24...v0.8.25

--- a/projects/packages/post-list/changelog/renovate-wordpress-monorepo2
+++ b/projects/packages/post-list/changelog/renovate-wordpress-monorepo2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/post-list/src/class-post-list.php
+++ b/projects/packages/post-list/src/class-post-list.php
@@ -16,7 +16,7 @@ use WP_Screen;
  */
 class Post_List {
 
-	const PACKAGE_VERSION = '0.8.27';
+	const PACKAGE_VERSION = '0.8.28';
 	const FEATURE         = 'enhanced_post_list';
 
 	/**

--- a/projects/packages/publicize/CHANGELOG.md
+++ b/projects/packages/publicize/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.66.11] - 2025-09-08
+### Changed
+- Update package dependencies. [#45027]
+
 ## [0.66.10] - 2025-09-01
 ### Fixed
 - Social: Allow default image to be cleared. [#44994]
@@ -1098,6 +1102,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Update package.json metadata.
 
+[0.66.11]: https://github.com/Automattic/jetpack-publicize/compare/v0.66.10...v0.66.11
 [0.66.10]: https://github.com/Automattic/jetpack-publicize/compare/v0.66.9...v0.66.10
 [0.66.9]: https://github.com/Automattic/jetpack-publicize/compare/v0.66.8...v0.66.9
 [0.66.8]: https://github.com/Automattic/jetpack-publicize/compare/v0.66.7...v0.66.8

--- a/projects/packages/publicize/changelog/fix-jetpack-direct_access_fatals_part_6
+++ b/projects/packages/publicize/changelog/fix-jetpack-direct_access_fatals_part_6
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Prevent PHP errors by limiting direct access to files.
-
-

--- a/projects/packages/publicize/changelog/renovate-wordpress-monorepo2
+++ b/projects/packages/publicize/changelog/renovate-wordpress-monorepo2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/publicize/package.json
+++ b/projects/packages/publicize/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-publicize",
-	"version": "0.66.10",
+	"version": "0.66.11",
 	"private": true,
 	"description": "Publicize makes it easy to share your site’s posts on several social media networks automatically when you publish a new post.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/publicize/#readme",

--- a/projects/packages/search/CHANGELOG.md
+++ b/projects/packages/search/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.52.16] - 2025-09-08
+### Changed
+- Update package dependencies. [#45027]
+
 ## [0.52.15] - 2025-09-01
 ### Changed
 - Update dependencies. [#44615]
@@ -1320,6 +1324,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Update PHPUnit configs to include just what needs coverage rather than include everything then try to exclude stuff that doesn't.
 
+[0.52.16]: https://github.com/Automattic/jetpack-search/compare/v0.52.15...v0.52.16
 [0.52.15]: https://github.com/Automattic/jetpack-search/compare/v0.52.14...v0.52.15
 [0.52.14]: https://github.com/Automattic/jetpack-search/compare/v0.52.13...v0.52.14
 [0.52.13]: https://github.com/Automattic/jetpack-search/compare/v0.52.12...v0.52.13

--- a/projects/packages/search/changelog/renovate-wordpress-monorepo2
+++ b/projects/packages/search/changelog/renovate-wordpress-monorepo2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -15,7 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Search package general information
  */
 class Package {
-	const VERSION = '0.52.15';
+	const VERSION = '0.52.16';
 	const SLUG    = 'search';
 
 	/**

--- a/projects/packages/status/CHANGELOG.md
+++ b/projects/packages/status/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.0.4] - 2025-09-08
+### Changed
+- Internal updates.
+
 ## [6.0.3] - 2025-08-14
 ### Changed
 - Update `is_frontend` method to allow not sending "Vary" header. [#44741]
@@ -505,6 +509,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Packages: Introduce a status package
 
+[6.0.4]: https://github.com/Automattic/jetpack-status/compare/v6.0.3...v6.0.4
 [6.0.3]: https://github.com/Automattic/jetpack-status/compare/v6.0.2...v6.0.3
 [6.0.2]: https://github.com/Automattic/jetpack-status/compare/v6.0.1...v6.0.2
 [6.0.1]: https://github.com/Automattic/jetpack-status/compare/v6.0.0...v6.0.1

--- a/projects/packages/status/changelog/fix-phan-PhanTypeMismatchArgumentInternal
+++ b/projects/packages/status/changelog/fix-phan-PhanTypeMismatchArgumentInternal
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Fix some PhanTypeMismatchArgument violations.
-
-

--- a/projects/packages/subscribers-dashboard/CHANGELOG.md
+++ b/projects/packages/subscribers-dashboard/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.0 - 2025-09-08
+### Changed
+- Update @wordpress/dataviews package v5.0.0 → v7.0.0 [#45012]
+- Update package dependencies. [#45027] [#45097]
+
 ## 0.2.5 - 2025-09-01
 ### Changed
 - Remove unused JavaScript dependencies. [#44813]

--- a/projects/packages/subscribers-dashboard/changelog/renovate-typescript-5.x
+++ b/projects/packages/subscribers-dashboard/changelog/renovate-typescript-5.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/subscribers-dashboard/changelog/renovate-wordpress-monorepo2
+++ b/projects/packages/subscribers-dashboard/changelog/renovate-wordpress-monorepo2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/subscribers-dashboard/changelog/update-dataviews-700
+++ b/projects/packages/subscribers-dashboard/changelog/update-dataviews-700
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Update @wordpress/dataviews package v5.0.0 → v7.0.0

--- a/projects/packages/subscribers-dashboard/composer.json
+++ b/projects/packages/subscribers-dashboard/composer.json
@@ -67,7 +67,7 @@
 		"autotagger": true,
 		"mirror-repo": "Automattic/jetpack-subscribers-dashboard",
 		"branch-alias": {
-			"dev-trunk": "0.2.x-dev"
+			"dev-trunk": "0.3.x-dev"
 		},
 		"textdomain": "jetpack-subscribers-dashboard",
 		"version-constants": {

--- a/projects/packages/subscribers-dashboard/package.json
+++ b/projects/packages/subscribers-dashboard/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-subscribers-dashboard",
-	"version": "0.2.5",
+	"version": "0.3.0",
 	"private": true,
 	"description": "WP Admin page to manage subscribers",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/subscribers-dashboard/#readme",

--- a/projects/packages/subscribers-dashboard/src/class-dashboard.php
+++ b/projects/packages/subscribers-dashboard/src/class-dashboard.php
@@ -17,7 +17,7 @@ use Automattic\Jetpack\Status\Host;
  * @package jetpack-subscribers
  */
 class Dashboard {
-	const VERSION = '0.2.5';
+	const VERSION = '0.3.0';
 	/**
 	 * Whether the class has been initialized
 	 *

--- a/projects/packages/sync/CHANGELOG.md
+++ b/projects/packages/sync/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.21.2] - 2025-09-08
+### Changed
+- Internal updates.
+
 ## [4.21.1] - 2025-09-02
 ### Changed
 - Remove unnecessary filter for deleted WooCommerce products in the WooCommerce_Products module. [#45011]
@@ -1544,6 +1548,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Packages: Move sync to a classmapped package
 
+[4.21.2]: https://github.com/Automattic/jetpack-sync/compare/v4.21.1...v4.21.2
 [4.21.1]: https://github.com/Automattic/jetpack-sync/compare/v4.21.0...v4.21.1
 [4.21.0]: https://github.com/Automattic/jetpack-sync/compare/v4.20.0...v4.21.0
 [4.20.0]: https://github.com/Automattic/jetpack-sync/compare/v4.19.0...v4.20.0

--- a/projects/packages/sync/changelog/fix-phan-PhanTypeMismatchArgumentInternal
+++ b/projects/packages/sync/changelog/fix-phan-PhanTypeMismatchArgumentInternal
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Fix some PhanTypeMismatchArgument violations.
-
-

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '4.21.1';
+	const PACKAGE_VERSION = '4.21.2';
 
 	const PACKAGE_SLUG = 'sync';
 

--- a/projects/packages/videopress/CHANGELOG.md
+++ b/projects/packages/videopress/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.32.4] - 2025-09-08
+### Changed
+- Update package dependencies. [#45027] [#45097]
+
 ## [0.32.3] - 2025-09-01
 ### Changed
 - Update dependencies. [#44736]
@@ -1732,6 +1736,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created empty package [#24952]
 
+[0.32.4]: https://github.com/Automattic/jetpack-videopress/compare/v0.32.3...v0.32.4
 [0.32.3]: https://github.com/Automattic/jetpack-videopress/compare/v0.32.2...v0.32.3
 [0.32.2]: https://github.com/Automattic/jetpack-videopress/compare/v0.32.1...v0.32.2
 [0.32.1]: https://github.com/Automattic/jetpack-videopress/compare/v0.32.0...v0.32.1

--- a/projects/packages/videopress/changelog/fix-phan-PhanTypeMismatchArgumentInternal
+++ b/projects/packages/videopress/changelog/fix-phan-PhanTypeMismatchArgumentInternal
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Fix some PhanTypeMismatchArgument violations.
-
-

--- a/projects/packages/videopress/changelog/renovate-typescript-5.x
+++ b/projects/packages/videopress/changelog/renovate-typescript-5.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/videopress/changelog/renovate-wordpress-monorepo2
+++ b/projects/packages/videopress/changelog/renovate-wordpress-monorepo2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.32.3",
+	"version": "0.32.4",
 	"private": true,
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",

--- a/projects/packages/videopress/src/class-package-version.php
+++ b/projects/packages/videopress/src/class-package-version.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * The Package_Version class.
  */
 class Package_Version {
-	const PACKAGE_VERSION = '0.32.3';
+	const PACKAGE_VERSION = '0.32.4';
 
 	const PACKAGE_SLUG = 'videopress';
 

--- a/projects/packages/waf/CHANGELOG.md
+++ b/projects/packages/waf/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.27.3] - 2025-09-08
+### Fixed
+- WAF: Prevent PHP warnings when the BFP transient is not set or when the hook data for the WAF update flag is not as expected. [#45088]
+
 ## [0.27.2] - 2025-08-11
 ### Changed
 - Internal updates.
@@ -481,6 +485,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Core: do not ship .phpcs.dir.xml in production builds.
 
+[0.27.3]: https://github.com/Automattic/jetpack-waf/compare/v0.27.2...v0.27.3
 [0.27.2]: https://github.com/Automattic/jetpack-waf/compare/v0.27.1...v0.27.2
 [0.27.1]: https://github.com/Automattic/jetpack-waf/compare/v0.27.0...v0.27.1
 [0.27.0]: https://github.com/Automattic/jetpack-waf/compare/v0.26.0...v0.27.0

--- a/projects/packages/waf/changelog/fix-jetpack-direct_access_fatals_part_6
+++ b/projects/packages/waf/changelog/fix-jetpack-direct_access_fatals_part_6
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Prevent PHP errors by limiting direct access to files.
-
-

--- a/projects/packages/waf/changelog/fix-phan-PhanTypeMismatchArgumentInternal
+++ b/projects/packages/waf/changelog/fix-phan-PhanTypeMismatchArgumentInternal
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Fix some PhanTypeMismatchArgument violations.
-
-

--- a/projects/packages/waf/changelog/waf-fix-warnings
+++ b/projects/packages/waf/changelog/waf-fix-warnings
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-WAF: Fix emitting PHP warnings when the BFP transient is not set, or when the hook data for the WAF update flag is not as expected.

--- a/projects/plugins/backup/changelog/prerelease#16
+++ b/projects/plugins/backup/changelog/prerelease#16
@@ -1,4 +1,5 @@
 Significance: patch
 Type: changed
+Comment: Update composer.lock.
 
 

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -1178,7 +1178,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "93884e455e86cc56a1abfc94e65c3c91ec4d3c9b"
+                "reference": "764d81091fa984bbb752efd23b39081c16b4a666"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1217,7 +1217,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "5.25.x-dev"
+                    "dev-trunk": "5.26.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/boost/changelog/prerelease#4
+++ b/projects/plugins/boost/changelog/prerelease#4
@@ -1,4 +1,5 @@
 Significance: patch
 Type: changed
+Comment: Update composer.lock.
 
-Update package dependencies.
+

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -1099,7 +1099,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "93884e455e86cc56a1abfc94e65c3c91ec4d3c9b"
+                "reference": "764d81091fa984bbb752efd23b39081c16b4a666"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1138,7 +1138,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "5.25.x-dev"
+                    "dev-trunk": "5.26.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/jetpack/CHANGELOG.md
+++ b/projects/plugins/jetpack/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ### This is a list detailing changes for all Jetpack releases.
 
+## 15.1-a.1 - 2025-09-08
+### Enhancements
+- Forms: Add hidden input field block. [#44079]
+- Forms: Make rating and slider fields available to self-hosted users. [#45094]
+
+### Bug fixes
+- Sharing: Fix Facebook sharing URL. [#45083]
+
+### Other changes <!-- Non-user-facing changes go here. This section will not be copied to readme.txt. -->
+- Add MCP abilities title to site settings. [#45064]
+- Block editor: Update allowed block types for the mobile editor. [#45039]
+- Forms: Track form submission failure. [#45090]
+- Subscribe and Button blocks: Add email rendering for the WooCommerce Email Editor. [#45006]
+- Update package dependencies. [#45027] [#45096] [#45097]
+- Writing Settings: Add Mailchimp connection. [#44999]
+
 ## 15.0 - 2025-09-04
 ### Enhancements
 - Add LaTeX block (Beta) to render mathematical formula. [#44895]
@@ -77,10 +93,7 @@
 - Slideshow block: Add email rendering. [#44835]
 - Tiled Gallery: Add initial state tests. [#44591]
 - Tiled gallery block: Add email rendering. [#44943]
-- Update package dependencies. [#44677]
-- Update package dependencies. [#44701] [#44725]
-- Update package dependencies. [#44870] [#44894] [#44899]
-- Update package dependencies. [#44948]
+- Update package dependencies. [#44677] [#44701] [#44725] [#44870] [#44894] [#44899] [#44948]
 - Use `wp_rand()` instead of `rand()` and `mt_rand()`. [#44964]
 - Writing Settings: Add Instagram connection. [#44936]
 

--- a/projects/plugins/jetpack/changelog/add-forms-hidden-field-block
+++ b/projects/plugins/jetpack/changelog/add-forms-hidden-field-block
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Forms: Add hidden input field block

--- a/projects/plugins/jetpack/changelog/add-logging-for-form-validation
+++ b/projects/plugins/jetpack/changelog/add-logging-for-form-validation
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Forms: track form submission failure

--- a/projects/plugins/jetpack/changelog/add-mailchimp-connection-writing-settings
+++ b/projects/plugins/jetpack/changelog/add-mailchimp-connection-writing-settings
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Writing Settings: Add Mailchimp connection

--- a/projects/plugins/jetpack/changelog/add-subscribe-block-wc-email-rendering
+++ b/projects/plugins/jetpack/changelog/add-subscribe-block-wc-email-rendering
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Subscribe and Button blocks: Add email rendering for the WooCommerce Email Editor."

--- a/projects/plugins/jetpack/changelog/feat-limit-mobile-editor-to-working-blocks
+++ b/projects/plugins/jetpack/changelog/feat-limit-mobile-editor-to-working-blocks
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Block editor: update allowed block types for the mobile editor

--- a/projects/plugins/jetpack/changelog/fix-boost-score-graph-css-hack
+++ b/projects/plugins/jetpack/changelog/fix-boost-score-graph-css-hack
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Fix e2e tests related to boost score graph update.
-
-

--- a/projects/plugins/jetpack/changelog/fix-jetpack-direct_access_fatals_part_6
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-direct_access_fatals_part_6
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Prevent PHP errors by limiting direct access to files.
-
-

--- a/projects/plugins/jetpack/changelog/fix-phan-PhanTypeMismatchArgumentInternal
+++ b/projects/plugins/jetpack/changelog/fix-phan-PhanTypeMismatchArgumentInternal
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Fix some PhanTypeMismatchArgument violations.
-
-

--- a/projects/plugins/jetpack/changelog/fix-sharing-buttons-facebook-url
+++ b/projects/plugins/jetpack/changelog/fix-sharing-buttons-facebook-url
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Sharing: Fix Facebook sharing URL.

--- a/projects/plugins/jetpack/changelog/renovate-lock-file-maintenance
+++ b/projects/plugins/jetpack/changelog/renovate-lock-file-maintenance
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Update package dependencies.

--- a/projects/plugins/jetpack/changelog/renovate-typescript-5.x
+++ b/projects/plugins/jetpack/changelog/renovate-typescript-5.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Update package dependencies.

--- a/projects/plugins/jetpack/changelog/renovate-wordpress-monorepo
+++ b/projects/plugins/jetpack/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Update package dependencies.

--- a/projects/plugins/jetpack/changelog/update-forms-release-rating-slider-in-jp
+++ b/projects/plugins/jetpack/changelog/update-forms-release-rating-slider-in-jp
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Forms: release rating and slide fields to Jetpack customers

--- a/projects/plugins/jetpack/changelog/update-mcp-abilities-site-settings
+++ b/projects/plugins/jetpack/changelog/update-mcp-abilities-site-settings
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Added MCP abilities title to site settings

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -111,7 +111,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ15_0",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ15_1_a_1",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -1490,7 +1490,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/forms",
-                "reference": "03ee958f5cc90a442282d02c3511898fc4968220"
+                "reference": "ac0b17e0da1e19bb0bd8c11d63cae97df9fe7d97"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1523,7 +1523,7 @@
                     "link-template": "https://github.com/automattic/jetpack-forms/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "6.2.x-dev"
+                    "dev-trunk": "6.3.x-dev"
                 },
                 "textdomain": "jetpack-forms",
                 "version-constants": {
@@ -2087,7 +2087,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "93884e455e86cc56a1abfc94e65c3c91ec4d3c9b"
+                "reference": "764d81091fa984bbb752efd23b39081c16b4a666"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -2126,7 +2126,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "5.25.x-dev"
+                    "dev-trunk": "5.26.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"
@@ -3114,7 +3114,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/subscribers-dashboard",
-                "reference": "79f01c5177095986566e9deb5832dfceb0b9aa14"
+                "reference": "81690137b50542f41b9ee5eb00841156118021e2"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -3139,7 +3139,7 @@
                 "autotagger": true,
                 "mirror-repo": "Automattic/jetpack-subscribers-dashboard",
                 "branch-alias": {
-                    "dev-trunk": "0.2.x-dev"
+                    "dev-trunk": "0.3.x-dev"
                 },
                 "textdomain": "jetpack-subscribers-dashboard",
                 "version-constants": {

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 15.0
+ * Version: 15.1-a.1
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -38,7 +38,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 if ( ! defined( 'JETPACK__VERSION' ) ) {
 	// This breaks the project version checks when a one-liner.
-	define( 'JETPACK__VERSION', '15.0' );
+	define( 'JETPACK__VERSION', '15.1-a.1' );
 }
 defined( 'JETPACK__MINIMUM_WP_VERSION' ) || define( 'JETPACK__MINIMUM_WP_VERSION', '6.7' );
 defined( 'JETPACK__MINIMUM_PHP_VERSION' ) || define( 'JETPACK__MINIMUM_PHP_VERSION', '7.2' );

--- a/projects/plugins/jetpack/readme.txt
+++ b/projects/plugins/jetpack/readme.txt
@@ -326,51 +326,13 @@ Jetpack Backup can do a full website migration to a new host, migrate theme file
 
 
 == Changelog ==
-### 15.0 - 2025-09-04
+### 15.1-a.1 - 2025-09-08
 #### Enhancements
-- Add LaTeX block (Beta) to render mathematical formula.
-- Blocks: Update JavaScript to be non-render blocking.
-- Carousel: Fix crashes on large galleries and reduce server requests by preloading only adjacent images instead of all at once.
-- Disallow inserting Simple Payments block via inserter.
-- Enable Settings > Sharing WP Admin page and ensure all relevant links point to this page.
-- Forms: Add MailPoet integration.
-- Forms: Add new Time field.
-- Forms: Add `has_field_type` method to Feedback.
-- Forms: Defer JavaScript loading for more responsive page loading.
-- Forms: Improve the checkbox style.
-- Forms: Preserve HTML IDs when processing feedback.
-- Forms: Save feedback entries in a new format.
-- Forms: Show trash action alongside view action in inbox.
-- Related Posts block: Update placeholder text for the site editor, and update the demo date.
-- Remove CRM installation nudge for Complete plan users
-- Shortcodes: Update embed reversal code to only run when content is inserted in the admin.
-- Site Accelerator: Ignore images from openlibrary.org.
-- Sitemaps: Add filter to allow suspending object cache addition during generation.
-- Social: Add font option for Social Image Generator.
-- Subscription block: Defer JavaScript loading.
-
-#### Improved compatibility
-- Open Graph Meta tags: Add new filter allowing one to define a custom site representative image.
+- Forms: Add hidden input field block.
+- Forms: Make rating and slider fields available to self-hosted users.
 
 #### Bug fixes
-- Carousel: Improve image size processing to return higher quality images in additional situations.
-- Crowdsignal: Improve escaping.
-- Forms: Fix default checkboxes styles, and allow for "browser" styles as a choice.
-- Forms: Fix error wrapper when placing button inside a group block.
-- Forms: Fix phone validation for responses.
-- Forms: Improve checkbox validation for older checkboxes.
-- Forms: Show the form variation picker if you only have the submit button.
-- Image CDN: Prevent errors attempting to filter null.
-- Improve escaping for recurring payment buttons.
-- Infinite Scroll: Prevent PHP warnings in various edge cases.
-- My Jetpack: Fix multisite availability check for restricted products and modules.
-- Prevent PHP fatals when handling unexpected data types.
-- Search: Ensure images are loaded efficiently when on https sites.
-- SEO settings: Update the default Open Graph image tag to match the one in use on the site.
-- Shortcodes: Improve embed detection.
-- Sitemaps: Fix PHP warning during generation if there are no posts or pages on the website.
-- Social: Allow default image to be cleared.
-- Social: Fix image generator token reset on save resulting in font not being saved.
+- Sharing: Fix Facebook sharing URL.
 
 --------
 

--- a/projects/plugins/jetpack/tests/php/modules/shortcodes/Jetpack_Shortcodes_CrowdSignal_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/shortcodes/Jetpack_Shortcodes_CrowdSignal_Test.php
@@ -275,7 +275,7 @@ class Jetpack_Shortcodes_CrowdSignal_Test extends WP_UnitTestCase {
 	 * This test verifies that malicious URLs embedded in HTML attributes are not processed
 	 * by the crowdsignal_link function, preventing potential XSS vulnerabilities.
 	 *
-	 * @since $$next-version$$
+	 * @since 15.1
 	 */
 	public function test_crowdsignal_link_xss_prevention() {
 		// Use the reporter's payload format with URLs on separate lines to trigger the regex

--- a/projects/plugins/mu-wpcom-plugin/changelog/prerelease#7
+++ b/projects/plugins/mu-wpcom-plugin/changelog/prerelease#7
@@ -1,4 +1,5 @@
 Significance: patch
 Type: changed
+Comment: Update composer.lock.
 
-Update package dependencies.
+

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -1608,7 +1608,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/subscribers-dashboard",
-                "reference": "79f01c5177095986566e9deb5832dfceb0b9aa14"
+                "reference": "81690137b50542f41b9ee5eb00841156118021e2"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1633,7 +1633,7 @@
                 "autotagger": true,
                 "mirror-repo": "Automattic/jetpack-subscribers-dashboard",
                 "branch-alias": {
-                    "dev-trunk": "0.2.x-dev"
+                    "dev-trunk": "0.3.x-dev"
                 },
                 "textdomain": "jetpack-subscribers-dashboard",
                 "version-constants": {

--- a/projects/plugins/protect/changelog/prerelease#9
+++ b/projects/plugins/protect/changelog/prerelease#9
@@ -1,4 +1,5 @@
 Significance: patch
 Type: changed
+Comment: Update composer.lock.
 
-Update package dependencies.
+

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -1162,7 +1162,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "93884e455e86cc56a1abfc94e65c3c91ec4d3c9b"
+                "reference": "764d81091fa984bbb752efd23b39081c16b4a666"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1201,7 +1201,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "5.25.x-dev"
+                    "dev-trunk": "5.26.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/search/changelog/prerelease#19
+++ b/projects/plugins/search/changelog/prerelease#19
@@ -1,4 +1,5 @@
 Significance: patch
 Type: changed
+Comment: Update composer.lock.
 
-Update package dependencies.
+

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -1038,7 +1038,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "93884e455e86cc56a1abfc94e65c3c91ec4d3c9b"
+                "reference": "764d81091fa984bbb752efd23b39081c16b4a666"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1077,7 +1077,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "5.25.x-dev"
+                    "dev-trunk": "5.26.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/social/changelog/prerelease#7
+++ b/projects/plugins/social/changelog/prerelease#7
@@ -1,4 +1,5 @@
 Significance: patch
 Type: changed
+Comment: Update composer.lock.
 
-Update package dependencies.
+

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -1038,7 +1038,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/my-jetpack",
-				"reference": "93884e455e86cc56a1abfc94e65c3c91ec4d3c9b"
+				"reference": "764d81091fa984bbb752efd23b39081c16b4a666"
 			},
 			"require": {
 				"automattic/jetpack-admin-ui": "@dev",
@@ -1077,7 +1077,7 @@
 					"link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
 				},
 				"branch-alias": {
-					"dev-trunk": "5.25.x-dev"
+					"dev-trunk": "5.26.x-dev"
 				},
 				"version-constants": {
 					"::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/starter-plugin/changelog/prerelease#18
+++ b/projects/plugins/starter-plugin/changelog/prerelease#18
@@ -1,4 +1,5 @@
 Significance: patch
 Type: changed
+Comment: Update composer.lock.
 
-Update package dependencies.
+

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -1038,7 +1038,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "93884e455e86cc56a1abfc94e65c3c91ec4d3c9b"
+                "reference": "764d81091fa984bbb752efd23b39081c16b4a666"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1077,7 +1077,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "5.25.x-dev"
+                    "dev-trunk": "5.26.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/videopress/changelog/prerelease#7
+++ b/projects/plugins/videopress/changelog/prerelease#7
@@ -1,4 +1,5 @@
 Significance: patch
 Type: changed
+Comment: Update composer.lock.
 
-Update package dependencies.
+

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -1038,7 +1038,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "93884e455e86cc56a1abfc94e65c3c91ec4d3c9b"
+                "reference": "764d81091fa984bbb752efd23b39081c16b4a666"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1077,7 +1077,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "5.25.x-dev"
+                    "dev-trunk": "5.26.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/wpcomsh/changelog/prerelease#7
+++ b/projects/plugins/wpcomsh/changelog/prerelease#7
@@ -1,4 +1,5 @@
 Significance: patch
 Type: changed
+Comment: Update composer.lock.
 
-Update package dependencies.
+

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -1883,7 +1883,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/subscribers-dashboard",
-                "reference": "79f01c5177095986566e9deb5832dfceb0b9aa14"
+                "reference": "81690137b50542f41b9ee5eb00841156118021e2"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1908,7 +1908,7 @@
                 "autotagger": true,
                 "mirror-repo": "Automattic/jetpack-subscribers-dashboard",
                 "branch-alias": {
-                    "dev-trunk": "0.2.x-dev"
+                    "dev-trunk": "0.3.x-dev"
                 },
                 "textdomain": "jetpack-subscribers-dashboard",
                 "version-constants": {


### PR DESCRIPTION
Closes MONOREP-102

 <!--- This template is used for backporting changes made during a plugin release back to trunk. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Backports changes for jetpack 15.1-a.1

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/a
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Proofread changes.