### PR TITLE
Backport jetpack 15.1-a.11 Changes

### DIFF
--- a/projects/packages/forms/CHANGELOG.md
+++ b/projects/packages/forms/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.7.0] - 2025-09-30
+### Changed
+- Forms: Use localized number format for number of responses shown. [#45326]
+
 ## [6.6.0] - 2025-09-29
 ### Added
 - Add options to disable "Go Back" link and summary after submission. [#45273]
@@ -27,9 +31,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [6.5.1] - 2025-09-22
 ### Fixed
-- Fix lints. [#45242]
-
-Fix image choice widths. [#45257]
+- Address linting issues. [#45242]
+- Fix image choice widths. [#45257]
 
 ## [6.5.0] - 2025-09-19
 ### Added
@@ -1625,6 +1628,7 @@ Fix image choice widths. [#45257]
 - Added a new jetpack/forms package [#28409]
 - Added a public load_contact_form method for initializing the contact form module. [#28416]
 
+[6.7.0]: https://github.com/automattic/jetpack-forms/compare/v6.6.0...v6.7.0
 [6.6.0]: https://github.com/automattic/jetpack-forms/compare/v6.5.1...v6.6.0
 [6.5.1]: https://github.com/automattic/jetpack-forms/compare/v6.5.0...v6.5.1
 [6.5.0]: https://github.com/automattic/jetpack-forms/compare/v6.4.0...v6.5.0

--- a/projects/packages/forms/changelog/update-forms-format-inbox-numbers
+++ b/projects/packages/forms/changelog/update-forms-format-inbox-numbers
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Forms: use localized number format for number of responses shown

--- a/projects/packages/forms/composer.json
+++ b/projects/packages/forms/composer.json
@@ -71,7 +71,7 @@
 			"link-template": "https://github.com/automattic/jetpack-forms/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "6.6.x-dev"
+			"dev-trunk": "6.7.x-dev"
 		},
 		"textdomain": "jetpack-forms",
 		"version-constants": {

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-forms",
-	"version": "6.6.0",
+	"version": "6.7.0",
 	"private": true,
 	"description": "Jetpack Forms",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/forms/#readme",

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -14,7 +14,7 @@ use Automattic\Jetpack\Forms\Dashboard\Dashboard;
  */
 class Jetpack_Forms {
 
-	const PACKAGE_VERSION = '6.6.0';
+	const PACKAGE_VERSION = '6.7.0';
 
 	/**
 	 * Load the contact form module.

--- a/projects/packages/woocommerce-analytics/CHANGELOG.md
+++ b/projects/packages/woocommerce-analytics/CHANGELOG.md
@@ -5,19 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.2] - 2025-09-30
+### Fixed
+- Prevent PHP error when WC_Tracks class is not available. [#45330]
+- Prevent PHP warnings when array key is undefined. [#45330]
+
 ## [0.9.1] - 2025-09-29
 ### Changed
 - Internal updates.
 
 ## [0.9.0] - 2025-09-25
 ### Added
-- Add experimental API-based event tracking [#45279]
-- Add IP-based visitor tracking as fallback when proxy tracking is enabled and cookies are unavailable [#45279]
-- Add proxy speed module to enhance proxy API performance [#45243]
-- Implement client-side analytics tracking [#45268]
+- Add experimental API-based event tracking. [#45279]
+- Add IP-based visitor tracking as fallback when proxy tracking is enabled and cookies are unavailable. [#45279]
+- Add proxy speed module to enhance proxy API performance. [#45243]
+- Implement client-side analytics tracking. [#45268]
 
 ### Changed
-- Update build scripts for production [#45296]
+- Update build scripts for production. [#45296]
 
 ## [0.8.0] - 2025-09-22
 ### Added
@@ -172,6 +177,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix namespace issue with WooCommerce class reference. [#35857]
 - General: bail early when WooCommerce is not active. [#36278]
 
+[0.9.2]: https://github.com/Automattic/woocommerce-analytics/compare/v0.9.1...v0.9.2
 [0.9.1]: https://github.com/Automattic/woocommerce-analytics/compare/v0.9.0...v0.9.1
 [0.9.0]: https://github.com/Automattic/woocommerce-analytics/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/Automattic/woocommerce-analytics/compare/v0.7.0...v0.8.0

--- a/projects/packages/woocommerce-analytics/changelog/fix-wc-analytics-fatals-warnings
+++ b/projects/packages/woocommerce-analytics/changelog/fix-wc-analytics-fatals-warnings
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-WC_Tracks class not found fatal error and key undefined warnings

--- a/projects/packages/woocommerce-analytics/package.json
+++ b/projects/packages/woocommerce-analytics/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/woocommerce-analytics",
-	"version": "0.9.1",
+	"version": "0.9.2",
 	"private": true,
 	"description": "WooCommerce Analytics package to track frontend events",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/woocommerce-analytics/#readme",

--- a/projects/packages/woocommerce-analytics/src/class-woocommerce-analytics.php
+++ b/projects/packages/woocommerce-analytics/src/class-woocommerce-analytics.php
@@ -21,7 +21,7 @@ class Woocommerce_Analytics {
 	/**
 	 * Package version.
 	 */
-	const PACKAGE_VERSION = '0.9.1';
+	const PACKAGE_VERSION = '0.9.2';
 
 	/**
 	 * Proxy speed module version.

--- a/projects/plugins/jetpack/CHANGELOG.md
+++ b/projects/plugins/jetpack/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ### This is a list detailing changes for all Jetpack releases.
 
+## 15.1-a.11 - 2025-09-30
+### Enhancements
+- Forms: Use localized number format for number of responses shown. [#45326]
+
+### Improved compatibility
+- Cookie Consent Block: Ensure we always have a default set of colors to style the block when theme colors are not available. [#45287]
+
+### Other changes <!-- Non-user-facing changes go here. This section will not be copied to readme.txt. -->
+- Editor assets endpoint: Enforce absolute URLs to mitigate failed requests from client origins. [#45319]
+- Widgets: Prevent PHP warnings. [#45327]
+
 ## 15.1-a.9 - 2025-09-29
 ### Enhancements
 - Forms: Add setting to enable or disable email notifications for form submissions. [#45230]
@@ -9,7 +20,7 @@
 
 ### Bug fixes
 - Forms: Don't override field labels on transforms. [#45281]
-- Forms: Fixes the missing rest attributes. [#45274]
+- Forms: Fix missing REST attributes. [#45274]
 - Resolve conflict with WordPress 6.7.3. [#45320]
 
 ### Other changes <!-- Non-user-facing changes go here. This section will not be copied to readme.txt. -->
@@ -37,7 +48,7 @@
 - Forms: Fix slider value position. [#45218]
 
 ### Other changes <!-- Non-user-facing changes go here. This section will not be copied to readme.txt. -->
-- On Dotcom Simple site, show all sharing settings even when the site is using a block theme, so that the sharing buttons filter can be disabled. [#45176]
+- Show all sharing settings on WordPress.com Simple sites even when using a block theme so that the sharing buttons filter can be disabled. [#45176]
 - Subscriptions: Always link to WP Admin in Newsletter widget. [#45180]
 - Update package dependencies. [#45173] [#45200] [#45229]
 - Widgets: Prevent PHP warnings when handling malformed data. [#45185]

--- a/projects/plugins/jetpack/changelog/fix-cookie-consent-block-color-fallback
+++ b/projects/plugins/jetpack/changelog/fix-cookie-consent-block-color-fallback
@@ -1,4 +1,0 @@
-Significance: patch
-Type: compat
-
-Cookie Consent Block: ensure we always have a default set of colors to style the block when theme colors are not available.

--- a/projects/plugins/jetpack/changelog/fix-editor-assets-endpoint-enforces-absolute-urls
+++ b/projects/plugins/jetpack/changelog/fix-editor-assets-endpoint-enforces-absolute-urls
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Editor assets endpoint: enforce absolute URLs to mitigate failed requests from client origins.

--- a/projects/plugins/jetpack/changelog/fix-widgets-avoid_more_php_warnings
+++ b/projects/plugins/jetpack/changelog/fix-widgets-avoid_more_php_warnings
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Widgets: Prevent PHP warnings.

--- a/projects/plugins/jetpack/changelog/update-forms-format-inbox-numbers
+++ b/projects/plugins/jetpack/changelog/update-forms-format-inbox-numbers
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Forms: use localized number format for number of responses shown

--- a/projects/plugins/jetpack/changelog/update-static-site-generation-comment
+++ b/projects/plugins/jetpack/changelog/update-static-site-generation-comment
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Update Static Site Generation comment.
-
-

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -111,7 +111,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ15_1_a_9",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ15_1_a_11",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -1490,7 +1490,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/forms",
-                "reference": "5fb7390abb583d9da42e51bed5d14e59bac84a5a"
+                "reference": "53e2d8a6640695be6c7c50d960639957f504b612"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1523,7 +1523,7 @@
                     "link-template": "https://github.com/automattic/jetpack-forms/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "6.6.x-dev"
+                    "dev-trunk": "6.7.x-dev"
                 },
                 "textdomain": "jetpack-forms",
                 "version-constants": {

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 15.1-a.9
+ * Version: 15.1-a.11
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -38,7 +38,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 if ( ! defined( 'JETPACK__VERSION' ) ) {
 	// This breaks the project version checks when a one-liner.
-	define( 'JETPACK__VERSION', '15.1-a.9' );
+	define( 'JETPACK__VERSION', '15.1-a.11' );
 }
 defined( 'JETPACK__MINIMUM_WP_VERSION' ) || define( 'JETPACK__MINIMUM_WP_VERSION', '6.7' );
 defined( 'JETPACK__MINIMUM_PHP_VERSION' ) || define( 'JETPACK__MINIMUM_PHP_VERSION', '7.2' );

--- a/projects/plugins/jetpack/readme.txt
+++ b/projects/plugins/jetpack/readme.txt
@@ -326,15 +326,12 @@ Jetpack Backup can do a full website migration to a new host, migrate theme file
 
 
 == Changelog ==
-### 15.1-a.9 - 2025-09-29
+### 15.1-a.11 - 2025-09-30
 #### Enhancements
-- Forms: Add setting to enable or disable email notifications for form submissions.
-- Forms: Rename 'Manage responses' forms sidebar block panel to 'Responses storage'.
+- Forms: Use localized number format for number of responses shown.
 
-#### Bug fixes
-- Forms: Don't override field labels on transforms.
-- Forms: Fixes the missing rest attributes.
-- Resolve conflict with WordPress 6.7.3.
+#### Improved compatibility
+- Cookie Consent Block: Ensure we always have a default set of colors to style the block when theme colors are not available.
 
 --------
 


### PR DESCRIPTION
Closes MONOREP-125

 <!--- This template is used for backporting changes made during a plugin release back to trunk. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Backports changes for jetpack 15.1-a.11

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/a
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Proofread changes.