### PR TITLE
Global Styles: Move frontend notice from launch bar to admin bar

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/dotthem-96-limited-global-styles-show-upsell-on-the-front-end-on-atomic
+++ b/projects/packages/jetpack-mu-wpcom/changelog/dotthem-96-limited-global-styles-show-upsell-on-the-front-end-on-atomic
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Global Styles: Move frontend notice from launch bar to admin bar

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/index.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/index.php
@@ -227,6 +227,10 @@ add_action( 'enqueue_block_editor_assets', 'wpcom_global_styles_enqueue_block_ed
  * @return void
  */
 function wpcom_global_styles_enqueue_assets() {
+	if ( ! wpcom_should_show_global_styles_admin_bar() ) {
+		return;
+	}
+
 	$asset_file = include Jetpack_Mu_Wpcom::BASE_DIR . 'build/wpcom-global-styles-frontend/wpcom-global-styles-frontend.asset.php';
 	wp_enqueue_script(
 		'wpcom-global-styles-frontend',
@@ -239,7 +243,7 @@ function wpcom_global_styles_enqueue_assets() {
 		'wpcom-global-styles-frontend',
 		'const launchBarUserData = ' . wp_json_encode(
 			array(
-				'blogId' => get_current_blog_id(),
+				'blogId' => wpcom_global_styles_get_wpcom_current_blog_id(),
 			)
 		),
 		'before'
@@ -253,6 +257,7 @@ function wpcom_global_styles_enqueue_assets() {
 		filemtime( Jetpack_Mu_Wpcom::BASE_DIR . 'build/wpcom-global-styles-frontend/wpcom-global-styles-frontend.css' )
 	);
 }
+add_action( 'wp_enqueue_scripts', 'wpcom_global_styles_enqueue_assets' );
 
 /**
  * Removes the user styles from a site with limited global styles.
@@ -487,15 +492,27 @@ function wpcom_premium_global_styles_is_site_exempt( $blog_id = 0 ) {
 }
 
 /**
- * Returns whether the global style banner should be shown or not.
+ * Returns whether the global style notice should be shown or not in the admin bar.
  *
- * @return bool Whether the global styles upgrade banner should be rendered.
+ * @return bool Whether the global styles notice should be rendered.
  */
-function wpcom_should_show_global_styles_launch_bar() {
+function wpcom_should_show_global_styles_admin_bar() {
+	// TODO: Remove this before merging. It's been added only to make easier the testing on Atomic sites.
+	$test_should_show_global_styles_admin_bar = apply_filters( 'wpcom_should_show_global_styles_admin_bar', false );
+	if ( $test_should_show_global_styles_admin_bar ) {
+		return true;
+	}
+
+	static $should_show_global_styles_admin_bar = null;
+	if ( $should_show_global_styles_admin_bar !== null ) {
+		return $should_show_global_styles_admin_bar;
+	}
+
 	$current_user_id = get_current_user_id();
 
 	if ( ! $current_user_id ) {
-		return false;
+		$should_show_global_styles_admin_bar = false;
+		return $should_show_global_styles_admin_bar;
 	}
 
 	$current_blog_id = get_current_blog_id();
@@ -504,11 +521,13 @@ function wpcom_should_show_global_styles_launch_bar() {
 		is_user_member_of_blog( $current_user_id, $current_blog_id ) &&
 		current_user_can( 'manage_options' )
 	) ) {
-		return false;
+		$should_show_global_styles_admin_bar = false;
+		return $should_show_global_styles_admin_bar;
 	}
 
 	if ( has_blog_sticker( 'difm-lite-in-progress' ) ) {
-		return false;
+		$should_show_global_styles_admin_bar = false;
+		return $should_show_global_styles_admin_bar;
 	}
 
 	// The site is being previewed in Calypso or Gutenberg.
@@ -521,30 +540,41 @@ function wpcom_should_show_global_styles_launch_bar() {
 		isset( $_GET['widget-preview'] ) || // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Not a form action (Gutenberg >= 9.2)
 		( isset( $_GET['hide_banners'] ) && $_GET['hide_banners'] === 'true' )  // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Not a form action
 	) {
-		return false;
+		$should_show_global_styles_admin_bar = false;
+		return $should_show_global_styles_admin_bar;
 	}
 
 	// Do not show the lanuch banner when previewed in the customizer
 	if ( is_customize_preview() ) {
-		return false;
+		$should_show_global_styles_admin_bar = false;
+		return $should_show_global_styles_admin_bar;
 	}
 
 	// No banner for agency-managed sites.
 	if ( ! empty( get_option( 'is_fully_managed_agency_site' ) ) ) {
-		return false;
+		$should_show_global_styles_admin_bar = false;
+		return $should_show_global_styles_admin_bar;
 	}
 
 	if ( ! wpcom_should_limit_global_styles() || ! wpcom_global_styles_in_use() ) {
-		return false;
+		$should_show_global_styles_admin_bar = false;
+		return $should_show_global_styles_admin_bar;
 	}
 
-	return true;
+	$should_show_global_styles_admin_bar = true;
+	return $should_show_global_styles_admin_bar;
 }
 
 /**
- * Renders the global style notice banner to the launch bar.
+ * Renders the global style notice in the admin bar.
+ *
+ * @param WP_Admin_Bar $wp_admin_bar The WP_Admin_Bar core object.
  */
-function wpcom_display_global_styles_launch_bar() {
+function wpcom_display_global_styles_notice_admin_bar( $wp_admin_bar ) {
+	if ( ! wpcom_should_show_global_styles_admin_bar() ) {
+		return;
+	}
+
 	if ( method_exists( '\WPCOM_Masterbar', 'get_calypso_site_slug' ) ) {
 		$site_slug = WPCOM_Masterbar::get_calypso_site_slug( get_current_blog_id() );
 	} else {
@@ -560,141 +590,100 @@ function wpcom_display_global_styles_launch_bar() {
 		$upgrade_url     = "https://wordpress.com/plans/$site_slug?plan=personal-bundle&feature=style-customization";
 	}
 
+	$support_url = function_exists( 'localized_wpcom_url' )
+		? localized_wpcom_url( 'https://wordpress.com/support/using-styles/' )
+		// phpcs:ignore WPCOM.I18nRules.LocalizedUrl.UnlocalizedUrl
+		: 'https://wordpress.com/support/using-styles/';
+
+	$message = sprintf(
+		/* translators: %1$s - documentation URL, %2$s - the name of the required plan */
+		__(
+			'Your site includes <a href="%1$s" target="_blank">premium styles</a> that are only visible to visitors after upgrading to the %2$s plan or higher.',
+			'jetpack-mu-wpcom'
+		),
+		$support_url,
+		get_store_product( $gs_upgrade_plan )->product_name
+	);
+
 	if ( wpcom_is_previewing_global_styles() ) {
-		$preview_location = add_query_arg( 'hide-global-styles', '' );
+		$preview_url = add_query_arg( 'hide-global-styles', '' );
 	} else {
-		$preview_location = remove_query_arg( 'hide-global-styles' );
+		$preview_url = remove_query_arg( 'hide-global-styles' );
 	}
 
-	?>
+	$wp_admin_bar->add_node(
+		array(
+			'id'    => 'wpcom-global-styles',
+			'title' => __( 'Upgrade required', 'jetpack-mu-wpcom' ),
+			'href'  => $upgrade_url,
+		)
+	);
 
-	<div class="launch-banner" id="launch-banner" style="display:none;">
-		<div class="launch-banner-content">
-			<div class="launch-banner-section bar-controls">
-				<div class="launch-bar-global-styles-button">
-					<?php if ( defined( 'IS_ATOMIC' ) && IS_ATOMIC ) : // Workaround for the shadow DOM used on Atomic sites. ?>
-						<style id="wpcom-launch-bar-global-styles-button-style">
-							<?php include __DIR__ . '/dist/wpcom-global-styles-view.css'; ?>
-							.hidden { display: none; }
-						</style>
-						<script id="wpcom-launch-bar-global-styles-button-script">
-							const launchBarUserData = {
-								blogId: <?php echo method_exists( '\Jetpack_Options', 'get_option' ) ? (int) \Jetpack_Options::get_option( 'id' ) : get_current_blog_id(); ?>,
-								isAtomic: true,
-							};
-							<?php
-							include __DIR__ . '/dist/wpcom-global-styles-view.min.js';
-							$asset_file   = plugin_dir_path( __FILE__ ) . 'dist/wpcom-global-styles-view.asset.php';
-							$asset        = file_exists( $asset_file ) ? require $asset_file : null;
-							$dependencies = $asset['dependencies'] ?? array();
-							foreach ( $dependencies as $dep ) {
-								$dep_script = wp_scripts()->registered[ $dep ];
-								if ( ! $dep_script ) {
-									continue;
-								}
-								include ABSPATH . $dep_script->src;
-							}
-							?>
-						</script>
-					<?php endif; ?>
-					<div class="launch-bar-global-styles-popover hidden">
-						<div class="launch-bar-global-styles-close">
-							<svg xmlns="http://www.w3.org/2000/svg" height="48" viewBox="0 96 960 960" width="48"><path d="m249 849-42-42 231-231-231-231 42-42 231 231 231-231 42 42-231 231 231 231-42 42-231-231-231 231Z"/></svg>
-						</div>
-						<div class="launch-bar-global-styles-message">
-							<?php
-							$support_url = function_exists( 'localized_wpcom_url' )
-								? localized_wpcom_url( 'https://wordpress.com/support/using-styles/' )
-								// phpcs:ignore WPCOM.I18nRules.LocalizedUrl.UnlocalizedUrl
-								: 'https://wordpress.com/support/using-styles/';
+	$wp_admin_bar->add_node(
+		array(
+			'parent' => 'wpcom-global-styles',
+			'id'     => 'wpcom-global-styles-description',
+			'title'  =>
+				'<button class="wpcom-global-styles-close">
+					<svg xmlns="http://www.w3.org/2000/svg" height="48" viewBox="0 96 960 960" width="48"><path d="m249 849-42-42 231-231-231-231 42-42 231 231 231-231 42 42-231 231 231 231-42 42-231-231-231 231Z"/></svg>
+				</button>' .
+				wp_kses(
+					$message,
+					array(
+						'a' => array(
+							'href'   => array(),
+							'target' => array(),
+						),
+					)
+				),
+		)
+	);
 
-							$message = sprintf(
-								/* translators: %1$s - documentation URL, %2$s - the name of the required plan */
-								__(
-									'Your site includes <a href="%1$s" target="_blank">premium styles</a> that are only visible to visitors after upgrading to the %2$s plan or higher.',
-									'jetpack-mu-wpcom'
-								),
-								$support_url,
-								get_store_product( $gs_upgrade_plan )->product_name
-							);
-							printf(
-								wp_kses(
-									$message,
-									array(
-										'a' => array(
-											'href'   => array(),
-											'target' => array(),
-										),
-									)
-								)
-							);
-							?>
-						</div>
-						<a
-							class="launch-bar-global-styles-upgrade"
-							href="<?php echo esc_url( $upgrade_url ); ?>"
-						>
-							<?php echo esc_html__( 'Upgrade now', 'jetpack-mu-wpcom' ); ?>
-						</a>
-						<a
-							class="launch-bar-global-styles-reset"
-							href="https://wordpress.com/support/using-styles/#reset-all-styles"
-							target="_blank"
-						>
-							<svg width="15" height="14" viewBox="0 0 15 14" fill="none" xmlns="http://www.w3.org/2000/svg">
-								<path d="M5.8125 5.6875C5.8125 4.75552 6.56802 4 7.5 4C8.43198 4 9.1875 4.75552 9.1875 5.6875C9.1875 6.55621 8.53108 7.2716 7.6872 7.36473C7.58427 7.37609 7.5 7.45895 7.5 7.5625V8.5M7.5 9.25V10.375M13.5 7C13.5 10.3137 10.8137 13 7.5 13C4.18629 13 1.5 10.3137 1.5 7C1.5 3.68629 4.18629 1 7.5 1C10.8137 1 13.5 3.68629 13.5 7Z" stroke="#1E1E1E" stroke-width="1.5"/>
-							</svg>
-							<?php echo esc_html__( 'Remove premium styles', 'jetpack-mu-wpcom' ); ?>
-							<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="15" height="15" aria-hidden="true" focusable="false"><path d="M18.2 17c0 .7-.6 1.2-1.2 1.2H7c-.7 0-1.2-.6-1.2-1.2V7c0-.7.6-1.2 1.2-1.2h3.2V4.2H7C5.5 4.2 4.2 5.5 4.2 7v10c0 1.5 1.2 2.8 2.8 2.8h10c1.5 0 2.8-1.2 2.8-2.8v-3.6h-1.5V17zM14.9 3v1.5h3.7l-6.4 6.4 1.1 1.1 6.4-6.4v3.7h1.5V3h-6.3z"></path></svg>
-						</a>
-						<a class="launch-bar-global-styles-preview" href="<?php echo esc_url( $preview_location ); ?>">
-							<label><input type="checkbox" <?php echo wpcom_is_previewing_global_styles() ? 'checked' : ''; ?>><span></span></label>
-							<?php echo esc_html__( 'Preview premium styles', 'jetpack-mu-wpcom' ); ?>
-						</a>
-					</div>
-					<a class="launch-bar-global-styles-toggle" href="#">
-						<svg width="25" height="25" viewBox="0 96 960 960" xmlns="http://www.w3.org/2000/svg">
-							<path d="M479.982 776q14.018 0 23.518-9.482 9.5-9.483 9.5-23.5 0-14.018-9.482-23.518-9.483-9.5-23.5-9.5-14.018 0-23.518 9.482-9.5 9.483-9.5 23.5 0 14.018 9.482 23.518 9.483 9.5 23.5 9.5ZM453 623h60V370h-60v253Zm27.266 353q-82.734 0-155.5-31.5t-127.266-86q-54.5-54.5-86-127.341Q80 658.319 80 575.5q0-82.819 31.5-155.659Q143 347 197.5 293t127.341-85.5Q397.681 176 480.5 176q82.819 0 155.659 31.5Q709 239 763 293t85.5 127Q880 493 880 575.734q0 82.734-31.5 155.5T763 858.316q-54 54.316-127 86Q563 976 480.266 976Zm.234-60Q622 916 721 816.5t99-241Q820 434 721.188 335 622.375 236 480 236q-141 0-240.5 98.812Q140 433.625 140 576q0 141 99.5 240.5t241 99.5Zm-.5-340Z" style="fill: orange"/>
-						</svg>
-						<span class="is-mobile">
-							<?php echo esc_html__( 'Upgrade', 'jetpack-mu-wpcom' ); ?>
-						</span>
-						<span class="is-desktop">
-							<?php echo esc_html__( 'Upgrade required', 'jetpack-mu-wpcom' ); ?>
-						</span>
-					</a>
-				</div>
-			</div>
-		</div>
-	</div>
-	<?php
+	$wp_admin_bar->add_node(
+		array(
+			'parent' => 'wpcom-global-styles',
+			'id'     => 'wpcom-global-styles-upgrade',
+			'title'  => esc_html__( 'Upgrade now', 'jetpack-mu-wpcom' ),
+			'href'   => $upgrade_url,
+		)
+	);
+
+	$wp_admin_bar->add_node(
+		array(
+			'parent' => 'wpcom-global-styles',
+			'id'     => 'wpcom-global-styles-reset',
+			'title'  =>
+				'<svg class="wpcom-global-styles-reset-help-icon" width="15" height="14" viewBox="0 0 15 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+					<path d="M5.8125 5.6875C5.8125 4.75552 6.56802 4 7.5 4C8.43198 4 9.1875 4.75552 9.1875 5.6875C9.1875 6.55621 8.53108 7.2716 7.6872 7.36473C7.58427 7.37609 7.5 7.45895 7.5 7.5625V8.5M7.5 9.25V10.375M13.5 7C13.5 10.3137 10.8137 13 7.5 13C4.18629 13 1.5 10.3137 1.5 7C1.5 3.68629 4.18629 1 7.5 1C10.8137 1 13.5 3.68629 13.5 7Z" stroke-width="1.5"/>
+				</svg>' .
+				esc_html__( 'Remove premium styles', 'jetpack-mu-wpcom' ) .
+				'<svg class="wpcom-global-styles-reset-external-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="15" height="15" aria-hidden="true" focusable="false"><path d="M18.2 17c0 .7-.6 1.2-1.2 1.2H7c-.7 0-1.2-.6-1.2-1.2V7c0-.7.6-1.2 1.2-1.2h3.2V4.2H7C5.5 4.2 4.2 5.5 4.2 7v10c0 1.5 1.2 2.8 2.8 2.8h10c1.5 0 2.8-1.2 2.8-2.8v-3.6h-1.5V17zM14.9 3v1.5h3.7l-6.4 6.4 1.1 1.1 6.4-6.4v3.7h1.5V3h-6.3z"></path></svg>',
+			'href'   => 'https://wordpress.com/support/using-styles/#remove-premium-styles',
+			'meta'   => array(
+				'target' => '_blank',
+			),
+		)
+	);
+
+	$wp_admin_bar->add_group(
+		array(
+			'parent' => 'wpcom-global-styles',
+			'id'     => 'wpcom-global-styles-preview',
+			'meta'   => array(
+				'class' => 'ab-sub-secondary',
+			),
+		)
+	);
+	$wp_admin_bar->add_node(
+		array(
+			'parent' => 'wpcom-global-styles-preview',
+			'id'     => 'wpcom-global-styles-preview-button',
+			'title'  => '<label><input type="checkbox" ' . ( wpcom_is_previewing_global_styles() ? 'checked' : '' ) . '><span></span></label>' . esc_html__( 'Preview premium styles', 'jetpack-mu-wpcom' ),
+			'href'   => $preview_url,
+		)
+	);
 }
-
-/**
- * Maybe registers the global styles banner.
- *
- * @param array $banners Banners.
- *
- * @return array
- */
-function wpcom_register_global_styles_launch_bar( $banners ) {
-	// If the banner shouldn't display, don't inject it.
-	if ( ! wpcom_should_show_global_styles_launch_bar() ) {
-		return $banners;
-	}
-
-	return array_merge( $banners, array( 'wpcom_launch_banner' => 'wpcom_init_global_styles_launch_bar' ) );
-}
-
-/**
- * Show the global styles banner for the current site.
- */
-function wpcom_init_global_styles_launch_bar() {
-	add_action( 'wp_head', 'wpcom_global_styles_enqueue_assets' );
-	add_filter( 'wp_footer', 'wpcom_display_global_styles_launch_bar' );
-}
-
-add_filter( 'wpcom_register_banners', 'wpcom_register_global_styles_launch_bar' );
+add_action( 'admin_bar_menu', 'wpcom_display_global_styles_notice_admin_bar', 499 ); // Before "Launch site".
 
 /**
  * Include the Rest API that returns the global style information for a give WordPress site.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/index.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/index.php
@@ -56,13 +56,13 @@ function wpcom_should_limit_global_styles( $blog_id = 0 ) {
 	}
 
 	// Do not limit Global Styles on theme demo sites.
-	if ( wpcom_global_styles_has_blog_sticker( 'theme-demo-site', $blog_id ) ) {
+	if ( wpcom_has_blog_sticker( 'theme-demo-site', $blog_id ) ) {
 		return false;
 	}
 
 	// Do not limit Global Styles on Big Sky free trial sites. Those sites will
 	// have their own paywall to go through.
-	if ( wpcom_global_styles_has_blog_sticker( 'big-sky-free-trial', $blog_id ) ) {
+	if ( wpcom_has_blog_sticker( 'big-sky-free-trial', $blog_id ) ) {
 		return false;
 	}
 
@@ -89,23 +89,6 @@ function wpcom_should_limit_global_styles( $blog_id = 0 ) {
 	}
 
 	return true;
-}
-
-/**
- * Wrapper to test a blog sticker on both Simple and Atomic sites at once.
- *
- * @param string $blog_sticker The blog sticker.
- * @param int    $blog_id The WPCOM blog ID.
- * @return bool Whether the site has the blog sticker.
- */
-function wpcom_global_styles_has_blog_sticker( $blog_sticker, $blog_id ) {
-	if ( function_exists( 'has_blog_sticker' ) && has_blog_sticker( $blog_sticker, $blog_id ) ) {
-		return true;
-	}
-	if ( function_exists( 'wpcomsh_is_site_sticker_active' ) && wpcomsh_is_site_sticker_active( $blog_sticker ) ) {
-		return true;
-	}
-	return false;
 }
 
 /**
@@ -430,8 +413,8 @@ function wpcom_premium_global_styles_is_site_exempt( $blog_id = 0 ) {
 	}
 
 	// If the exemption check has already been performed, just return if the site is exempt.
-	if ( wpcom_global_styles_has_blog_sticker( 'wpcom-premium-global-styles-exemption-checked', $blog_id ) ) {
-		return wpcom_global_styles_has_blog_sticker( 'wpcom-premium-global-styles-exempt', $blog_id );
+	if ( wpcom_has_blog_sticker( 'wpcom-premium-global-styles-exemption-checked', $blog_id ) ) {
+		return wpcom_has_blog_sticker( 'wpcom-premium-global-styles-exempt', $blog_id );
 	}
 
 	// If the current user cannot modify the `wp_global_styles` CPT, the exemption check is not needed;
@@ -499,7 +482,7 @@ function wpcom_should_show_global_styles_admin_bar() {
 		return $should_show_global_styles_admin_bar;
 	}
 
-	if ( wpcom_global_styles_has_blog_sticker( 'difm-lite-in-progress', $current_blog_id ) ) {
+	if ( wpcom_has_blog_sticker( 'difm-lite-in-progress', $current_blog_id ) ) {
 		$should_show_global_styles_admin_bar = false;
 		return $should_show_global_styles_admin_bar;
 	}
@@ -728,7 +711,7 @@ function wpcom_site_has_global_styles_feature( $blog_id = 0 ) {
 
 	// Users who bought a Personal plan during the GS on Personal experiment should
 	// retain access to Global Styles.
-	if ( wpcom_global_styles_has_blog_sticker( 'wpcom-global-styles-personal-plan', $blog_id ) ) {
+	if ( wpcom_has_blog_sticker( 'wpcom-global-styles-personal-plan', $blog_id ) ) {
 		if ( wpcom_site_has_personal_plan( $blog_id ) ) {
 			return true;
 		} else {

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/index.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/index.php
@@ -92,26 +92,6 @@ function wpcom_should_limit_global_styles( $blog_id = 0 ) {
 }
 
 /**
- * Get the WPCOM blog id of the current site for tracking purposes.
- */
-function wpcom_global_styles_get_wpcom_current_blog_id() {
-	if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-		return get_current_blog_id();
-	} elseif ( defined( 'IS_ATOMIC' ) && IS_ATOMIC ) {
-		/*
-		 * Atomic sites have the WP.com blog ID stored as a Jetpack option. This code deliberately
-		 * doesn't use `Jetpack_Options::get_option` so it works even when Jetpack has not been loaded.
-		 */
-		$jetpack_options = get_option( 'jetpack_options' );
-		if ( is_array( $jetpack_options ) && isset( $jetpack_options['id'] ) ) {
-			return (int) $jetpack_options['id'];
-		}
-	}
-
-	return null;
-}
-
-/**
  * Wrapper to test a blog sticker on both Simple and Atomic sites at once.
  *
  * @param string $blog_sticker The blog sticker.
@@ -205,7 +185,7 @@ function wpcom_global_styles_enqueue_block_editor_assets() {
 		'wpcomGlobalStyles',
 		array(
 			'upgradeUrl'                 => $upgrade_url,
-			'wpcomBlogId'                => wpcom_global_styles_get_wpcom_current_blog_id(),
+			'wpcomBlogId'                => get_wpcom_blog_id(),
 			'planName'                   => $plan_name,
 			'learnMoreAboutStylesUrl'    => $learn_more_about_styles_support_url,
 			'learnMoreAboutStylesPostId' => $learn_more_about_styles_post_id,
@@ -243,7 +223,7 @@ function wpcom_global_styles_enqueue_assets() {
 		'wpcom-global-styles-frontend',
 		'const launchBarUserData = ' . wp_json_encode(
 			array(
-				'blogId' => wpcom_global_styles_get_wpcom_current_blog_id(),
+				'blogId' => get_wpcom_blog_id(),
 			)
 		),
 		'before'
@@ -509,7 +489,7 @@ function wpcom_should_show_global_styles_admin_bar() {
 		return $should_show_global_styles_admin_bar;
 	}
 
-	$current_blog_id = wpcom_global_styles_get_wpcom_current_blog_id();
+	$current_blog_id = get_wpcom_blog_id();
 
 	if ( ! (
 		is_user_member_of_blog( $current_user_id, $current_blog_id ) &&

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/index.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/index.php
@@ -460,8 +460,14 @@ function wpcom_premium_global_styles_is_site_exempt( $blog_id = 0 ) {
  * @return bool Whether the global styles notice should be rendered.
  */
 function wpcom_should_show_global_styles_admin_bar() {
-		static $should_show_global_styles_admin_bar = null;
+	static $should_show_global_styles_admin_bar = null;
 	if ( $should_show_global_styles_admin_bar !== null ) {
+		return $should_show_global_styles_admin_bar;
+	}
+
+	// Only show notice in the frontend.
+	if ( is_admin() ) {
+		$should_show_global_styles_admin_bar = false;
 		return $should_show_global_styles_admin_bar;
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/index.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/index.php
@@ -584,10 +584,10 @@ function wpcom_display_global_styles_notice_admin_bar( $wp_admin_bar ) {
 	}
 
 	// @TODO Remove this once the global styles are available for all users on the Personal Plan.
-	$gs_upgrade_plan = WPCOM_VALUE_BUNDLE;
+	$gs_upgrade_plan = 'value_bundle';
 	$upgrade_url     = "https://wordpress.com/plans/$site_slug?plan=value_bundle&feature=style-customization";
 	if ( is_global_styles_on_personal_plan() ) {
-		$gs_upgrade_plan = WPCOM_PERSONAL_BUNDLE;
+		$gs_upgrade_plan = 'personal-bundle';
 		$upgrade_url     = "https://wordpress.com/plans/$site_slug?plan=personal-bundle&feature=style-customization";
 	}
 
@@ -603,7 +603,7 @@ function wpcom_display_global_styles_notice_admin_bar( $wp_admin_bar ) {
 			'jetpack-mu-wpcom'
 		),
 		$support_url,
-		get_store_product( $gs_upgrade_plan )->product_name
+		Plans::get_plan_short_name( $gs_upgrade_plan )
 	);
 
 	if ( wpcom_is_previewing_global_styles() ) {

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/index.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/index.php
@@ -497,13 +497,7 @@ function wpcom_premium_global_styles_is_site_exempt( $blog_id = 0 ) {
  * @return bool Whether the global styles notice should be rendered.
  */
 function wpcom_should_show_global_styles_admin_bar() {
-	// TODO: Remove this before merging. It's been added only to make easier the testing on Atomic sites.
-	$test_should_show_global_styles_admin_bar = apply_filters( 'wpcom_should_show_global_styles_admin_bar', false );
-	if ( $test_should_show_global_styles_admin_bar ) {
-		return true;
-	}
-
-	static $should_show_global_styles_admin_bar = null;
+		static $should_show_global_styles_admin_bar = null;
 	if ( $should_show_global_styles_admin_bar !== null ) {
 		return $should_show_global_styles_admin_bar;
 	}
@@ -518,7 +512,6 @@ function wpcom_should_show_global_styles_admin_bar() {
 	$current_blog_id = wpcom_global_styles_get_wpcom_current_blog_id();
 
 	if ( ! (
-		is_user_logged_in() &&
 		is_user_member_of_blog( $current_user_id, $current_blog_id ) &&
 		current_user_can( 'manage_options' )
 	) ) {
@@ -561,6 +554,12 @@ function wpcom_should_show_global_styles_admin_bar() {
 	if ( ! wpcom_should_limit_global_styles() || ! wpcom_global_styles_in_use() ) {
 		$should_show_global_styles_admin_bar = false;
 		return $should_show_global_styles_admin_bar;
+	}
+
+	// TODO: Remove this before merging. It's been added only to make easier the testing on Atomic sites.
+	$test_should_show_global_styles_admin_bar = apply_filters( 'wpcom_should_show_global_styles_admin_bar', false );
+	if ( $test_should_show_global_styles_admin_bar ) {
+		return true;
 	}
 
 	$should_show_global_styles_admin_bar = true;

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/index.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/index.php
@@ -515,7 +515,7 @@ function wpcom_should_show_global_styles_admin_bar() {
 		return $should_show_global_styles_admin_bar;
 	}
 
-	$current_blog_id = get_current_blog_id();
+	$current_blog_id = wpcom_global_styles_get_wpcom_current_blog_id();
 
 	if ( ! (
 		is_user_member_of_blog( $current_user_id, $current_blog_id ) &&
@@ -525,7 +525,8 @@ function wpcom_should_show_global_styles_admin_bar() {
 		return $should_show_global_styles_admin_bar;
 	}
 
-	if ( has_blog_sticker( 'difm-lite-in-progress' ) ) {
+	if ( ( function_exists( 'has_blog_sticker' ) && has_blog_sticker( 'difm-lite-in-progress' ) ) ||
+		( function_exists( 'wpcomsh_is_site_sticker_active' ) && wpcomsh_is_site_sticker_active( 'difm-lite-in-progress' ) ) ) {
 		$should_show_global_styles_admin_bar = false;
 		return $should_show_global_styles_admin_bar;
 	}
@@ -544,7 +545,7 @@ function wpcom_should_show_global_styles_admin_bar() {
 		return $should_show_global_styles_admin_bar;
 	}
 
-	// Do not show the lanuch banner when previewed in the customizer
+	// Do not show the notice when previewed in the customizer
 	if ( is_customize_preview() ) {
 		$should_show_global_styles_admin_bar = false;
 		return $should_show_global_styles_admin_bar;

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/index.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/index.php
@@ -519,8 +519,7 @@ function wpcom_should_show_global_styles_admin_bar() {
 		return $should_show_global_styles_admin_bar;
 	}
 
-	if ( ( function_exists( 'has_blog_sticker' ) && has_blog_sticker( 'difm-lite-in-progress' ) ) ||
-		( function_exists( 'wpcomsh_is_site_sticker_active' ) && wpcomsh_is_site_sticker_active( 'difm-lite-in-progress' ) ) ) {
+	if ( wpcom_global_styles_has_blog_sticker( 'difm-lite-in-progress', $current_blog_id ) ) {
 		$should_show_global_styles_admin_bar = false;
 		return $should_show_global_styles_admin_bar;
 	}

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/index.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/index.php
@@ -518,6 +518,7 @@ function wpcom_should_show_global_styles_admin_bar() {
 	$current_blog_id = wpcom_global_styles_get_wpcom_current_blog_id();
 
 	if ( ! (
+		is_user_logged_in() &&
 		is_user_member_of_blog( $current_user_id, $current_blog_id ) &&
 		current_user_can( 'manage_options' )
 	) ) {

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/index.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/index.php
@@ -551,15 +551,15 @@ function wpcom_should_show_global_styles_admin_bar() {
 		return $should_show_global_styles_admin_bar;
 	}
 
-	if ( ! wpcom_should_limit_global_styles() || ! wpcom_global_styles_in_use() ) {
-		$should_show_global_styles_admin_bar = false;
-		return $should_show_global_styles_admin_bar;
-	}
-
 	// TODO: Remove this before merging. It's been added only to make easier the testing on Atomic sites.
 	$test_should_show_global_styles_admin_bar = apply_filters( 'wpcom_should_show_global_styles_admin_bar', false );
 	if ( $test_should_show_global_styles_admin_bar ) {
 		return true;
+	}
+
+	if ( ! wpcom_should_limit_global_styles() || ! wpcom_global_styles_in_use() ) {
+		$should_show_global_styles_admin_bar = false;
+		return $should_show_global_styles_admin_bar;
 	}
 
 	$should_show_global_styles_admin_bar = true;

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/wpcom-global-styles-view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/wpcom-global-styles-view.js
@@ -41,6 +41,8 @@ document.addEventListener( 'DOMContentLoaded', () => {
 		return;
 	}
 
+	const isMobile = 'ontouchstart' in window;
+
 	const showPopover = () => {
 		container.classList.add( 'hover' );
 		popoverToggle.setAttribute( 'aria-expanded', 'true' );
@@ -53,27 +55,28 @@ document.addEventListener( 'DOMContentLoaded', () => {
 		setTimeout( () => container.classList.remove( 'hover' ), 180 );
 		popoverToggle.setAttribute( 'aria-expanded', 'false' );
 		popover.style.removeProperty( 'display' );
+		closeButton.style.removeProperty( 'visibility' );
 	};
 
 	const limitedGlobalStylesNoticeAction =
 		localStorage.getItem( 'limitedGlobalStylesNoticeAction' ) ?? 'show';
-	if ( limitedGlobalStylesNoticeAction === 'show' ) {
-		recordEvent( 'wpcom_global_styles_gating_notice', { action: 'show' } );
+	const shouldShowPopover = limitedGlobalStylesNoticeAction === 'show';
+
+	if ( shouldShowPopover ) {
 		showPopover();
 
-		otherAdminBarItems.forEach( item => {
-			item.addEventListener( 'click', () => {
-				hidePopover();
+		if ( isMobile ) {
+			// Hide the popover when any other admin bar item is pressed.
+			otherAdminBarItems.forEach( item => {
+				item.addEventListener( 'click', hidePopover );
 			} );
-		} );
+		}
 	}
 
 	closeButton.addEventListener( 'click', event => {
 		event.preventDefault();
-		recordEvent( 'wpcom_global_styles_gating_notice', { action: 'hide' } );
-		localStorage.setItem( 'limitedGlobalStylesNoticeAction', 'hide' );
 		hidePopover();
-		closeButton.style.removeProperty( 'visibility' );
+		localStorage.setItem( 'limitedGlobalStylesNoticeAction', 'hide' );
 	} );
 
 	upgradeButton.addEventListener( 'click', () => {
@@ -98,7 +101,7 @@ document.addEventListener( 'DOMContentLoaded', () => {
 
 	popoverToggle.addEventListener( 'click', () => {
 		// On desktop devices, clicking on the popover redirects to the upgrade page.
-		if ( ! ( 'ontouchstart' in window ) ) {
+		if ( ! isMobile ) {
 			recordEvent( 'wpcom_global_styles_gating_notice_upgrade' );
 		}
 	} );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/wpcom-global-styles-view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/wpcom-global-styles-view.js
@@ -17,14 +17,20 @@ function recordEvent( button, props = {} ) {
 }
 
 document.addEventListener( 'DOMContentLoaded', () => {
-	const popoverToggle = document.querySelector( '#wp-admin-bar-wpcom-global-styles' );
-	const popover = document.querySelector( '#wp-admin-bar-wpcom-global-styles .ab-sub-wrapper' );
-	const upgradeButton = document.querySelector( '#wp-admin-bar-wpcom-global-styles-upgrade a' );
-	const previewButton = document.querySelector( '#wp-admin-bar-wpcom-global-styles-preview a' );
-	const closeButton = document.querySelector( '#wpadminbar .wpcom-global-styles-close' );
-	const resetButton = document.querySelector( '#wp-admin-bar-wpcom-global-styles-reset a' );
+	const otherAdminBarItems = document.querySelectorAll(
+		'#wpadminbar .quicklinks > ul > li:not(#wp-admin-bar-wpcom-global-styles)'
+	);
+	const container = document.querySelector( '#wp-admin-bar-wpcom-global-styles' );
+	const popoverToggle = container.querySelector( '.ab-item' );
+	const popover = container.querySelector( '.ab-sub-wrapper' );
+	const upgradeButton = popover.querySelector( '#wp-admin-bar-wpcom-global-styles-upgrade a' );
+	const previewButton = popover.querySelector( '#wp-admin-bar-wpcom-global-styles-preview a' );
+	const closeButton = popover.querySelector( '.wpcom-global-styles-close' );
+	const resetButton = popover.querySelector( '#wp-admin-bar-wpcom-global-styles-reset a' );
 
 	if (
+		! otherAdminBarItems.length ||
+		! container ||
 		! popoverToggle ||
 		! popover ||
 		! upgradeButton ||
@@ -35,26 +41,39 @@ document.addEventListener( 'DOMContentLoaded', () => {
 		return;
 	}
 
+	const showPopover = () => {
+		container.classList.add( 'hover' );
+		popoverToggle.setAttribute( 'aria-expanded', 'true' );
+		popover.style.display = 'block';
+		closeButton.style.visibility = 'visible';
+	};
+
+	const hidePopover = () => {
+		// Core adds a 180ms delay to the hover state, so we need to wait for that to complete before removing the class.
+		setTimeout( () => container.classList.remove( 'hover' ), 180 );
+		popoverToggle.setAttribute( 'aria-expanded', 'false' );
+		popover.style.removeProperty( 'display' );
+	};
+
 	const limitedGlobalStylesNoticeAction =
 		localStorage.getItem( 'limitedGlobalStylesNoticeAction' ) ?? 'show';
 	if ( limitedGlobalStylesNoticeAction === 'show' ) {
 		recordEvent( 'wpcom_global_styles_gating_notice', { action: 'show' } );
-		popoverToggle.classList.add( 'hover' );
-		popoverToggle.querySelector( '.ab-item' ).setAttribute( 'aria-expanded', 'true' );
-		popover.style.display = 'block';
-	} else {
-		closeButton.style.display = 'none';
+		showPopover();
+
+		otherAdminBarItems.forEach( item => {
+			item.addEventListener( 'click', () => {
+				hidePopover();
+			} );
+		} );
 	}
 
 	closeButton.addEventListener( 'click', event => {
 		event.preventDefault();
 		recordEvent( 'wpcom_global_styles_gating_notice', { action: 'hide' } );
 		localStorage.setItem( 'limitedGlobalStylesNoticeAction', 'hide' );
-		// Core adds a 180ms delay to the hover state, so we need to wait for that to complete before removing the class.
-		setTimeout( () => popoverToggle.classList.remove( 'hover' ), 180 );
-		popoverToggle.querySelector( '.ab-item' ).setAttribute( 'aria-expanded', 'false' );
-		popover.style.removeProperty( 'display' );
-		closeButton.style.display = 'none';
+		hidePopover();
+		closeButton.style.removeProperty( 'visibility' );
 	} );
 
 	upgradeButton.addEventListener( 'click', () => {
@@ -75,5 +94,12 @@ document.addEventListener( 'DOMContentLoaded', () => {
 
 	resetButton.addEventListener( 'click', () => {
 		recordEvent( 'wpcom_global_styles_gating_notice_reset_support' );
+	} );
+
+	popoverToggle.addEventListener( 'click', () => {
+		// On desktop devices, clicking on the popover redirects to the upgrade page.
+		if ( ! ( 'ontouchstart' in window ) ) {
+			recordEvent( 'wpcom_global_styles_gating_notice_upgrade' );
+		}
 	} );
 } );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/wpcom-global-styles-view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/wpcom-global-styles-view.js
@@ -17,58 +17,51 @@ function recordEvent( button, props = {} ) {
 }
 
 document.addEventListener( 'DOMContentLoaded', () => {
-	const launchBanner = document.querySelector( '.launch-banner' );
+	const popoverToggle = document.querySelector( '#wp-admin-bar-wpcom-global-styles' );
+	const popover = document.querySelector( '#wp-admin-bar-wpcom-global-styles .ab-sub-wrapper' );
+	const upgradeButton = document.querySelector( '#wp-admin-bar-wpcom-global-styles-upgrade a' );
+	const previewButton = document.querySelector( '#wp-admin-bar-wpcom-global-styles-preview a' );
+	const closeButton = document.querySelector( '#wpadminbar .wpcom-global-styles-close' );
+	const resetButton = document.querySelector( '#wp-admin-bar-wpcom-global-styles-reset a' );
 
-	if ( ! launchBanner ) {
+	if (
+		! popoverToggle ||
+		! popover ||
+		! upgradeButton ||
+		! previewButton ||
+		! closeButton ||
+		! resetButton
+	) {
 		return;
 	}
-
-	// Don't show the banner if the site is previewed via an iframe.
-	if ( window.top !== window.self ) {
-		return;
-	}
-
-	document.body.style.marginTop = '50px';
-	document.body.style.scrollPaddingTop = '50px';
-	launchBanner.style.display = null;
-
-	const container = document;
-	const popoverToggle = container.querySelector( '.launch-bar-global-styles-toggle' );
-	const popover = container.querySelector( '.launch-bar-global-styles-popover' );
-	const upgradeButton = container.querySelector( '.launch-bar-global-styles-upgrade' );
-	const previewButton = container.querySelector( '.launch-bar-global-styles-preview' );
-	const closeButton = container.querySelector( '.launch-bar-global-styles-close' );
-	const resetButton = container.querySelector( '.launch-bar-global-styles-reset' );
 
 	const limitedGlobalStylesNoticeAction =
 		localStorage.getItem( 'limitedGlobalStylesNoticeAction' ) ?? 'show';
 	if ( limitedGlobalStylesNoticeAction === 'show' ) {
-		popover?.classList.remove( 'hidden' );
 		recordEvent( 'wpcom_global_styles_gating_notice', { action: 'show' } );
+		popoverToggle.classList.add( 'hover' );
+		popoverToggle.querySelector( '.ab-item' ).setAttribute( 'aria-expanded', 'true' );
+		popover.style.display = 'block';
+	} else {
+		closeButton.style.display = 'none';
 	}
 
-	popoverToggle?.addEventListener( 'click', event => {
-		event.preventDefault();
-		const action = popover?.classList.contains( 'hidden' ) ? 'show' : 'hide';
-		recordEvent( 'wpcom_global_styles_gating_notice', { action } );
-		localStorage.setItem( 'limitedGlobalStylesNoticeAction', action );
-		popover?.classList.toggle( 'hidden' );
-	} );
-
-	closeButton?.addEventListener( 'click', event => {
+	closeButton.addEventListener( 'click', event => {
 		event.preventDefault();
 		recordEvent( 'wpcom_global_styles_gating_notice', { action: 'hide' } );
 		localStorage.setItem( 'limitedGlobalStylesNoticeAction', 'hide' );
-		popover?.classList.add( 'hidden' );
+		// Core adds a 180ms delay to the hover state, so we need to wait for that to complete before removing the class.
+		setTimeout( () => popoverToggle.classList.remove( 'hover' ), 180 );
+		popoverToggle.querySelector( '.ab-item' ).setAttribute( 'aria-expanded', 'false' );
+		popover.style.removeProperty( 'display' );
+		closeButton.style.display = 'none';
 	} );
 
-	upgradeButton?.addEventListener( 'click', event => {
-		event.preventDefault();
+	upgradeButton.addEventListener( 'click', () => {
 		recordEvent( 'wpcom_global_styles_gating_notice_upgrade' );
-		window.location = upgradeButton.href;
 	} );
 
-	previewButton?.addEventListener( 'click', event => {
+	previewButton.addEventListener( 'click', event => {
 		event.preventDefault();
 		const checkbox = previewButton.querySelector( 'input[type="checkbox"]' );
 		if ( checkbox ) {
@@ -80,9 +73,7 @@ document.addEventListener( 'DOMContentLoaded', () => {
 		window.location = previewButton.href;
 	} );
 
-	resetButton?.addEventListener( 'click', event => {
-		event.preventDefault();
+	resetButton.addEventListener( 'click', () => {
 		recordEvent( 'wpcom_global_styles_gating_notice_reset_support' );
-		window.open( resetButton.href, '_blank' ).focus();
 	} );
 } );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/wpcom-global-styles-view.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/wpcom-global-styles-view.scss
@@ -29,6 +29,10 @@
 		}
 	}
 
+	.ab-sub-wrapper > ul > li {
+		padding: 4px 0;
+	}
+
 	#wp-admin-bar-wpcom-global-styles-description .ab-item {
 		height: auto;
 		white-space: normal;

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/wpcom-global-styles-view.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/wpcom-global-styles-view.scss
@@ -1,325 +1,266 @@
-/* stylelint-disable declaration-property-unit-allowed-list */
-.launch-banner {
-	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
-	font-size: 16px;
-	font-style: normal;
-	height: 48px;
-	line-height: normal;
-	background: #24282d;
-	position: fixed;
-	top: 0;
-	left: 0;
-	width: 100%;
-	z-index: 99998;
+#wpadminbar #wp-toolbar > ul > li#wp-admin-bar-wpcom-global-styles {
 
-
-	.is-mobile {
-		display: none;
-	}
-}
-
-.admin-bar #launch-banner.launch-banner {
-	top: 32px;
-	text-transform: initial;
-}
-
-.has-marketing-bar .launch-banner {
-	margin-top: 49px;
-}
-
-.launch-banner-content {
-	width: 100%;
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	color: #fff;
-}
-
-.launch-banner-content a,
-.launch-banner-content button {
-	border: none;
-	align-items: center;
-	color: #fff;
-	cursor: pointer;
-	display: flex;
-	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
-	font-size: 13px;
-	font-style: normal;
-	min-height: 48px;
-	outline: none;
-	padding: 0 20px;
-	text-decoration: none !important;
-}
-
-.launch-banner-content a:hover,
-.launch-banner-content button:hover {
-	background: #34383d;
-	cursor: pointer;
-}
-
-.launch-banner-content a:hover span,
-.launch-banner-content button:hover span {
-	color: #fff;
-}
-
-.launch-banner-section.bar-controls {
-	display: flex;
-	justify-content: center;
-	flex-grow: 1;
-}
-
-.launch-banner-section.bar-controls > * {
-	border-left: 1px solid #424446;
-}
-
-.launch-banner-section.bar-controls a,
-.launch-banner-section.bar-controls button {
-	font-weight: 500;
-}
-
-.launch-banner-section.bar-controls > :last-child {
-	border-right: 1px solid #424446;
-}
-
-.launch-banner-section .icon {
-	margin-right: 5px;
-	fill: none;
-}
-
-.launch-banner-section .icon path,
-.launch-banner-section .icon rect {
-	stroke: #b0b2b3;
-}
-
-@media screen and (max-width: 782px) {
-
-	.admin-bar #launch-banner.launch-banner {
-		top: 46px;
-	}
-
-	.launch-banner {
-		position: absolute;
-	}
-}
-
-@media screen and (max-width: 960px) {
-
-	.launch-banner .is-desktop {
-		display: none;
-	}
-
-	.launch-banner .is-mobile {
+	@media (max-width: 782px) {
 		display: block;
 	}
 
-	.launch-banner-content .bar-controls > * {
-		border-left: none;
-	}
+	> .ab-item {
 
-	.launch-banner-content .bar-controls a {
-		padding: 0 12px;
-	}
-
-	.launch-banner-section.bar-controls > :last-child {
-		border-right: none;
-	}
-}
-
-@media screen and (max-width: 460px) {
-
-	.launch-banner-section.bar-controls {
-		overflow-y: scroll;
-	}
-}
-
-.launch-bar-global-styles-button {
-	position: relative;
-}
-
-.launch-bar-global-styles-popover {
-	position: absolute;
-	width: 320px;
-	top: 48px;
-	font-size: 14px;
-	left: 50%;
-	transform: translateX(-50%);
-	background-color: #fff;
-	padding: 24px 24px 0;
-	line-height: 20px;
-	color: #2c3338;
-	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
-	border: 1px solid #c3c4c7;
-	display: flex;
-	flex-direction: column;
-	align-items: flex-start;
-	gap: 12px;
-
-	&::before {
-		content: "";
-		width: 0;
-		height: 0;
-		border-left: 8px solid transparent;
-		border-right: 8px solid transparent;
-		border-bottom: 8px solid #fff;
-		position: absolute;
-		top: -8px;
-		left: 50%;
-		transform: translateX(-50%);
-	}
-
-	.launch-bar-global-styles-upgrade,
-	.launch-bar-global-styles-reset {
-		min-height: 28px;
-		box-sizing: border-box;
-		width: 100%;
-		justify-content: center;
-		height: auto;
-	}
-
-	.launch-bar-global-styles-upgrade {
-		border: 1px solid #0675c4;
-		background: #0675c4;
-		color: #fff;
-		border-radius: 2px;
-
-		&:hover {
-			background: #006ba1;
-		}
-	}
-
-	.launch-bar-global-styles-reset {
-		color: inherit;
-		font-weight: 400 !important;
-
-		svg:first-child {
-			margin-right: 4px;
+		@media (max-width: 782px) {
+			width: 52px;
+			overflow: hidden;
+			white-space: nowrap;
 		}
 
-		svg:last-child {
-			margin-left: 4px;
-			position: relative;
-			top: 1px;
-		}
+		&::before {
+			color: #e68b28;
+			content: "\f534";
+			top: 2px;
 
-		&:hover {
-			background: transparent;
-			color: #676767;
-		}
-	}
-
-	&.hidden {
-		display: none;
-	}
-}
-
-.launch-banner-content .launch-bar-global-styles-preview {
-	border-top: 1px solid #c3c4c7;
-	width: calc(100% + 48px);
-	margin: 0 -24px;
-	box-sizing: border-box;
-	padding: 12px 24px;
-	font-size: 13px;
-	line-height: 17px;
-	color: inherit;
-
-	&:hover {
-		background: none;
-	}
-
-	label {
-		position: relative;
-		display: inline-block;
-		width: 36px;
-		height: 18px;
-		margin-right: 8px;
-
-		span {
-			position: absolute;
-			cursor: pointer;
-			top: 0;
-			left: 0;
-			right: 0;
-			bottom: 0;
-			background-color: #ccc;
-			transition: 0.4s;
-			/* stylelint-disable-next-line scales/radii */
-			border-radius: 18px;
-
-			&::before {
-				position: absolute;
-				content: "";
-				height: 12px;
-				width: 12px;
-				left: 3px;
-				bottom: 3px;
-				background-color: #fff;
-				transition: 0.4s;
-				border-radius: 50%;
+			@media (max-width: 782px) {
+				text-indent: 0;
+				font: 400 32px / 1 dashicons;
+				speak: never;
+				top: 7px;
+				width: 52px;
+				text-align: center;
 			}
 		}
+	}
 
-		input {
-			opacity: 0;
-			width: 0;
-			height: 0;
+	> .ab-sub-wrapper {
 
-			&:checked + span {
-				background-color: #0675c4;
+		@media (max-width: 782px) {
+			transform: translateX(calc(26px - 50%));
+		}
+	}
+
+	#wp-admin-bar-wpcom-global-styles-description .ab-item {
+		height: auto;
+		white-space: normal;
+		min-width: 300px;
+		line-height: 22px;
+		padding: 2px 12px;
+
+		@media (max-width: 782px) {
+			padding-top: 12px;
+		}
+
+		a {
+			display: inline;
+			padding: 0;
+			text-decoration: underline;
+			line-height: normal;
+
+			@media (max-width: 782px) {
+				font-size: 16px;
+			}
+		}
+	}
+
+	#wp-admin-bar-wpcom-global-styles-upgrade {
+		padding: 8px 10px;
+
+		@media (max-width: 782px) {
+			padding-bottom: 0;
+		}
+
+		.ab-item {
+			height: unset;
+			display: inline-block;
+			color: #fff;
+			background-color: #3858e9;
+			border-color: #3858e9;
+			border-radius: 2px;
+			padding: 2px;
+			box-sizing: border-box;
+			width: 100%;
+			text-align: center;
+
+			@media (max-width: 782px) {
+				height: 40px;
+				line-height: 38px;
+				font-size: 16px;
+			}
+
+			&:hover {
+				background-color: #4664eb;
+				border-color: #4664eb;
+			}
+		}
+	}
+
+	#wp-admin-bar-wpcom-global-styles-reset .ab-item {
+		text-align: center;
+		height: unset;
+		display: flex;
+		gap: 4px;
+		justify-content: center;
+
+		.wpcom-global-styles-reset-help-icon path {
+			stroke: #c3c4c7;
+		}
+
+		.wpcom-global-styles-reset-external-icon path {
+			fill: #c3c4c7;
+		}
+
+		&:hover {
+			color: #f6f7f7;
+
+			.wpcom-global-styles-reset-help-icon path {
+				stroke: #f6f7f7;
+			}
+
+			.wpcom-global-styles-reset-external-icon path {
+				fill: #f6f7f7;
+			}
+		}
+	}
+
+	#wp-admin-bar-wpcom-global-styles-preview {
+
+		.ab-item {
+			display: flex;
+			align-items: center;
+		}
+
+		label {
+			position: relative;
+			display: inline-block;
+			width: 36px;
+			height: 18px;
+			margin-right: 8px;
+
+			span {
+				position: absolute;
+				cursor: pointer;
+				top: 0;
+				left: 0;
+				right: 0;
+				bottom: 0;
+				background-color: #ccc;
+				transition: 0.4s;
+				/* stylelint-disable-next-line scales/radii */
+				border-radius: 18px;
 
 				&::before {
-					transform: translateX(18px);
+					position: absolute;
+					content: "";
+					height: 12px;
+					width: 12px;
+					left: 3px;
+					bottom: 3px;
+					background-color: #fff;
+					transition: 0.4s;
+					border-radius: 50%;
 				}
 			}
 
-			&:focus + span {
-				box-shadow: 0 0 1px #2196f3;
+			input {
+				opacity: 0;
+				width: 0;
+				height: 0;
+
+				&:checked + span {
+					background-color: #3858e9;
+
+					&::before {
+						transform: translateX(18px);
+					}
+				}
+
+				&:focus + span {
+					box-shadow: 0 0 1px #546ff3;
+				}
+			}
+		}
+	}
+
+	.wpcom-global-styles-close {
+		position: absolute;
+		top: -8px;
+		right: -1px;
+		width: 24px;
+		height: 24px;
+		cursor: pointer;
+		justify-content: center;
+		align-items: center;
+		background: none;
+		border: none;
+		outline: none;
+		display: flex;
+
+		@media (max-width: 782px) {
+			top: -2px;
+		}
+
+		svg {
+			fill: #c3c4c7;
+			width: 18px;
+			height: 18px;
+		}
+
+		&:hover {
+
+			svg {
+				fill: #f6f7f7;
 			}
 		}
 	}
 }
 
-.launch-banner-content .launch-bar-global-styles-popover .launch-bar-global-styles-message a {
-	display: inline;
-	color: inherit;
-	padding: 0;
-	font-weight: 400;
-	font-size: inherit;
-	text-decoration: underline !important;
-	background: none;
-}
+/**
+ * Hides certain icons on smaller viewports to ensure the GS notice is visible.
+ */
+@media (min-width: 782px) {
 
-.launch-bar-global-styles-toggle svg {
-	margin-right: 4px;
-}
+	@media (max-width: 940px) {
 
-.launch-bar-global-styles-close {
-	position: absolute;
-	top: 4px;
-	right: 4px;
-	width: 24px;
-	height: 24px;
-	cursor: pointer;
-	display: flex;
-	justify-content: center;
-	align-items: center;
+		#wpadminbar #wp-admin-bar-comments {
+			display: none !important;
+		}
+	}
 
-	svg {
-		fill: #1e1e1e;
-		width: 18px;
-		height: 18px;
+	@media (max-width: 900px) {
+
+		#wpadminbar #wp-admin-bar-new-content {
+			display: none !important;
+		}
+	}
+
+	@media (max-width: 830px) {
+
+		#wpadminbar .wp-admin-bar-reader {
+			display: none !important;
+		}
 	}
 }
 
-@media screen and (max-width: 460px) {
+@media (max-width: 600px) {
 
-	.launch-bar-global-styles-button {
-		position: static;
+	#wpadminbar #wp-admin-bar-comments {
+		display: none !important;
 	}
+}
 
-	.launch-bar-global-styles-popover {
-		width: auto;
-		left: 20px;
-		right: 20px;
-		transform: none;
+@media (max-width: 520px) {
+
+	#wpadminbar #wp-admin-bar-new-content {
+		display: none !important;
+	}
+}
+
+@media (max-width: 480px) {
+
+	#wpadminbar .wp-admin-bar-reader {
+		display: none !important;
+	}
+}
+
+@media (max-width: 380px) {
+
+	#wpadminbar #wp-admin-bar-edit {
+		display: none !important;
 	}
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/wpcom-global-styles-view.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/wpcom-global-styles-view.scss
@@ -2,6 +2,7 @@
 
 	@media (max-width: 782px) {
 		display: block;
+		position: static;
 	}
 
 	> .ab-item {
@@ -25,13 +26,6 @@
 				width: 52px;
 				text-align: center;
 			}
-		}
-	}
-
-	> .ab-sub-wrapper {
-
-		@media (max-width: 782px) {
-			transform: translateX(calc(26px - 50%));
 		}
 	}
 
@@ -189,6 +183,7 @@
 		border: none;
 		outline: none;
 		display: flex;
+		visibility: hidden;
 
 		@media (max-width: 782px) {
 			top: -2px;

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/wpcom-global-styles-view.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/wpcom-global-styles-view.scss
@@ -106,14 +106,13 @@
 		}
 
 		&:hover {
-			color: #f6f7f7;
 
 			.wpcom-global-styles-reset-help-icon path {
-				stroke: #f6f7f7;
+				stroke: #72aee6;
 			}
 
 			.wpcom-global-styles-reset-external-icon path {
-				fill: #f6f7f7;
+				fill: #72aee6;
 			}
 		}
 	}

--- a/projects/packages/jetpack-mu-wpcom/src/utils.php
+++ b/projects/packages/jetpack-mu-wpcom/src/utils.php
@@ -185,3 +185,20 @@ function is_user_connected( $user_id ) {
 
 	return ( new Connection_Manager( 'jetpack' ) )->is_user_connected( $user_id );
 }
+
+/**
+ * Wrapper to test a blog sticker on both Simple and Atomic sites at once.
+ *
+ * @param string $blog_sticker The blog sticker.
+ * @param int    $blog_id The WPCOM blog ID.
+ * @return bool Whether the site has the blog sticker.
+ */
+function wpcom_has_blog_sticker( $blog_sticker, $blog_id ) {
+	if ( function_exists( 'has_blog_sticker' ) && has_blog_sticker( $blog_sticker, $blog_id ) ) {
+		return true;
+	}
+	if ( function_exists( 'wpcomsh_is_site_sticker_active' ) && wpcomsh_is_site_sticker_active( $blog_sticker ) ) {
+		return true;
+	}
+	return false;
+}


### PR DESCRIPTION
Fixes DOTTHEM-96

## Proposed changes:

When a site that has limited Global Styles, we currently show an upsell in the launch banner on the front end (for admin users). However, the launch banner does not exist on Atomic sites, so we need a different place for the front end upsell when we'll extend Limited Global Styles to Atomic.

This PRs moves the upsell to the admin bar (which is where we moved the launch button too), instead of recreating the launch banner on Atomic sites.

Viewport | Before | After
--- | --- | ---
Desktop | <img width="400" alt="Screenshot 2025-10-08 at 12 32 55" src="https://github.com/user-attachments/assets/86e5e516-42b4-4b67-b5c8-329a60f55a8d" /> | <img width="400"  alt="Screenshot 2025-10-08 at 13 42 01" src="https://github.com/user-attachments/assets/bd4e598e-8e6a-4e6e-98c5-9858a090e879" />
Mobile | <img width="400" alt="Screenshot 2025-10-08 at 12 32 09" src="https://github.com/user-attachments/assets/bf2d4b79-4f30-4b6a-b8b8-447ef40765ea" /> | <img width="400" alt="Screenshot 2025-10-08 at 13 42 19" src="https://github.com/user-attachments/assets/39934a06-6ab6-4f5d-a8e1-8351d86324de" />




### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

- Apply these changes to your sandbox
- Sandbox a site with a Free plan
- Go the Site Editor > Styles and make some changes
- Save them and visit the frontend
- Make sure the notice is visible in the admin bar
- Click on the different links and make sure they redirect to the expected pages
- Apply these changes to an Atomic site now
- Since Limited Global Styles have not been extended to Atomic sites yet, you won't see any change on your site.
- You can though force the upsell to show up if you add this code somewhere (e.g. via the Code Snippets plugin):

```
add_filter( 'wpcom_should_show_global_styles_admin_bar', '__return_true' );
```

- Once you do that, visit the frontend
- Make sure the notice is displayed correctly in the admin bar
- Click on the different links and make sure they redirect to the expected pages (note that the Upgrade button links to the Plans grid with the Premium plan highlighted, but this won't work if your site already has a better plan)

