### PR TITLE
Forms: Improve preloading for endpoints

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-endpoints-preloading
+++ b/projects/packages/forms/changelog/fix-forms-endpoints-preloading
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: improve preloading for endpoints.

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -807,7 +807,9 @@ class Contact_Form_Block {
 	 */
 	public static function preload_endpoints( $paths ) {
 		$paths[] = array( '/wp/v2/feedback/config', 'GET' );
+		$paths[] = array( '/wp/v2/feedback/config?_locale=user', 'GET' );
 		$paths[] = array( '/wp/v2/feedback/integrations?version=2', 'GET' );
+		$paths[] = array( '/wp/v2/feedback/integrations?version=2&_locale=user', 'GET' );
 		return $paths;
 	}
 

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -85,7 +85,9 @@ class Dashboard {
 		// Preload Forms endpoints needed in dashboard context.
 		$preload_paths = array(
 			'/wp/v2/feedback/config',
+			'/wp/v2/feedback/config?_locale=user',
 			'/wp/v2/feedback/integrations?version=2',
+			'/wp/v2/feedback/integrations?version=2&_locale=user',
 		);
 		$preload_data  = array_reduce( $preload_paths, 'rest_preload_api_request', array() );
 		wp_add_inline_script(

--- a/projects/plugins/jetpack/changelog/fix-forms-endpoints-preloading
+++ b/projects/plugins/jetpack/changelog/fix-forms-endpoints-preloading
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: improve preloading for endpoints.


### PR DESCRIPTION
## Proposed changes:

We leverage WordPress core functionality to pre-load endpoints for the forms dashboard and block editor. This ensures data is immediately available and eliminates loading flicker. But we noticed it is not working in many cases. 

The reason is that apiFetch is often adding a _locale parameters. Preloading depends on exactly matching the endpoint url, including query parameters. To fix it, I've added the _locale param to our preloaded endpoint. I added this alongside the existing endpoint definition because I think there are cases where both may be called. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None. 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No. 

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the forms dashboard, and then the integrations tab. Confirm the integrations tab content loads immediately. You should not see an empty box. 
* Create a post and add a form block. In the sidebar, open the Integrations panel. Confirm you do not see a loading indicator there before any active integration icons (like Akismet) show.  