### PR TITLE
JSON API: Fix a fatal in non-existing menu fetching endpoint

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-api-non-existing-menu-fatal
+++ b/projects/plugins/jetpack/changelog/fix-api-non-existing-menu-fatal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Fix a fatal in fetching a non-existing menu in JSON API.

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-menus-v1-1-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-menus-v1-1-endpoint.php
@@ -1152,6 +1152,10 @@ class WPCOM_JSON_API_Menus_Get_Menu_Endpoint extends WPCOM_JSON_API_Menus_Abstra
 			return $menu;
 		}
 
+		if ( ! $menu instanceof WP_Term ) {
+			return new WP_Error( 'menu-not-found', 'Menu not found.', 404 );
+		}
+
 		$items = wp_get_nav_menu_items( $menu_id, array( 'update_post_term_cache' => false ) );
 
 		if ( is_wp_error( $items ) ) {


### PR DESCRIPTION
## Proposed changes:
If a non-existing menu is being fetched, the endpoint triggers a fatal error.
This PR will make it return the 404 error with appropriate error code instead.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1757600649646559-slack-CDLH4C1UZ

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
1. Start on `trunk`.
2. Connect Jetpack.
3. Use developer console to send a GET request to menu fetching endpoint. Use a non-existing menu ID:
```
/rest/v1.1/sites/your-blog-id/menus/12345
```
4. Confirm that the error 500 is returned. Check the WP logs, you should see the fatal error.
5. Checkout this branch.
6. Run the same request again, confirm it now returns error 404 with `menu-not-found` code.
7. Try again using an existing menu ID (you can find it in "Appearance -> Menus"). Confirm the menu gets returned correctly.