### PR TITLE
Docker: Only symlink actual plugins

### DIFF
--- a/tools/docker/bin/run.sh
+++ b/tools/docker/bin/run.sh
@@ -2,7 +2,7 @@
 set -e
 
 # This file is run for the Docker image defined in Dockerfile.
-# These commands will be run each time the container is run.
+# These commands will be run each time the container is created.
 #
 # If you modify anything here, remember to build the image again by running:
 # jetpack docker build-image
@@ -110,7 +110,8 @@ if [ "$COMPOSE_PROJECT_NAME" == "jetpack_dev" ] ; then
 fi
 
 for DIR in /usr/local/src/jetpack-monorepo/projects/plugins/*; do
-	[ -d "$DIR" ] || continue # We are only interested in directories, e.g. different plugins.
+	[[ -d "$DIR" ]] || continue # We are only interested in directories, e.g. different plugins.
+	[[ -f "$DIR/composer.json" ]] || continue # If there's no composer.json in the folder, it's probably not a plugin.
 	PLUGIN="$(basename "$DIR")"
 
 	# Read plugin slug from composer.json, with fallback to beta-plugin-slug


### PR DESCRIPTION
Closes MONOREP-121

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This only symlinks plugin folders that actually have a `composer.json` file.

Reported here: p1758006208251839-slack-CDLH4C1UZ

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Before #44188, we symlinked every folder in `project/plugins` as a plugin. After that PR, we used the slug as specified in `composer.json`. However, in local environments where there were local empty folders (e.g. remnants from deleted plugins), this would give an error and result in the Docker container not starting. This PR verifies the folder has a `composer.json` file before trying to get the plugin slug for the symlink.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

The easiest way to reproduce is to ensure you have an empty dir in the `projects/plugins` dir. With the `trunk` version of the container, it'll give an error, and with this branch's version (one can build with `jetpack docker build-image`) it'll work as expected.