### PR TITLE
Forms: don't override field labels on transforms

### DIFF
--- a/projects/packages/forms/changelog/update-forms-dont-override-label-on-transform
+++ b/projects/packages/forms/changelog/update-forms-dont-override-label-on-transform
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: don't override field labels on transforms

--- a/projects/packages/forms/src/blocks/shared/settings/transforms.js
+++ b/projects/packages/forms/src/blocks/shared/settings/transforms.js
@@ -157,7 +157,8 @@ const createTextFieldInnerBlocks = ( blockName, existingInnerBlocks = [] ) => {
 	return [
 		createBlock( 'jetpack/label', {
 			...( existingLabel?.attributes || {} ),
-			label: config.label,
+			// Use new field label only if there wasn't label already
+			label: existingLabel?.attributes?.label || config.label,
 			placeholder: config.labelPlaceholder,
 		} ),
 		createBlock( 'jetpack/input', {
@@ -178,7 +179,8 @@ const createChoiceFieldInnerBlocks = ( blockName, existingInnerBlocks = [], attr
 
 	const label = createBlock( 'jetpack/label', {
 		...( existingLabel?.attributes || {} ),
-		label: config.label,
+		// Use new field label only if there wasn't label already
+		label: existingLabel?.attributes?.label || config.label,
 		placeholder: config.labelPlaceholder,
 	} );
 

--- a/projects/plugins/jetpack/changelog/update-forms-dont-override-label-on-transform
+++ b/projects/plugins/jetpack/changelog/update-forms-dont-override-label-on-transform
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: don't override field labels on transforms


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes FORMS-296

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* When there's a label in the input, leave the label be when transferring to a new type of field - even if it was a default label of the previous field. This ensures any custom labels done by customers are kept.

### Before


https://github.com/user-attachments/assets/e44c7922-26c6-4505-9f18-f673c7b7f146



### After


https://github.com/user-attachments/assets/180a16fb-c972-4451-bd71-b82ab6d539a7


https://github.com/user-attachments/assets/676c2ec6-d21b-4fd3-ba41-92c9c5545527


### Before/after (unchanged)


https://github.com/user-attachments/assets/372b6bee-09f3-4ccc-b97c-a9c54d9ebc6d




### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add fields and transform them into another field
* Note how custom-written labels, as well as default labels from previous fields, now remain
* Placeholders and custom required texts already entered remained
* Empty placeholders get replaced with new ones