### PR TITLE
Launchpad: Link to domain-and-plan flow within domain_upsell task

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/domain-upsell-launchpad-redirects-to-domain-and-plan-flow
+++ b/projects/packages/jetpack-mu-wpcom/changelog/domain-upsell-launchpad-redirects-to-domain-and-plan-flow
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Launchpad: Link to domain-and-plan flow within domain_upsell task

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -102,7 +102,7 @@ function wpcom_launchpad_get_task_definitions() {
 						return '/domains/manage/' . $data['site_slug_encoded'];
 				}
 
-				return '/setup/domain-upsell/domains?siteSlug=' . $data['site_slug_encoded'];
+				return '/setup/domain-and-plan/domains?siteSlug=' . $data['site_slug_encoded'];
 			},
 		),
 		'first_post_published'            => array(


### PR DESCRIPTION
Closes DOMAINS-1633.

## Proposed changes:

In https://github.com/Automattic/wp-calypso/pull/105997, we removed `/setup/domain-upsell` in favor of `/setup/domain-and-plan`. This PR finishes the job by removing the references to the removed flow within Jetpack.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

Check the issue on Linear.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

- Apply this version to your sandbox [through the automated script](https://github.com/Automattic/jetpack/pull/45360#issuecomment-3362456835);
- Point `public-api.wordpress.com` and any WPCOM site you have - preferentially a free one - to your sandbox.

Enter the [dev console](https://developer.wordpress.com/docs/api/console/) and run this endpoint:

<img width="1183" height="193" alt="image" src="https://github.com/user-attachments/assets/0d7cb94f-f86c-4143-b779-891fc26ee2b7" />

Then visit `%s/wp-admin`. You should see the Launchpad in the Classic Admin home and the "Choose a domain" link should point to `/setup/domain-and-plan`:

<img width="705" height="415" alt="image" src="https://github.com/user-attachments/assets/062fcf8d-a755-4860-91a7-f6aa7e11833c" />
