### PR TITLE
WooCommerce Analytics: Implement server-side direct event delivery

### DIFF
--- a/projects/packages/woocommerce-analytics/changelog/update-wooa7s-491-implement-server-side-direct-event-delivery
+++ b/projects/packages/woocommerce-analytics/changelog/update-wooa7s-491-implement-server-side-direct-event-delivery
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Implement server-side direct event delivery

--- a/projects/packages/woocommerce-analytics/src/class-my-account.php
+++ b/projects/packages/woocommerce-analytics/src/class-my-account.php
@@ -21,7 +21,6 @@ class My_Account {
 		add_action( 'woocommerce_account_content', array( $this, 'track_tabs' ) );
 		add_action( 'woocommerce_account_content', array( $this, 'track_logouts' ) );
 		add_action( 'woocommerce_customer_save_address', array( $this, 'track_save_address' ), 10, 2 );
-		add_action( 'wp_head', array( $this, 'trigger_queued_events' ) );
 		add_action( 'wp', array( $this, 'track_add_payment_method' ) );
 		add_action( 'wp', array( $this, 'track_delete_payment_method' ) );
 		add_action( 'woocommerce_save_account_details', array( $this, 'track_save_account_details' ) );
@@ -133,7 +132,7 @@ class My_Account {
 	 * @param string $load_address The address type (billing, shipping).
 	 */
 	public function track_save_address( $customer_id, $load_address ) {
-		$this->queue_event( 'woocommerceanalytics_my_account_address_save', array( 'address' => $load_address ) );
+		WC_Analytics_Tracking::record_event( 'my_account_address_save', array( 'address' => $load_address ) );
 	}
 
 	/**
@@ -148,7 +147,7 @@ class My_Account {
 				return;
 			}
 
-			$this->queue_event( 'woocommerceanalytics_my_account_payment_save' );
+			WC_Analytics_Tracking::record_event( 'my_account_payment_save' );
 			return;
 		}
 	}
@@ -159,7 +158,7 @@ class My_Account {
 	public function track_delete_payment_method() {
 		global $wp;
 		if ( isset( $wp->query_vars['delete-payment-method'] ) ) {
-			$this->queue_event( 'woocommerceanalytics_my_account_payment_delete' );
+			WC_Analytics_Tracking::record_event( 'my_account_payment_delete' );
 			return;
 		}
 	}
@@ -169,7 +168,7 @@ class My_Account {
 	 */
 	public function track_order_cancel_event() {
 		if ( isset( $_GET['_wca_initiator'] ) && ( isset( $_GET['_wpnonce'] ) && wp_verify_nonce( wp_unslash( $_GET['_wpnonce'] ), 'woocommerce-cancel_order' ) ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-			$this->queue_event( 'woocommerceanalytics_my_account_order_action_click', array( 'action' => 'cancel' ) );
+			WC_Analytics_Tracking::record_event( 'my_account_order_action_click', array( 'action' => 'cancel' ) );
 		}
 	}
 
@@ -178,7 +177,7 @@ class My_Account {
 	 */
 	public function track_order_pay_event() {
 		if ( isset( $_GET['_wca_initiator'] ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized,WordPress.Security.NonceVerification.Recommended
-			$this->record_event( 'woocommerceanalytics_my_account_order_action_click', array( 'action' => 'pay' ) );
+			WC_Analytics_Tracking::record_event( 'my_account_order_action_click', array( 'action' => 'pay' ) );
 		}
 	}
 
@@ -186,7 +185,7 @@ class My_Account {
 	 * Track account details save events, this can only come from the my account page.
 	 */
 	public function track_save_account_details() {
-		$this->queue_event( 'woocommerceanalytics_my_account_details_save' );
+		WC_Analytics_Tracking::record_event( 'my_account_details_save' );
 	}
 
 	/**
@@ -275,44 +274,5 @@ class My_Account {
 	public function add_initiator_param_to_query_vars( $query_vars ) {
 		$query_vars[] = '_wca_initiator';
 		return $query_vars;
-	}
-
-	/**
-	 * Record all queued up events in session.
-	 *
-	 * This is called on every page load, and will record all events that were queued up in session.
-	 */
-	public function trigger_queued_events() {
-		if ( is_object( WC()->session ) ) {
-			$events = WC()->session->get( 'wca_queued_events', array() );
-
-			foreach ( $events as $event ) {
-				$this->record_event(
-					$event['event_name'],
-					$event['event_props']
-				);
-			}
-
-			// Clear data, now that these events have been recorded.
-			WC()->session->set( 'wca_queued_events', array() );
-
-		}
-	}
-
-	/**
-	 * Queue an event in session to be recorded later on next page load.
-	 *
-	 * @param string $event_name The event name.
-	 * @param array  $event_props The event properties.
-	 */
-	protected function queue_event( $event_name, $event_props = array() ) {
-		if ( is_object( WC()->session ) ) {
-			$events   = WC()->session->get( 'wca_queued_events', array() );
-			$events[] = array(
-				'event_name'  => $event_name,
-				'event_props' => $event_props,
-			);
-			WC()->session->set( 'wca_queued_events', $events );
-		}
 	}
 }

--- a/projects/packages/woocommerce-analytics/src/class-universal.php
+++ b/projects/packages/woocommerce-analytics/src/class-universal.php
@@ -28,9 +28,6 @@ class Universal {
 		$this->additional_blocks_on_cart_page     = $this->get_additional_blocks_on_page( 'cart' );
 		$this->additional_blocks_on_checkout_page = $this->get_additional_blocks_on_page( 'checkout' );
 
-		// delayed events stored in session (can be add_to_carts, product_views...)
-		add_action( 'wp_head', array( $this, 'loop_session_events' ), 2 );
-
 		// Capture search
 		add_action( 'template_redirect', array( $this, 'capture_search_query' ), 11 );
 
@@ -77,27 +74,6 @@ class Universal {
 	}
 
 	/**
-	 * On product lists or other non-product pages, add an event listener to "Add to Cart" button click
-	 */
-	public function loop_session_events() {
-		// Check for previous events queued in session data.
-		if ( is_object( WC()->session ) ) {
-			$data = WC()->session->get( 'wca_session_data' );
-			if ( ! empty( $data ) ) {
-				foreach ( $data as $data_instance ) {
-					$this->record_event(
-						$data_instance['event'],
-						$data_instance['properties'] ?? array(),
-						$data_instance['product_id']
-					);
-				}
-				// Clear data, now that these events have been recorded.
-				WC()->session->set( 'wca_session_data', '' );
-			}
-		}
-	}
-
-	/**
 	 * On the cart page, add an event listener for removal of product click
 	 */
 	public function remove_from_cart() {
@@ -136,7 +112,16 @@ class Universal {
 	 */
 	public function capture_remove_from_cart( $cart_item_key, $cart ) {
 		$item = $cart->removed_cart_contents[ $cart_item_key ] ?? null;
-		$this->capture_event_in_session_data( 'woocommerceanalytics_remove_from_cart', (int) $item['product_id'], (int) $item['quantity'] );
+
+		WC_Analytics_Tracking::record_event(
+			'remove_from_cart',
+			$this->compose_event_properties(
+				array(
+					'pi' => $item['product_id'],
+					'pq' => $item['quantity'],
+				)
+			)
+		);
 	}
 
 	/**
@@ -152,13 +137,29 @@ class Universal {
 	public function capture_cart_quantity_update( $cart_item_key, $quantity, $old_quantity, $cart ) {
 		$product_id = $cart->cart_contents[ $cart_item_key ]['product_id'];
 		if ( $quantity > $old_quantity ) {
-			$this->capture_event_in_session_data( 'woocommerceanalytics_add_to_cart', $product_id, $quantity );
+			WC_Analytics_Tracking::record_event(
+				'add_to_cart',
+				$this->compose_event_properties(
+					array(
+						'pi' => $product_id,
+						'pq' => $quantity,
+					)
+				)
+			);
 			$this->lock_add_to_cart_events = true;
 			return;
 		}
 
 		if ( $quantity < $old_quantity ) {
-			$this->capture_event_in_session_data( 'woocommerceanalytics_remove_from_cart', $product_id, $quantity );
+			WC_Analytics_Tracking::record_event(
+				'remove_from_cart',
+				$this->compose_event_properties(
+					array(
+						'pi' => $product_id,
+						'pq' => $quantity,
+					)
+				)
+			);
 			return;
 		}
 	}
@@ -347,28 +348,29 @@ class Universal {
 				$order_coupons_count = count( $order_coupons );
 			}
 
-			$this->capture_event_in_session_data(
-				'woocommerceanalytics_product_purchase',
-				$product_id,
-				$order_item->get_quantity(),
-				array(
-					'oi'                       => $order->get_order_number(),
-					'pq'                       => $order_item->get_quantity(),
-					'payment_option'           => $payment_option,
-					'create_account'           => $create_account,
-					'guest_checkout'           => $guest_checkout,
-					'delayed_account_creation' => $delayed_account_creation,
-					'express_checkout'         => $express_checkout,
-					'coupon_used'              => $order_coupons_count,
-					'products_count'           => $order_items_count,
-					'order_value'              => $order->get_subtotal(),
-					'order_total'              => $order->get_total(),
-					'total_discount'           => $order->get_discount_total(),
-					'total_taxes'              => $order->get_total_tax(),
-					'total_shipping'           => $order->get_shipping_total(),
-					'from_checkout'            => $checkout_page_used,
-					'checkout_page_contains_checkout_block' => $checkout_page_contains_checkout_block,
-					'checkout_page_contains_checkout_shortcode' => $checkout_page_contains_checkout_shortcode,
+			WC_Analytics_Tracking::record_event(
+				'product_purchase',
+				$this->compose_event_properties(
+					array(
+						'oi'                       => $order->get_order_number(),
+						'pi'                       => $product_id,
+						'pq'                       => $order_item->get_quantity(),
+						'payment_option'           => $payment_option,
+						'create_account'           => $create_account,
+						'guest_checkout'           => $guest_checkout,
+						'delayed_account_creation' => $delayed_account_creation,
+						'express_checkout'         => $express_checkout,
+						'coupon_used'              => $order_coupons_count,
+						'products_count'           => $order_items_count,
+						'order_value'              => $order->get_subtotal(),
+						'order_total'              => $order->get_total(),
+						'total_discount'           => $order->get_discount_total(),
+						'total_taxes'              => $order->get_total_tax(),
+						'total_shipping'           => $order->get_shipping_total(),
+						'from_checkout'            => $checkout_page_used,
+						'checkout_page_contains_checkout_block' => $checkout_page_contains_checkout_block,
+						'checkout_page_contains_checkout_shortcode' => $checkout_page_contains_checkout_shortcode,
+					)
 				)
 			);
 		}
@@ -444,56 +446,31 @@ class Universal {
 		if ( $this->lock_add_to_cart_events ) {
 			return;
 		}
-		$this->capture_event_in_session_data( 'woocommerceanalytics_add_to_cart', $product_id, $quantity );
+		WC_Analytics_Tracking::record_event(
+			'add_to_cart',
+			$this->compose_event_properties(
+				array(
+					'pi' => $product_id,
+					'pq' => $quantity,
+				)
+			)
+		);
 	}
 
 	/**
-	 * Track in-session data.
+	 * Compose event properties. Composes the event properties with the product details.
 	 *
-	 * @param string $event Fired event.
-	 * @param int    $product_id Product ID.
-	 * @param int    $quantity Quantity.
-	 * @param array  $properties Event properties.
+	 * @param array $event_properties Event properties.
 	 */
-	public function capture_event_in_session_data( $event, $product_id, $quantity, $properties = array() ) {
-
-		$product = wc_get_product( $product_id );
-		if ( ! $product instanceof WC_Product ) {
-			return;
+	public function compose_event_properties( $event_properties = array() ) {
+		if ( isset( $event_properties['pq'] ) ) {
+			$event_properties['pq'] = 0 === $event_properties['pq'] ? 1 : ( $event_properties['pq'] ?? null );
 		}
-		$quantity = ( 0 === $quantity ) ? 1 : $quantity;
+		$product          = isset( $event_properties['pi'] ) ? wc_get_product( $event_properties['pi'] ) : null;
+		$product_details  = $product instanceof WC_Product ? $this->get_product_details( $product ) : array();
+		$event_properties = array_merge( $event_properties, $product_details );
 
-		// check for existing data.
-		if ( is_object( WC()->session ) ) {
-			$data = WC()->session->get( 'wca_session_data' );
-			if ( empty( $data ) || ! is_array( $data ) ) {
-				$data = array();
-			}
-		} else {
-			$data = array();
-		}
-
-		$event_properties = array_merge(
-			array(
-				'pq'           => isset( $quantity ) ? (string) $quantity : null,
-				'session_id'   => $this->get_session_id(),
-				'landing_page' => $this->get_landing_page(),
-				'is_engaged'   => $this->is_engaged_session(),
-			),
-			$properties
-		);
-
-		// extract new event data.
-		$new_data = array(
-			'event'      => $event,
-			'product_id' => (string) $product_id,
-			'properties' => $event_properties,
-		);
-
-		// append new data.
-		$data[] = $new_data;
-
-		WC()->session->set( 'wca_session_data', $data );
+		return $event_properties;
 	}
 
 	/**

--- a/projects/packages/woocommerce-analytics/src/class-universal.php
+++ b/projects/packages/woocommerce-analytics/src/class-universal.php
@@ -115,7 +115,7 @@ class Universal {
 
 		WC_Analytics_Tracking::record_event(
 			'remove_from_cart',
-			$this->compose_event_properties(
+			$this->get_cart_checkout_event_properties(
 				array(
 					'pi' => (int) $item['product_id'],
 					'pq' => (int) $item['quantity'],
@@ -139,7 +139,7 @@ class Universal {
 		if ( $quantity > $old_quantity ) {
 			WC_Analytics_Tracking::record_event(
 				'add_to_cart',
-				$this->compose_event_properties(
+				$this->get_cart_checkout_event_properties(
 					array(
 						'pi' => $product_id,
 						'pq' => $quantity,
@@ -153,7 +153,7 @@ class Universal {
 		if ( $quantity < $old_quantity ) {
 			WC_Analytics_Tracking::record_event(
 				'remove_from_cart',
-				$this->compose_event_properties(
+				$this->get_cart_checkout_event_properties(
 					array(
 						'pi' => $product_id,
 						'pq' => $quantity,
@@ -350,7 +350,7 @@ class Universal {
 
 			WC_Analytics_Tracking::record_event(
 				'product_purchase',
-				$this->compose_event_properties(
+				$this->get_cart_checkout_event_properties(
 					array(
 						'oi'                       => $order->get_order_number(),
 						'pi'                       => $product_id,
@@ -448,7 +448,7 @@ class Universal {
 		}
 		WC_Analytics_Tracking::record_event(
 			'add_to_cart',
-			$this->compose_event_properties(
+			$this->get_cart_checkout_event_properties(
 				array(
 					'pi' => $product_id,
 					'pq' => $quantity,
@@ -458,18 +458,32 @@ class Universal {
 	}
 
 	/**
-	 * Compose event properties. Composes the event properties with the product details.
+	 * Get the event properties for the cart and checkout events.
 	 *
 	 * @param array $event_properties Event properties.
 	 */
-	public function compose_event_properties( $event_properties = array() ) {
+	public function get_cart_checkout_event_properties( $event_properties = array() ) {
 		if ( isset( $event_properties['pq'] ) ) {
 			$event_properties['pq'] = 0 === $event_properties['pq'] ? 1 : $event_properties['pq'];
 			$event_properties['pq'] = (string) $event_properties['pq'];
 		}
-		$product          = isset( $event_properties['pi'] ) ? wc_get_product( $event_properties['pi'] ) : null;
-		$product_details  = $product instanceof WC_Product ? $this->get_product_details( $product ) : array();
-		$event_properties = array_merge( $event_properties, $product_details );
+		$product         = isset( $event_properties['pi'] ) ? wc_get_product( $event_properties['pi'] ) : null;
+		$product_details = $product instanceof WC_Product ? $this->get_product_details( $product ) : array();
+
+		$checkout_cart_details = array(
+			'template_used'                      => $this->cart_checkout_templates_in_use ? '1' : '0',
+			'additional_blocks_on_cart_page'     => $this->additional_blocks_on_cart_page,
+			'additional_blocks_on_checkout_page' => $this->additional_blocks_on_checkout_page,
+			'order_value'                        => $this->get_cart_subtotal(),
+			'order_total'                        => $this->get_cart_total(),
+			'total_tax'                          => $this->get_cart_taxes(),
+			'total_discount'                     => $this->get_total_discounts(),
+			'total_shipping'                     => $this->get_cart_shipping_total(),
+			'products_count'                     => $this->get_cart_items_count(),
+		);
+		$cart_checkout_info    = $this->get_cart_checkout_info();
+
+		$event_properties = array_merge( $event_properties, $product_details, $checkout_cart_details, $cart_checkout_info );
 
 		return $event_properties;
 	}

--- a/projects/packages/woocommerce-analytics/src/class-universal.php
+++ b/projects/packages/woocommerce-analytics/src/class-universal.php
@@ -117,8 +117,8 @@ class Universal {
 			'remove_from_cart',
 			$this->compose_event_properties(
 				array(
-					'pi' => $item['product_id'],
-					'pq' => $item['quantity'],
+					'pi' => (int) $item['product_id'],
+					'pq' => (int) $item['quantity'],
 				)
 			)
 		);
@@ -464,7 +464,8 @@ class Universal {
 	 */
 	public function compose_event_properties( $event_properties = array() ) {
 		if ( isset( $event_properties['pq'] ) ) {
-			$event_properties['pq'] = 0 === $event_properties['pq'] ? 1 : ( $event_properties['pq'] ?? null );
+			$event_properties['pq'] = 0 === $event_properties['pq'] ? 1 : $event_properties['pq'];
+			$event_properties['pq'] = (string) $event_properties['pq'];
 		}
 		$product          = isset( $event_properties['pi'] ) ? wc_get_product( $event_properties['pi'] ) : null;
 		$product_details  = $product instanceof WC_Product ? $this->get_product_details( $product ) : array();


### PR DESCRIPTION
Fixes [WOOA7S-492](https://linear.app/a8c/issue/WOOA7S-492/implement-server-side-tracker-class-for-pixel-event-delivery)

## Proposed changes:

- Replace queued event tracking with direct server-side event recording using new `WC_Analytics_Tracking ` class https://github.com/Automattic/jetpack/pull/45208
- Remove deprecated event queuing methods in `My_Account` and `Universal` classes


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?

This PR updates the delivery method for existing analytics events, with only minimal adjustments to the event properties.


- **Browser Data Collection:**  
  The following browser-related properties are no longer collected for these events:
  - `navigator.platform`
  - `window.height`
  - `window.width`
  - `scrollY`
  - `scrollX`
  - `browser_family`
  - `device_os`
  - `_dl` (browserdocumentlocation)

- **Landing Page Property:**  
  The `landing page` property is now encoded as a URL-encoded valid JSON string, rather than being double-encoded (URL encoding plus HTML entity encoding).

**Impact Assessment:**

- These properties are not used in our current analytics or reporting.  
- Therefore, this change should not impact our existing analysis or data usage.

If we require these properties in the future, we can reintroduce them by saving them in the cookie via JS and retrieving them from server-side code.


## Testing instructions:

1. Set up a Jetpack + WooCommerce site with this branch activated
2. Use the WooCommerce Analytics plugin to enable ClickHouse tracking
3. Use the following code snippet to log the events:

```php
 function log_remote_pixels( $preempt, $parsed_args, $url ) {
	if ( strpos( $url, WC_Tracks_Client::PIXEL ) === 0 ||  strpos( $url, 'https://pixel.wp.com/w.gif' ) === 0  ) {
		$parsed_url = wp_parse_url( $url );
		parse_str( $parsed_url['query'], $params );
		error_log( $url );
		error_log( $params['_en'] . ' -- ' . print_r( $params, true ));
	}

	return $preempt;
}

add_action( 'pre_http_request', 'log_remote_pixels', 10, 3 );
```

4. Perform actions that trigger events (account details save, cart updates, etc.)
5. Verify that events are delivered immediately  `tail -f wp-content/debug.log`
6. Ensure that events include all necessary properties, excluding those that depend on browser or client-side data (e.g., `navigator.platform`, `window.height`, etc.).
7. Only allowed events are sent to ClickHouse. (account-related events are not allowed)
8. Check the ClickHouse table for the presence of the events 

![https://github.com/user-attachments/assets/15a46b8b-9678-4754-b562-cda7b4aec435](https://github.com/user-attachments/assets/15a46b8b-9678-4754-b562-cda7b4aec435)