### PR TITLE
Forms: use new rating block on Feedback variation and pattern

### DIFF
--- a/projects/packages/forms/changelog/change-forms-use-rating-block-variations-patterns
+++ b/projects/packages/forms/changelog/change-forms-use-rating-block-variations-patterns
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: use new rating block on Feedback variation and pattern

--- a/projects/packages/forms/src/blocks/contact-form/variations.js
+++ b/projects/packages/forms/src/blocks/contact-form/variations.js
@@ -629,16 +629,7 @@ const variations = [
 			[
 				'jetpack/field-rating',
 				{ required: true, max: 5 },
-				[
-					[
-						{
-							name: 'jetpack/label',
-							attributes: {
-								label: __( 'Rate your experience', 'jetpack-forms' ),
-							},
-						},
-					],
-				],
+				[ [ 'jetpack/label', { label: __( 'Rate your experience', 'jetpack-forms' ) } ] ],
 			],
 			[
 				'jetpack/field-textarea',

--- a/projects/packages/forms/src/blocks/contact-form/variations.js
+++ b/projects/packages/forms/src/blocks/contact-form/variations.js
@@ -627,50 +627,16 @@ const variations = [
 				[ [ 'jetpack/label', { label: __( 'Email', 'jetpack-forms' ) } ], [ 'jetpack/input' ] ],
 			],
 			[
-				'jetpack/field-radio',
-				{ required: true },
+				'jetpack/field-rating',
+				{ required: true, max: 5 },
 				[
-					[ 'jetpack/label', { label: __( 'Please rate our website', 'jetpack-forms' ) } ],
 					[
-						'jetpack/options',
-						{ type: 'radio' },
-						[
-							[
-								'jetpack/option',
-								{
-									label: __( '1 - Very Bad', 'jetpack-forms' ),
-									placeholder: __( 'Add option…', 'jetpack-forms' ),
-								},
-							],
-							[
-								'jetpack/option',
-								{
-									label: __( '2 - Poor', 'jetpack-forms' ),
-									placeholder: __( 'Add option…', 'jetpack-forms' ),
-								},
-							],
-							[
-								'jetpack/option',
-								{
-									label: __( '3 - Average', 'jetpack-forms' ),
-									placeholder: __( 'Add option…', 'jetpack-forms' ),
-								},
-							],
-							[
-								'jetpack/option',
-								{
-									label: __( '4 - Good', 'jetpack-forms' ),
-									placeholder: __( 'Add option…', 'jetpack-forms' ),
-								},
-							],
-							[
-								'jetpack/option',
-								{
-									label: __( '5 - Excellent', 'jetpack-forms' ),
-									placeholder: __( 'Add option…', 'jetpack-forms' ),
-								},
-							],
-						],
+						{
+							name: 'jetpack/label',
+							attributes: {
+								label: __( 'Rate your experience', 'jetpack-forms' ),
+							},
+						},
 					],
 				],
 			],

--- a/projects/packages/forms/src/blocks/contact-form/variations.js
+++ b/projects/packages/forms/src/blocks/contact-form/variations.js
@@ -670,53 +670,12 @@ const variations = [
 					],
 				},
 				{
-					name: 'jetpack/field-radio',
-					attributes: { required: true },
+					name: 'jetpack/field-rating',
+					attributes: { required: true, max: 5 },
 					innerBlocks: [
 						{
 							name: 'jetpack/label',
-							attributes: { label: __( 'Please rate our website', 'jetpack-forms' ) },
-						},
-						{
-							name: 'jetpack/options',
-							attributes: { type: 'radio' },
-							innerBlocks: [
-								{
-									name: 'jetpack/option',
-									attributes: {
-										label: __( '1 - Very Bad', 'jetpack-forms' ),
-										placeholder: __( 'Add option…', 'jetpack-forms' ),
-									},
-								},
-								{
-									name: 'jetpack/option',
-									attributes: {
-										label: __( '2 - Poor', 'jetpack-forms' ),
-										placeholder: __( 'Add option…', 'jetpack-forms' ),
-									},
-								},
-								{
-									name: 'jetpack/option',
-									attributes: {
-										label: __( '3 - Average', 'jetpack-forms' ),
-										placeholder: __( 'Add option…', 'jetpack-forms' ),
-									},
-								},
-								{
-									name: 'jetpack/option',
-									attributes: {
-										label: __( '4 - Good', 'jetpack-forms' ),
-										placeholder: __( 'Add option…', 'jetpack-forms' ),
-									},
-								},
-								{
-									name: 'jetpack/option',
-									attributes: {
-										label: __( '5 - Excellent', 'jetpack-forms' ),
-										placeholder: __( 'Add option…', 'jetpack-forms' ),
-									},
-								},
-							],
+							attributes: { label: __( 'Rate your experience', 'jetpack-forms' ) },
 						},
 					],
 				},

--- a/projects/packages/forms/src/contact-form/class-util.php
+++ b/projects/packages/forms/src/contact-form/class-util.php
@@ -125,7 +125,10 @@ class Util {
                     <div class="wp-block-jetpack-contact-form">
                         <!-- wp:jetpack/field-name {"required":true} /-->
                         <!-- wp:jetpack/field-email {"required":true} /-->
-                        <!-- wp:jetpack/field-radio {"label":"Please rate our website","required":true,"options":["1 - Very Bad","2 - Poor","3 - Average","4 - Good","5 - Excellent"]} /-->
+                        <!-- wp:jetpack/field-rating {"required":true} -->
+							<div><!-- wp:jetpack/label {"label":"Rating"} /-->
+						<!-- wp:jetpack/input-rating /--></div>
+						<!-- /wp:jetpack/field-rating -->
                         <!-- wp:jetpack/field-textarea {"label":"How could we improve?"} /-->
                         <!-- wp:jetpack/button {"element":"button","text":"Send Feedback","lock":{"remove":true}} /-->
                     </div>

--- a/projects/packages/forms/src/contact-form/class-util.php
+++ b/projects/packages/forms/src/contact-form/class-util.php
@@ -126,7 +126,7 @@ class Util {
                         <!-- wp:jetpack/field-name {"required":true} /-->
                         <!-- wp:jetpack/field-email {"required":true} /-->
                         <!-- wp:jetpack/field-rating {"required":true} -->
-							<div><!-- wp:jetpack/label {"label":"Rating"} /-->
+							<div><!-- wp:jetpack/label {"label":"Please rate our website"} /-->
 						<!-- wp:jetpack/input-rating /--></div>
 						<!-- /wp:jetpack/field-rating -->
                         <!-- wp:jetpack/field-textarea {"label":"How could we improve?"} /-->


### PR DESCRIPTION
## Proposed changes:
This PR changes the "Feedback" variation and pattern to use the new Rating block instead of a multiple choice:

Before

<img width="851" height="658" alt="image" src="https://github.com/user-attachments/assets/478641c5-1fc7-473a-880d-e1c1e1bb656e" />

<img width="669" height="556" alt="image" src="https://github.com/user-attachments/assets/6fe498d4-76c0-4f81-b019-617e7814e8d3" />


After

<img width="849" height="653" alt="image" src="https://github.com/user-attachments/assets/a2368c02-f01c-4fd0-8593-1ed94ce50835" />

<img width="666" height="683" alt="image" src="https://github.com/user-attachments/assets/95ca0e44-7c99-45bf-866e-79cce3862417" />



### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1758032232313019-slack-C052XEUUBL4

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Insert a form on a post. While at the variations picker, use the button to explore Patterns. Look for the one that has a "Send Feedback" button. See that it has a Rating block. 

Insert it, check that the form looks like the pattern and it works on editor and frontend.

Insert another form, this time use the variation picker to choose "Feedback" form. See that the inserted form has a Rating block. Verify on editor and frontend.