### PR TITLE
Charts: Improve pie chart tooltip positioning closer to cursor

### DIFF
--- a/projects/js-packages/charts/changelog/fix-charts-106-improve-tooltip-positioning-closer-to-cursor
+++ b/projects/js-packages/charts/changelog/fix-charts-106-improve-tooltip-positioning-closer-to-cursor
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Charts: improve tooltip positioning in pie charts

--- a/projects/js-packages/charts/src/components/pie-chart/pie-chart.tsx
+++ b/projects/js-packages/charts/src/components/pie-chart/pie-chart.tsx
@@ -74,6 +74,16 @@ export interface PieChartProps extends BaseChartProps< DataPointPercentage[] > {
 	 * Use the children prop to render additional elements on the chart.
 	 */
 	children?: ReactNode;
+
+	/**
+	 * Horizontal offset for tooltip positioning in pixels (default: 0)
+	 */
+	tooltipOffsetX?: number;
+
+	/**
+	 * Vertical offset for tooltip positioning in pixels (default: -15)
+	 */
+	tooltipOffsetY?: number;
 }
 
 // Base props type with optional responsive properties
@@ -137,6 +147,8 @@ const PieChartInternal = ( {
 	showLabels = true,
 	legendValueDisplay = 'percentage',
 	children = null,
+	tooltipOffsetX = 0,
+	tooltipOffsetY = -15,
 }: PieChartProps ) => {
 	const providerTheme = useGlobalChartsTheme();
 	const chartId = useChartId( providedChartId );
@@ -281,8 +293,8 @@ const PieChartInternal = ( {
 											if ( coords ) {
 												showTooltip( {
 													tooltipData: arc.data,
-													tooltipLeft: coords.x,
-													tooltipTop: coords.y - 15,
+													tooltipLeft: coords.x + tooltipOffsetX,
+													tooltipTop: coords.y + tooltipOffsetY,
 												} );
 											}
 										}

--- a/projects/js-packages/charts/src/components/pie-chart/pie-chart.tsx
+++ b/projects/js-packages/charts/src/components/pie-chart/pie-chart.tsx
@@ -303,9 +303,10 @@ const PieChartInternal = ( {
 										'data-testid': 'pie-segment',
 									};
 
+									const groupProps: SVGProps< SVGGElement > = {};
 									if ( withTooltips ) {
-										pathProps.onMouseMove = handleMouseMove;
-										pathProps.onMouseLeave = onMouseLeave;
+										groupProps.onMouseMove = handleMouseMove;
+										groupProps.onMouseLeave = onMouseLeave;
 									}
 
 									// Estimate text width more accurately for background sizing
@@ -316,7 +317,7 @@ const PieChartInternal = ( {
 									const backgroundHeight = fontSize + labelPadding * 2;
 
 									return (
-										<g key={ `arc-${ index }` }>
+										<g key={ `arc-${ index }` } { ...groupProps }>
 											<path { ...pathProps } />
 											{ showLabels && hasSpaceForLabel && (
 												<g>

--- a/projects/js-packages/charts/src/components/pie-chart/pie-chart.tsx
+++ b/projects/js-packages/charts/src/components/pie-chart/pie-chart.tsx
@@ -297,7 +297,7 @@ const PieChartInternal = ( {
 										// Get SVG element and use localPoint as recommended by visx docs
 										const svg = ( event.currentTarget as SVGElement ).ownerSVGElement;
 										if ( svg ) {
-											const coords = localPoint( svg, event.nativeEvent );
+											const coords = localPoint( svg, event );
 											if ( coords ) {
 												showTooltip( {
 													tooltipData: arc.data,

--- a/projects/js-packages/charts/src/components/pie-chart/pie-chart.tsx
+++ b/projects/js-packages/charts/src/components/pie-chart/pie-chart.tsx
@@ -19,6 +19,7 @@ import { Legend, useChartLegendItems } from '../legend';
 import { ChartSVG, ChartHTML, useChartChildren } from '../private/chart-composition';
 import { SingleChartContext } from '../private/single-chart-context';
 import { withResponsive, ResponsiveConfig } from '../private/with-responsive';
+import { BaseTooltip } from '../tooltip';
 import styles from './pie-chart.module.scss';
 import type { BaseChartProps, DataPointPercentage, Optional } from '../../types';
 import type { LegendValueDisplay } from '../legend';
@@ -73,6 +74,12 @@ export interface PieChartProps extends BaseChartProps< DataPointPercentage[] > {
 	 * Use the children prop to render additional elements on the chart.
 	 */
 	children?: ReactNode;
+
+	/**
+	 * Vertical offset for tooltip positioning (in pixels)
+	 * @default 15
+	 */
+	tooltipOffset?: number;
 }
 
 // Base props type with optional responsive properties
@@ -113,27 +120,27 @@ const validateData = ( data: DataPointPercentage[] ) => {
 /**
  * Renders a pie or donut chart using the provided data.
  *
- * @param {PieChartProps} props - Component props.
- * @param {DataPointPercentage[]} props.data - Array of data points with percentage values.
- * @param {string} [props.chartId] - Optional chart identifier.
- * @param {boolean} [props.withTooltips] - Whether to show tooltips on hover.
- * @param {string} [props.className] - Optional CSS class name.
- * @param {boolean} [props.showLegend] - Whether to display the legend.
- * @param {'horizontal'|'vertical'} [props.legendOrientation] - Legend orientation.
- * @param {'top'|'bottom'|'left'|'right'} [props.legendPosition] - Legend position.
- * @param {'start'|'center'|'end'} [props.legendAlignment] - Legend alignment.
- * @param {number} [props.legendMaxWidth] - Maximum width for legend.
- * @param {'wrap'|'truncate'} [props.legendTextOverflow] - Text overflow behavior for legend.
- * @param {'circle'|'rect'|'line'} [props.legendShape] - Shape of legend markers.
- * @param {number} [props.size] - Chart size in pixels.
- * @param {number} [props.thickness] - Thickness of pie chart (0-1).
- * @param {number} [props.padding] - Padding around chart in pixels.
- * @param {number} [props.gapScale] - Scale of gaps between segments (0-1).
- * @param {number} [props.cornerScale] - Scale of corner radius for segments (0-1).
- * @param {boolean} [props.showLabels] - Whether to show labels on pie segments.
- * @param {LegendValueDisplay} [props.legendValueDisplay] - Type of values to display in legend.
- * @param {ReactNode} [props.children] - Child components to render.
- * @returns {JSX.Element} The rendered chart component.
+ * @param {PieChartProps}                 props                      - Component props.
+ * @param {DataPointPercentage[]}         props.data                 - Array of data points with percentage values.
+ * @param {string}                        [props.chartId]            - Optional chart identifier.
+ * @param {boolean}                       [props.withTooltips]       - Whether to show tooltips on hover.
+ * @param {string}                        [props.className]          - Optional CSS class name.
+ * @param {boolean}                       [props.showLegend]         - Whether to display the legend.
+ * @param {'horizontal'|'vertical'}       [props.legendOrientation]  - Legend orientation.
+ * @param {'top'|'bottom'|'left'|'right'} [props.legendPosition]     - Legend position.
+ * @param {'start'|'center'|'end'}        [props.legendAlignment]    - Legend alignment.
+ * @param {number}                        [props.legendMaxWidth]     - Maximum width for legend.
+ * @param {'wrap'|'truncate'}             [props.legendTextOverflow] - Text overflow behavior for legend.
+ * @param {'circle'|'rect'|'line'}        [props.legendShape]        - Shape of legend markers.
+ * @param {number}                        [props.size]               - Chart size in pixels.
+ * @param {number}                        [props.thickness]          - Thickness of pie chart (0-1).
+ * @param {number}                        [props.padding]            - Padding around chart in pixels.
+ * @param {number}                        [props.gapScale]           - Scale of gaps between segments (0-1).
+ * @param {number}                        [props.cornerScale]        - Scale of corner radius for segments (0-1).
+ * @param {boolean}                       [props.showLabels]         - Whether to show labels on pie segments.
+ * @param {LegendValueDisplay}            [props.legendValueDisplay] - Type of values to display in legend.
+ * @param {ReactNode}                     [props.children]           - Child components to render.
+ * @return {JSX.Element} The rendered chart component.
  */
 const PieChartInternal = ( {
 	data,
@@ -154,6 +161,7 @@ const PieChartInternal = ( {
 	cornerScale = 0,
 	showLabels = true,
 	legendValueDisplay = 'percentage',
+	tooltipOffset = 15,
 	children = null,
 }: PieChartProps ) => {
 	const providerTheme = useGlobalChartsTheme();
@@ -302,7 +310,7 @@ const PieChartInternal = ( {
 												showTooltip( {
 													tooltipData: arc.data,
 													tooltipLeft: coords.x,
-													tooltipTop: coords.y - 15, // Standard offset above cursor
+													tooltipTop: coords.y - tooltipOffset,
 												} );
 											}
 										}
@@ -383,9 +391,7 @@ const PieChartInternal = ( {
 
 				{ withTooltips && tooltipOpen && tooltipData && (
 					<TooltipInPortal top={ tooltipTop || 0 } left={ tooltipLeft || 0 }>
-						<div role="tooltip">
-							{ tooltipData.label }: { tooltipData.valueDisplay || tooltipData.value }
-						</div>
+						<BaseTooltip data={ tooltipData } top={ 0 } left={ 0 } renderContainer={ false } />
 					</TooltipInPortal>
 				) }
 

--- a/projects/js-packages/charts/src/components/pie-chart/pie-chart.tsx
+++ b/projects/js-packages/charts/src/components/pie-chart/pie-chart.tsx
@@ -384,7 +384,9 @@ const PieChartInternal = ( {
 
 				{ withTooltips && tooltipOpen && tooltipData && (
 					<TooltipInPortal top={ tooltipTop || 0 } left={ tooltipLeft || 0 }>
-						<BaseTooltip data={ tooltipData } top={ 0 } left={ 0 } renderContainer={ false } />
+						<div role="tooltip">
+							<BaseTooltip data={ tooltipData } top={ 0 } left={ 0 } renderContainer={ false } />
+						</div>
 					</TooltipInPortal>
 				) }
 

--- a/projects/js-packages/charts/src/components/pie-chart/pie-chart.tsx
+++ b/projects/js-packages/charts/src/components/pie-chart/pie-chart.tsx
@@ -311,6 +311,7 @@ const PieChartInternal = ( {
 									const pathProps: SVGProps< SVGPathElement > = {
 										d: pie.path( arc ) || '',
 										fill: accessors.fill( arc.data ),
+										'data-testid': 'pie-segment',
 									};
 
 									if ( withTooltips ) {

--- a/projects/js-packages/charts/src/components/pie-chart/pie-chart.tsx
+++ b/projects/js-packages/charts/src/components/pie-chart/pie-chart.tsx
@@ -74,12 +74,6 @@ export interface PieChartProps extends BaseChartProps< DataPointPercentage[] > {
 	 * Use the children prop to render additional elements on the chart.
 	 */
 	children?: ReactNode;
-
-	/**
-	 * Vertical offset for tooltip positioning (in pixels)
-	 * @default 15
-	 */
-	tooltipOffset?: number;
 }
 
 // Base props type with optional responsive properties
@@ -161,7 +155,6 @@ const PieChartInternal = ( {
 	cornerScale = 0,
 	showLabels = true,
 	legendValueDisplay = 'percentage',
-	tooltipOffset = 15,
 	children = null,
 }: PieChartProps ) => {
 	const providerTheme = useGlobalChartsTheme();
@@ -310,7 +303,7 @@ const PieChartInternal = ( {
 												showTooltip( {
 													tooltipData: arc.data,
 													tooltipLeft: coords.x,
-													tooltipTop: coords.y - tooltipOffset,
+													tooltipTop: coords.y - 15,
 												} );
 											}
 										}

--- a/projects/js-packages/charts/src/components/pie-chart/pie-chart.tsx
+++ b/projects/js-packages/charts/src/components/pie-chart/pie-chart.tsx
@@ -288,7 +288,7 @@ const PieChartInternal = ( {
 										}
 									};
 
-									const pathProps: SVGProps< SVGPathElement > = {
+									const pathProps: SVGProps< SVGPathElement > & { 'data-testid'?: string } = {
 										d: pie.path( arc ) || '',
 										fill: accessors.fill( arc.data ),
 										'data-testid': 'pie-segment',

--- a/projects/js-packages/charts/src/components/pie-chart/pie-chart.tsx
+++ b/projects/js-packages/charts/src/components/pie-chart/pie-chart.tsx
@@ -286,17 +286,14 @@ const PieChartInternal = ( {
 											return;
 										}
 
-										// Get SVG element and use localPoint as recommended by visx docs
-										const svg = ( event.currentTarget as SVGElement ).ownerSVGElement;
-										if ( svg ) {
-											const coords = localPoint( svg, event.nativeEvent );
-											if ( coords ) {
-												showTooltip( {
-													tooltipData: arc.data,
-													tooltipLeft: coords.x + tooltipOffsetX,
-													tooltipTop: coords.y + tooltipOffsetY,
-												} );
-											}
+										// Get coordinates relative to the current target element
+										const coords = localPoint( event );
+										if ( coords ) {
+											showTooltip( {
+												tooltipData: arc.data,
+												tooltipLeft: coords.x + tooltipOffsetX,
+												tooltipTop: coords.y + tooltipOffsetY,
+											} );
 										}
 									};
 

--- a/projects/js-packages/charts/src/components/pie-chart/pie-chart.tsx
+++ b/projects/js-packages/charts/src/components/pie-chart/pie-chart.tsx
@@ -114,25 +114,25 @@ const validateData = ( data: DataPointPercentage[] ) => {
  * Renders a pie or donut chart using the provided data.
  *
  * @param props                    - Component props
- * @param props.data
- * @param props.chartId
- * @param props.withTooltips
- * @param props.className
- * @param props.showLegend
- * @param props.legendOrientation
- * @param props.legendPosition
- * @param props.legendAlignment
- * @param props.legendMaxWidth
- * @param props.legendTextOverflow
- * @param props.legendShape
- * @param props.size
- * @param props.thickness
- * @param props.padding
- * @param props.gapScale
- * @param props.cornerScale
- * @param props.showLabels
- * @param props.legendValueDisplay
- * @param props.children
+ * @param props.data               - Array of data points with percentage values
+ * @param props.chartId            - Optional chart identifier
+ * @param props.withTooltips       - Whether to show tooltips on hover
+ * @param props.className          - Optional CSS class name
+ * @param props.showLegend         - Whether to display the legend
+ * @param props.legendOrientation  - Legend orientation (horizontal/vertical)
+ * @param props.legendPosition     - Legend position (top/bottom/left/right)
+ * @param props.legendAlignment    - Legend alignment (start/center/end)
+ * @param props.legendMaxWidth     - Maximum width for legend
+ * @param props.legendTextOverflow - Text overflow behavior for legend
+ * @param props.legendShape        - Shape of legend markers
+ * @param props.size               - Chart size in pixels
+ * @param props.thickness          - Thickness of pie chart (0-1)
+ * @param props.padding            - Padding around chart in pixels
+ * @param props.gapScale           - Scale of gaps between segments (0-1)
+ * @param props.cornerScale        - Scale of corner radius for segments (0-1)
+ * @param props.showLabels         - Whether to show labels on pie segments
+ * @param props.legendValueDisplay - Type of values to display in legend
+ * @param props.children           - Child components to render
  * @return The rendered chart component
  */
 const PieChartInternal = ( {

--- a/projects/js-packages/charts/src/components/pie-chart/pie-chart.tsx
+++ b/projects/js-packages/charts/src/components/pie-chart/pie-chart.tsx
@@ -113,27 +113,27 @@ const validateData = ( data: DataPointPercentage[] ) => {
 /**
  * Renders a pie or donut chart using the provided data.
  *
- * @param props                    - Component props
- * @param props.data               - Array of data points with percentage values
- * @param props.chartId            - Optional chart identifier
- * @param props.withTooltips       - Whether to show tooltips on hover
- * @param props.className          - Optional CSS class name
- * @param props.showLegend         - Whether to display the legend
- * @param props.legendOrientation  - Legend orientation (horizontal/vertical)
- * @param props.legendPosition     - Legend position (top/bottom/left/right)
- * @param props.legendAlignment    - Legend alignment (start/center/end)
- * @param props.legendMaxWidth     - Maximum width for legend
- * @param props.legendTextOverflow - Text overflow behavior for legend
- * @param props.legendShape        - Shape of legend markers
- * @param props.size               - Chart size in pixels
- * @param props.thickness          - Thickness of pie chart (0-1)
- * @param props.padding            - Padding around chart in pixels
- * @param props.gapScale           - Scale of gaps between segments (0-1)
- * @param props.cornerScale        - Scale of corner radius for segments (0-1)
- * @param props.showLabels         - Whether to show labels on pie segments
- * @param props.legendValueDisplay - Type of values to display in legend
- * @param props.children           - Child components to render
- * @return The rendered chart component
+ * @param {PieChartProps} props - Component props.
+ * @param {DataPointPercentage[]} props.data - Array of data points with percentage values.
+ * @param {string} [props.chartId] - Optional chart identifier.
+ * @param {boolean} [props.withTooltips] - Whether to show tooltips on hover.
+ * @param {string} [props.className] - Optional CSS class name.
+ * @param {boolean} [props.showLegend] - Whether to display the legend.
+ * @param {'horizontal'|'vertical'} [props.legendOrientation] - Legend orientation.
+ * @param {'top'|'bottom'|'left'|'right'} [props.legendPosition] - Legend position.
+ * @param {'start'|'center'|'end'} [props.legendAlignment] - Legend alignment.
+ * @param {number} [props.legendMaxWidth] - Maximum width for legend.
+ * @param {'wrap'|'truncate'} [props.legendTextOverflow] - Text overflow behavior for legend.
+ * @param {'circle'|'rect'|'line'} [props.legendShape] - Shape of legend markers.
+ * @param {number} [props.size] - Chart size in pixels.
+ * @param {number} [props.thickness] - Thickness of pie chart (0-1).
+ * @param {number} [props.padding] - Padding around chart in pixels.
+ * @param {number} [props.gapScale] - Scale of gaps between segments (0-1).
+ * @param {number} [props.cornerScale] - Scale of corner radius for segments (0-1).
+ * @param {boolean} [props.showLabels] - Whether to show labels on pie segments.
+ * @param {LegendValueDisplay} [props.legendValueDisplay] - Type of values to display in legend.
+ * @param {ReactNode} [props.children] - Child components to render.
+ * @returns {JSX.Element} The rendered chart component.
  */
 const PieChartInternal = ( {
 	data,

--- a/projects/js-packages/charts/src/components/pie-chart/pie-chart.tsx
+++ b/projects/js-packages/charts/src/components/pie-chart/pie-chart.tsx
@@ -308,7 +308,7 @@ const PieChartInternal = ( {
 										}
 									};
 
-									const pathProps: SVGProps< SVGPathElement > = {
+									const pathProps: SVGProps< SVGPathElement > & { 'data-testid'?: string } = {
 										d: pie.path( arc ) || '',
 										fill: accessors.fill( arc.data ),
 										'data-testid': 'pie-segment',

--- a/projects/js-packages/charts/src/components/pie-chart/pie-chart.tsx
+++ b/projects/js-packages/charts/src/components/pie-chart/pie-chart.tsx
@@ -1,8 +1,10 @@
+import { localPoint } from '@visx/event';
 import { Group } from '@visx/group';
 import { Pie } from '@visx/shape';
+import { useTooltip, useTooltipInPortal } from '@visx/tooltip';
 import clsx from 'clsx';
-import { useContext, useMemo } from 'react';
-import { useChartMouseHandler, useElementHeight } from '../../hooks';
+import { useCallback, useContext, useMemo } from 'react';
+import { useElementHeight } from '../../hooks';
 import {
 	GlobalChartsProvider,
 	useChartId,
@@ -17,7 +19,6 @@ import { Legend, useChartLegendItems } from '../legend';
 import { ChartSVG, ChartHTML, useChartChildren } from '../private/chart-composition';
 import { SingleChartContext } from '../private/single-chart-context';
 import { withResponsive, ResponsiveConfig } from '../private/with-responsive';
-import { BaseTooltip } from '../tooltip';
 import styles from './pie-chart.module.scss';
 import type { BaseChartProps, DataPointPercentage, Optional } from '../../types';
 import type { LegendValueDisplay } from '../legend';
@@ -112,8 +113,27 @@ const validateData = ( data: DataPointPercentage[] ) => {
 /**
  * Renders a pie or donut chart using the provided data.
  *
- * @param {PieChartProps} props - Component props
- * @return {JSX.Element} The rendered chart component
+ * @param props                    - Component props
+ * @param props.data
+ * @param props.chartId
+ * @param props.withTooltips
+ * @param props.className
+ * @param props.showLegend
+ * @param props.legendOrientation
+ * @param props.legendPosition
+ * @param props.legendAlignment
+ * @param props.legendMaxWidth
+ * @param props.legendTextOverflow
+ * @param props.legendShape
+ * @param props.size
+ * @param props.thickness
+ * @param props.padding
+ * @param props.gapScale
+ * @param props.cornerScale
+ * @param props.showLabels
+ * @param props.legendValueDisplay
+ * @param props.children
+ * @return The rendered chart component
  */
 const PieChartInternal = ( {
 	data,
@@ -139,10 +159,24 @@ const PieChartInternal = ( {
 	const providerTheme = useGlobalChartsTheme();
 	const chartId = useChartId( providedChartId );
 	const [ legendRef, legendHeight ] = useElementHeight< HTMLDivElement >();
-	const { onMouseMove, onMouseLeave, tooltipOpen, tooltipData, tooltipLeft, tooltipTop } =
-		useChartMouseHandler( {
-			withTooltips,
-		} );
+	// Use tooltip directly for better control over coordinates
+	const { tooltipOpen, tooltipLeft, tooltipTop, tooltipData, hideTooltip, showTooltip } =
+		useTooltip< DataPointPercentage >();
+
+	// Set up portal tooltip for better z-index handling
+	const { containerRef, TooltipInPortal } = useTooltipInPortal( {
+		detectBounds: true,
+		scroll: true,
+		debounce: 0,
+	} );
+
+	// Mouse handlers for tooltips
+	const onMouseLeave = useCallback( () => {
+		if ( ! withTooltips ) {
+			return;
+		}
+		hideTooltip();
+	}, [ withTooltips, hideTooltip ] );
 
 	// Memoize legend options to prevent unnecessary re-calculations
 	const legendOptions = useMemo(
@@ -229,6 +263,7 @@ const PieChartInternal = ( {
 			} }
 		>
 			<div
+				ref={ containerRef }
 				className={ clsx( 'pie-chart', styles[ 'pie-chart' ], className ) }
 				style={ {
 					display: 'flex',
@@ -254,8 +289,24 @@ const PieChartInternal = ( {
 								return pie.arcs.map( ( arc, index ) => {
 									const [ centroidX, centroidY ] = pie.path.centroid( arc );
 									const hasSpaceForLabel = arc.endAngle - arc.startAngle >= 0.25;
-									const handleMouseMove = ( event: MouseEvent< SVGElement > ) =>
-										onMouseMove( event, arc.data );
+									const handleMouseMove = ( event: MouseEvent< SVGElement > ) => {
+										if ( ! withTooltips ) {
+											return;
+										}
+
+										// Get SVG element and use localPoint as recommended by visx docs
+										const svg = ( event.currentTarget as SVGElement ).ownerSVGElement;
+										if ( svg ) {
+											const coords = localPoint( svg, event.nativeEvent );
+											if ( coords ) {
+												showTooltip( {
+													tooltipData: arc.data,
+													tooltipLeft: coords.x,
+													tooltipTop: coords.y - 8, // Closer offset above cursor
+												} );
+											}
+										}
+									};
 
 									const pathProps: SVGProps< SVGPathElement > = {
 										d: pie.path( arc ) || '',
@@ -330,14 +381,11 @@ const PieChartInternal = ( {
 				) }
 
 				{ withTooltips && tooltipOpen && tooltipData && (
-					<BaseTooltip
-						data={ tooltipData }
-						top={ tooltipTop || 0 }
-						left={ tooltipLeft || 0 }
-						style={ {
-							transform: 'translate(-50%, -100%)',
-						} }
-					/>
+					<TooltipInPortal top={ tooltipTop || 0 } left={ tooltipLeft || 0 }>
+						<div role="tooltip">
+							{ tooltipData.label }: { tooltipData.valueDisplay || tooltipData.value }
+						</div>
+					</TooltipInPortal>
 				) }
 
 				{ /* Render HTML component children from PieChart.HTML */ }

--- a/projects/js-packages/charts/src/components/pie-chart/pie-chart.tsx
+++ b/projects/js-packages/charts/src/components/pie-chart/pie-chart.tsx
@@ -289,10 +289,13 @@ const PieChartInternal = ( {
 										// Get coordinates relative to the current target element
 										const coords = localPoint( event );
 										if ( coords ) {
+											// Account for legend offset when legend is on top
+											const legendOffset =
+												showLegend && legendPosition === 'top' ? legendHeight : 0;
 											showTooltip( {
 												tooltipData: arc.data,
 												tooltipLeft: coords.x + tooltipOffsetX,
-												tooltipTop: coords.y + tooltipOffsetY,
+												tooltipTop: coords.y + legendOffset + tooltipOffsetY,
 											} );
 										}
 									};

--- a/projects/js-packages/charts/src/components/pie-chart/pie-chart.tsx
+++ b/projects/js-packages/charts/src/components/pie-chart/pie-chart.tsx
@@ -114,27 +114,8 @@ const validateData = ( data: DataPointPercentage[] ) => {
 /**
  * Renders a pie or donut chart using the provided data.
  *
- * @param {PieChartProps}                 props                      - Component props.
- * @param {DataPointPercentage[]}         props.data                 - Array of data points with percentage values.
- * @param {string}                        [props.chartId]            - Optional chart identifier.
- * @param {boolean}                       [props.withTooltips]       - Whether to show tooltips on hover.
- * @param {string}                        [props.className]          - Optional CSS class name.
- * @param {boolean}                       [props.showLegend]         - Whether to display the legend.
- * @param {'horizontal'|'vertical'}       [props.legendOrientation]  - Legend orientation.
- * @param {'top'|'bottom'|'left'|'right'} [props.legendPosition]     - Legend position.
- * @param {'start'|'center'|'end'}        [props.legendAlignment]    - Legend alignment.
- * @param {number}                        [props.legendMaxWidth]     - Maximum width for legend.
- * @param {'wrap'|'truncate'}             [props.legendTextOverflow] - Text overflow behavior for legend.
- * @param {'circle'|'rect'|'line'}        [props.legendShape]        - Shape of legend markers.
- * @param {number}                        [props.size]               - Chart size in pixels.
- * @param {number}                        [props.thickness]          - Thickness of pie chart (0-1).
- * @param {number}                        [props.padding]            - Padding around chart in pixels.
- * @param {number}                        [props.gapScale]           - Scale of gaps between segments (0-1).
- * @param {number}                        [props.cornerScale]        - Scale of corner radius for segments (0-1).
- * @param {boolean}                       [props.showLabels]         - Whether to show labels on pie segments.
- * @param {LegendValueDisplay}            [props.legendValueDisplay] - Type of values to display in legend.
- * @param {ReactNode}                     [props.children]           - Child components to render.
- * @return {JSX.Element} The rendered chart component.
+ * @param {PieChartProps} props - Component props
+ * @return {JSX.Element} The rendered chart component
  */
 const PieChartInternal = ( {
 	data,
@@ -160,7 +141,6 @@ const PieChartInternal = ( {
 	const providerTheme = useGlobalChartsTheme();
 	const chartId = useChartId( providedChartId );
 	const [ legendRef, legendHeight ] = useElementHeight< HTMLDivElement >();
-	// Use tooltip directly for better control over coordinates
 	const { tooltipOpen, tooltipLeft, tooltipTop, tooltipData, hideTooltip, showTooltip } =
 		useTooltip< DataPointPercentage >();
 
@@ -171,7 +151,6 @@ const PieChartInternal = ( {
 		debounce: 0,
 	} );
 
-	// Mouse handlers for tooltips
 	const onMouseLeave = useCallback( () => {
 		if ( ! withTooltips ) {
 			return;
@@ -298,7 +277,7 @@ const PieChartInternal = ( {
 										// Get SVG element and use localPoint as recommended by visx docs
 										const svg = ( event.currentTarget as SVGElement ).ownerSVGElement;
 										if ( svg ) {
-											const coords = localPoint( svg, event );
+											const coords = localPoint( svg, event.nativeEvent );
 											if ( coords ) {
 												showTooltip( {
 													tooltipData: arc.data,
@@ -309,7 +288,7 @@ const PieChartInternal = ( {
 										}
 									};
 
-									const pathProps: SVGProps< SVGPathElement > & { 'data-testid'?: string } = {
+									const pathProps: SVGProps< SVGPathElement > = {
 										d: pie.path( arc ) || '',
 										fill: accessors.fill( arc.data ),
 										'data-testid': 'pie-segment',

--- a/projects/js-packages/charts/src/components/pie-chart/pie-chart.tsx
+++ b/projects/js-packages/charts/src/components/pie-chart/pie-chart.tsx
@@ -302,7 +302,7 @@ const PieChartInternal = ( {
 												showTooltip( {
 													tooltipData: arc.data,
 													tooltipLeft: coords.x,
-													tooltipTop: coords.y - 8, // Closer offset above cursor
+													tooltipTop: coords.y - 15, // Standard offset above cursor
 												} );
 											}
 										}

--- a/projects/js-packages/charts/src/components/pie-chart/test/pie-chart.test.tsx
+++ b/projects/js-packages/charts/src/components/pie-chart/test/pie-chart.test.tsx
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { GlobalChartsProvider } from '../../../providers';
 import PieChart from '../pie-chart';
@@ -259,7 +259,7 @@ describe( 'PieChart', () => {
 			await waitFor( () => {
 				expect( screen.getByRole( 'tooltip' ) ).toBeInTheDocument();
 			} );
-			
+
 			const tooltip = screen.getByRole( 'tooltip' );
 			expect( tooltip ).toHaveTextContent( 'Windows: 80K' );
 		} );

--- a/projects/js-packages/charts/src/components/pie-chart/test/pie-chart.test.tsx
+++ b/projects/js-packages/charts/src/components/pie-chart/test/pie-chart.test.tsx
@@ -2,7 +2,8 @@
  * @jest-environment jsdom
  */
 
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { GlobalChartsProvider } from '../../../providers';
 import PieChart from '../pie-chart';
 
@@ -221,6 +222,116 @@ describe( 'PieChart', () => {
 			// Legend should have the correct number of items (labels only, no values)
 			const legendItems = screen.getAllByTestId( 'legend-item' );
 			expect( legendItems ).toHaveLength( 3 );
+		} );
+	} );
+
+	describe( 'Tooltip Functionality', () => {
+		const testData = [
+			{ label: 'Windows', value: 80000, valueDisplay: '80K', percentage: 70 },
+			{ label: 'MacOS', value: 30000, valueDisplay: '30K', percentage: 30 },
+		];
+
+		test( 'does not show tooltip when withTooltips is false', async () => {
+			const user = userEvent.setup();
+			renderWithTheme( {
+				data: testData,
+				withTooltips: false,
+			} );
+
+			const segments = screen.getAllByTestId( 'pie-segment' );
+			await user.hover( segments[ 0 ] );
+
+			// Should not find tooltip
+			expect( screen.queryByRole( 'tooltip' ) ).not.toBeInTheDocument();
+		} );
+
+		test( 'shows tooltip on hover when withTooltips is true', async () => {
+			const user = userEvent.setup();
+			renderWithTheme( {
+				data: testData,
+				withTooltips: true,
+			} );
+
+			const segments = screen.getAllByTestId( 'pie-segment' );
+			await user.hover( segments[ 0 ] );
+
+			// Wait for tooltip to appear
+			await waitFor( () => {
+				expect( screen.getByRole( 'tooltip' ) ).toBeInTheDocument();
+			} );
+			
+			const tooltip = screen.getByRole( 'tooltip' );
+			expect( tooltip ).toHaveTextContent( 'Windows: 80K' );
+		} );
+
+		test( 'hides tooltip on mouse leave', async () => {
+			const user = userEvent.setup();
+			renderWithTheme( {
+				data: testData,
+				withTooltips: true,
+			} );
+
+			const segments = screen.getAllByTestId( 'pie-segment' );
+			await user.hover( segments[ 0 ] );
+
+			// Wait for tooltip to appear
+			await waitFor( () => {
+				expect( screen.getByRole( 'tooltip' ) ).toBeInTheDocument();
+			} );
+
+			await user.unhover( segments[ 0 ] );
+
+			// Wait for tooltip to disappear
+			await waitFor( () => {
+				expect( screen.queryByRole( 'tooltip' ) ).not.toBeInTheDocument();
+			} );
+		} );
+
+		test( 'shows different tooltip content for different segments', async () => {
+			const user = userEvent.setup();
+			renderWithTheme( {
+				data: testData,
+				withTooltips: true,
+			} );
+
+			const segments = screen.getAllByTestId( 'pie-segment' );
+
+			// Test first segment
+			await user.hover( segments[ 0 ] );
+			await waitFor( () => {
+				expect( screen.getByRole( 'tooltip' ) ).toBeInTheDocument();
+			} );
+			expect( screen.getByRole( 'tooltip' ) ).toHaveTextContent( 'Windows: 80K' );
+
+			await user.unhover( segments[ 0 ] );
+			await waitFor( () => {
+				expect( screen.queryByRole( 'tooltip' ) ).not.toBeInTheDocument();
+			} );
+
+			// Test second segment
+			await user.hover( segments[ 1 ] );
+			await waitFor( () => {
+				expect( screen.getByRole( 'tooltip' ) ).toBeInTheDocument();
+			} );
+			expect( screen.getByRole( 'tooltip' ) ).toHaveTextContent( 'MacOS: 30K' );
+		} );
+
+		test( 'tooltip shows valueDisplay when available, falls back to value', async () => {
+			const user = userEvent.setup();
+			const dataWithoutValueDisplay = [ { label: 'Test', value: 42, percentage: 100 } ];
+
+			renderWithTheme( {
+				data: dataWithoutValueDisplay,
+				withTooltips: true,
+			} );
+
+			const segments = screen.getAllByTestId( 'pie-segment' );
+			await user.hover( segments[ 0 ] );
+
+			await waitFor( () => {
+				expect( screen.getByRole( 'tooltip' ) ).toBeInTheDocument();
+			} );
+			expect( screen.getByRole( 'tooltip' ) ).toHaveTextContent( 'Test: 42' );
 		} );
 	} );
 } );

--- a/projects/js-packages/charts/src/components/pie-semi-circle-chart/pie-semi-circle-chart.tsx
+++ b/projects/js-packages/charts/src/components/pie-semi-circle-chart/pie-semi-circle-chart.tsx
@@ -153,17 +153,14 @@ const PieSemiCircleChartInternal: FC< PieSemiCircleChartProps > = ( {
 
 	const handleMouseMove = useCallback(
 		( event: MouseEvent< SVGElement >, arc: ArcData ) => {
-			// Get SVG element and use localPoint as recommended by visx docs
-			const svg = ( event.currentTarget as SVGElement ).ownerSVGElement;
-			if ( svg ) {
-				const coords = localPoint( svg, event.nativeEvent );
-				if ( coords ) {
-					showTooltip( {
-						tooltipData: arc.data,
-						tooltipLeft: coords.x + tooltipOffsetX,
-						tooltipTop: coords.y + tooltipOffsetY,
-					} );
-				}
+			// Get coordinates relative to the current target element
+			const coords = localPoint( event );
+			if ( coords ) {
+				showTooltip( {
+					tooltipData: arc.data,
+					tooltipLeft: coords.x + tooltipOffsetX,
+					tooltipTop: coords.y + tooltipOffsetY,
+				} );
 			}
 		},
 		[ showTooltip, tooltipOffsetX, tooltipOffsetY ]

--- a/projects/js-packages/charts/src/components/pie-semi-circle-chart/pie-semi-circle-chart.tsx
+++ b/projects/js-packages/charts/src/components/pie-semi-circle-chart/pie-semi-circle-chart.tsx
@@ -69,12 +69,6 @@ export interface PieSemiCircleChartProps extends BaseChartProps< DataPointPercen
 	 * - 'none': Shows no values, only labels
 	 */
 	legendValueDisplay?: LegendValueDisplay;
-
-	/**
-	 * Vertical offset for tooltip positioning (in pixels)
-	 * @default 15
-	 */
-	tooltipOffset?: number;
 }
 
 // Base props type with optional responsive properties
@@ -128,7 +122,6 @@ const PieSemiCircleChartInternal: FC< PieSemiCircleChartProps > = ( {
 	legendTextOverflow = 'wrap',
 	legendShape = 'circle',
 	legendValueDisplay = 'percentage',
-	tooltipOffset = 15,
 	label,
 	note,
 	className,
@@ -157,12 +150,12 @@ const PieSemiCircleChartInternal: FC< PieSemiCircleChartProps > = ( {
 					showTooltip( {
 						tooltipData: arc.data,
 						tooltipLeft: coords.x,
-						tooltipTop: coords.y - tooltipOffset,
+						tooltipTop: coords.y - 15,
 					} );
 				}
 			}
 		},
-		[ showTooltip, tooltipOffset ]
+		[ showTooltip ]
 	);
 
 	const handleMouseLeave = useCallback( () => {

--- a/projects/js-packages/charts/src/components/pie-semi-circle-chart/pie-semi-circle-chart.tsx
+++ b/projects/js-packages/charts/src/components/pie-semi-circle-chart/pie-semi-circle-chart.tsx
@@ -330,7 +330,9 @@ const PieSemiCircleChartInternal: FC< PieSemiCircleChartProps > = ( {
 
 				{ withTooltips && tooltipOpen && tooltipData && (
 					<TooltipInPortal top={ tooltipTop || 0 } left={ tooltipLeft || 0 }>
-						<BaseTooltip data={ tooltipData } top={ 0 } left={ 0 } renderContainer={ false } />
+						<div role="tooltip">
+							<BaseTooltip data={ tooltipData } top={ 0 } left={ 0 } renderContainer={ false } />
+						</div>
 					</TooltipInPortal>
 				) }
 

--- a/projects/js-packages/charts/src/components/pie-semi-circle-chart/pie-semi-circle-chart.tsx
+++ b/projects/js-packages/charts/src/components/pie-semi-circle-chart/pie-semi-circle-chart.tsx
@@ -69,6 +69,16 @@ export interface PieSemiCircleChartProps extends BaseChartProps< DataPointPercen
 	 * - 'none': Shows no values, only labels
 	 */
 	legendValueDisplay?: LegendValueDisplay;
+
+	/**
+	 * Horizontal offset for tooltip positioning in pixels (default: 0)
+	 */
+	tooltipOffsetX?: number;
+
+	/**
+	 * Vertical offset for tooltip positioning in pixels (default: -15)
+	 */
+	tooltipOffsetY?: number;
 }
 
 // Base props type with optional responsive properties
@@ -126,6 +136,8 @@ const PieSemiCircleChartInternal: FC< PieSemiCircleChartProps > = ( {
 	note,
 	className,
 	children,
+	tooltipOffsetX = 0,
+	tooltipOffsetY = -15,
 } ) => {
 	const chartId = useChartId( providedChartId );
 	const [ legendRef, legendHeight ] = useElementHeight< HTMLDivElement >();
@@ -148,13 +160,13 @@ const PieSemiCircleChartInternal: FC< PieSemiCircleChartProps > = ( {
 				if ( coords ) {
 					showTooltip( {
 						tooltipData: arc.data,
-						tooltipLeft: coords.x,
-						tooltipTop: coords.y - 15,
+						tooltipLeft: coords.x + tooltipOffsetX,
+						tooltipTop: coords.y + tooltipOffsetY,
 					} );
 				}
 			}
 		},
-		[ showTooltip ]
+		[ showTooltip, tooltipOffsetX, tooltipOffsetY ]
 	);
 
 	const handleMouseLeave = useCallback( () => {

--- a/projects/js-packages/charts/src/components/pie-semi-circle-chart/pie-semi-circle-chart.tsx
+++ b/projects/js-packages/charts/src/components/pie-semi-circle-chart/pie-semi-circle-chart.tsx
@@ -330,10 +330,7 @@ const PieSemiCircleChartInternal: FC< PieSemiCircleChartProps > = ( {
 				</svg>
 
 				{ withTooltips && tooltipOpen && tooltipData && (
-					<TooltipInPortal
-						top={ tooltipTop || 0 }
-						left={ tooltipLeft || 0 }
-					>
+					<TooltipInPortal top={ tooltipTop || 0 } left={ tooltipLeft || 0 }>
 						<div role="tooltip">
 							{ tooltipData.label }: { tooltipData.valueDisplay || tooltipData.value }
 						</div>

--- a/projects/js-packages/charts/src/components/pie-semi-circle-chart/pie-semi-circle-chart.tsx
+++ b/projects/js-packages/charts/src/components/pie-semi-circle-chart/pie-semi-circle-chart.tsx
@@ -162,7 +162,7 @@ const PieSemiCircleChartInternal: FC< PieSemiCircleChartProps > = ( {
 	}, [ hideTooltip ] );
 
 	const handleArcMouseMove = useCallback(
-		( arc: ArcData ) => ( event: MouseEvent ) => {
+		( arc: ArcData ) => ( event: MouseEvent< SVGElement > ) => {
 			handleMouseMove( event, arc );
 		},
 		[ handleMouseMove ]

--- a/projects/js-packages/charts/src/components/pie-semi-circle-chart/pie-semi-circle-chart.tsx
+++ b/projects/js-packages/charts/src/components/pie-semi-circle-chart/pie-semi-circle-chart.tsx
@@ -2,7 +2,7 @@ import { localPoint } from '@visx/event';
 import { Group } from '@visx/group';
 import { Pie } from '@visx/shape';
 import { Text } from '@visx/text';
-import { useTooltip } from '@visx/tooltip';
+import { useTooltip, useTooltipInPortal } from '@visx/tooltip';
 import clsx from 'clsx';
 import { useCallback, useContext, useMemo } from 'react';
 import { useElementHeight } from '../../hooks';
@@ -18,7 +18,6 @@ import { Legend, useChartLegendItems } from '../legend';
 import { ChartSVG, ChartHTML, useChartChildren } from '../private/chart-composition';
 import { SingleChartContext } from '../private/single-chart-context';
 import { withResponsive } from '../private/with-responsive';
-import { BaseTooltip } from '../tooltip';
 import styles from './pie-semi-circle-chart.module.scss';
 import type { BaseChartProps, DataPointPercentage, Optional } from '../../types';
 import type { LegendValueDisplay } from '../legend';
@@ -129,19 +128,33 @@ const PieSemiCircleChartInternal: FC< PieSemiCircleChartProps > = ( {
 } ) => {
 	const chartId = useChartId( providedChartId );
 	const [ legendRef, legendHeight ] = useElementHeight< HTMLDivElement >();
+	// Import useTooltip back temporarily for semi-circle chart
 	const { tooltipOpen, tooltipLeft, tooltipTop, tooltipData, hideTooltip, showTooltip } =
 		useTooltip< DataPointPercentage >();
 
+	// Set up portal tooltip for better z-index handling
+	const { containerRef, TooltipInPortal } = useTooltipInPortal( {
+		detectBounds: true,
+		scroll: true,
+		debounce: 0,
+	} );
+
+	// Container ref for tooltip portal
+
 	const handleMouseMove = useCallback(
 		( event: MouseEvent, arc: ArcData ) => {
-			const coords = localPoint( event );
-			if ( ! coords ) return;
-
-			showTooltip( {
-				tooltipData: arc.data,
-				tooltipLeft: coords.x,
-				tooltipTop: coords.y - 10,
-			} );
+			// Get SVG element and use localPoint as recommended by visx docs
+			const svg = ( event.currentTarget as SVGElement ).ownerSVGElement;
+			if ( svg ) {
+				const coords = localPoint( svg, event.nativeEvent );
+				if ( coords ) {
+					showTooltip( {
+						tooltipData: arc.data,
+						tooltipLeft: coords.x,
+						tooltipTop: coords.y - 8, // Closer offset above cursor
+					} );
+				}
+			}
 		},
 		[ showTooltip ]
 	);
@@ -248,6 +261,7 @@ const PieSemiCircleChartInternal: FC< PieSemiCircleChartProps > = ( {
 			} }
 		>
 			<div
+				ref={ containerRef }
 				className={ clsx( 'pie-semi-circle-chart', styles[ 'pie-semi-circle-chart' ], className ) }
 				data-testid="pie-chart-container"
 				style={ {
@@ -277,15 +291,13 @@ const PieSemiCircleChartInternal: FC< PieSemiCircleChartProps > = ( {
 						>
 							{ pie => {
 								return pie.arcs.map( arc => (
-									<g
-										key={ arc.data.label }
-										onMouseMove={ handleArcMouseMove( arc ) }
-										onMouseLeave={ handleMouseLeave }
-									>
+									<g key={ arc.data.label }>
 										<path
 											d={ pie.path( arc ) || '' }
 											fill={ accessors.fill( arc.data ) }
 											data-testid="pie-segment"
+											onMouseMove={ withTooltips ? handleArcMouseMove( arc ) : undefined }
+											onMouseLeave={ withTooltips ? handleMouseLeave : undefined }
 										/>
 									</g>
 								) );
@@ -318,15 +330,14 @@ const PieSemiCircleChartInternal: FC< PieSemiCircleChartProps > = ( {
 				</svg>
 
 				{ withTooltips && tooltipOpen && tooltipData && (
-					<BaseTooltip
-						data={ {
-							label: tooltipData.label,
-							value: tooltipData.value,
-							valueDisplay: tooltipData.valueDisplay,
-						} }
+					<TooltipInPortal
 						top={ tooltipTop || 0 }
 						left={ tooltipLeft || 0 }
-					/>
+					>
+						<div role="tooltip">
+							{ tooltipData.label }: { tooltipData.valueDisplay || tooltipData.value }
+						</div>
+					</TooltipInPortal>
 				) }
 
 				{ showLegend && (

--- a/projects/js-packages/charts/src/components/pie-semi-circle-chart/pie-semi-circle-chart.tsx
+++ b/projects/js-packages/charts/src/components/pie-semi-circle-chart/pie-semi-circle-chart.tsx
@@ -289,13 +289,15 @@ const PieSemiCircleChartInternal: FC< PieSemiCircleChartProps > = ( {
 						>
 							{ pie => {
 								return pie.arcs.map( arc => (
-									<g key={ arc.data.label }>
+									<g
+										key={ arc.data.label }
+										onMouseMove={ withTooltips ? handleArcMouseMove( arc ) : undefined }
+										onMouseLeave={ withTooltips ? handleMouseLeave : undefined }
+									>
 										<path
 											d={ pie.path( arc ) || '' }
 											fill={ accessors.fill( arc.data ) }
 											data-testid="pie-segment"
-											onMouseMove={ withTooltips ? handleArcMouseMove( arc ) : undefined }
-											onMouseLeave={ withTooltips ? handleMouseLeave : undefined }
 										/>
 									</g>
 								) );

--- a/projects/js-packages/charts/src/components/pie-semi-circle-chart/pie-semi-circle-chart.tsx
+++ b/projects/js-packages/charts/src/components/pie-semi-circle-chart/pie-semi-circle-chart.tsx
@@ -151,7 +151,7 @@ const PieSemiCircleChartInternal: FC< PieSemiCircleChartProps > = ( {
 					showTooltip( {
 						tooltipData: arc.data,
 						tooltipLeft: coords.x,
-						tooltipTop: coords.y - 8, // Closer offset above cursor
+						tooltipTop: coords.y - 15, // Standard offset above cursor
 					} );
 				}
 			}

--- a/projects/js-packages/charts/src/components/pie-semi-circle-chart/pie-semi-circle-chart.tsx
+++ b/projects/js-packages/charts/src/components/pie-semi-circle-chart/pie-semi-circle-chart.tsx
@@ -128,7 +128,7 @@ const PieSemiCircleChartInternal: FC< PieSemiCircleChartProps > = ( {
 } ) => {
 	const chartId = useChartId( providedChartId );
 	const [ legendRef, legendHeight ] = useElementHeight< HTMLDivElement >();
-	// Import useTooltip back temporarily for semi-circle chart
+	// Use tooltip hook for interactive tooltips
 	const { tooltipOpen, tooltipLeft, tooltipTop, tooltipData, hideTooltip, showTooltip } =
 		useTooltip< DataPointPercentage >();
 
@@ -139,14 +139,12 @@ const PieSemiCircleChartInternal: FC< PieSemiCircleChartProps > = ( {
 		debounce: 0,
 	} );
 
-	// Container ref for tooltip portal
-
 	const handleMouseMove = useCallback(
 		( event: MouseEvent, arc: ArcData ) => {
 			// Get SVG element and use localPoint as recommended by visx docs
 			const svg = ( event.currentTarget as SVGElement ).ownerSVGElement;
 			if ( svg ) {
-				const coords = localPoint( svg, event.nativeEvent );
+				const coords = localPoint( svg, event );
 				if ( coords ) {
 					showTooltip( {
 						tooltipData: arc.data,

--- a/projects/js-packages/charts/src/components/pie-semi-circle-chart/pie-semi-circle-chart.tsx
+++ b/projects/js-packages/charts/src/components/pie-semi-circle-chart/pie-semi-circle-chart.tsx
@@ -129,7 +129,6 @@ const PieSemiCircleChartInternal: FC< PieSemiCircleChartProps > = ( {
 } ) => {
 	const chartId = useChartId( providedChartId );
 	const [ legendRef, legendHeight ] = useElementHeight< HTMLDivElement >();
-	// Use tooltip hook for interactive tooltips
 	const { tooltipOpen, tooltipLeft, tooltipTop, tooltipData, hideTooltip, showTooltip } =
 		useTooltip< DataPointPercentage >();
 
@@ -141,11 +140,11 @@ const PieSemiCircleChartInternal: FC< PieSemiCircleChartProps > = ( {
 	} );
 
 	const handleMouseMove = useCallback(
-		( event: MouseEvent, arc: ArcData ) => {
+		( event: MouseEvent< SVGElement >, arc: ArcData ) => {
 			// Get SVG element and use localPoint as recommended by visx docs
 			const svg = ( event.currentTarget as SVGElement ).ownerSVGElement;
 			if ( svg ) {
-				const coords = localPoint( svg, event );
+				const coords = localPoint( svg, event.nativeEvent );
 				if ( coords ) {
 					showTooltip( {
 						tooltipData: arc.data,

--- a/projects/js-packages/charts/src/components/pie-semi-circle-chart/pie-semi-circle-chart.tsx
+++ b/projects/js-packages/charts/src/components/pie-semi-circle-chart/pie-semi-circle-chart.tsx
@@ -18,6 +18,7 @@ import { Legend, useChartLegendItems } from '../legend';
 import { ChartSVG, ChartHTML, useChartChildren } from '../private/chart-composition';
 import { SingleChartContext } from '../private/single-chart-context';
 import { withResponsive } from '../private/with-responsive';
+import { BaseTooltip } from '../tooltip';
 import styles from './pie-semi-circle-chart.module.scss';
 import type { BaseChartProps, DataPointPercentage, Optional } from '../../types';
 import type { LegendValueDisplay } from '../legend';
@@ -68,6 +69,12 @@ export interface PieSemiCircleChartProps extends BaseChartProps< DataPointPercen
 	 * - 'none': Shows no values, only labels
 	 */
 	legendValueDisplay?: LegendValueDisplay;
+
+	/**
+	 * Vertical offset for tooltip positioning (in pixels)
+	 * @default 15
+	 */
+	tooltipOffset?: number;
 }
 
 // Base props type with optional responsive properties
@@ -121,6 +128,7 @@ const PieSemiCircleChartInternal: FC< PieSemiCircleChartProps > = ( {
 	legendTextOverflow = 'wrap',
 	legendShape = 'circle',
 	legendValueDisplay = 'percentage',
+	tooltipOffset = 15,
 	label,
 	note,
 	className,
@@ -149,12 +157,12 @@ const PieSemiCircleChartInternal: FC< PieSemiCircleChartProps > = ( {
 					showTooltip( {
 						tooltipData: arc.data,
 						tooltipLeft: coords.x,
-						tooltipTop: coords.y - 15, // Standard offset above cursor
+						tooltipTop: coords.y - tooltipOffset,
 					} );
 				}
 			}
 		},
-		[ showTooltip ]
+		[ showTooltip, tooltipOffset ]
 	);
 
 	const handleMouseLeave = useCallback( () => {
@@ -329,9 +337,7 @@ const PieSemiCircleChartInternal: FC< PieSemiCircleChartProps > = ( {
 
 				{ withTooltips && tooltipOpen && tooltipData && (
 					<TooltipInPortal top={ tooltipTop || 0 } left={ tooltipLeft || 0 }>
-						<div role="tooltip">
-							{ tooltipData.label }: { tooltipData.valueDisplay || tooltipData.value }
-						</div>
+						<BaseTooltip data={ tooltipData } top={ 0 } left={ 0 } renderContainer={ false } />
 					</TooltipInPortal>
 				) }
 

--- a/projects/js-packages/charts/src/components/pie-semi-circle-chart/pie-semi-circle-chart.tsx
+++ b/projects/js-packages/charts/src/components/pie-semi-circle-chart/pie-semi-circle-chart.tsx
@@ -156,14 +156,16 @@ const PieSemiCircleChartInternal: FC< PieSemiCircleChartProps > = ( {
 			// Get coordinates relative to the current target element
 			const coords = localPoint( event );
 			if ( coords ) {
+				// Account for legend offset when legend is on top
+				const legendOffset = showLegend && legendPosition === 'top' ? legendHeight : 0;
 				showTooltip( {
 					tooltipData: arc.data,
 					tooltipLeft: coords.x + tooltipOffsetX,
-					tooltipTop: coords.y + tooltipOffsetY,
+					tooltipTop: coords.y + legendOffset + tooltipOffsetY,
 				} );
 			}
 		},
-		[ showTooltip, tooltipOffsetX, tooltipOffsetY ]
+		[ showTooltip, tooltipOffsetX, tooltipOffsetY, showLegend, legendPosition, legendHeight ]
 	);
 
 	const handleMouseLeave = useCallback( () => {

--- a/projects/js-packages/charts/src/components/tooltip/base-tooltip.tsx
+++ b/projects/js-packages/charts/src/components/tooltip/base-tooltip.tsx
@@ -17,6 +17,12 @@ type TooltipCommonProps = {
 	left: number;
 	style?: CSSProperties;
 	className?: string;
+	/**
+	 * Whether to render the tooltip container div. When false, only renders the content.
+	 * Useful when the tooltip is rendered inside a portal or custom container.
+	 * @default true
+	 */
+	renderContainer?: boolean;
 };
 
 type DefaultDataTooltip = {
@@ -46,10 +52,18 @@ export const BaseTooltip = ( {
 	component: Component = DefaultTooltipContent,
 	children,
 	className,
+	style,
+	renderContainer = true,
 }: BaseTooltipProps ) => {
+	const content = children || ( data && <Component data={ data } className={ className } /> );
+
+	if ( ! renderContainer ) {
+		return content;
+	}
+
 	return (
-		<div className={ styles.tooltip } style={ { top, left } } role="tooltip">
-			{ children || ( data && <Component data={ data } className={ className } /> ) }
+		<div className={ styles.tooltip } style={ { top, left, ...style } } role="tooltip">
+			{ content }
 		</div>
 	);
 };

--- a/projects/js-packages/charts/src/hooks/test/use-chart-mouse-handler.test.tsx
+++ b/projects/js-packages/charts/src/hooks/test/use-chart-mouse-handler.test.tsx
@@ -19,10 +19,8 @@ describe( 'useChartMouseHandler', () => {
 		target: document.createElement( 'svg' ),
 	} as unknown as MouseEvent< SVGElement >;
 
-	const margin = { margin: { left: 0, right: 0, top: 0, bottom: 0 }, withTooltips: true };
-
 	test( 'initializes with default values', () => {
-		const { result } = renderHook( () => useChartMouseHandler( margin ) );
+		const { result } = renderHook( () => useChartMouseHandler( { withTooltips: true } ) );
 		expect( result.current.tooltipData ).toBeNull();
 		expect( result.current.tooltipOpen ).toBe( false );
 	} );
@@ -40,7 +38,7 @@ describe( 'useChartMouseHandler', () => {
 	} );
 
 	test( 'handles mouse leave', () => {
-		const { result } = renderHook( () => useChartMouseHandler( margin ) );
+		const { result } = renderHook( () => useChartMouseHandler( { withTooltips: true } ) );
 
 		act( () => {
 			result.current.onMouseMove( mockEvent, { value: 42, label: 'Test' } );

--- a/projects/js-packages/charts/src/hooks/use-chart-mouse-handler.ts
+++ b/projects/js-packages/charts/src/hooks/use-chart-mouse-handler.ts
@@ -8,6 +8,14 @@ type UseChartMouseHandlerProps = {
 	 * Whether tooltips are enabled
 	 */
 	withTooltips: boolean;
+	/**
+	 * Horizontal offset for tooltip positioning in pixels (default: 0)
+	 */
+	offsetX?: number;
+	/**
+	 * Vertical offset for tooltip positioning in pixels (default: -10)
+	 */
+	offsetY?: number;
 };
 
 type UseChartMouseHandlerReturn = {
@@ -45,11 +53,12 @@ type UseChartMouseHandlerReturn = {
  */
 export const useChartMouseHandler = ( {
 	withTooltips,
+	offsetX = 0,
+	offsetY = -10,
 }: UseChartMouseHandlerProps ): UseChartMouseHandlerReturn => {
 	const { tooltipOpen, tooltipLeft, tooltipTop, tooltipData, hideTooltip, showTooltip } =
 		useTooltip< DataPoint >();
 
-	// TODO: either debounce/throttle or use useTooltipInPortal with built-in debounce
 	const onMouseMove = useCallback(
 		( event: MouseEvent< SVGElement >, data: DataPoint ) => {
 			if ( ! withTooltips ) {
@@ -63,11 +72,11 @@ export const useChartMouseHandler = ( {
 
 			showTooltip( {
 				tooltipData: data,
-				tooltipLeft: coords.x,
-				tooltipTop: coords.y - 10,
+				tooltipLeft: coords.x + offsetX,
+				tooltipTop: coords.y + offsetY,
 			} );
 		},
-		[ withTooltips, showTooltip ]
+		[ withTooltips, showTooltip, offsetX, offsetY ]
 	);
 
 	const onMouseLeave = useCallback( () => {


### PR DESCRIPTION
## Proposed changes:

- Add `renderContainer` prop to BaseTooltip component allowing it to work seamlessly with TooltipInPortal
- Use BaseTooltip inside TooltipInPortal to solve stacking context problems while maintaining all tooltip customisation capabilities
- Improve tooltip positioning accuracy by using localPoint with React event directly (not nativeEvent) for better type safety and coordinate handling
- Standardise tooltip offset by using consistent 15px offset above cursor for optimal visibility

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?

No, it does not.

## Testing instructions:

* Go to `Storybook -> Charts -> Types -> Pie Chart -> WithTooltips` story
* Hover over different pie segments and verify tooltips appear 15px above cursor
* Test pie semi-circle chart tooltips with same behavior
* Verify tooltip content shows correct label and value format & appear above all chart content (no hiding behind elements) & are close to the cursor
* Test tooltip positioning accuracy when moving mouse across chart segments
* Ensure tooltips disappear properly when mouse leaves chart area
* Verify no visual regressions in chart rendering, legends, or other functionality
* Test that existing BaseTooltip usage in other components remains unchanged
