### PR TITLE
CRM - If an admin tries to accept a quote from the front end it would be denied

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-quote-accept-wpcom
+++ b/projects/plugins/crm/changelog/fix-crm-quote-accept-wpcom
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Allows admins or CRM quote managers to accept a quote from the front end

--- a/projects/plugins/crm/includes/ZeroBSCRM.AJAX.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.AJAX.php
@@ -1069,7 +1069,7 @@ function ZeroBSCRM_accept_quote() {
 
 		// validate that this has been posted by the contact associated with the quote, allow admin/staff to accept on behalf of the contact
 		global $zbs;
-		// reviewed and improved the layout.
+		// Check if user has admin privileges or quote permissions; otherwise, verify contact ownership for access control.
 		$can = zeroBSCRM_isZBSAdminOrAdmin() || zeroBSCRM_permsQuotes();
 		if ( ! $can ) {
 			// Require login

--- a/projects/plugins/crm/includes/ZeroBSCRM.AJAX.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.AJAX.php
@@ -1073,7 +1073,7 @@ function ZeroBSCRM_accept_quote() {
 		$can = zeroBSCRM_isZBSAdminOrAdmin() || zeroBSCRM_permsQuotes();
 		if ( ! $can ) {
 			// Require login
-			if ( empty( $uinfo ) || empty( $uinfo->ID ) ) {
+			if ( ! is_user_logged_in() ) {
 				wp_send_json_error( array( 'access' => 1 ), 403 );
 			}
 			// Resolve IDs safely

--- a/projects/plugins/crm/includes/ZeroBSCRM.AJAX.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.AJAX.php
@@ -1069,15 +1069,20 @@ function ZeroBSCRM_accept_quote() {
 
 		// validate that this has been posted by the contact associated with the quote, allow admin/staff to accept on behalf of the contact
 		global $zbs;
-		// Allow admins or CRM users with quote permissions to accept on behalf of the contact
-		if (
-			! ( zeroBSCRM_isZBSAdminOrAdmin() || zeroBSCRM_permsQuotes() )
-			&& (
-				! $uinfo->ID
-				|| zeroBS_getCustomerIDWithEmail( $uinfo->user_email ) !== $zbs->DAL->quotes->getQuoteContactID( $quoteID ) // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase,WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
-			)
-		) {
-			wp_send_json_error( array( 'access' => 1 ), 403 );
+		// reviewed and improved the layout.
+		$can = zeroBSCRM_isZBSAdminOrAdmin() || zeroBSCRM_permsQuotes();
+		if ( ! $can ) {
+			// Require login
+			if ( empty( $uinfo ) || empty( $uinfo->ID ) ) {
+				wp_send_json_error( array( 'access' => 1 ), 403 );
+			}
+			// Resolve IDs safely
+			$customer_id      = (int) zeroBS_getCustomerIDWithEmail( $uinfo->user_email );
+			$quote_contact_id = (int) $zbs->DAL->quotes->getQuoteContactID( $quoteID ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase,WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+			// Both IDs must exist and match
+			if ( $customer_id <= 0 || $quote_contact_id <= 0 || $customer_id !== $quote_contact_id ) {
+				wp_send_json_error( array( 'access' => 1 ), 403 );
+			}
 		}
 	} elseif ( ! zeroBSCRM_quotes_getFromHash( $quoteHash )['success'] ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 		wp_send_json_error( array( 'hash' => 1 ), 403 );

--- a/projects/plugins/crm/includes/ZeroBSCRM.AJAX.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.AJAX.php
@@ -1044,11 +1044,6 @@ add_action( 'wp_ajax_nopriv_zbs_quotes_accept_quote', 'ZeroBSCRM_accept_quote' )
 add_action( 'wp_ajax_zbs_quotes_accept_quote', 'ZeroBSCRM_accept_quote' );
 
 function ZeroBSCRM_accept_quote() {
-	// We probably want to see all errors:
-	ini_set( 'display_errors', 1 );
-	ini_set( 'display_startup_errors', 1 );
-	error_reporting( E_ALL );
-
 	// } Check nonce
 	check_ajax_referer( 'zbscrmquo-nonce', 'sec' );
 
@@ -1072,10 +1067,15 @@ function ZeroBSCRM_accept_quote() {
 	if ( empty( $quoteHash ) ) {
 		$uinfo = wp_get_current_user();
 
-		// validate that this has been posted by the contact associated with the quote
+		// validate that this has been posted by the contact associated with the quote, allow admin/staff to accept on behalf of the contact
 		global $zbs;
-		if ( ! $uinfo->ID
-			|| zeroBS_getCustomerIDWithEmail( $uinfo->user_email ) !== $zbs->DAL->quotes->getQuoteContactID( $quoteID ) // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase,WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+		// Allow admins or CRM users with quote permissions to accept on behalf of the contact
+		if (
+			! ( zeroBSCRM_isZBSAdminOrAdmin() || zeroBSCRM_permsQuotes() )
+			&& (
+				! $uinfo->ID
+				|| zeroBS_getCustomerIDWithEmail( $uinfo->user_email ) !== $zbs->DAL->quotes->getQuoteContactID( $quoteID ) // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase,WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+			)
 		) {
 			wp_send_json_error( array( 'access' => 1 ), 403 );
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes an UX issue where the `Quote could not be accepted at this time` error if an admin tries to accept a quote from the client portal which is not assigned to them (perhaps through testing, or accepting while on the phone to the client).

I also removed the error logging block which had been left in the code. I've left the front end error messages as is for now to avoid any error message hacking.

In addition, I've improved the if block to cast results and not allow edge cases through the checks. 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Allows admins and quote managers (CRM team members with a Quote manager role) to accept quotes from the front end.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

`JETCRM-38/error-message-after-accepting-quote` 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

In trunk

* Log in to your admin account e.g. admin@you.com
* Create a contact for a random user e.g. Randy Dom - random@me.com
* Create a quote and assign it to random@me.com 
* Preview the quote while logged in as admin@you.com
* Try and accept it, it'll fail and say "Quote cannot be accepted at this time"

In this branch
* The CRM admin, site admin, or CRM team member with "Quote Manager" permissions should be able to accept any quote from the Client Portal front end. 
