### PR TITLE
Backport automattic-for-agencies-client 0.7.1 Changes

### DIFF
--- a/projects/packages/connection/CHANGELOG.md
+++ b/projects/packages/connection/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.18.13] - 2025-10-09
+### Changed
+- Update error logging for external storage. [#45412]
+
 ## [6.18.12] - 2025-10-02
 ### Changed
 - Update package dependencies. [#45334]
@@ -1607,6 +1611,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Separate the connection library into its own package.
 
+[6.18.13]: https://github.com/Automattic/jetpack-connection/compare/v6.18.12...v6.18.13
 [6.18.12]: https://github.com/Automattic/jetpack-connection/compare/v6.18.11...v6.18.12
 [6.18.11]: https://github.com/Automattic/jetpack-connection/compare/v6.18.10...v6.18.11
 [6.18.10]: https://github.com/Automattic/jetpack-connection/compare/v6.18.9...v6.18.10

--- a/projects/packages/connection/changelog/update-external-storage-error-loging
+++ b/projects/packages/connection/changelog/update-external-storage-error-loging
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated error logging for external storage

--- a/projects/packages/connection/src/class-external-storage.php
+++ b/projects/packages/connection/src/class-external-storage.php
@@ -206,7 +206,7 @@ class External_Storage {
 		}
 
 		// Deprecated: JETPACK_EXTERNAL_STORAGE_REPORTING_ENABLED constant
-		// @deprecated $$next-version$$ Use should_report_errors_for() method in your Storage Provider instead.
+		// @deprecated 6.18.13 Use should_report_errors_for() method in your Storage Provider instead.
 		if ( defined( 'JETPACK_EXTERNAL_STORAGE_REPORTING_ENABLED' ) ) {
 			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error

--- a/projects/packages/connection/src/class-package-version.php
+++ b/projects/packages/connection/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Connection;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '6.18.12';
+	const PACKAGE_VERSION = '6.18.13';
 
 	const PACKAGE_SLUG = 'connection';
 

--- a/projects/packages/plugin-deactivation/CHANGELOG.md
+++ b/projects/packages/plugin-deactivation/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.18] - 2025-10-09
+### Changed
+- Update package dependencies. [#45173] [#45241]
+
 ## [0.3.17] - 2025-09-17
 ### Changed
 - Update package dependencies. [#45097]
@@ -135,6 +139,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added package to intercept plugin deactivation [#27081]
 
+[0.3.18]: https://github.com/Automattic/jetpack-plugin-deactivation/compare/v0.3.17...v0.3.18
 [0.3.17]: https://github.com/Automattic/jetpack-plugin-deactivation/compare/v0.3.16...v0.3.17
 [0.3.16]: https://github.com/Automattic/jetpack-plugin-deactivation/compare/v0.3.15...v0.3.16
 [0.3.15]: https://github.com/Automattic/jetpack-plugin-deactivation/compare/v0.3.14...v0.3.15

--- a/projects/packages/plugin-deactivation/changelog/renovate-tslib-2.x
+++ b/projects/packages/plugin-deactivation/changelog/renovate-tslib-2.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/plugin-deactivation/changelog/renovate-webpack-5.x
+++ b/projects/packages/plugin-deactivation/changelog/renovate-webpack-5.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/plugin-deactivation/package.json
+++ b/projects/packages/plugin-deactivation/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-plugin-deactivation",
-	"version": "0.3.17",
+	"version": "0.3.18",
 	"private": true,
 	"description": "Intercept plugin deactivation with a dialog",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/plugin-deactivation/#readme",

--- a/projects/packages/plugin-deactivation/src/class-deactivation-handler.php
+++ b/projects/packages/plugin-deactivation/src/class-deactivation-handler.php
@@ -21,7 +21,7 @@ class Deactivation_Handler {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.3.17';
+	const PACKAGE_VERSION = '0.3.18';
 
 	/**
 	 * Slug of the plugin to intercept deactivation for.

--- a/projects/plugins/automattic-for-agencies-client/CHANGELOG.md
+++ b/projects/plugins/automattic-for-agencies-client/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.1 - 2025-10-09
+### Changed
+- Update package dependencies. [#44677] [#44701] [#44725] [#45027] [#45096] [#45173] [#45200] [#45229] [#45298] [#45299] [#45334]
+
 ## 0.7.0 - 2025-08-06
 ### Changed
 - My Jetpack: Unify the user connection flow with a unified screen. [#44469]

--- a/projects/plugins/automattic-for-agencies-client/automattic-for-agencies-client.php
+++ b/projects/plugins/automattic-for-agencies-client/automattic-for-agencies-client.php
@@ -4,7 +4,7 @@
  * Plugin Name: Automattic for Agencies Client
  * Plugin URI: https://wordpress.org/plugins/automattic-for-agencies-client
  * Description: Securely connect your clients’ sites to the Automattic for Agencies Sites Dashboard. Manage your sites from one place and see what needs attention.
- * Version: 0.7.0
+ * Version: 0.7.1
  * Author: Automattic
  * Author URI: https://automattic.com/for-agencies/
  * License: GPLv2 or later

--- a/projects/plugins/automattic-for-agencies-client/changelog/e2e-add-tsconfigs-for-e2e-tests
+++ b/projects/plugins/automattic-for-agencies-client/changelog/e2e-add-tsconfigs-for-e2e-tests
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: E2E tests: add tsconfigs for e2e tests
-
-

--- a/projects/plugins/automattic-for-agencies-client/changelog/e2e-update-automattic-for-agencies-client-tests-remove-pages
+++ b/projects/plugins/automattic-for-agencies-client/changelog/e2e-update-automattic-for-agencies-client-tests-remove-pages
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: E2E tests updates
-
-

--- a/projects/plugins/automattic-for-agencies-client/changelog/prerelease
+++ b/projects/plugins/automattic-for-agencies-client/changelog/prerelease
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update composer.lock.
-
-

--- a/projects/plugins/automattic-for-agencies-client/changelog/prerelease#2
+++ b/projects/plugins/automattic-for-agencies-client/changelog/prerelease#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update composer.lock.
-
-

--- a/projects/plugins/automattic-for-agencies-client/changelog/prerelease#3
+++ b/projects/plugins/automattic-for-agencies-client/changelog/prerelease#3
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update composer.lock.
-
-

--- a/projects/plugins/automattic-for-agencies-client/changelog/prerelease#4
+++ b/projects/plugins/automattic-for-agencies-client/changelog/prerelease#4
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update composer.lock.
-
-

--- a/projects/plugins/automattic-for-agencies-client/changelog/prerelease#5
+++ b/projects/plugins/automattic-for-agencies-client/changelog/prerelease#5
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update composer.lock.
-
-

--- a/projects/plugins/automattic-for-agencies-client/changelog/renovate-allure-playwright-2.x
+++ b/projects/plugins/automattic-for-agencies-client/changelog/renovate-allure-playwright-2.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/plugins/automattic-for-agencies-client/changelog/renovate-babel-monorepo
+++ b/projects/plugins/automattic-for-agencies-client/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/plugins/automattic-for-agencies-client/changelog/renovate-lock-file-maintenance
+++ b/projects/plugins/automattic-for-agencies-client/changelog/renovate-lock-file-maintenance
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/plugins/automattic-for-agencies-client/changelog/renovate-lock-file-maintenance#2
+++ b/projects/plugins/automattic-for-agencies-client/changelog/renovate-lock-file-maintenance#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/plugins/automattic-for-agencies-client/changelog/renovate-playwright-monorepo
+++ b/projects/plugins/automattic-for-agencies-client/changelog/renovate-playwright-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/plugins/automattic-for-agencies-client/changelog/renovate-playwright-monorepo#2
+++ b/projects/plugins/automattic-for-agencies-client/changelog/renovate-playwright-monorepo#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/plugins/automattic-for-agencies-client/changelog/renovate-webpack-5.x
+++ b/projects/plugins/automattic-for-agencies-client/changelog/renovate-webpack-5.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/plugins/automattic-for-agencies-client/changelog/renovate-wordpress-monorepo
+++ b/projects/plugins/automattic-for-agencies-client/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/plugins/automattic-for-agencies-client/changelog/renovate-wordpress-monorepo#2
+++ b/projects/plugins/automattic-for-agencies-client/changelog/renovate-wordpress-monorepo#2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/plugins/automattic-for-agencies-client/changelog/renovate-wordpress-monorepo#3
+++ b/projects/plugins/automattic-for-agencies-client/changelog/renovate-wordpress-monorepo#3
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/plugins/automattic-for-agencies-client/changelog/renovate-wordpress-monorepo2
+++ b/projects/plugins/automattic-for-agencies-client/changelog/renovate-wordpress-monorepo2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/plugins/automattic-for-agencies-client/composer.json
+++ b/projects/plugins/automattic-for-agencies-client/composer.json
@@ -75,6 +75,6 @@
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true
 		},
-		"autoloader-suffix": "c4802e05bbcf59fd3b6350e8d3e5482c_automattic_for_agencies_clientⓥ0_7_0"
+		"autoloader-suffix": "c4802e05bbcf59fd3b6350e8d3e5482c_automattic_for_agencies_clientⓥ0_7_1"
 	}
 }

--- a/projects/plugins/automattic-for-agencies-client/readme.txt
+++ b/projects/plugins/automattic-for-agencies-client/readme.txt
@@ -44,10 +44,7 @@ Once connected, your site will display within Automattic for Agencies.
 1. Manage your connection to the agency dashboard from the Settings screen in your WordPress dashboard.
 
 == Changelog ==
-### 0.7.0 - 2025-08-06
+### 0.7.1 - 2025-10-09
 #### Changed
-- My Jetpack: Unify the user connection flow with a unified screen.
-- Sync: Ignore the ActivityPub Outbox CPT.
-- Update dependencies.
 - Update package dependencies.
 


### PR DESCRIPTION
Closes MONOREP-136

 <!--- This template is used for backporting changes made during a plugin release back to trunk. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Backports changes for automattic-for-agencies-client 0.7.1

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/a
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Proofread changes.