### PR TITLE
Boost: Add compatibility with Revslider when Defer JS is on

### DIFF
--- a/projects/plugins/boost/changelog/add-boost-revslider-exclude-defer-js
+++ b/projects/plugins/boost/changelog/add-boost-revslider-exclude-defer-js
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Defer JS: Exclude Slider Revolution scripts to avoid broken sliders.

--- a/projects/plugins/boost/compatibility/revslider.php
+++ b/projects/plugins/boost/compatibility/revslider.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Compatibility for Revolution Slider
+ *
+ * @package automattic/jetpack-boost
+ */
+
+namespace Automattic\Jetpack_Boost\Compatibility\Revslider;
+
+/**
+ * Exclude Revolution Slider scripts from deferred JS.
+ * We can't use handles, since revslider doesn't have a standartized naming convention.
+ *
+ * @param array $scripts The scripts to exclude.
+ * @return array The scripts to exclude.
+ */
+function exclude_revslider_scripts( $scripts ) {
+	// Don't check scripts if Revolution Slider isn't active.
+	if ( ! class_exists( '\RevSliderFront' ) ) {
+		return $scripts;
+	}
+
+	// Filter out any revslider scripts
+	$scripts = array_filter(
+		$scripts,
+		function ( $script ) {
+			// Check if it's a script tag and contains revslider
+			if ( is_array( $script ) && isset( $script[0] ) && strpos( $script[0], '<script' ) !== false ) {
+				return strpos( $script[0], '/revslider/' ) === false;
+			}
+			return true;
+		}
+	);
+
+	return $scripts;
+}
+
+add_filter( 'jetpack_boost_render_blocking_js_exclude_scripts', __NAMESPACE__ . '\exclude_revslider_scripts', 10, 1 );

--- a/projects/plugins/boost/compatibility/revslider.php
+++ b/projects/plugins/boost/compatibility/revslider.php
@@ -9,7 +9,7 @@ namespace Automattic\Jetpack_Boost\Compatibility\Revslider;
 
 /**
  * Exclude Revolution Slider scripts from deferred JS.
- * We can't use handles, since revslider doesn't have a standartized naming convention.
+ * We can't use handles, since revslider doesn't have a standardized naming convention.
  *
  * @param array $scripts The scripts to exclude.
  * @return array The scripts to exclude.
@@ -32,7 +32,7 @@ function exclude_revslider_scripts( $scripts ) {
 		}
 	);
 
-	return $scripts;
+	return array_values( $scripts );
 }
 
 add_filter( 'jetpack_boost_render_blocking_js_exclude_scripts', __NAMESPACE__ . '\exclude_revslider_scripts', 10, 1 );

--- a/projects/plugins/boost/jetpack-boost.php
+++ b/projects/plugins/boost/jetpack-boost.php
@@ -256,6 +256,8 @@ function include_compatibility_files() {
 
 	// Migrate from WP Super Cache
 	require_once __DIR__ . '/compatibility/wp-super-cache-migration.php';
+
+	require_once __DIR__ . '/compatibility/revslider.php';
 }
 
 add_action( 'plugins_loaded', __NAMESPACE__ . '\include_compatibility_files' );


### PR DESCRIPTION
Fixes HOG-371

## Proposed changes:

* Exclude scripts belonging to Revslider to prevent Defer JS from breaking its sliders.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

p1759890777636929-slack-C016BBAFHHS

## Does this pull request change what data or activity we track or use?

no

## Testing instructions:

### Test that it's broken

- Setup Boost from trunk/production;
- add revslider to your site;
- create a slider and add it to a page;
- enable Defer JS;
- visit page - slider should be broken.

### Test that it works

- Repeat the above steps but with Boost from this branch and the slider shouldn't be broken.