### PR TITLE
Forms: Fix slider min max editing

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-slider-min-max-values
+++ b/projects/packages/forms/changelog/fix-forms-slider-min-max-values
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Fix slider min/max editing.

--- a/projects/packages/forms/src/blocks/field-slider/edit.js
+++ b/projects/packages/forms/src/blocks/field-slider/edit.js
@@ -225,6 +225,8 @@ export default function SliderFieldEdit( props ) {
 					'jetpack/field-slider-onChangeDefault': onChangeDefault,
 					'jetpack/field-slider-onChangeMin': onChangeMin,
 					'jetpack/field-slider-onChangeMax': onChangeMax,
+					'jetpack/field-slider-minLabel': minLabel,
+					'jetpack/field-slider-maxLabel': maxLabel,
 					'jetpack/field-slider-onChangeMinLabel': onChangeMinLabel,
 					'jetpack/field-slider-onChangeMaxLabel': onChangeMaxLabel,
 				} }

--- a/projects/packages/forms/src/blocks/input-range/edit.js
+++ b/projects/packages/forms/src/blocks/input-range/edit.js
@@ -20,8 +20,8 @@ export default function SliderInputEdit( props ) {
 	const onChangeMin = context[ 'jetpack/field-slider-onChangeMin' ];
 	const onChangeMax = context[ 'jetpack/field-slider-onChangeMax' ];
 	const onKeyDown = useInsertAfterOnEnterKeyDown( clientId );
-	const minTextLabel = context[ 'jetpack/field-slider-minLabel' ];
-	const maxTextLabel = context[ 'jetpack/field-slider-maxLabel' ];
+	const minLabelFromContext = context[ 'jetpack/field-slider-minLabel' ];
+	const maxLabelFromContext = context[ 'jetpack/field-slider-maxLabel' ];
 	const onChangeMinLabel = context[ 'jetpack/field-slider-onChangeMinLabel' ];
 	const onChangeMaxLabel = context[ 'jetpack/field-slider-onChangeMaxLabel' ];
 
@@ -30,8 +30,10 @@ export default function SliderInputEdit( props ) {
 	const [ localMax, setLocalMax ] = useState( String( maxFromContext ) );
 	const [ minFocused, setMinFocused ] = useState( false );
 	const [ maxFocused, setMaxFocused ] = useState( false );
-	const [ localMinLabel, setLocalMinLabel ] = useState( String( minTextLabel ) );
-	const [ localMaxLabel, setLocalMaxLabel ] = useState( String( maxTextLabel ) );
+	const [ localMinLabel, setLocalMinLabel ] = useState( String( minLabelFromContext ) );
+	const [ localMaxLabel, setLocalMaxLabel ] = useState( String( maxLabelFromContext ) );
+	const [ minLabelFocused, setMinLabelFocused ] = useState( false );
+	const [ maxLabelFocused, setMaxLabelFocused ] = useState( false );
 
 	// Derived variables
 	const isMinValid = Number( localMin ) <= Number( localMax );
@@ -73,6 +75,16 @@ export default function SliderInputEdit( props ) {
 			setLocalMax( String( maxFromContext ) );
 		}
 	}, [ minFromContext, maxFromContext, minFocused, maxFocused ] );
+
+	// Sync label text fields when context labels change, unless focused locally
+	useEffect( () => {
+		if ( ! minLabelFocused ) {
+			setLocalMinLabel( String( minLabelFromContext ?? '' ) );
+		}
+		if ( ! maxLabelFocused ) {
+			setLocalMaxLabel( String( maxLabelFromContext ?? '' ) );
+		}
+	}, [ minLabelFromContext, maxLabelFromContext, minLabelFocused, maxLabelFocused ] );
 
 	return (
 		<div { ...blockProps }>
@@ -150,7 +162,9 @@ export default function SliderInputEdit( props ) {
 					value={ localMinLabel }
 					placeholder={ __( 'Add label…', 'jetpack-forms' ) }
 					onChange={ e => setLocalMinLabel( e.target.value ) }
+					onFocus={ () => setMinLabelFocused( true ) }
 					onBlur={ () => {
+						setMinLabelFocused( false );
 						onChangeMinLabel?.( localMinLabel );
 					} }
 				/>
@@ -162,7 +176,9 @@ export default function SliderInputEdit( props ) {
 					value={ localMaxLabel }
 					placeholder={ __( 'Add label…', 'jetpack-forms' ) }
 					onChange={ e => setLocalMaxLabel( e.target.value ) }
+					onFocus={ () => setMaxLabelFocused( true ) }
 					onBlur={ () => {
+						setMaxLabelFocused( false );
 						onChangeMaxLabel?.( localMaxLabel );
 					} }
 				/>

--- a/projects/plugins/jetpack/changelog/fix-forms-slider-min-max-values
+++ b/projects/plugins/jetpack/changelog/fix-forms-slider-min-max-values
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: Fix slider min/max editing.


### PR DESCRIPTION
## Proposed changes:

When testing another PR, I found that when you edit the min / max labels for the slider in the block sidebar, the values do not update in the editor canvas. The inverse works fine - if you update in the editor canvas, the sidebar values will update. 

This PR fixes the syncing between those by ensuring we pass and update the min/max label value in block context correctly. 

<img width="1233" height="401" alt="min-max-labels-sidebar" src="https://github.com/user-attachments/assets/99802a07-da4f-4f08-932e-260ad74ace2d" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add a form to a page and add a slider field
* Update min/max labels in the settings sidebar and confirm they update in the canvas
* Updating min/max labels in the canvas and confirm they update in the settings sidebar