### PR TITLE
Forms: Fix feedback source

### DIFF
--- a/projects/packages/forms/changelog/fix-feedback-source
+++ b/projects/packages/forms/changelog/fix-feedback-source
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Store the feedback source info with more context

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -1900,7 +1900,7 @@ class Contact_Form_Plugin {
 		if ( empty( $this->current_widget_id ) || empty( $this->current_sidebar_id ) ) {
 			return '';
 		}
-		return $this->current_widget_id . '-' . $this->current_sidebar_id;
+		return $this->current_widget_id . '||' . $this->current_sidebar_id;
 	}
 
 	/**

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -518,6 +518,28 @@ class Contact_Form extends Contact_Form_Shortcode {
 	}
 
 	/**
+	 * Get the feedback source based on attributes.
+	 *
+	 * @param array $attributes The form attributes.
+	 * @return Feedback_Source The feedback source instance.
+	 */
+	public function get_feedback_source( $attributes ) {
+		if ( isset( $attributes['widget'] ) && ! empty( $attributes['widget'] ) ) {
+			return Feedback_Source::from_widget( $attributes['widget'] );
+		}
+
+		if ( isset( $attributes['block_template'] ) && ! empty( $attributes['block_template'] ) ) {
+			return Feedback_Source::from_block_template();
+		}
+
+		if ( isset( $attributes['block_template_part'] ) && ! empty( $attributes['block_template_part'] ) ) {
+			return Feedback_Source::from_block_template_part( $attributes['block_template_part'] );
+		}
+		global $page;
+		return new Feedback_Source( \get_the_ID(), \get_the_title(), $page, 'single', \get_the_ID() );
+	}
+
+	/**
 	 * The contact-form shortcode processor
 	 *
 	 * @param array       $attributes Key => Value pairs as parsed by shortcode_parse_atts().
@@ -745,6 +767,11 @@ class Contact_Form extends Contact_Form_Shortcode {
 			if ( $has_submit_button_block ) {
 				$form_classes .= ' wp-block-jetpack-contact-form';
 			}
+
+			$feedback_source = $form->get_feedback_source( $attributes );
+
+			$r .= '<a href="' . $feedback_source->get_editor_url() . '">EDIT FORM</a> | ';
+			$r .= '<a href="' . $feedback_source->get_permalink() . '">View FORM</a>';
 
 			$r .= "<form action='" . esc_url( $url ) . "'
 				id='" . $element_id . "'

--- a/projects/packages/forms/src/contact-form/class-feedback-source.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-source.php
@@ -44,18 +44,38 @@ class Feedback_Source {
 	private $page_number = 1;
 
 	/**
+	 * The source type of the feedback entry.
+	 * This is used to determine how the feedback was created.
+	 *
+	 * @var string
+	 */
+	private $source_type = 'single';
+
+	/**
+	 * The source type of the feedback entry.
+	 * This is used to determine how the feedback was created.
+	 *
+	 * @var string
+	 */
+	public $source_id = '';
+
+	/**
 	 * Constructor for Feedback_Source.
 	 *
 	 * @param int    $id          The ID of the feedback entry.
 	 * @param string $title       The title of the feedback entry.
 	 * @param int    $page_number The page number of the feedback entry, default is 1.
+	 * @param string $source_type The source type of the feedback entry.
+	 * @param string $source_id   The source ID of the feedback entry.
 	 */
-	public function __construct( $id, $title, $page_number = 1 ) {
+	public function __construct( $id = 0, $title = '', $page_number = 1, $source_type = 'single', $source_id = '' ) {
 
 		$this->id          = $id > 0 ? (int) $id : 0;
 		$this->title       = $title;
 		$this->page_number = $page_number;
 		$this->permalink   = $this->id === 0 ? home_url() : '';
+		$this->source_type = $source_type; // possible source types: single, widget, template, template-part
+		$this->source_id   = $source_id;
 
 		if ( $id <= 0 ) {
 			return;
@@ -94,8 +114,16 @@ class Feedback_Source {
 	 * @return string The permalink of the feedback entry.
 	 */
 	public function get_permalink() {
-		if ( $this->page_number > 1 && ! empty( $this->permalink ) ) {
-			return add_query_arg( 'page', $this->page_number, $this->permalink );
+		if ( $this->source_type === 'widget' ) {
+			if ( $this->page_number > 1 && ! empty( $this->permalink ) ) {
+				return add_query_arg( 'page', $this->page_number, $this->permalink );
+			}
+		}
+
+		if ( $this->source_type === 'widget' ) {
+			if ( $this->page_number > 1 && ! empty( $this->permalink ) ) {
+				return add_query_arg( 'page', $this->page_number, $this->permalink );
+			}
 		}
 		return $this->permalink;
 	}
@@ -146,6 +174,113 @@ class Feedback_Source {
 		return array(
 			'entry_title' => $this->title,
 			'entry_page'  => $this->page_number,
+			'source_type' => $this->source_type,
+			'source_id'   => $this->source_id,
 		);
+	}
+
+	/**
+	 * Creates a Feedback_Source instance from a block template.
+	 *
+	 * @return Feedback_Source Returns an instance of Feedback_Source.
+	 */
+	public static function from_block_template() {
+		global $_wp_current_template_id;
+
+		return new self( 0, self::title_from_template(), 0, 'block_template', $_wp_current_template_id );
+	}
+
+	/**
+	 * Creates a Feedback_Source instance from a block template part.
+	 *
+	 * @param string $part The template part identifier.
+	 * @return Feedback_Source Returns an instance of Feedback_Source.
+	 */
+	public static function from_block_template_part( $part ) {
+		return new self( 0, self::title_from_template(), 0, 'block_template_part', $part );
+	}
+
+	/**
+	 * Creates a Feedback_Source instance from a widget.
+	 *
+	 * @param string $widget_name The widget name.
+	 * @return Feedback_Source Returns an instance of Feedback_Source.
+	 */
+	public static function from_widget( $widget_name ) {
+
+		$sidebar    = explode( '||', $widget_name );
+		$sidebar_id = $sidebar[1] ?? '';
+
+		$sidebar_info = wp_get_sidebar( $sidebar_id );
+		if ( ! $sidebar_info ) {
+			$sidebar_info = array( 'name' => 'Unknown Sidebar' );
+		}
+
+		return new self( 0, $sidebar_info['name'], 0, 'widget', $widget_name );
+	}
+
+	/**
+	 * Creates a Feedback_Source instance from serialized data.
+	 *
+	 * @param array $data The serialized data.
+	 * @return Feedback_Source|null Returns an instance of Feedback_Source or null if data is invalid.
+	 */
+	public static function from_serialized( $data ) {
+		if ( ! is_array( $data ) ) {
+			return null;
+		}
+
+		$id          = isset( $data['id'] ) ? (int) $data['id'] : 0;
+		$title       = isset( $data['entry_title'] ) ? $data['entry_title'] : '';
+		$page_number = isset( $data['entry_page'] ) ? (int) $data['entry_page'] : 1;
+		$source_type = isset( $data['source_type'] ) ? $data['source_type'] : 'single';
+		$source_id   = isset( $data['source_id'] ) ? $data['source_id'] : '';
+
+		return new self( $id, $title, $page_number, $source_type, $source_id );
+	}
+
+	/**
+	 * Gets the title based on the current template context.
+	 *
+	 * @return string The template title.
+	 */
+	private static function title_from_template() {
+		if ( is_home() ) {
+			return __( 'Home Page', 'jetpack-forms' );
+		}
+
+		if ( is_front_page() ) {
+			return __( 'Front Page', 'jetpack-forms' );
+		}
+
+		if ( is_archive() ) {
+			return __( 'Archive Page', 'jetpack-forms' );
+		}
+
+		return __( 'Unknown Template', 'jetpack-forms' );
+	}
+
+	/**
+	 * Return the editor URL for the feedback entry.
+	 * So that users can edit the
+	 */
+	public function get_editor_url() {
+		if ( $this->source_type === 'block_template' ) {
+			return admin_url( 'site-editor.php?p=' . esc_attr( '/wp_template/' . addslashes( $this->source_id ) ) . '&canvas=edit' );
+		}
+
+		if ( $this->source_type === 'block_template_part' ) {
+			return admin_url( 'site-editor.php?p=' . esc_attr( '/wp_template_part/' . addslashes( $this->source_id ) ) . '&canvas=edit' );
+		}
+
+		if ( $this->source_type === 'block_template_part' ) {
+			return admin_url( 'site-editor.php?p=' . esc_attr( '/wp_template_part/' . addslashes( $this->source_id ) ) . '&canvas=edit' );
+		}
+
+		if ( $this->source_type === 'widget' ) {
+			return admin_url( 'widgets.php' );
+		}
+
+		return get_edit_post_link( $this->source_id );
 	}
 }

--- a/projects/plugins/jetpack/changelog/fix-feedback-source
+++ b/projects/plugins/jetpack/changelog/fix-feedback-source
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: store the Form source with more context so that we can better show an edit link


### PR DESCRIPTION
Fixes FORMS-211

## Proposed changes:
* Store more info about the source of the form. 
* Improve the links to the source and the title.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
See FORMS-211

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
TBD. 
