### PR TITLE
Forms: Update registerField to be more defensive

### DIFF
--- a/projects/packages/forms/changelog/update-be-more-defensive-in-forms
+++ b/projects/packages/forms/changelog/update-be-more-defensive-in-forms
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: improve cross plugin compatibility

--- a/projects/packages/forms/src/modules/form/view.js
+++ b/projects/packages/forms/src/modules/form/view.js
@@ -65,6 +65,10 @@ const registerField = (
 ) => {
 	const context = getContext();
 
+	if ( ! context.fields ) {
+		context.fields = {};
+	}
+
 	if ( ! context.fields[ fieldId ] ) {
 		context.fields[ fieldId ] = {
 			id: fieldId,


### PR DESCRIPTION
Currently there are plugins that implement their own form Ajax form submission.
This PR tries to help them by removing js errors for them.  

## Proposed changes:
* Detect if the fields exists in the context and if not create it. 

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?


## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Add a new form. 
Does the form submit as expected? 

