### PR TITLE
Woo Analytics: Fix fatal error: Include WC_Analytics_Tracking_Proxy class

### DIFF
--- a/projects/packages/woocommerce-analytics/changelog/fix-woocommerce-analytics-missing-class-clean
+++ b/projects/packages/woocommerce-analytics/changelog/fix-woocommerce-analytics-missing-class-clean
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix fatal error by including missing WC_Analytics_Tracking_Proxy class file before instantiation

--- a/projects/packages/woocommerce-analytics/src/class-woocommerce-analytics.php
+++ b/projects/packages/woocommerce-analytics/src/class-woocommerce-analytics.php
@@ -128,6 +128,7 @@ class Woocommerce_Analytics {
 	 * Register REST API routes.
 	 */
 	public static function register_rest_routes() {
+		require_once __DIR__ . '/API/class-wc-analytics-tracking-proxy.php';
 		$controller = new WC_Analytics_Tracking_Proxy();
 		$controller->register_routes();
 	}


### PR DESCRIPTION
## Changes proposed in this Pull Request:

- Fix fatal error by including missing `WC_Analytics_Tracking_Proxy` class file before instantiation in `register_rest_routes()` method

```[24-Sep-2025 17:56:51 UTC] PHP Fatal error:  Uncaught Error: Class "Automattic\Woocommerce_Analytics\WC_Analytics_Tracking_Proxy" not found in /usr/local/src/jetpack-monorepo/projects/packages/woocommerce-analytics/src/class-woocommerce-analytics.php:131
Stack trace:
#0 /var/www/html/wp-includes/class-wp-hook.php(324): Automattic\Woocommerce_Analytics::register_rest_routes()
#1 /var/www/html/wp-includes/class-wp-hook.php(348): WP_Hook->apply_filters()
#2 /var/www/html/wp-includes/plugin.php(517): WP_Hook->do_action()
#3 /var/www/html/wp-includes/rest-api.php(628): do_action()
#4 /var/www/html/wp-includes/rest-api.php(452): rest_get_server()
#5 /var/www/html/wp-includes/class-wp-hook.php(324): rest_api_loaded()
#6 /var/www/html/wp-includes/class-wp-hook.php(348): WP_Hook->apply_filters()
#7 /var/www/html/wp-includes/plugin.php(565): WP_Hook->do_action()
#8 /var/www/html/wp-includes/class-wp.php(418): do_action_ref_array()
#9 /var/www/html/wp-includes/class-wp.php(818): WP->parse_request()
#10 /var/www/html/wp-includes/functions.php(1342): WP->main()
#11 /var/www/html/wp-blog-header.php(16): wp()
#12 /var/www/html/index.php(17): require('...')
#13 {main}
  thrown in /
```

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

1. Enable WooCommerce Analytics package in a development environment
2. Navigate to any page that triggers REST API initialization
3. Verify no fatal error occurs: `Class "Automattic\Woocommerce_Analytics\WC_Analytics_Tracking_Proxy" not found`
