### PR TITLE
Add testing instructions for Jetpack 15.1

### DIFF
--- a/projects/plugins/jetpack/to-test.md
+++ b/projects/plugins/jetpack/to-test.md
@@ -11,4 +11,18 @@
 
 You can see a [full list of changes in this release here](https://github.com/Automattic/jetpack-production/blob/trunk/CHANGELOG.md). Please feel free to test any and all functionality mentioned!
 
+### Forms changes
+In particular, play around with the following:
+* Phone field with country selector: https://github.com/Automattic/jetpack/pull/45120
+* Hidden field block: https://github.com/Automattic/jetpack/pull/44079
+* Email notifications: https://github.com/Automattic/jetpack/pull/45230
+
+### Recipes shortcode
+The way this shortcode's dependencies are loaded have changed. Make sure it still works as expected.
+
+Note: UI quirks are out of scope for this release; the goal is to ensure no regressions.
+
+### General testing
+Poke around and identify any rough spots that changes in the [CHANGELOG.md] may have touched.
+
 **Thank you for all your help!**


### PR DESCRIPTION
Closes MONOREP-126

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Add testing instructions for Jetpack 15.1

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

