### PR TITLE
Widgets: Avoid PHP warnings when handling malformed data

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-widgets-avoid_php_warnings
+++ b/projects/plugins/jetpack/changelog/fix-widgets-avoid_php_warnings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Widgets: Prevent PHP warnings when handling malformed data.

--- a/projects/plugins/jetpack/modules/widget-visibility/widget-conditions.php
+++ b/projects/plugins/jetpack/modules/widget-visibility/widget-conditions.php
@@ -1200,6 +1200,10 @@ class Jetpack_Widget_Conditions {
 
 		$sidebars_widgets = get_option( 'sidebars_widgets' );
 
+		if ( ! is_array( $sidebars_widgets ) ) {
+			return;
+		}
+
 		// Going through all sidebars and through inactive and orphaned widgets.
 		foreach ( $sidebars_widgets as $sidebar ) {
 			if ( ! is_array( $sidebar ) ) {
@@ -1230,6 +1234,7 @@ class Jetpack_Widget_Conditions {
 					if (
 						! is_array( $instance ) ||
 						empty( $instance['conditions'] ) ||
+						! is_array( $instance['conditions']['rules'] ) ||
 						empty( $instance['conditions']['rules'] )
 					) {
 						continue;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Every week upon deploy we end up with many warnings when trying to iterate through widget data that is malformed. This skips the processing if the data is not an array.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
These are the warnings in question:
```
PHP Warning: foreach() argument must be of type array|object, string given in /wordpress/plugins/jetpack/15.1-a.3/modules/widget-visibility/widget-conditions.php on line 1204
```
```
PHP Warning: foreach() argument must be of type array|object, string given in /wordpress/plugins/jetpack/15.1-a.3/modules/widget-visibility/widget-conditions.php on line 1239
```

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

