### PR TITLE
Fix Jetpack AI upgrade nudge link

### DIFF
--- a/projects/js-packages/shared-extension-utils/changelog/fix-jetpack-ai-upgrade-nudge-link
+++ b/projects/js-packages/shared-extension-utils/changelog/fix-jetpack-ai-upgrade-nudge-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Wrap upgrade nudge with span due to an ongoing Gutenberg issue

--- a/projects/js-packages/shared-extension-utils/src/components/upgrade-nudge/index.jsx
+++ b/projects/js-packages/shared-extension-utils/src/components/upgrade-nudge/index.jsx
@@ -49,7 +49,7 @@ export const Nudge = ( {
 						} ) }
 						isBusy={ isRedirecting }
 					>
-						{ isRedirecting ? redirectingText : buttonText }
+						<span>{ isRedirecting ? redirectingText : buttonText }</span>
 					</Button>
 				) }
 			</div>

--- a/projects/plugins/jetpack/changelog/fix-jetpack-ai-upgrade-nudge-link
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-ai-upgrade-nudge-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Wrap upgrade nudge with span due to an ongoing Gutenberg issue where link clicks are not captured unless wrapped 


### PR DESCRIPTION
## Proposed changes:
This PR wraps another upgrade link with a `<span>` to regain functionality. It is a follow up to https://github.com/Automattic/jetpack/pull/44405 

There's is some

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1753220554625149-slack-C45SNKV4Z

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Follow instructions on https://github.com/Automattic/jetpack/pull/44405
As a free user, insert an AI block and see the upgrade button works on the nudge:
<img width="677" height="213" alt="image" src="https://github.com/user-attachments/assets/aa84939e-c10a-4802-b4a1-75b356db7680" />
