### PR TITLE
Forms: Add Hostinger Reach integration

### DIFF
--- a/projects/packages/forms/changelog/add-forms-hostinger-integration
+++ b/projects/packages/forms/changelog/add-forms-hostinger-integration
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: add Hostinger Reach integration.

--- a/projects/packages/forms/src/blocks/contact-form/attributes.ts
+++ b/projects/packages/forms/src/blocks/contact-form/attributes.ts
@@ -55,6 +55,13 @@ export default {
 			listName: null,
 		},
 	},
+	hostingerReach: {
+		type: 'object',
+		default: {
+			listId: null,
+			listName: null,
+		},
+	},
 	saveResponses: {
 		type: 'boolean',
 		default: true,

--- a/projects/packages/forms/src/blocks/contact-form/attributes.ts
+++ b/projects/packages/forms/src/blocks/contact-form/attributes.ts
@@ -58,8 +58,7 @@ export default {
 	hostingerReach: {
 		type: 'object',
 		default: {
-			listId: null,
-			listName: null,
+			groupName: '',
 		},
 	},
 	saveResponses: {

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/active-integrations/index.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/active-integrations/index.js
@@ -54,7 +54,7 @@ export default function ActiveIntegrations( { integrations, attributes, isLoadin
 					acc.push( {
 						...integration,
 						icon: <HostingerReachIcon width={ 30 } height={ 30 } />,
-						tooltip: __( 'MailPoet is connected for this form', 'jetpack-forms' ),
+						tooltip: __( 'Hostinger Reach is connected for this form', 'jetpack-forms' ),
 					} );
 				}
 				break;

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/active-integrations/index.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/active-integrations/index.js
@@ -3,6 +3,7 @@ import { JetpackIcon } from '@automattic/jetpack-components';
 import { Spinner, Tooltip } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import AkismetIcon from '../../../../../icons/akismet';
+import HostingerReachIcon from '../../../../../icons/hostinger-reach';
 import MailPoetOrangeIcon from '../../../../../icons/mailpoet-orange';
 import SalesforceCircleIcon from '../../../../../icons/salesforce-circle';
 import { isValidSalesforceOrgId } from '../salesforce-card';
@@ -40,6 +41,19 @@ export default function ActiveIntegrations( { integrations, attributes, isLoadin
 					acc.push( {
 						...integration,
 						icon: <MailPoetOrangeIcon width={ 30 } height={ 30 } />,
+						tooltip: __( 'MailPoet is connected for this form', 'jetpack-forms' ),
+					} );
+				}
+				break;
+			case 'hostinger-reach':
+				if (
+					integration.isActive &&
+					integration.isConnected &&
+					attributes.hostingerReach?.enabledForForm
+				) {
+					acc.push( {
+						...integration,
+						icon: <HostingerReachIcon width={ 30 } height={ 30 } />,
 						tooltip: __( 'MailPoet is connected for this form', 'jetpack-forms' ),
 					} );
 				}

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/hostinger-reach-card.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/hostinger-reach-card.tsx
@@ -4,28 +4,19 @@ import {
 	Button,
 	ExternalLink,
 	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
-	SelectControl,
 	ToggleControl,
 } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { createInterpolateElement, useEffect, useMemo } from '@wordpress/element';
+import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import HostingerReachIcon from '../../../../icons/hostinger-reach';
 import IntegrationCard from './integration-card';
 import type { SingleIntegrationCardProps, IntegrationCardData } from '../../../../types';
 
 interface HostingerReachCardProps extends SingleIntegrationCardProps {
-	hostingerReach: {
-		enabledForForm?: boolean;
-		listId?: string | null;
-		listName?: string | null;
-	};
-	setAttributes: ( attrs: {
-		hostingerReach: { enabledForForm?: boolean; listId?: string | null; listName?: string | null };
-	} ) => void;
+	hostingerReach: { enabledForForm?: boolean };
+	setAttributes: ( attrs: { hostingerReach: { enabledForForm?: boolean } } ) => void;
 }
-
-type HostingerList = { id: string; name: string };
 
 const HostingerReachCard = ( {
 	isExpanded,
@@ -36,12 +27,6 @@ const HostingerReachCard = ( {
 	refreshStatus,
 }: HostingerReachCardProps ) => {
 	const { isConnected = false, settingsUrl = '' } = data || {};
-
-	const lists: HostingerList[] = useMemo(
-		() =>
-			Array.isArray( data?.details?.lists ) ? ( data.details.lists as HostingerList[] ) : [],
-		[ data?.details?.lists ]
-	);
 
 	const selectedBlock = useSelect( select => select( blockEditorStore ).getSelectedBlock(), [] );
 	const { insertBlock, removeBlock } = useDispatch( blockEditorStore );
@@ -63,38 +48,6 @@ const HostingerReachCard = ( {
 			await insertBlock( newConsentBlock, buttonBlockIndex, selectedBlock.clientId, false );
 		}
 	};
-
-	useEffect( () => {
-		if ( ! hostingerReach.enabledForForm ) {
-			return;
-		}
-
-		// If there are no lists, clear the selection
-		if ( lists.length === 0 ) {
-			if ( hostingerReach.listId || hostingerReach.listName ) {
-				setAttributes( {
-					hostingerReach: {
-						...hostingerReach,
-						listId: null,
-						listName: null,
-					},
-				} );
-			}
-			return;
-		}
-
-		const listIsValid =
-			hostingerReach.listId && lists.some( list => list.id === hostingerReach.listId );
-		if ( ! listIsValid ) {
-			setAttributes( {
-				hostingerReach: {
-					...hostingerReach,
-					listId: lists[ 0 ].id,
-					listName: lists[ 0 ].name,
-				},
-			} );
-		}
-	}, [ hostingerReach, lists, setAttributes ] );
 
 	const cardData: IntegrationCardData = {
 		...data,
@@ -161,35 +114,6 @@ const HostingerReachCard = ( {
 				</div>
 			) : (
 				<div>
-					{ lists?.length ? (
-						<SelectControl
-							label={ __(
-								'Which Hostinger Reach list should contacts be added to?',
-								'jetpack-forms'
-							) }
-							value={ hostingerReach.listId }
-							options={ lists.map( list => ( { label: list.name, value: list.id } ) ) }
-							onChange={ value => {
-								const selected = lists.find( l => l.id === value );
-								setAttributes( {
-									hostingerReach: {
-										...hostingerReach,
-										listId: selected?.id ?? null,
-										listName: selected?.name ?? null,
-									},
-								} );
-							} }
-							__next40pxDefaultSize={ true }
-							__nextHasNoMarginBottom={ true }
-						/>
-					) : (
-						<p className="integration-card__description">
-							{ __(
-								'You do not have any Hostinger Reach lists yet. Click the dashboard button below to create one.',
-								'jetpack-forms'
-							) }
-						</p>
-					) }
 					{ hasEmailBlock && (
 						<div className="integration-card__section">
 							<ToggleControl

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/hostinger-reach-card.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/hostinger-reach-card.tsx
@@ -5,6 +5,7 @@ import {
 	ExternalLink,
 	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	ToggleControl,
+	TextControl,
 } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
@@ -14,8 +15,10 @@ import IntegrationCard from './integration-card';
 import type { SingleIntegrationCardProps, IntegrationCardData } from '../../../../types';
 
 interface HostingerReachCardProps extends SingleIntegrationCardProps {
-	hostingerReach: { enabledForForm?: boolean };
-	setAttributes: ( attrs: { hostingerReach: { enabledForForm?: boolean } } ) => void;
+	hostingerReach: { enabledForForm?: boolean; groupName?: string };
+	setAttributes: ( attrs: {
+		hostingerReach: { enabledForForm?: boolean; groupName?: string };
+	} ) => void;
 }
 
 const HostingerReachCard = ( {
@@ -114,6 +117,22 @@ const HostingerReachCard = ( {
 				</div>
 			) : (
 				<div>
+					<div className="integration-card__section">
+						<TextControl
+							label={ __( 'Group name (optional)', 'jetpack-forms' ) }
+							help={ __(
+								"If empty, contacts will be added under 'Jetpack Forms'.",
+								'jetpack-forms'
+							) }
+							value={ hostingerReach.groupName ?? '' }
+							onChange={ value =>
+								setAttributes( {
+									hostingerReach: { ...hostingerReach, groupName: value },
+								} )
+							}
+							__nextHasNoMarginBottom
+						/>
+					</div>
 					{ hasEmailBlock && (
 						<div className="integration-card__section">
 							<ToggleControl

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/hostinger-reach-card.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/hostinger-reach-card.tsx
@@ -1,0 +1,214 @@
+import { store as blockEditorStore } from '@wordpress/block-editor';
+import { createBlock } from '@wordpress/blocks';
+import {
+	Button,
+	ExternalLink,
+	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+	SelectControl,
+	ToggleControl,
+} from '@wordpress/components';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { createInterpolateElement, useEffect, useMemo } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import HostingerReachIcon from '../../../../icons/hostinger-reach';
+import IntegrationCard from './integration-card';
+import type { SingleIntegrationCardProps, IntegrationCardData } from '../../../../types';
+
+interface HostingerReachCardProps extends SingleIntegrationCardProps {
+	hostingerReach: {
+		enabledForForm?: boolean;
+		listId?: string | null;
+		listName?: string | null;
+	};
+	setAttributes: ( attrs: {
+		hostingerReach: { enabledForForm?: boolean; listId?: string | null; listName?: string | null };
+	} ) => void;
+}
+
+type HostingerList = { id: string; name: string };
+
+const HostingerReachCard = ( {
+	isExpanded,
+	onToggle,
+	hostingerReach,
+	setAttributes,
+	data,
+	refreshStatus,
+}: HostingerReachCardProps ) => {
+	const { isConnected = false, settingsUrl = '' } = data || {};
+
+	const lists: HostingerList[] = useMemo(
+		() =>
+			Array.isArray( data?.details?.lists ) ? ( data.details.lists as HostingerList[] ) : [],
+		[ data?.details?.lists ]
+	);
+
+	const selectedBlock = useSelect( select => select( blockEditorStore ).getSelectedBlock(), [] );
+	const { insertBlock, removeBlock } = useDispatch( blockEditorStore );
+	const hasEmailBlock = selectedBlock?.innerBlocks?.some(
+		( { name }: { name: string } ) => name === 'jetpack/field-email'
+	);
+	const consentBlock = selectedBlock?.innerBlocks?.find(
+		( { name }: { name: string } ) => name === 'jetpack/field-consent'
+	);
+
+	const toggleConsent = async () => {
+		if ( consentBlock ) {
+			await removeBlock( consentBlock.clientId, false );
+		} else {
+			const buttonBlockIndex = selectedBlock.innerBlocks.findIndex(
+				( { name }: { name: string } ) => name === 'jetpack/button'
+			);
+			const newConsentBlock = await createBlock( 'jetpack/field-consent' );
+			await insertBlock( newConsentBlock, buttonBlockIndex, selectedBlock.clientId, false );
+		}
+	};
+
+	useEffect( () => {
+		if ( ! hostingerReach.enabledForForm ) {
+			return;
+		}
+
+		// If there are no lists, clear the selection
+		if ( lists.length === 0 ) {
+			if ( hostingerReach.listId || hostingerReach.listName ) {
+				setAttributes( {
+					hostingerReach: {
+						...hostingerReach,
+						listId: null,
+						listName: null,
+					},
+				} );
+			}
+			return;
+		}
+
+		const listIsValid =
+			hostingerReach.listId && lists.some( list => list.id === hostingerReach.listId );
+		if ( ! listIsValid ) {
+			setAttributes( {
+				hostingerReach: {
+					...hostingerReach,
+					listId: lists[ 0 ].id,
+					listName: lists[ 0 ].name,
+				},
+			} );
+		}
+	}, [ hostingerReach, lists, setAttributes ] );
+
+	const cardData: IntegrationCardData = {
+		...data,
+		showHeaderToggle: true,
+		headerToggleValue: !! hostingerReach?.enabledForForm,
+		isHeaderToggleEnabled: isConnected,
+		onHeaderToggleChange: ( value: boolean ) =>
+			setAttributes( { hostingerReach: { ...hostingerReach, enabledForForm: value } } ),
+		isLoading: ! data || typeof data.isInstalled === 'undefined',
+		refreshStatus,
+		trackEventName: 'jetpack_forms_upsell_hostinger_reach_click',
+		notInstalledMessage: createInterpolateElement(
+			__(
+				'Add powerful email marketing to your forms with Hostinger Reach. Simply install the plugin to start sending emails.',
+				'jetpack-forms'
+			),
+			{
+				a: <ExternalLink href={ data?.marketingUrl || '' } />, // placeholder if we add marketingUrl later
+			}
+		),
+		notActivatedMessage: __(
+			'Hostinger Reach is installed. Just activate the plugin to start sending emails.',
+			'jetpack-forms'
+		),
+	};
+
+	return (
+		<IntegrationCard
+			title={ data?.title }
+			description={ data?.subtitle }
+			icon={ <HostingerReachIcon width={ 28 } height={ 28 } /> }
+			isExpanded={ isExpanded }
+			onToggle={ onToggle }
+			cardData={ cardData }
+			toggleTooltip={ __( 'Grow your audience with Hostinger Reach', 'jetpack-forms' ) }
+		>
+			{ ! isConnected ? (
+				<div>
+					<p className="integration-card__description">
+						{ createInterpolateElement(
+							__(
+								'Hostinger Reach is active. There is one step left. Please complete <a>Hostinger Reach setup</a>.',
+								'jetpack-forms'
+							),
+							{
+								a: <ExternalLink href={ settingsUrl } />,
+							}
+						) }
+					</p>
+					<HStack spacing="3" justify="start">
+						<Button
+							variant="secondary"
+							href={ settingsUrl }
+							target="_blank"
+							rel="noopener noreferrer"
+							__next40pxDefaultSize={ true }
+						>
+							{ __( 'Complete Hostinger Reach setup', 'jetpack-forms' ) }
+						</Button>
+						<Button variant="tertiary" onClick={ refreshStatus } __next40pxDefaultSize={ true }>
+							{ __( 'Refresh status', 'jetpack-forms' ) }
+						</Button>
+					</HStack>
+				</div>
+			) : (
+				<div>
+					{ lists?.length ? (
+						<SelectControl
+							label={ __(
+								'Which Hostinger Reach list should contacts be added to?',
+								'jetpack-forms'
+							) }
+							value={ hostingerReach.listId }
+							options={ lists.map( list => ( { label: list.name, value: list.id } ) ) }
+							onChange={ value => {
+								const selected = lists.find( l => l.id === value );
+								setAttributes( {
+									hostingerReach: {
+										...hostingerReach,
+										listId: selected?.id ?? null,
+										listName: selected?.name ?? null,
+									},
+								} );
+							} }
+							__next40pxDefaultSize={ true }
+							__nextHasNoMarginBottom={ true }
+						/>
+					) : (
+						<p className="integration-card__description">
+							{ __(
+								'You do not have any Hostinger Reach lists yet. Click the dashboard button below to create one.',
+								'jetpack-forms'
+							) }
+						</p>
+					) }
+					{ hasEmailBlock && (
+						<div className="integration-card__section">
+							<ToggleControl
+								label={ __( 'Add email permission request before submit button', 'jetpack-forms' ) }
+								checked={ !! consentBlock }
+								onChange={ toggleConsent }
+								__nextHasNoMarginBottom
+							/>
+						</div>
+					) }
+					<p className="integration-card__description">
+						<ExternalLink href={ settingsUrl }>
+							{ __( 'View Hostinger Reach dashboard', 'jetpack-forms' ) }
+						</ExternalLink>
+					</p>
+				</div>
+			) }
+		</IntegrationCard>
+	);
+};
+
+export default HostingerReachCard;

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/hostinger-reach-card.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/hostinger-reach-card.tsx
@@ -68,7 +68,7 @@ const HostingerReachCard = ( {
 				'jetpack-forms'
 			),
 			{
-				a: <ExternalLink href={ data?.marketingUrl || '' } />, // placeholder if we add marketingUrl later
+				a: <ExternalLink href={ data?.marketingUrl } />,
 			}
 		),
 		notActivatedMessage: __(

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/index.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/index.tsx
@@ -11,6 +11,7 @@ import { __ } from '@wordpress/i18n';
 import AkismetCard from './akismet-card';
 import CreativeMailCard from './creative-mail-card';
 import GoogleSheetsCard from './google-sheets-card';
+import HostingerReachCard from './hostinger-reach-card';
 import JetpackCRMCard from './jetpack-crm-card';
 import MailPoetCard from './mailpoet-card';
 import SalesforceCard from './salesforce-card';
@@ -35,6 +36,7 @@ const IntegrationsModal = ( {
 		creativemail: false,
 		salesforce: false,
 		mailpoet: false,
+		hostingerReach: false,
 	} );
 
 	if ( ! isOpen ) {
@@ -51,6 +53,7 @@ const IntegrationsModal = ( {
 	const mailpoetData = findIntegrationById( 'mailpoet' );
 	const salesforceData = findIntegrationById( 'salesforce' );
 	const creativeMailData = findIntegrationById( 'creative-mail-by-constant-contact' );
+	const hostingerReachData = findIntegrationById( 'hostinger-reach' );
 
 	const toggleCard = ( cardId: string ) => {
 		setExpandedCards( prev => {
@@ -121,6 +124,16 @@ const IntegrationsModal = ( {
 						data={ salesforceData }
 						refreshStatus={ refreshIntegrations }
 						salesforceData={ attributes.salesforceData }
+						setAttributes={ setAttributes }
+					/>
+				) }
+				{ hostingerReachData && (
+					<HostingerReachCard
+						isExpanded={ expandedCards.hostingerReach }
+						onToggle={ () => toggleCard( 'hostingerReach' ) }
+						data={ hostingerReachData }
+						refreshStatus={ refreshIntegrations }
+						hostingerReach={ attributes.hostingerReach }
 						setAttributes={ setAttributes }
 					/>
 				) }

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/style.scss
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/style.scss
@@ -153,7 +153,8 @@
 	}
 
 	&__service-icon--google-sheets,
-	&__service-icon--mailpoet {
+	&__service-icon--mailpoet,
+	&__service-icon--hostinger-reach {
 		border-radius: 0 !important;
 	}
 

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -95,6 +95,20 @@ class Jetpack_Forms {
 	}
 
 	/**
+	 * Returns true if Hostinger Reach integration is enabled.
+	 *
+	 * @return boolean
+	 */
+	public static function is_hostinger_reach_enabled() {
+		/**
+		 * Enable Hostinger Reach integration.
+		 *
+		 * @param bool false Whether Hostinger Reach integration be enabled. Default is false.
+		 */
+		return apply_filters( 'jetpack_forms_hostinger_reach_enable', false );
+	}
+
+	/**
 	 * Returns true if the Integrations UI should be enabled.
 	 *
 	 * @return boolean

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -107,7 +107,7 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 				'type'                    => 'plugin',
 				'file'                    => 'hostinger-reach/hostinger-reach.php',
 				'settings_url'            => 'admin.php?page=hostinger-reach#/home',
-				'marketing_redirect_slug' => null,
+				'marketing_redirect_slug' => 'hostinger-reach',
 				'title'                   => __( 'Hostinger Reach', 'jetpack-forms' ),
 				'subtitle'                => __( 'Send newsletters and marketing emails via Hostinger Reach.', 'jetpack-forms' ),
 				// Overriding this may automatically enable/disable the integration when editing a form.
@@ -1179,6 +1179,43 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 			case 'hostinger-reach':
 				// Hostinger Reach is a plugin that requires additional setup/connection.
 				$status['needsConnection'] = true;
+				$status['isConnected']     = false;
+				// Determine if Hostinger Reach is connected using its public handler.
+				if ( $is_active
+					&& class_exists( \Hostinger\Reach\Api\Handlers\ReachApiHandler::class )
+					&& class_exists( \Hostinger\Reach\Functions::class )
+					&& class_exists( \Hostinger\Reach\Api\ApiKeyManager::class )
+				) {
+					$reach_handler = new \Hostinger\Reach\Api\Handlers\ReachApiHandler(
+						new \Hostinger\Reach\Functions(),
+						new \Hostinger\Reach\Api\ApiKeyManager()
+					);
+					if ( method_exists( $reach_handler, 'is_connected' ) ) {
+						$status['isConnected'] = (bool) $reach_handler->is_connected();
+					}
+
+					// Populate available groups/lists for selection in the editor when connected.
+					if (
+						$status['isConnected']
+						&& class_exists( \Hostinger\Reach\Repositories\ContactListRepository::class )
+						&& class_exists( \Hostinger\Reach\Admin\Database\ContactListsTable::class )
+					) {
+						global $wpdb;
+						$contact_list_repository = new \Hostinger\Reach\Repositories\ContactListRepository( $wpdb, new \Hostinger\Reach\Admin\Database\ContactListsTable( $wpdb ) );
+
+						$contact_lists              = $contact_list_repository->all();
+						$contact_lists              = is_array( $contact_lists ) ? $contact_lists : array();
+						$status['details']['lists'] = array_map(
+							function ( $list ) {
+								return array(
+									'id'   => $list['id'] ?? null,
+									'name' => $list['name'] ?? '',
+								);
+							},
+							$contact_lists
+						);
+					}
+				}
 				break;
 		}
 

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -1193,8 +1193,8 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 						new \Hostinger\Reach\Functions(), // @phan-suppress-current-line PhanUndeclaredClassMethod
 						new \Hostinger\Reach\Api\ApiKeyManager() // @phan-suppress-current-line PhanUndeclaredClassMethod
 					);
-					// @phan-suppress-next-line PhanUndeclaredClassMethod
 					if ( method_exists( $reach_handler, 'is_connected' ) ) {
+						// @phan-suppress-next-line PhanUndeclaredClassMethod
 						$status['isConnected'] = (bool) $reach_handler->is_connected();
 					}
 				}

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -1182,14 +1182,18 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 				$status['isConnected']     = false;
 				// Determine if Hostinger Reach is connected using its public handler.
 				if ( $is_active
+					// @phan-suppress-next-line PhanUndeclaredClassReference
 					&& class_exists( \Hostinger\Reach\Api\Handlers\ReachApiHandler::class )
+					// @phan-suppress-next-line PhanUndeclaredClassReference
 					&& class_exists( \Hostinger\Reach\Functions::class )
+					// @phan-suppress-next-line PhanUndeclaredClassReference
 					&& class_exists( \Hostinger\Reach\Api\ApiKeyManager::class )
 				) {
 					$reach_handler = new \Hostinger\Reach\Api\Handlers\ReachApiHandler( // @phan-suppress-current-line PhanUndeclaredClassMethod
 						new \Hostinger\Reach\Functions(), // @phan-suppress-current-line PhanUndeclaredClassMethod
 						new \Hostinger\Reach\Api\ApiKeyManager() // @phan-suppress-current-line PhanUndeclaredClassMethod
 					);
+					// @phan-suppress-next-line PhanUndeclaredClassMethod
 					if ( method_exists( $reach_handler, 'is_connected' ) ) {
 						$status['isConnected'] = (bool) $reach_handler->is_connected();
 					}

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -1186,34 +1186,12 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 					&& class_exists( \Hostinger\Reach\Functions::class )
 					&& class_exists( \Hostinger\Reach\Api\ApiKeyManager::class )
 				) {
-					$reach_handler = new \Hostinger\Reach\Api\Handlers\ReachApiHandler(
-						new \Hostinger\Reach\Functions(),
-						new \Hostinger\Reach\Api\ApiKeyManager()
+					$reach_handler = new \Hostinger\Reach\Api\Handlers\ReachApiHandler( // @phan-suppress-current-line PhanUndeclaredClassMethod
+						new \Hostinger\Reach\Functions(), // @phan-suppress-current-line PhanUndeclaredClassMethod
+						new \Hostinger\Reach\Api\ApiKeyManager() // @phan-suppress-current-line PhanUndeclaredClassMethod
 					);
 					if ( method_exists( $reach_handler, 'is_connected' ) ) {
 						$status['isConnected'] = (bool) $reach_handler->is_connected();
-					}
-
-					// Populate available groups/lists for selection in the editor when connected.
-					if (
-						$status['isConnected']
-						&& class_exists( \Hostinger\Reach\Repositories\ContactListRepository::class )
-						&& class_exists( \Hostinger\Reach\Admin\Database\ContactListsTable::class )
-					) {
-						global $wpdb;
-						$contact_list_repository = new \Hostinger\Reach\Repositories\ContactListRepository( $wpdb, new \Hostinger\Reach\Admin\Database\ContactListsTable( $wpdb ) );
-
-						$contact_lists              = $contact_list_repository->all();
-						$contact_lists              = is_array( $contact_lists ) ? $contact_lists : array();
-						$status['details']['lists'] = array_map(
-							function ( $list ) {
-								return array(
-									'id'   => $list['id'] ?? null,
-									'name' => $list['name'] ?? '',
-								);
-							},
-							$contact_lists
-						);
 					}
 				}
 				break;

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -101,6 +101,20 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 			),
 		);
 
+		// Conditionally add Hostinger Reach integration behind feature flag.
+		if ( Jetpack_Forms::is_hostinger_reach_enabled() ) {
+			$supported_integrations['hostinger-reach'] = array(
+				'type'                    => 'plugin',
+				'file'                    => 'hostinger-reach/hostinger-reach.php',
+				'settings_url'            => 'admin.php?page=hostinger-reach#/home',
+				'marketing_redirect_slug' => null,
+				'title'                   => __( 'Hostinger Reach', 'jetpack-forms' ),
+				'subtitle'                => __( 'Send newsletters and marketing emails via Hostinger Reach.', 'jetpack-forms' ),
+				// Overriding this may automatically enable/disable the integration when editing a form.
+				'enabled_by_default'      => false,
+			);
+		}
+
 		/**
 		 * Filters the list of supported integrations available in Jetpack Forms.
 		 *
@@ -1162,6 +1176,10 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 				// Add MailPoet lists to details
 				$status['details']['lists'] = MailPoet_Integration::get_all_lists();
 				break;
+			case 'hostinger-reach':
+				// Hostinger Reach is a plugin that requires additional setup/connection.
+				$status['needsConnection'] = true;
+				break;
 		}
 
 		return $status;
@@ -1242,6 +1260,7 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 			// From jpFormsBlocks in class-contact-form-block.php.
 			'formsResponsesUrl'       => Forms_Dashboard::get_forms_admin_url(),
 			'isMailPoetEnabled'       => Jetpack_Forms::is_mailpoet_enabled(),
+			'isHostingerReachEnabled' => Jetpack_Forms::is_hostinger_reach_enabled(),
 			// From config in class-dashboard.php.
 			'blogId'                  => get_current_blog_id(),
 			'gdriveConnectSupportURL' => esc_url( Redirect::get_url( 'jetpack-support-contact-form-export' ) ),

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -11,6 +11,7 @@ use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Extensions\Contact_Form\Contact_Form_Block;
 use Automattic\Jetpack\Forms\Jetpack_Forms;
+use Automattic\Jetpack\Forms\Service\Hostinger_Reach_Integration;
 use Automattic\Jetpack\Forms\Service\MailPoet_Integration;
 use Automattic\Jetpack\Forms\Service\Post_To_Url;
 use Automattic\Jetpack\Status;
@@ -332,6 +333,16 @@ class Contact_Form_Plugin {
 				'grunion_after_feedback_post_inserted',
 				array( MailPoet_Integration::class, 'handle_mailpoet_integration' ),
 				15,
+				4
+			);
+		}
+
+		// Register Hostinger Reach integration hook after the class is loaded.
+		if ( Jetpack_Forms::is_hostinger_reach_enabled() ) {
+			add_action(
+				'grunion_after_feedback_post_inserted',
+				array( Hostinger_Reach_Integration::class, 'handle_hostinger_reach_integration' ),
+				16,
 				4
 			);
 		}

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -189,6 +189,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 			'confirmationType'       => null, // The type of confirmation to show after submitting a form. 'text' for a text message, 'redirect' for a redirect link.
 			'jetpackCRM'             => true, // Whether Jetpack CRM should store the form submission.
 			'mailpoet'               => null,
+			'hostingerReach'         => null,
 			'className'              => null,
 			'postToUrl'              => null,
 			'salesforceData'         => null,

--- a/projects/packages/forms/src/dashboard/integrations/hostinger-reach-card.tsx
+++ b/projects/packages/forms/src/dashboard/integrations/hostinger-reach-card.tsx
@@ -1,0 +1,89 @@
+import { Button, ExternalLink, __experimentalHStack as HStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
+import { createInterpolateElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import IntegrationCard from '../../blocks/contact-form/components/jetpack-integrations-modal/integration-card';
+import HostingerReachIcon from '../../icons/hostinger-reach';
+import type { SingleIntegrationCardProps, IntegrationCardData } from '../../types';
+
+const HostingerReachDashboardCard = ( {
+	isExpanded,
+	onToggle,
+	data,
+	refreshStatus,
+}: SingleIntegrationCardProps ) => {
+	const { isConnected = false, settingsUrl = '', marketingUrl = '' } = data || {};
+
+	const cardData: IntegrationCardData = {
+		...data,
+		showHeaderToggle: false,
+		isLoading: ! data || typeof data.isInstalled === 'undefined',
+		refreshStatus,
+		trackEventName: 'jetpack_forms_upsell_hostinger_reach_click',
+		notInstalledMessage: createInterpolateElement(
+			__(
+				'Add powerful email marketing to your forms with <a>Hostinger Reach</a>. Simply install the plugin to start sending emails.',
+				'jetpack-forms'
+			),
+			{
+				a: <ExternalLink href={ marketingUrl } />,
+			}
+		),
+		notActivatedMessage: __(
+			'Hostinger Reach is installed. Just activate the plugin to start sending emails.',
+			'jetpack-forms'
+		),
+	};
+
+	return (
+		<IntegrationCard
+			title={ data?.title }
+			description={ data?.subtitle }
+			icon={ <HostingerReachIcon width={ 28 } height={ 28 } /> }
+			isExpanded={ isExpanded }
+			onToggle={ onToggle }
+			cardData={ cardData }
+			toggleTooltip={ __( 'Grow your audience with Hostinger Reach', 'jetpack-forms' ) }
+		>
+			{ ! isConnected ? (
+				<div>
+					<p className="integration-card__description">
+						{ createInterpolateElement(
+							__(
+								'Hostinger Reach is active. There is one step left. Please complete <a>Hostinger Reach setup</a>.',
+								'jetpack-forms'
+							),
+							{
+								a: <ExternalLink href={ settingsUrl } />,
+							}
+						) }
+					</p>
+					<HStack spacing="3" justify="start">
+						<Button
+							variant="secondary"
+							href={ settingsUrl }
+							target="_blank"
+							rel="noopener noreferrer"
+							__next40pxDefaultSize={ true }
+						>
+							{ __( 'Complete Hostinger Reach setup', 'jetpack-forms' ) }
+						</Button>
+						<Button variant="tertiary" onClick={ refreshStatus } __next40pxDefaultSize={ true }>
+							{ __( 'Refresh status', 'jetpack-forms' ) }
+						</Button>
+					</HStack>
+				</div>
+			) : (
+				<div>
+					<p className="integration-card__description">
+						{ __( 'You can now send marketing emails with Hostinger Reach.', 'jetpack-forms' ) }
+					</p>
+					<Button variant="link" href={ settingsUrl } target="_blank" rel="noopener noreferrer">
+						{ __( 'View Hostinger Reach dashboard', 'jetpack-forms' ) }
+					</Button>
+				</div>
+			) }
+		</IntegrationCard>
+	);
+};
+
+export default HostingerReachDashboardCard;

--- a/projects/packages/forms/src/dashboard/integrations/index.tsx
+++ b/projects/packages/forms/src/dashboard/integrations/index.tsx
@@ -12,6 +12,7 @@ import { INTEGRATIONS_STORE } from '../../store/integrations';
 import AkismetDashboardCard from './akismet-card';
 import CreativeMailDashboardCard from './creative-mail-card';
 import GoogleSheetsDashboardCard from './google-sheets-card';
+import HostingerReachDashboardCard from './hostinger-reach-card';
 import JetpackCRMDashboardCard from './jetpack-crm-card';
 import MailPoetDashboardCard from './mailpoet-card';
 import SalesforceDashboardCard from './salesforce-card';
@@ -37,6 +38,7 @@ const Integrations = () => {
 		creativemail: false,
 		salesforce: false,
 		mailpoet: false,
+		hostingerReach: false,
 	} );
 
 	const toggleCard = useCallback( ( cardId: keyof typeof expandedCards ) => {
@@ -69,6 +71,10 @@ const Integrations = () => {
 		[ toggleCard ]
 	);
 	const handleToggleMailPoet = useCallback( () => toggleCard( 'mailpoet' ), [ toggleCard ] );
+	const handleToggleHostingerReach = useCallback(
+		() => toggleCard( 'hostingerReach' ),
+		[ toggleCard ]
+	);
 
 	const findIntegrationById = ( id: string ) =>
 		integrations.find( integration => integration.id === id );
@@ -80,6 +86,7 @@ const Integrations = () => {
 	const mailpoetData = findIntegrationById( 'mailpoet' );
 	const salesforceData = findIntegrationById( 'salesforce' );
 	const creativeMailData = findIntegrationById( 'creative-mail-by-constant-contact' );
+	const hostingerReachData = findIntegrationById( 'hostinger-reach' );
 
 	return (
 		<div className="jp-forms__integrations">
@@ -141,6 +148,14 @@ const Integrations = () => {
 							isExpanded={ expandedCards.creativemail }
 							onToggle={ handleToggleCreativeMail }
 							data={ creativeMailData }
+							refreshStatus={ refreshIntegrations }
+						/>
+					) }
+					{ hostingerReachData && (
+						<HostingerReachDashboardCard
+							isExpanded={ expandedCards.hostingerReach }
+							onToggle={ handleToggleHostingerReach }
+							data={ hostingerReachData }
 							refreshStatus={ refreshIntegrations }
 						/>
 					) }

--- a/projects/packages/forms/src/dashboard/integrations/index.tsx
+++ b/projects/packages/forms/src/dashboard/integrations/index.tsx
@@ -143,19 +143,19 @@ const Integrations = () => {
 							refreshStatus={ refreshIntegrations }
 						/>
 					) }
-					{ creativeMailData && (
-						<CreativeMailDashboardCard
-							isExpanded={ expandedCards.creativemail }
-							onToggle={ handleToggleCreativeMail }
-							data={ creativeMailData }
-							refreshStatus={ refreshIntegrations }
-						/>
-					) }
 					{ hostingerReachData && (
 						<HostingerReachDashboardCard
 							isExpanded={ expandedCards.hostingerReach }
 							onToggle={ handleToggleHostingerReach }
 							data={ hostingerReachData }
+							refreshStatus={ refreshIntegrations }
+						/>
+					) }
+					{ creativeMailData && (
+						<CreativeMailDashboardCard
+							isExpanded={ expandedCards.creativemail }
+							onToggle={ handleToggleCreativeMail }
+							data={ creativeMailData }
 							refreshStatus={ refreshIntegrations }
 						/>
 					) }

--- a/projects/packages/forms/src/icons/hostinger-reach.tsx
+++ b/projects/packages/forms/src/icons/hostinger-reach.tsx
@@ -1,0 +1,24 @@
+import { __ } from '@wordpress/i18n';
+import { SVG, Path, SVGProps } from '@wordpress/primitives';
+
+const HostingerReachIcon = ( props: SVGProps & { width?: number; height?: number } ) => (
+	<SVG
+		{ ...props }
+		width={ props.width || 30 }
+		height={ props.height || 30 }
+		viewBox="7.002 8.287 148.203 175.426"
+		fill="none"
+		xmlns="http://www.w3.org/2000/svg"
+		role="img"
+		aria-label={ __( 'Hostinger Reach icon', 'jetpack-forms' ) }
+	>
+		<Path
+			d="m7.002 8.287 39.319 21.172v39.32h57.467l36.295 21.172h-133.081zm148.203 75.615v-54.443l-42.344-21.172v51.418zm0 99.811-39.319-21.172v-39.32h-57.467l-36.295-21.172h133.081zm-148.203-75.615v54.443l42.343 21.172v-51.418z"
+			fill="#6747c7"
+			fillRule="evenodd"
+			clipRule="evenodd"
+		/>
+	</SVG>
+);
+
+export default HostingerReachIcon;

--- a/projects/packages/forms/src/service/class-hostinger-reach-integration.php
+++ b/projects/packages/forms/src/service/class-hostinger-reach-integration.php
@@ -49,8 +49,11 @@ class Hostinger_Reach_Integration {
 	protected static function get_api() {
 		if (
 			null === self::$hostinger_api
+			// @phan-suppress-next-line PhanUndeclaredClassReference
 			&& class_exists( \Hostinger\Reach\Api\Handlers\ReachApiHandler::class )
+			// @phan-suppress-next-line PhanUndeclaredClassReference
 			&& class_exists( \Hostinger\Reach\Functions::class )
+			// @phan-suppress-next-line PhanUndeclaredClassReference
 			&& class_exists( \Hostinger\Reach\Api\ApiKeyManager::class )
 		) {
 			// @phan-suppress-next-line PhanUndeclaredClassMethod

--- a/projects/packages/forms/src/service/class-hostinger-reach-integration.php
+++ b/projects/packages/forms/src/service/class-hostinger-reach-integration.php
@@ -27,15 +27,17 @@ class Hostinger_Reach_Integration {
 	/**
 	 * Submit contact to Hostinger Reach.
 	 *
-	 * @param mixed $api_handler     Reach API handler.
-	 * @param array $subscriber_data Associative array: email, first_name, last_name.
+	 * @param mixed  $api_handler     Reach API handler.
+	 * @param array  $subscriber_data Associative array: email, first_name, last_name.
+	 * @param string $group_name      Target group name.
 	 * @return void
 	 */
-	protected static function submit_contact( $api_handler, array $subscriber_data ) {
+	protected static function submit_contact( $api_handler, array $subscriber_data, $group_name ) {
 		if ( ! $api_handler || empty( $subscriber_data['email'] ) ) {
 			return;
 		}
 
+		$subscriber_data['group'] = $group_name;
 		$api_handler->post_contact( $subscriber_data );
 	}
 
@@ -64,6 +66,19 @@ class Hostinger_Reach_Integration {
 	}
 
 	/**
+	 * Get group name from form attributes, falling back to 'Jetpack Forms'.
+	 *
+	 * @param mixed $form Contact form instance.
+	 * @return string
+	 */
+	protected static function get_group_name( $form ) {
+		$group_name = ! empty( $form->attributes['hostingerReach']['groupName'] ?? '' )
+			? trim( $form->attributes['hostingerReach']['groupName'] )
+			: 'Jetpack Forms';
+		return $group_name;
+	}
+
+	/**
 	 * Extract subscriber data (email, first_name, last_name) using Feedback API (v2 storage).
 	 *
 	 * @param Feedback $feedback Feedback object for the submission.
@@ -76,7 +91,6 @@ class Hostinger_Reach_Integration {
 
 		$subscriber_data          = array();
 		$subscriber_data['email'] = $feedback->get_author_email();
-		$subscriber_data['group'] = 'Jetpack Forms';
 
 		if ( $feedback->get_field_value_by_label( 'First Name' ) ) {
 			$subscriber_data['name'] = $feedback->get_field_value_by_label( 'First Name' );
@@ -115,8 +129,8 @@ class Hostinger_Reach_Integration {
 			return array();
 		}
 
-		$subscriber_data          = array();
-		$subscriber_data['group'] = 'Jetpack Forms';
+		$subscriber_data = array();
+
 		foreach ( $form->fields as $field ) {
 			$id    = strtolower( str_replace( array( ' ', '_' ), '', $field->get_attribute( 'id' ) ) );
 			$label = strtolower( str_replace( array( ' ', '_' ), '', $field->get_attribute( 'label' ) ) );
@@ -231,6 +245,8 @@ class Hostinger_Reach_Integration {
 			return;
 		}
 
-		self::submit_contact( $api_handler, $subscriber_data );
+		$group_name = self::get_group_name( $form );
+
+		self::submit_contact( $api_handler, $subscriber_data, $group_name );
 	}
 }

--- a/projects/packages/forms/src/service/class-hostinger-reach-integration.php
+++ b/projects/packages/forms/src/service/class-hostinger-reach-integration.php
@@ -25,36 +25,17 @@ class Hostinger_Reach_Integration {
 	protected static $hostinger_api = null;
 
 	/**
-	 * Resolve the group name to use for the subscriber.
-	 *
-	 * @param mixed $form Contact form instance.
-	 * @return string Group name.
-	 */
-	protected static function resolve_group_name( $form ) {
-		$attr = array();
-		if ( is_object( $form ) && isset( $form->attributes ) && is_array( $form->attributes ) ) {
-			$attr = is_array( $form->attributes['hostingerReach'] ?? null ) ? $form->attributes['hostingerReach'] : array();
-		}
-		$group_name = isset( $attr['listName'] ) && is_string( $attr['listName'] ) && $attr['listName'] !== ''
-			? $attr['listName']
-			: 'Jetpack Forms';
-		return $group_name;
-	}
-
-	/**
 	 * Submit contact to Hostinger Reach.
 	 *
-	 * @param mixed  $api_handler     Reach API handler.
-	 * @param array  $subscriber_data Associative array: email, first_name, last_name.
-	 * @param string $group_name      Target group name.
+	 * @param mixed $api_handler     Reach API handler.
+	 * @param array $subscriber_data Associative array: email, first_name, last_name.
 	 * @return void
 	 */
-	protected static function submit_contact( $api_handler, array $subscriber_data, $group_name ) {
+	protected static function submit_contact( $api_handler, array $subscriber_data ) {
 		if ( ! $api_handler || empty( $subscriber_data['email'] ) ) {
 			return;
 		}
 
-		$subscriber_data['group'] = $group_name;
 		$api_handler->post_contact( $subscriber_data );
 	}
 
@@ -95,6 +76,7 @@ class Hostinger_Reach_Integration {
 
 		$subscriber_data          = array();
 		$subscriber_data['email'] = $feedback->get_author_email();
+		$subscriber_data['group'] = 'Jetpack Forms';
 
 		if ( $feedback->get_field_value_by_label( 'First Name' ) ) {
 			$subscriber_data['name'] = $feedback->get_field_value_by_label( 'First Name' );
@@ -133,7 +115,8 @@ class Hostinger_Reach_Integration {
 			return array();
 		}
 
-		$subscriber_data = array();
+		$subscriber_data          = array();
+		$subscriber_data['group'] = 'Jetpack Forms';
 		foreach ( $form->fields as $field ) {
 			$id    = strtolower( str_replace( array( ' ', '_' ), '', $field->get_attribute( 'id' ) ) );
 			$label = strtolower( str_replace( array( ' ', '_' ), '', $field->get_attribute( 'label' ) ) );
@@ -243,13 +226,11 @@ class Hostinger_Reach_Integration {
 			return;
 		}
 
-		// Resolve group name and prepare subscriber data (email is required).
-		$group_name      = self::resolve_group_name( $form );
 		$subscriber_data = $is_v2_data ? self::get_subscriber_data( $feedback ) : self::get_subscriber_data_from_fields( $fields );
 		if ( empty( $subscriber_data ) ) {
 			return;
 		}
 
-		self::submit_contact( $api_handler, $subscriber_data, $group_name );
+		self::submit_contact( $api_handler, $subscriber_data );
 	}
 }

--- a/projects/packages/forms/src/service/class-hostinger-reach-integration.php
+++ b/projects/packages/forms/src/service/class-hostinger-reach-integration.php
@@ -70,8 +70,11 @@ class Hostinger_Reach_Integration {
 			&& class_exists( \Hostinger\Reach\Functions::class )
 			&& class_exists( \Hostinger\Reach\Api\ApiKeyManager::class )
 		) {
+			// @phan-suppress-next-line PhanUndeclaredClassMethod
 			self::$hostinger_api = new \Hostinger\Reach\Api\Handlers\ReachApiHandler(
+				// @phan-suppress-next-line PhanUndeclaredClassMethod
 				new \Hostinger\Reach\Functions(),
+				// @phan-suppress-next-line PhanUndeclaredClassMethod
 				new \Hostinger\Reach\Api\ApiKeyManager()
 			);
 		}

--- a/projects/packages/forms/src/service/class-hostinger-reach-integration.php
+++ b/projects/packages/forms/src/service/class-hostinger-reach-integration.php
@@ -1,0 +1,252 @@
+<?php
+/**
+ * Hostinger Reach Integration for Jetpack Contact Forms.
+ *
+ * @package automattic/jetpack
+ */
+
+namespace Automattic\Jetpack\Forms\Service;
+
+use Automattic\Jetpack\Forms\ContactForm\Feedback;
+
+/**
+ * Class Hostinger_Reach_Integration
+ *
+ * Scaffolding for handling integration with Hostinger Reach for Jetpack Contact Forms.
+ * Public API docs are limited; this class mirrors the structure of MailPoet_Integration
+ * and will be implemented once the Hostinger Reach plugin APIs are confirmed.
+ */
+class Hostinger_Reach_Integration {
+	/**
+	 * Placeholder for a Hostinger Reach API instance, if needed later.
+	 *
+	 * @var mixed
+	 */
+	protected static $hostinger_api = null;
+
+	/**
+	 * Resolve the group name to use for the subscriber.
+	 *
+	 * @param mixed $form Contact form instance.
+	 * @return string Group name.
+	 */
+	protected static function resolve_group_name( $form ) {
+		$attr = array();
+		if ( is_object( $form ) && isset( $form->attributes ) && is_array( $form->attributes ) ) {
+			$attr = is_array( $form->attributes['hostingerReach'] ?? null ) ? $form->attributes['hostingerReach'] : array();
+		}
+		$group_name = isset( $attr['listName'] ) && is_string( $attr['listName'] ) && $attr['listName'] !== ''
+			? $attr['listName']
+			: 'Jetpack Forms';
+		return $group_name;
+	}
+
+	/**
+	 * Submit contact to Hostinger Reach.
+	 *
+	 * @param mixed  $api_handler     Reach API handler.
+	 * @param array  $subscriber_data Associative array: email, first_name, last_name.
+	 * @param string $group_name      Target group name.
+	 * @return void
+	 */
+	protected static function submit_contact( $api_handler, array $subscriber_data, $group_name ) {
+		if ( ! $api_handler || empty( $subscriber_data['email'] ) ) {
+			return;
+		}
+
+		$subscriber_data['group'] = $group_name;
+		$api_handler->post_contact( $subscriber_data );
+	}
+
+	/**
+	 * Get the Hostinger Reach API instance.
+	 *
+	 * @return mixed
+	 */
+	protected static function get_api() {
+		if (
+			null === self::$hostinger_api
+			&& class_exists( \Hostinger\Reach\Api\Handlers\ReachApiHandler::class )
+			&& class_exists( \Hostinger\Reach\Functions::class )
+			&& class_exists( \Hostinger\Reach\Api\ApiKeyManager::class )
+		) {
+			self::$hostinger_api = new \Hostinger\Reach\Api\Handlers\ReachApiHandler(
+				new \Hostinger\Reach\Functions(),
+				new \Hostinger\Reach\Api\ApiKeyManager()
+			);
+		}
+
+		return self::$hostinger_api;
+	}
+
+	/**
+	 * Extract subscriber data (email, first_name, last_name) using Feedback API (v2 storage).
+	 *
+	 * @param Feedback $feedback Feedback object for the submission.
+	 * @return array Associative array with at least 'email', optionally 'first_name', 'last_name'. Empty array if no email found.
+	 */
+	protected static function get_subscriber_data( $feedback ) {
+		if ( ! $feedback->get_author_email() ) {
+			return array();
+		}
+
+		$subscriber_data          = array();
+		$subscriber_data['email'] = $feedback->get_author_email();
+
+		if ( $feedback->get_field_value_by_label( 'First Name' ) ) {
+			$subscriber_data['name'] = $feedback->get_field_value_by_label( 'First Name' );
+		} elseif ( $feedback->get_field_value_by_form_field_id( 'firstname' ) ) {
+			$subscriber_data['name'] = $feedback->get_field_value_by_form_field_id( 'firstname' );
+		} elseif ( $feedback->get_field_value_by_form_field_id( 'first-name' ) ) {
+			$subscriber_data['name'] = $feedback->get_field_value_by_form_field_id( 'first-name' );
+		}
+		if ( $feedback->get_field_value_by_label( 'Last Name' ) ) {
+			$subscriber_data['surname'] = $feedback->get_field_value_by_label( 'Last Name' );
+		} elseif ( $feedback->get_field_value_by_form_field_id( 'lastname' ) ) {
+			$subscriber_data['surname'] = $feedback->get_field_value_by_form_field_id( 'lastname' );
+		} elseif ( $feedback->get_field_value_by_form_field_id( 'last-name' ) ) {
+			$subscriber_data['surname'] = $feedback->get_field_value_by_form_field_id( 'last-name' );
+		}
+
+		return $subscriber_data;
+	}
+
+	/**
+	 * Extract subscriber data (email, first_name, last_name) from legacy field data (v1 storage).
+	 *
+	 * @param array $fields Collection of Contact_Form_Field instances.
+	 * @return array Associative array with at least 'email', optionally 'first_name', 'last_name'. Empty array if no email found.
+	 */
+	protected static function get_subscriber_data_from_fields( $fields ) {
+		// Try and get the form from any of the fields
+		$form = null;
+		foreach ( $fields as $field ) {
+			if ( ! empty( $field->form ) ) {
+				$form = $field->form;
+				break;
+			}
+		}
+		if ( ! $form || ! is_a( $form, 'Automattic\\Jetpack\\Forms\\ContactForm\\Contact_Form' ) ) {
+			return array();
+		}
+
+		$subscriber_data = array();
+		foreach ( $form->fields as $field ) {
+			$id    = strtolower( str_replace( array( ' ', '_' ), '', $field->get_attribute( 'id' ) ) );
+			$label = strtolower( str_replace( array( ' ', '_' ), '', $field->get_attribute( 'label' ) ) );
+
+			if ( ! is_string( $field->value ) ) {
+				continue;
+			}
+
+			$value = trim( $field->value );
+
+			if ( ( $id === 'email' || $label === 'email' ) && ! empty( $value ) ) {
+				$subscriber_data['email'] = $value;
+			} elseif ( ( $id === 'firstname' || $label === 'firstname' ) && ! empty( $value ) ) {
+				$subscriber_data['name'] = $value;
+			} elseif ( ( $id === 'lastname' || $label === 'lastname' ) && ! empty( $value ) ) {
+				$subscriber_data['surname'] = $value;
+			}
+		}
+
+		if ( empty( $subscriber_data['email'] ) ) {
+			return array();
+		}
+
+		return $subscriber_data;
+	}
+
+	/**
+	 * Check if submission has consent when required.
+	 *
+	 * @param Feedback $feedback Feedback object for the submission.
+	 * @param mixed    $form     Contact form instance.
+	 * @param bool     $is_v2    Whether the data comes from v2 storage.
+	 * @return bool True if consent is present or not required; false otherwise.
+	 */
+	protected static function has_consent( $feedback, $form, $is_v2 ) {
+		if ( $is_v2 ) {
+			if ( $feedback->has_field_type( 'consent' ) && ! $feedback->has_consent() ) {
+				return false;
+			}
+			return true;
+		}
+
+		$consent_field = null;
+		if ( is_object( $form ) && is_array( $form->fields ) ) {
+			foreach ( $form->fields as $form_field ) {
+				if ( 'consent' === $form_field->get_attribute( 'type' ) ) {
+					$consent_field = $form_field;
+					break;
+				}
+			}
+		}
+		if ( $consent_field ) {
+			$consent_type = strtolower( (string) $consent_field->get_attribute( 'consenttype' ) );
+			if ( 'explicit' === $consent_type && ! $consent_field->value ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Handle Hostinger Reach integration after feedback post is inserted.
+	 *
+	 * For now, this only validates preconditions and returns early; real actions will be implemented later.
+	 *
+	 * @param int   $post_id The post ID for the feedback CPT.
+	 * @param array $fields  Collection of Contact_Form_Field instances.
+	 * @param bool  $is_spam Whether the submission is spam.
+	 */
+	public static function handle_hostinger_reach_integration( $post_id, $fields, $is_spam ) {
+		if ( $is_spam ) {
+			return;
+		}
+
+		// Try and get the form from any of the fields
+		$form = null;
+		foreach ( $fields as $field ) {
+			if ( ! empty( $field->form ) ) {
+				$form = $field->form;
+				break;
+			}
+		}
+		if ( ! $form || ! is_a( $form, 'Automattic\\Jetpack\\Forms\\ContactForm\\Contact_Form' ) ) {
+			return;
+		}
+
+		// Feature is toggled per-form.
+		if ( empty( $form->attributes['hostingerReach']['enabledForForm'] ?? null ) ) {
+			return;
+		}
+
+		$feedback = Feedback::get( $post_id );
+		if ( ! $feedback ) {
+			return;
+		}
+
+		$api_handler = self::get_api();
+		if ( ! $api_handler ) {
+			return;
+		}
+
+		// Respect consent if a consent field exists.
+		$post       = get_post( $post_id );
+		$is_v2_data = ( $post && $post->post_mime_type === 'v2' );
+		if ( ! self::has_consent( $feedback, $form, $is_v2_data ) ) {
+			return;
+		}
+
+		// Resolve group name and prepare subscriber data (email is required).
+		$group_name      = self::resolve_group_name( $form );
+		$subscriber_data = $is_v2_data ? self::get_subscriber_data( $feedback ) : self::get_subscriber_data_from_fields( $fields );
+		if ( empty( $subscriber_data ) ) {
+			return;
+		}
+
+		self::submit_contact( $api_handler, $subscriber_data, $group_name );
+	}
+}

--- a/projects/packages/forms/src/types/index.ts
+++ b/projects/packages/forms/src/types/index.ts
@@ -214,6 +214,8 @@ export type BlockEditorStoreSelect = {
 export interface FormsConfigData {
 	/** Whether MailPoet integration is enabled across contexts. */
 	isMailPoetEnabled?: boolean;
+	/** Whether Hostinger Reach integration is enabled across contexts. */
+	isHostingerReachEnabled?: boolean;
 	/** Whether integrations UI is enabled (feature-flagged). */
 	isIntegrationsEnabled?: boolean;
 	/** Whether the current user can install plugins (install_plugins). */

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -2734,6 +2734,7 @@ EOT;
 		$expected_attributes['notificationRecipients'] = array();
 		$expected_attributes['disableSummary']         = '';
 		$expected_attributes['confirmationType']       = '';
+		$expected_attributes['hostingerReach']      = '';
 
 		$form = new Contact_Form(
 			$attributes,

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -2734,7 +2734,7 @@ EOT;
 		$expected_attributes['notificationRecipients'] = array();
 		$expected_attributes['disableSummary']         = '';
 		$expected_attributes['confirmationType']       = '';
-		$expected_attributes['hostingerReach']      = '';
+		$expected_attributes['hostingerReach']         = '';
 
 		$form = new Contact_Form(
 			$attributes,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Addresses [FORMS: Hostinger Reach Integration](https://linear.app/a8c/project/forms-hostinger-reach-integration-33af24f5b007/overview)

## Proposed changes:

This PR adds Hostinger Reach integration behind a feature flag. Specific changes:
* Returns Hostinger Reach information and status from the integrations endpoint.
* Adds 'hostinger' attribute to the forms block. 
* Adds Hostinger Reach cards to the forms dashboard and block modal. These allow installing/activating the plugin and connecting the service. The block modal allows enabling the integration for a form and adding a group name.
* Adds backend integration with new Hostinger_Reach_Integration class. We hook in to a form submission hook; check if Hostinger is enabled for the form (along with other checks); get name, email, and group name from the submission; and add the contact to Hostinger.
* Updates tests.

**Forms dashboard**
<img width="740" height="627" alt="hostinger-reach-integration" src="https://github.com/user-attachments/assets/14baa74d-1090-41b7-be1c-5bffb7cda910" />

**Block modal**
<img width="1247" height="653" alt="hostinger-reach-modal" src="https://github.com/user-attachments/assets/1cfb39cf-b3a3-435f-afab-d0f896d9f612" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
See linear issue above.
See linear issue above.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* **Feature flag**. Enable Hostinger Reach integration with `add_filter( 'jetpack_forms_hostinger_reach_enable', '__return_true' );`
* **Integrations dashboard.** Confirm Hostinger shows in the dashboard integrations list, and that you can install, activate, and connect the service.
   - **Install/Activate plugin**. If not done already, install plugin from from the integrations dashboard, confirm plugin installs and activates, and confirm that card status updates once done.
   - **Connect site**. If you haven't connected Hostinger Reach already, you'll see button to complete setup. Click that to go to Hostinger settings page in your WordPress admin. Click the 'Connect Site' button and set up a free account.
   - **Confirm connected state.** After connecting site, go back to integrations dashboard. If needed click Refresh Status. Confirm that you no longer see buttons to install, activate, or complete setup, but rather just a link to the Hostinger dashboard. Confirm that links works. 
 
* **Integrations modal.** Confirm Hostinger Reach shows in the block modal, and that you can enable it for the form and add a group name.
   - **Create form**. Create post with a new form. Be sure to include First Name, Last Name, and Email fields. 
   - **Integrations modal.** Open the integrations modal. Confirm you see Hostinger Reach. Enable the integration with the header toggle. Add a Group Name.  
   - **Active integrations.** Close the modal and confirm that the Hostinger icon now shows on the block sidebar. 
  
* **Form submission.** Go to the frontend and submit your form.
  - **No submit errors.** Confirm no submit errors. 
  - **Contact added to Hostinger.** Confirm contact is added to your Hostinger Reach account, and with the group name you added (or the default "Jetpack Forms" if you did not add a group name).
  
* **Tests.** Confirm tests pass.