### PR TITLE
Forms: fix response mobile dialog name

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-response-mobile-dialog-name
+++ b/projects/packages/forms/changelog/fix-forms-response-mobile-dialog-name
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Forms: add ID on modal header to be properly identified by e2e

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
@@ -468,7 +468,10 @@ const InboxResponseMobile = ( { response, data, closeModal } ) => {
 				justify="space-between"
 				className="jp-forms__inbox__response-mobile__header"
 			>
-				<h1 className="jp-forms__inbox__response-mobile__header-heading">
+				<h1
+					className="jp-forms__inbox__response-mobile__header-heading"
+					id="components-modal-header-0" // e2e looks for this ID when opening the modal
+				>
 					{ __( 'Response', 'jetpack-forms' ) }
 				</h1>
 				<HStack


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
This PR adds an ID to the heading element of the response modal on mobile

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
This fix is for e2e to pass. If you need to check, open the Jetpack Forms dashboard while emulating mobile view. Open a response and look into the developer console.

Type `document.getElementById('components-modal-header-0')` and hit enter. The result should be an existing element that is the H1 for the opened response (modal is fullscreen on mobile)