### PR TITLE
Forms: more elaborate empty states

### DIFF
--- a/projects/packages/forms/changelog/update-forms-elaborate-empty-states
+++ b/projects/packages/forms/changelog/update-forms-elaborate-empty-states
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: more elaborate empty states.

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -1140,6 +1140,7 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 			'canActivatePlugins'      => current_user_can( 'activate_plugins' ),
 			'exportNonce'             => wp_create_nonce( 'feedback_export' ),
 			'newFormNonce'            => wp_create_nonce( 'create_new_form' ),
+			'emptyTrashDays'          => defined( 'EMPTY_TRASH_DAYS' ) ? EMPTY_TRASH_DAYS : 0,
 		);
 
 		return rest_ensure_response( $config );

--- a/projects/packages/forms/src/dashboard/inbox/empty-responses.tsx
+++ b/projects/packages/forms/src/dashboard/inbox/empty-responses.tsx
@@ -1,4 +1,12 @@
-import { __ } from '@wordpress/i18n';
+import { __experimentalVStack as VStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
+import { __, _n, sprintf } from '@wordpress/i18n';
+import useFormsConfig from '../../hooks/use-forms-config';
+
+const EmptyWrapper = ( { children } ) => (
+	<VStack alignment="center" spacing="0">
+		{ children }
+	</VStack>
+);
 
 type EmptyResponsesProps = {
 	status: string;
@@ -6,25 +14,59 @@ type EmptyResponsesProps = {
 };
 
 const EmptyResponses = ( { status, isSearch }: EmptyResponsesProps ) => {
-	const searchMessage = __( 'No responses found', 'jetpack-forms' );
+	const formsConfig = useFormsConfig();
+	const emptyTrashDays = formsConfig?.emptyTrashDays ?? 0;
+
+	const searchHeading = __( 'No responses found', 'jetpack-forms' );
+	const searchMessage = __( 'Your search returned no results.', 'jetpack-forms' );
 	if ( isSearch ) {
-		return <p>{ searchMessage }</p>;
+		return (
+			<EmptyWrapper>
+				<h4>{ searchHeading }</h4>
+				<p>{ searchMessage }</p>
+			</EmptyWrapper>
+		);
 	}
 
-	const noTrashMessage = __( 'Trash is empty', 'jetpack-forms' );
+	const noTrashHeading = __( 'Trash is empty', 'jetpack-forms' );
+	const noTrashMessage = sprintf(
+		/* translators: %d number of days. */
+		_n(
+			'Responses moved to trash will be deleted forever after %d day.',
+			'Responses moved to trash will be deleted forever after %d days.',
+			emptyTrashDays,
+			'jetpack-forms'
+		),
+		emptyTrashDays
+	);
 	if ( status === 'trash' ) {
-		return <p>{ noTrashMessage }</p>;
+		return (
+			<EmptyWrapper>
+				<h4>{ noTrashHeading }</h4>
+				<p>{ emptyTrashDays > 0 && noTrashMessage }</p>;
+			</EmptyWrapper>
+		);
 	}
 
+	const noSpamHeading = __( 'Lucky you, no spam!', 'jetpack-forms' );
 	const noSpamMessage = __(
 		'Spam responses are automatically trashed after 15 days.',
 		'jetpack-forms'
 	);
 	if ( status === 'spam' ) {
-		return <p>{ noSpamMessage }</p>;
+		return (
+			<EmptyWrapper>
+				<h4>{ noSpamHeading }</h4>
+				<p>{ noSpamMessage }</p>
+			</EmptyWrapper>
+		);
 	}
 
-	return <p>{ __( 'No responses', 'jetpack-forms' ) }</p>;
+	return (
+		<EmptyWrapper>
+			<p>{ __( 'No responses', 'jetpack-forms' ) }</p>
+		</EmptyWrapper>
+	);
 };
 
 export default EmptyResponses;

--- a/projects/packages/forms/src/dashboard/inbox/empty-responses.tsx
+++ b/projects/packages/forms/src/dashboard/inbox/empty-responses.tsx
@@ -17,8 +17,11 @@ const EmptyResponses = ( { status, isSearch }: EmptyResponsesProps ) => {
 	const formsConfig = useFormsConfig();
 	const emptyTrashDays = formsConfig?.emptyTrashDays ?? 0;
 
-	const searchHeading = __( 'No responses found', 'jetpack-forms' );
-	const searchMessage = __( 'Your search returned no results.', 'jetpack-forms' );
+	const searchHeading = __( 'No results found', 'jetpack-forms' );
+	const searchMessage = __(
+		"Try adjusting your search or filters to find what you're looking for.",
+		'jetpack-forms'
+	);
 	if ( isSearch ) {
 		return (
 			<EmptyWrapper>
@@ -32,8 +35,8 @@ const EmptyResponses = ( { status, isSearch }: EmptyResponsesProps ) => {
 	const noTrashMessage = sprintf(
 		/* translators: %d number of days. */
 		_n(
-			'Responses moved to trash will be deleted forever after %d day.',
-			'Responses moved to trash will be deleted forever after %d days.',
+			'Items in trash are permanently deleted after %d day.',
+			'Items in trash are permanently deleted after %d days.',
 			emptyTrashDays,
 			'jetpack-forms'
 		),
@@ -49,10 +52,7 @@ const EmptyResponses = ( { status, isSearch }: EmptyResponsesProps ) => {
 	}
 
 	const noSpamHeading = __( 'Lucky you, no spam!', 'jetpack-forms' );
-	const noSpamMessage = __(
-		'Spam responses are automatically trashed after 15 days.',
-		'jetpack-forms'
-	);
+	const noSpamMessage = __( 'Spam responses are moved to trash after 15 days.', 'jetpack-forms' );
 	if ( status === 'spam' ) {
 		return (
 			<EmptyWrapper>
@@ -64,7 +64,13 @@ const EmptyResponses = ( { status, isSearch }: EmptyResponsesProps ) => {
 
 	return (
 		<EmptyWrapper>
-			<p>{ __( 'No responses', 'jetpack-forms' ) }</p>
+			<h4>{ __( "You're set up. No responses yet.", 'jetpack-forms' ) }</h4>
+			<p>
+				{ __(
+					'Share your form to start collecting responses. New items will appear here.',
+					'jetpack-forms'
+				) }
+			</p>
 		</EmptyWrapper>
 	);
 };

--- a/projects/packages/forms/src/dashboard/inbox/empty-responses.tsx
+++ b/projects/packages/forms/src/dashboard/inbox/empty-responses.tsx
@@ -1,10 +1,18 @@
-import { __experimentalVStack as VStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
+import {
+	__experimentalText as Text, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+	__experimentalVStack as VStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+} from '@wordpress/components';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import useFormsConfig from '../../hooks/use-forms-config';
 
-const EmptyWrapper = ( { children } ) => (
-	<VStack alignment="center" spacing="0">
-		{ children }
+const EmptyWrapper = ( { heading = '', body = '' } ) => (
+	<VStack alignment="center" spacing="2">
+		{ heading && (
+			<Text as="h3" weight="500" size="15">
+				{ heading }
+			</Text>
+		) }
+		{ body && <Text variant="muted">{ body }</Text> }
 	</VStack>
 );
 
@@ -23,12 +31,7 @@ const EmptyResponses = ( { status, isSearch }: EmptyResponsesProps ) => {
 		'jetpack-forms'
 	);
 	if ( isSearch ) {
-		return (
-			<EmptyWrapper>
-				<h4>{ searchHeading }</h4>
-				<p>{ searchMessage }</p>
-			</EmptyWrapper>
-		);
+		return <EmptyWrapper heading={ searchHeading } body={ searchMessage } />;
 	}
 
 	const noTrashHeading = __( 'Trash is empty', 'jetpack-forms' );
@@ -44,34 +47,24 @@ const EmptyResponses = ( { status, isSearch }: EmptyResponsesProps ) => {
 	);
 	if ( status === 'trash' ) {
 		return (
-			<EmptyWrapper>
-				<h4>{ noTrashHeading }</h4>
-				<p>{ emptyTrashDays > 0 && noTrashMessage }</p>;
-			</EmptyWrapper>
+			<EmptyWrapper heading={ noTrashHeading } body={ emptyTrashDays > 0 && noTrashMessage } />
 		);
 	}
 
 	const noSpamHeading = __( 'Lucky you, no spam!', 'jetpack-forms' );
 	const noSpamMessage = __( 'Spam responses are moved to trash after 15 days.', 'jetpack-forms' );
 	if ( status === 'spam' ) {
-		return (
-			<EmptyWrapper>
-				<h4>{ noSpamHeading }</h4>
-				<p>{ noSpamMessage }</p>
-			</EmptyWrapper>
-		);
+		return <EmptyWrapper heading={ noSpamHeading } body={ noSpamMessage } />;
 	}
 
 	return (
-		<EmptyWrapper>
-			<h4>{ __( "You're set up. No responses yet.", 'jetpack-forms' ) }</h4>
-			<p>
-				{ __(
-					'Share your form to start collecting responses. New items will appear here.',
-					'jetpack-forms'
-				) }
-			</p>
-		</EmptyWrapper>
+		<EmptyWrapper
+			heading={ __( "You're set up. No responses yet.", 'jetpack-forms' ) }
+			body={ __(
+				'Share your form to start collecting responses. New items will appear here.',
+				'jetpack-forms'
+			) }
+		/>
 	);
 };
 

--- a/projects/packages/forms/src/dashboard/inbox/response.js
+++ b/projects/packages/forms/src/dashboard/inbox/response.js
@@ -682,17 +682,15 @@ const InboxResponse = ( {
 				</ConfirmDialog>
 			</div>
 			{ response.status === 'spam' && (
-				<Tip>
-					{ __( 'Spam responses are automatically trashed after 15 days.', 'jetpack-forms' ) }
-				</Tip>
+				<Tip>{ __( 'Spam responses are moved to trash after 15 days.', 'jetpack-forms' ) }</Tip>
 			) }
 			{ response.status === 'trash' && (
 				<Tip>
 					{ sprintf(
 						/* translators: %d number of days. */
 						_n(
-							'Responses moved to trash will be deleted forever after %d day.',
-							'Responses moved to trash will be deleted forever after %d days.',
+							'Items in trash are permanently deleted after %d day.',
+							'Items in trash are permanently deleted after %d days.',
 							emptyTrashDays,
 							'jetpack-forms'
 						),

--- a/projects/packages/forms/src/dashboard/inbox/response.js
+++ b/projects/packages/forms/src/dashboard/inbox/response.js
@@ -18,12 +18,13 @@ import { useRegistry, useDispatch } from '@wordpress/data';
 import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
 import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
-import { __, sprintf } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 import { download, close, chevronLeft, chevronRight } from '@wordpress/icons';
 import clsx from 'clsx';
 /**
  * Internal dependencies
  */
+import useFormsConfig from '../../hooks/use-forms-config';
 import CopyClipboardButton from '../components/copy-clipboard-button';
 import Gravatar from '../components/gravatar';
 import { useMarkAsSpam } from '../hooks/use-mark-as-spam';
@@ -205,6 +206,9 @@ const InboxResponse = ( {
 	const [ hasMarkedSelfAsRead, setHasMarkedSelfAsRead ] = useState( false );
 
 	const { editEntityRecord } = useDispatch( 'core' );
+
+	const formsConfig = useFormsConfig();
+	const emptyTrashDays = formsConfig?.emptyTrashDays ?? 0;
 
 	// When opening a "Mark as spam" link from the email, the InboxResponse component is rendered, so we use a hook here to handle it.
 	const { isConfirmDialogOpen, onConfirmMarkAsSpam, onCancelMarkAsSpam } =
@@ -678,8 +682,22 @@ const InboxResponse = ( {
 				</ConfirmDialog>
 			</div>
 			{ response.status === 'spam' && (
-				<Tip className="jp-forms__inbox-spam">
+				<Tip>
 					{ __( 'Spam responses are automatically trashed after 15 days.', 'jetpack-forms' ) }
+				</Tip>
+			) }
+			{ response.status === 'trash' && (
+				<Tip>
+					{ sprintf(
+						/* translators: %d number of days. */
+						_n(
+							'Responses moved to trash will be deleted forever after %d day.',
+							'Responses moved to trash will be deleted forever after %d days.',
+							emptyTrashDays,
+							'jetpack-forms'
+						),
+						emptyTrashDays
+					) }
 				</Tip>
 			) }
 		</>

--- a/projects/packages/forms/src/dashboard/inbox/response.js
+++ b/projects/packages/forms/src/dashboard/inbox/response.js
@@ -682,10 +682,12 @@ const InboxResponse = ( {
 				</ConfirmDialog>
 			</div>
 			{ response.status === 'spam' && (
-				<Tip>{ __( 'Spam responses are moved to trash after 15 days.', 'jetpack-forms' ) }</Tip>
+				<Tip className="jp-forms__inbox-response-tip">
+					{ __( 'Spam responses are moved to trash after 15 days.', 'jetpack-forms' ) }
+				</Tip>
 			) }
 			{ response.status === 'trash' && (
-				<Tip>
+				<Tip className="jp-forms__inbox-response-tip">
 					{ sprintf(
 						/* translators: %d number of days. */
 						_n(

--- a/projects/packages/forms/src/dashboard/inbox/response.js
+++ b/projects/packages/forms/src/dashboard/inbox/response.js
@@ -682,12 +682,10 @@ const InboxResponse = ( {
 				</ConfirmDialog>
 			</div>
 			{ response.status === 'spam' && (
-				<Tip className="jp-forms__inbox-response-tip">
-					{ __( 'Spam responses are moved to trash after 15 days.', 'jetpack-forms' ) }
-				</Tip>
+				<Tip>{ __( 'Spam responses are moved to trash after 15 days.', 'jetpack-forms' ) }</Tip>
 			) }
 			{ response.status === 'trash' && (
-				<Tip className="jp-forms__inbox-response-tip">
+				<Tip>
 					{ sprintf(
 						/* translators: %d number of days. */
 						_n(

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -527,3 +527,8 @@ body.jetpack_page_jetpack-forms-admin {
 	margin-left: -12px;
 	vertical-align: middle;
 }
+
+.jp-forms__inbox-response-tip {
+	align-items: anchor-center;
+	text-wrap: pretty;
+}

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -406,10 +406,12 @@
 	}
 
 	.components-tip {
+		align-items: anchor-center;
 		background-color: rgba(var(--wp-admin-theme-color--rgb), 0.04);
-		margin: 0 24px 16px;
+		border-radius: variables.$radius-small;
+		margin: 8px 24px 16px;
 		padding: 8px 16px;
-		border-radius: 4px;
+		text-wrap: pretty;
 	}
 }
 
@@ -526,9 +528,4 @@ body.jetpack_page_jetpack-forms-admin {
 	margin-right: 4.5px;
 	margin-left: -12px;
 	vertical-align: middle;
-}
-
-.jp-forms__inbox-response-tip {
-	align-items: anchor-center;
-	text-wrap: pretty;
 }

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -407,10 +407,9 @@
 
 	.components-tip {
 		align-items: anchor-center;
-		background-color: rgba(var(--wp-admin-theme-color--rgb), 0.04);
-		border-radius: variables.$radius-small;
-		margin: 8px 24px 16px;
-		padding: 8px 16px;
+		border-top: 1px solid var(--jp-forms-border-color);
+		margin: 8px 0 56px 0;
+		padding: 16px;
 		text-wrap: pretty;
 	}
 }

--- a/projects/packages/forms/src/types/index.ts
+++ b/projects/packages/forms/src/types/index.ts
@@ -238,4 +238,6 @@ export interface FormsConfigData {
 	exportNonce?: string;
 	/** Nonce for creating a new form (dashboard-only). */
 	newFormNonce?: string;
+	/** Number of days before WordPress permanently deletes trash. See https://developer.wordpress.org/advanced-administration/wordpress/wp-config/#empty-trash */
+	emptyTrashDays?: number;
 }

--- a/projects/plugins/jetpack/changelog/update-forms-elaborate-empty-states
+++ b/projects/plugins/jetpack/changelog/update-forms-elaborate-empty-states
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: more elaborate empty states.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Continues previous PR adding better empty states for forms:
- https://github.com/Automattic/jetpack/pull/45013

This change adds more elaborate, fun and educational copies for each empty state.

The next step would be to use a more elaborate `EmptyState` component that is currently being built (1156-ghe-Automattic/ciab-admin).

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds notice under every response in trash about trash emptied in 30 days
* Update copy of spam notice

<img width="1082" height="729" alt="Screenshot 2025-10-09 at 12 01 55" src="https://github.com/user-attachments/assets/97d41541-41b5-4df9-ae74-ad1f63feee27" />
<img width="1084" height="631" alt="image" src="https://github.com/user-attachments/assets/17dc0ae5-da1b-43d2-9c80-0e3e438a2b91" />


* Changes copy of empty inbox, no search results, empty spam and empty trash views

<img width="855" height="600" alt="Screenshot 2025-10-09 at 11 36 20" src="https://github.com/user-attachments/assets/a3b8d558-25d8-46d6-993f-abde973ae8fa" />
<img width="858" height="674" alt="Screenshot 2025-10-09 at 11 36 13" src="https://github.com/user-attachments/assets/f2615238-8283-4bdb-91fa-77f4425180cf" />
<img width="860" height="580" alt="Screenshot 2025-10-09 at 11 35 46" src="https://github.com/user-attachments/assets/743dbb4b-70ee-4124-8964-d0dab693c0a4" />
<img width="853" height="612" alt="Screenshot 2025-10-09 at 11 35 41" src="https://github.com/user-attachments/assets/773d648e-82b2-4d4b-bf27-32bde848868e" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* In trash, open one response and see notice under response
* See how inbox, search results, spam and trash look when they're empty.