### PR TITLE
refactor: VideoPress utilizes the `@wordpress/api-fetch` utility for GutenbergKit only

### DIFF
--- a/projects/packages/videopress/changelog/refactor-videopress-utilizes-api-fetch-utility
+++ b/projects/packages/videopress/changelog/refactor-videopress-utilizes-api-fetch-utility
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: utilize the `@wordpress/api-fetch` utility rather than the native `fetch` API.

--- a/projects/packages/videopress/changelog/refactor-videopress-utilizes-api-fetch-utility
+++ b/projects/packages/videopress/changelog/refactor-videopress-utilizes-api-fetch-utility
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-VideoPress: utilize the `@wordpress/api-fetch` utility rather than the native `fetch` API.
+VideoPress: use `apiFetch` in GutenbergKit for token authentication middleware support.

--- a/projects/packages/videopress/global.d.ts
+++ b/projects/packages/videopress/global.d.ts
@@ -1,6 +1,10 @@
 export declare global {
 	interface Window {
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		wp: { media: any };
+		wp: {
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			media: any;
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			apiFetch?: ( options: Record< string, any > ) => Promise< Response >;
+		};
 	}
 }

--- a/projects/packages/videopress/src/client/lib/get-media-token/index.ts
+++ b/projects/packages/videopress/src/client/lib/get-media-token/index.ts
@@ -94,9 +94,7 @@ const requestMediaToken = function (
 
 		const fetchPromise: Promise< Response > = useApiFetch
 			? window.wp.apiFetch( {
-					...( /^https?:\/\//.test( adminAjaxAPI )
-						? { url: adminAjaxAPI }
-						: { path: adminAjaxAPI } ),
+					url: adminAjaxAPI,
 					...fetchOptions,
 					parse: false,
 			  } )

--- a/projects/packages/videopress/src/client/lib/get-media-token/index.ts
+++ b/projects/packages/videopress/src/client/lib/get-media-token/index.ts
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import apiFetch from '@wordpress/api-fetch';
 import debugFactory from 'debug';
 /**
  * Internal dependencies
@@ -80,7 +81,13 @@ const requestMediaToken = function (
 				break;
 		}
 
-		fetch( adminAjaxAPI, {
+		const urlOrPath = /^https?:\/\//.test( adminAjaxAPI )
+			? { url: adminAjaxAPI }
+			: { path: adminAjaxAPI };
+
+		apiFetch( {
+			...urlOrPath,
+			parse: false,
 			method: 'POST',
 			credentials: 'same-origin',
 			body: new URLSearchParams( fetchData ),

--- a/projects/packages/videopress/src/client/lib/get-media-token/index.ts
+++ b/projects/packages/videopress/src/client/lib/get-media-token/index.ts
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import apiFetch from '@wordpress/api-fetch';
 import debugFactory from 'debug';
 /**
  * Internal dependencies
@@ -81,17 +80,29 @@ const requestMediaToken = function (
 				break;
 		}
 
-		const urlOrPath = /^https?:\/\//.test( adminAjaxAPI )
-			? { url: adminAjaxAPI }
-			: { path: adminAjaxAPI };
+		// Use apiFetch when running inside GutenbergKit (for app password auth
+		// middleware), but fall back to native fetch everywhere else — including
+		// the block editor, token-bridge.js, and the front-end — where
+		// wp.apiFetch may not be enqueued.
+		const useApiFetch = !! window?.GBKit && typeof window.wp?.apiFetch === 'function';
 
-		apiFetch( {
-			...urlOrPath,
-			parse: false,
+		const fetchOptions = {
 			method: 'POST',
 			credentials: 'same-origin',
 			body: new URLSearchParams( fetchData ),
-		} )
+		};
+
+		const fetchPromise: Promise< Response > = useApiFetch
+			? window.wp.apiFetch( {
+					...( /^https?:\/\//.test( adminAjaxAPI )
+						? { url: adminAjaxAPI }
+						: { path: adminAjaxAPI } ),
+					...fetchOptions,
+					parse: false,
+			  } )
+			: fetch( adminAjaxAPI, fetchOptions );
+
+		fetchPromise
 			.then( response => {
 				if ( ! response.ok ) {
 					throw new Error( 'Network response was not ok' );

--- a/projects/packages/videopress/src/client/lib/get-media-token/types.ts
+++ b/projects/packages/videopress/src/client/lib/get-media-token/types.ts
@@ -51,5 +51,6 @@ declare global {
 		};
 		ajaxurl?: string;
 		__guidsToPlanIds?: object;
+		GBKit?: object;
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Ref CMM-713. Close CMM-769.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
For the [GutenbergKit](https://github.com/wordpress-mobile/GutenbergKit) environment only (mobile app editor), utilize the `@wordpress/api-fetch` utility to enable usage of its middleware functionality. The middleware is important as GutenbergKit does not have authentication cookies and must authenticate requests via [token authentication](https://github.com/wordpress-mobile/GutenbergKit/blob/5b66f8ec33edc49004dbd27b59dfd53279acdf38/src/utils/api-fetch.js#L80-L102). 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pbArwn-7AD-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

GutenbergKit functionality will be tested at a later time via https://github.com/Automattic/jetpack/pull/45255. 

For now, it's important to smoke test token-related VideoPress features on the web platform for regressions. I tested: 

- Uploading videos in the WP Admin block editor. 
- Attaching VTT files to videos in the WP Admin block editor. 
- Marking videos as private in the WP Admin block editor. 
- Playing private videos on a site's front end while authenticated. 
- Verifying private videos were inaccessible on a site's front end while unauthenticated. 