### PR TITLE
Forms: Better handle custom submission message formatting

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-success-message-formatting
+++ b/projects/packages/forms/changelog/fix-forms-success-message-formatting
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Better handle custom submission message formatting

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1007,7 +1007,10 @@ class Contact_Form extends Contact_Form_Shortcode {
 				),
 			);
 
-			$html .= wp_kses( $raw_message, $allowed_html );
+			$message = wp_kses( $raw_message, $allowed_html );
+			$message = '<div class="contact-form-custom-success-message">' . $message . '</div>';
+
+			$html .= $message;
 		} elseif ( ! $disable_summary ) {
 			$html .= '<template data-wp-each--submission="context.formattedSubmissionData">
 				<div>
@@ -1072,7 +1075,9 @@ class Contact_Form extends Contact_Form_Shortcode {
 					'style' => array(),
 				),
 			);
-			$message      = wp_kses( $raw_message, $allowed_html );
+
+			$message = wp_kses( $raw_message, $allowed_html );
+			$message = '<div class="contact-form-custom-success-message">' . $message . '</div>';
 		} elseif ( ! $disable_summary ) {
 			$compiled_form = self::get_compiled_form( $feedback_id );
 			$message       = '<p>' . implode( '</p><p>', $compiled_form ) . '</p>';

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1009,7 +1009,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 			);
 
 			$message = wp_kses( $raw_message, $allowed_html );
-			$message = '<div class="contact-form-custom-success-message">' . $message . '</div>';
+			$message = '<div class="jetpack_forms_contact-form-custom-success-message">' . $message . '</div>';
 
 			$html .= $message;
 		} elseif ( ! $disable_summary ) {
@@ -1079,7 +1079,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 			);
 
 			$message = wp_kses( $raw_message, $allowed_html );
-			$message = '<div class="contact-form-custom-success-message">' . $message . '</div>';
+			$message = '<div class="jetpack_forms_contact-form-custom-success-message">' . $message . '</div>';
 		} elseif ( ! $disable_summary ) {
 			$compiled_form = self::get_compiled_form( $feedback_id );
 			$message       = '<p>' . implode( '</p><p>', $compiled_form ) . '</p>';

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -991,7 +991,8 @@ class Contact_Form extends Contact_Form_Shortcode {
 			"</h4>\n\n";
 
 		if ( 'message' === $form->get_attribute( 'customThankyou' ) ) {
-			$raw_message = wpautop( $form->get_attribute( 'customThankyouMessage' ) );
+			$raw_message = $form->get_attribute( 'customThankyouMessage' );
+
 			// Add more allowed HTML elements for file download links
 			$allowed_html = array(
 				'br'         => array(),
@@ -1060,7 +1061,8 @@ class Contact_Form extends Contact_Form_Shortcode {
 		$disable_summary = 'noSummary' === $form->get_attribute( 'customThankyou' );
 
 		if ( 'message' === $form->get_attribute( 'customThankyou' ) ) {
-			$raw_message = wpautop( $form->get_attribute( 'customThankyouMessage' ) );
+			$raw_message = $form->get_attribute( 'customThankyouMessage' );
+
 			// Add more allowed HTML elements for file download links
 			$allowed_html = array(
 				'br'         => array(),

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -225,6 +225,10 @@ that needs to mimic the input element styles */
 	word-wrap: break-word;
 }
 
+:where(.contact-form-submission) .contact-form-custom-success-message p {
+	margin: revert;
+}
+
 .contact-form-submission h4 {
 	margin-top: 32px;
 	margin-bottom: 32px;

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -225,12 +225,13 @@ that needs to mimic the input element styles */
 	word-wrap: break-word;
 }
 
-.contact-form-submission :where(.contact-form-custom-success-message) p {
+.contact-form-submission :where(.jetpack_forms_contact-form-custom-success-message) p {
 	margin: revert;
 }
 
-.contact-form-submission :where(.contact-form-custom-success-message) {
+.contact-form-submission :where(.jetpack_forms_contact-form-custom-success-message) {
 	white-space: pre-wrap;
+	text-wrap: pretty;
 }
 
 .contact-form-submission h4 {

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -229,6 +229,10 @@ that needs to mimic the input element styles */
 	margin: revert;
 }
 
+:where(.contact-form-submission) .contact-form-custom-success-message {
+	white-space: pre-wrap;
+}
+
 .contact-form-submission h4 {
 	margin-top: 32px;
 	margin-bottom: 32px;

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -225,11 +225,11 @@ that needs to mimic the input element styles */
 	word-wrap: break-word;
 }
 
-:where(.contact-form-submission) .contact-form-custom-success-message p {
+.contact-form-submission :where(.contact-form-custom-success-message) p {
 	margin: revert;
 }
 
-:where(.contact-form-submission) .contact-form-custom-success-message {
+.contact-form-submission :where(.contact-form-custom-success-message) {
 	white-space: pre-wrap;
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes FORMS-310

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Keeps default paragraph margins for custom response messages
* Use pre-wrap white-space instead of using wpautop function, allowing vertical spacing control to work as expected, respecting multiple lines

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add a form with a custom message on submission (form block > Action after submit > "Show a custom text message")
* Make sure the custom text message has more than one paragraph by using newlines
* Publish the post and submit the form
* Check that the vertical spacing between lines is respected.

Editor:
<img width="275" height="664" alt="Screenshot from 2025-10-13 16-38-52" src="https://github.com/user-attachments/assets/8630ba57-8ea6-4786-9782-cb7b0dce7b49" />

| Before | After |
| - | - |
| <img width="715" height="515" alt="Screenshot from 2025-10-13 16-41-33" src="https://github.com/user-attachments/assets/840cdb7e-9921-434f-a044-fe713c130e19" /> | <img width="739" height="841" alt="Screenshot from 2025-10-13 16-39-13" src="https://github.com/user-attachments/assets/efc7929e-737c-4817-80bb-02827a8084d0" />

