### PR TITLE
Forms: Fix forms source warning

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-source-warning
+++ b/projects/packages/forms/changelog/fix-forms-source-warning
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: fix php warning for when a site doesn't have the JWT token yet

--- a/projects/packages/forms/changelog/fix-forms-source-warning
+++ b/projects/packages/forms/changelog/fix-forms-source-warning
@@ -1,4 +1,4 @@
 Significance: patch
-Type: fixed
+Type: bugfix
 
-Forms: fix php warning for when a site doesn't have the JWT token yet
+Forms: fix PHP warning for when a site doesn't have the JWT token yet

--- a/projects/packages/forms/changelog/fix-forms-source-warning
+++ b/projects/packages/forms/changelog/fix-forms-source-warning
@@ -1,4 +1,4 @@
 Significance: patch
-Type: bugfix
+Type: fixed
 
 Forms: fix PHP warning for when a site doesn't have the JWT token yet

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -256,11 +256,11 @@ class Contact_Form extends Contact_Form_Shortcode {
 		} catch ( \Exception $e ) {
 			return null;
 		}
-		$source = $data['source'] ?? null;
+		$source = $data['source'] ?? array();
 		if ( empty( $source ) ) {
-			// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce verification happens in process_form_submission() for logged-in users
-			$source_post_id = ! empty( $_POST['contact-form-id'] ) && is_numeric( $_POST['contact-form-id'] ) ? intval( $_POST['contact-form-id'] ) : 0;
-			$post           = get_post( intval( $source_post_id ) );
+			// phpcs:ignore WordPress.Security.NonceVerification.Missing -- check done by caller process_form_submission()
+			$source_post_id = ! empty( $_POST['contact-form-id'] ) && is_numeric( $_POST['contact-form-id'] ) ? absint( wp_unslash( $_POST['contact-form-id'] ) ) : 0;
+			$post           = get_post( $source_post_id );
 			if ( $post !== null && $source_post_id > 0 ) {
 				// create a fallback source
 				$source = array(

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -256,9 +256,25 @@ class Contact_Form extends Contact_Form_Shortcode {
 		} catch ( \Exception $e ) {
 			return null;
 		}
+		$source = $data['source'] ?? null;
+		if ( empty( $source ) ) {
+			// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce verification happens in process_form_submission() for logged-in users
+			$source_post_id = ! empty( $_POST['contact-form-id'] ) && is_numeric( $_POST['contact-form-id'] ) ? intval( $_POST['contact-form-id'] ) : 0;
+			$post           = get_post( intval( $source_post_id ) );
+			if ( $post !== null ) {
+				// create a fallback source
+				$source = array(
+					'source_id'   => $post->ID,
+					'entry_title' => $post->post_title,
+					'entry_page'  => 1,
+					'source_type' => 'single',
+					'request_url' => get_permalink( $post ),
+				);
+			}
+		}
 
 		$form                   = new self( $data['attributes'], $data['content'], empty( $data['attributes']['id'] ) );
-		$form->source           = Feedback_Source::from_serialized( $data['source'] );
+		$form->source           = Feedback_Source::from_serialized( $source );
 		$form->hash             = $data['hash'];
 		$form->has_verified_jwt = true;
 		return $form;

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -261,7 +261,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 			// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce verification happens in process_form_submission() for logged-in users
 			$source_post_id = ! empty( $_POST['contact-form-id'] ) && is_numeric( $_POST['contact-form-id'] ) ? intval( $_POST['contact-form-id'] ) : 0;
 			$post           = get_post( intval( $source_post_id ) );
-			if ( $post !== null ) {
+			if ( $post !== null && $source_post_id > 0 ) {
 				// create a fallback source
 				$source = array(
 					'source_id'   => $post->ID,

--- a/projects/plugins/jetpack/changelog/fix-forms-source-warning
+++ b/projects/plugins/jetpack/changelog/fix-forms-source-warning
@@ -1,5 +1,5 @@
 Significance: patch
 Type: bugfix
-Comment: THis change has not been deployed to jetpack sites yet
+Comment: This change has not been deployed to jetpack sites yet
 
 

--- a/projects/plugins/jetpack/changelog/fix-forms-source-warning
+++ b/projects/plugins/jetpack/changelog/fix-forms-source-warning
@@ -1,0 +1,5 @@
+Significance: patch
+Type: bugfix
+Comment: THis change has not been deployed to jetpack sites yet
+
+


### PR DESCRIPTION
This PR fixes the PHP warning that comes when the JWT token doesn't have the expected source value yet.
This can happen when the JWT token is has been cached on the page and the underlying submission hasn't changed. 

## Proposed changes:
* Suppress the JWT warning. 
* Add fallback so that we do have a source value since it is something that we pass to the site. 

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1760470896669009-slack-CDLH4C1UZ

## Does this pull request change what data or activity we track or use?
No
## Testing instructions:
Do the tests pass? 
Uncomment the // source in line 396 of class-contact-form.php (so that the JWT doesn't have the expected value) 
Monitor for PHP warning and notice that the form the PHP warning has gone away.