### PR TITLE
Charts: Specify the color for axis labels in the theme

### DIFF
--- a/projects/js-packages/charts/changelog/charts-127-specify-colors-for-woo-axis-and-legend-labels
+++ b/projects/js-packages/charts/changelog/charts-127-specify-colors-for-woo-axis-and-legend-labels
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Charts: Set the color of the axis labels via the theme

--- a/projects/js-packages/charts/src/providers/chart-context/themes.ts
+++ b/projects/js-packages/charts/src/providers/chart-context/themes.ts
@@ -24,6 +24,7 @@ const defaultTheme: CompleteChartTheme = {
 	seriesLineStyles: [],
 	legendShapeStyles: [],
 	glyphs: [],
+	svgLabelSmall: { fill: 'var(--jp-gray-80, #2c3338)' },
 	annotationStyles: {
 		label: {
 			anchorLineStroke: 'var(--jp-gray-80, #2c3338)',
@@ -82,6 +83,7 @@ const jetpackTheme: ChartTheme = {
 	legendLabelStyles: {
 		color: 'var(--jp-gray-80, #2c3338)',
 	},
+	svgLabelSmall: { fill: 'var(--jp-gray-80, #2c3338)' },
 	annotationStyles: {
 		label: {
 			anchorLineStroke: 'var(--jp-gray-80, #2c3338)',
@@ -141,6 +143,7 @@ const wooTheme: ChartTheme = {
 	tickLength: 4,
 	gridColor: '',
 	gridColorDark: '',
+	svgLabelSmall: { fill: '#757575' },
 	xTickLineStyles: { stroke: 'black' },
 	xAxisLineStyles: { stroke: '#DCDCDE', strokeWidth: 1 },
 	legendLabelStyles: {

--- a/projects/js-packages/charts/src/types.ts
+++ b/projects/js-packages/charts/src/types.ts
@@ -183,7 +183,7 @@ export type ChartTheme = {
 	legendLabelStyles?: CSSProperties;
 	/** Styles for legend container */
 	legendContainerStyles?: CSSProperties;
-	/** Styles for the axis labels */
+	/** Styles for small SVG text (eg. axis tick labels), passed through to the XYChart theme. */
 	svgLabelSmall?: TextProps;
 	annotationStyles?: AnnotationStyles;
 	/** LeaderboardChart specific settings */

--- a/projects/js-packages/charts/src/types.ts
+++ b/projects/js-packages/charts/src/types.ts
@@ -5,6 +5,7 @@ import type { LineSubjectProps } from '@visx/annotation/lib/components/LineSubje
 import type { AxisScale, Orientation, TickFormatter, AxisRendererProps } from '@visx/axis';
 import type { LegendShape } from '@visx/legend/lib/types';
 import type { ScaleInput, ScaleType } from '@visx/scale';
+import type { TextProps } from '@visx/text/lib/Text';
 import type { EventHandlerParams, GlyphProps, GridStyles, LineStyles } from '@visx/xychart';
 import type { CSSProperties, PointerEvent, ReactNode } from 'react';
 
@@ -182,6 +183,8 @@ export type ChartTheme = {
 	legendLabelStyles?: CSSProperties;
 	/** Styles for legend container */
 	legendContainerStyles?: CSSProperties;
+	/** Styles for the axis labels */
+	svgLabelSmall?: TextProps;
 	annotationStyles?: AnnotationStyles;
 	/** LeaderboardChart specific settings */
 	leaderboardChart?: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes [CHARTS-127: Specify colors for Woo axis and legend labels](https://linear.app/a8c/issue/CHARTS-127/specify-colors-for-woo-axis-and-legend-labels)

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds the `svgLabelSmall` property to the theme, which is passed to the XYChart theme, and controls the color of the text elements in the axis label svg
* Sets the color for each theme to match designs and other colors 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Axis labels are rendered for several charts:

1. http://localhost:50240/?path=/story/js-packages-charts-types-bar-chart--with-legend
2. http://localhost:50240/?path=/story/js-packages-charts-types-bar-list-chart--default
4. http://localhost:50240/?path=/story/js-packages-charts-types-line-chart--with-legend

For each:
* Inspect the axis labels and ensure they use the color specified in the theme (jetpack: var(--jp-gray-80, #2c3338), woo: #757575)
* If there is a legend, check that the text in the legend items is the same color
* Switch theme and check again
