### PR TITLE
Override so that garden sites have the DOMAIN_MAPPING feature

### DIFF
--- a/projects/plugins/wpcomsh/changelog/garden-override-domain-mapping-feature
+++ b/projects/plugins/wpcomsh/changelog/garden-override-domain-mapping-feature
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Override so that garden sites have the DOMAIN_MAPPING feature

--- a/projects/plugins/wpcomsh/wpcom-features/functions-wpcom-features.php
+++ b/projects/plugins/wpcomsh/wpcom-features/functions-wpcom-features.php
@@ -68,6 +68,13 @@ function wpcom_site_has_feature( $feature, $blog_id = 0 ) {
 	}
 
 	/*
+	 * Override for garden sites. May remove this in the future if CIAB plans handle this.
+	 */
+	if ( $feature === WPCOM_Features::DOMAIN_MAPPING && function_exists( 'wpcom_is_garden_site' ) && wpcom_is_garden_site( $blog_id ) ) {
+		return true;
+	}
+
+	/*
 	 * A8C override for internal P2s
 	 */
 	if ( $feature === WPCOM_Features::AI_ASSISTANT && wpcom_is_automattic_p2_site( $blog_id ) ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

(This ports the change from 194133-ghe-Automattic/wpcom)

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This adds an override so we always treat garden sites as having the DOMAIN_MAPPING feature.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Visual inspection