### PR TITLE
Charts: Simplify PieSemiCircleChart API to use children composition

### DIFF
--- a/projects/js-packages/charts/BREAKING_CHANGES.md
+++ b/projects/js-packages/charts/BREAKING_CHANGES.md
@@ -1,0 +1,93 @@
+# Breaking Changes - PieSemiCircleChart
+
+## Summary
+
+The `label` and `note` props have been removed from `PieSemiCircleChart` in favor of the more flexible composition API using the `children` prop.
+
+## Migration Guide
+
+### Before (Deprecated)
+```tsx
+<PieSemiCircleChart
+  data={data}
+  width={400}
+  label="Operating Systems"
+  note="Windows +10%"
+/>
+```
+
+### After (New API)
+
+**Option 1: Direct Group usage**
+```tsx
+import { Group } from '@visx/group';
+import { Text } from '@visx/text';
+
+<PieSemiCircleChart
+  data={data}
+  width={400}
+>
+  <Group>
+    <Text textAnchor="middle" y={-40} fontSize={16} fontWeight={600}>
+      Operating Systems
+    </Text>
+    <Text textAnchor="middle" y={-20} fontSize={14}>
+      Windows +10%
+    </Text>
+  </Group>
+</PieSemiCircleChart>
+```
+
+**Option 2: Compound components (more explicit)**
+```tsx
+import { Group } from '@visx/group';
+import { Text } from '@visx/text';
+
+<PieSemiCircleChart
+  data={data}
+  width={400}
+>
+  <PieSemiCircleChart.SVG>
+    <Group>
+      <Text textAnchor="middle" y={-40} fontSize={16} fontWeight={600}>
+        Operating Systems
+      </Text>
+      <Text textAnchor="middle" y={-20} fontSize={14}>
+        Windows +10%
+      </Text>
+    </Group>
+  </PieSemiCircleChart.SVG>
+</PieSemiCircleChart>
+```
+
+## Affected Consumer Files
+
+### WooCommerce Analytics
+
+The following files in the WooCommerce Analytics repository need to be updated:
+
+1. **`/js/src/widgets/payments-by-method/payments-by-method.tsx`** (Lines 41-43)
+   - Uses: `label="$122K"` and `note="+3%"`
+   - Action: Convert to composition API
+
+2. **`/js/src/widgets/taxes-by-code/index.tsx`** (Lines 45-47)
+   - Uses: `label={label}` and `note={info}`
+   - Action: Convert to composition API
+
+3. **`/js/src/widgets/coupons-widget/coupons-widget.tsx`** (Line 82)
+   - Uses: `label=""`
+   - Action: Remove empty label prop
+
+4. **`/next-woocommerce-analytics/packages/widgets/src/shared/semi-circle-chart/semi-circle-chart.tsx`** (Line 93)
+   - Uses: `label=""`
+   - Action: Remove empty label prop
+
+### Jetpack Stats
+
+No breaking changes found - PieSemiCircleChart is not currently used in Jetpack Stats.
+
+## Notes
+
+- The `label=""` empty string usage can simply be removed without replacement
+- For actual label/note values, use the composition API examples above
+- Import `Group` from `@visx/group` and `Text` from `@visx/text` when using the composition API

--- a/projects/js-packages/charts/changelog/charts-65-iterate-over-pie-and-piesemicircle-composition
+++ b/projects/js-packages/charts/changelog/charts-65-iterate-over-pie-and-piesemicircle-composition
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Charts: improve pie semi circle chart composition

--- a/projects/js-packages/charts/src/components/pie-semi-circle-chart/pie-semi-circle-chart.tsx
+++ b/projects/js-packages/charts/src/components/pie-semi-circle-chart/pie-semi-circle-chart.tsx
@@ -1,7 +1,6 @@
 import { localPoint } from '@visx/event';
 import { Group } from '@visx/group';
 import { Pie } from '@visx/shape';
-import { Text } from '@visx/text';
 import { useTooltip, useTooltipInPortal } from '@visx/tooltip';
 import clsx from 'clsx';
 import { useCallback, useContext, useMemo } from 'react';
@@ -47,17 +46,8 @@ export interface PieSemiCircleChartProps extends BaseChartProps< DataPointPercen
 	clockwise?: boolean;
 
 	/**
-	 * Label text to display above the chart
-	 */
-	label?: string;
-
-	/**
-	 * Note text to display below the label
-	 */
-	note?: string;
-
-	/**
 	 * Use the children prop to render additional elements on the chart.
+	 * Supports composition API with PieSemiCircleChart.SVG and PieSemiCircleChart.HTML components.
 	 */
 	children?: ReactNode;
 
@@ -133,8 +123,6 @@ const PieSemiCircleChartInternal: FC< PieSemiCircleChartProps > = ( {
 	legendItemClassName,
 	legendShape = 'circle',
 	legendValueDisplay = 'percentage',
-	label,
-	note,
 	className,
 	children,
 	tooltipOffsetX = 0,
@@ -315,26 +303,6 @@ const PieSemiCircleChartInternal: FC< PieSemiCircleChartProps > = ( {
 								) );
 							} }
 						</Pie>
-
-						{ /* Label and note text */ }
-						<Group>
-							<Text
-								textAnchor="middle"
-								verticalAnchor="start"
-								y={ -40 } // Position above the chart with space for note
-								className={ styles.label }
-							>
-								{ label }
-							</Text>
-							<Text
-								textAnchor="middle"
-								verticalAnchor="start"
-								y={ -20 } // Position between label and chart
-								className={ styles.note }
-							>
-								{ note }
-							</Text>
-						</Group>
 
 						{ /* Render SVG children from composition API */ }
 						{ svgChildren }

--- a/projects/js-packages/charts/src/components/pie-semi-circle-chart/pie-semi-circle-chart.tsx
+++ b/projects/js-packages/charts/src/components/pie-semi-circle-chart/pie-semi-circle-chart.tsx
@@ -48,6 +48,39 @@ export interface PieSemiCircleChartProps extends BaseChartProps< DataPointPercen
 	/**
 	 * Use the children prop to render additional elements on the chart.
 	 * Supports composition API with PieSemiCircleChart.SVG and PieSemiCircleChart.HTML components.
+	 *
+	 * @example
+	 * // Render title and note using Group and Text (direct approach)
+	 * <PieSemiCircleChart data={data}>
+	 *   <Group>
+	 *     <Text textAnchor="middle" y={-40} fontSize={16} fontWeight={600}>
+	 *       Chart Title
+	 *     </Text>
+	 *     <Text textAnchor="middle" y={-20} fontSize={14}>
+	 *       Subtitle or note
+	 *     </Text>
+	 *   </Group>
+	 * </PieSemiCircleChart>
+	 *
+	 * @example
+	 * // Using compound components for more explicit control
+	 * <PieSemiCircleChart data={data}>
+	 *   <PieSemiCircleChart.SVG>
+	 *     <Group>
+	 *       <Text textAnchor="middle" y={-40} fontSize={16} fontWeight={600}>
+	 *         Chart Title
+	 *       </Text>
+	 *       <Text textAnchor="middle" y={-20} fontSize={14}>
+	 *         Subtitle or note
+	 *       </Text>
+	 *     </Group>
+	 *   </PieSemiCircleChart.SVG>
+	 *   <PieSemiCircleChart.HTML>
+	 *     <div style={{ textAlign: 'center', marginTop: '1rem' }}>
+	 *       Additional HTML content below the chart
+	 *     </div>
+	 *   </PieSemiCircleChart.HTML>
+	 * </PieSemiCircleChart>
 	 */
 	children?: ReactNode;
 

--- a/projects/js-packages/charts/src/components/pie-semi-circle-chart/stories/index.api.mdx
+++ b/projects/js-packages/charts/src/components/pie-semi-circle-chart/stories/index.api.mdx
@@ -16,16 +16,67 @@ Main component for rendering semi-circular pie charts.
 | `width` | `number` | `400` | Width of the chart in pixels (height is automatically half of width) |
 | `thickness` | `number` | `0.4` | Thickness of the pie segments (0-1, where 1 is full thickness) |
 | `clockwise` | `boolean` | `true` | Direction of segment rendering |
-| `label` | `string` | - | Text displayed above the chart |
-| `note` | `string` | - | Additional text displayed below the label |
+| `children` | `ReactNode` | - | Custom content to render. Supports Group elements or PieSemiCircleChart.SVG/HTML compound components |
 | `withTooltips` | `boolean` | `false` | Enable interactive tooltips on hover |
 | `showLegend` | `boolean` | `false` | Display legend below the chart |
 | `legendOrientation` | `'horizontal' \| 'vertical'` | `'horizontal'` | Legend layout direction |
 | `legendAlignment` | `'start' \| 'center' \| 'end'` | `'center'` | Legend alignment within its position |
 | `legendPosition` | `'top' \| 'bottom'` | `'bottom'` | Legend position (where the legend appears) |
 | `legendShape` | `'circle' \| 'rect' \| 'line'` | `'circle'` | Shape of legend indicators |
+| `legendValueDisplay` | `'percentage' \| 'value' \| 'valueDisplay' \| 'none'` | `'percentage'` | Type of value to display in legend |
+| `legendMaxWidth` | `number` | - | Maximum width for legend items |
+| `legendTextOverflow` | `'wrap' \| 'truncate'` | `'wrap'` | How to handle long legend text |
+| `legendItemClassName` | `string` | - | Custom CSS class for legend items |
 | `className` | `string` | - | Additional CSS class for the container |
 | `chartId` | `string` | - | Optional unique identifier (auto-generated if not provided) |
+| `tooltipOffsetX` | `number` | `0` | Horizontal offset for tooltip positioning in pixels |
+| `tooltipOffsetY` | `number` | `-15` | Vertical offset for tooltip positioning in pixels |
+
+## Compound Components
+
+### PieSemiCircleChart.SVG
+
+Wrapper for SVG elements to be rendered inside the chart (positioned within the semi-circle).
+
+**Usage:**
+```jsx
+<PieSemiCircleChart data={data}>
+  <PieSemiCircleChart.SVG>
+    <Group>
+      <Text textAnchor="middle" y={-40}>Title</Text>
+    </Group>
+  </PieSemiCircleChart.SVG>
+</PieSemiCircleChart>
+```
+
+### PieSemiCircleChart.HTML
+
+Wrapper for HTML elements to be rendered outside the SVG (below the chart).
+
+**Usage:**
+```jsx
+<PieSemiCircleChart data={data}>
+  <PieSemiCircleChart.HTML>
+    <div>Additional HTML content</div>
+  </PieSemiCircleChart.HTML>
+</PieSemiCircleChart>
+```
+
+### PieSemiCircleChart.Legend
+
+Legend component for flexible placement within the composition API.
+
+**Props:**
+- All legend-related props from the main component (orientation, alignment, position, shape, etc.)
+
+**Usage:**
+```jsx
+<PieSemiCircleChart data={data}>
+  <PieSemiCircleChart.HTML>
+    <PieSemiCircleChart.Legend orientation="horizontal" />
+  </PieSemiCircleChart.HTML>
+</PieSemiCircleChart>
+```
 
 ## DataPointPercentage Type
 

--- a/projects/js-packages/charts/src/components/pie-semi-circle-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/components/pie-semi-circle-chart/stories/index.docs.mdx
@@ -42,11 +42,18 @@ const data = [
 	data={ data }
 	width={ 600 }
 	thickness={ 0.4 }
-	label="Operating Systems"
-	note="Windows +10%"
 	withTooltips={ true }
 	showLegend={ true }
-/>` }
+>
+	<Group>
+		<Text textAnchor="middle" y={ -40 } fontSize={ 16 } fontWeight={ 600 }>
+			Operating Systems
+		</Text>
+		<Text textAnchor="middle" y={ -20 } fontSize={ 14 }>
+			Windows +10%
+		</Text>
+	</Group>
+</PieSemiCircleChart>` }
 />
 
 The chart automatically validates data to ensure positive values and meaningful percentages, displaying error states for invalid data configurations.
@@ -106,9 +113,16 @@ Add `withTooltips` to enable hover interactions that display detailed informatio
 	data={ data }
 	width={ 600 }
 	withTooltips={ true }
-	label="OS Distribution"
-	note="Hover segments for details"
-/>` }
+>
+	<Group>
+		<Text textAnchor="middle" y={ -40 } fontSize={ 16 } fontWeight={ 600 }>
+			OS Distribution
+		</Text>
+		<Text textAnchor="middle" y={ -20 } fontSize={ 14 }>
+			Hover segments for details
+		</Text>
+	</Group>
+</PieSemiCircleChart>` }
 />
 
 ### Counter-Clockwise Direction
@@ -121,8 +135,13 @@ Use the `clockwise` prop to control the rendering direction of segments:
 	data={ data }
 	width={ 600 }
 	clockwise={ false }
-	label="Counter-clockwise Rendering"
-/>` }
+>
+	<Group>
+		<Text textAnchor="middle" y={ -40 } fontSize={ 16 } fontWeight={ 600 }>
+			Counter-clockwise Rendering
+		</Text>
+	</Group>
+</PieSemiCircleChart>` }
 />
 
 ### Different Thickness Values
@@ -136,16 +155,26 @@ Adjust the visual weight of the chart using the `thickness` prop:
 	data={ data }
 	width={ 400 }
 	thickness={ 0.2 }
-	label="Thin Ring"
-/>
+>
+	<Group>
+		<Text textAnchor="middle" y={ -40 } fontSize={ 16 } fontWeight={ 600 }>
+			Thin Ring
+		</Text>
+	</Group>
+</PieSemiCircleChart>
 
 // Thick ring (thickness: 0.8)
 <PieSemiCircleChart
 	data={ data }
 	width={ 400 }
 	thickness={ 0.8 }
-	label="Thick Ring"
-/>` }
+>
+	<Group>
+		<Text textAnchor="middle" y={ -40 } fontSize={ 16 } fontWeight={ 600 }>
+			Thick Ring
+		</Text>
+	</Group>
+</PieSemiCircleChart>` }
 />
 
 ## Responsive Behavior
@@ -162,9 +191,14 @@ The chart can be made responsive by omitting the `width` prop, allowing it to ad
 <PieSemiCircleChart
 	data={ data }
 	thickness={ 0.4 }
-	label="Responsive Chart"
 	withTooltips={ true }
-/>` }
+>
+	<Group>
+		<Text textAnchor="middle" y={ -40 } fontSize={ 16 } fontWeight={ 600 }>
+			Responsive Chart
+		</Text>
+	</Group>
+</PieSemiCircleChart>` }
 />
 
 The responsive behavior maintains the 2:1 aspect ratio (width:height) and scales proportionally.
@@ -195,25 +229,36 @@ Segments automatically use theme colors, but you can override individual segment
 <PieSemiCircleChart
 	data={ customColorData }
 	width={ 400 }
-	label="Custom Colors"
-/>` }
+>
+	<Group>
+		<Text textAnchor="middle" y={ -40 } fontSize={ 16 } fontWeight={ 600 }>
+			Custom Colors
+		</Text>
+	</Group>
+</PieSemiCircleChart>` }
 />
 
-### Label and Note Styling
+### Custom Text Styling
 
-The chart includes built-in styling for labels and notes with appropriate typography hierarchy:
-
-- **Label**: 16px, font-weight 600, positioned above the chart
-- **Note**: 14px, positioned below the label
+You can add custom titles and notes using the composition API with full control over styling:
 
 <Source
 	language="jsx"
 	code={ `<PieSemiCircleChart
 	data={ data }
 	width={ 600 }
-	label="Primary Heading"
-	note="Secondary information or context"
-/>` }
+>
+	<Group>
+		{/* Primary heading - 16px, font-weight 600 */}
+		<Text textAnchor="middle" y={ -40 } fontSize={ 16 } fontWeight={ 600 }>
+			Primary Heading
+		</Text>
+		{/* Secondary note - 14px */}
+		<Text textAnchor="middle" y={ -20 } fontSize={ 14 }>
+			Secondary information or context
+		</Text>
+	</Group>
+</PieSemiCircleChart>` }
 />
 
 ### Theme Integration
@@ -293,8 +338,13 @@ The chart gracefully handles single data points, rendering a complete semi-circl
 <PieSemiCircleChart
 	data={ singlePointData }
 	width={ 400 }
-	label="Single Category"
-/>` }
+>
+	<Group>
+		<Text textAnchor="middle" y={ -40 } fontSize={ 16 } fontWeight={ 600 }>
+			Single Category
+		</Text>
+	</Group>
+</PieSemiCircleChart>` }
 />
 
 ## Advanced Features
@@ -385,4 +435,51 @@ const semiCircleData = [
 const partialData = [
 	{ label: 'Progress', value: 60, percentage: 60 }, // Shows 60% of semi-circle
 ];` }
+/>
+
+### Migrating from label/note Props (Breaking Change)
+
+The `label` and `note` props have been removed in favor of the more flexible composition API. Here's how to migrate:
+
+<Source
+	language="jsx"
+	code={ `// ❌ Old API (deprecated)
+<PieSemiCircleChart
+	data={ data }
+	width={ 400 }
+	label="Operating Systems"
+	note="Windows +10%"
+/>
+
+// ✅ New API - Direct Group usage
+<PieSemiCircleChart
+	data={ data }
+	width={ 400 }
+>
+	<Group>
+		<Text textAnchor="middle" y={ -40 } fontSize={ 16 } fontWeight={ 600 }>
+			Operating Systems
+		</Text>
+		<Text textAnchor="middle" y={ -20 } fontSize={ 14 }>
+			Windows +10%
+		</Text>
+	</Group>
+</PieSemiCircleChart>
+
+// ✅ New API - Compound components (more explicit)
+<PieSemiCircleChart
+	data={ data }
+	width={ 400 }
+>
+	<PieSemiCircleChart.SVG>
+		<Group>
+			<Text textAnchor="middle" y={ -40 } fontSize={ 16 } fontWeight={ 600 }>
+				Operating Systems
+			</Text>
+			<Text textAnchor="middle" y={ -20 } fontSize={ 14 }>
+				Windows +10%
+			</Text>
+		</Group>
+	</PieSemiCircleChart.SVG>
+</PieSemiCircleChart>` }
 />

--- a/projects/js-packages/charts/src/components/pie-semi-circle-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/components/pie-semi-circle-chart/stories/index.stories.tsx
@@ -53,9 +53,23 @@ export const Default: Story = {
 		resize: 'none',
 		thickness: 0.4,
 		data,
-		label: 'OS',
-		note: 'Windows +10%',
 		clockwise: true,
+		children: (
+			<Group>
+				<Text
+					textAnchor="middle"
+					verticalAnchor="start"
+					y={ -40 }
+					fontSize={ 16 }
+					fontWeight={ 600 }
+				>
+					OS
+				</Text>
+				<Text textAnchor="middle" verticalAnchor="start" y={ -20 } fontSize={ 14 }>
+					Windows +10%
+				</Text>
+			</Group>
+		),
 	},
 };
 
@@ -95,24 +109,46 @@ export const WithCompositionLegend: Story = {
 				<PieSemiCircleChart
 					width={ 400 }
 					data={ args.data }
-					label="Performance Metrics"
-					note="Q4 2023 Results"
 					showLegend={ true }
 					legendPosition={ args.legendPosition || 'bottom' }
 					legendOrientation={ args.legendOrientation || 'horizontal' }
 					legendAlignment={ args.legendAlignment || 'center' }
 					legendMaxWidth={ args.legendMaxWidth }
 					legendTextOverflow={ args.legendTextOverflow || 'wrap' }
-				/>
+				>
+					<Group>
+						<Text
+							textAnchor="middle"
+							verticalAnchor="start"
+							y={ -40 }
+							fontSize={ 16 }
+							fontWeight={ 600 }
+						>
+							Performance Metrics
+						</Text>
+						<Text textAnchor="middle" verticalAnchor="start" y={ -20 } fontSize={ 14 }>
+							Q4 2023 Results
+						</Text>
+					</Group>
+				</PieSemiCircleChart>
 			</div>
 			<div>
 				<h3>Composition API with Legend Component</h3>
-				<PieSemiCircleChart
-					width={ 400 }
-					data={ args.data }
-					label="Performance Metrics"
-					note="Q4 2023 Results"
-				>
+				<PieSemiCircleChart width={ 400 } data={ args.data }>
+					<Group>
+						<Text
+							textAnchor="middle"
+							verticalAnchor="start"
+							y={ -40 }
+							fontSize={ 16 }
+							fontWeight={ 600 }
+						>
+							Performance Metrics
+						</Text>
+						<Text textAnchor="middle" verticalAnchor="start" y={ -20 } fontSize={ 14 }>
+							Q4 2023 Results
+						</Text>
+					</Group>
 					<PieSemiCircleChart.Legend
 						position={ args.legendPosition || 'bottom' }
 						orientation={ args.legendOrientation || 'horizontal' }
@@ -163,14 +199,28 @@ export const CustomLegendPositioning: Story = {
 				percentage: 48,
 			},
 		],
-		label: 'OS',
-		note: 'Windows +10%',
 		withTooltips: true,
 		showLegend: true,
 		legendOrientation: 'vertical',
 		legendAlignment: 'end',
 		legendPosition: 'top',
 		legendShape: 'circle',
+		children: (
+			<Group>
+				<Text
+					textAnchor="middle"
+					verticalAnchor="start"
+					y={ -40 }
+					fontSize={ 16 }
+					fontWeight={ 600 }
+				>
+					OS
+				</Text>
+				<Text textAnchor="middle" verticalAnchor="start" y={ -20 } fontSize={ 14 }>
+					Windows +10%
+				</Text>
+			</Group>
+		),
 	},
 	parameters: {
 		docs: {
@@ -261,15 +311,15 @@ export const CompositionAPI: Story = {
 			>
 				<div>
 					<h3>With Custom SVG Elements</h3>
-					<PieSemiCircleChart
-						width={ 400 }
-						data={ args.data }
-						label="OS Usage"
-						note="Q4 2023"
-						withTooltips={ true }
-					>
+					<PieSemiCircleChart width={ 400 } data={ args.data } withTooltips={ true }>
 						<PieSemiCircleChart.SVG>
 							<Group>
+								<Text textAnchor="middle" y={ -40 } fontSize={ 16 } fontWeight={ 600 }>
+									OS Usage
+								</Text>
+								<Text textAnchor="middle" y={ -20 } fontSize={ 14 }>
+									Q4 2023
+								</Text>
 								<Text
 									x={ 0 }
 									y={ -80 }
@@ -300,12 +350,17 @@ export const CompositionAPI: Story = {
 
 				<div>
 					<h3>With Custom Legend and HTML Content</h3>
-					<PieSemiCircleChart
-						width={ 400 }
-						data={ args.data }
-						label="Performance"
-						note="Latest Results"
-					>
+					<PieSemiCircleChart width={ 400 } data={ args.data }>
+						<PieSemiCircleChart.SVG>
+							<Group>
+								<Text textAnchor="middle" y={ -40 } fontSize={ 16 } fontWeight={ 600 }>
+									Performance
+								</Text>
+								<Text textAnchor="middle" y={ -20 } fontSize={ 14 }>
+									Latest Results
+								</Text>
+							</Group>
+						</PieSemiCircleChart.SVG>
 						<PieSemiCircleChart.HTML>
 							<div
 								style={ {
@@ -350,19 +405,20 @@ export const CompositionAPI: Story = {
 			</div>
 
 			<div style={ { marginTop: '3rem' } }>
-				<h3>Legacy Support - Direct Group Components</h3>
+				<h3>Direct Group Components</h3>
 				<p style={ { fontSize: '14px', color: '#666', marginBottom: '1rem' } }>
-					For backward compatibility, Group components are still supported directly:
+					Group components are supported directly for simpler use cases:
 				</p>
-				<PieSemiCircleChart
-					width={ 400 }
-					data={ args.data }
-					label="Legacy Mode"
-					note="Still works!"
-				>
+				<PieSemiCircleChart width={ 400 } data={ args.data }>
 					<Group>
+						<Text textAnchor="middle" y={ -40 } fontSize={ 16 } fontWeight={ 600 }>
+							Direct Usage
+						</Text>
+						<Text textAnchor="middle" y={ -20 } fontSize={ 14 }>
+							Simple and clean!
+						</Text>
 						<Text x={ 0 } y={ -70 } textAnchor="middle" fontSize={ 12 } fill="#999">
-							Direct Group usage
+							Additional annotation
 						</Text>
 						<rect x={ -30 } y={ -85 } width={ 60 } height={ 2 } fill="#ddd" />
 					</Group>

--- a/projects/js-packages/charts/src/components/pie-semi-circle-chart/test/pie-semi-circle-chart.test.tsx
+++ b/projects/js-packages/charts/src/components/pie-semi-circle-chart/test/pie-semi-circle-chart.test.tsx
@@ -208,68 +208,62 @@ describe( 'PieSemiCircleChart', () => {
 		} );
 
 		it( 'renders PieSemiCircleChart.SVG compound component', () => {
-			render(
-				<GlobalChartsProvider>
-					<PieSemiCircleChart data={ mockData }>
-						<PieSemiCircleChart.SVG>
-							<Group>
-								<Text textAnchor="middle" y={ -50 }>
-									SVG Component Title
-								</Text>
-							</Group>
-						</PieSemiCircleChart.SVG>
-					</PieSemiCircleChart>
-				</GlobalChartsProvider>
-			);
+			renderPieChart( {
+				data: mockData,
+				children: (
+					<PieSemiCircleChart.SVG>
+						<Group>
+							<Text textAnchor="middle" y={ -50 }>
+								SVG Component Title
+							</Text>
+						</Group>
+					</PieSemiCircleChart.SVG>
+				),
+			} );
 
 			expect( screen.getByText( 'SVG Component Title' ) ).toBeInTheDocument();
 		} );
 
 		it( 'renders PieSemiCircleChart.HTML compound component', () => {
-			render(
-				<GlobalChartsProvider>
-					<PieSemiCircleChart data={ mockData }>
-						<PieSemiCircleChart.HTML>
-							<div data-testid="html-content">HTML Content</div>
-						</PieSemiCircleChart.HTML>
-					</PieSemiCircleChart>
-				</GlobalChartsProvider>
-			);
+			renderPieChart( {
+				data: mockData,
+				children: (
+					<PieSemiCircleChart.HTML>
+						<div data-testid="html-content">HTML Content</div>
+					</PieSemiCircleChart.HTML>
+				),
+			} );
 
 			expect( screen.getByTestId( 'html-content' ) ).toBeInTheDocument();
 			expect( screen.getByText( 'HTML Content' ) ).toBeInTheDocument();
 		} );
 
 		it( 'renders mixed SVG and HTML compound components', () => {
-			render(
-				<GlobalChartsProvider>
-					<PieSemiCircleChart data={ mockData }>
-						<PieSemiCircleChart.SVG>
-							<Group>
-								<Text textAnchor="middle" y={ -50 }>
-									SVG Title
-								</Text>
-							</Group>
-						</PieSemiCircleChart.SVG>
-						<PieSemiCircleChart.HTML>
-							<div data-testid="footer">Chart Footer</div>
-						</PieSemiCircleChart.HTML>
-					</PieSemiCircleChart>
-				</GlobalChartsProvider>
-			);
+			renderPieChart( {
+				data: mockData,
+				children: [
+					<PieSemiCircleChart.SVG key="svg">
+						<Group>
+							<Text textAnchor="middle" y={ -50 }>
+								SVG Title
+							</Text>
+						</Group>
+					</PieSemiCircleChart.SVG>,
+					<PieSemiCircleChart.HTML key="html">
+						<div data-testid="footer">Chart Footer</div>
+					</PieSemiCircleChart.HTML>,
+				],
+			} );
 
 			expect( screen.getByText( 'SVG Title' ) ).toBeInTheDocument();
 			expect( screen.getByTestId( 'footer' ) ).toBeInTheDocument();
 		} );
 
 		it( 'renders Legend as compound component', () => {
-			render(
-				<GlobalChartsProvider>
-					<PieSemiCircleChart data={ mockData }>
-						<PieSemiCircleChart.Legend orientation="horizontal" />
-					</PieSemiCircleChart>
-				</GlobalChartsProvider>
-			);
+			renderPieChart( {
+				data: mockData,
+				children: <PieSemiCircleChart.Legend orientation="horizontal" />,
+			} );
 
 			expect( screen.getByText( 'Category A' ) ).toBeInTheDocument();
 			expect( screen.getByText( 'Category B' ) ).toBeInTheDocument();

--- a/projects/js-packages/charts/src/components/pie-semi-circle-chart/test/pie-semi-circle-chart.test.tsx
+++ b/projects/js-packages/charts/src/components/pie-semi-circle-chart/test/pie-semi-circle-chart.test.tsx
@@ -1,5 +1,7 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { Group } from '@visx/group';
+import { Text } from '@visx/text';
 import { act } from 'react';
 import { GlobalChartsProvider } from '../../../providers';
 import PieSemiCircleChart from '../pie-semi-circle-chart';
@@ -35,13 +37,23 @@ describe( 'PieSemiCircleChart', () => {
 		expect( segments ).toHaveLength( 2 );
 	} );
 
-	it( 'renders label and note when provided', () => {
-		const label = 'Chart Title';
-		const note = 'Additional Info';
-		renderPieChart( { data: mockData, label, note } );
+	it( 'renders custom children content', () => {
+		renderPieChart( {
+			data: mockData,
+			children: (
+				<Group>
+					<Text textAnchor="middle" y={ -40 }>
+						Chart Title
+					</Text>
+					<Text textAnchor="middle" y={ -20 }>
+						Additional Info
+					</Text>
+				</Group>
+			),
+		} );
 
-		expect( screen.getByText( label ) ).toBeInTheDocument();
-		expect( screen.getByText( note ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Chart Title' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Additional Info' ) ).toBeInTheDocument();
 	} );
 
 	it( 'shows legend when showLegend is true', () => {
@@ -176,6 +188,91 @@ describe( 'PieSemiCircleChart', () => {
 			expect(
 				screen.getByText( 'Invalid data: Negative values are not allowed' )
 			).toBeInTheDocument();
+		} );
+	} );
+
+	describe( 'Composition API', () => {
+		it( 'renders children with SVG content', () => {
+			renderPieChart( {
+				data: mockData,
+				children: (
+					<Group>
+						<Text textAnchor="middle" y={ -40 }>
+							Custom Title
+						</Text>
+					</Group>
+				),
+			} );
+
+			expect( screen.getByText( 'Custom Title' ) ).toBeInTheDocument();
+		} );
+
+		it( 'renders PieSemiCircleChart.SVG compound component', () => {
+			render(
+				<GlobalChartsProvider>
+					<PieSemiCircleChart data={ mockData }>
+						<PieSemiCircleChart.SVG>
+							<Group>
+								<Text textAnchor="middle" y={ -50 }>
+									SVG Component Title
+								</Text>
+							</Group>
+						</PieSemiCircleChart.SVG>
+					</PieSemiCircleChart>
+				</GlobalChartsProvider>
+			);
+
+			expect( screen.getByText( 'SVG Component Title' ) ).toBeInTheDocument();
+		} );
+
+		it( 'renders PieSemiCircleChart.HTML compound component', () => {
+			render(
+				<GlobalChartsProvider>
+					<PieSemiCircleChart data={ mockData }>
+						<PieSemiCircleChart.HTML>
+							<div data-testid="html-content">HTML Content</div>
+						</PieSemiCircleChart.HTML>
+					</PieSemiCircleChart>
+				</GlobalChartsProvider>
+			);
+
+			expect( screen.getByTestId( 'html-content' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'HTML Content' ) ).toBeInTheDocument();
+		} );
+
+		it( 'renders mixed SVG and HTML compound components', () => {
+			render(
+				<GlobalChartsProvider>
+					<PieSemiCircleChart data={ mockData }>
+						<PieSemiCircleChart.SVG>
+							<Group>
+								<Text textAnchor="middle" y={ -50 }>
+									SVG Title
+								</Text>
+							</Group>
+						</PieSemiCircleChart.SVG>
+						<PieSemiCircleChart.HTML>
+							<div data-testid="footer">Chart Footer</div>
+						</PieSemiCircleChart.HTML>
+					</PieSemiCircleChart>
+				</GlobalChartsProvider>
+			);
+
+			expect( screen.getByText( 'SVG Title' ) ).toBeInTheDocument();
+			expect( screen.getByTestId( 'footer' ) ).toBeInTheDocument();
+		} );
+
+		it( 'renders Legend as compound component', () => {
+			render(
+				<GlobalChartsProvider>
+					<PieSemiCircleChart data={ mockData }>
+						<PieSemiCircleChart.Legend orientation="horizontal" />
+					</PieSemiCircleChart>
+				</GlobalChartsProvider>
+			);
+
+			expect( screen.getByText( 'Category A' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Category B' ) ).toBeInTheDocument();
 		} );
 	} );
 } );

--- a/projects/js-packages/charts/src/providers/chart-context/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/providers/chart-context/stories/index.stories.tsx
@@ -1,4 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react';
+import { Group } from '@visx/group';
+import { Text } from '@visx/text';
 import {
 	LineChart,
 	BarChart,
@@ -186,10 +188,21 @@ const ChartGrid = ( { args }: { args: StoryArgs } ) => {
 			<PieSemiCircleChart
 				data={ pieChartData }
 				width={ 350 }
-				label="Semi-Circle Chart"
 				withTooltips={ true }
 				showLegend={ true }
-			/>
+			>
+				<Group>
+					<Text
+						textAnchor="middle"
+						verticalAnchor="start"
+						y={ -40 }
+						fontSize={ 16 }
+						fontWeight={ 600 }
+					>
+						Semi-Circle Chart
+					</Text>
+				</Group>
+			</PieSemiCircleChart>
 
 			<BarListChart data={ barListChartData } width={ 350 } height={ 250 } withTooltips={ true } />
 
@@ -247,10 +260,21 @@ const ChartGridWithColorOverrides = ( { args }: { args: StoryArgs } ) => {
 			<PieSemiCircleChart
 				data={ pieChartData }
 				width={ 350 }
-				label="Semi-Circle Chart"
 				withTooltips={ true }
 				showLegend={ true }
-			/>
+			>
+				<Group>
+					<Text
+						textAnchor="middle"
+						verticalAnchor="start"
+						y={ -40 }
+						fontSize={ 16 }
+						fontWeight={ 600 }
+					>
+						Semi-Circle Chart
+					</Text>
+				</Group>
+			</PieSemiCircleChart>
 
 			<BarListChart data={ barListChartData } width={ 350 } height={ 250 } withTooltips={ true } />
 


### PR DESCRIPTION
## Proposed changes:
* Remove `label` and `note` props from PieSemiCircleChart component
* Update component to use `children` composition pattern like PieChart
* Remove unused label and note CSS styles from component stylesheet
* Update all tests to use children composition with visx Group and Text components
* Update component stories to demonstrate children composition pattern
* Update chart-context provider stories to use new API

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?

No, it does not.

## Testing instructions:

* Go to Storybook -> Charts -> Types -> Pie Semi Circle Chart
* Verify all stories render correctly with the new children composition API
* Check the "Default" story shows text rendered using Group and Text components
* Verify the "With Composition Legend" story works as expected
* Test the "Composition API" story to see various composition patterns
* Ensure tooltips, legends, and all chart interactions continue to work
* Verify no TypeScript errors in any story files
* Confirm visual appearance matches previous implementation
* Test that custom children content can be easily added using visx components