### PR TITLE
WooCommerce Analytics: Implement WP Consent API Integration

### DIFF
--- a/projects/packages/woocommerce-analytics/.phan/stubs/wp-consent-api-stubs.php
+++ b/projects/packages/woocommerce-analytics/.phan/stubs/wp-consent-api-stubs.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Stubs for WP Consent API plugin functions.
+ *
+ * @see https://wordpress.org/plugins/wp-consent-api/
+ */
+
+/**
+ * Check if consent is given for a specific consent category.
+ *
+ * @param string $category The consent category to check (e.g., 'statistics', 'marketing').
+ * @return bool True if consent is given for the category, false otherwise.
+ */
+function wp_has_consent( $category ) {
+	return false;
+}

--- a/projects/packages/woocommerce-analytics/README.md
+++ b/projects/packages/woocommerce-analytics/README.md
@@ -65,50 +65,111 @@ add_filter( 'woocommerce_analytics_clickhouse_enabled', '__return_true' );
 add_filter( 'woocommerce_analytics_experimental_proxy_tracking_enabled', '__return_true' );
 ```
 
+## Privacy & Consent Management
+
+### WP Consent API Integration
+
+The package integrates with [WP Consent API](https://wordpress.org/plugins/wp-consent-api/) to ensure GDPR and privacy regulation compliance. Tracking only occurs when users have granted consent for statistics collection.
+
+#### How It Works
+
+**Client-Side Consent Checking:**
+
+- Analytics initialization is blocked until `wp_has_consent('statistics')` returns `true`
+- Dynamic consent change handling automatically starts/stops tracking when consent is granted/withdrawn
+- Session data is automatically cleared when consent is withdrawn
+
+**Server-Side Consent Checking:**
+
+- All server-side event recording checks consent before processing
+- REST API proxy endpoint respects consent status
+- Events are silently skipped when consent is not granted (no errors thrown)
+
+#### Backward Compatibility
+
+When WP Consent API is not available, the package defaults to allowing all tracking to maintain backward compatibility with existing installations.
+
+#### Integration Example
+
+```php
+// The package automatically detects and integrates with WP Consent API
+// No additional configuration required
+
+// To check consent status programmatically:
+use Automattic\Woocommerce_Analytics\Consent_Manager;
+
+if ( Consent_Manager::has_statistics_consent() ) {
+    // Tracking is allowed
+}
+```
+
+#### Client-Side Implementation
+
+```javascript
+// Client-side consent checking is automatic
+// Analytics will only initialize when consent is granted
+
+// For custom integrations, use the consent manager:
+import { consentManager } from './consent';
+
+if ( consentManager.hasStatisticsConsent() ) {
+	// Proceed with analytics
+}
+
+// Listen for consent changes:
+consentManager.addConsentChangeListener( hasConsent => {
+	if ( hasConsent ) {
+		// Consent granted - start tracking
+	} else {
+		// Consent withdrawn - stop tracking
+	}
+} );
+```
+
 ## Tracked Events
 
 ### Session Events
 
-| Event Name            | Trigger                        | ClickHouse | Recording Method   | Description                                                   |
-|---------------------- |--------------------------------|------------|--------------------|---------------------------------------------------------------|
-| `session_started`     | Page load                      | ✓          | JS                 | When user session begins                                      |
-| `session_engagement`  | Page load (returning session)  | ✓          | JS                 | When user visits site in existing session (engagement marker) |
+| Event Name           | Trigger                       | ClickHouse | Recording Method | Description                                                   |
+| -------------------- | ----------------------------- | ---------- | ---------------- | ------------------------------------------------------------- |
+| `session_started`    | Page load                     | ✓          | JS               | When user session begins                                      |
+| `session_engagement` | Page load (returning session) | ✓          | JS               | When user visits site in existing session (engagement marker) |
 
 ### Navigation Events
 
-| Event Name   | Trigger       | ClickHouse | Recording Method   | Description                        |
-|-------------|---------------|------------|--------------------|------------------------------------|
-| `page_view` | Page load     | ✓          | JS                 | General page view tracking         |
-| `search`    | Search action | ✓          | PHP → JS Queue     | When site search is performed     |
+| Event Name  | Trigger       | ClickHouse | Recording Method | Description                   |
+| ----------- | ------------- | ---------- | ---------------- | ----------------------------- |
+| `page_view` | Page load     | ✓          | JS               | General page view tracking    |
+| `search`    | Search action | ✓          | PHP → JS Queue   | When site search is performed |
 
 ### Store Events
 
-| Event Name                 | Trigger                | ClickHouse | Recording Method   | Description                                         |
-|--------------------------- |----------------------- |------------|--------------------|-----------------------------------------------------|
-| `product_view`             | Single product page    | ✓          | PHP → JS Queue     | When product page is viewed                         |
-| `cart_view`                | Cart page              | ✓          | PHP → JS Queue     | When cart page is viewed                            |
-| `add_to_cart`              | Add to cart action     | ✓          | PHP (Immediate)    | When products are added to cart                     |
-| `remove_from_cart`         | Remove from cart       | ✓          | PHP (Immediate)    | When products are removed from cart                 |
-| `checkout_view`            | Checkout page          | ✓          | PHP → JS Queue     | When checkout page is viewed                        |
-| `product_checkout`         | Checkout page          | ✓          | PHP → JS Queue     | When checkout page is viewed and cart is not empty  |
-| `product_purchase`         | Order placed           | ✓          | PHP (Immediate)    | When purchase is completed                          |
-| `order_confirmation_view`   | Thank you page         | ✓          | PHP → JS Queue     | When order confirmation page is viewed               |
-| `post_account_creation`    | Account creation       | -          | PHP → JS Queue     | When new account is created during checkout         |
+| Event Name                | Trigger             | ClickHouse | Recording Method | Description                                        |
+| ------------------------- | ------------------- | ---------- | ---------------- | -------------------------------------------------- |
+| `product_view`            | Single product page | ✓          | PHP → JS Queue   | When product page is viewed                        |
+| `cart_view`               | Cart page           | ✓          | PHP → JS Queue   | When cart page is viewed                           |
+| `add_to_cart`             | Add to cart action  | ✓          | PHP (Immediate)  | When products are added to cart                    |
+| `remove_from_cart`        | Remove from cart    | ✓          | PHP (Immediate)  | When products are removed from cart                |
+| `checkout_view`           | Checkout page       | ✓          | PHP → JS Queue   | When checkout page is viewed                       |
+| `product_checkout`        | Checkout page       | ✓          | PHP → JS Queue   | When checkout page is viewed and cart is not empty |
+| `product_purchase`        | Order placed        | ✓          | PHP (Immediate)  | When purchase is completed                         |
+| `order_confirmation_view` | Thank you page      | ✓          | PHP → JS Queue   | When order confirmation page is viewed             |
+| `post_account_creation`   | Account creation    | -          | PHP → JS Queue   | When new account is created during checkout        |
 
 ### Account Events
 
-| Event Name                     | Trigger               | ClickHouse | Recording Method   | Description                                    |
-|--------------------------------|-----------------------|------------|--------------------|------------------------------------------------|
-| `my_account_tab_click`         | Tab click             | -          | JS                 | When account navigation log out tab is clicked |
-| `my_account_page_view`         | Tab view              | -          | PHP → JS Queue     | When account tabs/pages are viewed             |
-| `my_account_order_number_click`| Order number click    | -          | PHP → JS Queue     | When order number link is clicked              |
-| `my_account_order_action_click`| Order action click    | -          | PHP → JS Queue     | When order action buttons are clicked          |
-| `my_account_address_click`     | Address link click    | -          | PHP → JS Queue     | When address edit links are clicked            |
-| `my_account_address_save`      | Address update        | -          | PHP (Immediate)    | When user saves address information            |
-| `my_account_payment_add`       | Payment method page   | -          | PHP → JS Queue     | When add payment method page is viewed         |
-| `my_account_payment_save`      | Payment method add    | -          | PHP (Immediate)    | When payment method is added                   |
-| `my_account_payment_delete`    | Payment method delete | -          | PHP (Immediate)    | When payment method is deleted                 |
-| `my_account_details_save`      | Profile update         | -          | PHP (Immediate)    | When account details are saved                 |
+| Event Name                      | Trigger               | ClickHouse | Recording Method | Description                                    |
+| ------------------------------- | --------------------- | ---------- | ---------------- | ---------------------------------------------- |
+| `my_account_tab_click`          | Tab click             | -          | JS               | When account navigation log out tab is clicked |
+| `my_account_page_view`          | Tab view              | -          | PHP → JS Queue   | When account tabs/pages are viewed             |
+| `my_account_order_number_click` | Order number click    | -          | PHP → JS Queue   | When order number link is clicked              |
+| `my_account_order_action_click` | Order action click    | -          | PHP → JS Queue   | When order action buttons are clicked          |
+| `my_account_address_click`      | Address link click    | -          | PHP → JS Queue   | When address edit links are clicked            |
+| `my_account_address_save`       | Address update        | -          | PHP (Immediate)  | When user saves address information            |
+| `my_account_payment_add`        | Payment method page   | -          | PHP → JS Queue   | When add payment method page is viewed         |
+| `my_account_payment_save`       | Payment method add    | -          | PHP (Immediate)  | When payment method is added                   |
+| `my_account_payment_delete`     | Payment method delete | -          | PHP (Immediate)  | When payment method is deleted                 |
+| `my_account_details_save`       | Profile update        | -          | PHP (Immediate)  | When account details are saved                 |
 
 ### Recording Methods Explained
 
@@ -233,7 +294,7 @@ Enable debug mode for detailed logging:
 
 ```javascript
 // In browser console or add to page
-localStorage.setItem('debug', 'wc-analytics:*');
+localStorage.setItem( 'debug', 'wc-analytics:*' );
 ```
 
 ## Security

--- a/projects/packages/woocommerce-analytics/README.md
+++ b/projects/packages/woocommerce-analytics/README.md
@@ -71,60 +71,7 @@ add_filter( 'woocommerce_analytics_experimental_proxy_tracking_enabled', '__retu
 
 The package integrates with [WP Consent API](https://wordpress.org/plugins/wp-consent-api/) to ensure GDPR and privacy regulation compliance. Tracking only occurs when users have granted consent for statistics collection.
 
-#### How It Works
-
-**Client-Side Consent Checking:**
-
-- Analytics initialization is blocked until `wp_has_consent('statistics')` returns `true`
-- Dynamic consent change handling automatically starts/stops tracking when consent is granted/withdrawn
-- Session data is automatically cleared when consent is withdrawn
-
-**Server-Side Consent Checking:**
-
-- All server-side event recording checks consent before processing
-- REST API proxy endpoint respects consent status
-- Events are silently skipped when consent is not granted (no errors thrown)
-
-#### Backward Compatibility
-
-When WP Consent API is not available, the package defaults to allowing all tracking to maintain backward compatibility with existing installations.
-
-#### Integration Example
-
-```php
-// The package automatically detects and integrates with WP Consent API
-// No additional configuration required
-
-// To check consent status programmatically:
-use Automattic\Woocommerce_Analytics\Consent_Manager;
-
-if ( Consent_Manager::has_statistics_consent() ) {
-    // Tracking is allowed
-}
-```
-
-#### Client-Side Implementation
-
-```javascript
-// Client-side consent checking is automatic
-// Analytics will only initialize when consent is granted
-
-// For custom integrations, use the consent manager:
-import { consentManager } from './consent';
-
-if ( consentManager.hasStatisticsConsent() ) {
-	// Proceed with analytics
-}
-
-// Listen for consent changes:
-consentManager.addConsentChangeListener( hasConsent => {
-	if ( hasConsent ) {
-		// Consent granted - start tracking
-	} else {
-		// Consent withdrawn - stop tracking
-	}
-} );
-```
+When WP Consent API is not available, the package defaults to allowing all tracking to maintain backward compatibility.
 
 ## Tracked Events
 

--- a/projects/packages/woocommerce-analytics/changelog/wooa7s-526-implement-wp-consent-api-integration-in-woocommerce
+++ b/projects/packages/woocommerce-analytics/changelog/wooa7s-526-implement-wp-consent-api-integration-in-woocommerce
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Implement WP Consent API Integration

--- a/projects/packages/woocommerce-analytics/package.json
+++ b/projects/packages/woocommerce-analytics/package.json
@@ -22,7 +22,7 @@
 		"test-coverage": "pnpm run test --coverage",
 		"typecheck": "tsc --noEmit",
 		"validate": "pnpm exec validate-es build/",
-		"watch": "pnpm build && pnpm build-client --watch"
+		"watch": "pnpm build --watch"
 	},
 	"dependencies": {
 		"@wordpress/api-fetch": "7.31.0",

--- a/projects/packages/woocommerce-analytics/src/API/class-wc-analytics-tracking-proxy.php
+++ b/projects/packages/woocommerce-analytics/src/API/class-wc-analytics-tracking-proxy.php
@@ -55,6 +55,18 @@ class WC_Analytics_Tracking_Proxy extends \WC_REST_Controller {
 	 * @return \WP_REST_Response|\WP_Error Response object on success, or WP_Error object on failure.
 	 */
 	public function track_events( $request ) {
+		// Check consent before processing any events
+		if ( ! Consent_Manager::has_statistics_consent() ) {
+			return new \WP_REST_Response(
+				array(
+					'success' => true,
+					'message' => 'Events skipped due to lack of statistics consent',
+					'results' => array(),
+				),
+				200
+			);
+		}
+
 		$events = $request->get_json_params();
 
 		if ( ! is_array( $events ) || ( isset( $events['event_name'] ) ) ) {

--- a/projects/packages/woocommerce-analytics/src/API/class-wc-analytics-tracking-proxy.php
+++ b/projects/packages/woocommerce-analytics/src/API/class-wc-analytics-tracking-proxy.php
@@ -60,7 +60,7 @@ class WC_Analytics_Tracking_Proxy extends \WC_REST_Controller {
 			return new \WP_REST_Response(
 				array(
 					'success' => true,
-					'message' => 'Events skipped due to lack of statistics consent',
+					'message' => 'Events skipped due to lack of analytics consent',
 					'results' => array(),
 				),
 				200

--- a/projects/packages/woocommerce-analytics/src/API/class-wc-analytics-tracking-proxy.php
+++ b/projects/packages/woocommerce-analytics/src/API/class-wc-analytics-tracking-proxy.php
@@ -56,7 +56,7 @@ class WC_Analytics_Tracking_Proxy extends \WC_REST_Controller {
 	 */
 	public function track_events( $request ) {
 		// Check consent before processing any events
-		if ( ! Consent_Manager::has_statistics_consent() ) {
+		if ( ! Consent_Manager::has_analytics_consent() ) {
 			return new \WP_REST_Response(
 				array(
 					'success' => true,

--- a/projects/packages/woocommerce-analytics/src/class-consent-manager.php
+++ b/projects/packages/woocommerce-analytics/src/class-consent-manager.php
@@ -24,6 +24,7 @@ class Consent_Manager {
 	 */
 	public static function has_analytics_consent() {
 		if ( ! function_exists( 'wp_has_consent' ) ) {
+			// If WP Consent API is not available, default to true for backward compatibility
 			return true;
 		}
 

--- a/projects/packages/woocommerce-analytics/src/class-consent-manager.php
+++ b/projects/packages/woocommerce-analytics/src/class-consent-manager.php
@@ -13,7 +13,7 @@ namespace Automattic\Woocommerce_Analytics;
 class Consent_Manager {
 
 	/**
-	 * Consent type that we check for analytics tracking
+	 * WP Consent API's consent type we check for analytics tracking
 	 */
 	const WP_CONSENT_API_STATISTICS_TYPE = 'statistics';
 

--- a/projects/packages/woocommerce-analytics/src/class-consent-manager.php
+++ b/projects/packages/woocommerce-analytics/src/class-consent-manager.php
@@ -18,22 +18,12 @@ class Consent_Manager {
 	const WP_CONSENT_API_STATISTICS_TYPE = 'statistics';
 
 	/**
-	 * Check if WP Consent API is available
+	 * Check if user has consent for analytics tracking
 	 *
 	 * @return bool
 	 */
-	public static function is_wp_consent_api_available() {
-		return function_exists( 'wp_has_consent' );
-	}
-
-	/**
-	 * Check if user has consent for statistics tracking
-	 *
-	 * @return bool
-	 */
-	public static function has_statistics_consent() {
-		// If WP Consent API is not available, default to true for backward compatibility
-		if ( ! self::is_wp_consent_api_available() ) {
+	public static function has_analytics_consent() {
+		if ( ! function_exists( 'wp_has_consent' ) ) {
 			return true;
 		}
 

--- a/projects/packages/woocommerce-analytics/src/class-consent-manager.php
+++ b/projects/packages/woocommerce-analytics/src/class-consent-manager.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Consent management for WP Consent API integration
+ *
+ * @package automattic/woocommerce-analytics
+ */
+
+namespace Automattic\Woocommerce_Analytics;
+
+/**
+ * Manages consent checking for WooCommerce Analytics
+ */
+class Consent_Manager {
+
+	/**
+	 * Consent type that we check for analytics tracking
+	 */
+	const WP_CONSENT_API_STATISTICS_TYPE = 'statistics';
+
+	/**
+	 * Check if WP Consent API is available
+	 *
+	 * @return bool
+	 */
+	public static function is_wp_consent_api_available() {
+		return function_exists( 'wp_has_consent' );
+	}
+
+	/**
+	 * Check if user has consent for statistics tracking
+	 *
+	 * @return bool
+	 */
+	public static function has_statistics_consent() {
+		// If WP Consent API is not available, default to true for backward compatibility
+		if ( ! self::is_wp_consent_api_available() ) {
+			return true;
+		}
+
+		return \wp_has_consent( self::WP_CONSENT_API_STATISTICS_TYPE );
+	}
+}

--- a/projects/packages/woocommerce-analytics/src/class-wc-analytics-tracking.php
+++ b/projects/packages/woocommerce-analytics/src/class-wc-analytics-tracking.php
@@ -81,6 +81,11 @@ class WC_Analytics_Tracking extends WC_Tracks {
 	 * @return bool|WP_Error True for success or WP_Error if the event pixel could not be fired.
 	 */
 	public static function record_event( $event_name, $event_properties = array() ) {
+		// Check consent before recording any event
+		if ( ! Consent_Manager::has_statistics_consent() ) {
+			return true; // Skip recording.
+		}
+
 		$prefixed_event_name = self::PREFIX . $event_name;
 		$properties          = self::get_properties( $prefixed_event_name, $event_properties );
 

--- a/projects/packages/woocommerce-analytics/src/class-wc-analytics-tracking.php
+++ b/projects/packages/woocommerce-analytics/src/class-wc-analytics-tracking.php
@@ -82,7 +82,7 @@ class WC_Analytics_Tracking extends WC_Tracks {
 	 */
 	public static function record_event( $event_name, $event_properties = array() ) {
 		// Check consent before recording any event
-		if ( ! Consent_Manager::has_statistics_consent() ) {
+		if ( ! Consent_Manager::has_analytics_consent() ) {
 			return true; // Skip recording.
 		}
 

--- a/projects/packages/woocommerce-analytics/src/client/analytics.ts
+++ b/projects/packages/woocommerce-analytics/src/client/analytics.ts
@@ -115,7 +115,7 @@ export class Analytics {
 	 */
 	recordEvent = ( event: string, properties: Record< string, unknown > = {} ): void => {
 		// Check consent before recording any event
-		if ( ! consentManager.hasStatisticsConsent() ) {
+		if ( ! consentManager.hasAnalyticsConsent() ) {
 			debug( 'Skipping event recording due to lack of statistics consent: %s', event );
 			return;
 		}

--- a/projects/packages/woocommerce-analytics/src/client/analytics.ts
+++ b/projects/packages/woocommerce-analytics/src/client/analytics.ts
@@ -6,6 +6,7 @@ import debugFactory from 'debug';
  * Internal dependencies
  */
 import { ApiClient } from './api-client';
+import { consentManager } from './consent';
 import { EVENT_NAME_REGEX, EVENT_PREFIX, CLICK_HOUSE_EVENTS } from './constants';
 import SessionManager from './session-manager';
 import type { AnalyticsConfig } from './types/shared';
@@ -56,6 +57,9 @@ export class Analytics {
 		 * only if the ClickHouse (ch) feature is enabled as these events are relevant exclusively when ClickHouse is active.
 		 */
 		if ( this.features.sessionTracking ) {
+			// Set up consent change listener
+			consentManager.addConsentChangeListener( this.handleConsentChange );
+
 			this.sessionManager.init();
 			const { sessionId, landingPage, isNewSession } = this.sessionManager;
 
@@ -110,6 +114,12 @@ export class Analytics {
 	 * @param properties - The properties of the event.
 	 */
 	recordEvent = ( event: string, properties: Record< string, unknown > = {} ): void => {
+		// Check consent before recording any event
+		if ( ! consentManager.hasStatisticsConsent() ) {
+			debug( 'Skipping event recording due to lack of statistics consent: %s', event );
+			return;
+		}
+
 		// Validate event name
 		if ( typeof event !== 'string' || ! EVENT_NAME_REGEX.test( event ) ) {
 			debug( 'Skipping event recording because event name is not valid' );
@@ -224,5 +234,20 @@ export class Analytics {
 
 		this.sessionManager.setEngaged();
 		this.recordEvent( 'session_engagement' );
+	};
+
+	/**
+	 * Handle consent changes
+	 *
+	 * @param hasConsent - Whether the user has granted consent
+	 */
+	handleConsentChange = ( hasConsent: boolean ): void => {
+		if ( ! hasConsent ) {
+			// Consent withdrawn - clear session data if session tracking is enabled
+			this.sessionManager.clearSession();
+		} else if ( ! this.sessionManager.sessionId ) {
+			// Consent granted - reinitialize session if needed
+			this.sessionManager.init();
+		}
 	};
 }

--- a/projects/packages/woocommerce-analytics/src/client/consent.ts
+++ b/projects/packages/woocommerce-analytics/src/client/consent.ts
@@ -31,18 +31,18 @@ export class ConsentManager {
 	}
 
 	/**
-	 * Check if user has consent for statistics tracking
+	 * Check if user has consent for analytics/statistics tracking
 	 *
 	 * @return The consent status
 	 */
-	hasStatisticsConsent(): boolean {
+	hasAnalyticsConsent(): boolean {
 		if ( ! this.isWpConsentApiAvailable() ) {
 			debug( 'WP Consent API not available, defaulting to true for backward compatibility' );
 			return true;
 		}
 
 		const hasConsent = window.wp_has_consent!( WP_CONSENT_API_STATISTICS_TYPE );
-		debug( 'Statistics consent status:', hasConsent );
+		debug( 'Analytics consent status:', hasConsent );
 		return hasConsent;
 	}
 

--- a/projects/packages/woocommerce-analytics/src/client/consent.ts
+++ b/projects/packages/woocommerce-analytics/src/client/consent.ts
@@ -7,13 +7,6 @@ const debug = debugFactory( 'wc-analytics:consent' );
 
 const WP_CONSENT_API_STATISTICS_TYPE = 'statistics' as const;
 
-declare global {
-	interface Window {
-		wp_has_consent?: ( type: string ) => boolean;
-		wp_listen_for_consent_change?: ( callback: ( type: string, value: boolean ) => void ) => void;
-	}
-}
-
 /**
  * Consent utility functions for WP Consent API integration
  */
@@ -54,18 +47,6 @@ export class ConsentManager {
 	addConsentChangeListener( callback: ( hasConsent: boolean ) => void ): void {
 		this.consentListeners.push( callback );
 		this.initializeConsentListener();
-	}
-
-	/**
-	 * Remove a consent change listener
-	 *
-	 * @param callback - The callback to remove
-	 */
-	removeConsentChangeListener( callback: ( hasConsent: boolean ) => void ): void {
-		const index = this.consentListeners.indexOf( callback );
-		if ( index > -1 ) {
-			this.consentListeners.splice( index, 1 );
-		}
 	}
 
 	/**

--- a/projects/packages/woocommerce-analytics/src/client/consent.ts
+++ b/projects/packages/woocommerce-analytics/src/client/consent.ts
@@ -1,0 +1,111 @@
+/**
+ * External dependencies
+ */
+import debugFactory from 'debug';
+
+const debug = debugFactory( 'wc-analytics:consent' );
+
+const WP_CONSENT_API_STATISTICS_TYPE = 'statistics' as const;
+
+declare global {
+	interface Window {
+		wp_has_consent?: ( type: string ) => boolean;
+		wp_listen_for_consent_change?: ( callback: ( type: string, value: boolean ) => void ) => void;
+	}
+}
+
+/**
+ * Consent utility functions for WP Consent API integration
+ */
+export class ConsentManager {
+	private consentListeners: Array< ( hasConsent: boolean ) => void > = [];
+	private isListenerInitialized = false;
+
+	/**
+	 * Check if WP Consent API is available
+	 *
+	 * @return The consent status
+	 */
+	isWpConsentApiAvailable(): boolean {
+		return typeof window.wp_has_consent === 'function';
+	}
+
+	/**
+	 * Check if user has consent for statistics tracking
+	 *
+	 * @return The consent status
+	 */
+	hasStatisticsConsent(): boolean {
+		if ( ! this.isWpConsentApiAvailable() ) {
+			debug( 'WP Consent API not available, defaulting to true for backward compatibility' );
+			return true;
+		}
+
+		const hasConsent = window.wp_has_consent!( WP_CONSENT_API_STATISTICS_TYPE );
+		debug( 'Statistics consent status:', hasConsent );
+		return hasConsent;
+	}
+
+	/**
+	 * Add a listener for consent changes
+	 *
+	 * @param callback - The callback to call when consent changes
+	 */
+	addConsentChangeListener( callback: ( hasConsent: boolean ) => void ): void {
+		this.consentListeners.push( callback );
+		this.initializeConsentListener();
+	}
+
+	/**
+	 * Remove a consent change listener
+	 *
+	 * @param callback - The callback to remove
+	 */
+	removeConsentChangeListener( callback: ( hasConsent: boolean ) => void ): void {
+		const index = this.consentListeners.indexOf( callback );
+		if ( index > -1 ) {
+			this.consentListeners.splice( index, 1 );
+		}
+	}
+
+	/**
+	 * Initialize the consent change listener if not already done
+	 */
+	private initializeConsentListener(): void {
+		if ( this.isListenerInitialized || ! this.isWpConsentApiAvailable() ) {
+			return;
+		}
+
+		debug( 'Initializing consent change listener' );
+
+		document.addEventListener( 'wp_listen_for_consent_change', event => {
+			const changedConsentCategory = ( event as CustomEvent ).detail;
+			for ( const key in changedConsentCategory ) {
+				if ( Object.prototype.hasOwnProperty.call( changedConsentCategory, key ) ) {
+					if ( key === WP_CONSENT_API_STATISTICS_TYPE ) {
+						this.notifyListeners( changedConsentCategory[ key ] === 'allow' );
+					}
+				}
+			}
+		} );
+
+		this.isListenerInitialized = true;
+	}
+
+	/**
+	 * Notify all registered listeners about consent changes
+	 *
+	 * @param hasConsent - The consent status
+	 */
+	private notifyListeners( hasConsent: boolean ): void {
+		this.consentListeners.forEach( listener => {
+			try {
+				listener( hasConsent );
+			} catch ( error ) {
+				debug( 'Error in consent change listener:', error );
+			}
+		} );
+	}
+}
+
+export const consentManager = new ConsentManager();

--- a/projects/packages/woocommerce-analytics/src/client/index.ts
+++ b/projects/packages/woocommerce-analytics/src/client/index.ts
@@ -4,6 +4,7 @@
  * Internal dependencies
  */
 import { Analytics } from './analytics';
+import { consentManager } from './consent';
 import SessionManager from './session-manager';
 
 jQuery( () => {
@@ -11,12 +12,30 @@ jQuery( () => {
 		return;
 	}
 
-	const sessionManager = new SessionManager();
-	const analytics = new Analytics( sessionManager, {
-		eventQueue: window.wcAnalytics.eventQueue,
-		commonProps: window.wcAnalytics.commonProps,
-		features: window.wcAnalytics.features,
-		pages: window.wcAnalytics.pages,
+	// Check for consent before initializing analytics
+	if ( consentManager.hasStatisticsConsent() ) {
+		initializeAnalytics();
+		return;
+	}
+
+	// Set up consent change listener to initialize when consent is granted
+	consentManager.addConsentChangeListener( ( hasConsent: boolean ) => {
+		if ( hasConsent ) {
+			initializeAnalytics();
+		}
 	} );
-	analytics.init();
+
+	/**
+	 * Initialize analytics
+	 */
+	function initializeAnalytics() {
+		const sessionManager = new SessionManager();
+		const analytics = new Analytics( sessionManager, {
+			eventQueue: window.wcAnalytics.eventQueue,
+			commonProps: window.wcAnalytics.commonProps,
+			features: window.wcAnalytics.features,
+			pages: window.wcAnalytics.pages,
+		} );
+		analytics.init();
+	}
 } );

--- a/projects/packages/woocommerce-analytics/src/client/index.ts
+++ b/projects/packages/woocommerce-analytics/src/client/index.ts
@@ -3,9 +3,7 @@
 /**
  * Internal dependencies
  */
-import { Analytics } from './analytics';
 import { consentManager } from './consent';
-import SessionManager from './session-manager';
 
 jQuery( () => {
 	if ( ! window.wcAnalytics ) {
@@ -14,28 +12,14 @@ jQuery( () => {
 
 	// Check for consent before initializing analytics
 	if ( consentManager.hasAnalyticsConsent() ) {
-		initializeAnalytics();
+		import( './init' );
 		return;
 	}
 
 	// Set up consent change listener to initialize when consent is granted
 	consentManager.addConsentChangeListener( ( hasConsent: boolean ) => {
 		if ( hasConsent ) {
-			initializeAnalytics();
+			import( './init' );
 		}
 	} );
-
-	/**
-	 * Initialize analytics
-	 */
-	function initializeAnalytics() {
-		const sessionManager = new SessionManager();
-		const analytics = new Analytics( sessionManager, {
-			eventQueue: window.wcAnalytics.eventQueue,
-			commonProps: window.wcAnalytics.commonProps,
-			features: window.wcAnalytics.features,
-			pages: window.wcAnalytics.pages,
-		} );
-		analytics.init();
-	}
 } );

--- a/projects/packages/woocommerce-analytics/src/client/index.ts
+++ b/projects/packages/woocommerce-analytics/src/client/index.ts
@@ -13,7 +13,7 @@ jQuery( () => {
 	}
 
 	// Check for consent before initializing analytics
-	if ( consentManager.hasStatisticsConsent() ) {
+	if ( consentManager.hasAnalyticsConsent() ) {
 		initializeAnalytics();
 		return;
 	}

--- a/projects/packages/woocommerce-analytics/src/client/init.ts
+++ b/projects/packages/woocommerce-analytics/src/client/init.ts
@@ -1,0 +1,21 @@
+/**
+ * Internal dependencies
+ */
+import { Analytics } from './analytics';
+import SessionManager from './session-manager';
+
+/**
+ * Initialize analytics
+ */
+function initAnalytics() {
+	const sessionManager = new SessionManager();
+	const analytics = new Analytics( sessionManager, {
+		eventQueue: window.wcAnalytics.eventQueue,
+		commonProps: window.wcAnalytics.commonProps,
+		features: window.wcAnalytics.features,
+		pages: window.wcAnalytics.pages,
+	} );
+	analytics.init();
+}
+
+initAnalytics();

--- a/projects/packages/woocommerce-analytics/src/client/session-manager.ts
+++ b/projects/packages/woocommerce-analytics/src/client/session-manager.ts
@@ -192,4 +192,19 @@ export default class SessionManager {
 
 		this.isEngaged = true;
 	}
+
+	/**
+	 * Clear session data (for consent withdrawal)
+	 */
+	clearSession() {
+		// Clear cookie
+		document.cookie = `${ COOKIE_NAME }=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/; secure; samesite=strict`;
+
+		// Reset session variables
+		this.sessionId = null;
+		this.landingPage = null;
+		this.isEngaged = false;
+		this.isNewSession = false;
+		this.isInitialized = false;
+	}
 }

--- a/projects/packages/woocommerce-analytics/src/client/types/global.d.ts
+++ b/projects/packages/woocommerce-analytics/src/client/types/global.d.ts
@@ -14,6 +14,7 @@ declare global {
 		_wca?: {
 			push: ( props: Record< string, unknown > ) => void;
 		};
+		wp_has_consent?: ( type: string ) => boolean;
 	}
 }
 


### PR DESCRIPTION
## Changes proposed in this Pull Request:

This PR implements the WP Consent API integration in the WooCommerce Analytics package to ensure compliance with GDPR and other privacy regulations. The implementation adds consent checking at multiple levels to only track users who have granted consent for statistics/analytics collection.

### How It Works

**Client-Side Consent Checking:**

- Analytics initialization is blocked until `wp_has_consent('statistics')` returns `true`
- Dynamic consent change handling automatically starts/stops tracking when consent is granted/withdrawn
- Session data is automatically cleared when consent is withdrawn

**Server-Side Consent Checking:**

- All server-side event recording checks consent before processing
- REST API proxy endpoint respects consent status
- Events are silently skipped when consent is not granted

https://github.com/user-attachments/assets/66b8e398-8808-47cd-b6c2-b3435a9ea489



## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

### Test with WP Consent API Available:

1. Install and activate the [WP Consent API plugin](https://wordpress.org/plugins/wp-consent-api/)
2. Install and activate [Complianz GDPR](https://wordpress.org/plugins/complianz-gdpr/) or any other consent management plugin that integrates with WP Consent API.
3. Go to `/wp-admin/admin.php?page=complianz` and complete the setup process.
4. Go to your site frontend and verify that the cookies banner is displayed. You can use [Region Parameters to view your Cookie Banner per Region](https://complianz.io/using-region-parameters-to-view-your-cookie-banner-per-region/).
5. Add the following code to the WooCommerce Analytics plugin's woocommerce-analytics.php file to log server-side events:

```php
function log_remote_pixels( $preempt, $parsed_args, $url ) {
	if ( strpos( $url, WC_Tracks_Client::PIXEL ) === 0 ||  strpos( $url, 'https://pixel.wp.com/w.gif' ) === 0  ) {
		$parsed_url = wp_parse_url( $url );
		parse_str( $parsed_url['query'], $params );
		error_log( $url );
		error_log( $params['_en'] . ' -- ' . print_r( $params, true ));
	}
	return $preempt;
}

add_action( 'pre_http_request', 'log_remote_pixels', 10, 3 );
```

6. Open an incognito browser window and visit a WooCommerce store page
7. Run `window.localStorage.setItem( 'debug', '*')` in the browser console to activate debugging
8. Reload the page and confirm that no analytics events are fired
9. Grant statistics consent via the consent management plugin
10. Verify that analytics events start firing immediately
11. Withdraw consent and verify that tracking stops and session data is cleared
12. Go to the product page and add to cart
13. Verify that the analytics event is NOT fired in server-side logs (`wp-content/debug.log`)
14. Grant statistics consent again
15. Add another item to the cart and verify that the `woocommerceanalytics_add_to_cart` event is fired in server-side logs

<img width="391" height="103" alt="Screenshot 2025-09-29 at 14 19 08" src="https://github.com/user-attachments/assets/905e883d-4439-4417-9564-a18824139f86" />


<img width="823" height="169" alt="Screenshot 2025-09-29 at 14 19 21" src="https://github.com/user-attachments/assets/0895f56d-6302-49bf-b9d3-5f6efac9aa1f" />

<img width="1063" height="448" alt="Screenshot 2025-09-29 at 14 21 26" src="https://github.com/user-attachments/assets/71b28065-468d-4cea-9bcf-70bc6c423383" />


### Test without WP Consent API:

1. Ensure WP Consent API plugin is not activated
2. Visit WooCommerce store pages  
3. Verify that analytics events fire normally (backward compatibility)
