### PR TITLE
Forms: Try a horizontal form variation

### DIFF
--- a/projects/packages/forms/changelog/try-horizontal-form-variation
+++ b/projects/packages/forms/changelog/try-horizontal-form-variation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Forms: Add a new horizontal form variation

--- a/projects/packages/forms/src/blocks/contact-form/edit.js
+++ b/projects/packages/forms/src/blocks/contact-form/edit.js
@@ -181,7 +181,10 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 
 	const wrapperRef = useRef();
 	const innerRef = useRef();
-	const blockProps = useBlockProps( { ref: wrapperRef } );
+	const blockProps = useBlockProps( {
+		ref: wrapperRef,
+		className: { 'is-horizontal': variationName === 'horizontal' },
+	} );
 	const formClassnames = clsx(
 		className,
 		'jetpack-contact-form',

--- a/projects/packages/forms/src/blocks/contact-form/edit.js
+++ b/projects/packages/forms/src/blocks/contact-form/edit.js
@@ -183,7 +183,7 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 	const innerRef = useRef();
 	const blockProps = useBlockProps( {
 		ref: wrapperRef,
-		className: { 'is-horizontal': variationName === 'horizontal' },
+		className: { 'variation-horizontal': variationName === 'horizontal' },
 	} );
 	const formClassnames = clsx(
 		className,

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -1208,3 +1208,36 @@
 		}
 	}
 }
+
+/* Horizontal form layout */
+.wp-block-jetpack-contact-form.is-horizontal {
+
+	.jetpack-contact-form {
+		display: flex;
+		flex-direction: row;
+		flex-wrap: wrap;
+		align-items: flex-end;
+		gap: var(--wp--style--block-gap, 1.5rem);
+
+		> .wp-block {
+			flex: 1 1 0;
+			min-width: 0;
+
+			&.wp-block-jetpack-button {
+				flex: 0 0 auto;
+			}
+
+			&.wp-block-jetpack-field-textarea {
+				flex: 1 1 100%;
+			}
+		}
+
+		@media (max-width: #{ (gb.$break-mobile) }) {
+			flex-direction: column;
+
+			> .wp-block {
+				flex: 1 1 auto;
+			}
+		}
+	}
+}

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -1210,7 +1210,7 @@
 }
 
 /* Horizontal form layout */
-.wp-block-jetpack-contact-form.is-horizontal {
+.wp-block-jetpack-contact-form.variation-horizontal {
 
 	.jetpack-contact-form {
 		display: flex;

--- a/projects/packages/forms/src/blocks/contact-form/variations.js
+++ b/projects/packages/forms/src/blocks/contact-form/variations.js
@@ -26,7 +26,7 @@ const variations = [
 			variationName: 'default-empty',
 		},
 		scope: [ 'transform' ],
-		isActive: ( { variationName } ) => ![ 'multistep', 'horizontal' ].includes( variationName ),
+		isActive: ( { variationName } ) => ! [ 'multistep', 'horizontal' ].includes( variationName ),
 	},
 	{
 		name: 'contact-form',
@@ -1013,7 +1013,7 @@ const variations = [
 	},
 	{
 		name: 'horizontal-form',
-		title: __( 'Horizontal', 'jetpack-forms' ),
+		title: __( 'Horizontal form', 'jetpack-forms' ),
 		description: __( 'A form with fields displayed horizontally side by side.', 'jetpack-forms' ),
 		icon: {
 			foreground: getIconColor(),

--- a/projects/packages/forms/src/blocks/contact-form/variations.js
+++ b/projects/packages/forms/src/blocks/contact-form/variations.js
@@ -26,7 +26,7 @@ const variations = [
 			variationName: 'default-empty',
 		},
 		scope: [ 'transform' ],
-		isActive: ( { variationName } ) => variationName !== 'multistep',
+		isActive: ( { variationName } ) => ![ 'multistep', 'horizontal' ].includes( variationName ),
 	},
 	{
 		name: 'contact-form',
@@ -1009,6 +1009,54 @@ const variations = [
 					},
 				},
 			],
+		},
+	},
+	{
+		name: 'horizontal-form',
+		title: __( 'Horizontal', 'jetpack-forms' ),
+		description: __( 'A form with fields displayed horizontally side by side.', 'jetpack-forms' ),
+		icon: {
+			foreground: getIconColor(),
+			src: renderMaterialIcon(
+				<>
+					<Path fillRule="evenodd" clipRule="evenodd" d="M18 9H13V7.5H18V9Z" />
+					<Path
+						fillRule="evenodd"
+						clipRule="evenodd"
+						d="M9.5 7.5H7.5V9.5H9.5V7.5ZM7.5 6H9.5C10.3284 6 11 6.67157 11 7.5V9.5C11 10.3284 10.3284 11 9.5 11H7.5C6.67157 11 6 10.3284 6 9.5V7.5C6 6.67157 6.67157 6 7.5 6Z"
+					/>
+					<Path
+						fillRule="evenodd"
+						clipRule="evenodd"
+						d="M19 4.5H5C4.72386 4.5 4.5 4.72386 4.5 5V19C4.5 19.2761 4.72386 19.5 5 19.5H19C19.2761 19.5 19.5 19.2761 19.5 19V5C19.5 4.72386 19.2761 4.5 19 4.5ZM5 3C3.89543 3 3 3.89543 3 5V19C3 20.1046 3.89543 21 5 21H19C20.1046 21 21 20.1046 21 19V5C21 3.89543 20.1046 3 19 3H5Z"
+					/>
+				</>
+			),
+		},
+		innerBlocks: [
+			[
+				'jetpack/field-name',
+				{ required: true },
+				[ [ 'jetpack/label', { label: __( 'Name', 'jetpack-forms' ) } ], [ 'jetpack/input' ] ],
+			],
+			[
+				'jetpack/field-email',
+				{ required: true },
+				[ [ 'jetpack/label', { label: __( 'Email', 'jetpack-forms' ) } ], [ 'jetpack/input' ] ],
+			],
+			[
+				'jetpack/button',
+				{
+					text: __( 'Subscribe', 'jetpack-forms' ),
+					element: 'button',
+					lock: { remove: true },
+				},
+			],
+		],
+		scope: [ 'block', 'inserter', 'transform' ],
+		isActive: [ 'variationName' ],
+		attributes: {
+			variationName: 'horizontal',
 		},
 	},
 ].filter( Boolean );

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -748,7 +748,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 			}
 
 			if ( $is_horizontal ) {
-				$form_classes .= ' is-horizontal ';
+				$form_classes .= ' variation-horizontal ';
 			}
 
 			$r .= "<form action='" . esc_url( $url ) . "'

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -735,7 +735,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 			 */
 			$url                     = apply_filters( 'grunion_contact_form_form_action', $url, $GLOBALS['post'], $id, $page );
 			$has_submit_button_block = str_contains( $content, 'wp-block-jetpack-button' );
-			$form_classes            = 'contact-form commentsblock';
+			$form_classes            = 'contact-form';
 			if ( $submission_success ) {
 				$form_classes .= ' submission-success';
 			}

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -622,8 +622,9 @@ class Contact_Form extends Contact_Form_Shortcode {
 			}
 		}
 
-		$is_multistep = $max_steps > 0;
-		$element_id   = 'jp-form-' . esc_attr( $form->hash );
+		$is_multistep  = $max_steps > 0;
+		$is_horizontal = isset( $attributes['variationName'] ) && $attributes['variationName'] === 'horizontal';
+		$element_id    = 'jp-form-' . esc_attr( $form->hash );
 
 		// Initial data used to render the success message when the page is reloaded after a successful submission
 		// Don't show the feedback details unless the nonce matches
@@ -746,6 +747,10 @@ class Contact_Form extends Contact_Form_Shortcode {
 				$form_classes .= ' wp-block-jetpack-contact-form';
 			}
 
+			if ( $is_horizontal ) {
+				$form_classes .= ' is-horizontal ';
+			}
+
 			$r .= "<form action='" . esc_url( $url ) . "'
 				id='" . $element_id . "'
 				method='post'
@@ -769,7 +774,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 			} elseif ( $has_submit_button_block ) {
 				// Place the error wrapper before the FIRST button block only to avoid duplicates (e.g., navigation buttons in multistep forms).
 				// Replace only the first occurrence.
-				$r = preg_replace( '/<div class="wp-block-jetpack-button/', self::render_error_wrapper() . ' <div class="wp-block-jetpack-button', $r, 1 );
+				$r = preg_replace( '/<div class="wp-block-jetpack-button/', self::render_error_wrapper( $is_horizontal ) . ' <div class="wp-block-jetpack-button', $r, 1 );
 			}
 
 			// In new versions of the contact form block the button is an inner block
@@ -806,7 +811,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 					$submit_button_text = $form->get_attribute( 'submit_button_text' );
 				}
 
-				$r .= self::render_error_wrapper();
+				$r .= self::render_error_wrapper( $is_horizontal );
 				$r .= "\t\t<button type='submit' class='" . esc_attr( $submit_button_class ) . "'";
 				if ( ! empty( $submit_button_styles ) ) {
 					$r .= " style='" . esc_attr( $submit_button_styles ) . "'";
@@ -927,9 +932,14 @@ class Contact_Form extends Contact_Form_Shortcode {
 	/**
 	 * Helper function that display the error wrapper.
 	 *
+	 * @param bool $do_not_render Whether to render the error wrapper or not.
+	 *
 	 * @return string HTML string for the error wrapper.
 	 */
-	private static function render_error_wrapper() {
+	private static function render_error_wrapper( $do_not_render = false ) {
+		if ( $do_not_render ) {
+			return '';
+		}
 		$html  = '<div class="contact-form__error" data-wp-class--show-errors="state.showFormErrors">';
 		$html .= '<span class="contact-form__warning-icon"><span class="visually-hidden">' . __( 'Warning.', 'jetpack-forms' ) . '</span><i aria-hidden="true"></i></span>
 				<span data-wp-text="state.getFormErrorMessage"></span>

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -1192,7 +1192,7 @@ on production builds, the attributes are being reordered, causing side-effects
 	transition: opacity 200ms cubic-bezier(0.34, 0.8, 0.34, 1), transform 200ms cubic-bezier(0.34, 0.8, 0.34, 1);
 }
 
-.is-horizontal {
+.variation-horizontal {
 
 	.contact-form__input-error.has-errors {
 		position: absolute;
@@ -1252,7 +1252,7 @@ on production builds, the attributes are being reordered, causing side-effects
 }
 
 /* Horizontal form layout */
-.wp-block-jetpack-contact-form.is-horizontal > .wp-block-jetpack-contact-form {
+.wp-block-jetpack-contact-form.variation-horizontal > .wp-block-jetpack-contact-form {
 	display: flex;
 	flex-direction: row;
 	flex-wrap: wrap;

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -1192,6 +1192,13 @@ on production builds, the attributes are being reordered, causing side-effects
 	transition: opacity 200ms cubic-bezier(0.34, 0.8, 0.34, 1), transform 200ms cubic-bezier(0.34, 0.8, 0.34, 1);
 }
 
+.is-horizontal {
+
+	.contact-form__input-error.has-errors {
+		position: absolute;
+	}
+}
+
 .contact-form [aria-invalid="true"]:not(fieldset),
 .contact-form .wp-block-jetpack-contact-form.is-style-outlined fieldset[aria-invalid="true"] {
 	border: solid 1px var(--jetpack--contact-form--error-color);
@@ -1245,7 +1252,7 @@ on production builds, the attributes are being reordered, causing side-effects
 }
 
 /* Horizontal form layout */
-.wp-block-jetpack-contact-form.is-horizontal {
+.wp-block-jetpack-contact-form.is-horizontal > .wp-block-jetpack-contact-form {
 	display: flex;
 	flex-direction: row;
 	flex-wrap: wrap;

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -1243,3 +1243,33 @@ on production builds, the attributes are being reordered, causing side-effects
 .contact-form-ajax-submission:not(.submission-success) {
 	display: none;
 }
+
+/* Horizontal form layout */
+.wp-block-jetpack-contact-form.is-horizontal {
+	display: flex;
+	flex-direction: row;
+	flex-wrap: wrap;
+	align-items: flex-end;
+	gap: var(--wp--style--block-gap, 1.5rem);
+
+	> * {
+		flex: 1 1 0;
+		min-width: 0;
+
+		&.wp-block-jetpack-button {
+			flex: 0 0 auto;
+		}
+
+		&.grunion-field-textarea-wrap {
+			flex: 1 1 100%;
+		}
+	}
+
+	@media (max-width: 480px) {
+		flex-direction: column;
+
+		> * {
+			flex: 1 1 auto;
+		}
+	}
+}

--- a/projects/plugins/jetpack/changelog/try-horizontal-form-variation
+++ b/projects/plugins/jetpack/changelog/try-horizontal-form-variation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Forms: Add a new horizontal form variation


### PR DESCRIPTION
This PR makes it easier to create horizontal forms. 
By adding a new horizontal form variation. 

This is juts an exploration if this is the way we want to go. 

<img width="1249" height="397" alt="Screenshot 2025-09-18 at 4 01 18 PM" src="https://github.com/user-attachments/assets/d87780bd-20b3-41fd-8762-4061b0912d36" />


## Proposed changes:
* Make a new horizontal form variation. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
In the editor. 
Add a new form. Select the new horizontal form variation. 
Does it look as you would expect? Does it load on the front end as you would expect. 

