### PR TITLE
Fix call to undefined method `WC_Tracks::get_server_details()`

### DIFF
--- a/projects/packages/woocommerce-analytics/changelog/fix-wc-analytics-undefined-methods
+++ b/projects/packages/woocommerce-analytics/changelog/fix-wc-analytics-undefined-methods
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix call to undefined method WC_Tracks::get_server_details()

--- a/projects/packages/woocommerce-analytics/src/class-wc-analytics-tracking.php
+++ b/projects/packages/woocommerce-analytics/src/class-wc-analytics-tracking.php
@@ -251,7 +251,7 @@ class WC_Analytics_Tracking extends WC_Tracks {
 			$data = parent::get_server_details();
 		} elseif ( method_exists( WC_Site_Tracking::class, 'get_server_details' ) ) {
 			// WC < 6.8
-			$data = WC_Site_Tracking::get_server_details();
+			$data = WC_Site_Tracking::get_server_details(); // @phan-suppress-current-line PhanUndeclaredStaticMethod -- method is available in WC < 6.8
 		}
 
 		return array_merge(
@@ -277,7 +277,7 @@ class WC_Analytics_Tracking extends WC_Tracks {
 			return parent::get_blog_details( $blog_id );
 		} elseif ( method_exists( WC_Site_Tracking::class, 'get_blog_details' ) ) {
 			// WC < 6.8
-			return WC_Site_Tracking::get_blog_details( $blog_id );
+			return WC_Site_Tracking::get_blog_details( $blog_id ); // @phan-suppress-current-line PhanUndeclaredStaticMethod -- method is available in WC < 6.8
 		}
 		return array();
 	}

--- a/projects/packages/woocommerce-analytics/src/class-wc-analytics-tracking.php
+++ b/projects/packages/woocommerce-analytics/src/class-wc-analytics-tracking.php
@@ -8,6 +8,7 @@
 namespace Automattic\Woocommerce_Analytics;
 
 use Automattic\Jetpack\Connection\Manager as Jetpack_Connection;
+use WC_Site_Tracking;
 use WC_Tracks;
 use WC_Tracks_Client;
 use WC_Tracks_Event;
@@ -244,7 +245,15 @@ class WC_Analytics_Tracking extends WC_Tracks {
 	 * @return array Server details.
 	 */
 	public static function get_server_details() {
-		$data = parent::get_server_details();
+		$data = array();
+
+		if ( method_exists( parent::class, 'get_server_details' ) ) {
+			$data = parent::get_server_details();
+		} elseif ( method_exists( WC_Site_Tracking::class, 'get_server_details' ) ) {
+			// WC < 6.8
+			$data = WC_Site_Tracking::get_server_details();
+		}
+
 		return array_merge(
 			$data,
 			array(
@@ -255,6 +264,22 @@ class WC_Analytics_Tracking extends WC_Tracks {
 				'_lg'      => isset( $_SERVER['HTTP_ACCEPT_LANGUAGE'] ) ? substr( sanitize_text_field( wp_unslash( $_SERVER['HTTP_ACCEPT_LANGUAGE'] ) ), 0, 5 ) : '',
 			)
 		);
+	}
+
+	/**
+	 * Get the blog details.
+	 *
+	 * @param int $blog_id The blog ID.
+	 * @return array The blog details.
+	 */
+	public static function get_blog_details( $blog_id ) {
+		if ( method_exists( parent::class, 'get_blog_details' ) ) {
+			return parent::get_blog_details( $blog_id );
+		} elseif ( method_exists( WC_Site_Tracking::class, 'get_blog_details' ) ) {
+			// WC < 6.8
+			return WC_Site_Tracking::get_blog_details( $blog_id );
+		}
+		return array();
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes p1759758124573359/1759158780.923629-slack-CK365S85V

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

Implement conditional checks for `get_server_details` and `get_blog_details` methods to support `WC_Site_Tracking` for versions below 6.8.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->


- Use WC 6.8 or moved `get_blog_details` and `get_session_details` methods from `‎woocommerce/includes/tracks/class-wc-tracks.php‎` to `‎woocommerce/includes/tracks/class-wc-site-tracking.php‎`
- Go to your site frontend and check that no errors are thrown.