### PR TITLE
Forms: Use integrations store for modal

### DIFF
--- a/projects/packages/forms/changelog/udpate-forms-integrations-modal-store
+++ b/projects/packages/forms/changelog/udpate-forms-integrations-modal-store
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: use store for integrations modal.

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integration-controls.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integration-controls.js
@@ -1,12 +1,13 @@
 import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { BlockControls } from '@wordpress/block-editor';
 import { ToolbarGroup, ToolbarButton, Button, PanelBody } from '@wordpress/components';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { plugins } from '@wordpress/icons';
+import { INTEGRATIONS_STORE } from '../../../store/integrations';
 import IntegrationsModal from './jetpack-integrations-modal';
 import ActiveIntegrations from './jetpack-integrations-modal/active-integrations';
-import { useIntegrationsStatus } from './jetpack-integrations-modal/hooks/use-integrations-status';
 
 /**
  * Integration controls component containing Panel for settings sidebar and block toolbar.
@@ -18,7 +19,12 @@ import { useIntegrationsStatus } from './jetpack-integrations-modal/hooks/use-in
  */
 export default function IntegrationControls( { attributes, setAttributes } ) {
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
-	const { integrations, refreshIntegrations, isLoading } = useIntegrationsStatus();
+	const integrations = useSelect( select => {
+		const store = select( INTEGRATIONS_STORE );
+		return store.getIntegrations() || [];
+	}, [] );
+	const isLoading = useSelect( select => select( INTEGRATIONS_STORE ).isIntegrationsLoading(), [] );
+	const { refreshIntegrations } = useDispatch( INTEGRATIONS_STORE );
 	const { tracks } = useAnalytics();
 
 	const handleOpenModal = entry_point => {

--- a/projects/packages/forms/src/blocks/contact-form/shared/hooks/use-form-block-defaults.js
+++ b/projects/packages/forms/src/blocks/contact-form/shared/hooks/use-form-block-defaults.js
@@ -1,5 +1,6 @@
+import { useSelect } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
-import { useIntegrationsStatus } from '../../components/jetpack-integrations-modal/hooks/use-integrations-status';
+import { INTEGRATIONS_STORE } from '../../../../store/integrations';
 
 /**
  * Apply default form block settings once per block instance when needed.
@@ -12,7 +13,11 @@ import { useIntegrationsStatus } from '../../components/jetpack-integrations-mod
  * @param {Function} params.setAttributes - Setter for block attributes
  */
 export default function useFormBlockDefaults( { attributes, setAttributes } ) {
-	const { integrations, isLoading } = useIntegrationsStatus();
+	const integrations = useSelect( select => {
+		const store = select( INTEGRATIONS_STORE );
+		return store.getIntegrations() || [];
+	}, [] );
+	const isLoading = useSelect( select => select( INTEGRATIONS_STORE ).isIntegrationsLoading(), [] );
 
 	useEffect( () => {
 		if ( isLoading || ! Array.isArray( integrations ) ) {

--- a/projects/plugins/jetpack/changelog/udpate-forms-integrations-modal-store
+++ b/projects/plugins/jetpack/changelog/udpate-forms-integrations-modal-store
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: use store for integrations modal.


### PR DESCRIPTION
## Proposed changes:

Updates form block integrations modal to use the [new integrations store](https://github.com/Automattic/jetpack/pull/45372/files) to improves performance, reduce load time, and avoid re-hitting the endpoint unless needed. 

Once this PR and [this one](https://github.com/Automattic/jetpack/pull/45375/files) are merged, we can follow up and remove the useIntegrationStatus and useIntegrationsStatus hooks. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None. 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

This is essentially a refactor to use the integrations store rather than the useIntegrationsStatus hook to fetch integrations data. So the main test is to confirm that the integrations modal works as expected. 
* Add a form to a page or post
* Confirm the integrations modal opens, shows integrations quickly, and shows correct status for each
* Try activating / installing / connecting / enabling integrations
* Publish, submit a form, and confirm it works as expected

