### PR TITLE
Forms: Add supported integrations filter

### DIFF
--- a/projects/packages/forms/changelog/update-forms-supported-integrations-filter
+++ b/projects/packages/forms/changelog/update-forms-supported-integrations-filter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: Improve supported integrations filter.

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -809,6 +809,7 @@ class Contact_Form_Block {
 	 */
 	public static function preload_endpoints( $paths ) {
 		$paths[] = array( '/wp/v2/feedback/config', 'GET' );
+		$paths[] = array( '/wp/v2/feedback/integrations?version=2', 'GET' );
 		return $paths;
 	}
 

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/index.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/index.tsx
@@ -46,6 +46,17 @@ const IntegrationsModal = ( {
 
 	const isMailPoetEnabled = Boolean( config?.isMailPoetEnabled );
 
+	const findIntegrationById = ( id: string ) =>
+		integrationsData?.find( ( integration: Integration ) => integration.id === id );
+
+	// Cache lookups for readability and to avoid repeated finds
+	const akismetData = findIntegrationById( 'akismet' );
+	const googleDriveData = findIntegrationById( 'google-drive' );
+	const crmData = findIntegrationById( 'zero-bs-crm' );
+	const mailpoetData = findIntegrationById( 'mailpoet' );
+	const salesforceData = findIntegrationById( 'salesforce' );
+	const creativeMailData = findIntegrationById( 'creative-mail-by-constant-contact' );
+
 	const toggleCard = ( cardId: string ) => {
 		setExpandedCards( prev => {
 			const isExpanding = ! prev[ cardId ];
@@ -64,8 +75,7 @@ const IntegrationsModal = ( {
 		} );
 	};
 
-	const findIntegrationById = ( id: string ) =>
-		integrationsData?.find( ( integration: Integration ) => integration.id === id );
+	// findIntegrationById defined above
 
 	return (
 		<Modal
@@ -75,51 +85,61 @@ const IntegrationsModal = ( {
 			className="jetpack-forms-integrations-modal"
 		>
 			<VStack spacing="4">
-				<AkismetCard
-					isExpanded={ expandedCards.akismet }
-					onToggle={ () => toggleCard( 'akismet' ) }
-					data={ findIntegrationById( 'akismet' ) }
-					refreshStatus={ refreshIntegrations }
-				/>
-				<GoogleSheetsCard
-					isExpanded={ expandedCards.googleSheets }
-					onToggle={ () => toggleCard( 'googleSheets' ) }
-					data={ findIntegrationById( 'google-drive' ) }
-					refreshStatus={ refreshIntegrations }
-				/>
-				<JetpackCRMCard
-					isExpanded={ expandedCards.crm }
-					onToggle={ () => toggleCard( 'crm' ) }
-					jetpackCRM={ attributes.jetpackCRM }
-					setAttributes={ setAttributes }
-					data={ findIntegrationById( 'zero-bs-crm' ) }
-					refreshStatus={ refreshIntegrations }
-				/>
-				{ isMailPoetEnabled && (
+				{ akismetData && (
+					<AkismetCard
+						isExpanded={ expandedCards.akismet }
+						onToggle={ () => toggleCard( 'akismet' ) }
+						data={ akismetData }
+						refreshStatus={ refreshIntegrations }
+					/>
+				) }
+				{ googleDriveData && (
+					<GoogleSheetsCard
+						isExpanded={ expandedCards.googleSheets }
+						onToggle={ () => toggleCard( 'googleSheets' ) }
+						data={ googleDriveData }
+						refreshStatus={ refreshIntegrations }
+					/>
+				) }
+				{ crmData && (
+					<JetpackCRMCard
+						isExpanded={ expandedCards.crm }
+						onToggle={ () => toggleCard( 'crm' ) }
+						jetpackCRM={ attributes.jetpackCRM }
+						setAttributes={ setAttributes }
+						data={ crmData }
+						refreshStatus={ refreshIntegrations }
+					/>
+				) }
+				{ isMailPoetEnabled && mailpoetData && (
 					<MailPoetCard
 						isExpanded={ expandedCards.mailpoet }
 						onToggle={ () => toggleCard( 'mailpoet' ) }
-						data={ findIntegrationById( 'mailpoet' ) }
+						data={ mailpoetData }
 						refreshStatus={ refreshIntegrations }
 						mailpoet={ attributes.mailpoet }
 						setAttributes={ setAttributes }
 					/>
 				) }
-				<SalesforceCard
-					isExpanded={ expandedCards.salesforce }
-					onToggle={ () => toggleCard( 'salesforce' ) }
-					data={ findIntegrationById( 'salesforce' ) }
-					refreshStatus={ refreshIntegrations }
-					salesforceData={ attributes.salesforceData }
-					setAttributes={ setAttributes }
-				/>
-				<CreativeMailCard
-					isExpanded={ expandedCards.creativemail }
-					onToggle={ () => toggleCard( 'creativemail' ) }
-					data={ findIntegrationById( 'creative-mail-by-constant-contact' ) }
-					refreshStatus={ refreshIntegrations }
-					borderBottom={ false }
-				/>
+				{ salesforceData && (
+					<SalesforceCard
+						isExpanded={ expandedCards.salesforce }
+						onToggle={ () => toggleCard( 'salesforce' ) }
+						data={ salesforceData }
+						refreshStatus={ refreshIntegrations }
+						salesforceData={ attributes.salesforceData }
+						setAttributes={ setAttributes }
+					/>
+				) }
+				{ creativeMailData && (
+					<CreativeMailCard
+						isExpanded={ expandedCards.creativemail }
+						onToggle={ () => toggleCard( 'creativemail' ) }
+						data={ creativeMailData }
+						refreshStatus={ refreshIntegrations }
+						borderBottom={ false }
+					/>
+				) }
 			</VStack>
 		</Modal>
 	);

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/index.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/index.tsx
@@ -8,7 +8,6 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import useFormsConfig from '../../../../hooks/use-forms-config';
 import AkismetCard from './akismet-card';
 import CreativeMailCard from './creative-mail-card';
 import GoogleSheetsCard from './google-sheets-card';
@@ -38,18 +37,14 @@ const IntegrationsModal = ( {
 		mailpoet: false,
 	} );
 
-	const config = useFormsConfig();
-
 	if ( ! isOpen ) {
 		return null;
 	}
 
-	const isMailPoetEnabled = Boolean( config?.isMailPoetEnabled );
-
 	const findIntegrationById = ( id: string ) =>
 		integrationsData?.find( ( integration: Integration ) => integration.id === id );
 
-	// Cache lookups for readability and to avoid repeated finds
+	// Only supported integrations will be returned from endpoint.
 	const akismetData = findIntegrationById( 'akismet' );
 	const googleDriveData = findIntegrationById( 'google-drive' );
 	const crmData = findIntegrationById( 'zero-bs-crm' );
@@ -74,8 +69,6 @@ const IntegrationsModal = ( {
 			};
 		} );
 	};
-
-	// findIntegrationById defined above
 
 	return (
 		<Modal
@@ -111,7 +104,7 @@ const IntegrationsModal = ( {
 						refreshStatus={ refreshIntegrations }
 					/>
 				) }
-				{ isMailPoetEnabled && mailpoetData && (
+				{ mailpoetData && (
 					<MailPoetCard
 						isExpanded={ expandedCards.mailpoet }
 						onToggle={ () => toggleCard( 'mailpoet' ) }

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/style.scss
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/style.scss
@@ -1,3 +1,7 @@
 .jetpack-forms-integrations-modal .components-modal__header-heading {
 	font-weight: 400;
 }
+
+.jp-forms__integrations-body > div:last-of-type {
+	border-bottom: none;
+}

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -92,6 +92,23 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 	 * @return array Filtered list of supported integrations
 	 */
 	private function get_supported_integrations() {
+		/**
+		 * Filters the list of supported integrations available in Jetpack Forms.
+		 *
+		 * Use this filter to add, modify, or remove integrations. Removing an
+		 * integration here will prevent it from being returned by the REST
+		 * integrations endpoints and from being displayed in the UI.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param array $supported_integrations Associative array of integration
+		 *                                     configurations keyed by slug. Each
+		 *                                     configuration supports the following keys:
+		 *                                     - type (string)                  : 'plugin' or 'service'.
+		 *                                     - file (string|null)             : Plugin file path for plugins; null for services.
+		 *                                     - settings_url (string|null)     : Relative admin URL for settings, or null.
+		 *                                     - marketing_redirect_slug (string|null) : Redirect slug for marketing links, or null.
+		 */
 		return apply_filters( 'jetpack_forms_supported_integrations', $this->supported_integrations );
 	}
 

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -112,8 +112,11 @@ class Dashboard {
 		// Adds Connection package initial state.
 		Connection_Initial_State::render_script( self::SCRIPT_HANDLE );
 
-		// Preload Forms config endpoint for dashboard context.
-		$preload_paths = array( '/wp/v2/feedback/config' );
+		// Preload Forms endpoints needed in dashboard context.
+		$preload_paths = array(
+			'/wp/v2/feedback/config',
+			'/wp/v2/feedback/integrations?version=2',
+		);
 		$preload_data  = array_reduce( $preload_paths, 'rest_preload_api_request', array() );
 		wp_add_inline_script(
 			self::SCRIPT_HANDLE,

--- a/projects/packages/forms/src/dashboard/integrations/index.tsx
+++ b/projects/packages/forms/src/dashboard/integrations/index.tsx
@@ -8,7 +8,6 @@ import { useState, useCallback } from 'react';
  * Internal dependencies
  */
 import { useIntegrationsStatus } from '../../blocks/contact-form/components/jetpack-integrations-modal/hooks/use-integrations-status';
-import useFormsConfig from '../../hooks/use-forms-config';
 import AkismetDashboardCard from './akismet-card';
 import CreativeMailDashboardCard from './creative-mail-card';
 import GoogleSheetsDashboardCard from './google-sheets-card';
@@ -31,9 +30,6 @@ const Integrations = () => {
 		salesforce: false,
 		mailpoet: false,
 	} );
-
-	const config = useFormsConfig();
-	const isMailpoetEnabled = Boolean( config?.isMailPoetEnabled );
 
 	const toggleCard = useCallback( ( cardId: keyof typeof expandedCards ) => {
 		setExpandedCards( prev => {
@@ -69,7 +65,7 @@ const Integrations = () => {
 	const findIntegrationById = ( id: string ) =>
 		integrations?.find( ( integration: Integration ) => integration.id === id );
 
-	// Cache lookups per integration; cards render only when data exists
+	// Only supported integrations will be returned from endpoint.
 	const akismetData = findIntegrationById( 'akismet' );
 	const googleDriveData = findIntegrationById( 'google-drive' );
 	const crmData = findIntegrationById( 'zero-bs-crm' );
@@ -116,7 +112,7 @@ const Integrations = () => {
 							refreshStatus={ refreshIntegrations }
 						/>
 					) }
-					{ isMailpoetEnabled && mailpoetData && (
+					{ mailpoetData && (
 						<MailPoetDashboardCard
 							isExpanded={ expandedCards.mailpoet }
 							onToggle={ handleToggleMailPoet }

--- a/projects/packages/forms/src/dashboard/integrations/index.tsx
+++ b/projects/packages/forms/src/dashboard/integrations/index.tsx
@@ -69,6 +69,14 @@ const Integrations = () => {
 	const findIntegrationById = ( id: string ) =>
 		integrations?.find( ( integration: Integration ) => integration.id === id );
 
+	// Cache lookups per integration; cards render only when data exists
+	const akismetData = findIntegrationById( 'akismet' );
+	const googleDriveData = findIntegrationById( 'google-drive' );
+	const crmData = findIntegrationById( 'zero-bs-crm' );
+	const mailpoetData = findIntegrationById( 'mailpoet' );
+	const salesforceData = findIntegrationById( 'salesforce' );
+	const creativeMailData = findIntegrationById( 'creative-mail-by-constant-contact' );
+
 	return (
 		<div className="jp-forms__integrations">
 			<div className="jp-forms__integrations-wrapper">
@@ -84,45 +92,55 @@ const Integrations = () => {
 					</div>
 				</div>
 				<div className="jp-forms__integrations-body">
-					<AkismetDashboardCard
-						isExpanded={ expandedCards.akismet }
-						onToggle={ handleToggleAkismet }
-						data={ findIntegrationById( 'akismet' ) }
-						refreshStatus={ refreshIntegrations }
-					/>
-					<GoogleSheetsDashboardCard
-						isExpanded={ expandedCards.googleSheets }
-						onToggle={ handleToggleGoogleSheets }
-						data={ findIntegrationById( 'google-drive' ) }
-						refreshStatus={ refreshIntegrations }
-					/>
-					<JetpackCRMDashboardCard
-						isExpanded={ expandedCards.crm }
-						onToggle={ handleToggleCRM }
-						data={ findIntegrationById( 'zero-bs-crm' ) }
-						refreshStatus={ refreshIntegrations }
-					/>
-					{ isMailpoetEnabled && (
-						<MailPoetDashboardCard
-							isExpanded={ expandedCards.mailpoet }
-							onToggle={ handleToggleMailPoet }
-							data={ findIntegrationById( 'mailpoet' ) }
+					{ akismetData && (
+						<AkismetDashboardCard
+							isExpanded={ expandedCards.akismet }
+							onToggle={ handleToggleAkismet }
+							data={ akismetData }
 							refreshStatus={ refreshIntegrations }
 						/>
 					) }
-					<SalesforceDashboardCard
-						isExpanded={ expandedCards.salesforce }
-						onToggle={ handleToggleSalesforce }
-						data={ findIntegrationById( 'salesforce' ) }
-						refreshStatus={ refreshIntegrations }
-					/>
-					<CreativeMailDashboardCard
-						isExpanded={ expandedCards.creativemail }
-						onToggle={ handleToggleCreativeMail }
-						data={ findIntegrationById( 'creative-mail-by-constant-contact' ) }
-						refreshStatus={ refreshIntegrations }
-						borderBottom={ false }
-					/>
+					{ googleDriveData && (
+						<GoogleSheetsDashboardCard
+							isExpanded={ expandedCards.googleSheets }
+							onToggle={ handleToggleGoogleSheets }
+							data={ googleDriveData }
+							refreshStatus={ refreshIntegrations }
+						/>
+					) }
+					{ crmData && (
+						<JetpackCRMDashboardCard
+							isExpanded={ expandedCards.crm }
+							onToggle={ handleToggleCRM }
+							data={ crmData }
+							refreshStatus={ refreshIntegrations }
+						/>
+					) }
+					{ isMailpoetEnabled && mailpoetData && (
+						<MailPoetDashboardCard
+							isExpanded={ expandedCards.mailpoet }
+							onToggle={ handleToggleMailPoet }
+							data={ mailpoetData }
+							refreshStatus={ refreshIntegrations }
+						/>
+					) }
+					{ salesforceData && (
+						<SalesforceDashboardCard
+							isExpanded={ expandedCards.salesforce }
+							onToggle={ handleToggleSalesforce }
+							data={ salesforceData }
+							refreshStatus={ refreshIntegrations }
+						/>
+					) }
+					{ creativeMailData && (
+						<CreativeMailDashboardCard
+							isExpanded={ expandedCards.creativemail }
+							onToggle={ handleToggleCreativeMail }
+							data={ creativeMailData }
+							refreshStatus={ refreshIntegrations }
+							borderBottom={ false }
+						/>
+					) }
 				</div>
 			</div>
 		</div>

--- a/projects/packages/forms/src/dashboard/integrations/style.scss
+++ b/projects/packages/forms/src/dashboard/integrations/style.scss
@@ -30,6 +30,10 @@
 		border-radius: 8px;
 		padding: 12px 24px;
 
+		> div:last-of-type {
+			border-bottom: none;
+		}
+
 		@media ( max-width: 782px ) {
 			padding: 12px 8px;
 		}

--- a/projects/plugins/jetpack/changelog/update-forms-supported-integrations-filter
+++ b/projects/plugins/jetpack/changelog/update-forms-supported-integrations-filter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: Improve supported integrations filter.


### PR DESCRIPTION
Partially addresses [FORMS-266](https://linear.app/a8c/issue/FORMS-266/forms-allow-hiding-and-modifying-integrations-programmatically)

## Proposed changes:

We want to let developers turn specific integrations on or off via filter. We have a `jetpack_forms_supported_integrations` filter that takes in and returns an array of supported integrations, each with base settings. But we weren't leveraging this filter in our code. This PR leverages this filter to hide/show integrations. 

Specific changes:
* Adds documentation for the existing filter
* Uses the filtered data on the frontend to hide/show specific integrations
* Preloads the integrations endpoint (we added [preloading here](https://github.com/Automattic/jetpack/pull/45091)) to avoid jumpiness now that individual integration cards are conditional

Example: here's how the filter would be used to hide the Salesforce integration. 

```
add_filter( 'jetpack_forms_supported_integrations', function ( $integrations ) {
	unset( $integrations['salesforce'] ); // Remove sales force from the array of supported integrations
	return $integrations; // Return all the rest
} );
```

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
While this is a general improvement, it's also part of our preparation for CIAB. [See linear issue.](https://linear.app/a8c/issue/FORMS-266/forms-allow-hiding-and-modifying-integrations-programmatically) 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Test the filter by trying to hide specific integrations. Add the following to a plugin or theme functions.php file. You can uncomment any integration you want to hide. Then check the list of integration cards in the dashboard and block modal to confirm hiddent integrations do not show. 

```
add_filter( 'jetpack_forms_supported_integrations', function ( $integrations ) {
	// unset( $integrations['akismet'] );                           // Hide Akismet
	// unset( $integrations['creative-mail-by-constant-contact'] ); // Hide Creative Mail
	// unset( $integrations['zero-bs-crm'] );                       // Hide Jetpack CRM
	// unset( $integrations['salesforce'] );                        // Hide Salesforce
	// unset( $integrations['google-drive'] );                      // Hide Google Drive
	// unset( $integrations['mailpoet'] );                          // Hide MailPoet

	return $integrations;
} );
```

 

