### PR TITLE
Bump print-this dependency to 1.16.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
 			"@swc/core",
 			"core-js",
 			"esbuild",
+			"print-this",
 			"svelte-preprocess",
 			"swiper",
 			"unrs-resolver"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4794,8 +4794,8 @@ importers:
         specifier: 12.1.11
         version: 12.1.11(postcss@8.4.47)
       print-this:
-        specifier: 1.9.0
-        version: 1.9.0
+        specifier: 1.16.0
+        version: 1.16.0
       prop-types:
         specifier: 15.8.1
         version: 15.8.1
@@ -13135,10 +13135,6 @@ packages:
   jquery-modal@0.9.2:
     resolution: {integrity: sha512-Bx6jTBuiUbdywriWd0UAZK9v7FKEDCOD5uRh47qd4coGvx+dG4w8cOGe4TG2OoR1dNrXn6Aqaeu8MAA+Oz7vOw==}
 
-  jquery@1.11.3:
-    resolution: {integrity: sha512-pHM/XLofp0FJc0/0AsRm8q/5ob+a1kno+vfclXGozaMBPv3qD7Xq19loECVcBB4MOLdygnyneQMPTsH5QiVNBQ==}
-    deprecated: This version is deprecated. Please upgrade to the latest version or find support at https://www.herodevs.com/support/jquery-nes.
-
   jquery@3.7.1:
     resolution: {integrity: sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==}
 
@@ -14038,6 +14034,10 @@ packages:
       zod:
         optional: true
 
+  opencollective-postinstall@2.0.3:
+    resolution: {integrity: sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==}
+    hasBin: true
+
   openurl@1.1.1:
     resolution: {integrity: sha512-d/gTkTb1i1GKz5k3XE3XFV/PxQ1k45zDqGP2OA7YhgsaLoqm6qRvARAZOFer1fcXritWlGBRCu/UgeS4HAnXAA==}
 
@@ -14708,8 +14708,8 @@ packages:
     resolution: {integrity: sha512-D1tKtYvByrBkFLe2wHJl2bwMJIiT8rW+XA+TiataH79/FszLQMrpGEvzUVkzPau7OCO0Qnrhpe87PqtOAIB8Yw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  print-this@1.9.0:
-    resolution: {integrity: sha512-XmFQbASfdd+vXvuSIxiux1dHEU6rXnCYFXzU8NEsf8IgV7p20guyzhcOlR1EjprWvNLP6nCRfvj1WV8ivq01Vg==}
+  print-this@1.16.0:
+    resolution: {integrity: sha512-8iBsqf0vyG6uqknuzcJs2+JbGADCgScvSQhETv/w1dR56M08gv4pH2DDcUJI9R1Web3YBYSaqixVrQ3ACjoIxA==}
 
   process-on-spawn@1.1.0:
     resolution: {integrity: sha512-JOnOPQ/8TZgjs1JIH/m9ni7FfimjNa/PRx7y/Wb5qdItsnhO0jE4AT7fC0HjC28DUQWDr50dwSYZLdRMlqDq3Q==}
@@ -27897,8 +27897,6 @@ snapshots:
 
   jquery-modal@0.9.2: {}
 
-  jquery@1.11.3: {}
-
   jquery@3.7.1: {}
 
   js-base64@3.7.8: {}
@@ -29026,6 +29024,8 @@ snapshots:
 
   openai@5.3.0: {}
 
+  opencollective-postinstall@2.0.3: {}
+
   openurl@1.1.1: {}
 
   optionator@0.9.4:
@@ -29705,9 +29705,10 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 18.3.1
 
-  print-this@1.9.0:
+  print-this@1.16.0:
     dependencies:
-      jquery: 1.11.3
+      jquery: 3.7.1
+      opencollective-postinstall: 2.0.3
 
   process-on-spawn@1.1.0:
     dependencies:

--- a/projects/plugins/jetpack/changelog/update-jetpack-bump_print-this-dep_to_1.16.0
+++ b/projects/plugins/jetpack/changelog/update-jetpack-bump_print-this-dep_to_1.16.0
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Bump print-this to 1.16.0

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -113,7 +113,7 @@
 		"nspell": "2.1.5",
 		"photon": "4.1.1",
 		"postcss-custom-properties": "12.1.11",
-		"print-this": "1.9.0",
+		"print-this": "1.16.0",
 		"prop-types": "15.8.1",
 		"react-redux": "7.2.8",
 		"react-router": "7.6.2",


### PR DESCRIPTION
Closes MONOREP-110

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

In #45089, the dependency was switched from being hard-coded to being an NPM dependency (yay!). However, the version in question uses a quite-old jQuery version; this bumps the print-this version from 1.9.0 to 1.16.0, which specifically allows newer jQuery versions as a subdependency.

Probably 2.0 would have been safe as well, but that changes defaults (jasonday/printThis#233) so I'm leaving that for another person or another day.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Add a shortcode block to a new post.
2. Use this as its content: `[recipe title="Pancakes à la Sergey" cooktime="5 minutes"]Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur?[/recipe]`
3. Save the post and view it.
5. Verify the Print button continues to work.