### PR TITLE
Pocket Casts logo: remove duplicate codepoint entry

### DIFF
--- a/projects/js-packages/social-logos/changelog/fix-pocket-casts-duplicate-entry
+++ b/projects/js-packages/social-logos/changelog/fix-pocket-casts-duplicate-entry
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Pocket Casts: remove duplicate entry.
+
+

--- a/projects/js-packages/social-logos/src/font/codepoints.json
+++ b/projects/js-packages/social-logos/src/font/codepoints.json
@@ -72,7 +72,6 @@
 	"untappd": 63025,
 	"vk": 63026,
 	"substack": 63027,
-	"pocket-casts": 63028,
 	"apple-podcasts": 63028,
-	"pocketcasts": 63029
+	"pocket-casts": 63029
 }


### PR DESCRIPTION
Follow-up to #45485

## Proposed changes:

I'll get it right eventually...

<img width="212" height="397" alt="image" src="https://github.com/user-attachments/assets/728748a3-98e5-46ff-afd4-36558c46db6f" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

Not much to test this time around, but just in case:

* Check this PR locally, do `cd projects/js-packages/storybook && pnpm storybook:dev`
* Go to http://localhost:50240/?path=/docs/js-packages-social-logos-icons--docs

