### PR TITLE
Forms: Update feedback endpoint is to remove data that is not needed

### DIFF
--- a/projects/packages/forms/changelog/fix-feedback-is_unread-endpoint
+++ b/projects/packages/forms/changelog/fix-feedback-is_unread-endpoint
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: fix sending data that is not needed in the endpoint to prevent exposing data

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -521,9 +521,24 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 			'readonly'    => true,
 		);
 
+		foreach ( $this->get_keys_to_remove() as $key ) {
+			if ( isset( $schema['properties'][ $key ] ) ) {
+				unset( $schema['properties'][ $key ] );
+			}
+		}
+
 		$this->schema = $schema;
 
 		return $this->add_additional_fields_schema( $this->schema );
+	}
+
+	/**
+	 * Get keys to remove from the endpoint that are usually part of a custom post type but not from the feedback one.
+	 *
+	 * @return array List of keys to remove.
+	 */
+	private function get_keys_to_remove() {
+		return array( 'link', 'password', 'template', 'title', 'content', 'excerpt' );
 	}
 
 	/**
@@ -669,12 +684,6 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 		}
 
 		// Remove field that are not relevant to feedback.
-		unset( $data['link'] );
-		unset( $data['password'] );
-		unset( $data['template'] );
-		unset( $data['title'] );
-		unset( $data['content'] );
-		unset( $data['excerpt'] );
 
 		$response->set_data( $data );
 

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -675,8 +675,6 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 			$data['is_unread'] = $feedback_response->is_unread();
 		}
 
-		// Remove field that are not relevant to feedback.
-
 		$response->set_data( $data );
 
 		return rest_ensure_response( $response );

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -668,6 +668,14 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 			$data['is_unread'] = $feedback_response->is_unread();
 		}
 
+		unset( $data['parent'] );
+		unset( $data['link'] );
+		unset( $data['password'] );
+		unset( $data['template'] );
+		unset( $data['title'] );
+		unset( $data['content'] );
+		unset( $data['excerpt'] );
+
 		$response->set_data( $data );
 
 		return rest_ensure_response( $response );

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -333,6 +333,13 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 	public function get_item_schema() {
 		$schema = parent::get_item_schema();
 
+		// Remove fields that are not relevant to feedback.
+		foreach ( array( 'link', 'password', 'template', 'title', 'content', 'excerpt' ) as $key ) {
+			if ( isset( $schema['properties'][ $key ] ) ) {
+				unset( $schema['properties'][ $key ] );
+			}
+		}
+
 		$schema['properties']['parent'] = array(
 			'description' => __( 'The ID for the parent of the post. This refers to the post/page where the feedback was created.', 'jetpack-forms' ),
 			'type'        => 'integer',
@@ -521,24 +528,9 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 			'readonly'    => true,
 		);
 
-		foreach ( $this->get_keys_to_remove() as $key ) {
-			if ( isset( $schema['properties'][ $key ] ) ) {
-				unset( $schema['properties'][ $key ] );
-			}
-		}
-
 		$this->schema = $schema;
 
 		return $this->add_additional_fields_schema( $this->schema );
-	}
-
-	/**
-	 * Get keys to remove from the endpoint that are usually part of a custom post type but not from the feedback one.
-	 *
-	 * @return array List of keys to remove.
-	 */
-	private function get_keys_to_remove() {
-		return array( 'link', 'password', 'template', 'title', 'content', 'excerpt' );
 	}
 
 	/**

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -668,7 +668,7 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 			$data['is_unread'] = $feedback_response->is_unread();
 		}
 
-		unset( $data['parent'] );
+		// Remove field that are not relevant to feedback.
 		unset( $data['link'] );
 		unset( $data['password'] );
 		unset( $data['template'] );

--- a/projects/packages/forms/src/dashboard/hooks/use-inbox-data.ts
+++ b/projects/packages/forms/src/dashboard/hooks/use-inbox-data.ts
@@ -47,23 +47,6 @@ interface UseInboxDataReturn {
 	filterOptions: Record< string, unknown >;
 }
 
-const RESPONSE_FIELDS = [
-	'id',
-	'status',
-	'date',
-	'date_gmt',
-	'author_name',
-	'author_email',
-	'author_url',
-	'author_avatar',
-	'ip',
-	'entry_title',
-	'entry_permalink',
-	'has_file',
-	'fields',
-	'is_unread',
-].join( ',' );
-
 /**
  * Hook to get all inbox related data.
  *
@@ -92,7 +75,6 @@ export default function useInboxData(): UseInboxDataReturn {
 		totalPages,
 	} = useEntityRecords( 'postType', 'feedback', {
 		...currentQuery,
-		_fields: RESPONSE_FIELDS,
 	} );
 
 	// Merge raw records with any local edits from editEntityRecord

--- a/projects/packages/forms/src/dashboard/hooks/use-inbox-data.ts
+++ b/projects/packages/forms/src/dashboard/hooks/use-inbox-data.ts
@@ -61,6 +61,7 @@ const RESPONSE_FIELDS = [
 	'entry_permalink',
 	'has_file',
 	'fields',
+	'is_unread',
 ].join( ',' );
 
 /**

--- a/projects/packages/forms/src/types/index.ts
+++ b/projects/packages/forms/src/types/index.ts
@@ -96,6 +96,8 @@ export interface FormResponse {
 	entry_permalink: string;
 	/** Whether the response has a file attached. */
 	has_file: boolean;
+	/** Whether the response is unread. */
+	is_unread: boolean;
 	/** The fields of the response. */
 	fields: Record< string, unknown >;
 }

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Endpoint_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Endpoint_Test.php
@@ -141,6 +141,14 @@ class Contact_Form_Endpoint_Test extends TestCase {
 		$this->assertArrayHasKey( 'subject', $schema_properties );
 		$this->assertArrayHasKey( 'fields', $schema_properties );
 		$this->assertArrayHasKey( 'is_unread', $schema_properties );
+
+		// Also make sure that we don't have fields that are not relevant to feedback.
+		$this->assertArrayNotHasKey( 'link', $schema_properties );
+		$this->assertArrayNotHasKey( 'password', $schema_properties );
+		$this->assertArrayNotHasKey( 'template', $schema_properties );
+		$this->assertArrayNotHasKey( 'title', $schema_properties );
+		$this->assertArrayNotHasKey( 'content', $schema_properties );
+		$this->assertArrayNotHasKey( 'excerpt', $schema_properties );
 	}
 
 	/**


### PR DESCRIPTION
This PR fixes an issue with sending too much data to the front end. Which was fixed by https://github.com/Automattic/jetpack/pull/45376 but then https://github.com/Automattic/jetpack/pull/45350 created a regressions. So we are taking a different approach here. 

## Proposed changes:
* Always remove data from the feedback endpoint that is never suppose to be there in the first place. Since it is data that is not being used on the front end but also is not used. 

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Load the dashboard does it still work as expected? Are you able to do all the things. 
Try the different filters, tabs and search. 


