### PR TITLE
Subscriptions: Always link to WP Admin in Newsletter widget

### DIFF
--- a/projects/plugins/jetpack/changelog/dotcom-14519-replace-the-calypso-stats-quick-link-in-the-widget-with-the
+++ b/projects/plugins/jetpack/changelog/dotcom-14519-replace-the-calypso-stats-quick-link-in-the-widget-with-the
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Subscriptions: Always link to WP Admin in Newsletter widget

--- a/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/class-jetpack-newsletter-dashboard-widget.php
+++ b/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/class-jetpack-newsletter-dashboard-widget.php
@@ -89,7 +89,7 @@ class Jetpack_Newsletter_Dashboard_Widget {
 
 			$config_data['showHeader'] = $config_data['isStatsModuleActive'] && ( $config_data['allSubscribers'] > 0 || $config_data['paidSubscribers'] > 0 );
 			foreach ( $config_data['subscriberTotalsByDate'] as $day ) {
-				if ( $day && ( $day['all'] > 5 || $day['paid'] > 0 ) ) {
+				if ( $day && ( $day['all'] >= 5 || $day['paid'] > 0 ) ) {
 					$config_data['showChart'] = true;
 					break;
 				}

--- a/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/class-jetpack-newsletter-dashboard-widget.php
+++ b/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/class-jetpack-newsletter-dashboard-widget.php
@@ -78,6 +78,17 @@ class Jetpack_Newsletter_Dashboard_Widget {
 			}
 
 			$config_data['isStatsModuleActive'] = ( new Modules() )->is_active( 'stats' );
+
+			$config_data['showHeader'] = $config_data['isStatsModuleActive'] && ( $config_data['allSubscribers'] > 0 || $config_data['paidSubscribers'] > 0 );
+			$config_data['showChart']  = false;
+			foreach ( $config_data['subscriberTotalsByDate'] as $day ) {
+				if ( $day && ( $day['all'] >= 5 || $day['paid'] > 0 ) ) {
+					$config_data['showChart'] = true;
+					break;
+				}
+			}
+
+			$config_data['isWidgetVisible'] = $config_data['showHeader'] || $config_data['showChart'];
 		}
 
 		return $config_data;
@@ -93,12 +104,18 @@ class Jetpack_Newsletter_Dashboard_Widget {
 		}
 
 		if ( Jetpack::is_connection_ready() ) {
+			$config_data = static::get_config_data();
+
+			if ( ! $config_data['isWidgetVisible'] ) {
+				return;
+			}
+
 			static::load_admin_scripts(
 				'jp-newsletter-widget',
 				'newsletter-widget',
 				array(
 					'config_variable_name' => 'jetpackNewsletterWidgetConfigData',
-					'config_data'          => static::get_config_data(),
+					'config_data'          => $config_data,
 					'load_minified_js'     => false,
 				)
 			);

--- a/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/class-jetpack-newsletter-dashboard-widget.php
+++ b/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/class-jetpack-newsletter-dashboard-widget.php
@@ -44,8 +44,16 @@ class Jetpack_Newsletter_Dashboard_Widget {
 	 * @return array
 	 */
 	public static function get_config_data() {
-		$subscriber_counts = array();
-		$config_data       = array();
+		$config_data = array(
+			'emailSubscribers'       => 0,
+			'paidSubscribers'        => 0,
+			'allSubscribers'         => 0,
+			'subscriberTotalsByDate' => array(),
+			'isStatsModuleActive'    => false,
+			'showHeader'             => false,
+			'showChart'              => false,
+			'isWidgetVisible'        => false,
+		);
 
 		if ( Jetpack::is_connection_ready() ) {
 			$site_id  = Jetpack_Options::get_option( 'id' );
@@ -80,9 +88,8 @@ class Jetpack_Newsletter_Dashboard_Widget {
 			$config_data['isStatsModuleActive'] = ( new Modules() )->is_active( 'stats' );
 
 			$config_data['showHeader'] = $config_data['isStatsModuleActive'] && ( $config_data['allSubscribers'] > 0 || $config_data['paidSubscribers'] > 0 );
-			$config_data['showChart']  = false;
 			foreach ( $config_data['subscriberTotalsByDate'] as $day ) {
-				if ( $day && ( $day['all'] >= 5 || $day['paid'] > 0 ) ) {
+				if ( $day && ( $day['all'] > 5 || $day['paid'] > 0 ) ) {
 					$config_data['showChart'] = true;
 					break;
 				}

--- a/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/src/components/newsletter-widget.tsx
+++ b/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/src/components/newsletter-widget.tsx
@@ -139,15 +139,16 @@ export const NewsletterWidget = ( {
 								{ __( 'Publish your next post', 'jetpack' ) }
 							</a>
 						</li>
-						<li>
-							{ isStatsModuleActive &&
-								DashboardLink(
+						{ isStatsModuleActive && (
+							<li>
+								{ DashboardLink(
 									true,
 									getSubscriberStatsUrl( site, adminUrl ),
 									'view_stats_click',
 									__( 'View subscriber stats', 'jetpack' )
 								) }
-						</li>
+							</li>
+						) }
 						<li>
 							{ DashboardLink(
 								isWpcomSite,

--- a/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/src/components/newsletter-widget.tsx
+++ b/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/src/components/newsletter-widget.tsx
@@ -49,6 +49,10 @@ export const NewsletterWidget = ( {
 		tracks.recordEvent( `${ TRACKS_EVENT_NAME_PREFIX }_view` );
 	}, [ tracks ] );
 
+	if ( showHeader && ! isStatsModuleActive && ! showChart ) {
+		return null;
+	}
+
 	const subscribersText = sprintf(
 		//translators: %1$s is the total number of subscribers, %2$s is the number of email subscribers
 		_n(
@@ -72,7 +76,7 @@ export const NewsletterWidget = ( {
 
 	return (
 		<div className="newsletter-widget">
-			{ showHeader && (
+			{ showHeader && isStatsModuleActive && (
 				<div className="newsletter-widget__header">
 					<div className="newsletter-widget__stats">
 						<span className="newsletter-widget__stat-item">
@@ -83,7 +87,7 @@ export const NewsletterWidget = ( {
 								<span className="newsletter-widget__stat-label">
 									{ DashboardLink(
 										isInternalLink,
-										getSubscriberStatsUrl( site, isWpcomSite, adminUrl, isStatsModuleActive ),
+										getSubscriberStatsUrl( site, adminUrl ),
 										'all_subscribers_click',
 										subscribersText
 									) }
@@ -98,7 +102,7 @@ export const NewsletterWidget = ( {
 								<span className="newsletter-widget__stat-label">
 									{ DashboardLink(
 										isInternalLink,
-										getSubscriberStatsUrl( site, isWpcomSite, adminUrl, isStatsModuleActive ),
+										getSubscriberStatsUrl( site, adminUrl ),
 										'paid_subscribers_click',
 										paidSubscribersText
 									) }
@@ -144,12 +148,13 @@ export const NewsletterWidget = ( {
 							</a>
 						</li>
 						<li>
-							{ DashboardLink(
-								isInternalLink,
-								getSubscriberStatsUrl( site, isWpcomSite, adminUrl, isStatsModuleActive ),
-								'view_stats_click',
-								__( 'View subscriber stats', 'jetpack' )
-							) }
+							{ isStatsModuleActive &&
+								DashboardLink(
+									isInternalLink,
+									getSubscriberStatsUrl( site, adminUrl ),
+									'view_stats_click',
+									__( 'View subscriber stats', 'jetpack' )
+								) }
 						</li>
 						<li>
 							{ DashboardLink(

--- a/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/src/components/newsletter-widget.tsx
+++ b/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/src/components/newsletter-widget.tsx
@@ -26,6 +26,8 @@ export interface NewsletterWidgetProps {
 	paidSubscribers?: number;
 	allSubscribers?: number;
 	subscriberTotalsByDate?: SubscriberTotalsByDate;
+	showHeader?: boolean;
+	showChart?: boolean;
 }
 
 export const NewsletterWidget = ( {
@@ -37,21 +39,14 @@ export const NewsletterWidget = ( {
 	paidSubscribers = 0,
 	allSubscribers = 0,
 	subscriberTotalsByDate = {},
+	showHeader,
+	showChart,
 }: NewsletterWidgetProps ) => {
-	const showHeader = allSubscribers > 0 || paidSubscribers > 0;
-	const showChart = Object.values( subscriberTotalsByDate ).some(
-		day => day?.all >= 5 || day?.paid > 0
-	);
-
 	const { tracks } = useAnalytics();
 
 	useEffect( () => {
 		tracks.recordEvent( `${ TRACKS_EVENT_NAME_PREFIX }_view` );
 	}, [ tracks ] );
-
-	if ( showHeader && ! isStatsModuleActive && ! showChart ) {
-		return null;
-	}
 
 	const subscribersText = sprintf(
 		//translators: %1$s is the total number of subscribers, %2$s is the number of email subscribers
@@ -71,12 +66,9 @@ export const NewsletterWidget = ( {
 		formatNumber( paidSubscribers )
 	);
 
-	// For WordPress.com sites, links should always be considered internal.
-	const isInternalLink = isStatsModuleActive || isWpcomSite;
-
 	return (
 		<div className="newsletter-widget">
-			{ showHeader && isStatsModuleActive && (
+			{ showHeader && (
 				<div className="newsletter-widget__header">
 					<div className="newsletter-widget__stats">
 						<span className="newsletter-widget__stat-item">
@@ -86,7 +78,7 @@ export const NewsletterWidget = ( {
 							<span className="newsletter-widget__stat-content">
 								<span className="newsletter-widget__stat-label">
 									{ DashboardLink(
-										isInternalLink,
+										true,
 										getSubscriberStatsUrl( site, adminUrl ),
 										'all_subscribers_click',
 										subscribersText
@@ -101,7 +93,7 @@ export const NewsletterWidget = ( {
 							<span className="newsletter-widget__stat-content">
 								<span className="newsletter-widget__stat-label">
 									{ DashboardLink(
-										isInternalLink,
+										true,
 										getSubscriberStatsUrl( site, adminUrl ),
 										'paid_subscribers_click',
 										paidSubscribersText
@@ -150,7 +142,7 @@ export const NewsletterWidget = ( {
 						<li>
 							{ isStatsModuleActive &&
 								DashboardLink(
-									isInternalLink,
+									true,
 									getSubscriberStatsUrl( site, adminUrl ),
 									'view_stats_click',
 									__( 'View subscriber stats', 'jetpack' )

--- a/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/src/helpers.ts
+++ b/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/src/helpers.ts
@@ -45,25 +45,12 @@ export const buildJPRedirectSource = ( url: string, isWpcomSite: boolean = true 
 /**
  * Generates the URL for subscriber statistics based on site context.
  *
- * @param {string}  site                - The site identifier
- * @param {boolean} isWpcomSite         - Whether the site is on WordPress.com
- * @param {string}  adminUrl            - The admin URL for self-hosted sites
- * @param {boolean} isStatsModuleActive - Whether or not the Stats module is enabled
+ * @param {string} site     - The site identifier
+ * @param {string} adminUrl - The admin URL for self-hosted sites
  * @returns {string} The appropriate subscriber stats URL
  */
-export const getSubscriberStatsUrl = (
-	site: string,
-	isWpcomSite: boolean,
-	adminUrl: string,
-	isStatsModuleActive: boolean
-): string => {
-	if ( isStatsModuleActive && ! isWpcomSite ) {
-		return `${ adminUrl }admin.php?page=stats#!/stats/subscribers/${ site }`;
-	}
-
-	// If the stats module is not active,
-	// we can always redirect the old Calypso blue stats sub-page for subscribers stats.
-	return getRedirectUrl( `https://wordpress.com/stats/subscribers/${ site }` );
+export const getSubscriberStatsUrl = ( site: string, adminUrl: string ): string => {
+	return `${ adminUrl }admin.php?page=stats#!/stats/subscribers/${ site }`;
 };
 
 /**

--- a/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/src/index.tsx
+++ b/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/src/index.tsx
@@ -11,6 +11,8 @@ declare global {
 			allSubscribers?: number;
 			subscriberTotalsByDate?: SubscriberTotalsByDate;
 			isStatsModuleActive?: boolean;
+			showHeader?: boolean;
+			showChart?: boolean;
 		};
 	}
 }
@@ -28,6 +30,8 @@ document.addEventListener( 'DOMContentLoaded', () => {
 		allSubscribers,
 		subscriberTotalsByDate,
 		isStatsModuleActive,
+		showHeader,
+		showChart,
 	} = window.jetpackNewsletterWidgetConfigData || {};
 	const { suffix: site } = jpDataUtils.getSiteData();
 	const adminUrl = jpDataUtils.getAdminUrl();
@@ -48,6 +52,8 @@ document.addEventListener( 'DOMContentLoaded', () => {
 			paidSubscribers={ paidSubscribers }
 			allSubscribers={ allSubscribers }
 			subscriberTotalsByDate={ subscriberTotalsByDate }
+			showHeader={ showHeader }
+			showChart={ showChart }
 		/>
 	);
 } );

--- a/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/test/helpers.test.ts
+++ b/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/test/helpers.test.ts
@@ -156,21 +156,11 @@ describe( 'helpers', () => {
 		const testSite = 'example.com';
 		const testAdminUrl = 'https://example.com/wp-admin/';
 
-		it( 'returns WordPress.com URL for WordPress.com sites', () => {
-			const url = getSubscriberStatsUrl( testSite, true, testAdminUrl, true );
-			expect( url ).toBe( getRedirectUrl( 'https://wordpress.com/stats/subscribers/' + testSite ) );
-		} );
-
-		it( 'returns WP-admin URL for self-hosted sites when stats module is active', () => {
-			const url = getSubscriberStatsUrl( testSite, false, testAdminUrl, true );
+		it( 'returns WP-admin URL', () => {
+			const url = getSubscriberStatsUrl( testSite, testAdminUrl );
 			expect( url ).toBe(
 				`${ testAdminUrl }admin.php?page=stats#!/stats/subscribers/${ testSite }`
 			);
-		} );
-
-		it( 'returns WordPress.com URL for self-hosted sites when stats module is not active', () => {
-			const url = getSubscriberStatsUrl( testSite, false, testAdminUrl, false );
-			expect( url ).toBe( getRedirectUrl( 'https://wordpress.com/stats/subscribers/' + testSite ) );
 		} );
 	} );
 

--- a/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/test/newsletter-widget.test.tsx
+++ b/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/test/newsletter-widget.test.tsx
@@ -68,9 +68,7 @@ describe( 'NewsletterWidget', () => {
 			},
 			{
 				text: 'View subscriber stats',
-				href: getRedirectUrl(
-					`https://${ redirectDomain }/stats/subscribers/${ defaultProps.site }`
-				),
+				href: 'https://example.com/wp-admin/admin.php?page=stats#!/stats/subscribers/example.com',
 			},
 			{
 				text: 'Import subscribers',

--- a/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/test/newsletter-widget.test.tsx
+++ b/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/test/newsletter-widget.test.tsx
@@ -34,6 +34,8 @@ describe( 'NewsletterWidget', () => {
 				paid: 5,
 			},
 		},
+		showHeader: true,
+		showChart: true,
 	};
 
 	it( 'renders', () => {
@@ -51,6 +53,9 @@ describe( 'NewsletterWidget', () => {
 		expect(
 			screen.getByText( `${ defaultProps.paidSubscribers } paid subscribers` )
 		).toBeInTheDocument();
+
+		// Check for chart label
+		expect( screen.getByText( 'Total Subscribers' ) ).toBeInTheDocument();
 	} );
 
 	it( 'renders correct quick links when hosted on WordPress.com', () => {
@@ -146,111 +151,20 @@ describe( 'NewsletterWidget', () => {
 	} );
 
 	describe( 'Stats display conditions', () => {
-		it( 'shows stats section when allSubscribers > 0', () => {
-			render(
-				<NewsletterWidget
-					{ ...defaultProps }
-					allSubscribers={ 10 }
-					emailSubscribers={ 0 }
-					paidSubscribers={ 0 }
-				/>
-			);
-
-			expect( screen.getByText( '10 subscribers (0 via email)' ) ).toBeInTheDocument();
-		} );
-
-		it( 'shows stats section when paidSubscribers > 0', () => {
-			render( <NewsletterWidget { ...defaultProps } allSubscribers={ 0 } paidSubscribers={ 5 } /> );
-
-			expect( screen.getByText( '5 paid subscribers' ) ).toBeInTheDocument();
-		} );
-
-		it( 'hides stats section when allSubscribers and paidSubscribers are 0', () => {
-			render(
-				<NewsletterWidget
-					{ ...defaultProps }
-					allSubscribers={ 0 }
-					emailSubscribers={ 0 }
-					paidSubscribers={ 0 }
-				/>
-			);
+		it( 'hides stats when showHeader = false', () => {
+			render( <NewsletterWidget { ...defaultProps } showHeader={ false } /> );
 
 			expect( screen.queryByText( /subscribers \(\d+ via email\)/ ) ).not.toBeInTheDocument();
 
 			expect( screen.queryByText( /paid subscribers/ ) ).not.toBeInTheDocument();
 		} );
-
-		it( 'shows stats section when allSubscribers = 1', () => {
-			render(
-				<NewsletterWidget
-					{ ...defaultProps }
-					allSubscribers={ 1 }
-					emailSubscribers={ 1 }
-					paidSubscribers={ 0 }
-				/>
-			);
-
-			expect( screen.getByText( '1 subscriber (1 via email)' ) ).toBeInTheDocument();
-			expect( screen.getByText( '0 paid subscribers' ) ).toBeInTheDocument();
-		} );
-
-		it( 'shows stats section when paidSubscribers = 1', () => {
-			render(
-				<NewsletterWidget
-					{ ...defaultProps }
-					allSubscribers={ 10 }
-					emailSubscribers={ 7 }
-					paidSubscribers={ 1 }
-				/>
-			);
-
-			expect( screen.getByText( '10 subscribers (7 via email)' ) ).toBeInTheDocument();
-			expect( screen.getByText( '1 paid subscriber' ) ).toBeInTheDocument();
-		} );
 	} );
 
 	describe( 'Chart display conditions', () => {
-		it( 'shows chart when at least one day has a total "all" count >= 5', () => {
+		it( 'hides chart when showChart = false', () => {
 			const props: NewsletterWidgetProps = {
 				...defaultProps,
-				subscriberTotalsByDate: {
-					'2021-01-01': { all: 5, paid: 0 },
-				},
-			};
-
-			render( <NewsletterWidget { ...props } /> );
-			expect( screen.getByText( 'Total Subscribers' ) ).toBeInTheDocument();
-		} );
-
-		it( 'shows chart when at least one day has a total "paid" > 0', () => {
-			const props: NewsletterWidgetProps = {
-				...defaultProps,
-				subscriberTotalsByDate: {
-					'2021-01-01': { all: 0, paid: 1 },
-				},
-			};
-
-			render( <NewsletterWidget { ...props } /> );
-			expect( screen.getByText( 'Total Subscribers' ) ).toBeInTheDocument();
-		} );
-
-		it( 'hides chart when no day has "all" count >= 5 or "paid" count > 0', () => {
-			const props: NewsletterWidgetProps = {
-				...defaultProps,
-				subscriberTotalsByDate: {
-					'2021-01-01': { all: 4, paid: 0 },
-					'2021-01-02': { all: 3, paid: 0 },
-				},
-			};
-
-			render( <NewsletterWidget { ...props } /> );
-			expect( screen.queryByText( 'Total Subscribers' ) ).not.toBeInTheDocument();
-		} );
-
-		it( 'handles empty subscriberTotalsByDate by hiding chart', () => {
-			const props = {
-				...defaultProps,
-				subscriberTotalsByDate: {},
+				showChart: false,
 			};
 
 			render( <NewsletterWidget { ...props } /> );

--- a/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/test/newsletter-widget.test.tsx
+++ b/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/test/newsletter-widget.test.tsx
@@ -261,28 +261,10 @@ describe( 'NewsletterWidget', () => {
 	} );
 
 	describe( 'Stats module inactive behavior', () => {
-		it( 'uses WordPress.com URL for stats URL when stats module is inactive, even if we are on a self-hosted site', () => {
-			render(
-				<NewsletterWidget { ...defaultProps } isWpcomSite={ false } isStatsModuleActive={ false } />
-			);
+		it( 'hides subscriber stats link when stats module is inactive', () => {
+			render( <NewsletterWidget { ...defaultProps } isStatsModuleActive={ false } /> );
 
-			const statsLink = screen.getByText( 'View subscriber stats' );
-			expect( statsLink ).toHaveAttribute(
-				'href',
-				getRedirectUrl( 'https://wordpress.com/stats/subscribers/example.com' )
-			);
-		} );
-
-		it( 'uses WordPress.com for stats URL on WordPress.com site, regardless of stats module status', () => {
-			render(
-				<NewsletterWidget { ...defaultProps } isWpcomSite={ true } isStatsModuleActive={ false } />
-			);
-
-			const statsLink = screen.getByText( 'View subscriber stats' );
-			expect( statsLink ).toHaveAttribute(
-				'href',
-				getRedirectUrl( 'https://wordpress.com/stats/subscribers/example.com' )
-			);
+			expect( screen.queryByText( 'View subscriber stats' ) ).not.toBeInTheDocument();
 		} );
 	} );
 } );


### PR DESCRIPTION
Fixes DOTCOM-14519

## Proposed changes:

Updates the Stats links of the Newsletter widget so it always point to WP Admin (the Calypso Stats are being deprecated).

<img width="503" height="310" alt="Screenshot 2025-09-15 at 18 47 21" src="https://github.com/user-attachments/assets/323a4400-108d-41ec-b180-d369d5fc02a3" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
- Apply these changes to your site
- Visit the WP Admin Dashboard
- Check the Newsletter widget
- Make sure the links highlighted in the screenshot above redirect to the WP Admin version of Jetpack Stats
- On a self-hosted Jetpack site or WP.com Atomic site, disable the Stats module.
- Make sure the widget is not visible

