### PR TITLE
jetpack-mu-wpcom: Code Block / Improve safety when modifying modules actions

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/wpcom-code-block-improve-module-actions-safety
+++ b/projects/packages/jetpack-mu-wpcom/changelog/wpcom-code-block-improve-module-actions-safety
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Code Block: Ensure Core Script Modules actions are safely removed and restored.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/class-code-block.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/class-code-block.php
@@ -469,11 +469,21 @@ HTML;
 	 */
 	public static function after_setup_theme() {
 		foreach ( array( 'wp_head', 'wp_footer', 'admin_print_footer_scripts' ) as $hook ) {
-			if ( ! remove_action( $hook, array( wp_script_modules(), 'print_enqueued_script_modules' ) ) ) {
+			/*
+			 * Script module actions are expected in this order:
+			 *
+			 * - WP_Script_Modules::print_import_map
+			 * - WP_Script_Modules::print_script_module_preloads
+			 * - WP_Script_Modules::print_enqueued_script_modules
+			 *
+			 * Attempt to remove actions starting from the end to that if a removal fails,
+			 * the action can be restored to the expected position by adding it again.
+			 */
+			if ( ! remove_action( $hook, array( wp_script_modules(), 'print_script_module_preloads' ) ) ) {
 				continue;
 			}
-			if ( ! remove_action( $hook, array( wp_script_modules(), 'print_script_module_preloads' ) ) ) {
-				add_action( $hook, array( wp_script_modules(), 'print_enqueued_script_modules' ) );
+			if ( ! remove_action( $hook, array( wp_script_modules(), 'print_enqueued_script_modules' ) ) ) {
+				add_action( $hook, array( wp_script_modules(), 'print_script_module_preloads' ) );
 				continue;
 			}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/class-code-block.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/code/class-code-block.php
@@ -466,13 +466,16 @@ HTML;
 	 * This is not essential, but does save some HTML on the page and a network request.
 	 * The dummy module is only used to signal that some additional modules
 	 * should be included in the importmap.
-	 *
-	 * @TODO: Be safer. Check the return (bool: was removed) and behave accordingly.
 	 */
 	public static function after_setup_theme() {
 		foreach ( array( 'wp_head', 'wp_footer', 'admin_print_footer_scripts' ) as $hook ) {
-			remove_action( $hook, array( wp_script_modules(), 'print_enqueued_script_modules' ) );
-			remove_action( $hook, array( wp_script_modules(), 'print_script_module_preloads' ) );
+			if ( ! remove_action( $hook, array( wp_script_modules(), 'print_enqueued_script_modules' ) ) ) {
+				continue;
+			}
+			if ( ! remove_action( $hook, array( wp_script_modules(), 'print_script_module_preloads' ) ) ) {
+				add_action( $hook, array( wp_script_modules(), 'print_enqueued_script_modules' ) );
+				continue;
+			}
 
 			add_action(
 				$hook,


### PR DESCRIPTION
## Proposed changes:

The Code block modifies the script modules actions in order to insert its own action between some of the Core actions.

This change attempts to abort and restore the Core actions in case they cannot be removed as expected.

Follow-up to https://github.com/Automattic/jetpack/pull/45181

The block enqueues an empty "dummy" module in order to add modules to the importmap. Without more invasive tools like Reflection, this method works. In order to avoid actually printing the empty module script tag and requesting the empty JavaScript file, an action is inserted to dequeue and re-enqueue the empty module at appropriate times. This requires moving the script modules printing actions so that the module can be dequeued and enqueued in the right order.

If, for some reason, there's a problem removing the existing actions, this process should abort and attempt to restore the previous behavior. This will result in the empty module being requested, which is harmless.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:

The Core modules actions can be moved like this:

```php
add_action(
	'after_setup_theme',
	function () {
		foreach ( array( 'wp_head', 'wp_footer', 'admin_print_footer_scripts' ) as $hook ) {
				remove_action( $hook, array( wp_script_modules(), 'print_import_map' ) );
				remove_action( $hook, array( wp_script_modules(), 'print_enqueued_script_modules' ) );
				remove_action( $hook, array( wp_script_modules(), 'print_script_module_preloads' ) );
				add_action( $hook, array( wp_script_modules(), 'print_import_map' ), 8 );
				add_action( $hook, array( wp_script_modules(), 'print_enqueued_script_modules' ), 8 );
				add_action( $hook, array( wp_script_modules(), 'print_script_module_preloads' ), 8 );
		}
	},
	80
);
```

If this is done on `trunk`, the core modules actions fail to be removed correctly so run twice. The result is duplicate script tags and preloads. This PR fixes that so that there are no duplicate tags. In both cases, the empty module script tag is printed (harmless).
