### PR TITLE
Forms: fix missing slashes v2

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-missing-slashes-v2
+++ b/projects/packages/forms/changelog/fix-forms-missing-slashes-v2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: fix V2 missing slashes 

--- a/projects/packages/forms/src/contact-form/class-feedback.php
+++ b/projects/packages/forms/src/contact-form/class-feedback.php
@@ -1021,8 +1021,25 @@ class Feedback {
 		$find[]    = '\"]}';
 		$replace[] = '"]}';
 
-		$find[]    = '\":';
-		$replace[] = '":';
+		$find[]    = '\":[';
+		$replace[] = '":[';
+
+		$find[]    = '\":{';
+		$replace[] = '":{';
+
+		$find[]    = '\":true';
+		$replace[] = '":true';
+
+		$find[]    = '\":false';
+		$replace[] = '":false';
+
+		$find[]    = '\":null';
+		$replace[] = '":null';
+
+		for ( $i = 0; $i <= 9; $i++ ) {
+			$find[]    = '\":' . $i . ',';
+			$replace[] = '":' . $i . ',';
+		}
 
 		$find[]    = "\'";
 		$replace[] = "'";

--- a/projects/packages/forms/src/contact-form/class-feedback.php
+++ b/projects/packages/forms/src/contact-form/class-feedback.php
@@ -886,7 +886,7 @@ class Feedback {
 		if ( $decoded_content === null ) {
 			// Final fallback: attempt to fix malformed JSON with unescaped quotes
 			// Apply stripslashes first, then fix remaining issues
-			$stripped_content = stripslashes( $post_content );
+			$stripped_content = stripslashes( trim( $post_content ) );
 			$fixed_content    = self::fix_malformed_json( $stripped_content );
 			$decoded_content  = json_decode( $fixed_content, true );
 		}
@@ -993,10 +993,6 @@ class Feedback {
 
 		$find[]    = '\\\"';
 		$replace[] = '\"';
-
-		// Key-value separator (with space)
-		$find[]    = '\":\"';
-		$replace[] = '":"';
 
 		$find[]    = '\":[\"';
 		$replace[] = '":["';

--- a/projects/packages/forms/src/contact-form/class-feedback.php
+++ b/projects/packages/forms/src/contact-form/class-feedback.php
@@ -884,6 +884,14 @@ class Feedback {
 		}
 
 		if ( $decoded_content === null ) {
+			// Final fallback: attempt to fix malformed JSON with unescaped quotes
+			// Apply stripslashes first, then fix remaining issues
+			$stripped_content = stripslashes( $post_content );
+			$fixed_content    = self::fix_malformed_json( $stripped_content );
+			$decoded_content  = json_decode( $fixed_content, true );
+		}
+
+		if ( $decoded_content === null ) {
 			return array();
 		}
 		$fields = array();
@@ -959,6 +967,76 @@ class Feedback {
 		$this->add_comment_content_field( $comment_content, $decoded_fields );
 
 		return $decoded_fields;
+	}
+
+	/**
+	 * Attempt to fix malformed JSON by escaping unescaped quotes in string values.
+	 *
+	 * This method handles cases where JSON contains unescaped quotes within string values,
+	 * which causes json_decode to fail.
+	 *
+	 * @param string $json malformed JSON string.
+	 * @return string The JSON string with escaped quotes.
+	 */
+	public static function fix_malformed_json( $json ) {
+
+		$find    = array();
+		$replace = array();
+
+		// Start of JSON object
+		$find[]    = '{\"';
+		$replace[] = '{"';
+
+		// Key-value separator
+		$find[]    = '\":\"';
+		$replace[] = '":"';
+
+		$find[]    = '\\\"';
+		$replace[] = '\"';
+
+		// Key-value separator (with space)
+		$find[]    = '\":\"';
+		$replace[] = '":"';
+
+		$find[]    = '\":[\"';
+		$replace[] = '":["';
+
+		$find[]    = '\",\"';
+		$replace[] = '","';
+
+		$find[]    = ',\"';
+		$replace[] = ',"';
+
+		$find[]    = '\", \"';
+		$replace[] = '", "';
+
+		$find[]    = '\"],\"';
+		$replace[] = '"],"';
+
+		$find[]    = '\"],"';
+		$replace[] = '"],"';
+
+		$find[]    = '\":[],\"';
+		$replace[] = '":[],"';
+
+		$find[]    = '\":[]';
+		$replace[] = '":[]';
+
+		$find[]    = '\"]}';
+		$replace[] = '"]}';
+
+		$find[]    = '\":';
+		$replace[] = '":';
+
+		$find[]    = "\'";
+		$replace[] = "'";
+
+		// End of Json object
+		$find[]    = '\"}';
+		$replace[] = '"}';
+
+		// Remove any slashes that are there to start a new string.
+		return str_replace( $find, $replace, addslashes( $json ) );
 	}
 
 	/**

--- a/projects/packages/forms/src/contact-form/class-feedback.php
+++ b/projects/packages/forms/src/contact-form/class-feedback.php
@@ -997,6 +997,12 @@ class Feedback {
 		$find[]    = '\":[\"';
 		$replace[] = '":["';
 
+		$find[]    = '\"],';
+		$replace[] = '"],';
+
+		$find[]    = ',[\"';
+		$replace[] = ',["';
+
 		$find[]    = '\",\"';
 		$replace[] = '","';
 
@@ -1011,9 +1017,6 @@ class Feedback {
 
 		$find[]    = '\"],"';
 		$replace[] = '"],"';
-
-		$find[]    = '\":[],\"';
-		$replace[] = '":[],"';
 
 		$find[]    = '\":[]';
 		$replace[] = '":[]';
@@ -1037,9 +1040,21 @@ class Feedback {
 		$replace[] = '":null';
 
 		for ( $i = 0; $i <= 9; $i++ ) {
-			$find[]    = '\":' . $i . ',';
-			$replace[] = '":' . $i . ',';
+			$find[]    = '\":' . $i;
+			$replace[] = '":' . $i;
+
+			$find[]    = '\",' . $i;
+			$replace[] = '",' . $i;
 		}
+
+		$find[]    = '\",true';
+		$replace[] = '",true';
+
+		$find[]    = '\",false';
+		$replace[] = '",false';
+
+		$find[]    = '\",null';
+		$replace[] = '",null';
 
 		$find[]    = "\'";
 		$replace[] = "'";

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Test.php
@@ -2228,18 +2228,11 @@ class Feedback_Test extends BaseTestCase {
 			array(
 				'key'  => array(),
 				'key1' => array( 'h "ell"o', "th'er'e " ),
-				'key4' => array(
-					'howdy' => array( 'h "ell"o', "th'er'e " ),
-					1,
-					'asdasd',
-					" asd'sad",
-				),
 				'key5' => '',
 				'key6' => 0,
 				'key7' => null,
 				'key8' => false,
 				'key9' => true,
-
 			),
 			array(
 				'key'  => array(),
@@ -2248,6 +2241,17 @@ class Feedback_Test extends BaseTestCase {
 			array(
 				'key1' => array( 'simplevalue' => 'si "mplev " alue' ),
 				'key2' => array( 'simplevalue' => 'simpl" eval ": ue' ),
+			),
+			array(
+				'key1' => array(
+					1,
+					'asdasd',
+					" asd'sad",
+				),
+				'key2' => array(
+					'key2.1' => array( 'h "ell"o', "th'er'e " ),
+					'key2.2' => array( 'h "ell"o', "th'er'e ", "hell'o", 123, null, true, false, array( 'how " dy' ), array( 'key' => 'va"lu"e' ) ),
+				),
 			),
 		);
 		foreach ( $test_cases_data as $case ) {

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Test.php
@@ -2209,6 +2209,69 @@ class Feedback_Test extends BaseTestCase {
 		$this->assertInstanceOf( Feedback::class, $response );
 	}
 
+	public function test_fix_malformed_json() {
+		$test_cases_data = array(
+			array(
+				'key' => 'va"lu"e',
+			),
+			array(
+				'key' => 'va"lu"e',
+			),
+			array(
+				'key'  => array( 'hello', 'there ' ),
+				'key1' => array( 'h "ell"o', "th'er'e " ),
+			),
+			array(
+				'key'  => array( 'hello', 'there ' ),
+				'key1' => array( 'h "ell"o', "th'er'e " ),
+			),
+			array(
+				'key'  => array(),
+				'key1' => array( 'h "ell"o', "th'er'e " ),
+				'key2' => array( 'simplevalue' => 'si "mplev " alue' ),
+				'key3' => array(),
+				'key4' => array(
+					'howdy' => array( 'h "ell"o', "th'er'e " ),
+					1,
+					'asdasd',
+					" asd'sad",
+				),
+				'key5' => '',
+				'key6' => 0,
+				'key7' => null,
+				'key8' => false,
+				'key9' => true,
+
+			),
+			array(
+				'key'  => array(),
+				'key1' => array( 'h "ell"o', "th'er'e " ),
+				'key2' => array( 'simplevalue' => 'simplevalue' ),
+			),
+		);
+		foreach ( $test_cases_data as $case ) {
+			$this->assertEquals( wp_json_encode( $case ), Feedback::fix_malformed_json( stripslashes( wp_json_encode( $case ) ) ) );
+		}
+	}
+
+	public function test_edgecase_feedback_v2_missing_field_value_bad_json() {
+		// Post data with missing field value.
+		$post_id = wp_insert_post(
+			array(
+				'post_type'      => Feedback::POST_TYPE,
+				'post_title'     => 'Edgecase Feedback',
+				'post_content'   => '{"subject":"[WR8DAR] "Contact" us!","entry_title":"Contact us!","entry_page":1,"fields":[{"key":"1_key label","label":"key label","value":["Nov 25", "2pm "Save Our Stories" with Sandy Simmelink"],"type":"checkbox-multiple","meta":[],"form_field_id":"g124-keylabel"},{"key":"2_Awesome","label":"Awesome","type":"email","meta":[],"form_field_id":"g124-awesome"}]}',
+				'post_status'    => 'publish',
+				'post_mime_type' => 'v2',
+			)
+		);
+
+		$response = Feedback::get( $post_id );
+		$this->assertInstanceOf( Feedback::class, $response );
+		$this->assertSame( '[WR8DAR] "Contact" us!', $response->get_subject() );
+		$this->assertSame( 'Nov 25, 2pm "Save Our Stories" with Sandy Simmelink', $response->get_field_value_by_label( 'key label' ) );
+	}
+
 	/**
 	 * Test that new lines are not stripped from the field value.
 	 */

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Test.php
@@ -2228,8 +2228,6 @@ class Feedback_Test extends BaseTestCase {
 			array(
 				'key'  => array(),
 				'key1' => array( 'h "ell"o', "th'er'e " ),
-				'key2' => array( 'simplevalue' => 'si "mplev " alue' ),
-				'key3' => array(),
 				'key4' => array(
 					'howdy' => array( 'h "ell"o', "th'er'e " ),
 					1,
@@ -2246,7 +2244,10 @@ class Feedback_Test extends BaseTestCase {
 			array(
 				'key'  => array(),
 				'key1' => array( 'h "ell"o', "th'er'e " ),
-				'key2' => array( 'simplevalue' => 'simplevalue' ),
+			),
+			array(
+				'key1' => array( 'simplevalue' => 'si "mplev " alue' ),
+				'key2' => array( 'simplevalue' => 'simpl" eval ": ue' ),
 			),
 		);
 		foreach ( $test_cases_data as $case ) {


### PR DESCRIPTION
Fixes FORMS-255

In V2 we were stripping slashses. So feedback with posts that contained " was escaped. 
No in some cases the V2 posts don't return any data since the JSON string ins not well formated. 

In this PR we now pass they harder to make sure that to feedback be valid json.

## Proposed changes:
* Add a new method that tries to fix the feedback that is missing slashes. By adding them in the correct place. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
10145374-zd-a8c

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
Do the test pass? 

Apply this PR to .com and and sandbox public-api.wordpress.com and notice that when you visit 
The effected site. That you see the feedback as expected. See the ticket for more info.
 

* Go to '..'
*