### PR TITLE
Calypsoify: mark package as abandoned

### DIFF
--- a/projects/packages/calypsoify/README.md
+++ b/projects/packages/calypsoify/README.md
@@ -2,6 +2,9 @@
 
 Calypsoify is designed to make sure specific wp-admin pages include navigation that prioritizes the Calypso navigation experience.
 
+> [!CAUTION]
+> This package is abandoned. Its features are now part of the block editor for everyone.
+
 ![](https://cldup.com/awmrHOWz7t.png)
 
 ## How to install Calypsoify

--- a/projects/packages/calypsoify/changelog/update-abandon-calypsoify-45356
+++ b/projects/packages/calypsoify/changelog/update-abandon-calypsoify-45356
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Mark package as abandoned.

--- a/projects/packages/calypsoify/composer.json
+++ b/projects/packages/calypsoify/composer.json
@@ -62,5 +62,6 @@
 	},
 	"suggest": {
 		"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
-	}
+	},
+	"abandoned": true
 }

--- a/projects/plugins/mu-wpcom-plugin/changelog/update-abandon-calypsoify-45356
+++ b/projects/plugins/mu-wpcom-plugin/changelog/update-abandon-calypsoify-45356
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -393,7 +393,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/calypsoify",
-                "reference": "1e57eb50b5a1d78b81fd8e4241073d1f9ed56142"
+                "reference": "5f052281a3effc4251b834f23178864d9555e1be"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -449,6 +449,7 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Calypsoify is designed to make sure specific wp-admin pages include navigation that prioritizes the Calypso navigation experience.",
+            "abandoned": true,
             "transport-options": {
                 "relative": true
             }

--- a/projects/plugins/wpcomsh/changelog/update-abandon-calypsoify-45356
+++ b/projects/plugins/wpcomsh/changelog/update-abandon-calypsoify-45356
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -530,7 +530,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/calypsoify",
-                "reference": "1e57eb50b5a1d78b81fd8e4241073d1f9ed56142"
+                "reference": "5f052281a3effc4251b834f23178864d9555e1be"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -586,6 +586,7 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Calypsoify is designed to make sure specific wp-admin pages include navigation that prioritizes the Calypso navigation experience.",
+            "abandoned": true,
             "transport-options": {
                 "relative": true
             }


### PR DESCRIPTION
See #45356

## Proposed changes:

Mark package as abandoned so its mirror repo gets updated to mark the package as abandoned.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* No

## Does this pull request change what data or activity we track or use?

* N/A

## Testing instructions:

* Check for typos
