### PR TITLE
wpcomsh: stop autoloading deprecated class

### DIFF
--- a/projects/plugins/wpcomsh/changelog/remove-deprecated-token-class
+++ b/projects/plugins/wpcomsh/changelog/remove-deprecated-token-class
@@ -1,0 +1,4 @@
+Significance: major
+Type: removed
+
+Stop loading deprecated WPCOMSH_Blog_Token_Resilience class

--- a/projects/plugins/wpcomsh/composer.json
+++ b/projects/plugins/wpcomsh/composer.json
@@ -34,7 +34,6 @@
 			"imports",
 			"jetpack-require-connection-owner",
 			"jetpack-token-error-header",
-			"jetpack-token-resilience",
 			"lib",
 			"mailpoet",
 			"notices",

--- a/projects/plugins/wpcomsh/jetpack-token-resilience/class-wpcomsh-blog-token-resilience.php
+++ b/projects/plugins/wpcomsh/jetpack-token-resilience/class-wpcomsh-blog-token-resilience.php
@@ -38,4 +38,5 @@ class WPCOMSH_Blog_Token_Resilience {
 
 // Keep for backward compatibility but with lower priority
 // The new External Storage Handler runs earlier and will handle most cases
-add_filter( 'jetpack_options', array( 'WPCOMSH_Blog_Token_Resilience', 'filter_get_option' ), 15, 2 );
+// DISABLED: Removing deprecated class - External Storage Handler should handle all cases now
+// add_filter( 'jetpack_options', array( 'WPCOMSH_Blog_Token_Resilience', 'filter_get_option' ), 15, 2 );


### PR DESCRIPTION
The WPCOMSH_Blog_Token_Resilience has been deprecated because the logic to use persistent data for blog tokens has moved to the Atomic_Storage_Provider class. This PR stops autoloading the class and using the hook.
The class will get removed in a separate PR.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related CONNECT-75

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Code review
* Load the PR via beta blugin and check error logs

