### PR TITLE
Jetpack Sync: Add 'is_connected' property to synced users

### DIFF
--- a/projects/packages/sync/changelog/update-sync-users-is_connected
+++ b/projects/packages/sync/changelog/update-sync-users-is_connected
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Jetpack Sync: Add 'is_connected' property to synced users

--- a/projects/packages/sync/src/modules/class-users.php
+++ b/projects/packages/sync/src/modules/class-users.php
@@ -7,6 +7,7 @@
 
 namespace Automattic\Jetpack\Sync\Modules;
 
+use Automattic\Jetpack\Connection\Manager;
 use Automattic\Jetpack\Constants as Jetpack_Constants;
 use Automattic\Jetpack\Password_Checker;
 use Automattic\Jetpack\Sync\Defaults;
@@ -252,6 +253,8 @@ class Users extends Module {
 		if ( get_locale() !== get_user_locale( $user->ID ) ) {
 			$user->locale = get_user_locale( $user->ID );
 		}
+
+		$user->is_connected = ( new Manager( 'jetpack' ) )->is_user_connected( $user->ID );
 
 		return $user;
 	}

--- a/projects/plugins/jetpack/changelog/update-sync-users-is_connected
+++ b/projects/plugins/jetpack/changelog/update-sync-users-is_connected
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Update Sync related unit tests
+
+

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Users_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Users_Test.php
@@ -451,6 +451,7 @@ class Jetpack_Sync_Users_Test extends Jetpack_Sync_TestBase {
 
 		// TODO: this is to address a testing bug, alas :/
 		unset( $retrieved_user->data->allowed_mime_types );
+		unset( $retrieved_user->data->is_connected );
 
 		$this->assertEquals( $synced_user, $retrieved_user );
 	}

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Users_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Users_Test.php
@@ -579,9 +579,32 @@ class Jetpack_Sync_Users_Test extends Jetpack_Sync_TestBase {
 
 		// TODO: this is to address a testing bug, alas :/
 		unset( $retrieved_user->data->allowed_mime_types );
+
+		$this->assertFalse( $retrieved_user->data->is_connected );
 		unset( $retrieved_user->data->is_connected );
 
 		$this->assertEquals( $synced_user, $retrieved_user );
+	}
+
+	public function test_returns_user_object_by_id_with_connected_user() {
+		Jetpack_Options::update_option(
+			'user_tokens',
+			array(
+				$this->user_id => 'apple.a.' . $this->user_id,
+			)
+		);
+
+		$user_sync_module = Modules::get_module( 'users' );
+		// grab the codec - we need to simulate the stripping of types that comes with encoding/decoding
+		$codec = $this->sender->get_codec();
+
+		$retrieved_user = $codec->decode(
+			$codec->encode(
+				$user_sync_module->get_object_by_id( 'user', $this->user_id )
+			)
+		);
+
+		$this->assertTrue( $retrieved_user->data->is_connected );
 	}
 
 	public function test_update_user_locale_changed_is_synced() {

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Users_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Users_Test.php
@@ -55,6 +55,7 @@ class Jetpack_Sync_Users_Test extends Jetpack_Sync_TestBase {
 
 		// TODO: this is to address a testing bug, alas :/
 		unset( $retrieved_user->data->allowed_mime_types );
+		unset( $retrieved_user->data->is_connected );
 
 		$this->assertEquals( $synced_user, $retrieved_user, 'Retrieved user must equal the synced user.' );
 	}
@@ -578,6 +579,7 @@ class Jetpack_Sync_Users_Test extends Jetpack_Sync_TestBase {
 
 		// TODO: this is to address a testing bug, alas :/
 		unset( $retrieved_user->data->allowed_mime_types );
+		unset( $retrieved_user->data->is_connected );
 
 		$this->assertEquals( $synced_user, $retrieved_user );
 	}

--- a/projects/plugins/jetpack/tests/php/sync/server/class.jetpack-sync-test-replicastore.php
+++ b/projects/plugins/jetpack/tests/php/sync/server/class.jetpack-sync-test-replicastore.php
@@ -588,6 +588,8 @@ class Jetpack_Sync_Test_Replicastore implements Replicastore_Interface {
 			$this->users_locale[ get_current_blog_id() ][ $user->ID ] = $user->data->locale;
 			unset( $user->data->locale );
 		}
+		unset( $user->data->is_connected );
+
 		$this->users[ get_current_blog_id() ][ $user->ID ] = $user;
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR adds a new user property: `is_connected` to the user data we sync. This will be `true` if the user has connected their WPCOM account, `false` otherwise.
Having this info on WPCOM will allow us to fix a checksum inconsistency when calculating usermeta checksums on both ends plus potentially introduce automated connection error healing triggers when a user is connected on WPCOM but their token is missing from the remote site and vice-versa.

Full Context: SYNC-17

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* `Automattic\Jetpack\Sync\Modules\Users`: Update `expand_user` with an additional user property: `is_connected`. This will be `true` if the user has connected their WPCOM account, `false` otherwise.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
SYNC-17

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* See 192430-ghe-Automattic/wpcom