### PR TITLE
Fix/mapkit map.additems validation error

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-mapkit-map.additems-validation-error
+++ b/projects/plugins/jetpack/changelog/fix-mapkit-map.additems-validation-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Maps Block: fix compatibility with MapKit JS version 5.80.0+.

--- a/projects/plugins/jetpack/extensions/blocks/map/mapkit/hooks/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/map/mapkit/hooks/index.js
@@ -183,7 +183,7 @@ const useMapkitZoom = ( zoom, setZoom ) => {
 };
 
 const useMapkitPoints = ( points, markerColor, callOutElement = null, onSelect = null ) => {
-	const { mapkit, map, loaded } = useMapkit();
+	const { mapkit, map, loaded, currentWindow } = useMapkit();
 
 	// avoid rerenders by making these refs
 	const callOutElementRef = useRef( callOutElement );
@@ -225,10 +225,13 @@ const useMapkitPoints = ( points, markerColor, callOutElement = null, onSelect =
 				return marker;
 			} );
 			if ( map.annotations.length !== annotations.length ) {
-				map.showItems( annotations );
+				// Rebuild the annotations array using currentWindow to avoid issues with
+				// "instanceof Array" checks on the array in the MapKit code in case this
+				// code is running in a different realm.
+				map.showItems( new currentWindow.Array( ...annotations ) );
 			}
 		}
-	}, [ points, loaded, map, mapkit, markerColor, callOutElementRef, onSelectRef ] );
+	}, [ points, loaded, map, mapkit, markerColor, callOutElementRef, onSelectRef, currentWindow ] );
 };
 
 const useMapkitOnMapLoad = onMapLoad => {


### PR DESCRIPTION
Fixes MapKit JS compatibility failure discussed in p1759943003399849-slack-C034JEXD1RD

## Proposed changes:
* Uses the `currentWindow` object to remake the `annotations` array in the same realm as the realm that the MapKit library runs in before passing it to `map.showItems()`. This avoids a validation failure in MapKit when checking the passed array using `instanceof Array` when the Map Block code is executing in a different realm as the MapKit code.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1759943003399849-slack-C034JEXD1RD

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
1. Test on a WoW site that can run this branch of code.
2. Start the test on trunk without this fix.
3. Edit the content of a post or page.
4. Add a Map Block.
5. Add a marker to the map.
6. The block should no longer render properly and its content is replaced with the following error message: "This block has encountered an error and cannot be previewed."
7. If you do not get this error message, you may not be able to recreate the bug on that specific test site. Try running these testing instructions with another test site until you can recreate the issue.
8. Switch to running this PR's branch.
9. Retry steps 3 through 5.
10. While running this PR, the block should no longer break when adding markers.
11. Confirm that you can add multiple markers and that the map updates to show a region displaying the added markers. 

