### PR TITLE
Forms: Add temp feedback scheduled deletion

### DIFF
--- a/projects/packages/forms/changelog/add-temp-feedback-scheduled-deletion
+++ b/projects/packages/forms/changelog/add-temp-feedback-scheduled-deletion
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: add scheduled deletion for submissions that skip the submission's inbox and are stored as temporary feedback.

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -2064,6 +2064,11 @@ class Contact_Form extends Contact_Form_Shortcode {
 			wp_schedule_event( time() + 250, 'daily', 'grunion_scheduled_delete' );
 		}
 
+		// schedule deletes of old temp feedbacks
+		if ( ! wp_next_scheduled( 'grunion_scheduled_delete_temp' ) ) {
+			wp_schedule_event( time() + 250, 'daily', 'grunion_scheduled_delete_temp' );
+		}
+
 		if (
 			$is_spam !== true &&
 			/**

--- a/projects/packages/forms/src/contact-form/class-util.php
+++ b/projects/packages/forms/src/contact-form/class-util.php
@@ -35,6 +35,7 @@ class Util {
 
 		add_action( 'init', '\Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::init', 9 );
 		add_action( 'grunion_scheduled_delete', '\Automattic\Jetpack\Forms\ContactForm\Util::grunion_delete_old_spam' );
+		add_action( 'grunion_scheduled_delete_temp', '\Automattic\Jetpack\Forms\ContactForm\Util::grunion_delete_old_temp_feedback' );
 		add_action( 'grunion_pre_message_sent', '\Automattic\Jetpack\Forms\ContactForm\Util::jetpack_tracks_record_grunion_pre_message_sent', 12, 3 );
 	}
 
@@ -277,6 +278,57 @@ class Util {
 		// if we hit the max then schedule another run
 		if ( count( $post_ids ) >= $grunion_delete_limit ) {
 			wp_schedule_single_event( time() + 700, 'grunion_scheduled_delete' );
+		}
+	}
+
+	/**
+	 * Deletes old temp feedback to keep the posts table size under control.
+	 *
+	 * @since $$next-version$$
+	 */
+	public static function grunion_delete_old_temp_feedback() {
+		global $wpdb;
+
+		$grunion_delete_limit = 100;
+
+		$now_gmt  = current_time( 'mysql', 1 );
+		$sql      = $wpdb->prepare(
+			"
+			SELECT `ID`
+			FROM $wpdb->posts
+			WHERE DATE_SUB( %s, INTERVAL 1 DAY ) > `post_date_gmt`
+				AND `post_type` = 'feedback'
+				AND `post_status` = 'jp-temp-feedback'
+			LIMIT %d
+		",
+			$now_gmt,
+			$grunion_delete_limit
+		);
+		$post_ids = $wpdb->get_col( $sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+
+		foreach ( (array) $post_ids as $post_id ) {
+			// force a full delete, skip the trash
+			wp_delete_post( $post_id, true );
+		}
+
+		if (
+			/**
+			 * Filter if the module run OPTIMIZE TABLE on the core WP tables.
+			 *
+			 * @module contact-form
+			 *
+			 * @since $$next-version$$
+			 *
+			 * @param bool $filter Should Jetpack optimize the table, defaults to false.
+			 */
+			apply_filters( 'grunion_optimize_table', false )
+		) {
+			$wpdb->query( "OPTIMIZE TABLE $wpdb->posts" ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		}
+
+		// if we hit the max then schedule another run
+		if ( count( $post_ids ) >= $grunion_delete_limit ) {
+			wp_schedule_single_event( time() + 700, 'grunion_scheduled_delete_temp' );
 		}
 	}
 

--- a/projects/packages/forms/src/contact-form/class-util.php
+++ b/projects/packages/forms/src/contact-form/class-util.php
@@ -291,8 +291,8 @@ class Util {
 
 		$grunion_delete_limit = 100;
 
-		$now_gmt  = current_time( 'mysql', 1 );
-		$sql      = $wpdb->prepare(
+		$now_gmt = current_time( 'mysql', 1 );
+		$sql     = $wpdb->prepare(
 			"
 			SELECT `ID`
 			FROM $wpdb->posts
@@ -304,6 +304,8 @@ class Util {
 			$now_gmt,
 			$grunion_delete_limit
 		);
+
+		// The SQL query is already prepared with $wpdb->prepare() above, and direct query is needed for performance-critical cleanup operation
 		$post_ids = $wpdb->get_col( $sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 
 		foreach ( (array) $post_ids as $post_id ) {
@@ -323,6 +325,7 @@ class Util {
 			 */
 			apply_filters( 'grunion_optimize_table', false )
 		) {
+			// OPTIMIZE TABLE is a MySQL-specific maintenance command that cannot be prepared and is only run when explicitly enabled via filter
 			$wpdb->query( "OPTIMIZE TABLE $wpdb->posts" ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		}
 

--- a/projects/plugins/jetpack/changelog/add-temp-feedback-scheduled-deletion
+++ b/projects/plugins/jetpack/changelog/add-temp-feedback-scheduled-deletion
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: add scheduled deletion for submissions that skip the submission's inbox and are stored as temporary feedback.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to FORMS-247

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Added scheduled deletion for posts with temp feedback status.
* It follows the same approach we use for automatically deleting spam feedback, but deletes posts older than one day.
* The deletion job is scheduled the first time when a form is submitted, and then it runs daily.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
Testing this PR is a bit cumbersome, as it requires running some CLI commands and modifying the wp_posts table rows if you don't want to wait a day for the cron job to pick up the rows to delete. If you tested #45072 on your local machine, you'll still have feedback posts with `jp-temp-feedback` status lying around, in which case, just continue with the instructions below. If not, you'll have to create a form with the `Save responses` toggle off and then submit some responses.
* From your local dev environment, run `jetpack docker db`
* Run this query ```SELECT id, post_date_gmt FROM wp_posts WHERE  `post_type` = 'feedback' AND `post_status` = 'jp-temp-feedback';``` and check that there are some rows in there.
* Update `wp_posts` table if you have to, to make the feedback posts at least 1 day older than the current timestamp, like so: ```update wp_posts set post_date_gmt = '2025-09-11 13:40:35' where id = [insert your post id here];```
* Do a post-submission on your site—any form would do—so that the deletion job is scheduled. You'd have to wait ~5 minutes for the job to be scheduled the first time.
* Then, from another terminal, run ```jetpack docker wp cron event run grunion_scheduled_delete_temp```
* Check the db again to make sure the feedback posts were deleted: ```SELECT id, post_date_gmt FROM wp_posts WHERE  `post_type` = 'feedback' AND `post_status` = 'jp-temp-feedback';```

