### PR TITLE
Comment Likes: Prevent PHP warnings when home URL is invalid

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-prevent_warnings_on_comment_likes_when_invalid_home_url
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-prevent_warnings_on_comment_likes_when_invalid_home_url
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Comment likes: Prevent PHP warnings if site URL is invalid.

--- a/projects/plugins/jetpack/modules/comment-likes.php
+++ b/projects/plugins/jetpack/modules/comment-likes.php
@@ -70,7 +70,12 @@ class Jetpack_Comment_Likes {
 		$this->settings = new Jetpack_Likes_Settings();
 		$this->blog_id  = Jetpack_Options::get_option( 'id' );
 		$url_parts      = wp_parse_url( home_url() );
-		$this->domain   = $url_parts['host'];
+
+		// Abort if domain can't be determined.
+		if ( ! $url_parts || ! isset( $url_parts['host'] ) ) {
+			return;
+		}
+		$this->domain = $url_parts['host'];
 
 		add_action( 'template_redirect', array( $this, 'frontend_init' ) );
 		add_action( 'admin_init', array( $this, 'admin_init' ) );


### PR DESCRIPTION
Closes MONOREP-135

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This addresses the following warning:
```
PHP Warning: Undefined array key "host" in /wordpress/plugins/jetpack/15.1-beta.2/modules/comment-likes.php on line 73
```

Sites that triggered this warning either did not have the `home` option set or had it set to `https://`. Rather than change the way we grab the URL, potentially messing up like stats, this PR proposes returning early.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

