### PR TITLE
Garden: Expose the garden_is_provisioned flag in the site endpoint

### DIFF
--- a/projects/plugins/jetpack/changelog/add-garden-is-provisioned-site-endpoint
+++ b/projects/plugins/jetpack/changelog/add-garden-is-provisioned-site-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Garden Sites: Exposes the garden_is_provisioned flag on the site endpoint

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -98,6 +98,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'is_garden'                   => '(bool) If the site is a Garden site.',
 		'garden_name'                 => '(string) The name of the Garden site.',
 		'garden_partner'              => '(string) The partner of the Garden site.',
+		'garden_is_provisioned'       => '(bool) If the Garden site is provisioned.',
 	);
 
 	/**
@@ -253,6 +254,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'is_garden',
 		'garden_name',
 		'garden_partner',
+		'garden_is_provisioned',
 	);
 
 	/**
@@ -647,6 +649,9 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 				break;
 			case 'garden_partner':
 				$response[ $key ] = $this->site->garden_partner();
+				break;
+			case 'garden_is_provisioned':
+				$response[ $key ] = $this->site->garden_is_provisioned();
 				break;
 		}
 

--- a/projects/plugins/jetpack/sal/class.json-api-site-base.php
+++ b/projects/plugins/jetpack/sal/class.json-api-site-base.php
@@ -1733,4 +1733,13 @@ abstract class SAL_Site {
 	public function garden_partner() {
 		return null;
 	}
+
+	/**
+	 * Detect whether the Garden site is provisioned.
+	 *
+	 * @return bool
+	 */
+	public function garden_is_provisioned() {
+		return false;
+	}
 }

--- a/projects/plugins/jetpack/sal/class.json-api-site-base.php
+++ b/projects/plugins/jetpack/sal/class.json-api-site-base.php
@@ -1737,9 +1737,9 @@ abstract class SAL_Site {
 	/**
 	 * Detect whether the Garden site is provisioned.
 	 *
-	 * @return bool
+	 * @return bool|null
 	 */
 	public function garden_is_provisioned() {
-		return false;
+		return null;
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to BSKY-1135

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Uses the methods introduced in 192999-ghe-Automattic/wpcom to expose the `garden_is_provisioned` flag in the response from `/sites/:siteId`.

This allows us to easily check if a garden site is fully provisioned.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this Jetpack change on your sandbox.
```
bin/jetpack-downloader test jetpack garden/is-provisioned-meta
```
* Create a new garden site.
* Get the WPCOM site id
* Use the [Developer Console](https://developer.wordpress.com/docs/api/console/) and request `/v1.1/sites/:siteId`.
* Verify that you see `garden_is_provisioned` in the response.