### PR TITLE
Newsletter Settings: add clarify to clarify reply-to settings

### DIFF
--- a/projects/plugins/jetpack/_inc/client/newsletter/email-settings.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/email-settings.jsx
@@ -417,6 +417,12 @@ const EmailSettings = props => {
 						'Choose who receives emails when subscribers reply to your newsletter.',
 						'jetpack'
 					) }
+					{ subscriptionReplyTo === 'author' &&
+						' ' +
+							__(
+								'The author’s account must be connected to WordPress.com to use their email as the reply-to address.',
+								'jetpack'
+							) }
 				</p>
 				<RadioControl
 					className="jp-form-radio-gap"

--- a/projects/plugins/jetpack/_inc/client/newsletter/email-settings.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/email-settings.jsx
@@ -218,6 +218,45 @@ const EmailSettings = props => {
 					toogling={ isSavingAnyOption( [ FEATURED_IMAGE_IN_EMAIL_OPTION ] ) }
 					label={ <span className="jp-form-toggle-explanation">{ featuredImageInfo }</span> }
 					onChange={ handleEnableFeaturedImageInEmailToggleChange }
+					className="email-settings__featured-image-toggle"
+				/>
+			</SettingsGroup>
+			<SettingsGroup
+				hasChild
+				disableInOfflineMode
+				disableInSiteConnectionMode={ ! siteHasConnectedUser }
+				module={ subscriptionsModule }
+				support={ {
+					link: subscriptionsAndNewslettersSupportUrl,
+					text: __(
+						'Sets whether email subscribers can read full posts in emails or just an excerpt and link to the full version of the post.',
+						'jetpack'
+					),
+				} }
+			>
+				<FormLegend className="jp-form-label-wide">
+					{ __( 'For each new post email, include', 'jetpack' ) }
+				</FormLegend>
+
+				<RadioControl
+					className="jp-form-radio-gap"
+					selected={ subscriptionEmailsUseExcerpt ? 'excerpt' : 'full' }
+					disabled={ excerptInputDisabled }
+					options={ [
+						{
+							label: (
+								<span className="jp-form-toggle-explanation">{ __( 'Full text', 'jetpack' ) }</span>
+							),
+							value: 'full',
+						},
+						{
+							label: (
+								<span className="jp-form-toggle-explanation">{ __( 'Excerpt', 'jetpack' ) }</span>
+							),
+							value: 'excerpt',
+						},
+					] }
+					onChange={ handleSubscriptionEmailsUseExcerptChange }
 				/>
 			</SettingsGroup>
 			<SettingsGroup
@@ -334,44 +373,6 @@ const EmailSettings = props => {
 				disableInOfflineMode
 				disableInSiteConnectionMode={ ! siteHasConnectedUser }
 				module={ subscriptionsModule }
-				support={ {
-					link: subscriptionsAndNewslettersSupportUrl,
-					text: __(
-						'Sets whether email subscribers can read full posts in emails or just an excerpt and link to the full version of the post.',
-						'jetpack'
-					),
-				} }
-			>
-				<FormLegend className="jp-form-label-wide">
-					{ __( 'For each new post email, include', 'jetpack' ) }
-				</FormLegend>
-
-				<RadioControl
-					className="jp-form-radio-gap"
-					selected={ subscriptionEmailsUseExcerpt ? 'excerpt' : 'full' }
-					disabled={ excerptInputDisabled }
-					options={ [
-						{
-							label: (
-								<span className="jp-form-toggle-explanation">{ __( 'Full text', 'jetpack' ) }</span>
-							),
-							value: 'full',
-						},
-						{
-							label: (
-								<span className="jp-form-toggle-explanation">{ __( 'Excerpt', 'jetpack' ) }</span>
-							),
-							value: 'excerpt',
-						},
-					] }
-					onChange={ handleSubscriptionEmailsUseExcerptChange }
-				/>
-			</SettingsGroup>
-			<SettingsGroup
-				hasChild
-				disableInOfflineMode
-				disableInSiteConnectionMode={ ! siteHasConnectedUser }
-				module={ subscriptionsModule }
 				className="newsletter-group"
 				support={ {
 					link: getRedirectUrl( 'jetpack-support-subscriptions', {
@@ -383,15 +384,7 @@ const EmailSettings = props => {
 					),
 				} }
 			>
-				<FormLegend className="jp-form-label-wide">
-					{ __( 'Sender name and reply-to settings', 'jetpack' ) }
-				</FormLegend>
-				<p>
-					{ __(
-						"This is the name that appears in subscribers' inboxes. It's usually the name of your newsletter or the author.",
-						'jetpack'
-					) }
-				</p>
+				<FormLegend className="jp-form-label-wide">{ __( 'Sender name', 'jetpack' ) }</FormLegend>
 				<Container horizontalGap={ 0 } fluid className="sender-name">
 					<Col sm={ 3 } md={ 4 } lg={ 4 }>
 						<TextInput
@@ -411,19 +404,41 @@ const EmailSettings = props => {
 							{ __( 'Save', 'jetpack' ) }
 						</Button>
 					</Col>
+					<Col className="sender-name-example">
+						{ sprintf(
+							/* translators: 1. Site name or user entered replacement value 2. is the example email */
+							__( 'Preview: %1$s <%2$s>', 'jetpack' ),
+							fromNameState.value || siteName,
+							getExampleEmail( subscriptionReplyTo )
+						) }
+					</Col>
 				</Container>
-				<p className="reply-to">
+				<p className="jp-form-setting-explanation">
 					{ __(
-						'Choose who receives emails when subscribers reply to your newsletter.',
+						"This is the name that appears in subscribers' inboxes. It's usually the name of your newsletter or the author.",
 						'jetpack'
 					) }
-					{ subscriptionReplyTo === 'author' &&
-						' ' +
-							__(
-								'The author’s account must be connected to WordPress.com to use their email as the reply-to address.',
-								'jetpack'
-							) }
 				</p>
+			</SettingsGroup>
+			<SettingsGroup
+				hasChild
+				disableInOfflineMode
+				disableInSiteConnectionMode={ ! siteHasConnectedUser }
+				module={ subscriptionsModule }
+				className="newsletter-group"
+				support={ {
+					link: getRedirectUrl( 'jetpack-support-subscriptions', {
+						anchor: 'reply-to-email-address',
+					} ),
+					text: __(
+						"Sets the reply to email address for your newsletter emails. It's the email where subscribers send their replies.",
+						'jetpack'
+					),
+				} }
+			>
+				<FormLegend className="jp-form-label-wide">
+					{ __( 'Reply-to settings', 'jetpack' ) }
+				</FormLegend>
 				<RadioControl
 					className="jp-form-radio-gap"
 					selected={ subscriptionReplyTo || 'comment' }
@@ -456,16 +471,18 @@ const EmailSettings = props => {
 					] }
 					onChange={ handleSubscriptionReplyToChange }
 				/>
-				<Container horizontalGap={ 0 } fluid className="sender-name">
-					<Col className="sender-name-example byline-preview">
-						{ sprintf(
-							/* translators: 1. Site name or user entered replacement value 2. is the example email */
-							__( 'Preview: %1$s <%2$s>', 'jetpack' ),
-							fromNameState.value || siteName,
-							getExampleEmail( subscriptionReplyTo )
-						) }
-					</Col>
-				</Container>
+				<p className="reply-to jp-form-setting-explanation">
+					{ __(
+						'Choose who receives emails when subscribers reply to your newsletter.',
+						'jetpack'
+					) }
+					{ subscriptionReplyTo === 'author' &&
+						' ' +
+							__(
+								'The author’s account must be connected to WordPress.com to use their email as the reply-to address.',
+								'jetpack'
+							) }
+				</p>
 			</SettingsGroup>
 		</SettingsCard>
 	);

--- a/projects/plugins/jetpack/_inc/client/newsletter/style.scss
+++ b/projects/plugins/jetpack/_inc/client/newsletter/style.scss
@@ -66,17 +66,29 @@
 	margin-bottom: 16px;
 }
 
-.jp-form-settings-group.newsletter-group .sender-name {
-	--vertical-gutter: 8px;
-}
+.jp-form-settings-group.newsletter-group {
 
-.sender-name-example {
-	font-size: var(--font-body-small);
-	margin-top: 8px;
+	.sender-name {
+		--vertical-gutter: 8px;
+
+		.sender-name-example {
+			font-size: var(--font-body-small);
+			margin-top: 8px;
+		}
+	}
+
+	.reply-to {
+		margin-top: 16px;
+	}
+
 }
 
 #jp-settings-subscriptions .jp-form-fieldset:not(:first-of-type) {
 	margin-top: 24px;
+}
+
+.jp-settings-container form#jp-settings-newsletter-jetpack .jp-form-settings-group .components-base-control.email-settings__featured-image-toggle:last-of-type {
+	margin-bottom: 0;
 }
 
 .byline-preview {
@@ -86,66 +98,62 @@
 	margin-bottom: 24px;
 	padding: 16px;
 	background-color: var(--jp-gray-0);
+
+	.byline-preview__label {
+		height: 24px;
+		line-height: 24px;
+		margin-right: 8px;
+	}
+
+	.byline-preview__gravatar {
+		border-radius: 50%;
+		width: 24px;
+		height: 24px;
+		margin: 0 8px 0 0;
+	}
 }
 
-.byline-preview__label {
-	height: 24px;
-	line-height: 24px;
-	margin-right: 8px;
-}
-
-.byline-preview__gravatar {
-	border-radius: 50%;
-	width: 24px;
-	height: 24px;
-	margin: 0 8px 0 0;
-}
-
-.email-settings__help-info {
+.jp-settings-container .email-settings__help-info {
 	margin-left: 60px;
 	margin-bottom: 12px;
 	margin-top: -12px;
 	color: #747474;
 	padding-right: 48px;
+
+	a.components-button {
+		text-decoration: none;
+	}
+
+	a.components-button.is-link {
+		text-decoration: underline;
+	}
+
+	.email-settings__gravatar-help-info {
+		display: flex;
+		align-items: center;
+
+		.email-settings__gravatar-image {
+			width: 60px;
+			height: 60px;
+			border-radius: 50%;
+			margin-right: 16px;
+		}
+
+		.email-settings__gravatar-help-text {
+			margin-bottom: 8px;
+		}
+	}
 }
 
-.jp-settings-container .email-settings__help-info a.components-button {
-	text-decoration: none;
-}
-
-.jp-settings-container .email-settings__help-info a.components-button.is-link {
-	text-decoration: underline;
-}
-
-.email-settings__gravatar-help-info {
-	display: flex;
-	align-items: center;
-}
-
-.email-settings__gravatar {
+.jp-form-settings-group .email-settings__gravatar {
 	position: relative;
 	margin-right: -48px;
-}
 
-.jp-form-settings-group .email-settings__gravatar .jp-support-info {
-	top: 3px;
-}
-
-.email-settings__gravatar-image {
-	width: 60px;
-	height: 60px;
-	border-radius: 50%;
-	margin-right: 16px;
-}
-
-.email-settings__gravatar-help-text {
-	margin-bottom: 8px;
+	.jp-support-info {
+		top: 3px;
+	}
 }
 
 #jp-settings-subscriptions .dops-textarea {
 	field-sizing: content;
-}
-
-.newsletter-group .reply-to {
-	margin-top: 16px;
 }

--- a/projects/plugins/jetpack/changelog/fix-newsletter-settings-clarify-reply-to
+++ b/projects/plugins/jetpack/changelog/fix-newsletter-settings-clarify-reply-to
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Newsletter Settings: update wording to clarify how the reply-to settings can be used.


### PR DESCRIPTION
Fixes CML-934

## Proposed changes:

When one enables the option for replies to be sent to the post author's email, this will only work if the post author has linked their account to their WordPress.com account.

We want to highlight that in the newsletter settings. We've discussed multiple options in CML-934, and ended up with this choice:

<img width="1091" height="366" alt="image" src="https://github.com/user-attachments/assets/d6131de7-8dd0-4982-ad04-c6b40cbe10c9" />

<img width="1059" height="365" alt="image" src="https://github.com/user-attachments/assets/39a423fc-087b-4724-b807-99ca50f65c26" />

> show the highlighted text when the “Replies will be sent to the post author’s email” option is selected AND the current site is self-hosted?

Since we only want to show that option on self-hosted sites, we won't be adding it to the Calypso UI here:
https://github.com/Automattic/wp-calypso/blob/a6947294442abc306659ccf8c4e2e35fd9460edd/client/my-sites/site-settings/settings-newsletter/ReplyToSetting.tsx#L53

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* See CML-934

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Go to Jetpack > Settings > Newsletter
* Enable the feature
* Scroll down to "Sender name and reply-to settings"
* Pick "Replies will be sent to the post author's email"
* See the text changing just above.
