### PR TITLE
Forms: Fix terms consent label colon issue

### DIFF
--- a/projects/packages/forms/changelog/fix-form-consent-label-colon-issue
+++ b/projects/packages/forms/changelog/fix-form-consent-label-colon-issue
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: strip period from Terms submission label on the post-submission page.

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -2578,7 +2578,8 @@ class Contact_Form extends Contact_Form_Shortcode {
 	 */
 	private static function maybe_add_colon_to_label( $label ) {
 		$formatted_label = $label ? $label : '';
-		$formatted_label = str_ends_with( $formatted_label, '?' ) ? $formatted_label : rtrim( $formatted_label, ':' ) . ':';
+		// Special case for the Terms consent field block which a period after the label.
+		$formatted_label = str_ends_with( $formatted_label, '?' ) ? $formatted_label : rtrim( $formatted_label, ':.' ) . ':';
 
 		return $formatted_label;
 	}

--- a/projects/packages/forms/src/modules/form/view.js
+++ b/projects/packages/forms/src/modules/form/view.js
@@ -103,8 +103,10 @@ const maybeAddColonToLabel = label => {
 	if ( ! formattedLabel ) {
 		return null;
 	}
-
-	return formattedLabel.endsWith( '?' ) ? formattedLabel : formattedLabel.replace( /:$/, '' ) + ':';
+	// Special case for the Terms consent field block which has a period at the end of the text.
+	return formattedLabel.endsWith( '?' )
+		? formattedLabel
+		: formattedLabel.replace( /[.:]$/, '' ) + ':';
 };
 
 const maybeTransformValue = value => {

--- a/projects/plugins/jetpack/changelog/fix-form-consent-label-colon-issue
+++ b/projects/plugins/jetpack/changelog/fix-form-consent-label-colon-issue
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Forms: strip period from Terms submission label on the post-submission page.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->
When we render a form submission that has a terms consent block, we're not stripping the period at the end of the label text, resulting in a period followed by a semicolon, like in this image:
<img width="689" height="120" alt="Screenshot 2025-10-15 at 15 25 58" src="https://github.com/user-attachments/assets/bc3d0061-5397-43a3-a334-d8258b58ba80" />

Fixes [FORMS-324](https://linear.app/a8c/issue/FORMS-324/remove-period-from-terms-consent-label-before-rendering)

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Strip period from the label text before rendering on the form submission page.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a form and add a terms consent block.
* Publish the post and go to submit the form.
* Check that the term consent text has no period before the colon.

