### PR TITLE
WooCommerce Analytics: Add JSON_HEX_TAG to wp_json_encode

### DIFF
--- a/projects/packages/woocommerce-analytics/changelog/update-save-wp-json-encode
+++ b/projects/packages/woocommerce-analytics/changelog/update-save-wp-json-encode
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Enhance JSON encoding by adding JSON_HEX_TAG and JSON_UNESCAPED_SLASHES options

--- a/projects/packages/woocommerce-analytics/src/class-universal.php
+++ b/projects/packages/woocommerce-analytics/src/class-universal.php
@@ -84,10 +84,10 @@ class Universal {
 				const wcAnalytics = window.wcAnalytics;
 
 				// Set common properties for all events.
-				wcAnalytics.commonProps = <?php echo wp_json_encode( $common_properties ); ?>;
+				wcAnalytics.commonProps = <?php echo wp_json_encode( $common_properties, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ); ?>;
 
 				// Set the event queue.
-				wcAnalytics.eventQueue = <?php echo wp_json_encode( WC_Analytics_Tracking::get_event_queue() ); ?>;
+				wcAnalytics.eventQueue = <?php echo wp_json_encode( WC_Analytics_Tracking::get_event_queue(), JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ); ?>;
 
 				// Features.
 				wcAnalytics.features = {
@@ -96,7 +96,7 @@ class Universal {
 					proxy: <?php echo $is_proxy_tracking_enabled ? 'true' : 'false'; ?>,
 				};
 
-				wcAnalytics.breadcrumbs = <?php echo wp_json_encode( $this->get_breadcrumb_titles() ); ?>;
+				wcAnalytics.breadcrumbs = <?php echo wp_json_encode( $this->get_breadcrumb_titles(), JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ); ?>;
 
 				// Page context flags.
 				wcAnalytics.pages = {

--- a/projects/packages/woocommerce-analytics/src/class-woo-analytics-trait.php
+++ b/projects/packages/woocommerce-analytics/src/class-woo-analytics-trait.php
@@ -90,7 +90,7 @@ trait Woo_Analytics_Trait {
 			$products[] = $data;
 		}
 
-		return wp_json_encode( $products );
+		return wp_json_encode( $products, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES );
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes WOOA7S-535

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

Add safe JSON encoding flags to inline script data that assigns to window.* globals and product prop, ensuring tags are hex-escaped while keeping slashes unescaped where appropriate.


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->


1. Go to your site frontend
2. Open the browser console and verify that the `window.wcAnalytics` exists and contains sensible data
3. Enable `window.localStorage.setItem( 'debug', 'wc-analytics*')` in the console and
4. Add a product to the cart and go to the checkout page
5. Verify that the `checkout_view` event is fired with the correct "products" property.

<img width="1168" height="427" alt="Screenshot 2025-10-07 at 14 20 59" src="https://github.com/user-attachments/assets/5151368b-7868-4ea4-91e2-43a12baaba7c" />

