### PR TITLE
Forms: set `text-wrap:pretty` for all panels

### DIFF
--- a/projects/packages/forms/changelog/update-forms-advanced-and-no-orphans
+++ b/projects/packages/forms/changelog/update-forms-advanced-and-no-orphans
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: avoid typohraphic orphans in Forms panels in editor

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integration-controls.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integration-controls.js
@@ -30,7 +30,7 @@ export default function IntegrationControls( { attributes, setAttributes } ) {
 		<>
 			<PanelBody
 				title={ __( 'Integrations', 'jetpack-forms' ) }
-				className="jetpack-contact-form__integrations-panel"
+				className="jetpack-contact-form__panel jetpack-contact-form__integrations-panel"
 				initialOpen={ false }
 			>
 				<ActiveIntegrations

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -751,7 +751,7 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 				<InspectorControls>
 					<PanelBody
 						title={ __( 'Responses storage', 'jetpack-forms' ) }
-						className="jetpack-contact-form__responses-storage-panel"
+						className="jetpack-contact-form__panel jetpack-contact-form__responses-storage-panel"
 						initialOpen={ false }
 					>
 						<JetpackManageResponsesSettings
@@ -759,7 +759,11 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 							setAttributes={ setAttributes }
 						/>
 					</PanelBody>
-					<PanelBody title={ __( 'Action after submit', 'jetpack-forms' ) } initialOpen={ false }>
+					<PanelBody
+						title={ __( 'Action after submit', 'jetpack-forms' ) }
+						initialOpen={ false }
+						className="jetpack-contact-form__panel"
+					>
 						<InspectorHint>
 							{ __( 'Customize the view after form submission:', 'jetpack-forms' ) }
 						</InspectorHint>
@@ -833,7 +837,11 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 							</div>
 						) }
 					</PanelBody>
-					<PanelBody title={ __( 'Email responses', 'jetpack-forms' ) } initialOpen={ false }>
+					<PanelBody
+						title={ __( 'Email responses', 'jetpack-forms' ) }
+						initialOpen={ false }
+						className="jetpack-contact-form__panel"
+					>
 						<JetpackEmailConnectionSettings
 							emailAddress={ to }
 							emailSubject={ subject }
@@ -844,7 +852,11 @@ function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, cl
 						/>
 					</PanelBody>
 					{ hasFeatureFlag( 'form-notifications' ) && (
-						<PanelBody title={ __( 'Form notifications', 'jetpack-forms' ) } initialOpen={ false }>
+						<PanelBody
+							title={ __( 'Form notifications', 'jetpack-forms' ) }
+							initialOpen={ false }
+							className="jetpack-contact-form__panel"
+						>
 							<NotificationsSettings
 								notificationRecipients={ notificationRecipients }
 								setAttributes={ setAttributes }

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -1150,6 +1150,10 @@
 	}
 }
 
+.jetpack-contact-form__panel {
+	text-wrap: pretty;
+}
+
 :where(.wp-block-jetpack-input) {
 	width: 100%;
 	box-sizing: border-box;

--- a/projects/packages/forms/src/blocks/field-checkbox/edit.js
+++ b/projects/packages/forms/src/blocks/field-checkbox/edit.js
@@ -1,5 +1,4 @@
 import {
-	InspectorAdvancedControls,
 	InspectorControls,
 	BlockControls,
 	useBlockProps,
@@ -106,17 +105,16 @@ export default function CheckboxFieldEdit( props ) {
 						__nextHasNoMarginBottom={ true }
 					/>
 					<JetpackFieldWidth setAttributes={ setAttributes } width={ width } />
+
+					<ToggleControl
+						label={ __( 'Sync fields style', 'jetpack-forms' ) }
+						checked={ attributes.shareFieldAttributes }
+						onChange={ onShareFieldAttributesChange }
+						help={ __( 'Deactivate for individual styling of this block', 'jetpack-forms' ) }
+						__nextHasNoMarginBottom={ true }
+					/>
 				</PanelBody>
 			</InspectorControls>
-			<InspectorAdvancedControls>
-				<ToggleControl
-					label={ __( 'Sync fields style', 'jetpack-forms' ) }
-					checked={ attributes.shareFieldAttributes }
-					onChange={ onShareFieldAttributesChange }
-					help={ __( 'Deactivate for individual styling of this block', 'jetpack-forms' ) }
-					__nextHasNoMarginBottom={ true }
-				/>
-			</InspectorAdvancedControls>
 		</>
 	);
 }

--- a/projects/packages/forms/src/blocks/field-checkbox/edit.js
+++ b/projects/packages/forms/src/blocks/field-checkbox/edit.js
@@ -1,4 +1,5 @@
 import {
+	InspectorAdvancedControls,
 	InspectorControls,
 	BlockControls,
 	useBlockProps,
@@ -80,7 +81,10 @@ export default function CheckboxFieldEdit( props ) {
 				<ToolbarRequiredGroup required={ required } onClick={ onRequiredToggle } />
 			</BlockControls>
 			<InspectorControls>
-				<PanelBody title={ __( 'Checkbox settings', 'jetpack-forms' ) }>
+				<PanelBody
+					title={ __( 'Checkbox settings', 'jetpack-forms' ) }
+					className="jetpack-contact-form__panel"
+				>
 					<ToggleControl
 						label={ __( 'Checked by default', 'jetpack-forms' ) }
 						checked={ !! defaultValue }
@@ -90,7 +94,10 @@ export default function CheckboxFieldEdit( props ) {
 				</PanelBody>
 			</InspectorControls>
 			<InspectorControls>
-				<PanelBody title={ __( 'Field settings', 'jetpack-forms' ) }>
+				<PanelBody
+					title={ __( 'Field settings', 'jetpack-forms' ) }
+					className="jetpack-contact-form__panel"
+				>
 					<ToggleControl
 						label={ __( 'Field is required', 'jetpack-forms' ) }
 						checked={ required }
@@ -99,16 +106,17 @@ export default function CheckboxFieldEdit( props ) {
 						__nextHasNoMarginBottom={ true }
 					/>
 					<JetpackFieldWidth setAttributes={ setAttributes } width={ width } />
-
-					<ToggleControl
-						label={ __( 'Sync fields style', 'jetpack-forms' ) }
-						checked={ attributes.shareFieldAttributes }
-						onChange={ onShareFieldAttributesChange }
-						help={ __( 'Deactivate for individual styling of this block', 'jetpack-forms' ) }
-						__nextHasNoMarginBottom={ true }
-					/>
 				</PanelBody>
 			</InspectorControls>
+			<InspectorAdvancedControls>
+				<ToggleControl
+					label={ __( 'Sync fields style', 'jetpack-forms' ) }
+					checked={ attributes.shareFieldAttributes }
+					onChange={ onShareFieldAttributesChange }
+					help={ __( 'Deactivate for individual styling of this block', 'jetpack-forms' ) }
+					__nextHasNoMarginBottom={ true }
+				/>
+			</InspectorAdvancedControls>
 		</>
 	);
 }

--- a/projects/packages/forms/src/blocks/field-consent/edit.js
+++ b/projects/packages/forms/src/blocks/field-consent/edit.js
@@ -1,4 +1,5 @@
 import {
+	InspectorAdvancedControls,
 	InspectorControls,
 	store as blockEditorStore,
 	useBlockProps,
@@ -160,17 +161,16 @@ export default function ConsentFieldEdit( props ) {
 		<>
 			<div { ...innerBlocksProps } />
 			<InspectorControls>
-				<PanelBody title={ __( 'Field settings', 'jetpack-forms' ) }>
+				<PanelBody
+					title={ __( 'Field settings', 'jetpack-forms' ) }
+					className="jetpack-contact-form__panel"
+				>
 					<JetpackFieldWidth setAttributes={ setAttributes } width={ width } />
-					<ToggleControl
-						label={ __( 'Sync fields style', 'jetpack-forms' ) }
-						checked={ attributes.shareFieldAttributes }
-						onChange={ onShareFieldAttributesChange }
-						help={ __( 'Deactivate for individual styling of this block', 'jetpack-forms' ) }
-						__nextHasNoMarginBottom
-					/>
 				</PanelBody>
-				<PanelBody title={ __( 'Consent settings', 'jetpack-forms' ) }>
+				<PanelBody
+					title={ __( 'Consent settings', 'jetpack-forms' ) }
+					className="jetpack-contact-form__panel"
+				>
 					<BaseControl __nextHasNoMarginBottom>
 						<SelectControl
 							label={ __( 'Permission to email', 'jetpack-forms' ) }
@@ -192,6 +192,15 @@ export default function ConsentFieldEdit( props ) {
 					</BaseControl>
 				</PanelBody>
 			</InspectorControls>
+			<InspectorAdvancedControls>
+				<ToggleControl
+					label={ __( 'Sync fields style', 'jetpack-forms' ) }
+					checked={ attributes.shareFieldAttributes }
+					onChange={ onShareFieldAttributesChange }
+					help={ __( 'Deactivate for individual styling of this block', 'jetpack-forms' ) }
+					__nextHasNoMarginBottom
+				/>
+			</InspectorAdvancedControls>
 		</>
 	);
 }

--- a/projects/packages/forms/src/blocks/field-consent/edit.js
+++ b/projects/packages/forms/src/blocks/field-consent/edit.js
@@ -1,5 +1,4 @@
 import {
-	InspectorAdvancedControls,
 	InspectorControls,
 	store as blockEditorStore,
 	useBlockProps,
@@ -166,6 +165,13 @@ export default function ConsentFieldEdit( props ) {
 					className="jetpack-contact-form__panel"
 				>
 					<JetpackFieldWidth setAttributes={ setAttributes } width={ width } />
+					<ToggleControl
+						label={ __( 'Sync fields style', 'jetpack-forms' ) }
+						checked={ attributes.shareFieldAttributes }
+						onChange={ onShareFieldAttributesChange }
+						help={ __( 'Deactivate for individual styling of this block', 'jetpack-forms' ) }
+						__nextHasNoMarginBottom
+					/>
 				</PanelBody>
 				<PanelBody
 					title={ __( 'Consent settings', 'jetpack-forms' ) }
@@ -192,15 +198,6 @@ export default function ConsentFieldEdit( props ) {
 					</BaseControl>
 				</PanelBody>
 			</InspectorControls>
-			<InspectorAdvancedControls>
-				<ToggleControl
-					label={ __( 'Sync fields style', 'jetpack-forms' ) }
-					checked={ attributes.shareFieldAttributes }
-					onChange={ onShareFieldAttributesChange }
-					help={ __( 'Deactivate for individual styling of this block', 'jetpack-forms' ) }
-					__nextHasNoMarginBottom
-				/>
-			</InspectorAdvancedControls>
 		</>
 	);
 }

--- a/projects/packages/forms/src/blocks/form-step/attributes-controls.js
+++ b/projects/packages/forms/src/blocks/form-step/attributes-controls.js
@@ -14,7 +14,11 @@ const AttributesControls = ( { attributes, setAttributes } ) => {
 
 	return (
 		<InspectorControls>
-			<PanelBody title={ __( 'Settings', 'jetpack-forms' ) } initialOpen={ true }>
+			<PanelBody
+				title={ __( 'Settings', 'jetpack-forms' ) }
+				initialOpen={ true }
+				className="jetpack-contact-form__panel"
+			>
 				<TextControl
 					label={ __( 'Step label', 'jetpack-forms' ) }
 					value={ stepLabel }

--- a/projects/packages/forms/src/blocks/input/edit.js
+++ b/projects/packages/forms/src/blocks/input/edit.js
@@ -96,7 +96,10 @@ const InputEdit = ( { attributes, clientId, isSelected, name, setAttributes, con
 			/>
 			{ type === 'number' && (
 				<InspectorControls>
-					<PanelBody title={ __( 'Settings', 'jetpack-forms' ) }>
+					<PanelBody
+						title={ __( 'Settings', 'jetpack-forms' ) }
+						className="jetpack-contact-form__panel"
+					>
 						<NumberControl
 							key="min"
 							label={ __( 'Minimum value', 'jetpack-forms' ) }

--- a/projects/packages/forms/src/blocks/shared/components/jetpack-field-controls.js
+++ b/projects/packages/forms/src/blocks/shared/components/jetpack-field-controls.js
@@ -89,14 +89,6 @@ const JetpackFieldControls = ( {
 			/>
 		),
 		<JetpackFieldWidth key="width" setAttributes={ setAttributes } width={ width } />,
-		<ToggleControl
-			key="shareFieldAttributes"
-			label={ __( 'Sync fields style', 'jetpack-forms' ) }
-			checked={ attributes.shareFieldAttributes }
-			onChange={ value => setAttributes( { shareFieldAttributes: value } ) }
-			help={ __( 'Deactivate for individual styling of this block', 'jetpack-forms' ) }
-			__nextHasNoMarginBottom={ true }
-		/>,
 	];
 
 	extraFieldSettings.forEach( ( { element, index } ) => {
@@ -125,11 +117,22 @@ const JetpackFieldControls = ( {
 			</BlockControls>
 
 			<InspectorControls>
-				<PanelBody title={ __( 'Field settings', 'jetpack-forms' ) }>
+				<PanelBody
+					title={ __( 'Field settings', 'jetpack-forms' ) }
+					className="jetpack-contact-form__panel"
+				>
 					<>{ fieldSettings }</>
 				</PanelBody>
 			</InspectorControls>
 			<InspectorAdvancedControls>
+				<ToggleControl
+					key="shareFieldAttributes"
+					label={ __( 'Sync fields style', 'jetpack-forms' ) }
+					checked={ attributes.shareFieldAttributes }
+					onChange={ value => setAttributes( { shareFieldAttributes: value } ) }
+					help={ __( 'Deactivate for individual styling of this block', 'jetpack-forms' ) }
+					__nextHasNoMarginBottom={ true }
+				/>
 				<TextControl
 					className={ errorState.error ? 'jetpack-forms-field-controls__input-error' : '' }
 					label={ __( 'Name/ID', 'jetpack-forms' ) }

--- a/projects/packages/forms/src/blocks/shared/components/jetpack-field-controls.js
+++ b/projects/packages/forms/src/blocks/shared/components/jetpack-field-controls.js
@@ -89,6 +89,14 @@ const JetpackFieldControls = ( {
 			/>
 		),
 		<JetpackFieldWidth key="width" setAttributes={ setAttributes } width={ width } />,
+		<ToggleControl
+			key="shareFieldAttributes"
+			label={ __( 'Sync fields style', 'jetpack-forms' ) }
+			checked={ attributes.shareFieldAttributes }
+			onChange={ value => setAttributes( { shareFieldAttributes: value } ) }
+			help={ __( 'Deactivate for individual styling of this block', 'jetpack-forms' ) }
+			__nextHasNoMarginBottom={ true }
+		/>,
 	];
 
 	extraFieldSettings.forEach( ( { element, index } ) => {
@@ -125,14 +133,6 @@ const JetpackFieldControls = ( {
 				</PanelBody>
 			</InspectorControls>
 			<InspectorAdvancedControls>
-				<ToggleControl
-					key="shareFieldAttributes"
-					label={ __( 'Sync fields style', 'jetpack-forms' ) }
-					checked={ attributes.shareFieldAttributes }
-					onChange={ value => setAttributes( { shareFieldAttributes: value } ) }
-					help={ __( 'Deactivate for individual styling of this block', 'jetpack-forms' ) }
-					__nextHasNoMarginBottom={ true }
-				/>
 				<TextControl
 					className={ errorState.error ? 'jetpack-forms-field-controls__input-error' : '' }
 					label={ __( 'Name/ID', 'jetpack-forms' ) }

--- a/projects/plugins/jetpack/changelog/update-forms-advanced-and-no-orphans
+++ b/projects/plugins/jetpack/changelog/update-forms-advanced-and-no-orphans
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: avoid typohraphic orphans in Forms panels in editor


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->



## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Avoids typographic orphans in all Forms panels by setting `text-wrap:pretty`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Use panels in editor
