### PR TITLE
Forms: reverse copy of 'go back' toggle

### DIFF
--- a/projects/packages/forms/changelog/update-forms-go-back-toggle-copy
+++ b/projects/packages/forms/changelog/update-forms-go-back-toggle-copy
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: reverse copy of 'go back' toggle

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -785,9 +785,9 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 							<>
 								<ToggleControl
 									label={ __( 'Show "Go back" link', 'jetpack-forms' ) }
-									checked={ !! disableGoBack }
+									checked={ ! disableGoBack }
 									onChange={ ( newDisableGoBack: boolean ) =>
-										setAttributes( { disableGoBack: newDisableGoBack } )
+										setAttributes( { disableGoBack: ! newDisableGoBack } )
 									}
 									__nextHasNoMarginBottom={ true }
 									__next40pxDefaultSize={ true }

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -784,8 +784,8 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 						{ 'redirect' !== customThankyou && (
 							<>
 								<ToggleControl
-									label={ __( 'Disable "Go back" link', 'jetpack-forms' ) }
-									checked={ disableGoBack }
+									label={ __( 'Show "Go back" link', 'jetpack-forms' ) }
+									checked={ !! disableGoBack }
 									onChange={ ( newDisableGoBack: boolean ) =>
 										setAttributes( { disableGoBack: newDisableGoBack } )
 									}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Improves how "go back" toggle works; instead of  enabling toggle to "disable" feature, we reverse it; when toggle is enabled, link is there, when disabled, it isn't.

Before

<img width="274" height="300" alt="image" src="https://github.com/user-attachments/assets/98b41c4f-a963-4366-b15b-c6f2e3f8af88" />


After

<img width="274" height="316" alt="Screenshot 2025-10-09 at 19 33 23" src="https://github.com/user-attachments/assets/c821768e-d5af-49c9-9ef5-9d9307519666" />




### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add forms block
* In the sidebar, see "action after submit" section
* Try setting toggle enabled/disabled without PR
* Then try how each state shows up with PR (sould be reversed)
* Toggle actaully still works and hides link when needed :-) 

