### PR TITLE
Sharing Settings: On Dotcom Simple, show all settings even when using a block theme

### DIFF
--- a/projects/plugins/jetpack/changelog/dotcom-14065-untangling-ia-hostingtools-marketing-sharing-buttons
+++ b/projects/plugins/jetpack/changelog/dotcom-14065-untangling-ia-hostingtools-marketing-sharing-buttons
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+On Dotcom Simple site, show all sharing settings even when the site is using a block theme, so that the sharing buttons filter can be disabled

--- a/projects/plugins/jetpack/modules/sharedaddy/sharing.php
+++ b/projects/plugins/jetpack/modules/sharedaddy/sharing.php
@@ -364,10 +364,8 @@ class Sharing_Admin {
 		?>
 
 		<?php
-			$block_availability = Jetpack_Gutenberg::get_cached_availability();
-			$is_block_available = (bool) isset( $block_availability['sharing-buttons'] ) && $block_availability['sharing-buttons']['available'];
-			$is_block_theme     = wp_is_block_theme();
-			$show_block_message = $is_block_available && $is_block_theme;
+			$is_simple_site     = defined( 'IS_WPCOM' ) && IS_WPCOM;
+			$show_block_message = $this->should_use_site_editor() && ! $is_simple_site;
 
 			// We either show old services config or the sharing block message.
 		if ( current_user_can( 'manage_options' ) ) :
@@ -399,6 +397,18 @@ class Sharing_Admin {
 	}
 
 	/**
+	 * Check if we should encourage to use the site editor instead of the legacy sharing settings.
+	 *
+	 * @return boolean
+	 */
+	public function should_use_site_editor() {
+			$block_availability = Jetpack_Gutenberg::get_cached_availability();
+			$is_block_available = (bool) isset( $block_availability['sharing-buttons'] ) && $block_availability['sharing-buttons']['available'];
+			$is_block_theme     = wp_is_block_theme();
+			return $is_block_available && $is_block_theme;
+	}
+
+	/**
 	 * Display services admin UI for settings.
 	 *
 	 * @return void
@@ -417,6 +427,20 @@ class Sharing_Admin {
 		<div class="share_manage_options">
 		<h2><?php esc_html_e( 'Sharing Buttons', 'jetpack' ); ?></h2>
 		<p><?php esc_html_e( 'Add sharing buttons to your blog and allow your visitors to share posts with their friends.', 'jetpack' ); ?></p>
+
+		<?php
+			$is_simple_site = defined( 'IS_WPCOM' ) && IS_WPCOM;
+		if ( $this->should_use_site_editor() && $is_simple_site ) :
+			$this->site_editor_prompt_display();
+			?>
+					<div class="notice notice-info inline">
+						<p>
+						<?php esc_html_e( 'You are using a block-based theme. We recommend that you disable the legacy sharing features below and add a sharing button block to your theme’s template instead.', 'jetpack' ); ?>
+						</p>
+					</div>
+				<?php
+			endif;
+		?>
 
 		<div id="services-config">
 			<table id="available-services">
@@ -735,16 +759,6 @@ class Sharing_Admin {
 			},
 			false
 		);
-
-		$host = new Status\Host();
-
-		$wpcom_link = 'https://wordpress.com/support/wordpress-editor/blocks/sharing-buttons-block/';
-
-		if ( function_exists( 'localized_wpcom_url' ) ) {
-			$wpcom_link = localized_wpcom_url( $wpcom_link );
-		}
-
-		$link = $host->is_wpcom_platform() ? $wpcom_link : Redirect::get_url( 'jetpack-support-sharing-block' );
 		?>
 
 		<div class="share_manage_options">
@@ -753,14 +767,7 @@ class Sharing_Admin {
 			<div class="sharing-block-message__items-wrapper">
 				<div>
 					<p><?php esc_html_e( 'Add sharing buttons to your blog and allow your visitors to share posts with their friends.', 'jetpack' ); ?></p>
-					<div class="sharing-block-message__buttons-wrapper">
-						<a href="<?php echo esc_url( admin_url( 'site-editor.php?path=%2Fwp_template' ) ); ?>" class="button button-primary">
-							<?php esc_html_e( 'Go to the site editor', 'jetpack' ); ?>
-						</a>
-						<a data-target="wpcom-help-center" href="<?php echo esc_url( $link ); ?>" class="button" target="_blank" rel="noopener noreferrer">
-							<?php esc_html_e( 'Learn how to add Sharing Buttons', 'jetpack' ); ?>
-						</a>
-					</div>
+					<?php $this->site_editor_prompt_display(); ?>
 				</div>
 				<div>
 					<p><?php esc_html_e( 'Sharing Buttons example:', 'jetpack' ); ?></p>
@@ -793,6 +800,34 @@ class Sharing_Admin {
 			</div>
 			<br class="clearing" />
 		</div>
+		<?php
+	}
+
+	/**
+	 * Display the "Go to the site editor" prompt.
+	 *
+	 * @return void
+	 */
+	public function site_editor_prompt_display() {
+		$host = new Status\Host();
+
+		$wpcom_link = 'https://wordpress.com/support/wordpress-editor/blocks/sharing-buttons-block/';
+
+		if ( function_exists( 'localized_wpcom_url' ) ) {
+			$wpcom_link = localized_wpcom_url( $wpcom_link );
+		}
+
+		$link = $host->is_wpcom_platform() ? $wpcom_link : Redirect::get_url( 'jetpack-support-sharing-block' );
+
+		?>
+			<div class="sharing-block-message__buttons-wrapper">
+				<a href="<?php echo esc_url( admin_url( 'site-editor.php?path=%2Fwp_template' ) ); ?>" class="button button-primary">
+					<?php esc_html_e( 'Go to the site editor', 'jetpack' ); ?>
+				</a>
+				<a data-target="wpcom-help-center" href="<?php echo esc_url( $link ); ?>" class="button" target="_blank" rel="noopener noreferrer">
+					<?php esc_html_e( 'Learn how to add Sharing Buttons', 'jetpack' ); ?>
+				</a>
+			</div>
 		<?php
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes DOTTHEM-84

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

When using a classic theme, sharing buttons are appended to the post content via filter, and can be controlled from [Settings -> Sharing].

When using a block theme, sharing buttons should be added as a block in the site editor; [Settings -> Sharing] shows only a link to the site editor, but the legacy filter still works.

On Dotcom, we recently consolidated the sharing settings into [Settings -> Sharing], relying on [Jetpack -> Settings -> Sharing] for disabling the `sharedaddy` module altogether.

On Simple sites, where [Jetpack -> Settings -> Sharing] is not available and the `sharedaddy` module is always enabled, that consolidation practically locked out sites using a block theme from being able to disable sharing buttons.

This change ensures that, on Simple sites, sharing settings are displayed even when running a block theme.

Users are still encouraged to use the site editor, but they can control (and possibly turn off) all the legacy sharing buttons.

| Before<br>(classic theme) | Before<br>(block theme) | After<br>(block theme) |
|--------|--------|--------|
| <img width="2084" height="1872" alt="Screenshot 2025-09-15 at 13 30 28" src="https://github.com/user-attachments/assets/eba42a46-1589-4958-b002-0f60e94af8e8" /> | <img width="2310" height="1872" alt="Screenshot 2025-09-15 at 13 27 20" src="https://github.com/user-attachments/assets/0c7c753b-4d5a-493a-839c-d51dff73faf5" /> | <img width="2082" height="1872" alt="Screenshot 2025-09-15 at 13 27 36" src="https://github.com/user-attachments/assets/a843d3db-1a7a-4ce9-b0a8-f0a353867766" /> |

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Use a Simple site to test.
   * Enable a classic theme and open Settings -> Sharing.
      * Ensure you see the form without any notice encouraging to use the site editor.
   * Enable a block theme and open Settings -> Sharing. (This is the only expected change!)
      * Ensure you see the form; a notice and "Go to the site editor" button are displayed right above the form.
* Use an Atomic or self-hosted site to test.
   * Enable a classic theme and open Settings -> Sharing.
      * Ensure you see the form without any notice encouraging to use the site editor.
   * Enable a block theme and open Settings -> Sharing.
      * Ensure you don't see the form, but only the "Go to the site editor" button.