### PR TITLE
Forms: Fix feedback empty response fatal

### DIFF
--- a/projects/packages/forms/changelog/fix-feedback-empty-response-fatal
+++ b/projects/packages/forms/changelog/fix-feedback-empty-response-fatal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: fixed 404 reponse for empty feedback

--- a/projects/packages/forms/changelog/fix-feedback-empty-response-fatal
+++ b/projects/packages/forms/changelog/fix-feedback-empty-response-fatal
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Forms: fixed 404 reponse for empty feedback
+Forms: fixed 404 response for empty feedback

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -588,7 +588,7 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 		$fields   = $this->get_fields_for_response( $request );
 
 		$feedback_response = Feedback::get( $item->ID );
-		if ( ! $response ) {
+		if ( ! $feedback_response ) {
 			return rest_ensure_response( $data );
 		}
 

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Endpoint_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Endpoint_Test.php
@@ -507,6 +507,15 @@ class Contact_Form_Endpoint_Test extends TestCase {
 		remove_filter( 'wp_mail', array( $this, 'mock_wp_mail_succeeded' ) );
 	}
 
+	public function test_404_single_feedback_response() {
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/feedback/999999' );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 404, $response->get_status() );
+		$data = $response->get_data();
+		$this->assertEquals( 'rest_post_invalid_id', $data['code'] );
+		$this->assertEquals( 'Invalid post ID.', $data['message'] );
+	}
+
 	/**
 	 * Mock wp_mail_succeeded filter
 	 */


### PR DESCRIPTION
Fixes Fatal error when for requests that don't return anything. 

## Proposed changes:
* Add a test to make sure that the correct response is returned. 
* Fixes a typo. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1758705546124279-slack-C06QF6JJD TM

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
Do the tests pass? 