### PR TITLE
feat: Editor assets endpoint allows the VideoPress block

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-block-editor-assets.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-block-editor-assets.php
@@ -112,6 +112,7 @@ class WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets extends WP_REST_Controller 
 		'premium-content/logged-out-view',
 		'premium-content/login-button',
 		'premium-content/subscriber-view',
+		'videopress/video',
 	);
 
 	/**

--- a/projects/plugins/jetpack/changelog/feat-editor-assets-endpoint-allows-videopress
+++ b/projects/plugins/jetpack/changelog/feat-editor-assets-endpoint-allows-videopress
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Editor assets endpoint: allow the VideoPress block type.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Ref CMM-713. 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Allow the `videopress/video` block type for the GutenbergKit mobile app editor. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pbArwn-7AD-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Apply these Jetpack changes to your site (see [comment](https://github.com/Automattic/jetpack/pull/45255#issuecomment-3313588564)). 
1. Make a request to the `/wpcom/v2/sites/<site_id>/editor-assets` endpoint for the WPCOM site—via [API Console](https://developer.wordpress.com/docs/api/console/), `curl`, etc. 
1. Verify the 200 response includes the `videopress/video` block type within the `allow_block_types`.
