### PR TITLE
Blaze: do not display toggle on WoA sites

### DIFF
--- a/projects/plugins/jetpack/_inc/client/traffic/blaze.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/blaze.jsx
@@ -38,7 +38,7 @@ function Blaze( props ) {
 
 	const { can_init: canInit, reason } = blazeAvailable;
 
-	if ( isWoASite() && ! blazeDashboardEnabled ) {
+	if ( isWoASite() ) {
 		return null;
 	}
 

--- a/projects/plugins/jetpack/changelog/fix-blaze-not-on-woa
+++ b/projects/plugins/jetpack/changelog/fix-blaze-not-on-woa
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Blaze: do not display module toggle on WordPress.com sites.


### PR DESCRIPTION
Fixes JETPACK-902

## Proposed changes:

The feature is force enabled on WoA sites:
https://github.com/Automattic/jetpack/blob/516d24b761ba01f175085bff07ab4c15ebc92a0b/projects/plugins/wpcomsh/feature-plugins/blaze.php#L4

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A 

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

> [!NOTE]
> Test on a WoA site

* Go to Jetpack > Settings > Traffic
    * You should not see a Blaze toggle
