### PR TITLE
Forms: remove input element height CSS rule 

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-input-heights-after-new-probe-attr
+++ b/projects/packages/forms/changelog/fix-forms-input-heights-after-new-probe-attr
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: remove input element height CSS rule after fixing form-styles hook attribute

--- a/projects/packages/forms/src/contact-form/css/phone-field.scss
+++ b/projects/packages/forms/src/contact-form/css/phone-field.scss
@@ -56,7 +56,6 @@
 			padding: 0;
 			min-width: unset;
 			min-height: unset;
-			height: var(--jetpack--contact-form--input-height, unset);
 
 			&:not(.jetpack-field__input-prefix .jetpack-field__input-element) {
 				letter-spacing: inherit;


### PR DESCRIPTION

## Proposed changes:
This PR removes a CSS rule used as fallback for input element height. The fallback became redundant after fixing form-styles hook attribute.

Before:
<img width="746" height="429" alt="image" src="https://github.com/user-attachments/assets/77a287b7-30ff-4d1d-b161-baa4b595aeb4" />


After:
<img width="739" height="384" alt="image" src="https://github.com/user-attachments/assets/4f053c2c-848e-4573-b57e-03b0b8f78a49" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Just confirm a telephone input looks good with or without the country dropdown selector