### PR TITLE
Forms: rename responses storage panel

### DIFF
--- a/projects/packages/forms/changelog/update-forms-responses-storage-panel
+++ b/projects/packages/forms/changelog/update-forms-responses-storage-panel
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Forms: rename 'Manage responses' forms sidebar block panel to 'Responses storage'

--- a/projects/packages/forms/src/blocks/contact-form/edit.js
+++ b/projects/packages/forms/src/blocks/contact-form/edit.js
@@ -682,8 +682,8 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 				</BlockControls>
 				<InspectorControls>
 					<PanelBody
-						title={ __( 'Manage responses', 'jetpack-forms' ) }
-						className="jetpack-contact-form__manage-responses-panel"
+						title={ __( 'Responses storage', 'jetpack-forms' ) }
+						className="jetpack-contact-form__responses-storage-panel"
 						initialOpen={ false }
 					>
 						<JetpackManageResponsesSettings

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -1126,7 +1126,7 @@
 }
 
 /* Styles for form inspector panels */
-.jetpack-contact-form__manage-responses-panel,
+.jetpack-contact-form__responses-storage-panel,
 .jetpack-contact-form__integrations-panel {
 
 	.components-button.is-secondary {

--- a/projects/packages/forms/src/blocks/shared/components/jetpack-manage-responses-settings.js
+++ b/projects/packages/forms/src/blocks/shared/components/jetpack-manage-responses-settings.js
@@ -10,7 +10,7 @@ const JetpackManageResponsesSettings = ( { attributes, setAttributes } ) => {
 			<ToggleControl
 				label={ __( 'Save responses', 'jetpack-forms' ) }
 				help={ __(
-					'Store form submissions in your WordPress admin for review and export.',
+					'Keep responses saved, or set up email/integration to avoid losing them.',
 					'jetpack-forms'
 				) }
 				checked={ saveResponses }

--- a/projects/packages/forms/src/blocks/shared/components/jetpack-manage-responses-settings.js
+++ b/projects/packages/forms/src/blocks/shared/components/jetpack-manage-responses-settings.js
@@ -20,9 +20,6 @@ const JetpackManageResponsesSettings = ( { attributes, setAttributes } ) => {
 			{ saveResponses && (
 				<Button variant="secondary" href={ FULL_RESPONSES_PATH } __next40pxDefaultSize={ true }>
 					{ __( 'View form responses', 'jetpack-forms' ) }
-					<span className="screen-reader-text">
-						{ __( '(opens in a new tab)', 'jetpack-forms' ) }
-					</span>
 				</Button>
 			) }
 		</>

--- a/projects/packages/forms/src/blocks/shared/components/jetpack-manage-responses-settings.js
+++ b/projects/packages/forms/src/blocks/shared/components/jetpack-manage-responses-settings.js
@@ -1,7 +1,6 @@
 import { Button, ToggleControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { FULL_RESPONSES_PATH } from '../../../util/get-preferred-responses-view';
-import InspectorHint from './inspector-hint';
 
 const JetpackManageResponsesSettings = ( { attributes, setAttributes } ) => {
 	const { saveResponses = true } = attributes;
@@ -18,15 +17,14 @@ const JetpackManageResponsesSettings = ( { attributes, setAttributes } ) => {
 				onChange={ value => setAttributes( { saveResponses: value } ) }
 				__nextHasNoMarginBottom={ true }
 			/>
-			<InspectorHint>
-				{ __( 'Manage and export your form responses in WPAdmin:', 'jetpack-forms' ) }
-			</InspectorHint>
-			<Button variant="secondary" href={ FULL_RESPONSES_PATH } __next40pxDefaultSize={ true }>
-				{ __( 'View form responses', 'jetpack-forms' ) }
-				<span className="screen-reader-text">
-					{ __( '(opens in a new tab)', 'jetpack-forms' ) }
-				</span>
-			</Button>
+			{ saveResponses && (
+				<Button variant="secondary" href={ FULL_RESPONSES_PATH } __next40pxDefaultSize={ true }>
+					{ __( 'View form responses', 'jetpack-forms' ) }
+					<span className="screen-reader-text">
+						{ __( '(opens in a new tab)', 'jetpack-forms' ) }
+					</span>
+				</Button>
+			) }
 		</>
 	);
 };

--- a/projects/plugins/jetpack/changelog/update-forms-responses-storage-panel
+++ b/projects/plugins/jetpack/changelog/update-forms-responses-storage-panel
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Forms: rename 'Manage responses' forms sidebar block panel to 'Responses storage'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to FORMS-247

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Renamed `Manage responses` panel to `Responses storage` as `Manage responses`  implies that you can manage (edit, delete, export, etc.) responses.
* Hide `View responses` button when `Save responses` toggle is off.
* Copy change pending.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

<table>
<tr>
<th> Before </th>
<th> After </th>
</tr>
<tr>
<td>
<img width="278" height="263" alt="Screenshot 2025-09-22 at 12 44 48" src="https://github.com/user-attachments/assets/398f5785-e7b1-4799-9176-2be35f5829f0" />

</td>
<td>
<img width="284" height="205" alt="Screenshot 2025-09-22 at 12 43 51" src="https://github.com/user-attachments/assets/908b2828-7118-4476-af48-9f579ee98934" />

</td>
</tr>
</table>

* Add a form to a post.
* Select the form block and check that the panel shows the updated title and copy. 
* Check that the `View responses` button is hidden when the `Save responses` toggle is disabled.

