### PR TITLE
AI assistant: fix spacing on forms block

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-form-ai-assistant-positioning
+++ b/projects/plugins/jetpack/changelog/fix-form-ai-assistant-positioning
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+AI assistant: Fix spacing on forms block.

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/text-blocks/jetpack-form/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/text-blocks/jetpack-form/index.tsx
@@ -25,6 +25,7 @@ export class JetpackFormHandler extends BlockHandler {
 		this.feature = 'jetpack-form-ai-extension';
 		this.startOpen = true;
 		this.hideOnBlockFocus = false;
+		this.adjustPosition = false;
 		this.supports = {
 			file_upload_field: 1,
 		};


### PR DESCRIPTION
NOTE: Until this issue is fixed, some forms E2E tests in Calypso are muted [here](https://teamcity.a8c.com/buildConfiguration/calypso_WPComTests_jetpack_simple_deployment_e2e_desktop/15668879) and [here](https://teamcity.a8c.com/buildConfiguration/calypso_WPComTests_jetpack_simple_deployment_e2e_mobile/15669067). Once merged, we should unmute those tests. 

## Proposed changes:

On WordPress.com simple sites (but not self hosted sites), the AI assistant is being pushed up over the top of the forms block, covering the Browse Form Patterns button (and breaking E2E tests in Calypso). This is because negative margin is conditionally applied to the AI assistant in certain circumstances. This PR leverages existing props/settings to ensure the negative margin is not applied to AI assistant when attached to the form block.

Before
<img width="1482" height="900" alt="image" src="https://github.com/user-attachments/assets/287deaed-9560-4e5e-bfc7-d2bc1efa6887" />

After
<img width="1402" height="1098" alt="image" src="https://github.com/user-attachments/assets/c51eaf1e-7bd1-4cd8-9ba9-425afd923ab5" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test on self hosted site to ensure no regressions. 
   - Add a new form to page or post, and confirm the AI assistant is correctly positioned just below the form. 
* Test on WordPress.com simple site to confirm the issue is fixed. 
   - Use the command below to checkout this branch in your sandbox
   - Sandbox the url of a simple site 
   - Add a new form to page and confirm the AI assistant is positions correctly just below the form
* Bonus: Not required, but try running Calypso E2E tests against this branch to confirm tests now pass. This is no required because I've already tested and confirmed myself, and it is complicated to do. For instructions see this P2: peKye1-1Fh-p2. Once you are set up, you will want to run `yarn workspace wp-e2e-tests build && yarn workspace wp-e2e-tests test test/e2e/specs/blocks/blocks__jetpack-forms.ts`.