### PR TITLE
Forms: optimistically update count in sidebar for read/unread actions (take two)

### DIFF
--- a/projects/packages/forms/changelog/add-forms-unread-state-optimistic-updates2
+++ b/projects/packages/forms/changelog/add-forms-unread-state-optimistic-updates2
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: update read/unread counts optimistically in the sidebar

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -1415,9 +1415,7 @@ class Contact_Form_Plugin {
 			$unread = self::get_unread_count();
 
 			if ( isset( $submenu['jetpack'] ) && is_array( $submenu['jetpack'] ) && ! empty( $submenu['jetpack'] ) ) {
-				$inline_style = ( $unread > 0 ) ? '' : 'style="display: none;"';
-
-				$forms_unread_count_tag = " <span class='jp-feedback-unread-counter count-{$unread} awaiting-mod' {$inline_style}><span class='feedback-unread-counter'>" . number_format_i18n( $unread ) . '</span></span>';
+				$forms_unread_count_tag = " <span class='jp-feedback-unread-counter count-{$unread} awaiting-mod'><span class='feedback-unread-counter'>" . number_format_i18n( $unread ) . '</span></span>';
 				$jetpack_badge_count    = $unread;
 
 				// Main menu entries

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/actions.js
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/actions.js
@@ -340,8 +340,9 @@ export const markAsReadAction = {
 		const { editEntityRecord } = registry.dispatch( coreStore );
 		const { getEntityRecord } = registry.select( coreStore );
 		const { createSuccessNotice, createErrorNotice } = registry.dispatch( noticesStore );
+
 		const promises = await Promise.allSettled(
-			items.map( async ( { id } ) => {
+			items.map( async ( { id, status } ) => {
 				// Get current entity from store
 				const currentEntity = getEntityRecord( 'postType', 'feedback', id );
 
@@ -351,8 +352,10 @@ export const markAsReadAction = {
 						is_unread: false,
 					} );
 
-					// Immediately update menu counters optimistically to avoid delays
-					updateMenuCounterOptimistically( -items.length );
+					// Immediately update menu counters optimistically to avoid delays, but only for inbox
+					if ( status === 'publish' ) {
+						updateMenuCounterOptimistically( -1 );
+					}
 				}
 
 				// Update on server
@@ -362,7 +365,7 @@ export const markAsReadAction = {
 					data: { is_unread: false },
 				} )
 					.then( ( { count } ) => {
-						// Update the unread count in the menu.
+						// Update menu counter with accurate count from server.
 						updateMenuCounter( count );
 					} )
 					.catch( () => {
@@ -372,8 +375,10 @@ export const markAsReadAction = {
 								is_unread: true,
 							} );
 
-							// Revert the change in the sidebar
-							updateMenuCounterOptimistically( items.length );
+							// Revert the optimistic change in the sidebar.
+							if ( status === 'publish' ) {
+								updateMenuCounterOptimistically( 1 );
+							}
 						}
 						throw new Error( 'Failed to mark as read' );
 					} );
@@ -425,7 +430,7 @@ export const markAsUnreadAction = {
 		const { getEntityRecord } = registry.select( coreStore );
 		const { createSuccessNotice, createErrorNotice } = registry.dispatch( noticesStore );
 		const promises = await Promise.allSettled(
-			items.map( async ( { id } ) => {
+			items.map( async ( { id, status } ) => {
 				// Get current entity from store
 				const currentEntity = getEntityRecord( 'postType', 'feedback', id );
 
@@ -435,8 +440,10 @@ export const markAsUnreadAction = {
 						is_unread: true,
 					} );
 
-					// Immediately update menu counters optimistically to avoid delays
-					updateMenuCounterOptimistically( items.length );
+					// Immediately update menu counters optimistically to avoid delays, but only for inbox
+					if ( status === 'publish' ) {
+						updateMenuCounterOptimistically( 1 );
+					}
 				}
 
 				// Update on server
@@ -446,7 +453,7 @@ export const markAsUnreadAction = {
 					data: { is_unread: true },
 				} )
 					.then( ( { count } ) => {
-						// Update the unread count in the menu.
+						// Update menu counter with accurate count from server.
 						updateMenuCounter( count );
 					} )
 					.catch( () => {
@@ -456,8 +463,10 @@ export const markAsUnreadAction = {
 								is_unread: false,
 							} );
 
-							// Revert the change in the sidebar
-							updateMenuCounterOptimistically( -items.length );
+							// Revert the optimistic change in the sidebar.
+							if ( status === 'publish' ) {
+								updateMenuCounterOptimistically( -1 );
+							}
 						}
 						throw new Error( 'Failed to mark as unread' );
 					} );

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/actions.js
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/actions.js
@@ -7,7 +7,7 @@ import { store as noticesStore } from '@wordpress/notices';
 import { notSpam, spam } from '../../icons';
 import { store as dashboardStore } from '../../store';
 import InboxResponse from '../response';
-import { updateMenuCounter } from '../utils';
+import { updateMenuCounter, updateMenuCounterOptimistically } from '../utils';
 
 export const BULK_ACTIONS = {
 	markAsSpam: 'mark_as_spam',
@@ -350,6 +350,9 @@ export const markAsReadAction = {
 					editEntityRecord( 'postType', 'feedback', id, {
 						is_unread: false,
 					} );
+
+					// Immediately update menu counters optimistically to avoid delays
+					updateMenuCounterOptimistically( -items.length );
 				}
 
 				// Update on server
@@ -368,6 +371,9 @@ export const markAsReadAction = {
 							editEntityRecord( 'postType', 'feedback', id, {
 								is_unread: true,
 							} );
+
+							// Revert the change in the sidebar
+							updateMenuCounterOptimistically( items.length );
 						}
 						throw new Error( 'Failed to mark as read' );
 					} );
@@ -428,6 +434,9 @@ export const markAsUnreadAction = {
 					editEntityRecord( 'postType', 'feedback', id, {
 						is_unread: true,
 					} );
+
+					// Immediately update menu counters optimistically to avoid delays
+					updateMenuCounterOptimistically( items.length );
 				}
 
 				// Update on server
@@ -446,6 +455,9 @@ export const markAsUnreadAction = {
 							editEntityRecord( 'postType', 'feedback', id, {
 								is_unread: false,
 							} );
+
+							// Revert the change in the sidebar
+							updateMenuCounterOptimistically( -items.length );
 						}
 						throw new Error( 'Failed to mark as unread' );
 					} );

--- a/projects/packages/forms/src/dashboard/inbox/response.js
+++ b/projects/packages/forms/src/dashboard/inbox/response.js
@@ -551,7 +551,9 @@ const InboxResponse = ( {
 		} );
 
 		// Immediately update menu counters optimistically to avoid delays
-		updateMenuCounterOptimistically( -1 );
+		if ( response.status === 'publish' ) {
+			updateMenuCounterOptimistically( -1 );
+		}
 
 		// Then update on server
 		apiFetch( {
@@ -570,7 +572,9 @@ const InboxResponse = ( {
 				} );
 
 				// Revert the change in the sidebar
-				updateMenuCounterOptimistically( 1 );
+				if ( response.status === 'publish' ) {
+					updateMenuCounterOptimistically( 1 );
+				}
 			} );
 	}, [ response, editEntityRecord, hasMarkedSelfAsRead ] );
 

--- a/projects/packages/forms/src/dashboard/inbox/response.js
+++ b/projects/packages/forms/src/dashboard/inbox/response.js
@@ -37,7 +37,7 @@ import {
 	markAsReadAction,
 	markAsUnreadAction,
 } from './dataviews/actions';
-import { getPath, updateMenuCounter } from './utils';
+import { getPath, updateMenuCounter, updateMenuCounterOptimistically } from './utils';
 
 const getDisplayName = response => {
 	const { author_name, author_email, author_url, ip } = response;
@@ -550,6 +550,9 @@ const InboxResponse = ( {
 			is_unread: false,
 		} );
 
+		// Immediately update menu counters optimistically to avoid delays
+		updateMenuCounterOptimistically( -1 );
+
 		// Then update on server
 		apiFetch( {
 			path: `/wp/v2/feedback/${ response.id }/read`,
@@ -557,12 +560,17 @@ const InboxResponse = ( {
 			data: { is_unread: false },
 		} )
 			.then( ( { count } ) => {
+				// Update menu counter with accurate count from server
 				updateMenuCounter( count );
 			} )
 			.catch( () => {
+				// Revert the change in the store
 				editEntityRecord( 'postType', 'feedback', response.id, {
 					is_unread: true,
 				} );
+
+				// Revert the change in the sidebar
+				updateMenuCounterOptimistically( 1 );
 			} );
 	}, [ response, editEntityRecord, hasMarkedSelfAsRead ] );
 

--- a/projects/packages/forms/src/dashboard/inbox/utils.js
+++ b/projects/packages/forms/src/dashboard/inbox/utils.js
@@ -17,12 +17,30 @@ export const updateMenuCounter = count => {
 	// iterate over all elements with the class 'jp-feedback-unread-counter' and update their text content
 	document.querySelectorAll( '.jp-feedback-unread-counter' ).forEach( item => {
 		if ( item.dataset.unreadDiff ) {
-			const newCount = parseInt( item.dataset.unreadDiff, 10 ) + count;
-			item.textContent = newCount > 0 ? newCount : '';
-			item.style.display = newCount > 0 ? '' : 'none';
+			const unreadDiff = parseInt( item.dataset.unreadDiff, 10 ) + count;
+			item.textContent = unreadDiff > 0 ? unreadDiff : '';
+			item.style.display = unreadDiff > 0 ? '' : 'none';
 		} else {
 			item.textContent = count > 0 ? count : '';
 			item.style.display = count > 0 ? '' : 'none';
 		}
+	} );
+};
+
+/**
+ *
+ * Update the unread count in the admin menu by addition or substraction, not by knowing the actual count.
+ * @param {number} count - By how much we should add or substract from the current sidebar menu count; either positive or negative integer.
+ */
+export const updateMenuCounterOptimistically = count => {
+	// iterate over all elements with the class 'jp-feedback-unread-counter' and update their text content
+	document.querySelectorAll( '.jp-feedback-unread-counter' ).forEach( item => {
+		let optimisticCount = 0;
+		if ( item.textContent !== '' ) {
+			optimisticCount = parseInt( item.textContent, 10 ) + count;
+		}
+
+		item.textContent = optimisticCount > 0 ? optimisticCount : '';
+		item.style.display = optimisticCount > 0 ? '' : 'none';
 	} );
 };

--- a/projects/packages/forms/src/dashboard/inbox/utils.js
+++ b/projects/packages/forms/src/dashboard/inbox/utils.js
@@ -9,38 +9,49 @@ export const getPath = item => {
 };
 
 /**
- * Update the unread count in the admin menu.
+ * Update `count-0` style CSS class in the unread menu badge with new count like `count-1`.
+ *
+ * @param {HTMLElement} element - Counter badge element
+ * @param {number}      count   - Count to use in new CSS class
+ */
+function updateBadge( element, count ) {
+	const oldClass = [ ...element.classList ].find( c => c.startsWith( 'count-' ) );
+	element.classList.replace( oldClass, `count-${ count }` );
+	element.ariaHidden = count > 0 ? 'false' : 'true';
+	element.textContent = count;
+}
+
+/**
+ * Update the unread count in the admin menu to specific count.
  *
  * @param {number} count - The new unread count.
  */
 export const updateMenuCounter = count => {
-	// iterate over all elements with the class 'jp-feedback-unread-counter' and update their text content
+	// Iterate over all badges with the class 'jp-feedback-unread-counter' and update their count
 	document.querySelectorAll( '.jp-feedback-unread-counter' ).forEach( item => {
+		// Jetpack menu item has combined count and forms unread counter
 		if ( item.dataset.unreadDiff ) {
 			const unreadDiff = parseInt( item.dataset.unreadDiff, 10 ) + count;
-			item.textContent = unreadDiff > 0 ? unreadDiff : '';
-			item.style.display = unreadDiff > 0 ? '' : 'none';
+			updateBadge( item, unreadDiff );
 		} else {
-			item.textContent = count > 0 ? count : '';
-			item.style.display = count > 0 ? '' : 'none';
+			updateBadge( item, count );
 		}
 	} );
 };
 
 /**
- *
  * Update the unread count in the admin menu by addition or substraction, not by knowing the actual count.
+ *
  * @param {number} count - By how much we should add or substract from the current sidebar menu count; either positive or negative integer.
  */
 export const updateMenuCounterOptimistically = count => {
-	// iterate over all elements with the class 'jp-feedback-unread-counter' and update their text content
+	// Iterate over all badges with the class 'jp-feedback-unread-counter' and update their count
 	document.querySelectorAll( '.jp-feedback-unread-counter' ).forEach( item => {
 		let optimisticCount = 0;
 		if ( item.textContent !== '' ) {
 			optimisticCount = parseInt( item.textContent, 10 ) + count;
 		}
 
-		item.textContent = optimisticCount > 0 ? optimisticCount : '';
-		item.style.display = optimisticCount > 0 ? '' : 'none';
+		updateBadge( item, optimisticCount );
 	} );
 };

--- a/projects/packages/forms/src/dashboard/inbox/utils.js
+++ b/projects/packages/forms/src/dashboard/inbox/utils.js
@@ -60,6 +60,8 @@ export const updateMenuCounterOptimistically = count => {
 			optimisticCount = parseInt( item.textContent.replace( /\D/g, '' ), 10 ) + count;
 		}
 
-		updateBadge( item, optimisticCount );
+		if ( optimisticCount >= 0 ) {
+			updateBadge( item, optimisticCount );
+		}
 	} );
 };

--- a/projects/packages/forms/src/dashboard/inbox/utils.js
+++ b/projects/packages/forms/src/dashboard/inbox/utils.js
@@ -1,3 +1,5 @@
+import { formatNumber } from '@automattic/number-formatters';
+
 // Function to get the URL of the page or post where the form was submitted.
 export const getPath = item => {
 	try {
@@ -18,7 +20,7 @@ function updateBadge( element, count ) {
 	const oldClass = [ ...element.classList ].find( c => c.startsWith( 'count-' ) );
 	element.classList.replace( oldClass, `count-${ count }` );
 	element.ariaHidden = count > 0 ? 'false' : 'true';
-	element.textContent = count;
+	element.textContent = formatNumber( count );
 }
 
 /**
@@ -49,7 +51,8 @@ export const updateMenuCounterOptimistically = count => {
 	document.querySelectorAll( '.jp-feedback-unread-counter' ).forEach( item => {
 		let optimisticCount = 0;
 		if ( item.textContent !== '' ) {
-			optimisticCount = parseInt( item.textContent, 10 ) + count;
+			// Ensure large formatted numbers like "1,000" are converted to integers properly
+			optimisticCount = parseInt( item.textContent.replace( /\D/g, '' ), 10 ) + count;
 		}
 
 		updateBadge( item, optimisticCount );

--- a/projects/packages/forms/src/dashboard/inbox/utils.js
+++ b/projects/packages/forms/src/dashboard/inbox/utils.js
@@ -18,7 +18,12 @@ export const getPath = item => {
  */
 function updateBadge( element, count ) {
 	const oldClass = [ ...element.classList ].find( c => c.startsWith( 'count-' ) );
-	element.classList.replace( oldClass, `count-${ count }` );
+	if ( oldClass ) {
+		element.classList.replace( oldClass, `count-${ count }` );
+	} else {
+		element.classList.add( `count-${ count }` );
+	}
+
 	element.ariaHidden = count > 0 ? 'false' : 'true';
 	element.textContent = formatNumber( count );
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Builds on top of:
- https://github.com/Automattic/jetpack/pull/45350

Replaced previous PR:
- https://github.com/Automattic/jetpack/pull/45425

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
- Relies on `count-0` class to hide badges instead of `display:none`
- Updates counts optimistically before we get repliable count from the server

Pay attention to the counters in the sidebar:

Before

https://github.com/user-attachments/assets/246063a6-dff0-4b90-9ee2-480ae425dcf0

After


https://github.com/user-attachments/assets/6a679d78-79ea-4dc1-b21b-2d54b189053e







### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Have Jetpack notifications (e.g. disable Boost while you have paid complete plan)
* Start with 0 notifications in Forms menu, but mark something as unread — count should appear and +1
* Mark something as unread until badge goes away
* Mark things as unread/read via actions in list, action in sidebar, and also by just opening a response
* Ensure marking things as unread in trash/spam doesn't bump the counter up
* When API call to mark things as read fails, it should return optimistic count back to what it was before

