### PR TITLE
Forms: Ignore node_modules on build when watching

### DIFF
--- a/projects/js-packages/webpack-config/README.md
+++ b/projects/js-packages/webpack-config/README.md
@@ -139,7 +139,7 @@ This is an object suitable for spreading some defaults into Webpack's `resolve` 
 
 `watchOptions` is an object suitable for spreading some defaults into Webpack's `watchOptions` setting. It sets the following:
 
-* `ignored`: `[ '**/node_modules' ]`.
+* `ignored`: `[ '**/node_modules', '**/dist', '**/vendor' ]`.
 
 #### Plugins
 

--- a/projects/js-packages/webpack-config/README.md
+++ b/projects/js-packages/webpack-config/README.md
@@ -25,6 +25,9 @@ module.exports = {
 	resolve: {
 		...jetpackWebpackConfig.resolve,
 	},
+	watchOptions: {
+		...jetpackWebpackConfig.watchOptions,
+	},
 	node: false,
 	plugins: [
 		...jetpackWebpackConfig.StandardPlugins(),
@@ -131,6 +134,12 @@ This is an object suitable for spreading some defaults into Webpack's `resolve` 
 
 * For `extensions`, we add `.jsx`, `.ts`, and `.tsx` to Webpack's defaults.
 * If `npm_config_jetpack_webpack_config_resolve_conditions` is set in the environment (e.g. by setting `jetpack-webpack-config-resolve-conditions` in `.npmrc`), [`conditionNames`](https://webpack.js.org/configuration/resolve/#resolveconditionnames) will be set to add the values (comma-separated) to Webpack's defaults.
+
+#### `watchOptions`
+
+`watchOptions` is an object suitable for spreading some defaults into Webpack's `watchOptions` setting. It sets the following:
+
+* `ignored`: `[ '**/node_modules' ]`.
 
 #### Plugins
 

--- a/projects/js-packages/webpack-config/changelog/fix-forms-webpack-watch-ignore
+++ b/projects/js-packages/webpack-config/changelog/fix-forms-webpack-watch-ignore
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Webpack Config: Add watchOptions to shared config

--- a/projects/js-packages/webpack-config/src/webpack.js
+++ b/projects/js-packages/webpack-config/src/webpack.js
@@ -118,6 +118,9 @@ const resolve = {
 		'...',
 	],
 };
+const watchOptions = {
+	ignored: [ '**/node_modules' ],
+};
 
 /****** Plugins ******/
 
@@ -303,6 +306,7 @@ module.exports = {
 	TerserPlugin,
 	CssMinimizerPlugin,
 	resolve,
+	watchOptions,
 	// Plugins.
 	StandardPlugins,
 	DefinePlugin,

--- a/projects/js-packages/webpack-config/src/webpack.js
+++ b/projects/js-packages/webpack-config/src/webpack.js
@@ -119,7 +119,7 @@ const resolve = {
 	],
 };
 const watchOptions = {
-	ignored: [ '**/node_modules' ],
+	ignored: [ '**/node_modules', '**/dist', '**/vendor' ],
 };
 
 /****** Plugins ******/

--- a/projects/packages/forms/changelog/fix-forms-webpack-watch-ignore
+++ b/projects/packages/forms/changelog/fix-forms-webpack-watch-ignore
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: A dev environment webpack change
+
+

--- a/projects/packages/forms/tools/webpack.config.blocks.js
+++ b/projects/packages/forms/tools/webpack.config.blocks.js
@@ -79,6 +79,9 @@ const sharedWebpackConfig = {
 			jetpackWebpackConfig.FileRule(),
 		],
 	},
+	watchOptions: {
+		ignored: [ '**/node_modules' ],
+	},
 };
 
 module.exports = [

--- a/projects/packages/forms/tools/webpack.config.blocks.js
+++ b/projects/packages/forms/tools/webpack.config.blocks.js
@@ -80,7 +80,7 @@ const sharedWebpackConfig = {
 		],
 	},
 	watchOptions: {
-		ignored: [ '**/node_modules' ],
+		...jetpackWebpackConfig.watchOptions,
 	},
 };
 

--- a/projects/packages/forms/tools/webpack.config.contact-form.js
+++ b/projects/packages/forms/tools/webpack.config.contact-form.js
@@ -89,6 +89,9 @@ const sharedWebpackConfig = {
 				name.startsWith( 'css' ) && ( name.endsWith( '.js' ) || name.endsWith( 'map' ) ),
 		} ),
 	],
+	watchOptions: {
+		ignored: [ '**/node_modules' ],
+	},
 };
 
 // CSS files using `wp_style_add_data( $handle, 'rtl', 'replace' )` need the

--- a/projects/packages/forms/tools/webpack.config.contact-form.js
+++ b/projects/packages/forms/tools/webpack.config.contact-form.js
@@ -90,7 +90,7 @@ const sharedWebpackConfig = {
 		} ),
 	],
 	watchOptions: {
-		ignored: [ '**/node_modules' ],
+		...jetpackWebpackConfig.watchOptions,
 	},
 };
 

--- a/projects/packages/forms/tools/webpack.config.dashboard.js
+++ b/projects/packages/forms/tools/webpack.config.dashboard.js
@@ -99,6 +99,6 @@ module.exports = {
 	},
 	plugins: [ ...jetpackWebpackConfig.StandardPlugins() ],
 	watchOptions: {
-		ignored: [ '**/node_modules' ],
+		...jetpackWebpackConfig.watchOptions,
 	},
 };

--- a/projects/packages/forms/tools/webpack.config.dashboard.js
+++ b/projects/packages/forms/tools/webpack.config.dashboard.js
@@ -98,4 +98,7 @@ module.exports = {
 		],
 	},
 	plugins: [ ...jetpackWebpackConfig.StandardPlugins() ],
+	watchOptions: {
+		ignored: [ '**/node_modules' ],
+	},
 };

--- a/projects/packages/forms/tools/webpack.config.modules.js
+++ b/projects/packages/forms/tools/webpack.config.modules.js
@@ -110,6 +110,9 @@ if ( ! fs.existsSync( moduleSrcDir ) ) {
 					I18nCheckPlugin: false,
 				} ),
 			],
+			watchOptions: {
+				ignored: [ '**/node_modules' ],
+			},
 		};
 
 		module.exports = moduleWebpackConfig;

--- a/projects/packages/forms/tools/webpack.config.modules.js
+++ b/projects/packages/forms/tools/webpack.config.modules.js
@@ -111,7 +111,7 @@ if ( ! fs.existsSync( moduleSrcDir ) ) {
 				} ),
 			],
 			watchOptions: {
-				ignored: [ '**/node_modules' ],
+				...jetpackWebpackConfig.watchOptions,
 			},
 		};
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Uses https://webpack.js.org/configuration/watch/#watchoptionsignored to ignore the node_modules folder when watching, as that started giving me errors of too many watched files.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Run `jetpack watch packages/forms`
* Make some change
* Check that it is rebuilt as expected
* No "System limit for number of file watchers reached" error.
