### PR TITLE
Staging Sites: Add CLI commands to clear WPCOM Performance Profiler data after site cloning

### DIFF
--- a/projects/plugins/wpcomsh/changelog/add-site-clone-performance-profiler-data-clearing-handling
+++ b/projects/plugins/wpcomsh/changelog/add-site-clone-performance-profiler-data-clearing-handling
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Site Clone: Add WPCOM Performance report URLs deletion on site clone
+Staging Sites: Add CLI commands to clear WPCOM Performance Profiler data after site cloning

--- a/projects/plugins/wpcomsh/changelog/add-site-clone-performance-profiler-data-clearing-handling
+++ b/projects/plugins/wpcomsh/changelog/add-site-clone-performance-profiler-data-clearing-handling
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Site Clone: Add WPCOM Performance report URLs deletion on site clone

--- a/projects/plugins/wpcomsh/woa.php
+++ b/projects/plugins/wpcomsh/woa.php
@@ -219,13 +219,15 @@ function wpcomsh_woa_post_clone_clear_performance_profiler_data( $args, $assoc_a
 		return;
 	}
 
-	WP_CLI::runcommand(
-		'option delete wpcom_performance_report_url',
-		array(
-			'launch'     => false,
-			'exit_error' => false,
-		)
-	);
+	if ( get_option( 'wpcom_performance_report_url' ) ) {
+		WP_CLI::runcommand(
+			'option delete wpcom_performance_report_url',
+			array(
+				'launch'     => false,
+				'exit_error' => false,
+			)
+		);
+	}
 
 	$query   = "DELETE FROM wp_postmeta WHERE meta_key = '_wpcom_performance_report_url';";
 	$command = sprintf( 'db query "%s"', $query );

--- a/projects/plugins/wpcomsh/woa.php
+++ b/projects/plugins/wpcomsh/woa.php
@@ -222,15 +222,24 @@ function wpcomsh_woa_post_clone_clear_performance_profiler_data( $args, $assoc_a
 	}
 
 	if ( get_option( 'wpcom_performance_report_url' ) ) {
-		WP_CLI::runcommand(
+		WP_CLI::log( 'Deleting performance profiler option' );
+		$result = WP_CLI::runcommand(
 			'option delete wpcom_performance_report_url',
 			array(
 				'launch'     => false,
 				'exit_error' => false,
+				'return'     => 'all',
 			)
 		);
+
+		if ( 0 === $result->return_code ) {
+			WP_CLI::success( 'Performance profiler option deleted' );
+		} else {
+			WP_CLI::warning( 'Failed to delete performance profiler option: ' . $result->stderr );
+		}
 	}
 
+	WP_CLI::log( 'Deleting performance profiler postmeta (if they exist)' );
 	$query   = "DELETE FROM {$wpdb->postmeta} WHERE meta_key = '_wpcom_performance_report_url'";
 	$command = sprintf( 'db query "%s"', $query );
 	WP_CLI::runcommand(
@@ -240,8 +249,6 @@ function wpcomsh_woa_post_clone_clear_performance_profiler_data( $args, $assoc_a
 			'exit_error' => false,
 		)
 	);
-
-	WP_CLI::success( 'Performance profiler data cleared' );
 }
 add_action( 'wpcomsh_woa_post_clone', 'wpcomsh_woa_post_clone_clear_performance_profiler_data', 10, 2 );
 

--- a/projects/plugins/wpcomsh/woa.php
+++ b/projects/plugins/wpcomsh/woa.php
@@ -208,6 +208,40 @@ function wpcomsh_woa_post_clone_set_staging_environment_type( $args, $assoc_args
 add_action( 'wpcomsh_woa_post_clone', 'wpcomsh_woa_post_clone_set_staging_environment_type', 10, 2 );
 
 /**
+ * Clear performance profiler data.
+ *
+ * @param array $args       Arguments.
+ * @param array $assoc_args Associated arguments.
+ */
+function wpcomsh_woa_post_clone_clear_performance_profiler_data( $args, $assoc_args ) {
+	$clear_performance_profiler_data = WP_CLI\Utils\get_flag_value( $assoc_args, 'clear-performance-profiler-data', false );
+	if ( ! $clear_performance_profiler_data ) {
+		return;
+	}
+
+	WP_CLI::runcommand(
+		'option delete wpcom_performance_report_url',
+		array(
+			'launch'     => false,
+			'exit_error' => false,
+		)
+	);
+
+	$query   = "DELETE FROM wp_postmeta WHERE meta_key = '_wpcom_performance_report_url';";
+	$command = sprintf( 'db query "%s"', $query );
+	WP_CLI::runcommand(
+		$command,
+		array(
+			'launch'     => false,
+			'exit_error' => false,
+		)
+	);
+
+	WP_CLI::success( 'Performance profiler data cleared' );
+}
+add_action( 'wpcomsh_woa_post_clone', 'wpcomsh_woa_post_clone_clear_performance_profiler_data', 10, 2 );
+
+/**
  * Install marketplace software after a site transfer.
  *
  * @param array $args       Arguments.

--- a/projects/plugins/wpcomsh/woa.php
+++ b/projects/plugins/wpcomsh/woa.php
@@ -229,7 +229,7 @@ function wpcomsh_woa_post_clone_clear_performance_profiler_data( $args, $assoc_a
 		);
 	}
 
-	$query   = "DELETE FROM wp_postmeta WHERE meta_key = '_wpcom_performance_report_url';";
+	$query   = "DELETE FROM wp_postmeta WHERE meta_key = '_wpcom_performance_report_url'";
 	$command = sprintf( 'db query "%s"', $query );
 	WP_CLI::runcommand(
 		$command,

--- a/projects/plugins/wpcomsh/woa.php
+++ b/projects/plugins/wpcomsh/woa.php
@@ -214,6 +214,8 @@ add_action( 'wpcomsh_woa_post_clone', 'wpcomsh_woa_post_clone_set_staging_enviro
  * @param array $assoc_args Associated arguments.
  */
 function wpcomsh_woa_post_clone_clear_performance_profiler_data( $args, $assoc_args ) {
+	global $wpdb;
+
 	$clear_performance_profiler_data = WP_CLI\Utils\get_flag_value( $assoc_args, 'clear-performance-profiler-data', false );
 	if ( ! $clear_performance_profiler_data ) {
 		return;
@@ -229,7 +231,7 @@ function wpcomsh_woa_post_clone_clear_performance_profiler_data( $args, $assoc_a
 		);
 	}
 
-	$query   = "DELETE FROM wp_postmeta WHERE meta_key = '_wpcom_performance_report_url'";
+	$query   = "DELETE FROM {$wpdb->postmeta} WHERE meta_key = '_wpcom_performance_report_url'";
 	$command = sprintf( 'db query "%s"', $query );
 	WP_CLI::runcommand(
 		$command,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to DOTCOM-14653
Related backend PR: 192867-ghe-Automattic/wpcom

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* add `wpcomsh_woa_post_clone_clear_performance_profiler_data` that will run the two following WP CLI commands after site clone if the `clear-performance-profiler-data` flag* is present:
  * `wpcom_performance_report_url` site option (if it exists)
  * all records in the `wp_postmeta` table with the key `_wpcom_performance_report_url`

*We have added this flag in 192867-ghe-Automattic/wpcom.

**Background:**

The reason we need to clear the `wpcom_performance_report_url` site option and all records in the `wp_postmeta` table with the key `_wpcom_performance_report_url` is that they include URLs for the WordPress.com Performance Profiler with incorrect hash that has been calculated based on the production / source site ID. This then results in the issue described in DOTCOM-14653.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

Does not apply.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No, it does not.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Please note that the testing instructions are quite long. If something isn't clear, let me know. Also happy to explain on a call or pair for testing. 🙂 

1. If you don't have any, create a WoA dev site by following these steps: p9o2xV-1r2-p2. With need this site to be able to override wpcomsh.
2. Once your test site is ready and transferred, we will need to perform the following tasks with it:
- Install and activate _Jetpack Beta Tester_ plugin: https://jetpack.com/download-jetpack-beta/
- Head over to the plugin settings and select there this branch:
<img width="1488" height="540" alt="Markup on 2025-09-26 at 14:57:44" src="https://github.com/user-attachments/assets/cea0e848-6a7d-4938-b31d-c1356ecffc36" />

<img width="1550" height="648" alt="Markup on 2025-09-26 at 13:27:13" src="https://github.com/user-attachments/assets/c6ba43ec-8d72-47b7-9a4f-3db28fca43f0" />

- Navigate to the `Performance` tab of the site in the V1 dashboard and generate performance reports of at least two pages of the site (Homepage and one other page):

<img width="2280" height="1028" alt="Markup on 2025-09-26 at 15:41:21" src="https://github.com/user-attachments/assets/c4a3d0a2-58d6-4cf7-8840-90f7a099b5d6" />

3. While still in the V1 dashboard, navigate to `Settings` → `Database` to open phpMyAdmin. Ensure that each performance report has its own URL recorded:
- Homepage has the record stored in the `wpcom_performance_report_url` site option:
<img width="1494" height="842" alt="Markup on 2025-09-26 at 15:02:30" src="https://github.com/user-attachments/assets/335f4445-9441-474c-a379-e65625b56c09" />
- other pages have their records in the `wp_postmeta` table with the `_wpcom_performance_report_url` key:

<img width="2426" height="1030" alt="Markup on 2025-09-26 at 15:03:55" src="https://github.com/user-attachments/assets/473a6ea2-70e9-43d1-8b12-9bd6b8754ad9" />

4. Open the site's CLI through `/_cli` parameter in the URL.
5. Run the following command: `wp wpcomsh post-clone --clear-performance-profiler-data`
6. Observe the logs:

<img width="1936" height="322" alt="Markup on 2025-09-26 at 15:22:17" src="https://github.com/user-attachments/assets/51504c2b-8505-4e3f-a18d-05b5413cdbd3" />

7. Head back to phpMyAdmin to confirm the site option and related `wp_postmeta` records are gone.
8. Try to run the CLI command again (now when the site option and related `wp_postmeta` records are gone). There should be no warning / error.