### PR TITLE
Phan: Address PhanTypeSuspiciousStringExpression violations

### DIFF
--- a/projects/packages/sync/.phan/baseline.php
+++ b/projects/packages/sync/.phan/baseline.php
@@ -28,7 +28,6 @@ return [
     // PhanTypeMismatchPropertyDefault : 2 occurrences
     // PhanTypeMismatchReturnNullable : 2 occurrences
     // PhanTypePossiblyInvalidDimOffset : 2 occurrences
-    // PhanTypeSuspiciousStringExpression : 2 occurrences
     // PhanParamTooManyCallable : 1 occurrence
     // PhanPluginUseReturnValueInternalKnown : 1 occurrence
     // PhanTypeInvalidLeftOperandOfNumericOp : 1 occurrence
@@ -47,7 +46,7 @@ return [
         'src/class-listener.php' => ['PhanNonClassMethodCall', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeArraySuspicious', 'PhanTypeExpectedObjectPropAccess', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal'],
         'src/class-lock.php' => ['PhanTypeMismatchReturn'],
         'src/class-queue.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullableInternal'],
-        'src/class-replicastore.php' => ['PhanAccessMethodInternal', 'PhanParamSignatureMismatch', 'PhanPluginDuplicateSwitchCaseLooseEquality', 'PhanTypeArraySuspiciousNullable', 'PhanTypeMismatchArgument', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnNullable', 'PhanTypeSuspiciousStringExpression'],
+        'src/class-replicastore.php' => ['PhanAccessMethodInternal', 'PhanParamSignatureMismatch', 'PhanPluginDuplicateSwitchCaseLooseEquality', 'PhanTypeArraySuspiciousNullable', 'PhanTypeMismatchArgument', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnNullable'],
         'src/class-rest-endpoints.php' => ['PhanParamTooManyCallable', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal', 'PhanTypePossiblyInvalidDimOffset'],
         'src/class-rest-sender.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgumentProbablyReal'],
         'src/class-sender.php' => ['PhanNonClassMethodCall', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchProperty', 'PhanTypeMismatchReturnProbablyReal'],

--- a/projects/packages/sync/changelog/fix-phan-PhanTypeSuspiciousStringExpression
+++ b/projects/packages/sync/changelog/fix-phan-PhanTypeSuspiciousStringExpression
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Phan: Address various PhanTypeSuspiciousStringExpression violations.
+
+

--- a/projects/packages/sync/src/class-replicastore.php
+++ b/projects/packages/sync/src/class-replicastore.php
@@ -1293,7 +1293,7 @@ class Replicastore implements Replicastore_Interface {
 		try {
 			$range_edges = $checksum_table->get_range_edges( $start_id, $end_id );
 		} catch ( Exception $ex ) {
-			return new WP_Error( 'invalid_range_edges', '[' . $start_id . '-' . $end_id . ']: ' . $ex->getMessage() );
+			return new WP_Error( 'invalid_range_edges', '[' . ( $start_id ?? 'null' ) . '-' . ( $end_id ?? 'null' ) . ']: ' . $ex->getMessage() );
 		}
 
 		if ( $only_range_edges ) {

--- a/projects/plugins/crm/.phan/baseline.php
+++ b/projects/plugins/crm/.phan/baseline.php
@@ -51,13 +51,12 @@ return [
     // PhanUndeclaredFunction : 20+ occurrences
     // PhanUndeclaredVariableDim : 20+ occurrences
     // PhanEmptyForeach : 15+ occurrences
-    // PhanNoopBinaryOperator : 15+ occurrences
     // PhanTypeComparisonFromArray : 15+ occurrences
     // PhanTypeMismatchDeclaredReturnNullable : 15+ occurrences
     // PhanTypeMismatchProperty : 15+ occurrences
-    // PhanTypeSuspiciousStringExpression : 15+ occurrences
     // PhanUndeclaredGlobalVariable : 15+ occurrences
     // PhanUndeclaredTypeProperty : 15+ occurrences
+    // PhanNoopBinaryOperator : 10+ occurrences
     // PhanTypeMismatchPropertyDefault : 10+ occurrences
     // PhanTypeMismatchReturnNullable : 10+ occurrences
     // PhanUndeclaredClassCatch : 10+ occurrences
@@ -66,12 +65,12 @@ return [
     // PhanAccessMethodPrivate : 9 occurrences
     // PhanTypeMismatchDimFetchNullable : 9 occurrences
     // PhanPluginNeverReturnFunction : 7 occurrences
-    // PhanTypeInvalidDimOffset : 7 occurrences
     // PhanUndeclaredTypeReturnType : 7 occurrences
     // PhanAbstractStaticMethodCallInStatic : 6 occurrences
     // PhanTypeInvalidLeftOperandOfNumericOp : 6 occurrences
     // PhanTypeMismatchDeclaredReturn : 6 occurrences
     // PhanTypeConversionFromArray : 5 occurrences
+    // PhanTypeInvalidDimOffset : 5 occurrences
     // PhanUndeclaredClassReference : 5 occurrences
     // PhanUndeclaredConstant : 5 occurrences
     // PhanPluginDuplicateExpressionBinaryOp : 4 occurrences
@@ -117,7 +116,7 @@ return [
     'file_suppressions' => [
         'admin/activation/welcome-to-jpcrm.php' => ['PhanTypeMismatchForeach'],
         'admin/activation/wizard.ajax.php' => ['PhanRedundantCondition', 'PhanSuspiciousValueComparison'],
-        'admin/company/view.page.php' => ['PhanNoopBinaryOperator', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanRedundantCondition', 'PhanSuspiciousValueComparison', 'PhanTypeArraySuspiciousNullable', 'PhanTypePossiblyInvalidDimOffset', 'PhanTypeSuspiciousStringExpression'],
+        'admin/company/view.page.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanRedundantCondition', 'PhanSuspiciousValueComparison', 'PhanTypeArraySuspiciousNullable', 'PhanTypePossiblyInvalidDimOffset'],
         'admin/contact/add-file.page.php' => ['PhanPossiblyUndeclaredVariable', 'PhanTypeArraySuspiciousNullable', 'PhanTypeMismatchArgumentNullable', 'PhanTypePossiblyInvalidDimOffset', 'PhanUndeclaredFunction'],
         'admin/contact/contact.ajax.php' => ['PhanDeprecatedFunction'],
         'admin/contact/view.page.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanRedundantCondition', 'PhanTypeArraySuspiciousNullable', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchArgumentNullableInternal', 'PhanTypePossiblyInvalidDimOffset'],
@@ -125,7 +124,7 @@ return [
         'admin/dashboard/dashboard.ajax.php' => ['PhanDeprecatedFunction', 'PhanTypeArraySuspiciousNullable'],
         'admin/dashboard/main.page.php' => ['PhanDeprecatedFunction', 'PhanRedundantCondition', 'PhanTypeInvalidLeftOperandOfNumericOp', 'PhanTypeMismatchArgument'],
         'admin/email/email.ajax.php' => ['PhanPluginNeverReturnFunction', 'PhanPossiblyUndeclaredVariable', 'PhanTypeArraySuspiciousNullable', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchDefault'],
-        'admin/email/main.page.php' => ['PhanEmptyForeach', 'PhanPluginDuplicateAdjacentStatement', 'PhanRedundantCondition', 'PhanTypeInvalidDimOffset', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullable', 'PhanTypeSuspiciousStringExpression'],
+        'admin/email/main.page.php' => ['PhanEmptyForeach', 'PhanPluginDuplicateAdjacentStatement', 'PhanRedundantCondition', 'PhanTypeMismatchArgument'],
         'admin/export/main.page.php' => ['PhanTypeMismatchArgument', 'PhanTypePossiblyInvalidDimOffset'],
         'admin/settings/client-portal.page.php' => ['PhanUndeclaredVariableDim'],
         'admin/settings/custom-fields.page.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanPossiblyUndeclaredGlobalVariable', 'PhanTypeMismatchDimFetch'],
@@ -140,7 +139,7 @@ return [
         'admin/settings/main.page.php' => ['PhanTypePossiblyInvalidDimOffset', 'PhanUnextractableAnnotationElementName'],
         'admin/settings/oauth-connections.page.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],
         'admin/settings/partials/menu.block.php' => ['PhanUndeclaredGlobalVariable'],
-        'admin/settings/partials/template-variant-setting.block.php' => ['PhanNoopBinaryOperator', 'PhanTypeSuspiciousStringExpression', 'PhanUndeclaredGlobalVariable'],
+        'admin/settings/partials/template-variant-setting.block.php' => ['PhanUndeclaredGlobalVariable'],
         'admin/settings/partials/title.block.php' => ['PhanUndeclaredGlobalVariable'],
         'admin/settings/quotes.page.php' => ['PhanUndeclaredVariableDim'],
         'admin/support/main.page.php' => ['PhanPluginDuplicateAdjacentStatement', 'PhanPossiblyUndeclaredGlobalVariable', 'PhanTypeMismatchArgumentNullable'],
@@ -168,10 +167,10 @@ return [
         'includes/ZeroBSCRM.DAL2.Mail.php' => ['PhanPluginRedundantAssignment', 'PhanTypeArraySuspiciousNullable', 'PhanTypeExpectedObjectPropAccess', 'PhanTypeMismatchDefault'],
         'includes/ZeroBSCRM.DAL3.Export.php' => ['PhanRedundantCondition'],
         'includes/ZeroBSCRM.DAL3.Fields.php' => ['PhanPluginMixedKeyNoKey', 'PhanPluginUseReturnValueInternalKnown', 'PhanPossiblyUndeclaredVariable', 'PhanRedefineFunction', 'PhanRedundantCondition', 'PhanTypePossiblyInvalidDimOffset'],
-        'includes/ZeroBSCRM.DAL3.Helpers.php' => ['PhanDeprecatedFunction', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanPluginRedundantAssignment', 'PhanPluginUnreachableCode', 'PhanPossiblyUndeclaredVariable', 'PhanRedundantCondition', 'PhanSuspiciousValueComparison', 'PhanTypeArraySuspiciousNullable', 'PhanTypeConversionFromArray', 'PhanTypeExpectedObjectPropAccess', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchDefault', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal', 'PhanTypePossiblyInvalidDimOffset', 'PhanTypeSuspiciousStringExpression', 'PhanUndeclaredVariable', 'PhanUnextractableAnnotationElementName'],
+        'includes/ZeroBSCRM.DAL3.Helpers.php' => ['PhanDeprecatedFunction', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanPluginRedundantAssignment', 'PhanPluginUnreachableCode', 'PhanPossiblyUndeclaredVariable', 'PhanRedundantCondition', 'PhanSuspiciousValueComparison', 'PhanTypeArraySuspiciousNullable', 'PhanTypeConversionFromArray', 'PhanTypeExpectedObjectPropAccess', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchDefault', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal', 'PhanTypePossiblyInvalidDimOffset', 'PhanUndeclaredVariable', 'PhanUnextractableAnnotationElementName'],
         'includes/ZeroBSCRM.DAL3.Obj.Addresses.php' => ['PhanEmptyForeach'],
         'includes/ZeroBSCRM.DAL3.Obj.Companies.php' => ['PhanCommentParamWithoutRealParam', 'PhanEmptyForeach', 'PhanNoopBinaryOperator', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanPluginDuplicateExpressionAssignmentOperation', 'PhanPluginRedundantAssignment', 'PhanPluginUnreachableCode', 'PhanPossiblyUndeclaredVariable', 'PhanRedundantCondition', 'PhanSuspiciousValueComparison', 'PhanSuspiciousWeakTypeComparison', 'PhanTypeArraySuspicious', 'PhanTypeArraySuspiciousNull', 'PhanTypeArraySuspiciousNullable', 'PhanTypeComparisonFromArray', 'PhanTypeExpectedObjectPropAccess', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentInternalReal', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchArgumentNullableInternal', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchDefault', 'PhanTypeMismatchDimAssignment', 'PhanTypeMismatchDimFetchNullable', 'PhanTypeMismatchForeach', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnNullable', 'PhanTypeMismatchReturnProbablyReal', 'PhanTypePossiblyInvalidDimOffset', 'PhanUndeclaredVariable', 'PhanUndeclaredVariableDim', 'PhanUnextractableAnnotationElementName'],
-        'includes/ZeroBSCRM.DAL3.Obj.Contacts.php' => ['PhanCommentParamWithoutRealParam', 'PhanEmptyForeach', 'PhanNoopBinaryOperator', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanPluginDuplicateExpressionAssignmentOperation', 'PhanPluginRedundantAssignment', 'PhanPluginUnreachableCode', 'PhanPossiblyUndeclaredVariable', 'PhanRedundantCondition', 'PhanSuspiciousValueComparison', 'PhanSuspiciousWeakTypeComparison', 'PhanTypeArraySuspicious', 'PhanTypeArraySuspiciousNull', 'PhanTypeArraySuspiciousNullable', 'PhanTypeComparisonFromArray', 'PhanTypeExpectedObjectPropAccess', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchArgumentInternalProbablyReal', 'PhanTypeMismatchArgumentInternalReal', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchArgumentNullableInternal', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchArgumentReal', 'PhanTypeMismatchDefault', 'PhanTypeMismatchDimFetchNullable', 'PhanTypeMismatchForeach', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnNullable', 'PhanTypeMismatchReturnProbablyReal', 'PhanTypePossiblyInvalidDimOffset', 'PhanTypeSuspiciousStringExpression', 'PhanUndeclaredVariable', 'PhanUndeclaredVariableDim', 'PhanUnextractableAnnotationElementName'],
+        'includes/ZeroBSCRM.DAL3.Obj.Contacts.php' => ['PhanCommentParamWithoutRealParam', 'PhanEmptyForeach', 'PhanNoopBinaryOperator', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanPluginDuplicateExpressionAssignmentOperation', 'PhanPluginRedundantAssignment', 'PhanPluginUnreachableCode', 'PhanPossiblyUndeclaredVariable', 'PhanRedundantCondition', 'PhanSuspiciousValueComparison', 'PhanSuspiciousWeakTypeComparison', 'PhanTypeArraySuspicious', 'PhanTypeArraySuspiciousNull', 'PhanTypeArraySuspiciousNullable', 'PhanTypeComparisonFromArray', 'PhanTypeExpectedObjectPropAccess', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchArgumentInternalProbablyReal', 'PhanTypeMismatchArgumentInternalReal', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchArgumentNullableInternal', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchArgumentReal', 'PhanTypeMismatchDefault', 'PhanTypeMismatchDimFetchNullable', 'PhanTypeMismatchForeach', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnNullable', 'PhanTypeMismatchReturnProbablyReal', 'PhanTypePossiblyInvalidDimOffset', 'PhanUndeclaredVariable', 'PhanUndeclaredVariableDim', 'PhanUnextractableAnnotationElementName'],
         'includes/ZeroBSCRM.DAL3.Obj.EventReminders.php' => ['PhanEmptyForeach', 'PhanPluginDuplicateExpressionAssignmentOperation', 'PhanPluginRedundantAssignment', 'PhanPluginUnreachableCode', 'PhanPossiblyUndeclaredVariable', 'PhanRedundantCondition', 'PhanSuspiciousValueComparison', 'PhanSuspiciousWeakTypeComparison', 'PhanTypeArraySuspiciousNullable', 'PhanTypeComparisonFromArray', 'PhanTypeExpectedObjectPropAccess', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchArgumentInternalReal', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchDefault', 'PhanTypeMismatchForeach', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnNullable', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredVariable', 'PhanUnextractableAnnotationElementName'],
         'includes/ZeroBSCRM.DAL3.Obj.Events.php' => ['PhanCommentParamWithoutRealParam', 'PhanEmptyForeach', 'PhanNoopBinaryOperator', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanPluginDuplicateExpressionAssignmentOperation', 'PhanPluginRedundantAssignment', 'PhanPluginUnreachableCode', 'PhanPossiblyUndeclaredVariable', 'PhanRedundantCondition', 'PhanSuspiciousValueComparison', 'PhanSuspiciousWeakTypeComparison', 'PhanTypeArraySuspiciousNull', 'PhanTypeArraySuspiciousNullable', 'PhanTypeComparisonFromArray', 'PhanTypeExpectedObjectPropAccess', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentInternalReal', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchDefault', 'PhanTypeMismatchForeach', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnNullable', 'PhanTypeMismatchReturnProbablyReal', 'PhanTypePossiblyInvalidDimOffset', 'PhanUndeclaredVariable', 'PhanUndeclaredVariableDim', 'PhanUnextractableAnnotationElementName'],
         'includes/ZeroBSCRM.DAL3.Obj.Forms.php' => ['PhanCommentParamWithoutRealParam', 'PhanEmptyForeach', 'PhanNoopBinaryOperator', 'PhanPluginDuplicateExpressionAssignmentOperation', 'PhanPluginRedundantAssignment', 'PhanPluginUnreachableCode', 'PhanPossiblyUndeclaredVariable', 'PhanRedundantCondition', 'PhanSuspiciousValueComparison', 'PhanSuspiciousWeakTypeComparison', 'PhanTypeArraySuspiciousNull', 'PhanTypeArraySuspiciousNullable', 'PhanTypeComparisonFromArray', 'PhanTypeExpectedObjectPropAccess', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchArgumentInternalReal', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchDefault', 'PhanTypeMismatchDimAssignment', 'PhanTypeMismatchDimFetchNullable', 'PhanTypeMismatchForeach', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnNullable', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredVariable', 'PhanUndeclaredVariableDim', 'PhanUnextractableAnnotationElementName'],
@@ -196,13 +195,13 @@ return [
         'includes/ZeroBSCRM.GeneralFuncs.php' => ['PhanCommentParamWithoutRealParam', 'PhanMisspelledAnnotation', 'PhanPluginNeverReturnFunction', 'PhanPluginSimplifyExpressionBool', 'PhanPluginUnreachableCode', 'PhanRedundantCondition', 'PhanSuspiciousValueComparison', 'PhanTypeInvalidLeftOperandOfNumericOp', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchArgumentNullableInternal', 'PhanTypeMismatchDimFetch', 'PhanUndeclaredConstant', 'PhanUndeclaredFunction', 'PhanUndeclaredVariableDim'],
         'includes/ZeroBSCRM.IntegrationFuncs.php' => ['PhanPluginRedundantAssignment', 'PhanPluginUnreachableCode', 'PhanRedundantCondition'],
         'includes/ZeroBSCRM.InternalAutomatorRecipes.php' => ['PhanPluginRedundantAssignment', 'PhanRedundantCondition', 'PhanSuspiciousValueComparison'],
-        'includes/ZeroBSCRM.InvoiceBuilder.php' => ['PhanPluginDuplicateAdjacentStatement', 'PhanPluginDuplicateExpressionAssignmentOperation', 'PhanPluginDuplicateExpressionBinaryOp', 'PhanPluginRedundantAssignment', 'PhanPossiblyUndeclaredVariable', 'PhanTypeExpectedObjectPropAccess', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturn', 'PhanTypePossiblyInvalidDimOffset', 'PhanTypeSuspiciousStringExpression', 'PhanUndeclaredVariable'],
+        'includes/ZeroBSCRM.InvoiceBuilder.php' => ['PhanPluginDuplicateAdjacentStatement', 'PhanPluginDuplicateExpressionAssignmentOperation', 'PhanPluginDuplicateExpressionBinaryOp', 'PhanPluginRedundantAssignment', 'PhanPossiblyUndeclaredVariable', 'PhanTypeExpectedObjectPropAccess', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturn', 'PhanTypePossiblyInvalidDimOffset', 'PhanUndeclaredVariable'],
         'includes/ZeroBSCRM.Jetpack.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],
         'includes/ZeroBSCRM.List.Columns.php' => ['PhanPluginMixedKeyNoKey'],
         'includes/ZeroBSCRM.List.php' => ['PhanPossiblyUndeclaredVariable', 'PhanRedundantCondition', 'PhanTypeArraySuspicious', 'PhanTypeArraySuspiciousNullable', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentInternal'],
-        'includes/ZeroBSCRM.Mail.php' => ['PhanPluginMixedKeyNoKey', 'PhanPluginRedundantAssignment', 'PhanPluginUnreachableCode', 'PhanRedundantCondition', 'PhanSuspiciousValueComparison', 'PhanTypeSuspiciousStringExpression', 'PhanUndeclaredClassCatch', 'PhanUndeclaredClassInstanceof', 'PhanUndeclaredClassMethod', 'PhanUndeclaredClassProperty', 'PhanUndeclaredClassReference', 'PhanUndeclaredVariable', 'PhanUnreferencedUseNormal'],
+        'includes/ZeroBSCRM.Mail.php' => ['PhanPluginMixedKeyNoKey', 'PhanPluginRedundantAssignment', 'PhanPluginUnreachableCode', 'PhanRedundantCondition', 'PhanSuspiciousValueComparison', 'PhanUndeclaredClassCatch', 'PhanUndeclaredClassInstanceof', 'PhanUndeclaredClassMethod', 'PhanUndeclaredClassProperty', 'PhanUndeclaredClassReference', 'PhanUndeclaredVariable', 'PhanUnreferencedUseNormal'],
         'includes/ZeroBSCRM.MailTracking.php' => ['PhanTypeArraySuspiciousNullable'],
-        'includes/ZeroBSCRM.MetaBox.php' => ['PhanTypeConversionFromArray', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullableInternal', 'PhanTypeSuspiciousStringExpression'],
+        'includes/ZeroBSCRM.MetaBox.php' => ['PhanTypeConversionFromArray', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullableInternal'],
         'includes/ZeroBSCRM.MetaBoxes3.Companies.php' => ['PhanDeprecatedFunction', 'PhanPluginDuplicateAdjacentStatement', 'PhanRedundantCondition', 'PhanTypeMismatchArgument', 'PhanTypePossiblyInvalidDimOffset', 'PhanUndeclaredVariable'],
         'includes/ZeroBSCRM.MetaBoxes3.Contacts.php' => ['PhanDeprecatedFunction', 'PhanPluginDuplicateAdjacentStatement', 'PhanPluginSimplifyExpressionBool', 'PhanRedundantCondition', 'PhanTypeArraySuspicious', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullable', 'PhanTypePossiblyInvalidDimOffset', 'PhanUndeclaredVariable'],
         'includes/ZeroBSCRM.MetaBoxes3.Forms.php' => ['PhanRedundantCondition', 'PhanTypeMismatchArgument'],
@@ -210,11 +209,11 @@ return [
         'includes/ZeroBSCRM.MetaBoxes3.Logs.php' => ['PhanRedundantCondition', 'PhanTypeMismatchArgumentNullableInternal', 'PhanTypePossiblyInvalidDimOffset'],
         'includes/ZeroBSCRM.MetaBoxes3.Ownership.php' => ['PhanTypeExpectedObjectPropAccessButGotNull', 'PhanUndeclaredVariable'],
         'includes/ZeroBSCRM.MetaBoxes3.Quotes.php' => ['PhanRedundantCondition', 'PhanTypeMismatchArgument'],
-        'includes/ZeroBSCRM.MetaBoxes3.Tags.php' => ['PhanDeprecatedFunction', 'PhanNoopBinaryOperator', 'PhanTypeSuspiciousStringExpression'],
+        'includes/ZeroBSCRM.MetaBoxes3.Tags.php' => ['PhanDeprecatedFunction'],
         'includes/ZeroBSCRM.MetaBoxes3.Tasks.php' => ['PhanRedundantCondition', 'PhanTypeVoidAssignment'],
         'includes/ZeroBSCRM.MetaBoxes3.Transactions.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeArraySuspiciousNullable', 'PhanTypeMismatchArgument'],
         'includes/ZeroBSCRM.Migrations.php' => ['PhanPluginRedundantAssignment'],
-        'includes/ZeroBSCRM.NotifyMe.php' => ['PhanNoopBinaryOperator', 'PhanPluginDuplicateAdjacentStatement', 'PhanTypeSuspiciousStringExpression'],
+        'includes/ZeroBSCRM.NotifyMe.php' => ['PhanPluginDuplicateAdjacentStatement'],
         'includes/ZeroBSCRM.Permissions.php' => ['PhanDeprecatedFunction', 'PhanPluginNeverReturnFunction', 'PhanPossiblyUndeclaredVariable'],
         'includes/ZeroBSCRM.PluginUpdates.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanRedundantCondition', 'PhanTypeArraySuspiciousNullable', 'PhanTypeMismatchReturnProbablyReal', 'PhanTypePossiblyInvalidDimOffset'],
         'includes/ZeroBSCRM.QuoteBuilder.php' => ['PhanMisspelledAnnotation', 'PhanTypeMismatchDefault', 'PhanTypeMismatchReturn'],

--- a/projects/plugins/crm/admin/company/view.page.php
+++ b/projects/plugins/crm/admin/company/view.page.php
@@ -346,11 +346,11 @@ function jpcrm_render_company_view_page( $id = -1 ) {
 									<div class="ui horizontal list">
 									<?php
 
-									foreach ( $tels as $telKey => $telNo ) {
+									foreach ( $tels as $tel_key => $tel_num ) {
 										?>
 										<div class="item">
 										<?php
-										switch ( $telKey ) {
+										switch ( $tel_key ) {
 
 											case 'sectel':
 												echo '<i class="large phone icon"></i>';
@@ -363,9 +363,9 @@ function jpcrm_render_company_view_page( $id = -1 ) {
 										?>
 										<div class="content">
 											<?php if ( $click2call == '1' ) { ?>
-											<a class="ui small button" href="<?php echo esc_attr( zeroBSCRM_clickToCallPrefix() . $telNo ); ?>" title="<?php esc_attr_e( 'Call', 'zero-bs-crm' ) . ' ' . $telNo; ?>"><?php echo esc_html( $telNo ); ?></a>
+											<a class="ui small button" href="<?php echo esc_attr( zeroBSCRM_clickToCallPrefix() . $tel_num ); ?>" title="<?php echo esc_attr( __( 'Call', 'zero-bs-crm' ) . ' ' . $tel_num ); ?>"><?php echo esc_html( $tel_num ); ?></a>
 											<?php } else { ?>
-											<div class="header"><?php echo esc_html( $telNo ); ?></div>
+											<div class="header"><?php echo esc_html( $tel_num ); ?></div>
 											<?php } ?>
 										</div>
 										</div>

--- a/projects/plugins/crm/admin/email/main.page.php
+++ b/projects/plugins/crm/admin/email/main.page.php
@@ -453,8 +453,8 @@ function zeroBSCRM_pages_admin_sendmail() {
 			<form autocomplete="<?php echo esc_attr( jpcrm_disable_browser_autocomplete() ); ?>" id="zbs-send-single-email" class="ui form" action="<?php echo esc_url( zeroBSCRM_getAdminURL( $zbs->slugs['emails'] ) ); ?>" method="POST">
 
 			<?php
-			if ( is_array( $customerMeta ) && array_key_exists( 'fname', $customerMeta ) ) {
-				$custName = $customerMeta['fname'] . ' ' . $customerMeta['lname'];
+			if ( is_array( $customerMeta ) && ! empty( $customerMeta ) ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+				$custName = ( $customerMeta['fname'] ?? '' ) . ' ' . ( $customerMeta['lname'] ?? '' ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 				$toEmail  = $customerMeta['email'];
 			} else {
 				$custName = '';

--- a/projects/plugins/crm/admin/settings/partials/template-variant-setting.block.php
+++ b/projects/plugins/crm/admin/settings/partials/template-variant-setting.block.php
@@ -46,7 +46,8 @@ if ( is_array( $variants ) && count( $variants ) > 0 ) { ?>
 							>
 								<?php
 								if ( $default ) {
-									esc_html_e( 'Default Template:', 'zero-bs-crm' ) . ' ';}
+									echo esc_html( __( 'Default Template:', 'zero-bs-crm' ) . ' ' );
+								}
 								?>
 								<?php echo esc_html( $template_info['filename'] . ' (' . $template_info['origin'] . ')' ); ?>
 							</option>

--- a/projects/plugins/crm/changelog/fix-phan-PhanTypeSuspiciousStringExpression
+++ b/projects/plugins/crm/changelog/fix-phan-PhanTypeSuspiciousStringExpression
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Phan: Address various PhanTypeSuspiciousStringExpression violations.
+
+

--- a/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Helpers.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Helpers.php
@@ -248,7 +248,7 @@ function zeroBS_getCustomerIcoHTML($cID=-1,$additionalClasses=''){
 	global $zbs; $thumbURL = $zbs->DAL->contacts->getContactAvatarURL($cID);
 	if (!empty($thumbURL)) {
 
-		$thumbHTML = '<img src="'.$thumb_url.'" alt="" />';
+		$thumbHTML = '<img src="' . $thumbURL . '" alt="" />'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 
 	}
 
@@ -7313,11 +7313,11 @@ function zeroBSCRM_getCompanyStatuses() {
 					// exception: event tags
 					if ( $objTypeID == ZBS_TYPE_TASK ) {
 
-						return esc_url_raw( admin_url( 'admin.php?page=' . $zbs->slugs['manage-tasks-list'] . '&zbs_tag=' . $taxonomy ) );
+						return esc_url_raw( admin_url( 'admin.php?page=' . $zbs->slugs['manage-tasks-list'] . ( is_string( $taxonomy ) ? '&zbs_tag=' . $taxonomy : '' ) ) );
 
 					}
 
-					return esc_url_raw( admin_url( 'admin.php?page=' . $zbs->DAL->listViewSlugFromObjID( $objTypeID ) . '&zbs_tag=' . $taxonomy ) );
+					return esc_url_raw( admin_url( 'admin.php?page=' . $zbs->DAL->listViewSlugFromObjID( $objTypeID ) . ( is_string( $taxonomy ) ? '&zbs_tag=' . $taxonomy : '' ) ) ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase,WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 
 				} // / got objType
 				break;

--- a/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Obj.Contacts.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Obj.Contacts.php
@@ -4834,9 +4834,12 @@ class zbsDAL_contacts extends zbsDAL_ObjectLayer {
 
         $whereArr = array();
 
-        if ($inCompany) $whereArr['incompany'] = array('ID','IN','(SELECT DISTINCT zbsol_objid_from FROM '.$ZBSCRM_t['objlinks']." WHERE zbsol_objtype_from = ".ZBS_TYPE_CONTACT." AND zbsol_objtype_to = ".ZBS_TYPE_COMPANY." AND zbsol_objid_to = %d)",$inCompany);
-
 			// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable, WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+			if ( $inCompany ) {
+				global $ZBSCRM_t;
+				$whereArr['incompany'] = array( 'ID', 'IN', '(SELECT DISTINCT zbsol_objid_from FROM ' . $ZBSCRM_t['objlinks'] . ' WHERE zbsol_objtype_from = ' . ZBS_TYPE_CONTACT . ' AND zbsol_objtype_to = ' . ZBS_TYPE_COMPANY . ' AND zbsol_objid_to = %d)', $inCompany );
+			}
+
 			if ( $withStatus !== false && ! empty( $withStatus ) ) {
 				$whereArr['status'] = array( 'zbsc_status', '=', 'convert(%s using utf8mb4) collate utf8mb4_bin', $withStatus );
 			}

--- a/projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php
@@ -356,7 +356,7 @@ function zeroBSCRM_invoicing_generateStatementPDF( $contactID = -1, $returnPDF =
 
             //print the pdf file to the screen for saving
             header('Content-type: application/pdf');
-            header('Content-Disposition: attachment; filename="invoice-'.$invoiceID.'.pdf"');
+			header( 'Content-Disposition: attachment; filename="' . __( 'statement', 'zero-bs-crm' ) . '-' . $contactID . '.pdf' ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
             header('Content-Transfer-Encoding: binary');
             header('Content-Length: ' . filesize($statementFilename));
             header('Accept-Ranges: bytes');

--- a/projects/plugins/crm/includes/ZeroBSCRM.Mail.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Mail.php
@@ -1355,7 +1355,9 @@ function jpcrm_mail_delivery_send_via_gmail_oauth( $args ){
 				}
 
 				// build message
+				// @phan-suppress-next-line PhanTypeSuspiciousStringExpression - These vars are defined at the beginning of the function.
 				$raw_message = "From: {$send_from_name} <{$send_from}>\r\n";
+				// @phan-suppress-next-line PhanTypeSuspiciousStringExpression - These vars are defined at the beginning of the function.
 				$raw_message .= "To: {$send_to_name} <{$send_to}>\r\n";
 				// @phan-suppress-next-line PhanCoalescingAlwaysNull - Phan is understandably confused, but $subject is defined at the beginning of the function.
 				$raw_message .= 'Subject: =?utf-8?B?' . base64_encode( $subject ?? '' ) . "?=\r\n"; // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode,VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable

--- a/projects/plugins/crm/includes/ZeroBSCRM.MetaBox.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.MetaBox.php
@@ -78,13 +78,16 @@ defined( 'ZEROBSCRM_PATH' ) || exit( 0 );
                 // add save func, even if will be blank :)
                 // WP was using filters, I'll move to actions (makes more sense to me, having read actions vs filters)
                 //add_filter( 'zerobs_save_'.$this->postType, array( $this, 'save_meta_box' ), 10, 2 );
+			if ( $this->objType ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
                 add_action( 'zerobs_save_'.$this->objType, array( $this, 'save_meta_box' ), $this->saveOrder, 2 );
+			}
                 // This is fired by edit page do_action
 
                 // this is then set to fire after ALL other save funcs :)
                 // ... by way of a 999 priority
+			if ( $this->objType ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
                 add_action( 'zerobs_save_'.$this->objType, array( $this, 'post_save_meta_box' ), 999, 2 );
-
+			}
             }
 
 
@@ -167,8 +170,10 @@ defined( 'ZEROBSCRM_PATH' ) || exit( 0 );
 
         public function print_meta_box( $obj, $metabox ) {
 
-            // nonce output by parent class
+					// nonce output by parent class
+		if ( $this->metaboxID ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
             wp_nonce_field( 'save_' . $this->metaboxID, $this->metaboxID . '_nonce' );
+		}
 
             $this->html($obj,$metabox);
 
@@ -179,7 +184,9 @@ defined( 'ZEROBSCRM_PATH' ) || exit( 0 );
         public function save_meta_box( $objID, $obj ) {
 
             // metabox set?
-            if (!isset($_POST[$this->metaboxID . '_nonce']) || empty($_POST[$this->metaboxID . '_nonce'] )){ return; }
+		if ( ! $this->metaboxID || ! isset( $_POST[ $this->metaboxID . '_nonce' ] ) || empty( $_POST[ $this->metaboxID . '_nonce' ] ) ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+			return;
+		}
             // autosave? (legacy, probswill never do as our own page now)
             if( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ){ return; }
             // final nonce check

--- a/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Tags.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Tags.php
@@ -118,7 +118,7 @@ class zeroBS__Metabox_Tags extends zeroBS__Metabox {
                                 */
                             if (is_array($tagSuggestions) && count($tagSuggestions) > 0){ ?>
                         <div id="zbs-tags-suggestions-wrap">
-                            <div class="ui horizontal divider zbs-tags-suggestions-title"><?php esc_html_e('Suggested Tags','zero-bs-crm').':'; ?></div>
+						<div class="ui horizontal divider zbs-tags-suggestions-title"><?php esc_html_e( 'Suggested Tags', 'zero-bs-crm' ); ?></div>
                             <div id="zbs-tags-suggestions">
                                 <?php 
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.NotifyMe.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.NotifyMe.php
@@ -128,7 +128,7 @@ function zeroBSCRM_notifyme_echo_type($type = '', $title = '', $sender = -999, $
         break;
 
     case 'salesdash.suggestion':
-        esc_html_e( '⛽ See all your sales information in a sales dashboard built just for you.', 'zero-bs-crm') . ' ';
+			echo esc_html( __( '⛽ See all your sales information in a sales dashboard built just for you.', 'zero-bs-crm' ) . ' ' );
         break;
 
 

--- a/projects/plugins/jetpack/.phan/baseline.php
+++ b/projects/plugins/jetpack/.phan/baseline.php
@@ -47,8 +47,8 @@ return [
     // PhanRedefinedClassReference : 8 occurrences
     // PhanTypeMissingReturn : 8 occurrences
     // PhanTypeComparisonToArray : 7 occurrences
-    // PhanTypeInvalidLeftOperandOfNumericOp : 7 occurrences
     // PhanCommentAbstractOnInheritedMethod : 6 occurrences
+    // PhanTypeInvalidLeftOperandOfNumericOp : 6 occurrences
     // PhanDeprecatedClass : 5 occurrences
     // PhanTypeMismatchDimAssignment : 5 occurrences
     // PhanAccessMethodInternal : 4 occurrences
@@ -56,7 +56,6 @@ return [
     // PhanTypeInvalidLeftOperandOfAdd : 4 occurrences
     // PhanTypeInvalidLeftOperandOfBitwiseOp : 4 occurrences
     // PhanTypeInvalidRightOperandOfBitwiseOp : 4 occurrences
-    // PhanTypeSuspiciousStringExpression : 4 occurrences
     // PhanDeprecatedFunctionInternal : 3 occurrences
     // PhanDeprecatedTrait : 3 occurrences
     // PhanStaticPropIsStaticType : 3 occurrences
@@ -78,6 +77,7 @@ return [
     // PhanStaticCallToNonStatic : 1 occurrence
     // PhanTypeMismatchArgumentInternalProbablyReal : 1 occurrence
     // PhanTypeMismatchArgumentInternalReal : 1 occurrence
+    // PhanTypeSuspiciousStringExpression : 1 occurrence
     // PhanUndeclaredExtendedClass : 1 occurrence
     // PhanUndeclaredTypeReturnType : 1 occurrence
 
@@ -142,7 +142,7 @@ return [
         'class.jetpack-admin.php' => ['PhanPluginMixedKeyNoKey', 'PhanTypeMismatchArgumentProbablyReal'],
         'class.jetpack-autoupdate.php' => ['PhanTypeMismatchArgument'],
         'class.jetpack-cli.php' => ['PhanAccessMethodInternal', 'PhanParamTooManyCallable', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchDefault', 'PhanTypeMismatchReturn'],
-        'class.jetpack-gutenberg.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgumentNullableInternal', 'PhanTypeMismatchPropertyProbablyReal', 'PhanTypeMismatchReturn', 'PhanTypeSuspiciousStringExpression'],
+        'class.jetpack-gutenberg.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgumentNullableInternal', 'PhanTypeMismatchPropertyProbablyReal', 'PhanTypeMismatchReturn'],
         'class.jetpack-heartbeat.php' => ['PhanTypeMismatchPropertyDefault'],
         'class.jetpack-modules-list-table.php' => ['PhanCommentAbstractOnInheritedMethod'],
         'class.jetpack-network-sites-list-table.php' => ['PhanCommentAbstractOnInheritedMethod'],
@@ -300,7 +300,7 @@ return [
         'modules/post-by-email/class-jetpack-post-by-email.php' => ['PhanUndeclaredMethodInCallable'],
         'modules/publicize.php' => ['PhanRedefineFunction'],
         'modules/related-posts/class.related-posts-customize.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],
-        'modules/related-posts/jetpack-related-posts.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanPluginSimplifyExpressionBool', 'PhanTypeInvalidLeftOperandOfNumericOp', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchReturnProbablyReal', 'PhanTypeSuspiciousStringExpression', 'PhanUndeclaredFunction'],
+        'modules/related-posts/jetpack-related-posts.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanPluginSimplifyExpressionBool', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredFunction'],
         'modules/scan/class-admin-bar-notice.php' => ['PhanRedundantCondition', 'PhanTypeMismatchReturnProbablyReal'],
         'modules/search.php' => ['PhanTypeMismatchArgument'],
         'modules/seo-tools/class-jetpack-seo.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],
@@ -349,7 +349,6 @@ return [
         'modules/sitemaps/sitemap-buffer-video.php' => ['PhanRedefineClass'],
         'modules/sitemaps/sitemap-buffer.php' => ['PhanTypeMismatchReturn'],
         'modules/sitemaps/sitemap-builder.php' => ['PhanPluginSimplifyExpressionBool', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullableInternal', 'PhanTypeMismatchDimFetch', 'PhanTypeMismatchReturnProbablyReal'],
-        'modules/sitemaps/sitemap-constants.php' => ['PhanTypeSuspiciousStringExpression'],
         'modules/sitemaps/sitemap-librarian.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchReturnProbablyReal'],
         'modules/sitemaps/sitemap-logger.php' => ['PhanTypeMismatchProperty'],
         'modules/sitemaps/sitemaps.php' => ['PhanTypeMismatchArgument'],

--- a/projects/plugins/jetpack/changelog/fix-phan-PhanTypeSuspiciousStringExpression
+++ b/projects/plugins/jetpack/changelog/fix-phan-PhanTypeSuspiciousStringExpression
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Phan: Address various PhanTypeSuspiciousStringExpression violations.
+
+

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -629,7 +629,7 @@ class Jetpack_Gutenberg {
 				// The Map block is dependent on wp-element, and it doesn't appear to to be possible to load
 				// this dynamically into the customizer iframe currently.
 				if ( 'map' === $type ) {
-					echo '<div>' . esc_html_e( 'No map preview available. Publish and refresh to see this widget.', 'jetpack' ) . '</div>';
+					echo '<div>' . esc_html__( 'No map preview available. Publish and refresh to see this widget.', 'jetpack' ) . '</div>';
 					echo '<script>';
 					echo 'Array.from(document.getElementsByClassName(\'wp-block-jetpack-map\')).forEach(function(element){element.style.display = \'none\';})';
 					echo '</script>';

--- a/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
+++ b/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
@@ -129,7 +129,7 @@ class Jetpack_RelatedPosts {
 	/**
 	 * Get the blog ID.
 	 *
-	 * @return Object current blog id.
+	 * @return mixed current blog id.
 	 */
 	protected function get_blog_id() {
 		return Jetpack_Options::get_option( 'id' );

--- a/projects/plugins/jetpack/modules/sitemaps/sitemap-constants.php
+++ b/projects/plugins/jetpack/modules/sitemaps/sitemap-constants.php
@@ -152,7 +152,7 @@ if ( ! defined( 'JP_VIDEO_SITEMAP_INDEX_TYPE' ) ) {
  */
 function jp_sitemap_filename( $type, $number = null ) {
 	if ( $number === null ) {
-		return "error-not-int-$type-$number.xml";
+		return "error-not-int-$type-null.xml";
 	} elseif ( JP_MASTER_SITEMAP_TYPE === $type ) {
 		return 'sitemap.xml';
 	} elseif ( JP_PAGE_SITEMAP_TYPE === $type ) {

--- a/projects/plugins/super-cache/.phan/baseline.php
+++ b/projects/plugins/super-cache/.phan/baseline.php
@@ -11,21 +11,19 @@ return [
     // # Issue statistics:
     // PhanPluginSimplifyExpressionBool : 80+ occurrences
     // PhanUndeclaredGlobalVariable : 45+ occurrences
-    // PhanTypeMismatchArgumentNullableInternal : 25+ occurrences
     // PhanPossiblyUndeclaredVariable : 20+ occurrences
     // PhanUndeclaredVariable : 20+ occurrences
-    // PhanTypeMismatchArgumentInternal : 15+ occurrences
     // PhanTypeMismatchArgument : 10+ occurrences
+    // PhanTypeMismatchArgumentNullableInternal : 10+ occurrences
     // PhanTypeNonVarPassByRef : 10+ occurrences
     // PhanTypePossiblyInvalidDimOffset : 10+ occurrences
-    // PhanTypeSuspiciousStringExpression : 10+ occurrences
     // PhanUndeclaredFunctionInCallable : 10+ occurrences
     // PhanUndeclaredFunction : 8 occurrences
-    // PhanTypeArraySuspiciousNull : 7 occurrences
-    // PhanTypeArraySuspiciousNullable : 7 occurrences
     // PhanSuspiciousValueComparison : 6 occurrences
+    // PhanTypeArraySuspiciousNull : 6 occurrences
     // PhanTypeInvalidDimOffset : 6 occurrences
     // PhanUndeclaredVariableDim : 6 occurrences
+    // PhanTypeArraySuspiciousNullable : 5 occurrences
     // PhanTypeMismatchArgumentProbablyReal : 5 occurrences
     // PhanTypeMismatchArgumentInternalProbablyReal : 4 occurrences
     // PhanTypeMismatchArgumentInternalReal : 4 occurrences
@@ -40,15 +38,16 @@ return [
     // PhanPluginUnreachableCode : 2 occurrences
     // PhanPossiblyUndeclaredGlobalVariable : 2 occurrences
     // PhanRedundantCondition : 2 occurrences
+    // PhanTypeMismatchArgumentNullable : 2 occurrences
     // PhanTypeMismatchReturn : 2 occurrences
+    // PhanTypeSuspiciousStringExpression : 2 occurrences
     // PhanCommentParamWithoutRealParam : 1 occurrence
     // PhanPluginDuplicateIfCondition : 1 occurrence
-    // PhanTypeArraySuspicious : 1 occurrence
     // PhanTypeConversionFromArray : 1 occurrence
     // PhanTypeInvalidLeftOperandOfBitwiseOp : 1 occurrence
     // PhanTypeInvalidRightOperandOfAdd : 1 occurrence
     // PhanTypeInvalidRightOperandOfBitwiseOp : 1 occurrence
-    // PhanTypeMismatchArgumentNullable : 1 occurrence
+    // PhanTypeMismatchArgumentInternal : 1 occurrence
     // PhanTypeMismatchDimAssignment : 1 occurrence
     // PhanTypeMissingReturn : 1 occurrence
     // PhanUndeclaredConstant : 1 occurrence
@@ -75,8 +74,8 @@ return [
         'tests/e2e/tools/mu-test-helpers.php' => ['PhanTypeMismatchArgument'],
         'wp-cache-base.php' => ['PhanTypeMismatchArgumentNullableInternal'],
         'wp-cache-phase1.php' => ['PhanTypeNonVarPassByRef'],
-        'wp-cache-phase2.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanPluginDuplicateIfCondition', 'PhanPluginRedundantAssignment', 'PhanPluginSimplifyExpressionBool', 'PhanPluginUnreachableCode', 'PhanPossiblyUndeclaredVariable', 'PhanSuspiciousValueComparison', 'PhanTypeArraySuspicious', 'PhanTypeArraySuspiciousNull', 'PhanTypeArraySuspiciousNullable', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchArgumentInternalProbablyReal', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchArgumentNullableInternal', 'PhanTypeNonVarPassByRef', 'PhanTypePossiblyInvalidDimOffset', 'PhanTypeSuspiciousNonTraversableForeach', 'PhanTypeSuspiciousStringExpression', 'PhanUndeclaredVariableDim'],
-        'wp-cache.php' => ['PhanPluginDuplicateAdjacentStatement', 'PhanPluginDuplicateExpressionAssignmentOperation', 'PhanPluginNeverReturnFunction', 'PhanPluginSimplifyExpressionBool', 'PhanPossiblyUndeclaredVariable', 'PhanRedundantCondition', 'PhanSuspiciousValueComparison', 'PhanTypeArraySuspiciousNullable', 'PhanTypeInvalidDimOffset', 'PhanTypeInvalidLeftOperandOfBitwiseOp', 'PhanTypeInvalidLeftOperandOfNumericOp', 'PhanTypeInvalidRightOperandOfAdd', 'PhanTypeInvalidRightOperandOfBitwiseOp', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchArgumentInternalProbablyReal', 'PhanTypeMismatchArgumentInternalReal', 'PhanTypeMismatchArgumentNullableInternal', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeNonVarPassByRef', 'PhanTypePossiblyInvalidDimOffset', 'PhanTypeSuspiciousNonTraversableForeach', 'PhanTypeSuspiciousStringExpression', 'PhanUndeclaredFunction', 'PhanUndeclaredVariable', 'PhanUndeclaredVariableDim'],
+        'wp-cache-phase2.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanPluginDuplicateIfCondition', 'PhanPluginRedundantAssignment', 'PhanPluginSimplifyExpressionBool', 'PhanPluginUnreachableCode', 'PhanPossiblyUndeclaredVariable', 'PhanSuspiciousValueComparison', 'PhanTypeArraySuspiciousNullable', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentInternalProbablyReal', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchArgumentNullableInternal', 'PhanTypeNonVarPassByRef', 'PhanTypePossiblyInvalidDimOffset', 'PhanTypeSuspiciousNonTraversableForeach', 'PhanTypeSuspiciousStringExpression', 'PhanUndeclaredVariableDim'],
+        'wp-cache.php' => ['PhanPluginDuplicateAdjacentStatement', 'PhanPluginDuplicateExpressionAssignmentOperation', 'PhanPluginNeverReturnFunction', 'PhanPluginSimplifyExpressionBool', 'PhanPossiblyUndeclaredVariable', 'PhanRedundantCondition', 'PhanSuspiciousValueComparison', 'PhanTypeArraySuspiciousNullable', 'PhanTypeInvalidDimOffset', 'PhanTypeInvalidLeftOperandOfBitwiseOp', 'PhanTypeInvalidLeftOperandOfNumericOp', 'PhanTypeInvalidRightOperandOfAdd', 'PhanTypeInvalidRightOperandOfBitwiseOp', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchArgumentInternalProbablyReal', 'PhanTypeMismatchArgumentInternalReal', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchArgumentNullableInternal', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeNonVarPassByRef', 'PhanTypePossiblyInvalidDimOffset', 'PhanTypeSuspiciousNonTraversableForeach', 'PhanUndeclaredFunction', 'PhanUndeclaredVariable', 'PhanUndeclaredVariableDim'],
     ],
     // 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.
     // (directory_suppressions will currently be ignored by subsequent calls to --save-baseline, but may be preserved in future Phan releases)

--- a/projects/plugins/super-cache/changelog/fix-phan-PhanTypeSuspiciousStringExpression
+++ b/projects/plugins/super-cache/changelog/fix-phan-PhanTypeSuspiciousStringExpression
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Phan: Address various PhanTypeSuspiciousStringExpression violations.
+
+

--- a/projects/plugins/super-cache/wp-cache-phase2.php
+++ b/projects/plugins/super-cache/wp-cache-phase2.php
@@ -1353,6 +1353,9 @@ function wpsc_delete_url_cache( $url ) {
 }
 
 // from legolas558 d0t users dot sf dot net at http://www.php.net/is_writable
+/**
+ * @param string $path
+ */
 function is_writeable_ACLSafe( $path ) {
 
 	if (
@@ -1365,7 +1368,7 @@ function is_writeable_ACLSafe( $path ) {
 
 	// PHP's is_writable does not work with Win32 NTFS
 
-	if ( $path[ strlen( $path ) - 1 ] == '/' ) { // recursively return a temporary file path
+	if ( $path[ strlen( $path ) - 1 ] === '/' ) { // recursively return a temporary file path
 		return is_writeable_ACLSafe( $path . uniqid( (string) wp_rand() ) . '.tmp' );
 	} elseif ( is_dir( $path ) ) {
 		return is_writeable_ACLSafe( $path . '/' . uniqid( (string) wp_rand() ) . '.tmp' );
@@ -1404,7 +1407,7 @@ function wp_cache_setting( $field, $value ) {
 }
 
 function wp_cache_replace_line( $old, $new, $my_file ) {
-	if ( @is_file( $my_file ) == false ) {
+	if ( ! is_string( $my_file ) || @is_file( $my_file ) === false ) { // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
 		if ( function_exists( 'set_transient' ) ) {
 			set_transient( 'wpsc_config_error', 'config_file_missing', 10 );
 		}

--- a/projects/plugins/super-cache/wp-cache.php
+++ b/projects/plugins/super-cache/wp-cache.php
@@ -3047,7 +3047,9 @@ function update_cached_mobile_ua_list( $mobile_browsers, $mobile_prefixes = 0, $
 
 function wpsc_update_htaccess() {
 	extract( wpsc_get_htaccess_info() ); // $document_root, $apache_root, $home_path, $home_root, $home_root_lc, $inst_root, $wprules, $scrules, $condition_rules, $rules, $gziprules
+	// @phan-suppress-next-line PhanTypeSuspiciousStringExpression -- $home_path is set via extract()
 	wpsc_remove_marker( $home_path.'.htaccess', 'WordPress' ); // remove original WP rules so SuperCache rules go on top
+	// @phan-suppress-next-line PhanTypeSuspiciousStringExpression -- $home_path is set via extract()
 	if( insert_with_markers( $home_path.'.htaccess', 'WPSuperCache', explode( "\n", $rules ) ) && insert_with_markers( $home_path.'.htaccess', 'WordPress', explode( "\n", $wprules ) ) ) {
 		return true;
 	} else {
@@ -3060,6 +3062,7 @@ function wpsc_update_htaccess_form( $short_form = true ) {
 
 	$admin_url = admin_url( 'options-general.php?page=wpsupercache' );
 	extract( wpsc_get_htaccess_info() ); // $document_root, $apache_root, $home_path, $home_root, $home_root_lc, $inst_root, $wprules, $scrules, $condition_rules, $rules, $gziprules
+	// @phan-suppress-next-line PhanTypeSuspiciousStringExpression -- $home_path is set via extract()
 	if( !is_writeable_ACLSafe( $home_path . ".htaccess" ) ) {
 		echo "<div style='padding:0 8px;color:#9f6000;background-color:#feefb3;border:1px solid #9f6000;'><h5>" . __( 'Cannot update .htaccess', 'wp-super-cache' ) . "</h5><p>" . sprintf( __( 'The file <code>%s.htaccess</code> cannot be modified by the web server. Please correct this using the chmod command or your ftp client.', 'wp-super-cache' ), $home_path ) . "</p><p>" . __( 'Refresh this page when the file permissions have been modified.' ) . "</p><p>" . sprintf( __( 'Alternatively, you can edit your <code>%s.htaccess</code> file manually and add the following code (before any WordPress rules):', 'wp-super-cache' ), $home_path ) . "</p>";
 		echo "<p><pre># BEGIN WPSuperCache\n" . esc_html( $rules ) . "# END WPSuperCache</pre></p></div>";
@@ -3794,6 +3797,7 @@ function wp_cache_disable_plugin( $delete_config_file = true ) {
 		}
 	}
 	extract( wpsc_get_htaccess_info() ); // $document_root, $apache_root, $home_path, $home_root, $home_root_lc, $inst_root, $wprules, $scrules, $condition_rules, $rules, $gziprules
+	// @phan-suppress-next-line PhanTypeSuspiciousStringExpression -- $home_path is set via extract()
 	if ( $scrules != '' && insert_with_markers( $home_path.'.htaccess', 'WPSuperCache', array() ) ) {
 		$wp_rewrite->flush_rules();
 	} elseif( $scrules != '' ) {

--- a/projects/plugins/wpcomsh/changelog/fix-phan-PhanTypeSuspiciousStringExpression
+++ b/projects/plugins/wpcomsh/changelog/fix-phan-PhanTypeSuspiciousStringExpression
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Phan: Address various PhanTypeSuspiciousStringExpression violations.
+
+

--- a/projects/plugins/wpcomsh/tests/lib/mocks/class-jetpack-options.php
+++ b/projects/plugins/wpcomsh/tests/lib/mocks/class-jetpack-options.php
@@ -17,8 +17,8 @@ if ( ! class_exists( 'Jetpack_Options' ) ) {
 		/**
 		 * Get option.
 		 *
-		 * @param string        $option_name Option name.
-		 * @param string|boolen $default     Optional. Default false.
+		 * @param string         $option_name Option name.
+		 * @param string|boolean $default     Optional. Default false.
 		 * @return mixed Option value.
 		 */
 		public static function get_option( $option_name, $default = false ) { // phpcs:ignore Universal.NamingConventions.NoReservedKeywordParameterNames.defaultFound


### PR DESCRIPTION
Closes MONOREP-117

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This addresses most `PhanTypeSuspiciousStringExpression` violations in the monorepo. Of note:

* Variants like `esc_html_e() . 'asdf'` → `echo esc_html( __() . 'asdf' )`
* Added `null` coalescing
* Some outright typos (e.g. `$thumbURL` vs. `$thumb_url`)
* Undefined vars in paths that were unused but theoretically possible (e.g. in `zeroBSCRM_invoicing_generateStatementPDF()`)
* Some wrong types in PHPDoc

There were also a few false positives due to `extract()` and similar routines.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

CI should be happy.
