### PR TITLE
Forms: fix error wrapper styles

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-error-wrapper-styles
+++ b/projects/packages/forms/changelog/fix-forms-error-wrapper-styles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: address some wee issues on field error stylings

--- a/projects/packages/forms/src/blocks/contact-form/util/form-styles.js
+++ b/projects/packages/forms/src/blocks/contact-form/util/form-styles.js
@@ -128,7 +128,7 @@ window.jetpackForms.generateStyleVariables = function ( formNode ) {
 		fontSize,
 		fontFamily,
 		lineHeight,
-		inputHeight,
+		height: inputHeight,
 	} = window.getComputedStyle( inputNode );
 
 	styleProbe.remove();

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -1164,7 +1164,7 @@ on production builds, the attributes are being reordered, causing side-effects
 }
 
 .contact-form__input-error {
-	margin: 0.25rem 0;
+	margin: 0;
 	gap: 0.33em;
 	font-size: 1rem;
 	color: var(--jetpack--contact-form--error-color);
@@ -1176,9 +1176,10 @@ on production builds, the attributes are being reordered, causing side-effects
 }
 
 .contact-form__input-error.has-errors {
+	margin: 0.25rem 0;
 	display: flex;
 	opacity: 1;
-	max-height: 2em;
+	max-height: unset;
 	transform: translateY(0);
 	transition: opacity 200ms cubic-bezier(0.34, 0.8, 0.34, 1), transform 200ms cubic-bezier(0.34, 0.8, 0.34, 1);
 }

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -1196,16 +1196,13 @@ on production builds, the attributes are being reordered, causing side-effects
 }
 
 .contact-form__warning-icon {
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	margin: auto 0;
+	margin-top: 0.125em;
 }
 
 .contact-form__warning-icon svg {
 	fill: currentColor;
-	display: block;
-	margin: 0 auto;
+	width: 1em;
+	height: 1em;
 }
 
 .contact-form__checkbox-wrap {


### PR DESCRIPTION


## Proposed changes:
This PR addresses some buggy CSS used on the field error wrapper styles.

Error message cut due to max-height on the error wrapper:
<img width="389" height="203" alt="image" src="https://github.com/user-attachments/assets/7ec21a7c-711f-4366-84ae-65679d632f66" />

Error icon not following font size:
<img width="522" height="219" alt="image" src="https://github.com/user-attachments/assets/78314851-ead0-4872-9db4-8f8ced93bf91" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Create a form, add some fields. Easier to test with Email field that has live validation, but you can use others as well.

Make sure you set some of the fields to 50% so they are shown side by side (this makes it easier to spot when the max-height bug has been addressed).

Type an invalid email address on the Email field (any character will do) and lose focus. Field validation should trigger and the error should show. See that even when the error text wraps it can be seen entirelly:

<img width="346" height="176" alt="image" src="https://github.com/user-attachments/assets/a955c885-b822-4edc-9fef-21adc0fb92e7" />

With the error on screen, ese devtools to change font-size of the `contact-form__input-error has-errors` div, enlarge it. See that the icon size remains relative and properly (mostly) aligned with the text:

<img width="344" height="301" alt="image" src="https://github.com/user-attachments/assets/605dbe0e-48b3-40a0-9cb9-61f43bf76693" />


