### PR TITLE
feat: Allow VideoPress admin-ajax authentication via application passwords

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-application-password-extras.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-application-password-extras.php
@@ -18,6 +18,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Jetpack_Application_Password_Extras {
 
 	/**
+	 * The AJAX action prefix for VideoPress actions.
+	 *
+	 * @var string
+	 */
+	private const VIDEOPRESS_AJAX_PREFIX = 'videopress-';
+
+	/**
 	 * Initialize the main hooks.
 	 */
 	public static function init() {
@@ -38,8 +45,8 @@ class Jetpack_Application_Password_Extras {
 			return true;
 		}
 
-		// Allow Application Password access to admin-ajax.php
-		if ( is_admin() && wp_doing_ajax() ) {
+		// Allow Application Password access to admin-ajax.php for VideoPress actions only
+		if ( is_admin() && wp_doing_ajax() && self::is_videopress_ajax_action() ) {
 			return true;
 		}
 
@@ -54,14 +61,30 @@ class Jetpack_Application_Password_Extras {
 	}
 
 	/**
+	 * Check if the current AJAX request is for a VideoPress action.
+	 *
+	 * @return bool True if the action starts with 'videopress-', false otherwise.
+	 */
+	private static function is_videopress_ajax_action() {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- We're only checking the action name, not processing the request.
+		$action = isset( $_REQUEST['action'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['action'] ) ) : '';
+
+		if ( empty( $action ) ) {
+			return false;
+		}
+
+		return str_starts_with( $action, self::VIDEOPRESS_AJAX_PREFIX );
+	}
+
+	/**
 	 * Get the abilities that this extension provides.
 	 *
 	 * @return array Array of abilities with their status.
 	 */
 	public static function get_abilities() {
 		return array(
-			'admin-ajax'    => true,
-			'post-previews' => true,
+			'admin-ajax-videopress' => true,
+			'post-previews'         => true,
 		);
 	}
 }

--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-application-password-extras.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-application-password-extras.php
@@ -34,6 +34,10 @@ class Jetpack_Application_Password_Extras {
 	 * @return bool The new value of the filter.
 	 */
 	public static function application_password_extras( $original_value ) {
+		if ( $original_value ) {
+			return true;
+		}
+
 		// Allow Application Password access to admin-ajax.php
 		if ( is_admin() && wp_doing_ajax() ) {
 			return true;

--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-application-password-extras.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-application-password-extras.php
@@ -40,8 +40,9 @@ class Jetpack_Application_Password_Extras {
 		}
 
 		// Allow access to post/page previews
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		if ( isset( $_GET['p'] ) || isset( $_GET['page_id'] ) ) {
+		$is_preview_request = isset( $_GET['preview'] ) && 'true' === $_GET['preview']; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$has_post_id        = isset( $_GET['p'] ) || isset( $_GET['page_id'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( $is_preview_request && $has_post_id ) {
 			return true;
 		}
 

--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-application-password-extras.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-application-password-extras.php
@@ -46,7 +46,7 @@ class Jetpack_Application_Password_Extras {
 		}
 
 		// Allow Application Password access to admin-ajax.php for VideoPress actions only
-		if ( is_admin() && wp_doing_ajax() && self::is_videopress_ajax_action() ) {
+		if ( is_admin() && wp_doing_ajax() && self::is_ajax_action_allowed() ) {
 			return true;
 		}
 
@@ -54,11 +54,11 @@ class Jetpack_Application_Password_Extras {
 	}
 
 	/**
-	 * Check if the current AJAX request is for a VideoPress action.
+	 * Check if the current AJAX action is allowed for Application Password authentication.
 	 *
-	 * @return bool True if the action starts with 'videopress-', false otherwise.
+	 * @return bool True if the action is allowed, false otherwise.
 	 */
-	private static function is_videopress_ajax_action() {
+	private static function is_ajax_action_allowed() {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- We're only checking the action name, not processing the request.
 		$action = isset( $_REQUEST['action'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['action'] ) ) : '';
 

--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-application-password-extras.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-application-password-extras.php
@@ -45,12 +45,7 @@ class Jetpack_Application_Password_Extras {
 			return true;
 		}
 
-		// Allow Application Password access to admin-ajax.php for VideoPress actions only
-		if ( is_admin() && wp_doing_ajax() && self::is_ajax_action_allowed() ) {
-			return true;
-		}
-
-		return $original_value;
+		return is_admin() && wp_doing_ajax() && self::is_ajax_action_allowed();
 	}
 
 	/**

--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-application-password-extras.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-application-password-extras.php
@@ -83,8 +83,8 @@ class Jetpack_Application_Password_Extras {
 	 */
 	public static function get_abilities() {
 		return array(
-			'admin-ajax-videopress' => true,
-			'post-previews'         => true,
+			'admin-ajax'    => true,
+			'post-previews' => true,
 		);
 	}
 }

--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-application-password-extras.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-application-password-extras.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Jetpack Application Password Extras
+ *
+ * Extends WordPress Application Passwords to work with additional abilities
+ * beyond the REST API.
+ *
+ * @package jetpack
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
+/**
+ * Extends Application Password functionality beyond the REST API.
+ */
+class Jetpack_Application_Password_Extras {
+
+	/**
+	 * Initialize the main hooks.
+	 */
+	public static function init() {
+		add_filter( 'application_password_is_api_request', array( __CLASS__, 'application_password_extras' ) );
+	}
+
+	/**
+	 * Allow Application Password access to additional abilities.
+	 *
+	 * NOTE: If expanding this to include more abilities, consider updating the
+	 * `get_abilities` method to include new abilities.
+	 *
+	 * @param bool $original_value The original value of the filter.
+	 * @return bool The new value of the filter.
+	 */
+	public static function application_password_extras( $original_value ) {
+		// Allow Application Password access to admin-ajax.php
+		if ( is_admin() && wp_doing_ajax() ) {
+			return true;
+		}
+
+		// Allow access to post/page previews
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( isset( $_GET['p'] ) || isset( $_GET['page_id'] ) ) {
+			return true;
+		}
+
+		return $original_value;
+	}
+
+	/**
+	 * Get the abilities that this extension provides.
+	 *
+	 * @return array Array of abilities with their status.
+	 */
+	public static function get_abilities() {
+		return array(
+			'admin-ajax'    => true,
+			'post-previews' => true,
+		);
+	}
+}

--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-application-password-extras.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-application-password-extras.php
@@ -50,13 +50,6 @@ class Jetpack_Application_Password_Extras {
 			return true;
 		}
 
-		// Allow access to post/page previews
-		$is_preview_request = isset( $_GET['preview'] ) && 'true' === $_GET['preview']; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$has_post_id        = isset( $_GET['p'] ) || isset( $_GET['page_id'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		if ( $is_preview_request && $has_post_id ) {
-			return true;
-		}
-
 		return $original_value;
 	}
 
@@ -83,8 +76,7 @@ class Jetpack_Application_Password_Extras {
 	 */
 	public static function get_abilities() {
 		return array(
-			'admin-ajax'    => true,
-			'post-previews' => true,
+			'admin-ajax' => true,
 		);
 	}
 }

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-application-password-extras.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-application-password-extras.php
@@ -49,18 +49,6 @@ class WPCOM_REST_API_V2_Endpoint_Application_Password_Extras extends WP_REST_Con
 				),
 			)
 		);
-
-		register_rest_route(
-			$this->namespace,
-			$this->rest_base . '/post-previews',
-			array(
-				array(
-					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => array( $this, 'get_abilities' ),
-					'permission_callback' => array( $this, 'get_item_permissions_check' ),
-				),
-			)
-		);
 	}
 
 	/**

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-application-password-extras.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-application-password-extras.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * REST API endpoint for application password extras abilities.
+ *
+ * @package automattic/jetpack
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
+/**
+ * Class WPCOM_REST_API_V2_Endpoint_Application_Password_Extras
+ */
+class WPCOM_REST_API_V2_Endpoint_Application_Password_Extras extends WP_REST_Controller {
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		$this->namespace = 'wpcom/v2';
+		$this->rest_base = 'application-password-extras';
+		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+	}
+
+	/**
+	 * Register routes.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			$this->rest_base . '/abilities',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_abilities' ),
+					'permission_callback' => array( $this, 'get_item_permissions_check' ),
+				),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
+			$this->rest_base . '/admin-ajax',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_abilities' ),
+					'permission_callback' => array( $this, 'get_item_permissions_check' ),
+				),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
+			$this->rest_base . '/post-previews',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_abilities' ),
+					'permission_callback' => array( $this, 'get_item_permissions_check' ),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Checks if a given request has access to application password extras.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return true|WP_Error True if the request has read access, WP_Error object otherwise.
+	 */
+	public function get_item_permissions_check( $request ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter, VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		if ( ! is_user_logged_in() ) {
+			return new WP_Error(
+				'rest_forbidden',
+				__( 'Sorry, you must be logged in to access this endpoint.', 'jetpack' ),
+				array( 'status' => rest_authorization_required_code() )
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Retrieves the application password extras abilities.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
+	public function get_abilities( $request ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter, VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		if ( ! class_exists( 'Jetpack_Application_Password_Extras' ) ) {
+			return new WP_Error(
+				'rest_application_password_extras_unavailable',
+				__( 'Application password extras functionality is not available.', 'jetpack' ),
+				array( 'status' => 503 )
+			);
+		}
+
+		return rest_ensure_response( Jetpack_Application_Password_Extras::get_abilities() );
+	}
+}
+
+wpcom_rest_api_v2_load_plugin( 'WPCOM_REST_API_V2_Endpoint_Application_Password_Extras' );

--- a/projects/plugins/jetpack/changelog/feat-expand-application-passwords-abilities
+++ b/projects/plugins/jetpack/changelog/feat-expand-application-passwords-abilities
@@ -1,4 +1,4 @@
 Significance: minor
 Type: other
 
-Application passwords: allow authenticating `admin-ajax` and post preview requests via application passwords.
+Application Passwords: allow authenticating post preview requests and VideoPress AJAX actions via application passwords.

--- a/projects/plugins/jetpack/changelog/feat-expand-application-passwords-abilities
+++ b/projects/plugins/jetpack/changelog/feat-expand-application-passwords-abilities
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Application passwords: allow authenticating `admin-ajax` and post preview requests via application passwords.

--- a/projects/plugins/jetpack/changelog/feat-expand-application-passwords-abilities
+++ b/projects/plugins/jetpack/changelog/feat-expand-application-passwords-abilities
@@ -1,4 +1,4 @@
 Significance: minor
 Type: other
 
-Application Passwords: allow authenticating post preview requests and VideoPress AJAX actions via application passwords.
+Application Passwords: allow authenticating VideoPress AJAX actions via application passwords.

--- a/projects/plugins/jetpack/load-jetpack.php
+++ b/projects/plugins/jetpack/load-jetpack.php
@@ -56,6 +56,9 @@ Jetpack_XMLRPC_Methods::init();
 require_once JETPACK__PLUGIN_DIR . 'class-jetpack-connection-status.php';
 Jetpack_Connection_Status::init();
 
+require_once JETPACK__PLUGIN_DIR . '_inc/lib/class-jetpack-application-password-extras.php';
+Jetpack_Application_Password_Extras::init();
+
 require_once JETPACK__PLUGIN_DIR . '_inc/lib/class-jetpack-recommendations.php';
 
 if ( is_admin() ) {

--- a/projects/plugins/jetpack/tests/php/_inc/lib/Jetpack_Application_Password_Extras_Test.php
+++ b/projects/plugins/jetpack/tests/php/_inc/lib/Jetpack_Application_Password_Extras_Test.php
@@ -49,6 +49,7 @@ class Jetpack_Application_Password_Extras_Test extends Jetpack_REST_TestCase {
 		parent::tear_down();
 		unset( $_GET['p'] );
 		unset( $_GET['page_id'] );
+		unset( $_GET['preview'] );
 		unset( $GLOBALS['wp_current_filter'] );
 	}
 
@@ -103,7 +104,8 @@ class Jetpack_Application_Password_Extras_Test extends Jetpack_REST_TestCase {
 	 * Test that post preview requests are allowed.
 	 */
 	public function test_post_preview_request_allowed() {
-		$_GET['p'] = '123';
+		$_GET['p']       = '123';
+		$_GET['preview'] = 'true';
 
 		$result = Jetpack_Application_Password_Extras::application_password_extras( false );
 
@@ -115,6 +117,7 @@ class Jetpack_Application_Password_Extras_Test extends Jetpack_REST_TestCase {
 	 */
 	public function test_page_preview_request_allowed() {
 		$_GET['page_id'] = '456';
+		$_GET['preview'] = 'true';
 
 		$result = Jetpack_Application_Password_Extras::application_password_extras( false );
 

--- a/projects/plugins/jetpack/tests/php/_inc/lib/Jetpack_Application_Password_Extras_Test.php
+++ b/projects/plugins/jetpack/tests/php/_inc/lib/Jetpack_Application_Password_Extras_Test.php
@@ -237,8 +237,8 @@ class Jetpack_Application_Password_Extras_Test extends Jetpack_REST_TestCase {
 		$abilities = Jetpack_Application_Password_Extras::get_abilities();
 
 		$expected_abilities = array(
-			'admin-ajax-videopress' => true,
-			'post-previews'         => true,
+			'admin-ajax'    => true,
+			'post-previews' => true,
 		);
 
 		$this->assertEquals( $expected_abilities, $abilities, 'get_abilities should return all expected abilities' );

--- a/projects/plugins/jetpack/tests/php/_inc/lib/Jetpack_Application_Password_Extras_Test.php
+++ b/projects/plugins/jetpack/tests/php/_inc/lib/Jetpack_Application_Password_Extras_Test.php
@@ -6,7 +6,6 @@
  */
 
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\DataProvider;
 
 require_once JETPACK__PLUGIN_DIR . '/tests/php/lib/Jetpack_REST_TestCase.php';
 require_once JETPACK__PLUGIN_DIR . '/_inc/lib/class-jetpack-application-password-extras.php';
@@ -86,74 +85,33 @@ class Jetpack_Application_Password_Extras_Test extends Jetpack_REST_TestCase {
 	}
 
 	/**
-	 * Test that VideoPress AJAX actions are allowed.
-	 *
-	 * @param string $action The VideoPress action name.
-	 * @dataProvider videopress_action_provider
+	 * Test that a VideoPress AJAX action is allowed.
 	 */
-	#[DataProvider( 'videopress_action_provider' )]
-	public function test_videopress_ajax_action_allowed( $action ) {
+	public function test_videopress_ajax_action_allowed() {
 		set_current_screen( 'dashboard' );
 		add_filter( 'wp_doing_ajax', '__return_true' );
-		$_REQUEST['action'] = $action;
+		$_REQUEST['action'] = 'videopress-get-upload-token';
 
 		$result = Jetpack_Application_Password_Extras::application_password_extras( false );
 
 		remove_filter( 'wp_doing_ajax', '__return_true' );
 
-		$this->assertTrue( $result, "VideoPress action '$action' should be allowed" );
+		$this->assertTrue( $result, 'VideoPress action should be allowed' );
 	}
 
 	/**
-	 * Data provider for VideoPress action tests.
-	 *
-	 * @return array
+	 * Test that a non-VideoPress AJAX action is NOT allowed.
 	 */
-	public static function videopress_action_provider() {
-		return array(
-			'get-upload-token'          => array( 'videopress-get-upload-token' ),
-			'get-upload-jwt'            => array( 'videopress-get-upload-jwt' ),
-			'get-playback-jwt'          => array( 'videopress-get-playback-jwt' ),
-			'update-transcoding-status' => array( 'videopress-update-transcoding-status' ),
-			'future-videopress-action'  => array( 'videopress-some-future-action' ),
-		);
-	}
-
-	/**
-	 * Test that non-VideoPress AJAX actions are NOT allowed.
-	 *
-	 * @param string $action The non-VideoPress action name.
-	 * @dataProvider non_videopress_action_provider
-	 */
-	#[DataProvider( 'non_videopress_action_provider' )]
-	public function test_non_videopress_ajax_action_not_allowed( $action ) {
+	public function test_non_videopress_ajax_action_not_allowed() {
 		set_current_screen( 'dashboard' );
 		add_filter( 'wp_doing_ajax', '__return_true' );
-		$_REQUEST['action'] = $action;
+		$_REQUEST['action'] = 'heartbeat';
 
 		$result = Jetpack_Application_Password_Extras::application_password_extras( false );
 
 		remove_filter( 'wp_doing_ajax', '__return_true' );
 
-		$this->assertFalse( $result, "Non-VideoPress action '$action' should NOT be allowed" );
-	}
-
-	/**
-	 * Data provider for non-VideoPress action tests.
-	 *
-	 * @return array
-	 */
-	public static function non_videopress_action_provider() {
-		return array(
-			'heartbeat'            => array( 'heartbeat' ),
-			'wp_ajax_send_link'    => array( 'wp-link-ajax' ),
-			'inline_save'          => array( 'inline-save' ),
-			'get_attachment'       => array( 'get-attachment' ),
-			'query_attachments'    => array( 'query-attachments' ),
-			'save_post'            => array( 'save-post' ),
-			'videopress_lookalike' => array( 'not-videopress-action' ),
-			'prefix_videopress'    => array( 'my-videopress-action' ),
-		);
+		$this->assertFalse( $result, 'Non-VideoPress action should NOT be allowed' );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/_inc/lib/Jetpack_Application_Password_Extras_Test.php
+++ b/projects/plugins/jetpack/tests/php/_inc/lib/Jetpack_Application_Password_Extras_Test.php
@@ -6,6 +6,7 @@
  */
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 require_once JETPACK__PLUGIN_DIR . '/tests/php/lib/Jetpack_REST_TestCase.php';
 require_once JETPACK__PLUGIN_DIR . '/_inc/lib/class-jetpack-application-password-extras.php';
@@ -50,6 +51,7 @@ class Jetpack_Application_Password_Extras_Test extends Jetpack_REST_TestCase {
 		unset( $_GET['p'] );
 		unset( $_GET['page_id'] );
 		unset( $_GET['preview'] );
+		unset( $_REQUEST['action'] );
 		unset( $GLOBALS['wp_current_filter'] );
 	}
 
@@ -87,17 +89,104 @@ class Jetpack_Application_Password_Extras_Test extends Jetpack_REST_TestCase {
 	}
 
 	/**
-	 * Test that admin-ajax requests are allowed.
+	 * Test that VideoPress AJAX actions are allowed.
+	 *
+	 * @param string $action The VideoPress action name.
+	 * @dataProvider videopress_action_provider
 	 */
-	public function test_admin_ajax_request_allowed() {
+	#[DataProvider( 'videopress_action_provider' )]
+	public function test_videopress_ajax_action_allowed( $action ) {
 		set_current_screen( 'dashboard' );
 		add_filter( 'wp_doing_ajax', '__return_true' );
+		$_REQUEST['action'] = $action;
 
 		$result = Jetpack_Application_Password_Extras::application_password_extras( false );
 
 		remove_filter( 'wp_doing_ajax', '__return_true' );
 
-		$this->assertTrue( $result, 'Result should be true' );
+		$this->assertTrue( $result, "VideoPress action '$action' should be allowed" );
+	}
+
+	/**
+	 * Data provider for VideoPress action tests.
+	 *
+	 * @return array
+	 */
+	public static function videopress_action_provider() {
+		return array(
+			'get-upload-token'          => array( 'videopress-get-upload-token' ),
+			'get-upload-jwt'            => array( 'videopress-get-upload-jwt' ),
+			'get-playback-jwt'          => array( 'videopress-get-playback-jwt' ),
+			'update-transcoding-status' => array( 'videopress-update-transcoding-status' ),
+			'future-videopress-action'  => array( 'videopress-some-future-action' ),
+		);
+	}
+
+	/**
+	 * Test that non-VideoPress AJAX actions are NOT allowed.
+	 *
+	 * @param string $action The non-VideoPress action name.
+	 * @dataProvider non_videopress_action_provider
+	 */
+	#[DataProvider( 'non_videopress_action_provider' )]
+	public function test_non_videopress_ajax_action_not_allowed( $action ) {
+		set_current_screen( 'dashboard' );
+		add_filter( 'wp_doing_ajax', '__return_true' );
+		$_REQUEST['action'] = $action;
+
+		$result = Jetpack_Application_Password_Extras::application_password_extras( false );
+
+		remove_filter( 'wp_doing_ajax', '__return_true' );
+
+		$this->assertFalse( $result, "Non-VideoPress action '$action' should NOT be allowed" );
+	}
+
+	/**
+	 * Data provider for non-VideoPress action tests.
+	 *
+	 * @return array
+	 */
+	public static function non_videopress_action_provider() {
+		return array(
+			'heartbeat'            => array( 'heartbeat' ),
+			'wp_ajax_send_link'    => array( 'wp-link-ajax' ),
+			'inline_save'          => array( 'inline-save' ),
+			'get_attachment'       => array( 'get-attachment' ),
+			'query_attachments'    => array( 'query-attachments' ),
+			'save_post'            => array( 'save-post' ),
+			'videopress_lookalike' => array( 'not-videopress-action' ),
+			'prefix_videopress'    => array( 'my-videopress-action' ),
+		);
+	}
+
+	/**
+	 * Test that AJAX request with empty action is NOT allowed.
+	 */
+	public function test_ajax_request_with_empty_action_not_allowed() {
+		set_current_screen( 'dashboard' );
+		add_filter( 'wp_doing_ajax', '__return_true' );
+		$_REQUEST['action'] = '';
+
+		$result = Jetpack_Application_Password_Extras::application_password_extras( false );
+
+		remove_filter( 'wp_doing_ajax', '__return_true' );
+
+		$this->assertFalse( $result, 'AJAX request with empty action should NOT be allowed' );
+	}
+
+	/**
+	 * Test that AJAX request with no action set is NOT allowed.
+	 */
+	public function test_ajax_request_with_no_action_not_allowed() {
+		set_current_screen( 'dashboard' );
+		add_filter( 'wp_doing_ajax', '__return_true' );
+		unset( $_REQUEST['action'] );
+
+		$result = Jetpack_Application_Password_Extras::application_password_extras( false );
+
+		remove_filter( 'wp_doing_ajax', '__return_true' );
+
+		$this->assertFalse( $result, 'AJAX request with no action should NOT be allowed' );
 	}
 
 	/**
@@ -130,7 +219,9 @@ class Jetpack_Application_Password_Extras_Test extends Jetpack_REST_TestCase {
 	public function test_multiple_conditions_prioritize_first_match() {
 		set_current_screen( 'dashboard' );
 		add_filter( 'wp_doing_ajax', '__return_true' );
-		$_GET['p'] = '123';
+		$_REQUEST['action'] = 'videopress-get-upload-token';
+		$_GET['p']          = '123';
+		$_GET['preview']    = 'true';
 
 		$result = Jetpack_Application_Password_Extras::application_password_extras( false );
 
@@ -146,8 +237,8 @@ class Jetpack_Application_Password_Extras_Test extends Jetpack_REST_TestCase {
 		$abilities = Jetpack_Application_Password_Extras::get_abilities();
 
 		$expected_abilities = array(
-			'admin-ajax'    => true,
-			'post-previews' => true,
+			'admin-ajax-videopress' => true,
+			'post-previews'         => true,
 		);
 
 		$this->assertEquals( $expected_abilities, $abilities, 'get_abilities should return all expected abilities' );

--- a/projects/plugins/jetpack/tests/php/_inc/lib/Jetpack_Application_Password_Extras_Test.php
+++ b/projects/plugins/jetpack/tests/php/_inc/lib/Jetpack_Application_Password_Extras_Test.php
@@ -48,9 +48,6 @@ class Jetpack_Application_Password_Extras_Test extends Jetpack_REST_TestCase {
 	 */
 	public function tear_down() {
 		parent::tear_down();
-		unset( $_GET['p'] );
-		unset( $_GET['page_id'] );
-		unset( $_GET['preview'] );
 		unset( $_REQUEST['action'] );
 		unset( $GLOBALS['wp_current_filter'] );
 	}
@@ -190,55 +187,13 @@ class Jetpack_Application_Password_Extras_Test extends Jetpack_REST_TestCase {
 	}
 
 	/**
-	 * Test that post preview requests are allowed.
-	 */
-	public function test_post_preview_request_allowed() {
-		$_GET['p']       = '123';
-		$_GET['preview'] = 'true';
-
-		$result = Jetpack_Application_Password_Extras::application_password_extras( false );
-
-		$this->assertTrue( $result, 'Post preview requests should be allowed' );
-	}
-
-	/**
-	 * Test that page preview requests are allowed.
-	 */
-	public function test_page_preview_request_allowed() {
-		$_GET['page_id'] = '456';
-		$_GET['preview'] = 'true';
-
-		$result = Jetpack_Application_Password_Extras::application_password_extras( false );
-
-		$this->assertTrue( $result, 'Page preview requests should be allowed' );
-	}
-
-	/**
-	 * Test multiple conditions at once.
-	 */
-	public function test_multiple_conditions_prioritize_first_match() {
-		set_current_screen( 'dashboard' );
-		add_filter( 'wp_doing_ajax', '__return_true' );
-		$_REQUEST['action'] = 'videopress-get-upload-token';
-		$_GET['p']          = '123';
-		$_GET['preview']    = 'true';
-
-		$result = Jetpack_Application_Password_Extras::application_password_extras( false );
-
-		remove_filter( 'wp_doing_ajax', '__return_true' );
-
-		$this->assertTrue( $result, 'Should return true when any condition matches' );
-	}
-
-	/**
 	 * Test that get_abilities returns all expected abilities.
 	 */
 	public function test_get_abilities_complete() {
 		$abilities = Jetpack_Application_Password_Extras::get_abilities();
 
 		$expected_abilities = array(
-			'admin-ajax'    => true,
-			'post-previews' => true,
+			'admin-ajax' => true,
 		);
 
 		$this->assertEquals( $expected_abilities, $abilities, 'get_abilities should return all expected abilities' );

--- a/projects/plugins/jetpack/tests/php/_inc/lib/Jetpack_Application_Password_Extras_Test.php
+++ b/projects/plugins/jetpack/tests/php/_inc/lib/Jetpack_Application_Password_Extras_Test.php
@@ -1,0 +1,152 @@
+<?php
+/**
+ * Tests for Jetpack_Application_Password_Extras class
+ *
+ * @package automattic/jetpack
+ */
+
+use PHPUnit\Framework\Attributes\CoversClass;
+
+require_once JETPACK__PLUGIN_DIR . '/tests/php/lib/Jetpack_REST_TestCase.php';
+require_once JETPACK__PLUGIN_DIR . '/_inc/lib/class-jetpack-application-password-extras.php';
+
+/**
+ * Class Jetpack_Application_Password_Extras_Test
+ *
+ * @covers \Jetpack_Application_Password_Extras
+ */
+#[CoversClass( Jetpack_Application_Password_Extras::class )]
+class Jetpack_Application_Password_Extras_Test extends Jetpack_REST_TestCase {
+
+	/**
+	 * Mock user ID.
+	 *
+	 * @var int
+	 */
+	private static $user_id = 0;
+
+	/**
+	 * Create shared database fixtures.
+	 *
+	 * @param WP_UnitTest_Factory $factory Fixture factory.
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		static::$user_id = $factory->user->create( array( 'role' => 'administrator' ) );
+	}
+
+	/**
+	 * Setup the environment for a test.
+	 */
+	public function set_up() {
+		parent::set_up();
+		wp_set_current_user( static::$user_id );
+	}
+
+	/**
+	 * Tear down the environment after a test.
+	 */
+	public function tear_down() {
+		parent::tear_down();
+		unset( $_GET['p'] );
+		unset( $_GET['page_id'] );
+		unset( $GLOBALS['wp_current_filter'] );
+	}
+
+	/**
+	 * Test that init method registers the hook correctly.
+	 */
+	public function test_init_registers_hook() {
+		remove_all_filters( 'application_password_is_api_request' );
+		Jetpack_Application_Password_Extras::init();
+
+		$this->assertNotFalse(
+			has_filter( 'application_password_is_api_request', array( 'Jetpack_Application_Password_Extras', 'application_password_extras' ) ),
+			'Hook should be registered'
+		);
+	}
+
+	/**
+	 * Test that non-matching requests preserve original false value.
+	 */
+	public function test_non_matching_request_preserves_original_false_value() {
+		set_current_screen( 'dashboard' );
+
+		$result = Jetpack_Application_Password_Extras::application_password_extras( false );
+		$this->assertFalse( $result, 'Should preserve false when not in matching context' );
+	}
+
+	/**
+	 * Test that non-matching requests preserve original true value.
+	 */
+	public function test_non_matching_request_preserves_original_true_value() {
+		set_current_screen( 'dashboard' );
+
+		$result = Jetpack_Application_Password_Extras::application_password_extras( true );
+		$this->assertTrue( $result, 'Should preserve true when not in matching context' );
+	}
+
+	/**
+	 * Test that admin-ajax requests are allowed.
+	 */
+	public function test_admin_ajax_request_allowed() {
+		set_current_screen( 'dashboard' );
+		add_filter( 'wp_doing_ajax', '__return_true' );
+
+		$result = Jetpack_Application_Password_Extras::application_password_extras( false );
+
+		remove_filter( 'wp_doing_ajax', '__return_true' );
+
+		$this->assertTrue( $result, 'Result should be true' );
+	}
+
+	/**
+	 * Test that post preview requests are allowed.
+	 */
+	public function test_post_preview_request_allowed() {
+		$_GET['p'] = '123';
+
+		$result = Jetpack_Application_Password_Extras::application_password_extras( false );
+
+		$this->assertTrue( $result, 'Post preview requests should be allowed' );
+	}
+
+	/**
+	 * Test that page preview requests are allowed.
+	 */
+	public function test_page_preview_request_allowed() {
+		$_GET['page_id'] = '456';
+
+		$result = Jetpack_Application_Password_Extras::application_password_extras( false );
+
+		$this->assertTrue( $result, 'Page preview requests should be allowed' );
+	}
+
+	/**
+	 * Test multiple conditions at once.
+	 */
+	public function test_multiple_conditions_prioritize_first_match() {
+		set_current_screen( 'dashboard' );
+		add_filter( 'wp_doing_ajax', '__return_true' );
+		$_GET['p'] = '123';
+
+		$result = Jetpack_Application_Password_Extras::application_password_extras( false );
+
+		remove_filter( 'wp_doing_ajax', '__return_true' );
+
+		$this->assertTrue( $result, 'Should return true when any condition matches' );
+	}
+
+	/**
+	 * Test that get_abilities returns all expected abilities.
+	 */
+	public function test_get_abilities_complete() {
+		$abilities = Jetpack_Application_Password_Extras::get_abilities();
+
+		$expected_abilities = array(
+			'admin-ajax'    => true,
+			'post-previews' => true,
+		);
+
+		$this->assertEquals( $expected_abilities, $abilities, 'get_abilities should return all expected abilities' );
+	}
+}

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Application_Password_Extras_Test.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Application_Password_Extras_Test.php
@@ -1,0 +1,217 @@
+<?php
+/**
+ * Tests for /wpcom/v2/application-password-extras endpoints.
+ *
+ * @package automattic/jetpack
+ */
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use WpOrg\Requests\Requests;
+
+require_once dirname( __DIR__, 2 ) . '/lib/Jetpack_REST_TestCase.php';
+require_once JETPACK__PLUGIN_DIR . '/_inc/lib/class-jetpack-application-password-extras.php';
+
+/**
+ * Class WPCOM_REST_API_V2_Endpoint_Application_Password_Extras_Test
+ *
+ * @covers \WPCOM_REST_API_V2_Endpoint_Application_Password_Extras
+ */
+#[CoversClass( WPCOM_REST_API_V2_Endpoint_Application_Password_Extras::class )]
+class WPCOM_REST_API_V2_Endpoint_Application_Password_Extras_Test extends Jetpack_REST_TestCase {
+
+	/**
+	 * Mock user ID.
+	 *
+	 * @var int
+	 */
+	private static $user_id = 0;
+
+	/**
+	 * Mock editor user ID.
+	 *
+	 * @var int
+	 */
+	private static $editor_id = 0;
+
+	/**
+	 * Create shared database fixtures.
+	 *
+	 * @param WP_UnitTest_Factory $factory Fixture factory.
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		static::$user_id   = $factory->user->create( array( 'role' => 'administrator' ) );
+		static::$editor_id = $factory->user->create( array( 'role' => 'editor' ) );
+	}
+
+	/**
+	 * Setup the environment for a test.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		// Initialize the class to ensure it's available
+		Jetpack_Application_Password_Extras::init();
+
+		wp_set_current_user( static::$user_id );
+	}
+
+	/**
+	 * Test that routes are registered correctly.
+	 */
+	public function test_routes_registered() {
+		$routes = rest_get_server()->get_routes();
+
+		$this->assertArrayHasKey( '/wpcom/v2/application-password-extras/abilities', $routes );
+		$this->assertArrayHasKey( '/wpcom/v2/application-password-extras/admin-ajax', $routes );
+		$this->assertArrayHasKey( '/wpcom/v2/application-password-extras/post-previews', $routes );
+	}
+
+	/**
+	 * Test permission check for unauthenticated users.
+	 */
+	public function test_unauthenticated_user_cannot_access_abilities() {
+		wp_set_current_user( 0 );
+
+		$request  = new WP_REST_Request( Requests::GET, '/wpcom/v2/application-password-extras/abilities' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertErrorResponse( 'rest_forbidden', $response, 401 );
+		$data = $response->get_data();
+		$this->assertEquals( 'Sorry, you must be logged in to access this endpoint.', $data['message'] );
+	}
+
+	/**
+	 * Test permission check for authenticated users.
+	 */
+	public function test_authenticated_user_can_access_abilities() {
+		wp_set_current_user( static::$user_id );
+
+		$request  = new WP_REST_Request( Requests::GET, '/wpcom/v2/application-password-extras/abilities' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	/**
+	 * Test that get_abilities endpoint returns correct data.
+	 */
+	public function test_get_abilities_endpoint_returns_correct_data() {
+		wp_set_current_user( static::$user_id );
+
+		$request  = new WP_REST_Request( Requests::GET, '/wpcom/v2/application-password-extras/abilities' );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertIsArray( $data );
+		$this->assertArrayHasKey( 'admin-ajax', $data );
+		$this->assertArrayHasKey( 'post-previews', $data );
+		$this->assertTrue( $data['admin-ajax'] );
+		$this->assertTrue( $data['post-previews'] );
+	}
+
+	/**
+	 * Data provider for endpoint tests
+	 *
+	 * @return array
+	 */
+	public static function endpoint_provider() {
+		return array(
+			'abilities endpoint'     => array( '/wpcom/v2/application-password-extras/abilities' ),
+			'admin-ajax endpoint'    => array( '/wpcom/v2/application-password-extras/admin-ajax' ),
+			'post-previews endpoint' => array( '/wpcom/v2/application-password-extras/post-previews' ),
+		);
+	}
+
+	/**
+	 * Test that all endpoints work correctly for authenticated users.
+	 *
+	 * @dataProvider endpoint_provider
+	 * @param string $endpoint The endpoint to test.
+	 */
+	#[DataProvider( 'endpoint_provider' )]
+	public function test_endpoints_work_for_authenticated_users( $endpoint ) {
+		wp_set_current_user( static::$user_id );
+
+		$request  = new WP_REST_Request( Requests::GET, $endpoint );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertIsArray( $data );
+		$this->assertArrayHasKey( 'admin-ajax', $data );
+		$this->assertArrayHasKey( 'post-previews', $data );
+	}
+
+	/**
+	 * Test that all endpoints require authentication.
+	 *
+	 * @dataProvider endpoint_provider
+	 * @param string $endpoint The endpoint to test.
+	 */
+	#[DataProvider( 'endpoint_provider' )]
+	public function test_endpoints_require_authentication( $endpoint ) {
+		wp_set_current_user( 0 );
+
+		$request  = new WP_REST_Request( Requests::GET, $endpoint );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertErrorResponse( 'rest_forbidden', $response, 401 );
+	}
+
+	/**
+	 * Test that editor users can access abilities.
+	 */
+	public function test_editor_can_access_abilities() {
+		wp_set_current_user( static::$editor_id );
+
+		$request  = new WP_REST_Request( Requests::GET, '/wpcom/v2/application-password-extras/abilities' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$data = $response->get_data();
+		$this->assertIsArray( $data );
+	}
+
+	/**
+	 * Test that only GET requests are allowed.
+	 */
+	public function test_only_get_requests_allowed() {
+		wp_set_current_user( static::$user_id );
+
+		$disallowed_methods = array(
+			Requests::POST,
+			Requests::PUT,
+			Requests::DELETE,
+			Requests::PATCH,
+		);
+
+		foreach ( $disallowed_methods as $method ) {
+			$request  = new WP_REST_Request( $method, '/wpcom/v2/application-password-extras/abilities' );
+			$response = $this->server->dispatch( $request );
+
+			// Routes that don't support a method typically return 404 (not found) in WordPress REST API
+			$this->assertContains(
+				$response->get_status(),
+				array( 404, 405 ),
+				"Method $method should not be allowed (status should be 404 or 405)"
+			);
+		}
+	}
+
+	/**
+	 * Test response headers are set correctly.
+	 */
+	public function test_response_headers() {
+		wp_set_current_user( static::$user_id );
+
+		$request  = new WP_REST_Request( Requests::GET, '/wpcom/v2/application-password-extras/abilities' );
+		$response = $this->server->dispatch( $request );
+
+		$headers = $response->get_headers();
+
+		// Standard REST API headers should be present
+		$this->assertIsArray( $headers );
+	}
+}

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Application_Password_Extras_Test.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Application_Password_Extras_Test.php
@@ -28,20 +28,12 @@ class WPCOM_REST_API_V2_Endpoint_Application_Password_Extras_Test extends Jetpac
 	private static $user_id = 0;
 
 	/**
-	 * Mock editor user ID.
-	 *
-	 * @var int
-	 */
-	private static $editor_id = 0;
-
-	/**
 	 * Create shared database fixtures.
 	 *
 	 * @param WP_UnitTest_Factory $factory Fixture factory.
 	 */
 	public static function wpSetUpBeforeClass( $factory ) {
-		static::$user_id   = $factory->user->create( array( 'role' => 'administrator' ) );
-		static::$editor_id = $factory->user->create( array( 'role' => 'editor' ) );
+		static::$user_id = $factory->user->create( array( 'role' => 'administrator' ) );
 	}
 
 	/**
@@ -159,7 +151,8 @@ class WPCOM_REST_API_V2_Endpoint_Application_Password_Extras_Test extends Jetpac
 	 * Test that editor users can access abilities.
 	 */
 	public function test_editor_can_access_abilities() {
-		wp_set_current_user( static::$editor_id );
+		$editor_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+		wp_set_current_user( $editor_id );
 
 		$request  = new WP_REST_Request( Requests::GET, '/wpcom/v2/application-password-extras/abilities' );
 		$response = $this->server->dispatch( $request );

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Application_Password_Extras_Test.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Application_Password_Extras_Test.php
@@ -105,9 +105,9 @@ class WPCOM_REST_API_V2_Endpoint_Application_Password_Extras_Test extends Jetpac
 
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertIsArray( $data );
-		$this->assertArrayHasKey( 'admin-ajax-videopress', $data );
+		$this->assertArrayHasKey( 'admin-ajax', $data );
 		$this->assertArrayHasKey( 'post-previews', $data );
-		$this->assertTrue( $data['admin-ajax-videopress'] );
+		$this->assertTrue( $data['admin-ajax'] );
 		$this->assertTrue( $data['post-previews'] );
 	}
 
@@ -140,7 +140,7 @@ class WPCOM_REST_API_V2_Endpoint_Application_Password_Extras_Test extends Jetpac
 
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertIsArray( $data );
-		$this->assertArrayHasKey( 'admin-ajax-videopress', $data );
+		$this->assertArrayHasKey( 'admin-ajax', $data );
 		$this->assertArrayHasKey( 'post-previews', $data );
 	}
 

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Application_Password_Extras_Test.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Application_Password_Extras_Test.php
@@ -105,9 +105,9 @@ class WPCOM_REST_API_V2_Endpoint_Application_Password_Extras_Test extends Jetpac
 
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertIsArray( $data );
-		$this->assertArrayHasKey( 'admin-ajax', $data );
+		$this->assertArrayHasKey( 'admin-ajax-videopress', $data );
 		$this->assertArrayHasKey( 'post-previews', $data );
-		$this->assertTrue( $data['admin-ajax'] );
+		$this->assertTrue( $data['admin-ajax-videopress'] );
 		$this->assertTrue( $data['post-previews'] );
 	}
 
@@ -140,7 +140,7 @@ class WPCOM_REST_API_V2_Endpoint_Application_Password_Extras_Test extends Jetpac
 
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertIsArray( $data );
-		$this->assertArrayHasKey( 'admin-ajax', $data );
+		$this->assertArrayHasKey( 'admin-ajax-videopress', $data );
 		$this->assertArrayHasKey( 'post-previews', $data );
 	}
 

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Application_Password_Extras_Test.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Application_Password_Extras_Test.php
@@ -64,7 +64,6 @@ class WPCOM_REST_API_V2_Endpoint_Application_Password_Extras_Test extends Jetpac
 
 		$this->assertArrayHasKey( '/wpcom/v2/application-password-extras/abilities', $routes );
 		$this->assertArrayHasKey( '/wpcom/v2/application-password-extras/admin-ajax', $routes );
-		$this->assertArrayHasKey( '/wpcom/v2/application-password-extras/post-previews', $routes );
 	}
 
 	/**
@@ -106,9 +105,7 @@ class WPCOM_REST_API_V2_Endpoint_Application_Password_Extras_Test extends Jetpac
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertIsArray( $data );
 		$this->assertArrayHasKey( 'admin-ajax', $data );
-		$this->assertArrayHasKey( 'post-previews', $data );
 		$this->assertTrue( $data['admin-ajax'] );
-		$this->assertTrue( $data['post-previews'] );
 	}
 
 	/**
@@ -118,9 +115,8 @@ class WPCOM_REST_API_V2_Endpoint_Application_Password_Extras_Test extends Jetpac
 	 */
 	public static function endpoint_provider() {
 		return array(
-			'abilities endpoint'     => array( '/wpcom/v2/application-password-extras/abilities' ),
-			'admin-ajax endpoint'    => array( '/wpcom/v2/application-password-extras/admin-ajax' ),
-			'post-previews endpoint' => array( '/wpcom/v2/application-password-extras/post-previews' ),
+			'abilities endpoint'  => array( '/wpcom/v2/application-password-extras/abilities' ),
+			'admin-ajax endpoint' => array( '/wpcom/v2/application-password-extras/admin-ajax' ),
 		);
 	}
 
@@ -141,7 +137,6 @@ class WPCOM_REST_API_V2_Endpoint_Application_Password_Extras_Test extends Jetpac
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertIsArray( $data );
 		$this->assertArrayHasKey( 'admin-ajax', $data );
-		$this->assertArrayHasKey( 'post-previews', $data );
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Allow authenticating `admin-ajax` requests with application passwords. This enables cookie-less clients—e.g, the iOS and Android mobile apps—to successfully authenticate VideoPress AJAX requests.

Ref CMM-713.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Leverage the `application_password_is_api_request` filter to conditionally extend application password authentication for VideoPress `admin-ajax` actions.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
- pbArwn-7AD-p2
- p5TWut-1qz-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

> [!Important]
> Apply these Jetpack changes to your site (see [comment](https://github.com/Automattic/jetpack/pull/45220#issuecomment-3304356979)) before testing.  

> [!Important]
> Replace the placeholder values (wrapped with `<some_value>`) with valid information. 

### 1. Authenticate VideoPress `admin-ajax` requests with application passwords
1. Request a VideoPress `admin-ajax`action:
    ```bash
    curl -i 'https://<site_domain>/wp-admin/admin-ajax.php?action=videopress-get-upload-jwt'
    ```
1. **Verify** the 400 response without an authentication token.
1. Request a VideoPress `admin-ajax`action:
    ```bash
    curl -i 'https://<site_domain>/wp-admin/admin-ajax.php?action=videopress-get-upload-jwt' \
      -H "Authorization: Basic $(echo -n '<username>:<application_password>' | base64)"
    ```
1. **Verify** the 200 response with an authentication token for VideoPress actions.
1. Request a non-VideoPress `admin-ajax`action:
    ```bash
    curl -i 'https://<site_domain>/wp-admin/admin-ajax.php?action=ajax-tag-search&tax=post_tag&q=<example_tag>&number=20' \
      -H "Authorization: Basic $(echo -n '<username>:<application_password>' | base64)"
    ```
1. **Verify** the 400 response with an authentication token for non-VideoPress actions.

### 2. Retrieve application password abilities
1. Request the REST API endpoint: 
    ```bash
    curl -i 'https://<site_domain>/wp-json/wpcom/v2/application-password-extras/abilities' \
      -H "Authorization: Basic $(echo -n '<username>:<application_password>' | base64)"
    ```
1. **Verify** the expected response: 
    ```json
    {"admin-ajax":true}
    ```