### PR TITLE
Forms: Hide Google export card if disabled

### DIFF
--- a/projects/packages/forms/changelog/update-forms-google-enabled-check
+++ b/projects/packages/forms/changelog/update-forms-google-enabled-check
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: hide Google export card if disabled.

--- a/projects/packages/forms/src/dashboard/components/export-responses-modal/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/export-responses-modal/index.tsx
@@ -2,12 +2,16 @@
  * External dependencies
  */
 import { Modal, __experimentalVStack as VStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
+import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { INTEGRATIONS_STORE } from '../../../store/integrations';
 import CSVExport from '../../inbox/export-responses/csv';
 import GoogleDriveExport from '../../inbox/export-responses/google-drive';
+import type { SelectIntegrations } from '../../../store/integrations';
+import type { Integration } from '../../../types';
 
 type ExportResponsesModalProps = {
 	onRequestClose: () => void;
@@ -20,6 +24,16 @@ const ExportResponsesModal = ( {
 	onExport,
 	autoConnectGdrive,
 }: ExportResponsesModalProps ) => {
+	const { integrations } = useSelect( ( select: SelectIntegrations ) => {
+		const store = select( INTEGRATIONS_STORE );
+		return {
+			integrations: store.getIntegrations() || [],
+		};
+	}, [] ) as { integrations: Integration[] };
+
+	const isGoogleDriveEnabled = integrations.some(
+		integration => integration.id === 'google-drive'
+	);
 	return (
 		<Modal
 			title={ __( 'Export responses', 'jetpack-forms' ) }
@@ -28,7 +42,9 @@ const ExportResponsesModal = ( {
 		>
 			<VStack spacing={ 8 }>
 				<CSVExport onExport={ onExport } />
-				<GoogleDriveExport onExport={ onExport } autoConnect={ autoConnectGdrive } />
+				{ isGoogleDriveEnabled && (
+					<GoogleDriveExport onExport={ onExport } autoConnect={ autoConnectGdrive } />
+				) }
 			</VStack>
 		</Modal>
 	);

--- a/projects/packages/forms/src/dashboard/inbox/export-responses/google-drive.tsx
+++ b/projects/packages/forms/src/dashboard/inbox/export-responses/google-drive.tsx
@@ -6,6 +6,7 @@ import { isSimpleSite } from '@automattic/jetpack-script-data';
 import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import requestExternalAccess from '@automattic/request-external-access';
 import { Button, Path, Spinner, SVG } from '@wordpress/components';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { useCallback, useRef, useState } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
 import clsx from 'clsx';
@@ -13,12 +14,22 @@ import clsx from 'clsx';
  * Internal dependencies
  */
 import { config } from '../..';
-import { useIntegrationStatus } from '../../../blocks/contact-form/components/jetpack-integrations-modal/hooks/use-integration-status';
+import { INTEGRATIONS_STORE } from '../../../store/integrations';
 import { PARTIAL_RESPONSES_PATH } from '../../../util/get-preferred-responses-view';
+/**
+ * Internal dependencies
+ */
+import type { SelectIntegrations, IntegrationsDispatch } from '../../../store/integrations';
+import type { Integration } from '../../../types';
 
 const GoogleDriveExport = ( { onExport, autoConnect = false } ) => {
 	const [ isExporting, setIsExporting ] = useState( false );
-	const { integration, refreshStatus } = useIntegrationStatus( 'google-drive' );
+	const { integration } = useSelect( ( select: SelectIntegrations ) => {
+		const store = select( INTEGRATIONS_STORE );
+		const list = store.getIntegrations() || [];
+		return { integration: list.find( ( i: Integration ) => i.id === 'google-drive' ) };
+	}, [] ) as { integration?: Integration };
+	const { refreshIntegrations } = useDispatch( INTEGRATIONS_STORE ) as IntegrationsDispatch;
 	const isConnectedToGoogleDrive = !! integration?.isConnected;
 	const { tracks } = useAnalytics();
 	const autoConnectOpened = useRef( false );
@@ -58,12 +69,12 @@ const GoogleDriveExport = ( { onExport, autoConnect = false } ) => {
 		setIsTogglingConnection( true );
 		requestExternalAccess( integration?.settingsUrl, ( { keyring_id: keyringId } ) => {
 			if ( keyringId ) {
-				refreshStatus();
+				refreshIntegrations();
 			} else {
 				setIsTogglingConnection( false );
 			}
 		} );
-	}, [ tracks, integration?.settingsUrl, refreshStatus ] );
+	}, [ tracks, integration?.settingsUrl, refreshIntegrations ] );
 
 	if ( isOfflineMode ) {
 		return null;

--- a/projects/plugins/jetpack/changelog/update-forms-google-enabled-check
+++ b/projects/plugins/jetpack/changelog/update-forms-google-enabled-check
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: hide Google export card if disabled.


### PR DESCRIPTION
## Proposed changes:

As of this [PR](https://github.com/Automattic/jetpack/pull/45123), users can filter what integrations are enabled for Jetpack Forms. 

In CIAB, we disable most integrations, including Google Drive. We found that when Google Drive is disabled, we still show the Google Drive export card in the forms dashboard, but the export button is a never ending spinner since have a separate check just for the button. This PR uses the [new integrations store](https://github.com/Automattic/jetpack/pull/45372) to check if Google is enabled, and if not, hide that card. It also updates the check on the Export button to use the same store-based check (we could skip this check since the whole card is now hidden). 

**Before**
<img width="853" height="426" alt="google-drive-not-hidden" src="https://github.com/user-attachments/assets/c63fc07c-c7fc-4f3f-9f95-02e5e8cd2c98" />

**After**
<img width="850" height="246" alt="google-drive-hidden" src="https://github.com/user-attachments/assets/bac413f5-c912-411e-8762-42527bffebe7" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None. 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Test no regressions. 
* Go to Jetpack > Forms, click the Export button, and export your responses to Google. Everything should work as before. 

2. Test when Google is disabled. 
* Disable the Google Drive integrations by adding the snippet below.
* Go to Jetpack > Forms. Click the Export button in the upper right. Confirm that the Google export card no longer shows in the modal. 


```
add_filter( 'jetpack_forms_supported_integrations', function ( $integrations ) {
  unset( $integrations['google-drive'] ); // Hide Google Drive
  return $integrations;
} );
```
