### PR TITLE
Forms: Trim empty options and display custom placeholder for image select field

### DIFF
--- a/projects/packages/forms/changelog/update-forms-image-select-empty-options
+++ b/projects/packages/forms/changelog/update-forms-image-select-empty-options
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Forms: Trim empty options and display custom placeholder

--- a/projects/packages/forms/src/blocks/field-image-select/editor.scss
+++ b/projects/packages/forms/src/blocks/field-image-select/editor.scss
@@ -1,4 +1,5 @@
 @use "style" as *;
+@use "../shared/styles/empty_image_option" as *;
 
 // Editor-only styles.
 
@@ -15,6 +16,16 @@
 
 .jetpack-contact-form .jetpack-input-image-option .components-placeholder.has-illustration {
 	overflow: hidden;
+	position: relative;
+
+	&::after {
+
+		@extend %empty-image-option-icon;
+	}
+
+	.components-placeholder__illustration {
+		display: none;
+	}
 }
 
 // There is no outer block in the editor, so we apply

--- a/projects/packages/forms/src/blocks/field-image-select/style.scss
+++ b/projects/packages/forms/src/blocks/field-image-select/style.scss
@@ -1,5 +1,6 @@
 @use "@automattic/jetpack-base-styles/gutenberg-base-styles" as gb;
 @use "../shared/styles/visually-hidden" as *;
+@use "../shared/styles/empty_image_option" as *;
 
 @mixin image-select-responsive-width {
 	width: calc(( 1 / var(--row-options-count) ) * 100% - var(--jetpack-field-image-options-gap) * ( (var(--row-options-count) - 1) / var(--row-options-count) ));
@@ -160,4 +161,18 @@ div:where(.jetpack-input-image-option) {
 	border-radius: 4px;
 	padding: 8px;
 	margin: 0;
+}
+
+.jetpack-input-image-option__empty-image {
+	position: relative;
+
+	&::before {
+
+		@extend %empty-image-option-background;
+	}
+
+	&::after {
+
+		@extend %empty-image-option-icon;
+	}
 }

--- a/projects/packages/forms/src/blocks/shared/styles/_empty_image_option.scss
+++ b/projects/packages/forms/src/blocks/shared/styles/_empty_image_option.scss
@@ -1,0 +1,24 @@
+%empty-image-option-icon {
+	content: "";
+	$mask-url: "data:image/svg+xml,%3Csvg width='20' height='20' viewBox='0 0 19 18' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M16.5 0H2.5C1.4 0 0.5 0.9 0.5 2V16C0.5 17.1 1.4 18 2.5 18H16.5C17.6 18 18.5 17.1 18.5 16V2C18.5 0.9 17.6 0 16.5 0ZM2.5 1.5H16.5C16.8 1.5 17 1.7 17 2V10.4L14 7.5C13.7 7.2 13.2 7.2 13 7.5L9.4 11L6.5 9C6.2 8.8 5.9 8.8 5.7 9L2.1 11.6V2C2 1.7 2.2 1.5 2.5 1.5ZM16.5 16.5H2.5C2.2 16.5 2 16.3 2 16V13.6L6.1 10.6L9.1 12.5C9.4 12.7 9.8 12.7 10 12.4L13.5 9L17 12.4V16C17 16.3 16.8 16.5 16.5 16.5Z' fill='%233858E9'/%3E%3C/svg%3E";
+	mask-image: url(#{$mask-url});
+	mask-size: contain;
+	mask-repeat: no-repeat;
+	position: absolute;
+	top: calc(50% - 10px);
+	left: calc(50% - 10px);
+	width: 20px;
+	height: 20px;
+	background-color: var(--jetpack--contact-form--primary-color);
+}
+
+%empty-image-option-background {
+	content: "";
+	position: absolute;
+	top: 0;
+	bottom: 0;
+	left: 0;
+	right: 0;
+	opacity: 0.1;
+	background: currentColor;
+}

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -2063,7 +2063,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 						}
 					}
 				} else {
-					$rendered_image_block = '<figure class="wp-block-image"><img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=" alt="" style="aspect-ratio:1;object-fit:cover"/></figure>';
+					$rendered_image_block = '<figure class="wp-block-image jetpack-input-image-option__empty-image"><img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=" alt="" style="aspect-ratio:1;object-fit:cover"/></figure>';
 				}
 
 				$option_value                = wp_json_encode(

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -2013,7 +2013,11 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		$field .= "<div class='" . esc_attr( $options_classes ) . " jetpack-field jetpack-fieldset-image-options' style='" . esc_attr( $options_styles ) . "'>";
 		$field .= "<div class='jetpack-fieldset-image-options__wrapper'>";
 
-		$options_data  = $this->get_attribute( 'optionsdata' );
+		$options_data = $this->get_attribute( 'optionsdata' );
+
+		// Filter out empty options from the end
+		$options_data = $this->trim_image_select_options( $options_data );
+
 		$used_html_ids = array();
 
 		if ( ! empty( $options_data ) ) {
@@ -2030,6 +2034,9 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 			// Randomize options if requested, but preserve original letter values
 			if ( $randomize_options ) {
 				shuffle( $working_options );
+
+				// Trims options after randomization to ensure the last option has a label or image.
+				$working_options = $this->trim_image_select_options( $working_options );
 			}
 
 			// Calculate row options count for CSS variable
@@ -3218,5 +3225,45 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 			array( '@wordpress/interactivity' ),
 			$version
 		);
+	}
+
+	/**
+	 * Trims the image select options from the end of the array if they are empty.
+	 *
+	 * @param array $options The options to trim.
+	 *
+	 * @return array The trimmed options array.
+	 */
+	private function trim_image_select_options( $options ) {
+		if ( empty( $options ) ) {
+			return $options;
+		}
+
+		// Work backwards through the array to find the last valid option
+		$last_valid_index = -1;
+
+		for ( $i = count( $options ) - 1; $i >= 0; $i-- ) {
+			$option = $options[ $i ];
+
+			// Check if option has a label
+			$has_label = ! empty( $option['label'] );
+
+			// Check if option has an image with src
+			$has_image = false;
+
+			if ( isset( $option['image']['innerHTML'] ) ) {
+				// Extract src from innerHTML using regex
+				preg_match( '/src="([^"]*)"/', $option['image']['innerHTML'], $matches );
+				$has_image = ! empty( $matches[1] );
+			}
+
+			// If this option has either a label or an image, it's valid
+			if ( $has_label || $has_image ) {
+				$last_valid_index = $i;
+				break;
+			}
+		}
+
+		return array_slice( $options, 0, $last_valid_index + 1 );
 	}
 }

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1065,7 +1065,10 @@ class Contact_Form extends Contact_Form_Shortcode {
 						<div class="field-value" data-wp-text="context.submission.value"></div>
 						<div class="field-images" data-wp-bind--hidden="!context.submission.images">
 							<template data-wp-each--image="context.submission.images">
-								<img class="field-image" data-wp-bind--src="context.image" data-wp-bind--hidden="!context.image"/>
+								<figure class="field-image" data-wp-class--is-empty="!context.image">
+									<img data-wp-bind--src="context.image" data-wp-bind--hidden="!context.image" />
+									<img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=" data-wp-bind--hidden="context.image" />
+								</figure>
 							</template>
 						</div>
 					</div>
@@ -1080,7 +1083,10 @@ class Contact_Form extends Contact_Form_Shortcode {
 
 					if ( ! empty( $submission['images'] ) ) {
 						foreach ( $submission['images'] as $image ) {
-							$html .= '<img data-wp-each-child class="field-image" data-wp-bind--src="context.image" src="' . $image . '" data-wp-bind--hidden="!context.image" ' . ( empty( $image ) ? 'hidden' : '' ) . ' />';
+							$html .= '<figure data-wp-each-child class="field-image ' . ( empty( $image ) ? 'is-empty' : '' ) . '" data-wp-class--is-empty="!context.image">';
+							$html .= '<img data-wp-bind--src="context.image" src="' . $image . '" data-wp-bind--hidden="!context.image"' . ( empty( $image ) ? 'hidden' : '' ) . '/>';
+							$html .= '<img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=" data-wp-bind--hidden="context.image"' . ( empty( $image ) ? '' : 'hidden' ) . '/>';
+							$html .= '</figure>';
 						}
 					} else {
 						$html .= '<template data-wp-each--image="context.submission.images"></template>';

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -1,5 +1,6 @@
 /* Import shared visually-hidden utility so editor and frontend match */
 @use "../../blocks/shared/styles/visually-hidden" as *;
+@use "../../blocks/shared/styles/empty_image_option" as *;
 
 :root {
 	--jetpack--contact-form--border: 1px solid #8c8f94;
@@ -271,9 +272,28 @@ that needs to mimic the input element styles */
 	}
 
 	.field-image {
-		width: 200px;
-		aspect-ratio: 1/1;
-		object-fit: cover;
+		width: 196px;
+		height: 196px;
+
+		&.is-empty {
+			position: relative;
+
+			&::before {
+
+				@extend %empty-image-option-background;
+			}
+
+			&::after {
+
+				@extend %empty-image-option-icon;
+			}
+		}
+
+		img {
+			width: 100%;
+			aspect-ratio: 1/1;
+			object-fit: cover;
+		}
 	}
 }
 

--- a/projects/packages/forms/src/dashboard/components/response-view/body.tsx
+++ b/projects/packages/forms/src/dashboard/components/response-view/body.tsx
@@ -260,16 +260,25 @@ const ResponseViewBody = ( {
 							</div>
 							<div className="image-select-field-images">
 								{ value.choices.map( choice => {
+									const imageSrc =
+										choice.image?.src ||
+										'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=';
+
 									return (
-										<img
+										<figure
 											key={ choice.selected }
-											className="image-select-field-image"
-											src={
-												choice.image.src ||
-												'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs='
-											}
-											alt={ choice.selected }
-										/>
+											className={ clsx( 'image-select-field-image', {
+												'is-empty': ! choice.image?.src,
+											} ) }
+										>
+											<img
+												className={ clsx( 'image-select-field-image', {
+													'is-empty': ! choice.image?.src,
+												} ) }
+												src={ imageSrc }
+												alt={ choice.selected }
+											/>
+										</figure>
 									);
 								} ) }
 							</div>
@@ -359,7 +368,7 @@ const ResponseViewBody = ( {
 			method: 'POST',
 			data: { is_unread: false },
 		} )
-			.then( ( { count } ) => {
+			.then( ( { count }: { count: number } ) => {
 				// Update menu counter with accurate count from server
 				updateMenuCounter( count );
 			} )

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -1,5 +1,6 @@
 @use "@wordpress/base-styles/breakpoints";
 @use "@wordpress/base-styles/variables";
+@use "../../blocks/shared/styles/empty_image_option" as *;
 @import "@wordpress/dataviews/build-style/style.css";
 
 .jp-forms__inbox {
@@ -280,9 +281,29 @@
 	}
 
 	.image-select-field-image {
+		margin: 0;
 		width: 200px;
-		aspect-ratio: 1/1;
-		object-fit: cover;
+		height: 200px;
+
+		&.is-empty {
+			position: relative;
+
+			&::before {
+
+				@extend %empty-image-option-background;
+			}
+
+			&::after {
+
+				@extend %empty-image-option-icon;
+				background-color: #000;
+			}
+		}
+
+		img {
+			aspect-ratio: 1/1;
+			object-fit: cover;
+		}
 	}
 }
 

--- a/projects/packages/forms/src/modules/form/view.js
+++ b/projects/packages/forms/src/modules/form/view.js
@@ -135,7 +135,7 @@ const maybeTransformValue = value => {
 
 const getImages = value => {
 	if ( value?.type === 'image-select' ) {
-		return value.choices.filter( choice => choice.image?.src ).map( choice => choice.image?.src );
+		return value.choices.map( choice => choice.image?.src );
 	}
 
 	return null;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of FORMS-60

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR deals with the treatment of empty options. It trims options without label AND image if doing so would not compromise the option ordering, so empty options at the end are removed, but if they are before a valid image, they remain as to not shift the valid option letter.
In the case that an option without image can't be removed or has a label, a visible placeholder is displayed, matching the placeholder in the editor.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add an image select field
* Check that leading empty options are removed (see screenshots)
* Check that empty images have the same placeholder everywhere, including the editor

Field with leading empty options:
<img width="711" height="1114" alt="Screenshot from 2025-10-16 21-37-46" src="https://github.com/user-attachments/assets/71bc02ea-ebae-449d-8eb5-d8f43f32e70e" />

Published form with empty options removed:
<img width="660" height="829" alt="Screenshot from 2025-10-16 21-38-02" src="https://github.com/user-attachments/assets/b9e4021d-adbb-4bf6-817d-3399647c3538" />

Post-submission page displaying empty image with a placeholder:
<img width="693" height="315" alt="Screenshot from 2025-10-16 21-38-17" src="https://github.com/user-attachments/assets/6add277a-2272-4e88-ac2b-1655a20c3144" />

Dashboard:
<img width="674" height="282" alt="Screenshot from 2025-10-16 21-38-38" src="https://github.com/user-attachments/assets/67c8dbc3-e703-4f1f-8a85-59711db5ecc9" />
