### PR TITLE
Jetpack Sync: Stop triggering 'jetpack_wp_login' actions with empty user ID

### DIFF
--- a/projects/packages/sync/changelog/update-sync-wp_login-stricter-checks
+++ b/projects/packages/sync/changelog/update-sync-wp_login-stricter-checks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Jetpack Sync: Stop triggering 'jetpack_wp_login' actions with empty user ID

--- a/projects/packages/sync/src/modules/class-users.php
+++ b/projects/packages/sync/src/modules/class-users.php
@@ -362,7 +362,7 @@ class Users extends Module {
 	 * @param \WP_User $user       The user object.
 	 */
 	public function wp_login_handler( $user_login, $user = null ) {
-		if ( ! $user instanceof \WP_User ) {
+		if ( ! $user instanceof \WP_User || empty( $user->ID ) ) {
 			return;
 		}
 

--- a/projects/plugins/jetpack/changelog/update-sync-wp_login-stricter-checks
+++ b/projects/plugins/jetpack/changelog/update-sync-wp_login-stricter-checks
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Add Sync unit test
+
+

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Users_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Users_Test.php
@@ -473,6 +473,17 @@ class Jetpack_Sync_Users_Test extends Jetpack_Sync_TestBase {
 		$this->assertFalse( isset( $user_data_sent_to_server->data->user_pass ) );
 	}
 
+	public function test_does_not_sync_user_authentication_attempts_with_empty_user() {
+		add_filter( 'pre_http_request', array( 'Jetpack_Sync_TestBase', 'pre_http_request_bruteprotect_api' ), 10, 3 );
+		do_action( 'wp_login', '', new WP_User() );
+		remove_filter( 'pre_http_request', array( 'Jetpack_Sync_TestBase', 'pre_http_request_bruteprotect_api' ) );
+
+		$this->sender->do_sync();
+
+		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_wp_login' );
+		$this->assertFalse( $event );
+	}
+
 	public function test_syncs_user_logout_event() {
 		$user_id = self::factory()->user->create( array( 'user_login' => 'foobar' ) );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Closes SYNC-56
Based on existing logs (see product discussion), we seem to send `jetpack_wp_login` actions to WPCOM with an empty user ID.
These actions are not processed anyways and are logged as having invalid data therefore there's no reason for Sync to send them.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* `Automattic\Jetpack\Sync\Modules\Users`: Update `wp_login_handler` with a stricter check to early return if the corresponding user ID is empty.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
- SYNC-56

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
- No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Code review should be sufficient here

