### PR TITLE
Help Center: Fix help Center package header

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-help-center-package
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-help-center-package
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Add plugin header to the Help Center plugin file

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/help-center.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/help-center.php
@@ -1,7 +1,9 @@
 <?php
 /**
- * Help center
- * This file is used to load the Help Center as a standalone plugin. It's not used by Jetpack.
+ * Plugin Name: Help Center
+ * Plugin URI: https://github.com/Automattic/jetpack/blob/trunk/projects/packages/jetpack-mu-wpcom/src/features/help-center
+ * Description: The Help Center is the main tool our customers use to reach for support.
+ * Text Domain: jetpack-mu-wpcom
  *
  * @package automattic/jetpack-mu-wpcom
  */

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/help-center.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/help-center.php
@@ -1,9 +1,10 @@
 <?php
 /**
- * Plugin Name: Help Center. This file is used to load the Help Center as a standalone plugin. It's not used by Jetpack.
+ * Plugin Name: Help Center
  * Plugin URI: https://github.com/Automattic/jetpack/blob/trunk/projects/packages/jetpack-mu-wpcom/src/features/help-center
- * Description: The Help Center is the main tool our customers use to reach for support.
+ * Description: It is how you reach support
  * Text Domain: jetpack-mu-wpcom
+ * Note: This file is used to load the Help Center as a standalone plugin. It's not used by Jetpack
  *
  * @package automattic/jetpack-mu-wpcom
  */

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/help-center.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/help-center.php
@@ -2,9 +2,9 @@
 /**
  * Plugin Name: Help Center
  * Plugin URI: https://github.com/Automattic/jetpack/blob/trunk/projects/packages/jetpack-mu-wpcom/src/features/help-center
- * Description: This plugin loads the Help Center. It is how you reach support
+ * Description: This plugin loads the Help Center. It is how you reach support.
  * Text Domain: jetpack-mu-wpcom
- * Note: This file is used to load the Help Center as a standalone plugin. It's not used by Jetpack
+ * Note: This file is used to load the Help Center as a standalone plugin. It's not used by Jetpack.
  *
  * @package automattic/jetpack-mu-wpcom
  */

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/help-center.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/help-center.php
@@ -1,9 +1,11 @@
 <?php
 /**
  * Plugin Name: Help Center
- * Plugin URI: https://github.com/Automattic/jetpack/blob/trunk/projects/packages/jetpack-mu-wpcom/src/features/help-center
  * Description: This plugin loads the Help Center. It is how you reach support.
  * Text Domain: jetpack-mu-wpcom
+ * Author: Automattic
+ * Author URI: https://automattic.com/
+ * Requires Plugins: jetpack
  * Note: This file is used to load the Help Center as a standalone plugin. It's not used by Jetpack.
  *
  * @package automattic/jetpack-mu-wpcom

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/help-center.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/help-center.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Help Center
  * Plugin URI: https://github.com/Automattic/jetpack/blob/trunk/projects/packages/jetpack-mu-wpcom/src/features/help-center
- * Description: It is how you reach support
+ * Description: This plugin loads the Help Center. It is how you reach support
  * Text Domain: jetpack-mu-wpcom
  * Note: This file is used to load the Help Center as a standalone plugin. It's not used by Jetpack
  *

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/help-center.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/help-center.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Plugin Name: Help Center
+ * Plugin Name: Help Center. This file is used to load the Help Center as a standalone plugin. It's not used by Jetpack.
  * Plugin URI: https://github.com/Automattic/jetpack/blob/trunk/projects/packages/jetpack-mu-wpcom/src/features/help-center
  * Description: The Help Center is the main tool our customers use to reach for support.
  * Text Domain: jetpack-mu-wpcom


### PR DESCRIPTION
Fixes DOTCOM-14886

## Proposed changes:
Turns out the plugin header comment is required for the plugin to be registered.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

