### PR TITLE
Charts: Separate API reference docs from usage docs

### DIFF
--- a/projects/js-packages/charts/changelog/charts-124-separate-api-reference-docs
+++ b/projects/js-packages/charts/changelog/charts-124-separate-api-reference-docs
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-Charts: Seperate API reference documentation from usage documentation
+Charts: Separate API reference documentation from usage documentation

--- a/projects/js-packages/charts/changelog/charts-124-separate-api-reference-docs
+++ b/projects/js-packages/charts/changelog/charts-124-separate-api-reference-docs
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Charts: Seperate API reference documentation from usage documentation

--- a/projects/js-packages/charts/docs/ai-documentation-guide.md
+++ b/projects/js-packages/charts/docs/ai-documentation-guide.md
@@ -170,46 +170,38 @@ Always include accessibility information:
 - Focus behavior and visual indicators
 ```
 
-### 9. API Reference
+### 9. API Reference (Separate Document)
 
-Comprehensive prop documentation:
+The API reference should be created as a separate MDX document using the `feature-api-documentation.mdx.template`. This document will appear as a separate entry in Storybook below the main 'Docs' entry.
 
-````mdx
-## API Reference
+```mdx
+import { Meta } from '@storybook/addon-docs/blocks';
 
-### [Component].[SubComponent]
+<Meta title="JS Packages/Charts/[Category]/[Component]/[Feature]/API Reference" />
 
-Description of the component.
+# [Feature Name] API Reference
 
-**Props:**
-
-- `children`: Description
-
-### [Component].[MainComponent]
-
-Description of main component.
-
-**Props:**
-| Prop | Type | Default | Description |
-| ---- | ---- | ------- | ----------- |
-| `requiredProp` | `Type` | - | **Required.** Description |
-| `optionalProp` | `Type \| Other` | `default` | Description |
-
-### [TypeName] Type
-
-```typescript
-type TypeName = {
-	property: Type;
-	optional?: Type;
-};
+[Use the feature-api-documentation.mdx.template structure]
 ```
-````
 
-````
+The separate API reference should include:
+
+- Complete component documentation with prop tables
+- TypeScript type definitions
+- Comprehensive parameter descriptions
+- Required vs optional prop distinctions
+
+This separation allows users to:
+
+- Quickly access examples and usage patterns in the main docs
+- Reference detailed API information when needed
+- Navigate Storybook more efficiently with focused documentation
 
 ### 10. Migration
+
 ```mdx
 ## Migration from [Legacy/Previous API]
+
 If applicable, provide migration examples:
 
 <Source language="jsx" code={`
@@ -219,7 +211,7 @@ If applicable, provide migration examples:
 // New API
 [new-example]
 `} />
-````
+```
 
 ## Content Guidelines
 
@@ -260,6 +252,7 @@ If applicable, provide migration examples:
 ### File Naming
 
 - Main docs: `[feature-name].docs.mdx`
+- API reference: `[feature-name].api.mdx`
 - Stories: `[feature-name].stories.tsx`
 
 ### Directory Structure
@@ -267,6 +260,7 @@ If applicable, provide migration examples:
 ```
 src/components/[chart-type]/stories/
 ├── [feature-name].docs.mdx
+├── [feature-name].api.mdx
 ├── [feature-name].stories.tsx
 ```
 
@@ -278,28 +272,33 @@ src/components/[chart-type]/stories/
 
 ## Quality Checklist
 
-Before considering documentation complete, verify:
+Before considering documentation complete, verify both main docs and API reference:
 
 ### Completeness
 
-- [ ] All props documented with types and descriptions
-- [ ] Visual examples for all major variations
-- [ ] Code examples are complete and runnable
-- [ ] Accessibility considerations covered
-- [ ] Browser compatibility notes included
+- [ ] Main docs: All usage patterns and examples documented
+- [ ] API docs: All props documented with types and descriptions
+- [ ] Visual examples for all major variations in main docs
+- [ ] Code examples are complete and runnable in main docs
+- [ ] Accessibility considerations covered in main docs
+- [ ] Browser compatibility notes included where relevant
+- [ ] Both documents created using appropriate templates
 
 ### Accuracy
 
 - [ ] Code examples match actual implementation
-- [ ] Type definitions are current
+- [ ] API reference type definitions are current and accurate
 - [ ] Examples use current API patterns
+- [ ] Prop names and types match between documents
+- [ ] Cross-references between docs are accurate
 
 ### Usability
 
-- [ ] Progressive complexity (simple → advanced)
-- [ ] Clear section headings and navigation
-- [ ] Practical use case examples
+- [ ] Main docs: Progressive complexity (simple → advanced)
+- [ ] Clear section headings and navigation in both documents
+- [ ] Practical use case examples in main docs
 - [ ] Migration guidance where applicable
+- [ ] API reference is easily discoverable from main docs
 
 ### Standards Compliance
 
@@ -307,18 +306,36 @@ Before considering documentation complete, verify:
 - [ ] Uses established styling conventions
 - [ ] Integrates with chart theming system
 - [ ] Maintains accessibility standards
+- [ ] Proper Storybook organization with separate API reference entry
 
-## Using the Feature Documentation Template
+## Using the Documentation Templates
 
-AI agents should use the provided `feature-documentation.mdx.template` as a starting point for any new chart feature documentation:
+AI agents should use both provided templates when creating comprehensive chart feature documentation:
 
-1. **Copy the template**: Start with `feature-documentation.mdx.template`
+### Main Feature Documentation
+
+1. **Copy the main template**: Start with `feature-documentation.mdx.template`
 2. **Replace all bracketed placeholders**: Fill in `[Component]`, `[FeatureName]`, `[feature-name]`, etc. with actual values
 3. **Follow the structure**: Keep all sections but adapt content to your specific feature
 4. **Remove irrelevant sections**: If your feature doesn't have certain capabilities (e.g., no interactive features), remove those sections
 5. **Add feature-specific sections**: Include additional sections if your feature has unique aspects not covered in the template
 
-The template includes all the standard sections, proper MDX formatting, and placeholder text to guide content creation.
+### API Reference Documentation
+
+1. **Copy the API template**: Start with `feature-api-documentation.mdx.template`
+2. **Replace all bracketed placeholders**: Fill in component and type names
+3. **Complete all prop tables**: Ensure comprehensive coverage of all component props
+4. **Include TypeScript definitions**: Document all custom types used by the feature
+5. **Use consistent naming**: Match prop names and types exactly as implemented
+
+### Template Integration
+
+- The main documentation focuses on usage patterns, examples, and best practices
+- The API reference provides comprehensive technical details and prop specifications
+- Both documents should cross-reference each other where appropriate
+- Maintain consistent terminology and naming between both documents
+
+Both templates include proper MDX formatting and placeholder text to guide content creation.
 
 ## Example Analysis
 

--- a/projects/js-packages/charts/docs/ai-documentation-guide.md
+++ b/projects/js-packages/charts/docs/ai-documentation-guide.md
@@ -53,7 +53,44 @@ The [Component] component supports [feature description], providing [benefits]:
 />
 ```
 
-### 4. Basic Usage Section
+### 4. API Reference Section (Link)
+
+Immediately after the overview, include a link to the separate API reference document:
+
+```mdx
+## API Reference
+
+For detailed information about component props, types, and method signatures, see the [[Component] API Reference](./?path=/docs/js-packages-charts-[category]-[component]-api-reference--docs).
+```
+
+#### Creating the Separate API Reference Document
+
+The API reference should be created as a separate MDX document using the `feature-api-documentation.mdx.template`. This document will appear as a separate entry in Storybook below the main 'Docs' entry.
+
+```mdx
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="JS Packages/Charts/[Category]/[Component]/[Feature]/API Reference" />
+
+# [Feature Name] API Reference
+
+[Use the feature-api-documentation.mdx.template structure]
+```
+
+The separate API reference should include:
+
+- Complete component documentation with prop tables
+- TypeScript type definitions
+- Comprehensive parameter descriptions
+- Required vs optional prop distinctions
+
+This separation allows users to:
+
+- Quickly access examples and usage patterns in the main docs
+- Reference detailed API information when needed
+- Navigate Storybook more efficiently with focused documentation
+
+### 5. Basic Usage Section
 
 ```mdx
 ## Basic Usage
@@ -73,11 +110,10 @@ Description of simplest implementation:
 
 ### Optional Props
 
-- **`optionalProp`**: Description and default behavior
-- **`anotherOptional`**: Description
+For detailed information about all optional props, see the [[Component] API Reference](./?path=/docs/js-packages-charts-[category]-[component]-api-reference--docs).
 ```
 
-### 5. Feature Variations
+### 6. Feature Variations
 
 Document all major variations with:
 
@@ -104,7 +140,7 @@ Description and use case:
 <Source language="jsx" code={ `example-code` } />
 ```
 
-### 6. Styling and Customization
+### 7. Styling and Customization
 
 ```mdx
 ## Styling and Customization
@@ -133,7 +169,7 @@ Controls [what this category affects]:
 Explanation of how feature integrates with chart themes.
 ```
 
-### 7. Advanced Features
+### 8. Advanced Features
 
 Document complex functionality:
 
@@ -149,7 +185,7 @@ Explanation of complex functionality with examples.
 More advanced usage patterns.
 ```
 
-### 8. Accessibility Section
+### 9. Accessibility Section
 
 Always include accessibility information:
 
@@ -169,33 +205,6 @@ Always include accessibility information:
 
 - Focus behavior and visual indicators
 ```
-
-### 9. API Reference (Separate Document)
-
-The API reference should be created as a separate MDX document using the `feature-api-documentation.mdx.template`. This document will appear as a separate entry in Storybook below the main 'Docs' entry.
-
-```mdx
-import { Meta } from '@storybook/addon-docs/blocks';
-
-<Meta title="JS Packages/Charts/[Category]/[Component]/[Feature]/API Reference" />
-
-# [Feature Name] API Reference
-
-[Use the feature-api-documentation.mdx.template structure]
-```
-
-The separate API reference should include:
-
-- Complete component documentation with prop tables
-- TypeScript type definitions
-- Comprehensive parameter descriptions
-- Required vs optional prop distinctions
-
-This separation allows users to:
-
-- Quickly access examples and usage patterns in the main docs
-- Reference detailed API information when needed
-- Navigate Storybook more efficiently with focused documentation
 
 ### 10. Migration
 

--- a/projects/js-packages/charts/docs/feature-api-documentation.mdx.template
+++ b/projects/js-packages/charts/docs/feature-api-documentation.mdx.template
@@ -1,0 +1,42 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="JS Packages/Charts/[Category]/[Component]/[Feature]/API" />
+
+# [Feature Name] API Reference
+
+## [Component].[FeatureComponent]
+
+[Description of the container/wrapper component].
+
+**Props:**
+
+- `children`: [Description of expected children]
+
+## [Component].[SubComponent]
+
+[Description of the main feature component].
+
+**Props:**
+
+| Prop | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| `[requiredProp]` | `[Type]` | - | **Required.** [Description] |
+| `[optionalProp]` | `[Type] \| [AlternativeType]` | `[default]` | [Description] |
+| `[anotherProp]` | `[ComplexType]` | - | [Description] |
+
+## [TypeName] Type
+
+```typescript
+type [TypeName] = {
+	[property]: [Type];
+	[optionalProperty]?: [Type];
+};
+```
+
+## [AnotherTypeName] Type
+
+```typescript
+type [AnotherTypeName] = {
+	[property]: [Type];
+};
+```

--- a/projects/js-packages/charts/docs/feature-api-documentation.mdx.template
+++ b/projects/js-packages/charts/docs/feature-api-documentation.mdx.template
@@ -1,8 +1,4 @@
-import { Meta } from '@storybook/addon-docs/blocks';
-
-<Meta title="JS Packages/Charts/[Category]/[Component]/[Feature]/API" />
-
-# [Feature Name] API Reference
+# API Reference
 
 ## [Component].[FeatureComponent]
 

--- a/projects/js-packages/charts/docs/feature-documentation.mdx.template
+++ b/projects/js-packages/charts/docs/feature-documentation.mdx.template
@@ -179,45 +179,6 @@ Controls [what this affects]:
 - [Focus behavior and visual indicators]
 - [Focus trapping or restoration if applicable]
 
-## API Reference
-
-### [Component].[FeatureComponent]
-
-[Description of the container/wrapper component].
-
-**Props:**
-
-- `children`: [Description of expected children]
-
-### [Component].[SubComponent]
-
-[Description of the main feature component].
-
-**Props:**
-
-| Prop | Type | Default | Description |
-| ---- | ---- | ------- | ----------- |
-| `[requiredProp]` | `[Type]` | - | **Required.** [Description] |
-| `[optionalProp]` | `[Type] \| [AlternativeType]` | `[default]` | [Description] |
-| `[anotherProp]` | `[ComplexType]` | - | [Description] |
-
-### [TypeName] Type
-
-```typescript
-type [TypeName] = {
-	[property]: [Type];
-	[optionalProperty]?: [Type];
-};
-```
-
-### [AnotherTypeName] Type
-
-```typescript
-type [AnotherTypeName] = {
-	[property]: [Type];
-};
-```
-
 ## Migration from [Legacy API]
 
 [If applicable, provide migration examples]:

--- a/projects/js-packages/charts/docs/feature-documentation.mdx.template
+++ b/projects/js-packages/charts/docs/feature-documentation.mdx.template
@@ -27,6 +27,10 @@ The [Component] component supports [feature description], providing [benefits an
 	</[Component]>` }
 />
 
+## API Reference
+
+For detailed information about component props, types, and method signatures, see the [[Component] [Feature Name] API Reference](./?path=/docs/js-packages-charts-[category]-[component]-[feature]-api-reference--docs).
+
 ## Basic Usage
 
 ### Basic [Feature Name]
@@ -53,8 +57,7 @@ The [Component] component supports [feature description], providing [benefits an
 
 ### Optional Props
 
-- **`[optionalProp]`**: [Description and default behavior]
-- **`[anotherOptional]`**: [Description and use cases]
+For detailed information about all optional props, see the [[Component] [Feature Name] API Reference](./?path=/docs/js-packages-charts-[category]-[component]-[feature]-api-reference--docs).
 
 ## [Feature] Types
 

--- a/projects/js-packages/charts/src/components/bar-chart/stories/index.api.mdx
+++ b/projects/js-packages/charts/src/components/bar-chart/stories/index.api.mdx
@@ -1,0 +1,102 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="JS Packages/Charts/Types/Bar Chart/API Reference" />
+
+# Bar Chart API Reference
+
+## BarChart
+
+Main chart component with responsive behavior by default.
+
+**Props:**
+
+| Prop | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| `data` | `SeriesData[]` | - | **Required.** Array of data series to display |
+| `chartId` | `string` | auto-generated | Optional unique identifier for the chart |
+| `width` | `number` | responsive | Chart width in pixels |
+| `height` | `number` | `400` | Chart height in pixels |
+| `orientation` | `'vertical' \| 'horizontal'` | `'vertical'` | Bar orientation |
+| `withTooltips` | `boolean` | `false` | Enable interactive tooltips |
+| `withPatterns` | `boolean` | `false` | Use pattern fills for accessibility |
+| `showZeroValues` | `boolean` | `false` | Display zero values with minimum visual height |
+| `showLegend` | `boolean` | `false` | Display chart legend |
+| `legendOrientation` | `'horizontal' \| 'vertical'` | `'horizontal'` | Legend layout orientation |
+| `legendAlignment` | `'start' \| 'center' \| 'end'` | `'center'` | Legend alignment within its position |
+| `legendPosition` | `'top' \| 'bottom'` | `'bottom'` | Legend position (where the legend appears) |
+| `legendShape` | `LegendShape` | `'rect'` | Shape used in legend markers |
+| `gridVisibility` | `'x' \| 'y' \| 'xy' \| 'none'` | orientation-based | Grid line visibility |
+| `renderTooltip` | `(params: RenderTooltipParams) => ReactNode` | - | Custom tooltip render function |
+| `margin` | `{ top?: number; right?: number; bottom?: number; left?: number }` | calculated | Chart margins |
+| `options` | `ChartOptions` | `{}` | Advanced axis and scale configuration |
+| `className` | `string` | - | Additional CSS class name |
+| `children` | `ReactNode` | - | Child components (e.g., `<BarChart.Legend />`) |
+
+## BarChart.Legend
+
+Composition API component for displaying chart legends. Must be used as a child of `<BarChart>`.
+
+**Props:**
+
+| Prop | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| `orientation` | `'horizontal' \| 'vertical'` | `'horizontal'` | Legend layout orientation |
+| `alignment` | `'start' \| 'center' \| 'end'` | `'center'` | Horizontal legend alignment |
+| `position` | `'top' \| 'bottom'` | `'bottom'` | Vertical legend alignment |
+| `shape` | `LegendShape` | `'rect'` | Shape used in legend markers |
+| `className` | `string` | - | Additional CSS class name |
+| `chartId` | `string` | auto-detected | Chart ID (automatically detected from parent context) |
+
+## SeriesData Type
+
+```typescript
+type SeriesData = {
+	label: string;
+	data: DataPointDate[];
+	options?: {
+		stroke?: string;
+	};
+};
+```
+
+## DataPointDate Type
+
+```typescript
+type DataPointDate = {
+	date?: Date;
+	dateString?: string; // Multiple formats supported
+	value: number | null;
+	label?: string;
+};
+```
+
+## ChartOptions Type
+
+```typescript
+type ChartOptions = {
+	yScale?: {
+		type?: 'linear' | 'band';
+		zero?: boolean;
+		domain?: [number, number];
+		nice?: boolean;
+		padding?: number;
+	};
+	xScale?: {
+		type?: 'time' | 'linear' | 'band';
+		domain?: [Date, Date] | [number, number];
+		padding?: number;
+	};
+	axis?: {
+		x?: {
+			orientation?: 'top' | 'bottom';
+			numTicks?: number;
+			tickFormat?: (value: any) => string;
+		};
+		y?: {
+			orientation?: 'left' | 'right';
+			numTicks?: number;
+			tickFormat?: (value: number) => string;
+		};
+	};
+};
+```

--- a/projects/js-packages/charts/src/components/bar-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/components/bar-chart/stories/index.docs.mdx
@@ -491,105 +491,6 @@ Full functionality in all modern browsers supporting:
 - Automatic data validation and error boundaries
 - Efficient pattern generation for accessibility features
 
-## API Reference
-
-### BarChart
-
-Main chart component with responsive behavior by default.
-
-**Props:**
-
-| Prop | Type | Default | Description |
-| ---- | ---- | ------- | ----------- |
-| `data` | `SeriesData[]` | - | **Required.** Array of data series to display |
-| `chartId` | `string` | auto-generated | Optional unique identifier for the chart |
-| `width` | `number` | responsive | Chart width in pixels |
-| `height` | `number` | `400` | Chart height in pixels |
-| `orientation` | `'vertical' \| 'horizontal'` | `'vertical'` | Bar orientation |
-| `withTooltips` | `boolean` | `false` | Enable interactive tooltips |
-| `withPatterns` | `boolean` | `false` | Use pattern fills for accessibility |
-| `showZeroValues` | `boolean` | `false` | Display zero values with minimum visual height |
-| `showLegend` | `boolean` | `false` | Display chart legend |
-| `legendOrientation` | `'horizontal' \| 'vertical'` | `'horizontal'` | Legend layout orientation |
-| `legendAlignment` | `'start' \| 'center' \| 'end'` | `'center'` | Legend alignment within its position |
-| `legendPosition` | `'top' \| 'bottom'` | `'bottom'` | Legend position (where the legend appears) |
-| `legendShape` | `LegendShape` | `'rect'` | Shape used in legend markers |
-| `gridVisibility` | `'x' \| 'y' \| 'xy' \| 'none'` | orientation-based | Grid line visibility |
-| `renderTooltip` | `(params: RenderTooltipParams) => ReactNode` | - | Custom tooltip render function |
-| `margin` | `{ top?: number; right?: number; bottom?: number; left?: number }` | calculated | Chart margins |
-| `options` | `ChartOptions` | `{}` | Advanced axis and scale configuration |
-| `className` | `string` | - | Additional CSS class name |
-| `children` | `ReactNode` | - | Child components (e.g., `<BarChart.Legend />`) |
-
-### BarChart.Legend
-
-Composition API component for displaying chart legends. Must be used as a child of `<BarChart>`.
-
-**Props:**
-
-| Prop | Type | Default | Description |
-| ---- | ---- | ------- | ----------- |
-| `orientation` | `'horizontal' \| 'vertical'` | `'horizontal'` | Legend layout orientation |
-| `alignment` | `'start' \| 'center' \| 'end'` | `'center'` | Horizontal legend alignment |
-| `position` | `'top' \| 'bottom'` | `'bottom'` | Vertical legend alignment |
-| `shape` | `LegendShape` | `'rect'` | Shape used in legend markers |
-| `className` | `string` | - | Additional CSS class name |
-| `chartId` | `string` | auto-detected | Chart ID (automatically detected from parent context) |
-
-### SeriesData Type
-
-```typescript
-type SeriesData = {
-	label: string;
-	data: DataPointDate[];
-	options?: {
-		stroke?: string;
-	};
-};
-```
-
-### DataPointDate Type
-
-```typescript
-type DataPointDate = {
-	date?: Date;
-	dateString?: string; // Multiple formats supported
-	value: number | null;
-	label?: string;
-};
-```
-
-### ChartOptions Type
-
-```typescript
-type ChartOptions = {
-	yScale?: {
-		type?: 'linear' | 'band';
-		zero?: boolean;
-		domain?: [number, number];
-		nice?: boolean;
-		padding?: number;
-	};
-	xScale?: {
-		type?: 'time' | 'linear' | 'band';
-		domain?: [Date, Date] | [number, number];
-		padding?: number;
-	};
-	axis?: {
-		x?: {
-			orientation?: 'top' | 'bottom';
-			numTicks?: number;
-			tickFormat?: (value: any) => string;
-		};
-		y?: {
-			orientation?: 'left' | 'right';
-			numTicks?: number;
-			tickFormat?: (value: number) => string;
-		};
-	};
-};
-```
-
 ## Performance Considerations
 
 ### Built-in Optimizations
@@ -619,3 +520,7 @@ Bar Charts integrate seamlessly with the chart theming system:
 - **Custom**: Define your own theme object with custom color schemes
 
 The component automatically adapts bar colors, patterns, and styling based on the active theme while maintaining accessibility standards.
+
+## API Reference
+
+For detailed information about component props, types, and method signatures, see the [Bar Chart API Reference](./?path=/docs/js-packages-charts-types-bar-chart-api-reference--docs).

--- a/projects/js-packages/charts/src/components/bar-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/components/bar-chart/stories/index.docs.mdx
@@ -25,6 +25,10 @@ The Bar Chart component provides a flexible, accessible, and highly customizable
 	/>` }
 />
 
+## API Reference
+
+For detailed information about component props, types, and method signatures, see the [Bar Chart API Reference](./?path=/docs/js-packages-charts-types-bar-chart-api-reference--docs).
+
 ## Basic Usage
 
 ### Simple Bar Chart
@@ -520,7 +524,3 @@ Bar Charts integrate seamlessly with the chart theming system:
 - **Custom**: Define your own theme object with custom color schemes
 
 The component automatically adapts bar colors, patterns, and styling based on the active theme while maintaining accessibility standards.
-
-## API Reference
-
-For detailed information about component props, types, and method signatures, see the [Bar Chart API Reference](./?path=/docs/js-packages-charts-types-bar-chart-api-reference--docs).

--- a/projects/js-packages/charts/src/components/bar-list-chart/stories/index.api.mdx
+++ b/projects/js-packages/charts/src/components/bar-list-chart/stories/index.api.mdx
@@ -1,0 +1,76 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="JS Packages/Charts/Types/Bar List Chart/API Reference" />
+
+# Bar List Chart API Reference
+
+## BarListChart
+
+A horizontal bar chart component optimized for list-style data presentation.
+
+**Props:**
+
+| Prop | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| `data` | `SeriesData[]` | - | **Required.** Array of series data objects |
+| `width` | `number` | - | Chart width in pixels |
+| `height` | `number` | `400` | Chart height in pixels |
+| `margin` | `ChartMargin` | `{ left: 0, right: 20, bottom: 0, top: 0 }` | Chart margins |
+| `withTooltips` | `boolean` | `false` | Enable interactive tooltips |
+| `renderTooltip` | `Function` | - | Custom tooltip render function |
+| `options` | `BarListChartOptions` | `{}` | Chart configuration options |
+
+## SeriesData Type
+
+```typescript
+type SeriesData = {
+	group: string;
+	label: string;
+	data: Array<{
+		label: string;
+		value: number;
+	}>;
+};
+```
+
+## BarListChartOptions Type
+
+```typescript
+type BarListChartOptions = {
+	yScale?: Omit<ScaleOptions, 'type'>;
+	xScale?: Omit<ScaleOptions, 'type'>;
+	labelFormatter?: (value: string) => string;
+	valueFormatter?: (value: number) => string;
+	yOffset?: number;
+	labelPosition?: number;
+	valuePosition?: number;
+	labelComponent?: ComponentType<RenderLabelProps>;
+	valueComponent?: ComponentType<RenderValueProps>;
+};
+```
+
+## RenderLabelProps Type
+
+```typescript
+type RenderLabelProps = {
+	textProps: TextProps;
+	x: number;
+	y: number;
+	label: string;
+	formatter: (value: string) => string;
+};
+```
+
+## RenderValueProps Type
+
+```typescript
+type RenderValueProps = {
+	textProps: TextProps;
+	x: number;
+	y: number;
+	value: number;
+	data: SeriesData[];
+	index: number;
+	formatter: (value: number) => string;
+};
+```

--- a/projects/js-packages/charts/src/components/bar-list-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/components/bar-list-chart/stories/index.docs.mdx
@@ -39,6 +39,10 @@ Key features:
 - Custom component rendering for advanced styling
 - Responsive design with automatic sizing
 
+## API Reference
+
+For detailed information about component props, types, and method signatures, see the [Bar List Chart API Reference](./?path=/docs/js-packages-charts-types-bar-list-chart-api-reference--docs).
+
 ## Basic Usage
 
 ### Single Series Data
@@ -306,10 +310,6 @@ Override automatic positioning when needed:
 ## Accessibility
 
 BarListChart inherits accessibility features from the underlying BarChart component, including keyboard navigation support when tooltips are enabled and proper ARIA attributes for screen readers.
-
-## API Reference
-
-For detailed information about component props, types, and method signatures, see the [Bar List Chart API Reference](./?path=/docs/js-packages-charts-types-bar-list-chart-api-reference--docs).
 
 ## Migration from Bar Chart
 

--- a/projects/js-packages/charts/src/components/bar-list-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/components/bar-list-chart/stories/index.docs.mdx
@@ -104,7 +104,7 @@ Compare data across different time periods or categories:
 
 - **`data`**: Array of SeriesData objects containing the chart data
 
-For detailed prop information and configuration options, see the [API Reference](#api-reference) section below.
+For detailed prop information and configuration options, see the [Bar List Chart API Reference](./?path=/docs/js-packages-charts-types-bar-list-chart-api-reference--docs).
 
 ## Chart Types
 
@@ -309,76 +309,7 @@ BarListChart inherits accessibility features from the underlying BarChart compon
 
 ## API Reference
 
-### BarListChart
-
-A horizontal bar chart component optimized for list-style data presentation.
-
-**Props:**
-
-| Prop | Type | Default | Description |
-| ---- | ---- | ------- | ----------- |
-| `data` | `SeriesData[]` | - | **Required.** Array of series data objects |
-| `width` | `number` | - | Chart width in pixels |
-| `height` | `number` | `400` | Chart height in pixels |
-| `margin` | `ChartMargin` | `{ left: 0, right: 20, bottom: 0, top: 0 }` | Chart margins |
-| `withTooltips` | `boolean` | `false` | Enable interactive tooltips |
-| `renderTooltip` | `Function` | - | Custom tooltip render function |
-| `options` | `BarListChartOptions` | `{}` | Chart configuration options |
-
-### SeriesData Type
-
-```typescript
-type SeriesData = {
-	group: string;
-	label: string;
-	data: Array<{
-		label: string;
-		value: number;
-	}>;
-};
-```
-
-### BarListChartOptions Type
-
-```typescript
-type BarListChartOptions = {
-	yScale?: Omit<ScaleOptions, 'type'>;
-	xScale?: Omit<ScaleOptions, 'type'>;
-	labelFormatter?: (value: string) => string;
-	valueFormatter?: (value: number) => string;
-	yOffset?: number;
-	labelPosition?: number;
-	valuePosition?: number;
-	labelComponent?: ComponentType<RenderLabelProps>;
-	valueComponent?: ComponentType<RenderValueProps>;
-};
-```
-
-### RenderLabelProps Type
-
-```typescript
-type RenderLabelProps = {
-	textProps: TextProps;
-	x: number;
-	y: number;
-	label: string;
-	formatter: (value: string) => string;
-};
-```
-
-### RenderValueProps Type
-
-```typescript
-type RenderValueProps = {
-	textProps: TextProps;
-	x: number;
-	y: number;
-	value: number;
-	data: SeriesData[];
-	index: number;
-	formatter: (value: number) => string;
-};
-```
+For detailed information about component props, types, and method signatures, see the [Bar List Chart API Reference](./?path=/docs/js-packages-charts-types-bar-list-chart-api-reference--docs).
 
 ## Migration from Bar Chart
 

--- a/projects/js-packages/charts/src/components/conversion-funnel-chart/stories/index.api.mdx
+++ b/projects/js-packages/charts/src/components/conversion-funnel-chart/stories/index.api.mdx
@@ -1,0 +1,67 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="JS Packages/Charts/Types/Conversion Funnel Chart/API Reference" />
+
+# Conversion Funnel Chart API Reference
+
+## ConversionFunnelChart
+
+Main component for displaying conversion funnel visualizations.
+
+**Props:**
+
+| Prop | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| `mainRate` | `number` | - | **Required.** Main conversion rate to highlight (0-100) |
+| `steps` | `FunnelStep[]` | - | **Required.** Array of funnel steps |
+| `changeIndicator` | `string` | - | Change indicator (e.g., "+2%", "-1.5%") |
+| `loading` | `boolean` | `false` | Whether the chart is in loading state |
+| `className` | `string` | - | Additional CSS class name |
+| `chartId` | `string` | - | Optional unique identifier for the chart |
+| `style` | `React.CSSProperties` | - | Custom styling for the chart container |
+| `renderStepLabel` | `(props: StepLabelRenderProps) => ReactNode` | - | Custom render function for step labels |
+| `renderStepRate` | `(props: StepRateRenderProps) => ReactNode` | - | Custom render function for step rates |
+| `renderMainMetric` | `(props: MainMetricRenderProps) => ReactNode` | - | Custom render function for main metric section |
+| `renderTooltip` | `(props: TooltipRenderProps) => ReactNode` | - | Custom render function for tooltip content |
+
+## FunnelStep Type
+
+```typescript
+interface FunnelStep {
+	id: string;           // Unique identifier
+	label: string;        // Display name for the step
+	rate: number;         // Conversion rate as percentage (0-100)
+	count?: number;       // Optional absolute count
+}
+```
+
+## Render Prop Types
+
+```typescript
+interface StepLabelRenderProps {
+	step: FunnelStep;
+	index: number;
+	className?: string;
+}
+
+interface StepRateRenderProps {
+	step: FunnelStep;
+	index: number;
+	className?: string;
+}
+
+interface MainMetricRenderProps {
+	mainRate: number;
+	changeIndicator?: string;
+	className?: string;
+	changeColor?: string;
+}
+
+interface TooltipRenderProps {
+	step: FunnelStep;
+	index: number;
+	top: number;
+	left: number;
+	className?: string;
+}
+```

--- a/projects/js-packages/charts/src/components/conversion-funnel-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/components/conversion-funnel-chart/stories/index.docs.mdx
@@ -40,6 +40,10 @@ The ConversionFunnelChart component provides a specialized visualization for tra
 	/>` }
 />
 
+## API Reference
+
+For detailed information about component props, types, and method signatures, see the [Conversion Funnel Chart API Reference](./?path=/docs/js-packages-charts-types-conversion-funnel-chart-api-reference--docs).
+
 ## Basic Usage
 
 ### Simple Conversion Funnel
@@ -324,8 +328,4 @@ Measure content consumption funnel from page views to conversions.
 - **Logical Tab Order**: Focus moves through steps in visual order
 - **Dynamic `tabIndex`**: Blurred (non-selected) steps are removed from tab order when another step is selected
 - **Visual Focus Indicators**: CSS focus styles provide clear visual feedback
-
-## API Reference
-
-For detailed information about component props, types, and method signatures, see the [Conversion Funnel Chart API Reference](./?path=/docs/js-packages-charts-types-conversion-funnel-chart-api-reference--docs).
 

--- a/projects/js-packages/charts/src/components/conversion-funnel-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/components/conversion-funnel-chart/stories/index.docs.mdx
@@ -70,6 +70,8 @@ The most basic implementation requires only the main conversion rate and steps d
 - **`chartId`**: Optional unique identifier for the chart
 - **`style`**: Custom styling for the chart container
 
+For detailed prop information and render prop types, see the [Conversion Funnel Chart API Reference](./?path=/docs/js-packages-charts-types-conversion-funnel-chart-api-reference--docs).
+
 ## Chart Variations
 
 ### Positive Change Indicator (Default)
@@ -325,65 +327,5 @@ Measure content consumption funnel from page views to conversions.
 
 ## API Reference
 
-### ConversionFunnelChart
-
-Main component for displaying conversion funnel visualizations.
-
-**Props:**
-
-| Prop | Type | Default | Description |
-| ---- | ---- | ------- | ----------- |
-| `mainRate` | `number` | - | **Required.** Main conversion rate to highlight (0-100) |
-| `steps` | `FunnelStep[]` | - | **Required.** Array of funnel steps |
-| `changeIndicator` | `string` | - | Change indicator (e.g., "+2%", "-1.5%") |
-| `loading` | `boolean` | `false` | Whether the chart is in loading state |
-| `className` | `string` | - | Additional CSS class name |
-| `chartId` | `string` | - | Optional unique identifier for the chart |
-| `style` | `React.CSSProperties` | - | Custom styling for the chart container |
-| `renderStepLabel` | `(props: StepLabelRenderProps) => ReactNode` | - | Custom render function for step labels |
-| `renderStepRate` | `(props: StepRateRenderProps) => ReactNode` | - | Custom render function for step rates |
-| `renderMainMetric` | `(props: MainMetricRenderProps) => ReactNode` | - | Custom render function for main metric section |
-| `renderTooltip` | `(props: TooltipRenderProps) => ReactNode` | - | Custom render function for tooltip content |
-
-### FunnelStep Type
-
-```typescript
-interface FunnelStep {
-	id: string;           // Unique identifier
-	label: string;        // Display name for the step
-	rate: number;         // Conversion rate as percentage (0-100)
-	count?: number;       // Optional absolute count
-}
-```
-
-### Render Prop Types
-
-```typescript
-interface StepLabelRenderProps {
-	step: FunnelStep;
-	index: number;
-	className?: string;
-}
-
-interface StepRateRenderProps {
-	step: FunnelStep;
-	index: number;
-	className?: string;
-}
-
-interface MainMetricRenderProps {
-	mainRate: number;
-	changeIndicator?: string;
-	className?: string;
-	changeColor?: string;
-}
-
-interface TooltipRenderProps {
-	step: FunnelStep;
-	index: number;
-	top: number;
-	left: number;
-	className?: string;
-}
-```
+For detailed information about component props, types, and method signatures, see the [Conversion Funnel Chart API Reference](./?path=/docs/js-packages-charts-types-conversion-funnel-chart-api-reference--docs).
 

--- a/projects/js-packages/charts/src/components/leaderboard-chart/stories/index.api.mdx
+++ b/projects/js-packages/charts/src/components/leaderboard-chart/stories/index.api.mdx
@@ -1,0 +1,56 @@
+import { Meta, Source } from '@storybook/addon-docs/blocks';
+
+<Meta title="JS Packages/Charts/Types/Leaderboard Chart/API Reference" />
+
+# Leaderboard Chart API Reference
+
+## LeaderboardChart
+
+Main chart component for displaying ranked data with optional comparison values.
+
+**Props:**
+
+| Prop | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| `data` | `LeaderboardEntry[]` | - | **Required.** Array of leaderboard entries to display |
+| `withComparison` | `boolean` | `false` | Whether to show comparison data (previous period bars and delta values) |
+| `withOverlayLabel` | `boolean` | `false` | Whether to overlay the label on top of the bar |
+| `primaryColor` | `string` | theme default | Primary color for current period bars |
+| `secondaryColor` | `string` | theme default | Secondary color for comparison period bars |
+| `valueFormatter` | `(value: number) => string` | `defaultValueFormatter` | Custom formatter for values |
+| `deltaFormatter` | `(value: number) => string` | `defaultDeltaFormatter` | Custom formatter for delta values |
+| `loading` | `boolean` | `false` | Whether the chart is in loading state |
+| `showLegend` | `boolean` | `false` | Whether to display the legend |
+| `legendPosition` | `'top' \| 'bottom'` | `'bottom'` | Position of the legend |
+| `legendAlignment` | `'start' \| 'center' \| 'end'` | `'center'` | Alignment within position |
+| `legendOrientation` | `'horizontal' \| 'vertical'` | `'horizontal'` | Layout direction of legend items |
+| `legendShape` | `LegendShape` | `'circle'` | Shape of legend markers |
+| `legendShapeWidth` | `number` | `8` | Width of legend shapes in pixels |
+| `legendShapeHeight` | `number` | `8` | Height of legend shapes in pixels |
+| `legendLabels` | `{ primary?: string; comparison?: string }` | `undefined` | Custom labels for legend items |
+| `className` | `string` | `undefined` | Additional CSS class name for the chart container |
+| `style` | `React.CSSProperties & CustomProperties` | `undefined` | Custom styling for the chart container |
+
+## LeaderboardEntry Type
+
+```typescript
+interface LeaderboardEntry {
+	id: string;                  // Unique identifier
+	label: string | JSX.Element; // Display name or React component
+	currentValue: number;        // Current period value
+	previousValue: number;       // Previous period value
+	currentShare: number;        // Current bar width (0-100)
+	previousShare: number;       // Previous bar width (0-100)
+	delta: number;               // Percentage change
+	imageColor?: string;         // Optional color for the entry's image/icon
+}
+```
+
+## CustomProperties Type
+
+```typescript
+type CustomProperties = {
+	'--a8c--charts--leaderboard--bar--border-radius'?: string;
+};
+```
+

--- a/projects/js-packages/charts/src/components/leaderboard-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/components/leaderboard-chart/stories/index.docs.mdx
@@ -25,6 +25,10 @@ The Leaderboard Chart component provides a clean, responsive visualization for d
 	/>` }
 />
 
+## API Reference
+
+For detailed information about component props, types, and method signatures, see the [Leaderboard Chart API Reference](./?path=/docs/js-packages-charts-types-leaderboard-chart-api-reference--docs).
+
 ## Basic Usage
 
 ### Simple Leaderboard Chart
@@ -517,7 +521,3 @@ Supports all modern browsers with CSS Grid and ES6+ features:
 
 	<LeaderboardChart data={trafficData} withComparison={true} />
 ` } />
-
-## API Reference
-
-For detailed information about component props, types, and method signatures, see the [Leaderboard Chart API Reference](./?path=/docs/js-packages-charts-types-leaderboard-chart-api-reference--docs).

--- a/projects/js-packages/charts/src/components/leaderboard-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/components/leaderboard-chart/stories/index.docs.mdx
@@ -80,6 +80,8 @@ The simplest leaderboard chart requires only a `data` prop with pre-processed le
 - **`className`**: Additional CSS class name for the chart container
 - **`style`**: Custom styling including CSS custom properties for border radius
 
+For detailed prop information, type definitions, and examples, see the [Leaderboard Chart API Reference](./?path=/docs/js-packages-charts-types-leaderboard-chart-api-reference--docs).
+
 ## Comparison Features
 
 ### With Comparison Data
@@ -316,15 +318,12 @@ Customize legend labels with specific date ranges or descriptive text:
 	/>` }
 />
 
-**Legend Props:**
-- **`showLegend`**: Whether to display the legend - `false` by default
-- **`legendPosition`**: Position of the legend - `'top'` or `'bottom'` (default: `'bottom'`)
-- **`legendAlignment`**: Alignment within position - `'start'`, `'center'`, or `'end'` (default: `'center'`)
-- **`legendOrientation`**: Layout direction - `'horizontal'` or `'vertical'` (default: `'horizontal'`)
-- **`legendShape`**: Shape of legend markers - `'rect'`, `'circle'`, `'square'`, etc. (default: `'circle'`)
-- **`legendShapeWidth`**: Width of legend shapes in pixels (default: `8`)
-- **`legendShapeHeight`**: Height of legend shapes in pixels (default: `8`)
-- **`legendLabels`**: Custom labels for legend items - `{ primary?: string; comparison?: string }`
+**Legend Configuration Options:**
+- Control legend positioning, alignment, and visual appearance
+- Customize legend shapes and sizes
+- Add custom labels for different time periods or data series
+
+See the [API Reference](./?path=/docs/js-packages-charts-types-leaderboard-chart-api-reference--docs) for detailed prop information.
 
 ## Data States
 
@@ -491,57 +490,6 @@ Supports all modern browsers with CSS Grid and ES6+ features:
 - Internet Explorer not supported
 - Mobile-friendly with responsive design
 
-## API Reference
-
-### LeaderboardChart
-
-Main chart component for displaying ranked data with optional comparison values.
-
-**Props:**
-
-| Prop | Type | Default | Description |
-| ---- | ---- | ------- | ----------- |
-| `data` | `LeaderboardEntry[]` | - | **Required.** Array of leaderboard entries to display |
-| `withComparison` | `boolean` | `false` | Whether to show comparison data (previous period bars and delta values) |
-| `withOverlayLabel` | `boolean` | `false` | Whether to overlay the label on top of the bar |
-| `primaryColor` | `string` | theme default | Primary color for current period bars |
-| `secondaryColor` | `string` | theme default | Secondary color for comparison period bars |
-| `valueFormatter` | `(value: number) => string` | `defaultValueFormatter` | Custom formatter for values |
-| `deltaFormatter` | `(value: number) => string` | `defaultDeltaFormatter` | Custom formatter for delta values |
-| `loading` | `boolean` | `false` | Whether the chart is in loading state |
-| `showLegend` | `boolean` | `false` | Whether to display the legend |
-| `legendPosition` | `'top' \| 'bottom'` | `'bottom'` | Position of the legend |
-| `legendAlignment` | `'start' \| 'center' \| 'end'` | `'center'` | Alignment within position |
-| `legendOrientation` | `'horizontal' \| 'vertical'` | `'horizontal'` | Layout direction of legend items |
-| `legendShape` | `LegendShape` | `'circle'` | Shape of legend markers |
-| `legendShapeWidth` | `number` | `8` | Width of legend shapes in pixels |
-| `legendShapeHeight` | `number` | `8` | Height of legend shapes in pixels |
-| `legendLabels` | `{ primary?: string; comparison?: string }` | `undefined` | Custom labels for legend items |
-| `className` | `string` | `undefined` | Additional CSS class name for the chart container |
-| `style` | `React.CSSProperties & CustomProperties` | `undefined` | Custom styling for the chart container |
-
-### LeaderboardEntry Type
-
-<Source language="tsx" code={ `
-	interface LeaderboardEntry {
-		id: string;                  // Unique identifier
-		label: string | JSX.Element; // Display name or React component
-		currentValue: number;        // Current period value
-		previousValue: number;       // Previous period value
-		currentShare: number;        // Current bar width (0-100)
-		previousShare: number;       // Previous bar width (0-100)
-		delta: number;               // Percentage change
-		imageColor?: string;         // Optional color for the entry's image/icon
-	}
-` } />
-
-### Custom Style Properties
-
-<Source language="tsx" code={ `
-	type CustomProperties = {
-		'--a8c--charts--leaderboard--bar--border-radius'?: string;
-	};
-` } />
 
 ## Examples
 
@@ -569,3 +517,7 @@ Main chart component for displaying ranked data with optional comparison values.
 
 	<LeaderboardChart data={trafficData} withComparison={true} />
 ` } />
+
+## API Reference
+
+For detailed information about component props, types, and method signatures, see the [Leaderboard Chart API Reference](./?path=/docs/js-packages-charts-types-leaderboard-chart-api-reference--docs).

--- a/projects/js-packages/charts/src/components/line-chart/stories/annotation.docs.mdx
+++ b/projects/js-packages/charts/src/components/line-chart/stories/annotation.docs.mdx
@@ -366,72 +366,7 @@ The component uses the native [HTML Popover API](https://developer.mozilla.org/e
 
 ## API Reference
 
-### LineChart.AnnotationsOverlay
-
-Container component that manages annotation rendering and chart synchronization.
-
-**Props:**
-
-- `children`: Annotation components
-
-### LineChart.Annotation
-
-Individual annotation component.
-
-**Props:**
-
-| Prop								 | Type																							 | Default		| Description													|
-| -------------------- | -------------------------------------------------- | ---------- | ------------------------------------ |
-| `datum`							| `DataPointDate`																		| -					| **Required.** Data point to annotate |
-| `title`							| `string`																					 | -					| **Required.** Main annotation text	 |
-| `subtitle`					 | `string`																					 | -					| Additional descriptive text					|
-| `subjectType`				| `'circle' \| 'line-vertical' \| 'line-horizontal'` | `'circle'` | Visual annotation style							|
-| `styles`						 | `AnnotationStyles`																 | -					| Custom styling options							 |
-| `renderLabel`				| `FC<{title: string, subtitle?: string}>`					 | -					| Custom label component. **Disables smart positioning.** |
-| `renderLabelPopover` | `FC<{title: string, subtitle?: string}>`					 | -					| Interactive popover content					|
-| `testId`						 | `string`																					 | -					| Test identifier											|
-
-### DataPointDate Type
-
-```typescript
-type DataPointDate = {
-	date: Date;
-	value: number;
-	label?: string;
-};
-```
-
-### AnnotationStyles Type
-
-```typescript
-type AnnotationStyles = {
-	circleSubject?: {
-		fill?: string;
-		stroke?: string;
-		radius?: number;
-		// ... other circle properties
-	};
-	lineSubject?: {
-		stroke?: string;
-		strokeWidth?: number;
-		// ... other line properties
-	};
-	connector?: {
-		stroke?: string;
-		strokeWidth?: number;
-		// ... other connector properties
-	};
-	label?: {
-		backgroundFill?: string;
-		fontColor?: string;
-		showAnchorLine?: boolean;
-		maxWidth?: number;
-		x?: number | 'start' | 'end';
-		y?: number | 'start' | 'end';
-		// ... other label properties
-	};
-};
-```
+For detailed information about annotation component props, types, and styling options, see the [Line Chart API Reference](./?path=/docs/js-packages-charts-types-line-chart-api-reference--docs).
 
 ## Examples and Stories
 

--- a/projects/js-packages/charts/src/components/line-chart/stories/index.api.mdx
+++ b/projects/js-packages/charts/src/components/line-chart/stories/index.api.mdx
@@ -1,0 +1,179 @@
+import { Meta, Source } from '@storybook/addon-docs/blocks';
+
+<Meta title="JS Packages/Charts/Types/Line Chart/API Reference" />
+
+# Line Chart API Reference
+
+## LineChart
+
+Main chart component with responsive behavior by default.
+
+**Props:**
+
+| Prop | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| `data` | `SeriesData[]` | - | **Required.** Array of data series to display |
+| `width` | `number?` | responsive | Chart width in pixels |
+| `height` | `number?` | responsive | Chart height in pixels |
+| `curveType` | `'smooth' \| 'linear' \| 'monotone'?` | `'smooth'` | Line curve interpolation type |
+| `withGradientFill` | `boolean` | `false` | Fill area under lines with gradient |
+| `withTooltips` | `boolean` | `true` | Enable interactive tooltips |
+| `withTooltipCrosshairs` | `{ showVertical?: boolean; showHorizontal?: boolean }?` | - | Show crosshair guides with tooltips |
+| `showLegend` | `boolean` | `false` | Display chart legend |
+| `legendOrientation` | `'horizontal' \| 'vertical'` | `'horizontal'` | Legend layout orientation |
+| `legendAlignment` | `'start' \| 'center' \| 'end'` | `'center'` | Legend alignment within its position |
+| `legendPosition` | `'top' \| 'bottom'` | `'bottom'` | Legend position (where the legend appears) |
+| `legendShape` | `LegendShape` | `'line'` | Shape used in legend markers |
+| `withStartGlyphs` | `boolean?` | `false` | Show markers at the first data point of each series |
+| `withLegendGlyph` | `boolean?` | `false` | Use custom glyphs in legend |
+| `renderGlyph` | `(props: GlyphProps) => ReactNode?` | - | Custom glyph render function |
+| `glyphStyle` | `SVGProps<SVGCircleElement>?` | `{}` | Styling for chart glyphs |
+| `renderTooltip` | `(params: RenderTooltipParams) => ReactNode?` | - | Custom tooltip render function |
+| `margin` | `{ top?: number; right?: number; bottom?: number; left?: number }?` | calculated | Chart margins |
+| `options` | `ChartOptions?` | `{}` | Advanced axis and scale configuration |
+| `onPointerDown` | `(event: EventHandlerParams) => void?` | - | Pointer down event handler |
+| `onPointerUp` | `(event: EventHandlerParams) => void?` | - | Pointer up event handler |
+| `onPointerMove` | `(event: EventHandlerParams) => void?` | - | Pointer move event handler |
+| `onPointerOut` | `(event: PointerEvent) => void?` | - | Pointer out event handler |
+| `children` | `ReactNode?` | - | Child components (e.g., annotations) |
+
+## LineChart.AnnotationsOverlay
+
+Container component that manages annotation rendering and chart synchronization.
+
+**Props:**
+
+- `children`: Annotation components
+
+## LineChart.Annotation
+
+Individual annotation component for highlighting specific data points or events.
+
+**Props:**
+
+| Prop | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| `datum` | `DataPointDate` | - | **Required.** Data point to annotate |
+| `title` | `string` | - | **Required.** Main annotation text |
+| `subtitle` | `string` | - | Additional descriptive text |
+| `subjectType` | `'circle' \| 'line-vertical' \| 'line-horizontal'` | `'circle'` | Visual annotation style |
+| `styles` | `AnnotationStyles` | - | Custom styling options |
+| `renderLabel` | `FC<{title: string, subtitle?: string}>` | - | Custom label component. **Disables smart positioning.** |
+| `renderLabelPopover` | `FC<{title: string, subtitle?: string}>` | - | Interactive popover content |
+| `testId` | `string` | - | Test identifier |
+
+## SeriesData Type
+
+```typescript
+type SeriesData = {
+	label: string;
+	data: DataPointDate[];
+	options?: {
+		gradient?: {
+			from?: string;
+			to?: string;
+			fromOpacity?: number;
+			toOpacity?: number;
+			stops?: Array<{
+				offset: string;
+				color?: string;
+				opacity?: number;
+			}>;
+		};
+		stroke?: string;
+		seriesLineStyle?: LineStyles;
+		legendShapeStyle?: CSSProperties;
+		type?: 'comparison'; // Semantic type for automatic theme styling
+	};
+};
+```
+
+### Gradient Options
+
+The `gradient` option in `SeriesData.options` accepts the following configuration:
+
+**Basic Gradient (Two-Color):**
+- `from`: Start color (hex, rgb, CSS variable) - defaults to series color
+- `to`: End color (hex, rgb, CSS variable) - defaults to transparent background
+- `fromOpacity`: Start opacity (0-1, default: 0.4)
+- `toOpacity`: End opacity (0-1, default: 0.1)
+
+**Advanced Gradient (Multi-Stop):**
+- `stops`: Array of gradient stops for complex gradients
+  - `offset`: Position along gradient (percentage string, e.g., '25%')
+  - `color`: Color at this stop (hex, rgb, CSS variable) - defaults to line color if omitted
+  - `opacity`: Opacity at this stop (0-1, default: 1)
+
+**Note**: When using `stops`, the `from`, `to`, `fromOpacity`, and `toOpacity` properties are ignored.
+
+## DataPointDate Type
+
+```typescript
+type DataPointDate = {
+	date?: Date;
+	dateString?: string; // Multiple formats supported
+	value: number | null;
+	label?: string;
+};
+```
+
+## AnnotationStyles Type
+
+```typescript
+type AnnotationStyles = {
+	circleSubject?: {
+		fill?: string;
+		stroke?: string;
+		radius?: number;
+		// ... other circle properties
+	};
+	lineSubject?: {
+		stroke?: string;
+		strokeWidth?: number;
+		// ... other line properties
+	};
+	connector?: {
+		stroke?: string;
+		strokeWidth?: number;
+		// ... other connector properties
+	};
+	label?: {
+		backgroundFill?: string;
+		fontColor?: string;
+		showAnchorLine?: boolean;
+		maxWidth?: number;
+		x?: number | 'start' | 'end';
+		y?: number | 'start' | 'end';
+		// ... other label properties
+	};
+};
+```
+
+## ChartOptions Type
+
+```typescript
+type ChartOptions = {
+	yScale?: {
+		type?: 'linear' | 'log';
+		zero?: boolean;
+		domain?: [number, number];
+		nice?: boolean;
+	};
+	xScale?: {
+		type?: 'time' | 'linear';
+		domain?: [Date, Date] | [number, number];
+	};
+	axis?: {
+		x?: {
+			orientation?: 'top' | 'bottom';
+			numTicks?: number;
+			tickFormat?: (value: any) => string;
+		};
+		y?: {
+			orientation?: 'left' | 'right';
+			numTicks?: number;
+			tickFormat?: (value: number) => string;
+		};
+	};
+};
+```

--- a/projects/js-packages/charts/src/components/line-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/components/line-chart/stories/index.docs.mdx
@@ -96,6 +96,8 @@ The simplest line chart requires only a `data` prop with time-series data:
 - **`options`**: Advanced axis and scale configuration
 - **`children`**: Child components (e.g., annotations)
 
+For detailed prop information, type definitions, gradient configuration options, and complete annotation API reference, see the [Line Chart API Reference](./?path=/docs/js-packages-charts-types-line-chart-api-reference--docs).
+
 ## Curve Types
 
 ### Linear Curves
@@ -520,7 +522,7 @@ Control chart layout with precise margin settings:
 
 ## Annotations
 
-Add contextual information to highlight specific data points or events. For comprehensive annotation documentation, see the [Line Chart Annotations](?path=/docs/js-packages-charts-types-line-chart-annotations--docs) guide:
+Add contextual information to highlight specific data points or events. For comprehensive annotation documentation, see the [Line Chart Annotations](?path=/docs/js-packages-charts-types-line-chart-annotations--docs) guide. For detailed annotation API reference, see the [Line Chart API Reference](./?path=/docs/js-packages-charts-types-line-chart-api-reference--docs):
 
 <Source
 	language="jsx"
@@ -622,138 +624,6 @@ Full functionality in all modern browsers supporting:
 - Graceful degradation for older browsers
 - Touch-friendly interactions on mobile devices
 
-## API Reference
-
-### LineChart
-
-Main chart component with responsive behavior by default.
-
-**Props:**
-
-| Prop | Type | Default | Description |
-| ---- | ---- | ------- | ----------- |
-| `data` | `SeriesData[]` | - | **Required.** Array of data series to display |
-| `width` | `number?` | responsive | Chart width in pixels |
-| `height` | `number?` | responsive | Chart height in pixels |
-| `curveType` | `'smooth' \| 'linear' \| 'monotone'?` | `'smooth'` | Line curve interpolation type |
-| `withGradientFill` | `boolean` | `false` | Fill area under lines with gradient |
-| `withTooltips` | `boolean` | `true` | Enable interactive tooltips |
-| `withTooltipCrosshairs` | `{ showVertical?: boolean; showHorizontal?: boolean }?` | - | Show crosshair guides with tooltips |
-| `showLegend` | `boolean` | `false` | Display chart legend |
-| `legendOrientation` | `'horizontal' \| 'vertical'` | `'horizontal'` | Legend layout orientation |
-| `legendAlignment` | `'start' \| 'center' \| 'end'` | `'center'` | Legend alignment within its position |
-| `legendPosition` | `'top' \| 'bottom'` | `'bottom'` | Legend position (where the legend appears) |
-| `legendShape` | `LegendShape` | `'line'` | Shape used in legend markers |
-| `withStartGlyphs` | `boolean?` | `false` | Show markers at the first data point of each series |
-| `withLegendGlyph` | `boolean?` | `false` | Use custom glyphs in legend |
-| `renderGlyph` | `(props: GlyphProps) => ReactNode?` | - | Custom glyph render function |
-| `glyphStyle` | `SVGProps<SVGCircleElement>?` | `{}` | Styling for chart glyphs |
-| `renderTooltip` | `(params: RenderTooltipParams) => ReactNode?` | - | Custom tooltip render function |
-| `margin` | `{ top?: number; right?: number; bottom?: number; left?: number }?` | calculated | Chart margins |
-| `options` | `ChartOptions?` | `{}` | Advanced axis and scale configuration |
-| `onPointerDown` | `(event: EventHandlerParams) => void?` | - | Pointer down event handler |
-| `onPointerUp` | `(event: EventHandlerParams) => void?` | - | Pointer up event handler |
-| `onPointerMove` | `(event: EventHandlerParams) => void?` | - | Pointer move event handler |
-| `onPointerOut` | `(event: PointerEvent) => void?` | - | Pointer out event handler |
-| `children` | `ReactNode?` | - | Child components (e.g., annotations) |
-
-### LineChart.AnnotationsOverlay
-
-Container component for chart annotations. See [Annotations documentation](?path=/docs/js-packages-charts-types-line-chart-annotations--docs) for complete details.
-
-**Props:**
-
-- `children`: Annotation components
-
-### LineChart.Annotation
-
-Individual annotation component. See [Annotations documentation](?path=/docs/js-packages-charts-types-line-chart-annotations--docs) for complete API reference.
-
-### SeriesData Type
-
-```typescript
-type SeriesData = {
-	label: string;
-	data: DataPointDate[];
-	options?: {
-		gradient?: {
-			from?: string;
-			to?: string;
-			fromOpacity?: number;
-			toOpacity?: number;
-			stops?: Array<{
-				offset: string;
-				color?: string;
-				opacity?: number;
-			}>;
-		};
-		stroke?: string;
-		seriesLineStyle?: LineStyles;
-		legendShapeStyle?: CSSProperties;
-		type?: 'comparison'; // Semantic type for automatic theme styling
-	};
-};
-```
-
-#### Gradient Options
-
-The `gradient` option in `SeriesData.options` accepts the following configuration:
-
-**Basic Gradient (Two-Color):**
-- `from`: Start color (hex, rgb, CSS variable) - defaults to series color
-- `to`: End color (hex, rgb, CSS variable) - defaults to transparent background
-- `fromOpacity`: Start opacity (0-1, default: 0.4)
-- `toOpacity`: End opacity (0-1, default: 0.1)
-
-**Advanced Gradient (Multi-Stop):**
-- `stops`: Array of gradient stops for complex gradients
-  - `offset`: Position along gradient (percentage string, e.g., '25%')
-  - `color`: Color at this stop (hex, rgb, CSS variable) - defaults to line color if omitted
-  - `opacity`: Opacity at this stop (0-1, default: 1)
-
-**Note**: When using `stops`, the `from`, `to`, `fromOpacity`, and `toOpacity` properties are ignored.
-
-### DataPointDate Type
-
-```typescript
-type DataPointDate = {
-	date?: Date;
-	dateString?: string; // Multiple formats supported
-	value: number | null;
-	label?: string;
-};
-```
-
-### ChartOptions Type
-
-```typescript
-type ChartOptions = {
-	yScale?: {
-		type?: 'linear' | 'log';
-		zero?: boolean;
-		domain?: [number, number];
-		nice?: boolean;
-	};
-	xScale?: {
-		type?: 'time' | 'linear';
-		domain?: [Date, Date] | [number, number];
-	};
-	axis?: {
-		x?: {
-			orientation?: 'top' | 'bottom';
-			numTicks?: number;
-			tickFormat?: (value: any) => string;
-		};
-		y?: {
-			orientation?: 'left' | 'right';
-			numTicks?: number;
-			tickFormat?: (value: number) => string;
-		};
-	};
-};
-```
-
-
 ## Performance Considerations
 
 ### Built-in Optimizations
@@ -786,3 +656,7 @@ Line Charts integrate seamlessly with the chart theming system:
 - **Jetpack**: Jetpack brand colors and styling
 - **Woo**: WooCommerce brand colors and styling
 - **Custom**: Define your own theme object
+
+## API Reference
+
+For detailed information about component props, types, and method signatures, see the [Line Chart API Reference](./?path=/docs/js-packages-charts-types-line-chart-api-reference--docs).

--- a/projects/js-packages/charts/src/components/line-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/components/line-chart/stories/index.docs.mdx
@@ -29,6 +29,10 @@ The Line Chart component provides a flexible, accessible, and highly customizabl
 	</LineChart>` }
 />
 
+## API Reference
+
+For detailed information about component props, types, and method signatures, see the [Line Chart API Reference](./?path=/docs/js-packages-charts-types-line-chart-api-reference--docs).
+
 ## Basic Usage
 
 ### Simple Line Chart
@@ -656,7 +660,3 @@ Line Charts integrate seamlessly with the chart theming system:
 - **Jetpack**: Jetpack brand colors and styling
 - **Woo**: WooCommerce brand colors and styling
 - **Custom**: Define your own theme object
-
-## API Reference
-
-For detailed information about component props, types, and method signatures, see the [Line Chart API Reference](./?path=/docs/js-packages-charts-types-line-chart-api-reference--docs).

--- a/projects/js-packages/charts/src/components/pie-chart/stories/donut.docs.mdx
+++ b/projects/js-packages/charts/src/components/pie-chart/stories/donut.docs.mdx
@@ -11,6 +11,12 @@ Donut Charts are circular charts with a hollow center, perfect for displaying pr
 
 <Canvas of={ DonutStories.Doughnut } />
 
+## API Reference
+
+Donut charts are created using the PieChart component with `thickness` < 1. All PieChart props are available.
+
+For detailed information about component props, types, compound components, and theme properties, see the [Pie Chart API Reference](./?path=/docs/js-packages-charts-types-pie-chart-api-reference--docs).
+
 ## Basic Usage
 
 ### Simple Donut Chart
@@ -365,9 +371,3 @@ Display resource distribution with totals:
 		</Group>
 	</PieChart>` }
 />
-
-## API Reference
-
-Donut charts are created using the PieChart component with `thickness` < 1. All PieChart props are available.
-
-For detailed information about component props, types, compound components, and theme properties, see the [Pie Chart API Reference](./?path=/docs/js-packages-charts-types-pie-chart-api-reference--docs).

--- a/projects/js-packages/charts/src/components/pie-chart/stories/donut.docs.mdx
+++ b/projects/js-packages/charts/src/components/pie-chart/stories/donut.docs.mdx
@@ -47,21 +47,7 @@ Create a donut chart by setting the `thickness` prop to a value between 0 and 1:
 
 ### Optional Props
 
-All optional props from [PieChart](./?path=/docs/js-packages-charts-types-pie-chart--docs) are supported:
-
-- **`size`** (default: `400`): Diameter of the chart in pixels
-- **`padding`** (default: `20`): Padding around the chart in pixels
-- **`withTooltips`** (default: `false`): Enables interactive tooltips on hover
-- **`showLegend`** (default: `false`): Shows a legend for the chart data
-- **`gapScale`** (default: `0`): Scale of gaps between segments (0-1)
-- **`cornerScale`** (default: `0`): Scale of corner rounding for segments (0-1)
-- **`className`**: Additional CSS class name for the chart container
-- **`chartId`**: Optional unique identifier for the chart
-- **`margin`**: Chart margins as an object with `top`, `right`, `bottom`, `left` properties
-- **`legendOrientation`** (default: `'horizontal'`): Legend orientation (`'horizontal'` | `'vertical'`)
-- **`legendShape`** (default: `'circle'`): Legend shape
-- **`legendAlignment`** (default: `'center'`): Legend alignment within its position
-- **`legendPosition`** (default: `'bottom'`): Legend position (where the legend appears)
+All optional props from [PieChart](./?path=/docs/js-packages-charts-types-pie-chart--docs) are supported. For detailed prop information, see the [Pie Chart API Reference](./?path=/docs/js-packages-charts-types-pie-chart-api-reference--docs).
 
 ### Key Differences from Pie Charts
 
@@ -382,53 +368,6 @@ Display resource distribution with totals:
 
 ## API Reference
 
-### PieChart (Donut Mode)
+Donut charts are created using the PieChart component with `thickness` < 1. All PieChart props are available.
 
-Donut charts are created using the PieChart component with `thickness` < 1. All PieChart props are available:
-
-**Props:**
-
-| Prop | Type | Default | Description |
-| ---- | ---- | ------- | ----------- |
-| `data` | `DataPointPercentage[]` | - | **Required.** Array of data points with label, value, and percentage |
-| `thickness` | `number` | `1` | **Required for donut.** Value between 0 and 1 to create hollow center |
-| `size` | `number` | `400` | Diameter of the chart in pixels |
-| `padding` | `number` | `20` | Padding around the chart in pixels |
-| `gapScale` | `number` | `0` | Scale of gaps between segments (0-1) |
-| `cornerScale` | `number` | `0` | Scale of corner rounding for segments (0-1) |
-| `withTooltips` | `boolean` | `false` | Enables interactive tooltips on hover |
-| `showLegend` | `boolean` | `false` | Shows a legend for the chart data |
-| `legendOrientation` | `'horizontal' \| 'vertical'` | `'horizontal'` | Legend orientation |
-| `legendShape` | `LegendShape` | `'circle'` | Legend shape |
-| `legendAlignment` | `'start' \| 'center' \| 'end'` | `'center'` | Legend alignment within its position |
-| `legendPosition` | `'top' \| 'bottom'` | `'bottom'` | Legend position (where the legend appears) |
-| `className` | `string` | - | Additional CSS class name for the chart container |
-| `chartId` | `string` | - | Optional unique identifier for the chart |
-| `margin` | `ChartMargin` | - | Chart margins with top, right, bottom, left properties |
-| `children` | `ReactNode` | - | Custom content to render in the center area |
-| `maxWidth` | `number` | - | Maximum width for responsive charts |
-| `aspectRatio` | `number` | `1` | Aspect ratio for responsive charts |
-| `resizeDebounceTime` | `number` | `100` | Debounce time for resize events (ms) |
-
-### DataPointPercentage Type
-
-```typescript
-type DataPointPercentage = {
-	label: string;
-	value: number;
-	percentage: number;
-	color?: string; // Optional custom color
-	valueDisplay?: string; // Optional formatted value for display
-};
-```
-
-### ChartMargin Type
-
-```typescript
-type ChartMargin = {
-	top?: number;
-	right?: number;
-	bottom?: number;
-	left?: number;
-};
-```
+For detailed information about component props, types, compound components, and theme properties, see the [Pie Chart API Reference](./?path=/docs/js-packages-charts-types-pie-chart-api-reference--docs).

--- a/projects/js-packages/charts/src/components/pie-chart/stories/index.api.mdx
+++ b/projects/js-packages/charts/src/components/pie-chart/stories/index.api.mdx
@@ -1,0 +1,95 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="JS Packages/Charts/Types/Pie Chart/API Reference" />
+
+# Pie Chart API Reference
+
+## PieChart
+
+Main component for rendering pie and donut charts.
+
+**Props:**
+
+| Prop | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| `data` | `DataPointPercentage[]` | - | **Required.** Array of data objects with label, value, and percentage |
+| `size` | `number` | - | Diameter of the chart in pixels (omit for responsive behavior) |
+| `thickness` | `number` | `1` | Thickness of the pie chart segments (0-1). Values less than 1 create donut charts |
+| `padding` | `number` | `20` | Padding around the chart in pixels |
+| `gapScale` | `number` | `0` | Scale of gaps between segments (0-1) |
+| `cornerScale` | `number` | `0` | Scale of corner rounding for segments (0-1) |
+| `withTooltips` | `boolean` | `false` | Enable interactive tooltips on hover |
+| `showLegend` | `boolean` | `false` | Display chart legend |
+| `legendOrientation` | `'horizontal' \| 'vertical'` | `'horizontal'` | Legend layout direction |
+| `legendAlignment` | `'start' \| 'center' \| 'end'` | `'center'` | Legend alignment within its position |
+| `legendPosition` | `'top' \| 'bottom'` | `'bottom'` | Legend position (where the legend appears) |
+| `legendShape` | `LegendShape` | `'circle'` | Shape of legend markers |
+| `children` | `ReactNode` | - | Optional content to render inside chart center (useful for donut charts) |
+| `className` | `string` | - | Additional CSS class names |
+| `chartId` | `string` | - | Custom chart identifier for accessibility |
+| `maxWidth` | `number` | - | Maximum width for responsive charts |
+| `aspectRatio` | `number` | `1` | Aspect ratio for responsive charts |
+| `resizeDebounceTime` | `number` | `100` | Debounce time for resize events (ms) |
+
+## Theme Properties
+
+The following properties can be customized via the theme system:
+
+| Prop | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| `labelTextColor` | `string` | `'#FFFFFF'` | Color of text displayed on pie chart segments |
+| `labelBackgroundColor` | `string` | `'transparent'` | Background color for labels. Set to any color value to enable label backgrounds |
+
+## Compound Components
+
+### PieChart.SVG
+
+Container for SVG elements to be rendered inside the chart area.
+
+```jsx
+<PieChart.SVG>
+  <text x={0} y={0}>Center Text</text>
+</PieChart.SVG>
+```
+
+### PieChart.HTML
+
+Container for HTML elements to be rendered outside the SVG area.
+
+```jsx
+<PieChart.HTML>
+  <h3>Chart Title</h3>
+  <PieChart.Legend />
+</PieChart.HTML>
+```
+
+### PieChart.Legend
+
+The Legend component for displaying chart data labels. Can be used either as a prop or within composition:
+
+```jsx
+// As a prop
+<PieChart showLegend={true} legendPosition="bottom" />
+
+// With composition
+<PieChart>
+  <PieChart.Legend position="bottom" orientation="horizontal" />
+</PieChart>
+```
+
+## DataPointPercentage Type
+
+```typescript
+type DataPointPercentage = {
+	/** Label for the data point */
+	label: string;
+	/** Numerical value */
+	value: number;
+	/** Formatted value for display */
+	valueDisplay?: string;
+	/** Percentage value (must sum to 100 across all data points) */
+	percentage: number;
+	/** Optional custom color override */
+	color?: string;
+};
+```

--- a/projects/js-packages/charts/src/components/pie-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/components/pie-chart/stories/index.docs.mdx
@@ -61,6 +61,8 @@ The simplest pie chart requires only a `data` prop with percentage-based data:
 - **`cornerScale`** (default: `0`): Scale of corner rounding for segments (0-1)
 - **`children`**: Optional React node to render inside the chart center (useful for donut charts)
 
+For detailed prop information, compound components, and type definitions, see the [Pie Chart API Reference](./?path=/docs/js-packages-charts-types-pie-chart-api-reference--docs).
+
 ## Composition API
 
 The Pie Chart now supports a compound component pattern for advanced customization:
@@ -100,6 +102,8 @@ The composition API allows you to add custom SVG and HTML elements to your chart
 - **Type Safety**: TypeScript knows where each element type belongs
 - **Flexibility**: Add custom visualizations, annotations, or UI elements
 - **Backward Compatible**: Existing implementations continue to work unchanged
+
+For detailed information about compound components (`PieChart.SVG`, `PieChart.HTML`, `PieChart.Legend`), see the [Pie Chart API Reference](./?path=/docs/js-packages-charts-types-pie-chart-api-reference--docs).
 
 ## Interactive Features
 
@@ -288,92 +292,4 @@ Pie Charts automatically integrate with the chart theme system, inheriting color
 
 ## API Reference
 
-### PieChart
-
-Main component for rendering pie and donut charts.
-
-**Props:**
-
-| Prop                        | Type                            | Default        | Description                                                                       |
-| --------------------------- | ------------------------------- | -------------- | --------------------------------------------------------------------------------- |
-| `data`                      | `DataPointPercentage[]`         | -              | **Required.** Array of data objects with label, value, and percentage             |
-| `size`                      | `number`                        | -              | Diameter of the chart in pixels (omit for responsive behavior)                    |
-| `thickness`                 | `number`                        | `1`            | Thickness of the pie chart segments (0-1). Values less than 1 create donut charts |
-| `padding`                   | `number`                        | `20`           | Padding around the chart in pixels                                                |
-| `gapScale`                  | `number`                        | `0`            | Scale of gaps between segments (0-1)                                              |
-| `cornerScale`               | `number`                        | `0`            | Scale of corner rounding for segments (0-1)                                       |
-| `withTooltips`              | `boolean`                       | `false`        | Enable interactive tooltips on hover                                              |
-| `showLegend`                | `boolean`                       | `false`        | Display chart legend                                                              |
-| `legendOrientation`         | `'horizontal' \| 'vertical'`    | `'horizontal'` | Legend layout direction                                                           |
-| `legendAlignment` | `'start' \| 'center' \| 'end'` | `'center'`     | Legend alignment within its position                                                       |
-| `legendPosition`   | `'top' \| 'bottom'`             | `'bottom'`     | Legend position (where the legend appears)                                                          |
-| `legendShape`               | `LegendShape`                   | `'circle'`     | Shape of legend markers                                                           |
-| `children`                  | `ReactNode`                     | -              | Optional content to render inside chart center (useful for donut charts)          |
-| `className`                 | `string`                        | -              | Additional CSS class names                                                        |
-| `chartId`                   | `string`                        | -              | Custom chart identifier for accessibility                                         |
-| `maxWidth`                  | `number`                        | -              | Maximum width for responsive charts                                               |
-| `aspectRatio`               | `number`                        | `1`            | Aspect ratio for responsive charts                                                |
-| `resizeDebounceTime`        | `number`                        | `100`          | Debounce time for resize events (ms)                                              |
-
-### Theme Properties
-
-The following properties can be customized via the theme system:
-
-| Prop                        | Type                            | Default        | Description                                                                       |
-| --------------------------- | ------------------------------- | -------------- | --------------------------------------------------------------------------------- |
-| `labelTextColor`            | `string`                        | `'#FFFFFF'`    | Color of text displayed on pie chart segments                                    |
-| `labelBackgroundColor`      | `string`                        | `'transparent'` | Background color for labels. Set to any color value to enable label backgrounds |
-
-### Compound Components
-
-#### PieChart.SVG
-
-Container for SVG elements to be rendered inside the chart area.
-
-```jsx
-<PieChart.SVG>
-  <text x={0} y={0}>Center Text</text>
-</PieChart.SVG>
-```
-
-#### PieChart.HTML
-
-Container for HTML elements to be rendered outside the SVG area.
-
-```jsx
-<PieChart.HTML>
-  <h3>Chart Title</h3>
-  <PieChart.Legend />
-</PieChart.HTML>
-```
-
-#### PieChart.Legend
-
-The Legend component for displaying chart data labels. Can be used either as a prop or within composition:
-
-```jsx
-// As a prop
-<PieChart showLegend={true} legendPosition="bottom" />
-
-// With composition
-<PieChart>
-  <PieChart.Legend position="bottom" orientation="horizontal" />
-</PieChart>
-```
-
-### DataPointPercentage Type
-
-```typescript
-type DataPointPercentage = {
-	/** Label for the data point */
-	label: string;
-	/** Numerical value */
-	value: number;
-	/** Formatted value for display */
-	valueDisplay?: string;
-	/** Percentage value (must sum to 100 across all data points) */
-	percentage: number;
-	/** Optional custom color override */
-	color?: string;
-};
-```
+For detailed information about component props, types, compound components, and theme properties, see the [Pie Chart API Reference](./?path=/docs/js-packages-charts-types-pie-chart-api-reference--docs).

--- a/projects/js-packages/charts/src/components/pie-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/components/pie-chart/stories/index.docs.mdx
@@ -26,6 +26,10 @@ The Pie Chart component provides a flexible, accessible, and highly customizable
 
 />
 
+## API Reference
+
+For detailed information about component props, types, compound components, and theme properties, see the [Pie Chart API Reference](./?path=/docs/js-packages-charts-types-pie-chart-api-reference--docs).
+
 ## Basic Usage
 
 ### Simple Pie Chart
@@ -289,7 +293,3 @@ Pie Charts automatically integrate with the chart theme system, inheriting color
     </GlobalChartsProvider>` }
 
 />
-
-## API Reference
-
-For detailed information about component props, types, compound components, and theme properties, see the [Pie Chart API Reference](./?path=/docs/js-packages-charts-types-pie-chart-api-reference--docs).

--- a/projects/js-packages/charts/src/components/pie-semi-circle-chart/stories/index.api.mdx
+++ b/projects/js-packages/charts/src/components/pie-semi-circle-chart/stories/index.api.mdx
@@ -1,0 +1,45 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="JS Packages/Charts/Types/Pie Semi Circle Chart/API Reference" />
+
+# Pie Semi Circle Chart API Reference
+
+## PieSemiCircleChart
+
+Main component for rendering semi-circular pie charts.
+
+**Props:**
+
+| Prop | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| `data` | `DataPointPercentage[]` | - | **Required.** Array of data points to display |
+| `width` | `number` | `400` | Width of the chart in pixels (height is automatically half of width) |
+| `thickness` | `number` | `0.4` | Thickness of the pie segments (0-1, where 1 is full thickness) |
+| `clockwise` | `boolean` | `true` | Direction of segment rendering |
+| `label` | `string` | - | Text displayed above the chart |
+| `note` | `string` | - | Additional text displayed below the label |
+| `withTooltips` | `boolean` | `false` | Enable interactive tooltips on hover |
+| `showLegend` | `boolean` | `false` | Display legend below the chart |
+| `legendOrientation` | `'horizontal' \| 'vertical'` | `'horizontal'` | Legend layout direction |
+| `legendAlignment` | `'start' \| 'center' \| 'end'` | `'center'` | Legend alignment within its position |
+| `legendPosition` | `'top' \| 'bottom'` | `'bottom'` | Legend position (where the legend appears) |
+| `legendShape` | `'circle' \| 'rect' \| 'line'` | `'circle'` | Shape of legend indicators |
+| `className` | `string` | - | Additional CSS class for the container |
+| `chartId` | `string` | - | Optional unique identifier (auto-generated if not provided) |
+
+## DataPointPercentage Type
+
+```typescript
+type DataPointPercentage = {
+	/** Label for the data point */
+	label: string;
+	/** Numerical value */
+	value: number;
+	/** Formatted value for display in tooltips and legends */
+	valueDisplay?: string;
+	/** Percentage value (must be positive, doesn't need to sum to 100) */
+	percentage: number;
+	/** Optional custom color override */
+	color?: string;
+};
+```

--- a/projects/js-packages/charts/src/components/pie-semi-circle-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/components/pie-semi-circle-chart/stories/index.docs.mdx
@@ -86,13 +86,7 @@ The simplest implementation requires only data with proper percentage values. Un
 
 ### Optional Props
 
-- **`width`**: Chart width in pixels (height is automatically calculated as half the width)
-- **`thickness`**: Ring thickness as a value between 0 and 1 (default: 0.4)
-- **`clockwise`**: Direction of rendering - true for clockwise, false for counter-clockwise (default: true)
-- **`label`**: Text displayed above the chart
-- **`note`**: Additional text displayed below the label
-- **`withTooltips`**: Enable interactive tooltips on hover (default: false)
-- **`showLegend`**: Display legend below the chart (default: false)
+For detailed information about all optional props, see the [Pie Semi Circle Chart API Reference](./?path=/docs/js-packages-charts-types-pie-semi-circle-chart-api-reference--docs).
 
 ## Chart Variations
 
@@ -339,45 +333,7 @@ The chart integrates with the chart context system for consistent behavior acros
 
 ## API Reference
 
-### PieSemiCircleChart
-
-Main component for rendering semi-circular pie charts.
-
-**Props:**
-
-| Prop | Type | Default | Description |
-| ---- | ---- | ------- | ----------- |
-| `data` | `DataPointPercentage[]` | - | **Required.** Array of data points to display |
-| `width` | `number` | `400` | Width of the chart in pixels (height is automatically half of width) |
-| `thickness` | `number` | `0.4` | Thickness of the pie segments (0-1, where 1 is full thickness) |
-| `clockwise` | `boolean` | `true` | Direction of segment rendering |
-| `label` | `string` | - | Text displayed above the chart |
-| `note` | `string` | - | Additional text displayed below the label |
-| `withTooltips` | `boolean` | `false` | Enable interactive tooltips on hover |
-| `showLegend` | `boolean` | `false` | Display legend below the chart |
-| `legendOrientation` | `'horizontal' \| 'vertical'` | `'horizontal'` | Legend layout direction |
-| `legendAlignment` | `'start' \| 'center' \| 'end'` | `'center'` | Legend alignment within its position |
-| `legendPosition` | `'top' \| 'bottom'` | `'bottom'` | Legend position (where the legend appears) |
-| `legendShape` | `'circle' \| 'rect' \| 'line'` | `'circle'` | Shape of legend indicators |
-| `className` | `string` | - | Additional CSS class for the container |
-| `chartId` | `string` | - | Optional unique identifier (auto-generated if not provided) |
-
-### DataPointPercentage Type
-
-```typescript
-type DataPointPercentage = {
-	/** Label for the data point */
-	label: string;
-	/** Numerical value */
-	value: number;
-	/** Formatted value for display in tooltips and legends */
-	valueDisplay?: string;
-	/** Percentage value (must be positive, doesn't need to sum to 100) */
-	percentage: number;
-	/** Optional custom color override */
-	color?: string;
-};
-```
+For detailed information about component props, types, and method signatures, see the [Pie Semi Circle Chart API Reference](./?path=/docs/js-packages-charts-types-pie-semi-circle-chart-api-reference--docs).
 
 ## Migration
 

--- a/projects/js-packages/charts/src/components/pie-semi-circle-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/components/pie-semi-circle-chart/stories/index.docs.mdx
@@ -51,6 +51,10 @@ const data = [
 
 The chart automatically validates data to ensure positive values and meaningful percentages, displaying error states for invalid data configurations.
 
+## API Reference
+
+For detailed information about component props, types, and method signatures, see the [Pie Semi Circle Chart API Reference](./?path=/docs/js-packages-charts-types-pie-semi-circle-chart-api-reference--docs).
+
 ## Basic Usage
 
 ### Basic Semi-Circle Chart
@@ -330,10 +334,6 @@ The chart integrates with the chart context system for consistent behavior acros
 - Automatic chart ID generation for accessibility
 - Theme consistency across multiple charts
 - Legend item registration for cross-chart interactions
-
-## API Reference
-
-For detailed information about component props, types, and method signatures, see the [Pie Semi Circle Chart API Reference](./?path=/docs/js-packages-charts-types-pie-semi-circle-chart-api-reference--docs).
 
 ## Migration
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes [CHARTS-124: Separate API Reference docs](https://linear.app/a8c/issue/CHARTS-124/separate-api-reference-docs)

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Separates the API reference documentation for each chart from the usage documentation, into a new API Reference storybook documentation entry
* Moves the existing API Reference section in each main Docs entry up to immediately below the Overview, for easy discovery
* Updates the AI guidelines for documentation to create the separate docs, updates the existing docs template, and adds a new template for the API reference

### Screenshots

| Main Docs | API Reference |
|-|-|
| <img width="2878" height="2376" alt="localhost_50240__path=_docs_js-packages-charts-types-bar-list-chart--docs (1)" src="https://github.com/user-attachments/assets/e1d8402d-1f8e-4be1-b4af-f81155e1cbbf" /> | <img width="2878" height="2376" alt="localhost_50240__path=_docs_js-packages-charts-types-bar-list-chart--docs" src="https://github.com/user-attachments/assets/2d1b153b-11e9-4ab5-b1e9-76744ac6373e" /> |

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to http://localhost:50240/?path=/docs/js-packages-charts-types-bar-chart--docs
* Check the main Docs has no API reference details, and instead has a section immediately below the Overview that links to http://localhost:50240/?path=/docs/js-packages-charts-types-bar-chart-api-reference--docs
* Review the new API reference against the existing at https://automattic.github.io/jetpack-storybook/?path=/docs/js-packages-charts-types-bar-chart--docs#api-reference. There should be no significant changes, although it's possible the AI might have updated details it found to be incorrect. I haven't observed this though.
* Repeat this for the other charts
* Check that the Line Chart annotation API reference has been included in the main Line Chart API reference, and the Donut Chart API reference links to the Pie Chart API reference
