### PR TITLE
E2E: Update connection URL and speed up onboarding test

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-e2e-onboarding
+++ b/projects/plugins/jetpack/changelog/fix-e2e-onboarding
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+E2E: Update connection URL and speed up onboarding test.

--- a/projects/plugins/jetpack/tests/e2e/helpers/onboarding.ts
+++ b/projects/plugins/jetpack/tests/e2e/helpers/onboarding.ts
@@ -50,7 +50,10 @@ export class Onboarding {
 	async waitForRedirectToWpcom() {
 		const wpcomUrl = 'https://wordpress.com/log-in/jetpack**';
 
-		return await this.page.waitForURL( wpcomUrl, { timeout: DEFAULT_TIMEOUT } );
+		return await this.page.waitForURL( wpcomUrl, {
+			timeout: DEFAULT_TIMEOUT,
+			waitUntil: 'domcontentloaded',
+		} );
 	}
 
 	/**
@@ -72,7 +75,10 @@ export class Onboarding {
 					url.searchParams.get( 'page' ) === 'my-jetpack'
 				);
 			},
-			{ timeout: DEFAULT_TIMEOUT }
+			{
+				timeout: DEFAULT_TIMEOUT,
+				waitUntil: 'domcontentloaded',
+			}
 		);
 
 		logger.info( 'Click on "Connect account" button and wait for redirect to My Jetpack' );

--- a/projects/plugins/jetpack/tests/e2e/helpers/onboarding.ts
+++ b/projects/plugins/jetpack/tests/e2e/helpers/onboarding.ts
@@ -1,10 +1,6 @@
 import logger from '_jetpack-e2e-commons/logger';
 import type { Page } from '@playwright/test';
 
-type RedirectToWpcomOptions = {
-	wpcomLoggedIn?: boolean;
-};
-
 // Onboarding API calls and redirects can take a while to complete, so we increase the timeout.
 const DEFAULT_TIMEOUT = 60000;
 
@@ -49,16 +45,10 @@ export class Onboarding {
 	/**
 	 * Wait for the redirect to the wp.com connect page.
 	 *
-	 * @param {StartOnboardingOptions} options - Options.
-	 *
 	 * @return A promise that resolves when the redirect to the wp.com connect page is completed.
 	 */
-	async waitForRedirectToWpcom( options?: RedirectToWpcomOptions ) {
-		const opts = { wpcomLoggedIn: true, ...options };
-
-		const wpcomUrl = opts.wpcomLoggedIn
-			? 'https://wordpress.com/jetpack/connect/authorize**'
-			: 'https://wordpress.com/log-in/jetpack**';
+	async waitForRedirectToWpcom() {
+		const wpcomUrl = 'https://wordpress.com/log-in/jetpack**';
 
 		return await this.page.waitForURL( wpcomUrl, { timeout: DEFAULT_TIMEOUT } );
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

It seems something with the connection flow changed, though I wasn't able to find what. Now for onboarding tests we only look for the `https://wordpress.com/log-in/jetpack**` URL rather than `https://wordpress.com/jetpack/connect/authorize**`.

I also updated two `waitForUrl()` calls to use `waitUntil: 'domcontentloaded'`, which should speed things up a bit.

Reported in p1757604098934889-slack-CDLH4C1UZ.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

```
pnpm test:run --debug specs/onboarding/site-connection.test.ts
```