### PR TITLE
Forms: split components files

### DIFF
--- a/projects/packages/forms/changelog/change-forms-split-inbox-components
+++ b/projects/packages/forms/changelog/change-forms-split-inbox-components
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Split components and hooks into their own files

--- a/projects/packages/forms/src/dashboard/components/response-view/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/response-view/index.tsx
@@ -1,0 +1,514 @@
+/**
+ * External dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+import {
+	Button,
+	ExternalLink,
+	Modal,
+	Tooltip,
+	Spinner,
+	Icon,
+	Tip,
+	__experimentalConfirmDialog as ConfirmDialog, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+	__experimentalVStack as VStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+} from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
+import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
+import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
+import { decodeEntities } from '@wordpress/html-entities';
+import { __, _n, sprintf } from '@wordpress/i18n';
+import { download } from '@wordpress/icons';
+import clsx from 'clsx';
+/**
+ * Internal dependencies
+ */
+import useFormsConfig from '../../../hooks/use-forms-config';
+import { useMarkAsSpam } from '../../hooks/use-mark-as-spam';
+import { getPath, updateMenuCounter, updateMenuCounterOptimistically } from '../../inbox/utils';
+import CopyClipboardButton from '../copy-clipboard-button';
+import Gravatar from '../gravatar';
+import ResponseMobileView from './mobile.tsx';
+import type { FormResponse } from '../../../types';
+
+const getDisplayName = response => {
+	const { author_name, author_email, author_url, ip } = response;
+	return decodeEntities( author_name || author_email || author_url || ip );
+};
+
+const isFileUploadField = value => {
+	return value && typeof value === 'object' && 'files' in value;
+};
+
+const isImageSelectField = value => {
+	return value?.type === 'image-select';
+};
+
+const isLikelyPhoneNumber = value => {
+	// Only operate on strings to avoid coercing numbers (e.g., 2024) into strings that could match
+	if ( typeof value !== 'string' ) {
+		return false;
+	}
+
+	const normalizedValue = value.trim();
+
+	// Allow only digits, spaces, parentheses, hyphens, dots, plus
+	if ( ! /^[\d+\-\s().]+$/.test( normalizedValue ) ) {
+		return false;
+	}
+
+	// Exclude common date formats to avoid false positives
+	// - ISO-like: 2025-11-01 or 2025/11/01
+	if ( /^\d{4}[-/]\d{1,2}[-/]\d{1,2}$/.test( normalizedValue ) ) {
+		return false;
+	}
+	// - Locale-like: 01/11/2025, 1/11/25, 11-01-2025
+	if ( /^\d{1,2}[-/]\d{1,2}[-/]\d{2,4}$/.test( normalizedValue ) ) {
+		return false;
+	}
+
+	// Strip non-digits and validate digit count within a typical global range
+	const digits = normalizedValue.replace( /\D/g, '' );
+	if ( digits.length < 7 || digits.length > 15 ) {
+		return false;
+	}
+
+	return true;
+};
+
+const PreviewFile = ( { file, isLoading, onImageLoaded } ) => {
+	const imageClass = clsx( 'jp-forms__inbox-file-preview-container', {
+		'is-loading': isLoading,
+	} );
+
+	return (
+		<div className="jp-forms__inbox-file-preview-shell">
+			{ isLoading && (
+				<div className="jp-forms__inbox-file-loading">
+					<Spinner className="jp-forms__inbox-spinner" />
+					<div className="jp-forms__inbox-file-loading-message ">
+						{ __( 'Loading preview…', 'jetpack-forms' ) }
+					</div>
+				</div>
+			) }
+
+			<div className={ imageClass }>
+				<img
+					src={ file.url }
+					alt={ decodeEntities( file.name ) }
+					onLoad={ onImageLoaded }
+					className="jp-forms__inbox-file-preview-image"
+				/>
+			</div>
+		</div>
+	);
+};
+
+const FileField = ( { file, onClick } ) => {
+	const fileExtension = file.name.split( '.' ).pop().toLowerCase();
+	const fileType = file.type.split( '/' )[ 0 ];
+
+	const iconMap = {
+		image: 'png',
+		video: 'mp4',
+		audio: 'mp3',
+		document: 'pdf',
+		application: 'txt',
+	};
+
+	const extensionMap = {
+		pdf: 'pdf',
+		png: 'png',
+		jpg: 'png',
+		jpeg: 'png',
+		gif: 'png',
+		mp4: 'mp4',
+		mp3: 'mp3',
+		webm: 'webm',
+		doc: 'doc',
+		docx: 'doc',
+		txt: 'txt',
+		ppt: 'ppt',
+		pptx: 'ppt',
+		xls: 'xls',
+		xlsx: 'xls',
+		csv: 'xls',
+		zip: 'zip',
+		sql: 'sql',
+		cal: 'cal',
+	};
+	const iconType = extensionMap[ fileExtension ] || iconMap[ fileType ] || 'txt';
+	const iconClass = clsx( 'file-field__icon', 'icon-' + iconType );
+	return (
+		<div className="file-field__item">
+			<div className="file-field__info">
+				<div className={ iconClass }></div>
+				<div className="file-field__name">
+					{ file.is_previewable && (
+						<Button target="_blank" variant="link" onClick={ onClick }>
+							{ decodeEntities( file.name ) }
+						</Button>
+					) }
+					{ ! file.is_previewable && (
+						<ExternalLink href={ file.url + '&preview=true' }>
+							{ decodeEntities( file.name ) }
+						</ExternalLink>
+					) }
+					<div className="file-field__meta-info">
+						{ sprintf(
+							/* translators: %1$s size of the file and %2$s is the file extension */
+							__( '%1$s, %2$s', 'jetpack-forms' ),
+							file.size,
+							fileExtension.toUpperCase()
+						) }
+					</div>
+				</div>
+			</div>
+			<span className="file-field__item-actions">
+				<Tooltip text={ __( 'Download', 'jetpack-forms' ) }>
+					<Button variant="secondary" href={ file.url } target="_blank">
+						<Icon icon={ download } />
+					</Button>
+				</Tooltip>
+			</span>
+		</div>
+	);
+};
+
+export type ResponseViewProps = {
+	response: FormResponse;
+	isLoading: boolean;
+	onModalStateChange?: ( toggleOpen: boolean ) => void;
+	isMobile?: boolean;
+};
+
+/**
+ * Renders the dashboard response view.
+ *
+ * @param {object}   props                    - The props object.
+ * @param {object}   props.response           - The response item.
+ * @param {boolean}  props.isLoading          - Whether the response is loading.
+ * @param {Function} props.onModalStateChange - Function to update the modal state.
+ * @return {import('react').JSX.Element} The dashboard response view.
+ */
+const ResponseView = ( {
+	response,
+	isLoading,
+	onModalStateChange,
+}: ResponseViewProps ): import('react').JSX.Element => {
+	const [ isPreviewModalOpen, setIsPreviewModalOpen ] = useState( false );
+	const [ previewFile, setPreviewFile ] = useState< null | object >( null );
+	const [ isImageLoading, setIsImageLoading ] = useState( true );
+	const [ hasMarkedSelfAsRead, setHasMarkedSelfAsRead ] = useState( 0 );
+
+	const { editEntityRecord } = useDispatch( 'core' );
+
+	const formsConfig = useFormsConfig();
+	const emptyTrashDays = formsConfig?.emptyTrashDays ?? 0;
+
+	// When opening a "Mark as spam" link from the email, the ResponseView component is rendered, so we use a hook here to handle it.
+	const { isConfirmDialogOpen, onConfirmMarkAsSpam, onCancelMarkAsSpam } = useMarkAsSpam(
+		response as FormResponse
+	);
+
+	const ref = useRef( undefined );
+
+	const openFilePreview = useCallback(
+		file => {
+			setIsImageLoading( true );
+			setPreviewFile( file );
+			setIsPreviewModalOpen( true );
+			if ( onModalStateChange ) {
+				onModalStateChange( true );
+			}
+		},
+		[ onModalStateChange, setPreviewFile, setIsPreviewModalOpen ]
+	);
+
+	const handleFilePreview = useCallback(
+		file => openFilePreview.bind( null, file ),
+		[ openFilePreview ]
+	);
+
+	const closePreviewModal = useCallback( () => {
+		setIsPreviewModalOpen( false );
+		setIsImageLoading( true );
+		// Notify parent component that this modal is closed
+		if ( onModalStateChange ) {
+			onModalStateChange( false );
+		}
+	}, [ onModalStateChange, setIsPreviewModalOpen, setIsImageLoading ] );
+
+	const renderFieldValue = value => {
+		if ( isImageSelectField( value ) ) {
+			return (
+				<div className="image-select-field">
+					{ ( value.choices?.length ?? 0 ) === 0 && '-' }
+					{ ( value.choices?.length ?? 0 ) > 0 && (
+						<>
+							<div className="image-select-field-choices">
+								{ value.choices
+									.map( choice => {
+										let transformedValue = choice.selected;
+
+										if ( choice.label != null && choice.label !== '' ) {
+											transformedValue += ' - ' + choice.label;
+										}
+
+										return transformedValue;
+									} )
+									.join( ', ' ) }
+							</div>
+							<div className="image-select-field-images">
+								{ value.choices.map( choice => {
+									return (
+										<img
+											key={ choice.selected }
+											className="image-select-field-image"
+											src={
+												choice.image.src ||
+												'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs='
+											}
+											alt={ choice.selected }
+										/>
+									);
+								} ) }
+							</div>
+						</>
+					) }
+				</div>
+			);
+		}
+
+		if ( isFileUploadField( value ) ) {
+			return (
+				<div className="file-field">
+					{ value.files?.length
+						? value.files.map( file => {
+								if ( ! file || ! file.name ) {
+									return '-';
+								}
+								return (
+									<FileField
+										file={ file }
+										onClick={ handleFilePreview( file ) }
+										key={ file.file_id }
+									/>
+								);
+						  } )
+						: '-' }
+				</div>
+			);
+		}
+
+		// Emails
+		const emailRegEx = /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i;
+		if ( emailRegEx.test( value ) ) {
+			return (
+				<div className="email-field">
+					<a href={ `mailto:${ value }` }>{ value }</a>
+					<CopyClipboardButton text={ value } />
+				</div>
+			);
+		}
+
+		// Phone numbers
+		if ( isLikelyPhoneNumber( value ) ) {
+			return (
+				<div className="phone-field">
+					<a href={ `tel:${ value }` }>{ value }</a>
+				</div>
+			);
+		}
+
+		return value;
+	};
+
+	useEffect( () => {
+		if ( ! ref.current ) {
+			return;
+		}
+
+		ref.current.scrollTop = 0;
+	}, [ response ] );
+
+	// Mark feedback as read when viewing
+	useEffect( () => {
+		if ( ! response || ! response.id || ! response.is_unread ) {
+			setHasMarkedSelfAsRead( response.id );
+			return;
+		}
+		if ( hasMarkedSelfAsRead === response.id ) {
+			return;
+		}
+
+		setHasMarkedSelfAsRead( response.id );
+
+		// Immediately update entity in store
+		editEntityRecord( 'postType', 'feedback', response.id, {
+			is_unread: false,
+		} );
+
+		// Immediately update menu counters optimistically to avoid delays
+		if ( response.status === 'publish' ) {
+			updateMenuCounterOptimistically( -1 );
+		}
+
+		// Then update on server
+		apiFetch( {
+			path: `/wp/v2/feedback/${ response.id }/read`,
+			method: 'POST',
+			data: { is_unread: false },
+		} )
+			.then( ( { count } ) => {
+				// Update menu counter with accurate count from server
+				updateMenuCounter( count );
+			} )
+			.catch( () => {
+				// Revert the change in the store
+				editEntityRecord( 'postType', 'feedback', response.id, {
+					is_unread: true,
+				} );
+
+				// Revert the change in the sidebar
+				if ( response.status === 'publish' ) {
+					updateMenuCounterOptimistically( 1 );
+				}
+			} );
+	}, [ response, editEntityRecord, hasMarkedSelfAsRead ] );
+
+	const handelImageLoaded = useCallback( () => {
+		return setIsImageLoading( false );
+	}, [ setIsImageLoading ] );
+
+	if ( ! isLoading && ! response ) {
+		return null;
+	}
+
+	if ( isPreviewModalOpen && ! onModalStateChange ) {
+		return (
+			<PreviewFile
+				file={ previewFile }
+				isLoading={ isImageLoading }
+				onImageLoaded={ handelImageLoaded }
+			/>
+		);
+	}
+
+	const displayName = getDisplayName( response );
+
+	return (
+		<>
+			<div ref={ ref } className="jp-forms__inbox-response">
+				<div className="jp-forms__inbox-response-header">
+					<HStack alignment="topLeft" spacing="3">
+						{ response.author_email && (
+							<Gravatar
+								email={ response.author_email }
+								displayName={ displayName }
+								key={ response.author_email }
+							/>
+						) }
+						<VStack spacing="0" className="jp-forms__inbox-response-header-title">
+							<h3 className="jp-forms__inbox-response-name">{ displayName }</h3>
+							{ response.author_email && displayName !== response.author_email && (
+								<p className="jp-forms__inbox-response-email">
+									<a href={ `mailto:${ response.author_email }` }>{ response.author_email }</a>
+									<CopyClipboardButton text={ response.author_email } />
+								</p>
+							) }
+						</VStack>
+					</HStack>
+				</div>
+
+				<div className="jp-forms__inbox-response-meta">
+					<div className="jp-forms__inbox-response-meta-label">
+						<span className="jp-forms__inbox-response-meta-key">
+							{ __( 'Date:', 'jetpack-forms' ) }&nbsp;
+						</span>
+						<span className="jp-forms__inbox-response-meta-value">
+							{ sprintf(
+								/* Translators: %1$s is the date, %2$s is the time. */
+								__( '%1$s at %2$s', 'jetpack-forms' ),
+								dateI18n( getDateSettings().formats.date, response.date ),
+								dateI18n( getDateSettings().formats.time, response.date )
+							) }
+						</span>
+					</div>
+					<div className="jp-forms__inbox-response-meta-label">
+						<span className="jp-forms__inbox-response-meta-key">
+							{ __( 'Source:', 'jetpack-forms' ) }&nbsp;
+						</span>
+						<span className="jp-forms__inbox-response-meta-value">
+							<ExternalLink href={ response.entry_permalink }>
+								{ decodeEntities( response.entry_title ) || getPath( response ) }
+							</ExternalLink>
+						</span>
+					</div>
+					<div className="jp-forms__inbox-response-meta-label">
+						<span className="jp-forms__inbox-response-meta-key	">
+							{ __( 'IP address:', 'jetpack-forms' ) }&nbsp;
+						</span>
+						<span className="jp-forms__inbox-response-meta-value">{ response.ip }</span>
+					</div>
+				</div>
+
+				<div className="jp-forms__inbox-response-data">
+					{ Object.entries( response.fields ).map( ( [ key, value ] ) => (
+						<div key={ key } className="jp-forms__inbox-response-item">
+							<div className="jp-forms__inbox-response-data-label">
+								{ key.endsWith( '?' ) ? key : `${ key }:` }
+							</div>
+							<div className="jp-forms__inbox-response-data-value">
+								{ renderFieldValue( value ) }
+							</div>
+						</div>
+					) ) }
+				</div>
+
+				{ isPreviewModalOpen && previewFile && onModalStateChange && (
+					<Modal
+						title={ decodeEntities( ( previewFile as { name: string } ).name ) }
+						onRequestClose={ closePreviewModal }
+						className="jp-forms__inbox-file-preview-modal"
+					>
+						<PreviewFile
+							file={ previewFile }
+							isLoading={ isImageLoading }
+							onImageLoaded={ handelImageLoaded }
+						/>
+					</Modal>
+				) }
+
+				<ConfirmDialog
+					isOpen={ isConfirmDialogOpen }
+					onConfirm={ onConfirmMarkAsSpam }
+					onCancel={ onCancelMarkAsSpam }
+				>
+					{ __( 'Are you sure you want to mark this response as spam?', 'jetpack-forms' ) }
+				</ConfirmDialog>
+			</div>
+			{ response.status === 'spam' && (
+				<Tip>{ __( 'Spam responses are moved to trash after 15 days.', 'jetpack-forms' ) }</Tip>
+			) }
+			{ response.status === 'trash' && (
+				<Tip>
+					{ sprintf(
+						/* translators: %d number of days. */
+						_n(
+							'Items in trash are permanently deleted after %d day.',
+							'Items in trash are permanently deleted after %d days.',
+							emptyTrashDays,
+							'jetpack-forms'
+						),
+						emptyTrashDays
+					) }
+				</Tip>
+			) }
+		</>
+	);
+};
+
+export default ResponseView;
+export { ResponseMobileView };

--- a/projects/packages/forms/src/dashboard/components/response-view/mobile.tsx
+++ b/projects/packages/forms/src/dashboard/components/response-view/mobile.tsx
@@ -1,0 +1,97 @@
+import {
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalHStack as HStack,
+} from '@wordpress/components';
+import { useState, useMemo, useCallback } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { getItemId } from '../../inbox/utils';
+import ResponseActions from '../response-actions';
+import ResponseNavigation from '../response-navigation';
+import ResponseView from './index';
+
+/**
+ * Component wrapper for InboxResponse in DataViews modal
+ * Renders response with navigation in modal header for mobile view
+ * @param {object}   props            - The props object.
+ * @param {Array}    props.data       - The responses list array.
+ * @param {object}   props.response   - The response item.
+ * @param {Function} props.closeModal - Function to close the DataViews modal.
+ * @return {import('react').JSX.Element} The DataViews component.
+ */
+const ResponseMobileView = ( { response, data, closeModal } ) => {
+	const [ currentResponse, setCurrentResponse ] = useState( response );
+
+	const currentIndex = useMemo(
+		() =>
+			currentResponse && data
+				? data.findIndex( item => getItemId( item ) === getItemId( currentResponse ) )
+				: -1,
+		[ currentResponse, data ]
+	);
+
+	const hasNext = currentIndex >= 0 && currentIndex < ( data?.length ?? 0 ) - 1;
+	const hasPrevious = currentIndex > 0;
+
+	const handleNext = useCallback( () => {
+		if ( hasNext && data && currentIndex >= 0 ) {
+			const nextItem = data[ currentIndex + 1 ];
+			if ( nextItem ) {
+				setCurrentResponse( nextItem );
+			}
+		}
+	}, [ hasNext, data, currentIndex ] );
+
+	const handlePrevious = useCallback( () => {
+		if ( hasPrevious && data && currentIndex >= 0 ) {
+			const prevItem = data[ currentIndex - 1 ];
+			if ( prevItem ) {
+				setCurrentResponse( prevItem );
+			}
+		}
+	}, [ hasPrevious, data, currentIndex ] );
+
+	// Action complete handler is a bit different on mobile view.
+	// We don't close the modal if the response hasn't changed status (read/unread toggle)
+	// and we don't change nor mess with the selection.
+	const handleActionComplete = useCallback(
+		actionedResponse => {
+			if ( actionedResponse && actionedResponse.status === response.status ) {
+				setCurrentResponse( actionedResponse );
+				return;
+			}
+			closeModal?.();
+		},
+		[ closeModal, response ]
+	);
+
+	return (
+		<div className="jp-forms__inbox__response-mobile">
+			<HStack
+				spacing="2"
+				justify="space-between"
+				className="jp-forms__inbox__response-mobile__header"
+			>
+				<h1 className="jp-forms__inbox__response-mobile__header-heading">
+					{ __( 'Response', 'jetpack-forms' ) }
+				</h1>
+				<HStack
+					spacing="2"
+					justify="space-between"
+					className="jp-forms__inbox__response-mobile__header-actions"
+				>
+					<ResponseActions response={ currentResponse } onActionComplete={ handleActionComplete } />
+					<ResponseNavigation
+						hasNext={ hasNext }
+						hasPrevious={ hasPrevious }
+						onNext={ handleNext }
+						onPrevious={ handlePrevious }
+						onClose={ closeModal }
+					/>
+				</HStack>
+			</HStack>
+			<ResponseView isLoading={ false } response={ currentResponse } />
+		</div>
+	);
+};
+
+export default ResponseMobileView;

--- a/projects/packages/forms/src/dashboard/hooks/use-response-navigation.ts
+++ b/projects/packages/forms/src/dashboard/hooks/use-response-navigation.ts
@@ -5,15 +5,15 @@ import { getItemId } from '../inbox/utils';
 interface UseResponseNavigationProps {
 	data: FormResponse[];
 	onChangeSelection: ( responses: string[] ) => void | null;
-	sidePanelItem: FormResponse;
-	setSidePanelItem: ( response: FormResponse ) => void;
+	record: FormResponse;
+	setRecord: ( response: FormResponse ) => void;
 }
 
 const useResponseNavigation = ( {
 	data,
 	onChangeSelection,
-	sidePanelItem: record,
-	setSidePanelItem: setRecord,
+	record,
+	setRecord,
 }: UseResponseNavigationProps ) => {
 	const currentIndex = useMemo(
 		() =>

--- a/projects/packages/forms/src/dashboard/hooks/use-response-navigation.ts
+++ b/projects/packages/forms/src/dashboard/hooks/use-response-navigation.ts
@@ -1,48 +1,53 @@
 import { useMemo, useCallback } from '@wordpress/element';
 import { FormResponse } from '../../types';
 import { getItemId } from '../inbox/utils';
+import useInboxData from './use-inbox-data';
 
 interface UseResponseNavigationProps {
-	data: FormResponse[];
 	onChangeSelection: ( responses: string[] ) => void | null;
 	record: FormResponse;
 	setRecord: ( response: FormResponse ) => void;
 }
 
 const useResponseNavigation = ( {
-	data,
 	onChangeSelection,
 	record,
 	setRecord,
 }: UseResponseNavigationProps ) => {
+	const { records } = useInboxData();
 	const currentIndex = useMemo(
 		() =>
-			record && data ? data.findIndex( item => getItemId( item ) === getItemId( record ) ) : -1,
-		[ record, data ]
+			record && records
+				? records.findIndex( item => getItemId( item ) === getItemId( record ) )
+				: -1,
+		[ record, records ]
 	);
 
-	const hasNext = currentIndex >= 0 && currentIndex < ( data?.length ?? 0 ) - 1;
-	const hasPrevious = currentIndex > 0;
+	const hasNext = useMemo(
+		() => currentIndex >= 0 && currentIndex < ( records?.length ?? 0 ) - 1,
+		[ currentIndex, records ]
+	);
+	const hasPrevious = useMemo( () => currentIndex > 0, [ currentIndex ] );
 
 	const handleNext = useCallback( () => {
-		if ( hasNext && data && currentIndex >= 0 ) {
-			const nextItem = data[ currentIndex + 1 ];
+		if ( hasNext && records && currentIndex >= 0 ) {
+			const nextItem = records[ currentIndex + 1 ];
 			if ( nextItem ) {
 				setRecord( nextItem );
 				onChangeSelection?.( [ getItemId( nextItem ) ] );
 			}
 		}
-	}, [ hasNext, data, currentIndex, setRecord, onChangeSelection ] );
+	}, [ hasNext, records, currentIndex, setRecord, onChangeSelection ] );
 
 	const handlePrevious = useCallback( () => {
-		if ( hasPrevious && data && currentIndex >= 0 ) {
-			const prevItem = data[ currentIndex - 1 ];
+		if ( hasPrevious && records && currentIndex >= 0 ) {
+			const prevItem = records[ currentIndex - 1 ];
 			if ( prevItem ) {
 				setRecord( prevItem );
 				onChangeSelection?.( [ getItemId( prevItem ) ] );
 			}
 		}
-	}, [ hasPrevious, data, currentIndex, setRecord, onChangeSelection ] );
+	}, [ hasPrevious, records, currentIndex, setRecord, onChangeSelection ] );
 
 	return {
 		currentIndex,

--- a/projects/packages/forms/src/dashboard/hooks/use-response-navigation.ts
+++ b/projects/packages/forms/src/dashboard/hooks/use-response-navigation.ts
@@ -1,0 +1,56 @@
+import { useMemo, useCallback } from '@wordpress/element';
+import { FormResponse } from '../../types';
+import { getItemId } from '../inbox/utils';
+
+interface UseResponseNavigationProps {
+	data: FormResponse[];
+	onChangeSelection: ( responses: string[] ) => void | null;
+	sidePanelItem: FormResponse;
+	setSidePanelItem: ( response: FormResponse ) => void;
+}
+
+const useResponseNavigation = ( {
+	data,
+	onChangeSelection,
+	sidePanelItem: record,
+	setSidePanelItem: setRecord,
+}: UseResponseNavigationProps ) => {
+	const currentIndex = useMemo(
+		() =>
+			record && data ? data.findIndex( item => getItemId( item ) === getItemId( record ) ) : -1,
+		[ record, data ]
+	);
+
+	const hasNext = currentIndex >= 0 && currentIndex < ( data?.length ?? 0 ) - 1;
+	const hasPrevious = currentIndex > 0;
+
+	const handleNext = useCallback( () => {
+		if ( hasNext && data && currentIndex >= 0 ) {
+			const nextItem = data[ currentIndex + 1 ];
+			if ( nextItem ) {
+				setRecord( nextItem );
+				onChangeSelection?.( [ getItemId( nextItem ) ] );
+			}
+		}
+	}, [ hasNext, data, currentIndex, setRecord, onChangeSelection ] );
+
+	const handlePrevious = useCallback( () => {
+		if ( hasPrevious && data && currentIndex >= 0 ) {
+			const prevItem = data[ currentIndex - 1 ];
+			if ( prevItem ) {
+				setRecord( prevItem );
+				onChangeSelection?.( [ getItemId( prevItem ) ] );
+			}
+		}
+	}, [ hasPrevious, data, currentIndex, setRecord, onChangeSelection ] );
+
+	return {
+		currentIndex,
+		hasNext,
+		hasPrevious,
+		handleNext,
+		handlePrevious,
+	};
+};
+
+export default useResponseNavigation;

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
@@ -21,10 +21,10 @@ import { useSearchParams } from 'react-router';
 import InboxStatusToggle from '../../components/inbox-status-toggle';
 import ResponseActions from '../../components/response-actions';
 import ResponseNavigation from '../../components/response-navigation';
+import ResponseView, { ResponseMobileView } from '../../components/response-view';
 import useInboxData from '../../hooks/use-inbox-data';
 import useResponseNavigation from '../../hooks/use-response-navigation';
 import EmptyResponses from '../empty-responses';
-import InboxResponse from '../response';
 import { getPath, getItemId } from '../utils.js';
 import {
 	viewAction,
@@ -307,7 +307,7 @@ export default function InboxView() {
 				RenderModal: ( { items, closeModal } ) => {
 					const [ item ] = items;
 					return (
-						<InboxResponseMobile response={ item } data={ records } closeModal={ closeModal } />
+						<ResponseMobileView response={ item } data={ records } closeModal={ closeModal } />
 					);
 				},
 				hideModalHeader: true,
@@ -367,96 +367,6 @@ export default function InboxView() {
 		</HStack>
 	);
 }
-
-/**
- * Component wrapper for InboxResponse in DataViews modal
- * Renders response with navigation in modal header for mobile view
- * @param {object}   props            - The props object.
- * @param {Array}    props.data       - The responses list array.
- * @param {object}   props.response   - The response item.
- * @param {Function} props.closeModal - Function to close the DataViews modal.
- * @return {import('react').JSX.Element} The DataViews component.
- */
-const InboxResponseMobile = ( { response, data, closeModal } ) => {
-	const [ currentResponse, setCurrentResponse ] = useState( response );
-
-	const currentIndex = useMemo(
-		() =>
-			currentResponse && data
-				? data.findIndex( item => getItemId( item ) === getItemId( currentResponse ) )
-				: -1,
-		[ currentResponse, data ]
-	);
-
-	const hasNext = currentIndex >= 0 && currentIndex < ( data?.length ?? 0 ) - 1;
-	const hasPrevious = currentIndex > 0;
-
-	const handleNext = useCallback( () => {
-		if ( hasNext && data && currentIndex >= 0 ) {
-			const nextItem = data[ currentIndex + 1 ];
-			if ( nextItem ) {
-				setCurrentResponse( nextItem );
-			}
-		}
-	}, [ hasNext, data, currentIndex ] );
-
-	const handlePrevious = useCallback( () => {
-		if ( hasPrevious && data && currentIndex >= 0 ) {
-			const prevItem = data[ currentIndex - 1 ];
-			if ( prevItem ) {
-				setCurrentResponse( prevItem );
-			}
-		}
-	}, [ hasPrevious, data, currentIndex ] );
-
-	// Action complete handler is a bit different on mobile view.
-	// We don't close the modal if the response hasn't changed status (read/unread toggle)
-	// and we don't change nor mess with the selection.
-	const handleActionComplete = useCallback(
-		actionedResponse => {
-			if ( actionedResponse && actionedResponse.status === response.status ) {
-				setCurrentResponse( actionedResponse );
-				return;
-			}
-			closeModal?.();
-		},
-		[ closeModal, response ]
-	);
-
-	return (
-		<div className="jp-forms__inbox__response-mobile">
-			<HStack
-				spacing="2"
-				justify="space-between"
-				className="jp-forms__inbox__response-mobile__header"
-			>
-				<h1 className="jp-forms__inbox__response-mobile__header-heading">
-					{ __( 'Response', 'jetpack-forms' ) }
-				</h1>
-				<HStack
-					spacing="2"
-					justify="space-between"
-					className="jp-forms__inbox__response-mobile__header-actions"
-				>
-					<ResponseActions response={ currentResponse } onActionComplete={ handleActionComplete } />
-					<ResponseNavigation
-						hasNext={ hasNext }
-						hasPrevious={ hasPrevious }
-						onNext={ handleNext }
-						onPrevious={ handlePrevious }
-						onClose={ closeModal }
-					/>
-				</HStack>
-			</HStack>
-			<InboxResponse
-				isMobile={ true }
-				isLoading={ false }
-				response={ currentResponse }
-				onClose={ null }
-			/>
-		</div>
-	);
-};
 
 const SingleResponse = ( {
 	sidePanelItem,
@@ -519,19 +429,27 @@ const SingleResponse = ( {
 	};
 
 	const contents = (
-		<InboxResponse
+		<ResponseView
 			response={ sidePanelItem }
 			isLoading={ isLoadingData }
-			isMobile={ isMobile }
 			onModalStateChange={ handleModalStateChange }
-			onClose={ isMobile ? null : onRequestClose }
-			{ ...navigationProps }
-			onActionComplete={ handleActionComplete }
 		/>
 	);
 
 	if ( ! isMobile ) {
-		return <div className="jp-forms__inbox__dataviews-response">{ contents }</div>;
+		return (
+			<div className="jp-forms__inbox__dataviews-response">
+				<HStack spacing="0" justify="space-between" className="jp-forms__inbox-response-actions">
+					<HStack alignment="left">
+						<ResponseActions onActionComplete={ handleActionComplete } response={ sidePanelItem } />
+					</HStack>
+					<HStack alignment="right">
+						<ResponseNavigation { ...navigationProps } onClose={ onRequestClose } />
+					</HStack>
+				</HStack>
+				{ contents }
+			</div>
+		);
 	}
 
 	return (

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
@@ -22,6 +22,7 @@ import InboxStatusToggle from '../../components/inbox-status-toggle';
 import ResponseActions from '../../components/response-actions';
 import ResponseNavigation from '../../components/response-navigation';
 import useInboxData from '../../hooks/use-inbox-data';
+import useResponseNavigation from '../../hooks/use-response-navigation';
 import EmptyResponses from '../empty-responses';
 import InboxResponse from '../response';
 import { getPath, getItemId } from '../utils.js';
@@ -455,47 +456,6 @@ const InboxResponseMobile = ( { response, data, closeModal } ) => {
 			/>
 		</div>
 	);
-};
-
-const useResponseNavigation = ( { data, onChangeSelection, sidePanelItem, setSidePanelItem } ) => {
-	const currentIndex = useMemo(
-		() =>
-			sidePanelItem && data
-				? data.findIndex( item => getItemId( item ) === getItemId( sidePanelItem ) )
-				: -1,
-		[ sidePanelItem, data ]
-	);
-
-	const hasNext = currentIndex >= 0 && currentIndex < ( data?.length ?? 0 ) - 1;
-	const hasPrevious = currentIndex > 0;
-
-	const handleNext = useCallback( () => {
-		if ( hasNext && data && currentIndex >= 0 ) {
-			const nextItem = data[ currentIndex + 1 ];
-			if ( nextItem ) {
-				setSidePanelItem( nextItem );
-				onChangeSelection( [ getItemId( nextItem ) ] );
-			}
-		}
-	}, [ hasNext, data, currentIndex, setSidePanelItem, onChangeSelection ] );
-
-	const handlePrevious = useCallback( () => {
-		if ( hasPrevious && data && currentIndex >= 0 ) {
-			const prevItem = data[ currentIndex - 1 ];
-			if ( prevItem ) {
-				setSidePanelItem( prevItem );
-				onChangeSelection( [ getItemId( prevItem ) ] );
-			}
-		}
-	}, [ hasPrevious, data, currentIndex, setSidePanelItem, onChangeSelection ] );
-
-	return {
-		currentIndex,
-		hasNext,
-		hasPrevious,
-		handleNext,
-		handlePrevious,
-	};
 };
 
 const SingleResponse = ( {

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
@@ -412,8 +412,8 @@ const SingleResponse = ( {
 	const navigation = useResponseNavigation( {
 		data,
 		onChangeSelection,
-		sidePanelItem,
-		setSidePanelItem,
+		record: sidePanelItem,
+		setRecord: setSidePanelItem,
 	} );
 
 	if ( ! sidePanelItem ) {

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
@@ -360,7 +360,6 @@ export default function InboxView() {
 				setSidePanelItem={ setSidePanelItem }
 				isLoadingData={ isLoadingData }
 				isMobile={ isMobile }
-				data={ records }
 				onChangeSelection={ onChangeSelection }
 				selection={ selection }
 			/>
@@ -373,7 +372,6 @@ const SingleResponse = ( {
 	setSidePanelItem,
 	isLoadingData,
 	isMobile,
-	data,
 	onChangeSelection,
 	selection,
 } ) => {
@@ -410,7 +408,6 @@ const SingleResponse = ( {
 
 	// Use the navigation hook
 	const navigation = useResponseNavigation( {
-		data,
 		onChangeSelection,
 		record: sidePanelItem,
 		setRecord: setSidePanelItem,

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
@@ -24,7 +24,7 @@ import ResponseNavigation from '../../components/response-navigation';
 import useInboxData from '../../hooks/use-inbox-data';
 import EmptyResponses from '../empty-responses';
 import InboxResponse from '../response';
-import { getPath } from '../utils.js';
+import { getPath, getItemId } from '../utils.js';
 import {
 	viewAction,
 	markAsSpamAction,
@@ -39,7 +39,6 @@ import { useView, defaultLayouts } from './views';
 
 const EMPTY_ARRAY = [];
 const MOBILE_BREAKPOINT = 780;
-const getItemId = item => item?.id?.toString() ?? '';
 
 const updateSidebarWidth = () => {
 	const wrapper = document.querySelector( '.dataviews-wrapper' );

--- a/projects/packages/forms/src/dashboard/inbox/utils.js
+++ b/projects/packages/forms/src/dashboard/inbox/utils.js
@@ -65,3 +65,11 @@ export const updateMenuCounterOptimistically = count => {
 		}
 	} );
 };
+
+/**
+ * Get the ID of an item.
+ *
+ * @param {object} item - The item to get the ID of.
+ * @return {string} The ID of the item.
+ */
+export const getItemId = item => item?.id?.toString() ?? '';


### PR DESCRIPTION


## Proposed changes:
This PR is part of a janitorial series to get a better component structure. 

- create components/response-view/index to replace inbox/response.js
- move the InboxResponseMobile component outside inbox/dataviews/index and into components/response-view/mobile and 
- move useResponseNavigation out of inbox/dataviews/index and into hooks/use-response-navigation
- 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Just reorganizing, things should just work as before