### PR TITLE
Forms: Fix feedback parsing when JSON_DATA is not preceeded by a newline

### DIFF
--- a/projects/packages/forms/changelog/fix-feedback-parsing-forms
+++ b/projects/packages/forms/changelog/fix-feedback-parsing-forms
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Fix a warning and bad handleing when JSON_DATA is not precceeded by a new line.

--- a/projects/packages/forms/changelog/fix-feedback-parsing-forms
+++ b/projects/packages/forms/changelog/fix-feedback-parsing-forms
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Forms: Fix a warning and bad handleing when JSON_DATA is not precceeded by a new line.
+Forms: Fix a warning and bad handling when JSON_DATA is not preceded by a new line.

--- a/projects/packages/forms/src/contact-form/class-feedback.php
+++ b/projects/packages/forms/src/contact-form/class-feedback.php
@@ -1028,7 +1028,17 @@ class Feedback {
 	 * @return array Parsed JSON data.
 	 */
 	private function parse_json_data( $field_content ) {
-		$chunks    = explode( "\nJSON_DATA", $field_content );
+		$chunks = explode( "\nJSON_DATA", $field_content );
+
+		if ( ! isset( $chunks[1] ) ) {
+			// Try with 'JSON_DATA' without the newline as a fallback.
+			$chunks = explode( 'JSON_DATA', $field_content );
+			if ( ! isset( $chunks[1] ) ) {
+				// If JSON_DATA is still not found, return an empty array.
+				return array();
+			}
+		}
+
 		$json_data = $chunks[1];
 
 		$all_values = json_decode( $json_data, true );

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Test.php
@@ -2307,6 +2307,8 @@ class Feedback_Test extends BaseTestCase {
 
 		$response = Feedback::get( $post_id );
 
+		$this->assertStringNotContainsString( "\nJSON_DATA", get_post( $post_id )->post_content );
+
 		$this->assertEquals( 'こんにちは世界', $response->get_field_value_by_label( 'special' ), 'Special field value should match' );
 		$this->assertEquals( '🙈', $response->get_field_value_by_label( 'message' ), 'Message field value should match' );
 	}

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Test.php
@@ -2289,6 +2289,54 @@ class Feedback_Test extends BaseTestCase {
 		$this->assertEquals( '🙈', $response->get_field_value_by_label( 'message' ), 'Message field value should match' );
 	}
 
+	public function test_escape_legacy_special_characters_handeling_strip_new_lines() {
+		$post_id = Utility::create_legacy_feedback(
+			array(
+				'special' => 'こんにちは世界',
+				'message' => '🙈',
+			),
+			null,
+			null,
+			null,
+			null,
+			null,
+			null,
+			'publish',
+			true // strip new lines.
+		);
+
+		$response = Feedback::get( $post_id );
+
+		$this->assertEquals( 'こんにちは世界', $response->get_field_value_by_label( 'special' ), 'Special field value should match' );
+		$this->assertEquals( '🙈', $response->get_field_value_by_label( 'message' ), 'Message field value should match' );
+	}
+
+	public function test_bad_feedback_data_does_not_produce_warnings() {
+		$post_id  = wp_insert_post(
+			array(
+				'post_type'    => Feedback::POST_TYPE,
+				'post_title'   => 'Bad Feedback',
+				'post_content' => 'junk data',
+				'post_status'  => 'publish',
+			)
+		);
+		$response = Feedback::get( $post_id );
+		$this->assertInstanceOf( Feedback::class, $response );
+	}
+
+	public function test_bad_feedback_data_does_not_produce_warnings_bad_data() {
+		$post_id  = wp_insert_post(
+			array(
+				'post_type'    => Feedback::POST_TYPE,
+				'post_title'   => 'Bad Feedback JSON_DATA Bad Feedback',
+				'post_content' => 'junk data',
+				'post_status'  => 'publish',
+			)
+		);
+		$response = Feedback::get( $post_id );
+		$this->assertInstanceOf( Feedback::class, $response );
+	}
+
 	public function test_escape_legacy_v2_special_characters_handeling() {
 		$post_id = Utility::create_legacy_feedback_v2(
 			array(

--- a/projects/packages/forms/tests/php/contact-form/class-utility.php
+++ b/projects/packages/forms/tests/php/contact-form/class-utility.php
@@ -11,14 +11,15 @@ class Utility {
 	 *
 	 * This function creates a mock feedback post in the legacy format used by Jetpack Contact Form.
 	 *
-	 * @param array       $all_values               An associative array of field values.
-	 * @param string|null $comment_content          The content of the comment.
-	 * @param string|null $comment_author           The name of the comment author.
-	 * @param string|null $comment_author_email     The email of the comment author.
-	 * @param string|null $comment_author_url       The URL of the comment author.
-	 * @param string|null $comment_ip_text          The IP address of the comment author.
-	 * @param string|null $subject                  The subject of the feedback.
-	 * @param string|null $status                   The status of the post (default is 'publish').
+	 * @param array        $all_values               An associative array of field values.
+	 * @param string|null  $comment_content          The content of the comment.
+	 * @param string|null  $comment_author           The name of the comment author.
+	 * @param string|null  $comment_author_email     The email of the comment author.
+	 * @param string|null  $comment_author_url       The URL of the comment author.
+	 * @param string|null  $comment_ip_text          The IP address of the comment author.
+	 * @param string|null  $subject                  The subject of the feedback.
+	 * @param string|null  $status                   The status of the post (default is 'publish').
+	 * @param boolean|null $strip_new_lines          Whether to strip new lines from the content (default is false).
 	 *
 	 * @return int|\WP_Error The ID of the created post on success, or a WP_Error object on failure.
 	 */
@@ -30,7 +31,8 @@ class Utility {
 		$comment_author_url = 'http://example.com',
 		$comment_ip_text = 'https://127.0.0.1',
 		$subject = 'Test Subject',
-		$status = 'publish'
+		$status = 'publish',
+		$strip_new_lines = false
 	) {
 		global $post;
 		$feedback_time  = current_time( 'mysql' );
@@ -65,7 +67,9 @@ class Utility {
 		);
 
 		$content = addslashes( wp_kses( "$comment_content\n<!--more-->\nAUTHOR: {$comment_author}\nAUTHOR EMAIL: {$comment_author_email}\nAUTHOR URL: {$comment_author_url}\nSUBJECT: {$subject}\nIP: {$comment_ip_text}\nJSON_DATA\n" . wp_json_encode( $all_values ), array() ) );
-
+		if ( $strip_new_lines ) {
+			$content = str_replace( array( "\n", "\r" ), ' ', $content );
+		}
 		// Create a mock post with JSON_DATA format
 		return wp_insert_post(
 			array(


### PR DESCRIPTION
We noticed that some form data (Only on one site) store data with that strips out new lines. 


## Proposed changes:
* Add a test to check for that case. 
* Do we still return the expected data? 
* Add tests with bad data to make sure that we don't see PHP notices. 

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1757359771734069-slack-C052XEUUBL4

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Do the tests pass?

