### PR TITLE
Tooling: Allow `workflow_dispatch` on more mirror repo actions

### DIFF
--- a/.github/files/gh-autotagger/workflows/autotagger.yml
+++ b/.github/files/gh-autotagger/workflows/autotagger.yml
@@ -6,6 +6,7 @@ on:
       - trunk
       - prerelease
       - '*/branch-*'
+  workflow_dispatch:
 
 jobs:
   tag:

--- a/.github/files/gh-npmjs-autopublisher/workflows/npmjs-autopublisher.yml
+++ b/.github/files/gh-npmjs-autopublisher/workflows/npmjs-autopublisher.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - 'v*.*.*'
+  workflow_dispatch:
 
 jobs:
   publish:


### PR DESCRIPTION
Closes MONOREP-152

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Previously we enabled `workflow_dispatch` for `autorelease.yml`. This PR expands it to `autotagger.yml` and `npmjs-autopublisher.yml`.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

After this is merged, the respective mirror repos should have the option to run these actions manually.
