### PR TITLE
Forms: fixes the responses endpoint

### DIFF
--- a/projects/packages/forms/changelog/fix-form-responses-endpoint
+++ b/projects/packages/forms/changelog/fix-form-responses-endpoint
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: fixes the missing _links attribute

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -588,50 +588,53 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 		$data     = $response->get_data();
 		$fields   = $this->get_fields_for_response( $request );
 
-		$response = Feedback::get( $item->ID );
+		$feedback_response = Feedback::get( $item->ID );
 		if ( ! $response ) {
 			return rest_ensure_response( $data );
 		}
 
 		$data['date'] = get_the_date( 'c', $data['id'] );
 		if ( rest_is_field_included( 'uid', $fields ) ) {
-			$data['uid'] = $response->get_feedback_id();
+			$data['uid'] = $feedback_response->get_feedback_id();
 		}
 		if ( rest_is_field_included( 'author_name', $fields ) ) {
-			$data['author_name'] = $response->get_author();
+			$data['author_name'] = $feedback_response->get_author();
 		}
 		if ( rest_is_field_included( 'author_email', $fields ) ) {
-			$data['author_email'] = $response->get_author_email();
+			$data['author_email'] = $feedback_response->get_author_email();
 		}
 		if ( rest_is_field_included( 'author_url', $fields ) ) {
-			$data['author_url'] = $response->get_author_url();
+			$data['author_url'] = $feedback_response->get_author_url();
 		}
 		if ( rest_is_field_included( 'author_avatar', $fields ) ) {
-			$data['author_avatar'] = $response->get_author_avatar();
+			$data['author_avatar'] = $feedback_response->get_author_avatar();
 		}
 		if ( rest_is_field_included( 'email_marketing_consent', $fields ) ) {
-			$data['email_marketing_consent'] = $response->has_consent() ? '1' : '';
+			$data['email_marketing_consent'] = $feedback_response->has_consent() ? '1' : '';
 		}
 		if ( rest_is_field_included( 'ip', $fields ) ) {
-			$data['ip'] = $response->get_ip_address();
+			$data['ip'] = $feedback_response->get_ip_address();
 		}
 		if ( rest_is_field_included( 'entry_title', $fields ) ) {
-			$data['entry_title'] = $response->get_entry_title();
+			$data['entry_title'] = $feedback_response->get_entry_title();
 		}
 		if ( rest_is_field_included( 'entry_permalink', $fields ) ) {
-			$data['entry_permalink'] = $response->get_entry_permalink();
+			$data['entry_permalink'] = $feedback_response->get_entry_permalink();
 		}
 		if ( rest_is_field_included( 'subject', $fields ) ) {
-			$data['subject'] = $response->get_subject();
+			$data['subject'] = $feedback_response->get_subject();
 		}
 		if ( rest_is_field_included( 'fields', $fields ) ) {
-			$data['fields'] = $response->get_compiled_fields( 'api', 'label-value' );
+			$data['fields'] = $feedback_response->get_compiled_fields( 'api', 'label-value' );
 		}
 
 		if ( rest_is_field_included( 'has_file', $fields ) ) {
-			$data['has_file'] = $response->has_file();
+			$data['has_file'] = $feedback_response->has_file();
 		}
-		return rest_ensure_response( $data );
+
+		$response->set_data( $data );
+
+		return rest_ensure_response( $response );
 	}
 
 	/**

--- a/projects/plugins/jetpack/changelog/fix-form-responses-endpoint
+++ b/projects/plugins/jetpack/changelog/fix-form-responses-endpoint
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: fixes the missing rest attributes


### PR DESCRIPTION
This Pr fixes I bug with the feedback responses endpoint. 

While testing the CIAB UX. We noticed that the UI was making a request for each of the different feedback responses endpoints. 
This is due to the fact that we currently don't respond with the the expected payload. We were missing the `_links` attribute. Since we never needed it on the current inbox implementation. 

## Proposed changes:
* Returns more the feedback responses data

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
none

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Do the tests pass? 

* Load the inbox view does it still load as expected? 
* Load the view in CIAB does it not load each of the different feedback endpoints. 
