### PR TITLE
e2e tests: Update verification step for WordPress.com user login

### DIFF
--- a/tools/e2e-commons/setup-specs/auth.setup.ts
+++ b/tools/e2e-commons/setup-specs/auth.setup.ts
@@ -37,9 +37,12 @@ setup(
 			// use the browser to ensure JS routing is executed
 			const page = await authenticatedContext.newPage();
 			await page.goto( 'https://wordpress.com/me' );
-			expect
-				.soft( await page.content(), 'User is redirected to profile page' )
-				.toContain( `Howdy, ${ dotComCredentials.username }` );
+			await expect
+				.soft(
+					page.getByRole( 'link', { name: `Howdy, ${ dotComCredentials.username }` } ),
+					'User is logged in and username is visible'
+				)
+				.toBeVisible();
 		} );
 	}
 );


### PR DESCRIPTION
## Proposed changes:

Update the verification step for the wordpress.com authentication setup step.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
* e2e tests pass

