### PR TITLE
WooCommerce Analytics: Add IP-based unique visitor identification

### DIFF
--- a/projects/packages/woocommerce-analytics/changelog/wooa7s-488-improve-visitor-tracking-switch-from-cookie-based-to-ip
+++ b/projects/packages/woocommerce-analytics/changelog/wooa7s-488-improve-visitor-tracking-switch-from-cookie-based-to-ip
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add IP-based visitor tracking as fallback when proxy tracking is enabled and cookies are unavailable

--- a/projects/packages/woocommerce-analytics/src/class-features.php
+++ b/projects/packages/woocommerce-analytics/src/class-features.php
@@ -25,7 +25,7 @@ class Features {
 		 *
 		 * @param bool $enabled Whether proxy tracking is enabled. Default false.
 		 */
-		return apply_filters( 'woocommerce_analytics_experimental_proxy_tracking_enabled', true );
+		return apply_filters( 'woocommerce_analytics_experimental_proxy_tracking_enabled', false );
 	}
 
 	/**

--- a/projects/packages/woocommerce-analytics/src/class-features.php
+++ b/projects/packages/woocommerce-analytics/src/class-features.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Features class for WooCommerce Analytics.
+ *
+ * @package automattic/woocommerce-analytics
+ */
+
+namespace Automattic\Woocommerce_Analytics;
+
+/**
+ * Features class for WooCommerce Analytics.
+ */
+class Features {
+
+	/**
+	 * Check if proxy tracking is enabled.
+	 *
+	 * @return bool
+	 */
+	public static function is_proxy_tracking_enabled() {
+		/**
+		 * Filter to enable/disable experimental proxy tracking for WooCommerce Analytics
+		 *
+		 * @since 0.9.0
+		 *
+		 * @param bool $enabled Whether proxy tracking is enabled. Default false.
+		 */
+		return apply_filters( 'woocommerce_analytics_experimental_proxy_tracking_enabled', true );
+	}
+
+	/**
+	 * Check if ClickHouse is enabled.
+	 *
+	 * @return bool
+	 */
+	public static function is_clickhouse_enabled() {
+		/**
+		 * Filter to enable/disable ClickHouse event tracking.
+		 *
+		 * @module woocommerce-analytics
+		 *
+		 * @since 0.5.0
+		 *
+		 * @param bool $enabled Whether ClickHouse event tracking is enabled.
+		 */
+		return apply_filters( 'woocommerce_analytics_clickhouse_enabled', false );
+	}
+}

--- a/projects/packages/woocommerce-analytics/src/class-universal.php
+++ b/projects/packages/woocommerce-analytics/src/class-universal.php
@@ -73,8 +73,8 @@ class Universal {
 	 * Inject analytics data into the window object
 	 */
 	public function inject_analytics_data() {
-		$is_clickhouse_enabled     = $this->is_clickhouse_enabled();
-		$is_proxy_tracking_enabled = $this->is_proxy_tracking_enabled();
+		$is_clickhouse_enabled     = Features::is_clickhouse_enabled();
+		$is_proxy_tracking_enabled = Features::is_proxy_tracking_enabled();
 		// When proxy tracking is enabled, we don't need to send the common properties to the client.
 		$common_properties = $is_proxy_tracking_enabled ? array() : $this->get_common_properties();
 		?>
@@ -93,7 +93,7 @@ class Universal {
 				wcAnalytics.features = {
 					ch: <?php echo $is_clickhouse_enabled ? 'true' : 'false'; ?>,
 					sessionTracking: <?php echo $is_clickhouse_enabled ? 'true' : 'false'; ?>,
-					proxy: <?php echo $this->is_proxy_tracking_enabled() ? 'true' : 'false'; ?>,
+					proxy: <?php echo $is_proxy_tracking_enabled ? 'true' : 'false'; ?>,
 				};
 
 				wcAnalytics.breadcrumbs = <?php echo wp_json_encode( $this->get_breadcrumb_titles() ); ?>;

--- a/projects/packages/woocommerce-analytics/src/class-wc-analytics-tracking.php
+++ b/projects/packages/woocommerce-analytics/src/class-wc-analytics-tracking.php
@@ -367,7 +367,7 @@ class WC_Analytics_Tracking extends WC_Tracks {
 		// Create hash from: daily_salt + domain + ip + user_agent
 		$hash_input = $salt . $domain . $ip . $user_agent;
 
-		return substr( md5( $hash_input ), 0, 16 );
+		return substr( hash( 'sha256', $hash_input ), 0, 16 );
 	}
 
 	/**

--- a/projects/packages/woocommerce-analytics/src/class-wc-analytics-tracking.php
+++ b/projects/packages/woocommerce-analytics/src/class-wc-analytics-tracking.php
@@ -359,8 +359,15 @@ class WC_Analytics_Tracking extends WC_Tracks {
 			return null;
 		}
 
-		$salt = self::get_daily_salt();
-		return substr( md5( $ip . $salt ), 0, 16 );
+		$salt       = self::get_daily_salt();
+		$url_parts  = wp_parse_url( home_url() );
+		$domain     = isset( $url_parts['host'] ) ? $url_parts['host'] : '';
+		$user_agent = isset( $_SERVER['HTTP_USER_AGENT'] ) ? sanitize_text_field( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ) : '';
+
+		// Create hash from: daily_salt + domain + ip + user_agent
+		$hash_input = $salt . $domain . $ip . $user_agent;
+
+		return substr( md5( $hash_input ), 0, 16 );
 	}
 
 	/**

--- a/projects/packages/woocommerce-analytics/src/class-wc-analytics-tracking.php
+++ b/projects/packages/woocommerce-analytics/src/class-wc-analytics-tracking.php
@@ -402,11 +402,6 @@ class WC_Analytics_Tracking extends WC_Tracks {
 			return $salt_data['salt'];
 		}
 
-		// Clean up expired/invalid salt data
-		if ( false !== $salt_data ) {
-			delete_option( self::DAILY_SALT_OPTION );
-		}
-
 		// Generate new salt for today
 		$new_salt = wp_generate_password( 32, false );
 

--- a/projects/packages/woocommerce-analytics/src/class-wc-analytics-tracking.php
+++ b/projects/packages/woocommerce-analytics/src/class-wc-analytics-tracking.php
@@ -25,6 +25,13 @@ class WC_Analytics_Tracking extends WC_Tracks {
 	const PREFIX = 'woocommerceanalytics_';
 
 	/**
+	 * Option name for storing daily salt data.
+	 *
+	 * @var string
+	 */
+	const DAILY_SALT_OPTION = 'wc_analytics_daily_salt';
+
+	/**
 	 * Allowed ClickHouse events.
 	 *
 	 * @var array
@@ -50,6 +57,20 @@ class WC_Analytics_Tracking extends WC_Tracks {
 	 * @var array
 	 */
 	protected static $event_queue = array();
+
+	/**
+	 * Cached user IP address for the current request.
+	 *
+	 * @var string|null
+	 */
+	private static $cached_ip = null;
+
+	/**
+	 * Cached visitor ID for the current request.
+	 *
+	 * @var string|null
+	 */
+	private static $cached_visitor_id = null;
 
 	/**
 	 * Record an event in Tracks and ClickHouse (If enabled).
@@ -249,14 +270,29 @@ class WC_Analytics_Tracking extends WC_Tracks {
 	}
 
 	/**
-	 * Get the visitor id from the cookie.
+	 * Get the visitor id from the cookie or IP address (if proxy tracking is enabled).
 	 *
 	 * @return string|null
 	 */
 	private static function get_visitor_id() {
-		if ( isset( $_COOKIE['tk_ai'] ) ) {
-			return sanitize_text_field( wp_unslash( $_COOKIE['tk_ai'] ) );
+		// Return cached result if available.
+		if ( null !== self::$cached_visitor_id ) {
+			return self::$cached_visitor_id;
 		}
+
+		// Prefer tk_ai cookie if present.
+		if ( ! empty( $_COOKIE['tk_ai'] ) ) {
+			self::$cached_visitor_id = sanitize_text_field( wp_unslash( $_COOKIE['tk_ai'] ) );
+			return self::$cached_visitor_id;
+		}
+
+		// Fallback to IP-based visitor ID if proxy tracking is enabled.
+		if ( Features::is_proxy_tracking_enabled() ) {
+			self::$cached_visitor_id = self::get_ip_based_visitor_id();
+			return self::$cached_visitor_id;
+		}
+
+		self::$cached_visitor_id = null;
 		return null;
 	}
 
@@ -295,6 +331,11 @@ class WC_Analytics_Tracking extends WC_Tracks {
 	 * @return string The user's IP address. An empty string if no valid IP address is found.
 	 */
 	private static function get_user_ip_address() {
+		// Return cached IP if available
+		if ( null !== self::$cached_ip ) {
+			return self::$cached_ip;
+		}
+
 		$ip_headers = array(
 			'HTTP_CF_CONNECTING_IP', // Cloudflare specific header.
 			'HTTP_X_FORWARDED_FOR',
@@ -312,12 +353,70 @@ class WC_Analytics_Tracking extends WC_Tracks {
 						FILTER_VALIDATE_IP,
 						array( FILTER_FLAG_NO_RES_RANGE, FILTER_FLAG_IPV6 )
 					) ) {
-						return $ip_candidate;
+						// Cache the resolved IP
+						self::$cached_ip = $ip_candidate;
+						return self::$cached_ip;
 					}
 				}
 			}
 		}
 
-		return '';
+		// Cache empty result
+		self::$cached_ip = '';
+		return self::$cached_ip;
+	}
+
+	/**
+	 * Get IP-based visitor ID for proxy tracking mode.
+	 *
+	 * @return string|null
+	 */
+	private static function get_ip_based_visitor_id() {
+		$ip = self::get_user_ip_address();
+		if ( empty( $ip ) ) {
+			return null;
+		}
+
+		$salt = self::get_daily_salt();
+		return substr( md5( $ip . $salt ), 0, 16 );
+	}
+
+	/**
+	 * Get or generate daily salt for visitor ID hashing.
+	 * Creates a new salt value each day (UTC) for privacy protection.
+	 *
+	 * @return string The daily salt.
+	 */
+	private static function get_daily_salt() {
+		$today = gmdate( 'Y-m-d' ); // UTC date
+
+		$salt_data = get_option( self::DAILY_SALT_OPTION );
+
+		// Check if salt exists and is still valid for today
+		if (
+			is_array( $salt_data )
+			&& isset( $salt_data['date'] )
+			&& isset( $salt_data['salt'] )
+			&& $salt_data['date'] === $today
+		) {
+			return $salt_data['salt'];
+		}
+
+		// Clean up expired/invalid salt data
+		if ( false !== $salt_data ) {
+			delete_option( self::DAILY_SALT_OPTION );
+		}
+
+		// Generate new salt for today
+		$new_salt = wp_generate_password( 32, false );
+
+		// Store salt with date (no expiration time needed)
+		$salt_data = array(
+			'date' => $today,
+			'salt' => $new_salt,
+		);
+
+		update_option( self::DAILY_SALT_OPTION, $salt_data );
+		return $new_salt;
 	}
 }

--- a/projects/packages/woocommerce-analytics/src/class-wc-analytics-tracking.php
+++ b/projects/packages/woocommerce-analytics/src/class-wc-analytics-tracking.php
@@ -361,8 +361,8 @@ class WC_Analytics_Tracking extends WC_Tracks {
 
 		$salt       = self::get_daily_salt();
 		$url_parts  = wp_parse_url( home_url() );
-		$domain     = isset( $url_parts['host'] ) ? $url_parts['host'] : '';
-		$user_agent = isset( $_SERVER['HTTP_USER_AGENT'] ) ? sanitize_text_field( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ) : '';
+		$domain     = $url_parts['host'] ?? '';
+		$user_agent = sanitize_text_field( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ?? '' ) );
 
 		// Create hash from: daily_salt + domain + ip + user_agent
 		$hash_input = $salt . $domain . $ip . $user_agent;

--- a/projects/packages/woocommerce-analytics/src/class-wc-analytics-tracking.php
+++ b/projects/packages/woocommerce-analytics/src/class-wc-analytics-tracking.php
@@ -303,26 +303,8 @@ class WC_Analytics_Tracking extends WC_Tracks {
 	 * @return bool True if it should be sent to ClickHouse
 	 */
 	private static function should_send_to_clickhouse( $event ) {
-		return self::is_clickhouse_enabled() &&
+		return Features::is_clickhouse_enabled() &&
 			in_array( $event, self::ALLOWED_CH_EVENTS, true );
-	}
-
-	/**
-	 * Check if ClickHouse is enabled.
-	 *
-	 * @return bool
-	 */
-	private static function is_clickhouse_enabled() {
-		/**
-		 * Filter to enable/disable ClickHouse event tracking.
-		 *
-		 * @module woocommerce-analytics
-		 *
-		 * @since 0.5.0
-		 *
-		 * @param bool $enabled Whether ClickHouse event tracking is enabled.
-		 */
-		return apply_filters( 'woocommerce_analytics_clickhouse_enabled', false );
 	}
 
 	/**

--- a/projects/packages/woocommerce-analytics/src/class-wc-analytics-tracking.php
+++ b/projects/packages/woocommerce-analytics/src/class-wc-analytics-tracking.php
@@ -29,7 +29,7 @@ class WC_Analytics_Tracking extends WC_Tracks {
 	 *
 	 * @var string
 	 */
-	const DAILY_SALT_OPTION = 'wc_analytics_daily_salt';
+	const DAILY_SALT_OPTION = 'woocommerce_analytics_daily_salt';
 
 	/**
 	 * Allowed ClickHouse events.

--- a/projects/packages/woocommerce-analytics/src/class-woo-analytics-trait.php
+++ b/projects/packages/woocommerce-analytics/src/class-woo-analytics-trait.php
@@ -608,24 +608,6 @@ trait Woo_Analytics_Trait {
 	}
 
 	/**
-	 * Check if ClickHouse is enabled.
-	 *
-	 * @return bool
-	 */
-	private function is_clickhouse_enabled() {
-		/**
-		 * Filter to enable/disable ClickHouse event tracking.
-		 *
-		 * @module woocommerce-analytics
-		 *
-		 * @since 0.5.0
-		 *
-		 * @param bool $enabled Whether ClickHouse event tracking is enabled.
-		 */
-		return apply_filters( 'woocommerce_analytics_clickhouse_enabled', false );
-	}
-
-	/**
 	 * Retrieves the breadcrumb trail as an array of page titles.
 	 *
 	 * This function attempts to generate a hierarchical breadcrumb trail for the current page or post.
@@ -693,21 +675,5 @@ trait Woo_Analytics_Trait {
 		}
 
 		return array_merge( array( $shop_page_title ), $titles );
-	}
-
-	/**
-	 * Check if proxy tracking is enabled
-	 *
-	 * @return bool
-	 */
-	private function is_proxy_tracking_enabled() {
-		/**
-		 * Filter to enable/disable experimental proxy tracking for WooCommerce Analytics
-		 *
-		 * @since 0.9.0
-		 *
-		 * @param bool $enabled Whether proxy tracking is enabled. Default false.
-		 */
-		return apply_filters( 'woocommerce_analytics_experimental_proxy_tracking_enabled', false );
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes [WOOA7S-488](https://linear.app/a8c/issue/WOOA7S-488/improve-visitor-tracking-switch-from-cookie-based-to-ip-based-unique)

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

* Add IP-based visitor tracking as fallback when proxy tracking is enabled and cookies are unavailable. If proxy tracking is disabled, avoid using the IP-based method to ensure the user ID remains consistent with the client-side.
* Implement daily salt generation with automatic rotation for enhanced privacy protection

Reference Plausible Analytics documentation on cookieless visitor tracking: https://plausible.io/data-policy#how-we-count-unique-users-without-cookies


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->

Yes, this PR introduces IP-based visitor tracking as a fallback mechanism when cookies are unavailable and proxy tracking is enabled. Key privacy considerations:

* **IP hashing**: IP addresses are hashed with daily-rotating salts, not stored directly
* **Daily salt rotation**: New salt generated each day (UTC) for enhanced privacy protection  
* **Fallback only**: IP-based tracking only used when cookies unavailable and proxy tracking enabled
* **No persistent storage**: Salts automatically cleaned up, no long-term IP data retention
* **Consistent with existing privacy**: Maintains same visitor tracking patterns as cookie-based approach

## Testing instructions:

### Prerequisites

* Set up a WooCommerce site with Jetpack WooCommerce Analytics enabled
* Enable proxy tracking with filter: `add_filter( 'woocommerce_analytics_experimental_proxy_tracking_enabled', '__return_true' );`
* Enable server-side logging: add this code snippet to monitor the server-side activity:

```php
function log_remote_pixels( $preempt, $parsed_args, $url ) {
	if ( strpos( $url, WC_Tracks_Client::PIXEL ) === 0 ||  strpos( $url, 'https://pixel.wp.com/w.gif' ) === 0  ) {
		$parsed_url = wp_parse_url( $url );
		parse_str( $parsed_url['query'], $params );
		error_log( $url );
		error_log( $params['_en'] . ' -- ' . print_r( $params, true ));
	}

	return $preempt;
}

add_action( 'pre_http_request', 'log_remote_pixels', 10, 3 );
```

### Test Cases

#### Test 1: Cookie-based tracking (existing behavior)

* Ensure `tk_ai` cookie exists in browser (Your can set it manually if needed)
* Visit WooCommerce pages and confirm that the event is tracked by checking `wp-content/debug.log`.
* Confirm that the `_ui` prop comes from `tk_ai` cookie value
* **Expected**: Same behavior as before, no changes

<img width="631" height="340" alt="Screenshot 2025-09-24 at 14 01 57" src="https://github.com/user-attachments/assets/d25c0bb8-a1a8-4b40-9a61-b5790e0a30c9" />
<img width="658" height="430" alt="Screenshot 2025-09-24 at 14 02 54" src="https://github.com/user-attachments/assets/a5966c84-1899-429c-b3c5-63d58f839fdb" />


#### Test 2: IP-based fallback (new behavior)  

* Clear all cookies or use incognito/private browsing mode
* Confirm that `tk_ai cookie does not exist in browser
* Visit WooCommerce pages

* **Expected**: `_ui` prop  should be generated from IP address hash (16 chars)
* **Expected**: Same visitor should get a consistent ID throughout the day

* Try accessing from a different device or a browser (Safari <-> Chrome) with a different user agent.
* Verify that the generated ID is different from the previous test due to the change in user agent.

#### Test 3: Daily salt rotation

* Clear the `woocommerce_analytics_daily_salt` option from wp_options table
* Ensure `tk_ai` does not exist in browser
* Go to WooCommerce Pages
* Confirm that `woocommerce_analytics_daily_salt` option is created
* Manually change the date in the salt option to yesterday `wp option update woocommerce_analytics_daily_salt '{"date":"2025-09-23","salt":"your_existing_salt_here"}' --format=json`
* Go to WooCommerce Pages
* **Expected**: New salt should be created for today, old salt deleted

<img width="742" height="160" alt="Screenshot 2025-09-24 at 14 07 09" src="https://github.com/user-attachments/assets/938667b3-93c7-41bd-b02d-8f76f0c06ebf" />
