### PR TITLE
My Home Suggestions Card: Update find other domains link to /setup/domain-and-plan flow

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/domain-search-rewrite-cleanup-remove-domainandplanpackage-references
+++ b/projects/packages/jetpack-mu-wpcom/changelog/domain-search-rewrite-cleanup-remove-domainandplanpackage-references
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+My Home Suggestions Card: Update find other domains link to /setup/domain-and-plan flow

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-general-tasks-widget/tasks/home-task-domain-upsell/index.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-general-tasks-widget/tasks/home-task-domain-upsell/index.js
@@ -29,9 +29,8 @@ export default ( { siteDomain, sitePlan } ) => {
 	}
 
 	const getLink = `http://wordpress.com/checkout/${ siteDomain }/${ cart.join( ',' ) }`;
-	const searchLink = addQueryArgs( `https://wordpress.com/domains/add/${ siteDomain }`, {
-		domainAndPlanPackage: true,
-		domain: true,
+	const searchLink = addQueryArgs( 'https://wordpress.com/setup/domain-and-plan', {
+		siteSlug: siteDomain,
 	} );
 
 	return (


### PR DESCRIPTION
Part of DOMAINS-1715.

## Proposed changes:

Updates the link to "Find other domains" within the Suggestions card in WP Admin to `/setup/domain-and-plan` now that we're removing `domainAndPlanPackage` which was part of the legacy domain search UI.

<img width="697" height="407" alt="image" src="https://github.com/user-attachments/assets/2a0e1ca1-5bd3-4bc4-9b4d-b970ab2c58f5" />


### Other information:

- N/A Have you written new tests for your changes, if applicable?
- N/A Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

Apply this patch to your sandbox and proxy `public-api.wordpress.com` and a free site to your sandbox's IP address.

Update the `onboarding_checklist_completed` option to `1` on that free site.

Enter `%s/wp-admin` and verify you see the Suggestions card pointing to `/setup/domain-and-plan?siteSlug=%s` when you hover over "Find other domains".