### PR TITLE
Shortcodes: fix a fatal caused by undefined dependencies function

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-shortcodes-dependencies-fatal
+++ b/projects/plugins/jetpack/changelog/fix-shortcodes-dependencies-fatal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Fix fatal caused by an undefined shortcode dependencies function.

--- a/projects/plugins/jetpack/modules/shortcodes.php
+++ b/projects/plugins/jetpack/modules/shortcodes.php
@@ -90,26 +90,6 @@ function jetpack_load_shortcodes() {
 }
 
 /**
- * Registering shortcode dependencies.
- * They are few and only needed for very few shortcodes, so we load them on-demand.
- *
- * @return void
- */
-function jetpack_shortcode_register_dependencies() {
-	if ( wp_script_is( 'jetpack-shortcode-deps', 'registered' ) ) {
-		return;
-	}
-
-	wp_register_script(
-		'jetpack-shortcode-deps',
-		plugins_url( '_inc/build/shortcodes/js/dependencies.min.js', JETPACK__PLUGIN_FILE ),
-		array( 'jquery' ),
-		'20250905',
-		true
-	);
-}
-
-/**
  * Runs preg_replace so that replacements don't happen within open tags.
  * Parameters are the same as preg_replace, with an added optional search param for improved performance
  *

--- a/projects/plugins/jetpack/modules/shortcodes/recipe.php
+++ b/projects/plugins/jetpack/modules/shortcodes/recipe.php
@@ -117,7 +117,13 @@ class Jetpack_Recipes {
 			return;
 		}
 
-		jetpack_shortcode_register_dependencies();
+		wp_register_script(
+			'jetpack-shortcode-deps',
+			plugins_url( '_inc/build/shortcodes/js/dependencies.min.js', JETPACK__PLUGIN_FILE ),
+			array( 'jquery' ),
+			'20250905',
+			true
+		);
 
 		wp_enqueue_script(
 			'jetpack-recipes-js',

--- a/projects/plugins/jetpack/modules/shortcodes/slideshow.php
+++ b/projects/plugins/jetpack/modules/shortcodes/slideshow.php
@@ -264,7 +264,13 @@ class Jetpack_Slideshow_Shortcode {
 	 */
 	public function enqueue_scripts() {
 
-		jetpack_shortcode_register_dependencies();
+		wp_register_script(
+			'jetpack-shortcode-deps',
+			plugins_url( '_inc/build/shortcodes/js/dependencies.min.js', JETPACK__PLUGIN_FILE ),
+			array( 'jquery' ),
+			'20250905',
+			true
+		);
 
 		wp_enqueue_script(
 			'jetpack-slideshow',


### PR DESCRIPTION
## Proposed changes:
Fix a fatal introduced in #45089

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1757510985417159-slack-C4N88L95W

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
1. Deploy the PR on WPCOM
2. Open the post editor, upload a few images to the post.
3. Add a shortcode block: `[slideshow][/slideshow]`
4. Add another shortcode block:
```
[recipe title="Pancakes" cooktime="5 minutes"]Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur?[/recipe]
```
5. Save the changes. Reload the editor, confirm it loads well.
6. Check the page in the frontend, confirm displays well with both the slideshow and the recipe blocks working fine.