### PR TITLE
Forms: fix sticky loading state for trash view action

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-view-actions-trash-loading
+++ b/projects/packages/forms/changelog/fix-forms-view-actions-trash-loading
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: fix sticky loading state for trash view action

--- a/projects/packages/forms/src/dashboard/inbox/response.js
+++ b/projects/packages/forms/src/dashboard/inbox/response.js
@@ -251,7 +251,7 @@ const InboxResponse = ( {
 	const handleMoveToTrash = useCallback( async () => {
 		setIsMovingToTrash( true );
 		await moveToTrashAction.callback( [ response ], { registry } );
-		setIsMovingToTrash( true );
+		setIsMovingToTrash( false );
 		onActionComplete?.( response.id.toString() );
 	}, [ response, registry, onActionComplete ] );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes small issue with loading state staying visible when trashing items:
- https://github.com/Automattic/jetpack/pull/45352

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* fix loading state

<img width="344" height="92" alt="Screenshot 2025-10-08 at 16 21 55" src="https://github.com/user-attachments/assets/6ba0545b-ce1c-468c-8bf6-1bba2d0d574a" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* In Jetpack -> Forms, open one response
* In response sidebar, click trash
* Before it would continue look like loading but it actually finished already. Now it finishes loading.