### PR TITLE
Charts: Fix conversion funnel height inconsistency

### DIFF
--- a/projects/js-packages/charts/changelog/fix-conversion-funnel-metric-height-changes
+++ b/projects/js-packages/charts/changelog/fix-conversion-funnel-metric-height-changes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix conversion funnel height inconsistency when toggling comparison mode

--- a/projects/js-packages/charts/src/components/conversion-funnel-chart/conversion-funnel-chart.module.scss
+++ b/projects/js-packages/charts/src/components/conversion-funnel-chart/conversion-funnel-chart.module.scss
@@ -12,6 +12,7 @@
 	align-items: baseline;
 	gap: 8px;
 	margin-bottom: 24px;
+	height: 20px;
 }
 
 .main-rate {


### PR DESCRIPTION
Fixes WOOA7S-508

## Proposed changes:

Set a fixed height of 20px for the main metric container to prevent layout shifts. The reason the height of the main metric container changes is that we use baseline alignment to align the texts within the main metric container. When a comparison metric is added, the baseline of the texts will be changed, causing the height of the primary metric container to change.


Before:


https://github.com/user-attachments/assets/21583b7d-b0d5-416a-ba86-21e8c9df987e


After:


https://github.com/user-attachments/assets/338bf7f5-ca4b-405c-b254-007fafef6779



### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

1. Start the storybook server
2. Go to http://localhost:50240/?path=/story/js-packages-charts-types-conversion-funnel-chart--default
3. Clear the `changeIndicator` value and then restore it to confirm that the height remains unchanged
