### PR TITLE
Forms: show checkbox when consent inserted

### DIFF
--- a/projects/packages/forms/changelog/update-forms-integrations-consent
+++ b/projects/packages/forms/changelog/update-forms-integrations-consent
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: show checkbox when consent inserted.

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/creative-mail-card.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/creative-mail-card.tsx
@@ -48,11 +48,14 @@ const CreativeMailCard = ( {
 		if ( consentBlock ) {
 			await removeBlock( consentBlock.clientId, false );
 		} else {
-			const buttonBlockIndex = selectedBlock.innerBlocks.findIndex(
-				( { name }: { name: string } ) => name === 'jetpack/button'
+			// Insert consent after the email field or at end if not found
+			const emailBlockIndex = selectedBlock.innerBlocks.findIndex(
+				( { name }: { name: string } ) => name === 'jetpack/field-email'
 			);
-			const newConsentBlock = await createBlock( 'jetpack/field-consent' );
-			await insertBlock( newConsentBlock, buttonBlockIndex, selectedBlock.clientId, false );
+			const insertIndex =
+				emailBlockIndex === -1 ? selectedBlock.innerBlocks.length : emailBlockIndex + 1;
+			const newConsentBlock = createBlock( 'jetpack/field-consent', { consentType: 'explicit' } );
+			await insertBlock( newConsentBlock, insertIndex, selectedBlock.clientId, false );
 		}
 	};
 
@@ -75,7 +78,7 @@ const CreativeMailCard = ( {
 				</p>
 				{ hasEmailBlock && (
 					<ToggleControl
-						label={ __( 'Add email permission request before submit button', 'jetpack-forms' ) }
+						label={ __( 'Add email permission request after the email field', 'jetpack-forms' ) }
 						checked={ !! consentBlock }
 						onChange={ toggleConsent }
 						__nextHasNoMarginBottom

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/mailpoet-card.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/mailpoet-card.tsx
@@ -58,11 +58,14 @@ const MailPoetCard = ( {
 		if ( consentBlock ) {
 			await removeBlock( consentBlock.clientId, false );
 		} else {
-			const buttonBlockIndex = selectedBlock.innerBlocks.findIndex(
-				( { name }: { name: string } ) => name === 'jetpack/button'
+			// Insert consent after the email field or at end if not found
+			const emailBlockIndex = selectedBlock.innerBlocks.findIndex(
+				( { name }: { name: string } ) => name === 'jetpack/field-email'
 			);
-			const newConsentBlock = await createBlock( 'jetpack/field-consent' );
-			await insertBlock( newConsentBlock, buttonBlockIndex, selectedBlock.clientId, false );
+			const insertIndex =
+				emailBlockIndex === -1 ? selectedBlock.innerBlocks.length : emailBlockIndex + 1;
+			const newConsentBlock = createBlock( 'jetpack/field-consent', { consentType: 'explicit' } );
+			await insertBlock( newConsentBlock, insertIndex, selectedBlock.clientId, false );
 		}
 	};
 
@@ -192,7 +195,10 @@ const MailPoetCard = ( {
 					{ hasEmailBlock && (
 						<div className="integration-card__section">
 							<ToggleControl
-								label={ __( 'Add email permission request before submit button', 'jetpack-forms' ) }
+								label={ __(
+									'Add email permission request after the email field',
+									'jetpack-forms'
+								) }
 								checked={ !! consentBlock }
 								onChange={ toggleConsent }
 								__nextHasNoMarginBottom

--- a/projects/packages/forms/src/blocks/field-consent/edit.js
+++ b/projects/packages/forms/src/blocks/field-consent/edit.js
@@ -13,6 +13,15 @@ import { __, sprintf } from '@wordpress/i18n';
 import JetpackFieldWidth from '../shared/components/jetpack-field-width';
 import useFormWrapper from '../shared/hooks/use-form-wrapper';
 
+// Helper: centralize the consent placeholder string
+function getConsentPlaceholder( type ) {
+	return sprintf(
+		/* translators: %s a type of consent: implicit or explicit */
+		__( 'Add %s consent message…', 'jetpack-forms' ),
+		type
+	);
+}
+
 export default function ConsentFieldEdit( props ) {
 	const { attributes, clientId, setAttributes } = props;
 	const { consentType, width, implicitConsentMessage, explicitConsentMessage, className } =
@@ -42,11 +51,7 @@ export default function ConsentFieldEdit( props ) {
 				'jetpack/option',
 				{
 					label: implicitConsentMessage,
-					placeholder: sprintf(
-						/* translators: %s a type of consent: implicit or explicit */
-						__( 'Add %s consent message…', 'jetpack-forms' ),
-						'implicit'
-					),
+					placeholder: getConsentPlaceholder( 'implicit' ),
 					isStandalone: true,
 					hideInput: true,
 				},
@@ -73,26 +78,31 @@ export default function ConsentFieldEdit( props ) {
 	const prevConsentType = usePrevious( consentType );
 	const prevLabel = usePrevious( optionBlock?.attributes?.label );
 
-	// Update the inner option block when the consentType changes.
+	// Update inner option block when the consentType changes
+	// or hideInput is out of sync with the consentType.
 	useEffect( () => {
-		if ( optionBlockId && consentType !== prevConsentType ) {
-			const label = consentType === 'explicit' ? explicitConsentMessage : implicitConsentMessage;
+		if ( ! optionBlockId ) {
+			return;
+		}
 
-			// As this is an automated update, ensure it doesn't end up in the undo stack
-			// by calling `__unstableMarkNextChangeAsNotPersistent`.
+		const shouldHideInput = consentType !== 'explicit';
+		const label = shouldHideInput ? implicitConsentMessage : explicitConsentMessage;
+		const placeholder = getConsentPlaceholder( consentType );
+
+		const shouldUpdate =
+			optionBlock?.attributes?.hideInput !== shouldHideInput || consentType !== prevConsentType;
+
+		if ( shouldUpdate ) {
 			__unstableMarkNextChangeAsNotPersistent();
 			updateBlockAttributes( optionBlockId, {
+				hideInput: shouldHideInput,
 				label,
-				placeholder: sprintf(
-					/* translators: %s a type of consent: implicit or explicit */
-					__( 'Add %s consent message…', 'jetpack-forms' ),
-					consentType
-				),
-				hideInput: consentType !== 'explicit',
+				placeholder,
 			} );
 		}
 	}, [
 		optionBlockId,
+		optionBlock?.attributes?.hideInput,
 		consentType,
 		prevConsentType,
 		explicitConsentMessage,

--- a/projects/plugins/jetpack/changelog/update-forms-integrations-consent
+++ b/projects/plugins/jetpack/changelog/update-forms-integrations-consent
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: show checkbox when consent inserted.


### PR DESCRIPTION
Fixes [FORMS-292](https://linear.app/a8c/issue/FORMS-292/forms-mailpoet-integration-consent-checkbox)

## Proposed changes:

The MailPoet and Creative Mail integrations both show a toggle to automatically a consent field. This PR updates the toggle so the consent file is inserted after the email (vs at end of form), and the consent type is explicit with checkbox (vs implicit). 

I also had to add a bit of extra logic to make sure the checkbox and correct message show when programatically inserting the consent field as explicit. 

<img width="839" height="588" alt="mailpoet-consent-toggle" src="https://github.com/user-attachments/assets/027dc4b3-b418-4564-b6df-54ee59e2e12a" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
See linear issue.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add a form to a page
* Open the integrations modal and click the MailPoet toggle to add a consent field. Confirm the explicit (checkbox) version is added, and after the email
* Click the Creative Mail toggle to add a consent field, and again confirm the explicit (checkbox) version is added, and after the email

