### PR TITLE
Connection: Avoid PHP warnings when user ID doesn't match a valid user

### DIFF
--- a/projects/packages/connection/changelog/fix-connection-avoid_php_warnings_on_non_user
+++ b/projects/packages/connection/changelog/fix-connection-avoid_php_warnings_on_non_user
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Prevent PHP warnings when handling invalid user data.

--- a/projects/packages/connection/src/sso/class-user-admin.php
+++ b/projects/packages/connection/src/sso/class-user-admin.php
@@ -1085,8 +1085,12 @@ class User_Admin extends Base_Admin {
 	 * @return false|string returns the user invite code if the user is invited, false otherwise.
 	 */
 	private static function has_pending_wpcom_invite( $user_id ) {
+		$user = get_user_by( 'id', $user_id );
+		if ( ! $user instanceof \WP_User ) {
+			return false;
+		}
+
 		$blog_id       = Manager::get_site_id( true );
-		$user          = get_user_by( 'id', $user_id );
 		$cached_invite = self::get_pending_cached_wpcom_invite( $user->user_email );
 
 		if ( $cached_invite ) {


### PR DESCRIPTION
Closes MONOREP-120

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

When deploying to WP Cloud, we noticed a spike of these warnings:
```
PHP Warning: Attempt to read property "user_email" on false in /wordpress/plugins/jetpack/15.1-a.3/jetpack_vendor/automattic/jetpack-connection/src/sso/class-user-admin.php on line 1090
PHP Deprecated: rawurlencode(): Passing null to parameter #1 ($string) of type string is deprecated in /wordpress/plugins/jetpack/15.1-a.3/jetpack_vendor/automattic/jetpack-connection/src/sso/class-user-admin.php on line 1099
PHP Warning: Attempt to read property "user_email" on false in /wordpress/plugins/jetpack/15.1-a.3/jetpack_vendor/automattic/jetpack-connection/src/sso/class-user-admin.php on line 1099
```

It turns out it was a coincidence unrelated to the deploy, but the fix is easy enough: verify `$user` is of `WP_User` type prior to using it as such.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

🤷