### PR TITLE
Forms: fix telephone country dropdown when selected

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-field-telephone-dropdown-z
+++ b/projects/packages/forms/changelog/fix-forms-field-telephone-dropdown-z
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: fix telephone field block country selector dropdown so it shows in front of other blocks while selected

--- a/projects/packages/forms/src/blocks/input-phone/editor.scss
+++ b/projects/packages/forms/src/blocks/input-phone/editor.scss
@@ -16,6 +16,7 @@
 		&.is-selected {
 			border-color: #2271b1;
 			box-shadow: 0 0 0 1px #2271b1;
+			z-index: 1;
 		}
 
 		// these class is used to style input and textarea elements


### PR DESCRIPTION


## Proposed changes:
This PR fixes a wee issue seen on some themes when the country dropdown is shown on the telephone field. The dropdown can show behind other content. The fix raises the z-index to 1 on the container div.

Before:
<img width="616" height="335" alt="image" src="https://github.com/user-attachments/assets/9a376a99-0ded-4b17-8189-85ee46d8e3d6" />


After:
<img width="634" height="398" alt="image" src="https://github.com/user-attachments/assets/d481086f-8df4-4516-bba1-c17be9d4bd7e" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Insert a telephone field block, open the country selector dropdown. Verify that it renders on top of other content.