### PR TITLE
PayPal Payments: Improve robustness of payment buttons parsing logic

### DIFF
--- a/projects/packages/paypal-payments/changelog/update-paypal-payment-buttons-robustness
+++ b/projects/packages/paypal-payments/changelog/update-paypal-payment-buttons-robustness
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Improve robustness of PayPal payment buttons parsing

--- a/projects/packages/paypal-payments/src/paypal-payment-buttons/class-paypal-payment-buttons.php
+++ b/projects/packages/paypal-payments/src/paypal-payment-buttons/class-paypal-payment-buttons.php
@@ -114,11 +114,13 @@ class PayPal_Payment_Buttons {
 
 			$button_html = sprintf(
 				'<style>.pp-%1$s{text-align:center;border:none;border-radius:0.25rem;min-width:11.625rem;padding:0 2rem;height:2.625rem;font-weight:bold;background-color:#FFD140;color:#000000;font-family:"Helvetica Neue",Arial,sans-serif;font-size:1rem;line-height:1.25rem;cursor:pointer;}</style>
+<div>
 <form action="%2$s" method="post" target="_blank" style="display:inline-grid;justify-items:center;align-content:start;gap:0.5rem;">
   <input class="pp-%1$s" type="submit" value="%3$s" />
   <img src="https://www.paypalobjects.com/images/Debit_Credit_APM.svg" alt="cards" />
   <section style="font-size: 0.75rem;"> Powered by <img src="https://www.paypalobjects.com/paypal-ui/logos/svg/paypal-wordmark-color.svg" alt="paypal" style="height:0.875rem;vertical-align:middle;"/></section>
-</form>',
+</form>
+</div>',
 				$payment_id,
 				$action_url,
 				$button_text_escaped

--- a/projects/packages/paypal-payments/src/paypal-payment-buttons/edit.js
+++ b/projects/packages/paypal-payments/src/paypal-payment-buttons/edit.js
@@ -43,7 +43,7 @@ const extractHostedButtonId = codeBody => {
 	// Extract ID before any query parameters or spaces
 	if ( ! buttonId ) {
 		const actionMatch = codeBody.match(
-			/action\s*=\s*["'](?:https?:)?\/\/(?:www\.)?paypal\.[a-z.]+\/ncp\/payment\/([A-Za-z0-9_-]+)\s*(?:\?[^"']*)?["']/i
+			/action\s*=\s*["'](?:https?:)?\/\/(?:www\.)?(?:sandbox\.)?paypal\.[a-z.]+\/ncp\/payment\/([A-Za-z0-9_-]+)\s*(?:\?[^"']*)?["']/i
 		);
 		if ( actionMatch ) {
 			buttonId = actionMatch[ 1 ];

--- a/projects/packages/paypal-payments/src/paypal-payment-buttons/edit.js
+++ b/projects/packages/paypal-payments/src/paypal-payment-buttons/edit.js
@@ -18,6 +18,8 @@ import { __ } from '@wordpress/i18n';
 import PayPalIcon from './icon';
 import './editor.scss';
 
+const BUTTON_ID_PATTERN = '[A-Za-z0-9_-]+';
+
 const extractScriptSrc = codeHead => {
 	const match = codeHead.match(
 		/src="(https:\/\/(www\.)?(sandbox\.)?paypal\.com\/sdk\/js\?[^"]+)"/
@@ -26,39 +28,36 @@ const extractScriptSrc = codeHead => {
 };
 
 const extractHostedButtonId = codeBody => {
-	// Try to extract from hostedButtonId property first (stacked buttons)
-	const hostedButtonMatch = codeBody.match( /hostedButtonId:\s*["']([^"']+)["']/ );
-	if ( hostedButtonMatch ) {
-		return hostedButtonMatch[ 1 ];
-	}
+	let buttonId = '';
 
-	// Try to extract from container ID (stacked buttons)
-	const containerMatch = codeBody.match( /paypal-container-([^"']+)/ );
-	if ( containerMatch ) {
-		return containerMatch[ 1 ];
+	// Try to extract from hostedButtonId property first (stacked buttons)
+	const hostedButtonMatch = codeBody.match(
+		new RegExp( `hostedButtonId:\\s*["'](${ BUTTON_ID_PATTERN })["']` )
+	);
+	if ( hostedButtonMatch ) {
+		buttonId = hostedButtonMatch[ 1 ];
 	}
 
 	// Try to extract from form action URL (single buttons)
-	const actionMatch = codeBody.match(
-		/action=["']https:\/\/www\.paypal\.com\/ncp\/payment\/([^"']+)["']/
-	);
-	if ( actionMatch ) {
-		return actionMatch[ 1 ];
+	// Support international domains, protocol-relative URLs, and case-insensitive domain matching
+	// Extract ID before any query parameters or spaces
+	if ( ! buttonId ) {
+		const actionMatch = codeBody.match(
+			/action\s*=\s*["'](?:https?:)?\/\/(?:www\.)?paypal\.[a-z.]+\/ncp\/payment\/([A-Za-z0-9_-]+)\s*(?:\?[^"']*)?["']/i
+		);
+		if ( actionMatch ) {
+			buttonId = actionMatch[ 1 ];
+		}
 	}
 
-	// Try to extract from CSS class (single buttons)
-	const cssMatch = codeBody.match( /\.pp-([A-Z0-9]+)/ );
-	if ( cssMatch ) {
-		return cssMatch[ 1 ];
-	}
-
-	return '';
+	return buttonId.trim();
 };
 
 const extractButtonText = codeBody => {
 	// Extract button text from input value attribute (single buttons)
-	const inputMatch = codeBody.match( /<input[^>]*value=["']([^"']+)["'][^>]*\/>/ );
-	return inputMatch ? inputMatch[ 1 ] : '';
+	// Support spaces around equals sign and both self-closing and non-self-closing tags
+	const inputMatch = codeBody.match( /<input[^>]*value\s*=\s*["']([^"']+)["'][^>]*\/?>/ );
+	return inputMatch ? inputMatch[ 1 ].trim() : '';
 };
 
 const generateHeadCode = scriptSrc => {
@@ -93,7 +92,10 @@ const generateBodyCode = ( hostedButtonId, buttonType = 'stacked', buttonText = 
 const validScriptSrc = scriptSrc =>
 	/^https:\/\/(www\.)?(sandbox\.)?paypal\.com\/sdk\/js\?client-id=/.test( scriptSrc );
 
-const validHostedButtonId = hostedButtonId => /^[A-Z0-9]+$/.test( hostedButtonId );
+const validHostedButtonId = hostedButtonId => {
+	// Validate the button ID format
+	return new RegExp( `^${ BUTTON_ID_PATTERN }$` ).test( hostedButtonId );
+};
 
 const validButtonText = buttonText =>
 	buttonText && buttonText.trim().length > 0 && buttonText.length <= 50;

--- a/projects/packages/paypal-payments/tests/js/paypal-payment-buttons-block-tests/edit.test.js
+++ b/projects/packages/paypal-payments/tests/js/paypal-payment-buttons-block-tests/edit.test.js
@@ -515,6 +515,35 @@ describe( 'Edit', () => {
 			} );
 		} );
 
+		it( 'handles sandbox PayPal domain', () => {
+			const setAttributes = jest.fn();
+			render(
+				<Edit
+					attributes={ { ...defaultProps.attributes, buttonType: 'single' } }
+					setAttributes={ setAttributes }
+					isSelected={ true }
+				/>
+			);
+
+			const snippetSandbox = `<style>.pp-FHK6SXBKZXM4A{text-align:center;border:none;border-radius:0.25rem;min-width:11.625rem;padding:0 2rem;height:2.625rem;font-weight:bold;background-color:#FFD140;color:#000000;font-family:"Helvetica Neue",Arial,sans-serif;font-size:1rem;line-height:1.25rem;cursor:pointer;}</style>
+<form action="https://www.sandbox.paypal.com/ncp/payment/FHK6SXBKZXM4A" method="post" target="_blank" style="display:inline-grid;justify-items:center;align-content:start;gap:0.5rem;">
+  <input class="pp-FHK6SXBKZXM4A" type="submit" value="Buy Now" />
+  <img src=https://www.paypalobjects.com/images/Debit_Credit_APM.svg alt="cards" />
+  <section style="font-size: 0.75rem;"> Powered by <img src="https://www.paypalobjects.com/paypal-ui/logos/svg/paypal-wordmark-color.svg" alt="paypal" style="height:0.875rem;vertical-align:middle;"/></section>
+</form>`;
+
+			const inputs = screen.getAllByTestId( 'plain-text' );
+			// eslint-disable-next-line testing-library/prefer-user-event
+			fireEvent.change( inputs[ 0 ], {
+				target: { value: snippetSandbox },
+			} );
+
+			expect( setAttributes ).toHaveBeenCalledWith( {
+				hostedButtonId: 'FHK6SXBKZXM4A',
+				buttonText: 'Buy Now',
+			} );
+		} );
+
 		it( 'handles spaces around equals sign in attributes', () => {
 			const setAttributes = jest.fn();
 			render(

--- a/projects/packages/paypal-payments/tests/js/paypal-payment-buttons-block-tests/edit.test.js
+++ b/projects/packages/paypal-payments/tests/js/paypal-payment-buttons-block-tests/edit.test.js
@@ -266,6 +266,442 @@ describe( 'Edit', () => {
 		} );
 	} );
 
+	describe( 'PayPal Code Snippet Parsing', () => {
+		it( 'parses original PayPal single button snippet correctly', () => {
+			const setAttributes = jest.fn();
+			render(
+				<Edit
+					attributes={ { ...defaultProps.attributes, buttonType: 'single' } }
+					setAttributes={ setAttributes }
+					isSelected={ true }
+				/>
+			);
+
+			const originalSnippet = `<style>.pp-HLDQA6NDL5TLG{text-align:center;border:none;border-radius:0.25rem;min-width:11.625rem;padding:0 2rem;height:2.625rem;font-weight:bold;background-color:#FFD140;color:#000000;font-family:"Helvetica Neue",Arial,sans-serif;font-size:1rem;line-height:1.25rem;cursor:pointer;}</style> <form action="https://www.paypal.com/ncp/payment/HLDQA6NDL5TLG" method="post" target="_blank" style="display:inline-grid;justify-items:center;align-content:start;gap:0.5rem;">   <input class="pp-HLDQA6NDL5TLG" type="submit" value="Buy Now" />   <img src=https://www.paypalobjects.com/images/Debit_Credit_APM.svg alt="cards" />   <section style="font-size: 0.75rem;"> Powered by <img src="https://www.paypalobjects.com/paypal-ui/logos/svg/paypal-wordmark-color.svg" alt="paypal" style="height:0.875rem;vertical-align:middle;"/></section> </form>`;
+
+			const inputs = screen.getAllByTestId( 'plain-text' );
+			// eslint-disable-next-line testing-library/prefer-user-event
+			fireEvent.change( inputs[ 0 ], {
+				target: { value: originalSnippet },
+			} );
+
+			expect( setAttributes ).toHaveBeenCalledWith( {
+				hostedButtonId: 'HLDQA6NDL5TLG',
+				buttonText: 'Buy Now',
+			} );
+		} );
+
+		it( 'parses PayPal snippet with query parameters and div wrapper', () => {
+			const setAttributes = jest.fn();
+			render(
+				<Edit
+					attributes={ { ...defaultProps.attributes, buttonType: 'single' } }
+					setAttributes={ setAttributes }
+					isSelected={ true }
+				/>
+			);
+
+			const snippetWithQueryParams = `<div><style>.pp-HLDQA6NDL5TLG{text-align:center;border:none;border-radius:0.25rem;min-width:11.625rem;padding:0 2rem;height:2.625rem;font-weight:bold;background-color:#FFD140;color:#000000;font-family:"Helvetica Neue",Arial,sans-serif;font-size:1rem;line-height:1.25rem;cursor:pointer;}</style><form action="https://www.paypal.com/ncp/payment/HLDQA6NDL5TLG?at_code=WooNCPS_Ecom_Wordpress" method="post" target="_blank" style="display:inline-grid;justify-items:center;align-content:start;gap:0.5rem;">
+  <input class="pp-HLDQA6NDL5TLG" type="submit" value="Buy Now">
+  <img src="https://www.paypalobjects.com/images/Debit_Credit_APM.svg" alt="cards">
+  <section style="font-size: 0.75rem;"> Powered by <img src="https://www.paypalobjects.com/paypal-ui/logos/svg/paypal-wordmark-color.svg" alt="paypal" style="height:0.875rem;vertical-align:middle;"></section>
+</form></div>`;
+
+			const inputs = screen.getAllByTestId( 'plain-text' );
+			// eslint-disable-next-line testing-library/prefer-user-event
+			fireEvent.change( inputs[ 0 ], {
+				target: { value: snippetWithQueryParams },
+			} );
+
+			expect( setAttributes ).toHaveBeenCalledWith( {
+				hostedButtonId: 'HLDQA6NDL5TLG',
+				buttonText: 'Buy Now',
+			} );
+		} );
+
+		it( 'parses non-self-terminating input tags correctly', () => {
+			const setAttributes = jest.fn();
+			render(
+				<Edit
+					attributes={ { ...defaultProps.attributes, buttonType: 'single' } }
+					setAttributes={ setAttributes }
+					isSelected={ true }
+				/>
+			);
+
+			const snippetNonSelfTerminating = `<form action="https://www.paypal.com/ncp/payment/ABC123DEF" method="post">
+				<input class="pp-ABC123DEF" type="submit" value="Purchase Item">
+			</form>`;
+
+			const inputs = screen.getAllByTestId( 'plain-text' );
+			// eslint-disable-next-line testing-library/prefer-user-event
+			fireEvent.change( inputs[ 0 ], {
+				target: { value: snippetNonSelfTerminating },
+			} );
+
+			expect( setAttributes ).toHaveBeenCalledWith( {
+				hostedButtonId: 'ABC123DEF',
+				buttonText: 'Purchase Item',
+			} );
+		} );
+
+		it( 'handles URL with multiple query parameters', () => {
+			const setAttributes = jest.fn();
+			render(
+				<Edit
+					attributes={ { ...defaultProps.attributes, buttonType: 'single' } }
+					setAttributes={ setAttributes }
+					isSelected={ true }
+				/>
+			);
+
+			const snippetMultipleParams = `<form action="https://www.paypal.com/ncp/payment/XYZ789GHI?at_code=WooNCPS_Ecom_Wordpress&utm_source=wordpress&campaign=test" method="post">
+				<input type="submit" value="Subscribe" />
+			</form>`;
+
+			const inputs = screen.getAllByTestId( 'plain-text' );
+			// eslint-disable-next-line testing-library/prefer-user-event
+			fireEvent.change( inputs[ 0 ], {
+				target: { value: snippetMultipleParams },
+			} );
+
+			expect( setAttributes ).toHaveBeenCalledWith( {
+				hostedButtonId: 'XYZ789GHI',
+				buttonText: 'Subscribe',
+			} );
+		} );
+
+		it( 'handles multi-line input with various formatting', () => {
+			const setAttributes = jest.fn();
+			render(
+				<Edit
+					attributes={ { ...defaultProps.attributes, buttonType: 'single' } }
+					setAttributes={ setAttributes }
+					isSelected={ true }
+				/>
+			);
+
+			const multiLineSnippet = `<style>
+				.pp-MULTILINE123 {
+					text-align: center;
+				}
+			</style>
+			<form
+				action="https://www.paypal.com/ncp/payment/MULTILINE123"
+				method="post"
+				target="_blank">
+				<input
+					class="pp-MULTILINE123"
+					type="submit"
+					value="Multi Line Button" />
+			</form>`;
+
+			const inputs = screen.getAllByTestId( 'plain-text' );
+			// eslint-disable-next-line testing-library/prefer-user-event
+			fireEvent.change( inputs[ 0 ], {
+				target: { value: multiLineSnippet },
+			} );
+
+			expect( setAttributes ).toHaveBeenCalledWith( {
+				hostedButtonId: 'MULTILINE123',
+				buttonText: 'Multi Line Button',
+			} );
+		} );
+	} );
+
+	describe( 'Edge Cases Handling', () => {
+		it( 'handles lowercase button IDs', () => {
+			const setAttributes = jest.fn();
+			render(
+				<Edit
+					attributes={ { ...defaultProps.attributes, buttonType: 'single' } }
+					setAttributes={ setAttributes }
+					isSelected={ true }
+				/>
+			);
+
+			const snippet = `<form action="https://www.paypal.com/ncp/payment/abc123def" method="post">
+				<input type="submit" value="Buy" />
+			</form>`;
+
+			const inputs = screen.getAllByTestId( 'plain-text' );
+			// eslint-disable-next-line testing-library/prefer-user-event
+			fireEvent.change( inputs[ 0 ], {
+				target: { value: snippet },
+			} );
+
+			expect( setAttributes ).toHaveBeenCalledWith( {
+				hostedButtonId: 'abc123def',
+				buttonText: 'Buy',
+			} );
+		} );
+
+		it( 'handles button IDs with hyphens and underscores', () => {
+			const setAttributes = jest.fn();
+			render(
+				<Edit
+					attributes={ { ...defaultProps.attributes, buttonType: 'single' } }
+					setAttributes={ setAttributes }
+					isSelected={ true }
+				/>
+			);
+
+			const snippet = `<style>.pp-ABC-123_DEF{}</style>
+				<form action="https://www.paypal.com/ncp/payment/ABC-123_DEF" method="post">
+					<input class="pp-ABC-123_DEF" type="submit" value="Purchase" />
+				</form>`;
+
+			const inputs = screen.getAllByTestId( 'plain-text' );
+			// eslint-disable-next-line testing-library/prefer-user-event
+			fireEvent.change( inputs[ 0 ], {
+				target: { value: snippet },
+			} );
+
+			expect( setAttributes ).toHaveBeenCalledWith( {
+				hostedButtonId: 'ABC-123_DEF',
+				buttonText: 'Purchase',
+			} );
+		} );
+
+		it( 'handles HTML entities in button text', () => {
+			const setAttributes = jest.fn();
+			render(
+				<Edit
+					attributes={ { ...defaultProps.attributes, buttonType: 'single' } }
+					setAttributes={ setAttributes }
+					isSelected={ true }
+				/>
+			);
+
+			const snippet = `<form action="https://www.paypal.com/ncp/payment/TEST123" method="post">
+				<input type="submit" value="Buy &amp; Save" />
+			</form>`;
+
+			const inputs = screen.getAllByTestId( 'plain-text' );
+			// eslint-disable-next-line testing-library/prefer-user-event
+			fireEvent.change( inputs[ 0 ], {
+				target: { value: snippet },
+			} );
+
+			expect( setAttributes ).toHaveBeenCalledWith( {
+				hostedButtonId: 'TEST123',
+				buttonText: 'Buy & Save',
+			} );
+		} );
+
+		it( 'handles special characters and quotes in button text', () => {
+			const setAttributes = jest.fn();
+			render(
+				<Edit
+					attributes={ { ...defaultProps.attributes, buttonType: 'single' } }
+					setAttributes={ setAttributes }
+					isSelected={ true }
+				/>
+			);
+
+			const snippet = `<form action="https://www.paypal.com/ncp/payment/QUOTES123" method="post">
+				<input type="submit" value="John&apos;s &quot;Special&quot; Shop" />
+			</form>`;
+
+			const inputs = screen.getAllByTestId( 'plain-text' );
+			// eslint-disable-next-line testing-library/prefer-user-event
+			fireEvent.change( inputs[ 0 ], {
+				target: { value: snippet },
+			} );
+
+			expect( setAttributes ).toHaveBeenCalledWith( {
+				hostedButtonId: 'QUOTES123',
+				buttonText: 'John\'s "Special" Shop',
+			} );
+		} );
+
+		it( 'handles international PayPal domains', () => {
+			const setAttributes = jest.fn();
+			render(
+				<Edit
+					attributes={ { ...defaultProps.attributes, buttonType: 'single' } }
+					setAttributes={ setAttributes }
+					isSelected={ true }
+				/>
+			);
+
+			const snippetUK = `<form action="https://www.paypal.co.uk/ncp/payment/UK123ABC" method="post">
+				<input type="submit" value="Buy from UK" />
+			</form>`;
+
+			const inputs = screen.getAllByTestId( 'plain-text' );
+			// eslint-disable-next-line testing-library/prefer-user-event
+			fireEvent.change( inputs[ 0 ], {
+				target: { value: snippetUK },
+			} );
+
+			expect( setAttributes ).toHaveBeenCalledWith( {
+				hostedButtonId: 'UK123ABC',
+				buttonText: 'Buy from UK',
+			} );
+		} );
+
+		it( 'handles German PayPal domain', () => {
+			const setAttributes = jest.fn();
+			render(
+				<Edit
+					attributes={ { ...defaultProps.attributes, buttonType: 'single' } }
+					setAttributes={ setAttributes }
+					isSelected={ true }
+				/>
+			);
+
+			const snippetDE = `<form action="https://www.paypal.de/ncp/payment/DE789XYZ" method="post">
+				<input type="submit" value="Jetzt kaufen" />
+			</form>`;
+
+			const inputs = screen.getAllByTestId( 'plain-text' );
+			// eslint-disable-next-line testing-library/prefer-user-event
+			fireEvent.change( inputs[ 0 ], {
+				target: { value: snippetDE },
+			} );
+
+			expect( setAttributes ).toHaveBeenCalledWith( {
+				hostedButtonId: 'DE789XYZ',
+				buttonText: 'Jetzt kaufen',
+			} );
+		} );
+
+		it( 'handles spaces around equals sign in attributes', () => {
+			const setAttributes = jest.fn();
+			render(
+				<Edit
+					attributes={ { ...defaultProps.attributes, buttonType: 'single' } }
+					setAttributes={ setAttributes }
+					isSelected={ true }
+				/>
+			);
+
+			const snippet = `<form action = "https://www.paypal.com/ncp/payment/SPACES123" method="post">
+				<input type="submit" value = "Buy Now" />
+			</form>`;
+
+			const inputs = screen.getAllByTestId( 'plain-text' );
+			// eslint-disable-next-line testing-library/prefer-user-event
+			fireEvent.change( inputs[ 0 ], {
+				target: { value: snippet },
+			} );
+
+			expect( setAttributes ).toHaveBeenCalledWith( {
+				hostedButtonId: 'SPACES123',
+				buttonText: 'Buy Now',
+			} );
+		} );
+
+		it( 'trims whitespace from extracted values', () => {
+			const setAttributes = jest.fn();
+			render(
+				<Edit
+					attributes={ { ...defaultProps.attributes, buttonType: 'single' } }
+					setAttributes={ setAttributes }
+					isSelected={ true }
+				/>
+			);
+
+			const snippet = `<form action="https://www.paypal.com/ncp/payment/TRIM123  " method="post">
+				<input type="submit" value="  Buy Now  " />
+			</form>`;
+
+			const inputs = screen.getAllByTestId( 'plain-text' );
+			// eslint-disable-next-line testing-library/prefer-user-event
+			fireEvent.change( inputs[ 0 ], {
+				target: { value: snippet },
+			} );
+
+			expect( setAttributes ).toHaveBeenCalledWith( {
+				hostedButtonId: 'TRIM123',
+				buttonText: 'Buy Now',
+			} );
+		} );
+
+		it( 'handles multiple buttons - extracts only the first', () => {
+			const setAttributes = jest.fn();
+			render(
+				<Edit
+					attributes={ { ...defaultProps.attributes, buttonType: 'single' } }
+					setAttributes={ setAttributes }
+					isSelected={ true }
+				/>
+			);
+
+			const snippet = `<form action="https://www.paypal.com/ncp/payment/FIRST123" method="post">
+				<input type="submit" value="First Button" />
+			</form>
+			<form action="https://www.paypal.com/ncp/payment/SECOND456" method="post">
+				<input type="submit" value="Second Button" />
+			</form>`;
+
+			const inputs = screen.getAllByTestId( 'plain-text' );
+			// eslint-disable-next-line testing-library/prefer-user-event
+			fireEvent.change( inputs[ 0 ], {
+				target: { value: snippet },
+			} );
+
+			// Should extract only the first button
+			expect( setAttributes ).toHaveBeenCalledWith( {
+				hostedButtonId: 'FIRST123',
+				buttonText: 'First Button',
+			} );
+		} );
+
+		it( 'handles protocol-relative URLs', () => {
+			const setAttributes = jest.fn();
+			render(
+				<Edit
+					attributes={ { ...defaultProps.attributes, buttonType: 'single' } }
+					setAttributes={ setAttributes }
+					isSelected={ true }
+				/>
+			);
+
+			const snippet = `<form action="//www.paypal.com/ncp/payment/PROTOCOL123" method="post">
+				<input type="submit" value="Buy" />
+			</form>`;
+
+			const inputs = screen.getAllByTestId( 'plain-text' );
+			// eslint-disable-next-line testing-library/prefer-user-event
+			fireEvent.change( inputs[ 0 ], {
+				target: { value: snippet },
+			} );
+
+			expect( setAttributes ).toHaveBeenCalledWith( {
+				hostedButtonId: 'PROTOCOL123',
+				buttonText: 'Buy',
+			} );
+		} );
+
+		it( 'handles mixed case in domain names', () => {
+			const setAttributes = jest.fn();
+			render(
+				<Edit
+					attributes={ { ...defaultProps.attributes, buttonType: 'single' } }
+					setAttributes={ setAttributes }
+					isSelected={ true }
+				/>
+			);
+
+			const snippet = `<form action="https://www.PayPal.COM/ncp/payment/MIXEDCASE123" method="post">
+				<input type="submit" value="Buy" />
+			</form>`;
+
+			const inputs = screen.getAllByTestId( 'plain-text' );
+			// eslint-disable-next-line testing-library/prefer-user-event
+			fireEvent.change( inputs[ 0 ], {
+				target: { value: snippet },
+			} );
+
+			expect( setAttributes ).toHaveBeenCalledWith( {
+				hostedButtonId: 'MIXEDCASE123',
+				buttonText: 'Buy',
+			} );
+		} );
+	} );
+
 	describe( 'Validation Notices', () => {
 		it( 'shows error notice for invalid script URL', () => {
 			render(
@@ -307,7 +743,7 @@ describe( 'Edit', () => {
 					attributes={ {
 						buttonType: 'stacked',
 						scriptSrc: 'https://www.paypal.com/sdk/js?client-id=test',
-						hostedButtonId: 'invalid-button-id-123',
+						hostedButtonId: 'invalid@button#id!123', // Contains invalid characters
 					} }
 					setAttributes={ jest.fn() }
 					isSelected={ false }

--- a/projects/packages/paypal-payments/tests/js/paypal-payment-buttons-block-tests/edit.test.js
+++ b/projects/packages/paypal-payments/tests/js/paypal-payment-buttons-block-tests/edit.test.js
@@ -463,58 +463,6 @@ describe( 'Edit', () => {
 			} );
 		} );
 
-		it( 'handles HTML entities in button text', () => {
-			const setAttributes = jest.fn();
-			render(
-				<Edit
-					attributes={ { ...defaultProps.attributes, buttonType: 'single' } }
-					setAttributes={ setAttributes }
-					isSelected={ true }
-				/>
-			);
-
-			const snippet = `<form action="https://www.paypal.com/ncp/payment/TEST123" method="post">
-				<input type="submit" value="Buy &amp; Save" />
-			</form>`;
-
-			const inputs = screen.getAllByTestId( 'plain-text' );
-			// eslint-disable-next-line testing-library/prefer-user-event
-			fireEvent.change( inputs[ 0 ], {
-				target: { value: snippet },
-			} );
-
-			expect( setAttributes ).toHaveBeenCalledWith( {
-				hostedButtonId: 'TEST123',
-				buttonText: 'Buy & Save',
-			} );
-		} );
-
-		it( 'handles special characters and quotes in button text', () => {
-			const setAttributes = jest.fn();
-			render(
-				<Edit
-					attributes={ { ...defaultProps.attributes, buttonType: 'single' } }
-					setAttributes={ setAttributes }
-					isSelected={ true }
-				/>
-			);
-
-			const snippet = `<form action="https://www.paypal.com/ncp/payment/QUOTES123" method="post">
-				<input type="submit" value="John&apos;s &quot;Special&quot; Shop" />
-			</form>`;
-
-			const inputs = screen.getAllByTestId( 'plain-text' );
-			// eslint-disable-next-line testing-library/prefer-user-event
-			fireEvent.change( inputs[ 0 ], {
-				target: { value: snippet },
-			} );
-
-			expect( setAttributes ).toHaveBeenCalledWith( {
-				hostedButtonId: 'QUOTES123',
-				buttonText: 'John\'s "Special" Shop',
-			} );
-		} );
-
 		it( 'handles international PayPal domains', () => {
 			const setAttributes = jest.fn();
 			render(


### PR DESCRIPTION
## Proposed changes:
For security reasons, we parse the code that is entered into the block, store it as attributes, and then render later. This parsing adds complexity and means that we need to handle several cases. For example, without these changes, there are several cases that were found that break the parsing:

- Code on multiple lines.
- Query parameters passed into the code.
- Not having a self-closing input.

This pull request attempts to address several cases that might break parsing. Starting by creating tests for those conditions and then ensuring that the tests pass.

This pull request also adds a `<div>` wrapper around the single button code. The reason for this is to minimize conflicts with the single button's `display:inline-grid;` and themes.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Ensure that tests pass in CI. Or run `jetpack test -v js packages/paypal-payments`
- Insert the PayPal Payment Buttons block and follow instructions to create both a single button and stacked button on PayPal.