### PR TITLE
Forms: allow custom search placeholder in phone field

### DIFF
--- a/projects/packages/forms/changelog/update-forms-phone-custom-search-placeholder
+++ b/projects/packages/forms/changelog/update-forms-phone-custom-search-placeholder
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: allow custom search placeholder for phone field

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -349,6 +349,10 @@ class Contact_Form_Block {
 						'type' => 'string',
 						'role' => 'content',
 					),
+					'searchPlaceholder'   => array(
+						'type' => 'string',
+						'role' => 'content',
+					),
 				),
 				'supports'         => array(
 					'interactivity' => true,
@@ -358,6 +362,7 @@ class Contact_Form_Block {
 					'jetpack/field-required'             => 'required',
 					'jetpack/field-prefix-default'       => 'default',
 					'jetpack/field-phone-country-toggle' => 'showCountrySelector',
+					'jetpack/field-phone-search-placeholder' => 'searchPlaceholder',
 				),
 			)
 		);

--- a/projects/packages/forms/src/blocks/field-telephone/edit.js
+++ b/projects/packages/forms/src/blocks/field-telephone/edit.js
@@ -140,7 +140,7 @@ export default function PhoneFieldEdit( props ) {
 					/>
 					{ showCountrySelector && (
 						<TextControl
-							label={ __( 'Search input placeholder', 'jetpack-forms' ) }
+							label={ __( 'Search placeholder', 'jetpack-forms' ) }
 							value={ searchPlaceholder }
 							placeholder={ __( 'Search countries…', 'jetpack-forms' ) }
 							onChange={ newValue => setAttributes( { searchPlaceholder: newValue } ) }

--- a/projects/packages/forms/src/blocks/field-telephone/edit.js
+++ b/projects/packages/forms/src/blocks/field-telephone/edit.js
@@ -5,7 +5,13 @@ import {
 	BlockContextProvider,
 	BlockControls,
 } from '@wordpress/block-editor';
-import { PanelBody, ToggleControl, ToolbarButton, ToolbarGroup } from '@wordpress/components';
+import {
+	PanelBody,
+	TextControl,
+	ToggleControl,
+	ToolbarButton,
+	ToolbarGroup,
+} from '@wordpress/components';
 import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { globe } from '@wordpress/icons';
@@ -32,6 +38,7 @@ export default function PhoneFieldEdit( props ) {
 		required,
 		requiredText,
 		placeholder,
+		searchPlaceholder,
 		default: defaultCountry,
 	} = attributes;
 	const [ countryList, setCountryList ] = useState( EMPTY_ARRAY );
@@ -106,6 +113,7 @@ export default function PhoneFieldEdit( props ) {
 				value={ {
 					'jetpack/field-prefix-onChange': onChangeDefaultCountry,
 					'jetpack/field-prefix-options': countryList,
+					'jetpack/field-phone-searchPlaceholder': searchPlaceholder,
 				} }
 			>
 				<div { ...innerBlocksProps } />
@@ -130,6 +138,16 @@ export default function PhoneFieldEdit( props ) {
 						onChange={ onChangeShowCountrySelector }
 						__nextHasNoMarginBottom={ true }
 					/>
+					{ showCountrySelector && (
+						<TextControl
+							label={ __( 'Search input placeholder', 'jetpack-forms' ) }
+							value={ searchPlaceholder }
+							placeholder={ __( 'Search countries…', 'jetpack-forms' ) }
+							onChange={ newValue => setAttributes( { searchPlaceholder: newValue } ) }
+							__nextHasNoMarginBottom={ true }
+							__next40pxDefaultSize={ true }
+						/>
+					) }
 				</PanelBody>
 			</InspectorControls>
 

--- a/projects/packages/forms/src/blocks/field-telephone/edit.js
+++ b/projects/packages/forms/src/blocks/field-telephone/edit.js
@@ -113,7 +113,7 @@ export default function PhoneFieldEdit( props ) {
 				value={ {
 					'jetpack/field-prefix-onChange': onChangeDefaultCountry,
 					'jetpack/field-prefix-options': countryList,
-					'jetpack/field-phone-searchPlaceholder': searchPlaceholder,
+					'jetpack/field-phone-search-placeholder': searchPlaceholder,
 				} }
 			>
 				<div { ...innerBlocksProps } />

--- a/projects/packages/forms/src/blocks/field-telephone/index.js
+++ b/projects/packages/forms/src/blocks/field-telephone/index.js
@@ -42,6 +42,7 @@ export const settings = {
 	providesContext: {
 		...defaultSettings.providesContext,
 		'jetpack/field-prefix-default': 'default',
+		'jetpack/field-phone-search-placeholder': 'searchPlaceholder',
 		'jetpack/field-phone-country-toggle': 'showCountrySelector',
 	},
 	allowedBlocks: [ 'jetpack/label', 'jetpack/phone-input' ],

--- a/projects/packages/forms/src/blocks/field-telephone/index.js
+++ b/projects/packages/forms/src/blocks/field-telephone/index.js
@@ -30,6 +30,10 @@ export const settings = {
 		default: {
 			type: 'string',
 		},
+		searchPlaceholder: {
+			type: 'string',
+			default: '',
+		},
 	},
 	supports: {
 		...defaultSettings.supports,

--- a/projects/packages/forms/src/blocks/input-phone/edit.js
+++ b/projects/packages/forms/src/blocks/input-phone/edit.js
@@ -52,6 +52,9 @@ const PhoneInputEdit = ( { attributes, clientId, isSelected, name, setAttributes
 	// Prefix/Country selector
 	const defaultPrefix = context?.[ 'jetpack/field-prefix-default' ] || 'US';
 	const showCountrySelector = context?.[ 'jetpack/field-phone-country-toggle' ] || false;
+	const searchPlaceholder =
+		context?.[ 'jetpack/field-phone-searchPlaceholder' ] ||
+		__( 'Search countries…', 'jetpack-forms' );
 
 	const handleChangeDefaultPrefix = useCallback(
 		event => {
@@ -91,7 +94,7 @@ const PhoneInputEdit = ( { attributes, clientId, isSelected, name, setAttributes
 							onOptionChange={ handleChangeDefaultPrefix }
 							isOpen={ comboboxOpen }
 							onOpenChange={ setComboboxOpen }
-							placeholer={ __( 'Search countries…', 'jetpack-forms' ) }
+							placeholer={ searchPlaceholder }
 							parentStyle={ blockProps?.style }
 						/>
 					</div>

--- a/projects/packages/forms/src/blocks/input-phone/edit.js
+++ b/projects/packages/forms/src/blocks/input-phone/edit.js
@@ -94,7 +94,7 @@ const PhoneInputEdit = ( { attributes, clientId, isSelected, name, setAttributes
 							onOptionChange={ handleChangeDefaultPrefix }
 							isOpen={ comboboxOpen }
 							onOpenChange={ setComboboxOpen }
-							placeholer={ searchPlaceholder }
+							placeholder={ searchPlaceholder }
 							parentStyle={ blockProps?.style }
 						/>
 					</div>

--- a/projects/packages/forms/src/blocks/input-phone/edit.js
+++ b/projects/packages/forms/src/blocks/input-phone/edit.js
@@ -53,7 +53,7 @@ const PhoneInputEdit = ( { attributes, clientId, isSelected, name, setAttributes
 	const defaultPrefix = context?.[ 'jetpack/field-prefix-default' ] || 'US';
 	const showCountrySelector = context?.[ 'jetpack/field-phone-country-toggle' ] || false;
 	const searchPlaceholder =
-		context?.[ 'jetpack/field-phone-searchPlaceholder' ] ||
+		context?.[ 'jetpack/field-phone-search-placeholder' ] ||
 		__( 'Search countries…', 'jetpack-forms' );
 
 	const handleChangeDefaultPrefix = useCallback(

--- a/projects/packages/forms/src/blocks/input-phone/index.js
+++ b/projects/packages/forms/src/blocks/input-phone/index.js
@@ -22,6 +22,7 @@ const settings = {
 		'jetpack/field-prefix-default',
 		'jetpack/field-prefix-onChange',
 		'jetpack/field-phone-country-toggle',
+		'jetpack/field-phone-searchPlaceholder',
 	],
 	supports: {
 		reusable: false,

--- a/projects/packages/forms/src/blocks/input-phone/index.js
+++ b/projects/packages/forms/src/blocks/input-phone/index.js
@@ -22,7 +22,7 @@ const settings = {
 		'jetpack/field-prefix-default',
 		'jetpack/field-prefix-onChange',
 		'jetpack/field-phone-country-toggle',
-		'jetpack/field-phone-searchPlaceholder',
+		'jetpack/field-phone-search-placeholder',
 	],
 	supports: {
 		reusable: false,

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -1085,7 +1085,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 							<input
 								class="jetpack-combobox-search"
 								type="text"
-								placeholder="<?php echo esc_attr__( 'Search countries…', 'jetpack-forms' ); ?>"
+								placeholder="<?php echo esc_attr( $this->get_attribute( 'searchPlaceholder' ) ); ?>"
 								data-wp-on--input="actions.phoneComboboxInputHandler"
 								data-wp-on--keydown="actions.phoneComboboxKeydownHandler">
 							<div class="jetpack-combobox-options">

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -993,7 +993,6 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		$show_country_selector = $this->get_attribute( 'showcountryselector' );
 		$default_country       = $this->get_attribute( 'default' );
 		$search_placeholder    = $this->get_attribute( 'searchPlaceholder' );
-		l( 'search_placeholder:', $search_placeholder );
 
 		if ( ! $show_country_selector ) {
 			// old telephone field treatment

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -992,6 +992,8 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 	public function render_telephone_field( $id, $label, $value, $class, $required, $required_field_text, $placeholder ) {
 		$show_country_selector = $this->get_attribute( 'showcountryselector' );
 		$default_country       = $this->get_attribute( 'default' );
+		$search_placeholder    = $this->get_attribute( 'searchPlaceholder' );
+		l( 'search_placeholder:', $search_placeholder );
 
 		if ( ! $show_country_selector ) {
 			// old telephone field treatment
@@ -999,6 +1001,10 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 			$label = $this->render_label( 'telephone', $id, $label, $required, $required_field_text );
 			$field = $this->render_input_field( 'tel', $id, $value, $class, $placeholder, $required );
 			return $label . $field;
+		}
+
+		if ( empty( $search_placeholder ) ) {
+			$search_placeholder = __( 'Search countries…', 'jetpack-forms' );
 		}
 
 		$this->enqueue_phone_field_assets();
@@ -1085,7 +1091,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 							<input
 								class="jetpack-combobox-search"
 								type="text"
-								placeholder="<?php echo esc_attr( $this->get_attribute( 'searchPlaceholder' ) ); ?>"
+								placeholder="<?php echo esc_attr( $search_placeholder ); ?>"
 								data-wp-on--input="actions.phoneComboboxInputHandler"
 								data-wp-on--keydown="actions.phoneComboboxKeydownHandler">
 							<div class="jetpack-combobox-options">

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -164,6 +164,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 				'iconstyle'                => null, // For rating field icon style (lowercase for shortcode compatibility)
 				// full phone field attributes, might become a standalone country list input block
 				'showcountryselector'      => false,
+				'searchplaceholder'        => false,
 				// Image select field attributes
 				'ismultiple'               => null,
 				'showlabels'               => null,
@@ -992,7 +993,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 	public function render_telephone_field( $id, $label, $value, $class, $required, $required_field_text, $placeholder ) {
 		$show_country_selector = $this->get_attribute( 'showcountryselector' );
 		$default_country       = $this->get_attribute( 'default' );
-		$search_placeholder    = $this->get_attribute( 'searchPlaceholder' );
+		$search_placeholder    = $this->get_attribute( 'searchplaceholder' );
 
 		if ( ! $show_country_selector ) {
 			// old telephone field treatment

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -1326,6 +1326,7 @@ class Contact_Form_Test extends BaseTestCase {
 			'default'             => 'foo',
 			'placeholder'         => 'PLACEHOLDTHIS!',
 			'id'                  => 'funID',
+			'searchplaceholder'   => 'Search…',
 		);
 
 		$expected_attributes = array_merge( $attributes, array( 'input_type' => 'tel' ) );
@@ -1345,6 +1346,7 @@ class Contact_Form_Test extends BaseTestCase {
 			'placeholder'         => 'PLACEHOLDTHIS!',
 			'id'                  => 'funID',
 			'showcountryselector' => true,
+			'searchplaceholder'   => 'Search…',
 		);
 
 		$expected_attributes = array_merge( $attributes, array( 'input_type' => 'tel' ) );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of FORMS-196

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds a new attribute allowing customers to translate or customise the "Search country…" label. Particularly, translations are an important use case since we translate by default to 16 languages "only".
* [Fix](https://github.com/Automattic/jetpack/pull/45197#discussion_r2358827116) placeholder being different in editor than in frontend

### Editor default state:

<img width="1050" height="237" alt="image" src="https://github.com/user-attachments/assets/dc433deb-ec1d-4028-bef0-01e25bfc012a" />

<img width="687" height="297" alt="image" src="https://github.com/user-attachments/assets/e27409a6-cc3a-47d2-85d6-7e0b0be34a3d" />


### Editor edited state:

<img width="1076" height="352" alt="Screenshot 2025-09-18 at 13 02 57" src="https://github.com/user-attachments/assets/445dba1a-b23d-4e7e-bafa-6a70c67cde26" />

<img width="703" height="154" alt="Screenshot 2025-09-18 at 13 02 41" src="https://github.com/user-attachments/assets/000009dd-2c05-4a73-9a3f-0f875de048bc" />

### Frontend edited state:

<img width="713" height="376" alt="image" src="https://github.com/user-attachments/assets/9f1b516c-b287-4ce3-8286-b47eb913d80f" />

When disabled, there's no input:

<img width="1059" height="234" alt="image" src="https://github.com/user-attachments/assets/c394d72d-adc9-4edc-96b0-7a9071c09fd4" />



### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Insert old phone field
* Apply PR and reload editor; everything continues to work
* Customize label
* See custom label in frontend and editor
