### PR TITLE
Cookie Consent Widget: ensure the default text can be translated

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-legacy-cookie-consent-i18n
+++ b/projects/plugins/jetpack/changelog/fix-legacy-cookie-consent-i18n
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Cookie Consent Widget: ensure the default widget text can be translated.

--- a/projects/plugins/jetpack/modules/widgets/class-jetpack-eu-cookie-law-widget.php
+++ b/projects/plugins/jetpack/modules/widgets/class-jetpack-eu-cookie-law-widget.php
@@ -136,7 +136,12 @@ if ( ! class_exists( 'Jetpack_EU_Cookie_Law_Widget' ) ) {
 				'position'           => $this->position_options[0],
 				'policy-link-text'   => esc_html__( 'Cookie Policy', 'jetpack' ),
 				'button'             => esc_html__( 'Close and accept', 'jetpack' ),
-				'default-text'       => esc_html__( "Privacy & Cookies: This site uses cookies. By continuing to use this website, you agree to their use. \r\nTo find out more, including how to control cookies, see here:", 'jetpack' ),
+				'default-text'       => esc_html__(
+					'Privacy & Cookies: This site uses cookies. By continuing to use this website, you agree to their use.
+
+To find out more, including how to control cookies, see here:',
+					'jetpack'
+				),
 			);
 		}
 


### PR DESCRIPTION
Fixes #45364

## Proposed changes:

Move away from using carriage returns in translatable string to ensure it can be translated properly.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

> [!NOTE]
> Unfortunately we cannot test the translation in the fix since the new string will need to be translated first.
> We can, however, check that the string is still displayed properly in English.

* Start with a site connected to WordPress.com, and where you've activated the Extra Sidebar Widgets module.
* Go to Appearance > Themes and install & activate the Twenty Ten theme
* Go to Plugins > Add New and install & activate the Classic widgets plugin
* Go to Appearance > Widgets
* Drag the Cookie Consent widget to a widget area
* Check the frontend
    * The widget should be properly displayed
