### PR TITLE
PayPal Payments: Improve validation of PayPal sdk URL

### DIFF
--- a/projects/packages/paypal-payments/changelog/update-improve-validation-of-paypal-payment-button-url
+++ b/projects/packages/paypal-payments/changelog/update-improve-validation-of-paypal-payment-button-url
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+Improve PayPal SDK host validation for PayPal Payment Buttons

--- a/projects/packages/paypal-payments/src/paypal-payment-buttons/class-paypal-payment-buttons.php
+++ b/projects/packages/paypal-payments/src/paypal-payment-buttons/class-paypal-payment-buttons.php
@@ -46,7 +46,9 @@ class PayPal_Payment_Buttons {
 			return false;
 		}
 
+		// Normalize the host
 		$host = strtolower( $parsed_url['host'] );
+		$host = rtrim( $host, '.' );
 
 		// Only allow specific PayPal domains
 		$allowed_hosts = array(

--- a/projects/packages/paypal-payments/src/paypal-payment-buttons/class-paypal-payment-buttons.php
+++ b/projects/packages/paypal-payments/src/paypal-payment-buttons/class-paypal-payment-buttons.php
@@ -32,10 +32,9 @@ class PayPal_Payment_Buttons {
 
 	/**
 	 * Validates and sanitizes a script URL to ensure it's from an allowed PayPal domain.
-	 * If the host is not from paypal.com or sandbox.paypal.com, it will be replaced with www.paypal.com.
 	 *
 	 * @param string $url The URL to validate and sanitize.
-	 * @return string|false The sanitized URL with a valid PayPal host, or false if URL cannot be parsed.
+	 * @return string|false The sanitized URL, or false if URL is not from an allowed PayPal domain.
 	 */
 	public static function sanitize_paypal_script_url( $url ) {
 		if ( empty( $url ) ) {
@@ -43,41 +42,27 @@ class PayPal_Payment_Buttons {
 		}
 
 		$parsed_url = wp_parse_url( $url );
-		if ( ! $parsed_url ) {
-			return false;
-		}
-
-		// If there's no host, return false
-		if ( empty( $parsed_url['host'] ) ) {
+		if ( ! $parsed_url || empty( $parsed_url['host'] ) ) {
 			return false;
 		}
 
 		$host = strtolower( $parsed_url['host'] );
 
-		// Only allow paypal.com and sandbox.paypal.com domains
-		$allowed_domains = array( 'paypal.com', 'sandbox.paypal.com' );
-		$is_valid        = false;
+		// Only allow specific PayPal domains
+		$allowed_hosts = array(
+			'www.paypal.com',
+			'paypal.com',
+			'www.sandbox.paypal.com',
+			'sandbox.paypal.com',
+		);
 
-		foreach ( $allowed_domains as $allowed_domain ) {
-			if ( $host === $allowed_domain || str_ends_with( $host, '.' . $allowed_domain ) ) {
-				$is_valid = true;
-				break;
-			}
+		if ( ! in_array( $host, $allowed_hosts, true ) ) {
+			return false;
 		}
 
-		// If the host is not valid, replace it with www.paypal.com
-		if ( ! $is_valid ) {
-			$parsed_url['host'] = 'www.paypal.com';
-		}
+		// Rebuild the URL with HTTPS
+		$sanitized_url = 'https://' . $host;
 
-		// Ensure we're using https
-		$parsed_url['scheme'] = 'https';
-
-		// Rebuild the URL
-		$sanitized_url = 'https://';
-		if ( isset( $parsed_url['host'] ) ) {
-			$sanitized_url .= $parsed_url['host'];
-		}
 		if ( isset( $parsed_url['path'] ) ) {
 			$sanitized_url .= $parsed_url['path'];
 		}

--- a/projects/packages/paypal-payments/src/paypal-payment-buttons/class-paypal-payment-buttons.php
+++ b/projects/packages/paypal-payments/src/paypal-payment-buttons/class-paypal-payment-buttons.php
@@ -31,6 +31,73 @@ class PayPal_Payment_Buttons {
 	public const PAYPAL_PARTNER_ATTRIBUTION_ID = 'WooNCPS_Ecom_Wordpress';
 
 	/**
+	 * Validates and sanitizes a script URL to ensure it's from an allowed PayPal domain.
+	 * If the host is not from paypal.com or sandbox.paypal.com, it will be replaced with www.paypal.com.
+	 *
+	 * @param string $url The URL to validate and sanitize.
+	 * @return string|false The sanitized URL with a valid PayPal host, or false if URL cannot be parsed.
+	 */
+	public static function sanitize_paypal_script_url( $url ) {
+		if ( empty( $url ) ) {
+			return false;
+		}
+
+		$parsed_url = wp_parse_url( $url );
+		if ( ! $parsed_url ) {
+			return false;
+		}
+
+		// If there's no host, return false
+		if ( empty( $parsed_url['host'] ) ) {
+			return false;
+		}
+
+		$host = strtolower( $parsed_url['host'] );
+
+		// Only allow paypal.com and sandbox.paypal.com domains
+		$allowed_domains = array( 'paypal.com', 'sandbox.paypal.com' );
+		$is_valid        = false;
+
+		foreach ( $allowed_domains as $allowed_domain ) {
+			if ( $host === $allowed_domain || str_ends_with( $host, '.' . $allowed_domain ) ) {
+				$is_valid = true;
+				break;
+			}
+		}
+
+		// If the host is not valid, replace it with www.paypal.com
+		if ( ! $is_valid ) {
+			$parsed_url['host'] = 'www.paypal.com';
+		}
+
+		// Ensure we're using https
+		$parsed_url['scheme'] = 'https';
+
+		// Rebuild the URL
+		$sanitized_url = '';
+		if ( isset( $parsed_url['scheme'] ) ) {
+			$sanitized_url .= $parsed_url['scheme'] . '://';
+		}
+		if ( isset( $parsed_url['host'] ) ) {
+			$sanitized_url .= $parsed_url['host'];
+		}
+		if ( isset( $parsed_url['port'] ) ) {
+			$sanitized_url .= ':' . $parsed_url['port'];
+		}
+		if ( isset( $parsed_url['path'] ) ) {
+			$sanitized_url .= $parsed_url['path'];
+		}
+		if ( isset( $parsed_url['query'] ) ) {
+			$sanitized_url .= '?' . $parsed_url['query'];
+		}
+		if ( isset( $parsed_url['fragment'] ) ) {
+			$sanitized_url .= '#' . $parsed_url['fragment'];
+		}
+
+		return $sanitized_url;
+	}
+
+	/**
 	 * Registers the block for use in Gutenberg
 	 * This is done via an action so that we can disable
 	 * registration if we need to.
@@ -70,7 +137,13 @@ class PayPal_Payment_Buttons {
 		}
 
 		if ( 'stacked' === $button_type ) {
-			$script_url = esc_url( $script_src );
+			// Sanitize the script URL to ensure it's from an allowed PayPal domain
+			$sanitized_url = self::sanitize_paypal_script_url( $script_src );
+			if ( false === $sanitized_url ) {
+				return;
+			}
+
+			$script_url = esc_url( $sanitized_url );
 			// We can't include the version number here. If we do, it is appended to the URL and causes a 400 response.
 			wp_enqueue_script( 'paypal-payment-buttons-block-head', $script_url, array(), null, false ); // phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
 			add_filter(

--- a/projects/packages/paypal-payments/src/paypal-payment-buttons/class-paypal-payment-buttons.php
+++ b/projects/packages/paypal-payments/src/paypal-payment-buttons/class-paypal-payment-buttons.php
@@ -74,24 +74,15 @@ class PayPal_Payment_Buttons {
 		$parsed_url['scheme'] = 'https';
 
 		// Rebuild the URL
-		$sanitized_url = '';
-		if ( isset( $parsed_url['scheme'] ) ) {
-			$sanitized_url .= $parsed_url['scheme'] . '://';
-		}
+		$sanitized_url = 'https://';
 		if ( isset( $parsed_url['host'] ) ) {
 			$sanitized_url .= $parsed_url['host'];
-		}
-		if ( isset( $parsed_url['port'] ) ) {
-			$sanitized_url .= ':' . $parsed_url['port'];
 		}
 		if ( isset( $parsed_url['path'] ) ) {
 			$sanitized_url .= $parsed_url['path'];
 		}
 		if ( isset( $parsed_url['query'] ) ) {
 			$sanitized_url .= '?' . $parsed_url['query'];
-		}
-		if ( isset( $parsed_url['fragment'] ) ) {
-			$sanitized_url .= '#' . $parsed_url['fragment'];
 		}
 
 		return $sanitized_url;

--- a/projects/packages/paypal-payments/tests/php/Paypal_Payment_Buttons_Test.php
+++ b/projects/packages/paypal-payments/tests/php/Paypal_Payment_Buttons_Test.php
@@ -57,45 +57,35 @@ class Paypal_Payment_Buttons_Test extends TestCase {
 	}
 
 	/**
-	 * Test that invalid URLs have their hosts replaced with www.paypal.com.
+	 * Test that invalid URLs are rejected and return false.
 	 *
 	 * @dataProvider invalid_urls_provider
 	 *
-	 * @param string $url                The URL to test.
-	 * @param bool   $should_be_replaced Whether the URL should be sanitized or return false.
+	 * @param string $url The URL to test.
 	 */
 	#[DataProvider( 'invalid_urls_provider' )]
-	public function test_invalid_urls_are_sanitized( $url, $should_be_replaced ) {
+	public function test_invalid_urls_are_rejected( $url ) {
 		$result = PayPal_Payment_Buttons::sanitize_paypal_script_url( $url );
-
-		if ( ! $should_be_replaced ) {
-			$this->assertFalse( $result, "URL should return false: $url" );
-		} else {
-			$this->assertNotFalse( $result, "URL should be sanitized: $url" );
-
-			$result_parsed = wp_parse_url( $result );
-			$this->assertEquals( 'www.paypal.com', $result_parsed['host'], "Host should be replaced with www.paypal.com for: $url" );
-			$this->assertEquals( 'https', $result_parsed['scheme'], "Scheme should be https for: $url" );
-		}
+		$this->assertFalse( $result, "URL should return false: $url" );
 	}
 
 	/**
 	 * Data provider for invalid URLs.
 	 *
-	 * @return array Array of [url, should_be_replaced].
+	 * @return array
 	 */
 	public static function invalid_urls_provider() {
 		return array(
-			'empty string'              => array( '', false ),
-			'attacker domain'           => array( 'https://attacker.example/x.js', true ),
-			'attacker with paypal name' => array( 'https://paypal.com.evil.com/script.js', true ),
-			'subdomain injection'       => array( 'https://evilpaypal.com/script.js', true ),
-			'javascript protocol'       => array( 'javascript:alert(1)', false ),
-			'data protocol'             => array( 'data:text/html,<script>alert(1)</script>', false ),
-			'no host'                   => array( '/script.js', false ),
-			'malformed url'             => array( 'not-a-url', false ),
-			'paypal typo domain'        => array( 'https://paypai.com/script.js', true ),
-			'different TLD'             => array( 'https://paypal.co/script.js', true ),
+			'empty string'              => array( '' ),
+			'attacker domain'           => array( 'https://attacker.example/x.js' ),
+			'attacker with paypal name' => array( 'https://paypal.com.evil.com/script.js' ),
+			'subdomain injection'       => array( 'https://evilpaypal.com/script.js' ),
+			'javascript protocol'       => array( 'javascript:alert(1)' ),
+			'data protocol'             => array( 'data:text/html,<script>alert(1)</script>' ),
+			'no host'                   => array( '/script.js' ),
+			'malformed url'             => array( 'not-a-url' ),
+			'paypal typo domain'        => array( 'https://paypai.com/script.js' ),
+			'different TLD'             => array( 'https://paypal.co/script.js' ),
 		);
 	}
 
@@ -109,14 +99,6 @@ class Paypal_Payment_Buttons_Test extends TestCase {
 
 		$result_parsed = wp_parse_url( $result );
 		$this->assertEquals( '/sdk/js/some/deep/path.js', $result_parsed['path'] );
-
-		// Invalid URL with path - should preserve path but replace host
-		$invalid_url = 'https://evil.com/malicious/script.js';
-		$result      = PayPal_Payment_Buttons::sanitize_paypal_script_url( $invalid_url );
-
-		$result_parsed = wp_parse_url( $result );
-		$this->assertEquals( 'www.paypal.com', $result_parsed['host'] );
-		$this->assertEquals( '/malicious/script.js', $result_parsed['path'] );
 	}
 
 	/**
@@ -129,14 +111,6 @@ class Paypal_Payment_Buttons_Test extends TestCase {
 
 		$result_parsed = wp_parse_url( $result );
 		$this->assertEquals( 'client-id=test&currency=USD&locale=en_US', $result_parsed['query'] );
-
-		// Invalid URL with query params - should preserve query but replace host
-		$invalid_url = 'https://evil.com/script.js?param1=value1&param2=value2';
-		$result      = PayPal_Payment_Buttons::sanitize_paypal_script_url( $invalid_url );
-
-		$result_parsed = wp_parse_url( $result );
-		$this->assertEquals( 'www.paypal.com', $result_parsed['host'] );
-		$this->assertEquals( 'param1=value1&param2=value2', $result_parsed['query'] );
 	}
 
 	/**
@@ -150,21 +124,13 @@ class Paypal_Payment_Buttons_Test extends TestCase {
 
 		$result_parsed = wp_parse_url( $result );
 		$this->assertArrayNotHasKey( 'fragment', $result_parsed );
-
-		// Invalid URL with fragment - should strip fragment and replace host
-		$invalid_url = 'https://evil.com/script.js#anchor';
-		$result      = PayPal_Payment_Buttons::sanitize_paypal_script_url( $invalid_url );
-
-		$result_parsed = wp_parse_url( $result );
-		$this->assertEquals( 'www.paypal.com', $result_parsed['host'] );
-		$this->assertArrayNotHasKey( 'fragment', $result_parsed );
 	}
 
 	/**
 	 * Test that all URL components work together.
 	 */
 	public function test_all_url_components_together() {
-		// Valid PayPal URL with all components
+		// Valid PayPal URL with all components (fragment and port are stripped)
 		$valid_url = 'https://www.paypal.com:443/sdk/js?client-id=test&currency=USD#init';
 		$result    = PayPal_Payment_Buttons::sanitize_paypal_script_url( $valid_url );
 
@@ -174,18 +140,6 @@ class Paypal_Payment_Buttons_Test extends TestCase {
 		$this->assertEquals( '/sdk/js', $result_parsed['path'] );
 		$this->assertEquals( 'client-id=test&currency=USD', $result_parsed['query'] );
 		$this->assertArrayNotHasKey( 'fragment', $result_parsed, 'Fragment should be stripped' );
-
-		// Invalid URL with all components - should preserve path and query but strip fragment and port
-		$invalid_url = 'http://evil.com:8080/malicious/path?bad=params#fragment';
-		$result      = PayPal_Payment_Buttons::sanitize_paypal_script_url( $invalid_url );
-
-		$result_parsed = wp_parse_url( $result );
-		$this->assertEquals( 'www.paypal.com', $result_parsed['host'], 'Host should be replaced' );
-		$this->assertEquals( 'https', $result_parsed['scheme'], 'Scheme should be forced to https' );
-		$this->assertEquals( '/malicious/path', $result_parsed['path'], 'Path should be preserved' );
-		$this->assertEquals( 'bad=params', $result_parsed['query'], 'Query should be preserved' );
-		$this->assertArrayNotHasKey( 'fragment', $result_parsed, 'Fragment should be stripped' );
-		$this->assertArrayNotHasKey( 'port', $result_parsed, 'Port should be stripped' );
 	}
 
 	/**
@@ -198,13 +152,6 @@ class Paypal_Payment_Buttons_Test extends TestCase {
 
 		$result_parsed = wp_parse_url( $result );
 		$this->assertEquals( 'https', $result_parsed['scheme'], 'HTTP should be upgraded to HTTPS' );
-
-		// Invalid URL with http should also get https
-		$invalid_http = 'http://evil.com/script.js';
-		$result       = PayPal_Payment_Buttons::sanitize_paypal_script_url( $invalid_http );
-
-		$result_parsed = wp_parse_url( $result );
-		$this->assertEquals( 'https', $result_parsed['scheme'], 'HTTP should be upgraded to HTTPS even for invalid hosts' );
 	}
 
 	/**
@@ -214,13 +161,6 @@ class Paypal_Payment_Buttons_Test extends TestCase {
 		$malicious_url = 'https://attacker.example/malicious.js';
 		$result        = PayPal_Payment_Buttons::sanitize_paypal_script_url( $malicious_url );
 
-		$this->assertNotFalse( $result );
-
-		$result_parsed = wp_parse_url( $result );
-		$this->assertEquals( 'www.paypal.com', $result_parsed['host'], 'Malicious host should be replaced with www.paypal.com' );
-		$this->assertEquals( 'https', $result_parsed['scheme'], 'Scheme should be https' );
-
-		// The path from the malicious URL should be preserved
-		$this->assertEquals( '/malicious.js', $result_parsed['path'] );
+		$this->assertFalse( $result, 'Malicious URL should be rejected' );
 	}
 }

--- a/projects/packages/paypal-payments/tests/php/Paypal_Payment_Buttons_Test.php
+++ b/projects/packages/paypal-payments/tests/php/Paypal_Payment_Buttons_Test.php
@@ -163,4 +163,28 @@ class Paypal_Payment_Buttons_Test extends TestCase {
 
 		$this->assertFalse( $result, 'Malicious URL should be rejected' );
 	}
+
+	/**
+	 * Test that trailing dots in hostnames are normalized.
+	 * FQDNs can technically end with a dot (DNS root), so www.paypal.com. should be treated as www.paypal.com
+	 */
+	public function test_trailing_dot_is_normalized() {
+		// Test with trailing dot
+		$url_with_dot = 'https://www.paypal.com./sdk/js';
+		$result       = PayPal_Payment_Buttons::sanitize_paypal_script_url( $url_with_dot );
+
+		$this->assertNotFalse( $result, 'URL with trailing dot should be accepted' );
+
+		$result_parsed = wp_parse_url( $result );
+		$this->assertEquals( 'www.paypal.com', $result_parsed['host'], 'Trailing dot should be stripped' );
+
+		// Test sandbox with trailing dot
+		$sandbox_with_dot = 'https://sandbox.paypal.com./sdk/js';
+		$result           = PayPal_Payment_Buttons::sanitize_paypal_script_url( $sandbox_with_dot );
+
+		$this->assertNotFalse( $result, 'Sandbox URL with trailing dot should be accepted' );
+
+		$result_parsed = wp_parse_url( $result );
+		$this->assertEquals( 'sandbox.paypal.com', $result_parsed['host'], 'Trailing dot should be stripped from sandbox' );
+	}
 }

--- a/projects/packages/paypal-payments/tests/php/Paypal_Payment_Buttons_Test.php
+++ b/projects/packages/paypal-payments/tests/php/Paypal_Payment_Buttons_Test.php
@@ -140,23 +140,24 @@ class Paypal_Payment_Buttons_Test extends TestCase {
 	}
 
 	/**
-	 * Test that fragments are preserved when sanitizing URLs.
+	 * Test that fragments are stripped when sanitizing URLs.
+	 * PayPal SDK URLs don't use fragments, so they are not preserved.
 	 */
-	public function test_fragments_are_preserved() {
+	public function test_fragments_are_stripped() {
 		// Valid PayPal URL with fragment
 		$valid_url = 'https://www.paypal.com/sdk/js#section';
 		$result    = PayPal_Payment_Buttons::sanitize_paypal_script_url( $valid_url );
 
 		$result_parsed = wp_parse_url( $result );
-		$this->assertEquals( 'section', $result_parsed['fragment'] );
+		$this->assertArrayNotHasKey( 'fragment', $result_parsed );
 
-		// Invalid URL with fragment - should preserve fragment but replace host
+		// Invalid URL with fragment - should strip fragment and replace host
 		$invalid_url = 'https://evil.com/script.js#anchor';
 		$result      = PayPal_Payment_Buttons::sanitize_paypal_script_url( $invalid_url );
 
 		$result_parsed = wp_parse_url( $result );
 		$this->assertEquals( 'www.paypal.com', $result_parsed['host'] );
-		$this->assertEquals( 'anchor', $result_parsed['fragment'] );
+		$this->assertArrayNotHasKey( 'fragment', $result_parsed );
 	}
 
 	/**
@@ -172,9 +173,9 @@ class Paypal_Payment_Buttons_Test extends TestCase {
 		$this->assertEquals( 'https', $result_parsed['scheme'] );
 		$this->assertEquals( '/sdk/js', $result_parsed['path'] );
 		$this->assertEquals( 'client-id=test&currency=USD', $result_parsed['query'] );
-		$this->assertEquals( 'init', $result_parsed['fragment'] );
+		$this->assertArrayNotHasKey( 'fragment', $result_parsed, 'Fragment should be stripped' );
 
-		// Invalid URL with all components - should preserve everything except host and scheme
+		// Invalid URL with all components - should preserve path and query but strip fragment and port
 		$invalid_url = 'http://evil.com:8080/malicious/path?bad=params#fragment';
 		$result      = PayPal_Payment_Buttons::sanitize_paypal_script_url( $invalid_url );
 
@@ -183,8 +184,8 @@ class Paypal_Payment_Buttons_Test extends TestCase {
 		$this->assertEquals( 'https', $result_parsed['scheme'], 'Scheme should be forced to https' );
 		$this->assertEquals( '/malicious/path', $result_parsed['path'], 'Path should be preserved' );
 		$this->assertEquals( 'bad=params', $result_parsed['query'], 'Query should be preserved' );
-		$this->assertEquals( 'fragment', $result_parsed['fragment'], 'Fragment should be preserved' );
-		$this->assertSame( '8080', $result_parsed['port'], 'Port should be preserved' );
+		$this->assertArrayNotHasKey( 'fragment', $result_parsed, 'Fragment should be stripped' );
+		$this->assertArrayNotHasKey( 'port', $result_parsed, 'Port should be stripped' );
 	}
 
 	/**

--- a/projects/packages/paypal-payments/tests/php/Paypal_Payment_Buttons_Test.php
+++ b/projects/packages/paypal-payments/tests/php/Paypal_Payment_Buttons_Test.php
@@ -1,0 +1,225 @@
+<?php
+/**
+ * Tests for the PayPal_Payment_Buttons class.
+ *
+ * @package automattic/jetpack-paypal-payments
+ */
+
+namespace Automattic\Jetpack\PaypalPayments;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class Paypal_Payment_Buttons_Test
+ *
+ * @coversDefaultClass Automattic\Jetpack\PaypalPayments\PayPal_Payment_Buttons
+ * @covers \Automattic\Jetpack\PaypalPayments\PayPal_Payment_Buttons
+ */
+#[CoversClass( PayPal_Payment_Buttons::class )]
+class Paypal_Payment_Buttons_Test extends TestCase {
+
+	/**
+	 * Test that valid PayPal URLs pass through unchanged.
+	 *
+	 * @dataProvider valid_paypal_urls_provider
+	 *
+	 * @param string $url The URL to test.
+	 */
+	#[DataProvider( 'valid_paypal_urls_provider' )]
+	public function test_valid_paypal_urls_pass_through( $url ) {
+		$result = PayPal_Payment_Buttons::sanitize_paypal_script_url( $url );
+
+		$this->assertNotFalse( $result, "URL should not return false: $url" );
+
+		// Parse both URLs to compare hosts
+		$original_parsed = wp_parse_url( $url );
+		$result_parsed   = wp_parse_url( $result );
+
+		$this->assertEquals( $original_parsed['host'], $result_parsed['host'], "Host should remain unchanged for valid PayPal URL: $url" );
+	}
+
+	/**
+	 * Data provider for valid PayPal URLs.
+	 *
+	 * @return array
+	 */
+	public static function valid_paypal_urls_provider() {
+		return array(
+			'paypal.com'                    => array( 'https://www.paypal.com/sdk/js' ),
+			'paypal.com subdomain'          => array( 'https://www.paypal.com/sdk/js?client-id=test' ),
+			'sandbox.paypal.com'            => array( 'https://www.sandbox.paypal.com/sdk/js' ),
+			'sandbox.paypal.com with query' => array( 'https://www.sandbox.paypal.com/sdk/js?client-id=test&currency=USD' ),
+			'www.paypal.com'                => array( 'https://www.paypal.com/webapps/xoplatform' ),
+			'www.sandbox.paypal.com'        => array( 'https://www.sandbox.paypal.com/webapps/xoplatform' ),
+		);
+	}
+
+	/**
+	 * Test that invalid URLs have their hosts replaced with www.paypal.com.
+	 *
+	 * @dataProvider invalid_urls_provider
+	 *
+	 * @param string $url                The URL to test.
+	 * @param bool   $should_be_replaced Whether the URL should be sanitized or return false.
+	 */
+	#[DataProvider( 'invalid_urls_provider' )]
+	public function test_invalid_urls_are_sanitized( $url, $should_be_replaced ) {
+		$result = PayPal_Payment_Buttons::sanitize_paypal_script_url( $url );
+
+		if ( ! $should_be_replaced ) {
+			$this->assertFalse( $result, "URL should return false: $url" );
+		} else {
+			$this->assertNotFalse( $result, "URL should be sanitized: $url" );
+
+			$result_parsed = wp_parse_url( $result );
+			$this->assertEquals( 'www.paypal.com', $result_parsed['host'], "Host should be replaced with www.paypal.com for: $url" );
+			$this->assertEquals( 'https', $result_parsed['scheme'], "Scheme should be https for: $url" );
+		}
+	}
+
+	/**
+	 * Data provider for invalid URLs.
+	 *
+	 * @return array Array of [url, should_be_replaced].
+	 */
+	public static function invalid_urls_provider() {
+		return array(
+			'empty string'              => array( '', false ),
+			'attacker domain'           => array( 'https://attacker.example/x.js', true ),
+			'attacker with paypal name' => array( 'https://paypal.com.evil.com/script.js', true ),
+			'subdomain injection'       => array( 'https://evilpaypal.com/script.js', true ),
+			'javascript protocol'       => array( 'javascript:alert(1)', false ),
+			'data protocol'             => array( 'data:text/html,<script>alert(1)</script>', false ),
+			'no host'                   => array( '/script.js', false ),
+			'malformed url'             => array( 'not-a-url', false ),
+			'paypal typo domain'        => array( 'https://paypai.com/script.js', true ),
+			'different TLD'             => array( 'https://paypal.co/script.js', true ),
+		);
+	}
+
+	/**
+	 * Test that paths are preserved when sanitizing URLs.
+	 */
+	public function test_paths_are_preserved() {
+		// Valid PayPal URL with path
+		$valid_url = 'https://www.paypal.com/sdk/js/some/deep/path.js';
+		$result    = PayPal_Payment_Buttons::sanitize_paypal_script_url( $valid_url );
+
+		$result_parsed = wp_parse_url( $result );
+		$this->assertEquals( '/sdk/js/some/deep/path.js', $result_parsed['path'] );
+
+		// Invalid URL with path - should preserve path but replace host
+		$invalid_url = 'https://evil.com/malicious/script.js';
+		$result      = PayPal_Payment_Buttons::sanitize_paypal_script_url( $invalid_url );
+
+		$result_parsed = wp_parse_url( $result );
+		$this->assertEquals( 'www.paypal.com', $result_parsed['host'] );
+		$this->assertEquals( '/malicious/script.js', $result_parsed['path'] );
+	}
+
+	/**
+	 * Test that query parameters are preserved when sanitizing URLs.
+	 */
+	public function test_query_parameters_are_preserved() {
+		// Valid PayPal URL with query params
+		$valid_url = 'https://www.paypal.com/sdk/js?client-id=test&currency=USD&locale=en_US';
+		$result    = PayPal_Payment_Buttons::sanitize_paypal_script_url( $valid_url );
+
+		$result_parsed = wp_parse_url( $result );
+		$this->assertEquals( 'client-id=test&currency=USD&locale=en_US', $result_parsed['query'] );
+
+		// Invalid URL with query params - should preserve query but replace host
+		$invalid_url = 'https://evil.com/script.js?param1=value1&param2=value2';
+		$result      = PayPal_Payment_Buttons::sanitize_paypal_script_url( $invalid_url );
+
+		$result_parsed = wp_parse_url( $result );
+		$this->assertEquals( 'www.paypal.com', $result_parsed['host'] );
+		$this->assertEquals( 'param1=value1&param2=value2', $result_parsed['query'] );
+	}
+
+	/**
+	 * Test that fragments are preserved when sanitizing URLs.
+	 */
+	public function test_fragments_are_preserved() {
+		// Valid PayPal URL with fragment
+		$valid_url = 'https://www.paypal.com/sdk/js#section';
+		$result    = PayPal_Payment_Buttons::sanitize_paypal_script_url( $valid_url );
+
+		$result_parsed = wp_parse_url( $result );
+		$this->assertEquals( 'section', $result_parsed['fragment'] );
+
+		// Invalid URL with fragment - should preserve fragment but replace host
+		$invalid_url = 'https://evil.com/script.js#anchor';
+		$result      = PayPal_Payment_Buttons::sanitize_paypal_script_url( $invalid_url );
+
+		$result_parsed = wp_parse_url( $result );
+		$this->assertEquals( 'www.paypal.com', $result_parsed['host'] );
+		$this->assertEquals( 'anchor', $result_parsed['fragment'] );
+	}
+
+	/**
+	 * Test that all URL components work together.
+	 */
+	public function test_all_url_components_together() {
+		// Valid PayPal URL with all components
+		$valid_url = 'https://www.paypal.com:443/sdk/js?client-id=test&currency=USD#init';
+		$result    = PayPal_Payment_Buttons::sanitize_paypal_script_url( $valid_url );
+
+		$result_parsed = wp_parse_url( $result );
+		$this->assertEquals( 'www.paypal.com', $result_parsed['host'] );
+		$this->assertEquals( 'https', $result_parsed['scheme'] );
+		$this->assertEquals( '/sdk/js', $result_parsed['path'] );
+		$this->assertEquals( 'client-id=test&currency=USD', $result_parsed['query'] );
+		$this->assertEquals( 'init', $result_parsed['fragment'] );
+
+		// Invalid URL with all components - should preserve everything except host and scheme
+		$invalid_url = 'http://evil.com:8080/malicious/path?bad=params#fragment';
+		$result      = PayPal_Payment_Buttons::sanitize_paypal_script_url( $invalid_url );
+
+		$result_parsed = wp_parse_url( $result );
+		$this->assertEquals( 'www.paypal.com', $result_parsed['host'], 'Host should be replaced' );
+		$this->assertEquals( 'https', $result_parsed['scheme'], 'Scheme should be forced to https' );
+		$this->assertEquals( '/malicious/path', $result_parsed['path'], 'Path should be preserved' );
+		$this->assertEquals( 'bad=params', $result_parsed['query'], 'Query should be preserved' );
+		$this->assertEquals( 'fragment', $result_parsed['fragment'], 'Fragment should be preserved' );
+		$this->assertSame( '8080', $result_parsed['port'], 'Port should be preserved' );
+	}
+
+	/**
+	 * Test that HTTP scheme is upgraded to HTTPS.
+	 */
+	public function test_http_is_upgraded_to_https() {
+		// Valid PayPal URL with http should be upgraded to https
+		$http_url = 'http://www.paypal.com/sdk/js';
+		$result   = PayPal_Payment_Buttons::sanitize_paypal_script_url( $http_url );
+
+		$result_parsed = wp_parse_url( $result );
+		$this->assertEquals( 'https', $result_parsed['scheme'], 'HTTP should be upgraded to HTTPS' );
+
+		// Invalid URL with http should also get https
+		$invalid_http = 'http://evil.com/script.js';
+		$result       = PayPal_Payment_Buttons::sanitize_paypal_script_url( $invalid_http );
+
+		$result_parsed = wp_parse_url( $result );
+		$this->assertEquals( 'https', $result_parsed['scheme'], 'HTTP should be upgraded to HTTPS even for invalid hosts' );
+	}
+
+	/**
+	 * Test that the XSS attack from the security report is mitigated.
+	 */
+	public function test_xss_attack_is_mitigated() {
+		$malicious_url = 'https://attacker.example/malicious.js';
+		$result        = PayPal_Payment_Buttons::sanitize_paypal_script_url( $malicious_url );
+
+		$this->assertNotFalse( $result );
+
+		$result_parsed = wp_parse_url( $result );
+		$this->assertEquals( 'www.paypal.com', $result_parsed['host'], 'Malicious host should be replaced with www.paypal.com' );
+		$this->assertEquals( 'https', $result_parsed['scheme'], 'Scheme should be https' );
+
+		// The path from the malicious URL should be preserved
+		$this->assertEquals( '/malicious.js', $result_parsed['path'] );
+	}
+}


### PR DESCRIPTION
Closes PAYPAL-96

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Improves validation of the PayPal script URL when rendering the block to complement existing validation logic in the editor. 

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Checkout branch
* Build with `jetpack build packages/paypal-payments && jetpack build plugins/paypal-payment-buttons`
* Insert the PayPal Payment Buttons block
* Add the information for a stacked block
* Save
* Ensure the block still renders and functions

