### PR TITLE
PayPal Payments: Use namespace for loading SDK to minimize error

### DIFF
--- a/projects/packages/paypal-payments/changelog/update-paypal-payment-buttons-sdk-conflict
+++ b/projects/packages/paypal-payments/changelog/update-paypal-payment-buttons-sdk-conflict
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Namespace PayPal SDK to minimize loading conflicts when using other PayPal blocks.

--- a/projects/packages/paypal-payments/src/paypal-payment-buttons/class-paypal-payment-buttons.php
+++ b/projects/packages/paypal-payments/src/paypal-payment-buttons/class-paypal-payment-buttons.php
@@ -77,6 +77,11 @@ class PayPal_Payment_Buttons {
 				'script_loader_tag',
 				function ( $tag, $handle, $src ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 					if ( 'paypal-payment-buttons-block-head' === $handle ) {
+						// Add namespace to avoid conflicts with other PayPal SDK versions
+						if ( ! str_contains( $tag, 'data-namespace' ) ) {
+							$tag = preg_replace( '/(\s+)src=([\'"])/', '$1 data-namespace="paypal_payment_buttons" src=$2', $tag );
+						}
+						// Add partner attribution ID
 						if ( ! str_contains( $tag, 'data-paypal-partner-attribution-id' ) ) {
 							$tag = preg_replace( '/(\s+)src=([\'"])/', '$1 data-paypal-partner-attribution-id="' . self::PAYPAL_PARTNER_ATTRIBUTION_ID . '" src=$2', $tag );
 						}
@@ -92,7 +97,7 @@ class PayPal_Payment_Buttons {
 			$button_html  = '<div id="' . $container_id . '"></div>';
 
 			$inline_script = sprintf(
-				'paypal.HostedButtons({
+				'(window.paypal_payment_buttons || window.paypal).HostedButtons({
 					hostedButtonId: "%s",
 				}).render("#%s");',
 				esc_js( $hosted_button_id ),

--- a/projects/packages/paypal-payments/src/paypal-payment-buttons/edit.js
+++ b/projects/packages/paypal-payments/src/paypal-payment-buttons/edit.js
@@ -64,7 +64,7 @@ const generateHeadCode = scriptSrc => {
 	if ( ! scriptSrc ) {
 		return '';
 	}
-	return `<script src="${ scriptSrc }"></script>`;
+	return `<script src="${ scriptSrc }" data-namespace="paypal_payment_buttons"></script>`;
 };
 
 const generateBodyCode = ( hostedButtonId, buttonType = 'stacked', buttonText = '' ) => {
@@ -83,7 +83,7 @@ const generateBodyCode = ( hostedButtonId, buttonType = 'stacked', buttonText = 
 
 	return `<div id="paypal-container-${ hostedButtonId }"></div>
 <script>
-  paypal.HostedButtons({
+  (window.paypal_payment_buttons || window.paypal).HostedButtons({
     hostedButtonId: "${ hostedButtonId }",
   }).render("#paypal-container-${ hostedButtonId }")
 </script>`;

--- a/projects/packages/paypal-payments/tests/js/paypal-payment-buttons-block-tests/edit.test.js
+++ b/projects/packages/paypal-payments/tests/js/paypal-payment-buttons-block-tests/edit.test.js
@@ -230,7 +230,7 @@ describe( 'Edit', () => {
 		fireEvent.change( inputs[ 1 ], {
 			target: {
 				value:
-					'paypal.HostedButtons({ hostedButtonId: "ABC123DEF", }).render("#paypal-container-ABC123DEF")',
+					'(window.paypal_payment_buttons || window.paypal).HostedButtons({ hostedButtonId: "ABC123DEF", }).render("#paypal-container-ABC123DEF")',
 			},
 		} );
 


### PR DESCRIPTION
Fixes MON-59.

This PR fixes an SDK version conflict that occurs when both the older PayPal/Simple Payments block and the newer PayPal Payment Buttons block are present on the same page. The conflict happens because the older block loads a PayPal file that then loads the SDK v4.0.344, while the newer block attempts to load SDK v5.0.502, resulting in a JavaScript error that prevents the PayPal Payment Buttons from rendering.

```
Uncaught Error: Attempted to load sdk version 5.0.502 on page, but window.paypal at version 4.0.344 already loaded.

To load this sdk alongside the existing version, please specify a different namespace in the script tag, e.g. <script src="https://www.paypal.com/sdk/js?client-id=CLIENT_ID" data-namespace="paypal_sdk"></script>, then use the paypal_sdk namespace in place of paypal in your code.
```

The older PayPal SDK version is being loaded from a PayPal script (`https://www.paypalobjects.com/api/checkout.js`) by the Simple Payments block, which uses the global `window.paypal` object. Since we cannot control how third-party scripts load the SDK, namespacing our SDK instance seems like the best approach to avoid conflicts.

<img width="3070" height="1172" alt="CleanShot 2025-09-17 at 16 28 48@2x" src="https://github.com/user-attachments/assets/aa5eda2a-1ad8-4e4d-88b5-c6f0534bc7be" />

## Proposed changes:

Namespace PayPal SDK used for PayPal Payment Buttons to minimize conflicts when legacy PayPal blocks are in use on the same page.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
NA

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Checkout branch
- `jetpack build packages/paypal-payments && jetpack build plugins/paypal-payment-buttons`
- Test with PayPal Payment Buttons and ensure that the button remains functional
- On frontend of page, with embedded block, run `console.log( window.paypal_payment_buttons );` and ensure you get an object back
- Ensure unit tests pass
- Checkout patch on WPCOM sandbox and test against site mentioned in MON-59.
