### PR TITLE
Asset CDN: support badly formatted data returned by W.org

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-fatal-asset-cdn-remote
+++ b/projects/plugins/jetpack/changelog/fix-fatal-asset-cdn-remote
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Asset CDN: avoid errors when we do not receive valid information about a plugin from WordPress.org.

--- a/projects/plugins/jetpack/modules/photon-cdn.php
+++ b/projects/plugins/jetpack/modules/photon-cdn.php
@@ -294,8 +294,11 @@ class Jetpack_Photon_Static_Assets_CDN {
 		$body = json_decode( $body, true );
 
 		$return = time();
-		if ( is_array( $body ) ) {
-			$return = array_filter( array_keys( $body['files'] ), array( __CLASS__, 'is_js_or_css_file' ) );
+		if ( is_array( $body ) && isset( $body['files'] ) && is_array( $body['files'] ) ) {
+			$return = array_filter(
+				array_keys( $body['files'] ),
+				array( __CLASS__, 'is_js_or_css_file' )
+			);
 		}
 
 		$cache[ $plugin ]             = array();


### PR DESCRIPTION
Fixes #45386

## Proposed changes:

This should avoid errors like this one:

```
An error of type E_ERROR was caused in line 298 of the file wp-content/plugins/jetpack/modules/photon-cdn.php. Error message: Uncaught TypeError: array_keys(): Argument #1 ($array) must be of type array, null given in wp-content/plugins/jetpack/modules/photon-cdn.php:298
```

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?
* No

## Testing instructions:

This is not easy to reproduce, but I think a code review may be enough since this is just adding an extra check around the type of data we're processing.
