### PR TITLE
Forms: add interactivity API withSyncEvent fallback

### DIFF
--- a/projects/packages/forms/changelog/add-forms-interactivity-api-withsyncevent-fallback
+++ b/projects/packages/forms/changelog/add-forms-interactivity-api-withsyncevent-fallback
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: add withSyncEvent fallback for pre 6.8 compatibility

--- a/projects/packages/forms/changelog/fix-missing-withSyncEvent
+++ b/projects/packages/forms/changelog/fix-missing-withSyncEvent
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Resolved conflict with WordPress 6.7.3

--- a/projects/packages/forms/src/modules/field-phone/view.js
+++ b/projects/packages/forms/src/modules/field-phone/view.js
@@ -1,8 +1,20 @@
-import { store, getContext, getConfig, getElement, withSyncEvent } from '@wordpress/interactivity';
+import {
+	store,
+	getContext,
+	getConfig,
+	getElement,
+	withSyncEvent as originalWithSyncEvent,
+} from '@wordpress/interactivity';
 import parsePhoneNumber, { AsYouType } from 'libphonenumber-js';
 import { countries } from '../../blocks/field-telephone/country-list';
 import { isEmptyValue } from '../../contact-form/js/validate-helper';
 const NAMESPACE = 'jetpack/form';
+
+const withSyncEvent =
+	originalWithSyncEvent ||
+	( cb =>
+		( ...args ) =>
+			cb( ...args ) );
 
 const asYouTypes = {};
 const phoneInputRefs = {};

--- a/projects/packages/forms/src/modules/form-step-navigation/view.js
+++ b/projects/packages/forms/src/modules/form-step-navigation/view.js
@@ -1,7 +1,17 @@
-import { getContext, store, withSyncEvent } from '@wordpress/interactivity';
+import {
+	getContext,
+	store,
+	withSyncEvent as originalWithSyncEvent,
+} from '@wordpress/interactivity';
 import { focusNextInput } from '../form/shared';
 
 const NAMESPACE = 'jetpack/form';
+
+const withSyncEvent =
+	originalWithSyncEvent ||
+	( cb =>
+		( ...args ) =>
+			cb( ...args ) );
 
 const { state } = store( NAMESPACE, {
 	state: {

--- a/projects/plugins/jetpack/changelog/fix-missing-withSyncEvent
+++ b/projects/plugins/jetpack/changelog/fix-missing-withSyncEvent
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Resolved conflict with WordPress 6.7.3


### PR DESCRIPTION
## Proposed changes:
This PR is a follow up on https://github.com/Automattic/jetpack/pull/45310, merely cherry-pick'ing the commit there to port it to trunk after the point release (ported on https://github.com/Automattic/jetpack/pull/45312).

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1758837192089929/1758821250.714199-slack-C09H2EPM2S1
p1758904544969069/1758896371.136539-slack-C052XEUUBL4

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Test on editor by inserting a form with a phone field. Try browsing the block library. Everything should work. Then verify the frontend works.

Downgrade to WP 6.7.x and repeat the process both on editor and frontend, it should work as before.