### PR TITLE
 Forms: UX improvements for Image Select field

### DIFF
--- a/projects/packages/forms/changelog/update-forms-image-select-feedback
+++ b/projects/packages/forms/changelog/update-forms-image-select-feedback
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Forms: UX improvements for Image Select field

--- a/projects/packages/forms/src/blocks/field-image-select/edit.tsx
+++ b/projects/packages/forms/src/blocks/field-image-select/edit.tsx
@@ -178,6 +178,10 @@ export default function ImageSelectFieldEdit( props ) {
 								label={ __( 'Show labels', 'jetpack-forms' ) }
 								checked={ attributes?.showLabels }
 								onChange={ ( value: boolean ) => setAttributes( { showLabels: value } ) }
+								help={ __(
+									'Displays the labels for the images in the published form. They are always visible for you in the editor and in the responses.',
+									'jetpack-forms'
+								) }
 							/>
 						),
 					},
@@ -190,6 +194,7 @@ export default function ImageSelectFieldEdit( props ) {
 								label={ __( 'Supersized', 'jetpack-forms' ) }
 								checked={ attributes?.isSupersized }
 								onChange={ ( value: boolean ) => updateSupersized( value ) }
+								help={ __( 'Changes the size of the images.', 'jetpack-forms' ) }
 							/>
 						),
 					},
@@ -202,6 +207,7 @@ export default function ImageSelectFieldEdit( props ) {
 								label={ __( 'Multiple selection', 'jetpack-forms' ) }
 								checked={ attributes?.isMultiple }
 								onChange={ ( value: boolean ) => setAttributes( { isMultiple: value } ) }
+								help={ __( 'Allows visitors to select more than one image.', 'jetpack-forms' ) }
 							/>
 						),
 					},
@@ -214,6 +220,10 @@ export default function ImageSelectFieldEdit( props ) {
 								label={ __( 'Randomize', 'jetpack-forms' ) }
 								checked={ attributes?.randomizeOptions }
 								onChange={ ( value: boolean ) => setAttributes( { randomizeOptions: value } ) }
+								help={ __(
+									'Randomizes the order of the images in the published form to avoid order bias. This setting does not affect the order in the editor.',
+									'jetpack-forms'
+								) }
 							/>
 						),
 					},

--- a/projects/packages/forms/src/blocks/field-image-select/edit.tsx
+++ b/projects/packages/forms/src/blocks/field-image-select/edit.tsx
@@ -8,8 +8,9 @@ import {
 	BlockControls,
 } from '@wordpress/block-editor';
 import { ToggleControl, ToolbarButton, ToolbarGroup } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
-import { useMemo } from '@wordpress/element';
+import { store as coreStore } from '@wordpress/core-data';
+import { useDispatch, useSelect, select as globalSelect } from '@wordpress/data';
+import { useCallback, useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 /**
@@ -25,23 +26,51 @@ import './editor.scss';
  * Types
  */
 import type { Block, BlockEditorStoreSelect } from '../../types';
+import type { Attachment } from '@wordpress/core-data';
 
 export default function ImageSelectFieldEdit( props ) {
 	const { attributes, clientId, setAttributes, name } = props;
 	const { id, required, width } = attributes;
+	const { updateBlockAttributes } = useDispatch( blockEditorStore );
 	const { blockStyle } = useJetpackFieldStyles( attributes );
 
-	const { optionsBlock } = useSelect(
+	const { optionsBlock, imagesData } = useSelect(
 		select => {
 			const { getBlock } = select( blockEditorStore ) as BlockEditorStoreSelect;
 
+			const block = getBlock( clientId )?.innerBlocks.find(
+				( innerBlock: Block ) => innerBlock.name === 'jetpack/fieldset-image-options'
+			);
+
+			const images =
+				block?.innerBlocks?.[ 0 ]?.innerBlocks
+					// Filter out inner blocks that don't have a media id, i.e. external images.
+					?.filter( innerBlock => innerBlock.attributes?.id !== undefined )
+					// Map the inner blocks to an array of objects with the media id and client id.
+					?.map( innerBlock => ( {
+						clientId: innerBlock.clientId,
+						mediaId: innerBlock.attributes.id as number,
+					} ) ) ?? [];
+
 			return {
-				optionsBlock: getBlock( clientId )?.innerBlocks.find(
-					( block: Block ) => block.name === 'jetpack/fieldset-image-options'
-				),
+				optionsBlock: block,
+				imagesData: images,
 			};
 		},
 		[ clientId ]
+	);
+
+	// Preload the image entity records reactively, as they are not available on first load.
+	// This is necessary to ensure the image URLs can be updated correctly when the supersized attribute is changed.
+	useSelect(
+		select => {
+			return imagesData.map( image =>
+				select( coreStore ).getEntityRecord( 'postType', 'attachment', image.mediaId, {
+					context: 'view',
+				} )
+			);
+		},
+		[ imagesData ]
 	);
 
 	// This wraps the field in a form block if it is added directly to the editor.
@@ -83,6 +112,44 @@ export default function ImageSelectFieldEdit( props ) {
 		}
 	);
 
+	const updateSupersized = useCallback(
+		( value: boolean ) => {
+			setAttributes( { isSupersized: value } );
+
+			const inputImageOptions = optionsBlock?.innerBlocks;
+
+			if ( inputImageOptions && inputImageOptions.length > 0 ) {
+				const imageBlocks = inputImageOptions.map( ( block: Block ) => block.innerBlocks[ 0 ] );
+				const newSizeSlug = value ? 'full' : 'medium';
+
+				imageBlocks.forEach( imageBlock => {
+					updateBlockAttributes( imageBlock.clientId, {
+						sizeSlug: newSizeSlug,
+					} );
+
+					const record = globalSelect( coreStore ).getEntityRecord(
+						'postType',
+						'attachment',
+						imageBlock.attributes.id as number,
+						{
+							context: 'view',
+						}
+					);
+
+					const newUrl = ( record as Attachment )?.media_details?.sizes?.[ newSizeSlug ]
+						?.source_url;
+
+					if ( newUrl ) {
+						updateBlockAttributes( imageBlock.clientId, {
+							url: newUrl,
+						} );
+					}
+				} );
+			}
+		},
+		[ setAttributes, optionsBlock?.innerBlocks, updateBlockAttributes ]
+	);
+
 	return (
 		<div { ...blockProps }>
 			<div { ...innerBlocksProps } />
@@ -122,7 +189,7 @@ export default function ImageSelectFieldEdit( props ) {
 								key="is-supersized"
 								label={ __( 'Supersized', 'jetpack-forms' ) }
 								checked={ attributes?.isSupersized }
-								onChange={ ( value: boolean ) => setAttributes( { isSupersized: value } ) }
+								onChange={ ( value: boolean ) => updateSupersized( value ) }
 							/>
 						),
 					},

--- a/projects/packages/forms/src/blocks/field-image-select/editor.scss
+++ b/projects/packages/forms/src/blocks/field-image-select/editor.scss
@@ -13,6 +13,10 @@
 	flex-grow: 0;
 }
 
+.jetpack-contact-form .jetpack-input-image-option .components-placeholder.has-illustration {
+	overflow: hidden;
+}
+
 // There is no outer block in the editor, so we apply
 // the styles directly to the input image option.
 .jetpack-input-image-option {

--- a/projects/packages/forms/src/blocks/field-image-select/index.tsx
+++ b/projects/packages/forms/src/blocks/field-image-select/index.tsx
@@ -5,7 +5,6 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { getImageOptionLabel } from '../input-image-option/label';
 import defaultSettings from '../shared/settings';
 import edit from './edit';
 import icon from './icon';
@@ -72,9 +71,6 @@ const settings = {
 				innerBlocks: [
 					{
 						name: 'jetpack/input-image-option',
-						attributes: {
-							label: getImageOptionLabel( 1 ),
-						},
 						innerBlocks: [
 							{
 								name: 'core/image',
@@ -88,9 +84,6 @@ const settings = {
 					},
 					{
 						name: 'jetpack/input-image-option',
-						attributes: {
-							label: getImageOptionLabel( 2 ),
-						},
 						innerBlocks: [
 							{
 								name: 'core/image',

--- a/projects/packages/forms/src/blocks/fieldset-image-options/edit.tsx
+++ b/projects/packages/forms/src/blocks/fieldset-image-options/edit.tsx
@@ -9,7 +9,6 @@ import clsx from 'clsx';
 /**
  * Internal dependencies
  */
-import { getImageOptionLabel } from '../input-image-option/label';
 import useAddImageOption from '../shared/hooks/use-add-image-option';
 import useJetpackFieldStyles from '../shared/hooks/use-jetpack-field-styles';
 
@@ -26,9 +25,9 @@ export default function ImageOptionsFieldsetEdit( props ) {
 
 	// Starts with 3 empty options.
 	const template = [
-		[ 'jetpack/input-image-option', { label: getImageOptionLabel( 1 ) } ],
-		[ 'jetpack/input-image-option', { label: getImageOptionLabel( 2 ) } ],
-		[ 'jetpack/input-image-option', { label: getImageOptionLabel( 3 ) } ],
+		[ 'jetpack/input-image-option' ],
+		[ 'jetpack/input-image-option' ],
+		[ 'jetpack/input-image-option' ],
 	];
 
 	const defaultBlock = useMemo( () => newImageOption(), [ newImageOption ] );

--- a/projects/packages/forms/src/blocks/input-image-option/edit.tsx
+++ b/projects/packages/forms/src/blocks/input-image-option/edit.tsx
@@ -114,7 +114,7 @@ export default function ImageOptionInputEdit( props ) {
 					tagName="span"
 					className="jetpack-input-image-option__label"
 					value={ label }
-					placeholder={ __( 'Add option…', 'jetpack-forms' ) }
+					placeholder={ __( 'Add label', 'jetpack-forms' ) }
 					__unstableDisableFormats
 					onChange={ ( newLabel: string ) => setAttributes( { label: newLabel } ) }
 				/>

--- a/projects/packages/forms/src/blocks/input-image-option/edit.tsx
+++ b/projects/packages/forms/src/blocks/input-image-option/edit.tsx
@@ -8,12 +8,13 @@ import {
 	RichText,
 } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
-import { useMemo } from '@wordpress/element';
+import { useMemo, useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 /**
  * Internal dependencies
  */
+import useAddImageOption from '../shared/hooks/use-add-image-option';
 import useJetpackFieldStyles from '../shared/hooks/use-jetpack-field-styles';
 import { useSyncedAttributes } from '../shared/hooks/use-synced-attributes';
 import { getImageOptionLetter } from './label';
@@ -40,7 +41,7 @@ export default function ImageOptionInputEdit( props ) {
 
 	const { 'jetpack/field-image-select-is-supersized': isSupersized } = context || {};
 
-	const { positionLetter, rowOptionsCount } = useSelect(
+	const { positionIndex, positionLetter, rowOptionsCount, parentId } = useSelect(
 		select => {
 			const blockEditor = select( blockEditorStore ) as BlockEditorStoreSelect;
 			const { getBlock } = blockEditor;
@@ -49,8 +50,8 @@ export default function ImageOptionInputEdit( props ) {
 				clientId,
 				'jetpack/fieldset-image-options'
 			);
-			const parentId = parentClientIds[ parentClientIds.length - 1 ];
-			const parentBlock = getBlock( parentId );
+			const parentBlockId = parentClientIds[ parentClientIds.length - 1 ];
+			const parentBlock = getBlock( parentBlockId );
 
 			// Find position within parent's inner blocks
 			const position =
@@ -63,11 +64,41 @@ export default function ImageOptionInputEdit( props ) {
 			const rowSiblingCount = Math.min( totalOptionsCount, maxImagesPerRow );
 
 			return {
+				positionIndex: position,
 				positionLetter: getImageOptionLetter( position ),
 				rowOptionsCount: rowSiblingCount,
+				parentId: parentBlockId,
 			};
 		},
 		[ clientId, isSupersized ]
+	);
+
+	const { addOption } = useAddImageOption( parentId );
+
+	// Handle key events to prevent newlines and add new option on Enter
+	const handleKeyDown = useCallback(
+		( event: KeyboardEvent ) => {
+			if ( event.key === 'Enter' ) {
+				event.preventDefault();
+				addOption( positionIndex );
+			}
+		},
+		[ addOption, positionIndex ]
+	);
+
+	// Filter pasted content to remove newlines
+	const handlePaste = useCallback(
+		( event: ClipboardEvent ) => {
+			event.preventDefault();
+
+			const pastedText = event.clipboardData?.getData( 'text/plain' ) || '';
+			const cleanText = pastedText.replace( /[\r\n]+/g, ' ' ).trim();
+
+			if ( cleanText ) {
+				setAttributes( { label: cleanText } );
+			}
+		},
+		[ setAttributes ]
 	);
 
 	// Use the block's own synced attributes for styling
@@ -117,6 +148,8 @@ export default function ImageOptionInputEdit( props ) {
 					placeholder={ __( 'Add label', 'jetpack-forms' ) }
 					__unstableDisableFormats
 					onChange={ ( newLabel: string ) => setAttributes( { label: newLabel } ) }
+					onKeyDown={ handleKeyDown }
+					onPaste={ handlePaste }
 				/>
 			</div>
 		</div>

--- a/projects/packages/forms/src/blocks/input-image-option/edit.tsx
+++ b/projects/packages/forms/src/blocks/input-image-option/edit.tsx
@@ -90,10 +90,11 @@ export default function ImageOptionInputEdit( props ) {
 				{
 					scale: 'cover',
 					aspectRatio: '1', // Square aspect ratio for uniform grid
+					sizeSlug: isSupersized ? 'full' : 'medium',
 				},
 			],
 		];
-	}, [] );
+	}, [ isSupersized ] );
 
 	const innerBlocksProps = useInnerBlocksProps(
 		{ className: 'jetpack-input-image-option__wrapper' },

--- a/projects/packages/forms/src/blocks/input-image-option/index.tsx
+++ b/projects/packages/forms/src/blocks/input-image-option/index.tsx
@@ -90,6 +90,23 @@ const settings = {
 			type: 'string',
 			default: '',
 		},
+		style: {
+			type: 'object',
+			default: {
+				border: {
+					radius: '4px',
+					width: '1px',
+				},
+				spacing: {
+					padding: {
+						top: '8px',
+						right: '8px',
+						bottom: '8px',
+						left: '8px',
+					},
+				},
+			},
+		},
 	},
 	save,
 };

--- a/projects/packages/forms/src/blocks/input-image-option/label.tsx
+++ b/projects/packages/forms/src/blocks/input-image-option/label.tsx
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { __, sprintf } from '@wordpress/i18n';
-
-/**
  * Generates a letter-based label for image option fields.
  * Converts position to letters: 1=A, 2=B, ..., 26=Z, 27=AA, 28=AB, etc.
  *
@@ -22,18 +17,4 @@ export const getImageOptionLetter = ( position: number ): string => {
 	}
 
 	return result;
-};
-
-/**
- * Generates a translated label for image option fields.
- *
- * @param {number} index - The 1-based index of the image option.
- * @return {string} The translated label for the image option.
- */
-export const getImageOptionLabel = ( index: number ): string => {
-	return sprintf(
-		// translators: %d is the number of the choice, e.g. "Choice 1".
-		__( 'Choice %d', 'jetpack-forms' ),
-		index
-	);
 };

--- a/projects/packages/forms/src/blocks/shared/hooks/use-add-image-option.ts
+++ b/projects/packages/forms/src/blocks/shared/hooks/use-add-image-option.ts
@@ -21,7 +21,7 @@ export default function useAddImageOption( optionsClientId: string ): {
 		name: string;
 		attributes: Record< string, unknown >;
 	};
-	addOption: () => void;
+	addOption: ( index?: number ) => void;
 } {
 	const { insertBlock } = useDispatch( blockEditorStore ) as BlockEditorStoreDispatch;
 	const { getBlock } = useSelect( blockEditorStore, [] ) as BlockEditorStoreSelect;
@@ -35,20 +35,27 @@ export default function useAddImageOption( optionsClientId: string ): {
 		};
 	}, [] );
 
-	const addOption = useCallback( () => {
-		// Get the current options block
-		const optionsBlock = getBlock( optionsClientId );
+	const addOption = useCallback(
+		( index?: number ) => {
+			// Get the current options block
+			const optionsBlock = getBlock( optionsClientId );
 
-		// If there is no options block, return
-		if ( ! optionsBlock ) {
-			return;
-		}
+			// If there is no options block, return
+			if ( ! optionsBlock ) {
+				return;
+			}
 
-		const { name, attributes } = newImageOption();
-		const newOptionBlock = createBlock( name, attributes );
+			const { name, attributes } = newImageOption();
+			const newOptionBlock = createBlock( name, attributes );
 
-		insertBlock( newOptionBlock, optionsBlock.innerBlocks.length, optionsClientId );
-	}, [ getBlock, optionsClientId, newImageOption, insertBlock ] );
+			if ( ! Number.isInteger( index ) || index < 0 || index > optionsBlock.innerBlocks.length ) {
+				index = optionsBlock.innerBlocks.length;
+			}
+
+			insertBlock( newOptionBlock, index, optionsClientId );
+		},
+		[ getBlock, optionsClientId, newImageOption, insertBlock ]
+	);
 
 	return { newImageOption, addOption };
 }

--- a/projects/packages/forms/src/blocks/shared/hooks/use-add-image-option.ts
+++ b/projects/packages/forms/src/blocks/shared/hooks/use-add-image-option.ts
@@ -6,10 +6,6 @@ import { createBlock } from '@wordpress/blocks';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useCallback } from '@wordpress/element';
 /**
- * Internal dependencies
- */
-import { getImageOptionLabel } from '../../input-image-option/label';
-/**
  * Types
  */
 import type { BlockEditorStoreDispatch, BlockEditorStoreSelect } from '../../../types';
@@ -28,20 +24,16 @@ export default function useAddImageOption( optionsClientId: string ): {
 	addOption: () => void;
 } {
 	const { insertBlock } = useDispatch( blockEditorStore ) as BlockEditorStoreDispatch;
-	const { getBlock, getBlocks } = useSelect( blockEditorStore, [] ) as BlockEditorStoreSelect;
-
-	const childBlocksCount = getBlocks( optionsClientId ).length;
+	const { getBlock } = useSelect( blockEditorStore, [] ) as BlockEditorStoreSelect;
 
 	const newImageOption = useCallback( () => {
-		const newIndex = childBlocksCount + 1;
-
 		return {
 			name: 'jetpack/input-image-option',
 			attributes: {
-				label: getImageOptionLabel( newIndex ),
+				label: '',
 			},
 		};
-	}, [ childBlocksCount ] );
+	}, [] );
 
 	const addOption = useCallback( () => {
 		// Get the current options block


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of FORMS-60

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Addresses part of the feedback from peKye1-1Lg-p2.
- Fixes the inner image scroll issue
- Sets the image resolution to "medium" by default and auto-adjusts it to "full" if "supersize" is turned on
- Sets the default styling explicitly so it is more easily visible in the editor
- Adds helper text to the settings to help with options that are not reflected visually in the editor
- Removes the default numbered labels (Choice 1, Choice 2...) as they do not add any value and end up adding confusion to the "randomize" option
- Prevents newlines on labels
- Adds options when pressing enter on a label

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Check the proposed changes and test them one by one:
* Add an image select field and scroll over the image placeholders without selecting them. Check that there is no inner scrolling going on anymore
* Add an image and click on it to see the image block's settings. Check that its resolution is set to "medium". Enable the "supersize" option and check that the image resolution changes to "full" and that the image is reloaded as expected. Try changing it back as well
* Check that the 8px padding and the 1px-wide border with 4px radius are set in the option styles
* Check that there are no default labels anymore
* Check that pressing "enter" on an option label creates another option
* Check that newlines on text are filtered out when pasting on an option label
* Check the helper text, see if you agree or would suggest any changes:
<img width="295" height="681" alt="Screenshot from 2025-10-15 20-08-21" src="https://github.com/user-attachments/assets/66ec0a75-4a82-4b78-93b8-99886a603724" />
