### PR TITLE
Connection: add support for granular error logs in external storage

### DIFF
--- a/projects/packages/connection/changelog/update-external-storage-error-loging
+++ b/projects/packages/connection/changelog/update-external-storage-error-loging
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated error logging for external storage

--- a/projects/packages/connection/src/class-external-storage.php
+++ b/projects/packages/connection/src/class-external-storage.php
@@ -201,6 +201,7 @@ class External_Storage {
 		// Check if provider implements per-option reporting (optional method not defined in interface).
 		// Providers can optionally implement: public function should_report_errors_for( $option_name )
 		if ( null !== $provider && method_exists( $provider, 'should_report_errors_for' ) && ! empty( $key ) ) {
+			// @phan-suppress-next-line PhanUndeclaredMethodInCallable - Optional method, checked via method_exists()
 			return call_user_func( array( $provider, 'should_report_errors_for' ), $key );
 		}
 

--- a/projects/packages/connection/src/class-external-storage.php
+++ b/projects/packages/connection/src/class-external-storage.php
@@ -154,10 +154,10 @@ class External_Storage {
 
 		if ( 'error' === $event_type ) {
 			// Report external storage errors for supported environments
-			$should_report_remote = self::should_report_for_environment();
+			$should_report_remote = self::should_report_for_environment( $key );
 		} elseif ( 'empty' === $event_type ) {
 			// Use delay mechanism to distinguish disconnection from a delay
-			$should_report_remote = self::should_report_for_environment() && self::should_report_empty_state( $key );
+			$should_report_remote = self::should_report_for_environment( $key ) && self::should_report_empty_state( $key );
 		}
 
 		if ( ! $should_report_remote || ! class_exists( 'Automattic\Jetpack\Connection\Error_Handler' ) ) {
@@ -188,15 +188,33 @@ class External_Storage {
 
 	/**
 	 * Determine if the current environment should report external storage errors to WordPress.com.
-	 * Allows wpcomsh and other environments to control remote error reporting independently.
+	 * Allows providers to control remote error reporting per-option via optional should_report_errors_for() method.
 	 *
 	 * @since 6.18.0
 	 *
+	 * @param string $key The option key being accessed.
 	 * @return bool True if this environment should report external storage errors to WordPress.com.
 	 */
-	private static function should_report_for_environment() {
-		if ( defined( 'JETPACK_EXTERNAL_STORAGE_REPORTING_ENABLED' ) && constant( 'JETPACK_EXTERNAL_STORAGE_REPORTING_ENABLED' ) ) {
-			return true;
+	private static function should_report_for_environment( $key = '' ) {
+		$provider = self::$provider;
+
+		// Check if provider implements per-option reporting (optional method not defined in interface).
+		// Providers can optionally implement: public function should_report_errors_for( $option_name )
+		if ( null !== $provider && method_exists( $provider, 'should_report_errors_for' ) && ! empty( $key ) ) {
+			return call_user_func( array( $provider, 'should_report_errors_for' ), $key );
+		}
+
+		// Deprecated: JETPACK_EXTERNAL_STORAGE_REPORTING_ENABLED constant
+		// @deprecated $$next-version$$ Use should_report_errors_for() method in your Storage Provider instead.
+		if ( defined( 'JETPACK_EXTERNAL_STORAGE_REPORTING_ENABLED' ) ) {
+			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+				trigger_error(
+					'JETPACK_EXTERNAL_STORAGE_REPORTING_ENABLED constant is deprecated. Implement should_report_errors_for() method in your Storage Provider instead.',
+					E_USER_DEPRECATED
+				);
+			}
+			return (bool) constant( 'JETPACK_EXTERNAL_STORAGE_REPORTING_ENABLED' );
 		}
 
 		return false;


### PR DESCRIPTION
Minor update to error logging in the external storage class. The error logging hasn't been used so far.

The change allows specifying which options should report errors instead of using a constant that enables error reporting for all.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to CONNECT-81

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Code review
