### PR TITLE
Forms: Add missing dependency on jetpack-blocks-editor

### DIFF
--- a/projects/packages/forms/changelog/fix-jp-forms-blocks-dependency
+++ b/projects/packages/forms/changelog/fix-jp-forms-blocks-dependency
@@ -1,0 +1,3 @@
+Significance: patch
+Type: fixed
+Comment: Add missing jetpack-blocks-editor dependency to jp-forms-blocks script to fix block registration timing issues.

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -770,11 +770,12 @@ class Contact_Form_Block {
 			'../../../dist/blocks/editor.js',
 			__FILE__,
 			array(
-				'in_footer'  => true,
-				'textdomain' => 'jetpack-forms',
-				'enqueue'    => true,
+				'dependencies' => array( 'jetpack-blocks-editor' ),
+				'in_footer'    => true,
+				'textdomain'   => 'jetpack-forms',
+				'enqueue'      => true,
 				// Editor styles are loaded separately, see load_editor_styles().
-				'css_path'   => null,
+				'css_path'     => null,
 			)
 		);
 


### PR DESCRIPTION
Fixes #

## Proposed changes:
* Add `jetpack-blocks-editor` as a dependency for the `jp-forms-blocks` script to ensure proper loading order
* This fixes timing issues where Jetpack Forms blocks tried to register before required editor state was available

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
No, this is a script dependency fix that does not change data tracking or activity.

## Testing instructions:

* Test that Jetpack Forms blocks appear correctly in the WordPress block editor
* Verify that block registration happens after all required dependencies are loaded  
* Confirm no JavaScript errors related to missing Jetpack editor state
* Test in environments where editor assets are loaded dynamically