### PR TITLE
Forms: Fix the loading state to prevent an empty state flash

### DIFF
--- a/projects/packages/forms/changelog/optimize-inbox-loading-state
+++ b/projects/packages/forms/changelog/optimize-inbox-loading-state
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Forms: improve loading state to show spinner immediately when data hasn't loaded.

--- a/projects/packages/forms/src/dashboard/hooks/use-inbox-data.ts
+++ b/projects/packages/forms/src/dashboard/hooks/use-inbox-data.ts
@@ -82,7 +82,7 @@ export default function useInboxData(): UseInboxDataReturn {
 
 	const {
 		records: rawRecords,
-		isResolving: isLoadingRecordsData,
+		hasResolved,
 		totalItems,
 		totalPages,
 	} = useEntityRecords( 'postType', 'feedback', {
@@ -131,12 +131,14 @@ export default function useInboxData(): UseInboxDataReturn {
 		[ countsQueryParams ]
 	);
 
+	const isLoadingData = ! rawRecords?.length && ! hasResolved;
+
 	return {
 		totalItemsInbox,
 		totalItemsSpam,
 		totalItemsTrash,
 		records,
-		isLoadingData: isLoadingRecordsData,
+		isLoadingData,
 		totalItems,
 		totalPages,
 		selectedResponsesCount,


### PR DESCRIPTION
## Summary
Improves loading state logic to show spinner immediately when data hasn't resolved yet, preventing empty state flash before data loads.

## Changes
- Changed loading condition from `isResolving` to `!rawRecords?.length && !hasResolved`
- Shows loading spinner immediately if no data and not yet resolved
- Prevents jarring empty state → loading → content transition

## UX Impact
- Smoother perceived performance
- No visual flash of empty state
- Loading spinner appears immediately when expected

## Related
Main PR: https://github.com/Automattic/jetpack/pull/45339