### PR TITLE
Update/threat toolbar

### DIFF
--- a/projects/plugins/jetpack/changelog/update-threat-toolbar
+++ b/projects/plugins/jetpack/changelog/update-threat-toolbar
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Minor css change
+
+

--- a/projects/plugins/jetpack/modules/scan/class-admin-bar-notice.php
+++ b/projects/plugins/jetpack/modules/scan/class-admin-bar-notice.php
@@ -141,10 +141,10 @@ class Admin_Bar_Notice {
 		}
 
 		// We might be showing the threats in the admin bar lets make sure that they look great!
-		$hide_wording_on_mobile = '#wp-admin-bar-jetpack-scan-notice .is-hidden { display:none; } @media screen and (max-width: 959px ) { #wpadminbar #wp-admin-bar-jetpack-scan-notice { width:32px; } #wpadminbar #wp-admin-bar-jetpack-scan-notice a { color: transparent!important; } }';
-		$style                  = '#wp-admin-bar-jetpack-scan-notice svg { float:left; margin-top: 4px; margin-right: 6px; width: 18px; height: 22px; }' . $hide_wording_on_mobile;
+		$hide_wording_on_tablet = '#wp-admin-bar-jetpack-scan-notice .is-hidden { display:none; } @media screen and (max-width: 1079px ) { #wpadminbar #wp-admin-bar-jetpack-scan-notice { width:32px; } #wpadminbar #wp-admin-bar-jetpack-scan-notice a { color: transparent!important; } }';
+		$style                  = '#wp-admin-bar-jetpack-scan-notice svg { float:left; margin-top: 4px; margin-right: 6px; width: 18px; height: 22px; }' . $hide_wording_on_tablet;
 		if ( is_rtl() ) {
-			$style = '#wp-admin-bar-jetpack-scan-notice svg { float:right; margin-top: 4px; margin-left: 6px; width: 18px; height: 22px; }' . $hide_wording_on_mobile;
+			$style = '#wp-admin-bar-jetpack-scan-notice svg { float:right; margin-top: 4px; margin-left: 6px; width: 18px; height: 22px; }' . $hide_wording_on_tablet;
 		}
 		wp_add_inline_style( 'admin-bar', $style );
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #PROTECT-127

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* When the toolbar has many items in it that expand it's total width past the normal toolbar breakpoint of 959px it'll overlap.  This reduces the chance that Protect contributes to this problem by reducing it's size at a higher breakpoint.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a Jurassic Ninja site with Jetpack Beta and Jetpack Protect
* Add a threat to the site, like a vulnerable plugin
* Ensure you see a "Threats Found" in the toolbar
* Reduce the width of the site to ensure that the toolbar doesn't drop down to the next line before the "Threats Found" text is removed and the element is reduced to only the shield icon.

