### PR TITLE
forms: Fix flakey E2E tests

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-forms-flakey-e2e-tests
+++ b/projects/plugins/jetpack/changelog/fix-forms-flakey-e2e-tests
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Fixed forms e2e tests.
+
+

--- a/projects/plugins/jetpack/tests/e2e/specs/forms/submission.test.ts
+++ b/projects/plugins/jetpack/tests/e2e/specs/forms/submission.test.ts
@@ -1,3 +1,4 @@
+import { Response } from '@playwright/test';
 import { expect, test } from '_jetpack-e2e-commons/fixtures/base-test';
 
 test.afterEach( async ( { requestUtils } ) => {
@@ -28,6 +29,22 @@ test.afterEach( async ( { requestUtils } ) => {
 	);
 } );
 
+/**
+ * Checks whether the given response is a form submission response.
+ *
+ * @param response - The response to check.
+ * @return Whether the response is a form submission response.
+ */
+function isFormSubmissionResponse( response: Response ) {
+	const url = new URL( response.url() );
+
+	return (
+		url.pathname.includes( '/wp-admin/admin-ajax.php' ) &&
+		response.request().method() === 'POST' &&
+		url.searchParams.get( 'action' ) === 'grunion-contact-form'
+	);
+}
+
 test.describe( 'Forms: Submission', () => {
 	test( 'Submits a simple contact form', async ( { admin, editor } ) => {
 		const formTitle = 'E2E Test Form';
@@ -50,7 +67,10 @@ test.describe( 'Forms: Submission', () => {
 			await form.getByRole( 'textbox', { name: 'Name' } ).fill( 'John Doe' );
 			await form.getByRole( 'textbox', { name: 'Email' } ).fill( 'john@doe.com' );
 			await form.getByRole( 'textbox', { name: 'Message' } ).fill( 'Hello, world!' );
+			// Wait for the form submission to complete.
+			const submissionPromise = previewPage.waitForResponse( isFormSubmissionResponse );
 			await form.getByRole( 'button', { name: 'Contact Us' } ).click();
+			await submissionPromise;
 
 			await expect(
 				previewPage.getByRole( 'heading', { name: 'Your message has been sent' } )
@@ -127,7 +147,10 @@ test.describe( 'Forms: Submission', () => {
 			await formToSubmit.getByRole( 'textbox', { name: 'Name' } ).fill( 'John Doe' );
 			await formToSubmit.getByRole( 'textbox', { name: 'Email' } ).fill( 'john@doe.com' );
 			await formToSubmit.getByRole( 'textbox', { name: 'Message' } ).fill( 'Hello, world!' );
+			// Wait for the form submission to complete.
+			const submissionPromise = previewPage.waitForResponse( isFormSubmissionResponse );
 			await formToSubmit.getByRole( 'button', { name: 'Contact Us' } ).click();
+			await submissionPromise;
 
 			// Check the correct form was submitted.
 			const submittedFormWrapper = previewPage.locator( `#${ formId }` );


### PR DESCRIPTION
Since the form submission is asynchronous, it can sometimes take time for the form submission to complete and thus in that case, asserting the success immediately after clicking the submit button will result in test failure. This PR ensures that we wait for the submission to complete before the assertion.

Recent failures: [#45239](https://github.com/Automattic/jetpack/actions/runs/17849847607/job/50756502659?pr=45239), [#45240](https://github.com/Automattic/jetpack/actions/runs/17849875348/job/50756627891?pr=45240)

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* In form submission E2E tests, wait for the form submission to complete before asserting the successful submission.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check if the change makes sense
* CI should be all green
