### PR TITLE
Fix Launchpad's free plan check warning

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/.phan/baseline.php
+++ b/projects/packages/jetpack-mu-wpcom/.phan/baseline.php
@@ -18,7 +18,6 @@ return [
     // PhanTypePossiblyInvalidDimOffset : 3 occurrences
     // PhanEmptyFQSENInCallable : 2 occurrences
     // PhanTypeArraySuspicious : 2 occurrences
-    // PhanTypeArraySuspiciousNullable : 2 occurrences
     // PhanTypeMismatchDefault : 2 occurrences
     // PhanTypeMissingReturn : 2 occurrences
     // PhanUndeclaredFunction : 2 occurrences
@@ -26,6 +25,7 @@ return [
     // PhanNoopArrayAccess : 1 occurrence
     // PhanPluginSimplifyExpressionBool : 1 occurrence
     // PhanRedefineFunction : 1 occurrence
+    // PhanTypeArraySuspiciousNullable : 1 occurrence
     // PhanTypeComparisonToArray : 1 occurrence
     // PhanTypeMismatchDimFetch : 1 occurrence
     // PhanTypeMismatchReturnNullable : 1 occurrence
@@ -40,7 +40,7 @@ return [
         'src/features/coming-soon/fallback-coming-soon-page.php' => ['PhanTypeMismatchArgument', 'PhanTypeVoidArgument'],
         'src/features/error-reporting/error-reporting.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],
         'src/features/launchpad/class-launchpad-task-lists.php' => ['PhanNoopArrayAccess', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchDefault', 'PhanTypeMismatchReturn', 'PhanTypePossiblyInvalidDimOffset'],
-        'src/features/launchpad/launchpad-task-definitions.php' => ['PhanTypeArraySuspiciousNullable', 'PhanTypeComparisonToArray', 'PhanTypeMismatchArgument', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal', 'PhanTypeMissingReturn', 'PhanTypePossiblyInvalidDimOffset'],
+        'src/features/launchpad/launchpad-task-definitions.php' => ['PhanTypeComparisonToArray', 'PhanTypeMismatchArgument', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal', 'PhanTypeMissingReturn', 'PhanTypePossiblyInvalidDimOffset'],
         'src/features/launchpad/launchpad.php' => ['PhanTypeArraySuspiciousNullable', 'PhanTypeMismatchArgument', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal'],
         'src/features/marketplace-products-updater/class-marketplace-products-updater.php' => ['PhanTypeMismatchDimFetch', 'PhanTypeMismatchReturn'],
         'src/features/media/heif-support.php' => ['PhanPluginSimplifyExpressionBool'],

--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-plan-check-warnings
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-plan-check-warnings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix Launchpad's free plan check warning

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -2793,7 +2793,8 @@ add_action( 'activate_product', 'wpcom_launchpad_mark_domain_tasks_complete', 10
 function wpcom_launchpad_mark_plan_tasks_complete( $blog_id ) {
 	require_once WP_CONTENT_DIR . '/admin-plugins/wpcom-billing.php';
 	$current_plan = WPCOM_Store_API::get_current_plan( $blog_id );
-	if ( ! isset( $current_plan['is_free'] ) || $current_plan['is_free'] ) {
+
+	if ( $current_plan['is_free'] ?? true ) {
 		return;
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -2793,7 +2793,7 @@ add_action( 'activate_product', 'wpcom_launchpad_mark_domain_tasks_complete', 10
 function wpcom_launchpad_mark_plan_tasks_complete( $blog_id ) {
 	require_once WP_CONTENT_DIR . '/admin-plugins/wpcom-billing.php';
 	$current_plan = WPCOM_Store_API::get_current_plan( $blog_id );
-	if ( $current_plan['is_free'] ) {
+	if ( ! isset( $current_plan['is_free'] ) || $current_plan['is_free'] ) {
 		return;
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes [DOTOBRD-334](https://linear.app/a8c/issue/DOTOBRD-334/launchpad-tasks-definition-is-generating-the-undefined-array-key-is)


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* We're adding an `isset` check to ensure we won't run into warnings during a plan check.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Slack thread: p1759902017946569-slack-C034JEXD1RD

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Please give a confidence check as it's just an array check