### PR TITLE
Forms: reorganise settings to a single panel for rating, slider and phone fields

### DIFF
--- a/projects/packages/forms/changelog/update-forms-reorganise-field-settings
+++ b/projects/packages/forms/changelog/update-forms-reorganise-field-settings
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: reorganise settings to a single panel for rating, slider and phone fields

--- a/projects/packages/forms/src/blocks/field-rating/edit.js
+++ b/projects/packages/forms/src/blocks/field-rating/edit.js
@@ -1,12 +1,6 @@
-import {
-	useBlockProps,
-	useInnerBlocksProps,
-	InspectorControls,
-	BlockContextProvider,
-} from '@wordpress/block-editor';
+import { useBlockProps, useInnerBlocksProps, BlockContextProvider } from '@wordpress/block-editor';
 import {
 	__experimentalNumberControl as NumberControl, // eslint-disable-line @wordpress/no-unsafe-wp-apis
-	PanelBody,
 	RangeControl,
 } from '@wordpress/components';
 import { useCallback } from '@wordpress/element';
@@ -82,30 +76,6 @@ export default function RatingFieldEdit( props ) {
 				<div { ...innerBlocksProps } />
 			</BlockContextProvider>
 
-			<InspectorControls>
-				<PanelBody title={ __( 'Settings', 'jetpack-forms' ) }>
-					<NumberControl
-						__next40pxDefaultSize
-						__unstableInputWidth="50%"
-						help={ __( 'Highest rating users can select (2–10).', 'jetpack-forms' ) }
-						label={ __( 'Maximum rating', 'jetpack-forms' ) }
-						max={ 10 }
-						min={ 2 }
-						onChange={ updateMax }
-						spinControls="custom"
-						value={ max }
-					/>
-					<RangeControl
-						label={ __( 'Default rating', 'jetpack-forms' ) }
-						help={ __( 'Pre-selected rating value (0 for no selection)', 'jetpack-forms' ) }
-						min={ 0 }
-						max={ max }
-						value={ defaultValue }
-						onChange={ onChangeDefault }
-					/>
-				</PanelBody>
-			</InspectorControls>
-
 			<JetpackFieldControls
 				clientId={ clientId }
 				id={ id }
@@ -113,6 +83,34 @@ export default function RatingFieldEdit( props ) {
 				attributes={ attributes }
 				setAttributes={ setAttributes }
 				width={ width }
+				extraFieldSettings={ [
+					{
+						index: 1,
+						element: (
+							<>
+								<NumberControl
+									__next40pxDefaultSize
+									__unstableInputWidth="50%"
+									help={ __( 'Highest rating users can select (2–10).', 'jetpack-forms' ) }
+									label={ __( 'Maximum rating', 'jetpack-forms' ) }
+									max={ 10 }
+									min={ 2 }
+									onChange={ updateMax }
+									spinControls="custom"
+									value={ max }
+								/>
+								<RangeControl
+									label={ __( 'Default rating', 'jetpack-forms' ) }
+									help={ __( 'Pre-selected rating value (0 for no selection)', 'jetpack-forms' ) }
+									min={ 0 }
+									max={ max }
+									value={ defaultValue }
+									onChange={ onChangeDefault }
+								/>
+							</>
+						),
+					},
+				] }
 			/>
 		</>
 	);

--- a/projects/packages/forms/src/blocks/field-slider/edit.js
+++ b/projects/packages/forms/src/blocks/field-slider/edit.js
@@ -1,13 +1,7 @@
-import {
-	useBlockProps,
-	useInnerBlocksProps,
-	InspectorControls,
-	BlockContextProvider,
-} from '@wordpress/block-editor';
+import { useBlockProps, useInnerBlocksProps, BlockContextProvider } from '@wordpress/block-editor';
 import {
 	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalNumberControl as NumberControl, // eslint-disable-line @wordpress/no-unsafe-wp-apis
-	PanelBody,
 	TextControl,
 } from '@wordpress/components';
 import { useCallback, useEffect, useState } from '@wordpress/element';
@@ -149,77 +143,6 @@ export default function SliderFieldEdit( props ) {
 
 	return (
 		<>
-			<InspectorControls>
-				<PanelBody title={ __( 'Settings', 'jetpack-forms' ) }>
-					<HStack alignment="top" className="jp-field-slider-inspector-row">
-						<NumberControl
-							__next40pxDefaultSize
-							__nextHasNoMarginBottom
-							label={ __( 'Min value', 'jetpack-forms' ) }
-							max={ max }
-							min={ Number.MIN_SAFE_INTEGER }
-							onChange={ onChangeMin }
-							value={ min }
-							spinControls="custom"
-						/>
-						<NumberControl
-							__next40pxDefaultSize
-							__nextHasNoMarginBottom
-							label={ __( 'Max value', 'jetpack-forms' ) }
-							max={ Number.MAX_SAFE_INTEGER }
-							min={ min }
-							onChange={ onChangeMax }
-							value={ max }
-							spinControls="custom"
-						/>
-					</HStack>
-					<HStack alignment="top" className="jp-field-slider-inspector-row">
-						<TextControl
-							__next40pxDefaultSize
-							__nextHasNoMarginBottom
-							label={ __( 'Min label', 'jetpack-forms' ) }
-							value={ minLabel }
-							onChange={ onChangeMinLabel }
-						/>
-						<TextControl
-							__next40pxDefaultSize
-							__nextHasNoMarginBottom
-							label={ __( 'Max label', 'jetpack-forms' ) }
-							value={ maxLabel }
-							onChange={ onChangeMaxLabel }
-						/>
-					</HStack>
-					<HStack alignment="top" className="jp-field-slider-inspector-row">
-						<NumberControl
-							__next40pxDefaultSize
-							__nextHasNoMarginBottom
-							label={ __( 'Default value', 'jetpack-forms' ) }
-							min={ min }
-							max={ max }
-							value={ localDefault }
-							onChange={ val => {
-								setLocalDefault( val );
-								const snapped = snapToStep( val, step );
-								setAttributes( { default: snapped } );
-							} }
-							onFocus={ () => setDefaultFocused( true ) }
-							onBlur={ () => setDefaultFocused( false ) }
-							spinControls="custom"
-							step={ step || 1 }
-						/>
-						<NumberControl
-							__next40pxDefaultSize
-							__nextHasNoMarginBottom
-							label={ __( 'Increment', 'jetpack-forms' ) }
-							min={ 0 }
-							step={ 1 }
-							value={ step }
-							onChange={ onChangeStep }
-							spinControls="custom"
-						/>
-					</HStack>
-				</PanelBody>
-			</InspectorControls>
 			<BlockContextProvider
 				value={ {
 					'jetpack/field-slider-onChangeDefault': onChangeDefault,
@@ -239,6 +162,82 @@ export default function SliderFieldEdit( props ) {
 				required={ required }
 				setAttributes={ setAttributes }
 				width={ width }
+				extraFieldSettings={ [
+					{
+						index: 1,
+						element: (
+							<>
+								<HStack alignment="top" className="jp-field-slider-inspector-row">
+									<NumberControl
+										__next40pxDefaultSize
+										__nextHasNoMarginBottom
+										label={ __( 'Min value', 'jetpack-forms' ) }
+										max={ max }
+										min={ Number.MIN_SAFE_INTEGER }
+										onChange={ onChangeMin }
+										value={ min }
+										spinControls="custom"
+									/>
+									<NumberControl
+										__next40pxDefaultSize
+										__nextHasNoMarginBottom
+										label={ __( 'Max value', 'jetpack-forms' ) }
+										max={ Number.MAX_SAFE_INTEGER }
+										min={ min }
+										onChange={ onChangeMax }
+										value={ max }
+										spinControls="custom"
+									/>
+								</HStack>
+								<HStack alignment="top" className="jp-field-slider-inspector-row">
+									<TextControl
+										__next40pxDefaultSize
+										__nextHasNoMarginBottom
+										label={ __( 'Min label', 'jetpack-forms' ) }
+										value={ minLabel }
+										onChange={ onChangeMinLabel }
+									/>
+									<TextControl
+										__next40pxDefaultSize
+										__nextHasNoMarginBottom
+										label={ __( 'Max label', 'jetpack-forms' ) }
+										value={ maxLabel }
+										onChange={ onChangeMaxLabel }
+									/>
+								</HStack>
+								<HStack alignment="top" className="jp-field-slider-inspector-row">
+									<NumberControl
+										__next40pxDefaultSize
+										__nextHasNoMarginBottom
+										label={ __( 'Default value', 'jetpack-forms' ) }
+										min={ min }
+										max={ max }
+										value={ localDefault }
+										onChange={ val => {
+											setLocalDefault( val );
+											const snapped = snapToStep( val, step );
+											setAttributes( { default: snapped } );
+										} }
+										onFocus={ () => setDefaultFocused( true ) }
+										onBlur={ () => setDefaultFocused( false ) }
+										spinControls="custom"
+										step={ step || 1 }
+									/>
+									<NumberControl
+										__next40pxDefaultSize
+										__nextHasNoMarginBottom
+										label={ __( 'Increment', 'jetpack-forms' ) }
+										min={ 0 }
+										step={ 1 }
+										value={ step }
+										onChange={ onChangeStep }
+										spinControls="custom"
+									/>
+								</HStack>
+							</>
+						),
+					},
+				] }
 			/>
 		</>
 	);

--- a/projects/packages/forms/src/blocks/field-telephone/edit.js
+++ b/projects/packages/forms/src/blocks/field-telephone/edit.js
@@ -1,5 +1,4 @@
 import {
-	InspectorControls,
 	useBlockProps,
 	useInnerBlocksProps,
 	BlockContextProvider,
@@ -169,6 +168,19 @@ export default function PhoneFieldEdit( props ) {
 				attributes={ attributes }
 				setAttributes={ setAttributes }
 				width={ width }
+				extraFieldSettings={ [
+					{
+						index: 1,
+						element: (
+							<ToggleControl
+								label={ __( 'Show country selector', 'jetpack-forms' ) }
+								checked={ showCountrySelector || false }
+								onChange={ onChangeShowCountrySelector }
+								__nextHasNoMarginBottom={ true }
+							/>
+						),
+					},
+				] }
 			/>
 		</>
 	);

--- a/projects/packages/forms/src/blocks/field-telephone/edit.js
+++ b/projects/packages/forms/src/blocks/field-telephone/edit.js
@@ -4,13 +4,7 @@ import {
 	BlockContextProvider,
 	BlockControls,
 } from '@wordpress/block-editor';
-import {
-	PanelBody,
-	TextControl,
-	ToggleControl,
-	ToolbarButton,
-	ToolbarGroup,
-} from '@wordpress/components';
+import { TextControl, ToggleControl, ToolbarButton, ToolbarGroup } from '@wordpress/components';
 import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { globe } from '@wordpress/icons';
@@ -140,27 +134,6 @@ export default function PhoneFieldEdit( props ) {
 				</ToolbarGroup>
 			</BlockControls>
 
-			<InspectorControls>
-				<PanelBody title={ __( 'Settings', 'jetpack-forms' ) }>
-					<ToggleControl
-						label={ __( 'Show country selector', 'jetpack-forms' ) }
-						checked={ showCountrySelector || false }
-						onChange={ onChangeShowCountrySelector }
-						__nextHasNoMarginBottom={ true }
-					/>
-					{ showCountrySelector && (
-						<TextControl
-							label={ __( 'Search placeholder', 'jetpack-forms' ) }
-							value={ searchPlaceholder }
-							placeholder={ __( 'Search countries…', 'jetpack-forms' ) }
-							onChange={ newValue => setAttributes( { searchPlaceholder: newValue } ) }
-							__nextHasNoMarginBottom={ true }
-							__next40pxDefaultSize={ true }
-						/>
-					) }
-				</PanelBody>
-			</InspectorControls>
-
 			<JetpackFieldControls
 				clientId={ clientId }
 				id={ id }
@@ -172,12 +145,24 @@ export default function PhoneFieldEdit( props ) {
 					{
 						index: 1,
 						element: (
-							<ToggleControl
-								label={ __( 'Show country selector', 'jetpack-forms' ) }
-								checked={ showCountrySelector || false }
-								onChange={ onChangeShowCountrySelector }
-								__nextHasNoMarginBottom={ true }
-							/>
+							<>
+								<ToggleControl
+									label={ __( 'Show country selector', 'jetpack-forms' ) }
+									checked={ showCountrySelector || false }
+									onChange={ onChangeShowCountrySelector }
+									__nextHasNoMarginBottom={ true }
+								/>
+								{ showCountrySelector && (
+									<TextControl
+										label={ __( 'Search placeholder', 'jetpack-forms' ) }
+										value={ searchPlaceholder }
+										placeholder={ __( 'Search countries…', 'jetpack-forms' ) }
+										onChange={ newValue => setAttributes( { searchPlaceholder: newValue } ) }
+										__nextHasNoMarginBottom={ true }
+										__next40pxDefaultSize={ true }
+									/>
+								) }
+							</>
 						),
 					},
 				] }

--- a/projects/plugins/jetpack/changelog/update-forms-reorganise-field-settings
+++ b/projects/plugins/jetpack/changelog/update-forms-reorganise-field-settings
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: reorganise settings to a single panel for rating, slider and phone fields


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

I noticed we could follow date field example and append field-specific settings into the same panel with other settings, instead of creating a new panel and then awkwardly have two; "Settings" alongside "Field settings":

### Before
<img width="277" height="751" alt="image" src="https://github.com/user-attachments/assets/776c2aec-26cb-442b-b0d3-8e8cd9abea0d" />
<img width="278" height="742" alt="image" src="https://github.com/user-attachments/assets/8ade1262-40b3-4d4d-b8b2-d3ff9db463cb" />
<img width="295" height="515" alt="Screenshot 2025-09-16 at 15 13 48" src="https://github.com/user-attachments/assets/5bbed90f-9b68-4fa4-b4c8-99f99f153505" />

### After

<img width="284" height="697" alt="image" src="https://github.com/user-attachments/assets/a2d5de50-41fc-445e-9dcd-287e7a317764" />
<img width="281" height="668" alt="image" src="https://github.com/user-attachments/assets/494e8715-cc2d-45d2-9efe-2eb16c821650" />
<img width="278" height="460" alt="image" src="https://github.com/user-attachments/assets/be7b6966-78ec-44e5-97ee-e0a92bf18868" />


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Consolidate settings into a single "settings" panel for rating, slider and phone fields


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

