### PR TITLE
My Jetpack: Prevent red bubble fatals when notification data is malformed

### DIFF
--- a/projects/packages/my-jetpack/changelog/fix-my-jetpack-red_bubble_fatals
+++ b/projects/packages/my-jetpack/changelog/fix-my-jetpack-red_bubble_fatals
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Prevent PHP errors when notification data is malformed.

--- a/projects/packages/my-jetpack/src/class-red-bubble-notifications.php
+++ b/projects/packages/my-jetpack/src/class-red-bubble-notifications.php
@@ -43,6 +43,9 @@ class Red_Bubble_Notifications {
 							'type' => 'string',
 						),
 						'sanitize_callback' => function ( $param ) {
+							if ( ! is_array( $param ) ) {
+								return array();
+							}
 							return array_map( 'sanitize_text_field', $param );
 						},
 					),


### PR DESCRIPTION
Closes MONOREP-131

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

There was a burst of these recently:
```
PHP Fatal error: Uncaught TypeError: array_map(): Argument #2 ($array) must be of type array, string given in /wordpress/plugins/jetpack/15.1-a.11/jetpack_vendor/automattic/jetpack-my-jetpack/src/class-red-bubble-notifications.php:46
```

This PR ensures the data is an array before trying to run `array_map()` on it.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

I suspect posting a string to `/wp-json/my-jetpack/v1/red-bubble-notifications` should trigger it, but I'm not familiar with the proper auth required to do a POST. As an aside, I'm not sure why this is using `WP_REST_Server::CREATABLE` instead of `WP_REST_Server::READABLE`...