### PR TITLE
CRM: Fix tax rate duplication if a woo tax rate had 4 decimal places

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-tax-precision-insertion
+++ b/projects/plugins/crm/changelog/fix-crm-tax-precision-insertion
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+fixes issue where more than 2 decimal places would result in multiple tax rates being added

--- a/projects/plugins/crm/includes/ZeroBSCRM.Database.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Database.php
@@ -474,7 +474,7 @@ function zeroBSCRM_createTables(){
   `zbs_team` int(11) DEFAULT NULL,
   `zbs_owner` int(11) NOT NULL,
   `zbsc_tax_name` VARCHAR(100) NULL,
-  `zbsc_rate` DECIMAL(18,2) NOT NULL DEFAULT 0.00,
+  `zbsc_rate` DECIMAL(20,10) NOT NULL DEFAULT 0.0000000000,
   `zbsc_created` INT(14) NOT NULL,
   `zbsc_lastupdated` INT(14) NOT NULL,
   PRIMARY KEY (`ID`))

--- a/projects/plugins/crm/includes/ZeroBSCRM.Migrations.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Migrations.php
@@ -1287,7 +1287,9 @@ function zeroBSCRM_migration_tax_rate_precision_fix() {
 	$column_type = zeraBSCRM_migration_get_column_data_type( $ZBSCRM_t['tax'], 'zbsc_rate' ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 	if ( $column_type && strpos( $column_type, 'decimal(20,10)' ) === false ) {
 		// Table name is constructed internally and considered safe.
-		$wpdb->query( "ALTER TABLE `{$ZBSCRM_t['tax']}` MODIFY zbsc_rate DECIMAL(20,10) NOT NULL DEFAULT 0.0000000000" ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange, WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+		// Table name is constructed internally and escaped with backticks.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange, WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$wpdb->query( 'ALTER TABLE `' . esc_sql( $ZBSCRM_t['tax'] ) . '` MODIFY zbsc_rate DECIMAL(20,10) NOT NULL DEFAULT 0.0000000000' );
 	}
 
 	zeroBSCRM_migrations_markComplete( 'tax_rate_precision_fix', array( 'updated' => 1 ) );

--- a/projects/plugins/crm/includes/ZeroBSCRM.Migrations.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Migrations.php
@@ -1286,8 +1286,6 @@ function zeroBSCRM_migration_tax_rate_precision_fix() {
 	// For MySQL/MariaDB - check if the column exists and get its current data type.
 	$column_type = zeraBSCRM_migration_get_column_data_type( $ZBSCRM_t['tax'], 'zbsc_rate' ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 	if ( $column_type && strpos( $column_type, 'decimal(20,10)' ) === false ) {
-		// Table name is constructed internally and considered safe.
-		// Table name is constructed internally and escaped with backticks.
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange, WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		$wpdb->query( 'ALTER TABLE `' . esc_sql( $ZBSCRM_t['tax'] ) . '` MODIFY zbsc_rate DECIMAL(20,10) NOT NULL DEFAULT 0.0000000000' );
 	}

--- a/projects/plugins/crm/includes/ZeroBSCRM.Migrations.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Migrations.php
@@ -35,6 +35,7 @@ global $zeroBSCRM_migrations; $zeroBSCRM_migrations = array(
 	'create_workflows_table', // Create "workflows" table.
 	'invoice_language_fixes', // Store invoice statuses and mappings consistently
 	'gh3465_increase_city_field_size',  // from gh issue 3465, increases the city field size to 200
+	'tax_rate_precision_fix', // increase tax rate precision from 2 to 4 decimal places
 	);
 
 global $zeroBSCRM_migrations_requirements; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
@@ -1258,6 +1259,37 @@ function zeroBSCRM_migration_gh3465_increase_city_field_size() {
 	$wpdb->query( $sql ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
 
 	zeroBSCRM_migrations_markComplete( 'gh3465_increase_city_field_size', array( 'updated' => 1 ) );
+}
+
+/**
+ * Increase tax rate precision from 2 to 10 decimal places for WooCommerce sync compatibility
+ */
+function zeroBSCRM_migration_tax_rate_precision_fix() {
+
+	global $wpdb, $ZBSCRM_t; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+
+	$db_engine = jpcrm_database_engine();
+
+	if ( $db_engine === 'sqlite' ) {
+		// SQLite has dynamic typing - column types are flexible and can store high precision decimals
+		// No schema modification needed, but we can mark the migration as complete
+		zeroBSCRM_migrations_markComplete(
+			'tax_rate_precision_fix',
+			array(
+				'updated' => 0,
+				'note'    => 'SQLite dynamic typing - no schema change needed',
+			)
+		);
+		return;
+	}
+
+	// For MySQL/MariaDB - check if the column exists and get its current data type.
+	$column_type = zeraBSCRM_migration_get_column_data_type( $ZBSCRM_t['tax'], 'zbsc_rate' ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+	if ( $column_type && strpos( $column_type, 'decimal(20,10)' ) === false ) {
+		$wpdb->query( $wpdb->prepare( 'ALTER TABLE %1s MODIFY zbsc_rate DECIMAL(20,10) NOT NULL DEFAULT 0.0000000000', $ZBSCRM_t['tax'] ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange, WordPress.DB.PreparedSQLPlaceholders.UnquotedComplexPlaceholder, WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+	}
+
+	zeroBSCRM_migrations_markComplete( 'tax_rate_precision_fix', array( 'updated' => 1 ) );
 }
 
 /* ======================================================

--- a/projects/plugins/crm/includes/ZeroBSCRM.Migrations.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Migrations.php
@@ -35,7 +35,7 @@ global $zeroBSCRM_migrations; $zeroBSCRM_migrations = array(
 	'create_workflows_table', // Create "workflows" table.
 	'invoice_language_fixes', // Store invoice statuses and mappings consistently
 	'gh3465_increase_city_field_size',  // from gh issue 3465, increases the city field size to 200
-	'tax_rate_precision_fix', // increase tax rate precision from 2 to 4 decimal places
+	'tax_rate_precision_fix', // increase tax rate precision from 2 to 10 decimal places
 	);
 
 global $zeroBSCRM_migrations_requirements; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase

--- a/projects/plugins/crm/includes/ZeroBSCRM.Migrations.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Migrations.php
@@ -1286,7 +1286,8 @@ function zeroBSCRM_migration_tax_rate_precision_fix() {
 	// For MySQL/MariaDB - check if the column exists and get its current data type.
 	$column_type = zeraBSCRM_migration_get_column_data_type( $ZBSCRM_t['tax'], 'zbsc_rate' ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 	if ( $column_type && strpos( $column_type, 'decimal(20,10)' ) === false ) {
-		$wpdb->query( $wpdb->prepare( 'ALTER TABLE %1s MODIFY zbsc_rate DECIMAL(20,10) NOT NULL DEFAULT 0.0000000000', $ZBSCRM_t['tax'] ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange, WordPress.DB.PreparedSQLPlaceholders.UnquotedComplexPlaceholder, WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+		// Table name is constructed internally and considered safe.
+		$wpdb->query( "ALTER TABLE `{$ZBSCRM_t['tax']}` MODIFY zbsc_rate DECIMAL(20,10) NOT NULL DEFAULT 0.0000000000" ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange, WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 	}
 
 	zeroBSCRM_migrations_markComplete( 'tax_rate_precision_fix', array( 'updated' => 1 ) );

--- a/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-background-sync-job.php
+++ b/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-background-sync-job.php
@@ -1231,8 +1231,8 @@ class Woo_Sync_Background_Sync_Job {
 						// name
 						$tax_label === $tax_rate_detail['name']
 	        			&&
-	        			// rate
-	        			$tax_rate == $tax_rate_detail['rate']
+						// rate - compare with full precision to preserve accuracy
+						(float) $tax_rate === (float) $tax_rate_detail['rate']
 	        			
 	        			){
 

--- a/projects/plugins/crm/tests/codeception/acceptance/50_JPCRM_Settings_Cest.php
+++ b/projects/plugins/crm/tests/codeception/acceptance/50_JPCRM_Settings_Cest.php
@@ -186,7 +186,7 @@ class JPCRM_Settings_Cest {
 
 		$I->submitForm( 'form', $tax_data );
 
-		$I->seeInSource( '{"id":"1","owner":"1","name":"IGIC","rate":"7.0000"' );
+		$I->seeInSource( '{"id":"1","owner":"1","name":"IGIC","rate":"7.0000000000"' );
 	}
 
 	public function see_license_settings( AcceptanceTester $I ) {

--- a/projects/plugins/crm/tests/codeception/acceptance/50_JPCRM_Settings_Cest.php
+++ b/projects/plugins/crm/tests/codeception/acceptance/50_JPCRM_Settings_Cest.php
@@ -186,7 +186,7 @@ class JPCRM_Settings_Cest {
 
 		$I->submitForm( 'form', $tax_data );
 
-		$I->seeInSource( '{"id":"1","owner":"1","name":"IGIC","rate":"7.00"' );
+		$I->seeInSource( '{"id":"1","owner":"1","name":"IGIC","rate":"7.0000"' );
 	}
 
 	public function see_license_settings( AcceptanceTester $I ) {


### PR DESCRIPTION
# Fix WooCommerce Tax Rate Precision Issue - Prevent Duplicate Tax Rate Entries

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

*This PR description was drafted by AI*

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

* **Fixed WooCommerce tax rate synchronization precision issue** that was causing duplicate tax rate entries when WooCommerce tax rates had more than 2 decimal places
* **Updated database schema** to support high-precision tax rates (DECIMAL(20,10) instead of DECIMAL(18,2))
* **Added database migration** to upgrade existing installations without data loss
* **Improved tax rate comparison logic** to use full precision matching instead of truncated values
* **Added SQLite compatibility** for the migration with proper handling of dynamic typing

### Technical Details:

**Root Cause:** WooCommerce tax rates with high precision (e.g., 8.1234%) were being truncated to 2 decimal places (8.12%) when stored in CRM, but the sync process continued to compare against the original high-precision values, causing failed matches and duplicate insertions.

**Solution:**
1. **Database Schema Update**: Changed `zbsc_rate` column from `DECIMAL(18,2)` to `DECIMAL(20,10)` to preserve full precision
2. **Migration Function**: Added `zeroBSCRM_migration_tax_rate_precision_fix()` with proper SQLite handling
3. **Comparison Logic**: Updated tax rate matching to use strict comparison with full precision: `(float) $tax_rate === (float) $tax_rate_detail['rate']`

### Files Modified:
- `includes/ZeroBSCRM.Database.php` - Updated table schema for new installations
- `includes/ZeroBSCRM.Migrations.php` - Added migration function for existing installations  
- `modules/woo-sync/includes/class-woo-sync-background-sync-job.php` - Fixed comparison logic

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No, this PR does not change what data we track or use. It only improves the precision and accuracy of existing tax rate data storage and synchronization.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### Prerequisites:
* WordPress site with Jetpack CRM installed
* WooCommerce plugin active
* WooCommerce tax rates configured with high precision (more than 2 decimal places)

### Testing Steps:

#### Test 1: New Installation
1. Install fresh Jetpack CRM with this branch
2. Go to CRM Settings → Tax Settings
3. Verify tax table can store rates with high precision (e.g., 8.1234%)
4. Create a tax rate with 4+ decimal places and verify it saves correctly

#### Test 2: Migration Testing  
1. Start with existing CRM installation (pre-fix)
2. Create some tax rates with 2 decimal places in CRM
3. Set up WooCommerce tax rates with high precision (e.g., 8.1234%, 12.5678%)
4. Apply this branch update
5. Verify migration runs automatically and updates database schema
6. Check that existing tax rates are preserved
7. Verify new high-precision rates can be stored

#### Test 3: WooCommerce Sync Testing
1. Configure WooCommerce tax rates with high precision:
   - VAT: 8.1234%
   - GST: 12.5678% 
   - Local Tax: 3.9876%
2. Create a WooCommerce order with these tax rates applied
3. Trigger CRM sync (or wait for automatic sync)
4. Go to CRM → Settings → Tax Settings
5. **Before fix**: Would see multiple duplicate entries for same tax rate
6. **After fix**: Should see single entry for each tax rate with full precision preserved
7. Create another order with same tax rates
8. Verify no duplicate tax rates are created on subsequent syncs

#### Test 4: Database Engine Compatibility
1. Test with MySQL/MariaDB installation - verify migration alters column successfully
2. Test with SQLite installation - verify migration completes without errors (no schema change needed due to dynamic typing)

#### Test 5: Precision Verification
1. Create WooCommerce tax rate: 8.123456789%
2. Sync to CRM
3. Verify CRM stores: 8.1234567890% (full precision preserved)
4. Verify tax calculations use full precision in invoices/quotes

### Expected Results:
- No duplicate tax rate entries in CRM tax table
- High-precision tax rates preserved exactly as defined in WooCommerce  
- Existing tax rates remain unchanged after migration
- Tax calculations maintain accuracy with full precision
- Migration works on both MySQL and SQLite databases
