### PR TITLE
Forms: add manual cache busting version

### DIFF
--- a/projects/packages/forms/changelog/add-forms-country-selector-cache-busting-suffix
+++ b/projects/packages/forms/changelog/add-forms-country-selector-cache-busting-suffix
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Forms: try and fix deploy cache issue by adding a manual suffix for cache busting

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -3142,6 +3142,10 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 	private function enqueue_phone_field_assets() {
 		$version = defined( 'JETPACK__VERSION' ) ? \JETPACK__VERSION : '0.1';
 
+		// TODO: remove this manual cache busting
+		// SEE: p1757517146878719-slack-C01U2KGS2PQ
+		$version .= '-jetpack-combobox-v1';
+
 		// combobox styles
 		\wp_enqueue_style(
 			'jetpack-form-combobox',


### PR DESCRIPTION
Fixes p1757517146878719-slack-C01U2KGS2PQ

## Proposed changes:
This PR adds a manual cache busting suffix.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1757517146878719-slack-C01U2KGS2PQ

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Insert a phone field and publish. Visit frontend and inspect the loaded `view.js` file. It should have a query string value such as `ver=XXX-jetpack-combobox-v1`