### PR TITLE
Prioritize post description over title for Linkedin's share previews

### DIFF
--- a/projects/js-packages/publicize-components/changelog/fix-publicize-linkedin-description
+++ b/projects/js-packages/publicize-components/changelog/fix-publicize-linkedin-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Social previews: ensure trimmed post content is displayed in the Linkedin post preview.

--- a/projects/js-packages/publicize-components/src/components/social-post-modal/post-preview.tsx
+++ b/projects/js-packages/publicize-components/src/components/social-post-modal/post-preview.tsx
@@ -133,7 +133,7 @@ export function PostPreview( { connection }: PostPreviewProps ) {
 					jobTitle={ __( 'Job Title (Company Name)', 'jetpack-publicize-components' ) }
 					name={ user.displayName }
 					profileImage={ user.profileImage }
-					description={ message || title || description }
+					description={ message || description || title }
 				/>
 			);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of https://github.com/Automattic/wp-calypso/pull/105796

## Proposed changes:
* Prioritize post description over title for Linkedin's share previews

### Other information:

Currently, the LinkedIn post preview prioritizes the post title over the body. As per https://github.com/Automattic/wp-calypso/pull/105796, we're trying to improve the Linkedin share functionality to include part of its content (if no custom social message or excerpt is found) instead of the title. 

With this change, it will now be possible to access the post description in the `LinkedInPostPreview` component from calypso's `@automattic/social-previews`. 

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Testing instructions:
Once merged, we should follow the testing instructions detailed in https://github.com/Automattic/wp-calypso/pull/105796

## Does this pull request change what data or activity we track or use?

No. It just changes the data (description instead of the title) that is sent to the LinkedIn's share post preview.
