### PR TITLE
Forms: create a new version everytime we build the package

### DIFF
--- a/projects/packages/forms/.phan/baseline.php
+++ b/projects/packages/forms/.phan/baseline.php
@@ -11,9 +11,9 @@ return [
     // # Issue statistics:
     // PhanTypeMismatchArgument : 45+ occurrences
     // PhanPluginDuplicateConditionalNullCoalescing : 30+ occurrences
-    // PhanTypeMismatchReturnProbablyReal : 7 occurrences
+    // PhanTypeMismatchReturnProbablyReal : 8 occurrences
     // PhanTypeMismatchArgumentProbablyReal : 6 occurrences
-    // PhanPluginDuplicateAdjacentStatement : 2 occurrences
+    // PhanPluginDuplicateAdjacentStatement : 3 occurrences
     // PhanTypeConversionFromArray : 2 occurrences
     // PhanTypeMismatchReturn : 2 occurrences
     // PhanPluginMixedKeyNoKey : 1 occurrence
@@ -21,7 +21,6 @@ return [
     // PhanPossiblyNullTypeMismatchProperty : 1 occurrence
     // PhanTypeArraySuspiciousNullable : 1 occurrence
     // PhanTypeMismatchReturnNullable : 1 occurrence
-    // PhanUnreferencedUseNormal : 1 occurrence
 
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
@@ -30,7 +29,6 @@ return [
         'src/contact-form/class-contact-form-plugin.php' => ['PhanPluginDuplicateAdjacentStatement', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturnProbablyReal'],
         'src/contact-form/class-contact-form-shortcode.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchReturnProbablyReal'],
         'src/contact-form/class-contact-form.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanPluginRedundantAssignment', 'PhanTypeMismatchArgument', 'PhanTypeMismatchReturnNullable', 'PhanTypeMismatchReturnProbablyReal'],
-        'src/dashboard/class-dashboard-view-switch.php' => ['PhanUnreferencedUseNormal'],
         'src/service/class-google-drive.php' => ['PhanTypeMismatchReturnProbablyReal'],
         'tests/php/contact-form/Contact_Form_Plugin_Test.php' => ['PhanPluginMixedKeyNoKey'],
     ],

--- a/projects/packages/forms/changelog/fix-forms-js-version-busting
+++ b/projects/packages/forms/changelog/fix-forms-js-version-busting
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: update the version number every time we build the package

--- a/projects/packages/forms/composer.json
+++ b/projects/packages/forms/composer.json
@@ -46,12 +46,12 @@
 			"@php tools/update-version.php"
 		],
 		"build-production": [
-			"@update-version",
-			"pnpm run build-production"
+			"pnpm run build-production",
+			"@update-version"
 		],
 		"build-development": [
-			"@update-version",
-			"pnpm run build"
+			"pnpm run build",
+			"@update-version"
 		],
 		"watch": [
 			"Composer\\Config::disableProcessTimeout",

--- a/projects/packages/forms/composer.json
+++ b/projects/packages/forms/composer.json
@@ -42,10 +42,15 @@
 		"test-js": [
 			"pnpm run test"
 		],
+		"update-version": [
+			"@php tools/update-version.php"
+		],
 		"build-production": [
+			"@update-version",
 			"pnpm run build-production"
 		],
 		"build-development": [
+			"@update-version",
 			"pnpm run build"
 		],
 		"watch": [

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -16,6 +16,8 @@ class Jetpack_Forms {
 
 	const PACKAGE_VERSION = '6.3.0';
 
+	const PACKAGE_VERSION_AND_TIMESTAMP = '6.3.0-1757721161';
+
 	/**
 	 * Load the contact form module.
 	 */

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -16,8 +16,6 @@ class Jetpack_Forms {
 
 	const PACKAGE_VERSION = '6.3.0';
 
-	const PACKAGE_VERSION_AND_TIMESTAMP = '6.3.0-1757721161';
-
 	/**
 	 * Load the contact form module.
 	 */

--- a/projects/packages/forms/src/contact-form/class-admin.php
+++ b/projects/packages/forms/src/contact-form/class-admin.php
@@ -428,7 +428,7 @@ class Admin {
 
 		wp_enqueue_script( 'wp-lists' );
 
-		wp_register_style( 'grunion-admin.css', plugin_dir_url( __FILE__ ) . '/../../../dist/contact-form/css/grunion-admin.css', array(), \JETPACK__VERSION );
+		wp_register_style( 'grunion-admin.css', plugin_dir_url( __FILE__ ) . '/../../../dist/contact-form/css/grunion-admin.css', array(), Util::get_version() );
 		wp_style_add_data( 'grunion-admin.css', 'rtl', 'replace' );
 
 		wp_enqueue_style( 'grunion-admin.css' );
@@ -1309,7 +1309,7 @@ class Admin {
 			array(
 				'enqueue'      => true,
 				'dependencies' => array( 'jquery' ),
-				'version'      => \JETPACK__VERSION,
+				'version'      => Util::get_version(),
 				'in_footer'    => true,
 			)
 		);

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -8,7 +8,6 @@
 namespace Automattic\Jetpack\Forms\ContactForm;
 
 use Automattic\Jetpack\Assets;
-use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Forms\Jetpack_Forms;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -1058,33 +1057,33 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 					data-wp-init="callbacks.initializePhoneFieldCustomComboBox"
 					data-wp-on-document--click="actions.phoneComboboxDocumentClickHandler">
 					<div class="jetpack-custom-combobox">
-						
-						<button 
+
+						<button
 							class="jetpack-combobox-trigger"
 							type="button"
 							data-wp-on--click="actions.phoneComboboxToggle"
 							data-wp-bind--aria-expanded="context.comboboxOpen">
-							<span 
+							<span
 								class="jetpack-combobox-selected"
 								data-wp-text="context.selectedCountry.flag"></span>
-							<span 
+							<span
 								class="jetpack-combobox-trigger-arrow"
 								data-wp-class--is-open="context.comboboxOpen">
 								<svg width="10" height="6" viewBox="0 0 10 6" fill="none" xmlns="http://www.w3.org/2000/svg">
 									<path d="M1 1L5 5L9 1" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
 								</svg>
 							</span>
-							<span 
+							<span
 								class="jetpack-combobox-selected"
 								data-wp-text="context.selectedCountry.value"></span>
 						</button>
-						<div 
+						<div
 							class="jetpack-combobox-dropdown <?php echo esc_attr( $this->get_attribute( 'stylevariationclasses' ) ); ?>"
 							style="<?php echo ( ! empty( $this->field_styles ) && is_string( $this->field_styles ) ? esc_attr( $this->field_styles ) : '' ); ?>"
 							data-wp-bind--hidden="!context.comboboxOpen">
 							<input
-								class="jetpack-combobox-search" 
-								type="text" 
+								class="jetpack-combobox-search"
+								type="text"
 								placeholder="<?php echo esc_attr__( 'Search countries...', 'jetpack-forms' ); ?>"
 								data-wp-on--input="actions.phoneComboboxInputHandler"
 								data-wp-on--keydown="actions.phoneComboboxKeydownHandler">
@@ -1092,7 +1091,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 								<template
 									data-wp-each--filtered="context.filteredCountries"
 									data-wp-each-key="context.filtered.code">
-									<div 
+									<div
 										class="jetpack-combobox-option"
 										data-wp-key="context.filtered.code"
 										data-wp-class--jetpack-combobox-option-selected="context.filtered.selected"
@@ -1598,7 +1597,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 	 * @return void
 	 */
 	private function enqueue_file_field_assets() {
-		$version = Constants::get_constant( 'JETPACK__VERSION' );
+		$version = Util::get_version();
 
 		\wp_enqueue_script_module(
 			'jetpack-form-file-field',
@@ -1868,7 +1867,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 			array(
 				'enqueue'      => true,
 				'dependencies' => array(),
-				'version'      => Constants::get_constant( 'JETPACK__VERSION' ),
+				'version'      => Util::get_version(),
 			)
 		);
 
@@ -1965,7 +1964,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 	 * @return string HTML
 	 */
 	public function render_image_select_field( $id, $label, $value, $class, $required, $required_field_text ) {
-		wp_enqueue_style( 'jetpack-form-field-image-select-style', plugins_url( '../../dist/blocks/field-image-select/style.css', __FILE__ ), array(), Constants::get_constant( 'JETPACK__VERSION' ) );
+		wp_enqueue_style( 'jetpack-form-field-image-select-style', plugins_url( '../../dist/blocks/field-image-select/style.css', __FILE__ ), array(), Util::get_version() );
 
 		$is_multiple       = $this->get_attribute( 'ismultiple' );
 		$show_labels       = $this->get_attribute( 'showlabels' );
@@ -2668,7 +2667,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 	 */
 	private function render_rating_field( $id, $label, $value, $class, $required, $required_field_text ) {
 		// Enqueue stylesheet for rating field.
-		wp_enqueue_style( 'jetpack-form-field-rating-style', plugins_url( '../../dist/blocks/field-rating/style.css', __FILE__ ), array(), Constants::get_constant( 'JETPACK__VERSION' ) );
+		wp_enqueue_style( 'jetpack-form-field-rating-style', plugins_url( '../../dist/blocks/field-rating/style.css', __FILE__ ), array(), Util::get_version() );
 
 		// Read block attributes needed for rendering.
 		$max_attr   = $this->get_attribute( 'max' );
@@ -2883,7 +2882,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 	 * @return void
 	 */
 	private function enqueue_slider_field_assets() {
-		$version = defined( 'JETPACK__VERSION' ) ? \JETPACK__VERSION : '0.1';
+		$version = Util::get_version();
 
 		\wp_enqueue_style(
 			'jetpack-form-slider-field',
@@ -3159,11 +3158,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 	 * @return void
 	 */
 	private function enqueue_phone_field_assets() {
-		$version = defined( 'JETPACK__VERSION' ) ? \JETPACK__VERSION : '0.1';
-
-		// TODO: remove this manual cache busting
-		// SEE: p1757517146878719-slack-C01U2KGS2PQ
-		$version .= '-jetpack-combobox-v1';
+		$version = Util::get_version();
 
 		// combobox styles
 		\wp_enqueue_style(

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -8,7 +8,6 @@
 namespace Automattic\Jetpack\Forms\ContactForm;
 
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
-use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Extensions\Contact_Form\Contact_Form_Block;
 use Automattic\Jetpack\Forms\Jetpack_Forms;
 use Automattic\Jetpack\Forms\Service\MailPoet_Integration;
@@ -298,7 +297,7 @@ class Contact_Form_Plugin {
 		 *  }
 		 *  add_action('wp_print_styles', 'remove_grunion_style');
 		 */
-		wp_register_style( 'grunion.css', Jetpack_Forms::plugin_url() . '../dist/contact-form/css/grunion.css', array(), \JETPACK__VERSION );
+		wp_register_style( 'grunion.css', Jetpack_Forms::plugin_url() . '../dist/contact-form/css/grunion.css', array(), Util::get_version() );
 		wp_style_add_data( 'grunion.css', 'rtl', 'replace' );
 
 		add_filter( 'js_do_concat', array( __CLASS__, 'disable_forms_view_script_concat' ), 10, 3 );
@@ -756,16 +755,11 @@ class Contact_Form_Plugin {
 	public static function gutenblock_render_form_step( $atts, $content ) {
 		self::$step_count = 1 + self::$step_count;
 
-		$version = Constants::get_constant( 'JETPACK__VERSION' );
-		if ( empty( $version ) ) {
-			$version = '0.1';
-		}
-
 		\wp_enqueue_script_module(
 			'jetpack-form-step',
 			plugins_url( '../../dist/modules/form-step/view.js', __FILE__ ),
 			array( '@wordpress/interactivity' ),
-			$version
+			Util::get_version()
 		);
 
 		// Process content for marker classes and add interactivity
@@ -811,11 +805,8 @@ class Contact_Form_Plugin {
 	 * @return string HTML for the number field.
 	 */
 	public static function gutenblock_render_form_step_navigation( $atts, $content ) {
+		$version = Util::get_version();
 
-		$version = Constants::get_constant( 'JETPACK__VERSION' );
-		if ( empty( $version ) ) {
-			$version = '0.1';
-		}
 		\wp_enqueue_script_module(
 			'jetpack-form-step-navigation',
 			plugins_url( '../../dist/modules/form-step-navigation/view.js', __FILE__ ),
@@ -893,17 +884,13 @@ class Contact_Form_Plugin {
 	 * @return string HTML for the progress indicator.
 	 */
 	public static function gutenblock_render_form_progress_indicator( $attributes ) {
-		$version = Constants::get_constant( 'JETPACK__VERSION' );
-		if ( empty( $version ) ) {
-			$version = '0.1';
-		}
 
 		// Get step count from Contact_Form_Block
 		$max_steps = Contact_Form_Block::get_form_step_count();
 
 		$style_handle = 'jetpack-form-progress-indicator-style';
 		if ( ! wp_style_is( $style_handle, 'enqueued' ) ) {
-			wp_enqueue_style( $style_handle, plugins_url( 'dist/blocks/form-progress-indicator/style.css', dirname( __DIR__ ) ), array(), $version );
+			wp_enqueue_style( $style_handle, plugins_url( 'dist/blocks/form-progress-indicator/style.css', dirname( __DIR__ ) ), array(), Util::get_version() );
 		}
 
 		$script_handle = 'jetpack-form-progress-indicator';
@@ -911,7 +898,7 @@ class Contact_Form_Plugin {
 			$script_handle,
 			plugins_url( 'dist/modules/form-progress-indicator/view.js', dirname( __DIR__ ) ),
 			array( '@wordpress/interactivity' ),
-			$version
+			Util::get_version()
 		);
 
 		$variant       = isset( $attributes['variant'] ) ? $attributes['variant'] : 'line';

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -324,7 +324,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 	 */
 	private static function get_secret() {
 		$token          = ( new Tokens() )->get_access_token();
-		$default_secret = hash_hmac( 'md5', get_option( 'admin_email' ), JETPACK__VERSION );
+		$default_secret = hash_hmac( 'md5', get_option( 'admin_email' ), Util::get_version() );
 		if ( ! isset( $token->secret ) ) {
 			return $default_secret;
 		}
@@ -576,7 +576,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 			'jp-forms-view',
 			plugins_url( 'dist/modules/form/view.js', dirname( __DIR__ ) ),
 			array( '@wordpress/interactivity' ),
-			\JETPACK__VERSION
+			Util::get_version()
 		);
 
 		$container_classes        = array( 'wp-block-jetpack-contact-form-container' );
@@ -2303,7 +2303,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 		$event = new Jetpack_Tracks_Event(
 			(object) array(
 				'_en' => 'jetpack_forms_email_open',
-				'_ui' => hash_hmac( 'md5', get_option( 'admin_email' ), JETPACK__VERSION ),
+				'_ui' => hash_hmac( 'md5', get_option( 'admin_email' ), Util::get_version() ),
 				'_ut' => 'anon',
 			)
 		);

--- a/projects/packages/forms/src/contact-form/class-editor-view.php
+++ b/projects/packages/forms/src/contact-form/class-editor-view.php
@@ -89,7 +89,7 @@ class Editor_View {
 		add_filter( 'mce_external_plugins', array( __CLASS__, 'mce_external_plugins' ) );
 		add_filter( 'mce_buttons', array( __CLASS__, 'mce_buttons' ) );
 
-		wp_enqueue_style( 'grunion-editor-ui', plugins_url( '../../dist/contact-form/css/editor-ui.css', __FILE__ ), array(), \JETPACK__VERSION );
+		wp_enqueue_style( 'grunion-editor-ui', plugins_url( '../../dist/contact-form/css/editor-ui.css', __FILE__ ), array(), Util::get_version() );
 		wp_style_add_data( 'grunion-editor-ui', 'rtl', 'replace' );
 
 		Assets::register_script(
@@ -99,7 +99,7 @@ class Editor_View {
 			array(
 				'enqueue'      => true,
 				'dependencies' => array( 'wp-util', 'jquery', 'quicktags' ),
-				'version'      => \JETPACK__VERSION,
+				'version'      => Util::get_version(),
 				'in_footer'    => true,
 			)
 		);

--- a/projects/packages/forms/src/contact-form/class-form-view.php
+++ b/projects/packages/forms/src/contact-form/class-form-view.php
@@ -36,7 +36,7 @@ class Form_View {
 			__FILE__,
 			array(
 				'dependencies' => array( 'jquery', 'jquery-ui-sortable', 'jquery-ui-draggable' ),
-				'version'      => \JETPACK__VERSION,
+				'version'      => Util::get_version(),
 			)
 		);
 

--- a/projects/packages/forms/src/contact-form/class-util.php
+++ b/projects/packages/forms/src/contact-form/class-util.php
@@ -41,12 +41,37 @@ class Util {
 	}
 
 	/**
-	 * Returns the version of the contact form.
+	 * Cached version value to avoid repeated file operations.
 	 *
-	 * @return string The version of the contact form.
+	 * @var string|null
+	 */
+	private static $cached_version = null;
+
+	/**
+	 * Returns the version of the contact form with build timestamp for cache busting.
+	 *
+	 * @return string The version of the contact form with timestamp, or fallback to PACKAGE_VERSION constant.
 	 */
 	public static function get_version() {
-		return Jetpack_Forms::PACKAGE_VERSION_AND_TIMESTAMP;
+		// Return cached version if already loaded
+		if ( null !== self::$cached_version ) {
+			return self::$cached_version;
+		}
+
+		$version_file = __DIR__ . '/../../dist/version.php';
+
+		// Check if version file exists and is readable
+		if ( is_readable( $version_file ) ) {
+			$version_data = include $version_file;
+			if ( is_array( $version_data ) && isset( $version_data['timestamped_version'] ) ) {
+				self::$cached_version = $version_data['timestamped_version'];
+				return self::$cached_version;
+			}
+		}
+
+		// Fallback to constant if version file doesn't exist or is invalid
+		self::$cached_version = Jetpack_Forms::PACKAGE_VERSION;
+		return self::$cached_version;
 	}
 
 	/**

--- a/projects/packages/forms/src/contact-form/class-util.php
+++ b/projects/packages/forms/src/contact-form/class-util.php
@@ -7,6 +7,8 @@
 
 namespace Automattic\Jetpack\Forms\ContactForm;
 
+use Automattic\Jetpack\Forms\Jetpack_Forms;
+
 /**
  * This class serves as a container for what previously were standalone grunion functions.
  * In the long term we should aim to move things to other classes and gradually get rid of this rather than adding more.
@@ -36,6 +38,15 @@ class Util {
 		add_action( 'init', '\Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::init', 9 );
 		add_action( 'grunion_scheduled_delete', '\Automattic\Jetpack\Forms\ContactForm\Util::grunion_delete_old_spam' );
 		add_action( 'grunion_pre_message_sent', '\Automattic\Jetpack\Forms\ContactForm\Util::jetpack_tracks_record_grunion_pre_message_sent', 12, 3 );
+	}
+
+	/**
+	 * Returns the version of the contact form.
+	 *
+	 * @return string The version of the contact form.
+	 */
+	public static function get_version() {
+		return Jetpack_Forms::PACKAGE_VERSION_AND_TIMESTAMP;
 	}
 
 	/**

--- a/projects/packages/forms/src/dashboard/class-dashboard-view-switch.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard-view-switch.php
@@ -7,8 +7,8 @@
 
 namespace Automattic\Jetpack\Forms\Dashboard;
 
+use Automattic\Jetpack\Forms\ContactForm\Util;
 use Automattic\Jetpack\Forms\Jetpack_Forms;
-use JETPACK__VERSION;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit( 0 );
@@ -88,7 +88,7 @@ class Dashboard_View_Switch {
 			'jetpack-forms-dashboard-switch',
 			false,
 			array(),
-			JETPACK__VERSION
+			Util::get_version()
 		);
 		wp_enqueue_style( 'jetpack-forms-dashboard-switch' );
 

--- a/projects/packages/forms/tests/php/contact-form/Util_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Util_Test.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Unit Tests for Automattic\Jetpack\Forms\Contact_Form.
+ *
+ * To run the test visit the packages/forms directory and run composer test-php
+ *
+ * @package automattic/jetpack-forms
+ */
+
+namespace Automattic\Jetpack\Forms\ContactForm;
+
+require_once __DIR__ . '/class-utility.php'; // phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.NotAbsolutePath
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use WorDBless\BaseTestCase;
+
+/**
+ * Test class for Contact_Form
+ *
+ * @covers Automattic\Jetpack\Forms\ContactForm\Util
+ */
+#[CoversClass( Util::class )]
+class Util_Test extends BaseTestCase {
+
+	public function test_get_version() {
+		$version = Util::get_version();
+		$this->assertIsString( $version );
+		$this->assertGreaterThan( 0, strlen( $version ) );
+	}
+}

--- a/projects/packages/forms/tools/update-version.php
+++ b/projects/packages/forms/tools/update-version.php
@@ -1,13 +1,14 @@
 <?php
 /**
- * Update the PACKAGE_VERSION and PACKAGE_VERSION_AND_TIMESTAMP constants in Jetpack_Forms class
- * to match the version in package.json
+ * Generate version file for Jetpack_Forms to match the version in package.json
+ * Creates a version file in the dist folder with timestamped version info
  *
  * @package automattic/jetpack-forms
  */
 
-$package_json_path  = __DIR__ . '/../package.json';
-$jetpack_forms_path = __DIR__ . '/../src/class-jetpack-forms.php';
+$package_json_path = __DIR__ . '/../package.json';
+$dist_path         = __DIR__ . '/../dist';
+$version_file_path = $dist_path . '/version.php';
 
 // Read the version from package.json
 // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- This is a build script, not web-facing code
@@ -18,43 +19,44 @@ if ( ! $package_json ) {
 	exit( 1 );
 }
 
-$version = $package_json['version'];
+$version              = $package_json['version'];
+$timestamp            = time();
+$time_stamped_version = $version . '-' . $timestamp;
 
-// Read the PHP file
-// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- This is a build script, not web-facing code
-$php_content = file_get_contents( $jetpack_forms_path );
-if ( $php_content === false ) {
-	// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- This is a CLI script
-	echo "❌ Error: Could not read class-jetpack-forms.php\n";
-	exit( 1 );
-}
-
-$time_stamped_version = $version . '-' . time();
-
-$timestamp_pattern     = "/const PACKAGE_VERSION_AND_TIMESTAMP = '[^']+';/";
-$timestamp_replacement = "const PACKAGE_VERSION_AND_TIMESTAMP = '$time_stamped_version';";
-
-$updated = false;
-
-// Update PACKAGE_VERSION_AND_TIMESTAMP constant
-if ( preg_match( $timestamp_pattern, $php_content ) ) {
-	$php_content = preg_replace( $timestamp_pattern, $timestamp_replacement, $php_content );
-	$updated     = true;
-}
-
-if ( $updated ) {
-	// Write the updated content back
-	// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- This is a build script, not web-facing code
-	if ( file_put_contents( $jetpack_forms_path, $php_content ) === false ) {
+// Ensure dist directory exists
+if ( ! is_dir( $dist_path ) ) {
+	// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_mkdir -- This is a build script, not web-facing code
+	if ( ! mkdir( $dist_path, 0755, true ) ) {
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- This is a CLI script
-		echo "❌ Error: Could not write to class-jetpack-forms.php\n";
+		echo "❌ Error: Could not create dist directory\n";
 		exit( 1 );
 	}
+}
 
+// Generate version file content
+$version_file_content = "<?php
+/**
+ * Version information for Jetpack Forms package
+ * Generated automatically during build process
+ *
+ * @package automattic/jetpack-forms
+ */
+
+return array(
+	'version'           => '$version',
+	'timestamp'         => $timestamp,
+	'timestamped_version' => '$time_stamped_version',
+	'build_date'        => '" . gmdate( 'Y-m-d H:i:s', $timestamp ) . " UTC',
+);
+";
+
+// Write the version file
+// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- This is a build script, not web-facing code
+if ( file_put_contents( $version_file_path, $version_file_content ) === false ) {
 	// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- This is a CLI script
-	echo "✅ Updated PACKAGE_VERSION_AND_TIMESTAMP constant to '$time_stamped_version' in class-jetpack-forms.php\n";
-} else {
-	// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- This is a CLI script
-	echo "❌ Error: Could not find PACKAGE_VERSION_AND_TIMESTAMP constants to update\n";
+	echo "❌ Error: Could not write version file\n";
 	exit( 1 );
 }
+
+// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- This is a CLI script
+echo "✅ Generated version file with version '$time_stamped_version' in dist/version.php\n";

--- a/projects/packages/forms/tools/update-version.php
+++ b/projects/packages/forms/tools/update-version.php
@@ -31,20 +31,10 @@ if ( $php_content === false ) {
 
 $time_stamped_version = $version . '-' . time();
 
-// Replace both constants
-$version_pattern     = "/const PACKAGE_VERSION = '[^']+';/";
-$version_replacement = "const PACKAGE_VERSION = '$version';";
-
 $timestamp_pattern     = "/const PACKAGE_VERSION_AND_TIMESTAMP = '[^']+';/";
 $timestamp_replacement = "const PACKAGE_VERSION_AND_TIMESTAMP = '$time_stamped_version';";
 
 $updated = false;
-
-// Update PACKAGE_VERSION constant
-if ( preg_match( $version_pattern, $php_content ) ) {
-	$php_content = preg_replace( $version_pattern, $version_replacement, $php_content );
-	$updated     = true;
-}
 
 // Update PACKAGE_VERSION_AND_TIMESTAMP constant
 if ( preg_match( $timestamp_pattern, $php_content ) ) {
@@ -62,9 +52,9 @@ if ( $updated ) {
 	}
 
 	// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- This is a CLI script
-	echo "✅ Updated PACKAGE_VERSION to '$version' and PACKAGE_VERSION_AND_TIMESTAMP to '$time_stamped_version' in class-jetpack-forms.php\n";
+	echo "✅ Updated PACKAGE_VERSION_AND_TIMESTAMP constant to '$time_stamped_version' in class-jetpack-forms.php\n";
 } else {
 	// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- This is a CLI script
-	echo "❌ Error: Could not find PACKAGE_VERSION constants to update\n";
+	echo "❌ Error: Could not find PACKAGE_VERSION_AND_TIMESTAMP constants to update\n";
 	exit( 1 );
 }

--- a/projects/packages/forms/tools/update-version.php
+++ b/projects/packages/forms/tools/update-version.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Update the PACKAGE_VERSION and PACKAGE_VERSION_AND_TIMESTAMP constants in Jetpack_Forms class
+ * to match the version in package.json
+ *
+ * @package automattic/jetpack-forms
+ */
+
+$package_json_path  = __DIR__ . '/../package.json';
+$jetpack_forms_path = __DIR__ . '/../src/class-jetpack-forms.php';
+
+// Read the version from package.json
+// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- This is a build script, not web-facing code
+$package_json = json_decode( file_get_contents( $package_json_path ), true );
+if ( ! $package_json ) {
+	// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- This is a CLI script
+	echo "❌ Error: Could not read package.json\n";
+	exit( 1 );
+}
+
+$version = $package_json['version'];
+
+// Read the PHP file
+// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- This is a build script, not web-facing code
+$php_content = file_get_contents( $jetpack_forms_path );
+if ( $php_content === false ) {
+	// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- This is a CLI script
+	echo "❌ Error: Could not read class-jetpack-forms.php\n";
+	exit( 1 );
+}
+
+$time_stamped_version = $version . '-' . time();
+
+// Replace both constants
+$version_pattern     = "/const PACKAGE_VERSION = '[^']+';/";
+$version_replacement = "const PACKAGE_VERSION = '$version';";
+
+$timestamp_pattern     = "/const PACKAGE_VERSION_AND_TIMESTAMP = '[^']+';/";
+$timestamp_replacement = "const PACKAGE_VERSION_AND_TIMESTAMP = '$time_stamped_version';";
+
+$updated = false;
+
+// Update PACKAGE_VERSION constant
+if ( preg_match( $version_pattern, $php_content ) ) {
+	$php_content = preg_replace( $version_pattern, $version_replacement, $php_content );
+	$updated     = true;
+}
+
+// Update PACKAGE_VERSION_AND_TIMESTAMP constant
+if ( preg_match( $timestamp_pattern, $php_content ) ) {
+	$php_content = preg_replace( $timestamp_pattern, $timestamp_replacement, $php_content );
+	$updated     = true;
+}
+
+if ( $updated ) {
+	// Write the updated content back
+	// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- This is a build script, not web-facing code
+	if ( file_put_contents( $jetpack_forms_path, $php_content ) === false ) {
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- This is a CLI script
+		echo "❌ Error: Could not write to class-jetpack-forms.php\n";
+		exit( 1 );
+	}
+
+	// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- This is a CLI script
+	echo "✅ Updated PACKAGE_VERSION to '$version' and PACKAGE_VERSION_AND_TIMESTAMP to '$time_stamped_version' in class-jetpack-forms.php\n";
+} else {
+	// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- This is a CLI script
+	echo "❌ Error: Could not find PACKAGE_VERSION constants to update\n";
+	exit( 1 );
+}


### PR DESCRIPTION
Resolves FORMS-287

Currently when we build we might not be updating the version which can result in stale js and css being loaded on the client side. 

This PR tries to address this by creating a version everytime we create a build. 

## Proposed changes:
* Have all the different assets enque with one version that gets updated everytime we build the forms package. 

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion


## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
Do the tests pass? 
Add a form to a page. 
Load the form on the front end. 
View Source: Notice that the assets build from are loaded using one version from the build.

