### PR TITLE
wpsh: Enable error reporting for APD

### DIFF
--- a/projects/plugins/wpcomsh/changelog/add-wpcomsh-apd-error-logging
+++ b/projects/plugins/wpcomsh/changelog/add-wpcomsh-apd-error-logging
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Enabled APD error reporting

--- a/projects/plugins/wpcomsh/connection/class-atomic-storage-provider.php
+++ b/projects/plugins/wpcomsh/connection/class-atomic-storage-provider.php
@@ -58,6 +58,22 @@ if ( interface_exists( 'Automattic\Jetpack\Connection\Storage_Provider_Interface
 		}
 
 		/**
+		 * Determine if errors should be reported for this option.
+		 *
+		 * Only report errors for critical connection options (blog_token and id).
+		 * This enables selective error reporting to WordPress.com for specific options.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param string $option_name The option name to check.
+		 * @return bool True if errors should be reported for this option.
+		 */
+		public function should_report_errors_for( $option_name ) {
+			// Only report errors for blog_token and id (blog_id)
+			return in_array( $option_name, array( 'blog_token', 'id' ), true );
+		}
+
+		/**
 		 * Get environment identifier for logging.
 		 *
 		 * @return string Environment identifier.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Enables error reporting for missing blog ID and token values in APD.
Can be merged after https://github.com/Automattic/jetpack/pull/45412 is deployed to Atomic.

Closes CONNECT-81

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Code review

