### PR TITLE
Update wpcomsh to use wc-calypso-bridge 2.11.3

### DIFF
--- a/projects/plugins/wpcomsh/changelog/update-wpcomsh-to-use-wc-calypso-bridge-2.11.3
+++ b/projects/plugins/wpcomsh/changelog/update-wpcomsh-to-use-wc-calypso-bridge-2.11.3
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+Update wc-calypso-bridge from 2.11.2 to 2.11.3

--- a/projects/plugins/wpcomsh/composer.json
+++ b/projects/plugins/wpcomsh/composer.json
@@ -9,7 +9,7 @@
 		"automattic/custom-fonts": "^3.0",
 		"automattic/custom-fonts-typekit": "^2.0",
 		"automattic/text-media-widget-styles": "^2.0",
-		"automattic/wc-calypso-bridge": "2.11.2",
+		"automattic/wc-calypso-bridge": "2.11.3",
 		"wordpress/classic-editor-plugin": "1.6.7",
 		"automattic/jetpack-autoloader": "@dev",
 		"automattic/jetpack-composer-plugin": "@dev",

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "26335f6723fffa1b26ae5a942697dee3",
+    "content-hash": "73f7b19533abcfcc07b1cffb4e24411d",
     "packages": [
         {
             "name": "automattic/at-pressable-podcasting",
@@ -2113,16 +2113,16 @@
         },
         {
             "name": "automattic/wc-calypso-bridge",
-            "version": "v2.11.2",
+            "version": "v2.11.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/wc-calypso-bridge.git",
-                "reference": "58a48bf01ae28a4c974bdcc0449733f03b2326de"
+                "reference": "5b82125fbb5aed63c84bba2e7e2bebcae17a24db"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/wc-calypso-bridge/zipball/58a48bf01ae28a4c974bdcc0449733f03b2326de",
-                "reference": "58a48bf01ae28a4c974bdcc0449733f03b2326de",
+                "url": "https://api.github.com/repos/Automattic/wc-calypso-bridge/zipball/5b82125fbb5aed63c84bba2e7e2bebcae17a24db",
+                "reference": "5b82125fbb5aed63c84bba2e7e2bebcae17a24db",
                 "shasum": ""
             },
             "require-dev": {
@@ -2164,7 +2164,7 @@
             "license": [
                 "GPL-2.0-or-later"
             ],
-            "time": "2025-07-22T10:34:27+00:00"
+            "time": "2025-10-08T10:52:37+00:00"
         },
         {
             "name": "scssphp/scssphp",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes [DOTDEV-127](https://linear.app/a8c/issue/DOTDEV-127/dotcom-nmit-7-woocommerce-coming-soon-mode-overrides-wordpresscom-un)
Relates to https://github.com/Automattic/wc-calypso-bridge/pull/1579

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR updates wc-calypso-bridge from 2.11.2 to 2.11.3 to pick up the changes documented in https://github.com/Automattic/wc-calypso-bridge/pull/1578.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* [Apply this patch on a Jetpack Atomic Business site](https://github.com/Automattic/jetpack/pull/45409#issuecomment-3381058400)
* Make sure the site is not launched yet (coming soon).
* Install the WooCommerce plugin.
* Go to WooCommerce -> Settings -> Site visibility and make sure `Apply to store pages only` is off.
* Log out and go to the homepage of the site.
* You should see the global Woo coming soon page.

<img width="690" height="287" alt="image" src="https://github.com/user-attachments/assets/9337a81b-9ba6-44ce-b0b8-24140be43b89" />

<img width="1022" height="556" alt="image" src="https://github.com/user-attachments/assets/070e6201-6cdc-4e9d-985b-5fa7851d8fe8" />

