### PR TITLE
WPCOMSH: Added missing WPCOM feature checks on theme API functions on Atomic

### DIFF
--- a/projects/plugins/wpcomsh/changelog/dotthem-98-theme-tiers-exclude-unavailable-dotcom-themes-from-the-wp
+++ b/projects/plugins/wpcomsh/changelog/dotthem-98-theme-tiers-exclude-unavailable-dotcom-themes-from-the-wp
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+Added missing WPCOM feature checks on theme API functions on Atomic.

--- a/projects/plugins/wpcomsh/wpcom-themes/includes/class-wpcom-themes-merger.php
+++ b/projects/plugins/wpcomsh/wpcom-themes/includes/class-wpcom-themes-merger.php
@@ -59,8 +59,8 @@ class WPCom_Themes_Merger {
 	 * @return stdClass The themes API result including wpcom themes.
 	 */
 	public function merge_by_release_date( stdClass $wporg_themes_object, array $wpcom_themes ): stdClass {
-		$last_theme_date  = strtotime( end( $wporg_themes_object->themes )->creation_time );
-		$first_theme_date = strtotime( reset( $wporg_themes_object->themes )->creation_time );
+		$last_theme_date  = strtotime( end( $wporg_themes_object->themes )?->creation_time ?? '2000-01-01' );
+		$first_theme_date = strtotime( reset( $wporg_themes_object->themes )?->creation_time ?? gmdate( 'Y-m-d' ) );
 
 		$themes = array();
 		foreach ( $wporg_themes_object->themes as $wporg_theme ) {

--- a/projects/plugins/wpcomsh/wpcom-themes/includes/class-wpcom-themes-merger.php
+++ b/projects/plugins/wpcomsh/wpcom-themes/includes/class-wpcom-themes-merger.php
@@ -14,7 +14,7 @@ class WPCom_Themes_Merger {
 	 * Merges themes prioritizing WPCom themes.
 	 *
 	 * @param stdClass $wporg_themes_object The WP.org themes API result.
-	 * @param array    $wpcom_themes The WP.com themes to include.
+	 * @param array    $wpcom_themes        The WP.com themes to include.
 	 *
 	 * @return stdClass The themes API result including wpcom themes.
 	 */
@@ -24,7 +24,7 @@ class WPCom_Themes_Merger {
 		// Create an associative array with theme slugs as keys for quick lookup
 		$wpcom_theme_slugs = array_flip(
 			array_map(
-				fn( $theme ) => $theme->slug,
+				fn ( $theme ) => $theme->slug,
 				$wpcom_themes
 			)
 		);
@@ -54,7 +54,7 @@ class WPCom_Themes_Merger {
 	 * Merge themes by release date with no particular bias.
 	 *
 	 * @param stdClass $wporg_themes_object The WP.org themes API result.
-	 * @param array    $wpcom_themes The WP.com themes to include.
+	 * @param array    $wpcom_themes        The WP.com themes to include.
 	 *
 	 * @return stdClass The themes API result including wpcom themes.
 	 */

--- a/projects/plugins/wpcomsh/wpcom-themes/includes/class-wpcom-themes-merger.php
+++ b/projects/plugins/wpcomsh/wpcom-themes/includes/class-wpcom-themes-merger.php
@@ -14,24 +14,17 @@ class WPCom_Themes_Merger {
 	 * Merges themes prioritizing WPCom themes.
 	 *
 	 * @param stdClass $wporg_themes_object The WP.org themes API result.
-	 * @param array    $wpcom_themes        The WP.com themes to include.
+	 * @param array    $wpcom_themes The WP.com themes to include.
 	 *
 	 * @return stdClass The themes API result including wpcom themes.
 	 */
 	public function merge_by_wpcom_first( stdClass $wporg_themes_object, array $wpcom_themes ): stdClass {
-		// If the site doesn't have the COMMUNITY_THEMES feature, skip merging and return only WPCom themes
-		if ( ! wpcom_site_has_feature( WPCOM_Features::COMMUNITY_THEMES ) ) {
-			$wporg_themes_object->info['results'] = count( $wpcom_themes );
-			$wporg_themes_object->themes          = $wpcom_themes;
-			return $wporg_themes_object;
-		}
-
 		$wporg_themes_excluding_wpcom = array();
 
 		// Create an associative array with theme slugs as keys for quick lookup
 		$wpcom_theme_slugs = array_flip(
 			array_map(
-				fn ( $theme ) => $theme->slug,
+				fn( $theme ) => $theme->slug,
 				$wpcom_themes
 			)
 		);
@@ -61,18 +54,11 @@ class WPCom_Themes_Merger {
 	 * Merge themes by release date with no particular bias.
 	 *
 	 * @param stdClass $wporg_themes_object The WP.org themes API result.
-	 * @param array    $wpcom_themes        The WP.com themes to include.
+	 * @param array    $wpcom_themes The WP.com themes to include.
 	 *
 	 * @return stdClass The themes API result including wpcom themes.
 	 */
 	public function merge_by_release_date( stdClass $wporg_themes_object, array $wpcom_themes ): stdClass {
-		// If the site doesn't have the COMMUNITY_THEMES feature, skip merging and return only WPCom themes
-		if ( ! wpcom_site_has_feature( WPCOM_Features::COMMUNITY_THEMES ) ) {
-			$wporg_themes_object->info['results'] = count( $wpcom_themes );
-			$wporg_themes_object->themes          = $wpcom_themes;
-			return $wporg_themes_object;
-		}
-
 		$last_theme_date  = strtotime( end( $wporg_themes_object->themes )->creation_time );
 		$first_theme_date = strtotime( reset( $wporg_themes_object->themes )->creation_time );
 

--- a/projects/plugins/wpcomsh/wpcom-themes/includes/class-wpcom-themes-merger.php
+++ b/projects/plugins/wpcomsh/wpcom-themes/includes/class-wpcom-themes-merger.php
@@ -19,6 +19,13 @@ class WPCom_Themes_Merger {
 	 * @return stdClass The themes API result including wpcom themes.
 	 */
 	public function merge_by_wpcom_first( stdClass $wporg_themes_object, array $wpcom_themes ): stdClass {
+		// If the site doesn't have the COMMUNITY_THEMES feature, skip merging and return only WPCom themes
+		if ( ! wpcom_site_has_feature( WPCOM_Features::COMMUNITY_THEMES ) ) {
+			$wporg_themes_object->info['results'] = count( $wpcom_themes );
+			$wporg_themes_object->themes          = $wpcom_themes;
+			return $wporg_themes_object;
+		}
+
 		$wporg_themes_excluding_wpcom = array();
 
 		// Create an associative array with theme slugs as keys for quick lookup
@@ -59,6 +66,13 @@ class WPCom_Themes_Merger {
 	 * @return stdClass The themes API result including wpcom themes.
 	 */
 	public function merge_by_release_date( stdClass $wporg_themes_object, array $wpcom_themes ): stdClass {
+		// If the site doesn't have the COMMUNITY_THEMES feature, skip merging and return only WPCom themes
+		if ( ! wpcom_site_has_feature( WPCOM_Features::COMMUNITY_THEMES ) ) {
+			$wporg_themes_object->info['results'] = count( $wpcom_themes );
+			$wporg_themes_object->themes          = $wpcom_themes;
+			return $wporg_themes_object;
+		}
+
 		$last_theme_date  = strtotime( end( $wporg_themes_object->themes )->creation_time );
 		$first_theme_date = strtotime( reset( $wporg_themes_object->themes )->creation_time );
 

--- a/projects/plugins/wpcomsh/wpcom-themes/includes/class-wpcom-themes-service.php
+++ b/projects/plugins/wpcomsh/wpcom-themes/includes/class-wpcom-themes-service.php
@@ -32,16 +32,6 @@ class WPCom_Themes_Service {
 	private WPCom_Themes_Merger $merger;
 
 	/**
-	 * Valid theme tiers for Atomic sites.
-	 */
-	private const VALID_THEME_TIERS = array(
-		'free',
-		'premium',
-		'personal',
-		'woocommerce',
-	);
-
-	/**
 	 * Class constructor.
 	 *
 	 * @param WPCom_Themes_Api    $api    The WordPress.com themes API.

--- a/projects/plugins/wpcomsh/wpcom-themes/includes/class-wpcom-themes-service.php
+++ b/projects/plugins/wpcomsh/wpcom-themes/includes/class-wpcom-themes-service.php
@@ -97,7 +97,13 @@ class WPCom_Themes_Service {
 	protected function map_and_filter_wpcom_themes( array $wpcom_themes ): array {
 		$themes = array();
 		foreach ( $wpcom_themes as $theme ) {
-			if ( $this->has_valid_theme_tier( $theme ) ) {
+			$theme_tier         = $theme->theme_tier->slug ?? '';
+			$theme_tier_feature = $theme_tier . '-themes';
+
+			if (
+				$theme_tier === 'free' ||
+				( $this->has_valid_theme_tier( $theme ) && wpcom_site_has_feature( $theme_tier_feature ) )
+			) {
 				$themes[] = $this->mapper->map_wpcom_to_wporg( $theme );
 			}
 		}

--- a/projects/plugins/wpcomsh/wpcom-themes/includes/class-wpcom-themes-service.php
+++ b/projects/plugins/wpcomsh/wpcom-themes/includes/class-wpcom-themes-service.php
@@ -106,7 +106,7 @@ class WPCom_Themes_Service {
 		$tier               = $theme->theme_tier->slug ?? 'premium';
 		$theme_tier_feature = $tier . '-themes';
 
-		return $tier === 'free' || wpcom_site_has_feature( $theme_tier_feature );
+		return $tier !== 'partner' && ( $tier === 'free' || wpcom_site_has_feature( $theme_tier_feature ) );
 	}
 
 	/**

--- a/projects/plugins/wpcomsh/wpcom-themes/includes/class-wpcom-themes-service.php
+++ b/projects/plugins/wpcomsh/wpcom-themes/includes/class-wpcom-themes-service.php
@@ -97,13 +97,7 @@ class WPCom_Themes_Service {
 	protected function map_and_filter_wpcom_themes( array $wpcom_themes ): array {
 		$themes = array();
 		foreach ( $wpcom_themes as $theme ) {
-			$theme_tier         = $theme->theme_tier->slug ?? '';
-			$theme_tier_feature = $theme_tier . '-themes';
-
-			if (
-				$theme_tier === 'free' ||
-				( $this->has_valid_theme_tier( $theme ) && wpcom_site_has_feature( $theme_tier_feature ) )
-			) {
+			if ( $this->has_valid_theme_tier( $theme ) ) {
 				$themes[] = $this->mapper->map_wpcom_to_wporg( $theme );
 			}
 		}
@@ -119,9 +113,10 @@ class WPCom_Themes_Service {
 	 * @return bool True if the theme has a valid tier, false otherwise.
 	 */
 	protected function has_valid_theme_tier( stdClass $theme ): bool {
-		$tier = $theme->theme_tier->slug ?? false;
+		$tier               = $theme->theme_tier->slug ?? 'premium';
+		$theme_tier_feature = $tier . '-themes';
 
-		return in_array( $tier, self::VALID_THEME_TIERS, true );
+		return $tier === 'free' || wpcom_site_has_feature( $theme_tier_feature );
 	}
 
 	/**

--- a/projects/plugins/wpcomsh/wpcom-themes/themes.php
+++ b/projects/plugins/wpcomsh/wpcom-themes/themes.php
@@ -34,6 +34,23 @@ function wpcomsh_get_wpcom_themes_service_instance(): WPCom_Themes_Service {
 }
 
 /**
+ * Perform necessary checks to remove dot org themes based on the plan and other features.
+ *
+ * @param mixed $res The result object.
+ *
+ * @return mixed|stdClass
+ */
+function wpcomsh_remove_dot_org_themes_based_on_plan( $res ) {
+	if ( ! wpcom_site_has_feature( WPCOM_Features::COMMUNITY_THEMES ) ) {
+		$res->info['results'] = 0;
+		$res->themes          = array();
+	}
+
+	return $res;
+}
+add_filter( 'themes_api_result', 'wpcomsh_remove_dot_org_themes_based_on_plan', 0, 1 );
+
+/**
  * Process the themes API result and add the recommended WPCom themes to the Popular tab.
  *
  * @param mixed  $res    The result object.
@@ -54,7 +71,7 @@ function wpcomsh_popular_wpcom_themes_api_result( $res, string $action, $args ) 
 	// Add results to the resulting array.
 	return $wpcom_themes_service->filter_themes_api_result_recommended( $res );
 }
-add_filter( 'themes_api_result', 'wpcomsh_popular_wpcom_themes_api_result', 0, 3 );
+add_filter( 'themes_api_result', 'wpcomsh_popular_wpcom_themes_api_result', 1, 3 );
 
 /**
  * Process the themes API result and add the latest WPCom themes to the Latest tab.
@@ -77,7 +94,7 @@ function wpcomsh_latest_wpcom_themes_api_result( $res, string $action, $args ) {
 	// Add results to the resulting array.
 	return $wpcom_themes_service->filter_themes_api_result_latest( $res );
 }
-add_filter( 'themes_api_result', 'wpcomsh_latest_wpcom_themes_api_result', 0, 3 );
+add_filter( 'themes_api_result', 'wpcomsh_latest_wpcom_themes_api_result', 1, 3 );
 
 /**
  * Process the themes API result and add the WPCom block themes to the Block themes tab.
@@ -100,7 +117,7 @@ function wpcomsh_block_themes_wpcom_themes_api_result( $res, string $action, $ar
 	// Add results to the resulting array.
 	return $wpcom_themes_service->filter_themes_api_result_block_themes( $res );
 }
-add_filter( 'themes_api_result', 'wpcomsh_block_themes_wpcom_themes_api_result', 0, 3 );
+add_filter( 'themes_api_result', 'wpcomsh_block_themes_wpcom_themes_api_result', 1, 3 );
 
 /**
  * Process the themes API result and add WPCom themes when using the search.
@@ -123,7 +140,7 @@ function wpcomsh_search_wpcom_themes_api_result( $res, string $action, $args ) {
 	// Add results to the resulting array.
 	return $wpcom_themes_service->filter_themes_api_result_search( $res, $search );
 }
-add_filter( 'themes_api_result', 'wpcomsh_search_wpcom_themes_api_result', 0, 3 );
+add_filter( 'themes_api_result', 'wpcomsh_search_wpcom_themes_api_result', 1, 3 );
 
 /**
  * Process the themes API result and add WPCom themes when using the filter feature.
@@ -150,7 +167,7 @@ function wpcomsh_feature_filter_wpcom_themes_api_result( $res, string $action, $
 	// Add results to the resulting array.
 	return $wpcom_themes_service->filter_themes_api_result_feature_filter( $res, $tags );
 }
-add_filter( 'themes_api_result', 'wpcomsh_feature_filter_wpcom_themes_api_result', 0, 3 );
+add_filter( 'themes_api_result', 'wpcomsh_feature_filter_wpcom_themes_api_result', 1, 3 );
 
 /**
  * Process the themes API result theme_information for WPCom themes if needed.
@@ -171,7 +188,7 @@ function wpcomsh_theme_information_wpcom_themes_api_result( $res, string $action
 
 	return $wpcom_themes_service->get_theme( $args->slug ) ?? $res;
 }
-add_filter( 'themes_api_result', 'wpcomsh_theme_information_wpcom_themes_api_result', 0, 3 );
+add_filter( 'themes_api_result', 'wpcomsh_theme_information_wpcom_themes_api_result', 1, 3 );
 
 /**
  * Remove the WP_Error object from the WP_Error object.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes DOTTHEM-94, DOTTHEM-98

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add WPCOM_Features checks on Dotcom themes, so that only those allowed on a site will be listed in theme-install.php.
* Stop showing Dotorg themes on sites without the `COMMUNITY_THEMES` feature.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a Dotcom site on the Personal plan.
* Install the [Jetpack Beta plugin](https://jetpack.com/download-jetpack-beta/).
* Enter Jetpack → Jetpack Beta, select WordPress.com Site Helper, and enable the `dotthem-98-theme-tiers-exclude-unavailable-dotcom-themes-from-the-wp` branch.
* Navigate to Appearance → Themes.
* Confirm that there are no Dotorg themes (Community tier) in the list.
    * Try searching for Astra.
* Confirm that there are no Dotcom themes unavailable to the Personal plan (no themes of tier Premium, Partner, WooCommerce, Sensei).
    * Try searching for Patisserie (Premium theme).
    * Try searching for SolarOne (Partner theme).
    * Try searching for Tsubaki (WooCommerce theme).
    * Try searching for Course (Sensei theme).
* Repeat the test on a Business site.
* Confirm that Dotorg themes (Community tier) are listed.
* Confirm that all Dotcom themes are listed, with the exception of Partner themes, which can only be purchased on the Calypso Theme Showcase.