### PR TITLE
feat: Allow Android WebView admin-ajax.php CORS requests

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-application-password-extras.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-application-password-extras.php
@@ -16,6 +16,12 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Extends Application Password functionality beyond the REST API.
  */
 class Jetpack_Application_Password_Extras {
+	/**
+	 * Allowed CORS origins for AJAX requests
+	 */
+	const ALLOWED_AJAX_CORS_ORIGINS = array(
+		'https://appassets.androidplatform.net', // Android WebView
+	);
 
 	/**
 	 * The AJAX action prefix for VideoPress actions.
@@ -29,6 +35,11 @@ class Jetpack_Application_Password_Extras {
 	 */
 	public static function init() {
 		add_filter( 'application_password_is_api_request', array( __CLASS__, 'application_password_extras' ) );
+		// Use a hook that runs early, before send_origin_headers, which exits before
+		// the `send_origin_headers` function is called.
+		// https://github.com/WordPress/wordpress-develop/blob/3c3852e8a2a70c4f09233ffe5bce03576a687130/src/wp-includes/http.php#L525-L527
+		add_action( 'wp_loaded', array( __CLASS__, 'add_ajax_preflight_headers' ), 5 );
+		add_filter( 'allowed_http_origins', array( __CLASS__, 'allow_ajax_cors_origins' ) );
 	}
 
 	/**
@@ -73,5 +84,94 @@ class Jetpack_Application_Password_Extras {
 		return array(
 			'admin-ajax' => true,
 		);
+	}
+
+	/**
+	 * Add CORS headers for OPTIONS preflight requests
+	 */
+	public static function add_ajax_preflight_headers() {
+		$origin = get_http_origin();
+		if ( ! self::is_ajax_preflight_request_allowed( $origin ) ) {
+			return;
+		}
+
+		header( 'Access-Control-Allow-Headers: Authorization, Content-Type, X-WP-Nonce' );
+		header( 'Access-Control-Allow-Methods: GET, POST, OPTIONS' );
+		header( 'Access-Control-Max-Age: 86400' );
+	}
+
+	/**
+	 * Allow CORS origins for authorized admin-ajax requests
+	 *
+	 * @param array $allowed_origins Array of allowed origin URLs.
+	 * @return array Array of allowed origin URLs.
+	 */
+	public static function allow_ajax_cors_origins( $allowed_origins ) {
+		$has_auth_header   = ! empty( $_SERVER['HTTP_AUTHORIZATION'] );
+		$is_auth_preflight = self::is_auth_preflight_request();
+		$is_admin_ajax     = self::is_admin_ajax_request();
+
+		// Only allow CORS for admin-ajax.php requests that have authorization or are authorization preflights
+		if ( $is_admin_ajax && ( $has_auth_header || $is_auth_preflight ) ) {
+			$origin = get_http_origin();
+			// Only allow whitelisted origins
+			if ( $origin && self::is_origin_in_ajax_allowed_list( $origin ) && ! in_array( $origin, $allowed_origins, true ) ) {
+				$allowed_origins[] = $origin;
+			}
+		}
+
+		return $allowed_origins;
+	}
+
+	/**
+	 * Check if AJAX preflight request should be allowed for the given origin
+	 *
+	 * @param string $origin The origin to check.
+	 * @return bool Whether the preflight request should be allowed.
+	 */
+	private static function is_ajax_preflight_request_allowed( $origin ) {
+		$is_origin_in_allowed_list = self::is_origin_in_ajax_allowed_list( $origin );
+		$is_auth_preflight         = self::is_auth_preflight_request();
+		$is_admin_ajax             = self::is_admin_ajax_request();
+
+		return $is_origin_in_allowed_list && $is_auth_preflight && $is_admin_ajax;
+	}
+
+	/**
+	 * Check if an origin is in the AJAX CORS allowed list
+	 *
+	 * @param string $origin The origin to check.
+	 * @return bool Whether the origin should be allowed.
+	 */
+	private static function is_origin_in_ajax_allowed_list( $origin ) {
+		/**
+		 * Filter the allowed AJAX CORS origins
+		 *
+		 * @param array $allowed_origins Array of allowed origin URLs
+		 */
+		$allowed_origins = apply_filters( 'ajax_allowed_cors_origins', self::ALLOWED_AJAX_CORS_ORIGINS );
+
+		return in_array( $origin, $allowed_origins, true );
+	}
+
+	/**
+	 * Check if the request is an authorization preflight request
+	 *
+	 * @return bool Whether the request is an authorization preflight request.
+	 */
+	private static function is_auth_preflight_request() {
+		$request_method  = isset( $_SERVER['REQUEST_METHOD'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REQUEST_METHOD'] ) ) : '';
+		$request_headers = isset( $_SERVER['HTTP_ACCESS_CONTROL_REQUEST_HEADERS'] ) ? sanitize_text_field( wp_unslash( $_SERVER['HTTP_ACCESS_CONTROL_REQUEST_HEADERS'] ) ) : '';
+
+		return 'OPTIONS' === $request_method && false !== stripos( $request_headers, 'authorization' );
+	}
+
+	/**
+	 * Check if the current request is an admin AJAX request
+	 *
+	 * @return bool Whether this is an admin-ajax.php request
+	 */
+	private static function is_admin_ajax_request() {
+		return is_admin() && wp_doing_ajax();
 	}
 }

--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-application-password-extras.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-application-password-extras.php
@@ -20,7 +20,7 @@ class Jetpack_Application_Password_Extras {
 	 * Allowed CORS origins for AJAX requests
 	 */
 	const ALLOWED_AJAX_CORS_ORIGINS = array(
-		'https://appassets.androidplatform.net', // Android WebView
+		'https://android-app-assets.jetpack.com', // Jetpack Android mobile app WebView
 	);
 
 	/**

--- a/projects/plugins/jetpack/changelog/feat-allow-android-web-view-ajax-cors-requests
+++ b/projects/plugins/jetpack/changelog/feat-allow-android-web-view-ajax-cors-requests
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Mobile editor: allow admin-ajax.php CORS requests for Android WebViews

--- a/projects/plugins/jetpack/tests/php/_inc/lib/Jetpack_Application_Password_Android_CORS_Test.php
+++ b/projects/plugins/jetpack/tests/php/_inc/lib/Jetpack_Application_Password_Android_CORS_Test.php
@@ -65,35 +65,35 @@ class Jetpack_Application_Password_Android_CORS_Test extends Jetpack_REST_TestCa
 	 * Test that CORS origin is added with authorization header.
 	 */
 	public function test_cors_origin_added_with_authorization() {
-		$_SERVER['HTTP_ORIGIN']        = 'https://appassets.androidplatform.net';
+		$_SERVER['HTTP_ORIGIN']        = 'https://android-app-assets.jetpack.com';
 		$_SERVER['HTTP_AUTHORIZATION'] = 'Basic xxxxx';
 		set_current_screen( 'admin-ajax' );
 		add_filter( 'wp_doing_ajax', '__return_true' );
 
 		$result = Jetpack_Application_Password_Extras::allow_ajax_cors_origins( array() );
 
-		$this->assertContains( 'https://appassets.androidplatform.net', $result, 'Android origin should be added when authorization is present' );
+		$this->assertContains( 'https://android-app-assets.jetpack.com', $result, 'Android origin should be added when authorization is present' );
 	}
 
 	/**
 	 * Test that CORS origin is not added without authorization.
 	 */
 	public function test_cors_origin_not_added_without_authorization() {
-		$_SERVER['HTTP_ORIGIN'] = 'https://appassets.androidplatform.net';
+		$_SERVER['HTTP_ORIGIN'] = 'https://android-app-assets.jetpack.com';
 		unset( $_SERVER['HTTP_AUTHORIZATION'] );
 		set_current_screen( 'admin-ajax' );
 		add_filter( 'wp_doing_ajax', '__return_true' );
 
 		$result = Jetpack_Application_Password_Extras::allow_ajax_cors_origins( array() );
 
-		$this->assertNotContains( 'https://appassets.androidplatform.net', $result, 'Android origin should not be added without authorization' );
+		$this->assertNotContains( 'https://android-app-assets.jetpack.com', $result, 'Android origin should not be added without authorization' );
 	}
 
 	/**
 	 * Test that CORS origin is added for preflight requests with Authorization header.
 	 */
 	public function test_cors_origin_added_for_preflight_with_auth() {
-		$_SERVER['HTTP_ORIGIN']                         = 'https://appassets.androidplatform.net';
+		$_SERVER['HTTP_ORIGIN']                         = 'https://android-app-assets.jetpack.com';
 		$_SERVER['REQUEST_METHOD']                      = 'OPTIONS';
 		$_SERVER['HTTP_ACCESS_CONTROL_REQUEST_HEADERS'] = 'Authorization, Content-Type';
 		unset( $_SERVER['HTTP_AUTHORIZATION'] );
@@ -102,14 +102,14 @@ class Jetpack_Application_Password_Android_CORS_Test extends Jetpack_REST_TestCa
 
 		$result = Jetpack_Application_Password_Extras::allow_ajax_cors_origins( array() );
 
-		$this->assertContains( 'https://appassets.androidplatform.net', $result, 'Android origin should be added for preflight requests with Authorization header' );
+		$this->assertContains( 'https://android-app-assets.jetpack.com', $result, 'Android origin should be added for preflight requests with Authorization header' );
 	}
 
 	/**
 	 * Test that CORS is not added for preflight requests without Authorization header.
 	 */
 	public function test_cors_not_added_for_preflight_without_auth() {
-		$_SERVER['HTTP_ORIGIN']                         = 'https://appassets.androidplatform.net';
+		$_SERVER['HTTP_ORIGIN']                         = 'https://android-app-assets.jetpack.com';
 		$_SERVER['REQUEST_METHOD']                      = 'OPTIONS';
 		$_SERVER['HTTP_ACCESS_CONTROL_REQUEST_HEADERS'] = 'Content-Type, X-Requested-With';
 		unset( $_SERVER['HTTP_AUTHORIZATION'] );
@@ -118,14 +118,14 @@ class Jetpack_Application_Password_Android_CORS_Test extends Jetpack_REST_TestCa
 
 		$result = Jetpack_Application_Password_Extras::allow_ajax_cors_origins( array() );
 
-		$this->assertNotContains( 'https://appassets.androidplatform.net', $result, 'Android origin should not be added for preflight without Authorization header' );
+		$this->assertNotContains( 'https://android-app-assets.jetpack.com', $result, 'Android origin should not be added for preflight without Authorization header' );
 	}
 
 	/**
 	 * Test that CORS is not added outside admin-ajax context.
 	 */
 	public function test_cors_not_added_outside_admin_ajax() {
-		$_SERVER['HTTP_ORIGIN']        = 'https://appassets.androidplatform.net';
+		$_SERVER['HTTP_ORIGIN']        = 'https://android-app-assets.jetpack.com';
 		$_SERVER['HTTP_AUTHORIZATION'] = 'Basic xxxxx';
 		// Not setting admin-ajax context
 
@@ -138,7 +138,7 @@ class Jetpack_Application_Password_Android_CORS_Test extends Jetpack_REST_TestCa
 	 * Test that CORS is not added for non-admin context even with wp_doing_ajax.
 	 */
 	public function test_cors_not_added_for_non_admin_context() {
-		$_SERVER['HTTP_ORIGIN']        = 'https://appassets.androidplatform.net';
+		$_SERVER['HTTP_ORIGIN']        = 'https://android-app-assets.jetpack.com';
 		$_SERVER['HTTP_AUTHORIZATION'] = 'Basic xxxxx';
 		add_filter( 'wp_doing_ajax', '__return_true' );
 		// Not setting admin screen
@@ -166,7 +166,7 @@ class Jetpack_Application_Password_Android_CORS_Test extends Jetpack_REST_TestCa
 	 * Test that existing allowed origins are preserved.
 	 */
 	public function test_preserves_existing_allowed_origins() {
-		$_SERVER['HTTP_ORIGIN']        = 'https://appassets.androidplatform.net';
+		$_SERVER['HTTP_ORIGIN']        = 'https://android-app-assets.jetpack.com';
 		$_SERVER['HTTP_AUTHORIZATION'] = 'Basic xxxxx';
 		set_current_screen( 'admin-ajax' );
 		add_filter( 'wp_doing_ajax', '__return_true' );
@@ -176,23 +176,23 @@ class Jetpack_Application_Password_Android_CORS_Test extends Jetpack_REST_TestCa
 
 		$this->assertContains( 'https://example.com', $result, 'Existing origins should be preserved' );
 		$this->assertContains( 'https://test.com', $result, 'Existing origins should be preserved' );
-		$this->assertContains( 'https://appassets.androidplatform.net', $result, 'Android origin should be added' );
+		$this->assertContains( 'https://android-app-assets.jetpack.com', $result, 'Android origin should be added' );
 	}
 
 	/**
 	 * Test that duplicate origins are not added.
 	 */
 	public function test_no_duplicate_origins() {
-		$_SERVER['HTTP_ORIGIN']        = 'https://appassets.androidplatform.net';
+		$_SERVER['HTTP_ORIGIN']        = 'https://android-app-assets.jetpack.com';
 		$_SERVER['HTTP_AUTHORIZATION'] = 'Basic xxxxx';
 		set_current_screen( 'admin-ajax' );
 		add_filter( 'wp_doing_ajax', '__return_true' );
 
-		$existing = array( 'https://appassets.androidplatform.net' );
+		$existing = array( 'https://android-app-assets.jetpack.com' );
 		$result   = Jetpack_Application_Password_Extras::allow_ajax_cors_origins( $existing );
 
 		$this->assertCount( 1, $result, 'Should not add duplicate origins' );
-		$this->assertEquals( array( 'https://appassets.androidplatform.net' ), $result );
+		$this->assertEquals( array( 'https://android-app-assets.jetpack.com' ), $result );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/_inc/lib/Jetpack_Application_Password_Android_CORS_Test.php
+++ b/projects/plugins/jetpack/tests/php/_inc/lib/Jetpack_Application_Password_Android_CORS_Test.php
@@ -1,0 +1,219 @@
+<?php
+/**
+ * Test Jetpack Application Password Android CORS functionality.
+ *
+ * @package jetpack
+ */
+
+use PHPUnit\Framework\Attributes\CoversClass;
+
+require_once JETPACK__PLUGIN_DIR . '/tests/php/lib/Jetpack_REST_TestCase.php';
+require_once JETPACK__PLUGIN_DIR . '/_inc/lib/class-jetpack-application-password-extras.php';
+
+/**
+ * Test class for Android CORS headers.
+ *
+ * @covers \Jetpack_Application_Password_Extras
+ */
+#[CoversClass( Jetpack_Application_Password_Extras::class )]
+class Jetpack_Application_Password_Android_CORS_Test extends Jetpack_REST_TestCase {
+
+	/**
+	 * Mock user ID.
+	 *
+	 * @var int
+	 */
+	private static $user_id = 0;
+
+	/**
+	 * Original server globals backup.
+	 *
+	 * @var array
+	 */
+	private $server_backup = array();
+
+	/**
+	 * Create shared database fixtures.
+	 *
+	 * @param WP_UnitTest_Factory $factory Fixture factory.
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		static::$user_id = $factory->user->create( array( 'role' => 'administrator' ) );
+	}
+
+	/**
+	 * Setup the environment for a test.
+	 */
+	public function set_up() {
+		parent::set_up();
+		wp_set_current_user( static::$user_id );
+		$this->server_backup = $_SERVER;
+		Jetpack_Application_Password_Extras::init();
+	}
+
+	/**
+	 * Tear down the environment after a test.
+	 */
+	public function tear_down() {
+		parent::tear_down();
+		$_SERVER = $this->server_backup;
+		remove_all_filters( 'wp_doing_ajax' );
+		remove_all_filters( 'ajax_allowed_cors_origins' );
+	}
+
+	/**
+	 * Test that CORS origin is added with authorization header.
+	 */
+	public function test_cors_origin_added_with_authorization() {
+		$_SERVER['HTTP_ORIGIN']        = 'https://appassets.androidplatform.net';
+		$_SERVER['HTTP_AUTHORIZATION'] = 'Basic xxxxx';
+		set_current_screen( 'admin-ajax' );
+		add_filter( 'wp_doing_ajax', '__return_true' );
+
+		$result = Jetpack_Application_Password_Extras::allow_ajax_cors_origins( array() );
+
+		$this->assertContains( 'https://appassets.androidplatform.net', $result, 'Android origin should be added when authorization is present' );
+	}
+
+	/**
+	 * Test that CORS origin is not added without authorization.
+	 */
+	public function test_cors_origin_not_added_without_authorization() {
+		$_SERVER['HTTP_ORIGIN'] = 'https://appassets.androidplatform.net';
+		unset( $_SERVER['HTTP_AUTHORIZATION'] );
+		set_current_screen( 'admin-ajax' );
+		add_filter( 'wp_doing_ajax', '__return_true' );
+
+		$result = Jetpack_Application_Password_Extras::allow_ajax_cors_origins( array() );
+
+		$this->assertNotContains( 'https://appassets.androidplatform.net', $result, 'Android origin should not be added without authorization' );
+	}
+
+	/**
+	 * Test that CORS origin is added for preflight requests with Authorization header.
+	 */
+	public function test_cors_origin_added_for_preflight_with_auth() {
+		$_SERVER['HTTP_ORIGIN']                         = 'https://appassets.androidplatform.net';
+		$_SERVER['REQUEST_METHOD']                      = 'OPTIONS';
+		$_SERVER['HTTP_ACCESS_CONTROL_REQUEST_HEADERS'] = 'Authorization, Content-Type';
+		unset( $_SERVER['HTTP_AUTHORIZATION'] );
+		set_current_screen( 'admin-ajax' );
+		add_filter( 'wp_doing_ajax', '__return_true' );
+
+		$result = Jetpack_Application_Password_Extras::allow_ajax_cors_origins( array() );
+
+		$this->assertContains( 'https://appassets.androidplatform.net', $result, 'Android origin should be added for preflight requests with Authorization header' );
+	}
+
+	/**
+	 * Test that CORS is not added for preflight requests without Authorization header.
+	 */
+	public function test_cors_not_added_for_preflight_without_auth() {
+		$_SERVER['HTTP_ORIGIN']                         = 'https://appassets.androidplatform.net';
+		$_SERVER['REQUEST_METHOD']                      = 'OPTIONS';
+		$_SERVER['HTTP_ACCESS_CONTROL_REQUEST_HEADERS'] = 'Content-Type, X-Requested-With';
+		unset( $_SERVER['HTTP_AUTHORIZATION'] );
+		set_current_screen( 'admin-ajax' );
+		add_filter( 'wp_doing_ajax', '__return_true' );
+
+		$result = Jetpack_Application_Password_Extras::allow_ajax_cors_origins( array() );
+
+		$this->assertNotContains( 'https://appassets.androidplatform.net', $result, 'Android origin should not be added for preflight without Authorization header' );
+	}
+
+	/**
+	 * Test that CORS is not added outside admin-ajax context.
+	 */
+	public function test_cors_not_added_outside_admin_ajax() {
+		$_SERVER['HTTP_ORIGIN']        = 'https://appassets.androidplatform.net';
+		$_SERVER['HTTP_AUTHORIZATION'] = 'Basic xxxxx';
+		// Not setting admin-ajax context
+
+		$result = Jetpack_Application_Password_Extras::allow_ajax_cors_origins( array() );
+
+		$this->assertEmpty( $result, 'CORS should not be added outside admin-ajax context' );
+	}
+
+	/**
+	 * Test that CORS is not added for non-admin context even with wp_doing_ajax.
+	 */
+	public function test_cors_not_added_for_non_admin_context() {
+		$_SERVER['HTTP_ORIGIN']        = 'https://appassets.androidplatform.net';
+		$_SERVER['HTTP_AUTHORIZATION'] = 'Basic xxxxx';
+		add_filter( 'wp_doing_ajax', '__return_true' );
+		// Not setting admin screen
+
+		$result = Jetpack_Application_Password_Extras::allow_ajax_cors_origins( array() );
+
+		$this->assertEmpty( $result, 'CORS should not be added when not in admin context' );
+	}
+
+	/**
+	 * Test that CORS is not added for different origin.
+	 */
+	public function test_cors_not_added_for_different_origin() {
+		$_SERVER['HTTP_ORIGIN']        = 'https://evil.com';
+		$_SERVER['HTTP_AUTHORIZATION'] = 'Basic xxxxx';
+		set_current_screen( 'admin-ajax' );
+		add_filter( 'wp_doing_ajax', '__return_true' );
+
+		$result = Jetpack_Application_Password_Extras::allow_ajax_cors_origins( array() );
+
+		$this->assertNotContains( 'https://evil.com', $result, 'Non-allowed origins should not be added' );
+	}
+
+	/**
+	 * Test that existing allowed origins are preserved.
+	 */
+	public function test_preserves_existing_allowed_origins() {
+		$_SERVER['HTTP_ORIGIN']        = 'https://appassets.androidplatform.net';
+		$_SERVER['HTTP_AUTHORIZATION'] = 'Basic xxxxx';
+		set_current_screen( 'admin-ajax' );
+		add_filter( 'wp_doing_ajax', '__return_true' );
+
+		$existing = array( 'https://example.com', 'https://test.com' );
+		$result   = Jetpack_Application_Password_Extras::allow_ajax_cors_origins( $existing );
+
+		$this->assertContains( 'https://example.com', $result, 'Existing origins should be preserved' );
+		$this->assertContains( 'https://test.com', $result, 'Existing origins should be preserved' );
+		$this->assertContains( 'https://appassets.androidplatform.net', $result, 'Android origin should be added' );
+	}
+
+	/**
+	 * Test that duplicate origins are not added.
+	 */
+	public function test_no_duplicate_origins() {
+		$_SERVER['HTTP_ORIGIN']        = 'https://appassets.androidplatform.net';
+		$_SERVER['HTTP_AUTHORIZATION'] = 'Basic xxxxx';
+		set_current_screen( 'admin-ajax' );
+		add_filter( 'wp_doing_ajax', '__return_true' );
+
+		$existing = array( 'https://appassets.androidplatform.net' );
+		$result   = Jetpack_Application_Password_Extras::allow_ajax_cors_origins( $existing );
+
+		$this->assertCount( 1, $result, 'Should not add duplicate origins' );
+		$this->assertEquals( array( 'https://appassets.androidplatform.net' ), $result );
+	}
+
+	/**
+	 * Test ajax_allowed_cors_origins filter extensibility.
+	 */
+	public function test_ajax_allowed_cors_origins_filter_extensibility() {
+		add_filter(
+			'ajax_allowed_cors_origins',
+			function ( $origins ) {
+				$origins[] = 'https://custom.origin.com';
+				return $origins;
+			}
+		);
+
+		$_SERVER['HTTP_ORIGIN']        = 'https://custom.origin.com';
+		$_SERVER['HTTP_AUTHORIZATION'] = 'Basic xxxxx';
+		set_current_screen( 'admin-ajax' );
+		add_filter( 'wp_doing_ajax', '__return_true' );
+
+		$result = Jetpack_Application_Password_Extras::allow_ajax_cors_origins( array() );
+
+		$this->assertContains( 'https://custom.origin.com', $result, 'Custom origins added via filter should be allowed' );
+	}
+}

--- a/projects/plugins/jetpack/tests/php/_inc/lib/Jetpack_Application_Password_Extras_Test.php
+++ b/projects/plugins/jetpack/tests/php/_inc/lib/Jetpack_Application_Password_Extras_Test.php
@@ -65,6 +65,26 @@ class Jetpack_Application_Password_Extras_Test extends Jetpack_REST_TestCase {
 	}
 
 	/**
+	 * Test that init method registers CORS-related hooks.
+	 */
+	public function test_init_registers_cors_hooks() {
+		remove_all_filters( 'allowed_http_origins' );
+		remove_all_actions( 'wp_loaded' );
+
+		Jetpack_Application_Password_Extras::init();
+
+		$this->assertNotFalse(
+			has_filter( 'allowed_http_origins', array( 'Jetpack_Application_Password_Extras', 'allow_ajax_cors_origins' ) ),
+			'CORS origins filter should be registered'
+		);
+
+		$this->assertNotFalse(
+			has_action( 'wp_loaded', array( 'Jetpack_Application_Password_Extras', 'add_ajax_preflight_headers' ) ),
+			'Preflight headers action should be registered'
+		);
+	}
+
+	/**
 	 * Test that non-matching requests preserve original false value.
 	 */
 	public function test_non_matching_request_preserves_original_false_value() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Ref CMM-713. Ref CMM-766. Ref CMM-767. 

Related: 209198-ghe-Automattic/wpcom

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
The Jetpack mobile app block editor relies upon Android WebViews for serving local Gutenberg files. Editor requests then originate from the `https://android-app-assets.jetpack.com` origin. To enable `admin-ajax.php` requests from the Android app, we must allow CORS requests from this origin.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
- pbArwn-7AD-p2
- p5TWut-1qz-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

> [!important]
> WP.com sites require 209198-ghe-Automattic/wpcom as well.

Apply the changes to your site (see [comment below](https://github.com/Automattic/jetpack/pull/45292#issuecomment-3330492458)). Verify the correct headers are returned for various request structures: 

- Allowed vs disallowed origin
- Authenticated vs unauthenticated
- `admin-ajax` vs non-`admin-ajax` 

An example script is provided below showcasing requests and expectations. The script can be run against a local Jetpack Docker environment site. 

1. Clone this feature branch. 
1. `jetpack docker up -d`
2. `jetpack docker install`
3. Run the test script below (or perform similar manual requests). 
4. **Verify** all tests pass. 
5. `git switch trunk`
6. Run the test script below (or perform similar manual requests). 
7. **Verify** test cases 1-2 fail and test cases 3-6 pass. 

<details><summary>Example test script</summary>
<p>

```bash
#!/usr/bin/env bash
#
# Test Android WebView CORS support for admin-ajax.php
#
# Uses the Jetpack Docker environment and WordPress Application Passwords.
# Run from anywhere inside the jetpack monorepo.
#
# Usage:
#   ./tools/docker/bin/test-android-cors.sh
#   SITE=http://localhost:8080 WP_USER=admin ./tools/docker/bin/test-android-cors.sh

set -euo pipefail

SITE="${SITE:-http://localhost}"
WP_USER="${WP_USER:-wordpress}"
ALLOWED_ORIGIN="https://android-app-assets.jetpack.com"
EVIL_ORIGIN="https://evil.com"

PASSED=0
FAILED=0
TOTAL=0

# Colors
RED='\033[0;31m'
GREEN='\033[0;32m'
BOLD='\033[1m'
NC='\033[0m'

##############################################################################
# Helpers
##############################################################################

DIM='\033[2m'

log_group() {
  echo ""
  echo -e "${BOLD}=== $1 ===${NC}"
  echo -e "${DIM}$2${NC}"
}

log_header() {
  echo ""
  echo -e "  ${BOLD}--- $1 ---${NC}"
}

log_pass() {
  ((PASSED++))
  ((TOTAL++))
  echo -e "  ${GREEN}PASS${NC}: $1"
}

log_fail() {
  ((FAILED++))
  ((TOTAL++))
  echo -e "  ${RED}FAIL${NC}: $1"
}

# Fetch response headers into a temp file and check for a header value.
# Usage: header_present "$headers" "Header-Name" "expected-value"
#   Returns 0 if the header is present with the expected value.
header_present() {
  local headers="$1" name="$2" value="$3"
  echo "$headers" | grep -qi "^${name}:.*${value}"
}

# Usage: header_absent "$headers" "Header-Name"
#   Returns 0 if the header is NOT present at all.
header_absent() {
  local headers="$1" name="$2"
  ! echo "$headers" | grep -qi "^${name}:"
}

##############################################################################
# Setup: ensure the site is reachable and create an Application Password
##############################################################################

log_group "Setup" "Verify Docker environment and create temporary Application Password"

log_header "Preflight check"
if ! curl -s --max-time 5 -o /dev/null -w '' "${SITE}/" 2>/dev/null; then
  echo -e "${RED}Cannot reach ${SITE}. Is the Docker environment running?${NC}"
  echo "Start it with: pnpm jetpack docker up"
  exit 1
fi
echo -e "  Site ${SITE} is reachable."

log_header "Creating Application Password"

SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
JETPACK_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"

# Run WP-CLI inside the Docker container via pnpm jetpack docker wp.
jetpack_wp() {
  pnpm --silent --dir="${JETPACK_ROOT}" jetpack docker wp -- "$@"
}

# Create app password via WP-CLI, capture the plaintext password.
APP_PASS_NAME="cors-test-$(date +%s)"
if ! APP_PASS_RAW=$(jetpack_wp user application-password create "${WP_USER}" "${APP_PASS_NAME}" --porcelain 2>&1); then
  echo -e "${RED}Failed to create Application Password:${NC}"
  echo "  $APP_PASS_RAW"
  exit 1
fi
APP_PASS=$(echo "$APP_PASS_RAW" | tr -d '[:space:]')

if [[ -z "$APP_PASS" ]]; then
  echo -e "${RED}Failed to create Application Password. Is the Docker container running?${NC}"
  exit 1
fi
echo "  Application Password created."

# Build Basic auth header value.
AUTH_HEADER="$(echo -n "${WP_USER}:${APP_PASS}" | base64)"

# Cleanup: delete the app password on exit.
cleanup() {
  jetpack_wp user application-password delete "${WP_USER}" --all > /dev/null 2>&1 || true
  echo ""
  echo "  Application Password cleaned up."
}
trap cleanup EXIT

##############################################################################
# Positive tests: CORS headers ARE expected for authorized requests from
# the allowed Android WebView origin. These validate the new behavior
# added by this branch — they should fail on trunk.
##############################################################################

log_group "Positive tests" "CORS headers expected for authorized requests from the allowed origin (should fail on trunk)"

log_header "Test 1: Preflight (OPTIONS) with allowed origin + Authorization header requested"

HEADERS=$(curl -sS -D - -o /dev/null -X OPTIONS \
  "${SITE}/wp-admin/admin-ajax.php?action=videopress-get-upload-jwt" \
  -H "Origin: ${ALLOWED_ORIGIN}" \
  -H "Access-Control-Request-Method: POST" \
  -H "Access-Control-Request-Headers: Authorization, Content-Type" 2>&1)

if header_present "$HEADERS" "Access-Control-Allow-Origin" "$ALLOWED_ORIGIN"; then
  log_pass "Access-Control-Allow-Origin present with allowed origin"
else
  log_fail "Access-Control-Allow-Origin missing or wrong"
fi

if header_present "$HEADERS" "Access-Control-Allow-Headers" "Authorization"; then
  log_pass "Access-Control-Allow-Headers includes Authorization"
else
  log_fail "Access-Control-Allow-Headers missing Authorization"
fi

if header_present "$HEADERS" "Access-Control-Allow-Methods" "POST"; then
  log_pass "Access-Control-Allow-Methods includes POST"
else
  log_fail "Access-Control-Allow-Methods missing POST"
fi

if header_present "$HEADERS" "Access-Control-Max-Age" "86400"; then
  log_pass "Access-Control-Max-Age is 86400"
else
  log_fail "Access-Control-Max-Age missing or wrong"
fi

##############################################################################
# Test 2: POST with Authorization from allowed origin
##############################################################################

log_header "Test 2: POST with Authorization from allowed origin"

HEADERS=$(curl -sS -D - -o /dev/null -X POST \
  "${SITE}/wp-admin/admin-ajax.php" \
  -H "Origin: ${ALLOWED_ORIGIN}" \
  -H "Authorization: Basic ${AUTH_HEADER}" \
  -d "action=videopress-get-upload-jwt" 2>&1)

if header_present "$HEADERS" "Access-Control-Allow-Origin" "$ALLOWED_ORIGIN"; then
  log_pass "Access-Control-Allow-Origin present for authenticated request"
else
  log_fail "Access-Control-Allow-Origin missing for authenticated request"
fi

##############################################################################
# Negative tests: CORS headers should NOT be present for disallowed origins,
# unauthenticated requests, non-auth preflights, or non-admin-ajax endpoints.
# These guard against over-permissive CORS and should pass on any branch.
##############################################################################

log_group "Negative tests" "CORS headers must be absent for unauthorized or disallowed requests (should pass on any branch)"

log_header "Test 3: POST with Authorization from disallowed origin"

HEADERS=$(curl -sS -D - -o /dev/null -X POST \
  "${SITE}/wp-admin/admin-ajax.php" \
  -H "Origin: ${EVIL_ORIGIN}" \
  -H "Authorization: Basic ${AUTH_HEADER}" \
  -d "action=videopress-get-upload-jwt" 2>&1)

if header_absent "$HEADERS" "Access-Control-Allow-Origin"; then
  log_pass "Access-Control-Allow-Origin absent for disallowed origin"
else
  # WordPress core may echo the origin via send_origin_headers if it's in
  # allowed_http_origins. We just need to confirm it is NOT the evil origin.
  if header_present "$HEADERS" "Access-Control-Allow-Origin" "$EVIL_ORIGIN"; then
    log_fail "Access-Control-Allow-Origin present for disallowed origin"
  else
    log_pass "Access-Control-Allow-Origin not set to disallowed origin"
  fi
fi

##############################################################################
# Test 4: POST without Authorization from allowed origin
##############################################################################

log_header "Test 4: POST without Authorization from allowed origin"

HEADERS=$(curl -sS -D - -o /dev/null -X POST \
  "${SITE}/wp-admin/admin-ajax.php" \
  -H "Origin: ${ALLOWED_ORIGIN}" \
  -d "action=videopress-get-upload-jwt" 2>&1)

if header_absent "$HEADERS" "Access-Control-Allow-Origin"; then
  log_pass "Access-Control-Allow-Origin absent without Authorization"
else
  if header_present "$HEADERS" "Access-Control-Allow-Origin" "$ALLOWED_ORIGIN"; then
    log_fail "Access-Control-Allow-Origin should not be set without Authorization"
  else
    log_pass "Access-Control-Allow-Origin not set to Android origin without auth"
  fi
fi

##############################################################################
# Test 5: OPTIONS preflight without Authorization in requested headers
##############################################################################

log_header "Test 5: Preflight (OPTIONS) without Authorization in requested headers"

HEADERS=$(curl -sS -D - -o /dev/null -X OPTIONS \
  "${SITE}/wp-admin/admin-ajax.php?action=videopress-get-upload-jwt" \
  -H "Origin: ${ALLOWED_ORIGIN}" \
  -H "Access-Control-Request-Method: POST" \
  -H "Access-Control-Request-Headers: Content-Type" 2>&1)

if header_absent "$HEADERS" "Access-Control-Allow-Methods"; then
  log_pass "Custom preflight headers absent when Authorization not requested"
else
  log_fail "Custom preflight headers should not appear without Authorization in request headers"
fi

##############################################################################
# Test 6: Non-admin-ajax endpoint should not get CORS headers
##############################################################################

log_header "Test 6: Non-admin-ajax endpoint (wp-login.php)"

HEADERS=$(curl -sS -D - -o /dev/null -X POST \
  "${SITE}/wp-login.php" \
  -H "Origin: ${ALLOWED_ORIGIN}" \
  -H "Authorization: Basic ${AUTH_HEADER}" 2>&1)

if header_absent "$HEADERS" "Access-Control-Allow-Origin"; then
  log_pass "Access-Control-Allow-Origin absent for non-admin-ajax endpoint"
else
  if header_present "$HEADERS" "Access-Control-Allow-Origin" "$ALLOWED_ORIGIN"; then
    log_fail "Access-Control-Allow-Origin should not appear for non-admin-ajax endpoint"
  else
    log_pass "Access-Control-Allow-Origin not set to Android origin for non-admin-ajax"
  fi
fi

##############################################################################
# Summary
##############################################################################

echo ""
echo -e "${BOLD}────────────────────────────────${NC}"
echo -e "${BOLD}Results: ${PASSED}/${TOTAL} passed${NC}"
if [[ $FAILED -gt 0 ]]; then
  echo -e "${RED}${FAILED} test(s) failed${NC}"
  exit 1
else
  echo -e "${GREEN}All tests passed${NC}"
fi

```

</p>
</details>