### PR TITLE
Blocks: Fix slideshow sizing for lazy-loaded images

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-slideshow-block-lazy-loading-size
+++ b/projects/plugins/jetpack/changelog/fix-slideshow-block-lazy-loading-size
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Blocks: fix slideshow sizing for lazy-loaded images.

--- a/projects/plugins/jetpack/extensions/blocks/slideshow/slideshow.php
+++ b/projects/plugins/jetpack/extensions/blocks/slideshow/slideshow.php
@@ -51,6 +51,19 @@ function load_assets( $attr, $content ) {
 		enqueue_swiper_library();
 	}
 
+	// Fix for lazy loading conflict with slideshow images.
+	if ( ! is_admin() ) {
+		add_filter(
+			'wp_content_img_tag',
+			function ( $image ) {
+				if ( str_contains( $image, 'loading="lazy"' ) && str_contains( $image, 'wp-block-jetpack-slideshow_image' ) ) {
+					$image = str_replace( 'sizes="auto, ', 'sizes="', $image );
+				}
+				return $image;
+			}
+		);
+	}
+
 	return $content;
 }
 


### PR DESCRIPTION
Fixes [JETPACK-799](https://linear.app/a8c/issue/JETPACK-799)

## Proposed changes:
* Fix sizing issue for lazy-loaded images (usually starting with 3rd image) in Slideshow block.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
https://linear.app/a8c/issue/JETPACK-799

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:

Follow steps in the Linear issue to confirm the sizing problem is now fixed.
