### PR TITLE
Forms: add first/last name field variations

### DIFF
--- a/projects/packages/forms/changelog/add-forms-name-variations
+++ b/projects/packages/forms/changelog/add-forms-name-variations
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: add first and last name variations.

--- a/projects/packages/forms/src/blocks/field-name/edit.js
+++ b/projects/packages/forms/src/blocks/field-name/edit.js
@@ -1,9 +1,12 @@
 import { __ } from '@wordpress/i18n';
 import JetpackField from '../shared/components/jetpack-field';
 import useFormWrapper from '../shared/hooks/use-form-wrapper';
+import useNameLabelSync from './hooks/use-name-label-sync';
 
 export default function NameFieldEdit( props ) {
 	useFormWrapper( props );
+
+	useNameLabelSync( { clientId: props.clientId, id: props.attributes?.id } );
 
 	return (
 		<JetpackField

--- a/projects/packages/forms/src/blocks/field-name/hooks/use-name-label-sync.js
+++ b/projects/packages/forms/src/blocks/field-name/hooks/use-name-label-sync.js
@@ -1,0 +1,81 @@
+import { store as blockEditorStore } from '@wordpress/block-editor';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { useEffect, useRef } from '@wordpress/element';
+import {
+	FIRST_NAME_ID,
+	LAST_NAME_ID,
+	DEFAULT_FIRST_NAME_LABEL,
+	DEFAULT_LAST_NAME_LABEL,
+	DEFAULT_NAME_LABEL,
+} from '../variations';
+
+const isKnownId = id => id === FIRST_NAME_ID || id === LAST_NAME_ID;
+
+const getDefaultLabelForId = id => {
+	if ( id === FIRST_NAME_ID ) return DEFAULT_FIRST_NAME_LABEL;
+	if ( id === LAST_NAME_ID ) return DEFAULT_LAST_NAME_LABEL;
+	return DEFAULT_NAME_LABEL;
+};
+
+/**
+ * Sync the nested label text with the Name field's variation id when users transform
+ * between known variations (first-name/last-name).
+ *
+ * @param {object} params          - Parameters.
+ * @param {string} params.clientId - Block clientId for the Name field
+ * @param {string} params.id       - Current variation id (e.g., 'first-name' | 'last-name')
+ */
+export default function useNameLabelSync( { clientId, id } ) {
+	const prevIdRef = useRef( id );
+	const { updateBlockAttributes } = useDispatch( blockEditorStore );
+
+	const labelClientId = useSelect(
+		select => {
+			const block = select( blockEditorStore ).getBlock( clientId );
+			const labelBlock = block?.innerBlocks?.find( b => b.name === 'jetpack/label' );
+			return labelBlock?.clientId;
+		},
+		[ clientId ]
+	);
+
+	const currentLabel = useSelect(
+		select => {
+			return labelClientId
+				? select( blockEditorStore ).getBlockAttributes( labelClientId )?.label
+				: undefined;
+		},
+		[ labelClientId ]
+	);
+
+	useEffect( () => {
+		const newId = id;
+		const prevId = prevIdRef.current;
+
+		if ( ! labelClientId ) {
+			prevIdRef.current = newId;
+			return;
+		}
+
+		// Handle transforms between known variations.
+		if ( isKnownId( newId ) && newId !== prevId ) {
+			const nextDefault = getDefaultLabelForId( newId );
+			// Ensure the parent block id matches the variation id.
+			if ( newId ) {
+				updateBlockAttributes( clientId, { id: newId } );
+			}
+			// Always set the label to the default for the selected variation.
+			updateBlockAttributes( labelClientId, { label: nextDefault } );
+		}
+
+		// Handle transforms from a known variation back to the base Name (no id).
+		const becameBase = isKnownId( prevId ) && ( newId === undefined || newId === '' );
+		if ( becameBase ) {
+			// Clear the parent block id when returning to base.
+			updateBlockAttributes( clientId, { id: '' } );
+			// Always set the label back to the base default.
+			updateBlockAttributes( labelClientId, { label: DEFAULT_NAME_LABEL } );
+		}
+
+		prevIdRef.current = newId;
+	}, [ id, clientId, labelClientId, currentLabel, updateBlockAttributes ] );
+}

--- a/projects/packages/forms/src/blocks/field-name/index.js
+++ b/projects/packages/forms/src/blocks/field-name/index.js
@@ -2,6 +2,7 @@ import { Path } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import renderMaterialIcon from '../shared/components/render-material-icon';
 import defaultSettings from '../shared/settings';
+import transformsSource from '../shared/settings/transforms';
 import { getIconColor } from '../shared/util/block-icons';
 import deprecated from './deprecated';
 import edit from './edit';
@@ -9,6 +10,22 @@ import save from './save';
 import variations from './variations';
 
 const name = 'field-name';
+
+// We define variations for Name, First name, and Last name.
+// For this block only, override transforms to remove the generic self-transform
+// to `jetpack/field-name`, so the Transform menu doesn’t show duplicate “Name”.
+// Other blocks still use the shared transforms (and can transform to Name/its variations).
+function notSelfNameTransform( transform ) {
+	return ! (
+		Array.isArray( transform.blocks ) && transform.blocks.includes( 'jetpack/field-name' )
+	);
+}
+
+const transforms = {
+	...transformsSource,
+	to: transformsSource.to.filter( notSelfNameTransform ),
+};
+
 const settings = {
 	...defaultSettings,
 	title: __( 'Name field', 'jetpack-forms' ),
@@ -19,6 +36,7 @@ const settings = {
 			<Path d="M8.25 11.5C9.63071 11.5 10.75 10.3807 10.75 9C10.75 7.61929 9.63071 6.5 8.25 6.5C6.86929 6.5 5.75 7.61929 5.75 9C5.75 10.3807 6.86929 11.5 8.25 11.5ZM8.25 10C8.80228 10 9.25 9.55228 9.25 9C9.25 8.44772 8.80228 8 8.25 8C7.69772 8 7.25 8.44772 7.25 9C7.25 9.55228 7.69772 10 8.25 10ZM13 15.5V17.5H11.5V15.5C11.5 14.8096 10.9404 14.25 10.25 14.25H6.25C5.55964 14.25 5 14.8096 5 15.5V17.5H3.5V15.5C3.5 13.9812 4.73122 12.75 6.25 12.75H10.25C11.7688 12.75 13 13.9812 13 15.5ZM20.5 11H14.5V9.5H20.5V11ZM20.5 14.5H14.5V13H20.5V14.5Z" />
 		),
 	},
+	transforms,
 	variations,
 	edit,
 	deprecated,

--- a/projects/packages/forms/src/blocks/field-name/index.js
+++ b/projects/packages/forms/src/blocks/field-name/index.js
@@ -6,6 +6,7 @@ import { getIconColor } from '../shared/util/block-icons';
 import deprecated from './deprecated';
 import edit from './edit';
 import save from './save';
+import variations from './variations';
 
 const name = 'field-name';
 const settings = {
@@ -18,6 +19,7 @@ const settings = {
 			<Path d="M8.25 11.5C9.63071 11.5 10.75 10.3807 10.75 9C10.75 7.61929 9.63071 6.5 8.25 6.5C6.86929 6.5 5.75 7.61929 5.75 9C5.75 10.3807 6.86929 11.5 8.25 11.5ZM8.25 10C8.80228 10 9.25 9.55228 9.25 9C9.25 8.44772 8.80228 8 8.25 8C7.69772 8 7.25 8.44772 7.25 9C7.25 9.55228 7.69772 10 8.25 10ZM13 15.5V17.5H11.5V15.5C11.5 14.8096 10.9404 14.25 10.25 14.25H6.25C5.55964 14.25 5 14.8096 5 15.5V17.5H3.5V15.5C3.5 13.9812 4.73122 12.75 6.25 12.75H10.25C11.7688 12.75 13 13.9812 13 15.5ZM20.5 11H14.5V9.5H20.5V11ZM20.5 14.5H14.5V13H20.5V14.5Z" />
 		),
 	},
+	variations,
 	edit,
 	deprecated,
 	save,

--- a/projects/packages/forms/src/blocks/field-name/variations.js
+++ b/projects/packages/forms/src/blocks/field-name/variations.js
@@ -10,34 +10,55 @@ const icon = {
 	),
 };
 
+export const FIRST_NAME_ID = 'first-name';
+export const LAST_NAME_ID = 'last-name';
+
+export const DEFAULT_FIRST_NAME_LABEL = __( 'First name', 'jetpack-forms' );
+export const DEFAULT_LAST_NAME_LABEL = __( 'Last name', 'jetpack-forms' );
+export const DEFAULT_NAME_LABEL = __( 'Name', 'jetpack-forms' );
+
 const variations = [
 	{
-		name: 'first-name',
-		title: __( 'First name', 'jetpack-forms' ),
+		name: 'name',
+		title: DEFAULT_NAME_LABEL,
+		description: __( 'Collect the visitor’s name.', 'jetpack-forms' ),
+		icon,
+		scope: [ 'transform' ],
+		attributes: {
+			id: '',
+		},
+		innerBlocks: [
+			[ 'jetpack/label', { label: DEFAULT_NAME_LABEL } ],
+			[ 'jetpack/input', { type: 'text' } ],
+		],
+	},
+	{
+		name: FIRST_NAME_ID,
+		title: DEFAULT_FIRST_NAME_LABEL,
 		description: __( 'Collect the visitor’s first name.', 'jetpack-forms' ),
 		icon,
 		scope: [ 'inserter', 'transform' ],
 		isActive: [ 'id' ],
 		attributes: {
-			id: 'first-name',
+			id: FIRST_NAME_ID,
 		},
 		innerBlocks: [
-			[ 'jetpack/label', { label: __( 'First name', 'jetpack-forms' ) } ],
+			[ 'jetpack/label', { label: DEFAULT_FIRST_NAME_LABEL } ],
 			[ 'jetpack/input', { type: 'text' } ],
 		],
 	},
 	{
-		name: 'last-name',
-		title: __( 'Last name', 'jetpack-forms' ),
+		name: LAST_NAME_ID,
+		title: DEFAULT_LAST_NAME_LABEL,
 		description: __( 'Collect the visitor’s last name.', 'jetpack-forms' ),
 		icon,
 		scope: [ 'inserter', 'transform' ],
 		isActive: [ 'id' ],
 		attributes: {
-			id: 'last-name',
+			id: LAST_NAME_ID,
 		},
 		innerBlocks: [
-			[ 'jetpack/label', { label: __( 'Last name', 'jetpack-forms' ) } ],
+			[ 'jetpack/label', { label: DEFAULT_LAST_NAME_LABEL } ],
 			[ 'jetpack/input', { type: 'text' } ],
 		],
 	},

--- a/projects/packages/forms/src/blocks/field-name/variations.js
+++ b/projects/packages/forms/src/blocks/field-name/variations.js
@@ -1,0 +1,46 @@
+import { Path } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import renderMaterialIcon from '../shared/components/render-material-icon';
+import { getIconColor } from '../shared/util/block-icons';
+
+const icon = {
+	foreground: getIconColor(),
+	src: renderMaterialIcon(
+		<Path d="M8.25 11.5C9.63071 11.5 10.75 10.3807 10.75 9C10.75 7.61929 9.63071 6.5 8.25 6.5C6.86929 6.5 5.75 7.61929 5.75 9C5.75 10.3807 6.86929 11.5 8.25 11.5ZM8.25 10C8.80228 10 9.25 9.55228 9.25 9C9.25 8.44772 8.80228 8 8.25 8C7.69772 8 7.25 8.44772 7.25 9C7.25 9.55228 7.69772 10 8.25 10ZM13 15.5V17.5H11.5V15.5C11.5 14.8096 10.9404 14.25 10.25 14.25H6.25C5.55964 14.25 5 14.8096 5 15.5V17.5H3.5V15.5C3.5 13.9812 4.73122 12.75 6.25 12.75H10.25C11.7688 12.75 13 13.9812 13 15.5ZM20.5 11H14.5V9.5H20.5V11ZM20.5 14.5H14.5V13H20.5V14.5Z" />
+	),
+};
+
+const variations = [
+	{
+		name: 'first-name',
+		title: __( 'First name', 'jetpack-forms' ),
+		description: __( 'Collect the visitor’s first name.', 'jetpack-forms' ),
+		icon,
+		scope: [ 'inserter', 'transform' ],
+		isActive: [ 'id' ],
+		attributes: {
+			id: 'first-name',
+		},
+		innerBlocks: [
+			[ 'jetpack/label', { label: __( 'First name', 'jetpack-forms' ) } ],
+			[ 'jetpack/input', { type: 'text' } ],
+		],
+	},
+	{
+		name: 'last-name',
+		title: __( 'Last name', 'jetpack-forms' ),
+		description: __( 'Collect the visitor’s last name.', 'jetpack-forms' ),
+		icon,
+		scope: [ 'inserter', 'transform' ],
+		isActive: [ 'id' ],
+		attributes: {
+			id: 'last-name',
+		},
+		innerBlocks: [
+			[ 'jetpack/label', { label: __( 'Last name', 'jetpack-forms' ) } ],
+			[ 'jetpack/input', { type: 'text' } ],
+		],
+	},
+];
+
+export default variations;

--- a/projects/plugins/jetpack/changelog/add-forms-name-variations
+++ b/projects/plugins/jetpack/changelog/add-forms-name-variations
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: add first and last name variations.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes [FORMS-293](https://linear.app/a8c/issue/FORMS-293/forms-add-firstlast-name-field-variations)

## Proposed changes:

**Add first and last name variations** to the name field **with the field HTML ID attribute to set to first-name and last-name**.

First/name fiels are generally useful - many forms have first/last name - but this also helps with integrations. Many integrations (MailPoet, Hostinger, plus MailChimp in the future) depend on having identifiable first and last name. Right now we look for "First Name" and "Last Name" labels, which are very English-centric, or users must manually add first-name or last-name ids. 

A user can insert these, and they **will automatically sync to MailPoet and Hostinger first/last fields**. 

<img width="727" height="400" alt="name-variations" src="https://github.com/user-attachments/assets/f03710c7-a280-482a-b8cd-8f1067f2a0b0" />

<img width="1246" height="442" alt="first-name" src="https://github.com/user-attachments/assets/0ab9758a-5468-4518-9f10-dc075209d6da" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
See linear issue above. 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No. 

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add a form block to a page or post
* Try adding a first and last name field
* Confirm each of those fields has the first-name or last-name id
* Submit form and confirm fields are submitted correctly

