### PR TITLE
Forms: Fix patterns required indicator issue

### DIFF
--- a/projects/packages/forms/changelog/fix-form-patterns-required-indicator
+++ b/projects/packages/forms/changelog/fix-form-patterns-required-indicator
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: fixed a bug that removed the required text from required fields when creating a form from a pattern.

--- a/projects/packages/forms/src/blocks/shared/deprecations/inner-blocks-deprecation.js
+++ b/projects/packages/forms/src/blocks/shared/deprecations/inner-blocks-deprecation.js
@@ -14,6 +14,10 @@ const INNER_BLOCKS_DEPRECATION = {
 		requiredText: {
 			type: 'string',
 		},
+		requiredIndicator: {
+			type: 'boolean',
+			default: true,
+		},
 		options: {
 			type: 'array',
 			default: [],
@@ -92,6 +96,7 @@ const INNER_BLOCKS_DEPRECATION = {
 			createBlock( 'jetpack/label', {
 				label: attributes.label,
 				requiredText: attributes.requiredText,
+				requiredIndicator: attributes.requiredIndicator,
 				style: labelStyles,
 			} ),
 			createBlock( 'jetpack/input', {

--- a/projects/plugins/jetpack/changelog/fix-form-patterns-required-indicator
+++ b/projects/plugins/jetpack/changelog/fix-form-patterns-required-indicator
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: fixed a bug that removed the required text from required fields when creating a form from a pattern.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes an issue that removed the required indicator next to required fields when creating a form using a pattern.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* I've added requiredIndicator to INNER_BLOCKS_DEPRECATION so the deprecated schema recognizes it as valid.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add form from the patterns sidebar or the forms About page.
* Check that required fields have the `(required)` text next to the field label.
* Publish the post/page and check that the `(required)` is rendered for required fields.

