### PR TITLE
Forms: Fix multistep dropdown showing 'Unlabeled' instead of default step titles

### DIFF
--- a/projects/packages/forms/changelog/fix-multistep-labels
+++ b/projects/packages/forms/changelog/fix-multistep-labels
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Fix multistep dropdown showing "Unlabeled" instead of default step titles like "Step 1", "Step 2", etc.

--- a/projects/packages/forms/src/blocks/form-step/edit.js
+++ b/projects/packages/forms/src/blocks/form-step/edit.js
@@ -8,6 +8,7 @@ import StepControls from '../shared/components/form-step-controls';
 import useFormSteps from '../shared/hooks/use-form-steps';
 import useParentFormClientId from '../shared/hooks/use-parent-form-client-id';
 import { CORE_BLOCKS } from '../shared/util/constants';
+import { getStepLabel } from '../shared/util/step-labels';
 import AttributesControls from './attributes-controls';
 
 import './editor.scss';
@@ -64,24 +65,12 @@ function StepBreak( { stepLabel, currentIndex, setAttributes, clientId } ) {
 		[ clientId ]
 	);
 
+	const listViewLabel = getStepLabel( currentIndex, stepLabel );
 	const stepNumberString = sprintf(
 		// translators: %d is the step number (1, 2, 3, etc.)
 		__( 'Step %d', 'jetpack-forms' ),
 		currentIndex + 1
 	);
-
-	// Build the full label string that should appear in List View.
-	const listViewLabel =
-		stepLabel && stepLabel !== ''
-			? sprintf(
-					/* translators: %1$d is the step number, %2$s is the custom label */ __(
-						'Step %1$d – %2$s',
-						'jetpack-forms'
-					),
-					currentIndex + 1,
-					stepLabel
-			  )
-			: stepNumberString;
 
 	// Keep List View label in sync whenever the label or step order changes.
 	useEffect( () => {

--- a/projects/packages/forms/src/blocks/shared/components/form-step-controls/index.js
+++ b/projects/packages/forms/src/blocks/shared/components/form-step-controls/index.js
@@ -8,12 +8,13 @@ import {
 	ToolbarDropdownMenu,
 } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { next, previous, check } from '@wordpress/icons';
 import { store as singleStepStore } from '../../../../store/form-step-preview';
 import StepIcon from '../../../form-step/icon';
 import StepContainerIcon from '../../../form-step-container/icon';
 import useStepNavigation from '../../hooks/use-step-navigation';
+import { getStepLabel } from '../../util/step-labels';
 
 /**
  * Toolbar controls for managing steps within a multi-step form.
@@ -121,12 +122,7 @@ export default function StepControls( { formClientId } ) {
 										) : null
 									}
 								>
-									{ sprintf(
-										/* translators: %1$d is the step number (1, 2, 3, etc.), %2$s is the step label. */
-										__( '%1$d – %2$s', 'jetpack-forms' ),
-										index + 1,
-										step?.attributes?.stepLabel || __( 'Unlabeled', 'jetpack-forms' )
-									) }
+									{ getStepLabel( index, step?.attributes?.stepLabel ) }
 								</MenuItem>
 							) ) }
 						</MenuGroup>

--- a/projects/packages/forms/src/blocks/shared/components/form-step-controls/index.js
+++ b/projects/packages/forms/src/blocks/shared/components/form-step-controls/index.js
@@ -6,6 +6,8 @@ import {
 	MenuGroup,
 	MenuItem,
 	ToolbarDropdownMenu,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalTruncate as Truncate,
 } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
@@ -122,7 +124,9 @@ export default function StepControls( { formClientId } ) {
 										) : null
 									}
 								>
-									{ getStepLabel( index, step?.attributes?.stepLabel ) }
+									<Truncate limit={ 50 }>
+										{ getStepLabel( index, step?.attributes?.stepLabel ) }
+									</Truncate>
 								</MenuItem>
 							) ) }
 						</MenuGroup>

--- a/projects/packages/forms/src/blocks/shared/util/step-labels.js
+++ b/projects/packages/forms/src/blocks/shared/util/step-labels.js
@@ -1,0 +1,27 @@
+import { __, sprintf } from '@wordpress/i18n';
+
+/**
+ * Generate a step label for display.
+ *
+ * @param {number} stepIndex   - Zero-based index of the step
+ * @param {string} customLabel - Optional custom label for the step
+ * @return {string} Formatted step label
+ */
+export function getStepLabel( stepIndex, customLabel = '' ) {
+	const stepNumber = stepIndex + 1;
+
+	if ( customLabel && customLabel !== '' ) {
+		return sprintf(
+			/* translators: %1$d is the step number, %2$s is the custom label */
+			__( 'Step %1$d – %2$s', 'jetpack-forms' ),
+			stepNumber,
+			customLabel
+		);
+	}
+
+	return sprintf(
+		/* translators: %d is the step number (1, 2, 3, etc.) */
+		__( 'Step %d', 'jetpack-forms' ),
+		stepNumber
+	);
+}


### PR DESCRIPTION
## Proposed changes:
* Fixed the multistep form dropdown menu to display "Step 1", "Step 2", "Step 3" instead of "1 - Unlabeled", "2 - Unlabeled", "3 - Unlabeled" for steps without custom labels
* Created a shared utility function `getStepLabel()` to ensure consistent label formatting across both the dropdown menu and the block list view
* The default step labels now match the placeholder text shown in the editor

### Other information:

- [x] Have you written new tests for your changes, if applicable?
  - No new tests needed - this is a UI label fix that uses existing patterns
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
No, this is a purely cosmetic UI fix.

## Testing instructions:

### Setup
1. Ensure you have a WordPress site with Jetpack Forms installed
2. Build the forms package: `cd projects/packages/forms && pnpm build`

### Testing
1. Create a new post or page
2. Add a "Contact Form" block
3. In the block settings, choose the "Multistep" variation (or add multiple Form Step Container blocks manually)
4. In the toolbar, click the dropdown that shows "All steps"
5. **Before this fix**: The dropdown would show "1 - Unlabeled", "2 - Unlabeled", "3 - Unlabeled"
6. **After this fix**: The dropdown should show "Step 1", "Step 2", "Step 3"
7. (Optional) Add a custom label to one of the steps by typing in the step label field
8. Verify the dropdown now shows "Step 1 – [your custom label]" format

### Expected behavior
- Steps without custom labels should display as "Step 1", "Step 2", etc.
- Steps with custom labels should display as "Step 1 – Custom Label"
- This matches the placeholder text shown in the editor