### PR TITLE
Forms: add read/unread state to the UI

### DIFF
--- a/projects/packages/forms/changelog/add-forms-unread-state
+++ b/projects/packages/forms/changelog/add-forms-unread-state
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Forms: add read and unread state 

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -254,6 +254,29 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 				'callback'            => array( $this, 'get_forms_config' ),
 			)
 		);
+
+		// Mark feedback as read/unread endpoint.
+		register_rest_route(
+			$this->namespace,
+			$this->rest_base . '/(?P<id>\d+)/read',
+			array(
+				'methods'             => \WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'update_read_status' ),
+				'permission_callback' => array( $this, 'update_item_permissions_check' ),
+				'args'                => array(
+					'id'        => array(
+						'type'              => 'integer',
+						'required'          => true,
+						'sanitize_callback' => 'absint',
+					),
+					'is_unread' => array(
+						'type'              => 'boolean',
+						'required'          => true,
+						'sanitize_callback' => 'rest_sanitize_boolean',
+					),
+				),
+			)
+		);
 	}
 
 	/**
@@ -488,6 +511,16 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 			'readonly'    => true,
 		);
 
+		$schema['properties']['is_unread'] = array(
+			'description' => __( 'Whether the form response is unread.', 'jetpack-forms' ),
+			'type'        => 'boolean',
+			'context'     => array( 'view', 'edit', 'embed' ),
+			'arg_options' => array(
+				'sanitize_callback' => 'rest_sanitize_boolean',
+			),
+			'readonly'    => true,
+		);
+
 		$this->schema = $schema;
 
 		return $this->add_additional_fields_schema( $this->schema );
@@ -629,6 +662,10 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 
 		if ( rest_is_field_included( 'has_file', $fields ) ) {
 			$data['has_file'] = $feedback_response->has_file();
+		}
+
+		if ( rest_is_field_included( 'is_unread', $fields ) ) {
+			$data['is_unread'] = $feedback_response->is_unread();
 		}
 
 		$response->set_data( $data );
@@ -1031,6 +1068,43 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 		}
 		$is_deleted = External_Connections::delete_connection( $slug );
 		return rest_ensure_response( array( 'deleted' => $is_deleted ) );
+	}
+
+	/**
+	 * Updates the read/unread status of a feedback item.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
+	public function update_read_status( $request ) {
+		$post_id   = $request->get_param( 'id' );
+		$is_unread = $request->get_param( 'is_unread' );
+
+		$feedback_response = Feedback::get( $post_id );
+		if ( ! $feedback_response ) {
+			return new WP_Error(
+				'rest_post_invalid_id',
+				__( 'Invalid feedback ID.', 'jetpack-forms' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		$success = $is_unread ? $feedback_response->mark_as_unread() : $feedback_response->mark_as_read();
+
+		if ( ! $success ) {
+			return new WP_Error(
+				'rest_cannot_update',
+				__( 'Failed to update feedback read status.', 'jetpack-forms' ),
+				array( 'status' => 500 )
+			);
+		}
+
+		return rest_ensure_response(
+			array(
+				'id'        => $post_id,
+				'is_unread' => $feedback_response->is_unread(),
+			)
+		);
 	}
 
 	/**

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -1091,6 +1091,7 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 
 		$success = $is_unread ? $feedback_response->mark_as_unread() : $feedback_response->mark_as_read();
 
+		Contact_Form_Plugin::recalculate_unread_count();
 		if ( ! $success ) {
 			return new WP_Error(
 				'rest_cannot_update',
@@ -1103,6 +1104,7 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 			array(
 				'id'        => $post_id,
 				'is_unread' => $feedback_response->is_unread(),
+				'count'     => Contact_Form_Plugin::get_unread_count(),
 			)
 		);
 	}

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -1406,68 +1406,89 @@ class Contact_Form_Plugin {
 	 * Display the count of new feedback entries received. It's reset when user visits the Feedback screen.
 	 *
 	 * @since 4.1.0
-	 *
-	 * @param object $screen Information about the current screen.
 	 */
-	public function unread_count( $screen ) {
-		if ( isset( $screen->post_type ) && 'feedback' === $screen->post_type || $screen->id === 'jetpack_page_jetpack-forms-admin' ) {
-			update_option( 'feedback_unread_count', 0 );
-		} else {
-			global $submenu, $menu;
-			if ( apply_filters( 'jetpack_forms_use_new_menu_parent', true ) && current_user_can( 'edit_pages' ) ) {
-				// show the count on Jetpack and Jetpack → Forms
-				$unread = get_option( 'feedback_unread_count', 0 );
+	public function unread_count() {
 
-				if ( $unread > 0 && isset( $submenu['jetpack'] ) && is_array( $submenu['jetpack'] ) && ! empty( $submenu['jetpack'] ) ) {
-					$forms_unread_count_tag = " <span class='count-{$unread} awaiting-mod'><span>" . number_format_i18n( $unread ) . '</span></span>';
-					$jetpack_badge_count    = $unread;
+		global $submenu, $menu;
+		if ( apply_filters( 'jetpack_forms_use_new_menu_parent', true ) && current_user_can( 'edit_pages' ) ) {
+			// show the count on Jetpack and Jetpack → Forms
+			$unread = self::get_unread_count();
 
-					// Main menu entries
-					foreach ( $menu as $index => $main_menu_item ) {
-						if ( isset( $main_menu_item[1] ) && 'jetpack_admin_page' === $main_menu_item[1] ) {
-							// Parse the menu item
-							$jetpack_menu_item = $this->parse_menu_item( $menu[ $index ][0] );
+			if ( $unread > 0 && isset( $submenu['jetpack'] ) && is_array( $submenu['jetpack'] ) && ! empty( $submenu['jetpack'] ) ) {
+				$forms_unread_count_tag = " <span class='jp-feedback-unread-counter count-{$unread} awaiting-mod'><span class='feedback-unread-counter'>" . number_format_i18n( $unread ) . '</span></span>';
+				$jetpack_badge_count    = $unread;
 
-							if ( isset( $jetpack_menu_item['badge'] ) && is_numeric( $jetpack_menu_item['badge'] ) && intval( $jetpack_menu_item['badge'] ) ) {
-								$jetpack_badge_count += intval( $jetpack_menu_item['badge'] );
-							}
+				// Main menu entries
+				foreach ( $menu as $index => $main_menu_item ) {
+					if ( isset( $main_menu_item[1] ) && 'jetpack_admin_page' === $main_menu_item[1] ) {
+						// Parse the menu item
+						$jetpack_menu_item = $this->parse_menu_item( $menu[ $index ][0] );
 
-							if ( isset( $jetpack_menu_item['count'] ) && is_numeric( $jetpack_menu_item['count'] ) && intval( $jetpack_menu_item['count'] ) ) {
-								$jetpack_badge_count += intval( $jetpack_menu_item['count'] );
-							}
-
-							$jetpack_unread_tag = " <span class='count-{$jetpack_badge_count} awaiting-mod'><span>" . number_format_i18n( $jetpack_badge_count ) . '</span></span>';
-
-							// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-							$menu[ $index ][0] = $jetpack_menu_item['title'] . ' ' . $jetpack_unread_tag;
+						if ( isset( $jetpack_menu_item['badge'] ) && is_numeric( $jetpack_menu_item['badge'] ) && intval( $jetpack_menu_item['badge'] ) ) {
+							$jetpack_badge_count += intval( $jetpack_menu_item['badge'] );
 						}
-					}
 
-					// Jetpack submenu entries
-					foreach ( $submenu['jetpack'] as $index => $menu_item ) {
-						if ( 'jetpack-forms-admin' === $menu_item[2] ) {
-							// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-							$submenu['jetpack'][ $index ][0] .= $forms_unread_count_tag;
+						if ( isset( $jetpack_menu_item['count'] ) && is_numeric( $jetpack_menu_item['count'] ) && intval( $jetpack_menu_item['count'] ) ) {
+							$jetpack_badge_count += intval( $jetpack_menu_item['count'] );
 						}
+
+						$jetpack_unread_tag = " <span data-unread-diff='" . ( $jetpack_badge_count - $unread ) . "' class='jp-feedback-unread-counter count-{$jetpack_badge_count} awaiting-mod'><span class='feedback-unread-counter'>" . number_format_i18n( $jetpack_badge_count ) . '</span></span>';
+
+						// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+						$menu[ $index ][0] = $jetpack_menu_item['title'] . ' ' . $jetpack_unread_tag;
 					}
 				}
-				return;
-			}
-			if ( isset( $submenu['feedback'] ) && is_array( $submenu['feedback'] ) && ! empty( $submenu['feedback'] ) ) {
-				foreach ( $submenu['feedback'] as $index => $menu_item ) {
-					if ( 'edit.php?post_type=feedback' === $menu_item[2] ) {
-						$unread = get_option( 'feedback_unread_count', 0 );
-						if ( $unread > 0 ) {
-							$unread_count = current_user_can( 'publish_pages' ) ? " <span class='feedback-unread count-{$unread} awaiting-mod'><span class='feedback-unread-count'>" . number_format_i18n( $unread ) . '</span></span>' : '';
 
-							// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-							$submenu['feedback'][ $index ][0] .= $unread_count;
-						}
-						break;
+				// Jetpack submenu entries
+				foreach ( $submenu['jetpack'] as $index => $menu_item ) {
+					if ( 'jetpack-forms-admin' === $menu_item[2] ) {
+						// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+						$submenu['jetpack'][ $index ][0] .= $forms_unread_count_tag;
 					}
+				}
+			}
+			return;
+		}
+
+		if ( isset( $submenu['feedback'] ) && is_array( $submenu['feedback'] ) && ! empty( $submenu['feedback'] ) ) {
+			foreach ( $submenu['feedback'] as $index => $menu_item ) {
+				if ( 'edit.php?post_type=feedback' === $menu_item[2] ) {
+					$unread = self::get_unread_count();
+
+					if ( $unread > 0 ) {
+						$unread_count = current_user_can( 'publish_pages' ) ? " <span class='feedback-unread jp-feedback-unread-counter count-{$unread} awaiting-mod'><span class='feedback-unread-count'>" . number_format_i18n( $unread ) . '</span></span>' : '';
+
+						// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+						$submenu['feedback'][ $index ][0] .= $unread_count;
+					}
+					break;
 				}
 			}
 		}
+	}
+
+	/**
+	 * Get the count of unread feedback entries.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return int The count of unread feedback entries.
+	 */
+	public static function get_unread_count() {
+		return (int) get_option( 'feedback_unread_count_v2', 0 );
+	}
+
+	/**
+	 * Recalculate the count of unread feedback entries.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return int The count of unread feedback entries.
+	 */
+	public static function recalculate_unread_count() {
+		$count = Feedback::get_unread_count();
+		update_option( 'feedback_unread_count_v2', $count );
+		return $count;
 	}
 
 	/**

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -1477,7 +1477,7 @@ class Contact_Form_Plugin {
 	 * @return int The count of unread feedback entries.
 	 */
 	public static function get_unread_count() {
-		return (int) get_option( 'feedback_unread_count_v2', 0 );
+		return (int) get_option( 'jetpack_feedback_unread_count', 0 ); // previously defaulted named "feedback_unread_count".
 	}
 
 	/**
@@ -1489,7 +1489,7 @@ class Contact_Form_Plugin {
 	 */
 	public static function recalculate_unread_count() {
 		$count = Feedback::get_unread_count();
-		update_option( 'feedback_unread_count_v2', $count );
+		update_option( 'jetpack_feedback_unread_count', $count );
 		return $count;
 	}
 

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -1414,8 +1414,10 @@ class Contact_Form_Plugin {
 			// show the count on Jetpack and Jetpack → Forms
 			$unread = self::get_unread_count();
 
-			if ( $unread > 0 && isset( $submenu['jetpack'] ) && is_array( $submenu['jetpack'] ) && ! empty( $submenu['jetpack'] ) ) {
-				$forms_unread_count_tag = " <span class='jp-feedback-unread-counter count-{$unread} awaiting-mod'><span class='feedback-unread-counter'>" . number_format_i18n( $unread ) . '</span></span>';
+			if ( isset( $submenu['jetpack'] ) && is_array( $submenu['jetpack'] ) && ! empty( $submenu['jetpack'] ) ) {
+				$inline_style = ( $unread > 0 ) ? '' : 'style="display: none;"';
+
+				$forms_unread_count_tag = " <span class='jp-feedback-unread-counter count-{$unread} awaiting-mod' {$inline_style}><span class='feedback-unread-counter'>" . number_format_i18n( $unread ) . '</span></span>';
 				$jetpack_badge_count    = $unread;
 
 				// Main menu entries

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1929,9 +1929,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 		update_post_meta( $post_id, '_feedback_extra_fields', $this->addslashes_deep( $extra_values ) );
 
 		if ( 'publish' === $feedback_status ) {
-			// Increase count of unread feedback.
-			$unread = (int) get_option( 'feedback_unread_count', 0 ) + 1;
-			update_option( 'feedback_unread_count', $unread );
+			Contact_Form_Plugin::recalculate_unread_count();
 		}
 
 		if ( defined( 'AKISMET_VERSION' ) ) {

--- a/projects/packages/forms/src/contact-form/class-feedback.php
+++ b/projects/packages/forms/src/contact-form/class-feedback.php
@@ -18,6 +18,20 @@ class Feedback {
 	const POST_TYPE = 'feedback';
 
 	/**
+	 * Comment status for unread feedback.
+	 *
+	 * @var string
+	 */
+	private const STATUS_UNREAD = 'open';
+
+	/**
+	 * Comment status for read feedback.
+	 *
+	 * @var string
+	 */
+	private const STATUS_READ = 'closed';
+
+	/**
 	 * The form field values.
 	 *
 	 * @var array
@@ -112,6 +126,20 @@ class Feedback {
 	protected $has_consent = false;
 
 	/**
+	 * Whether the feedback entry is unread.
+	 *
+	 * @var bool
+	 */
+	protected $is_unread = true;
+
+	/**
+	 * The post ID of the feedback entry.
+	 *
+	 * @var int|null
+	 */
+	protected $post_id = null;
+
+	/**
 	 * The entry object of the post that the feedback was submitted from.
 	 *
 	 * This is used to store the entry object of the post that the feedback was submitted from.
@@ -151,9 +179,11 @@ class Feedback {
 
 		$parsed_content = $this->parse_content( $feedback_post->post_content, $feedback_post->post_mime_type );
 
+		$this->post_id            = $feedback_post->ID;
 		$this->status             = $feedback_post->post_status;
 		$this->legacy_feedback_id = $feedback_post->post_name;
 		$this->feedback_time      = $feedback_post->post_date;
+		$this->is_unread          = $feedback_post->comment_status === self::STATUS_UNREAD;
 
 		$this->fields = $parsed_content['fields'] ?? array();
 
@@ -707,6 +737,65 @@ class Feedback {
 	}
 
 	/**
+	 * Check if the feedback is unread.
+	 *
+	 * @return bool
+	 */
+	public function is_unread() {
+		return $this->is_unread;
+	}
+
+	/**
+	 * Mark the feedback as read.
+	 *
+	 * @return bool True on success, false on failure.
+	 */
+	public function mark_as_read() {
+		if ( ! $this->post_id ) {
+			return false;
+		}
+
+		$updated = wp_update_post(
+			array(
+				'ID'             => $this->post_id,
+				'comment_status' => self::STATUS_READ,
+			)
+		);
+
+		if ( ! is_wp_error( $updated ) && $updated ) {
+			$this->is_unread = false;
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Mark the feedback as unread.
+	 *
+	 * @return bool True on success, false on failure.
+	 */
+	public function mark_as_unread() {
+		if ( ! $this->post_id ) {
+			return false;
+		}
+
+		$updated = wp_update_post(
+			array(
+				'ID'             => $this->post_id,
+				'comment_status' => self::STATUS_UNREAD,
+			)
+		);
+
+		if ( ! is_wp_error( $updated ) && $updated ) {
+			$this->is_unread = true;
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
 	 * Get the uploaded files from the feedback entry.
 	 *
 	 * @return array
@@ -817,6 +906,7 @@ class Feedback {
 				'post_content'   => $this->serialize(), // In V3 we started to addslashes.
 				'post_mime_type' => 'v3', // a way to help us identify what version of the data this is.
 				'post_parent'    => $this->source->get_id(),
+				'comment_status' => self::STATUS_UNREAD, // New feedback is unread by default.
 			)
 		);
 

--- a/projects/packages/forms/src/contact-form/class-feedback.php
+++ b/projects/packages/forms/src/contact-form/class-feedback.php
@@ -796,6 +796,24 @@ class Feedback {
 	}
 
 	/**
+	 * Get the count of unread feedback entries.
+	 *
+	 * @return int
+	 */
+	public static function get_unread_count() {
+		$query = new \WP_Query(
+			array(
+				'post_type'      => self::POST_TYPE,
+				'post_status'    => 'publish',
+				'comment_status' => self::STATUS_UNREAD,
+				'posts_per_page' => -1,
+				'fields'         => 'ids',
+			)
+		);
+		return (int) $query->found_posts;
+	}
+
+	/**
 	 * Get the uploaded files from the feedback entry.
 	 *
 	 * @return array

--- a/projects/packages/forms/src/dashboard/hooks/use-inbox-data.ts
+++ b/projects/packages/forms/src/dashboard/hooks/use-inbox-data.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { useEntityRecords } from '@wordpress/core-data';
+import { useEntityRecords, store as coreDataStore } from '@wordpress/core-data';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useSearchParams } from 'react-router';
 /**
@@ -75,7 +75,21 @@ export default function useInboxData(): UseInboxDataReturn {
 		totalPages,
 	} = useEntityRecords( 'postType', 'feedback', currentQuery );
 
-	const records = ( rawRecords || [] ) as FormResponse[];
+	// Merge raw records with any local edits from editEntityRecord
+	const records = useSelect(
+		select => {
+			return ( rawRecords || [] ).map( record => {
+				// Get the edited version of this record if it exists
+				const editedRecord = select( coreDataStore ).getEditedEntityRecord(
+					'postType',
+					'feedback',
+					record.id
+				);
+				return editedRecord || record;
+			} ) as FormResponse[];
+		},
+		[ rawRecords ]
+	);
 
 	const { isResolving: isLoadingInboxData, totalItems: totalItemsInbox = 0 } = useEntityRecords(
 		'postType',

--- a/projects/packages/forms/src/dashboard/hooks/use-inbox-data.ts
+++ b/projects/packages/forms/src/dashboard/hooks/use-inbox-data.ts
@@ -83,7 +83,7 @@ export default function useInboxData(): UseInboxDataReturn {
 				const editedRecord = select( coreDataStore ).getEditedEntityRecord(
 					'postType',
 					'feedback',
-					record.id
+					( record as FormResponse ).id
 				);
 				return editedRecord || record;
 			} ) as FormResponse[];

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/actions.js
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/actions.js
@@ -1,7 +1,8 @@
+import apiFetch from '@wordpress/api-fetch';
 import { Icon } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { seen, trash, backup } from '@wordpress/icons';
+import { seen, trash, backup, check, cancelCircleFilled } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
 import { notSpam, spam } from '../../icons';
 import { store as dashboardStore } from '../../store';
@@ -292,6 +293,118 @@ export const deleteAction = {
 							items.length
 					  );
 			createSuccessNotice( successMessage, { type: 'snackbar', id: 'move-to-trash-action' } );
+			return;
+		}
+		// There is at least one failure.
+		const numberOfErrors = promises.filter( ( { status } ) => status === 'rejected' ).length;
+		const errorMessage = getGenericErrorMessage( numberOfErrors );
+		createErrorNotice( errorMessage, { type: 'snackbar' } );
+	},
+};
+
+export const markAsReadAction = {
+	id: 'mark-as-read',
+	label: __( 'Mark as read', 'jetpack-forms' ),
+	isEligible: item => item.is_unread,
+	supportsBulk: true,
+	icon: <Icon icon={ check } />,
+	async callback( items, { registry } ) {
+		const { editEntityRecord } = registry.dispatch( coreStore );
+		const { createSuccessNotice, createErrorNotice } = registry.dispatch( noticesStore );
+		const promises = await Promise.allSettled(
+			items.map( async ( { id } ) => {
+				// Update entity in store
+				editEntityRecord( 'postType', 'feedback', id, { is_unread: false } );
+				// Update on server
+				return apiFetch( {
+					path: `/wp/v2/feedback/${ id }/read`,
+					method: 'POST',
+					data: { is_unread: false },
+				} );
+			} )
+		);
+		if ( promises.every( ( { status } ) => status === 'fulfilled' ) ) {
+			const successMessage =
+				items.length === 1
+					? __( 'Response marked as read.', 'jetpack-forms' )
+					: sprintf(
+							/* translators: %d: the number of responses. */
+							_n(
+								'%d response marked as read.',
+								'%d responses marked as read.',
+								items.length,
+								'jetpack-forms'
+							),
+							items.length
+					  );
+			createSuccessNotice( successMessage, {
+				type: 'snackbar',
+				id: 'mark-as-read-action',
+				actions: [
+					{
+						label: __( 'Undo', 'jetpack-forms' ),
+						onClick: () => {
+							markAsUnreadAction.callback( items, { registry } );
+						},
+					},
+				],
+			} );
+			return;
+		}
+		// There is at least one failure.
+		const numberOfErrors = promises.filter( ( { status } ) => status === 'rejected' ).length;
+		const errorMessage = getGenericErrorMessage( numberOfErrors );
+		createErrorNotice( errorMessage, { type: 'snackbar' } );
+	},
+};
+
+export const markAsUnreadAction = {
+	id: 'mark-as-unread',
+	label: __( 'Mark as unread', 'jetpack-forms' ),
+	isEligible: item => ! item.is_unread,
+	supportsBulk: true,
+	icon: <Icon icon={ cancelCircleFilled } />,
+	async callback( items, { registry } ) {
+		const { editEntityRecord } = registry.dispatch( coreStore );
+		const { createSuccessNotice, createErrorNotice } = registry.dispatch( noticesStore );
+		const promises = await Promise.allSettled(
+			items.map( async ( { id } ) => {
+				// Update entity in store
+				editEntityRecord( 'postType', 'feedback', id, { is_unread: true } );
+				// Update on server
+				return apiFetch( {
+					path: `/wp/v2/feedback/${ id }/read`,
+					method: 'POST',
+					data: { is_unread: true },
+				} );
+			} )
+		);
+		if ( promises.every( ( { status } ) => status === 'fulfilled' ) ) {
+			const successMessage =
+				items.length === 1
+					? __( 'Response marked as unread.', 'jetpack-forms' )
+					: sprintf(
+							/* translators: %d: the number of responses. */
+							_n(
+								'%d response marked as unread.',
+								'%d responses marked as unread.',
+								items.length,
+								'jetpack-forms'
+							),
+							items.length
+					  );
+			createSuccessNotice( successMessage, {
+				type: 'snackbar',
+				id: 'mark-as-unread-action',
+				actions: [
+					{
+						label: __( 'Undo', 'jetpack-forms' ),
+						onClick: () => {
+							markAsReadAction.callback( items, { registry } );
+						},
+					},
+				],
+			} );
 			return;
 		}
 		// There is at least one failure.

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/actions.js
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/actions.js
@@ -7,24 +7,7 @@ import { store as noticesStore } from '@wordpress/notices';
 import { notSpam, spam } from '../../icons';
 import { store as dashboardStore } from '../../store';
 import InboxResponse from '../response';
-/**
- * Update the unread count in the admin menu.
- *
- * @param {number} count - The new unread count.
- */
-export const updateMenuCounter = count => {
-	// iterate over all elements with the class 'jp-feedback-unread-counter' and update their text content
-	document.querySelectorAll( '.jp-feedback-unread-counter' ).forEach( item => {
-		if ( item.dataset.unreadDiff ) {
-			const newCount = parseInt( item.dataset.unreadDiff, 10 ) + count;
-			item.textContent = newCount > 0 ? newCount : '';
-			item.style.display = newCount > 0 ? '' : 'none';
-		} else {
-			item.textContent = count > 0 ? count : '';
-			item.style.display = count > 0 ? '' : 'none';
-		}
-	} );
-};
+import { updateMenuCounter } from '../utils';
 
 export const BULK_ACTIONS = {
 	markAsSpam: 'mark_as_spam',

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/actions.js
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/actions.js
@@ -13,7 +13,7 @@ import InboxResponse from '../response';
  * @param {number} count - The new unread count.
  */
 export const updateMenuCounter = count => {
-	// iterate over all elements with the class 'feedback-unread-counter' and update their text content
+	// iterate over all elements with the class 'jp-feedback-unread-counter' and update their text content
 	document.querySelectorAll( '.jp-feedback-unread-counter' ).forEach( item => {
 		if ( item.dataset.unreadDiff ) {
 			const newCount = parseInt( item.dataset.unreadDiff, 10 ) + count;
@@ -340,7 +340,7 @@ export const markAsReadAction = {
 					data: { is_unread: false },
 				} )
 					.then( ( { count } ) => {
-						// Update the unread count in the store.
+						// Update the unread count in the menu.
 						updateMenuCounter( count );
 					} )
 					.catch( () => {
@@ -405,7 +405,7 @@ export const markAsUnreadAction = {
 					data: { is_unread: true },
 				} )
 					.then( ( { count } ) => {
-						// Update the unread count in the store.
+						// Update the unread count in the menu.
 						updateMenuCounter( count );
 					} )
 					.catch( () => {

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/actions.js
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/actions.js
@@ -2,7 +2,7 @@ import apiFetch from '@wordpress/api-fetch';
 import { Icon } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { seen, trash, backup, check, cancelCircleFilled } from '@wordpress/icons';
+import { seen, unseen, trash, backup, commentContent } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
 import { notSpam, spam } from '../../icons';
 import { store as dashboardStore } from '../../store';
@@ -15,7 +15,7 @@ export const BULK_ACTIONS = {
 
 export const viewAction = {
 	id: 'view-response',
-	icon: <Icon icon={ seen } />,
+	icon: <Icon icon={ commentContent } />,
 	isPrimary: true,
 	label: __( 'View response', 'jetpack-forms' ),
 };
@@ -307,7 +307,7 @@ export const markAsReadAction = {
 	label: __( 'Mark as read', 'jetpack-forms' ),
 	isEligible: item => item.is_unread,
 	supportsBulk: true,
-	icon: <Icon icon={ check } />,
+	icon: <Icon icon={ seen } />,
 	async callback( items, { registry } ) {
 		const { editEntityRecord } = registry.dispatch( coreStore );
 		const { createSuccessNotice, createErrorNotice } = registry.dispatch( noticesStore );
@@ -363,7 +363,7 @@ export const markAsUnreadAction = {
 	label: __( 'Mark as unread', 'jetpack-forms' ),
 	isEligible: item => ! item.is_unread,
 	supportsBulk: true,
-	icon: <Icon icon={ cancelCircleFilled } />,
+	icon: <Icon icon={ unseen } />,
 	async callback( items, { registry } ) {
 		const { editEntityRecord } = registry.dispatch( coreStore );
 		const { createSuccessNotice, createErrorNotice } = registry.dispatch( noticesStore );

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/actions.js
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/actions.js
@@ -7,6 +7,24 @@ import { store as noticesStore } from '@wordpress/notices';
 import { notSpam, spam } from '../../icons';
 import { store as dashboardStore } from '../../store';
 import InboxResponse from '../response';
+/**
+ * Update the unread count in the admin menu.
+ *
+ * @param {number} count - The new unread count.
+ */
+export const updateMenuCounter = count => {
+	// iterate over all elements with the class 'feedback-unread-counter' and update their text content
+	document.querySelectorAll( '.jp-feedback-unread-counter' ).forEach( item => {
+		if ( item.dataset.unreadDiff ) {
+			const newCount = parseInt( item.dataset.unreadDiff, 10 ) + count;
+			item.textContent = newCount > 0 ? newCount : '';
+			item.style.display = newCount > 0 ? '' : 'none';
+		} else {
+			item.textContent = count > 0 ? count : '';
+			item.style.display = count > 0 ? '' : 'none';
+		}
+	} );
+};
 
 export const BULK_ACTIONS = {
 	markAsSpam: 'mark_as_spam',
@@ -320,7 +338,16 @@ export const markAsReadAction = {
 					path: `/wp/v2/feedback/${ id }/read`,
 					method: 'POST',
 					data: { is_unread: false },
-				} );
+				} )
+					.then( ( { count } ) => {
+						// Update the unread count in the store.
+						updateMenuCounter( count );
+					} )
+					.catch( () => {
+						// Revert the change in the store if the server update fails.
+						editEntityRecord( 'postType', 'feedback', id, { is_unread: true } );
+						throw new Error( 'Failed to mark as read' );
+					} );
 			} )
 		);
 		if ( promises.every( ( { status } ) => status === 'fulfilled' ) ) {
@@ -376,7 +403,16 @@ export const markAsUnreadAction = {
 					path: `/wp/v2/feedback/${ id }/read`,
 					method: 'POST',
 					data: { is_unread: true },
-				} );
+				} )
+					.then( ( { count } ) => {
+						// Update the unread count in the store.
+						updateMenuCounter( count );
+					} )
+					.catch( () => {
+						// Revert the change in the store if the server update fails.
+						editEntityRecord( 'postType', 'feedback', id, { is_unread: false } );
+						throw new Error( 'Failed to mark as unread' );
+					} );
 			} )
 		);
 		if ( promises.every( ( { status } ) => status === 'fulfilled' ) ) {

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
@@ -32,6 +32,8 @@ import {
 	moveToTrashAction,
 	deleteAction,
 	restoreAction,
+	markAsReadAction,
+	markAsUnreadAction,
 } from './actions';
 import { useView, defaultLayouts } from './views';
 
@@ -316,6 +318,8 @@ export default function InboxView() {
 
 	const actions = useMemo( () => {
 		const _actions = [
+			markAsReadAction,
+			markAsUnreadAction,
 			markAsSpamAction,
 			markAsNotSpamAction,
 			moveToTrashAction,

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
@@ -245,6 +245,24 @@ export default function InboxView() {
 			{
 				id: 'from',
 				label: __( 'From', 'jetpack-forms' ),
+				render: ( { item } ) => {
+					const authorInfo = decodeEntities(
+						item.author_name || item.author_email || item.author_url || item.ip
+					);
+					return (
+						<>
+							{ item.is_unread && (
+								<span
+									className="jp-forms__inbox__unread-indicator"
+									aria-label={ __( 'Unread', 'jetpack-forms' ) }
+								>
+									●
+								</span>
+							) }
+							{ authorInfo }
+						</>
+					);
+				},
 				getValue: ( { item } ) => {
 					return decodeEntities(
 						item.author_name || item.author_email || item.author_url || item.ip

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
@@ -245,14 +245,7 @@ export default function InboxView() {
 
 	const wrapperUnread = ( isUnread, itemValue ) => {
 		if ( isUnread ) {
-			return (
-				<span
-					className="jp-forms__inbox__unread-indicator"
-					aria-label={ __( 'Unread', 'jetpack-forms' ) }
-				>
-					{ itemValue }
-				</span>
-			);
+			return <span className="jp-forms__inbox__unread">{ itemValue }</span>;
 		}
 		return itemValue;
 	};
@@ -265,7 +258,19 @@ export default function InboxView() {
 					const authorInfo = decodeEntities(
 						item.author_name || item.author_email || item.author_url || item.ip
 					);
-					return <>{ wrapperUnread( item.is_unread, authorInfo ) }</>;
+					return (
+						<>
+							{ item.is_unread && (
+								<span
+									className="jp-forms__inbox__unread-indicator"
+									aria-label={ __( '(Unread form response)', 'jetpack-forms' ) }
+								>
+									●
+								</span>
+							) }
+							{ wrapperUnread( item.is_unread, authorInfo ) }
+						</>
+					);
 				},
 				getValue: ( { item } ) => {
 					return decodeEntities(

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
@@ -242,6 +242,20 @@ export default function InboxView() {
 		() => ( { totalItems, totalPages } ),
 		[ totalItems, totalPages ]
 	);
+
+	const wrapperUnread = ( isUnread, itemValue ) => {
+		if ( isUnread ) {
+			return (
+				<span
+					className="jp-forms__inbox__unread-indicator"
+					aria-label={ __( 'Unread', 'jetpack-forms' ) }
+				>
+					{ itemValue }
+				</span>
+			);
+		}
+		return itemValue;
+	};
 	const fields = useMemo(
 		() => [
 			{
@@ -251,19 +265,7 @@ export default function InboxView() {
 					const authorInfo = decodeEntities(
 						item.author_name || item.author_email || item.author_url || item.ip
 					);
-					return (
-						<>
-							{ item.is_unread && (
-								<span
-									className="jp-forms__inbox__unread-indicator"
-									aria-label={ __( 'Unread', 'jetpack-forms' ) }
-								>
-									●
-								</span>
-							) }
-							{ authorInfo }
-						</>
-					);
+					return <>{ wrapperUnread( item.is_unread, authorInfo ) }</>;
 				},
 				getValue: ( { item } ) => {
 					return decodeEntities(
@@ -276,7 +278,9 @@ export default function InboxView() {
 			{
 				id: 'date',
 				label: __( 'Date', 'jetpack-forms' ),
-				render: ( { item } ) => dateI18n( dateSettings.formats.date, item.date ),
+				render: ( { item } ) => {
+					return wrapperUnread( item.is_unread, dateI18n( dateSettings.formats.date, item.date ) );
+				},
 				elements: ( filterOptions?.date || [] ).map( _filter => {
 					const date = new Date();
 					date.setDate( 1 );
@@ -300,7 +304,10 @@ export default function InboxView() {
 				render: ( { item } ) => {
 					return (
 						<ExternalLink href={ item.entry_permalink }>
-							{ decodeEntities( item.entry_title ) || getPath( item ) }
+							{ wrapperUnread(
+								item.is_unread,
+								decodeEntities( item.entry_title ) || getPath( item )
+							) }
 						</ExternalLink>
 					);
 				},

--- a/projects/packages/forms/src/dashboard/inbox/response.js
+++ b/projects/packages/forms/src/dashboard/inbox/response.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import apiFetch from '@wordpress/api-fetch';
 import {
 	Button,
 	ExternalLink,
@@ -13,7 +14,7 @@ import {
 	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalVStack as VStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 } from '@wordpress/components';
-import { useRegistry } from '@wordpress/data';
+import { useRegistry, useDispatch } from '@wordpress/data';
 import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
 import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
@@ -199,6 +200,7 @@ const InboxResponse = ( {
 	const [ isMovingToTrash, setIsMovingToTrash ] = useState( false );
 	const [ isRestoring, setIsRestoring ] = useState( false );
 	const [ isDeleting, setIsDeleting ] = useState( false );
+	const { editEntityRecord } = useDispatch( 'core' );
 
 	// When opening a "Mark as spam" link from the email, the InboxResponse component is rendered, so we use a hook here to handle it.
 	const { isConfirmDialogOpen, onConfirmMarkAsSpam, onCancelMarkAsSpam } =
@@ -484,6 +486,28 @@ const InboxResponse = ( {
 
 		ref.current.scrollTop = 0;
 	}, [ response ] );
+
+	// Mark feedback as read when viewing
+	useEffect( () => {
+		if ( ! response || ! response.id || ! response.is_unread ) {
+			return;
+		}
+
+		// Immediately update entity in store
+		editEntityRecord( 'postType', 'feedback', response.id, {
+			is_unread: false,
+		} );
+
+		// Then update on server
+		apiFetch( {
+			path: `/wp/v2/feedback/${ response.id }/read`,
+			method: 'POST',
+			data: { is_unread: false },
+		} ).catch( error => {
+			// eslint-disable-next-line no-console
+			console.error( 'Failed to mark feedback as read:', error );
+		} );
+	}, [ response, editEntityRecord ] );
 
 	const handelImageLoaded = useCallback( () => {
 		return setIsImageLoading( false );

--- a/projects/packages/forms/src/dashboard/inbox/response.js
+++ b/projects/packages/forms/src/dashboard/inbox/response.js
@@ -33,6 +33,7 @@ import {
 	moveToTrashAction,
 	restoreAction,
 	deleteAction,
+	updateMenuCounter,
 } from './dataviews/actions';
 import { getPath } from './utils';
 
@@ -503,10 +504,15 @@ const InboxResponse = ( {
 			path: `/wp/v2/feedback/${ response.id }/read`,
 			method: 'POST',
 			data: { is_unread: false },
-		} ).catch( error => {
-			// eslint-disable-next-line no-console
-			console.error( 'Failed to mark feedback as read:', error );
-		} );
+		} )
+			.then( ( { count } ) => {
+				updateMenuCounter( count );
+			} )
+			.catch( () => {
+				editEntityRecord( 'postType', 'feedback', response.id, {
+					is_unread: true,
+				} );
+			} );
 	}, [ response, editEntityRecord ] );
 
 	const handelImageLoaded = useCallback( () => {

--- a/projects/packages/forms/src/dashboard/inbox/response.js
+++ b/projects/packages/forms/src/dashboard/inbox/response.js
@@ -33,9 +33,8 @@ import {
 	moveToTrashAction,
 	restoreAction,
 	deleteAction,
-	updateMenuCounter,
 } from './dataviews/actions';
-import { getPath } from './utils';
+import { getPath, updateMenuCounter } from './utils';
 
 const getDisplayName = response => {
 	const { author_name, author_email, author_url, ip } = response;

--- a/projects/packages/forms/src/dashboard/inbox/response.js
+++ b/projects/packages/forms/src/dashboard/inbox/response.js
@@ -33,6 +33,8 @@ import {
 	moveToTrashAction,
 	restoreAction,
 	deleteAction,
+	markAsReadAction,
+	markAsUnreadAction,
 } from './dataviews/actions';
 import { getPath, updateMenuCounter } from './utils';
 
@@ -200,6 +202,8 @@ const InboxResponse = ( {
 	const [ isMovingToTrash, setIsMovingToTrash ] = useState( false );
 	const [ isRestoring, setIsRestoring ] = useState( false );
 	const [ isDeleting, setIsDeleting ] = useState( false );
+	const [ hasMarkedSelfAsRead, setHasMarkedSelfAsRead ] = useState( false );
+
 	const { editEntityRecord } = useDispatch( 'core' );
 
 	// When opening a "Mark as spam" link from the email, the InboxResponse component is rendered, so we use a hook here to handle it.
@@ -271,6 +275,15 @@ const InboxResponse = ( {
 		onActionComplete?.( response.id.toString() );
 	}, [ response, registry, onActionComplete ] );
 
+	const handleMarkAsRead = useCallback( () => {
+		markAsReadAction.callback( [ response ], { registry } );
+	}, [ response, registry ] );
+
+	const handleMarkAsUnread = useCallback( () => {
+		setHasMarkedSelfAsRead( response.id );
+		markAsUnreadAction.callback( [ response ], { registry } );
+	}, [ response, registry ] );
+
 	const renderActionButtons = () => {
 		switch ( response.status ) {
 			case 'spam':
@@ -328,6 +341,28 @@ const InboxResponse = ( {
 			default: // 'publish' (inbox) or any other status
 				return (
 					<>
+						{ response.is_unread && (
+							<Button
+								variant="tertiary"
+								onClick={ handleMarkAsRead }
+								showTooltip={ true }
+								label={ handleMarkAsRead.label }
+								iconSize={ 24 }
+								icon={ markAsReadAction.icon }
+								size="compact"
+							></Button>
+						) }
+						{ ! response.is_unread && (
+							<Button
+								variant="tertiary"
+								onClick={ handleMarkAsUnread }
+								showTooltip={ true }
+								label={ markAsUnreadAction.label }
+								iconSize={ 24 }
+								icon={ markAsUnreadAction.icon }
+								size="compact"
+							></Button>
+						) }
 						<Button
 							variant="tertiary"
 							onClick={ handleMarkAsSpam }
@@ -490,8 +525,14 @@ const InboxResponse = ( {
 	// Mark feedback as read when viewing
 	useEffect( () => {
 		if ( ! response || ! response.id || ! response.is_unread ) {
+			setHasMarkedSelfAsRead( response.id );
 			return;
 		}
+		if ( hasMarkedSelfAsRead === response.id ) {
+			return;
+		}
+
+		setHasMarkedSelfAsRead( response.id );
 
 		// Immediately update entity in store
 		editEntityRecord( 'postType', 'feedback', response.id, {
@@ -512,7 +553,7 @@ const InboxResponse = ( {
 					is_unread: true,
 				} );
 			} );
-	}, [ response, editEntityRecord ] );
+	}, [ response, editEntityRecord, hasMarkedSelfAsRead ] );
 
 	const handelImageLoaded = useCallback( () => {
 		return setIsImageLoading( false );

--- a/projects/packages/forms/src/dashboard/inbox/response.js
+++ b/projects/packages/forms/src/dashboard/inbox/response.js
@@ -283,12 +283,39 @@ const InboxResponse = ( {
 		setHasMarkedSelfAsRead( response.id );
 		markAsUnreadAction.callback( [ response ], { registry } );
 	}, [ response, registry ] );
+	const readUnreadButtons = (
+		<>
+			{ response.is_unread && (
+				<Button
+					variant="tertiary"
+					onClick={ handleMarkAsRead }
+					showTooltip={ true }
+					label={ handleMarkAsRead.label }
+					iconSize={ 24 }
+					icon={ markAsReadAction.icon }
+					size="compact"
+				></Button>
+			) }
+			{ ! response.is_unread && (
+				<Button
+					variant="tertiary"
+					onClick={ handleMarkAsUnread }
+					showTooltip={ true }
+					label={ markAsUnreadAction.label }
+					iconSize={ 24 }
+					icon={ markAsUnreadAction.icon }
+					size="compact"
+				></Button>
+			) }
+		</>
+	);
 
 	const renderActionButtons = () => {
 		switch ( response.status ) {
 			case 'spam':
 				return (
 					<>
+						{ readUnreadButtons }
 						<Button
 							variant="tertiary"
 							onClick={ handleMarkAsNotSpam }
@@ -315,6 +342,7 @@ const InboxResponse = ( {
 			case 'trash':
 				return (
 					<>
+						{ readUnreadButtons }
 						<Button
 							variant="tertiary"
 							onClick={ handleRestore }
@@ -341,28 +369,7 @@ const InboxResponse = ( {
 			default: // 'publish' (inbox) or any other status
 				return (
 					<>
-						{ response.is_unread && (
-							<Button
-								variant="tertiary"
-								onClick={ handleMarkAsRead }
-								showTooltip={ true }
-								label={ handleMarkAsRead.label }
-								iconSize={ 24 }
-								icon={ markAsReadAction.icon }
-								size="compact"
-							></Button>
-						) }
-						{ ! response.is_unread && (
-							<Button
-								variant="tertiary"
-								onClick={ handleMarkAsUnread }
-								showTooltip={ true }
-								label={ markAsUnreadAction.label }
-								iconSize={ 24 }
-								icon={ markAsUnreadAction.icon }
-								size="compact"
-							></Button>
-						) }
+						{ readUnreadButtons }
 						<Button
 							variant="tertiary"
 							onClick={ handleMarkAsSpam }

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -517,7 +517,7 @@ body.jetpack_page_jetpack-forms-admin {
 }
 
 .jp-forms__inbox__unread-indicator {
-	color: #2271b1;
+	color: var(--wp-admin-theme-color, #2271b1);
 	font-size: 12px;
 	margin-right: 6px;
 	vertical-align: middle;

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -515,3 +515,10 @@ body.jetpack_page_jetpack-forms-admin {
 	gap: 16px;
 	align-items: center;
 }
+
+.jp-forms__inbox__unread-indicator {
+	color: #2271b1;
+	font-size: 12px;
+	margin-right: 6px;
+	vertical-align: middle;
+}

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -517,9 +517,10 @@ body.jetpack_page_jetpack-forms-admin {
 }
 
 .jp-forms__inbox__unread-indicator {
-	color: #d63638;
-	font-size: 8px;
-	margin-right: 4.5px;
-	margin-left: -12px;
-	vertical-align: middle;
+	font-weight: 600;
+	color: #222;
+}
+
+a .jp-forms__inbox__unread-indicator {
+	color: #135e96;
 }

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -517,8 +517,9 @@ body.jetpack_page_jetpack-forms-admin {
 }
 
 .jp-forms__inbox__unread-indicator {
-	color: var(--wp-admin-theme-color, #2271b1);
-	font-size: 12px;
-	margin-right: 6px;
+	color: #d63638;
+	font-size: 8px;
+	margin-right: 4.5px;
+	margin-left: -12px;
 	vertical-align: middle;
 }

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -521,7 +521,7 @@ body.jetpack_page_jetpack-forms-admin {
 }
 
 .jp-forms__inbox__unread-indicator {
-	color: var(--jp-blue-50, #135e96);
+	color: #d63638;
 	font-size: 8px;
 	margin-right: 4.5px;
 	margin-left: -12px;

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -516,11 +516,14 @@ body.jetpack_page_jetpack-forms-admin {
 	align-items: center;
 }
 
-.jp-forms__inbox__unread-indicator {
+.jp-forms__inbox__unread {
 	font-weight: 600;
-	color: #222;
 }
 
-a .jp-forms__inbox__unread-indicator {
-	color: #135e96;
+.jp-forms__inbox__unread-indicator {
+	color: var(--jp-blue-50, #135e96);
+	font-size: 8px;
+	margin-right: 4.5px;
+	margin-left: -12px;
+	vertical-align: middle;
 }

--- a/projects/packages/forms/src/dashboard/inbox/utils.js
+++ b/projects/packages/forms/src/dashboard/inbox/utils.js
@@ -7,3 +7,22 @@ export const getPath = item => {
 		return '';
 	}
 };
+
+/**
+ * Update the unread count in the admin menu.
+ *
+ * @param {number} count - The new unread count.
+ */
+export const updateMenuCounter = count => {
+	// iterate over all elements with the class 'jp-feedback-unread-counter' and update their text content
+	document.querySelectorAll( '.jp-feedback-unread-counter' ).forEach( item => {
+		if ( item.dataset.unreadDiff ) {
+			const newCount = parseInt( item.dataset.unreadDiff, 10 ) + count;
+			item.textContent = newCount > 0 ? newCount : '';
+			item.style.display = newCount > 0 ? '' : 'none';
+		} else {
+			item.textContent = count > 0 ? count : '';
+			item.style.display = count > 0 ? '' : 'none';
+		}
+	} );
+};

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Endpoint_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Endpoint_Test.php
@@ -723,6 +723,7 @@ JSON_DATA{"1_name":"Test Author","2_email":"author@example.com","3_file":{"field
 			'test@example.com',
 			'',
 			'',
+			'',
 			'publish',
 			false,
 			true // is_unread

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Endpoint_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Endpoint_Test.php
@@ -751,6 +751,90 @@ JSON_DATA{"1_name":"Test Author","2_email":"author@example.com","3_file":{"field
 	}
 
 	/**
+	 * Test marking feedback as read
+	 */
+	public function test_mark_feedback_as_read_on_non_feedback() {
+
+		// Mark as read
+		$request = new WP_REST_Request( 'POST', '/wp/v2/feedback/99999999/read' );
+		$request->set_param( 'is_unread', false );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 404, $response->get_status() );
+	}
+
+	/**
+	 * Test marking feedback as read
+	 */
+	public function test_mark_feedback_as_unread_on_non_feedback() {
+
+		// Mark as read
+		$request = new WP_REST_Request( 'POST', '/wp/v2/feedback/99999999/read' );
+		$request->set_param( 'is_unread', true );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 404, $response->get_status() );
+	}
+
+	public function test_bad_db_read_update() {
+
+		$post_id = Utility::create_legacy_feedback(
+			array(
+				'name'  => 'Test User',
+				'email' => 'test@example.com',
+			),
+			'Test message',
+			'Test User',
+			'test@example.com',
+			'',
+			'',
+			'',
+			'publish',
+			false,
+			true // is_unread
+		);
+
+		// Simulate DB error
+		add_filter( 'wp_checkdate', '__return_false' );
+		// Mark as read
+		$request = new WP_REST_Request( 'POST', '/wp/v2/feedback/' . $post_id . '/read' );
+		$request->set_param( 'is_unread', false );
+		$response = $this->server->dispatch( $request );
+		remove_filter( 'wp_checkdate', '__return_false' );
+
+		$this->assertEquals( 500, $response->get_status() );
+	}
+
+	public function test_bad_db_unread_update() {
+
+		$post_id = Utility::create_legacy_feedback(
+			array(
+				'name'  => 'Test User',
+				'email' => 'test@example.com',
+			),
+			'Test message',
+			'Test User',
+			'test@example.com',
+			'',
+			'',
+			'',
+			'publish',
+			false,
+			false // is_unread
+		);
+
+		// Simulate DB error
+		add_filter( 'wp_checkdate', '__return_false' );
+		// Mark as read
+		$request = new WP_REST_Request( 'POST', '/wp/v2/feedback/' . $post_id . '/read' );
+		$request->set_param( 'is_unread', true );
+		$response = $this->server->dispatch( $request );
+		remove_filter( 'wp_checkdate', '__return_false' );
+
+		$this->assertEquals( 500, $response->get_status() );
+	}
+
+	/**
 	 * Test marking feedback as unread
 	 */
 	public function test_mark_feedback_as_unread() {

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Endpoint_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Endpoint_Test.php
@@ -140,6 +140,7 @@ class Contact_Form_Endpoint_Test extends TestCase {
 		$this->assertArrayHasKey( 'entry_permalink', $schema_properties );
 		$this->assertArrayHasKey( 'subject', $schema_properties );
 		$this->assertArrayHasKey( 'fields', $schema_properties );
+		$this->assertArrayHasKey( 'is_unread', $schema_properties );
 	}
 
 	/**
@@ -673,5 +674,145 @@ JSON_DATA{"1_name":"Test Author","2_email":"author@example.com","3_file":{"field
 
 		$this->assertArrayHasKey( 'has_file', $data );
 		$this->assertFalse( $data['has_file'] );
+	}
+
+	/**
+	 * Test default unread state on new feedback
+	 */
+	public function test_feedback_is_unread_by_default() {
+		$post_id = Utility::create_legacy_feedback(
+			array(
+				'name'  => 'Test User',
+				'email' => 'test@example.com',
+			),
+			'Test message',
+			'Test User',
+			'test@example.com',
+			'',
+			'',
+			'Test Subject',
+			'spam',
+			null,
+			true // is_unread
+		);
+
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/feedback/' . $post_id );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertArrayHasKey( 'is_unread', $data );
+		$this->assertTrue( $data['is_unread'] );
+
+		// Verify Feedback class method
+		$feedback = \Automattic\Jetpack\Forms\ContactForm\Feedback::get( $post_id );
+		$this->assertTrue( $feedback->is_unread() );
+	}
+
+	/**
+	 * Test marking feedback as read
+	 */
+	public function test_mark_feedback_as_read() {
+		$post_id = Utility::create_legacy_feedback(
+			array(
+				'name'  => 'Test User',
+				'email' => 'test@example.com',
+			),
+			'Test message',
+			'Test User',
+			'test@example.com'
+		);
+
+		// Mark as read
+		$request = new WP_REST_Request( 'POST', '/wp/v2/feedback/' . $post_id . '/read' );
+		$request->set_param( 'is_unread', false );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$data = $response->get_data();
+		$this->assertEquals( $post_id, $data['id'] );
+		$this->assertFalse( $data['is_unread'] );
+
+		// Verify the state persists
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/feedback/' . $post_id );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+		$this->assertFalse( $data['is_unread'] );
+
+		// Verify Feedback class method
+		$feedback = \Automattic\Jetpack\Forms\ContactForm\Feedback::get( $post_id );
+		$this->assertFalse( $feedback->is_unread() );
+	}
+
+	/**
+	 * Test marking feedback as unread
+	 */
+	public function test_mark_feedback_as_unread() {
+		$post_id = Utility::create_legacy_feedback(
+			array(
+				'name'  => 'Test User',
+				'email' => 'test@example.com',
+			),
+			'Test message',
+			'Test User',
+			'test@example.com'
+		);
+
+		// First mark as read
+		wp_update_post(
+			array(
+				'ID'             => $post_id,
+				'comment_status' => 'closed',
+			)
+		);
+
+		// Then mark as unread
+		$request = new WP_REST_Request( 'POST', '/wp/v2/feedback/' . $post_id . '/read' );
+		$request->set_param( 'is_unread', true );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$data = $response->get_data();
+		$this->assertEquals( $post_id, $data['id'] );
+		$this->assertTrue( $data['is_unread'] );
+
+		// Verify Feedback class method
+		$feedback = \Automattic\Jetpack\Forms\ContactForm\Feedback::get( $post_id );
+		$this->assertTrue( $feedback->is_unread() );
+	}
+
+	/**
+	 * Test marking feedback with invalid ID
+	 */
+	public function test_mark_feedback_with_invalid_id() {
+		$request = new WP_REST_Request( 'POST', '/wp/v2/feedback/999999/read' );
+		$request->set_param( 'is_unread', false );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 404, $response->get_status() );
+		$data = $response->get_data();
+		$this->assertEquals( 'rest_post_invalid_id', $data['code'] );
+	}
+
+	/**
+	 * Test unauthorized access to mark feedback
+	 */
+	public function test_mark_feedback_unauthorized() {
+		$post_id = Utility::create_legacy_feedback(
+			array(
+				'name'  => 'Test User',
+				'email' => 'test@example.com',
+			),
+			'Test message',
+			'Test User',
+			'test@example.com'
+		);
+
+		wp_set_current_user( 0 );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/feedback/' . $post_id . '/read' );
+		$request->set_param( 'is_unread', false );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 401, $response->get_status() );
 	}
 }

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Endpoint_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Endpoint_Test.php
@@ -738,10 +738,12 @@ JSON_DATA{"1_name":"Test Author","2_email":"author@example.com","3_file":{"field
 		$response = $this->server->dispatch( $request );
 		$data     = $response->get_data();
 		$this->assertFalse( $data['is_unread'] );
+		$this->assertIsInt( 0, Contact_Form_Plugin::get_unread_count() );
 
 		// Verify Feedback class method
 		$feedback = \Automattic\Jetpack\Forms\ContactForm\Feedback::get( $post_id );
 		$this->assertFalse( $feedback->is_unread() );
+		$this->assertIsInt( 1, Contact_Form_Plugin::get_unread_count() );
 	}
 
 	/**

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Endpoint_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Endpoint_Test.php
@@ -720,7 +720,12 @@ JSON_DATA{"1_name":"Test Author","2_email":"author@example.com","3_file":{"field
 			),
 			'Test message',
 			'Test User',
-			'test@example.com'
+			'test@example.com',
+			'',
+			'',
+			'publish',
+			false,
+			true // is_unread
 		);
 
 		// Mark as read
@@ -738,12 +743,10 @@ JSON_DATA{"1_name":"Test Author","2_email":"author@example.com","3_file":{"field
 		$response = $this->server->dispatch( $request );
 		$data     = $response->get_data();
 		$this->assertFalse( $data['is_unread'] );
-		$this->assertIsInt( 0, Contact_Form_Plugin::get_unread_count() );
 
 		// Verify Feedback class method
 		$feedback = \Automattic\Jetpack\Forms\ContactForm\Feedback::get( $post_id );
 		$this->assertFalse( $feedback->is_unread() );
-		$this->assertIsInt( 1, Contact_Form_Plugin::get_unread_count() );
 	}
 
 	/**

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
@@ -844,4 +844,23 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 		);
 		$this->assertIsArray( $exporter, 'Expected the exporter to return an array.' );
 	}
+
+	public function test_get_unread_count_zero() {
+		delete_option( 'jetpack_feedback_unread_count' );
+		$this->assertIsInt( Contact_Form_Plugin::get_unread_count() );
+		$this->assertGreaterThanOrEqual( 0, Contact_Form_Plugin::get_unread_count() );
+	}
+
+	public function test_get_unread_count_nonzero() {
+		update_option( 'jetpack_feedback_unread_count', 5 );
+		$this->assertEquals( 5, Contact_Form_Plugin::get_unread_count() );
+		delete_option( 'jetpack_feedback_unread_count' );
+	}
+
+	public function test_recalculate_unread_count() {
+		update_option( 'jetpack_feedback_unread_count', 5 );
+		$this->assertEquals( 5, Contact_Form_Plugin::get_unread_count() );
+		Contact_Form_Plugin::recalculate_unread_count();
+		$this->assertSame( 0, Contact_Form_Plugin::get_unread_count() );
+	}
 }

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Test.php
@@ -2593,4 +2593,60 @@ class Feedback_Test extends BaseTestCase {
 		$post = get_post( $post_id );
 		$this->assertEquals( 'open', $post->comment_status, 'Unread feedback should have comment_status = open' );
 	}
+
+	public function test_mark_as_read_db_failure() {
+		$post_id = Utility::create_legacy_feedback(
+			array(
+				'name'  => 'Test User',
+				'email' => 'test@example.com',
+			),
+			'Test message',
+			'Test User',
+			'test@example.com',
+			'',
+			'',
+			'Test Subject',
+			'spam',
+			null,
+			true // unread
+		);
+
+		$feedback = Feedback::get( $post_id );
+
+		// Simulate DB error
+		add_filter( 'wp_checkdate', '__return_false' );
+		$result = $feedback->mark_as_read();
+		remove_filter( 'wp_checkdate', '__return_false' );
+
+		$this->assertFalse( $result, 'mark_as_read should return false on DB failure' );
+		$this->assertTrue( $feedback->is_unread(), 'Feedback should remain unread' );
+	}
+
+	public function test_mark_as_unread_db_failure() {
+		$post_id = Utility::create_legacy_feedback(
+			array(
+				'name'  => 'Test User',
+				'email' => 'test@example.com',
+			),
+			'Test message',
+			'Test User',
+			'test@example.com',
+			'',
+			'',
+			'Test Subject',
+			'spam',
+			null,
+			false // unread
+		);
+
+		$feedback = Feedback::get( $post_id );
+
+		// Simulate DB error
+		add_filter( 'wp_checkdate', '__return_false' );
+		$result = $feedback->mark_as_unread();
+		remove_filter( 'wp_checkdate', '__return_false' );
+
+		$this->assertFalse( $result, 'mark_as_unread should return false on DB failure' );
+		$this->assertFalse( $feedback->is_unread(), 'Feedback should remain read' );
+	}
 }

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Test.php
@@ -2512,4 +2512,85 @@ class Feedback_Test extends BaseTestCase {
 		$this->assertEquals( 'こんにちは世界', $saved_response->get_field_value_by_label( 'Special' ), 'Special field value should match saved value' );
 		$this->assertEquals( '🙈', $saved_response->get_field_value_by_label( 'Message' ), 'Message field value should match saved value' );
 	}
+
+	public function test_mark_as_read() {
+		$post_id = Utility::create_legacy_feedback(
+			array(
+				'name'  => 'Test User',
+				'email' => 'test@example.com',
+			),
+			'Test message',
+			'Test User',
+			'test@example.com',
+			'',
+			'',
+			'Test Subject',
+			'spam',
+			null,
+			true // is_unread
+		);
+
+		$feedback = Feedback::get( $post_id );
+		$this->assertTrue( $feedback->is_unread(), 'Feedback should start as unread' );
+
+		$result = $feedback->mark_as_read();
+		$this->assertTrue( $result, 'mark_as_read should return true on success' );
+		$this->assertFalse( $feedback->is_unread(), 'Feedback should be marked as read' );
+
+		// Then mark as unread
+		$result = $feedback->mark_as_unread();
+		$this->assertTrue( $result, 'mark_as_unread should return true on success' );
+		$this->assertTrue( $feedback->is_unread(), 'Feedback should be marked as unread' );
+	}
+
+	public function test_mark_as_read_without_post_id() {
+		$form     = new Contact_Form( array() );
+		$response = Feedback::from_submission( array(), $form );
+		$response->save();
+
+		// Should return false if not saved yet (no post_id)
+		$result = $response->mark_as_read();
+		$this->assertFalse( $result, 'mark_as_read should return false when post_id is not set' );
+	}
+
+	public function test_mark_as_unread_without_post_id() {
+		$form     = new Contact_Form( array() );
+		$response = Feedback::from_submission( array(), $form );
+
+		// Should return false if not saved yet (no post_id)
+		$result = $response->mark_as_unread();
+		$this->assertFalse( $result, 'mark_as_unread should return false when post_id is not set' );
+	}
+
+	public function test_unread_status_uses_constants() {
+		$post_id = Utility::create_legacy_feedback(
+			array(
+				'name'  => 'Test User',
+				'email' => 'test@example.com',
+			),
+			'Test message',
+			'Test User',
+			'test@example.com',
+			'',
+			'',
+			'Test Subject',
+			'spam',
+			null,
+			true // unread
+		);
+
+		$feedback = Feedback::get( $post_id );
+
+		// Check the comment_status field directly
+		$post = get_post( $post_id );
+		$this->assertEquals( 'open', $post->comment_status, 'Unread feedback should have comment_status = open' );
+
+		$feedback->mark_as_read();
+		$post = get_post( $post_id );
+		$this->assertEquals( 'closed', $post->comment_status, 'Read feedback should have comment_status = closed' );
+
+		$feedback->mark_as_unread();
+		$post = get_post( $post_id );
+		$this->assertEquals( 'open', $post->comment_status, 'Unread feedback should have comment_status = open' );
+	}
 }

--- a/projects/packages/forms/tests/php/contact-form/class-utility.php
+++ b/projects/packages/forms/tests/php/contact-form/class-utility.php
@@ -32,7 +32,8 @@ class Utility {
 		$comment_ip_text = 'https://127.0.0.1',
 		$subject = 'Test Subject',
 		$status = 'publish',
-		$strip_new_lines = false
+		$strip_new_lines = false,
+		$is_unread = false
 	) {
 		global $post;
 		$feedback_time  = current_time( 'mysql' );
@@ -73,13 +74,14 @@ class Utility {
 		// Create a mock post with JSON_DATA format
 		return wp_insert_post(
 			array(
-				'post_date'    => addslashes( $feedback_time ),
-				'post_type'    => 'feedback',
-				'post_status'  => addslashes( $status ),
-				'post_parent'  => $post ? $post->ID : 0,
-				'post_title'   => addslashes( wp_kses( $feedback_title, array() ) ),
-				'post_content' => $content, // so that search will pick up this data
-				'post_name'    => $feedback_id,
+				'post_date'      => addslashes( $feedback_time ),
+				'post_type'      => 'feedback',
+				'post_status'    => addslashes( $status ),
+				'post_parent'    => $post ? $post->ID : 0,
+				'post_title'     => addslashes( wp_kses( $feedback_title, array() ) ),
+				'post_content'   => $content, // so that search will pick up this data
+				'post_name'      => $feedback_id,
+				'comment_status' => $is_unread ? 'open' : 'closed',
 			)
 		);
 	}

--- a/projects/plugins/jetpack/changelog/add-forms-unread-state
+++ b/projects/plugins/jetpack/changelog/add-forms-unread-state
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Forms: add read and unread state for new form responses


### PR DESCRIPTION
Fixes FORMS-302

Adds new feedback/read endpoint and the new UI that lets you mark feedback as read and unread. 

<img width="589" height="549" alt="Screenshot 2025-10-02 at 7 38 58 AM" src="https://github.com/user-attachments/assets/1095dff1-4052-4930-81d8-2195f68594d8" />

This new state is shown as a dot. this is due to the current limitation of the data views which prevent the whole row from being bold. 

## Proposed changes:
* Adds a new endpoints for marking feedback responses from being read or unread. 
* Add UI changes so that you see unread feedback responses as read. 
* Add the ability to mark responses as read or unread. 


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
See FORMS-302

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* Add a form and fill it out. 
* Notice that this response will show up as unread in the forms UI. 
* Notice that you mark previous responses as read and unread. 
