### PR TITLE
Admin Bar: The admin bar links to Hosting Dashboard, if that is the preference

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/DOTDASH-400-top-bar-links-to-v2
+++ b/projects/packages/jetpack-mu-wpcom/changelog/DOTDASH-400-top-bar-links-to-v2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Admin bar links to Hosting Dashboard, if that is the user's preference.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
@@ -145,6 +145,13 @@ add_action( 'admin_bar_menu', 'wpcom_always_use_user_locale', -1 );
  * @param WP_Admin_Bar $wp_admin_bar The WP_Admin_Bar core object.
  */
 function wpcom_replace_wp_logo_with_wpcom_logo_menu( $wp_admin_bar ) {
+	$user_id     = get_current_user_id();
+	$preferences = get_user_attribute( $user_id, 'calypso_preferences' );
+	if ( empty( $preferences ) ) {
+		$preferences = array();
+	}
+	$hosting_dashboard = ! empty( $preferences['hosting-dashboard-opt-in'] ) && $preferences['hosting-dashboard-opt-in']['value'] === 'opt-in';
+
 	$about_node      = $wp_admin_bar->get_node( 'about' );
 	$contribute_node = $wp_admin_bar->get_node( 'contribute' );
 
@@ -161,7 +168,7 @@ function wpcom_replace_wp_logo_with_wpcom_logo_menu( $wp_admin_bar ) {
 						/* translators: Hidden accessibility text. */
 						__( 'All Sites', 'jetpack-mu-wpcom' ) .
 						'</span>',
-			'href'  => maybe_add_origin_site_id_to_url( 'https://wordpress.com/sites' ),
+			'href'  => maybe_add_origin_site_id_to_url( $hosting_dashboard ? 'https://wordpress.com/v2/sites' : 'https://wordpress.com/sites' ),
 			'meta'  => array(
 				'menu_title' => __( 'All Sites', 'jetpack-mu-wpcom' ),
 			),
@@ -173,7 +180,7 @@ function wpcom_replace_wp_logo_with_wpcom_logo_menu( $wp_admin_bar ) {
 			'parent' => 'wpcom-logo',
 			'id'     => 'wpcom-sites',
 			'title'  => __( 'Sites', 'jetpack-mu-wpcom' ),
-			'href'   => maybe_add_origin_site_id_to_url( 'https://wordpress.com/sites' ),
+			'href'   => maybe_add_origin_site_id_to_url( $hosting_dashboard ? 'https://wordpress.com/v2/sites' : 'https://wordpress.com/sites' ),
 		)
 	);
 
@@ -182,7 +189,7 @@ function wpcom_replace_wp_logo_with_wpcom_logo_menu( $wp_admin_bar ) {
 			'parent' => 'wpcom-logo',
 			'id'     => 'wpcom-domains',
 			'title'  => __( 'Domains', 'jetpack-mu-wpcom' ),
-			'href'   => maybe_add_origin_site_id_to_url( 'https://wordpress.com/domains/manage' ),
+			'href'   => maybe_add_origin_site_id_to_url( $hosting_dashboard ? 'https://wordpress.com/v2/domains' : 'https://wordpress.com/domains/manage' ),
 		)
 	);
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
@@ -145,12 +145,14 @@ add_action( 'admin_bar_menu', 'wpcom_always_use_user_locale', -1 );
  * @param WP_Admin_Bar $wp_admin_bar The WP_Admin_Bar core object.
  */
 function wpcom_replace_wp_logo_with_wpcom_logo_menu( $wp_admin_bar ) {
-	$user_id     = get_current_user_id();
-	$preferences = get_user_attribute( $user_id, 'calypso_preferences' );
-	if ( empty( $preferences ) ) {
-		$preferences = array();
-	}
-	$hosting_dashboard = ! empty( $preferences['hosting-dashboard-opt-in'] ) && $preferences['hosting-dashboard-opt-in']['value'] === 'opt-in';
+	$user_id           = get_current_user_id();
+	$preferences       = get_user_attribute( $user_id, 'calypso_preferences' );
+	$hosting_dashboard = (
+		! empty( $preferences ) &&
+		! empty( $preferences['hosting-dashboard-opt-in'] ) &&
+		! empty( $preferences['hosting-dashboard-opt-in']['value'] ) &&
+		$preferences['hosting-dashboard-opt-in']['value'] === 'opt-in'
+	);
 
 	$about_node      = $wp_admin_bar->get_node( 'about' );
 	$contribute_node = $wp_admin_bar->get_node( 'contribute' );

--- a/projects/packages/jetpack-mu-wpcom/tests/lib/functions-wordpress.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/lib/functions-wordpress.php
@@ -51,3 +51,17 @@ if ( ! function_exists( 'wpcom_rest_api_v2_load_plugin' ) ) {
 		}
 	}
 }
+
+if ( ! function_exists( 'get_user_attribute' ) ) {
+	/**
+	 * A drop-in for a WordPress.com function.
+	 * Tests can mock return value using the global $test_user_attributes variable.
+	 */
+	function get_user_attribute( $user_id, $attribute ) {
+		global $test_user_attributes;
+		if ( ! isset( $test_user_attributes ) || ! is_array( $test_user_attributes ) ) {
+			return null;
+		}
+		return $test_user_attributes[ $attribute ] ?? null;
+	}
+}

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-admin-bar/WPCOM_Admin_Bar_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-admin-bar/WPCOM_Admin_Bar_Test.php
@@ -1,0 +1,150 @@
+<?php
+/**
+ * Test class for admin bar changes.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+use Automattic\Jetpack\Jetpack_Mu_Wpcom;
+
+require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/wpcom-admin-bar/wpcom-admin-bar.php';
+require_once ABSPATH . 'wp-includes/class-wp-admin-bar.php';
+
+const WPCOM_ADMIN_BAR_TEST_OPT_IN  = 1;
+const WPCOM_ADMIN_BAR_TEST_OPT_OUT = 2;
+const WPCOM_ADMIN_BAR_TEST_UNSET   = 3;
+
+/**
+ * Class WPCOM_Admin_Bar_Test
+ */
+class WPCOM_Admin_Bar_Test extends \WorDBless\BaseTestCase {
+	private static function make_test_admin_bar() {
+			$admin_bar = new \WP_Admin_Bar();
+
+			$admin_bar->add_node(
+				array(
+					'id'    => 'wp-logo',
+					'title' => 'WordPress Logo',
+					'href'  => 'https://wordpress.org/',
+				)
+			);
+			$admin_bar->add_node(
+				array(
+					'id'     => 'about',
+					'parent' => 'wp-logo',
+					'title'  => 'About WordPress',
+					'href'   => 'https://wordpress.org/about/',
+				)
+			);
+			$admin_bar->add_node(
+				array(
+					'id'     => 'contribute',
+					'parent' => 'wp-logo',
+					'title'  => 'Get Involved',
+					'href'   => 'https://wordpress.org/contribute/',
+				)
+			);
+
+			return $admin_bar;
+	}
+
+	/**
+	 * Mock the user's hosting dashboard opt-in preference.
+	 *
+	 * @param int $value One of the WPCOM_ADMIN_BAR_TEST_* constants to define the test scenario.
+	 */
+	private static function mock_hosting_dashboard_opt_in_preference( int $value ) {
+		// See tests/lib/functions-wordpress.php for the get_user_attribute mock.
+		global $test_user_attributes;
+		$test_user_attributes = array();
+
+		// Set up preferences based on test scenario
+		if ( $value === WPCOM_ADMIN_BAR_TEST_OPT_IN ) {
+			$test_user_attributes = array(
+				'calypso_preferences' => array(
+					'hosting-dashboard-opt-in' => array(
+						'value' => 'opt-in',
+					),
+				),
+			);
+		} elseif ( $value === WPCOM_ADMIN_BAR_TEST_OPT_OUT ) {
+			$test_user_attributes = array(
+				'calypso_preferences' => array(
+					'hosting-dashboard-opt-in' => array(
+						'value' => 'opt-out',
+					),
+				),
+			);
+		}
+	}
+
+	public function test_wp_logo_replaced_by_wpcom_logo() {
+		self::mock_hosting_dashboard_opt_in_preference( WPCOM_ADMIN_BAR_TEST_UNSET );
+
+		$admin_bar = self::make_test_admin_bar();
+		wpcom_replace_wp_logo_with_wpcom_logo_menu( $admin_bar );
+
+		$this->assertNull( $admin_bar->get_node( 'wp-logo' ) );
+		$this->assertNotNull( $admin_bar->get_node( 'wpcom-logo' ) );
+	}
+
+	public function test_hosting_dashboard_opt_out_menu_links() {
+		self::mock_hosting_dashboard_opt_in_preference( WPCOM_ADMIN_BAR_TEST_OPT_OUT );
+
+		$admin_bar = self::make_test_admin_bar();
+		wpcom_replace_wp_logo_with_wpcom_logo_menu( $admin_bar );
+
+		$wpcom_logo_node = $admin_bar->get_node( 'wpcom-logo' );
+		$this->assertStringContainsString( 'https://wordpress.com/sites', $wpcom_logo_node->href );
+
+		$sites_node = $admin_bar->get_node( 'wpcom-sites' );
+		$this->assertNotNull( $sites_node );
+		$this->assertStringContainsString( 'https://wordpress.com/sites', $sites_node->href );
+		$this->assertEquals( 'wpcom-logo', $sites_node->parent );
+
+		$domains_node = $admin_bar->get_node( 'wpcom-domains' );
+		$this->assertNotNull( $domains_node );
+		$this->assertStringContainsString( 'https://wordpress.com/domains', $domains_node->href );
+		$this->assertEquals( 'wpcom-logo', $domains_node->parent );
+	}
+
+	public function test_hosting_dashboard_preference_unset_menu_links() {
+		self::mock_hosting_dashboard_opt_in_preference( WPCOM_ADMIN_BAR_TEST_UNSET );
+
+		$admin_bar = self::make_test_admin_bar();
+		wpcom_replace_wp_logo_with_wpcom_logo_menu( $admin_bar );
+
+		$wpcom_logo_node = $admin_bar->get_node( 'wpcom-logo' );
+		$this->assertStringContainsString( 'https://wordpress.com/sites', $wpcom_logo_node->href );
+
+		$sites_node = $admin_bar->get_node( 'wpcom-sites' );
+		$this->assertNotNull( $sites_node );
+		$this->assertStringContainsString( 'https://wordpress.com/sites', $sites_node->href );
+		$this->assertEquals( 'wpcom-logo', $sites_node->parent );
+
+		$domains_node = $admin_bar->get_node( 'wpcom-domains' );
+		$this->assertNotNull( $domains_node );
+		$this->assertStringContainsString( 'https://wordpress.com/domains', $domains_node->href );
+		$this->assertEquals( 'wpcom-logo', $domains_node->parent );
+	}
+
+	public function test_hosting_dashboard_opt_in_menu_links() {
+		self::mock_hosting_dashboard_opt_in_preference( WPCOM_ADMIN_BAR_TEST_OPT_IN );
+
+		$admin_bar = self::make_test_admin_bar();
+		wpcom_replace_wp_logo_with_wpcom_logo_menu( $admin_bar );
+
+		$wpcom_logo_node = $admin_bar->get_node( 'wpcom-logo' );
+		$this->assertStringContainsString( 'https://wordpress.com/v2/sites', $wpcom_logo_node->href );
+
+		$sites_node = $admin_bar->get_node( 'wpcom-sites' );
+		$this->assertNotNull( $sites_node );
+		$this->assertStringContainsString( 'https://wordpress.com/v2/sites', $sites_node->href );
+		$this->assertEquals( 'wpcom-logo', $sites_node->parent );
+
+		$domains_node = $admin_bar->get_node( 'wpcom-domains' );
+		$this->assertNotNull( $domains_node );
+		$this->assertStringContainsString( 'https://wordpress.com/v2/domains', $domains_node->href );
+		$this->assertEquals( 'wpcom-logo', $domains_node->parent );
+	}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes DOTDASH-400

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

Checks the Calypso preferences when rendering the admin bar.
If the user has opt'd in to the Hosting Dashboard, the (W) links will point to the Hosting Dashboard.

<img width="278" alt="CleanShot 2025-09-12 at 11 34 39@2x" src="https://github.com/user-attachments/assets/4d56f66f-c5b2-4126-9388-d117c2bfb40d" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

This is testable, but I don't know how we can merge this ahead of time 🤔 Site front ends don't have the equivalent of `wpcalypso` that we can deploy to.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Use `wpcalypso.wordpress.com/me/account` to opt-in/out of the hosting dashbaord
* Deploy this change to your sandbox
* Sandbox your test site
* Load the test site front end and confirm the (w) links in the top-left point to the correct place.