### PR TITLE
Forms: add email notification toggle

### DIFF
--- a/projects/packages/forms/changelog/add-forms-email-notification-toggle
+++ b/projects/packages/forms/changelog/add-forms-email-notification-toggle
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: add setting to enable or disable email notifications for form submissions

--- a/projects/packages/forms/src/blocks/contact-form/attributes.js
+++ b/projects/packages/forms/src/blocks/contact-form/attributes.js
@@ -53,4 +53,8 @@ export default {
 		type: 'boolean',
 		default: true,
 	},
+	emailNotifications: {
+		type: 'boolean',
+		default: true,
+	},
 };

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-email-connection-settings.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-email-connection-settings.js
@@ -1,4 +1,4 @@
-import { TextControl } from '@wordpress/components';
+import { TextControl, ToggleControl } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { validate as emailValidatorValidate } from 'email-validator';
@@ -8,6 +8,7 @@ import HelpMessage from '../components/help-message';
 const JetpackEmailConnectionSettings = ( {
 	emailAddress = '',
 	emailSubject = '',
+	emailNotifications = true,
 	instanceId,
 	setAttributes,
 	postAuthorEmail,
@@ -87,44 +88,58 @@ const JetpackEmailConnectionSettings = ( {
 
 	return (
 		<>
-			<InspectorHint>
-				{ __( 'Get incoming form responses sent to your email inbox:', 'jetpack-forms' ) }
-			</InspectorHint>
-			<TextControl
-				aria-describedby={ `contact-form-${ instanceId }-email-${
-					hasEmailErrors() ? 'error' : 'help'
-				}` }
-				label={ __( 'Email address to send to', 'jetpack-forms' ) }
-				placeholder={ __( 'name@example.com', 'jetpack-forms' ) }
-				onKeyDown={ e => {
-					if ( event.key === 'Enter' ) {
-						e.preventDefault();
-						e.stopPropagation();
-					}
-				} }
-				value={ emailAddress }
-				onBlur={ onBlurEmailField }
-				onChange={ onChangeEmailField }
+			<ToggleControl
+				label={ __( 'Send email notifications', 'jetpack-forms' ) }
+				checked={ emailNotifications }
+				onChange={ value => setAttributes( { emailNotifications: value } ) }
 				help={ __(
-					'You can enter multiple email addresses separated by commas.',
+					'Form submissions will be sent to the specified email address.',
 					'jetpack-forms'
 				) }
 				__nextHasNoMarginBottom={ true }
-				__next40pxDefaultSize={ true }
 			/>
+			{ emailNotifications && (
+				<>
+					<InspectorHint>
+						{ __( 'Get incoming form responses sent to your email inbox:', 'jetpack-forms' ) }
+					</InspectorHint>
+					<TextControl
+						aria-describedby={ `contact-form-${ instanceId }-email-${
+							hasEmailErrors() ? 'error' : 'help'
+						}` }
+						label={ __( 'Email address to send to', 'jetpack-forms' ) }
+						placeholder={ __( 'name@example.com', 'jetpack-forms' ) }
+						onKeyDown={ e => {
+							if ( event.key === 'Enter' ) {
+								e.preventDefault();
+								e.stopPropagation();
+							}
+						} }
+						value={ emailAddress }
+						onBlur={ onBlurEmailField }
+						onChange={ onChangeEmailField }
+						help={ __(
+							'You can enter multiple email addresses separated by commas.',
+							'jetpack-forms'
+						) }
+						__nextHasNoMarginBottom={ true }
+						__next40pxDefaultSize={ true }
+					/>
 
-			<HelpMessage isError id={ `contact-form-${ instanceId }-email-error` }>
-				{ getEmailErrors() }
-			</HelpMessage>
+					<HelpMessage isError id={ `contact-form-${ instanceId }-email-error` }>
+						{ getEmailErrors() }
+					</HelpMessage>
 
-			<TextControl
-				label={ __( 'Email subject line', 'jetpack-forms' ) }
-				value={ emailSubject }
-				placeholder={ __( 'Enter a subject', 'jetpack-forms' ) }
-				onChange={ newSubject => setAttributes( { subject: newSubject } ) }
-				__nextHasNoMarginBottom={ true }
-				__next40pxDefaultSize={ true }
-			/>
+					<TextControl
+						label={ __( 'Email subject line', 'jetpack-forms' ) }
+						value={ emailSubject }
+						placeholder={ __( 'Enter a subject', 'jetpack-forms' ) }
+						onChange={ newSubject => setAttributes( { subject: newSubject } ) }
+						__nextHasNoMarginBottom={ true }
+						__next40pxDefaultSize={ true }
+					/>
+				</>
+			) }
 		</>
 	);
 };

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-email-connection-settings.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-email-connection-settings.js
@@ -89,13 +89,9 @@ const JetpackEmailConnectionSettings = ( {
 	return (
 		<>
 			<ToggleControl
-				label={ __( 'Send email notifications', 'jetpack-forms' ) }
+				label={ __( 'Send responses to email', 'jetpack-forms' ) }
 				checked={ emailNotifications }
 				onChange={ value => setAttributes( { emailNotifications: value } ) }
-				help={ __(
-					'Form submissions will be sent to the specified email address.',
-					'jetpack-forms'
-				) }
 				__nextHasNoMarginBottom={ true }
 			/>
 			{ emailNotifications && (

--- a/projects/packages/forms/src/blocks/contact-form/edit.js
+++ b/projects/packages/forms/src/blocks/contact-form/edit.js
@@ -102,6 +102,7 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 		customThankyouRedirect,
 		formTitle,
 		variationName,
+		emailNotifications,
 	} = attributes;
 	const formsConfig = useFormsConfig();
 	const showFormIntegrations = Boolean( formsConfig?.isIntegrationsEnabled );
@@ -751,6 +752,7 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 						<JetpackEmailConnectionSettings
 							emailAddress={ to }
 							emailSubject={ subject }
+							emailNotifications={ emailNotifications }
 							instanceId={ instanceId }
 							postAuthorEmail={ postAuthorEmail }
 							setAttributes={ setAttributes }

--- a/projects/packages/forms/src/blocks/contact-form/edit.js
+++ b/projects/packages/forms/src/blocks/contact-form/edit.js
@@ -748,7 +748,7 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 							</div>
 						) }
 					</PanelBody>
-					<PanelBody title={ __( 'Email connection', 'jetpack-forms' ) } initialOpen={ false }>
+					<PanelBody title={ __( 'Email responses', 'jetpack-forms' ) } initialOpen={ false }>
 						<JetpackEmailConnectionSettings
 							emailAddress={ to }
 							emailSubject={ subject }

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -2085,21 +2085,38 @@ class Contact_Form extends Contact_Form_Shortcode {
 			wp_schedule_event( time() + 250, 'daily', 'grunion_scheduled_delete_temp' );
 		}
 
+		/**
+		 * Filter to choose whether an email should be sent after each successful contact form submission.
+		 * This filter takes precedence over the emailNotifications attribute.
+		 *
+		 * @module contact-form
+		 *
+		 * @since 2.6.0
+		 *
+		 * @param bool|null $should_send Should an email be sent after a form submission.
+		 *                              - true: Send email regardless of emailNotifications setting
+		 *                              - false: Don't send email regardless of emailNotifications setting
+		 *                              - null: Use emailNotifications attribute to determine (default behavior)
+		 * @param int $post_id Post ID.
+		 */
+		$should_send_email = apply_filters( 'grunion_should_send_email', null, $post_id );
+
+		// Determine if email should be sent based on filter precedence
+		$send_email = false;
+		if ( $should_send_email === true ) {
+			// Filter explicitly says to send email
+			$send_email = true;
+		} elseif ( $should_send_email === false ) {
+			// Filter explicitly says not to send email
+			$send_email = false;
+		} else {
+			// Filter is null (default), use emailNotifications attribute
+			$send_email = ( $this->get_attribute( 'emailNotifications' ) !== 'no' );
+		}
+
 		if (
 			$is_spam !== true &&
-			// Check if email notifications are enabled for this form
-			( $this->get_attribute( 'emailNotifications' ) !== 'no' ) &&
-			/**
-			 * Filter to choose whether an email should be sent after each successful contact form submission.
-			 *
-			 * @module contact-form
-			 *
-			 * @since 2.6.0
-			 *
-			 * @param bool true Should an email be sent after a form submission. Default to true.
-			 * @param int $post_id Post ID.
-			 */
-			true === apply_filters( 'grunion_should_send_email', true, $post_id )
+			$send_email
 		) {
 			self::wp_mail( $to, "{$spam}{$subject}", $message, $headers );
 		} elseif (

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -187,6 +187,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 			'hiddenFields'           => null,
 			'stepTransition'         => 'fade-slide', // The transition style for multi-step forms. Options: none, fade, slide, fade-slide
 			'saveResponses'          => 'yes',
+			'emailNotifications'     => 'yes',
 		);
 
 		$attributes = shortcode_atts( $this->defaults, $attributes, 'contact-form' );
@@ -194,6 +195,11 @@ class Contact_Form extends Contact_Form_Shortcode {
 		// Transform boolean saveResponses to string for backend compatibility
 		if ( isset( $attributes['saveResponses'] ) && is_bool( $attributes['saveResponses'] ) ) {
 			$attributes['saveResponses'] = $attributes['saveResponses'] ? 'yes' : 'no';
+		}
+
+		// Transform boolean emailNotifications to string for backend compatibility
+		if ( isset( $attributes['emailNotifications'] ) && is_bool( $attributes['emailNotifications'] ) ) {
+			$attributes['emailNotifications'] = $attributes['emailNotifications'] ? 'yes' : 'no';
 		}
 
 		// We only enable the contact-field shortcode temporarily while processing the contact-form shortcode.
@@ -2081,6 +2087,8 @@ class Contact_Form extends Contact_Form_Shortcode {
 
 		if (
 			$is_spam !== true &&
+			// Check if email notifications are enabled for this form
+			( $this->get_attribute( 'emailNotifications' ) !== 'no' ) &&
 			/**
 			 * Filter to choose whether an email should be sent after each successful contact form submission.
 			 *

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -3466,4 +3466,249 @@ EOT;
 
 		Contact_Form::reset_errors();
 	}
+
+	/**
+	 * Test that email is sent when emailNotifications is 'yes' (default behavior)
+	 */
+	public function test_process_submission_sends_email_when_email_notifications_enabled() {
+		// Fill field values
+		$this->add_field_values(
+			array(
+				'name'  => 'John Doe',
+				'email' => 'john@example.com',
+			)
+		);
+
+		// Track if wp_mail was called
+		$email_sent = false;
+		add_filter(
+			'wp_mail',
+			function ( $args ) use ( &$email_sent ) {
+				$email_sent = true;
+				$this->assertContains( 'john <john@example.com>', $args['to'] );
+				$this->assertEquals( 'Contact Form', $args['subject'] );
+				return $args;
+			}
+		);
+
+		// Initialize a form with emailNotifications explicitly set to 'yes'
+		$form = new Contact_Form(
+			array(
+				'to'                 => 'john@example.com',
+				'subject'            => 'Contact Form',
+				'emailNotifications' => 'yes',
+			),
+			"[contact-field label='Name' type='name' required='1'/][contact-field label='Email' type='email' required='1'/]"
+		);
+
+		$result = $form->process_submission();
+		$this->assertNotNull( $result );
+		$this->assertTrue( $email_sent, 'Email should be sent when emailNotifications is "yes"' );
+	}
+
+	/**
+	 * Test that email is NOT sent when emailNotifications is 'no'
+	 */
+	public function test_process_submission_does_not_send_email_when_email_notifications_disabled() {
+		// Fill field values
+		$this->add_field_values(
+			array(
+				'name'  => 'John Doe',
+				'email' => 'john@example.com',
+			)
+		);
+
+		// Track if wp_mail was called
+		$email_sent = false;
+		add_filter(
+			'wp_mail',
+			function ( $args ) use ( &$email_sent ) {
+				$email_sent = true;
+				return $args;
+			}
+		);
+
+		// Initialize a form with emailNotifications set to 'no'
+		$form = new Contact_Form(
+			array(
+				'to'                 => 'john@example.com',
+				'subject'            => 'Contact Form',
+				'emailNotifications' => 'no',
+			),
+			"[contact-field label='Name' type='name' required='1'/][contact-field label='Email' type='email' required='1'/]"
+		);
+
+		$result = $form->process_submission();
+		$this->assertNotNull( $result );
+		$this->assertFalse( $email_sent, 'Email should NOT be sent when emailNotifications is "no"' );
+	}
+
+	/**
+	 * Test that emailNotifications does not affect spam email behavior
+	 */
+	public function test_process_submission_email_notifications_does_not_affect_spam_behavior() {
+		// Fill field values
+		$this->add_field_values(
+			array(
+				'name'  => 'John Doe',
+				'email' => 'john@example.com',
+			)
+		);
+
+		// Mark submission as spam
+		add_filter( 'jetpack_contact_form_is_spam', '__return_true', 11 );
+
+		// Track if wp_mail was called for spam
+		$spam_email_sent = false;
+		add_filter(
+			'wp_mail',
+			function ( $args ) use ( &$spam_email_sent ) {
+				$spam_email_sent = true;
+				$this->assertStringContainsString( '***SPAM***', $args['subject'] );
+				return $args;
+			}
+		);
+
+		// Initialize a form with emailNotifications set to 'no' but spam email enabled
+		$form = new Contact_Form(
+			array(
+				'to'                 => 'john@example.com',
+				'subject'            => 'Contact Form',
+				'emailNotifications' => 'no',
+			),
+			"[contact-field label='Name' type='name' required='1'/][contact-field label='Email' type='email' required='1'/]"
+		);
+
+		$result = $form->process_submission();
+		$this->assertNotNull( $result );
+		// Spam email should still be sent regardless of emailNotifications setting
+		$this->assertFalse( $spam_email_sent, 'Spam email should NOT be sent by default even when emailNotifications is disabled' );
+
+		// Now enable spam email sending
+		add_filter( 'grunion_still_email_spam', '__return_true' );
+
+		$spam_email_sent = false;
+		$result          = $form->process_submission();
+		$this->assertNotNull( $result );
+		// Spam email should be sent when grunion_still_email_spam filter is true
+		$this->assertTrue( $spam_email_sent, 'Spam email should be sent when grunion_still_email_spam filter is true, regardless of emailNotifications setting' );
+	}
+
+	/**
+	 * Test that emailNotifications defaults to 'yes' when not specified
+	 */
+	public function test_process_submission_sends_email_when_email_notifications_not_specified() {
+		// Fill field values
+		$this->add_field_values(
+			array(
+				'name'  => 'John Doe',
+				'email' => 'john@example.com',
+			)
+		);
+
+		// Track if wp_mail was called
+		$email_sent = false;
+		add_filter(
+			'wp_mail',
+			function ( $args ) use ( &$email_sent ) {
+				$email_sent = true;
+				$this->assertContains( 'john <john@example.com>', $args['to'] );
+				return $args;
+			}
+		);
+
+		// Initialize a form without specifying emailNotifications (should default to 'yes')
+		$form = new Contact_Form(
+			array(
+				'to'      => 'john@example.com',
+				'subject' => 'Contact Form',
+			),
+			"[contact-field label='Name' type='name' required='1'/][contact-field label='Email' type='email' required='1'/]"
+		);
+
+		$result = $form->process_submission();
+		$this->assertNotNull( $result );
+		$this->assertTrue( $email_sent, 'Email should be sent when emailNotifications is not specified (defaults to "yes")' );
+	}
+
+	/**
+	 * Test that email is not sent when grunion_should_send_email filter is false and emailNotifications is set to 'yes'
+	 */
+	public function test_process_submission_does_not_send_email_when_grunion_should_send_email_filter_is_false_and_emailNotifications_is_set_to_yes() {
+		// Fill field values
+		$this->add_field_values(
+			array(
+				'name'  => 'John Doe',
+				'email' => 'john@example.com',
+			)
+		);
+
+		add_filter( 'grunion_should_send_email', '__return_false' );
+
+		// Track if wp_mail was called
+		$email_sent = false;
+		add_filter(
+			'wp_mail',
+			function ( $args ) use ( &$email_sent ) {
+				$email_sent = true;
+				return $args;
+			}
+		);
+
+		$form = new Contact_Form(
+			array(
+				'to'                 => 'john@example.com',
+				'subject'            => 'Contact Form',
+				'emailNotifications' => 'yes',
+			),
+			"[contact-field label='Name' type='name' required='1'/][contact-field label='Email' type='email' required='1'/]"
+		);
+
+		$result = $form->process_submission();
+		$this->assertNotNull( $result );
+		$this->assertFalse( $email_sent, 'Email should NOT be sent when grunion_should_send_email filter is false' );
+
+		remove_filter( 'grunion_should_send_email', '__return_false' );
+	}
+
+	/**
+	 * Test that email is sent when grunion_should_send_email filter is true and emailNotifications is set to 'no'
+	 */
+	public function test_process_submission_sends_email_when_grunion_should_send_email_filter_is_true_and_emailNotifications_is_set_to_no() {
+		// Fill field values
+		$this->add_field_values(
+			array(
+				'name'  => 'John Doe',
+				'email' => 'john@example.com',
+			)
+		);
+
+		add_filter( 'grunion_should_send_email', '__return_true' );
+
+		// Track if wp_mail was called
+		$email_sent = false;
+		add_filter(
+			'wp_mail',
+			function ( $args ) use ( &$email_sent ) {
+				$email_sent = true;
+				$this->assertContains( 'john <john@example.com>', $args['to'] );
+				return $args;
+			}
+		);
+
+		$form = new Contact_Form(
+			array(
+				'to'                 => 'john@example.com',
+				'subject'            => 'Contact Form',
+				'emailNotifications' => 'no',
+			),
+			"[contact-field label='Name' type='name' required='1'/][contact-field label='Email' type='email' required='1'/]"
+		);
+
+		$result = $form->process_submission();
+		$this->assertNotNull( $result );
+		$this->assertTrue( $email_sent, 'Email should be sent when grunion_should_send_email filter is true and emailNotifications is set to no' );
+
+		remove_filter( 'grunion_should_send_email', '__return_true' );
+	}
 }

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -2720,6 +2720,7 @@ EOT;
 			), // Hidden fields to include in the form.
 			'stepTransition'         => 'fade-slide',
 			'mailpoet'               => '',
+			'emailNotifications'     => 'yes',
 		);
 		// Add a widget ID to the attributes for testing.
 		$expected_attributes                        = $attributes;

--- a/projects/plugins/jetpack/changelog/add-forms-email-notification-toggle
+++ b/projects/plugins/jetpack/changelog/add-forms-email-notification-toggle
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: add setting to enable or disable email notifications for form submissions


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes FORMS-221

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Added a new toggle to control form submissions email notifications.
* To make it backward compatible with the filter `grunion_should_send_email`, the filter takes precedence over the toggle. If the filter returns:
  * true: Send email regardless of the toggle state
  * false: Don't send email regardless of the toggle state
  * null: Use toggles current state to determine if we should send responses through email (default behavior) 
* We also made the filter `grunion_still_email_spam` take precedence for the same backward compatibility reason
### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

<table>
<tr>
<th> Before </th>
<th> After </th>
</tr>
<tr>
<td>
<img width="282" height="778" alt="Screenshot 2025-09-19 at 18 25 08" src="https://github.com/user-attachments/assets/7c091a73-adb6-4822-84a0-3572846f67b5" />
</td>
<td>
<img width="281" height="810" alt="Screenshot 2025-09-19 at 18 23 41" src="https://github.com/user-attachments/assets/09af6e71-b1c2-4835-b72c-96ac8cdc65ac" />
</td>
</tr>
</table>

* Create a new form and make sure the toggle `Send email responses` is on and your email is in the input below it.
* Submit a form response and check that you've received an email notification.
* Go back to the form and set the `Send email responses` toggle off. 
* Submit a response and check that you haven't received an email notification.
* Add the filter `grunion_should_send_email` and set it to return true, and set the toggle off:
```
add_filter( 'grunion_should_send_email', '__return_true' );
```
* Check that you've received an email notification after a form submission.
* Set the `grunion_should_send_email` to false and set the toggle on.
```
add_filter( 'grunion_should_send_email', '__return_true' );
```
* Check that you haven't received an email notification after a form submission. 
