### PR TITLE
Forms: version iAPI modules with asset file hash instead of Jetpack version

### DIFF
--- a/projects/packages/forms/changelog/update-forms-version-modules-with-asset-file
+++ b/projects/packages/forms/changelog/update-forms-version-modules-with-asset-file
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: change how Forms iAPI modules are versioned to avoid sticky cache busted versions

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -2884,7 +2884,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 	 * @return void
 	 */
 	private function enqueue_slider_field_assets() {
-		$asset_file = plugin_dir_path( __FILE__ ) . 'dist/modules/slider-field/view.asset.php';
+		$asset_file = plugin_dir_path( __FILE__ ) . '../../dist/modules/slider-field/view.asset.php';
 		$version    = Util::get_view_asset_version( $asset_file );
 
 		\wp_enqueue_style(

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -1598,7 +1598,8 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 	 * @return void
 	 */
 	private function enqueue_file_field_assets() {
-		$version = Constants::get_constant( 'JETPACK__VERSION' );
+		$asset_file = plugin_dir_path( __FILE__ ) . '../../dist/modules/file-field/view.asset.php';
+		$version    = Util::get_view_asset_version( $asset_file );
 
 		\wp_enqueue_script_module(
 			'jetpack-form-file-field',
@@ -2883,7 +2884,8 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 	 * @return void
 	 */
 	private function enqueue_slider_field_assets() {
-		$version = defined( 'JETPACK__VERSION' ) ? \JETPACK__VERSION : '0.1';
+		$asset_file = plugin_dir_path( __FILE__ ) . 'dist/modules/slider-field/view.asset.php';
+		$version    = Util::get_view_asset_version( $asset_file );
 
 		\wp_enqueue_style(
 			'jetpack-form-slider-field',
@@ -3159,12 +3161,8 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 	 * @return void
 	 */
 	private function enqueue_phone_field_assets() {
-		$version = defined( 'JETPACK__VERSION' ) ? \JETPACK__VERSION : '0.1';
-
-		// extra cache busting strategy for view.js, seems they are left out of cache clearing on deploys
 		$asset_file = plugin_dir_path( __FILE__ ) . '../../dist/modules/field-phone/view.asset.php';
-		$asset      = file_exists( $asset_file ) ? require $asset_file : null;
-		$version   .= $asset['version'] ?? '';
+		$version    = Util::get_view_asset_version( $asset_file );
 
 		// combobox styles
 		\wp_enqueue_style(

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -8,7 +8,6 @@
 namespace Automattic\Jetpack\Forms\ContactForm;
 
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
-use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Extensions\Contact_Form\Contact_Form_Block;
 use Automattic\Jetpack\Forms\Jetpack_Forms;
 use Automattic\Jetpack\Forms\Service\MailPoet_Integration;
@@ -772,10 +771,8 @@ class Contact_Form_Plugin {
 	public static function gutenblock_render_form_step( $atts, $content ) {
 		self::$step_count = 1 + self::$step_count;
 
-		$version = Constants::get_constant( 'JETPACK__VERSION' );
-		if ( empty( $version ) ) {
-			$version = '0.1';
-		}
+		$asset_file = plugin_dir_path( __FILE__ ) . '../../dist/modules/form-step/view.asset.php';
+		$version    = Util::get_view_asset_version( $asset_file );
 
 		\wp_enqueue_script_module(
 			'jetpack-form-step',
@@ -827,11 +824,9 @@ class Contact_Form_Plugin {
 	 * @return string HTML for the number field.
 	 */
 	public static function gutenblock_render_form_step_navigation( $atts, $content ) {
+		$asset_file = plugin_dir_path( __FILE__ ) . '../../dist/modules/form-step-navigation/view.asset.php';
+		$version    = Util::get_view_asset_version( $asset_file );
 
-		$version = Constants::get_constant( 'JETPACK__VERSION' );
-		if ( empty( $version ) ) {
-			$version = '0.1';
-		}
 		\wp_enqueue_script_module(
 			'jetpack-form-step-navigation',
 			plugins_url( '../../dist/modules/form-step-navigation/view.js', __FILE__ ),
@@ -909,10 +904,8 @@ class Contact_Form_Plugin {
 	 * @return string HTML for the progress indicator.
 	 */
 	public static function gutenblock_render_form_progress_indicator( $attributes ) {
-		$version = Constants::get_constant( 'JETPACK__VERSION' );
-		if ( empty( $version ) ) {
-			$version = '0.1';
-		}
+		$asset_file = plugin_dir_path( __FILE__ ) . '../../dist/modules/form-progress-indicator/view.asset.php';
+		$version    = Util::get_view_asset_version( $asset_file );
 
 		// Get step count from Contact_Form_Block
 		$max_steps = Contact_Form_Block::get_form_step_count();

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -568,7 +568,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 			wp_enqueue_script( 'accessible-form' );
 		}
 
-		$asset_file = plugin_dir_path( __FILE__ ) . 'dist/modules/form/view.asset.php';
+		$asset_file = plugin_dir_path( __FILE__ ) . '../../dist/modules/form/view.asset.php';
 		$version    = Util::get_view_asset_version( $asset_file );
 
 		$config = array(

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -568,15 +568,8 @@ class Contact_Form extends Contact_Form_Shortcode {
 			wp_enqueue_script( 'accessible-form' );
 		}
 
-		$version = \JETPACK__VERSION;
-
-		// Extra cache busting strategy for view.js, seems they are left out of cache clearing on deploys
 		$asset_file = plugin_dir_path( __FILE__ ) . 'dist/modules/form/view.asset.php';
-		$asset      = file_exists( $asset_file ) ? require $asset_file : null;
-
-		if ( $asset && isset( $asset['version'] ) ) {
-			$version = $asset['version'];
-		}
+		$version    = Util::get_view_asset_version( $asset_file );
 
 		$config = array(
 			'error_types'    => array(

--- a/projects/packages/forms/src/contact-form/class-util.php
+++ b/projects/packages/forms/src/contact-form/class-util.php
@@ -402,6 +402,6 @@ class Util {
 			$jetpack_version = '0.1';
 		}
 
-		return ( $asset && ! empty( $asset['version'] ) ) ? $asset['version'] : $jetpack_version;
+		return ! empty( $asset['version'] ) ? $asset['version'] : $jetpack_version;
 	}
 }

--- a/projects/packages/forms/src/contact-form/class-util.php
+++ b/projects/packages/forms/src/contact-form/class-util.php
@@ -7,6 +7,8 @@
 
 namespace Automattic\Jetpack\Forms\ContactForm;
 
+use Automattic\Jetpack\Constants;
+
 /**
  * This class serves as a container for what previously were standalone grunion functions.
  * In the long term we should aim to move things to other classes and gradually get rid of this rather than adding more.
@@ -385,5 +387,21 @@ class Util {
 				sanitize_file_name( get_bloginfo( 'name' ) ),
 				sanitize_file_name( $source )
 			);
+	}
+
+	/**
+	 * Get version hash from generated `view.asset.php` files, or fallback to Jetpack version, to be used as cache bust for enqueing JS and CSS files.
+	 *
+	 * @param string $asset_file Path to view.asset.php file.
+	 * @return string either asset hash or Jetpack version.
+	 */
+	public static function get_view_asset_version( $asset_file ) {
+		$asset           = file_exists( $asset_file ) ? require $asset_file : null;
+		$jetpack_version = Constants::get_constant( 'JETPACK__VERSION' );
+		if ( empty( $jetpack_version ) ) {
+			$jetpack_version = '0.1';
+		}
+
+		return ( $asset && ! empty( $asset['version'] ) ) ? $asset['version'] : $jetpack_version;
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Resolves FORMS-287

Alternative to https://github.com/Automattic/jetpack/pull/45169

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds util pulling a version from the generated `view.asset.php` file, falling back to Jetpack version
* Use the new util in all iAPI modules for Forms

#### Before

<img width="803" height="171" alt="Screenshot 2025-09-16 at 13 44 38" src="https://github.com/user-attachments/assets/ac98c484-7e47-466f-a95d-868e080e6e9b" />

#### After

<img width="1119" height="197" alt="Screenshot 2025-09-16 at 13 43 49" src="https://github.com/user-attachments/assets/3a0ef495-d7a0-40d7-ba94-a8f0717e5ae0" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test forms frontend, check that file gets cache-busted with the hash found in the generated `view.asset.php` files
* Test multi step forms
* Test slider, rating, file upload, and phone fields
