### PR TITLE
Forms: add subscribe form variation

### DIFF
--- a/projects/packages/forms/changelog/add-forms-subscribe-variation
+++ b/projects/packages/forms/changelog/add-forms-subscribe-variation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Forms: add Subscribe form variation

--- a/projects/packages/forms/src/blocks/contact-form/variations.js
+++ b/projects/packages/forms/src/blocks/contact-form/variations.js
@@ -1011,6 +1011,39 @@ const variations = [
 			],
 		},
 	},
+	{
+		name: 'simple-subscribe-form',
+		title: __( 'Subscribe form', 'jetpack-forms' ),
+		description: __( 'A simple subscribe form.', 'jetpack-forms' ),
+		icon: {
+			foreground: getIconColor(),
+			src: people,
+		},
+		innerBlocks: [
+			[
+				'core/group',
+				{ layout: { type: 'flex', justifyContent: 'space-between' }, flexWrap: 'nowrap' },
+				[
+					[
+						'jetpack/field-email',
+						{ required: true, width: 75 },
+						[ [ 'jetpack/label', { label: __( 'Email', 'jetpack-forms' ) } ], [ 'jetpack/input' ] ],
+					],
+					[
+						'jetpack/button',
+						{
+							text: __( 'Subscribe', 'jetpack-forms' ),
+							element: 'button',
+							borderRadius: 0,
+							width: '',
+							lock: { move: false, remove: false },
+						},
+					],
+				],
+			],
+		],
+		attributes: {},
+	},
 ].filter( Boolean );
 
 export default variations;


### PR DESCRIPTION
## Proposed changes:
This PR adds a simple Subscribe form variation to allow people select a single line form. The variation takes care of the wee complexity of adding a stack to allow side by side layout of the input and the button. While this doesn't differ of the same result by just setting the field width to accommodate/fit the button, it is the way it's supposed to be done in Gutenberg.


https://github.com/user-attachments/assets/da99f1a0-4fae-4f50-a1c2-afb35294c375

It still needs a proper icon for the form variation.


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1758236622558259-slack-C052XEUUBL4

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Insert a form. Look in the variation picker for a "Subscribe" form, insert it. See that the form is composed by Email field and Submit button side by side.