### PR TITLE
Forms: Optimize inbox loading state

### DIFF
--- a/projects/packages/forms/changelog/fix-inbox-preload-matching
+++ b/projects/packages/forms/changelog/fix-inbox-preload-matching
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Forms: fix preload parameters to match actual feedback endpoint requests and avoid duplicate HTTP requests.

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -85,7 +85,7 @@ class Dashboard {
 		// Preload Forms endpoints needed in dashboard context.
 		// Pre-fetch the first inbox page so the UI renders instantly on first load.
 		$preload_params = array(
-			'context'  => 'view',
+			'context'  => 'edit',
 			'order'    => 'desc',
 			'orderby'  => 'date',
 			'page'     => 1,

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
@@ -137,9 +137,11 @@ export default function InboxView() {
 			return accumulator;
 		}, {} );
 		const _queryArgs = {
+			order: 'desc',
+			orderby: 'date',
 			per_page: view.perPage,
 			page: view.page,
-			search: view.search,
+			...( view.search ? { search: view.search } : {} ),
 			..._filters,
 			status: statusFilter,
 		};

--- a/projects/packages/forms/src/dashboard/store/reducer.js
+++ b/projects/packages/forms/src/dashboard/store/reducer.js
@@ -22,7 +22,6 @@ const filters = ( state = {}, action ) => {
 
 const currentQuery = (
 	state = {
-		context: 'view',
 		order: 'desc',
 		orderby: 'date',
 		page: 1,


### PR DESCRIPTION
## Proposed changes:
* Fix Forms inbox preload parameters to match the actual feedback endpoint requests made by `useEntityRecords`
* Update PHP preload `context` from `'view'` to `'edit'` to match what `useEntityRecords` automatically adds
* Add `order` and `orderby` parameters to DataViews query args for consistency with preload
* Only include `search` parameter when non-empty (PHP's `add_query_arg` skips empty values)
* Remove `context` from Redux reducer default state (since `useEntityRecords` adds it automatically)

**Result:** The feedback endpoint request now uses preloaded data instead of making a duplicate network request on initial page load.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A - Performance optimization

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* Open your browser's DevTools and go to the Network tab
* Filter requests by `feedback`
* Navigate to Jetpack → Forms → Inbox
* **Before this PR:** You would see two identical `/wp/v2/feedback?context=edit&order=desc&orderby=date&page=1&per_page=20&status=draft%2Cpublish&_locale=user` requests
* **After this PR:** You should no more requests
* Verify the inbox loads correctly with form responses displayed
* Test filtering, searching, and pagination to ensure functionality still works

Ref: https://github.com/Automattic/jetpack/pull/45339
