### PR TITLE
e2e tests: verify authentication is successful in setup

### DIFF
--- a/tools/e2e-commons/setup-specs/auth.setup.ts
+++ b/tools/e2e-commons/setup-specs/auth.setup.ts
@@ -1,17 +1,45 @@
-/**
- * Internal dependencies
- */
-import { test as setup } from '../fixtures/base-test';
+/* eslint-disable playwright/no-standalone-expect */
+import { test as setup, expect } from '../fixtures/base-test';
 import { getCIProjectNameTestTag } from '../utils/formatting';
 
-setup( 'authenticate users', { tag: [ getCIProjectNameTestTag() ] }, async ( { testUtils } ) => {
-	await setup.step( 'authenticate local user', async () => {
-		await testUtils.authenticateUser( testUtils, testUtils.getSiteCredentials() );
-	} );
+setup(
+	'authenticate users',
+	{ tag: [ getCIProjectNameTestTag() ] },
+	async ( { testUtils, browser } ) => {
+		const localCredentials = testUtils.getSiteCredentials();
+		const dotComCredentials = testUtils.getDotComCredentials();
 
-	await setup.step( 'authenticate wordpress.com user', async () => {
-		await testUtils.authenticateUser( testUtils, testUtils.getDotComCredentials(), {
-			siteUrl: 'https://wordpress.com',
+		await setup.step( 'authenticate local user', async () => {
+			await testUtils.authenticateUser( testUtils, localCredentials );
 		} );
-	} );
-} );
+
+		await setup.step( 'authenticate wordpress.com user', async () => {
+			await testUtils.authenticateUser( testUtils, dotComCredentials, {
+				siteUrl: 'https://wordpress.com',
+			} );
+		} );
+
+		// Create new request context with saved storage state for verification
+		const { STORAGE_STATE_PATH } = process.env;
+		const authenticatedContext = await browser.newContext( { storageState: STORAGE_STATE_PATH } );
+
+		await setup.step( 'verify local user authentication', async () => {
+			const r = await authenticatedContext.request.get( './wp-admin/profile.php' );
+			expect
+				.soft( r.url(), 'User is not redirected to login page' )
+				.not.toContain( 'wp-login.php' );
+			expect
+				.soft( await r.text(), 'User is redirected to profile page' )
+				.toContain( `Howdy, ${ localCredentials.username }` );
+		} );
+
+		await setup.step( 'verify wordpress.com user authentication', async () => {
+			// use the browser to ensure JS routing is executed
+			const page = await authenticatedContext.newPage();
+			await page.goto( 'https://wordpress.com/me' );
+			expect
+				.soft( await page.content(), 'User is redirected to profile page' )
+				.toContain( `Howdy, ${ dotComCredentials.username }` );
+		} );
+	}
+);


### PR DESCRIPTION
## Proposed changes:

Add steps to verify the authentication was successful in the global authentication setup spec.

Context: p1757669239762749/1757604098.934889-slack-CDLH4C1UZ

### Other information:

- [x] n/a Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] n/a Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
no

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
* e2e tests pass