### PR TITLE
Additional CSS: Show nudges to the correct Plan on both Simple and Atomic, independently of the admin interface

### DIFF
--- a/projects/packages/masterbar/changelog/dotthem-99-custom-css-always-show-the-upsell-when-the-conditions-are
+++ b/projects/packages/masterbar/changelog/dotthem-99-custom-css-always-show-the-upsell-when-the-conditions-are
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+Show Additional CSS nudges on both Simple and Atomic, independently of the admin interface.

--- a/projects/packages/masterbar/src/class-main.php
+++ b/projects/packages/masterbar/src/class-main.php
@@ -35,6 +35,9 @@ class Main {
 			add_filter( 'pre_option_wpcom_admin_interface', 'wpcom_admin_interface_pre_get_option', 10 );
 		}
 
+		// Show Additional CSS nudges on both Simple and Atomic, independently of the admin interface.
+		require_once __DIR__ . '/nudges/bootstrap.php';
+
 		if ( $is_wp_admin_interface ) {
 			return;
 		}
@@ -44,7 +47,6 @@ class Main {
 		if ( $host->is_wpcom_platform() ) {
 			new Inline_Help();
 			require_once __DIR__ . '/wp-posts-list/bootstrap.php';
-			require_once __DIR__ . '/nudges/bootstrap.php';
 		}
 
 		if ( $host->is_woa_site() ) {

--- a/projects/packages/masterbar/src/class-main.php
+++ b/projects/packages/masterbar/src/class-main.php
@@ -44,10 +44,8 @@ class Main {
 
 		$host = new Host();
 
-		if ( $host->is_wpcom_platform() ) {
-			new Inline_Help();
-			require_once __DIR__ . '/wp-posts-list/bootstrap.php';
-		}
+		new Inline_Help();
+		require_once __DIR__ . '/wp-posts-list/bootstrap.php';
 
 		if ( $host->is_woa_site() ) {
 			require_once __DIR__ . '/profile-edit/bootstrap.php';

--- a/projects/packages/masterbar/src/nudges/additional-css/class-atomic-additional-css-manager.php
+++ b/projects/packages/masterbar/src/nudges/additional-css/class-atomic-additional-css-manager.php
@@ -36,11 +36,11 @@ class Atomic_Additional_CSS_Manager {
 	 * @param \WP_Customize_Manager $wp_customize_manager Core customize manager.
 	 */
 	public function register_nudge( \WP_Customize_Manager $wp_customize_manager ) {
-		$plan = $this->get_plan_name();
+		$plan_name = $this->get_plan()->product_name_short;
 
 		$nudge_url = $this->get_nudge_url();
 		/* translators: %s is the plan name. */
-		$nudge_text = sprintf( __( 'Purchase the %s plan to<br> activate CSS customization', 'jetpack-masterbar' ), $plan );
+		$nudge_text = sprintf( __( 'Purchase the %s plan to<br> activate CSS customization', 'jetpack-masterbar' ), $plan_name );
 
 		$nudge = new CSS_Customizer_Nudge(
 			$nudge_url,
@@ -54,20 +54,22 @@ class Atomic_Additional_CSS_Manager {
 	}
 
 	/**
-	 * Get the plan name.
-	 *
-	 * @return mixed
-	 */
-	protected function get_plan_name() {
-		return \Automattic\Jetpack\Plans::get_plan( 'business-bundle' )->product_name_short;
-	}
-
-	/**
-	 * Get the Nudge URL.
+	 * Get the nudge URL in WPCOM.
 	 *
 	 * @return string
 	 */
 	private function get_nudge_url() {
-		return '/checkout/' . $this->domain . '/business';
+		return '/checkout/' . $this->domain . '/' . $this->get_plan()->path_slug;
+	}
+
+	/**
+	 * Get the plan.
+	 *
+	 * @return mixed
+	 */
+	protected function get_plan() {
+		$plan_slug = apply_filters( 'wpcom_customize_css_plan_slug', 'value_bundle' );
+
+		return \Automattic\Jetpack\Plans::get_plan( $plan_slug );
 	}
 }

--- a/projects/packages/masterbar/tests/php/Atomic_Additional_CSS_Manager_Test.php
+++ b/projects/packages/masterbar/tests/php/Atomic_Additional_CSS_Manager_Test.php
@@ -51,20 +51,25 @@ class Atomic_Additional_CSS_Manager_Test extends TestCase {
 	public function test_it_generates_proper_url_and_nudge() {
 		$manager = $this->getMockBuilder( Atomic_Additional_CSS_Manager::class )
 			->setConstructorArgs( array( 'foo.com' ) )
-			->onlyMethods( array( 'get_plan_name' ) )
+			->onlyMethods( array( 'get_plan' ) )
 			->getMock();
 
-		$manager->method( 'get_plan_name' )->willReturn( 'Business' );
+		$manager->method( 'get_plan' )->willReturn(
+			(object) array(
+				'product_name_short' => 'Premium',
+				'path_slug'          => 'premium',
+			)
+		);
 
 		$manager->register_nudge( $this->wp_customize );
 
 		$this->assertEquals(
-			'/checkout/foo.com/business',
+			'/checkout/foo.com/premium',
 			$this->wp_customize->controls()['custom_css_control']->cta_url
 		);
 
 		$this->assertEquals(
-			'Purchase the Business plan to<br> activate CSS customization',
+			'Purchase the Premium plan to<br> activate CSS customization',
 			$this->wp_customize->controls()['custom_css_control']->nudge_copy
 		);
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes DOTTHEM-99

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Show Additional CSS nudges on both Simple and Atomic, independently of the admin interface.
* Update the nudge on Atomic to prompt the proper plan (generally Premium).

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Test on Simple Personal, Simple Premium (or higher), Atomic Personal, Atomic Premium (or higher). Try both the Classic (wp-admin) and Default (Calypso) interfaces.

- Activate a classic theme (e.g. Intergalactic 2).
- Enter the Customizer.
- Open the Additional CSS section.
- On Personal (or lower) sites, there should be an "Upgrade" upsell pointing to Checkout with the Premium plan.
- On Premium (or higher) sites, there should be a textarea for custom CSS.