### PR TITLE
CRM: Refactor notifications table creation into dedicated function which is triggered on activation. 

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-wp-notifications-table-missing
+++ b/projects/plugins/crm/changelog/fix-crm-wp-notifications-table-missing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix to create the notifications table on activation

--- a/projects/plugins/crm/includes/ZeroBSCRM.Database.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Database.php
@@ -1054,7 +1054,7 @@ function jpcrm_create_notifications_table() {
     `zbsnotify_reference_id` INT(32) NOT NULL,
     `zbsnotify_created_at` INT(18) NOT NULL,
     PRIMARY KEY (`id`))
-    " . $storageEngineLine . '   
+    " . $storageEngineLine . '
     DEFAULT CHARACTER SET = ' . $characterSet . "
     COLLATE = " . $collation . ";";
     // phpcs:enable
@@ -1062,7 +1062,7 @@ function jpcrm_create_notifications_table() {
 	// Run the query
 	zeroBSCRM_db_runDelta( $sql );
 
-	// Check if table was created successfully
+	// Check if table was created successfully - the table name is set as a global variable so OK to put directly in the SQL
 	// phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 	$table_name = $ZBSCRM_t['notifications'];
 	// phpcs:disable

--- a/projects/plugins/crm/includes/ZeroBSCRM.Database.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Database.php
@@ -48,6 +48,7 @@ $ZBSCRM_t['eventreminders']        = $wpdb->prefix . 'zbs_event_reminders';
 $ZBSCRM_t['tax']                   = $wpdb->prefix . 'zbs_tax_table';
 $ZBSCRM_t['security_log']          = $wpdb->prefix . 'zbs_security_log';
 $ZBSCRM_t['automation-workflows']  = $wpdb->prefix . 'zbs_workflows';
+$ZBSCRM_t['notifications']         = $wpdb->prefix . 'zbs_notifications';
 // phpcs:enable WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 
 /**
@@ -835,26 +836,51 @@ function zeroBSCRM_createTables(){
 	// phpcs:enable WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 	zeroBSCRM_db_runDelta( $sql );
 
-  // As of v5.0, if we've created via the above SQL, we're at DAL3 :)
-  // so on fresh installs, immitate the fact that we've 'completed' DAL1->DAL2->DAL3 Migration chain
-  update_option( 'zbs_db_migration_253', array('completed'=>time(),'started'=>time()), false);
-  update_option( 'zbs_db_migration_300', array('completed'=>time(),'started'=>time()), false);
+	// Notifications Table - Use the dedicated function
+	jpcrm_create_notifications_table();
 
-  // if any errors, log to wp option (potentially can't save to our zbs settings table because may not exist)
-  $errors = $zbsDB_creationErrors;
-  if (is_array($errors)){
-    if (count($errors) > 0) 
-      update_option( 'zbs_db_creation_errors', array('lasttried' => time(),'errors' => $errors), false);
-    else
-      delete_option( 'zbs_db_creation_errors' ); // successful run kills the alert
-  }
+	// As of v5.0, if we've created via the above SQL, we're at DAL3 :)
+	// so on fresh installs, immitate the fact that we've 'completed' DAL1->DAL2->DAL3 Migration chain
+	update_option(
+		'zbs_db_migration_253',
+		array(
+			'completed' => time(),
+			'started'   => time(),
+		),
+		false
+	);
+	update_option(
+		'zbs_db_migration_300',
+		array(
+			'completed' => time(),
+			'started'   => time(),
+		),
+		false
+	);
+
+	// if any errors, log to wp option (potentially can't save to our zbs settings table because may not exist)
+	// phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+	$errors = $zbsDB_creationErrors;
+	if ( is_array( $errors ) ) {
+		if ( count( $errors ) > 0 ) {
+			update_option(
+				'zbs_db_creation_errors',
+				array(
+					'lasttried' => time(),
+					'errors'    => $errors,
+				),
+				false
+			);
+		} else {
+			delete_option( 'zbs_db_creation_errors' ); // successful run kills the alert
+		}
+	}
 
   // no longer needed
   unset($zbsDB_lastError,$zbsDB_creationErrors);
 
   // return any errors encountered
   return $errors;
-
 
 }
 
@@ -988,6 +1014,57 @@ function jpcrm_database_server_has_ability( $ability_name ) {
 	}
 
 	return false;
+}
+
+/**
+ * Create just the notifications table
+ *
+ * @since 5.6.0
+ * @return bool True if table was created successfully, false otherwise
+ */
+function jpcrm_create_notifications_table() {
+	// phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+	global $wpdb, $ZBSCRM_t;
+
+	// Get database settings
+	// phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+	$storageEngineLine = zeroBSCRM_DB_canInnoDB() ? 'ENGINE=InnoDB' : '';
+	// phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+	$characterSet = $wpdb->charset ? $wpdb->charset : 'utf8';
+	$collation    = $wpdb->collate ? $wpdb->collate : 'utf8_general_ci';
+
+	// Table creation SQL
+	// phpcs:disable
+	$sql = 'CREATE TABLE IF NOT EXISTS ' . $ZBSCRM_t['notifications'] . "(
+    `id` INT(32) UNSIGNED NOT NULL AUTO_INCREMENT,
+    `zbs_site` INT NULL DEFAULT NULL,
+    `zbs_team` INT NULL DEFAULT NULL,
+    `zbs_owner` INT NOT NULL,
+    `zbsnotify_recipient_id` INT(32) NOT NULL,
+    `zbsnotify_sender_id` INT(32) NOT NULL,
+    `zbsnotify_unread` TINYINT(1) NOT NULL DEFAULT '1',
+    `zbsnotify_emailed` TINYINT(1) NOT NULL DEFAULT '0',
+    `zbsnotify_type` VARCHAR(255) NOT NULL DEFAULT '',
+    `zbsnotify_parameters` TEXT NOT NULL,
+    `zbsnotify_reference_id` INT(32) NOT NULL,
+    `zbsnotify_created_at` INT(18) NOT NULL,
+    PRIMARY KEY (`id`))
+    " . $storageEngineLine . '   
+    DEFAULT CHARACTER SET = ' . $characterSet . "
+    COLLATE = " . $collation . ";";
+    // phpcs:enable
+
+	// Run the query
+	zeroBSCRM_db_runDelta( $sql );
+
+	// Check if table was created successfully
+	// phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+	$table_name = $ZBSCRM_t['notifications'];
+	// phpcs:disable
+	$table_exists = $wpdb->get_var( "SHOW TABLES LIKE '$table_name'" ) === $table_name;
+	// phpcs:enable
+
+	return $table_exists;
 }
 
 /* ======================================================

--- a/projects/plugins/crm/includes/ZeroBSCRM.Database.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Database.php
@@ -921,6 +921,11 @@ function zeroBSCRM_db_runDelta($sql=''){
   
     global $wpdb,$zbsDB_lastError,$zbsDB_creationErrors;
   
+	// Ensure dbDelta is available (can be missing outside of admin load order)
+	if ( ! function_exists( 'dbDelta' ) ) {
+		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+	}
+
     // enact
     dbDelta($sql);
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.Migrations.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Migrations.php
@@ -36,6 +36,7 @@ global $zeroBSCRM_migrations; $zeroBSCRM_migrations = array(
 	'invoice_language_fixes', // Store invoice statuses and mappings consistently
 	'gh3465_increase_city_field_size',  // from gh issue 3465, increases the city field size to 200
 	'tax_rate_precision_fix', // increase tax rate precision from 2 to 10 decimal places
+	'ensure_notifications_table', // Ensure notifications table exists
 	);
 
 global $zeroBSCRM_migrations_requirements; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
@@ -1291,6 +1292,65 @@ function zeroBSCRM_migration_tax_rate_precision_fix() {
 	}
 
 	zeroBSCRM_migrations_markComplete( 'tax_rate_precision_fix', array( 'updated' => 1 ) );
+}
+
+/**
+ * Ensure the notifications table exists
+ *
+ * This migration ensures the notifications table is created using the dedicated
+ * table creation function in ZeroBSCRM.Database.php
+ */
+function zeroBSCRM_migration_ensure_notifications_table() {
+	global $wpdb;
+
+	// Include the Database file if needed
+	if ( ! function_exists( 'jpcrm_create_notifications_table' ) ) {
+		require_once ZEROBSCRM_INCLUDE_PATH . 'ZeroBSCRM.Database.php';
+	}
+
+	// Check if table exists first
+	$table_name = $wpdb->prefix . 'zbs_notifications';
+
+	// phpcs:disable
+	$table_exists = $wpdb->get_var( "SHOW TABLES LIKE '$table_name'" ) === $table_name;
+	// phpcs:enable 
+
+	if ( ! $table_exists ) {
+		// Table doesn't exist, create just the notifications table
+		$result = jpcrm_create_notifications_table();
+
+		if ( $result ) {
+			zeroBSCRM_migrations_markComplete(
+				'ensure_notifications_table',
+				array(
+					'updated' => 1,
+					'note'    => 'Successfully created notifications table',
+				)
+			);
+			return true;
+		} else {
+			// Log error if table creation failed
+			zeroBSCRM_migrations_markComplete(
+				'ensure_notifications_table',
+				array(
+					'updated' => 0,
+					'note'    => 'Failed to create notifications table',
+					'error'   => true,
+				)
+			);
+			return false;
+		}
+	}
+
+	// Table already exists
+	zeroBSCRM_migrations_markComplete(
+		'ensure_notifications_table',
+		array(
+			'updated' => 0,
+			'note'    => 'Notifications table already exists',
+		)
+	);
+	return true;
 }
 
 /* ======================================================

--- a/projects/plugins/crm/includes/ZeroBSCRM.NotifyMe.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.NotifyMe.php
@@ -27,40 +27,6 @@ defined( 'ZEROBSCRM_PATH' ) || exit( 0 );
  *
  * ================================================================================================================ */
 
-
-//create the DB table on activation... (should move this into a classs.. probably)
-register_activation_hook(ZBS_ROOTFILE,'zeroBSCRM_notifyme_createDBtable');
-function zeroBSCRM_notifyme_createDBtable(){
-  global $wpdb;
-  $notify_table = $wpdb->prefix . "zbs_notifications";
-
-  /* reference ID is for our JSON notification check + update i.e. new posts we want to notify folks of 
-  /* will use WP cron to check that resource daily + run the script to update zbsnotify_reference_id 
-  */
-
-  $sql = "CREATE TABLE IF NOT EXISTS $notify_table (
-  `id` INT(32) unsigned NOT NULL AUTO_INCREMENT,
-  `zbs_site` INT NULL DEFAULT NULL,
-  `zbs_team` INT NULL DEFAULT NULL,
-  `zbs_owner` INT NOT NULL,
-  `zbsnotify_recipient_id` INT(32) NOT NULL,
-  `zbsnotify_sender_id` INT(32) NOT NULL,
-  `zbsnotify_unread` tinyint(1) NOT NULL DEFAULT '1',
-  `zbsnotify_emailed` tinyint(1) NOT NULL DEFAULT '0',    
-  `zbsnotify_type` varchar(255) NOT NULL DEFAULT '',
-  `zbsnotify_parameters` text NOT NULL,
-  `zbsnotify_reference_id` INT(32) NOT NULL,      
-  `zbsnotify_created_at` INT(18) NOT NULL,
-  PRIMARY KEY (`id`)
-  ) ENGINE = InnoDB
-  DEFAULT CHARACTER SET = utf8
-  COLLATE = utf8_general_ci";
-
-  require_once(ABSPATH . 'wp-admin/includes/upgrade.php');
-  dbDelta($sql);
-}
-
-
 function zeroBSCRM_notifyme_scripts(){
 	global $zbs;
 	wp_enqueue_script( 'jquery' );

--- a/projects/plugins/crm/tests/php/bootstrap.php
+++ b/projects/plugins/crm/tests/php/bootstrap.php
@@ -101,9 +101,6 @@ function _jpcrm_manually_load_plugin() {
 	$zbs = zeroBSCRM::instance();
 
 	$zbs->install();
-	if ( function_exists( 'zeroBSCRM_notifyme_createDBtable' ) ) {
-		zeroBSCRM_notifyme_createDBtable();
-	}
 }
 
 tests_add_filter( 'muplugins_loaded', '_jpcrm_manually_load_plugin' );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Refactor notifications table creation into dedicated function which is triggered on activation. 

Another artefact from moving the loading of the CRM later in the stack was that the notifications table DB creation script was in an include file which was included after the activation hook ran, so one DB table was no longer installed. 

```
[25-Sep-2025 21:10:06 UTC] WordPress database error Table 'local.wp_zbs_notifications' doesn't exist for query SELECT * FROM wp_zbs_notifications WHERE zbsnotify_recipient_id = 1 ORDER BY zbsnotify_created_at DESC LIMIT 20 made by do_action('admin_page_zerobscrm-notifications'), WP_Hook->do_action, WP_Hook->apply_filters, zeroBSCRM_pages_admin_notifications, zeroBSCRM_notifyme_activity
```

The notifications table is for _future_ potential build out of an "@" style system which would notify between different CRM team members. 

The current functionality is to only notify of "system" things, like a missing license key, or an extension that needs an update so the fact this table was not created did not break any functionality, and the message would show on AJAX poll of the notification table (or, if the notifications page was viewed).

## Proposed changes:
* Moved notifications table creation logic from an include file to a dedicated function in ZeroBSCRM.Database.php
* Created migration function to ensure table exists for existing installs of which the activation hook did not create the table.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable?

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No,.


## Testing instructions:
1. On a fresh WordPress installation:
   - Activate Jetpack CRM
   - Verify notifications table is created with correct schema


2. On an existing installation:
   - Verify migration runs during update on existing install
   - Check migration status on the "system assistant" `/wp-admin/admin.php?page=zerobscrm-systemstatus&tab=status` which will show `Migration: ensure_notifications_table:` and whether it is a success or not. 
   - Confirm notifications table is created if missing
