### PR TITLE
Forms: remove integrations loading spinner

### DIFF
--- a/projects/packages/forms/changelog/remove-forms-integration-spinner
+++ b/projects/packages/forms/changelog/remove-forms-integration-spinner
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: remove integrations loading spinner.

--- a/projects/packages/forms/src/dashboard/integrations/index.tsx
+++ b/projects/packages/forms/src/dashboard/integrations/index.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import jetpackAnalytics from '@automattic/jetpack-analytics';
-import { Spinner } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useState, useCallback } from 'react';
 /**
@@ -22,7 +21,7 @@ import './style.scss';
 import type { Integration } from '../../types';
 
 const Integrations = () => {
-	const { integrations, refreshIntegrations, isLoading } = useIntegrationsStatus();
+	const { integrations, refreshIntegrations } = useIntegrationsStatus();
 	const [ expandedCards, setExpandedCards ] = useState( {
 		akismet: false,
 		googleSheets: false,
@@ -88,65 +87,54 @@ const Integrations = () => {
 						) }
 					</div>
 				</div>
-				<div
-					className={
-						'jp-forms__integrations-body' +
-						( isLoading ? ' jp-forms__integrations-body--loading' : '' )
-					}
-				>
-					{ isLoading ? (
-						<Spinner />
-					) : (
-						<>
-							{ akismetData && (
-								<AkismetDashboardCard
-									isExpanded={ expandedCards.akismet }
-									onToggle={ handleToggleAkismet }
-									data={ akismetData }
-									refreshStatus={ refreshIntegrations }
-								/>
-							) }
-							{ googleDriveData && (
-								<GoogleSheetsDashboardCard
-									isExpanded={ expandedCards.googleSheets }
-									onToggle={ handleToggleGoogleSheets }
-									data={ googleDriveData }
-									refreshStatus={ refreshIntegrations }
-								/>
-							) }
-							{ crmData && (
-								<JetpackCRMDashboardCard
-									isExpanded={ expandedCards.crm }
-									onToggle={ handleToggleCRM }
-									data={ crmData }
-									refreshStatus={ refreshIntegrations }
-								/>
-							) }
-							{ mailpoetData && (
-								<MailPoetDashboardCard
-									isExpanded={ expandedCards.mailpoet }
-									onToggle={ handleToggleMailPoet }
-									data={ mailpoetData }
-									refreshStatus={ refreshIntegrations }
-								/>
-							) }
-							{ salesforceData && (
-								<SalesforceDashboardCard
-									isExpanded={ expandedCards.salesforce }
-									onToggle={ handleToggleSalesforce }
-									data={ salesforceData }
-									refreshStatus={ refreshIntegrations }
-								/>
-							) }
-							{ creativeMailData && (
-								<CreativeMailDashboardCard
-									isExpanded={ expandedCards.creativemail }
-									onToggle={ handleToggleCreativeMail }
-									data={ creativeMailData }
-									refreshStatus={ refreshIntegrations }
-								/>
-							) }
-						</>
+				<div className="jp-forms__integrations-body">
+					{ akismetData && (
+						<AkismetDashboardCard
+							isExpanded={ expandedCards.akismet }
+							onToggle={ handleToggleAkismet }
+							data={ akismetData }
+							refreshStatus={ refreshIntegrations }
+						/>
+					) }
+					{ googleDriveData && (
+						<GoogleSheetsDashboardCard
+							isExpanded={ expandedCards.googleSheets }
+							onToggle={ handleToggleGoogleSheets }
+							data={ googleDriveData }
+							refreshStatus={ refreshIntegrations }
+						/>
+					) }
+					{ crmData && (
+						<JetpackCRMDashboardCard
+							isExpanded={ expandedCards.crm }
+							onToggle={ handleToggleCRM }
+							data={ crmData }
+							refreshStatus={ refreshIntegrations }
+						/>
+					) }
+					{ mailpoetData && (
+						<MailPoetDashboardCard
+							isExpanded={ expandedCards.mailpoet }
+							onToggle={ handleToggleMailPoet }
+							data={ mailpoetData }
+							refreshStatus={ refreshIntegrations }
+						/>
+					) }
+					{ salesforceData && (
+						<SalesforceDashboardCard
+							isExpanded={ expandedCards.salesforce }
+							onToggle={ handleToggleSalesforce }
+							data={ salesforceData }
+							refreshStatus={ refreshIntegrations }
+						/>
+					) }
+					{ creativeMailData && (
+						<CreativeMailDashboardCard
+							isExpanded={ expandedCards.creativemail }
+							onToggle={ handleToggleCreativeMail }
+							data={ creativeMailData }
+							refreshStatus={ refreshIntegrations }
+						/>
 					) }
 				</div>
 			</div>

--- a/projects/packages/forms/src/dashboard/integrations/style.scss
+++ b/projects/packages/forms/src/dashboard/integrations/style.scss
@@ -31,13 +31,6 @@
 		border-radius: 8px;
 		padding: 12px 24px;
 
-		&.jp-forms__integrations-body--loading {
-			min-height: 240px;
-			display: flex;
-			align-items: center;
-			justify-content: center;
-		}
-
 		> div:last-of-type {
 			border-bottom: none;
 		}


### PR DESCRIPTION
## Proposed changes:

We added a loading spinner for the integrations list in this [PR](https://github.com/Automattic/jetpack/pull/45363). But it has some negative side effects. For example, if you install/activate a plugin that triggers loading state, and the entire integrations list is replaced with the loading spinner until resolved. 

We're removing this, and will rely on [preloading endpoints](https://github.com/Automattic/jetpack/pull/45362) and a new [integrations store](https://github.com/Automattic/jetpack/pull/45372) to improve how integrations data is loaded and handled. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None. 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Go to the Jetpack > Forms > Integrations screen and confirm integrations load quickly and as before. Try installing and activating plugins to confirm that changes in integration status are handled gracefully and don't trigger any unwanted loading states.

