### PR TITLE
Forms: Add options to disable "Go Back" link and summary after submission

### DIFF
--- a/projects/packages/forms/changelog/update-forms-disable-go-back
+++ b/projects/packages/forms/changelog/update-forms-disable-go-back
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Forms: Add options to disable "Go Back" link and summary after submission

--- a/projects/packages/forms/src/blocks/contact-form/attributes.ts
+++ b/projects/packages/forms/src/blocks/contact-form/attributes.ts
@@ -64,8 +64,4 @@ export default {
 		type: 'boolean',
 		default: false,
 	},
-	disableSummary: {
-		type: 'boolean',
-		default: false,
-	},
 };

--- a/projects/packages/forms/src/blocks/contact-form/attributes.ts
+++ b/projects/packages/forms/src/blocks/contact-form/attributes.ts
@@ -1,3 +1,6 @@
+/**
+ * External dependencies
+ */
 import { __ } from '@wordpress/i18n';
 
 export default {
@@ -56,5 +59,13 @@ export default {
 	emailNotifications: {
 		type: 'boolean',
 		default: true,
+	},
+	disableGoBack: {
+		type: 'boolean',
+		default: false,
+	},
+	disableSummary: {
+		type: 'boolean',
+		default: false,
 	},
 };

--- a/projects/packages/forms/src/blocks/contact-form/edit.js
+++ b/projects/packages/forms/src/blocks/contact-form/edit.js
@@ -18,6 +18,7 @@ import {
 	SelectControl,
 	TextareaControl,
 	TextControl,
+	ToggleControl,
 } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
 import { store as coreStore } from '@wordpress/core-data';
@@ -103,6 +104,8 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 		formTitle,
 		variationName,
 		emailNotifications,
+		disableGoBack,
+		disableSummary,
 	} = attributes;
 	const formsConfig = useFormsConfig();
 	const showFormIntegrations = Boolean( formsConfig?.isIntegrationsEnabled );
@@ -712,6 +715,24 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 								},
 							] }
 							onChange={ newMessage => setAttributes( { customThankyou: newMessage } ) }
+							__nextHasNoMarginBottom={ true }
+							__next40pxDefaultSize={ true }
+						/>
+
+						<ToggleControl
+							label={ __( 'Disable "Go back" link', 'jetpack-forms' ) }
+							checked={ disableGoBack }
+							onChange={ newDisableGoBack => setAttributes( { disableGoBack: newDisableGoBack } ) }
+							__nextHasNoMarginBottom={ true }
+							__next40pxDefaultSize={ true }
+						/>
+
+						<ToggleControl
+							label={ __( 'Disable summary', 'jetpack-forms' ) }
+							checked={ disableSummary }
+							onChange={ newDisableSummary =>
+								setAttributes( { disableSummary: newDisableSummary } )
+							}
 							__nextHasNoMarginBottom={ true }
 							__next40pxDefaultSize={ true }
 						/>

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -116,7 +116,6 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 		variationName,
 		emailNotifications,
 		disableGoBack,
-		disableSummary,
 	} = attributes;
 	const formsConfig = useFormsConfig();
 	const showFormIntegrations = Boolean( formsConfig?.isIntegrationsEnabled );
@@ -719,6 +718,10 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 							value={ customThankyou }
 							options={ [
 								{ label: __( 'Show a summary of submitted fields', 'jetpack-forms' ), value: '' },
+								{
+									label: __( 'Show the default text message without a summary', 'jetpack-forms' ),
+									value: 'noSummary',
+								},
 								{ label: __( 'Show a custom text message', 'jetpack-forms' ), value: 'message' },
 								{
 									label: __( 'Redirect to another webpage', 'jetpack-forms' ),
@@ -730,33 +733,29 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 							__next40pxDefaultSize={ true }
 						/>
 
-						<ToggleControl
-							label={ __( 'Disable "Go back" link', 'jetpack-forms' ) }
-							checked={ disableGoBack }
-							onChange={ newDisableGoBack => setAttributes( { disableGoBack: newDisableGoBack } ) }
-							__nextHasNoMarginBottom={ true }
-							__next40pxDefaultSize={ true }
-						/>
-
-						<ToggleControl
-							label={ __( 'Disable summary', 'jetpack-forms' ) }
-							checked={ disableSummary }
-							onChange={ newDisableSummary =>
-								setAttributes( { disableSummary: newDisableSummary } )
-							}
-							__nextHasNoMarginBottom={ true }
-							__next40pxDefaultSize={ true }
-						/>
-
 						{ 'redirect' !== customThankyou && (
-							<TextControl
-								label={ __( 'Message heading', 'jetpack-forms' ) }
-								value={ customThankyouHeading }
-								placeholder={ __( 'Your message has been sent', 'jetpack-forms' ) }
-								onChange={ newHeading => setAttributes( { customThankyouHeading: newHeading } ) }
-								__nextHasNoMarginBottom={ true }
-								__next40pxDefaultSize={ true }
-							/>
+							<>
+								<ToggleControl
+									label={ __( 'Disable "Go back" link', 'jetpack-forms' ) }
+									checked={ disableGoBack }
+									onChange={ ( newDisableGoBack: boolean ) =>
+										setAttributes( { disableGoBack: newDisableGoBack } )
+									}
+									__nextHasNoMarginBottom={ true }
+									__next40pxDefaultSize={ true }
+								/>
+
+								<TextControl
+									label={ __( 'Message heading', 'jetpack-forms' ) }
+									value={ customThankyouHeading }
+									placeholder={ __( 'Your message has been sent', 'jetpack-forms' ) }
+									onChange={ ( newHeading: string ) =>
+										setAttributes( { customThankyouHeading: newHeading } )
+									}
+									__nextHasNoMarginBottom={ true }
+									__next40pxDefaultSize={ true }
+								/>
+							</>
 						) }
 
 						{ 'message' === customThankyou && (
@@ -764,7 +763,9 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 								label={ __( 'Message text', 'jetpack-forms' ) }
 								value={ customThankyouMessage }
 								placeholder={ __( 'Thank you for your submission!', 'jetpack-forms' ) }
-								onChange={ newMessage => setAttributes( { customThankyouMessage: newMessage } ) }
+								onChange={ ( newMessage: string ) =>
+									setAttributes( { customThankyouMessage: newMessage } )
+								}
 								__nextHasNoMarginBottom={ true }
 							/>
 						) }
@@ -775,7 +776,9 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 									label={ __( 'Redirect address', 'jetpack-forms' ) }
 									value={ customThankyouRedirect }
 									className="jetpack-contact-form__thankyou-redirect-url"
-									onChange={ newURL => setAttributes( { customThankyouRedirect: newURL } ) }
+									onChange={ ( newURL: string ) =>
+										setAttributes( { customThankyouRedirect: newURL } )
+									}
 								/>
 							</div>
 						) }

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -1,3 +1,6 @@
+/*
+ * External dependencies
+ */
 import { ThemeProvider } from '@automattic/jetpack-components';
 import { useModuleStatus } from '@automattic/jetpack-shared-extension-utils';
 import {
@@ -27,6 +30,9 @@ import { store as editorStore } from '@wordpress/editor';
 import { useRef, useEffect, useCallback, lazy, Suspense } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
+/*
+ * Internal dependencies
+ */
 import useFormsConfig from '../../hooks/use-forms-config';
 import { store as singleStepStore } from '../../store/form-step-preview';
 import {
@@ -46,9 +52,10 @@ import { ContactFormPlaceholder } from './components/jetpack-contact-form-placeh
 import ContactFormSkeletonLoader from './components/jetpack-contact-form-skeleton-loader';
 import JetpackEmailConnectionSettings from './components/jetpack-email-connection-settings';
 import useFormBlockDefaults from './shared/hooks/use-form-block-defaults';
-const IntegrationControls = lazy( () => import( './components/jetpack-integration-controls' ) );
-import './util/form-styles.js';
 import VariationPicker from './variation-picker';
+import './util/form-styles.js';
+
+const IntegrationControls = lazy( () => import( './components/jetpack-integration-controls' ) );
 
 // Transforms
 const FormTransitionState = {
@@ -58,7 +65,11 @@ const FormTransitionState = {
 	IS_FORM: 'is-form',
 };
 
-const validFields = childBlocks.filter( ( { settings } ) => {
+const validFields = childBlocks.filter( childBlock => {
+	const settings = childBlock.settings as typeof childBlock.settings & {
+		parent?: string | string[];
+	};
+
 	return (
 		! settings.parent ||
 		settings.parent === 'jetpack/contact-form' ||
@@ -270,7 +281,7 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 	}, [] );
 
 	// Detect a conversion to a multistep form and structure inner blocks only once.
-	const formTransitionStateRef = useRef( false );
+	const formTransitionStateRef = useRef< string | null >( null );
 
 	useEffect( () => {
 		const hasMultistepBlock = containsMultistepBlock( currentInnerBlocks );

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -189,7 +189,6 @@ class Contact_Form extends Contact_Form_Shortcode {
 			'saveResponses'          => 'yes',
 			'emailNotifications'     => 'yes',
 			'disableGoBack'          => $attributes['disableGoBack'] ?? false,
-			'disableSummary'         => $attributes['disableSummary'] ?? false,
 		);
 
 		$attributes = shortcode_atts( $this->defaults, $attributes, 'contact-form' );
@@ -975,7 +974,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 
 		$back_url        = remove_query_arg( array( 'contact-form-id', 'contact-form-sent', '_wpnonce', 'contact-form-hash' ) );
 		$disable_go_back = $form->get_attribute( 'disableGoBack' );
-		$disable_summary = $form->get_attribute( 'disableSummary' );
+		$disable_summary = 'noSummary' === $form->get_attribute( 'customThankyou' );
 
 		$html = '<div class="' . esc_attr( $classes ) . '" data-wp-class--submission-success="context.submissionSuccess">';
 
@@ -1053,7 +1052,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 	 */
 	public static function success_message( $feedback_id, $form ) {
 		$message         = '';
-		$disable_summary = $form->get_attribute( 'disableSummary' );
+		$disable_summary = 'noSummary' === $form->get_attribute( 'customThankyou' );
 
 		if ( 'message' === $form->get_attribute( 'customThankyou' ) ) {
 			$raw_message = wpautop( $form->get_attribute( 'customThankyouMessage' ) );

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -188,6 +188,8 @@ class Contact_Form extends Contact_Form_Shortcode {
 			'stepTransition'         => 'fade-slide', // The transition style for multi-step forms. Options: none, fade, slide, fade-slide
 			'saveResponses'          => 'yes',
 			'emailNotifications'     => 'yes',
+			'disableGoBack'          => $attributes['disableGoBack'] ?? false,
+			'disableSummary'         => $attributes['disableSummary'] ?? false,
 		);
 
 		$attributes = shortcode_atts( $this->defaults, $attributes, 'contact-form' );
@@ -872,6 +874,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 	private static function render_noscript_success_message( $is_reload_nonce_valid, $feedback_id, $form ) {
 		$back_url        = remove_query_arg( array( 'contact-form-id', 'contact-form-sent', '_wpnonce', 'contact-form-hash' ) );
 		$contact_form_id = sanitize_text_field( wp_unslash( $_GET['contact-form-id'] ?? '' ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$disable_go_back = $form->get_attribute( 'disableGoBack' );
 
 		$message = '';
 
@@ -885,8 +888,12 @@ class Contact_Form extends Contact_Form_Shortcode {
 			}
 		</style>';
 
-		$message         .= '<div class="contact-form-submission">';
-		$success_message  = '<p class="go-back-message"> <a class="link" href="' . esc_url( $back_url ) . '">' . esc_html__( 'Go back', 'jetpack-forms' ) . '</a> </p>';
+		$message .= '<div class="contact-form-submission">';
+
+		if ( ! $disable_go_back ) {
+			$success_message = '<p class="go-back-message"> <a class="link" href="' . esc_url( $back_url ) . '">' . esc_html__( 'Go back', 'jetpack-forms' ) . '</a> </p>';
+		}
+
 		$success_message .= '<h4 id="contact-form-success-header">' . esc_html( $form->get_attribute( 'customThankyouHeading' ) ) . "</h4>\n\n";
 
 		// Don't show the feedback details unless the nonce matches
@@ -966,10 +973,18 @@ class Contact_Form extends Contact_Form_Shortcode {
 			$classes .= ' submission-success';
 		}
 
-		$back_url = remove_query_arg( array( 'contact-form-id', 'contact-form-sent', '_wpnonce', 'contact-form-hash' ) );
+		$back_url        = remove_query_arg( array( 'contact-form-id', 'contact-form-sent', '_wpnonce', 'contact-form-hash' ) );
+		$disable_go_back = $form->get_attribute( 'disableGoBack' );
+		$disable_summary = $form->get_attribute( 'disableSummary' );
 
-		$html  = '<div class="' . esc_attr( $classes ) . '" data-wp-class--submission-success="context.submissionSuccess">';
-		$html .= '<p class="go-back-message"><a class="link" role="button" tabindex="0" data-wp-on--click="actions.goBack" href="' . esc_url( $back_url ) . '">' . esc_html__( 'Go back', 'jetpack-forms' ) . '</a> </p>';
+		$html = '<div class="' . esc_attr( $classes ) . '" data-wp-class--submission-success="context.submissionSuccess">';
+
+		if ( ! $disable_go_back ) {
+			$html .= '<p class="go-back-message">';
+			$html .= '<a class="link" role="button" tabindex="0" data-wp-on--click="actions.goBack" href="' . esc_url( $back_url ) . '">' . esc_html__( 'Go back', 'jetpack-forms' ) . '</a>';
+			$html .= '</p>';
+		}
+
 		$html .=
 			'<h4 id="contact-form-success-header">' . esc_html( $form->get_attribute( 'customThankyouHeading' ) ) .
 			"</h4>\n\n";
@@ -992,7 +1007,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 			);
 
 			$html .= wp_kses( $raw_message, $allowed_html );
-		} else {
+		} elseif ( ! $disable_summary ) {
 			$html .= '<template data-wp-each--submission="context.formattedSubmissionData">
 				<div>
 					<div class="field-name" data-wp-text="context.submission.label" data-wp-bind--hidden="!context.submission.label"></div>
@@ -1037,6 +1052,8 @@ class Contact_Form extends Contact_Form_Shortcode {
 	 * @return string $message
 	 */
 	public static function success_message( $feedback_id, $form ) {
+		$message         = '';
+		$disable_summary = $form->get_attribute( 'disableSummary' );
 
 		if ( 'message' === $form->get_attribute( 'customThankyou' ) ) {
 			$raw_message = wpautop( $form->get_attribute( 'customThankyouMessage' ) );
@@ -1055,7 +1072,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 				),
 			);
 			$message      = wp_kses( $raw_message, $allowed_html );
-		} else {
+		} elseif ( ! $disable_summary ) {
 			$compiled_form = self::get_compiled_form( $feedback_id );
 			$message       = '<p>' . implode( '</p><p>', $compiled_form ) . '</p>';
 		}

--- a/projects/packages/forms/src/types/index.ts
+++ b/projects/packages/forms/src/types/index.ts
@@ -110,6 +110,10 @@ export interface JPFormsBlocksDefaults {
 	formsResponsesSpamUrl?: string;
 	/** Whether MailPoet integration is enabled. */
 	isMailPoetEnabled?: boolean;
+	/** The default subject for the form. */
+	subject?: string;
+	/** The default recipient email address for the form. */
+	to?: string;
 }
 
 /**

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -2721,6 +2721,8 @@ EOT;
 			'stepTransition'         => 'fade-slide',
 			'mailpoet'               => '',
 			'emailNotifications'     => 'yes',
+			'disableGoBack'          => false,
+			'disableSummary'         => false,
 		);
 		// Add a widget ID to the attributes for testing.
 		$expected_attributes                        = $attributes;

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -2722,7 +2722,6 @@ EOT;
 			'mailpoet'               => '',
 			'emailNotifications'     => 'yes',
 			'disableGoBack'          => false,
-			'disableSummary'         => false,
 		);
 		// Add a widget ID to the attributes for testing.
 		$expected_attributes                        = $attributes;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of FORMS-246

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds two options to disable the "go back" link and the submission summary
* Transform touched files to ts

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the editor and add a form
* On the form's "Action after submit" sidebar, use the 'Disable "Go Back" link' and 'Disable summary' links
* Publish the form
* Submit a response
* Check that the options are respected
