### PR TITLE
WooCommerce Analytics: Add experimental API-based event tracking

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3927,6 +3927,9 @@ importers:
 
   projects/packages/woocommerce-analytics:
     dependencies:
+      '@wordpress/api-fetch':
+        specifier: 7.31.0
+        version: 7.31.0
       debug:
         specifier: 4.4.3
         version: 4.4.3

--- a/projects/packages/woocommerce-analytics/changelog/update-use-proxy-tracking-api
+++ b/projects/packages/woocommerce-analytics/changelog/update-use-proxy-tracking-api
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add experimental API-based event tracking

--- a/projects/packages/woocommerce-analytics/changelog/wooa7s-488-improve-visitor-tracking-switch-from-cookie-based-to-ip
+++ b/projects/packages/woocommerce-analytics/changelog/wooa7s-488-improve-visitor-tracking-switch-from-cookie-based-to-ip
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add IP-based visitor tracking as fallback when proxy tracking is enabled and cookies are unavailable

--- a/projects/packages/woocommerce-analytics/package.json
+++ b/projects/packages/woocommerce-analytics/package.json
@@ -25,6 +25,7 @@
 		"watch": "pnpm build && pnpm build-client --watch"
 	},
 	"dependencies": {
+		"@wordpress/api-fetch": "7.31.0",
 		"debug": "4.4.3"
 	},
 	"devDependencies": {

--- a/projects/packages/woocommerce-analytics/src/class-features.php
+++ b/projects/packages/woocommerce-analytics/src/class-features.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Features class for WooCommerce Analytics.
+ *
+ * @package automattic/woocommerce-analytics
+ */
+
+namespace Automattic\Woocommerce_Analytics;
+
+/**
+ * Features class for WooCommerce Analytics.
+ */
+class Features {
+
+	/**
+	 * Check if proxy tracking is enabled.
+	 *
+	 * @return bool
+	 */
+	public static function is_proxy_tracking_enabled() {
+		/**
+		 * Filter to enable/disable experimental proxy tracking for WooCommerce Analytics
+		 *
+		 * @since 0.9.0
+		 *
+		 * @param bool $enabled Whether proxy tracking is enabled. Default false.
+		 */
+		return apply_filters( 'woocommerce_analytics_experimental_proxy_tracking_enabled', false );
+	}
+
+	/**
+	 * Check if ClickHouse is enabled.
+	 *
+	 * @return bool
+	 */
+	public static function is_clickhouse_enabled() {
+		/**
+		 * Filter to enable/disable ClickHouse event tracking.
+		 *
+		 * @module woocommerce-analytics
+		 *
+		 * @since 0.5.0
+		 *
+		 * @param bool $enabled Whether ClickHouse event tracking is enabled.
+		 */
+		return apply_filters( 'woocommerce_analytics_clickhouse_enabled', false );
+	}
+}

--- a/projects/packages/woocommerce-analytics/src/class-universal.php
+++ b/projects/packages/woocommerce-analytics/src/class-universal.php
@@ -73,7 +73,10 @@ class Universal {
 	 * Inject analytics data into the window object
 	 */
 	public function inject_analytics_data() {
-		$is_clickhouse_enabled = $this->is_clickhouse_enabled();
+		$is_clickhouse_enabled     = $this->is_clickhouse_enabled();
+		$is_proxy_tracking_enabled = $this->is_proxy_tracking_enabled();
+		// When proxy tracking is enabled, we don't need to send the common properties to the client.
+		$common_properties = $is_proxy_tracking_enabled ? array() : $this->get_common_properties();
 		?>
 		<script type="text/javascript">
 			(function() {
@@ -81,7 +84,7 @@ class Universal {
 				const wcAnalytics = window.wcAnalytics;
 
 				// Set common properties for all events.
-				wcAnalytics.commonProps = <?php echo wp_json_encode( $this->get_common_properties() ); ?>;
+				wcAnalytics.commonProps = <?php echo wp_json_encode( $common_properties ); ?>;
 
 				// Set the event queue.
 				wcAnalytics.eventQueue = <?php echo wp_json_encode( WC_Analytics_Tracking::get_event_queue() ); ?>;
@@ -90,6 +93,7 @@ class Universal {
 				wcAnalytics.features = {
 					ch: <?php echo $is_clickhouse_enabled ? 'true' : 'false'; ?>,
 					sessionTracking: <?php echo $is_clickhouse_enabled ? 'true' : 'false'; ?>,
+					proxy: <?php echo $this->is_proxy_tracking_enabled() ? 'true' : 'false'; ?>,
 				};
 
 				wcAnalytics.breadcrumbs = <?php echo wp_json_encode( $this->get_breadcrumb_titles() ); ?>;
@@ -272,7 +276,7 @@ class Universal {
 			}
 
 			$data['pq'] = $cart_item['quantity'];
-			$this->enqueue_event( 'product_checkout', $data, $product->get_id() );
+			$this->enqueue_event( 'product_checkout', $this->get_cart_checkout_event_properties( $data ), $product->get_id() );
 		}
 	}
 
@@ -446,7 +450,7 @@ class Universal {
 		);
 		$cart_checkout_info    = $this->get_cart_checkout_info();
 
-		$event_properties = array_merge( $event_properties, $product_details, $checkout_cart_details, $cart_checkout_info );
+		$event_properties = array_merge( $product_details, $checkout_cart_details, $cart_checkout_info, $event_properties ); // event properties should be last to allow for overrides
 
 		return $event_properties;
 	}
@@ -505,10 +509,12 @@ class Universal {
 
 			$this->enqueue_event(
 				'post_account_creation',
-				array(
-					'from_checkout' => $checkout_page_used,
-					'checkout_page_contains_checkout_block' => $checkout_page_contains_checkout_block,
-					'checkout_page_contains_checkout_shortcode' => $checkout_page_contains_checkout_shortcode,
+				$this->get_cart_checkout_event_properties(
+					array(
+						'from_checkout' => $checkout_page_used,
+						'checkout_page_contains_checkout_block' => $checkout_page_contains_checkout_block,
+						'checkout_page_contains_checkout_shortcode' => $checkout_page_contains_checkout_shortcode,
+					)
 				)
 			);
 		}
@@ -550,9 +556,8 @@ class Universal {
 
 		$this->enqueue_event(
 			'cart_view',
-			array_merge(
-				$this->get_cart_checkout_shared_data(),
-				array()
+			$this->get_cart_checkout_event_properties(
+				$this->get_cart_checkout_shared_data()
 			)
 		);
 	}
@@ -617,26 +622,28 @@ class Universal {
 		$delayed_account_creation = ucfirst( get_option( 'woocommerce_enable_delayed_account_creation', 'Yes' ) );
 		$this->enqueue_event(
 			'order_confirmation_view',
-			array(
-				'coupon_used'                           => $coupon_used,
-				'create_account'                        => $create_account,
-				'express_checkout'                      => 'null', // TODO: not solved yet.
-				'guest_checkout'                        => $order->get_customer_id() ? 'No' : 'Yes',
-				'delayed_account_creation'              => $delayed_account_creation,
-				'oi'                                    => $order->get_id(),
-				'order_value'                           => $order->get_subtotal(),
-				'order_total'                           => $order->get_total(),
-				'products_count'                        => $order->get_item_count(),
-				'total_discount'                        => $order->get_discount_total(),
-				'total_shipping'                        => $order->get_shipping_total(),
-				'total_tax'                             => $order->get_total_tax(),
-				'payment_option'                        => $order->get_payment_method(),
-				'products'                              => $this->format_items_to_json( $order->get_items() ),
-				'order_note'                            => $order->get_customer_note(),
-				'shipping_option'                       => $order->get_shipping_method(),
-				'from_checkout'                         => $checkout_page_used,
-				'checkout_page_contains_checkout_block' => $checkout_page_contains_checkout_block,
-				'checkout_page_contains_checkout_shortcode' => $checkout_page_contains_checkout_shortcode,
+			$this->get_cart_checkout_event_properties(
+				array(
+					'coupon_used'              => $coupon_used,
+					'create_account'           => $create_account,
+					'express_checkout'         => 'null', // TODO: not solved yet.
+					'guest_checkout'           => $order->get_customer_id() ? 'No' : 'Yes',
+					'delayed_account_creation' => $delayed_account_creation,
+					'oi'                       => $order->get_id(),
+					'order_value'              => $order->get_subtotal(),
+					'order_total'              => $order->get_total(),
+					'products_count'           => $order->get_item_count(),
+					'total_discount'           => $order->get_discount_total(),
+					'total_shipping'           => $order->get_shipping_total(),
+					'total_tax'                => $order->get_total_tax(),
+					'payment_option'           => $order->get_payment_method(),
+					'products'                 => $this->format_items_to_json( $order->get_items() ),
+					'order_note'               => $order->get_customer_note(),
+					'shipping_option'          => $order->get_shipping_method(),
+					'from_checkout'            => $checkout_page_used,
+					'checkout_page_contains_checkout_block' => $checkout_page_contains_checkout_block,
+					'checkout_page_contains_checkout_shortcode' => $checkout_page_contains_checkout_shortcode,
+				)
 			)
 		);
 	}
@@ -684,12 +691,14 @@ class Universal {
 
 		$this->enqueue_event(
 			'checkout_view',
-			array_merge(
-				$this->get_cart_checkout_shared_data(),
-				array(
-					'from_checkout' => $is_in_checkout_page,
-					'checkout_page_contains_checkout_block' => $checkout_page_contains_checkout_block,
-					'checkout_page_contains_checkout_shortcode' => $checkout_page_contains_checkout_shortcode,
+			$this->get_cart_checkout_event_properties(
+				array_merge(
+					$this->get_cart_checkout_shared_data(),
+					array(
+						'from_checkout' => $is_in_checkout_page,
+						'checkout_page_contains_checkout_block' => $checkout_page_contains_checkout_block,
+						'checkout_page_contains_checkout_shortcode' => $checkout_page_contains_checkout_shortcode,
+					)
 				)
 			)
 		);

--- a/projects/packages/woocommerce-analytics/src/class-universal.php
+++ b/projects/packages/woocommerce-analytics/src/class-universal.php
@@ -73,8 +73,8 @@ class Universal {
 	 * Inject analytics data into the window object
 	 */
 	public function inject_analytics_data() {
-		$is_clickhouse_enabled     = $this->is_clickhouse_enabled();
-		$is_proxy_tracking_enabled = $this->is_proxy_tracking_enabled();
+		$is_clickhouse_enabled     = Features::is_clickhouse_enabled();
+		$is_proxy_tracking_enabled = Features::is_proxy_tracking_enabled();
 		// When proxy tracking is enabled, we don't need to send the common properties to the client.
 		$common_properties = $is_proxy_tracking_enabled ? array() : $this->get_common_properties();
 		?>
@@ -93,7 +93,7 @@ class Universal {
 				wcAnalytics.features = {
 					ch: <?php echo $is_clickhouse_enabled ? 'true' : 'false'; ?>,
 					sessionTracking: <?php echo $is_clickhouse_enabled ? 'true' : 'false'; ?>,
-					proxy: <?php echo $this->is_proxy_tracking_enabled() ? 'true' : 'false'; ?>,
+					proxy: <?php echo $is_proxy_tracking_enabled ? 'true' : 'false'; ?>,
 				};
 
 				wcAnalytics.breadcrumbs = <?php echo wp_json_encode( $this->get_breadcrumb_titles() ); ?>;

--- a/projects/packages/woocommerce-analytics/src/class-wc-analytics-tracking.php
+++ b/projects/packages/woocommerce-analytics/src/class-wc-analytics-tracking.php
@@ -25,6 +25,13 @@ class WC_Analytics_Tracking extends WC_Tracks {
 	const PREFIX = 'woocommerceanalytics_';
 
 	/**
+	 * Option name for storing daily salt data.
+	 *
+	 * @var string
+	 */
+	const DAILY_SALT_OPTION = 'woocommerce_analytics_daily_salt';
+
+	/**
 	 * Allowed ClickHouse events.
 	 *
 	 * @var array
@@ -50,6 +57,20 @@ class WC_Analytics_Tracking extends WC_Tracks {
 	 * @var array
 	 */
 	protected static $event_queue = array();
+
+	/**
+	 * Cached user IP address for the current request.
+	 *
+	 * @var string|null
+	 */
+	private static $cached_ip = null;
+
+	/**
+	 * Cached visitor ID for the current request.
+	 *
+	 * @var string|null
+	 */
+	private static $cached_visitor_id = null;
 
 	/**
 	 * Record an event in Tracks and ClickHouse (If enabled).
@@ -249,14 +270,29 @@ class WC_Analytics_Tracking extends WC_Tracks {
 	}
 
 	/**
-	 * Get the visitor id from the cookie.
+	 * Get the visitor id from the cookie or IP address (if proxy tracking is enabled).
 	 *
 	 * @return string|null
 	 */
 	private static function get_visitor_id() {
-		if ( isset( $_COOKIE['tk_ai'] ) ) {
-			return sanitize_text_field( wp_unslash( $_COOKIE['tk_ai'] ) );
+		// Return cached result if available.
+		if ( null !== self::$cached_visitor_id ) {
+			return self::$cached_visitor_id;
 		}
+
+		// Prefer tk_ai cookie if present.
+		if ( ! empty( $_COOKIE['tk_ai'] ) ) {
+			self::$cached_visitor_id = sanitize_text_field( wp_unslash( $_COOKIE['tk_ai'] ) );
+			return self::$cached_visitor_id;
+		}
+
+		// Fallback to IP-based visitor ID if proxy tracking is enabled.
+		if ( Features::is_proxy_tracking_enabled() ) {
+			self::$cached_visitor_id = self::get_ip_based_visitor_id();
+			return self::$cached_visitor_id;
+		}
+
+		self::$cached_visitor_id = null;
 		return null;
 	}
 
@@ -267,26 +303,8 @@ class WC_Analytics_Tracking extends WC_Tracks {
 	 * @return bool True if it should be sent to ClickHouse
 	 */
 	private static function should_send_to_clickhouse( $event ) {
-		return self::is_clickhouse_enabled() &&
+		return Features::is_clickhouse_enabled() &&
 			in_array( $event, self::ALLOWED_CH_EVENTS, true );
-	}
-
-	/**
-	 * Check if ClickHouse is enabled.
-	 *
-	 * @return bool
-	 */
-	private static function is_clickhouse_enabled() {
-		/**
-		 * Filter to enable/disable ClickHouse event tracking.
-		 *
-		 * @module woocommerce-analytics
-		 *
-		 * @since 0.5.0
-		 *
-		 * @param bool $enabled Whether ClickHouse event tracking is enabled.
-		 */
-		return apply_filters( 'woocommerce_analytics_clickhouse_enabled', false );
 	}
 
 	/**
@@ -295,6 +313,11 @@ class WC_Analytics_Tracking extends WC_Tracks {
 	 * @return string The user's IP address. An empty string if no valid IP address is found.
 	 */
 	private static function get_user_ip_address() {
+		// Return cached IP if available
+		if ( null !== self::$cached_ip ) {
+			return self::$cached_ip;
+		}
+
 		$ip_headers = array(
 			'HTTP_CF_CONNECTING_IP', // Cloudflare specific header.
 			'HTTP_X_FORWARDED_FOR',
@@ -312,12 +335,72 @@ class WC_Analytics_Tracking extends WC_Tracks {
 						FILTER_VALIDATE_IP,
 						array( FILTER_FLAG_NO_RES_RANGE, FILTER_FLAG_IPV6 )
 					) ) {
-						return $ip_candidate;
+						// Cache the resolved IP
+						self::$cached_ip = $ip_candidate;
+						return self::$cached_ip;
 					}
 				}
 			}
 		}
 
-		return '';
+		// Cache empty result
+		self::$cached_ip = '';
+		return self::$cached_ip;
+	}
+
+	/**
+	 * Get IP-based visitor ID for proxy tracking mode.
+	 *
+	 * @return string|null
+	 */
+	private static function get_ip_based_visitor_id() {
+		$ip = self::get_user_ip_address();
+		if ( empty( $ip ) ) {
+			return null;
+		}
+
+		$salt       = self::get_daily_salt();
+		$url_parts  = wp_parse_url( home_url() );
+		$domain     = $url_parts['host'] ?? '';
+		$user_agent = sanitize_text_field( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ?? '' ) );
+
+		// Create hash from: daily_salt + domain + ip + user_agent
+		$hash_input = $salt . $domain . $ip . $user_agent;
+
+		return substr( hash( 'sha256', $hash_input ), 0, 16 );
+	}
+
+	/**
+	 * Get or generate daily salt for visitor ID hashing.
+	 * Creates a new salt value each day (UTC) for privacy protection.
+	 *
+	 * @return string The daily salt.
+	 */
+	private static function get_daily_salt() {
+		$today = gmdate( 'Y-m-d' ); // UTC date
+
+		$salt_data = get_option( self::DAILY_SALT_OPTION );
+
+		// Check if salt exists and is still valid for today
+		if (
+			is_array( $salt_data )
+			&& isset( $salt_data['date'] )
+			&& isset( $salt_data['salt'] )
+			&& $salt_data['date'] === $today
+		) {
+			return $salt_data['salt'];
+		}
+
+		// Generate new salt for today
+		$new_salt = wp_generate_password( 32, false );
+
+		// Store salt with date (no expiration time needed)
+		$salt_data = array(
+			'date' => $today,
+			'salt' => $new_salt,
+		);
+
+		update_option( self::DAILY_SALT_OPTION, $salt_data );
+		return $new_salt;
 	}
 }

--- a/projects/packages/woocommerce-analytics/src/class-wc-analytics-tracking.php
+++ b/projects/packages/woocommerce-analytics/src/class-wc-analytics-tracking.php
@@ -66,7 +66,6 @@ class WC_Analytics_Tracking extends WC_Tracks {
 		// Record Tracks event.
 		$tracks_error  = null;
 		$tracks_result = self::record_tracks_event( $properties );
-
 		if ( is_wp_error( $tracks_result ) ) {
 			$tracks_error = $tracks_result;
 		}

--- a/projects/packages/woocommerce-analytics/src/class-wc-analytics-tracking.php
+++ b/projects/packages/woocommerce-analytics/src/class-wc-analytics-tracking.php
@@ -66,6 +66,7 @@ class WC_Analytics_Tracking extends WC_Tracks {
 		// Record Tracks event.
 		$tracks_error  = null;
 		$tracks_result = self::record_tracks_event( $properties );
+
 		if ( is_wp_error( $tracks_result ) ) {
 			$tracks_error = $tracks_result;
 		}

--- a/projects/packages/woocommerce-analytics/src/class-woo-analytics-trait.php
+++ b/projects/packages/woocommerce-analytics/src/class-woo-analytics-trait.php
@@ -608,24 +608,6 @@ trait Woo_Analytics_Trait {
 	}
 
 	/**
-	 * Check if ClickHouse is enabled.
-	 *
-	 * @return bool
-	 */
-	private function is_clickhouse_enabled() {
-		/**
-		 * Filter to enable/disable ClickHouse event tracking.
-		 *
-		 * @module woocommerce-analytics
-		 *
-		 * @since 0.5.0
-		 *
-		 * @param bool $enabled Whether ClickHouse event tracking is enabled.
-		 */
-		return apply_filters( 'woocommerce_analytics_clickhouse_enabled', false );
-	}
-
-	/**
 	 * Retrieves the breadcrumb trail as an array of page titles.
 	 *
 	 * This function attempts to generate a hierarchical breadcrumb trail for the current page or post.
@@ -693,21 +675,5 @@ trait Woo_Analytics_Trait {
 		}
 
 		return array_merge( array( $shop_page_title ), $titles );
-	}
-
-	/**
-	 * Check if proxy tracking is enabled
-	 *
-	 * @return bool
-	 */
-	private function is_proxy_tracking_enabled() {
-		/**
-		 * Filter to enable/disable experimental proxy tracking for WooCommerce Analytics
-		 *
-		 * @since 0.9.0
-		 *
-		 * @param bool $enabled Whether proxy tracking is enabled. Default false.
-		 */
-		return apply_filters( 'woocommerce_analytics_experimental_proxy_tracking_enabled', false );
 	}
 }

--- a/projects/packages/woocommerce-analytics/src/class-woo-analytics-trait.php
+++ b/projects/packages/woocommerce-analytics/src/class-woo-analytics-trait.php
@@ -269,7 +269,7 @@ trait Woo_Analytics_Trait {
 			'device'         => wp_is_mobile() ? 'mobile' : 'desktop',
 			'store_currency' => get_woocommerce_currency(),
 			'timezone'       => wp_timezone_string(),
-			'is_guest'       => ($this->get_user_id() === null) ? 1 : 0,
+			'is_guest'       => ( $this->get_user_id() === null ) ? 1 : 0,
 		);
 
 		/**
@@ -708,6 +708,6 @@ trait Woo_Analytics_Trait {
 		 *
 		 * @param bool $enabled Whether proxy tracking is enabled. Default false.
 		 */
-		return apply_filters( 'woocommerce_analytics_experimental_proxy_tracking_enabled', true );
+		return apply_filters( 'woocommerce_analytics_experimental_proxy_tracking_enabled', false );
 	}
 }

--- a/projects/packages/woocommerce-analytics/src/class-woo-analytics-trait.php
+++ b/projects/packages/woocommerce-analytics/src/class-woo-analytics-trait.php
@@ -258,29 +258,19 @@ trait Woo_Analytics_Trait {
 	 * @return array Array of standard event props.
 	 */
 	public function get_common_properties() {
-		$site_info          = array(
-			'blog_id'                            => Jetpack_Connection::get_site_id(),
-			'store_id'                           => defined( '\\WC_Install::STORE_ID_OPTION' ) ? get_option( \WC_Install::STORE_ID_OPTION ) : false,
-			'ui'                                 => $this->get_user_id(),
-			'url'                                => home_url(),
-			'woo_version'                        => WC()->version,
-			'wp_version'                         => get_bloginfo( 'version' ),
-			'store_admin'                        => in_array( array( 'administrator', 'shop_manager' ), wp_get_current_user()->roles, true ) ? 1 : 0,
-			'device'                             => wp_is_mobile() ? 'mobile' : 'desktop',
-			'template_used'                      => $this->cart_checkout_templates_in_use ? '1' : '0',
-			'additional_blocks_on_cart_page'     => $this->additional_blocks_on_cart_page,
-			'additional_blocks_on_checkout_page' => $this->additional_blocks_on_checkout_page,
-			'store_currency'                     => get_woocommerce_currency(),
-			'timezone'                           => wp_timezone_string(),
-			'is_guest'                           => ( $this->get_user_id() === null ) ? 1 : 0,
-			'order_value'                        => $this->get_cart_subtotal(),
-			'order_total'                        => $this->get_cart_total(),
-			'total_tax'                          => $this->get_cart_taxes(),
-			'total_discount'                     => $this->get_total_discounts(),
-			'total_shipping'                     => $this->get_cart_shipping_total(),
-			'products_count'                     => $this->get_cart_items_count(),
+		$site_info = array(
+			'blog_id'        => Jetpack_Connection::get_site_id(),
+			'store_id'       => defined( '\\WC_Install::STORE_ID_OPTION' ) ? get_option( \WC_Install::STORE_ID_OPTION ) : false,
+			'ui'             => $this->get_user_id(),
+			'url'            => home_url(),
+			'woo_version'    => WC()->version,
+			'wp_version'     => get_bloginfo( 'version' ),
+			'store_admin'    => in_array( array( 'administrator', 'shop_manager' ), wp_get_current_user()->roles, true ) ? 1 : 0,
+			'device'         => wp_is_mobile() ? 'mobile' : 'desktop',
+			'store_currency' => get_woocommerce_currency(),
+			'timezone'       => wp_timezone_string(),
+			'is_guest'       => ($this->get_user_id() === null) ? 1 : 0,
 		);
-		$cart_checkout_info = $this->get_cart_checkout_info();
 
 		/**
 		 * Allow defining custom event properties in WooCommerce Analytics.
@@ -293,7 +283,7 @@ trait Woo_Analytics_Trait {
 		 */
 		$properties = apply_filters(
 			'jetpack_woocommerce_analytics_event_props',
-			array_merge( $site_info, $cart_checkout_info )
+			$site_info
 		);
 
 		return $properties;
@@ -703,5 +693,21 @@ trait Woo_Analytics_Trait {
 		}
 
 		return array_merge( array( $shop_page_title ), $titles );
+	}
+
+	/**
+	 * Check if proxy tracking is enabled
+	 *
+	 * @return bool
+	 */
+	private function is_proxy_tracking_enabled() {
+		/**
+		 * Filter to enable/disable experimental proxy tracking for WooCommerce Analytics
+		 *
+		 * @since 0.9.0
+		 *
+		 * @param bool $enabled Whether proxy tracking is enabled. Default false.
+		 */
+		return apply_filters( 'woocommerce_analytics_experimental_proxy_tracking_enabled', true );
 	}
 }

--- a/projects/packages/woocommerce-analytics/src/client/analytics.ts
+++ b/projects/packages/woocommerce-analytics/src/client/analytics.ts
@@ -5,6 +5,7 @@ import debugFactory from 'debug';
 /**
  * Internal dependencies
  */
+import { ApiClient } from './api-client';
 import { EVENT_NAME_REGEX, EVENT_PREFIX, CLICK_HOUSE_EVENTS } from './constants';
 import SessionManager from './session-manager';
 import type { AnalyticsConfig } from './types/shared';
@@ -17,6 +18,7 @@ const debug = debugFactory( 'wc-analytics:analytics' );
 export class Analytics {
 	private isInitialized: boolean;
 	private sessionManager: SessionManager;
+	private apiClient: ApiClient;
 	private eventQueue: AnalyticsConfig[ 'eventQueue' ];
 	private commonProps: AnalyticsConfig[ 'commonProps' ];
 	private features: AnalyticsConfig[ 'features' ];
@@ -29,6 +31,7 @@ export class Analytics {
 		this.isInitialized = false;
 
 		this.sessionManager = sessionManager;
+		this.apiClient = new ApiClient();
 		this.eventQueue = eventQueue;
 		this.commonProps = commonProps;
 		this.features = features;
@@ -43,6 +46,11 @@ export class Analytics {
 			return;
 		}
 
+		// Initialize API client if proxy tracking is enabled
+		if ( this.features.proxy ) {
+			this.apiClient.init();
+		}
+
 		/*
 		 * Initialize the session manager and record the page_view event
 		 * only if the ClickHouse (ch) feature is enabled as these events are relevant exclusively when ClickHouse is active.
@@ -51,12 +59,15 @@ export class Analytics {
 			this.sessionManager.init();
 			const { sessionId, landingPage, isNewSession } = this.sessionManager;
 
-			// Add session ID and landing page to common properties.
-			this.commonProps = {
-				...this.commonProps,
-				session_id: sessionId,
-				landing_page: landingPage,
-			};
+			// Not needed if proxy tracking is enabled.
+			if ( ! this.features.proxy ) {
+				// Add session ID and landing page to common properties.
+				this.commonProps = {
+					...this.commonProps,
+					session_id: sessionId,
+					landing_page: landingPage,
+				};
+			}
 
 			if ( isNewSession ) {
 				this.maybeRecordSessionStartedEvent();
@@ -99,11 +110,6 @@ export class Analytics {
 	 * @param properties - The properties of the event.
 	 */
 	recordEvent = ( event: string, properties: Record< string, unknown > = {} ): void => {
-		if ( ! window._wca ) {
-			debug( 'Skipping event recording because _wca is not defined' );
-			return;
-		}
-
 		// Validate event name
 		if ( typeof event !== 'string' || ! EVENT_NAME_REGEX.test( event ) ) {
 			debug( 'Skipping event recording because event name is not valid' );
@@ -114,6 +120,33 @@ export class Analytics {
 			...this.commonProps,
 			...properties,
 		};
+		// Use API client if enabled, otherwise fall back to _wca.push
+		if ( this.features.proxy ) {
+			// Add client specific properties to the event properties. We don't need to do this for direct pixel tracking since it's already done there.
+			this.addClientProperties( eventProperties );
+
+			this.apiClient.addEvent( event, eventProperties );
+		} else {
+			this.fireDirectPixel( event, eventProperties );
+		}
+
+		// Post initialization, maybe record engagement event.
+		if ( this.isInitialized ) {
+			this.maybeRecordEngagementEvent();
+		}
+	};
+
+	/**
+	 * Fire a pixel event.
+	 * @param event           - The name of the event.
+	 * @param eventProperties - The properties of the event.
+	 */
+	fireDirectPixel = ( event: string, eventProperties: Record< string, unknown > ): void => {
+		// Legacy _wca tracking
+		if ( ! window._wca ) {
+			debug( 'Skipping event recording because _wca is not defined' );
+			return;
+		}
 
 		if ( this.features.ch && CLICK_HOUSE_EVENTS.includes( event ) ) {
 			eventProperties.ch = 1;
@@ -121,15 +154,45 @@ export class Analytics {
 			delete eventProperties.ch;
 		}
 
-		const eventName = `${ EVENT_PREFIX }${ event }`;
-		eventProperties._en = eventName;
+		debug( 'Recording event via _wca: "%s" with props %o', event, eventProperties );
 
-		debug( 'Record event "%s" called with props %o', eventName, eventProperties );
+		eventProperties._en = `${ EVENT_PREFIX }${ event }`;
 		window._wca.push( eventProperties );
+	};
 
-		// Post initialization, maybe record engagement event.
-		if ( this.isInitialized ) {
-			this.maybeRecordEngagementEvent();
+	/**
+	 * Add client properties to the event properties.
+	 * @param eventProperties - The properties of the event.
+	 */
+	addClientProperties = ( eventProperties: Record< string, unknown > ): void => {
+		const date = new Date();
+		eventProperties._ts = date.getTime();
+		eventProperties._tz = date.getTimezoneOffset() / 60;
+
+		const nav = window.navigator;
+		const screen = window.screen;
+		eventProperties._lg = nav.language;
+		eventProperties._pf = navigator?.platform;
+		eventProperties._ht = screen.height;
+		eventProperties._wd = screen.width;
+
+		const sx =
+			window.pageXOffset !== undefined
+				? window.pageXOffset
+				: ( document.documentElement || document.body ).scrollLeft;
+		const sy =
+			window.pageYOffset !== undefined
+				? window.pageYOffset
+				: ( document.documentElement || document.body ).scrollTop;
+
+		eventProperties._sx = sx !== undefined ? sx : 0;
+		eventProperties._sy = sy !== undefined ? sy : 0;
+
+		if ( document.location !== undefined ) {
+			eventProperties._dl = document.location.toString();
+		}
+		if ( document.referrer !== undefined ) {
+			eventProperties._dr = document.referrer;
 		}
 	};
 

--- a/projects/packages/woocommerce-analytics/src/client/analytics.ts
+++ b/projects/packages/woocommerce-analytics/src/client/analytics.ts
@@ -124,7 +124,6 @@ export class Analytics {
 		if ( this.features.proxy ) {
 			// Add client specific properties to the event properties. We don't need to do this for direct pixel tracking since it's already done there.
 			this.addClientProperties( eventProperties );
-
 			this.apiClient.addEvent( event, eventProperties );
 		} else {
 			this.fireDirectPixel( event, eventProperties );

--- a/projects/packages/woocommerce-analytics/src/client/api-client.ts
+++ b/projects/packages/woocommerce-analytics/src/client/api-client.ts
@@ -18,13 +18,6 @@ export class ApiClient {
 	private eventQueue: ApiEvent[] = [];
 	private debounceTimer: number | null = null;
 	private isInitialized: boolean = false;
-
-	constructor() {
-		this.eventQueue = [];
-		this.debounceTimer = null;
-		this.isInitialized = false;
-	}
-
 	/**
 	 * Initialize the API client
 	 */

--- a/projects/packages/woocommerce-analytics/src/client/api-client.ts
+++ b/projects/packages/woocommerce-analytics/src/client/api-client.ts
@@ -1,0 +1,135 @@
+/**
+ * External dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+import debugFactory from 'debug';
+/**
+ * Internal dependencies
+ */
+import { API_NAMESPACE, API_ENDPOINT, BATCH_SIZE, DEBOUNCE_DELAY } from './constants';
+import type { ApiEvent, ApiFetchResponse } from './types/shared';
+
+const debug = debugFactory( 'wc-analytics:api-client' );
+
+/**
+ * API Client for sending analytics events to the WordPress REST API
+ */
+export class ApiClient {
+	private eventQueue: ApiEvent[] = [];
+	private debounceTimer: number | null = null;
+	private isInitialized: boolean = false;
+
+	constructor() {
+		this.eventQueue = [];
+		this.debounceTimer = null;
+		this.isInitialized = false;
+	}
+
+	/**
+	 * Initialize the API client
+	 */
+	init = (): void => {
+		if ( this.isInitialized ) {
+			return;
+		}
+
+		debug( 'API client initialized' );
+		// Send any pending events when the page is about to unload
+		window.addEventListener( 'beforeunload', this.flush );
+		window.addEventListener( 'pagehide', this.flush );
+
+		this.isInitialized = true;
+	};
+
+	/**
+	 * Add an event to the queue for batch sending
+	 *
+	 * @param eventName  - The name of the event.
+	 * @param properties - The properties of the event.
+	 */
+	addEvent = ( eventName: string, properties: Record< string, unknown > = {} ): void => {
+		if ( ! this.isInitialized ) {
+			debug( 'API client not initialized, skipping event: %s', eventName );
+			return;
+		}
+
+		debug( 'Recording event via API: "%s" with props %o', eventName, properties );
+		const apiEvent: ApiEvent = {
+			event_name: eventName,
+			properties,
+		};
+
+		this.eventQueue.push( apiEvent );
+		debug( 'Event added to queue: %s (queue size: %d)', eventName, this.eventQueue.length );
+
+		// Schedule debounced send
+		this.debouncedSend();
+
+		// If queue is full, send immediately
+		if ( this.eventQueue.length >= BATCH_SIZE ) {
+			this.flush();
+		}
+	};
+
+	/**
+	 * Debounced send function
+	 */
+	private debouncedSend = (): void => {
+		if ( this.debounceTimer ) {
+			clearTimeout( this.debounceTimer );
+		}
+
+		this.debounceTimer = window.setTimeout( () => {
+			this.flush();
+		}, DEBOUNCE_DELAY );
+	};
+
+	/**
+	 * Flush all pending events immediately
+	 */
+	flush = (): void => {
+		if ( this.debounceTimer ) {
+			clearTimeout( this.debounceTimer );
+			this.debounceTimer = null;
+		}
+
+		if ( this.eventQueue.length === 0 ) {
+			return;
+		}
+
+		const eventsToSend = [ ...this.eventQueue ];
+		this.eventQueue = [];
+
+		this.sendEvents( eventsToSend );
+	};
+
+	/**
+	 * Send events to the API
+	 *
+	 * @param events - The events to send.
+	 */
+	private sendEvents = async ( events: ApiEvent[] ): Promise< void > => {
+		if ( events.length === 0 ) {
+			return;
+		}
+
+		try {
+			debug( 'Sending %d events to API', events.length );
+
+			const response = await apiFetch< ApiFetchResponse >( {
+				path: `/${ API_NAMESPACE }/${ API_ENDPOINT }`,
+				method: 'POST',
+				data: events,
+			} );
+			debug( 'API response received: %o', response );
+
+			if ( ! response.success ) {
+				debug( 'Some events failed to send: %o', response.results );
+			}
+		} catch ( error ) {
+			debug( 'Failed to send events to API: %o', error );
+			// Re-add events to queue for potential retry on next event
+			this.eventQueue.unshift( ...events );
+		}
+	};
+}

--- a/projects/packages/woocommerce-analytics/src/client/constants.ts
+++ b/projects/packages/woocommerce-analytics/src/client/constants.ts
@@ -1,6 +1,13 @@
 export const COOKIE_NAME = 'woocommerceanalytics_session';
 export const EVENT_PREFIX = 'woocommerceanalytics_';
 export const EVENT_NAME_REGEX = /^[a-z_][a-z0-9_]*$/;
+
+// API Configuration
+export const API_NAMESPACE = 'woocommerce-analytics/v1';
+export const API_ENDPOINT = 'track';
+export const BATCH_SIZE = 10;
+export const DEBOUNCE_DELAY = 1000; // 1 second
+
 export const CLICK_HOUSE_EVENTS = [
 	'session_started',
 	'session_engagement',

--- a/projects/packages/woocommerce-analytics/src/client/types/shared.ts
+++ b/projects/packages/woocommerce-analytics/src/client/types/shared.ts
@@ -22,3 +22,13 @@ export interface QueuedEvent {
 	eventName: string;
 	props?: Record< string, unknown >;
 }
+
+export interface ApiEvent {
+	event_name: string;
+	properties: Record< string, unknown >;
+}
+
+export interface ApiFetchResponse {
+	success: boolean;
+	results: Array< { success: boolean; error?: string } >;
+}


### PR DESCRIPTION
Fixes [WOOA7S-490](https://linear.app/a8c/issue/WOOA7S-490/create-client-side-session-management-and-cacheable-analytics) WOOA7S-353

## Proposed changes:

Add a new experimental proxy tracking feature to send events via a REST API instead of pixel tracking. This will improve the reliability.

**Key Changes:**

* **New `ApiClient` class** - Handles REST API communication using `@wordpress/api-fetch`
* **Feature flag system** - Toggle between API and legacy pixel tracking via `woocommerce_analytics_experimental_proxy_tracking_enabled` filter
* **Debounced batch sending** - Events are queued and sent in batches (up to 10 events) with 1-second debouncing
* **Optimized common properties** - Reduced payload by removing cart/checkout data from common props when using proxy tracking
* **TypeScript integration** - Added `@wordpress/api-fetch` dependency and proper typing

**Technical Implementation:**

* Uses existing `/wp-json/woocommerce-analytics/v1/track` endpoint from PR #45227
* Events are batched client-side and sent via `@wordpress/api-fetch`
* Automatic event flushing on page unload/navigation
* Debug logging support for troubleshooting

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?

No, this PR does not change what data we track. It provides an alternative method for sending the same analytics events through a REST API instead of pixel tracking. The events and data collected remain identical.

## Testing instructions:

### Prerequisites:
* WordPress site with WooCommerce installed
* Jetpack connection established
* Enable debug logging: `localStorage.debug = 'wc-analytics:*'` in browser console
* Enable server-side logging: add this code snippet to monitor the server-side activity:

```php
function log_remote_pixels( $preempt, $parsed_args, $url ) {
	if ( strpos( $url, WC_Tracks_Client::PIXEL ) === 0 ||  strpos( $url, 'https://pixel.wp.com/w.gif' ) === 0  ) {
		$parsed_url = wp_parse_url( $url );
		parse_str( $parsed_url['query'], $params );
		error_log( $url );
		error_log( $params['_en'] . ' -- ' . print_r( $params, true ));
	}

	return $preempt;
}

add_action( 'pre_http_request', 'log_remote_pixels', 10, 3 );
```

### Testing Default Behavior (Feature Disabled):

1. Navigate to any WooCommerce page (product, cart, checkout, my account)
2. Open browser developer tools and check Network tab
3. Verify events are sent via traditional pixel tracking (`*.gif` requests).
4. Confirm no requests to `/wp-json/woocommerce-analytics/v1/track`

### Testing API Tracking (Feature Enabled):

1. Add the following to your theme's `functions.php` or a plugin:

   ```php
   add_filter( 'woocommerce_analytics_experimental_proxy_tracking_enabled', '__return_true' );
   ```

2. Clear any session cookies and reload the page
3. Navigate to various WooCommerce pages (product view, add to cart, checkout, etc.)
4. **Client-Side Testing:**
   * Check Console for debug messages showing API client initialization and event queueing
   * Check Network tab for POST requests to `/wp-json/woocommerce-analytics/v1/track`
   * Verify events are batched (multiple events in single API request)
5. **Server-Side Testing:**
   * Check server logs to confirm events are being forwarded to tracking endpoints
   * Verify that cart/checkout properties are properly included in events

### Testing Specific Events:

1. **Product View**: Visit any product page
2. **Cart View**: Visit cart page - verify cart properties are included
3. **Checkout**: Navigate to checkout page - verify checkout properties are included
4. **Order Confirmation**: Complete an order - verify order properties are included
5. **My Account**: Visit my account pages and test tab navigation
6. **Search**: Use WooCommerce product search

### Expected Behavior:

* **Feature Disabled**: Traditional pixel tracking via `_wca.push()`
* **Feature Enabled**: REST API tracking with batched requests
* Server logs should show events being forwarded to ClickHouse and Tracks endpoints
