### PR TITLE
Forms: Fix image choice widths

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-image-select-flex
+++ b/projects/packages/forms/changelog/fix-forms-image-select-flex
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Fix image choice widths

--- a/projects/packages/forms/src/blocks/field-image-select/editor.scss
+++ b/projects/packages/forms/src/blocks/field-image-select/editor.scss
@@ -10,6 +10,7 @@
 .jetpack-fieldset-image-options__wrapper
 .jetpack-input-image-option {
 	flex-basis: unset;
+	flex-grow: 0;
 }
 
 // There is no outer block in the editor, so we apply


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of FORMS-60
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Just a small fix for a regression due to recent changes of the forms CSS

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add an image select field with one more option than a single row can take (4, or 2 if supersized)
* Check that the single choice in the second row has the same width as the others

| Before | After |
| - | - |
| <img width="675" height="1057" alt="Screenshot from 2025-09-19 19-18-03" src="https://github.com/user-attachments/assets/15993a17-ae54-4aef-8409-cdf2099e3eb7" /> | <img width="675" height="771" alt="Screenshot from 2025-09-19 19-18-16" src="https://github.com/user-attachments/assets/9f008417-a18d-47bd-8143-29f7ac037ce5" /> |

