### PR TITLE
Tests: Address now-deprecated RunClassInSeparateProcess PHPUnit attribute

### DIFF
--- a/projects/packages/autoloader/changelog/fix-testing-replace_RunClassInSeparateProcess_with_RunTestsInSeparateProcesses
+++ b/projects/packages/autoloader/changelog/fix-testing-replace_RunClassInSeparateProcess_with_RunTestsInSeparateProcesses
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Tests: Replace deprecated RunClassInSeparateProcess attribute with errantly-equivalent RunTestsInSeparateProcesses. 

--- a/projects/packages/autoloader/tests/php/tests/unit/AutoloaderHandlerTest.php
+++ b/projects/packages/autoloader/tests/php/tests/unit/AutoloaderHandlerTest.php
@@ -9,16 +9,16 @@
 namespace Automattic\Jetpack\Autoloader\jpCurrent;
 
 use PHPUnit\Framework\Attributes\PreserveGlobalState;
-use PHPUnit\Framework\Attributes\RunClassInSeparateProcess;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use PHPUnit\Framework\TestCase;
 
 /**
  * Test suite class for the Autoloader handler.
  *
- * @runClassInSeparateProcess
+ * @runTestsInSeparateProcesses
  * @preserveGlobalState disabled
  */
-#[RunClassInSeparateProcess]
+#[RunTestsInSeparateProcesses]
 #[PreserveGlobalState( false )]
 class AutoloaderHandlerTest extends TestCase {
 

--- a/projects/packages/autoloader/tests/php/tests/unit/PluginLocatorTest.php
+++ b/projects/packages/autoloader/tests/php/tests/unit/PluginLocatorTest.php
@@ -9,16 +9,16 @@
 namespace Automattic\Jetpack\Autoloader\jpCurrent;
 
 use PHPUnit\Framework\Attributes\PreserveGlobalState;
-use PHPUnit\Framework\Attributes\RunClassInSeparateProcess;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use PHPUnit\Framework\TestCase;
 
 /**
  * Test suite class for the Autoloader part that handles active plugin guessing.
  *
- * @runClassInSeparateProcess
+ * @runTestsInSeparateProcesses
  * @preserveGlobalState disabled
  */
-#[RunClassInSeparateProcess]
+#[RunTestsInSeparateProcesses]
 #[PreserveGlobalState( false )]
 class PluginLocatorTest extends TestCase {
 


### PR DESCRIPTION
Closes MONOREP-128

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This replaces the deprecated `RunClassInSeparateProcess` attributes (and annotations) with `RunTestsInSeparateProcesses` attributes (and annotations).

Note: PHPUnit 11 removed annotations, but we still need them while we support older versions of PHP.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

In theory, the `RunClassInSeparateProcess` attribute should run all tests for said class in a single isolated process. However, per https://github.com/sebastianbergmann/phpunit/issues/5230#issuecomment-1437976939, it doesn't work and perhaps never did, instead behaving identical to `RunTestsInSeparateProcesses`.

With the release of PHPUnit 12.4, the `RunClassInSeparateProcess` attribute was deprecated, resulting in CI test failures. Swapping out the attributes seems safe enough, given that's effectively how things have been running anyway.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Is CI happy?