### PR TITLE
Forms: add loading spinner for integrations

### DIFF
--- a/projects/packages/forms/changelog/add-forms-integrations-loading-state
+++ b/projects/packages/forms/changelog/add-forms-integrations-loading-state
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: add loading spinner for integrations.

--- a/projects/packages/forms/src/dashboard/integrations/index.tsx
+++ b/projects/packages/forms/src/dashboard/integrations/index.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import jetpackAnalytics from '@automattic/jetpack-analytics';
+import { Spinner } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useState, useCallback } from 'react';
 /**
@@ -21,7 +22,7 @@ import './style.scss';
 import type { Integration } from '../../types';
 
 const Integrations = () => {
-	const { integrations, refreshIntegrations } = useIntegrationsStatus();
+	const { integrations, refreshIntegrations, isLoading } = useIntegrationsStatus();
 	const [ expandedCards, setExpandedCards ] = useState( {
 		akismet: false,
 		googleSheets: false,
@@ -87,54 +88,65 @@ const Integrations = () => {
 						) }
 					</div>
 				</div>
-				<div className="jp-forms__integrations-body">
-					{ akismetData && (
-						<AkismetDashboardCard
-							isExpanded={ expandedCards.akismet }
-							onToggle={ handleToggleAkismet }
-							data={ akismetData }
-							refreshStatus={ refreshIntegrations }
-						/>
-					) }
-					{ googleDriveData && (
-						<GoogleSheetsDashboardCard
-							isExpanded={ expandedCards.googleSheets }
-							onToggle={ handleToggleGoogleSheets }
-							data={ googleDriveData }
-							refreshStatus={ refreshIntegrations }
-						/>
-					) }
-					{ crmData && (
-						<JetpackCRMDashboardCard
-							isExpanded={ expandedCards.crm }
-							onToggle={ handleToggleCRM }
-							data={ crmData }
-							refreshStatus={ refreshIntegrations }
-						/>
-					) }
-					{ mailpoetData && (
-						<MailPoetDashboardCard
-							isExpanded={ expandedCards.mailpoet }
-							onToggle={ handleToggleMailPoet }
-							data={ mailpoetData }
-							refreshStatus={ refreshIntegrations }
-						/>
-					) }
-					{ salesforceData && (
-						<SalesforceDashboardCard
-							isExpanded={ expandedCards.salesforce }
-							onToggle={ handleToggleSalesforce }
-							data={ salesforceData }
-							refreshStatus={ refreshIntegrations }
-						/>
-					) }
-					{ creativeMailData && (
-						<CreativeMailDashboardCard
-							isExpanded={ expandedCards.creativemail }
-							onToggle={ handleToggleCreativeMail }
-							data={ creativeMailData }
-							refreshStatus={ refreshIntegrations }
-						/>
+				<div
+					className={
+						'jp-forms__integrations-body' +
+						( isLoading ? ' jp-forms__integrations-body--loading' : '' )
+					}
+				>
+					{ isLoading ? (
+						<Spinner />
+					) : (
+						<>
+							{ akismetData && (
+								<AkismetDashboardCard
+									isExpanded={ expandedCards.akismet }
+									onToggle={ handleToggleAkismet }
+									data={ akismetData }
+									refreshStatus={ refreshIntegrations }
+								/>
+							) }
+							{ googleDriveData && (
+								<GoogleSheetsDashboardCard
+									isExpanded={ expandedCards.googleSheets }
+									onToggle={ handleToggleGoogleSheets }
+									data={ googleDriveData }
+									refreshStatus={ refreshIntegrations }
+								/>
+							) }
+							{ crmData && (
+								<JetpackCRMDashboardCard
+									isExpanded={ expandedCards.crm }
+									onToggle={ handleToggleCRM }
+									data={ crmData }
+									refreshStatus={ refreshIntegrations }
+								/>
+							) }
+							{ mailpoetData && (
+								<MailPoetDashboardCard
+									isExpanded={ expandedCards.mailpoet }
+									onToggle={ handleToggleMailPoet }
+									data={ mailpoetData }
+									refreshStatus={ refreshIntegrations }
+								/>
+							) }
+							{ salesforceData && (
+								<SalesforceDashboardCard
+									isExpanded={ expandedCards.salesforce }
+									onToggle={ handleToggleSalesforce }
+									data={ salesforceData }
+									refreshStatus={ refreshIntegrations }
+								/>
+							) }
+							{ creativeMailData && (
+								<CreativeMailDashboardCard
+									isExpanded={ expandedCards.creativemail }
+									onToggle={ handleToggleCreativeMail }
+									data={ creativeMailData }
+									refreshStatus={ refreshIntegrations }
+								/>
+							) }
+						</>
 					) }
 				</div>
 			</div>

--- a/projects/packages/forms/src/dashboard/integrations/style.scss
+++ b/projects/packages/forms/src/dashboard/integrations/style.scss
@@ -31,6 +31,13 @@
 		border-radius: 8px;
 		padding: 12px 24px;
 
+		&.jp-forms__integrations-body--loading {
+			min-height: 240px;
+			display: flex;
+			align-items: center;
+			justify-content: center;
+		}
+
 		> div:last-of-type {
 			border-bottom: none;
 		}


### PR DESCRIPTION
## Proposed changes:

If the integrations endpoint is slow to load on the forms dashboard, we'll see an empty box like the screenshot below. We should be pre-loading the endpoint to avoid that, which I've fixed here. But we should still have a nicer loading indicator in place as a backup. 

**Before**
<img width="1337" height="330" alt="integrations-loading-state" src="https://github.com/user-attachments/assets/9ba147a9-a4e1-44bb-9d88-6355fdca2019" />

**After (only if preloading the endpoint fails)** 
<img width="1340" height="649" alt="integrations-dashboard-spinner" src="https://github.com/user-attachments/assets/44d27c77-bd9f-4940-b444-e7e969a83fc0" />

### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None. 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No. 

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* If the fix for preloading the endpoint is merged first, this could be hard to test, as the data should be preloaded. 
* Open your dev inspector tools, go to the Network tab, and set 'throttling' to 4G or 3G to slow down the load. 
* Go to the forms dashboard, then click on the integrations tab. Either integration data should already be preloaded and showing, or you should see a spinner like the 'after' screenshot above. You should never see the 'before' state above. 