### PR TITLE
 Forms: Show option label on selected options for Image Select Field

### DIFF
--- a/projects/packages/forms/changelog/update-forms-image-select-label
+++ b/projects/packages/forms/changelog/update-forms-image-select-label
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Forms: Show option label on selected options for Image Select Field

--- a/projects/packages/forms/src/blocks/input-image-option/edit.tsx
+++ b/projects/packages/forms/src/blocks/input-image-option/edit.tsx
@@ -66,7 +66,6 @@ export default function ImageOptionInputEdit( props ) {
 
 	const {
 		'jetpack/field-image-select-is-supersized': isSupersized,
-		'jetpack/field-image-select-show-labels': showLabels,
 		'jetpack/field-image-options-type': selectionType = 'radio',
 	} = context || {};
 
@@ -82,12 +81,6 @@ export default function ImageOptionInputEdit( props ) {
 		} ),
 		style: blockStyle,
 	} );
-
-	const labelClassName = useMemo( () => {
-		return clsx( 'jetpack-input-image-option__label', {
-			'visually-hidden': ! showLabels,
-		} );
-	}, [ showLabels ] );
 
 	const template = useMemo( () => {
 		return [
@@ -117,7 +110,7 @@ export default function ImageOptionInputEdit( props ) {
 				<div className="jetpack-input-image-option__label-code">{ positionLetter }</div>
 				<RichText
 					tagName="span"
-					className={ labelClassName }
+					className="jetpack-input-image-option__label"
 					value={ label }
 					placeholder={ __( 'Add option…', 'jetpack-forms' ) }
 					__unstableDisableFormats

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -1976,9 +1976,11 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 
 				$option_value                = wp_json_encode(
 					array(
-						'perceived' => $perceived_letters[ $option_index ],
-						'selected'  => $option_letter,
-						'image'     => array(
+						'perceived'  => $perceived_letters[ $option_index ],
+						'selected'   => $option_letter,
+						'label'      => $option_label,
+						'showLabels' => $show_labels,
+						'image'      => array(
 							'id'  => $image_block['attrs']['id'] ?? null,
 							'src' => $image_src ?? null,
 						),

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -612,12 +612,15 @@ class Contact_Form extends Contact_Form_Shortcode {
 		// Initial data used to render the success message when the page is reloaded after a successful submission
 		// Don't show the feedback details unless the nonce matches
 		$submission_data = null;
+
 		if ( $is_reload_after_success && $is_reload_nonce_valid ) {
 			$response = Feedback::get( (int) $_GET['contact-form-sent'] );
+
 			if ( $response ) {
 				$submission_data = $response->get_compiled_fields( 'web', 'label|value' );
 			}
 		}
+
 		$formatted_submission_data = $submission_data ? self::format_submission_data( $submission_data ) : array();
 		$submission_success        = $form->is_response_without_reload_enabled && $is_reload_after_success;
 		$has_custom_redirect       = $form->has_custom_redirect();
@@ -936,9 +939,11 @@ class Contact_Form extends Contact_Form_Shortcode {
 	 */
 	private static function render_ajax_success_wrapper( $form, $submission_success = false, $formatted_submission_data = array() ) {
 		$classes = 'contact-form-submission contact-form-ajax-submission';
+
 		if ( $submission_success ) {
 			$classes .= ' submission-success';
 		}
+
 		$back_url = remove_query_arg( array( 'contact-form-id', 'contact-form-sent', '_wpnonce', 'contact-form-hash' ) );
 
 		$html  = '<div class="' . esc_attr( $classes ) . '" data-wp-class--submission-success="context.submissionSuccess">';
@@ -2478,7 +2483,13 @@ class Contact_Form extends Contact_Form_Shortcode {
 				', ',
 				array_map(
 					function ( $choice ) {
-						return $choice['perceived'];
+						$value = $choice['perceived'];
+
+						if ( $choice['showLabels'] && ! empty( $choice['label'] ) ) {
+							$value .= ' - ' . $choice['label'];
+						}
+
+						return $value;
 					},
 					$value['choices']
 				)

--- a/projects/packages/forms/src/contact-form/class-feedback-field.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-field.php
@@ -167,7 +167,13 @@ class Feedback_Field {
 				', ',
 				array_map(
 					function ( $choice ) {
-						return $choice['selected'];
+						$value = $choice['selected'];
+
+						if ( ! empty( $choice['label'] ) ) {
+							$value .= ' - ' . $choice['label'];
+						}
+
+						return $value;
 					},
 					$this->value['choices']
 				)
@@ -201,7 +207,13 @@ class Feedback_Field {
 
 			foreach ( $this->value['choices'] as $choice ) {
 				// On the email, we want to show the actual selected value, not the perceived value, as the options can be shuffled.
-				$choices[] = $choice['selected'];
+				$value = $choice['selected'];
+
+				if ( ! empty( $choice['label'] ) ) {
+					$value .= ' - ' . $choice['label'];
+
+				}
+				$choices[] = $value;
 			}
 
 			return implode( ', ', $choices );

--- a/projects/packages/forms/src/dashboard/inbox/response.js
+++ b/projects/packages/forms/src/dashboard/inbox/response.js
@@ -216,7 +216,17 @@ const InboxResponse = ( { response, loading, onModalStateChange } ) => {
 					{ ( value.choices?.length ?? 0 ) > 0 && (
 						<>
 							<div className="image-select-field-choices">
-								{ value.choices.map( choice => choice.selected ).join( ', ' ) }
+								{ value.choices
+									.map( choice => {
+										let transformedValue = choice.selected;
+
+										if ( choice.label != null && choice.label !== '' ) {
+											transformedValue += ' - ' + choice.label;
+										}
+
+										return transformedValue;
+									} )
+									.join( ', ' ) }
 							</div>
 							<div className="image-select-field-images">
 								{ value.choices.map( choice => {
@@ -238,6 +248,7 @@ const InboxResponse = ( { response, loading, onModalStateChange } ) => {
 				</div>
 			);
 		}
+
 		if ( isFileUploadField( value ) ) {
 			return (
 				<div className="file-field">

--- a/projects/packages/forms/src/modules/form/view.js
+++ b/projects/packages/forms/src/modules/form/view.js
@@ -106,7 +106,17 @@ const maybeAddColonToLabel = label => {
 const maybeTransformValue = value => {
 	// For image select fields, we want to show the perceived values, as the choices can be shuffled.
 	if ( value?.type === 'image-select' ) {
-		return value.choices.map( choice => choice.perceived ).join( ', ' );
+		return value.choices
+			.map( choice => {
+				let transformedValue = choice.perceived;
+
+				if ( choice.showLabels && choice.label != null && choice.label !== '' ) {
+					transformedValue += ' - ' + choice.label;
+				}
+
+				return transformedValue;
+			} )
+			.join( ', ' );
 	}
 
 	// For file upload fields, we want to show the file name and size


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of FORMS-60

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Always display the label in the editor, hiding it only in the frontend
* Concatenates the option label to its letter if the label is defined, hiding it on post-submission if showLabels is false

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Enable the forms_alpha flag and add an image select field in the block editor
* Publish it
* Check that the label is displayed after the letter in the post-submission screen, email, dashboard and export
* Disable "Show Labels" and update the post
* Check that the labels are omitted in the frontend
* Submit again
* Check that the labels are omitted in the post-submission screen
* Reload the page
* Check that the labels are still omitted
* Check that the email, dashboard and export views do have the label

<img width="491" height="744" alt="Screenshot from 2025-09-09 21-59-13" src="https://github.com/user-attachments/assets/05d87283-fa54-4c8f-99e8-ee0d62ab9d04" />
