### PR TITLE
WIP: Fix blocks registration in other contexts.

### DIFF
--- a/projects/js-packages/shared-extension-utils/changelog/jetpack-fix-blocks-registration
+++ b/projects/js-packages/shared-extension-utils/changelog/jetpack-fix-blocks-registration
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add fetchJetpackData function for async data fetching when window data unavailable. Fixes Jetpack blocks not appearing in various editor contexts.

--- a/projects/js-packages/shared-extension-utils/index.js
+++ b/projects/js-packages/shared-extension-utils/index.js
@@ -1,5 +1,9 @@
 export * from './src/block-icons';
-export { default as getJetpackData, JETPACK_DATA_PATH } from './src/get-jetpack-data';
+export {
+	default as getJetpackData,
+	JETPACK_DATA_PATH,
+	fetchJetpackData,
+} from './src/get-jetpack-data';
 export { default as getSiteFragment } from './src/get-site-fragment';
 export { default as shouldUseInternalLinks } from './src/should-use-internal-links';
 export * from './src/site-type-utils';

--- a/projects/js-packages/shared-extension-utils/src/get-jetpack-data.js
+++ b/projects/js-packages/shared-extension-utils/src/get-jetpack-data.js
@@ -1,10 +1,67 @@
 export const JETPACK_DATA_PATH = 'Jetpack_Editor_Initial_State';
 
+// Cache for the fetched data
+let cachedData = null;
+let fetchPromise = null;
+
 /**
  * Retrieves Jetpack editor state
  *
- * @return {object|null}Object The Jetpack Editor State.
+ * @return {object|null} The Jetpack Editor State or null if not available
  */
 export default function getJetpackData() {
-	return 'object' === typeof window ? window?.[ JETPACK_DATA_PATH ] ?? null : null;
+	const windowData = window?.[ JETPACK_DATA_PATH ];
+	if ( windowData ) {
+		return windowData;
+	}
+
+	if ( cachedData ) {
+		return cachedData;
+	}
+
+	return null;
+}
+
+/**
+ * Fetches Jetpack editor state from API
+ *
+ * @return {Promise<object>} Promise that resolves to the Jetpack Editor State
+ */
+export function fetchJetpackData() {
+	return getJetpackDataAsync();
+}
+
+/**
+ * Internal async function to fetch Jetpack data
+ *
+ * @return {Promise<object>} Promise that resolves to the Jetpack Editor State
+ */
+async function getJetpackDataAsync() {
+	// Return existing promise if already in progress
+	if ( fetchPromise ) {
+		return await fetchPromise;
+	}
+
+	if ( window?.[ JETPACK_DATA_PATH ] ) {
+		return window[ JETPACK_DATA_PATH ];
+	}
+
+	if ( cachedData ) {
+		return cachedData;
+	}
+
+	try {
+		const { default: apiFetch } = await import( '@wordpress/api-fetch' );
+		const data = await apiFetch( {
+			path: '/wpcom/v2/gutenberg/editor-initial-state',
+		} );
+
+		cachedData = data;
+		fetchPromise = null;
+
+		return data;
+	} catch ( error ) {
+		fetchPromise = null;
+		throw error;
+	}
 }

--- a/projects/packages/forms/changelog/jetpack-fix-blocks-registration
+++ b/projects/packages/forms/changelog/jetpack-fix-blocks-registration
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add fallback mechanism for Jetpack block registration when editor data is unavailable. Enables blocks to work in various editor contexts.

--- a/projects/packages/forms/src/blocks/contact-form/util/register-jetpack-block.js
+++ b/projects/packages/forms/src/blocks/contact-form/util/register-jetpack-block.js
@@ -3,6 +3,7 @@ import {
 	withHasWarningIsInteractiveClassNames,
 	requiresPaidPlan,
 	getJetpackData,
+	fetchJetpackData,
 } from '@automattic/jetpack-shared-extension-utils';
 import { registerBlockType } from '@wordpress/blocks';
 import { addFilter } from '@wordpress/hooks';
@@ -17,8 +18,21 @@ import { addFilter } from '@wordpress/hooks';
  * @return {object|boolean} Either false if the block is not available, or the results of `registerBlockType`
  */
 export default function registerJetpackBlock( name, settings, childBlocks = [], prefix = true ) {
-	const { available, details, unavailableReason } = getJetpackExtensionAvailability( name );
 	const jetpackData = getJetpackData();
+
+	if ( ! jetpackData ) {
+		fetchJetpackData()
+			.then( () => {
+				registerJetpackBlock( name, settings, childBlocks, prefix );
+			} )
+			.catch( () => {
+				// Silently fail - block registration will be skipped
+			} );
+
+		return false;
+	}
+
+	const { available, details, unavailableReason } = getJetpackExtensionAvailability( name );
 	const isBeta = jetpackData?.blocks_variation === 'beta';
 
 	const requiredPlan = requiresPaidPlan( unavailableReason, details );

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/gutenberg-available-extensions.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/gutenberg-available-extensions.php
@@ -51,6 +51,27 @@ class WPCOM_REST_API_V2_Endpoint_Gutenberg_Available_Extensions extends WP_REST_
 				'schema' => array( $this, 'get_item_schema' ),
 			)
 		);
+
+		register_rest_route(
+			$this->namespace,
+			$this->rest_base . '/editor-initial-state',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_editor_initial_state' ),
+					'permission_callback' => array( $this, 'get_items_permission_check' ),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Get editor initial state data - uses the same method as enqueue_block_editor_assets
+	 *
+	 * @return array Editor initial state data
+	 */
+	public function get_editor_initial_state() {
+		return Jetpack_Gutenberg::get_initial_state();
 	}
 
 	/**

--- a/projects/plugins/jetpack/changelog/jetpack-fix-blocks-registration
+++ b/projects/plugins/jetpack/changelog/jetpack-fix-blocks-registration
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add REST API endpoint and fallback mechanism for Jetpack editor data when window data is unavailable. Enables Jetpack blocks in various editor contexts.

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -728,6 +728,43 @@ class Jetpack_Gutenberg {
 
 		Assets::enqueue_script( 'jetpack-blocks-editor' );
 
+		$initial_state = self::get_initial_state();
+
+		if ( $initial_state['blocks_variation'] === 'beta' && $initial_state['jetpack']['is_current_user_connected'] ) {
+			wp_enqueue_style( 'recoleta-font', '//s1.wp.com/i/fonts/recoleta/css/400.min.css', array(), Constants::get_constant( 'JETPACK__VERSION' ) );
+		}
+
+		wp_localize_script(
+			'jetpack-blocks-editor',
+			'Jetpack_Editor_Initial_State',
+			self::get_initial_state()
+		);
+
+		// Adds Connection package initial state.
+		Connection_Initial_State::render_script( 'jetpack-blocks-editor' );
+
+		// Register and enqueue the Jetpack Chrome AI token script
+		wp_register_script(
+			'jetpack-chrome-ai-token',
+			'https://widgets.wp.com/jetpack-chrome-ai/v1/3p-token.js',
+			array(),
+			gmdate( 'Ymd' ) . floor( (int) gmdate( 'G' ) / 12 ), // Cache buster: changes twice daily (morning/afternoon) in case we need to rotate the tokens
+			true
+		);
+		wp_enqueue_script( 'jetpack-chrome-ai-token' );
+	}
+
+	/**
+	 * Generate the initial state data for the block editor.
+	 *
+	 * @since 14.0
+	 *
+	 * @return array The initial state data
+	 */
+	public static function get_initial_state() {
+		$status           = new Status();
+		$blocks_variation = self::blocks_variation();
+
 		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
 			$user                      = wp_get_current_user();
 			$user_data                 = array(
@@ -743,9 +780,6 @@ class Jetpack_Gutenberg {
 			$is_current_user_connected = ( new Connection_Manager( 'jetpack' ) )->is_user_connected();
 		}
 
-		if ( $blocks_variation === 'beta' && $is_current_user_connected ) {
-			wp_enqueue_style( 'recoleta-font', '//s1.wp.com/i/fonts/recoleta/css/400.min.css', array(), Constants::get_constant( 'JETPACK__VERSION' ) );
-		}
 		// AI Assistant
 		$ai_assistant_state = array(
 			'is-enabled' => apply_filters( 'jetpack_ai_enabled', true ),
@@ -763,8 +797,9 @@ class Jetpack_Gutenberg {
 			$modules              = $module_list_endpoint->get_modules();
 		}
 
-		$jetpack_plan  = Jetpack_Plan::get();
-		$initial_state = array(
+		$jetpack_plan = Jetpack_Plan::get();
+
+		return array(
 			'available_blocks' => self::get_availability(),
 			'blocks_variation' => $blocks_variation,
 			'modules'          => $modules,
@@ -815,25 +850,6 @@ class Jetpack_Gutenberg {
 			'feature_flags'    => apply_filters( 'jetpack_block_editor_feature_flags', array() ),
 			'pluginBasePath'   => plugins_url( '', Constants::get_constant( 'JETPACK__PLUGIN_FILE' ) ),
 		);
-
-		wp_localize_script(
-			'jetpack-blocks-editor',
-			'Jetpack_Editor_Initial_State',
-			$initial_state
-		);
-
-		// Adds Connection package initial state.
-		Connection_Initial_State::render_script( 'jetpack-blocks-editor' );
-
-		// Register and enqueue the Jetpack Chrome AI token script
-		wp_register_script(
-			'jetpack-chrome-ai-token',
-			'https://widgets.wp.com/jetpack-chrome-ai/v1/3p-token.js',
-			array(),
-			gmdate( 'Ymd' ) . floor( (int) gmdate( 'G' ) / 12 ), // Cache buster: changes twice daily (morning/afternoon) in case we need to rotate the tokens
-			true
-		);
-		wp_enqueue_script( 'jetpack-chrome-ai-token' );
 	}
 
 	/**


### PR DESCRIPTION
Add REST API endpoint and fallback mechanism for Jetpack block registration when `window.Jetpack_Editor_Initial_State` is unavailable.

## Proposed changes:

- Add `/wpcom/v2/gutenberg/editor-initial-state` REST API endpoint that returns the same data as `window.Jetpack_Editor_Initial_State`
- Extract `get_initial_state()` method in `Jetpack_Gutenberg` class to avoid code duplication between window data and API endpoint
- Add `fetchJetpackData()` function for async data fetching with caching and promise deduplication
- Modify block registration to use async fallback when window data is unavailable
- Export `fetchJetpackData` function from shared extension utils

## Why are these changes being made?

Jetpack blocks fail to register in various editor contexts where `window.Jetpack_Editor_Initial_State` is not available. This happens because:

1. `jetpack-blocks-editor` script depends on `wp_should_load_block_editor_scripts_and_styles()` returning `true`
2. In some contexts, this function returns `false`, preventing the script from loading
3. Without the script, `wp_localize_script()` never registers the window data
4. Block registration fails due to missing availability data

## Testing instructions:

1. Test in a development environment where `window.Jetpack_Editor_Initial_State` might be unavailable
2. Verify that Jetpack blocks (like Contact Form) still register and appear in block inserter
3. Confirm that the API endpoint `/wpcom/v2/gutenberg/editor-initial-state` returns the expected data
4. Test that blocks work normally in standard WordPress editor contexts
5. Verify no performance impact from the fallback mechanism
