### PR TITLE
Tiled gallery: Improve image placeholder animation performance

### DIFF
--- a/projects/plugins/jetpack/changelog/improve-tiled-gallery-img-loading-animation-perf
+++ b/projects/plugins/jetpack/changelog/improve-tiled-gallery-img-loading-animation-perf
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Tiled Gallery: Improve editor animation performance by removing loading animations when possible.

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/editor.scss
@@ -58,7 +58,7 @@
 
 		&.is-loading > img {
 			// Inspired by Calypso's placeholder mixin
-			animation: tiled-gallery-img-placeholder 1.6s ease-in-out infinite alternate;
+			animation: tiled-gallery-img-placeholder .8s ease-in-out infinite alternate;
 		}
 
 		&.is-selected {

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/editor.scss
@@ -60,7 +60,7 @@
 			outline: none;
 		}
 
-		> img {
+		&.is-loading > img {
 			// Inspired by Calypso's placeholder mixin
 			animation: tiled-gallery-img-placeholder 1.6s ease-in-out infinite;
 		}

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/editor.scss
@@ -6,15 +6,11 @@
 @keyframes tiled-gallery-img-placeholder {
 
 	0% {
-		background-color: var(--color-neutral-0);
-	}
-
-	50% {
-		background-color: color-mix(in sRGB, var(--color-neutral-0) 50%, transparent);
+		background-color: rgb(from var(--color-neutral-0) r g b / 1);
 	}
 
 	100% {
-		background-color: var(--color-neutral-0);
+		background-color: rgb(from var(--color-neutral-0) r g b / 0.5);
 	}
 }
 
@@ -62,7 +58,7 @@
 
 		&.is-loading > img {
 			// Inspired by Calypso's placeholder mixin
-			animation: tiled-gallery-img-placeholder 1.6s ease-in-out infinite;
+			animation: tiled-gallery-img-placeholder 1.6s ease-in-out infinite alternate;
 		}
 
 		&.is-selected {

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/editor.scss
@@ -58,7 +58,7 @@
 
 		&.is-loading > img {
 			// Inspired by Calypso's placeholder mixin
-			animation: tiled-gallery-img-placeholder .8s ease-in-out infinite alternate;
+			animation: tiled-gallery-img-placeholder 0.8s ease-in-out infinite alternate;
 		}
 
 		&.is-selected {

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/gallery-image/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/gallery-image/edit.js
@@ -49,11 +49,9 @@ class GalleryImageEdit extends Component {
 			if ( ! isComplete ) {
 				this.img.current.addEventListener( 'load', this.onImageLoadComplete, {
 					once: true,
-					passive: true,
 				} );
 				this.img.current.addEventListener( 'error', this.onImageLoadComplete, {
 					once: true,
-					passive: true,
 				} );
 			}
 		}

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/gallery-image/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/gallery-image/edit.js
@@ -9,6 +9,9 @@ import { close, downChevron, leftChevron, rightChevron, upChevron } from '../ico
 
 class GalleryImageEdit extends Component {
 	img = createRef();
+	state = {
+		isLoading: false,
+	};
 
 	onImageClick = () => {
 		if ( ! this.props.isSelected ) {
@@ -26,8 +29,58 @@ class GalleryImageEdit extends Component {
 		}
 	};
 
-	componentDidUpdate() {
-		const { alt, height, image, link, url, width } = this.props;
+	onImageLoadComplete = () => {
+		this.setState( { isLoading: false } );
+	};
+
+	addImageEventListeners = () => {
+		this.removeImageEventListeners();
+
+		if ( this.img.current && ! isBlobURL( this.props.origUrl ) ) {
+			this.img.current.addEventListener( 'load', this.onImageLoadComplete );
+			this.img.current.addEventListener( 'error', this.onImageLoadComplete );
+
+			if ( this.img.current.complete ) {
+				this.onImageLoadComplete();
+			} else {
+				this.setState( { isLoading: true } );
+			}
+		}
+	};
+
+	removeImageEventListeners = () => {
+		if ( this.img.current ) {
+			this.img.current.removeEventListener( 'load', this.onImageLoadComplete );
+			this.img.current.removeEventListener( 'error', this.onImageLoadComplete );
+		}
+	};
+
+	componentDidMount() {
+		this.addImageEventListeners();
+	}
+
+	componentWillUnmount() {
+		this.removeImageEventListeners();
+	}
+
+	componentDidUpdate( prevProps ) {
+		const { alt, height, image, link, url, width, origUrl } = this.props;
+
+		// Handle URL transitions
+		const wasTransient = isBlobURL( prevProps.origUrl );
+		const isNowTransient = isBlobURL( origUrl );
+
+		// URL changed from blob to regular URL
+		if ( wasTransient && ! isNowTransient ) {
+			this.setState( { isLoading: false } );
+			this.addImageEventListeners();
+		}
+
+		// URL changed between regular URLs
+		if ( ! wasTransient && ! isNowTransient && prevProps.url !== url ) {
+			this.setState( { isLoading: false } );
+			this.addImageEventListeners();
+		}
 
 		if ( image ) {
 			const nextAtts = {};
@@ -78,6 +131,8 @@ class GalleryImageEdit extends Component {
 			width,
 		} = this.props;
 
+		const { isLoading } = this.state;
+
 		let href;
 
 		switch ( linkTo ) {
@@ -120,6 +175,7 @@ class GalleryImageEdit extends Component {
 				className={ clsx( 'tiled-gallery__item', {
 					'is-selected': isSelected,
 					'is-transient': isTransient,
+					'is-loading': ! isTransient && isLoading,
 					[ `filter__${ imageFilter }` ]: !! imageFilter,
 				} ) }
 				tabIndex="0"

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/gallery-image/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/gallery-image/edit.js
@@ -37,13 +37,13 @@ class GalleryImageEdit extends Component {
 		this.removeImageEventListeners();
 
 		if ( this.img.current && ! isBlobURL( this.props.origUrl ) ) {
-			this.img.current.addEventListener( 'load', this.onImageLoadComplete );
-			this.img.current.addEventListener( 'error', this.onImageLoadComplete );
+			const isComplete = this.img.current.complete;
+			this.setState( { isLoading: ! isComplete } );
 
-			if ( this.img.current.complete ) {
-				this.onImageLoadComplete();
-			} else {
-				this.setState( { isLoading: true } );
+			// Only add event listeners if image is not complete
+			if ( ! isComplete ) {
+				this.img.current.addEventListener( 'load', this.onImageLoadComplete );
+				this.img.current.addEventListener( 'error', this.onImageLoadComplete );
 			}
 		}
 	};

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/gallery-image/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/gallery-image/edit.js
@@ -8,7 +8,11 @@ import clsx from 'clsx';
 import { close, downChevron, leftChevron, rightChevron, upChevron } from '../icons';
 
 class GalleryImageEdit extends Component {
+	/**
+	 * @type {import('react').RefObject<HTMLImageElement>}
+	 */
 	img = createRef();
+
 	state = {
 		isLoading: false,
 	};
@@ -31,6 +35,7 @@ class GalleryImageEdit extends Component {
 
 	onImageLoadComplete = () => {
 		this.setState( { isLoading: false } );
+		this.removeImageEventListeners();
 	};
 
 	addImageEventListeners = () => {
@@ -62,11 +67,9 @@ class GalleryImageEdit extends Component {
 	};
 
 	componentDidMount() {
-		this.addImageEventListeners();
-
-		// Also check if image is already complete in case ref wasn't ready during addImageEventListeners
-		if ( this.img.current && ! isBlobURL( this.props.origUrl ) && this.img.current.complete ) {
-			this.setState( { isLoading: false } );
+		if ( ! isBlobURL( this.props.origUrl ) && ! this.img.current?.complete ) {
+			this.setState( { isLoading: true } );
+			this.addImageEventListeners();
 		}
 	}
 
@@ -79,17 +82,15 @@ class GalleryImageEdit extends Component {
 
 		// Handle URL transitions
 		const wasTransient = isBlobURL( prevProps.origUrl );
-		const isNowTransient = isBlobURL( origUrl );
+		const isTransient = isBlobURL( origUrl );
 
-		// URL changed from blob to regular URL
-		if ( wasTransient && ! isNowTransient ) {
-			this.setState( { isLoading: false } );
-			this.addImageEventListeners();
-		}
-
-		// URL changed between regular URLs
-		if ( ! wasTransient && ! isNowTransient && prevProps.url !== url ) {
-			this.setState( { isLoading: false } );
+		if (
+			! isTransient &&
+			! this.img.current?.complete &&
+			( wasTransient || // transitioned from blob to regular URL
+				prevProps.url !== url ) // URL updated
+		) {
+			this.setState( { isLoading: true } );
 			this.addImageEventListeners();
 		}
 

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/gallery-image/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/gallery-image/edit.js
@@ -57,6 +57,11 @@ class GalleryImageEdit extends Component {
 
 	componentDidMount() {
 		this.addImageEventListeners();
+
+		// Also check if image is already complete in case ref wasn't ready during addImageEventListeners
+		if ( this.img.current && ! isBlobURL( this.props.origUrl ) && this.img.current.complete ) {
+			this.setState( { isLoading: false } );
+		}
 	}
 
 	componentWillUnmount() {

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/gallery-image/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/gallery-image/edit.js
@@ -42,8 +42,14 @@ class GalleryImageEdit extends Component {
 
 			// Only add event listeners if image is not complete
 			if ( ! isComplete ) {
-				this.img.current.addEventListener( 'load', this.onImageLoadComplete );
-				this.img.current.addEventListener( 'error', this.onImageLoadComplete );
+				this.img.current.addEventListener( 'load', this.onImageLoadComplete, {
+					once: true,
+					passive: true,
+				} );
+				this.img.current.addEventListener( 'error', this.onImageLoadComplete, {
+					once: true,
+					passive: true,
+				} );
 			}
 		}
 	};


### PR DESCRIPTION
## Proposed changes:

Change a loading animation to be applied conditionally to images as they load in the editor.

Before this change, the background-color animations applied to images always ran, indefinitely, in the editor.

This is an important performance improvement because the animations continued to run and cause significant browser rendering work, even though the background and animations were not visible. It was particularly noticeable on some recent Safari versions.

That's _especially_ bad on sites where the editor assets are loaded on the frontend. That is not typically the case, but there are some sites that do that.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

Performance discussion: p1759329948724359-slack-C4GAQ900P

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:

- Try adding images to an image block in the editor.
- As the image uploads, the previous behavior should be used (for blob URLs).
- When the images switch to their regular URL (after they've been uploaded), as the images load they should use the loading animation. The image containers should have an `is-loading` class.
- After the images are uploaded or if they fail (try setting offline in browser network tools) the images should not have a loading animation.

https://github.com/user-attachments/assets/5c66c5b8-9c2c-44ad-9d9b-4dce46ffbb9b


