### PR TITLE
Forms: remove unused hasAI from config

### DIFF
--- a/projects/packages/forms/changelog/forms-remove-unused-hasai
+++ b/projects/packages/forms/changelog/forms-remove-unused-hasai
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: remove unusaed hasAI from config.

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -16,7 +16,6 @@ use Automattic\Jetpack\Forms\Service\MailPoet_Integration;
 use Automattic\Jetpack\Redirect;
 use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Status\Host;
-use Jetpack_AI_Helper;
 use WP_Error;
 use WP_REST_Request;
 use WP_REST_Response;
@@ -1269,12 +1268,6 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 	 * @return WP_REST_Response
 	 */
 	public function get_forms_config( WP_REST_Request $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-		$has_ai = false;
-		if ( class_exists( 'Jetpack_AI_Helper' ) ) {
-			$feature = Jetpack_AI_Helper::get_ai_assistance_feature();
-			$has_ai  = ! is_wp_error( $feature ) ? ( $feature['has-feature'] ?? false ) : false;
-		}
-
 		$config = array(
 			// From jpFormsBlocks in class-contact-form-block.php.
 			'formsResponsesUrl'       => Forms_Dashboard::get_forms_admin_url(),
@@ -1286,7 +1279,6 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 			'pluginAssetsURL'         => Jetpack_Forms::assets_url(),
 			'siteURL'                 => ( new Status() )->get_site_suffix(),
 			'hasFeedback'             => ( new Forms_Dashboard() )->has_feedback(),
-			'hasAI'                   => $has_ai,
 			'isIntegrationsEnabled'   => Jetpack_Forms::is_integrations_enabled(),
 			'dashboardURL'            => Forms_Dashboard::get_forms_admin_url(),
 			// New data.

--- a/projects/packages/forms/src/hooks/use-config-value.ts
+++ b/projects/packages/forms/src/hooks/use-config-value.ts
@@ -13,7 +13,6 @@ import type { FormsConfigData } from '../types';
  *
  * @example
  * const isMailPoetEnabled = useConfigValue( 'isMailPoetEnabled' );
- * const hasAI = useConfigValue( 'hasAI' );
  */
 export default function useConfigValue< K extends keyof FormsConfigData >(
 	key: K

--- a/projects/packages/forms/src/store/config/README.md
+++ b/projects/packages/forms/src/store/config/README.md
@@ -15,7 +15,6 @@ import useConfigValue from '../hooks/use-config-value';
 
 function MyComponent() {
   const isMailPoetEnabled = useConfigValue('isMailPoetEnabled');
-  const hasAI = useConfigValue('hasAI');
   const blogId = useConfigValue('blogId');
 
   if (isMailPoetEnabled === undefined) {
@@ -35,7 +34,6 @@ The store provides access to the following configuration values (see `FormsConfi
 - `canInstallPlugins` - Whether the current user can install plugins
 - `canActivatePlugins` - Whether the current user can activate plugins
 - `hasFeedback` - Whether there are any form responses on the site
-- `hasAI` - Whether AI Assist features are available
 - `formsResponsesUrl` - URL of the Forms responses list in wp-admin
 - `blogId` - Current site blog ID
 - `gdriveConnectSupportURL` - Support URL for Google Drive connect guidance
@@ -54,9 +52,9 @@ The store provides access to the following configuration values (see `FormsConfi
 import useConfigValue from '../hooks/use-config-value';
 
 function ExampleComponent() {
-  const hasAI = useConfigValue('hasAI');
+  const hasFeedback = useConfigValue('hasFeedback');
 
-  return hasAI ? <AIFeature /> : <RegularFeature />;
+  return hasFeedback ? <ResponsesPanel /> : <EmptyState />;
 }
 ```
 
@@ -96,8 +94,8 @@ function AdvancedComponent() {
   );
 
   // Get a specific value
-  const hasAI = useSelect(
-    select => select(CONFIG_STORE).getConfigValue('hasAI'),
+  const canInstall = useSelect(
+    select => select(CONFIG_STORE).getConfigValue('canInstallPlugins'),
     []
   );
 
@@ -209,12 +207,12 @@ The config store has one resolver: `getConfig`
 
 **How `useConfigValue` works:**
 
-When you call `useConfigValue('hasAI')`:
+When you call `useConfigValue('blogId')`:
 1. The hook internally calls `getConfig()` selector to fetch the entire config object
 2. WordPress automatically triggers the `getConfig` resolver if config isn't loaded
 3. The resolver checks if config is already loaded or currently loading via `isFulfilled`
 4. If not loaded, it fetches from `/wp/v2/feedback/config`
-5. Once loaded, it returns the value for the specific key (`config.hasAI`)
+5. Once loaded, it returns the value for the specific key (`config.blogId`)
 6. Subsequent calls to `useConfigValue()` with any key use the cached config
 
 **Request Deduplication:**
@@ -222,7 +220,7 @@ When you call `useConfigValue('hasAI')`:
 Multiple components calling different config values simultaneously:
 ```typescript
 // Component A
-const hasAI = useConfigValue('hasAI');
+const siteURL = useConfigValue('siteURL');
 
 // Component B
 const blogId = useConfigValue('blogId');
@@ -284,7 +282,6 @@ First, add your new config value to the REST API endpoint response. In the Forms
 public function get_config() {
     return array(
         'isMailPoetEnabled' => $this->is_mailpoet_enabled(),
-        'hasAI' => $this->has_ai(),
         // Add your new key here
         'myNewFeature' => $this->check_my_new_feature(),
     );
@@ -300,8 +297,7 @@ export interface FormsConfigData {
     /** Whether MailPoet integration is enabled across contexts. */
     isMailPoetEnabled?: boolean;
 
-    /** Whether AI Assist features are available for the site/user. */
-    hasAI?: boolean;
+    // Add your new key here with appropriate doc
 
     /** Whether my new feature is enabled. */
     myNewFeature?: boolean; // Add your new key with proper JSDoc

--- a/projects/packages/forms/src/types/index.ts
+++ b/projects/packages/forms/src/types/index.ts
@@ -224,8 +224,6 @@ export interface FormsConfigData {
 	canActivatePlugins?: boolean;
 	/** Whether there are any feedback (form response) posts on the site. */
 	hasFeedback?: boolean;
-	/** Whether AI Assist features are available for the site/user. */
-	hasAI?: boolean;
 	/** The URL of the Forms responses list in wp-admin. */
 	formsResponsesUrl?: string;
 	/** Current site blog ID. */

--- a/projects/packages/forms/tests/js/hooks/use-config-value.test.js
+++ b/projects/packages/forms/tests/js/hooks/use-config-value.test.js
@@ -15,7 +15,6 @@ const mockConfigData = {
 	canInstallPlugins: false,
 	canActivatePlugins: true,
 	hasFeedback: true,
-	hasAI: false,
 	formsResponsesUrl: 'https://example.com/wp-admin/edit.php?post_type=feedback',
 	blogId: 12345,
 	gdriveConnectSupportURL: 'https://example.com/support',

--- a/projects/packages/forms/tests/js/hooks/use-config-value.test.js
+++ b/projects/packages/forms/tests/js/hooks/use-config-value.test.js
@@ -43,7 +43,7 @@ describe( 'useConfigValue', () => {
 	} );
 
 	it( 'returns undefined when config is not loaded', () => {
-		const { result } = renderHook( () => useConfigValue( 'hasAI' ), { wrapper } );
+		const { result } = renderHook( () => useConfigValue( 'isIntegrationsEnabled' ), { wrapper } );
 
 		expect( result.current ).toBeUndefined();
 	} );
@@ -52,9 +52,9 @@ describe( 'useConfigValue', () => {
 		// Populate the store with config data
 		registry.dispatch( CONFIG_STORE ).receiveConfig( mockConfigData );
 
-		const { result } = renderHook( () => useConfigValue( 'hasAI' ), { wrapper } );
+		const { result } = renderHook( () => useConfigValue( 'isIntegrationsEnabled' ), { wrapper } );
 
-		expect( result.current ).toBe( false );
+		expect( result.current ).toBe( true );
 	} );
 
 	it( 'returns boolean values correctly', () => {
@@ -63,14 +63,12 @@ describe( 'useConfigValue', () => {
 		const { result: mailpoetResult } = renderHook( () => useConfigValue( 'isMailPoetEnabled' ), {
 			wrapper,
 		} );
-		const { result: aiResult } = renderHook( () => useConfigValue( 'hasAI' ), { wrapper } );
 		const { result: integrationsResult } = renderHook(
 			() => useConfigValue( 'isIntegrationsEnabled' ),
 			{ wrapper }
 		);
 
 		expect( mailpoetResult.current ).toBe( true );
-		expect( aiResult.current ).toBe( false );
 		expect( integrationsResult.current ).toBe( true );
 	} );
 
@@ -101,21 +99,23 @@ describe( 'useConfigValue', () => {
 	it( 'returns undefined for non-existent keys', () => {
 		registry.dispatch( CONFIG_STORE ).receiveConfig( { isMailPoetEnabled: true } );
 
-		const { result } = renderHook( () => useConfigValue( 'hasAI' ), { wrapper } );
+		const { result } = renderHook( () => useConfigValue( 'isIntegrationsEnabled' ), { wrapper } );
 
 		expect( result.current ).toBeUndefined();
 	} );
 
 	it( 'updates when config value changes', () => {
-		registry.dispatch( CONFIG_STORE ).receiveConfig( { hasAI: false } );
+		registry.dispatch( CONFIG_STORE ).receiveConfig( { isIntegrationsEnabled: false } );
 
-		const { result, rerender } = renderHook( () => useConfigValue( 'hasAI' ), { wrapper } );
+		const { result, rerender } = renderHook( () => useConfigValue( 'isIntegrationsEnabled' ), {
+			wrapper,
+		} );
 
 		expect( result.current ).toBe( false );
 
 		// Update the config
 		act( () => {
-			registry.dispatch( CONFIG_STORE ).receiveConfigValue( 'hasAI', true );
+			registry.dispatch( CONFIG_STORE ).receiveConfigValue( 'isIntegrationsEnabled', true );
 		} );
 		rerender();
 
@@ -125,13 +125,16 @@ describe( 'useConfigValue', () => {
 	it( 'multiple hooks can read different config values', () => {
 		registry.dispatch( CONFIG_STORE ).receiveConfig( mockConfigData );
 
-		const { result: hasAI } = renderHook( () => useConfigValue( 'hasAI' ), { wrapper } );
+		const { result: isIntegrations } = renderHook(
+			() => useConfigValue( 'isIntegrationsEnabled' ),
+			{ wrapper }
+		);
 		const { result: blogId } = renderHook( () => useConfigValue( 'blogId' ), { wrapper } );
 		const { result: isMailPoet } = renderHook( () => useConfigValue( 'isMailPoetEnabled' ), {
 			wrapper,
 		} );
 
-		expect( hasAI.current ).toBe( false );
+		expect( isIntegrations.current ).toBe( true );
 		expect( blogId.current ).toBe( 12345 );
 		expect( isMailPoet.current ).toBe( true );
 	} );
@@ -139,9 +142,11 @@ describe( 'useConfigValue', () => {
 	it( 'returns undefined when config is invalidated', () => {
 		registry.dispatch( CONFIG_STORE ).receiveConfig( mockConfigData );
 
-		const { result, rerender } = renderHook( () => useConfigValue( 'hasAI' ), { wrapper } );
+		const { result, rerender } = renderHook( () => useConfigValue( 'isIntegrationsEnabled' ), {
+			wrapper,
+		} );
 
-		expect( result.current ).toBe( false );
+		expect( result.current ).toBe( true );
 
 		// Invalidate the config
 		act( () => {
@@ -156,30 +161,35 @@ describe( 'useConfigValue', () => {
 		// Only set a few config values
 		registry.dispatch( CONFIG_STORE ).receiveConfig( {
 			isMailPoetEnabled: true,
-			hasAI: false,
+			isIntegrationsEnabled: false,
 		} );
 
 		const { result: mailpoetResult } = renderHook( () => useConfigValue( 'isMailPoetEnabled' ), {
 			wrapper,
 		} );
-		const { result: aiResult } = renderHook( () => useConfigValue( 'hasAI' ), { wrapper } );
+		const { result: integrationsResult } = renderHook(
+			() => useConfigValue( 'isIntegrationsEnabled' ),
+			{ wrapper }
+		);
 		const { result: blogIdResult } = renderHook( () => useConfigValue( 'blogId' ), { wrapper } );
 
 		expect( mailpoetResult.current ).toBe( true );
-		expect( aiResult.current ).toBe( false );
+		expect( integrationsResult.current ).toBe( false );
 		expect( blogIdResult.current ).toBeUndefined();
 	} );
 
 	it( 'works with different config keys in the same component', () => {
 		registry.dispatch( CONFIG_STORE ).receiveConfig( mockConfigData );
 
-		const { result: result1 } = renderHook( () => useConfigValue( 'hasAI' ), { wrapper } );
+		const { result: result1 } = renderHook( () => useConfigValue( 'isIntegrationsEnabled' ), {
+			wrapper,
+		} );
 		const { result: result2 } = renderHook( () => useConfigValue( 'blogId' ), { wrapper } );
 		const { result: result3 } = renderHook( () => useConfigValue( 'canInstallPlugins' ), {
 			wrapper,
 		} );
 
-		expect( result1.current ).toBe( false );
+		expect( result1.current ).toBe( true );
 		expect( result2.current ).toBe( 12345 );
 		expect( result3.current ).toBe( false );
 	} );
@@ -187,7 +197,7 @@ describe( 'useConfigValue', () => {
 	it( 'handles empty config object', () => {
 		registry.dispatch( CONFIG_STORE ).receiveConfig( {} );
 
-		const { result } = renderHook( () => useConfigValue( 'hasAI' ), { wrapper } );
+		const { result } = renderHook( () => useConfigValue( 'isIntegrationsEnabled' ), { wrapper } );
 
 		expect( result.current ).toBeUndefined();
 	} );

--- a/projects/packages/forms/tests/js/store/config.test.js
+++ b/projects/packages/forms/tests/js/store/config.test.js
@@ -23,7 +23,6 @@ const mockConfigData = {
 	canInstallPlugins: true,
 	canActivatePlugins: true,
 	hasFeedback: true,
-	hasAI: false,
 	formsResponsesUrl: 'https://example.com/wp-admin/edit.php?post_type=feedback',
 	blogId: 12345,
 	gdriveConnectSupportURL: 'https://example.com/support',
@@ -38,7 +37,7 @@ const mockConfigData = {
 describe( 'Config Store', () => {
 	describe( 'actions', () => {
 		it( 'receiveConfig', () => {
-			const config = { isMailPoetEnabled: true, hasAI: false };
+			const config = { isMailPoetEnabled: true, isIntegrationsEnabled: true };
 			const action = actions.receiveConfig( config );
 
 			expect( action ).toEqual( {
@@ -48,11 +47,11 @@ describe( 'Config Store', () => {
 		} );
 
 		it( 'receiveConfigValue', () => {
-			const action = actions.receiveConfigValue( 'hasAI', true );
+			const action = actions.receiveConfigValue( 'isIntegrationsEnabled', true );
 
 			expect( action ).toEqual( {
 				type: 'RECEIVE_CONFIG_VALUE',
-				key: 'hasAI',
+				key: 'isIntegrationsEnabled',
 				value: true,
 			} );
 		} );
@@ -98,7 +97,7 @@ describe( 'Config Store', () => {
 		} );
 
 		it( 'should handle RECEIVE_CONFIG', () => {
-			const config = { isMailPoetEnabled: true, hasAI: false };
+			const config = { isMailPoetEnabled: true, isIntegrationsEnabled: true };
 			const state = reducer( DEFAULT_STATE, {
 				type: 'RECEIVE_CONFIG',
 				config,
@@ -120,13 +119,13 @@ describe( 'Config Store', () => {
 
 			const state = reducer( initialState, {
 				type: 'RECEIVE_CONFIG_VALUE',
-				key: 'hasAI',
+				key: 'isIntegrationsEnabled',
 				value: true,
 			} );
 
 			expect( state.config ).toEqual( {
 				isMailPoetEnabled: true,
-				hasAI: true,
+				isIntegrationsEnabled: true,
 			} );
 		} );
 
@@ -219,7 +218,7 @@ describe( 'Config Store', () => {
 				error: null,
 			};
 
-			expect( selectors.getConfigValue( state, 'hasAI' ) ).toBe( false );
+			expect( selectors.getConfigValue( state, 'isIntegrationsEnabled' ) ).toBe( true );
 			expect( selectors.getConfigValue( state, 'blogId' ) ).toBe( 12345 );
 			expect( selectors.getConfigValue( state, 'isMailPoetEnabled' ) ).toBe( true );
 		} );
@@ -231,7 +230,7 @@ describe( 'Config Store', () => {
 				error: null,
 			};
 
-			expect( selectors.getConfigValue( state, 'hasAI' ) ).toBeUndefined();
+			expect( selectors.getConfigValue( state, 'isIntegrationsEnabled' ) ).toBeUndefined();
 		} );
 
 		it( 'getConfigValue returns undefined when config is null', () => {
@@ -241,7 +240,7 @@ describe( 'Config Store', () => {
 				error: null,
 			};
 
-			expect( selectors.getConfigValue( state, 'hasAI' ) ).toBeUndefined();
+			expect( selectors.getConfigValue( state, 'isIntegrationsEnabled' ) ).toBeUndefined();
 		} );
 
 		it( 'isConfigLoading returns loading state', () => {
@@ -320,27 +319,27 @@ describe( 'Config Store', () => {
 		} );
 
 		it( 'should allow manual config update', () => {
-			const config = { isMailPoetEnabled: true, hasAI: false };
+			const config = { isMailPoetEnabled: true, isIntegrationsEnabled: true };
 			registry.dispatch( CONFIG_STORE ).receiveConfig( config );
 
 			expect( registry.select( CONFIG_STORE ).getConfig() ).toEqual( config );
 		} );
 
 		it( 'should allow updating individual config values', () => {
-			const initialConfig = { isMailPoetEnabled: true, hasAI: false };
+			const initialConfig = { isMailPoetEnabled: true, isIntegrationsEnabled: false };
 			registry.dispatch( CONFIG_STORE ).receiveConfig( initialConfig );
 
-			registry.dispatch( CONFIG_STORE ).receiveConfigValue( 'hasAI', true );
+			registry.dispatch( CONFIG_STORE ).receiveConfigValue( 'isIntegrationsEnabled', true );
 
 			const config = registry.select( CONFIG_STORE ).getConfig();
 			expect( config ).toEqual( {
 				isMailPoetEnabled: true,
-				hasAI: true,
+				isIntegrationsEnabled: true,
 			} );
 		} );
 
 		it( 'should invalidate config', () => {
-			const config = { isMailPoetEnabled: true, hasAI: false };
+			const config = { isMailPoetEnabled: true, isIntegrationsEnabled: true };
 			registry.dispatch( CONFIG_STORE ).receiveConfig( config );
 
 			expect( registry.select( CONFIG_STORE ).getConfig() ).toEqual( config );
@@ -375,14 +374,18 @@ describe( 'Config Store', () => {
 			registry.dispatch( CONFIG_STORE ).receiveConfig( mockConfigData );
 
 			expect( registry.select( CONFIG_STORE ).getConfigValue( 'blogId' ) ).toBe( 12345 );
-			expect( registry.select( CONFIG_STORE ).getConfigValue( 'hasAI' ) ).toBe( false );
+			expect( registry.select( CONFIG_STORE ).getConfigValue( 'isIntegrationsEnabled' ) ).toBe(
+				true
+			);
 			expect( registry.select( CONFIG_STORE ).getConfigValue( 'isMailPoetEnabled' ) ).toBe( true );
 		} );
 
 		it( 'should return undefined for non-existent config keys', () => {
 			registry.dispatch( CONFIG_STORE ).receiveConfig( { isMailPoetEnabled: true } );
 
-			expect( registry.select( CONFIG_STORE ).getConfigValue( 'hasAI' ) ).toBeUndefined();
+			expect(
+				registry.select( CONFIG_STORE ).getConfigValue( 'isIntegrationsEnabled' )
+			).toBeUndefined();
 		} );
 	} );
 } );

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Endpoint_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Endpoint_Test.php
@@ -463,7 +463,6 @@ class Contact_Form_Endpoint_Test extends TestCase {
 			'pluginAssetsURL',
 			'siteURL',
 			'hasFeedback',
-			'hasAI',
 			'isIntegrationsEnabled',
 			'dashboardURL',
 			'canInstallPlugins',

--- a/projects/plugins/jetpack/changelog/forms-remove-unused-hasai
+++ b/projects/plugins/jetpack/changelog/forms-remove-unused-hasai
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: remove unusaed hasAI from config.


### PR DESCRIPTION
## Proposed changes:

I noticed when testing a recent PR to update the config endpoint and store that we don't actually use hasAI anywhere on the frontend? This PR removes it from the config endpoint, types, and tests. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None. 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

This is just code removal. Everything should work as before. Scan codebase to confirm we're not using hasAI, and scan PR to confirm we're not removing any needed production code. Quick test forms dashboard and block to confirm no issues. Possibly test Jetpack AI for forms, as that would likely be the only place affected. 

Run tests to confirm they pass. 

