### PR TITLE
Forms: add extra layer of cache busting 

### DIFF
--- a/projects/packages/forms/changelog/add-forms-cache-busting-strategy
+++ b/projects/packages/forms/changelog/add-forms-cache-busting-strategy
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Forms: add extra layer of cache busting for interactivity API files (view.js) with hash suffix

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -3142,9 +3142,10 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 	private function enqueue_phone_field_assets() {
 		$version = defined( 'JETPACK__VERSION' ) ? \JETPACK__VERSION : '0.1';
 
-		// TODO: remove this manual cache busting
-		// SEE: p1757517146878719-slack-C01U2KGS2PQ
-		$version .= '-jetpack-combobox-v1';
+		// extra cache busting strategy for view.js, seems they are left out of cache clearing on deploys
+		$asset_file = plugin_dir_path( __FILE__ ) . '../../dist/modules/field-phone/view.asset.php';
+		$asset      = file_exists( $asset_file ) ? require $asset_file : null;
+		$version   .= $asset['version'] ?? '';
 
 		// combobox styles
 		\wp_enqueue_style(


### PR DESCRIPTION
Part of FORMS-287

## Proposed changes:
This PR uses the assets build file hash version as suffix for the JETPACK_VERSION, used as cache busting strategy.
As it seems, interactivity API files (view.js by consensus) cache is not busted on deploys, leading CDNs to deliver a cached version of the file in certain scenarios.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1757517146878719-slack-C01U2KGS2PQ
p1757514447194439-slack-C052XEUUBL4

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Insert a phone field and publish the post. Load the frontend and look for `view.js` on the network tab of the devtools. It should be loaded with a query param that looks like `ver=15.1-a.1b38107a9552284f53fbf` where `15.1-a.1` is the JETPACK_VERSION and the rest is the build hash.

