### PR TITLE
Atomic: Display correct site visibility in wp-admin settings

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-woa-actual-site-visibility
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-woa-actual-site-visibility
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Atomic sites: Display site visibility in wp-admin settings based on the privacy model instead of the 'blog_public' option value.

--- a/projects/packages/jetpack-mu-wpcom/src/features/replace-site-visibility/replace-site-visibility.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/replace-site-visibility/replace-site-visibility.php
@@ -110,7 +110,7 @@ function replace_site_visibility_load_assets() {
 
 	$data = array(
 		'homeUrl'                => home_url( '/' ),
-		'siteTitle'              => bloginfo( 'name' ),
+		'siteTitle'              => get_bloginfo( 'name' ),
 		'isWpcomStagingSite'     => (bool) get_option( 'wpcom_is_staging_site' ),
 		'isUnlaunchedSite'       => get_option( 'launch-status' ) === 'unlaunched',
 		'hasSitePreviewLink'     => function_exists( 'wpcom_site_has_feature' ) && wpcom_site_has_feature( \WPCOM_Features::SITE_PREVIEW_LINKS ),

--- a/projects/packages/jetpack-mu-wpcom/src/features/replace-site-visibility/replace-site-visibility.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/replace-site-visibility/replace-site-visibility.php
@@ -6,6 +6,7 @@
  */
 
 use Automattic\Jetpack\Connection\Client;
+use Automattic\Jetpack\Status\Host;
 
 /**
  * Load dependencies.
@@ -122,7 +123,7 @@ function replace_site_visibility_load_assets() {
 	);
 
 	// If the site is launched, replace the option value with the actual site visibility.
-	if ( function_exists( '\Private_Site\site_is_private' )
+	if ( ( new Host() )->is_woa_site() && function_exists( '\Private_Site\site_is_private' )
 		&& ! $data['isUnlaunchedSite'] && ! $data['wpcomPublicComingSoon'] && ! $data['wpcomComingSoon'] && (string) $data['blogPublic'] !== '0'
 	) {
 		// @phan-suppress-next-line PhanUndeclaredFunction

--- a/projects/packages/jetpack-mu-wpcom/src/features/replace-site-visibility/replace-site-visibility.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/replace-site-visibility/replace-site-visibility.php
@@ -107,25 +107,31 @@ function wpcom_get_site_preview_link() {
 function replace_site_visibility_load_assets() {
 	$handle = jetpack_mu_wpcom_enqueue_assets( 'wpcom-replace-site-visibility', array( 'js', 'css' ) );
 
-	$data = wp_json_encode(
-		array(
-			'homeUrl'                => home_url( '/' ),
-			'siteTitle'              => bloginfo( 'name' ),
-			'isWpcomStagingSite'     => (bool) get_option( 'wpcom_is_staging_site' ),
-			'isUnlaunchedSite'       => get_option( 'launch-status' ) === 'unlaunched',
-			'hasSitePreviewLink'     => function_exists( 'wpcom_site_has_feature' ) && wpcom_site_has_feature( \WPCOM_Features::SITE_PREVIEW_LINKS ),
-			'sitePreviewLink'        => wpcom_get_site_preview_link(),
-			'sitePreviewLinkNonce'   => wp_create_nonce( 'wpcom_site_visibility_site_preview_link' ),
-			'blogPublic'             => get_option( 'blog_public' ),
-			'wpcomComingSoon'        => get_option( 'wpcom_coming_soon' ),
-			'wpcomPublicComingSoon'  => get_option( 'wpcom_public_coming_soon' ),
-			'wpcomDataSharingOptOut' => (bool) get_option( 'wpcom_data_sharing_opt_out' ),
-		)
+	$data = array(
+		'homeUrl'                => home_url( '/' ),
+		'siteTitle'              => bloginfo( 'name' ),
+		'isWpcomStagingSite'     => (bool) get_option( 'wpcom_is_staging_site' ),
+		'isUnlaunchedSite'       => get_option( 'launch-status' ) === 'unlaunched',
+		'hasSitePreviewLink'     => function_exists( 'wpcom_site_has_feature' ) && wpcom_site_has_feature( \WPCOM_Features::SITE_PREVIEW_LINKS ),
+		'sitePreviewLink'        => wpcom_get_site_preview_link(),
+		'sitePreviewLinkNonce'   => wp_create_nonce( 'wpcom_site_visibility_site_preview_link' ),
+		'blogPublic'             => get_option( 'blog_public' ),
+		'wpcomComingSoon'        => get_option( 'wpcom_coming_soon' ),
+		'wpcomPublicComingSoon'  => get_option( 'wpcom_public_coming_soon' ),
+		'wpcomDataSharingOptOut' => (bool) get_option( 'wpcom_data_sharing_opt_out' ),
 	);
 
+	// If the site is launched, replace the option value with the actual site visibility.
+	if ( function_exists( '\Private_Site\site_is_private' )
+		&& ! $data['isUnlaunchedSite'] && ! $data['wpcomPublicComingSoon'] && ! $data['wpcomComingSoon'] && (string) $data['blogPublic'] !== '0'
+	) {
+		$data['blogPublic'] = \Private_Site\site_is_private() ? '-1' : '1';
+	}
+
+	$encoded_data = wp_json_encode( $data );
 	wp_add_inline_script(
 		$handle,
-		"var JETPACK_MU_WPCOM_SITE_VISIBILITY = $data;",
+		"var JETPACK_MU_WPCOM_SITE_VISIBILITY = $encoded_data;",
 		'before'
 	);
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/replace-site-visibility/replace-site-visibility.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/replace-site-visibility/replace-site-visibility.php
@@ -125,6 +125,7 @@ function replace_site_visibility_load_assets() {
 	if ( function_exists( '\Private_Site\site_is_private' )
 		&& ! $data['isUnlaunchedSite'] && ! $data['wpcomPublicComingSoon'] && ! $data['wpcomComingSoon'] && (string) $data['blogPublic'] !== '0'
 	) {
+		// @phan-suppress-next-line PhanUndeclaredFunction
 		$data['blogPublic'] = \Private_Site\site_is_private() ? '-1' : '1';
 	}
 


### PR DESCRIPTION
## Proposed changes:
* Atomic sites: Display site visibility in wp-admin settings based on the privacy model instead of the `blog_public` option value.
* Fix a bug with improper fetching of site title for the `JETPACK_MU_WPCOM_SITE_VISIBILITY` data.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
https://linear.app/a8c/issue/CONNECT-47

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:

### Site visibility discrepancy
1. First, let's reproduce the problem (don't checkout the PR).
2. Create a WoA dev blog (p9o2xV-1r2-p2), install Jetpack Beta.
3. Launch the site, then go to `/wp-admin/options-reading.php` and make it "private". Confirm the checkbox "Private" stays marked after page refresh.
4. Use CLI to update the option value: `wp option update blog_public 1`. Refresh the page, confirm the "Site visibility" now has the "Public" active.
5. Try to load the site in a browser's private window, confirm it says "you need to be logged in", meaning the site actually is private.
6. Now let's try the fix. Use Jetpack Beta to switch "WordPress.com Site Helper" to this branch.
7. Refresh the "Reading Settings" page, confirm it now has the "Private" visibility active.
8. Change the setting to "Public" and save. Then use CLI to change the option: `wp option update blog_public -1`.
9. Refresh the "Reading Settings", confirm it shows "Public" nonetheless.
10. Load the site in a private window, confirm it now loads just fine.

### Missing site title
1. Go to `/wp-admin/options-reading.php`
2. Use browser console to check the value of the JS variable: `JETPACK_MU_WPCOM_SITE_VISIBILITY.siteTitle`. Confirm it contains the site title.