### PR TITLE
Forms: Fix default author non existing still sends emails to form (page/post author) 

### DIFF
--- a/projects/packages/forms/changelog/fix-default-author-non-existing
+++ b/projects/packages/forms/changelog/fix-default-author-non-existing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: do not send emails to the author of the form if they are no longer able to edit it

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -463,7 +463,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 			return $default_to;
 		}
 
-		// check that source is of type Feedback_Source
+		// Check that source is of type Feedback_Source
 		if ( ! $source instanceof Feedback_Source ) {
 			return $default_to;
 		}

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -453,6 +453,15 @@ class Contact_Form extends Contact_Form_Shortcode {
 			return $default_to;
 		}
 
+		// Check that source is of type Feedback_Source
+		if ( ! $source instanceof Feedback_Source ) {
+			return $default_to;
+		}
+
+		if ( absint( $source->get_id() ) === 0 ) {
+			return $default_to;
+		}
+
 		$post_author = get_userdata( $post_author_id );
 		if ( empty( $post_author ) || empty( $post_author->user_email ) ) {
 			return $default_to;
@@ -460,15 +469,6 @@ class Contact_Form extends Contact_Form_Shortcode {
 
 		// Check that the user is still a member of the blog.
 		if ( ! is_user_member_of_blog( $post_author_id ) ) {
-			return $default_to;
-		}
-
-		// Check that source is of type Feedback_Source
-		if ( ! $source instanceof Feedback_Source ) {
-			return $default_to;
-		}
-
-		if ( absint( $source->get_id() ) === 0 ) {
 			return $default_to;
 		}
 

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -439,9 +439,11 @@ class Contact_Form extends Contact_Form_Shortcode {
 	 * @return string The default recipient email address.
 	 */
 	public static function get_default_to( $post_author_id = null ) {
+
+		// Check that the user has edit permissions for this blog and has an email address
 		if ( $post_author_id ) {
 			$post_author = get_userdata( $post_author_id );
-			if ( ! empty( $post_author->user_email ) ) {
+			if ( is_user_member_of_blog( $post_author_id ) && ! empty( $post_author->user_email ) ) {
 				return $post_author->user_email;
 			}
 		}

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -150,9 +150,15 @@ class Contact_Form extends Contact_Form_Shortcode {
 
 		$this->is_response_without_reload_enabled = apply_filters( 'jetpack_forms_enable_ajax_submission', true );
 
+		// Initialize the source before setting defaults
+		if ( ! $this->source ) {
+			$attributes   = is_array( $attributes ) ? $attributes : array();
+			$this->source = Feedback_Source::get_current( $attributes );
+		}
+
 		// Set up the default subject and recipient for this form.
 		$post_author_id  = self::get_post_property( $this->current_post, 'post_author' );
-		$default_to      = self::get_default_to( $post_author_id );
+		$default_to      = self::get_default_to( $post_author_id, $this->source );
 		$default_subject = self::get_default_subject( $attributes, $this->current_post );
 
 		if ( ! isset( $attributes ) || ! is_array( $attributes ) ) {
@@ -434,21 +440,42 @@ class Contact_Form extends Contact_Form_Shortcode {
 	/**
 	 * Get the default recipient email address for the contact form.
 	 *
-	 * @param int|null $post_author_id The ID of the post author. If provided, will return the author's email.
+	 * @param int|null             $post_author_id The ID of the post author. If provided, will return the author's email.
+	 * @param Feedback_Source|null $source The source of the feedback entry. Optional, not used currently.
 	 *
 	 * @return string The default recipient email address.
 	 */
-	public static function get_default_to( $post_author_id = null ) {
-
-		// Check that the user has edit permissions for this blog and has an email address
-		if ( $post_author_id ) {
-			$post_author = get_userdata( $post_author_id );
-			if ( is_user_member_of_blog( $post_author_id ) && ! empty( $post_author->user_email ) ) {
-				return $post_author->user_email;
-			}
-		}
+	public static function get_default_to( $post_author_id = null, $source = null ) {
 		// Get the default recipient email address.
 		$default_to = get_option( 'admin_email' );
+		// Check that the user has edit permissions for this blog and has an email address
+		if ( ! $post_author_id ) {
+			return $default_to;
+		}
+
+		$post_author = get_userdata( $post_author_id );
+		if ( empty( $post_author ) || empty( $post_author->user_email ) ) {
+			return $default_to;
+		}
+
+		// Check that the user is still a member of the blog.
+		if ( ! is_user_member_of_blog( $post_author_id ) ) {
+			return $default_to;
+		}
+
+		// check that source is of type Feedback_Source
+		if ( ! $source instanceof Feedback_Source ) {
+			return $default_to;
+		}
+
+		if ( absint( $source->get_id() ) === 0 ) {
+			return $default_to;
+		}
+
+		// Check that the author can still edit the post or page.
+		if ( user_can( $post_author_id, 'edit_post', $source->get_id() ) ) {
+			return $post_author->user_email;
+		}
 
 		return $default_to;
 	}

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -2525,6 +2525,27 @@ EOT;
 		wp_delete_user( $author_id );
 		wp_delete_post( $source->get_id(), true );
 	}
+
+	/**
+	 * Tests get_default_to method with valid post author.
+	 */
+	public function test_get_default_to_with_valid_post_author_subscriber() {
+		$author_id = wp_insert_user(
+			array(
+				'user_email' => 'subscriber@example.com',
+				'user_login' => 'test_author',
+				'user_pass'  => 'password123',
+				'role'       => 'subscriber',
+			)
+		);
+		$source    = $this->get_source( $author_id );
+		$result    = Contact_Form::get_default_to( $author_id, $source );
+
+		$this->assertEquals( get_option( 'admin_email' ), $result );
+
+		wp_delete_user( $author_id );
+		wp_delete_post( $source->get_id(), true );
+	}
 	/**
 	 * Helper function to create a Feedback_Source object from a post.
 	 */
@@ -2550,9 +2571,10 @@ EOT;
 	 * Tests get_default_to method with invalid post author ID.
 	 */
 	public function test_get_default_to_with_invalid_post_author() {
+		$source = $this->get_source( 99999 );
+		$result = Contact_Form::get_default_to( 99999, $source ); // Non-existent user ID
 
-		$result = Contact_Form::get_default_to( 99999 ); // Non-existent user ID
-
+		wp_delete_post( $source->get_id(), true );
 		$this->assertEquals( get_option( 'admin_email' ), $result );
 	}
 
@@ -2574,6 +2596,7 @@ EOT;
 				'user_email' => '',
 				'user_login' => 'test_author_no_email',
 				'user_pass'  => 'password123',
+				'role'       => 'editor',
 			)
 		);
 

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -256,6 +256,7 @@ class Contact_Form_Test extends BaseTestCase {
 				'user_email' => 'john@example.com',
 				'user_login' => 'test_user',
 				'user_pass'  => 'abc123',
+				'role'       => 'author',
 			)
 		);
 
@@ -2507,25 +2508,49 @@ EOT;
 	 * Tests get_default_to method with valid post author.
 	 */
 	public function test_get_default_to_with_valid_post_author() {
+		$email     = 'author@example.com';
 		$author_id = wp_insert_user(
 			array(
-				'user_email' => 'author@example.com',
+				'user_email' => $email,
 				'user_login' => 'test_author',
 				'user_pass'  => 'password123',
+				'role'       => 'editor',
+			)
+		);
+		$source    = $this->get_source( $author_id );
+		$result    = Contact_Form::get_default_to( $author_id, $source );
+
+		$this->assertEquals( $email, $result );
+
+		wp_delete_user( $author_id );
+		wp_delete_post( $source->get_id(), true );
+	}
+	/**
+	 * Helper function to create a Feedback_Source object from a post.
+	 */
+	public function get_source( $author_id ) {
+		$post_id = wp_insert_post(
+			array(
+				'post_title'   => 'Test Post',
+				'post_content' => 'This is a test post.',
+				'post_status'  => 'publish',
+				'post_author'  => $author_id,
 			)
 		);
 
-		$result = Contact_Form::get_default_to( $author_id );
-
-		$this->assertEquals( 'author@example.com', $result );
-
-		wp_delete_user( $author_id );
+		return Feedback_Source::from_serialized(
+			array(
+				'source_id' => $post_id,
+				'title'     => 'Test Post',
+			)
+		);
 	}
 
 	/**
 	 * Tests get_default_to method with invalid post author ID.
 	 */
 	public function test_get_default_to_with_invalid_post_author() {
+
 		$result = Contact_Form::get_default_to( 99999 ); // Non-existent user ID
 
 		$this->assertEquals( get_option( 'admin_email' ), $result );
@@ -2552,11 +2577,14 @@ EOT;
 			)
 		);
 
-		$result = Contact_Form::get_default_to( $author_id );
+		$source = $this->get_source( $author_id );
+
+		$result = Contact_Form::get_default_to( $author_id, $source );
 
 		$this->assertEquals( get_option( 'admin_email' ), $result );
 
 		wp_delete_user( $author_id );
+		wp_delete_post( $source->get_id(), true );
 	}
 
 	/**

--- a/projects/plugins/jetpack/changelog/fix-default-author-non-existing
+++ b/projects/plugins/jetpack/changelog/fix-default-author-non-existing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: do not send emails to the author of the form if they are no longer able to edit it


### PR DESCRIPTION
Fixes FORMS-309

## Proposed changes:
* Update the get_default_to method to only return the authors email address if they are can still edit the author. Otherwise we need to set that email explicitly. 

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1759584451403339-slack-C086RGTJT1D

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Create a user. That is able to edit a page. 
Do not set the form email settings. 

The user should get the email once the form is filled out. 

Now set the users role to be an subscriber. Once you fill out the form the form shouldn't be sent to the author since the author doesn't have the edit privileges any more but it should be sent admin of the site.
