### PR TITLE
Update cipher used by K6 tests

### DIFF
--- a/.github/files/jetpack-staging-sites/k6-backend.js
+++ b/.github/files/jetpack-staging-sites/k6-backend.js
@@ -39,24 +39,28 @@ export default function () {
 				'connection status was 200': r => r.status == 200,
 				'verify connection message': r => r.body.includes( 'All connection tests passed' ),
 			} );
+			console.log( `${ site.url } connection test: ${ res.status }` );
 
 			// Jetpack sync status.
 			res = http.get( `${ site.url }/wp-json/jetpack/v4/sync/status`, params );
 			check( res, {
 				'sync status was 200': r => r.status == 200,
 			} );
+			console.log( `${ site.url } sync status: ${ res.status }` );
 
 			// /wp-json/wp/v2/posts
 			res = http.get( `${ site.url }/wp-json/wp/v2/posts`, params );
 			check( res, {
 				'posts status was 200': r => r.status == 200,
 			} );
+			console.log( `${ site.url } posts: ${ res.status }` );
 
 			// /wp-json/wp/v2/categories
 			res = http.get( `${ site.url }/wp-json/wp/v2/categories`, params );
 			check( res, {
 				'categories status was 200': r => r.status == 200,
 			} );
+			console.log( `${ site.url } categories: ${ res.status }` );
 
 			// /wp-json/wp-site-health/v1/tests/dotorg-communication
 			res = http.get(
@@ -68,6 +72,7 @@ export default function () {
 				'verify communication message': r =>
 					r.body.includes( 'Can communicate with WordPress.org' ),
 			} );
+			console.log( `${ site.url } WP.org communication: ${ res.status }` );
 		} );
 	} );
 }

--- a/.github/files/jetpack-staging-sites/k6-backend.js
+++ b/.github/files/jetpack-staging-sites/k6-backend.js
@@ -18,6 +18,7 @@ export const options = {
 			},
 		],
 	},
+	tlsCipherSuites: [ 'TLS_AES_256_GCM_SHA384' ],
 };
 
 /**

--- a/.github/files/jetpack-staging-sites/k6-frontend.js
+++ b/.github/files/jetpack-staging-sites/k6-frontend.js
@@ -29,17 +29,17 @@ export default function () {
 		group( `Frontend tests for site: ${ site.url } ( ${ site.blog_id } )`, () => {
 			// Homepage.
 			let res = http.get( site.url );
-			console.log( res.tls_version, res.tls_cipher_suite );
-
 			check( res, {
 				'homepage status was 200': r => r.status == 200,
 			} );
+			console.log( `${ site.url } homepage status: ${ res.status }` );
 
 			// A random post.
 			res = http.get( `${ site.url }/?random` );
 			check( res, {
 				'random post status was 200': r => r.status == 200,
 			} );
+			console.log( `${ site.url } random post status: ${ res.status }` );
 		} );
 	} );
 

--- a/.github/files/jetpack-staging-sites/k6-frontend.js
+++ b/.github/files/jetpack-staging-sites/k6-frontend.js
@@ -28,6 +28,8 @@ export default function () {
 		group( `Frontend tests for site: ${ site.url } ( ${ site.blog_id } )`, () => {
 			// Homepage.
 			let res = http.get( site.url );
+			console.log( res.tls_version, res.tls_cipher_suite );
+
 			check( res, {
 				'homepage status was 200': r => r.status == 200,
 			} );

--- a/.github/files/jetpack-staging-sites/k6-frontend.js
+++ b/.github/files/jetpack-staging-sites/k6-frontend.js
@@ -18,6 +18,7 @@ export const options = {
 			},
 		],
 	},
+	tlsCipherSuites: [ 'TLS_AES_256_GCM_SHA384' ],
 };
 
 /**


### PR DESCRIPTION
Closes MONOREP-127

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

The default cipher used by K6 to do smoke tests was resulting in the requests being blocked. This updates the cipher, allowing requests to go through.

I also added some verbosity to the testing output. K6 seems to eat any meaningful output, even in verbose mode, so for now some `console.log` output does the trick.

Note: This is an old workflow using a now-abandoned action. Updating the test is on our backlog, but is low-priority, so this should work in the meantime.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Run the workflow here: https://github.com/Automattic/jetpack/actions/workflows/update-jetpack-staging-sites.yml