### PR TITLE
Phan: Fix PhanTypeSuspiciousEcho violations

### DIFF
--- a/projects/packages/search/.phan/baseline.php
+++ b/projects/packages/search/.phan/baseline.php
@@ -16,7 +16,6 @@ return [
     // PhanTypeMismatchReturn : 4 occurrences
     // PhanPluginMixedKeyNoKey : 3 occurrences
     // PhanTypeMismatchProperty : 3 occurrences
-    // PhanTypeSuspiciousEcho : 3 occurrences
     // PhanDeprecatedFunction : 2 occurrences
     // PhanImpossibleCondition : 2 occurrences
     // PhanDeprecatedPartiallySupportedCallable : 1 occurrence
@@ -40,7 +39,7 @@ return [
         'src/classic-search/class-classic-search.php' => ['PhanPluginRedundantAssignment', 'PhanTypeInvalidDimOffset', 'PhanTypeMismatchDeclaredParamNullable', 'PhanTypeMismatchProperty', 'PhanTypeMismatchReturn', 'PhanTypePossiblyInvalidDimOffset'],
         'src/customizer/customize-controls/class-excluded-post-types-control.php' => ['PhanTypeMismatchReturnProbablyReal'],
         'src/instant-search/class-instant-search.php' => ['PhanTypeMismatchProperty', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal'],
-        'src/widgets/class-search-widget.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanPossiblyUndeclaredVariable', 'PhanTypeMismatchArgument', 'PhanTypeSuspiciousEcho'],
+        'src/widgets/class-search-widget.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanPossiblyUndeclaredVariable', 'PhanTypeMismatchArgument'],
         'src/wpes/class-query-builder.php' => ['PhanImpossibleCondition', 'PhanTypeMismatchDimAssignment', 'PhanTypeMismatchReturnProbablyReal'],
         'tests/php/Helpers_Test.php' => ['PhanPluginMixedKeyNoKey', 'PhanTypeMismatchArgument'],
         'tests/php/Plan_Test.php' => ['PhanDeprecatedFunction', 'PhanTypeMismatchArgumentProbablyReal'],

--- a/projects/packages/search/changelog/fix-phan-PhanTypeSuspiciousEcho
+++ b/projects/packages/search/changelog/fix-phan-PhanTypeSuspiciousEcho
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Phan: Fix PhanTypeSuspiciousEcho violations.
+
+

--- a/projects/packages/search/src/widgets/class-search-widget.php
+++ b/projects/packages/search/src/widgets/class-search-widget.php
@@ -833,9 +833,7 @@ class Search_Widget extends \WP_Widget {
 
 			<?php if ( ! $hide_filters ) : ?>
 				<script class="jetpack-search-filters-widget__filter-template" type="text/template">
-					<?php
-					echo $this->render_widget_edit_filter( array(), true ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-					?>
+					<?php $this->render_widget_edit_filter( array(), true ); ?>
 				</script>
 				<div class="jetpack-search-filters-widget__filters">
 					<?php foreach ( (array) $instance['filters'] as $filter ) : ?>
@@ -849,7 +847,7 @@ class Search_Widget extends \WP_Widget {
 				</p>
 				<noscript>
 					<p class="jetpack-search-filters-help">
-						<?php echo esc_html_e( 'Adding filters requires JavaScript!', 'jetpack-search-pkg' ); ?>
+						<?php esc_html_e( 'Adding filters requires JavaScript!', 'jetpack-search-pkg' ); ?>
 					</p>
 				</noscript>
 				<?php if ( is_customize_preview() ) : ?>
@@ -907,7 +905,7 @@ class Search_Widget extends \WP_Widget {
 				</script>
 				<noscript>
 					<p class="jetpack-search-filters-help">
-						<?php echo esc_html_e( 'Adding filters requires JavaScript!', 'jetpack-search-pkg' ); ?>
+						<?php esc_html_e( 'Adding filters requires JavaScript!', 'jetpack-search-pkg' ); ?>
 					</p>
 				</noscript>
 			<?php endif; ?>

--- a/projects/plugins/crm/.phan/baseline.php
+++ b/projects/plugins/crm/.phan/baseline.php
@@ -47,7 +47,6 @@ return [
     // PhanParamSignaturePHPDocMismatchReturnType : 20+ occurrences
     // PhanPossiblyUndeclaredGlobalVariable : 20+ occurrences
     // PhanTypeArraySuspiciousNull : 20+ occurrences
-    // PhanTypeSuspiciousStringExpression : 20+ occurrences
     // PhanUndeclaredClassProperty : 20+ occurrences
     // PhanUndeclaredFunction : 20+ occurrences
     // PhanUndeclaredVariableDim : 20+ occurrences
@@ -56,6 +55,7 @@ return [
     // PhanTypeComparisonFromArray : 15+ occurrences
     // PhanTypeMismatchDeclaredReturnNullable : 15+ occurrences
     // PhanTypeMismatchProperty : 15+ occurrences
+    // PhanTypeSuspiciousStringExpression : 15+ occurrences
     // PhanUndeclaredGlobalVariable : 15+ occurrences
     // PhanUndeclaredTypeProperty : 15+ occurrences
     // PhanTypeMismatchPropertyDefault : 10+ occurrences
@@ -71,7 +71,6 @@ return [
     // PhanAbstractStaticMethodCallInStatic : 6 occurrences
     // PhanTypeInvalidLeftOperandOfNumericOp : 6 occurrences
     // PhanTypeMismatchDeclaredReturn : 6 occurrences
-    // PhanTypeSuspiciousEcho : 6 occurrences
     // PhanTypeConversionFromArray : 5 occurrences
     // PhanUndeclaredClassReference : 5 occurrences
     // PhanUndeclaredConstant : 5 occurrences
@@ -133,7 +132,7 @@ return [
         'admin/settings/field-options.page.php' => ['PhanPossiblyUndeclaredGlobalVariable', 'PhanTypeInvalidDimOffset'],
         'admin/settings/field-sorts.page.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeArraySuspiciousNullable'],
         'admin/settings/forms.page.php' => ['PhanUndeclaredVariableDim'],
-        'admin/settings/general.page.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanPossiblyUndeclaredGlobalVariable', 'PhanTypeMismatchArgumentNullable', 'PhanTypeSuspiciousEcho'],
+        'admin/settings/general.page.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanPossiblyUndeclaredGlobalVariable', 'PhanTypeMismatchArgumentNullable'],
         'admin/settings/license.page.php' => ['PhanPluginDuplicateAdjacentStatement'],
         'admin/settings/locale.page.php' => ['PhanPossiblyUndeclaredGlobalVariable', 'PhanUndeclaredVariableDim'],
         'admin/settings/mail-delivery.ajax.php' => ['PhanRedundantCondition'],
@@ -156,9 +155,9 @@ return [
         'includes/ZeroBSCRM.AJAX.php' => ['PhanDeprecatedFunction', 'PhanPluginDuplicateAdjacentStatement', 'PhanPluginDuplicateExpressionAssignment', 'PhanPluginNeverReturnFunction', 'PhanPluginRedundantAssignment', 'PhanPluginSimplifyExpressionBool', 'PhanPossiblyUndeclaredVariable', 'PhanRedundantCondition', 'PhanTypeArraySuspicious', 'PhanTypeArraySuspiciousNullable', 'PhanTypeInvalidDimOffset', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchDimFetch', 'PhanTypePossiblyInvalidDimOffset', 'PhanTypeVoidAssignment', 'PhanUndeclaredConstant'],
         'includes/ZeroBSCRM.API.php' => ['PhanCommentParamWithoutRealParam', 'PhanRedefineFunctionInternal', 'PhanRedundantCondition'],
         'includes/ZeroBSCRM.AdminPages.Checks.php' => ['PhanPluginUnreachableCode'],
-        'includes/ZeroBSCRM.AdminPages.php' => ['PhanDeprecatedFunction', 'PhanPluginDuplicateAdjacentStatement', 'PhanPluginRedundantAssignment', 'PhanTypeExpectedObjectPropAccess', 'PhanTypeMismatchArgument', 'PhanTypeSuspiciousEcho'],
+        'includes/ZeroBSCRM.AdminPages.php' => ['PhanDeprecatedFunction', 'PhanPluginDuplicateAdjacentStatement', 'PhanPluginRedundantAssignment', 'PhanTypeExpectedObjectPropAccess', 'PhanTypeMismatchArgument'],
         'includes/ZeroBSCRM.AdminStyling.php' => ['PhanDeprecatedFunction', 'PhanPluginSimplifyExpressionBool'],
-        'includes/ZeroBSCRM.CSVImporter.php' => ['PhanPluginRedundantAssignment', 'PhanPossiblyUndeclaredVariable', 'PhanTypeArraySuspiciousNullable', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchArgumentNullableInternal', 'PhanTypePossiblyInvalidDimOffset', 'PhanTypeSuspiciousEcho', 'PhanUndeclaredVariableDim'],
+        'includes/ZeroBSCRM.CSVImporter.php' => ['PhanPluginRedundantAssignment', 'PhanPossiblyUndeclaredVariable', 'PhanTypeArraySuspiciousNullable', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchArgumentNullableInternal', 'PhanTypePossiblyInvalidDimOffset', 'PhanUndeclaredVariableDim'],
         'includes/ZeroBSCRM.Core.Extensions.php' => ['PhanRedundantCondition', 'PhanTypePossiblyInvalidDimOffset'],
         'includes/ZeroBSCRM.Core.Localisation.php' => ['PhanParamTooFew', 'PhanTypeMismatchArgument'],
         'includes/ZeroBSCRM.Core.Menus.Top.php' => ['PhanDeprecatedFunction', 'PhanTypeMismatchArgument', 'PhanTypeVoidArgument'],
@@ -193,7 +192,7 @@ return [
         'includes/ZeroBSCRM.ExternalSources.php' => ['PhanPluginMixedKeyNoKey', 'PhanPluginUnreachableCode'],
         'includes/ZeroBSCRM.FileUploads.php' => ['PhanTypeComparisonFromArray', 'PhanTypeMismatchDimFetch'],
         'includes/ZeroBSCRM.FormatHelpers.php' => ['PhanNoopVariable', 'PhanPluginRedundantAssignment', 'PhanPluginUnreachableCode', 'PhanPossiblyUndeclaredVariable', 'PhanRedundantCondition', 'PhanTypeArraySuspiciousNullable', 'PhanTypeInvalidLeftOperandOfAdd', 'PhanTypeMismatchArgument'],
-        'includes/ZeroBSCRM.Forms.php' => ['PhanPluginSimplifyExpressionBool', 'PhanTypeNonVarPassByRef', 'PhanTypeSuspiciousEcho', 'PhanTypeSuspiciousStringExpression', 'PhanUndeclaredVariable'],
+        'includes/ZeroBSCRM.Forms.php' => ['PhanPluginSimplifyExpressionBool', 'PhanTypeNonVarPassByRef'],
         'includes/ZeroBSCRM.GeneralFuncs.php' => ['PhanCommentParamWithoutRealParam', 'PhanMisspelledAnnotation', 'PhanPluginNeverReturnFunction', 'PhanPluginSimplifyExpressionBool', 'PhanPluginUnreachableCode', 'PhanRedundantCondition', 'PhanSuspiciousValueComparison', 'PhanTypeInvalidLeftOperandOfNumericOp', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchArgumentNullableInternal', 'PhanTypeMismatchDimFetch', 'PhanUndeclaredConstant', 'PhanUndeclaredFunction', 'PhanUndeclaredVariableDim'],
         'includes/ZeroBSCRM.IntegrationFuncs.php' => ['PhanPluginRedundantAssignment', 'PhanPluginUnreachableCode', 'PhanRedundantCondition'],
         'includes/ZeroBSCRM.InternalAutomatorRecipes.php' => ['PhanPluginRedundantAssignment', 'PhanRedundantCondition', 'PhanSuspiciousValueComparison'],

--- a/projects/plugins/crm/admin/settings/general.page.php
+++ b/projects/plugins/crm/admin/settings/general.page.php
@@ -499,7 +499,7 @@ if ( ! $confirmAct ) {
 																									echo ' checked="checked"';
 																								}
 																								?>
-							/> <?php echo esc_html_e( $field_label, 'zero-bs-crm' ); // phpcs:ignore WordPress.WP.I18n.NonSingularStringLiteralText ?><br />
+							/> <?php esc_html_e( $field_label, 'zero-bs-crm' ); // phpcs:ignore WordPress.WP.I18n.NonSingularStringLiteralText ?><br />
 						<?php } ?>
 					</td>
 

--- a/projects/plugins/crm/changelog/fix-phan-PhanTypeSuspiciousEcho
+++ b/projects/plugins/crm/changelog/fix-phan-PhanTypeSuspiciousEcho
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Phan: Fix PhanTypeSuspiciousEcho violations.
+
+

--- a/projects/plugins/crm/includes/ZeroBSCRM.AdminPages.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.AdminPages.php
@@ -2278,7 +2278,7 @@ function jpcrm_html_modules() {
 
 			}
 
-			echo zeroBSCRM_html_msg( 0, $msgHTML );
+			zeroBSCRM_html_msg( 0, $msgHTML ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 
 		} else {
 
@@ -2288,7 +2288,7 @@ function jpcrm_html_modules() {
 				$errmsg .= '<br />' . __( 'Installer Error:', 'zero-bs-crm' ) . ' ' . $module_messages['error_msg'];
 			}
 
-			echo zeroBSCRM_html_msg( -1, $errmsg );
+			zeroBSCRM_html_msg( -1, $errmsg );
 
 		}
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.CSVImporter.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.CSVImporter.php
@@ -429,7 +429,7 @@ function zeroBSCRM_CSVImporterLitehtml_app() {
 					<div>
 						<?php
 						// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-						echo zeroBSCRM_html_msg( 1, esc_html__( 'Note: There is no automatic way to undo a CSV import. To remove any contacts that have been added you will need to manually remove them.', 'zero-bs-crm' ) );
+						zeroBSCRM_html_msg( 1, esc_html__( 'Note: There is no automatic way to undo a CSV import. To remove any contacts that have been added you will need to manually remove them.', 'zero-bs-crm' ) );
 						?>
 					<form method="post" enctype="multipart/form-data" class="zbscrm-csv-import-form">
 						<input type="hidden" id="zbscrmcsvimpstage" name="zbscrmcsvimpstage" value="3" />

--- a/projects/plugins/crm/includes/ZeroBSCRM.Forms.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Forms.php
@@ -93,34 +93,30 @@ class ZBS_Form_Widget extends WP_Widget {
         );
     }
  
-    /**
-     * Front-end display of widget.
-     *
-     * @see WP_Widget::widget()
-     *
-     * @param array $args     Widget arguments.
-     * @param array $instance Saved values from database.
-     */
-    public function widget( $args, $instance ) {
-		
+	/**
+	 * Front-end display of widget.
+	 *
+	 * @see WP_Widget::widget()
+	 *
+	 * @param array $args     Widget arguments.
+	 * @param array $instance Saved values from database.
+	 */
+	public function widget( $args, $instance ) {
+
 		zeroBSCRM_forms_enqueuements();
-		
-        extract( $args );
-        $title = apply_filters( 'widget_title', $instance['title'] );
- 		$style = $instance['style'];
- 		$id = $instance['id'];
+		$title = apply_filters( 'widget_title', $instance['title'] );
+		$style = $instance['style'];
+		$id    = $instance['id'];
 
-        echo $before_widget;
-        if ( ! empty( $title ) ) {
-            echo $before_title . $title . $after_title;
-        }
-        if ( ! empty( $style) && ! empty($id)) {
-
-        	echo zeroBSCRM_forms_build_form_html($id,$style,__('You have not entered a style or ID in the form shortcode','zero-bs-crm'));
-
-        }
-        echo $after_widget;
-    }
+		echo $args['before_widget']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		if ( ! empty( $title ) ) {
+			echo $args['before_title'] . esc_html( $title ) . $args['after_title']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		}
+		if ( ! empty( $style ) && ! empty( $id ) ) {
+			echo zeroBSCRM_forms_build_form_html( $id, $style, __( 'You have not entered a style or ID in the form shortcode', 'zero-bs-crm' ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		}
+		echo $args['after_widget']; //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+	}
  
     /**
      * Back-end widget form.

--- a/projects/plugins/wpcomsh/.phan/baseline.php
+++ b/projects/plugins/wpcomsh/.phan/baseline.php
@@ -17,7 +17,6 @@ return [
     // PhanTypeVoidArgument : 5 occurrences
     // PhanTypeVoidAssignment : 5 occurrences
     // PhanUndeclaredConstant : 5 occurrences
-    // PhanTypeSuspiciousEcho : 4 occurrences
     // PhanTypeArraySuspiciousNullable : 3 occurrences
     // PhanUndeclaredClassMethod : 3 occurrences
     // PhanContextNotObject : 1 occurrence
@@ -44,9 +43,6 @@ return [
         'footer-credit/theme-optimizations.php' => ['PhanUndeclaredConstant', 'PhanUndeclaredStaticMethod'],
         'functions.php' => ['PhanUndeclaredClassStaticProperty'],
         'imports/playground/class-sql-importer.php' => ['PhanUndeclaredConstant'],
-        'private-site/access-denied-coming-soon-template.php' => ['PhanTypeSuspiciousEcho'],
-        'private-site/access-denied-preview-login-template.php' => ['PhanTypeSuspiciousEcho'],
-        'private-site/access-denied-private-site-template.php' => ['PhanTypeSuspiciousEcho'],
         'safeguard/utils.php' => ['PhanPossiblyUndeclaredVariable', 'PhanTypeMismatchArgument'],
         'tests/AnyoneCanRegisterNoticeTest.php' => ['PhanTypeMismatchArgument', 'PhanTypeVoidArgument', 'PhanTypeVoidAssignment'],
         'tests/FrontendNoticesTest.php' => ['PhanUndeclaredStaticMethod'],

--- a/projects/plugins/wpcomsh/changelog/fix-phan-PhanTypeSuspiciousEcho
+++ b/projects/plugins/wpcomsh/changelog/fix-phan-PhanTypeSuspiciousEcho
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Phan: Fix PhanTypeSuspiciousEcho violations.
+
+

--- a/projects/plugins/wpcomsh/private-site/access-denied-coming-soon-template.php
+++ b/projects/plugins/wpcomsh/private-site/access-denied-coming-soon-template.php
@@ -20,7 +20,7 @@ header( 'Content-Type: ' . get_bloginfo( 'html_type' ) . '; charset=' . get_blog
 <head>
 	<meta http-equiv="Content-Type" content="<?php bloginfo( 'html_type' ); ?>; charset=<?php bloginfo( 'charset' ); ?>" />
 	<meta name="viewport" content="width=device-width, initial-scale=1">
-	<title><?php echo bloginfo( 'name' ); ?></title>
+	<title><?php bloginfo( 'name' ); ?></title>
 
 	<?php
 	wp_enqueue_style( 'recoleta-font', '//s1.wp.com/i/fonts/recoleta/css/400.min.css', array(), WPCOMSH_VERSION );
@@ -47,7 +47,7 @@ header( 'Content-Type: ' . get_bloginfo( 'html_type' ) . '; charset=' . get_blog
 			<?php if ( ! is_user_logged_in() ) : ?>
 				<div class="marketing-copy">
 					<img src="https://s2.wp.com/wp-content/themes/a8c/domain-landing-page/wpcom-wmark-white.svg" alt="WordPress.com" class="logo" />
-					<p class="copy"><?php echo esc_html_e( 'Build a website. Sell your stuff. Write a blog. And so much more.', 'wpcomsh' ); ?></p>
+					<p class="copy"><?php esc_html_e( 'Build a website. Sell your stuff. Write a blog. And so much more.', 'wpcomsh' ); ?></p>
 				</div>
 				<div class="marketing-buttons">
 					<p><a class="button button-secondary" href="<?php echo esc_url( $login_link ); ?>"><?php esc_html_e( 'Log in', 'wpcomsh' ); ?></a></p>

--- a/projects/plugins/wpcomsh/private-site/access-denied-preview-login-template.php
+++ b/projects/plugins/wpcomsh/private-site/access-denied-preview-login-template.php
@@ -25,7 +25,7 @@ header( 'Content-Type: ' . get_bloginfo( 'html_type' ) . '; charset=' . get_blog
 	</script>
 	<meta http-equiv="Content-Type" content="<?php bloginfo( 'html_type' ); ?>; charset=<?php bloginfo( 'charset' ); ?>" />
 	<meta name="viewport" content="width=device-width, initial-scale=1">
-	<title><?php echo bloginfo( 'name' ); ?></title>
+	<title><?php bloginfo( 'name' ); ?></title>
 	<?php
 	// Use styles from wp-login.
 	wp_enqueue_style( 'login' );

--- a/projects/plugins/wpcomsh/private-site/access-denied-private-site-template.php
+++ b/projects/plugins/wpcomsh/private-site/access-denied-private-site-template.php
@@ -20,7 +20,7 @@ header( 'Content-Type: ' . get_bloginfo( 'html_type' ) . '; charset=' . get_blog
 <head>
 	<meta http-equiv="Content-Type" content="<?php bloginfo( 'html_type' ); ?>; charset=<?php bloginfo( 'charset' ); ?>" />
 	<meta name="viewport" content="width=device-width, initial-scale=1">
-	<title><?php echo bloginfo( 'name' ); ?></title>
+	<title><?php bloginfo( 'name' ); ?></title>
 	<?php
 	// Use styles from wp-login.
 	wp_enqueue_style( 'login' );


### PR DESCRIPTION
Closes MONOREP-115

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This resolves all PhanTypeSuspiciousEcho violations (`echo` when unneeded):

* `echo $this->render_widget_edit_filter()` → `$this->render_widget_edit_filter()`
* `echo esc_html_e()` → `esc_html_e()`
* `echo zeroBSCRM_html_msg()` → `zeroBSCRM_html_msg()`
* `echo bloginfo()` → `bloginfo()`

There were also some false positives in the `ZBS_Form_Widget::widget()` function due to the use of `extract()`, so I updated that function to directly use the keys from `$args`.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

🤷