### PR TITLE
Forms: Fix mobile UI of Image Select field

### DIFF
--- a/projects/packages/forms/changelog/update-forms-image-select-mobile
+++ b/projects/packages/forms/changelog/update-forms-image-select-mobile
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Fix mobile UI of Image Select field

--- a/projects/packages/forms/src/blocks/field-image-select/edit.tsx
+++ b/projects/packages/forms/src/blocks/field-image-select/edit.tsx
@@ -94,7 +94,9 @@ export default function ImageSelectFieldEdit( props ) {
 
 			<BlockControls>
 				<ToolbarGroup>
-					<ToolbarButton onClick={ addOption }>{ __( 'Add', 'jetpack-forms' ) }</ToolbarButton>
+					<ToolbarButton onClick={ addOption }>
+						{ __( 'Add choice', 'jetpack-forms' ) }
+					</ToolbarButton>
 				</ToolbarGroup>
 			</BlockControls>
 

--- a/projects/packages/forms/src/blocks/field-image-select/editor.scss
+++ b/projects/packages/forms/src/blocks/field-image-select/editor.scss
@@ -1,3 +1,5 @@
+@use "style" as *;
+
 // Editor-only styles.
 
 // There is a high specificity flex rule for form fields
@@ -14,11 +16,8 @@
 // the styles directly to the input image option.
 .jetpack-input-image-option {
 	display: flex;
-	width: calc(( 1 / 4 ) * 100% - var(--jetpack-field-image-options-gap) * ( 3 / 4 ));
 
-	&.is-supersized {
-		width: calc(( 1 / 2 ) * 100% - var(--jetpack-field-image-options-gap) * ( 1 / 2 ));
-	}
+	@include image-select-responsive-width;
 }
 
 div.wp-block.jetpack-input-image-option.jetpack-field {

--- a/projects/packages/forms/src/blocks/field-image-select/style.scss
+++ b/projects/packages/forms/src/blocks/field-image-select/style.scss
@@ -1,4 +1,21 @@
+@use "@automattic/jetpack-base-styles/gutenberg-base-styles" as gb;
 @use "../shared/styles/visually-hidden" as *;
+
+@mixin image-select-responsive-width {
+	width: calc(( 1 / var(--row-options-count) ) * 100% - var(--jetpack-field-image-options-gap) * ( (var(--row-options-count) - 1) / var(--row-options-count) ));
+
+	// Mobile adjustments for number of options per row
+	@media (max-width: #{ (gb.$break-mobile) }) {
+
+		&.is-supersized {
+			--row-options-count: 1 !important;
+		}
+
+		&:not(.is-supersized):not([style*="--row-options-count: 1"]) {
+			--row-options-count: 2 !important;
+		}
+	}
+}
 
 // Themes target the image block directly to fit their needs,
 // not expecting it to be inside an image select field.
@@ -30,11 +47,8 @@ figure.wp-block-image {
 	// Frontend-only wrapper element for background color change on hover.
 	.jetpack-input-image-option__outer {
 		display: flex;
-		width: calc(( 1 / 4 ) * 100% - var(--jetpack-field-image-options-gap) * ( 3 / 4 ));
 
-		&.is-supersized {
-			width: calc(( 1 / 2 ) * 100% - var(--jetpack-field-image-options-gap) * ( 1 / 2 ));
-		}
+		@include image-select-responsive-width;
 
 		.jetpack-input-image-option {
 			width: 100%;

--- a/projects/packages/forms/src/blocks/field-image-select/style.scss
+++ b/projects/packages/forms/src/blocks/field-image-select/style.scss
@@ -62,9 +62,14 @@ figure.wp-block-image {
 		overflow: hidden;
 
 		&:not(.wp-block):hover,
+		&:not(.wp-block):focus-within,
 		&.is-checked {
 			backdrop-filter: contrast(0.9) saturate(1.2);
 			cursor: pointer;
+		}
+
+		&:not(.wp-block):focus-within {
+			outline: 2px solid var(--wp--preset--color--primary, var(--jetpack--contact-form--button-outline--background-color));
 		}
 
 		.jetpack-input-image-option__wrapper {

--- a/projects/packages/forms/src/blocks/field-image-select/style.scss
+++ b/projects/packages/forms/src/blocks/field-image-select/style.scss
@@ -101,7 +101,7 @@ figure.wp-block-image {
 					border: solid currentColor;
 					border-width: 0 2px 2px 0;
 					transform: translate(-50%, -60%) rotate(40deg);
-					filter: invert(1) contrast(2) brightness(1.5);
+					color: var(--jetpack-input-image-option--check-color, #000);
 				}
 			}
 

--- a/projects/packages/forms/src/blocks/fieldset-image-options/edit.tsx
+++ b/projects/packages/forms/src/blocks/fieldset-image-options/edit.tsx
@@ -84,7 +84,9 @@ export default function ImageOptionsFieldsetEdit( props ) {
 
 			<BlockControls>
 				<ToolbarGroup>
-					<ToolbarButton onClick={ addOption }>{ __( 'Add', 'jetpack-forms' ) }</ToolbarButton>
+					<ToolbarButton onClick={ addOption }>
+						{ __( 'Add choice', 'jetpack-forms' ) }
+					</ToolbarButton>
 				</ToolbarGroup>
 			</BlockControls>
 		</div>

--- a/projects/packages/forms/src/blocks/input-image-option/edit.tsx
+++ b/projects/packages/forms/src/blocks/input-image-option/edit.tsx
@@ -38,7 +38,12 @@ export default function ImageOptionInputEdit( props ) {
 
 	useSyncedAttributes( name, isSynced, SYNCED_ATTRIBUTE_KEYS, attributes, setAttributes );
 
-	const { isInnerBlockSelected, imageBlockAttributes, positionLetter } = useSelect(
+	const {
+		'jetpack/field-image-select-is-supersized': isSupersized,
+		'jetpack/field-image-options-type': selectionType = 'radio',
+	} = context || {};
+
+	const { isInnerBlockSelected, imageBlockAttributes, positionLetter, rowOptionsCount } = useSelect(
 		select => {
 			const blockEditor = select( blockEditorStore ) as BlockEditorStoreSelect;
 			const { getBlock, hasSelectedInnerBlock } = blockEditor;
@@ -55,19 +60,20 @@ export default function ImageOptionInputEdit( props ) {
 			const position =
 				parentBlock.innerBlocks.findIndex( block => block.clientId === clientId ) + 1;
 
+			// Compute the number of options per row to set the element width
+			const totalOptionsCount = parentBlock.innerBlocks.length;
+			const maxRowCount = isSupersized ? 2 : 4;
+			const rowSiblingCount = Math.min( totalOptionsCount, maxRowCount );
+
 			return {
 				isInnerBlockSelected: hasSelectedInnerBlock( clientId, true ),
 				imageBlockAttributes: currentBlock?.innerBlocks[ 1 ]?.attributes,
 				positionLetter: getImageOptionLetter( position ),
+				rowOptionsCount: rowSiblingCount,
 			};
 		},
-		[ clientId ]
+		[ clientId, isSupersized ]
 	);
-
-	const {
-		'jetpack/field-image-select-is-supersized': isSupersized,
-		'jetpack/field-image-options-type': selectionType = 'radio',
-	} = context || {};
 
 	// Use the block's own synced attributes for styling
 	const { blockStyle } = useJetpackFieldStyles( attributes );
@@ -79,7 +85,10 @@ export default function ImageOptionInputEdit( props ) {
 			[ `is-${ selectionType }` ]: !! selectionType,
 			'is-supersized': isSupersized,
 		} ),
-		style: blockStyle,
+		style: {
+			...blockStyle,
+			'--row-options-count': rowOptionsCount >= 1 ? rowOptionsCount : 1,
+		},
 	} );
 
 	const template = useMemo( () => {

--- a/projects/packages/forms/src/blocks/input-image-option/edit.tsx
+++ b/projects/packages/forms/src/blocks/input-image-option/edit.tsx
@@ -62,8 +62,9 @@ export default function ImageOptionInputEdit( props ) {
 
 			// Compute the number of options per row to set the element width
 			const totalOptionsCount = parentBlock.innerBlocks.length;
-			const maxRowCount = isSupersized ? 2 : 4;
-			const rowSiblingCount = Math.min( totalOptionsCount, maxRowCount );
+			// Those values are halved on mobile via CSS media query
+			const maxImagesPerRow = isSupersized ? 2 : 4;
+			const rowSiblingCount = Math.min( totalOptionsCount, maxImagesPerRow );
 
 			return {
 				isInnerBlockSelected: hasSelectedInnerBlock( clientId, true ),

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -2012,8 +2012,9 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 
 			// Calculate row options count for CSS variable
 			$total_options_count = count( $options_data );
-			$max_row_count       = $is_supersized ? 2 : 4;
-			$row_options_count   = min( $total_options_count, $max_row_count );
+			// Those values are halved on mobile via CSS media query
+			$max_images_per_row = $is_supersized ? 2 : 4;
+			$row_options_count  = min( $total_options_count, $max_images_per_row );
 
 			foreach ( $working_options as $option_index => $option ) {
 				$option_label  = Contact_Form_Plugin::strip_tags( $option['label'] );

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -2096,6 +2096,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 				type='" . esc_attr( $input_type ) . "'
 				name='" . esc_attr( $input_name ) . "'
 				value='" . esc_attr( $option_value ) . "'
+				data-wp-on--keydown='actions.onKeyDownImageOption'
 				data-wp-on--change='" . ( $is_multiple ? 'actions.onMultipleFieldChange' : 'actions.onFieldChange' ) . "' "
 				. $class
 				. ( $is_multiple ? checked( in_array( $option_value, (array) $value, true ), true, false ) : checked( $option_value, $value, false ) ) . ' '

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -2010,6 +2010,11 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 				shuffle( $working_options );
 			}
 
+			// Calculate row options count for CSS variable
+			$total_options_count = count( $options_data );
+			$max_row_count       = $is_supersized ? 2 : 4;
+			$row_options_count   = min( $total_options_count, $max_row_count );
+
 			foreach ( $working_options as $option_index => $option ) {
 				$option_label  = Contact_Form_Plugin::strip_tags( $option['label'] );
 				$option_letter = Contact_Form_Plugin::strip_tags( $option['letter'] );
@@ -2071,8 +2076,9 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 					}
 				}
 
-				$option_outer_styles = ( empty( $option['stylecolor'] ) ? '' : $option['stylecolor'] ) . $border_styles;
-				$option_outer_styles = empty( $option_outer_styles ) ? '' : "style='" . esc_attr( $option_outer_styles ) . "'";
+				$option_outer_styles  = ( empty( $option['stylecolor'] ) ? '' : $option['stylecolor'] ) . $border_styles;
+				$option_outer_styles .= "--row-options-count: {$row_options_count};";
+				$option_outer_styles  = empty( $option_outer_styles ) ? '' : "style='" . esc_attr( $option_outer_styles ) . "'";
 
 				$field .= "<div class='{$option_outer_classes}' {$option_outer_styles}>";
 

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -2089,13 +2089,22 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 
 				$field .= "<div {$option_classes} {$option_styles} data-wp-on--click='actions.onImageOptionClick'>";
 
+				$input_id = esc_attr( $option_id );
+
+				$context             = array(
+					'inputId' => $input_id,
+				);
+				$interactivity_attrs = ' data-wp-interactive="jetpack/form" ' . wp_interactivity_data_wp_context( $context ) . ' ';
+
 				$field .= "<div class='jetpack-input-image-option__wrapper'>";
 				$field .= "<input
-				id='" . esc_attr( $option_id ) . "'
+				id='" . $input_id . "'
 				class='jetpack-input-image-option__input'
 				type='" . esc_attr( $input_type ) . "'
 				name='" . esc_attr( $input_name ) . "'
 				value='" . esc_attr( $option_value ) . "'
+				" . $interactivity_attrs . "
+				data-wp-init='callbacks.setImageOptionCheckColor'
 				data-wp-on--keydown='actions.onKeyDownImageOption'
 				data-wp-on--change='" . ( $is_multiple ? 'actions.onMultipleFieldChange' : 'actions.onFieldChange' ) . "' "
 				. $class

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -977,7 +977,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 					<div class="field-value" data-wp-text="context.submission.value"></div>
 					<div class="field-images" data-wp-bind--hidden="!context.submission.images">
 						<template data-wp-each--image="context.submission.images">
-							<img class="field-image" data-wp-bind--src="context.image" />
+							<img class="field-image" data-wp-bind--src="context.image" data-wp-bind--hidden="!context.image"/>
 						</template>
 					</div>
 				</div>
@@ -990,9 +990,9 @@ class Contact_Form extends Contact_Form_Shortcode {
 					<div class="field-value" data-wp-text="context.submission.value">' . $submission['value'] . '</div>
 					<div class="field-images" data-wp-bind--hidden="!context.submission.images">';
 
-				if ( $submission['images'] ) {
-					foreach ( $submission['images'] ?? array() as $image ) {
-						$html .= '<img data-wp-each-child class="field-image" data-wp-bind--src="context.image" src="' . $image . '" />';
+				if ( ! empty( $submission['images'] ) ) {
+					foreach ( $submission['images'] as $image ) {
+						$html .= '<img data-wp-each-child class="field-image" data-wp-bind--src="context.image" src="' . $image . '" data-wp-bind--hidden="!context.image" ' . ( empty( $image ) ? 'hidden' : '' ) . ' />';
 					}
 				} else {
 					$html .= '<template data-wp-each--image="context.submission.images"></template>';
@@ -2516,9 +2516,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 		if ( is_array( $value ) && isset( $value['type'] ) && $value['type'] === 'image-select' ) {
 			return array_map(
 				function ( $choice ) {
-					$src = $choice['image']['src'] ?? '';
-
-					return empty( $src ) ? 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=' : $src;
+					return $choice['image']['src'] ?? '';
 				},
 				$value['choices']
 			);

--- a/projects/packages/forms/src/modules/form/view.js
+++ b/projects/packages/forms/src/modules/form/view.js
@@ -573,5 +573,21 @@ const { state, actions } = store( NAMESPACE, {
 				context.hasClickedBack = false;
 			}
 		},
+
+		setImageOptionCheckColor() {
+			const context = getContext();
+
+			const { inputId } = context;
+			const input = document.getElementById( inputId );
+
+			if ( ! input ) {
+				return;
+			}
+
+			const color = window.getComputedStyle( input ).color;
+			const inverseColor = window.jetpackForms.getInverseReadableColor( color );
+
+			input.setAttribute( 'style', `--jetpack-input-image-option--check-color: ${ inverseColor }` );
+		},
 	},
 } );

--- a/projects/packages/forms/src/modules/form/view.js
+++ b/projects/packages/forms/src/modules/form/view.js
@@ -135,6 +135,34 @@ const getImages = value => {
 	return null;
 };
 
+const toggleImageOptionInput = ( input, optionElement ) => {
+	if ( input ) {
+		input.focus();
+
+		if ( input.type === 'checkbox' ) {
+			input.checked = ! input.checked;
+			optionElement.classList.toggle( 'is-checked', input.checked );
+		} else if ( input.type === 'radio' ) {
+			input.checked = true;
+
+			// Find all image options in the same fieldset and toggle the checked class
+			const fieldset = optionElement.closest( '.jetpack-fieldset-image-options__wrapper' );
+
+			if ( fieldset ) {
+				const imageOptions = fieldset.querySelectorAll( '.jetpack-input-image-option' );
+
+				imageOptions.forEach( imageOption => {
+					const imageOptionInput = imageOption.querySelector( 'input' );
+					imageOption.classList.toggle( 'is-checked', imageOptionInput.id === input.id );
+				} );
+			}
+		}
+
+		// Dispatch change event to trigger any change handlers
+		input.dispatchEvent( new Event( 'change', { bubbles: true } ) );
+	}
+};
+
 const { state, actions } = store( NAMESPACE, {
 	state: {
 		validators: {},
@@ -328,6 +356,32 @@ const { state, actions } = store( NAMESPACE, {
 			actions.updateField( fieldId, newValues );
 		},
 
+		onKeyDownImageOption: event => {
+			if ( event.key === 'Enter' || event.key === ' ' ) {
+				event.preventDefault();
+				actions.onImageOptionClick( event );
+			}
+
+			// If the key is any letter from a to z, we toggle that image option
+			if ( /^[a-z]$/i.test( event.key ) ) {
+				const fieldset = event.target.closest( '.jetpack-fieldset-image-options__wrapper' );
+				const labelCode = document.evaluate(
+					`.//div[contains(@class, "jetpack-input-image-option__label-code") and contains(text(), "${ event.key.toUpperCase() }")]`,
+					fieldset,
+					null,
+					XPathResult.FIRST_ORDERED_NODE_TYPE,
+					null
+				).singleNodeValue;
+
+				if ( labelCode ) {
+					const optionElement = labelCode.closest( '.jetpack-input-image-option' );
+					const input = optionElement.querySelector( '.jetpack-input-image-option__input' );
+
+					toggleImageOptionInput( input, optionElement );
+				}
+			}
+		},
+
 		onImageOptionClick: event => {
 			// Find the block container
 			let target = event.target;
@@ -340,29 +394,7 @@ const { state, actions } = store( NAMESPACE, {
 				// Find the input inside this container
 				const input = target.querySelector( '.jetpack-input-image-option__input' );
 
-				if ( input ) {
-					if ( input.type === 'checkbox' ) {
-						input.checked = ! input.checked;
-						target.classList.toggle( 'is-checked', input.checked );
-					} else if ( input.type === 'radio' ) {
-						input.checked = true;
-
-						// Find all image options in the same fieldset and toggle the checked class
-						const fieldset = target.closest( '.jetpack-fieldset-image-options__wrapper' );
-
-						if ( fieldset ) {
-							const imageOptions = fieldset.querySelectorAll( '.jetpack-input-image-option' );
-
-							imageOptions.forEach( imageOption => {
-								const imageOptionInput = imageOption.querySelector( 'input' );
-								imageOption.classList.toggle( 'is-checked', imageOptionInput.id === input.id );
-							} );
-						}
-					}
-
-					// Dispatch change event to trigger any change handlers
-					input.dispatchEvent( new Event( 'change', { bubbles: true } ) );
-				}
+				toggleImageOptionInput( input, target );
 			}
 		},
 

--- a/projects/packages/forms/src/modules/form/view.js
+++ b/projects/packages/forms/src/modules/form/view.js
@@ -129,9 +129,7 @@ const maybeTransformValue = value => {
 
 const getImages = value => {
 	if ( value?.type === 'image-select' ) {
-		return value.choices.map(
-			choice => choice.image?.src || 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs='
-		);
+		return value.choices.filter( choice => choice.image?.src ).map( choice => choice.image?.src );
 	}
 
 	return null;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of FORMS-60

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Shows at most 2 images per row on mobile
* Hides empty images from post-submission screen
* Updates the "Add" text

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Enable the forms_alpha feature flag
* Add a form with at least one empty image
* Check that you see an "Add choice" button on the toolbar of the Image Select field and the options wrapper
* Check that the form displays at most 2 options per row on mobile, or 1 with supersize or when there is only one option (including on desktop)
* Check that the form displays at most 4 options per row on desktop, or 2 with supersize
* Check that when less than 4 options now take the whole row's width when Supersize is off
* Submit the form
* Check that empty images are not displayed

Mobile:
<img width="408" height="752" alt="Screenshot from 2025-09-10 22-37-54" src="https://github.com/user-attachments/assets/a2fdac4b-c03a-40b5-a9ac-d22bc498b807" />

3 options taking full width on desktop:
<img width="717" height="359" alt="Screenshot from 2025-09-10 22-37-33" src="https://github.com/user-attachments/assets/d3930188-e033-4810-8a8a-18de5bc66f7e" />

Hidden empty image:
<img width="640" height="360" alt="Screenshot from 2025-09-10 22-37-22" src="https://github.com/user-attachments/assets/831bd198-bfc6-42d1-a4fb-e0dd0ea81d0e" />
