### PR TITLE
Admin Menu: Fix duplicate Jetpack submenus

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/dotcom-14506-duplicated-jetpack-submenus-if-site-url-contains-the-name-of
+++ b/projects/packages/jetpack-mu-wpcom/changelog/dotcom-14506-duplicated-jetpack-submenus-if-site-url-contains-the-name-of
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Admin Menu: Fix duplicate Jetpack submenus

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
@@ -193,12 +193,14 @@ function wpcom_reorder_submenu( $menu_slug, $desired_order ) {
 		return;
 	}
 
+	$domain          = wp_parse_url( home_url(), PHP_URL_HOST );
 	$ordered_submenu = array();
 
 	// Re-add submenu items in the desired order.
 	foreach ( $desired_order as $submenu_slug ) {
 		foreach ( $submenu[ $menu_slug ] as $item ) {
-			if ( str_contains( $item[2], $submenu_slug ) ) {
+			$clean_url = str_replace( $domain, '', $item[2] );
+			if ( str_contains( $clean_url, $submenu_slug ) ) {
 				$ordered_submenu[] = $item;
 			}
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes DOTCOM-14506

## Proposed changes:

Ensures that, when reordering the submenus, the site URL is ignored when checking if the submenu URL matches a given slug. This way, if a site has a URL that contains the slug of a Jetpack module, it won't be duplicated.

Before | After
--- | ---
<img width="200" alt="Screenshot 2025-09-10 at 13 35 58" src="https://github.com/user-attachments/assets/cfff67b7-ebc3-4de0-8945-7796b2d72766" /> | <img width="200" alt="Screenshot 2025-09-10 at 14 02 19" src="https://github.com/user-attachments/assets/661fd27a-166d-4957-b925-1365b2d3282b" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
- Apply these changes to your WP.com sandbox
- Sandbox a site whose URL contains the slug of a Jetpack module (my-jetpack, stats, forms, newsletter, etc).
  - Example: `formsresearch.wordpress.com`
- Visit /wp-admin 
- Check the Jetpack submenu
- Make sure items are not duplicated

