### PR TITLE
Forms: restrict jetpack button flex setup grow/shrink behavior

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-jetpack-button-flex-setup
+++ b/projects/packages/forms/changelog/fix-forms-jetpack-button-flex-setup
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: restrict button flex setup after last changes to improve overall layout

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -61,7 +61,7 @@
 			max-width: 100%;
 
 			&.wp-block-jetpack-button {
-				flex-basis: auto;
+				flex: 0 0 auto;
 				min-height: var(--jetpack--contact-form--input-height, auto);
 				align-self: flex-end;
 				line-height: 1;


### PR DESCRIPTION


## Proposed changes:
This PR addresses an issue with the flex behavior on buttons. As last change modified fields to better fit on the layout allowing them to grow/shrink as needed, the change also reached buttons, which follow a different set of rules.

Before:
<img width="1002" height="363" alt="image" src="https://github.com/user-attachments/assets/8647f3a3-127d-4709-8768-b23df6637ffe" />

After:
<img width="1002" height="351" alt="image" src="https://github.com/user-attachments/assets/800368ed-b06a-418c-8729-ce8b77a62c58" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
none

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Insert a form. Modify the submit button's width and see that the button size reflects the selected %, see screenshots for guidance, but overall it should just make sense
