### PR TITLE
Forms: Fix warning on post-submission screen

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-success-message-warning
+++ b/projects/packages/forms/changelog/fix-forms-success-message-warning
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Address a warning for uninitialized variable
+
+

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -887,7 +887,8 @@ class Contact_Form extends Contact_Form_Shortcode {
 			}
 		</style>';
 
-		$message .= '<div class="contact-form-submission">';
+		$message        .= '<div class="contact-form-submission">';
+		$success_message = '';
 
 		if ( ! $disable_go_back ) {
 			$success_message = '<p class="go-back-message"> <a class="link" href="' . esc_url( $back_url ) . '">' . esc_html__( 'Go back', 'jetpack-forms' ) . '</a> </p>';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Follow-up to #45273

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fixes an uninitialized variable causing a warning

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Submit a form
* Reload the page
* Check that there is no warning
