### PR TITLE
Forms: Fix plugin button activating state

### DIFF
--- a/projects/packages/forms/changelog/fix-form-plugin-install-load-state
+++ b/projects/packages/forms/changelog/fix-form-plugin-install-load-state
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: fix plugin activation state.

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/integration-card-header.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/integration-card-header.tsx
@@ -140,6 +140,7 @@ const IntegrationCardHeader = ( {
 							slug={ cardData.slug }
 							pluginFile={ cardData.pluginFile }
 							isInstalled={ isInstalled }
+							isActive={ isActive }
 							refreshStatus={ cardData.refreshStatus }
 							trackEventName={ cardData.trackEventName }
 						/>

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/plugin-action-button.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/integration-card/plugin-action-button.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { Button, Spinner, Tooltip } from '@wordpress/components';
+import { useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
@@ -13,6 +14,7 @@ type PluginActionButtonProps = {
 	slug: string;
 	pluginFile: string;
 	isInstalled: boolean;
+	isActive: boolean;
 	refreshStatus: () => void;
 	trackEventName: string;
 };
@@ -21,6 +23,7 @@ const PluginActionButton = ( {
 	slug,
 	pluginFile,
 	isInstalled,
+	isActive,
 	refreshStatus,
 	trackEventName,
 }: PluginActionButtonProps ) => {
@@ -31,13 +34,13 @@ const PluginActionButton = ( {
 		trackEventName
 	);
 
-	// Permissions from consolidated Forms config (shared across editor and dashboard)
 	const config = useFormsConfig();
 	const canUserInstallPlugins = Boolean( config?.canInstallPlugins );
 	const canUserActivatePlugins = Boolean( config?.canActivatePlugins );
 
 	const canPerformAction = isInstalled ? canUserActivatePlugins : canUserInstallPlugins;
-	const isDisabled = isInstalling || ! canPerformAction;
+	const [ isReconcilingStatus, setIsReconcilingStatus ] = useState( false );
+	const isDisabled = isInstalling || isReconcilingStatus || ! canPerformAction;
 
 	const handleAction = async ( event: MouseEvent ) => {
 		event.stopPropagation();
@@ -47,14 +50,23 @@ const PluginActionButton = ( {
 		const success = await installPlugin();
 
 		if ( success && refreshStatus ) {
+			setIsReconcilingStatus( true ); // Keeps button in loading state until integrations refresh.
 			refreshStatus();
 		}
 	};
 
+	useEffect( () => {
+		if ( isReconcilingStatus && isActive ) {
+			setIsReconcilingStatus( false ); // Removes button loading state when integratoin status is recevied and isActive.
+		}
+	}, [ isReconcilingStatus, isActive ] );
+
 	const getButtonText = () => {
 		return (
-			( isInstalling && isInstalled && __( 'Activating…', 'jetpack-forms' ) ) ||
-			( isInstalling && __( 'Installing…', 'jetpack-forms' ) ) ||
+			( ( isInstalling || isReconcilingStatus ) &&
+				isInstalled &&
+				__( 'Activating…', 'jetpack-forms' ) ) ||
+			( ( isInstalling || isReconcilingStatus ) && __( 'Installing…', 'jetpack-forms' ) ) ||
 			( isInstalled && __( 'Activate', 'jetpack-forms' ) ) ||
 			__( 'Install', 'jetpack-forms' )
 		);
@@ -89,7 +101,7 @@ const PluginActionButton = ( {
 					onClick={ handleAction }
 					disabled={ isDisabled }
 					style={ isDisabled ? { pointerEvents: 'none' } : undefined }
-					icon={ isInstalling ? <Spinner /> : undefined }
+					icon={ isInstalling || isReconcilingStatus ? <Spinner /> : undefined }
 					__next40pxDefaultSize
 				>
 					{ getButtonText() }

--- a/projects/plugins/jetpack/changelog/fix-form-plugin-install-load-state
+++ b/projects/plugins/jetpack/changelog/fix-form-plugin-install-load-state
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: fix plugin activation state.


### PR DESCRIPTION
## Proposed changes:

When you click the Install or Activate button to install or activate a plugin from our form integrations dashboard or modal, there's a bug where it goes into loading state, then returns to normal state once the plugin is installed, then disappears when we fetch integration status and find the plugin is installed. 

This occurs because we're sending two separate requests - one to activate the plugin, and another to fetch integration status. The install button only shows loading state during the first. 

I was going to fix this by showing button loading state when integrations are loading, but that would mean when you click to install one button, all the integrations buttons might suddenly show loading state, which is jarring. 

So the fix just tracks a 'reconciling' status for the current component. We set that to true once a plugin is active, but we're awaiting integration data, and set it back to false when we get the updated integration status. 

The result is the button just shows loading until it fully disappears. 

**Before**
https://github.com/user-attachments/assets/ee5665c6-761d-43ca-ba17-d70bf42b7674

**After**
https://github.com/user-attachments/assets/a448dec8-352d-447f-ad8d-69335599124d


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None. 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Go to the forms dashboard. Install or activate a plugin. Confirm that the install/activate button doesn't re-show in normal active state before disappearing. It should just stay loading until it disappears. 