### PR TITLE
Backport starter-plugin 0.8.0 Changes

### DIFF
--- a/projects/plugins/starter-plugin/CHANGELOG.md
+++ b/projects/plugins/starter-plugin/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.8.0 - 2025-09-09
+### Added
+- Added typecheck support for E2E tests. [#44788]
+- My Jetpack: Added analytics for empty product search results. [#44344]
+
+### Changed
+- Improve performance of WordPress.com comment likes by caching and minimizing API requests. [#44205]
+- My Jetpack: Enable access to My Jetpack on WP Multisite. [#44260]
+- My Jetpack: Fix multisite availability check for restricted products and modules. [#44710]
+- My Jetpack: Unify the user connection flow with a unified screen. [#44469]
+- My Jetpack: Update Stats card to include a chart for better analytics. [#43870]
+- Remove CRM installation nudge for Complete plan users. [#45026]
+- Sync: Ignore the ActivityPub Outbox CPT. [#44222]
+- Update package dependencies. [#44020] [#44148] [#44151] [#44206] [#44217] [#44356] [#44677] [#44701] [#44725] [#45027] [#45096] [#45097]
+
+### Fixed
+- JITM: Fix ineffective caching due to expired plugin sync transient [#44117]
+- JITM: Remove jQuery dependency. [#43783]
+- My Jetpack: Fix footer alignment for disconnected accounts. [#44468]
+- My Jetpack: Prevent expiration alerts for products covered by active bundles. [#44586]
+- My Jetpack: Restore plan purchase link. [#44535]
+
 ## 0.7.1 - 2025-06-18
 ### Changed
 - Update package dependencies. [#43839]

--- a/projects/plugins/starter-plugin/changelog/2025-07-08-14-34-04-300384
+++ b/projects/plugins/starter-plugin/changelog/2025-07-08-14-34-04-300384
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/add-myjp-208-empty-search-analytics
+++ b/projects/plugins/starter-plugin/changelog/add-myjp-208-empty-search-analytics
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-My Jetpack: Added analytics for empty product search results.

--- a/projects/plugins/starter-plugin/changelog/add-sync-activity-pub-cpt
+++ b/projects/plugins/starter-plugin/changelog/add-sync-activity-pub-cpt
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Sync: Ignore the ActivityPub Outbox CPT

--- a/projects/plugins/starter-plugin/changelog/add-typecheck-for-e2e-tests
+++ b/projects/plugins/starter-plugin/changelog/add-typecheck-for-e2e-tests
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Added typecheck support for E2E tests.

--- a/projects/plugins/starter-plugin/changelog/e2e-add-global-projects
+++ b/projects/plugins/starter-plugin/changelog/e2e-add-global-projects
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: E2E tests improvements
-
-

--- a/projects/plugins/starter-plugin/changelog/e2e-add-tsconfigs-for-e2e-tests
+++ b/projects/plugins/starter-plugin/changelog/e2e-add-tsconfigs-for-e2e-tests
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: E2E tests: add tsconfigs for e2e tests
-
-

--- a/projects/plugins/starter-plugin/changelog/e2e-clean-up-helpers-and-utils
+++ b/projects/plugins/starter-plugin/changelog/e2e-clean-up-helpers-and-utils
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: E2E tests: clean up unused helpers and utils
-
-

--- a/projects/plugins/starter-plugin/changelog/e2e-jetpack-711-e2e-improvements-update-pluginsstarter-plugin-e2e-tests
+++ b/projects/plugins/starter-plugin/changelog/e2e-jetpack-711-e2e-improvements-update-pluginsstarter-plugin-e2e-tests
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: E2E tests: updated the template test structure and removed use of pages
-
-

--- a/projects/plugins/starter-plugin/changelog/e2e-test-setup-tweaks
+++ b/projects/plugins/starter-plugin/changelog/e2e-test-setup-tweaks
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: E2E tests tweaks: removed redundant setup steps
-
-

--- a/projects/plugins/starter-plugin/changelog/fix-MYJP-245-expired-plan-w-complete
+++ b/projects/plugins/starter-plugin/changelog/fix-MYJP-245-expired-plan-w-complete
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-My Jetpack: Prevent expiration alerts for products covered by active bundles

--- a/projects/plugins/starter-plugin/changelog/fix-e2e-update_activation_slugs
+++ b/projects/plugins/starter-plugin/changelog/fix-e2e-update_activation_slugs
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: E2E: Fix regression after changing Docker plugin slugs.
-
-

--- a/projects/plugins/starter-plugin/changelog/fix-my-jetpack-multi-site
+++ b/projects/plugins/starter-plugin/changelog/fix-my-jetpack-multi-site
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-My Jetpack: Fixed multisite availability check for restricted products and modules

--- a/projects/plugins/starter-plugin/changelog/fix-my-jetpack-multisite-access
+++ b/projects/plugins/starter-plugin/changelog/fix-my-jetpack-multisite-access
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-My Jetpack: Enabled access to My Jetpack on WP Multisite.

--- a/projects/plugins/starter-plugin/changelog/fix-myjp-192-bg-colour-fixes
+++ b/projects/plugins/starter-plugin/changelog/fix-myjp-192-bg-colour-fixes
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: My Jetpack: Updating background colour.
-
-

--- a/projects/plugins/starter-plugin/changelog/fix-myjp-213-gradient-width
+++ b/projects/plugins/starter-plugin/changelog/fix-myjp-213-gradient-width
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: My Jetpack: Fixing gradient width for onboarding.
-
-

--- a/projects/plugins/starter-plugin/changelog/fix-phan-noopnew
+++ b/projects/plugins/starter-plugin/changelog/fix-phan-noopnew
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Phan: Clean up PhanNoopNew instances.
-

--- a/projects/plugins/starter-plugin/changelog/fix-unneeded-react-imports
+++ b/projects/plugins/starter-plugin/changelog/fix-unneeded-react-imports
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Replace `import React from 'react'` and the like with named imports. Should be no change to functionality.
-
-

--- a/projects/plugins/starter-plugin/changelog/prerelease
+++ b/projects/plugins/starter-plugin/changelog/prerelease
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/prerelease#10
+++ b/projects/plugins/starter-plugin/changelog/prerelease#10
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/prerelease#11
+++ b/projects/plugins/starter-plugin/changelog/prerelease#11
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/prerelease#12
+++ b/projects/plugins/starter-plugin/changelog/prerelease#12
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/prerelease#13
+++ b/projects/plugins/starter-plugin/changelog/prerelease#13
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/prerelease#14
+++ b/projects/plugins/starter-plugin/changelog/prerelease#14
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/prerelease#15
+++ b/projects/plugins/starter-plugin/changelog/prerelease#15
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/prerelease#16
+++ b/projects/plugins/starter-plugin/changelog/prerelease#16
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/prerelease#17
+++ b/projects/plugins/starter-plugin/changelog/prerelease#17
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/prerelease#18
+++ b/projects/plugins/starter-plugin/changelog/prerelease#18
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/prerelease#2
+++ b/projects/plugins/starter-plugin/changelog/prerelease#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/prerelease#3
+++ b/projects/plugins/starter-plugin/changelog/prerelease#3
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/prerelease#4
+++ b/projects/plugins/starter-plugin/changelog/prerelease#4
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/prerelease#5
+++ b/projects/plugins/starter-plugin/changelog/prerelease#5
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/prerelease#6
+++ b/projects/plugins/starter-plugin/changelog/prerelease#6
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/prerelease#7
+++ b/projects/plugins/starter-plugin/changelog/prerelease#7
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/prerelease#8
+++ b/projects/plugins/starter-plugin/changelog/prerelease#8
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/prerelease#9
+++ b/projects/plugins/starter-plugin/changelog/prerelease#9
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update composer.lock.
-
-

--- a/projects/plugins/starter-plugin/changelog/reish20250626-update-jitm-cache
+++ b/projects/plugins/starter-plugin/changelog/reish20250626-update-jitm-cache
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-JITM: Fix ineffective caching due to expired plugin sync transient

--- a/projects/plugins/starter-plugin/changelog/renovate-babel-monorepo
+++ b/projects/plugins/starter-plugin/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/plugins/starter-plugin/changelog/renovate-babel-monorepo#2
+++ b/projects/plugins/starter-plugin/changelog/renovate-babel-monorepo#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/plugins/starter-plugin/changelog/renovate-js-unit-testing-packages
+++ b/projects/plugins/starter-plugin/changelog/renovate-js-unit-testing-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/plugins/starter-plugin/changelog/renovate-lock-file-maintenance
+++ b/projects/plugins/starter-plugin/changelog/renovate-lock-file-maintenance
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/plugins/starter-plugin/changelog/renovate-lock-file-maintenance#2
+++ b/projects/plugins/starter-plugin/changelog/renovate-lock-file-maintenance#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/plugins/starter-plugin/changelog/renovate-lock-file-maintenance#3
+++ b/projects/plugins/starter-plugin/changelog/renovate-lock-file-maintenance#3
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/plugins/starter-plugin/changelog/renovate-typescript-5.x
+++ b/projects/plugins/starter-plugin/changelog/renovate-typescript-5.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/plugins/starter-plugin/changelog/renovate-wordpress-monorepo
+++ b/projects/plugins/starter-plugin/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/plugins/starter-plugin/changelog/renovate-wordpress-monorepo#2
+++ b/projects/plugins/starter-plugin/changelog/renovate-wordpress-monorepo#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/plugins/starter-plugin/changelog/renovate-wordpress-monorepo#3
+++ b/projects/plugins/starter-plugin/changelog/renovate-wordpress-monorepo#3
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/plugins/starter-plugin/changelog/renovate-wordpress-monorepo#4
+++ b/projects/plugins/starter-plugin/changelog/renovate-wordpress-monorepo#4
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/plugins/starter-plugin/changelog/renovate-wordpress-monorepo2
+++ b/projects/plugins/starter-plugin/changelog/renovate-wordpress-monorepo2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/plugins/starter-plugin/changelog/try-eslint-package-json-files
+++ b/projects/plugins/starter-plugin/changelog/try-eslint-package-json-files
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove unnecessary (and not really correct) fields in tests/e2e/package.json.
-
-

--- a/projects/plugins/starter-plugin/changelog/try-eslint-package-json-files#2
+++ b/projects/plugins/starter-plugin/changelog/try-eslint-package-json-files#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Sort and clean up package.json. Should be no change to functionality.
-
-

--- a/projects/plugins/starter-plugin/changelog/update-MYJP-239-footer-css
+++ b/projects/plugins/starter-plugin/changelog/update-MYJP-239-footer-css
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-My Jetpack: Fixing footer alignment for diconnected accounts.

--- a/projects/plugins/starter-plugin/changelog/update-MYJP-243-restore-plan-link
+++ b/projects/plugins/starter-plugin/changelog/update-MYJP-243-restore-plan-link
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-My Jetpack: Restoring plan purchase link.

--- a/projects/plugins/starter-plugin/changelog/update-do-not-force-install-crm-on-complete
+++ b/projects/plugins/starter-plugin/changelog/update-do-not-force-install-crm-on-complete
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Do not force CRM installation for Complete plan users

--- a/projects/plugins/starter-plugin/changelog/update-jetpack-mu-wpcom-improve-comments-performance
+++ b/projects/plugins/starter-plugin/changelog/update-jetpack-mu-wpcom-improve-comments-performance
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Improves performance of wpcom comments liking by caching and minimizing API requests.

--- a/projects/plugins/starter-plugin/changelog/update-jitms-remove-jquery
+++ b/projects/plugins/starter-plugin/changelog/update-jitms-remove-jquery
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Update JITMs to remove jQuery dependency

--- a/projects/plugins/starter-plugin/changelog/update-my-jetpack-unify-user-connection-screen
+++ b/projects/plugins/starter-plugin/changelog/update-my-jetpack-unify-user-connection-screen
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-My Jetpack: Unify the user connection flow with a unified screen.

--- a/projects/plugins/starter-plugin/changelog/update-myjetpack-myjp-149-onboarding-i4-stats-chart
+++ b/projects/plugins/starter-plugin/changelog/update-myjetpack-myjp-149-onboarding-i4-stats-chart
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-My Jetpack: Updating Stats card to include a chart for better analytics.

--- a/projects/plugins/starter-plugin/changelog/update-stylelint-enable_spacing_rules
+++ b/projects/plugins/starter-plugin/changelog/update-stylelint-enable_spacing_rules
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Stylelint: Fix spacing rules.
-
-

--- a/projects/plugins/starter-plugin/changelog/update-stylelint-fix_newline_rules
+++ b/projects/plugins/starter-plugin/changelog/update-stylelint-fix_newline_rules
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Stylelint: Enable newline rules.
-
-

--- a/projects/plugins/starter-plugin/changelog/update-stylelint-update_remaining_rules
+++ b/projects/plugins/starter-plugin/changelog/update-stylelint-update_remaining_rules
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Stylelint: Address remaining stylistic rules.
-
-

--- a/projects/plugins/starter-plugin/changelog/update-wordads-deprecate_package
+++ b/projects/plugins/starter-plugin/changelog/update-wordads-deprecate_package
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Update composer.lock file to remove reference to automattic/jetpack-wordads
-
-

--- a/projects/plugins/starter-plugin/composer.json
+++ b/projects/plugins/starter-plugin/composer.json
@@ -69,6 +69,6 @@
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true
 		},
-		"autoloader-suffix": "c4802e05bbcf59fd3b6350e8d3e5482c_starter_pluginⓥ0_7_1"
+		"autoloader-suffix": "c4802e05bbcf59fd3b6350e8d3e5482c_starter_pluginⓥ0_8_0"
 	}
 }

--- a/projects/plugins/starter-plugin/jetpack-starter-plugin.php
+++ b/projects/plugins/starter-plugin/jetpack-starter-plugin.php
@@ -4,7 +4,7 @@
  * Plugin Name: Jetpack Starter Plugin
  * Plugin URI: https://wordpress.org/plugins/jetpack-starter-plugin
  * Description: plugin--description.
- * Version: 0.7.1
+ * Version: 0.8.0
  * Author: Automattic
  * Author URI: https://jetpack.com/
  * License: GPLv2 or later

--- a/projects/plugins/starter-plugin/readme.txt
+++ b/projects/plugins/starter-plugin/readme.txt
@@ -33,9 +33,27 @@ directory take precedence. For example, `/assets/screenshot-1.png` would win ove
 2. This is the second screen shot
 
 == Changelog ==
-### 0.7.1 - 2025-06-18
+### 0.8.0 - 2025-09-09
+#### Added
+- Added typecheck support for E2E tests.
+- My Jetpack: Added analytics for empty product search results.
+
 #### Changed
+- Improve performance of WordPress.com comment likes by caching and minimizing API requests.
+- My Jetpack: Enable access to My Jetpack on WP Multisite.
+- My Jetpack: Fix multisite availability check for restricted products and modules.
+- My Jetpack: Unify the user connection flow with a unified screen.
+- My Jetpack: Update Stats card to include a chart for better analytics.
+- Remove CRM installation nudge for Complete plan users.
+- Sync: Ignore the ActivityPub Outbox CPT.
 - Update package dependencies.
+
+#### Fixed
+- JITM: Fix ineffective caching due to expired plugin sync transient
+- JITM: Remove jQuery dependency.
+- My Jetpack: Fix footer alignment for disconnected accounts.
+- My Jetpack: Prevent expiration alerts for products covered by active bundles.
+- My Jetpack: Restore plan purchase link.
 
 == Arbitrary section ==
 


### PR DESCRIPTION
Closes MONOREP-108

 <!--- This template is used for backporting changes made during a plugin release back to trunk. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Backports changes for starter-plugin 0.8.0

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/a
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Proofread changes.