### PR TITLE
Sync: Add WooCommerce capabilities to sync whitelist

### DIFF
--- a/projects/packages/sync/changelog/add-manage-woocommerce-capability
+++ b/projects/packages/sync/changelog/add-manage-woocommerce-capability
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+
+Add manage_woocommerce and view_woocommerce_reports capabilities to sync whitelist for WooCommerce integration.
+

--- a/projects/packages/sync/src/modules/class-woocommerce.php
+++ b/projects/packages/sync/src/modules/class-woocommerce.php
@@ -127,6 +127,7 @@ class WooCommerce extends Module {
 		add_filter( 'jetpack_sync_constants_whitelist', array( $this, 'add_woocommerce_constants_whitelist' ), 10 );
 		add_filter( 'jetpack_sync_post_meta_whitelist', array( $this, 'add_woocommerce_post_meta_whitelist' ), 10 );
 		add_filter( 'jetpack_sync_comment_meta_whitelist', array( $this, 'add_woocommerce_comment_meta_whitelist' ), 10 );
+		add_filter( 'jetpack_sync_capabilities_whitelist', array( $this, 'add_woocommerce_capabilities_whitelist' ), 10 );
 
 		add_filter( 'jetpack_sync_before_enqueue_woocommerce_new_order_item', array( $this, 'filter_order_item' ) );
 		add_filter( 'jetpack_sync_before_enqueue_woocommerce_update_order_item', array( $this, 'filter_order_item' ) );
@@ -394,6 +395,16 @@ class WooCommerce extends Module {
 	}
 
 	/**
+	 * Add WooCommerce capabilities to the capabilities whitelist.
+	 *
+	 * @param array $list Existing capabilities whitelist.
+	 * @return array Updated capabilities whitelist.
+	 */
+	public function add_woocommerce_capabilities_whitelist( $list ) {
+		return array_merge( $list, self::$wc_capabilities_whitelist );
+	}
+
+	/**
 	 * Adds 'revew' to the list of comment types so Sync will listen for status changes on 'reviews'.
 	 *
 	 * @access public
@@ -626,6 +637,19 @@ class WooCommerce extends Module {
 	 */
 	private static $wc_comment_meta_whitelist = array(
 		'rating',
+	);
+
+	/**
+	 * Whitelist for capabilities we are interested to sync.
+	 *
+	 * @access private
+	 * @static
+	 *
+	 * @var array
+	 */
+	private static $wc_capabilities_whitelist = array(
+		'manage_woocommerce',
+		'view_woocommerce_reports',
 	);
 
 	/**

--- a/projects/plugins/jetpack/changelog/add-woocommerce-capabilities-sync-test
+++ b/projects/plugins/jetpack/changelog/add-woocommerce-capabilities-sync-test
@@ -1,5 +1,5 @@
 Significance: patch
-Type: added
+Type: other
 
 Add test to verify WooCommerce capabilities are synced.
 

--- a/projects/plugins/jetpack/changelog/add-woocommerce-capabilities-sync-test
+++ b/projects/plugins/jetpack/changelog/add-woocommerce-capabilities-sync-test
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+
+Add test to verify WooCommerce capabilities are synced.
+

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_WooCommerce_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_WooCommerce_Test.php
@@ -40,7 +40,6 @@ class Jetpack_Sync_WooCommerce_Test extends Jetpack_Sync_TestBase {
 	}
 
 	public function test_woocommerce_capabilities_are_whitelisted() {
-		$woocommerce_module = Modules::get_module( 'woocommerce' );
 		$capabilities_whitelist = apply_filters( 'jetpack_sync_capabilities_whitelist', array() );
 
 		$this->assertContains( 'manage_woocommerce', $capabilities_whitelist );

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_WooCommerce_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_WooCommerce_Test.php
@@ -39,6 +39,14 @@ class Jetpack_Sync_WooCommerce_Test extends Jetpack_Sync_TestBase {
 		$this->assertTrue( (bool) Modules::get_module( 'woocommerce' ) );
 	}
 
+	public function test_woocommerce_capabilities_are_whitelisted() {
+		$woocommerce_module = Modules::get_module( 'woocommerce' );
+		$capabilities_whitelist = apply_filters( 'jetpack_sync_capabilities_whitelist', array() );
+
+		$this->assertContains( 'manage_woocommerce', $capabilities_whitelist );
+		$this->assertContains( 'view_woocommerce_reports', $capabilities_whitelist );
+	}
+
 	/** Incremental sync **/
 	public function test_orders_are_synced() {
 		$order = $this->createOrderWithItem();


### PR DESCRIPTION
Add `manage_woocommerce` and `view_woocommerce_reports` capabilities to the Jetpack Sync capabilities whitelist. This enables WPCOM to check WooCommerce permissions for connected users, which is needed for AI Abilities and other WooCommerce integrations.

- Add `$wc_capabilities_whitelist` array to WooCommerce sync module
- Add `add_woocommerce_capabilities_whitelist()` method to filter capabilities

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
