### PR TITLE
WooCommerce Analytics: Add proxy speed module to enhance proxy API performance

### DIFF
--- a/projects/packages/woocommerce-analytics/changelog/add-wca-proxy-speed-module
+++ b/projects/packages/woocommerce-analytics/changelog/add-wca-proxy-speed-module
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add proxy speed module to enhance proxy API performance

--- a/projects/packages/woocommerce-analytics/src/class-woocommerce-analytics.php
+++ b/projects/packages/woocommerce-analytics/src/class-woocommerce-analytics.php
@@ -22,6 +22,11 @@ class Woocommerce_Analytics {
 	 */
 	const PACKAGE_VERSION = '0.8.0';
 
+	/**
+	 * Proxy speed module version.
+	 *
+	 * @var string
+	*/
 	const PROXY_SPEED_MODULE_VERSION = '1.0.0';
 
 	/**
@@ -138,10 +143,6 @@ class Woocommerce_Analytics {
 	 * Maybe add proxy speed module.
 	 */
 	public static function maybe_add_proxy_speed_module() {
-		if ( ! current_user_can( 'install_plugins' ) ) {
-			return;
-		}
-
 		if ( ! function_exists( 'WP_Filesystem' ) ) {
 			require_once ABSPATH . 'wp-admin/includes/file.php';
 		}
@@ -165,8 +166,9 @@ class Woocommerce_Analytics {
 		}
 
 		update_option( 'woocommerce_analytics_proxy_speed_module_version', self::PROXY_SPEED_MODULE_VERSION );
-		$mu_plugin_src_dir = __DIR__ . '/mu-plugin';
-		$results           = copy_dir( $mu_plugin_src_dir, WPMU_PLUGIN_DIR );
+		$mu_plugin_src_file  = __DIR__ . '/mu-plugin/woocommerce-analytics-proxy-speed-module.php';
+		$mu_plugin_dest_file = WPMU_PLUGIN_DIR . '/woocommerce-analytics-proxy-speed-module.php';
+		$results             = copy( $mu_plugin_src_file, $mu_plugin_dest_file );
 
 		if ( is_wp_error( $results ) ) {
 			if ( function_exists( 'wc_get_logger' ) ) {
@@ -176,13 +178,9 @@ class Woocommerce_Analytics {
 	}
 
 	/**
-	 * Maybe remove proxy speed module.
+	 * Maybe removes the proxy speed module. This should be invoked when the plugin is deactivated.
 	 */
 	public static function maybe_remove_proxy_speed_module() {
-		if ( ! current_user_can( 'install_plugins' ) ) {
-			return;
-		}
-
 		/**
 		 * Clean up MU plugin.
 		 */

--- a/projects/packages/woocommerce-analytics/src/class-woocommerce-analytics.php
+++ b/projects/packages/woocommerce-analytics/src/class-woocommerce-analytics.php
@@ -184,7 +184,7 @@ class Woocommerce_Analytics {
 		/**
 		 * Clean up MU plugin.
 		 */
-		$file_path = WP_CONTENT_DIR . '/mu-plugins/woocommerce-analytics-proxy-speed-module.php';
+		$file_path = WPMU_PLUGIN_DIR . '/woocommerce-analytics-proxy-speed-module.php';
 
 		if ( file_exists( $file_path ) ) {
 			wp_delete_file( $file_path );

--- a/projects/packages/woocommerce-analytics/src/class-woocommerce-analytics.php
+++ b/projects/packages/woocommerce-analytics/src/class-woocommerce-analytics.php
@@ -170,7 +170,7 @@ class Woocommerce_Analytics {
 		$mu_plugin_dest_file = WPMU_PLUGIN_DIR . '/woocommerce-analytics-proxy-speed-module.php';
 		$results             = copy( $mu_plugin_src_file, $mu_plugin_dest_file );
 
-		if ( is_wp_error( $results ) ) {
+		if ( ! $results ) {
 			if ( function_exists( 'wc_get_logger' ) ) {
 				wc_get_logger()->error( 'Failed to copy the WooCommerce Analytics proxy speed module files.', array( 'source' => 'woocommerce-analytics' ) );
 			}

--- a/projects/packages/woocommerce-analytics/src/class-woocommerce-analytics.php
+++ b/projects/packages/woocommerce-analytics/src/class-woocommerce-analytics.php
@@ -22,6 +22,8 @@ class Woocommerce_Analytics {
 	 */
 	const PACKAGE_VERSION = '0.8.0';
 
+	const PROXY_SPEED_MODULE_VERSION = '1.0.0';
+
 	/**
 	 * Initializer.
 	 * Used to configure the WooCommerce Analytics package.
@@ -130,5 +132,66 @@ class Woocommerce_Analytics {
 	public static function register_rest_routes() {
 		$controller = new WC_Analytics_Tracking_Proxy();
 		$controller->register_routes();
+	}
+
+	/**
+	 * Maybe add proxy speed module.
+	 */
+	public static function maybe_add_proxy_speed_module() {
+		if ( ! current_user_can( 'install_plugins' ) ) {
+			return;
+		}
+
+		if ( ! function_exists( 'WP_Filesystem' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/file.php';
+		}
+
+		// Initialize the WP filesystem.
+		WP_Filesystem();
+
+		// Create the mu-plugin directory if it doesn't exist.
+		if ( ! is_dir( WPMU_PLUGIN_DIR ) ) {
+			wp_mkdir_p( WPMU_PLUGIN_DIR );
+		}
+
+		// If the mu-plugin directory doesn't exist, we can't copy the files.
+		if ( ! is_dir( WPMU_PLUGIN_DIR ) ) {
+			return;
+		}
+
+		if ( get_option( 'woocommerce_analytics_proxy_speed_module_version' ) === self::PROXY_SPEED_MODULE_VERSION ) {
+			// No need to copy the files again.
+			return;
+		}
+
+		update_option( 'woocommerce_analytics_proxy_speed_module_version', self::PROXY_SPEED_MODULE_VERSION );
+		$mu_plugin_src_dir = __DIR__ . '/mu-plugin';
+		$results           = copy_dir( $mu_plugin_src_dir, WPMU_PLUGIN_DIR );
+
+		if ( is_wp_error( $results ) ) {
+			if ( function_exists( 'wc_get_logger' ) ) {
+				wc_get_logger()->error( 'Failed to copy the WooCommerce Analytics proxy speed module files.', array( 'source' => 'woocommerce-analytics' ) );
+			}
+		}
+	}
+
+	/**
+	 * Maybe remove proxy speed module.
+	 */
+	public static function maybe_remove_proxy_speed_module() {
+		if ( ! current_user_can( 'install_plugins' ) ) {
+			return;
+		}
+
+		/**
+		 * Clean up MU plugin.
+		 */
+		$file_path = WP_CONTENT_DIR . '/mu-plugins/woocommerce-analytics-proxy-speed-module.php';
+
+		if ( file_exists( $file_path ) ) {
+			wp_delete_file( $file_path );
+		}
+
+		delete_option( 'woocommerce_analytics_proxy_speed_module_version' );
 	}
 }

--- a/projects/packages/woocommerce-analytics/src/mu-plugin/woocommerce-analytics-proxy-speed-module.php
+++ b/projects/packages/woocommerce-analytics/src/mu-plugin/woocommerce-analytics-proxy-speed-module.php
@@ -1,0 +1,114 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+/**
+ * Plugin Name: WooCommerce Analytics - Proxy Speed Module
+ * Description: Speeds up WooCommerce Analytics' proxy for avoiding ad blockers.
+ * Plugin URI: https://woocommerce.com
+ * Author: WooCommerce
+ * Version: 1.0.0
+ * Author URI: https://woocommerce.com
+ *
+ * Text Domain: woocommerce-analytics
+ *
+ * Inspired by: https://github.com/plausible/wordpress/blob/092b97b247f45bf347ae32f9614f20a81d9e10c0/mu-plugin/plausible-proxy-speed-module.php
+ */
+class WooCommerceAnalyticsProxySpeed {
+	/**
+	 * Is current request a request to our proxy?
+	 *
+	 * @var bool
+	 */
+	private $is_proxy_request = false;
+
+	/**
+	 * Current request URI.
+	 *
+	 * @var string
+	 */
+	private $request_uri = '';
+
+	/**
+	 * Path of the proxy request.
+	 *
+	 * @var string
+	 */
+	private $path = 'woocommerce-analytics/v1/track';
+
+	/**
+	 * Allowed plugin files.
+	 *
+	 * @var array
+	 */
+	private $allowed_plugin_files = array( 'woocommerce.php', 'woocommerce-analytics.php', 'jetpack.php' );
+
+	/**
+	 * Build properties.
+	 *
+	 * @return void
+	 */
+	public function __construct() {
+		$this->request_uri      = $this->get_request_uri();
+		$this->is_proxy_request = $this->is_proxy_request();
+
+		$this->init();
+	}
+
+	/**
+	 * Helper method to retrieve Request URI. Checks several globals.
+	 *
+	 * @return mixed
+	 */
+	private function get_request_uri() {
+		return isset( $_SERVER['REQUEST_URI'] ) ? wp_unslash( $_SERVER['REQUEST_URI'] ) : ''; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+	}
+
+	/**
+	 * Check if current request is a proxy request.
+	 *
+	 * @return bool
+	 */
+	private function is_proxy_request() {
+
+		if ( ! $this->path ) {
+			return false;
+		}
+
+		return strpos( $this->request_uri, $this->path ) !== false;
+	}
+
+	/**
+	 * Add filters and actions.
+	 *
+	 * @return void
+	 */
+	private function init() {
+		add_filter( 'option_active_plugins', array( $this, 'filter_active_plugins' ) );
+	}
+
+	/**
+	 * Filter the list of active plugins for custom endpoint requests.
+	 *
+	 * @param array $active_plugins The list of active plugins.
+	 *
+	 * @return array The filtered list of active plugins.
+	 */
+	public function filter_active_plugins( $active_plugins ) {
+		if ( ! $this->is_proxy_request || ! is_array( $active_plugins ) ) {
+			return $active_plugins;
+		}
+
+		$filtered_plugins = array();
+
+		foreach ( $active_plugins as $plugin ) {
+			foreach ( $this->allowed_plugin_files as $allowed_plugin_file ) {
+				if ( strpos( $plugin, $allowed_plugin_file ) !== false ) {
+					$filtered_plugins[] = $plugin;
+					break;
+				}
+			}
+		}
+
+		return $filtered_plugins;
+	}
+}
+
+new WooCommerceAnalyticsProxySpeed(); // @phan-suppress-current-line PhanNoopNew

--- a/projects/packages/woocommerce-analytics/src/mu-plugin/woocommerce-analytics-proxy-speed-module.php
+++ b/projects/packages/woocommerce-analytics/src/mu-plugin/woocommerce-analytics-proxy-speed-module.php
@@ -13,43 +13,52 @@
  */
 class WooCommerceAnalyticsProxySpeed {
 	/**
-	 * Is current request a request to our proxy?
-	 *
-	 * @var bool
-	 */
-	private $is_proxy_request = false;
-
-	/**
-	 * Current request URI.
-	 *
-	 * @var string
-	 */
-	private $request_uri = '';
-
-	/**
 	 * Path of the proxy request.
 	 *
 	 * @var string
 	 */
-	private $path = 'woocommerce-analytics/v1/track';
+	const PROXY_REQUEST_PATH = 'woocommerce-analytics/v1/track';
 
 	/**
-	 * Allowed plugin files.
+	 * Allowed plugin files for proxy request.
 	 *
 	 * @var array
 	 */
 	private $allowed_plugin_files = array( 'woocommerce.php', 'woocommerce-analytics.php', 'jetpack.php' );
 
 	/**
-	 * Build properties.
+	 * Add filters and actions.
 	 *
 	 * @return void
 	 */
-	public function __construct() {
-		$this->request_uri      = $this->get_request_uri();
-		$this->is_proxy_request = $this->is_proxy_request();
+	public function init() {
+		add_filter( 'option_active_plugins', array( $this, 'filter_active_plugins' ) );
+	}
 
-		$this->init();
+	/**
+	 * Filter the list of active plugins for custom endpoint requests.
+	 *
+	 * @param array $active_plugins The list of active plugins.
+	 *
+	 * @return array The filtered list of active plugins.
+	 */
+	public function filter_active_plugins( $active_plugins ) {
+		if ( ! $this->is_proxy_request() || ! is_array( $active_plugins ) ) {
+			return $active_plugins;
+		}
+
+		$filtered_plugins = array();
+
+		foreach ( $active_plugins as $plugin ) {
+			foreach ( $this->allowed_plugin_files as $allowed_plugin_file ) {
+				if ( strpos( $plugin, $allowed_plugin_file ) !== false ) {
+					$filtered_plugins[] = $plugin;
+					break;
+				}
+			}
+		}
+
+		return $filtered_plugins;
 	}
 
 	/**
@@ -67,48 +76,8 @@ class WooCommerceAnalyticsProxySpeed {
 	 * @return bool
 	 */
 	private function is_proxy_request() {
-
-		if ( ! $this->path ) {
-			return false;
-		}
-
-		return strpos( $this->request_uri, $this->path ) !== false;
-	}
-
-	/**
-	 * Add filters and actions.
-	 *
-	 * @return void
-	 */
-	private function init() {
-		add_filter( 'option_active_plugins', array( $this, 'filter_active_plugins' ) );
-	}
-
-	/**
-	 * Filter the list of active plugins for custom endpoint requests.
-	 *
-	 * @param array $active_plugins The list of active plugins.
-	 *
-	 * @return array The filtered list of active plugins.
-	 */
-	public function filter_active_plugins( $active_plugins ) {
-		if ( ! $this->is_proxy_request || ! is_array( $active_plugins ) ) {
-			return $active_plugins;
-		}
-
-		$filtered_plugins = array();
-
-		foreach ( $active_plugins as $plugin ) {
-			foreach ( $this->allowed_plugin_files as $allowed_plugin_file ) {
-				if ( strpos( $plugin, $allowed_plugin_file ) !== false ) {
-					$filtered_plugins[] = $plugin;
-					break;
-				}
-			}
-		}
-
-		return $filtered_plugins;
+		return strpos( $this->get_request_uri(), self::PROXY_REQUEST_PATH ) !== false;
 	}
 }
 
-new WooCommerceAnalyticsProxySpeed(); // @phan-suppress-current-line PhanNoopNew
+( new WooCommerceAnalyticsProxySpeed() )->init();

--- a/projects/plugins/jetpack/changelog/add-wca-proxy-speed-module
+++ b/projects/plugins/jetpack/changelog/add-wca-proxy-speed-module
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Integrate calls to add and remove the proxy speed module in Jetpack plugin initialization and deactivation processes

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -39,6 +39,7 @@ use Automattic\Jetpack\Sync\Health;
 use Automattic\Jetpack\Sync\Sender;
 use Automattic\Jetpack\Terms_Of_Service;
 use Automattic\Jetpack\Tracking;
+use Automattic\Woocommerce_Analytics;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit( 0 );
@@ -2623,6 +2624,10 @@ p {
 			Sync_Actions::do_only_first_initial_sync();
 		}
 
+		if ( ! defined( 'WC_ANALYTICS' ) && class_exists( 'Automattic\Woocommerce_Analytics' ) ) {
+			Woocommerce_Analytics::maybe_add_proxy_speed_module();
+		}
+
 		self::plugin_initialize();
 	}
 
@@ -2802,6 +2807,10 @@ p {
 			add_filter( 'jetpack_update_activated_state_on_disconnect', '__return_false' );
 			self::disconnect();
 			Jetpack_Options::delete_option( 'version' );
+		}
+
+		if ( ! defined( 'WC_ANALYTICS' ) && class_exists( 'Automattic\Woocommerce_Analytics' ) ) {
+			Woocommerce_Analytics::maybe_remove_proxy_speed_module();
 		}
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to pfKYZu-2Yt-p2#comment-3041

## Proposed changes
<!--- Explain what functional changes your PR includes -->

This PR introduces a proxy speed module that inspired by Plausible's proxy speed module for WooCommerce Analytics to enhance the proxy API performance.

The module is placed in the mu-plugins directory to prevent unnecessary plugins from being loaded during proxy requests, thereby improving performance.

### Other information

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

n/a

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

**Confirm proxy speed module is added/removed as Jetpack is activated/deactivated**

1. Set up a WordPress site with both Jetpack and WooCommerce installed.
2. Check out and activate this branch of Jetpack.
3. If you have the local WooCommerce Analytics plugin activated, deactivate it. We will add similar logic in Woo Analytics so that the proxy speed module is added/removed as Woo Analytics is activated/deactivated.
4. Deactivate Jetpack. Then, verify that the file `wp-content/mu-plugins/woocommerce-analytics-proxy-speed-module.php` does **not** exist.
5. Activate Jetpack. Then, verify that the file `wp-content/mu-plugins/woocommerce-analytics-proxy-speed-module.php` **does** exist.
6. (Optional) Repeat steps 4 and 5 to confirm the file is created/removed as Jetpack is activated/deactivated.

**Test REST API request**

1. Install [Code Snippets](https://wordpress.org/plugins/code-snippets/) plugin
2. Add the following code snippet to the site:

```php
function test_add_rest_api( ) {
 error_log( 'test_add_rest_api is called' );
}

add_action( 'rest_api_init', 'test_add_rest_api' );
```

3. Test request to the cart API:

```bash
curl https://your-site.com/wp-json/wc/store/v1/cart
```

6. Confirm that the `test_add_rest_api function is called` is logged in the `wp-content/debug.log` file.
7. Test request to the proxy API

```bash
curl -X POST https://your-site.com/wp-json/woocommerce-analytics/v1/track \
  -H "Content-Type: application/json" \
  -d '{
    "event_name": "page_view"
  }'
```

8. Confirm that the test_add_rest_api function is not called.