### PR TITLE
Forms: Return integration titles from endpoint

### DIFF
--- a/projects/packages/forms/changelog/add-forms-filter-integration-titles
+++ b/projects/packages/forms/changelog/add-forms-filter-integration-titles
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: Return integration titles from endpoint.

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/akismet-card.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/akismet-card.tsx
@@ -45,8 +45,10 @@ const AkismetCard = ( {
 
 	return (
 		<IntegrationCard
-			title={ __( 'Akismet Spam Protection', 'jetpack-forms' ) }
-			description={ __( 'Akismet filters out form spam with 99% accuracy', 'jetpack-forms' ) }
+			title={ data?.title ?? __( 'Akismet Spam Protection', 'jetpack-forms' ) }
+			description={
+				data?.subtitle ?? __( 'Akismet filters out form spam with 99% accuracy', 'jetpack-forms' )
+			}
 			icon={ <AkismetIcon width={ 28 } height={ 28 } /> }
 			isExpanded={ isExpanded }
 			onToggle={ onToggle }

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/akismet-card.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/akismet-card.tsx
@@ -45,10 +45,8 @@ const AkismetCard = ( {
 
 	return (
 		<IntegrationCard
-			title={ data?.title ?? __( 'Akismet Spam Protection', 'jetpack-forms' ) }
-			description={
-				data?.subtitle ?? __( 'Akismet filters out form spam with 99% accuracy', 'jetpack-forms' )
-			}
+			title={ data?.title }
+			description={ data?.subtitle }
 			icon={ <AkismetIcon width={ 28 } height={ 28 } /> }
 			isExpanded={ isExpanded }
 			onToggle={ onToggle }

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/creative-mail-card.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/creative-mail-card.tsx
@@ -58,8 +58,8 @@ const CreativeMailCard = ( {
 
 	return (
 		<IntegrationCard
-			title={ __( 'Creative Mail', 'jetpack-forms' ) }
-			description={ __( 'Manage email contacts and campaigns', 'jetpack-forms' ) }
+			title={ data?.title ?? __( 'Creative Mail', 'jetpack-forms' ) }
+			description={ data?.subtitle ?? __( 'Manage email contacts and campaigns', 'jetpack-forms' ) }
 			icon={ <CreativeMailIcon /> }
 			isExpanded={ isExpanded }
 			onToggle={ onToggle }

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/creative-mail-card.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/creative-mail-card.tsx
@@ -58,8 +58,8 @@ const CreativeMailCard = ( {
 
 	return (
 		<IntegrationCard
-			title={ data?.title ?? __( 'Creative Mail', 'jetpack-forms' ) }
-			description={ data?.subtitle ?? __( 'Manage email contacts and campaigns', 'jetpack-forms' ) }
+			title={ data?.title }
+			description={ data?.subtitle }
 			icon={ <CreativeMailIcon /> }
 			isExpanded={ isExpanded }
 			onToggle={ onToggle }

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/google-sheets-card.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/google-sheets-card.tsx
@@ -67,8 +67,10 @@ const GoogleSheetsCard = ( {
 
 	return (
 		<IntegrationCard
-			title={ __( 'Google Sheets', 'jetpack-forms' ) }
-			description={ __( 'Export form responses to Google Sheets.', 'jetpack-forms' ) }
+			title={ data?.title ?? __( 'Google Sheets', 'jetpack-forms' ) }
+			description={
+				data?.subtitle ?? __( 'Export form responses to Google Sheets.', 'jetpack-forms' )
+			}
 			icon={ <GoogleSheetsIcon className="google-sheets-icon" /> }
 			isExpanded={ isExpanded }
 			onToggle={ onToggle }

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/google-sheets-card.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/google-sheets-card.tsx
@@ -67,10 +67,8 @@ const GoogleSheetsCard = ( {
 
 	return (
 		<IntegrationCard
-			title={ data?.title ?? __( 'Google Sheets', 'jetpack-forms' ) }
-			description={
-				data?.subtitle ?? __( 'Export form responses to Google Sheets.', 'jetpack-forms' )
-			}
+			title={ data?.title }
+			description={ data?.subtitle }
 			icon={ <GoogleSheetsIcon className="google-sheets-icon" /> }
 			isExpanded={ isExpanded }
 			onToggle={ onToggle }

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/jetpack-crm-card.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/jetpack-crm-card.tsx
@@ -140,10 +140,8 @@ const JetpackCRMCard = ( {
 
 	return (
 		<IntegrationCard
-			title={ data?.title ?? __( 'Jetpack CRM', 'jetpack-forms' ) }
-			description={
-				data?.subtitle ?? __( 'Store contact form submissions in your CRM', 'jetpack-forms' )
-			}
+			title={ data?.title }
+			description={ data?.subtitle }
 			icon={ <JetpackIcon color={ COLOR_JETPACK } /> }
 			isExpanded={ isExpanded }
 			onToggle={ onToggle }

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/jetpack-crm-card.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/jetpack-crm-card.tsx
@@ -140,8 +140,10 @@ const JetpackCRMCard = ( {
 
 	return (
 		<IntegrationCard
-			title={ __( 'Jetpack CRM', 'jetpack-forms' ) }
-			description={ __( 'Store contact form submissions in your CRM', 'jetpack-forms' ) }
+			title={ data?.title ?? __( 'Jetpack CRM', 'jetpack-forms' ) }
+			description={
+				data?.subtitle ?? __( 'Store contact form submissions in your CRM', 'jetpack-forms' )
+			}
 			icon={ <JetpackIcon color={ COLOR_JETPACK } /> }
 			isExpanded={ isExpanded }
 			onToggle={ onToggle }

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/mailpoet-card.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/mailpoet-card.tsx
@@ -125,11 +125,8 @@ const MailPoetCard = ( {
 	};
 	return (
 		<IntegrationCard
-			title={ data?.title ?? __( 'MailPoet email marketing', 'jetpack-forms' ) }
-			description={
-				data?.subtitle ??
-				__( 'Send newsletters and marketing emails directly from your site.', 'jetpack-forms' )
-			}
+			title={ data?.title }
+			description={ data?.subtitle }
 			icon={ <MailPoetIcon width={ 28 } height={ 28 } /> }
 			isExpanded={ isExpanded }
 			onToggle={ onToggle }

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/mailpoet-card.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/mailpoet-card.tsx
@@ -125,11 +125,11 @@ const MailPoetCard = ( {
 	};
 	return (
 		<IntegrationCard
-			title={ __( 'MailPoet email marketing', 'jetpack-forms' ) }
-			description={ __(
-				'Send newsletters and marketing emails directly from your site.',
-				'jetpack-forms'
-			) }
+			title={ data?.title ?? __( 'MailPoet email marketing', 'jetpack-forms' ) }
+			description={
+				data?.subtitle ??
+				__( 'Send newsletters and marketing emails directly from your site.', 'jetpack-forms' )
+			}
 			icon={ <MailPoetIcon width={ 28 } height={ 28 } /> }
 			isExpanded={ isExpanded }
 			onToggle={ onToggle }

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/salesforce-card.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/salesforce-card.tsx
@@ -77,8 +77,8 @@ const SalesforceCard = ( {
 
 	return (
 		<IntegrationCard
-			title={ __( 'Salesforce', 'jetpack-forms' ) }
-			description={ __( 'Send form contacts to Salesforce', 'jetpack-forms' ) }
+			title={ data?.title }
+			description={ data?.subtitle }
 			icon={ <SalesforceIcon width={ 32 } height={ 32 } /> }
 			isExpanded={ isExpanded }
 			onToggle={ onToggle }

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -34,64 +34,62 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 
 	/**
-	 * Supported integrations configuration.
-	 *
-	 * Each integration array supports the following keys:
-	 * - type (string)                  : 'plugin' or 'service'
-	 * - file (string|null)             : Plugin file path (for plugins), or null for services
-	 * - settings_url (string|null)     : Relative admin URL for settings, or null if none
-	 * - marketing_redirect_slug (string|null) : Slug for Redirect::get_url() for marketing links, or null if none
-	 *
-	 * For marketing_redirect_slug, you'll need to add those here first:
-	 * https://mc.a8c.com/jetpack-crew/redirects/
-	 *
-	 * @var array
-	 */
-	private $supported_integrations = array(
-		'akismet'                           => array(
-			'type'                    => 'plugin',
-			'file'                    => 'akismet/akismet.php',
-			'settings_url'            => 'admin.php?page=akismet-key-config',
-			'marketing_redirect_slug' => 'org-spam',
-		),
-		'creative-mail-by-constant-contact' => array(
-			'type'                    => 'plugin',
-			'file'                    => 'creative-mail-by-constant-contact/creative-mail-plugin.php',
-			'settings_url'            => 'admin.php?page=creativemail',
-			'marketing_redirect_slug' => 'creative-mail',
-		),
-		'zero-bs-crm'                       => array(
-			'type'                    => 'plugin',
-			'file'                    => 'zero-bs-crm/ZeroBSCRM.php',
-			'settings_url'            => 'admin.php?page=zerobscrm-plugin-settings',
-			'marketing_redirect_slug' => 'org-crm',
-		),
-		'salesforce'                        => array(
-			'type'                    => 'service',
-			'file'                    => null,
-			'settings_url'            => null,
-			'marketing_redirect_slug' => null,
-		),
-		'google-drive'                      => array(
-			'type'                    => 'service',
-			'file'                    => null,
-			'settings_url'            => null,
-			'marketing_redirect_slug' => null,
-		),
-		'mailpoet'                          => array(
-			'type'                    => 'plugin',
-			'file'                    => 'mailpoet/mailpoet.php',
-			'settings_url'            => 'admin.php?page=mailpoet-homepage',
-			'marketing_redirect_slug' => 'org-mailpoet',
-		),
-	);
-
-	/**
 	 * Get filtered list of supported integrations
 	 *
 	 * @return array Filtered list of supported integrations
 	 */
 	private function get_supported_integrations() {
+		$supported_integrations = array(
+			'akismet'                           => array(
+				'type'                    => 'plugin',
+				'file'                    => 'akismet/akismet.php',
+				'settings_url'            => 'admin.php?page=akismet-key-config',
+				'marketing_redirect_slug' => 'org-spam',
+				'title'                   => __( 'Akismet Spam Protection', 'jetpack-forms' ),
+				'subtitle'                => __( 'Akismet filters out form spam with 99% accuracy', 'jetpack-forms' ),
+			),
+			'creative-mail-by-constant-contact' => array(
+				'type'                    => 'plugin',
+				'file'                    => 'creative-mail-by-constant-contact/creative-mail-plugin.php',
+				'settings_url'            => 'admin.php?page=creativemail',
+				'marketing_redirect_slug' => 'creative-mail',
+				'title'                   => __( 'Creative Mail', 'jetpack-forms' ),
+				'subtitle'                => __( 'Manage email contacts and campaigns', 'jetpack-forms' ),
+			),
+			'zero-bs-crm'                       => array(
+				'type'                    => 'plugin',
+				'file'                    => 'zero-bs-crm/ZeroBSCRM.php',
+				'settings_url'            => 'admin.php?page=zerobscrm-plugin-settings',
+				'marketing_redirect_slug' => 'org-crm',
+				'title'                   => __( 'Jetpack CRM', 'jetpack-forms' ),
+				'subtitle'                => __( 'Store contact form submissions in your CRM', 'jetpack-forms' ),
+			),
+			'salesforce'                        => array(
+				'type'                    => 'service',
+				'file'                    => null,
+				'settings_url'            => null,
+				'marketing_redirect_slug' => null,
+				'title'                   => __( 'Salesforce', 'jetpack-forms' ),
+				'subtitle'                => __( 'Send form contacts to Salesforce', 'jetpack-forms' ),
+			),
+			'google-drive'                      => array(
+				'type'                    => 'service',
+				'file'                    => null,
+				'settings_url'            => null,
+				'marketing_redirect_slug' => null,
+				'title'                   => __( 'Google Sheets', 'jetpack-forms' ),
+				'subtitle'                => __( 'Export form responses to Google Sheets.', 'jetpack-forms' ),
+			),
+			'mailpoet'                          => array(
+				'type'                    => 'plugin',
+				'file'                    => 'mailpoet/mailpoet.php',
+				'settings_url'            => 'admin.php?page=mailpoet-homepage',
+				'marketing_redirect_slug' => 'org-mailpoet',
+				'title'                   => __( 'MailPoet email marketing', 'jetpack-forms' ),
+				'subtitle'                => __( 'Send newsletters and marketing emails directly from your site.', 'jetpack-forms' ),
+			),
+		);
+
 		/**
 		 * Filters the list of supported integrations available in Jetpack Forms.
 		 *
@@ -101,15 +99,16 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 		 *
 		 * @since $$next-version$$
 		 *
-		 * @param array $supported_integrations Associative array of integration
-		 *                                     configurations keyed by slug. Each
-		 *                                     configuration supports the following keys:
-		 *                                     - type (string)                  : 'plugin' or 'service'.
-		 *                                     - file (string|null)             : Plugin file path for plugins; null for services.
-		 *                                     - settings_url (string|null)     : Relative admin URL for settings, or null.
-		 *                                     - marketing_redirect_slug (string|null) : Redirect slug for marketing links, or null.
+		 * @param array $integrations Associative array of integration configurations keyed by slug.
+		 *                            Each configuration supports the following keys:
+		 *                            - type (string)                  : 'plugin' or 'service'.
+		 *                            - file (string|null)             : Plugin file path for plugins; null for services.
+		 *                            - settings_url (string|null)     : Relative admin URL for settings, or null.
+		 *                            - marketing_redirect_slug (string|null) : Redirect slug for marketing links, or null.
+		 *                            - title (string)                 : Default UI title for the integration.
+		 *                            - subtitle (string)              : Default UI subtitle/description for the integration.
 		 */
-		return apply_filters( 'jetpack_forms_supported_integrations', $this->supported_integrations );
+		return apply_filters( 'jetpack_forms_supported_integrations', $supported_integrations );
 	}
 
 	/**
@@ -841,11 +840,34 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 	 * @return array Integration status data.
 	 */
 	private function get_integration( $slug ) {
-		$config       = $this->get_supported_integrations()[ $slug ];
-		$status       = $config['type'] === 'plugin'
-			? $this->get_plugin_status( $slug )
-			: $this->get_service_status( $slug );
-		$status['id'] = $slug;
+		$config = $this->get_supported_integrations()[ $slug ];
+		$type   = isset( $config['type'] ) ? $config['type'] : null;
+
+		$marketing_redirect_slug = $config['marketing_redirect_slug'] ?? null;
+
+		// Base shape for all integrations.
+		$base = array(
+			'id'              => $slug,
+			'slug'            => $slug,
+			'type'            => $type,
+			'title'           => isset( $config['title'] ) ? sanitize_text_field( $config['title'] ) : '',
+			'subtitle'        => isset( $config['subtitle'] ) ? sanitize_text_field( $config['subtitle'] ) : '',
+			'marketingUrl'    => $marketing_redirect_slug ? Redirect::get_url( $marketing_redirect_slug ) : null,
+			'pluginFile'      => ( $type === 'plugin' && ! empty( $config['file'] ) ) ? str_replace( '.php', '', $config['file'] ) : null,
+			'isInstalled'     => false,
+			'isActive'        => false,
+			'needsConnection' => ( $type === 'service' ),
+			'isConnected'     => false,
+			'version'         => null,
+			'settingsUrl'     => null,
+			'details'         => array(),
+		);
+
+		// Override base shape based on integration type.
+		$status = $type === 'plugin'
+			? $this->get_plugin_status( $slug, $base )
+			: $this->get_service_status( $slug, $base );
+
 		return $status;
 	}
 
@@ -889,40 +911,25 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 	/**
 	 * Get status for internal/service integrations.
 	 *
-	 * @param string $slug Service slug.
+	 * @param string $slug   Service slug.
+	 * @param array  $status Base status shape to mutate and return.
 	 * @return array Service status data.
 	 */
-	private function get_service_status( $slug ) {
-		$config                  = $this->get_supported_integrations()[ $slug ];
-		$marketing_redirect_slug = $config['marketing_redirect_slug'] ?? null;
+	private function get_service_status( $slug, array $status ) {
+		$config = $this->get_supported_integrations()[ $slug ];
 
-		// Default response for all integrations
-		$response = array(
-			'type'            => $config['type'],
-			'slug'            => $slug,
-			'needsConnection' => true,
-			'isConnected'     => false,
-			'settingsUrl'     => $config['settings_url'] ?? null,
-			'marketingUrl'    => $marketing_redirect_slug ? Redirect::get_url( $marketing_redirect_slug ) : null,
-			'pluginFile'      => null,
-			'isInstalled'     => false,
-			'isActive'        => false,
-			'version'         => null,
-			'details'         => array(),
-		);
-
-		// Process settingsUrl to return a full URL if present (for services only)
-		if ( $response['settingsUrl'] ) {
-			$response['settingsUrl'] = esc_url( Redirect::get_url( $response['settingsUrl'] ) );
+		// If a settings redirect slug/url is configured, convert to full URL
+		if ( ! empty( $config['settings_url'] ) ) {
+			$status['settingsUrl'] = esc_url( Redirect::get_url( $config['settings_url'] ) );
 		}
 
+		// Override base shape for specific services.
 		switch ( $slug ) {
 			case 'google-drive':
-				$user_id                 = get_current_user_id();
-				$jetpack_connected       = ( new Host() )->is_wpcom_simple() || ( new Connection_Manager( 'jetpack-forms' ) )->is_user_connected( $user_id );
-				$is_connected            = $jetpack_connected && Google_Drive::has_valid_connection();
-				$response['isConnected'] = $is_connected;
-				$response['settingsUrl'] = External_Connections::get_connect_url( $slug );
+				$user_id               = get_current_user_id();
+				$jetpack_connected     = ( new Host() )->is_wpcom_simple() || ( new Connection_Manager( 'jetpack-forms' ) )->is_user_connected( $user_id );
+				$status['isConnected'] = $jetpack_connected && Google_Drive::has_valid_connection();
+				$status['settingsUrl'] = External_Connections::get_connect_url( $slug );
 				break;
 			case 'salesforce':
 				// No overrides needed for now; keep defaults.
@@ -930,74 +937,67 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 			// Add other service cases as needed.
 		}
 
-		return $response;
+		return $status;
 	}
 
 	/**
 	 * Get plugin status.
 	 *
 	 * @param string $plugin_slug Plugin slug.
+	 * @param array  $status      Base status shape to mutate and return.
 	 * @return array Plugin status data.
 	 */
-	private function get_plugin_status( $plugin_slug ) {
+	private function get_plugin_status( $plugin_slug, array $status ) {
 		if ( ! function_exists( 'get_plugins' ) ) {
 			require_once ABSPATH . 'wp-admin/includes/plugin.php';
 		}
 
-		$integrations            = $this->get_supported_integrations();
-		$plugin_config           = $integrations[ $plugin_slug ];
-		$marketing_redirect_slug = $plugin_config['marketing_redirect_slug'] ?? null;
+		$integrations  = $this->get_supported_integrations();
+		$plugin_config = $integrations[ $plugin_slug ];
 
 		$installed_plugins = get_plugins();
 		$is_installed      = isset( $installed_plugins[ $plugin_config['file'] ] );
 		$is_active         = is_plugin_active( $plugin_config['file'] );
 
-		$response = array(
-			'type'            => 'plugin',
-			'slug'            => $plugin_slug,
-			'pluginFile'      => str_replace( '.php', '', $plugin_config['file'] ),
-			'isInstalled'     => $is_installed,
-			'isActive'        => $is_active,
-			'needsConnection' => false,
-			'isConnected'     => false,
-			'version'         => $is_installed ? $installed_plugins[ $plugin_config['file'] ]['Version'] : null,
-			'settingsUrl'     => $is_active ? admin_url( $plugin_config['settings_url'] ) : null,
-			'marketingUrl'    => $marketing_redirect_slug ? Redirect::get_url( $marketing_redirect_slug ) : null,
-			'details'         => array(),
-		);
+		// Override base shape for all plugins.
+		$status['pluginFile']  = str_replace( '.php', '', $plugin_config['file'] );
+		$status['isInstalled'] = $is_installed;
+		$status['isActive']    = $is_active;
+		$status['version']     = $is_installed ? $installed_plugins[ $plugin_config['file'] ]['Version'] : null;
+		$status['settingsUrl'] = $is_active ? admin_url( $plugin_config['settings_url'] ) : null;
 
-		// Refactored to use a switch statement for plugin-specific logic.
+		// Override base shape for specific plugins.
 		switch ( $plugin_slug ) {
 			case 'akismet':
-				$dashboard_view_switch                         = new Dashboard_View_Switch();
-				$response['isConnected']                       = class_exists( 'Jetpack' ) && \Jetpack::is_akismet_active();
-				$response['details']['formSubmissionsSpamUrl'] = $dashboard_view_switch->get_forms_admin_url( 'spam' );
-				$response['needsConnection']                   = true;
+				$dashboard_view_switch                       = new Dashboard_View_Switch();
+				$status['isConnected']                       = class_exists( 'Jetpack' ) && \Jetpack::is_akismet_active();
+				$status['details']['formSubmissionsSpamUrl'] = $dashboard_view_switch->get_forms_admin_url( 'spam' );
+				$status['needsConnection']                   = true;
 				break;
 			case 'zero-bs-crm':
 				if ( $is_active ) {
-					$has_extension       = function_exists( 'zeroBSCRM_isExtensionInstalled' ) && zeroBSCRM_isExtensionInstalled( 'jetpackforms' ); // @phan-suppress-current-line PhanUndeclaredFunction -- We're checking the function exists first
-					$response['details'] = array(
+					$has_extension     = function_exists( 'zeroBSCRM_isExtensionInstalled' ) && zeroBSCRM_isExtensionInstalled( 'jetpackforms' ); // @phan-suppress-current-line PhanUndeclaredFunction -- We're checking the function exists first
+					$status['details'] = array(
 						'hasExtension'         => $has_extension,
 						'canActivateExtension' => current_user_can( 'manage_options' ),
 					);
 				}
 				break;
 			case 'mailpoet':
-				$response['needsConnection'] = true;
+				$status['needsConnection'] = true;
 				// Determine if MailPoet setup is complete using the public API.
 				if ( class_exists( \MailPoet\API\API::class ) ) { // @phan-suppress-current-line PhanUndeclaredClassReference
 					$mailpoet_api = \MailPoet\API\API::MP( 'v1' ); // @phan-suppress-current-line PhanUndeclaredClassMethod
 					if ( $mailpoet_api && method_exists( $mailpoet_api, 'isSetupComplete' ) ) {
-						$response['isConnected'] = (bool) $mailpoet_api->isSetupComplete();
+						$status['isConnected'] = (bool) $mailpoet_api->isSetupComplete();
 					}
 				}
 				// Add MailPoet lists to details
-				$response['details']['lists'] = MailPoet_Integration::get_all_lists();
+				$status['details']['lists'] = MailPoet_Integration::get_all_lists();
 				break;
 		}
 
-		return $response;
+		return $status;
 	}
 
 	/**

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -841,7 +841,7 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 	 */
 	private function get_integration( $slug ) {
 		$config = $this->get_supported_integrations()[ $slug ];
-		$type   = isset( $config['type'] ) ? $config['type'] : null;
+		$type   = $config['type'] ?? null;
 
 		$marketing_redirect_slug = $config['marketing_redirect_slug'] ?? null;
 

--- a/projects/packages/forms/src/dashboard/integrations/akismet-card.tsx
+++ b/projects/packages/forms/src/dashboard/integrations/akismet-card.tsx
@@ -56,10 +56,8 @@ const AkismetDashboardCard = ( {
 
 	return (
 		<IntegrationCard
-			title={ data?.title ?? __( 'Akismet Spam Protection', 'jetpack-forms' ) }
-			description={
-				data?.subtitle ?? __( 'Akismet filters out form spam with 99% accuracy', 'jetpack-forms' )
-			}
+			title={ data?.title }
+			description={ data?.subtitle }
 			icon={ <AkismetIcon width={ 28 } height={ 28 } /> }
 			isExpanded={ isExpanded }
 			onToggle={ onToggle }

--- a/projects/packages/forms/src/dashboard/integrations/akismet-card.tsx
+++ b/projects/packages/forms/src/dashboard/integrations/akismet-card.tsx
@@ -56,8 +56,10 @@ const AkismetDashboardCard = ( {
 
 	return (
 		<IntegrationCard
-			title={ __( 'Akismet Spam Protection', 'jetpack-forms' ) }
-			description={ __( 'Akismet filters out form spam with 99% accuracy', 'jetpack-forms' ) }
+			title={ data?.title ?? __( 'Akismet Spam Protection', 'jetpack-forms' ) }
+			description={
+				data?.subtitle ?? __( 'Akismet filters out form spam with 99% accuracy', 'jetpack-forms' )
+			}
 			icon={ <AkismetIcon width={ 28 } height={ 28 } /> }
 			isExpanded={ isExpanded }
 			onToggle={ onToggle }

--- a/projects/packages/forms/src/dashboard/integrations/creative-mail-card.tsx
+++ b/projects/packages/forms/src/dashboard/integrations/creative-mail-card.tsx
@@ -40,8 +40,8 @@ const CreativeMailDashboardCard = ( {
 
 	return (
 		<IntegrationCard
-			title={ __( 'Creative Mail', 'jetpack-forms' ) }
-			description={ __( 'Manage email contacts and campaigns', 'jetpack-forms' ) }
+			title={ data?.title ?? __( 'Creative Mail', 'jetpack-forms' ) }
+			description={ data?.subtitle ?? __( 'Manage email contacts and campaigns', 'jetpack-forms' ) }
 			icon={ <CreativeMailIcon /> }
 			isExpanded={ isExpanded }
 			onToggle={ onToggle }

--- a/projects/packages/forms/src/dashboard/integrations/creative-mail-card.tsx
+++ b/projects/packages/forms/src/dashboard/integrations/creative-mail-card.tsx
@@ -40,8 +40,8 @@ const CreativeMailDashboardCard = ( {
 
 	return (
 		<IntegrationCard
-			title={ data?.title ?? __( 'Creative Mail', 'jetpack-forms' ) }
-			description={ data?.subtitle ?? __( 'Manage email contacts and campaigns', 'jetpack-forms' ) }
+			title={ data?.title }
+			description={ data?.subtitle }
 			icon={ <CreativeMailIcon /> }
 			isExpanded={ isExpanded }
 			onToggle={ onToggle }

--- a/projects/packages/forms/src/dashboard/integrations/google-sheets-card.tsx
+++ b/projects/packages/forms/src/dashboard/integrations/google-sheets-card.tsx
@@ -78,10 +78,8 @@ const GoogleSheetsDashboardCard = ( {
 
 	return (
 		<IntegrationCard
-			title={ data?.title ?? __( 'Google Sheets', 'jetpack-forms' ) }
-			description={
-				data?.subtitle ?? __( 'Export form responses to Google Sheets.', 'jetpack-forms' )
-			}
+			title={ data?.title }
+			description={ data?.subtitle }
 			icon={ <GoogleSheetsIcon className="google-sheets-icon" /> }
 			isExpanded={ isExpanded }
 			onToggle={ onToggle }

--- a/projects/packages/forms/src/dashboard/integrations/google-sheets-card.tsx
+++ b/projects/packages/forms/src/dashboard/integrations/google-sheets-card.tsx
@@ -78,8 +78,10 @@ const GoogleSheetsDashboardCard = ( {
 
 	return (
 		<IntegrationCard
-			title={ __( 'Google Sheets', 'jetpack-forms' ) }
-			description={ __( 'Export form responses to Google Sheets.', 'jetpack-forms' ) }
+			title={ data?.title ?? __( 'Google Sheets', 'jetpack-forms' ) }
+			description={
+				data?.subtitle ?? __( 'Export form responses to Google Sheets.', 'jetpack-forms' )
+			}
 			icon={ <GoogleSheetsIcon className="google-sheets-icon" /> }
 			isExpanded={ isExpanded }
 			onToggle={ onToggle }

--- a/projects/packages/forms/src/dashboard/integrations/jetpack-crm-card.tsx
+++ b/projects/packages/forms/src/dashboard/integrations/jetpack-crm-card.tsx
@@ -133,10 +133,8 @@ const JetpackCRMDashboardCard = ( {
 
 	return (
 		<IntegrationCard
-			title={ data?.title ?? __( 'Jetpack CRM', 'jetpack-forms' ) }
-			description={
-				data?.subtitle ?? __( 'Store contact form submissions in your CRM', 'jetpack-forms' )
-			}
+			title={ data?.title }
+			description={ data?.subtitle }
 			icon={ <JetpackIcon color={ COLOR_JETPACK } /> }
 			isExpanded={ isExpanded }
 			onToggle={ onToggle }

--- a/projects/packages/forms/src/dashboard/integrations/jetpack-crm-card.tsx
+++ b/projects/packages/forms/src/dashboard/integrations/jetpack-crm-card.tsx
@@ -133,8 +133,10 @@ const JetpackCRMDashboardCard = ( {
 
 	return (
 		<IntegrationCard
-			title={ __( 'Jetpack CRM', 'jetpack-forms' ) }
-			description={ __( 'Store contact form submissions in your CRM', 'jetpack-forms' ) }
+			title={ data?.title ?? __( 'Jetpack CRM', 'jetpack-forms' ) }
+			description={
+				data?.subtitle ?? __( 'Store contact form submissions in your CRM', 'jetpack-forms' )
+			}
 			icon={ <JetpackIcon color={ COLOR_JETPACK } /> }
 			isExpanded={ isExpanded }
 			onToggle={ onToggle }

--- a/projects/packages/forms/src/dashboard/integrations/mailpoet-card.tsx
+++ b/projects/packages/forms/src/dashboard/integrations/mailpoet-card.tsx
@@ -40,11 +40,8 @@ const MailPoetDashboardCard = ( {
 
 	return (
 		<IntegrationCard
-			title={ data?.title ?? __( 'MailPoet Email Marketing', 'jetpack-forms' ) }
-			description={
-				data?.subtitle ??
-				__( 'Send newsletters and marketing emails directly from your site.', 'jetpack-forms' )
-			}
+			title={ data?.title }
+			description={ data?.subtitle }
 			icon={ <MailPoetIcon width={ 28 } height={ 28 } /> }
 			isExpanded={ isExpanded }
 			onToggle={ onToggle }

--- a/projects/packages/forms/src/dashboard/integrations/mailpoet-card.tsx
+++ b/projects/packages/forms/src/dashboard/integrations/mailpoet-card.tsx
@@ -40,11 +40,11 @@ const MailPoetDashboardCard = ( {
 
 	return (
 		<IntegrationCard
-			title={ __( 'MailPoet Email Marketing', 'jetpack-forms' ) }
-			description={ __(
-				'Send newsletters and marketing emails directly from your site.',
-				'jetpack-forms'
-			) }
+			title={ data?.title ?? __( 'MailPoet Email Marketing', 'jetpack-forms' ) }
+			description={
+				data?.subtitle ??
+				__( 'Send newsletters and marketing emails directly from your site.', 'jetpack-forms' )
+			}
 			icon={ <MailPoetIcon width={ 28 } height={ 28 } /> }
 			isExpanded={ isExpanded }
 			onToggle={ onToggle }

--- a/projects/packages/forms/src/dashboard/integrations/salesforce-card.tsx
+++ b/projects/packages/forms/src/dashboard/integrations/salesforce-card.tsx
@@ -49,7 +49,7 @@ const SalesforceDashboardCard = ( {
 	return (
 		<IntegrationCard
 			title={ data?.title }
-			description={ data?.title }
+			description={ data?.subtitle }
 			icon={ <SalesforceIcon width={ 32 } height={ 32 } /> }
 			isExpanded={ isExpanded }
 			onToggle={ onToggle }

--- a/projects/packages/forms/src/dashboard/integrations/salesforce-card.tsx
+++ b/projects/packages/forms/src/dashboard/integrations/salesforce-card.tsx
@@ -48,8 +48,8 @@ const SalesforceDashboardCard = ( {
 
 	return (
 		<IntegrationCard
-			title={ __( 'Salesforce', 'jetpack-forms' ) }
-			description={ __( 'Send form contacts to Salesforce', 'jetpack-forms' ) }
+			title={ data?.title }
+			description={ data?.title }
 			icon={ <SalesforceIcon width={ 32 } height={ 32 } /> }
 			isExpanded={ isExpanded }
 			onToggle={ onToggle }

--- a/projects/packages/forms/src/dashboard/integrations/style.scss
+++ b/projects/packages/forms/src/dashboard/integrations/style.scss
@@ -4,7 +4,8 @@
 .jp-forms__integrations {
 	padding: 32px 8px;
 	margin: 0 auto 24px auto;
-	max-width: 720px;
+	width: 720px;
+	max-width: 98%;
 
 	.jp-forms__integrations-header {
 		display: flex;

--- a/projects/packages/forms/src/types/index.ts
+++ b/projects/packages/forms/src/types/index.ts
@@ -11,6 +11,10 @@ export interface Integration {
 	slug: string;
 	/** The unique identifier for the integration. */
 	id: string;
+	/** Default title for displaying the integration (server-provided, filterable). */
+	title?: string;
+	/** Default subtitle/description for the integration (server-provided, filterable). */
+	subtitle?: string;
 	/** The plugin file path, if applicable. */
 	pluginFile?: string | null;
 	/** Whether the integration is installed. */

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Endpoint_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Endpoint_Test.php
@@ -171,6 +171,8 @@ class Contact_Form_Endpoint_Test extends TestCase {
 		$this->assertArrayHasKey( 'isActive', $data['akismet'] );
 		$this->assertArrayHasKey( 'isConnected', $data['akismet'] );
 		$this->assertArrayHasKey( 'needsConnection', $data['akismet'] );
+		$this->assertArrayHasKey( 'title', $data['akismet'] );
+		$this->assertArrayHasKey( 'subtitle', $data['akismet'] );
 
 		// Verify structure of google-drive
 		$this->assertArrayHasKey( 'type', $data['google-drive'] );
@@ -219,6 +221,8 @@ class Contact_Form_Endpoint_Test extends TestCase {
 			$this->assertArrayHasKey( 'details', $integration );
 			$this->assertArrayHasKey( 'needsConnection', $integration );
 			$this->assertArrayHasKey( 'marketingUrl', $integration );
+			$this->assertArrayHasKey( 'title', $integration );
+			$this->assertArrayHasKey( 'subtitle', $integration );
 
 			// Verify expected data types
 			$this->assertIsString( $integration['id'] );
@@ -233,6 +237,8 @@ class Contact_Form_Endpoint_Test extends TestCase {
 			$this->assertTrue( $integration['version'] === null || is_string( $integration['version'] ) );
 			$this->assertIsArray( $integration['details'] );
 			$this->assertTrue( $integration['marketingUrl'] === null || is_string( $integration['marketingUrl'] ) );
+			$this->assertTrue( $integration['title'] === '' || is_string( $integration['title'] ) );
+			$this->assertTrue( $integration['subtitle'] === '' || is_string( $integration['subtitle'] ) );
 		}
 	}
 
@@ -264,6 +270,8 @@ class Contact_Form_Endpoint_Test extends TestCase {
 		$this->assertArrayHasKey( 'version', $data );
 		$this->assertArrayHasKey( 'details', $data );
 		$this->assertArrayHasKey( 'needsConnection', $data );
+		$this->assertArrayHasKey( 'title', $data );
+		$this->assertArrayHasKey( 'subtitle', $data );
 	}
 
 	/**

--- a/projects/plugins/jetpack/changelog/add-forms-filter-integration-titles
+++ b/projects/plugins/jetpack/changelog/add-forms-filter-integration-titles
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: Return integration titles from endpoint.


### PR DESCRIPTION
## Proposed changes:

We want to allow users to filter or override integration titles and description. To do that: 
* We added the title and subtitle to all supported integrations in PHP.
* Users can now leverage the existing `jetpack_forms_supported_integrations` filter to change them.
* The title and subtitle are returned from the integration endpoint.
* On the frontend, we now render the title/subtitle from the endpoint, vs hardcoded JS values.

A few other changes were needed to support this:
* We moved the definition of $supported_integrations from a static property to a method, because you cannot use WordPress translated strings when defining a static property. 
* We refactored endpoint callbacks (get_integration, get plugin_status, get_service_status) to avoid duplication of return properties. 

**Example of how to use the filter**
The following code snippet will update the title and subtitle for Akismet, Jetpack CRM, MailPoet, and Google Drive. It hides Creative Mail and leave Salesforce as is. 

```
/**
 * Customize Jetpack Forms integrations (titles/subtitles and visibility).
 */
add_filter( 'jetpack_forms_supported_integrations', function( array $integrations ) {
	// Akismet
	if ( isset( $integrations['akismet'] ) ) {
		$integrations['akismet']['title']    = __( 'Spam', 'your-textdomain' );
		$integrations['akismet']['subtitle'] = __( 'Block 99% of spam.', 'your-textdomain' );
	}

	// Jetpack CRM
	if ( isset( $integrations['zero-bs-crm'] ) ) {
		$integrations['zero-bs-crm']['title']    = __( 'CRM', 'your-textdomain' );
		$integrations['zero-bs-crm']['subtitle'] = __( 'Send contacts to your CRM.', 'your-textdomain' );
	}

	// MailPoet
	if ( isset( $integrations['mailpoet'] ) ) {
		$integrations['mailpoet']['title']    = __( 'Newsletters', 'your-textdomain' );
		$integrations['mailpoet']['subtitle'] = __( 'Add contacts to your newsletter.', 'your-textdomain' );
	}

	// Google Drive
	if ( isset( $integrations['google-drive'] ) ) {
		$integrations['google-drive']['title'] = __( 'Google', 'your-textdomain' );
		$integrations['google-drive']['subtitle'] = __( 'Export contacts to Google.', 'your-textdomain' );
	}

	// Hide Creative Mail (slug: creative-mail-by-constant-contact)
	unset( $integrations['creative-mail-by-constant-contact'] );

	// Salesforce will be unchanged

	return $integrations;
} );
```

**Without any filter**
<img width="749" height="637" alt="integration-titles-before" src="https://github.com/user-attachments/assets/1fd31cee-e7e3-4c2a-b80d-2e1898730c93" />


**With the filter above applied**
<img width="645" height="548" alt="integration-titles-after" src="https://github.com/user-attachments/assets/d2115c68-df71-4031-8516-0d8a39228c37" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test no regressions. Since we made changes to the integrations endpoint, we should confirm no regressions.
   - With no filter applied, open the integrations dashboard and block modal.
   - Confirm all integration cards render as before.
   - Try installing and uninstalling plugins, or connecting services to confirm everything works like normal.
* Test the new filter. 
   - Apply the example filter above and confirm titles and subtitles update as expected, and that Creative Mail is hidden. 
   - Again try installing/uninstalling plugins, or connecting services, to confirm everything works like normal. 
* Tests were updated, so confirm those pass. 

**Known, unrelated issue**
- In my testing, the integration dashboard shows empty when first loading because data is missing. We are pre-loading the endpoint and that should not happen. In a follow up PR, I'll double check why that's happening, fix it, and also add a loading state for the page as a fallback. 