### PR TITLE
Charts: Add custom legend rendering

### DIFF
--- a/projects/js-packages/charts/changelog/charts-119-pie-donut-semi-circle-charts-custom-legend
+++ b/projects/js-packages/charts/changelog/charts-119-pie-donut-semi-circle-charts-custom-legend
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Charts: Add custom legend support

--- a/projects/js-packages/charts/src/components/legend/private/base-legend.tsx
+++ b/projects/js-packages/charts/src/components/legend/private/base-legend.tsx
@@ -79,6 +79,7 @@ export const BaseLegend: ForwardRefExoticComponent<
 			itemDirection = 'row',
 			legendLabelProps,
 			legendItemClassName,
+			render,
 			...legendItemProps
 		},
 		ref
@@ -96,7 +97,9 @@ export const BaseLegend: ForwardRefExoticComponent<
 			[ items ]
 		);
 
-		return (
+		return render ? (
+			render( items )
+		) : (
 			<LegendOrdinal
 				scale={ legendScale }
 				labelFormat={ labelFormat }

--- a/projects/js-packages/charts/src/components/legend/test/legend.test.tsx
+++ b/projects/js-packages/charts/src/components/legend/test/legend.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/jsx-no-bind */
 import { render, screen } from '@testing-library/react';
 import { BaseLegend } from '../private/base-legend';
 import type { LegendProps } from '../types';
@@ -205,6 +206,124 @@ describe( 'BaseLegend', () => {
 			// Should still render the legend items
 			const legendItems = screen.getAllByTestId( 'legend-item' );
 			expect( legendItems ).toHaveLength( 2 );
+		} );
+	} );
+
+	describe( 'custom render prop', () => {
+		test( 'calls render function with items', () => {
+			const renderFn = jest.fn( () => <div data-testid="custom-legend">Custom Legend</div> );
+			render( <BaseLegend items={ defaultItems } orientation="horizontal" render={ renderFn } /> );
+
+			expect( renderFn ).toHaveBeenCalledWith( defaultItems );
+			expect( screen.getByTestId( 'custom-legend' ) ).toBeInTheDocument();
+		} );
+
+		test( 'uses custom render instead of default legend markup', () => {
+			const renderFn = () => (
+				<div data-testid="custom-legend">
+					<span>Custom rendering</span>
+				</div>
+			);
+			render( <BaseLegend items={ defaultItems } orientation="horizontal" render={ renderFn } /> );
+
+			// Custom markup should be present
+			expect( screen.getByTestId( 'custom-legend' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Custom rendering' ) ).toBeInTheDocument();
+
+			// Default legend markup should not be present
+			expect( screen.queryByTestId( 'legend-horizontal' ) ).not.toBeInTheDocument();
+			expect( screen.queryByTestId( 'legend-item' ) ).not.toBeInTheDocument();
+		} );
+
+		test( 'custom render can access all item properties', () => {
+			const renderFn = ( items: typeof defaultItems ) => (
+				<ul data-testid="custom-legend-list">
+					{ items.map( ( item, index ) => (
+						<li key={ index } data-testid={ `custom-item-${ index }` }>
+							<span style={ { color: item.color } }>{ item.label }</span>
+							<span>{ item.value }</span>
+						</li>
+					) ) }
+				</ul>
+			);
+			render( <BaseLegend items={ defaultItems } orientation="horizontal" render={ renderFn } /> );
+
+			expect( screen.getByTestId( 'custom-legend-list' ) ).toBeInTheDocument();
+			expect( screen.getByTestId( 'custom-item-0' ) ).toBeInTheDocument();
+			expect( screen.getByTestId( 'custom-item-1' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Item 1' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Item 2' ) ).toBeInTheDocument();
+		} );
+
+		test( 'custom render handles empty items array', () => {
+			const renderFn = ( items: typeof defaultItems ) => (
+				<div data-testid="custom-legend">
+					{ items.length === 0 ? 'No items' : `${ items.length } items` }
+				</div>
+			);
+			render( <BaseLegend items={ [] } orientation="horizontal" render={ renderFn } /> );
+
+			expect( screen.getByTestId( 'custom-legend' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'No items' ) ).toBeInTheDocument();
+		} );
+
+		test( 'custom render can create alternative layouts', () => {
+			const renderFn = ( items: typeof defaultItems ) => (
+				<div data-testid="custom-grid-legend" style={ { display: 'grid' } }>
+					{ items.map( ( item, index ) => (
+						<div key={ index } data-testid="grid-item">
+							<div style={ { backgroundColor: item.color, width: 20, height: 20 } } />
+							<div>{ item.label }</div>
+							<div>{ item.value }</div>
+						</div>
+					) ) }
+				</div>
+			);
+			render( <BaseLegend items={ defaultItems } orientation="horizontal" render={ renderFn } /> );
+
+			expect( screen.getByTestId( 'custom-grid-legend' ) ).toBeInTheDocument();
+			const gridItems = screen.getAllByTestId( 'grid-item' );
+			expect( gridItems ).toHaveLength( 2 );
+		} );
+
+		test( 'custom render with complex JSX structure', () => {
+			const renderFn = ( items: typeof defaultItems ) => (
+				<div data-testid="complex-legend">
+					<h3>Legend Title</h3>
+					<div className="legend-body">
+						{ items.map( ( item, index ) => (
+							<div key={ index } className="legend-row">
+								<svg width={ 10 } height={ 10 }>
+									<circle cx={ 5 } cy={ 5 } r={ 5 } fill={ item.color } />
+								</svg>
+								<span>{ item.label }: </span>
+								<strong>{ item.value }</strong>
+							</div>
+						) ) }
+					</div>
+				</div>
+			);
+			render( <BaseLegend items={ defaultItems } orientation="horizontal" render={ renderFn } /> );
+
+			expect( screen.getByTestId( 'complex-legend' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Legend Title' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Item 1:' ) ).toBeInTheDocument();
+			expect( screen.getByText( '50%' ) ).toBeInTheDocument();
+		} );
+
+		test( 'orientation prop is ignored when using custom render', () => {
+			const renderFn = () => <div data-testid="custom-legend">Custom</div>;
+			const { rerender } = render(
+				<BaseLegend items={ defaultItems } orientation="horizontal" render={ renderFn } />
+			);
+
+			expect( screen.getByTestId( 'custom-legend' ) ).toBeInTheDocument();
+			expect( screen.queryByTestId( 'legend-horizontal' ) ).not.toBeInTheDocument();
+
+			rerender( <BaseLegend items={ defaultItems } orientation="vertical" render={ renderFn } /> );
+
+			expect( screen.getByTestId( 'custom-legend' ) ).toBeInTheDocument();
+			expect( screen.queryByTestId( 'legend-vertical' ) ).not.toBeInTheDocument();
 		} );
 	} );
 } );

--- a/projects/js-packages/charts/src/components/legend/types.ts
+++ b/projects/js-packages/charts/src/components/legend/types.ts
@@ -29,6 +29,10 @@ export type BaseLegendProps = Omit< LegendOrdinalProps, 'shapeStyle' > & {
 	 * This allows consumers to customize individual legend item styling.
 	 */
 	legendItemClassName?: string;
+	/**
+	 * Function for rendering a custom legend layout.
+	 */
+	render?: ( items: BaseLegendItem[] ) => ReactNode;
 };
 
 export type LegendProps = Omit< BaseLegendProps, 'items' > & {

--- a/projects/js-packages/charts/src/components/pie-chart/pie-chart.module.scss
+++ b/projects/js-packages/charts/src/components/pie-chart/pie-chart.module.scss
@@ -2,4 +2,6 @@
 	display: flex;
 	flex-direction: column;
 	overflow: hidden;
+	align-items: center;
+	gap: var(--wp-ui-stack-gap, 20px);
 }

--- a/projects/js-packages/charts/src/components/pie-chart/pie-chart.module.scss
+++ b/projects/js-packages/charts/src/components/pie-chart/pie-chart.module.scss
@@ -3,5 +3,5 @@
 	flex-direction: column;
 	overflow: hidden;
 	align-items: center;
-	gap: var(--wp-ui-stack-gap, 20px);
+	gap: 20px;
 }

--- a/projects/js-packages/charts/src/components/pie-chart/pie-chart.tsx
+++ b/projects/js-packages/charts/src/components/pie-chart/pie-chart.tsx
@@ -142,7 +142,7 @@ const PieChartInternal = ( {
 	legendShape = 'circle',
 	size,
 	thickness = 1,
-	padding = 20,
+	padding = 0,
 	gapScale = 0,
 	cornerScale = 0,
 	showLabels = true,

--- a/projects/js-packages/charts/src/components/pie-chart/stories/donut.stories.tsx
+++ b/projects/js-packages/charts/src/components/pie-chart/stories/donut.stories.tsx
@@ -1,3 +1,9 @@
+/* eslint-disable @wordpress/no-unsafe-wp-apis */
+import {
+	__experimentalText as WPText,
+	__experimentalHStack as HStack,
+} from '@wordpress/components';
+import { BaseLegendItem } from '../../../components/legend/types';
 import {
 	chartDecorator,
 	sharedChartArgTypes,
@@ -7,7 +13,7 @@ import {
 } from '../../../stories';
 import { Group } from '../../../visx/group';
 import { Text } from '../../../visx/text';
-import { PieChart } from '../../pie-chart';
+import { PieChart, PieChartUnresponsive } from '../../pie-chart';
 import type { Meta, StoryObj } from '@storybook/react';
 
 type StoryArgs = ChartStoryArgs< React.ComponentProps< typeof PieChart > >;
@@ -85,7 +91,6 @@ export const Default: Story = {
 		resize: 'none',
 		thickness: 0.5,
 		gapScale: 0.03,
-		padding: 20,
 		cornerScale: 0.03,
 		withTooltips: true,
 		data,
@@ -197,6 +202,7 @@ export const WithLegend: Story = {
 	args: {
 		...Default.args,
 		showLegend: true,
+		containerHeight: '500px',
 	},
 };
 
@@ -264,6 +270,7 @@ export const WithCompositionLegend: Story = {
 	args: {
 		data,
 		thickness: 0.5,
+		containerHeight: '500px',
 	},
 	parameters: {
 		docs: {
@@ -315,6 +322,112 @@ export const CustomLegendPositioning: Story = {
 		docs: {
 			description: {
 				story: 'Donut chart with vertical legend positioned at the top left.',
+			},
+		},
+	},
+};
+
+const WooPieLegend = ( {
+	legendItems,
+	legendData,
+	withComparison = false,
+}: {
+	legendItems: BaseLegendItem[];
+	legendData: { label: string; value: number; formattedValue: string; comparison?: number }[];
+	withComparison?: boolean;
+} ) => (
+	<div
+		style={ {
+			display: 'inline-grid',
+			gridTemplateColumns: '1fr auto auto',
+			gap: 'var(--wpds-spacing-05, 5px) var(--wpds-spacing-10, 10px)',
+		} }
+	>
+		{ legendData.map( ( item, index ) => {
+			const { color } = legendItems[ index ];
+
+			return (
+				<>
+					<HStack direction="row" justify="flex-start" gap={ 2 }>
+						<div
+							style={ {
+								width: '8px',
+								height: '8px',
+								borderRadius: '50%',
+								flexShrink: 0,
+								backgroundColor: color,
+							} }
+						/>
+						<WPText size="small">{ item.label }</WPText>
+					</HStack>
+					<WPText size="small" weight={ 600 } style={ { textAlign: 'right' } }>
+						{ item.formattedValue }
+					</WPText>
+					<WPText size="small" style={ { textAlign: 'right', color: '#008a20' } }>
+						{ withComparison && item.comparison }
+					</WPText>
+				</>
+			);
+		} ) }
+	</div>
+);
+
+export const CustomLegend: Story = {
+	render: args => (
+		<PieChartUnresponsive { ...args }>
+			<PieChartUnresponsive.Legend
+				// eslint-disable-next-line react/jsx-no-bind
+				render={ items => (
+					<WooPieLegend
+						legendItems={ items }
+						legendData={ args.legendData }
+						withComparison={ args.withComparison }
+					/>
+				) }
+			/>
+		</PieChartUnresponsive>
+	),
+	args: {
+		...Default.args,
+		data: [
+			{
+				label: '',
+				value: 302331.26999999984,
+				percentage: 66.97002374697931,
+			},
+			{
+				label: '',
+				value: 149111.40999999995,
+				percentage: 33.029976253020635,
+			},
+		],
+		legendData: [
+			{
+				label: 'New',
+				value: 302331.26999999984,
+				formattedValue: '$302.33K',
+				comparison: '14%',
+			},
+			{
+				label: 'Returning',
+				value: 149111.40999999995,
+				formattedValue: '$149.11K',
+				comparison: '133%',
+			},
+		],
+		showLegend: false,
+		children: null,
+		thickness: 0.3,
+		cornerScale: 0.03,
+		gapScale: 0.01,
+		size: 164,
+		withComparison: true,
+		withTooltips: false,
+	},
+	parameters: {
+		docs: {
+			description: {
+				story: 'Demonstrates how to customize the legend using the render prop.',
 			},
 		},
 	},

--- a/projects/js-packages/charts/src/components/pie-chart/stories/donut.stories.tsx
+++ b/projects/js-packages/charts/src/components/pie-chart/stories/donut.stories.tsx
@@ -11,6 +11,7 @@ import {
 	legendArgTypes,
 	themeArgTypes,
 } from '../../../stories';
+import { customerRevenueData, customerRevenueLegendData } from '../../../stories/sample-data';
 import { Group } from '../../../visx/group';
 import { Text } from '../../../visx/text';
 import { PieChart, PieChartUnresponsive } from '../../pie-chart';
@@ -329,12 +330,10 @@ export const CustomLegendPositioning: Story = {
 
 const WooPieLegend = ( {
 	legendItems,
-	legendData,
-	withComparison = false,
+	withComparison,
 }: {
 	legendItems: BaseLegendItem[];
-	legendData: { label: string; value: number; formattedValue: string; comparison?: number }[];
-	withComparison?: boolean;
+	withComparison: boolean;
 } ) => (
 	<div
 		style={ {
@@ -343,7 +342,7 @@ const WooPieLegend = ( {
 			gap: 'var(--wpds-spacing-05, 5px) var(--wpds-spacing-10, 10px)',
 		} }
 	>
-		{ legendData.map( ( item, index ) => {
+		{ customerRevenueLegendData.map( ( item, index ) => {
 			const { color } = legendItems[ index ];
 
 			return (
@@ -378,51 +377,21 @@ export const CustomLegend: Story = {
 			<PieChartUnresponsive.Legend
 				// eslint-disable-next-line react/jsx-no-bind
 				render={ items => (
-					<WooPieLegend
-						legendItems={ items }
-						legendData={ args.legendData }
-						withComparison={ args.withComparison }
-					/>
+					<WooPieLegend legendItems={ items } withComparison={ args.withComparison } />
 				) }
 			/>
 		</PieChartUnresponsive>
 	),
 	args: {
 		...Default.args,
-		data: [
-			{
-				label: '',
-				value: 302331.26999999984,
-				percentage: 66.97002374697931,
-			},
-			{
-				label: '',
-				value: 149111.40999999995,
-				percentage: 33.029976253020635,
-			},
-		],
-		legendData: [
-			{
-				label: 'New',
-				value: 302331.26999999984,
-				formattedValue: '$302.33K',
-				comparison: '14%',
-			},
-			{
-				label: 'Returning',
-				value: 149111.40999999995,
-				formattedValue: '$149.11K',
-				comparison: '133%',
-			},
-		],
-		showLegend: false,
-		children: null,
+		data: customerRevenueData.map( segment => ( { ...segment, label: '' } ) ),
 		thickness: 0.3,
 		cornerScale: 0.03,
 		gapScale: 0.01,
 		size: 164,
 		withComparison: true,
 		withTooltips: false,
+		containerHeight: '300px',
 	},
 	parameters: {
 		docs: {

--- a/projects/js-packages/charts/src/components/pie-chart/stories/donut.stories.tsx
+++ b/projects/js-packages/charts/src/components/pie-chart/stories/donut.stories.tsx
@@ -3,6 +3,7 @@ import {
 	__experimentalText as WPText,
 	__experimentalHStack as HStack,
 } from '@wordpress/components';
+import { Fragment } from 'react';
 import { BaseLegendItem } from '../../../components/legend/types';
 import {
 	chartDecorator,
@@ -329,10 +330,12 @@ export const CustomLegendPositioning: Story = {
 };
 
 const WooPieLegend = ( {
-	legendItems,
+	chartItems,
+	items,
 	withComparison,
 }: {
-	legendItems: BaseLegendItem[];
+	chartItems: BaseLegendItem[];
+	items: { label: string; value: number; formattedValue: string; comparison: string }[];
 	withComparison: boolean;
 } ) => (
 	<div
@@ -342,11 +345,11 @@ const WooPieLegend = ( {
 			gap: 'var(--wpds-spacing-05, 5px) var(--wpds-spacing-10, 10px)',
 		} }
 	>
-		{ customerRevenueLegendData.map( ( item, index ) => {
-			const { color } = legendItems[ index ];
+		{ items.map( ( item, index ) => {
+			const { color } = chartItems[ index ];
 
 			return (
-				<>
+				<Fragment key={ index }>
 					<HStack direction="row" justify="flex-start" gap={ 2 }>
 						<div
 							style={ {
@@ -365,7 +368,7 @@ const WooPieLegend = ( {
 					<WPText size="small" style={ { textAlign: 'right', color: '#008a20' } }>
 						{ withComparison && item.comparison }
 					</WPText>
-				</>
+				</Fragment>
 			);
 		} ) }
 	</div>
@@ -377,7 +380,11 @@ export const CustomLegend: Story = {
 			<PieChartUnresponsive.Legend
 				// eslint-disable-next-line react/jsx-no-bind
 				render={ items => (
-					<WooPieLegend legendItems={ items } withComparison={ args.withComparison } />
+					<WooPieLegend
+						chartItems={ items }
+						items={ customerRevenueLegendData }
+						withComparison={ args.withComparison }
+					/>
 				) }
 			/>
 		</PieChartUnresponsive>

--- a/projects/js-packages/charts/src/components/pie-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/components/pie-chart/stories/index.stories.tsx
@@ -108,7 +108,6 @@ export const Default: Story = {
 	args: {
 		thickness: 1,
 		gapScale: 0,
-		padding: 20,
 		cornerScale: 0,
 		withTooltips: false,
 		data,
@@ -137,6 +136,7 @@ export const WithLegend: Story = {
 	args: {
 		...Default.args,
 		showLegend: true,
+		containerHeight: '500px',
 	},
 };
 
@@ -180,6 +180,7 @@ export const WithCompositionLegend: Story = {
 	),
 	args: {
 		data,
+		containerHeight: '500px',
 	},
 	parameters: {
 		docs: {
@@ -341,6 +342,7 @@ This pattern provides:
 export const CustomLabelColors: Story = {
 	args: {
 		...Default.args,
+		showLegend: true,
 		thickness: 0.85, // Slightly thinner for better label visibility
 		data: [
 			{
@@ -368,6 +370,7 @@ export const CustomLabelColors: Story = {
 		labelTextColor: '#FFFFFF', // White text for contrast against dark background
 		labelBackgroundColor: 'rgba(0, 0, 0, 0.75)', // Dark semi-transparent background
 		size: 400,
+		containerHeight: '500px',
 	},
 	parameters: {
 		docs: {

--- a/projects/js-packages/charts/src/components/pie-semi-circle-chart/pie-semi-circle-chart.module.scss
+++ b/projects/js-packages/charts/src/components/pie-semi-circle-chart/pie-semi-circle-chart.module.scss
@@ -2,7 +2,7 @@
 	display: flex;
 	flex-direction: column;
 	text-align: center;
-
+	gap: 20px;
 
 	.label {
 		margin-bottom: 0; // Add space between label and pie chart

--- a/projects/js-packages/charts/src/index.ts
+++ b/projects/js-packages/charts/src/index.ts
@@ -13,7 +13,7 @@ export { ConversionFunnelChart } from './components/conversion-funnel-chart';
 // Chart components
 export { BaseTooltip } from './components/tooltip';
 export { Legend, useChartLegendItems } from './components/legend';
-export type { LegendValueDisplay } from './components/legend';
+export type { LegendValueDisplay, BaseLegendItem } from './components/legend';
 
 // Themes
 export { GlobalChartsProvider as ThemeProvider } from './providers';

--- a/projects/js-packages/charts/src/providers/chart-context/themes.ts
+++ b/projects/js-packages/charts/src/providers/chart-context/themes.ts
@@ -129,8 +129,8 @@ const wooTheme: ChartTheme = {
 	labelTextColor: '#FFFFFF', // label text color (white to match original behavior)
 	colors: [
 		'#3858E9', // WooCommerce brand blue
-		'#873EFF', // Purple
 		'#66BDFF', // Light blue
+		'#873EFF', // Purple
 		'#7B90FF', // Periwinkle blue
 		'#EB6594', // Pink/rose
 	],

--- a/projects/js-packages/charts/src/stories/sample-data/index.ts
+++ b/projects/js-packages/charts/src/stories/sample-data/index.ts
@@ -883,3 +883,49 @@ export const globalMarketComparisonByCountry: SeriesData[] = [
 		},
 	},
 ];
+
+/**
+ * Customer segmentation revenue data
+ *
+ * Revenue comparison between new and returning customers
+ * - Category: categorical
+ * - Data points: 2
+ * - Suitable for: PieChart, DonutChart
+ */
+export const customerRevenueData: DataPointPercentage[] = [
+	{
+		label: 'New',
+		value: 302331.27,
+		valueDisplay: '$302.33K',
+		percentage: 66.97,
+	},
+	{
+		label: 'Returning',
+		value: 149111.41,
+		valueDisplay: '$149.11K',
+		percentage: 33.03,
+	},
+];
+
+/**
+ * Customer segmentation legend data with comparison metrics
+ *
+ * Extended legend data for customer revenue with growth comparisons
+ * - Category: categorical with comparison
+ * - Data points: 2
+ * - Suitable for: Custom legends with PieChart, DonutChart
+ */
+export const customerRevenueLegendData = [
+	{
+		label: 'New',
+		value: 302331.27,
+		formattedValue: '$302.33K',
+		comparison: '14%',
+	},
+	{
+		label: 'Returning',
+		value: 149111.41,
+		formattedValue: '$149.11K',
+		comparison: '133%',
+	},
+];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes [CHARTS-119: Pie/Donut/Semi circle charts: Support custom rendering of legend](https://linear.app/a8c/issue/CHARTS-119/piedonutsemi-circle-charts-support-custom-rendering-of-legend), allowing rendering of custom legend, which uses CSS grid for layout and has conditional content (the comparison %). The custom legend has access to the colors it needs to match the chart.

### Storybook

<img src="https://github.com/user-attachments/assets/b833b1ff-9013-4876-8719-3818fa007ba9" width="360">

### Woo Analytics

![Screenshot 2025-10-06 at 4 47 37 PM](https://github.com/user-attachments/assets/2866922f-5aa5-4e18-9979-631d8120ef21)

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds support for rendering a custom legend
* The render prop receives the generated legend items for the chart, so the consumer can extract whatever data is needed, and return any markup.

A draft PR has been created to update Woo Analytics to use the render prop: https://github.com/woocommerce/woocommerce-analytics/pull/1253

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to http://localhost:50240/?path=/story/js-packages-charts-types-donut-chart--custom-legend&args=themeName:woo
* Toggle the `withComparison` control to see the delta visibility and layout centering change
* Switch theme and the legend item colors should update along with the chart
* Check other Pie and Donut chart legend stories and ensure the legend is not obscured
* Advanced: run the build and replace the `@automattic/charts` package in Woo Analytics with the `js-packages/charts` dir, and use  https://github.com/woocommerce/woocommerce-analytics/pull/1253 to test
