### PR TITLE
Garden Sites: Exposes the garden flags on the site endpoint

### DIFF
--- a/projects/plugins/jetpack/changelog/add-garden-flags-on-site-endpoint
+++ b/projects/plugins/jetpack/changelog/add-garden-flags-on-site-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Garden Sites: Exposes the Garden flags and information on the site endpoint

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -95,6 +95,9 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'is_deleted'                  => '(bool) If the site flagged as deleted.',
 		'is_a4a_client'               => '(bool) If the site is an A4A client site.',
 		'is_a4a_dev_site'             => '(bool) If the site is an A4A dev site.',
+		'is_garden'                   => '(bool) If the site is a Garden site.',
+		'garden_name'                 => '(string) The name of the Garden site.',
+		'garden_partner'              => '(string) The partner of the Garden site.',
 	);
 
 	/**
@@ -247,6 +250,9 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'was_hosting_trial',
 		'was_upgraded_from_trial',
 		'is_a4a_dev_site',
+		'is_garden',
+		'garden_name',
+		'garden_partner',
 	);
 
 	/**
@@ -632,6 +638,15 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 				break;
 			case 'is_a4a_dev_site':
 				$response[ $key ] = $this->site->is_a4a_dev_site();
+				break;
+			case 'is_garden':
+				$response[ $key ] = $this->site->is_garden();
+				break;
+			case 'garden_name':
+				$response[ $key ] = $this->site->garden_name();
+				break;
+			case 'garden_partner':
+				$response[ $key ] = $this->site->garden_partner();
 				break;
 		}
 

--- a/projects/plugins/jetpack/sal/class.json-api-site-base.php
+++ b/projects/plugins/jetpack/sal/class.json-api-site-base.php
@@ -1706,4 +1706,31 @@ abstract class SAL_Site {
 	 * @return bool
 	 */
 	abstract public function is_pending_plan();
+
+	/**
+	 * Detect whether the site is a Garden site.
+	 *
+	 * @return bool
+	 */
+	public function is_garden() {
+		return false;
+	}
+
+	/**
+	 * Get the Garden name.
+	 *
+	 * @return string
+	 */
+	public function garden_name() {
+		return null;
+	}
+
+	/**
+	 * Get the Garden partner.
+	 *
+	 * @return string
+	 */
+	public function garden_partner() {
+		return null;
+	}
 }

--- a/projects/plugins/jetpack/sal/class.json-api-site-jetpack.php
+++ b/projects/plugins/jetpack/sal/class.json-api-site-jetpack.php
@@ -735,34 +735,4 @@ class Jetpack_Site extends Abstract_Jetpack_Site {
 	public function is_pending_plan() {
 		return false;
 	}
-
-	/**
-	 * This function is used to detect whether the site is a Garden site on WPCOM side.
-	 *
-	 * @see /wpcom/public.api/rest/sal/class.json-api-site-jetpack-shadow.php
-	 * @return false
-	 */
-	public function is_garden() {
-		return false;
-	}
-
-	/**
-	 * This function is used to get the name of the Garden site on WPCOM side.
-	 *
-	 * @see /wpcom/public.api/rest/sal/class.json-api-site-jetpack-shadow.php
-	 * @return null
-	 */
-	public function garden_name() {
-		return null;
-	}
-
-	/**
-	 * This function is used to get the partner of the Garden site on WPCOM side.
-	 *
-	 * @see /wpcom/public.api/rest/sal/class.json-api-site-jetpack-shadow.php
-	 * @return null
-	 */
-	public function garden_partner() {
-		return null;
-	}
 }

--- a/projects/plugins/jetpack/sal/class.json-api-site-jetpack.php
+++ b/projects/plugins/jetpack/sal/class.json-api-site-jetpack.php
@@ -735,4 +735,34 @@ class Jetpack_Site extends Abstract_Jetpack_Site {
 	public function is_pending_plan() {
 		return false;
 	}
+
+	/**
+	 * This function is used to detect whether the site is a Garden site on WPCOM side.
+	 *
+	 * @see /wpcom/public.api/rest/sal/class.json-api-site-jetpack-shadow.php
+	 * @return false
+	 */
+	public function is_garden() {
+		return false;
+	}
+
+	/**
+	 * This function is used to get the name of the Garden site on WPCOM side.
+	 *
+	 * @see /wpcom/public.api/rest/sal/class.json-api-site-jetpack-shadow.php
+	 * @return null
+	 */
+	public function garden_name() {
+		return null;
+	}
+
+	/**
+	 * This function is used to get the partner of the Garden site on WPCOM side.
+	 *
+	 * @see /wpcom/public.api/rest/sal/class.json-api-site-jetpack-shadow.php
+	 * @return null
+	 */
+	public function garden_partner() {
+		return null;
+	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #
Related to: 191990-ghe-Automattic/wpcom

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Uses the methods introduced on 191990-ghe-Automattic/wpcom to expose the Garden information necessary for the front-end.
* This change will allow us to differentiate Garden sites from the other sites. It will also allow us to identify the Garden type and the Garden partner.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Use the testing instructions on 191990-ghe-Automattic/wpcom