### PR TITLE
Address lazy-load WP_User behavior introduced in WP 6.9

### DIFF
--- a/projects/packages/stats/changelog/fix-tests-wp_user_lazy_load
+++ b/projects/packages/stats/changelog/fix-tests-wp_user_lazy_load
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Handle lazy-loading of WP_User object properties.

--- a/projects/packages/stats/src/class-main.php
+++ b/projects/packages/stats/src/class-main.php
@@ -120,8 +120,11 @@ class Main {
 	public static function map_meta_caps( $caps, $cap, $user_id ) {
 		// Map view_stats to exists.
 		if ( 'view_stats' === $cap ) {
-			$user        = new WP_User( $user_id );
-			$user_role   = array_shift( $user->roles );
+			$user = new WP_User( $user_id );
+			// WordPress 6.9 introduced lazy-loading of some WP_User properties, including `roles`.
+			// It also made said properties protected, so we can't modify keys directly.
+			$user_roles  = $user->roles;
+			$user_role   = array_shift( $user_roles ); // Work with the copy
 			$stats_roles = Options::get_option( 'roles' );
 
 			// Is the users role in the available stats roles?

--- a/projects/packages/sync/changelog/fix-tests-wp_user_lazy_load
+++ b/projects/packages/sync/changelog/fix-tests-wp_user_lazy_load
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Handle lazy-loading of WP_User object properties.

--- a/projects/packages/sync/src/class-functions.php
+++ b/projects/packages/sync/src/class-functions.php
@@ -604,7 +604,21 @@ class Functions {
 	 */
 	public static function json_wrap( &$any, $seen_nodes = array() ) {
 		if ( is_object( $any ) ) {
-			$input        = get_object_vars( $any );
+			$input = get_object_vars( $any );
+
+			// WordPress 6.9 introduced lazy-loading of WP_User `roles`, `caps`, and `allcaps` properties.
+			// It also made said properties protected, so we need to access them and set them as keys manually.
+			if ( $any instanceof \WP_User ) {
+				$roles   = $any->roles;
+				$caps    = $any->caps;
+				$allcaps = $any->allcaps;
+
+				// For WordPress <6.8 the below are redundant. :shrug:
+				$input['roles']   = $roles;
+				$input['caps']    = $caps;
+				$input['allcaps'] = $allcaps;
+			}
+
 			$input['__o'] = 1;
 		} else {
 			$input = &$any;

--- a/projects/plugins/jetpack/changelog/fix-tests-wp_user_lazy_load
+++ b/projects/plugins/jetpack/changelog/fix-tests-wp_user_lazy_load
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Sync: Handle lazy-loading of WP_User object properties.

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Users_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Users_Test.php
@@ -35,8 +35,13 @@ class Jetpack_Sync_Users_Test extends Jetpack_Sync_TestBase {
 		// The regular user object doesn't have allowed_mime_types
 		unset( $server_user->data->allowed_mime_types );
 
-		unset( $user->allcaps['subscriber'] );
-		unset( $user->allcaps['level_0'] );
+		// WordPress 6.9 introduced lazy-loading of some WP_User properties.
+		// It also made said properties protected, so we can't modify keys directly.
+		$allcaps = $user->allcaps; // This triggers lazy loading
+		unset( $allcaps['subscriber'] );
+		unset( $allcaps['level_0'] );
+		$user->allcaps = $allcaps;
+
 		$this->assertEqualsObject( $user, $server_user, 'The replicastore user must equal the initial user.' );
 
 		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_register_user' );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

WordPress 6.9 lazy-loads the `roles`, `caps`, and `allcaps` properties of `WP_User`:
* Commit: https://github.com/WordPress/WordPress/commit/bf485c4bfea43a13abc2beecc74e2fe81eaf53e5
* Trac: https://core.trac.wordpress.org/ticket/58001

This means we can't use `get_object_vars()` to grab protected properties (so need to access them first). It also means we can't directly manipulate the keys of a protected property.

Tagging @Automattic/red for Stats and @Automattic/jetpack-vulcan for Sync.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Is CI happy?
* Are the changes functionally equivalent and safe?

