### PR TITLE
Cookie Consent block: add deprecation from old colors to new ones

### DIFF
--- a/projects/plugins/jetpack/changelog/update-cookie-consent-deprecate-old-default-styles
+++ b/projects/plugins/jetpack/changelog/update-cookie-consent-deprecate-old-default-styles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Cookie Consent Block: add deprecation handling to switch from old default colors to new ones.

--- a/projects/plugins/jetpack/extensions/blocks/cookie-consent/deprecated/v1/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/cookie-consent/deprecated/v1/index.js
@@ -1,0 +1,89 @@
+import save from '../../save';
+
+/**
+ * Deprecation reason:
+ * Added fallback colors to CSS custom properties in the default style attributes.
+ */
+export default {
+	attributes: {
+		text: {
+			type: 'string',
+			source: 'html',
+			selector: 'p',
+		},
+		style: {
+			type: 'object',
+			default: {
+				color: {
+					text: 'var(--wp--preset--color--contrast)',
+					background: 'var(--wp--preset--color--tertiary)',
+					link: 'var(--wp--preset--color--contrast)',
+				},
+				spacing: {
+					padding: {
+						top: '1em',
+						right: '1em',
+						bottom: '1em',
+						left: '1em',
+					},
+				},
+			},
+		},
+		align: {
+			type: 'string',
+			default: 'wide',
+		},
+		consentExpiryDays: {
+			type: 'integer',
+			default: 365,
+		},
+		showOverlay: {
+			type: 'boolean',
+			default: false,
+		},
+	},
+	migrate: attributes => {
+		const { style = {} } = attributes;
+		const { color = {} } = style;
+
+		// Add fallbacks to color properties that don't have them
+		const migratedColor = {};
+		if (
+			typeof color.text === 'string' &&
+			color.text.startsWith( 'var(' ) &&
+			! color.text.includes( ', #' )
+		) {
+			migratedColor.text = `${ color.text }, #000000`;
+		}
+		if (
+			typeof color.background === 'string' &&
+			color.background.startsWith( 'var(' ) &&
+			! color.background.includes( ', #' )
+		) {
+			migratedColor.background = `${ color.background }, #f0f0f0`;
+		}
+		if (
+			typeof color.link === 'string' &&
+			color.link.startsWith( 'var(' ) &&
+			! color.link.includes( ', #' )
+		) {
+			migratedColor.link = `${ color.link }, #000000`;
+		}
+
+		return {
+			...attributes,
+			style: {
+				...style,
+				color: {
+					...color,
+					...migratedColor,
+				},
+			},
+		};
+	},
+	isEligible: attributes => {
+		const { style } = attributes;
+		return style?.color?.text?.startsWith( 'var(' ) && ! style.color.text.includes( ',' );
+	},
+	save,
+};

--- a/projects/plugins/jetpack/extensions/blocks/cookie-consent/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/cookie-consent/editor.js
@@ -1,5 +1,6 @@
 import { registerJetpackBlockFromMetadata } from '../../shared/register-jetpack-block';
 import metadata from './block.json';
+import deprecatedV1 from './deprecated/v1';
 import edit from './edit';
 import save from './save';
 
@@ -8,4 +9,5 @@ import './editor.scss';
 registerJetpackBlockFromMetadata( metadata, {
 	edit,
 	save,
+	deprecated: [ deprecatedV1 ],
 } );


### PR DESCRIPTION
Fixes MARMON-7
Follow-up to #45287

## Proposed changes:

Let's ensure the switch from the old default colors to the new ones happens without any errors.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Start with a site running the current stable version of Jetpack, connected to WordPress.com, and using the Twenty Twenty Five theme.
* Go to Appearance > Editor > Patterns > Footer
* Edit the footer pattern and add a Cookie Consent Block
* Check the block's styles
    * You should see the error (the background "tertiary" style is not available).
* Save your changes to apply the cookie consent block to your site.
* Now update to this branch.
* Refresh the site editor
   * The background style should now work.
   * You should see the conversion in the js console. 
