### PR TITLE
Forms: Fix integrations bottom border

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-integrations-bottom-border
+++ b/projects/packages/forms/changelog/fix-forms-integrations-bottom-border
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: fix integrations bottom border.

--- a/projects/packages/forms/src/dashboard/integrations/index.tsx
+++ b/projects/packages/forms/src/dashboard/integrations/index.tsx
@@ -134,7 +134,6 @@ const Integrations = () => {
 							onToggle={ handleToggleCreativeMail }
 							data={ creativeMailData }
 							refreshStatus={ refreshIntegrations }
-							borderBottom={ false }
 						/>
 					) }
 				</div>


### PR DESCRIPTION
## Proposed changes:

The last card in the integrations list should not have a bottom border. We originally did this via a prop on the last item (Creative Mail), but since handle it via CSS since order can be dynamic. This removes the prop on the Creative Mail card so it will have a border as expected if it's not the last item. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None. 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to integrations dashboard and confirm last item still doesn't have a bottom border as expected.

