### PR TITLE
 Forms: Update "Action after submit" sidebar section

### DIFF
--- a/projects/packages/forms/changelog/update-forms-action-after-submit
+++ b/projects/packages/forms/changelog/update-forms-action-after-submit
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: Update "Action after submit" sidebar section

--- a/projects/packages/forms/src/blocks/contact-form/attributes.ts
+++ b/projects/packages/forms/src/blocks/contact-form/attributes.ts
@@ -28,6 +28,9 @@ export default {
 		type: 'string',
 		default: '',
 	},
+	confirmationType: {
+		enum: [ 'text', 'redirect' ],
+	},
 	jetpackCRM: {
 		type: 'boolean',
 	},
@@ -61,6 +64,10 @@ export default {
 		default: true,
 	},
 	disableGoBack: {
+		type: 'boolean',
+		default: false,
+	},
+	disableSummary: {
 		type: 'boolean',
 		default: false,
 	},

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -18,10 +18,10 @@ import { createBlock } from '@wordpress/blocks';
 import {
 	ExternalLink,
 	PanelBody,
-	SelectControl,
 	TextareaControl,
 	TextControl,
 	ToggleControl,
+	RadioControl,
 } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
 import { store as coreStore } from '@wordpress/core-data';
@@ -41,7 +41,6 @@ import {
 	NAVIGATION_TEMPLATE,
 } from '../form-step-navigation/edit';
 import StepControls from '../shared/components/form-step-controls';
-import InspectorHint from '../shared/components/inspector-hint';
 import JetpackManageResponsesSettings from '../shared/components/jetpack-manage-responses-settings';
 import { useFindBlockRecursively } from '../shared/hooks/use-find-block-recursively';
 import useFormSteps from '../shared/hooks/use-form-steps';
@@ -123,14 +122,17 @@ type CustomThankyouType =
 type JetpackContactFormAttributes = {
 	to: string;
 	subject: string;
+	// Legacy support for the customThankyou attribute
 	customThankyou: CustomThankyouType;
 	customThankyouHeading: string;
 	customThankyouMessage: string;
 	customThankyouRedirect: string;
+	confirmationType: 'text' | 'redirect';
 	formTitle: string;
 	variationName: string;
 	emailNotifications: boolean;
 	disableGoBack: boolean;
+	disableSummary: boolean;
 	notificationRecipients: string[];
 };
 type JetpackContactFormEditProps = {
@@ -158,15 +160,36 @@ function JetpackContactFormEdit( {
 		customThankyouHeading,
 		customThankyouMessage,
 		customThankyouRedirect,
+		confirmationType,
 		formTitle,
 		variationName,
 		emailNotifications,
 		disableGoBack,
+		disableSummary,
 		notificationRecipients,
 	} = attributes;
 	const formsConfig = useFormsConfig();
 	const showFormIntegrations = Boolean( formsConfig?.isIntegrationsEnabled );
 	const instanceId = useInstanceId( JetpackContactFormEdit );
+
+	// Backward compatibility for the deprecated customThankyou attribute.
+	// Older forms will have a customThankyou attribute set, but not a confirmationType attribute
+	// and not a disableSummary attribute, so we need to set it here.
+	useEffect( () => {
+		if ( confirmationType ) {
+			return;
+		}
+
+		if ( customThankyou === 'redirect' ) {
+			setAttributes( { confirmationType: 'redirect' } );
+		} else {
+			setAttributes( { confirmationType: 'text' } );
+
+			if ( [ 'noSummary', 'message' ].includes( customThankyou ) ) {
+				setAttributes( { disableSummary: true } );
+			}
+		}
+	}, [ confirmationType, customThankyou, setAttributes ] );
 
 	const steps = useFormSteps( clientId );
 
@@ -797,41 +820,20 @@ function JetpackContactFormEdit( {
 						initialOpen={ false }
 						className="jetpack-contact-form__panel"
 					>
-						<InspectorHint>
-							{ __( 'Customize the view after form submission:', 'jetpack-forms' ) }
-						</InspectorHint>
-						<SelectControl
-							label={ __( 'On submission', 'jetpack-forms' ) }
-							value={ customThankyou }
+						<RadioControl
+							label={ __( 'Confirmation type', 'jetpack-forms' ) }
+							selected={ confirmationType }
 							options={ [
-								{ label: __( 'Show a summary of submitted fields', 'jetpack-forms' ), value: '' },
-								{
-									label: __( 'Show the default text message without a summary', 'jetpack-forms' ),
-									value: 'noSummary',
-								},
-								{ label: __( 'Show a custom text message', 'jetpack-forms' ), value: 'message' },
-								{
-									label: __( 'Redirect to another webpage', 'jetpack-forms' ),
-									value: 'redirect',
-								},
+								{ label: __( 'Text', 'jetpack-forms' ), value: 'text' },
+								{ label: __( 'Redirect link', 'jetpack-forms' ), value: 'redirect' },
 							] }
-							onChange={ newMessage => setAttributes( { customThankyou: newMessage } ) }
-							__nextHasNoMarginBottom={ true }
-							__next40pxDefaultSize={ true }
+							onChange={ ( newValue: 'text' | 'redirect' ) =>
+								setAttributes( { confirmationType: newValue } )
+							}
 						/>
 
-						{ 'redirect' !== customThankyou && (
+						{ 'text' === confirmationType && (
 							<>
-								<ToggleControl
-									label={ __( 'Show "Go back" link', 'jetpack-forms' ) }
-									checked={ ! disableGoBack }
-									onChange={ ( newDisableGoBack: boolean ) =>
-										setAttributes( { disableGoBack: ! newDisableGoBack } )
-									}
-									__nextHasNoMarginBottom={ true }
-									__next40pxDefaultSize={ true }
-								/>
-
 								<TextControl
 									label={ __( 'Message heading', 'jetpack-forms' ) }
 									value={ customThankyouHeading }
@@ -842,22 +844,40 @@ function JetpackContactFormEdit( {
 									__nextHasNoMarginBottom={ true }
 									__next40pxDefaultSize={ true }
 								/>
+
+								<TextareaControl
+									label={ __( 'Message text', 'jetpack-forms' ) }
+									value={ customThankyouMessage }
+									placeholder={ __( 'Thank you for your submission!', 'jetpack-forms' ) }
+									onChange={ ( newMessage: string ) =>
+										setAttributes( { customThankyouMessage: newMessage } )
+									}
+									__nextHasNoMarginBottom={ true }
+								/>
+
+								<ToggleControl
+									label={ __( 'Show summary', 'jetpack-forms' ) }
+									checked={ ! disableSummary }
+									onChange={ ( newDisableSummary: boolean ) =>
+										setAttributes( { disableSummary: ! newDisableSummary } )
+									}
+									__nextHasNoMarginBottom={ true }
+									__next40pxDefaultSize={ true }
+								/>
+
+								<ToggleControl
+									label={ __( 'Show "Go back" link', 'jetpack-forms' ) }
+									checked={ ! disableGoBack }
+									onChange={ ( newDisableGoBack: boolean ) =>
+										setAttributes( { disableGoBack: ! newDisableGoBack } )
+									}
+									__nextHasNoMarginBottom={ true }
+									__next40pxDefaultSize={ true }
+								/>
 							</>
 						) }
 
-						{ 'message' === customThankyou && (
-							<TextareaControl
-								label={ __( 'Message text', 'jetpack-forms' ) }
-								value={ customThankyouMessage }
-								placeholder={ __( 'Thank you for your submission!', 'jetpack-forms' ) }
-								onChange={ ( newMessage: string ) =>
-									setAttributes( { customThankyouMessage: newMessage } )
-								}
-								__nextHasNoMarginBottom={ true }
-							/>
-						) }
-
-						{ 'redirect' === customThankyou && (
+						{ 'redirect' === confirmationType && (
 							<div>
 								<URLInput
 									label={ __( 'Redirect address', 'jetpack-forms' ) }

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -114,7 +114,40 @@ const isInputWithRequiredField = ( fullName?: string ): boolean => {
 	return hasRequired && ! isHidden;
 };
 
-function JetpackContactFormEdit( { name, attributes, setAttributes, clientId, className } ) {
+type CustomThankyouType =
+	| '' // default message
+	| 'noSummary' // default message without a summary
+	| 'message' // custom message
+	| 'redirect'; // redirect to a new URL
+
+type JetpackContactFormAttributes = {
+	to: string;
+	subject: string;
+	customThankyou: CustomThankyouType;
+	customThankyouHeading: string;
+	customThankyouMessage: string;
+	customThankyouRedirect: string;
+	formTitle: string;
+	variationName: string;
+	emailNotifications: boolean;
+	disableGoBack: boolean;
+	notificationRecipients: string[];
+};
+type JetpackContactFormEditProps = {
+	name: string;
+	attributes: JetpackContactFormAttributes;
+	setAttributes: ( attributes: Partial< JetpackContactFormAttributes > ) => void;
+	clientId: string;
+	className: string;
+};
+
+function JetpackContactFormEdit( {
+	name,
+	attributes,
+	setAttributes,
+	clientId,
+	className,
+}: JetpackContactFormEditProps ) {
 	// Initialize default form block settings as needed.
 	useFormBlockDefaults( { attributes, setAttributes } );
 

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -182,10 +182,11 @@ class Contact_Form extends Contact_Form_Shortcode {
 			'id'                     => null, // Not exposed to the user. Set above.
 			'submit_button_text'     => __( 'Submit', 'jetpack-forms' ),
 			// These attributes come from the block editor, so use camel case instead of snake case.
-			'customThankyou'         => '', // Whether to show a custom thankyou response after submitting a form. '' for no, 'noSummary' to disable the summary, 'message' for a custom message, 'redirect' to redirect to a new URL.
+			'customThankyou'         => '', // Whether to show a custom thankyou response after submitting a form. '' for no, 'noSummary' to disable the summary, 'message' for a custom message, 'redirect' to redirect to a new URL. Deprecated.
 			'customThankyouHeading'  => __( 'Your message has been sent', 'jetpack-forms' ), // The text to show above customThankyouMessage.
-			'customThankyouMessage'  => __( 'Thank you for your submission!', 'jetpack-forms' ), // The message to show when customThankyou is set to 'message'.
-			'customThankyouRedirect' => '', // The URL to redirect to when customThankyou is set to 'redirect'.
+			'customThankyouMessage'  => '', // The message to show when customThankyou is set to 'message'.
+			'customThankyouRedirect' => '', // The URL to redirect to when confirmationType is set to 'redirect'.
+			'confirmationType'       => null, // The type of confirmation to show after submitting a form. 'text' for a text message, 'redirect' for a redirect link.
 			'jetpackCRM'             => true, // Whether Jetpack CRM should store the form submission.
 			'mailpoet'               => null,
 			'className'              => null,
@@ -197,6 +198,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 			'emailNotifications'     => 'yes',
 			'notificationRecipients' => array(), // Array of user IDs who should receive form response notifications.
 			'disableGoBack'          => $attributes['disableGoBack'] ?? false,
+			'disableSummary'         => $attributes['disableSummary'] ?? false,
 		);
 
 		$attributes = shortcode_atts( $this->defaults, $attributes, 'contact-form' );
@@ -993,9 +995,14 @@ class Contact_Form extends Contact_Form_Shortcode {
 			$classes .= ' submission-success';
 		}
 
-		$back_url        = remove_query_arg( array( 'contact-form-id', 'contact-form-sent', '_wpnonce', 'contact-form-hash' ) );
-		$disable_go_back = $form->get_attribute( 'disableGoBack' );
-		$disable_summary = 'noSummary' === $form->get_attribute( 'customThankyou' );
+		$back_url          = remove_query_arg( array( 'contact-form-id', 'contact-form-sent', '_wpnonce', 'contact-form-hash' ) );
+		$disable_go_back   = $form->get_attribute( 'disableGoBack' );
+		$disable_summary   = $form->get_disable_summary();
+		$confirmation_type = $form->get_confirmation_type();
+
+		if ( $confirmation_type === 'redirect' ) {
+			return '';
+		}
 
 		$html = '<div class="' . esc_attr( $classes ) . '" data-wp-class--submission-success="context.submissionSuccess">';
 
@@ -1009,57 +1016,61 @@ class Contact_Form extends Contact_Form_Shortcode {
 			'<h4 id="contact-form-success-header">' . esc_html( $form->get_attribute( 'customThankyouHeading' ) ) .
 			"</h4>\n\n";
 
-		if ( 'message' === $form->get_attribute( 'customThankyou' ) ) {
+		if ( 'text' === $confirmation_type ) {
 			$raw_message = $form->get_attribute( 'customThankyouMessage' );
 
-			// Add more allowed HTML elements for file download links
-			$allowed_html = array(
-				'br'         => array(),
-				'blockquote' => array( 'class' => array() ),
-				'p'          => array(),
-				'div'        => array(
-					'class' => array(),
-					'style' => array(),
-				),
-				'span'       => array(
-					'class' => array(),
-					'style' => array(),
-				),
-			);
+			if ( $raw_message !== '' ) {
+				// Add more allowed HTML elements for file download links
+				$allowed_html = array(
+					'br'         => array(),
+					'blockquote' => array( 'class' => array() ),
+					'p'          => array(),
+					'div'        => array(
+						'class' => array(),
+						'style' => array(),
+					),
+					'span'       => array(
+						'class' => array(),
+						'style' => array(),
+					),
+				);
 
-			$message = wp_kses( $raw_message, $allowed_html );
-			$message = '<div class="jetpack_forms_contact-form-custom-success-message">' . $message . '</div>';
+				$message = wp_kses( $raw_message, $allowed_html );
+				$message = '<div class="jetpack_forms_contact-form-custom-success-message">' . $message . '</div>';
 
-			$html .= $message;
-		} elseif ( ! $disable_summary ) {
-			$html .= '<template data-wp-each--submission="context.formattedSubmissionData">
-				<div>
-					<div class="field-name" data-wp-text="context.submission.label" data-wp-bind--hidden="!context.submission.label"></div>
-					<div class="field-value" data-wp-text="context.submission.value"></div>
-					<div class="field-images" data-wp-bind--hidden="!context.submission.images">
-						<template data-wp-each--image="context.submission.images">
-							<img class="field-image" data-wp-bind--src="context.image" data-wp-bind--hidden="!context.image"/>
-						</template>
+				$html .= $message;
+			}
+
+			if ( ! $disable_summary ) {
+				$html .= '<template data-wp-each--submission="context.formattedSubmissionData">
+					<div class="jetpack_forms_contact-form-success-summary">
+						<div class="field-name" data-wp-text="context.submission.label" data-wp-bind--hidden="!context.submission.label"></div>
+						<div class="field-value" data-wp-text="context.submission.value"></div>
+						<div class="field-images" data-wp-bind--hidden="!context.submission.images">
+							<template data-wp-each--image="context.submission.images">
+								<img class="field-image" data-wp-bind--src="context.image" data-wp-bind--hidden="!context.image"/>
+							</template>
+						</div>
 					</div>
-				</div>
-			</template>';
+				</template>';
 
-			// For each entry in the submission data array, render a div with the label and value.
-			foreach ( $formatted_submission_data as $submission ) {
-				$html .= '<div data-wp-each-child>
-					<div class="field-name" data-wp-text="context.submission.label" data-wp-bind--hidden="!context.submission.label">' . $submission['label'] . '</div>
-					<div class="field-value" data-wp-text="context.submission.value">' . $submission['value'] . '</div>
-					<div class="field-images" data-wp-bind--hidden="!context.submission.images">';
+				// For each entry in the submission data array, render a div with the label and value.
+				foreach ( $formatted_submission_data as $submission ) {
+					$html .= '<div data-wp-each-child class="jetpack_forms_contact-form-success-summary">
+						<div class="field-name" data-wp-text="context.submission.label" data-wp-bind--hidden="!context.submission.label">' . $submission['label'] . '</div>
+						<div class="field-value" data-wp-text="context.submission.value">' . $submission['value'] . '</div>
+						<div class="field-images" data-wp-bind--hidden="!context.submission.images">';
 
-				if ( ! empty( $submission['images'] ) ) {
-					foreach ( $submission['images'] as $image ) {
-						$html .= '<img data-wp-each-child class="field-image" data-wp-bind--src="context.image" src="' . $image . '" data-wp-bind--hidden="!context.image" ' . ( empty( $image ) ? 'hidden' : '' ) . ' />';
+					if ( ! empty( $submission['images'] ) ) {
+						foreach ( $submission['images'] as $image ) {
+							$html .= '<img data-wp-each-child class="field-image" data-wp-bind--src="context.image" src="' . $image . '" data-wp-bind--hidden="!context.image" ' . ( empty( $image ) ? 'hidden' : '' ) . ' />';
+						}
+					} else {
+						$html .= '<template data-wp-each--image="context.submission.images"></template>';
 					}
-				} else {
-					$html .= '<template data-wp-each--image="context.submission.images"></template>';
-				}
 
-				$html .= '</div></div>';
+					$html .= '</div></div>';
+				}
 			}
 		}
 
@@ -1076,32 +1087,38 @@ class Contact_Form extends Contact_Form_Shortcode {
 	 * @return string $message
 	 */
 	public static function success_message( $feedback_id, $form ) {
-		$message         = '';
-		$disable_summary = 'noSummary' === $form->get_attribute( 'customThankyou' );
+		$message           = '';
+		$disable_summary   = $form->get_disable_summary();
+		$confirmation_type = $form->get_confirmation_type();
 
-		if ( 'message' === $form->get_attribute( 'customThankyou' ) ) {
+		if ( 'text' === $confirmation_type ) {
 			$raw_message = $form->get_attribute( 'customThankyouMessage' );
 
-			// Add more allowed HTML elements for file download links
-			$allowed_html = array(
-				'br'         => array(),
-				'blockquote' => array( 'class' => array() ),
-				'p'          => array(),
-				'div'        => array(
-					'class' => array(),
-					'style' => array(),
-				),
-				'span'       => array(
-					'class' => array(),
-					'style' => array(),
-				),
-			);
+			if ( $raw_message !== '' ) {
+				// Add more allowed HTML elements for file download links
+				$allowed_html = array(
+					'br'         => array(),
+					'blockquote' => array( 'class' => array() ),
+					'p'          => array(),
+					'div'        => array(
+						'class' => array(),
+						'style' => array(),
+					),
+					'span'       => array(
+						'class' => array(),
+						'style' => array(),
+					),
+				);
 
-			$message = wp_kses( $raw_message, $allowed_html );
-			$message = '<div class="jetpack_forms_contact-form-custom-success-message">' . $message . '</div>';
-		} elseif ( ! $disable_summary ) {
-			$compiled_form = self::get_compiled_form( $feedback_id );
-			$message       = '<p>' . implode( '</p><p>', $compiled_form ) . '</p>';
+				$message = wp_kses( $raw_message, $allowed_html );
+				$message = '<div class="jetpack_forms_contact-form-custom-success-message">' . $message . '</div>';
+			}
+
+			if ( ! $disable_summary ) {
+				$compiled_form = self::get_compiled_form( $feedback_id );
+
+				$message .= '<div class="jetpack_forms_contact-form-success-summary"><p>' . implode( '</p><p>', $compiled_form ) . '</p></div>';
+			}
 		}
 
 		return $message;
@@ -2234,7 +2251,9 @@ class Contact_Form extends Contact_Form_Shortcode {
 	 * @return bool True if the contact form has a custom redirect, false otherwise.
 	 */
 	public function has_custom_redirect() {
-		if ( ! empty( $this->get_attribute( 'customThankyouRedirect' ) ) && 'redirect' === $this->get_attribute( 'customThankyou' ) ) {
+		$confirmation_type = $this->get_confirmation_type();
+
+		if ( ! empty( $this->get_attribute( 'customThankyouRedirect' ) ) && 'redirect' === $confirmation_type ) {
 			return true;
 		}
 		/**
@@ -2259,9 +2278,11 @@ class Contact_Form extends Contact_Form_Shortcode {
 	 * @return string The redirect URL.
 	 */
 	public function get_redirect_url( $refresh_args, $id, $post_id ) {
-		$redirect        = '';
-		$custom_redirect = false;
-		if ( 'redirect' === $this->get_attribute( 'customThankyou' ) ) {
+		$confirmation_type = $this->get_confirmation_type();
+		$redirect          = '';
+		$custom_redirect   = false;
+
+		if ( 'redirect' === $confirmation_type ) {
 			$custom_redirect = true;
 			$redirect        = esc_url_raw( $this->get_attribute( 'customThankyouRedirect' ) );
 		}
@@ -2787,5 +2808,36 @@ class Contact_Form extends Contact_Form_Shortcode {
 		}
 		$id = $this->get_attribute( 'id' );
 		return self::$static_errors[ $id ]->get_error_messages();
+	}
+
+	/**
+	 * Get the confirmation type of the contact form from the deprecated customThankyou attribute.
+	 *
+	 * @return string The confirmation type of the contact form.
+	 */
+	public function get_confirmation_type() {
+		$confirmation_type = $this->get_attribute( 'confirmationType' );
+
+		if ( '' === $confirmation_type ) {
+			$confirmation_type = 'redirect' === $this->get_attribute( 'customThankyou' ) ? 'redirect' : 'text';
+		}
+
+		return $confirmation_type;
+	}
+
+	/**
+	 * Get the disable summary of the contact form from the deprecated customThankyou attribute.
+	 *
+	 * @return string The disable summary of the contact form.
+	 */
+	public function get_disable_summary() {
+		$disable_summary = $this->get_attribute( 'disableSummary' );
+		$custom_thankyou = $this->get_attribute( 'customThankyou' );
+
+		if ( '' === $disable_summary ) {
+			$disable_summary = 'noSummary' === $custom_thankyou || 'message' === $custom_thankyou;
+		}
+
+		return $disable_summary;
 	}
 }

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -182,7 +182,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 			'id'                     => null, // Not exposed to the user. Set above.
 			'submit_button_text'     => __( 'Submit', 'jetpack-forms' ),
 			// These attributes come from the block editor, so use camel case instead of snake case.
-			'customThankyou'         => '', // Whether to show a custom thankyou response after submitting a form. '' for no, 'message' for a custom message, 'redirect' to redirect to a new URL.
+			'customThankyou'         => '', // Whether to show a custom thankyou response after submitting a form. '' for no, 'noSummary' to disable the summary, 'message' for a custom message, 'redirect' to redirect to a new URL.
 			'customThankyouHeading'  => __( 'Your message has been sent', 'jetpack-forms' ), // The text to show above customThankyouMessage.
 			'customThankyouMessage'  => __( 'Thank you for your submission!', 'jetpack-forms' ), // The message to show when customThankyou is set to 'message'.
 			'customThankyouRedirect' => '', // The URL to redirect to when customThankyou is set to 'redirect'.

--- a/projects/packages/forms/src/contact-form/class-util.php
+++ b/projects/packages/forms/src/contact-form/class-util.php
@@ -411,7 +411,6 @@ class Util {
 						$match[0]
 					);
 				}
-				// $match['attrs'] includes trailing space: '{"customThankyou":"message"} '.
 				$attrs = json_decode( rtrim( $match['attrs'], ' ' ), true );
 				$attrs = array_merge( $attrs, $new_attr );
 				return str_replace(

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -234,6 +234,10 @@ that needs to mimic the input element styles */
 	text-wrap: pretty;
 }
 
+.jetpack_forms_contact-form-custom-success-message + .jetpack_forms_contact-form-success-summary {
+	margin-top: 32px;
+}
+
 .contact-form-submission h4 {
 	margin-top: 32px;
 	margin-bottom: 32px;

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -378,7 +378,7 @@ class Contact_Form_Test extends BaseTestCase {
 		// Create a contact form
 		$form = new Contact_Form(
 			array(
-				'customThankyou' => 'redirect', // Any value that's not 'message'
+				'customThankyou' => '',
 			),
 			"[contact-field label='Name' type='name' required='1'/][contact-field label='Email' type='email' required='1'/][contact-field label='Message' type='textarea' required='1'/]"
 		);
@@ -2732,6 +2732,8 @@ EOT;
 		$expected_attributes['saveResponses']          = 'yes';
 		$expected_attributes['disableGoBack']          = '';
 		$expected_attributes['notificationRecipients'] = array();
+		$expected_attributes['disableSummary']         = '';
+		$expected_attributes['confirmationType']       = '';
 
 		$form = new Contact_Form(
 			$attributes,

--- a/projects/plugins/jetpack/changelog/update-forms-action-after-submit
+++ b/projects/plugins/jetpack/changelog/update-forms-action-after-submit
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: Update "Action after submit" sidebar section


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of FORMS-246
Follow-up to https://github.com/Automattic/jetpack/pull/45273 and https://github.com/Automattic/jetpack/pull/45487

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This adds two new attributes, `disableSummary` and `confirmationType`, deprecating `customThankyou` without requiring a formal block deprecation. This allows for a custom message to also include the summary and simplifies the UX.
See screenshots at the bottom of the description.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1760435815738269/1759925173.540499-slack-C052XEUUBL4


## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Submit existing blocks without changing them
* Check that the post-submission screen works as expected, same as before
* Edit an existing form, check that the "Action after submit" section matches the old behavior
* Save and submit. Check that the post-submission screen works as expected
* Create a new form and set the confirmation type settings.
* Publish and submit. Check that the post-submission screen works as expected
* Test with different settings combinations, like redirections or text with or without custom messages and summary

| Before | After |
| - | - |
| <img width="326" height="465" alt="Screenshot from 2025-10-14 20-49-55" src="https://github.com/user-attachments/assets/d28fe895-59e6-493e-9115-b67d145c8862" /> | <img width="326" height="465" alt="Screenshot from 2025-10-14 20-48-28" src="https://github.com/user-attachments/assets/455422d4-980f-4a86-92ff-d88e6ae8332f" /> |

