### PR TITLE
Forms: Fix outline and animated styles for Image Select field

### DIFF
--- a/projects/packages/forms/changelog/update-forms-image-select-animated-outlined
+++ b/projects/packages/forms/changelog/update-forms-image-select-animated-outlined
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Fix outline and animated styles for Image Select field

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -776,7 +776,8 @@
 
 	.is-style-outlined & {
 
-		.block-editor-block-list__block:not([contenteditable]):focus::after {
+		// This hides the focus outline, so we exclude the non-outlined blocks.
+		.block-editor-block-list__block:not([contenteditable]):not(.is-non-outlined-block):not(.is-non-outlined-block *):focus::after {
 			top: -10px;
 			left: -10px;
 			bottom: -10px;
@@ -868,8 +869,12 @@
 			}
 
 			&.is-non-animated-label .notched-label__label {
-				position: static;
-				transform: unset;
+				position: static !important;
+				transform: unset !important;
+
+				.jetpack-field-label__input {
+					font-size: inherit !important;
+				}
 			}
 
 			&.is-selected,

--- a/projects/packages/forms/src/blocks/field-image-select/edit.tsx
+++ b/projects/packages/forms/src/blocks/field-image-select/edit.tsx
@@ -26,8 +26,6 @@ import './editor.scss';
  */
 import type { Block, BlockEditorStoreSelect } from '../../types';
 
-const showOtherOption = false;
-
 export default function ImageSelectFieldEdit( props ) {
 	const { attributes, clientId, isSelected, setAttributes, name } = props;
 	const { id, required, width } = attributes;
@@ -155,18 +153,6 @@ export default function ImageSelectFieldEdit( props ) {
 								label={ __( 'Randomize', 'jetpack-forms' ) }
 								checked={ attributes?.randomizeOptions }
 								onChange={ ( value: boolean ) => setAttributes( { randomizeOptions: value } ) }
-							/>
-						),
-					},
-					showOtherOption && {
-						index: 5,
-						element: (
-							<ToggleControl
-								__nextHasNoMarginBottom
-								key="show-other-option"
-								label={ __( '"Other" option', 'jetpack-forms' ) }
-								checked={ attributes?.showOtherOption }
-								onChange={ ( value: boolean ) => setAttributes( { showOtherOption: value } ) }
 							/>
 						),
 					},

--- a/projects/packages/forms/src/blocks/field-image-select/edit.tsx
+++ b/projects/packages/forms/src/blocks/field-image-select/edit.tsx
@@ -27,18 +27,15 @@ import './editor.scss';
 import type { Block, BlockEditorStoreSelect } from '../../types';
 
 export default function ImageSelectFieldEdit( props ) {
-	const { attributes, clientId, isSelected, setAttributes, name } = props;
+	const { attributes, clientId, setAttributes, name } = props;
 	const { id, required, width } = attributes;
 	const { blockStyle } = useJetpackFieldStyles( attributes );
 
-	const { isInnerBlockSelected, optionsBlock } = useSelect(
+	const { optionsBlock } = useSelect(
 		select => {
-			const { hasSelectedInnerBlock, getBlock } = select(
-				blockEditorStore
-			) as BlockEditorStoreSelect;
+			const { getBlock } = select( blockEditorStore ) as BlockEditorStoreSelect;
 
 			return {
-				isInnerBlockSelected: hasSelectedInnerBlock( clientId, true ),
 				optionsBlock: getBlock( clientId )?.innerBlocks.find(
 					( block: Block ) => block.name === 'jetpack/fieldset-image-options'
 				),
@@ -54,10 +51,7 @@ export default function ImageSelectFieldEdit( props ) {
 
 	const blockProps = useBlockProps( {
 		className: clsx(
-			'jetpack-field jetpack-field-image-select is-non-animated-label is-non-outlined-block',
-			{
-				'is-selected': isSelected || isInnerBlockSelected,
-			}
+			'jetpack-field jetpack-field-image-select is-non-animated-label is-non-outlined-block'
 		),
 		style: blockStyle,
 	} );

--- a/projects/packages/forms/src/blocks/field-image-select/edit.tsx
+++ b/projects/packages/forms/src/blocks/field-image-select/edit.tsx
@@ -55,9 +55,12 @@ export default function ImageSelectFieldEdit( props ) {
 	const { addOption } = useAddImageOption( optionsBlock?.clientId );
 
 	const blockProps = useBlockProps( {
-		className: clsx( 'jetpack-field jetpack-field-image-select', {
-			'is-selected': isSelected || isInnerBlockSelected,
-		} ),
+		className: clsx(
+			'jetpack-field jetpack-field-image-select is-non-animated-label is-non-outlined-block',
+			{
+				'is-selected': isSelected || isInnerBlockSelected,
+			}
+		),
 		style: blockStyle,
 	} );
 

--- a/projects/packages/forms/src/blocks/fieldset-image-options/edit.tsx
+++ b/projects/packages/forms/src/blocks/fieldset-image-options/edit.tsx
@@ -1,14 +1,8 @@
 /**
  * External dependencies
  */
-import {
-	store as blockEditorStore,
-	useBlockProps,
-	useInnerBlocksProps,
-	BlockControls,
-} from '@wordpress/block-editor';
+import { useBlockProps, useInnerBlocksProps, BlockControls } from '@wordpress/block-editor';
 import { ToolbarButton, ToolbarGroup } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
 import { useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
@@ -18,32 +12,15 @@ import clsx from 'clsx';
 import { getImageOptionLabel } from '../input-image-option/label';
 import useAddImageOption from '../shared/hooks/use-add-image-option';
 import useJetpackFieldStyles from '../shared/hooks/use-jetpack-field-styles';
-/**
- * Types
- */
-import type { BlockEditorStoreSelect } from '../../types';
 
 export default function ImageOptionsFieldsetEdit( props ) {
-	const { attributes, clientId, isSelected } = props;
+	const { attributes, clientId } = props;
 	const { blockStyle } = useJetpackFieldStyles( attributes );
 
 	const { addOption, newImageOption } = useAddImageOption( clientId );
 
-	const { isInnerBlockSelected } = useSelect(
-		select => {
-			const { hasSelectedInnerBlock } = select( blockEditorStore ) as BlockEditorStoreSelect;
-
-			return {
-				isInnerBlockSelected: hasSelectedInnerBlock( clientId, true ),
-			};
-		},
-		[ clientId ]
-	);
-
 	const blockProps = useBlockProps( {
-		className: clsx( 'jetpack-field jetpack-fieldset-image-options', {
-			'is-selected': isSelected || isInnerBlockSelected,
-		} ),
+		className: clsx( 'jetpack-field jetpack-fieldset-image-options' ),
 		style: blockStyle,
 	} );
 

--- a/projects/packages/forms/src/blocks/fieldset-image-options/edit.tsx
+++ b/projects/packages/forms/src/blocks/fieldset-image-options/edit.tsx
@@ -9,7 +9,7 @@ import {
 } from '@wordpress/block-editor';
 import { ToolbarButton, ToolbarGroup } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
-import { useEffect, useMemo } from '@wordpress/element';
+import { useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 /**
@@ -24,9 +24,8 @@ import useJetpackFieldStyles from '../shared/hooks/use-jetpack-field-styles';
 import type { BlockEditorStoreSelect } from '../../types';
 
 export default function ImageOptionsFieldsetEdit( props ) {
-	const { attributes, clientId, isSelected, context, setAttributes } = props;
+	const { attributes, clientId, isSelected } = props;
 	const { blockStyle } = useJetpackFieldStyles( attributes );
-	const { 'jetpack/field-image-select-is-multiple': isMultiple } = context || {};
 
 	const { addOption, newImageOption } = useAddImageOption( clientId );
 
@@ -40,15 +39,6 @@ export default function ImageOptionsFieldsetEdit( props ) {
 		},
 		[ clientId ]
 	);
-
-	// Update the type attribute when the parent's isMultiple context changes
-	useEffect( () => {
-		const newType = isMultiple ? 'checkbox' : 'radio';
-
-		if ( attributes.type !== newType ) {
-			setAttributes( { type: newType } );
-		}
-	}, [ isMultiple, attributes.type, setAttributes ] );
 
 	const blockProps = useBlockProps( {
 		className: clsx( 'jetpack-field jetpack-fieldset-image-options', {

--- a/projects/packages/forms/src/blocks/fieldset-image-options/index.tsx
+++ b/projects/packages/forms/src/blocks/fieldset-image-options/index.tsx
@@ -17,21 +17,7 @@ const settings = {
 	description: __( 'A list of image options for an image select field.', 'jetpack-forms' ),
 	icon,
 	parent: [ 'jetpack/field-image-select' ],
-	attributes: {
-		type: {
-			type: 'string',
-			default: 'radio',
-		},
-	},
 	allowedBlocks: [ 'jetpack/input-image-option' ],
-	providesContext: {
-		'jetpack/field-image-options-type': 'type',
-	},
-	usesContext: [
-		'jetpack/field-image-select-is-supersized',
-		'jetpack/field-image-select-is-multiple',
-		'jetpack/field-share-attributes',
-	],
 	edit,
 	save,
 };

--- a/projects/packages/forms/src/blocks/input-image-option/edit.tsx
+++ b/projects/packages/forms/src/blocks/input-image-option/edit.tsx
@@ -32,25 +32,19 @@ const SYNCED_ATTRIBUTE_KEYS = [
 ];
 
 export default function ImageOptionInputEdit( props ) {
-	const { clientId, isSelected, context, name, attributes, setAttributes } = props;
+	const { clientId, context, name, attributes, setAttributes } = props;
 	const { 'jetpack/field-share-attributes': isSynced } = context;
 	const { label } = attributes;
 
 	useSyncedAttributes( name, isSynced, SYNCED_ATTRIBUTE_KEYS, attributes, setAttributes );
 
-	const {
-		'jetpack/field-image-select-is-supersized': isSupersized,
-		'jetpack/field-image-select-is-multiple': isMultiple,
-	} = context || {};
+	const { 'jetpack/field-image-select-is-supersized': isSupersized } = context || {};
 
-	const selectionType = isMultiple ? 'checkbox' : 'radio';
-
-	const { isInnerBlockSelected, imageBlockAttributes, positionLetter, rowOptionsCount } = useSelect(
+	const { positionLetter, rowOptionsCount } = useSelect(
 		select => {
 			const blockEditor = select( blockEditorStore ) as BlockEditorStoreSelect;
-			const { getBlock, hasSelectedInnerBlock } = blockEditor;
+			const { getBlock } = blockEditor;
 
-			const currentBlock = getBlock( clientId );
 			const parentClientIds = blockEditor.getBlockParentsByBlockName(
 				clientId,
 				'jetpack/fieldset-image-options'
@@ -69,8 +63,6 @@ export default function ImageOptionInputEdit( props ) {
 			const rowSiblingCount = Math.min( totalOptionsCount, maxImagesPerRow );
 
 			return {
-				isInnerBlockSelected: hasSelectedInnerBlock( clientId, true ),
-				imageBlockAttributes: currentBlock?.innerBlocks[ 1 ]?.attributes,
 				positionLetter: getImageOptionLetter( position ),
 				rowOptionsCount: rowSiblingCount,
 			};
@@ -83,9 +75,6 @@ export default function ImageOptionInputEdit( props ) {
 
 	const blockProps = useBlockProps( {
 		className: clsx( 'jetpack-field jetpack-input-image-option', {
-			'is-selected': isSelected || isInnerBlockSelected,
-			'has-image': !! imageBlockAttributes?.url,
-			[ `is-${ selectionType }` ]: !! selectionType,
 			'is-supersized': isSupersized,
 		} ),
 		style: {

--- a/projects/packages/forms/src/blocks/input-image-option/edit.tsx
+++ b/projects/packages/forms/src/blocks/input-image-option/edit.tsx
@@ -40,8 +40,10 @@ export default function ImageOptionInputEdit( props ) {
 
 	const {
 		'jetpack/field-image-select-is-supersized': isSupersized,
-		'jetpack/field-image-options-type': selectionType = 'radio',
+		'jetpack/field-image-select-is-multiple': isMultiple,
 	} = context || {};
+
+	const selectionType = isMultiple ? 'checkbox' : 'radio';
 
 	const { isInnerBlockSelected, imageBlockAttributes, positionLetter, rowOptionsCount } = useSelect(
 		select => {

--- a/projects/packages/forms/src/blocks/input-image-option/index.tsx
+++ b/projects/packages/forms/src/blocks/input-image-option/index.tsx
@@ -20,7 +20,7 @@ const settings = {
 	usesContext: [
 		'jetpack/field-image-select-is-supersized',
 		'jetpack/field-image-select-show-labels',
-		'jetpack/field-image-options-type',
+		'jetpack/field-image-select-is-multiple',
 		'jetpack/field-share-attributes',
 	],
 	providesContext: {

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -1977,9 +1977,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 
 		$field = "<div class='jetpack-field jetpack-field-image-select'>";
 
-		$form_style        = $this->get_form_style();
-		$is_outlined_style = 'outlined' === $form_style; // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- TODO: Implement style variations
-		$fieldset_id       = "id='" . esc_attr( "$id-label" ) . "'";
+		$fieldset_id = "id='" . esc_attr( "$id-label" ) . "'";
 
 		$field .= "<fieldset {$fieldset_id} data-wp-bind--aria-invalid='state.fieldHasErrors' >";
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of FORMS-60

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fixes the outline and animated styles
* Simplifies the multiple selection implementation, doing away with the middle man of "fieldset-image-options"

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add an image select field
* Set the form style to outlined
* Check that the style does not affect the block, and that the options and its images retain the blue focus style when focused
* Publish the post
* Check that the image select field is displayed correctly
* Set the form style to animated
* Check that the label does not move on top of the images
* Save the post
* Check that the published form is displayed correctly
* Change the image select field to support multiple selection
* Check that it works as expected
