### PR TITLE
Forms: horizontal button align

### DIFF
--- a/projects/packages/forms/changelog/test-forms-horizontal-button-align
+++ b/projects/packages/forms/changelog/test-forms-horizontal-button-align
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: improve button alignment when field width allows wrapping the submit button

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -62,7 +62,7 @@
 
 			&.wp-block-jetpack-button {
 				flex-basis: auto;
-				height: var(--jetpack--contact-form--input-height, auto);
+				min-height: var(--jetpack--contact-form--input-height, auto);
 				align-self: flex-end;
 			}
 

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -62,6 +62,8 @@
 
 			&.wp-block-jetpack-button {
 				flex-basis: auto;
+				height: var(--jetpack--contact-form--input-height, auto);
+				align-self: flex-end;
 			}
 
 			&.jetpack-field__width-25,

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -64,6 +64,19 @@
 				flex-basis: auto;
 				min-height: var(--jetpack--contact-form--input-height, auto);
 				align-self: flex-end;
+				line-height: 1;
+
+				.wp-block-button__link {
+					min-height: var(--jetpack--contact-form--input-height, auto);
+				}
+			}
+
+			&.wp-block-group-is-layout-flex:not(.is-vertical) {
+				// when the button is on a row stack, we expect it to fill the width of the
+				// button block container (which is filling the provided column width)
+				.wp-block.wp-block-jetpack-button .wp-block-button__link {
+					width: 100%;
+				}
 			}
 
 			&.jetpack-field__width-25,

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -55,7 +55,7 @@
 		}
 
 		.wp-block {
-			flex: 0 0 100%;
+			flex: 1 1 100%;
 			margin-top: 0;
 			margin-bottom: 0;
 			max-width: 100%;

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -378,6 +378,7 @@ that needs to mimic the input element styles */
 .wp-block-jetpack-contact-form .grunion-field-wrap {
 	box-sizing: border-box;
 	position: relative;
+	flex: 1 1 100%;
 }
 
 .wp-block-jetpack-contact-form .grunion-field-width-25-wrap {

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -346,9 +346,14 @@ that needs to mimic the input element styles */
 }
 
 .wp-block-jetpack-contact-form .wp-block-jetpack-button {
-	width: fit-content;
-	height: var(--jetpack--contact-form--input-height, auto);
+	min-height: var(--jetpack--contact-form--input-height, auto);
 	align-self: flex-end;
+
+	.wp-block-button__link {
+		min-height: var(--jetpack--contact-form--input-height, auto);
+		padding: var(--jetpack--contact-form--input-padding);
+	}
+
 }
 
 .wp-block-jetpack-contact-form .wp-block-jetpack-button.aligncenter {

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -347,6 +347,8 @@ that needs to mimic the input element styles */
 
 .wp-block-jetpack-contact-form .wp-block-jetpack-button {
 	width: fit-content;
+	height: var(--jetpack--contact-form--input-height, auto);
+	align-self: flex-end;
 }
 
 .wp-block-jetpack-contact-form .wp-block-jetpack-button.aligncenter {


### PR DESCRIPTION
Part of FORMS-219
Part of FORMS-238

## Proposed changes:
This PR addresses some issues with button size and alignment when field width allows (un)wrapping the submit button.

It does also address some minor nuances given the form's flexbox layout, allowing for more "natural" (given Gutenberg context) handling of the layout through stacks and desired widths.

It is part of an ongoing effort to provide a more consistent behavior (and wysiwyg) throughout the form creation and customization process.

As such, it would be good to settle (or not) for small improvements and keep moving forward, ie: not try to address all at once as our stylesheets and layouts are utterly complex and drag some 12 years of hacking and tweaking.

Editor:
<img width="669" height="173" alt="image" src="https://github.com/user-attachments/assets/2558f968-6f50-4ee4-9374-fdcafb08e4a3" />

Frontend:
<img width="671" height="146" alt="image" src="https://github.com/user-attachments/assets/1c283562-0942-41b0-b0b2-41f9621eaaca" />

**NOTE**: there is still a big issue with error wrappers not playing nice with this approach, but it exceeds this PR. This PR is to get nicer rendering while we figure out the full extent of the markup issue.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1757580371602699-slack-C052XEUUBL4

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Insert a form with a single input, make the input width narrow enough so the button sits alongside the field. See that the size of the button now matches the input height. Test on editor and frontend.

Editor:
<img width="677" height="149" alt="image" src="https://github.com/user-attachments/assets/b7083fee-036c-4f15-a453-94569b0e3679" />

Frontend:
<img width="677" height="133" alt="image" src="https://github.com/user-attachments/assets/33b0c3f9-f47a-4863-9d2d-cb4c1c530ea2" />

Other things to look at:

- when using a row stack (instead of shortening the field, fit it inside a column) the field should not push other rows out of the layout:

Before:
<img width="1026" height="260" alt="image" src="https://github.com/user-attachments/assets/d0e7953b-862c-432f-a9dc-4d06a019b8a8" />

After:
<img width="1012" height="259" alt="image" src="https://github.com/user-attachments/assets/716c252a-33b6-4cd9-b62b-83e120e21dad" />

