### PR TITLE
Forms: Fix MailPoet string warning

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-mailpoet-string-error
+++ b/projects/packages/forms/changelog/fix-forms-mailpoet-string-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Fix MailPoet string warning.

--- a/projects/packages/forms/src/service/class-mailpoet-integration.php
+++ b/projects/packages/forms/src/service/class-mailpoet-integration.php
@@ -139,6 +139,12 @@ class MailPoet_Integration {
 		foreach ( $form->fields as $field ) {
 			$id    = strtolower( str_replace( array( ' ', '_' ), '', $field->get_attribute( 'id' ) ) );
 			$label = strtolower( str_replace( array( ' ', '_' ), '', $field->get_attribute( 'label' ) ) );
+
+			// If value is not a string, we already know it's not a valid name or email.
+			if ( ! is_string( $field->value ) ) {
+				continue;
+			}
+
 			$value = trim( $field->value );
 
 			if ( ( $id === 'email' || $label === 'email' ) && ! empty( $value ) ) {

--- a/projects/plugins/jetpack/changelog/fix-forms-mailpoet-string-error
+++ b/projects/plugins/jetpack/changelog/fix-forms-mailpoet-string-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: Fix MailPoet string warning.


### PR DESCRIPTION
## Proposed changes:

We've have a periodic PHP error generated in the MailPoet_Integration class when trying to apply trim() to a non-string value. The relevant code iterates over form fields and obtains field id / label / value to try to match for emails and names. But we were not checking for field value type before applying trim. So if a form has a multiple choice field or any other field without a string value, it will error. 

To fix, I added a simple check for string. If it's not a string, we already know it's not a valid value for name/email, so we can skip. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None. 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

You can see the error by enabling the debug log on your test site; adding a form with MailPoet integration enabled; and including a multiple choice field on the form. That will generate a non-string field value. Submitting will throw an error in your debug log. 

Test that on trunk to confirm. Then test with this branch to confirm the fix. 

