### PR TITLE
WooCommerce Analytics: Implement on-site pixel API endpoint with POST support

### DIFF
--- a/projects/packages/woocommerce-analytics/changelog/wooa7s-489-implement-on-site-pixel-api-endpoint-with-post-support
+++ b/projects/packages/woocommerce-analytics/changelog/wooa7s-489-implement-on-site-pixel-api-endpoint-with-post-support
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Implement on-site pixel API endpoint with POST support

--- a/projects/packages/woocommerce-analytics/src/API/class-wc-analytics-tracking-proxy.php
+++ b/projects/packages/woocommerce-analytics/src/API/class-wc-analytics-tracking-proxy.php
@@ -1,0 +1,137 @@
+<?php
+/**
+ * REST API: WC_Analytics_Tracking_Proxy class
+ *
+ * @package automattic/woocommerce-analytics
+ */
+
+namespace Automattic\Woocommerce_Analytics;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class to handle tracking events via the REST API
+ *
+ * @since 0.7.0
+ */
+class WC_Analytics_Tracking_Proxy extends \WC_REST_Controller {
+
+	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'woocommerce-analytics/v1';
+
+	/**
+	 * Route base.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'track';
+
+	/**
+	 * Register the routes for tracking.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			array(
+				array(
+					'methods'             => \WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'track_events' ),
+					'permission_callback' => '__return_true', // no need to check permissions
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
+	}
+
+	/**
+	 * Track events.
+	 *
+	 * @param \WP_REST_Request $request Full data about the request.
+	 * @return \WP_REST_Response|\WP_Error Response object on success, or WP_Error object on failure.
+	 */
+	public function track_events( $request ) {
+		$events = $request->get_json_params();
+
+		if ( ! is_array( $events ) ) {
+			$events = array( $events );
+		}
+
+		$results    = array();
+		$has_errors = false;
+
+		foreach ( $events as $index => $event ) {
+			// Validate event structure.
+			if ( empty( $event ) || ! is_array( $event ) ) {
+				$results[ $index ] = array(
+					'success' => false,
+					'error'   => 'Invalid event format',
+				);
+				$has_errors        = true;
+				continue;
+			}
+
+			// Validate event name and properties.
+			$event_name = isset( $event['event_name'] ) ? $event['event_name'] : null;
+			$properties = isset( $event['properties'] ) ? $event['properties'] : array();
+			if ( ! $event_name || ! is_array( $properties ) ) {
+				$results[ $index ] = array(
+					'success' => false,
+					'error'   => 'Missing event_name or invalid properties',
+				);
+				$has_errors        = true;
+				continue;
+			}
+
+			$result = WC_Analytics_Tracking::record_event( $event_name, $properties );
+
+			if ( is_wp_error( $result ) ) {
+				$results[ $index ] = array(
+					'success' => false,
+					'error'   => $result->get_error_message(),
+				);
+				$has_errors        = true;
+				continue;
+			}
+
+			$results[ $index ] = array( 'success' => true );
+		}
+
+		$response_data = array(
+			'success' => ! $has_errors,
+			'results' => $results,
+		);
+
+		return new \WP_REST_Response( $response_data, $has_errors ? 207 : 200 );
+	}
+
+	/**
+	 * Get the schema for tracking events.
+	 *
+	 * @return array
+	 */
+	public function get_item_schema() {
+		$schema = array(
+			'$schema' => 'http://json-schema.org/draft-04/schema#',
+			'title'   => 'tracking_events',
+			'type'    => 'array',
+			'items'   => array(
+				'type'       => 'object',
+				'properties' => array(
+					'event_name' => array(
+						'type' => 'string',
+					),
+					'properties' => array(
+						'type' => 'object',
+					),
+				),
+			),
+		);
+
+		return $this->add_additional_fields_schema( $schema );
+	}
+}

--- a/projects/packages/woocommerce-analytics/src/API/class-wc-analytics-tracking-proxy.php
+++ b/projects/packages/woocommerce-analytics/src/API/class-wc-analytics-tracking-proxy.php
@@ -42,8 +42,8 @@ class WC_Analytics_Tracking_Proxy extends \WC_REST_Controller {
 					'methods'             => \WP_REST_Server::CREATABLE,
 					'callback'            => array( $this, 'track_events' ),
 					'permission_callback' => '__return_true', // no need to check permissions
+					'schema'              => array( $this, 'get_public_item_schema' ),
 				),
-				'schema' => array( $this, 'get_public_item_schema' ),
 			)
 		);
 	}
@@ -57,7 +57,8 @@ class WC_Analytics_Tracking_Proxy extends \WC_REST_Controller {
 	public function track_events( $request ) {
 		$events = $request->get_json_params();
 
-		if ( ! is_array( $events ) ) {
+		if ( ! is_array( $events ) || ( isset( $events['event_name'] ) ) ) {
+			// If $events is a single event (associative array), wrap it in an array.
 			$events = array( $events );
 		}
 
@@ -76,8 +77,8 @@ class WC_Analytics_Tracking_Proxy extends \WC_REST_Controller {
 			}
 
 			// Validate event name and properties.
-			$event_name = isset( $event['event_name'] ) ? $event['event_name'] : null;
-			$properties = isset( $event['properties'] ) ? $event['properties'] : array();
+			$event_name = $event['event_name'] ?? null;
+			$properties = $event['properties'] ?? array();
 			if ( ! $event_name || ! is_array( $properties ) ) {
 				$results[ $index ] = array(
 					'success' => false,

--- a/projects/packages/woocommerce-analytics/src/class-woocommerce-analytics.php
+++ b/projects/packages/woocommerce-analytics/src/class-woocommerce-analytics.php
@@ -11,6 +11,7 @@ namespace Automattic;
 use Automattic\Jetpack\Connection\Manager as Jetpack_Connection;
 use Automattic\Woocommerce_Analytics\My_Account;
 use Automattic\Woocommerce_Analytics\Universal;
+use Automattic\Woocommerce_Analytics\WC_Analytics_Tracking_Proxy;
 
 /**
  * Instantiate WooCommerce Analytics
@@ -41,6 +42,9 @@ class Woocommerce_Analytics {
 		// Initialize general store tracking actions.
 		add_action( 'init', array( new Universal(), 'init_hooks' ) );
 		add_action( 'init', array( new My_Account(), 'init_hooks' ) );
+
+		// Initialize REST API endpoints.
+		add_action( 'rest_api_init', array( __CLASS__, 'register_rest_routes' ) );
 
 		/**
 		 * Fires after the WooCommerce Analytics package is initialized
@@ -118,5 +122,13 @@ class Woocommerce_Analytics {
 				'strategy'  => 'defer',
 			)
 		);
+	}
+
+	/**
+	 * Register REST API routes.
+	 */
+	public static function register_rest_routes() {
+		$controller = new WC_Analytics_Tracking_Proxy();
+		$controller->register_routes();
 	}
 }


### PR DESCRIPTION
Fixes [WOOA7S-489](https://linear.app/a8c/issue/WOOA7S-489)

## Proposed changes:

* Add REST API endpoint `/wp-json/woocommerce-analytics/v1/track` that accepts POST requests with tracking events
* Forward events to existing `WC_Analytics_Tracking::record_event()` method for delivery to both ClickHouse and Nosara Tracks endpoints
* Handle WP_Error responses from tracking calls with proper HTTP status codes (200 for success, 207 for partial errors)
* Support arrays of events in the request body

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
No, this PR only adds a new delivery mechanism for existing tracking events. 

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### Prerequisites

1. Set up a Jetpack + WooCommerce site with this branch activated
2. Use the WooCommerce Analytics plugin to enable ClickHouse tracking
3. Use the following code snippet to log the events:

```php
 function log_remote_pixels( $preempt, $parsed_args, $url ) {
	if ( strpos( $url, WC_Tracks_Client::PIXEL ) === 0 ||  strpos( $url, 'https://pixel.wp.com/w.gif' ) === 0  ) {
		$parsed_url = wp_parse_url( $url );
		parse_str( $parsed_url['query'], $params );
		error_log( $url );
		error_log( $params['_en'] . ' -- ' . print_r( $params, true ));
	}

	return $preempt;
}

add_action( 'pre_http_request', 'log_remote_pixels', 10, 3 );


```
### Testing the API endpoint
1. Test with a single event:
```bash
curl -X POST https://your-site.com/wp-json/woocommerce-analytics/v1/track \
  -H "Content-Type: application/json" \
  -d '{
    "event_name": "page_view"
  }'
```

2. Test with multiple events:

```bash
curl -X POST https://your-site.com/wp-json/woocommerce-analytics/v1/track \
  -H "Content-Type: application/json" \
  -d '[
    {
      "event_name": "page_view", 
      "properties": {"url": "https://example.com/page1"}
    },
      {
        "event_name": "product_view"
      },
      {
        "event_name": ""
      }
  ]'
```

4. Verify successful responses return `{"success":true,"results":[{"success":true}]}` with HTTP 200
5. Verify the endpoint handles errors gracefully and returns appropriate HTTP status codes
6. Check that events are properly forwarded to both ClickHouse and Nosara Tracks endpoints via the existing tracking infrastructure

### Expected Behavior
* Endpoint should accept POST requests only
* Response should indicate success/failure for each event processed
