### PR TITLE
Launchpad: Update social tasks to open Jetpack Social

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/dotcom-14515-replace-links-to-marketingconnectionssite-with-jetpack
+++ b/projects/packages/jetpack-mu-wpcom/changelog/dotcom-14515-replace-links-to-marketingconnectionssite-with-jetpack
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Launchpad: Update social tasks to open Jetpack Social

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -390,8 +390,9 @@ function wpcom_launchpad_get_task_definitions() {
 				return __( 'Drive traffic to your site', 'jetpack-mu-wpcom' );
 			},
 			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
-			'get_calypso_path'     => function ( $task, $default, $data ) {
-				return '/marketing/connections/' . $data['site_slug_encoded'];
+			'is_visible_callback'  => 'wpcom_launchpad_is_jetpack_social_available',
+			'get_calypso_path'     => function () {
+				return admin_url( 'admin.php?page=jetpack-social' );
 			},
 		),
 
@@ -658,8 +659,9 @@ function wpcom_launchpad_get_task_definitions() {
 				return __( 'Enable post sharing', 'jetpack-mu-wpcom' );
 			},
 			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
-			'get_calypso_path'     => function ( $task, $default, $data ) {
-				return '/marketing/connections/' . $data['site_slug_encoded'];
+			'is_visible_callback'  => 'wpcom_launchpad_is_jetpack_social_available',
+			'get_calypso_path'     => function () {
+				return admin_url( 'admin.php?page=jetpack-social' );
 			},
 		),
 		'front_page_updated'              => array(
@@ -2946,4 +2948,13 @@ function wpcom_launchpad_has_added_subscribe_block() {
 	}
 
 	return wpcom_launchpad_is_task_option_completed( array( 'id' => 'add_subscribe_block' ) );
+}
+
+/**
+ * Will return true if the user can set up social connections.
+ *
+ * @return bool
+ */
+function wpcom_launchpad_is_jetpack_social_available() {
+	return ! ( new Automattic\Jetpack\Status() )->is_private_site();
 }


### PR DESCRIPTION
Part of DOTCOM-14515

## Proposed changes:

Updates a couple of launchpad tasks so they link to Jetpack Social rather than to Marketing Connections.

Drive traffic to your site | Enable post sharing
--- | ---
<img width="1274" height="705" alt="Screenshot 2025-09-11 at 17 45 36" src="https://github.com/user-attachments/assets/f3ed78d3-b7f3-433f-8476-58018f0edfd2" /> | <img width="1281" height="837" alt="Screenshot 2025-09-11 at 13 10 08" src="https://github.com/user-attachments/assets/af4f8859-dcb4-4280-85fb-eaf3e0480ec4" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
- Apply these changes to your WP.com sandbox
- Sandbox the API
- Go to wordpress.com/setup and create a new site
- After the site is created, go to My Home and launch the site from the launchpad
- You'll see this card afterwards: 
<img width="600" height="809" alt="Screenshot 2025-09-11 at 13 09 17" src="https://github.com/user-attachments/assets/3f14741f-8a1c-4b6e-806a-f1cf48420083" />

- Click on the "Show site setup" button
- The "Drive traffic to your site" task should be visible
- Go to Settings > Reading
- Mark your site as private
- Go back to My Home
- The "Drive traffic to your site" task should be hidden
- Go back to Settings > Reading
- Mark your site as public now
- Go back to My Home
- Click on the "Drive traffic to your site" task
- Make sure it redirects to Jetpack Social
- Create now a site via the `with-theme` flow (example: https://wordpress.com/start/with-theme?ref=calypshowcase&theme=archivist&theme_type=free&intervalType=yearly)
- After the site is created, go to My Home
- The "Enable post sharing" task should be visible
- Make sure it redirects to Jetpack Social
- Launch your site
- Go to Settings > Reading
- Mark your site as private
- Go back to My Home
- The "Enable post sharing" task should be hidden
