### PR TITLE
Forms: Optimize inbox data loading with _fields parameter

### DIFF
--- a/projects/packages/forms/changelog/optimize-inbox-fields
+++ b/projects/packages/forms/changelog/optimize-inbox-fields
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Forms: optimize inbox data loading with _fields parameter to reduce payload size.

--- a/projects/packages/forms/src/dashboard/hooks/use-inbox-data.ts
+++ b/projects/packages/forms/src/dashboard/hooks/use-inbox-data.ts
@@ -47,6 +47,22 @@ interface UseInboxDataReturn {
 	filterOptions: Record< string, unknown >;
 }
 
+const RESPONSE_FIELDS = [
+	'id',
+	'status',
+	'date',
+	'date_gmt',
+	'author_name',
+	'author_email',
+	'author_url',
+	'author_avatar',
+	'ip',
+	'entry_title',
+	'entry_permalink',
+	'has_file',
+	'fields',
+].join( ',' );
+
 /**
  * Hook to get all inbox related data.
  *
@@ -73,7 +89,10 @@ export default function useInboxData(): UseInboxDataReturn {
 		isResolving: isLoadingRecordsData,
 		totalItems,
 		totalPages,
-	} = useEntityRecords( 'postType', 'feedback', currentQuery );
+	} = useEntityRecords( 'postType', 'feedback', {
+		...currentQuery,
+		_fields: RESPONSE_FIELDS,
+	} );
 
 	const records = ( rawRecords || [] ) as FormResponse[];
 


### PR DESCRIPTION
## Summary
Reduces payload size by explicitly requesting only required fields in the main inbox query.

## Changes
- Added `RESPONSE_FIELDS` constant with all needed fields
- Updated main `useEntityRecords` call to include `_fields` parameter

## Performance Impact
- Reduces response payload size
- Faster data transfer and parsing
- Particularly beneficial with large datasets


Before:

<img width="656" height="157" alt="Screenshot 2025-10-04 at 3 39 21 PM" src="https://github.com/user-attachments/assets/15adbae0-0a30-4e88-83af-c312ae7f947a" />

After:

<img width="656" height="155" alt="Screenshot 2025-10-04 at 3 38 42 PM" src="https://github.com/user-attachments/assets/dffcf97d-fa99-40d7-92a4-7e29c6b705c9" />

## Related
Main PR: https://github.com/Automattic/jetpack/pull/45339