### PR TITLE
Flex sites: Add is_wpcom_flex site flag in the API response

### DIFF
--- a/projects/plugins/jetpack/changelog/add-is-wpcom-flex-site
+++ b/projects/plugins/jetpack/changelog/add-is-wpcom-flex-site
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Flex sites: return the is_wpcom_flex flag from the sites API

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -99,6 +99,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'garden_name'                 => '(string) The name of the Garden site.',
 		'garden_partner'              => '(string) The partner of the Garden site.',
 		'garden_is_provisioned'       => '(bool) If the Garden site is provisioned.',
+		'is_wpcom_flex'               => '(bool) If the site is a Flex site',
 	);
 
 	/**
@@ -255,6 +256,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'garden_name',
 		'garden_partner',
 		'garden_is_provisioned',
+		'is_wpcom_flex',
 	);
 
 	/**
@@ -655,6 +657,10 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 			case 'garden_is_provisioned':
 				$response[ $key ] = $this->site->garden_is_provisioned();
 				break;
+			case 'is_wpcom_flex':
+				$response[ $key ] = $this->site->is_wpcom_flex();
+				break;
+			}
 		}
 
 		do_action( 'post_render_site_response_key', $key );

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -660,7 +660,6 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 			case 'is_wpcom_flex':
 				$response[ $key ] = $this->site->is_wpcom_flex();
 				break;
-			}
 		}
 
 		do_action( 'post_render_site_response_key', $key );

--- a/projects/plugins/jetpack/sal/class.json-api-site-base.php
+++ b/projects/plugins/jetpack/sal/class.json-api-site-base.php
@@ -1742,4 +1742,16 @@ abstract class SAL_Site {
 	public function garden_is_provisioned() {
 		return null;
 	}
+
+	/**
+	 * Detect whether the site is a Flex site.
+	 *
+	 * @return bool
+	 */
+	public function is_wpcom_flex() {
+		if ( function_exists( 'has_blog_sticker' ) ) {
+			return has_blog_sticker( 'flex-cache-site' );
+		}
+		return false;
+	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of DOTMART-18

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add the is_wpcom_flex field to the list of sites fields so that it could be used in various flows.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Follow the instructions from 106286-gh-Automattic/wp-calypso

