### PR TITLE
Forms: hide border on last integration card

### DIFF
--- a/projects/packages/forms/changelog/fix-form-integrations-bottom-border
+++ b/projects/packages/forms/changelog/fix-form-integrations-bottom-border
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Hide border on last integration card.

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/style.scss
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/style.scss
@@ -156,4 +156,8 @@
 	&__service-icon--mailpoet {
 		border-radius: 0 !important;
 	}
+
+	&:last-child {
+		border-bottom: none;
+	}
 }

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/style.scss
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/style.scss
@@ -1,7 +1,3 @@
 .jetpack-forms-integrations-modal .components-modal__header-heading {
 	font-weight: 400;
 }
-
-.jp-forms__integrations-body > div:last-of-type {
-	border-bottom: none;
-}


### PR DESCRIPTION
## Proposed changes:

We added a filter that allows hiding some integrations. But when used, we're showing an unsightly border on the bottom integration card. This just hides the border based on last child. 

**Before**
<img width="712" height="299" alt="integrations-border-showing" src="https://github.com/user-attachments/assets/685a3e5e-28ba-46db-a643-4273212f56f6" />

**After**
<img width="714" height="300" alt="integrations-border-hidden" src="https://github.com/user-attachments/assets/f105e61d-9d1d-4948-8117-c48ec9b2d7d8" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
This issue was mentioned in another PR here: 1159-ghe-Automattic/next-admin

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No. 

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply the filter below on your site. 
* Add a form to a post, open the integrations modal and confirm there's no bottom border on the last card. 

```
add_filter( 'jetpack_forms_supported_integrations', function ( $integrations ) {
	// Hide most integrations
	unset( $integrations['creative-mail-by-constant-contact'] );
	unset( $integrations['salesforce'] ); 
	unset( $integrations['google-drive'] );
	unset( $integrations['mailpoet'] );  

	return $integrations;
} );
```