### PR TITLE
Connection: extend options available through external storage

### DIFF
--- a/projects/packages/connection/changelog/update-external-storage-options
+++ b/projects/packages/connection/changelog/update-external-storage-options
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Extending currently unused feature
+
+

--- a/projects/packages/connection/legacy/class-jetpack-options.php
+++ b/projects/packages/connection/legacy/class-jetpack-options.php
@@ -250,7 +250,7 @@ class Jetpack_Options {
 	 *
 	 * @var array
 	 */
-	private static $external_storage_allowlist = array( 'blog_token', 'id' );
+	private static $external_storage_allowlist = array( 'blog_token', 'id', 'master_user', 'user_tokens' );
 
 	/**
 	 * Determines if external storage should be used for a given option.

--- a/projects/plugins/wpcomsh/changelog/update-external-storage-options
+++ b/projects/plugins/wpcomsh/changelog/update-external-storage-options
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Extending currently unused feature
+
+


### PR DESCRIPTION
Add user_tokens and master_user to the options available through external storage.
This is currently not used, but will be needed in the future.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add two more external options

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* None

