### PR TITLE
Analytics: Move "debug" from `devDependencies` to `dependencies`

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -243,10 +243,11 @@ importers:
         version: 5.9.2
 
   projects/js-packages/analytics:
-    devDependencies:
+    dependencies:
       debug:
         specifier: 4.4.1
         version: 4.4.1
+    devDependencies:
       jest:
         specifier: 30.0.4
         version: 30.0.4

--- a/projects/js-packages/analytics/CHANGELOG.md
+++ b/projects/js-packages/analytics/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### This is a list detailing changes for the Jetpack RNA Analytics package releases.
 
+## [1.0.5] - 2025-09-12
+### Changed
+- Fix package dependencies.
+
 ## [1.0.4] - 2025-08-04
 ### Changed
 - Internal updates.

--- a/projects/js-packages/analytics/package.json
+++ b/projects/js-packages/analytics/package.json
@@ -21,8 +21,10 @@
 		"test": "NODE_OPTIONS=--experimental-vm-modules jest",
 		"test-coverage": "pnpm run test --coverage"
 	},
+	"dependencies": {
+		"debug": "4.4.1"
+	},
 	"devDependencies": {
-		"debug": "4.4.1",
 		"jest": "30.0.4",
 		"jest-environment-jsdom": "30.0.4"
 	}


### PR DESCRIPTION
## Proposed changes:

The debug package is used in runtime, but since it is a dev-dependency, it is not included when a client-project installs `@automattic/jetpack-analytics`. Unless debug is already present in that client-project due to some other dependencies or explicit installation, it causes runtime error.

## Other information

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

_Doesn't have any functional change._
