### PR TITLE
PoC: use block module files from within block directory

### DIFF
--- a/projects/packages/forms/changelog/add-forms-modules-closer-to-blocks
+++ b/projects/packages/forms/changelog/add-forms-modules-closer-to-blocks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: allow block module files to live on ./module directory relative to block

--- a/projects/packages/forms/src/blocks/field-telephone/module/view.js
+++ b/projects/packages/forms/src/blocks/field-telephone/module/view.js
@@ -1,7 +1,7 @@
 import { store, getContext, getConfig, getElement, withSyncEvent } from '@wordpress/interactivity';
 import parsePhoneNumber, { AsYouType } from 'libphonenumber-js';
-import { countries } from '../../blocks/field-telephone/country-list';
-import { isEmptyValue } from '../../contact-form/js/validate-helper';
+import { isEmptyValue } from '../../../contact-form/js/validate-helper';
+import { countries } from '../country-list';
 const NAMESPACE = 'jetpack/form';
 
 const asYouTypes = {};

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -3181,7 +3181,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 
 		\wp_enqueue_script_module(
 			'jetpack-form-phone-field',
-			plugins_url( '../../dist/modules/field-phone/view.js', __FILE__ ),
+			plugins_url( '../../dist/modules/field-telephone/view.js', __FILE__ ),
 			array( '@wordpress/interactivity' ),
 			$version
 		);

--- a/projects/packages/forms/tools/webpack.config.modules.js
+++ b/projects/packages/forms/tools/webpack.config.modules.js
@@ -7,6 +7,7 @@ const jetpackWebpackConfig = require( '@automattic/jetpack-webpack-config/webpac
 const { glob } = require( 'glob' );
 
 const moduleSrcDir = path.join( __dirname, '../src/modules' );
+const blocksSrcDir = path.join( __dirname, '../src/blocks' );
 
 // Check if modules directory exists
 if ( ! fs.existsSync( moduleSrcDir ) ) {
@@ -16,12 +17,17 @@ if ( ! fs.existsSync( moduleSrcDir ) ) {
 } else {
 	// Find all JS and TS files in the modules directory
 	const moduleFiles = glob.sync( path.join( moduleSrcDir, '**/*.{js,ts}' ) );
+	const blockModuleFiles = glob.sync( path.join( blocksSrcDir, '**/module/*.{js,ts}' ) );
 
 	// Create entry points
-	const entry = moduleFiles.reduce( ( acc, filepath ) => {
+	const entry = [ ...moduleFiles, ...blockModuleFiles ].reduce( ( acc, filepath ) => {
 		// Maintain the directory structure relative to src/modules
 		const relativePath = path.relative( moduleSrcDir, filepath );
-		const outputPath = path.join( path.dirname( relativePath ), path.parse( filepath ).name );
+		const outputPath = path
+			.join( path.dirname( relativePath ), path.parse( filepath ).name )
+			.replace( '/module/', '/' ) // NOTE: these 2 replacements are for block module
+			.replace( '../blocks/', '' ); // files so they go into the dist/modules directory
+
 		acc[ outputPath ] = filepath;
 		return acc;
 	}, {} );


### PR DESCRIPTION
PoC

## Proposed changes:
This PR serves as a PoC while we look to move our module files closer to our block code.
The current changes on the webpack config allows us to keep our module files on both places:

- src/modules/*
- src/blocks/**/module/*

Any JS/TS file found on those globs will get built into:

- `dist/modules/MODULE_PATH/FILENAME` this is the legacy way we ship module files. Path and file name honor the same path under `src/modules`
- `dist/modules/BLOCK_PATH/FILENAME` this is the new option, the path will be the block's path (relative to `src/blocks`) and the filename will be whatever filename you use on the block's `module` directory.

That is a bit confusing, let me give an example. This is how our current files get built/moved:

```
src/modules/                            dist/modules/
├── file-field                          ├── file-field
│   └── view.js                         │   ├── view.asset.php
│                                       │   ├── view.js
│                                       │   └── view.js.map
│
├── form                                ├── form
│   ├── shared.ts                       │   ├── shared.asset.php
│   └── view.js                         │   ├── shared.js
|                                       │   ├── shared.js.map
|                                       │   ├── view.asset.php
|                                       │   ├── view.js
|                                       │   └── view.js.map
|
├── form-progress-indicator             ├── form-progress-indicator
│   └── view.js                         │   ├── view.asset.php
|                                       │   ├── view.js
|                                       │   └── view.js.map
|
├── form-step                           ├── form-step
│   └── view.js                         │   ├── view.asset.php
|                                       │   ├── view.js
|                                       │   └── view.js.map
|
├── form-step-navigation                ├── form-step-navigation
│   └── view.js                         │   ├── view.asset.php
|                                       │   ├── view.js
|                                       │   └── view.js.map
|                                       |
└── slider-field                        └── slider-field
    └── view.js                         │   ├── view.asset.php
                                        │   ├── view.js
                                        │   └── view.js.map
```

The new glob on the webpack config allows for also these files to get built and moved into dist:

```
src/blocks/field-telephone/module        dist/modules/field-telephone
└── view.js                              ├── view.js
                                         └── view.js.map
```


Allowing us to work on any block directory and have a module for it close by. However, the public path for them would continue to honor the usual path:

```php
		\wp_enqueue_script_module(
			'jetpack-form-phone-field',
			plugins_url( '../../dist/modules/field-telephone/view.js', __FILE__ ),
			array( '@wordpress/interactivity' ),
			$version
		);
```

Keeping both approaches presents a risk of us being able to overwrite one module with another (src/modules/field-telephone/view.js would get overwritten by src/blocks/field-telephone/module/view.js), so maybe it'd be a good idea to just pick one, shall it doesn't pose any threats or setbacks, and move on with it.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1758134017127229-slack-C052XEUUBL4

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Ongoing investigation. For the sake of testing this first approach, you can create a form with a phone field in it, publish and visit on frontend.
The country dropdown should continue to work. If inspected, the source files should have not changed (with the exception of field-phone now being field-telephone as a consequence of using the directory name instead of a custom one).