### PR TITLE
Stats: Fix stats for non-Odyssey users

### DIFF
--- a/projects/packages/stats-admin/changelog/fix-stats-dashboard-on-old-jetpack
+++ b/projects/packages/stats-admin/changelog/fix-stats-dashboard-on-old-jetpack
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix dashboard.wordpress.com breaking non-odyssey stats on older versions of Jetpack.

--- a/projects/packages/stats-admin/src/class-dashboard.php
+++ b/projects/packages/stats-admin/src/class-dashboard.php
@@ -58,6 +58,15 @@ class Dashboard {
 	 * @return void
 	 */
 	public function add_wp_admin_menu() {
+		/**
+		 * Disable this menu for dashboard.wordpress.com because older versions of Jetpack need to fetch the old Stats UI.
+		 *
+		 * If this menu is registered, it will conflict with the back-end and break non-odyssey Stats.
+		 */
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM && 120742 === get_current_blog_id() ) {
+			return;
+		}
+
 		$page_suffix = add_menu_page(
 			__( 'Stats', 'jetpack-stats-admin' ),
 			_x( 'Stats', 'product name shown in menu', 'jetpack-stats-admin' ),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Due to a regression introduced in https://github.com/Automattic/jetpack/pull/44524/, Jetpack sites using non-Odyssey Stats were broken because the old UI is delivered through dashboard.wordpress.com to Jetpack sites that are running older versions of Jetpack.

This PR fixes this regression by simply not registering the menu on this specific site.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* don't register the stats menu on dashboard.wordpress.com since it's used by non-odyssey sites.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this PR on your sandbox
* Create a jurassic ninja site (make sure you enable sandbox access from the additional options)
* Install Jetpack Beta
* Switch Jetpack to 11.3.4
* Go to Jetpack > Stats and notice that the UI is broken
* Go to Settings > Jetpack Constants
* Add your sandbox domain
* Go back to Stats and notice that the stats are working again.

