### PR TITLE
Help Center: Add isCIABGarden field

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/help-center-ciab-garden-field
+++ b/projects/packages/jetpack-mu-wpcom/changelog/help-center-ciab-garden-field
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Add isCIABGarden field to Help Center data for CIAB Garden integration
+
+

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
@@ -65,6 +65,8 @@ class Help_Center {
 		$language = get_user_locale();
 		$language = strtolower( $language );
 
+		l($language);
+
 		if ( in_array( $language, array( 'pt_br', 'pt-br', 'zh_tw', 'zh-tw', 'zh_cn', 'zh-cn' ), true ) ) {
 			$language = str_replace( '_', '-', $language );
 		} else {
@@ -210,18 +212,20 @@ class Help_Center {
 			$username      = $user_data->user_login;
 			$user_email    = $user_data->user_email;
 			$display_name  = $user_data->display_name;
-			$avatar_url    = function_exists( 'wpcom_get_avatar_url' ) ? wpcom_get_avatar_url( $user_email, 64, '', true )[0] : get_avatar_url( $user_id );
-			$is_next_admin = (bool) did_action( 'next_admin_init' );
+			$avatar_url      = function_exists( 'wpcom_get_avatar_url' ) ? wpcom_get_avatar_url( $user_email, 64, '', true )[0] : get_avatar_url( $user_id );
+			$is_next_admin   = (bool) did_action( 'next_admin_init' );
+			$is_ciab_garden  = (bool) did_action( 'ciab_garden_init' );
 
 			wp_add_inline_script(
 				'help-center',
 				'const helpCenterData = ' . wp_json_encode(
 					array(
-						'isProxied'   => boolval( self::is_proxied() ),
-						'isSU'        => defined( 'WPCOM_SUPPORT_SESSION' ) && WPCOM_SUPPORT_SESSION,
-						'isSSP'       => isset( $_COOKIE['ssp'] ),
-						'sectionName' => $this->is_support_site ? 'wp.com/support' : $variant,
-						'isNextAdmin' => $is_next_admin,
+						'isProxied'     => boolval( self::is_proxied() ),
+						'isSU'          => defined( 'WPCOM_SUPPORT_SESSION' ) && WPCOM_SUPPORT_SESSION,
+						'isSSP'         => isset( $_COOKIE['ssp'] ),
+						'sectionName'   => $this->is_support_site ? 'wp.com/support' : $variant,
+						'isNextAdmin'   => $is_next_admin,
+						'isCIABGarden'  => $is_ciab_garden,
 						'currentUser' => array(
 							'ID'           => $user_id,
 							'username'     => $username,
@@ -470,7 +474,8 @@ class Help_Center {
 		if ( $this->is_wc_admin_home_page() ) {
 			return;
 		}
-		$is_next_admin = (bool) did_action( 'next_admin_init' );
+		$is_next_admin  = (bool) did_action( 'next_admin_init' );
+		$is_ciab_garden = (bool) did_action( 'ciab_garden_init' );
 
 		require_once ABSPATH . 'wp-admin/includes/screen.php';
 
@@ -490,7 +495,7 @@ class Help_Center {
 			$variant = 'wp-admin' . ( $this->is_jetpack_disconnected() ? '-disconnected' : '' );
 		} elseif ( $this->is_loading_on_frontend() ) {
 			$variant = 'wp-admin-disconnected';
-		} elseif ( $this->is_block_editor() || $is_next_admin ) {
+		} elseif ( $this->is_block_editor() || $is_next_admin || $is_ciab_garden ) {
 			$variant = 'gutenberg' . ( $this->is_jetpack_disconnected() ? '-disconnected' : '' );
 		} else {
 			$variant = 'wp-admin' . ( $this->is_jetpack_disconnected() ? '-disconnected' : '' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
@@ -65,8 +65,6 @@ class Help_Center {
 		$language = get_user_locale();
 		$language = strtolower( $language );
 
-		l($language);
-
 		if ( in_array( $language, array( 'pt_br', 'pt-br', 'zh_tw', 'zh-tw', 'zh_cn', 'zh-cn' ), true ) ) {
 			$language = str_replace( '_', '-', $language );
 		} else {
@@ -207,34 +205,34 @@ class Help_Center {
 				'before'
 			);
 
-			$user_id       = get_current_user_id();
-			$user_data     = get_userdata( $user_id );
-			$username      = $user_data->user_login;
-			$user_email    = $user_data->user_email;
-			$display_name  = $user_data->display_name;
-			$avatar_url      = function_exists( 'wpcom_get_avatar_url' ) ? wpcom_get_avatar_url( $user_email, 64, '', true )[0] : get_avatar_url( $user_id );
-			$is_next_admin   = (bool) did_action( 'next_admin_init' );
-			$is_ciab_garden  = (bool) did_action( 'ciab_garden_init' );
+			$user_id        = get_current_user_id();
+			$user_data      = get_userdata( $user_id );
+			$username       = $user_data->user_login;
+			$user_email     = $user_data->user_email;
+			$display_name   = $user_data->display_name;
+			$avatar_url     = function_exists( 'wpcom_get_avatar_url' ) ? wpcom_get_avatar_url( $user_email, 64, '', true )[0] : get_avatar_url( $user_id );
+			$is_next_admin  = (bool) did_action( 'next_admin_init' );
+			$is_ciab_garden = (bool) did_action( 'ciab_garden_init' );
 
 			wp_add_inline_script(
 				'help-center',
 				'const helpCenterData = ' . wp_json_encode(
 					array(
-						'isProxied'     => boolval( self::is_proxied() ),
-						'isSU'          => defined( 'WPCOM_SUPPORT_SESSION' ) && WPCOM_SUPPORT_SESSION,
-						'isSSP'         => isset( $_COOKIE['ssp'] ),
-						'sectionName'   => $this->is_support_site ? 'wp.com/support' : $variant,
-						'isNextAdmin'   => $is_next_admin,
-						'isCIABGarden'  => $is_ciab_garden,
-						'currentUser' => array(
+						'isProxied'    => boolval( self::is_proxied() ),
+						'isSU'         => defined( 'WPCOM_SUPPORT_SESSION' ) && WPCOM_SUPPORT_SESSION,
+						'isSSP'        => isset( $_COOKIE['ssp'] ),
+						'sectionName'  => $this->is_support_site ? 'wp.com/support' : $variant,
+						'isNextAdmin'  => $is_next_admin,
+						'isCIABGarden' => $is_ciab_garden,
+						'currentUser'  => array(
 							'ID'           => $user_id,
 							'username'     => $username,
 							'display_name' => $display_name,
 							'avatar_URL'   => $avatar_url,
 							'email'        => $user_email,
 						),
-						'site'        => $this->get_current_site(),
-						'locale'      => self::determine_iso_639_locale(),
+						'site'         => $this->get_current_site(),
+						'locale'       => self::determine_iso_639_locale(),
 					)
 				),
 				'before'
@@ -474,8 +472,7 @@ class Help_Center {
 		if ( $this->is_wc_admin_home_page() ) {
 			return;
 		}
-		$is_next_admin  = (bool) did_action( 'next_admin_init' );
-		$is_ciab_garden = (bool) did_action( 'ciab_garden_init' );
+		$is_next_admin = (bool) did_action( 'next_admin_init' );
 
 		require_once ABSPATH . 'wp-admin/includes/screen.php';
 
@@ -495,7 +492,7 @@ class Help_Center {
 			$variant = 'wp-admin' . ( $this->is_jetpack_disconnected() ? '-disconnected' : '' );
 		} elseif ( $this->is_loading_on_frontend() ) {
 			$variant = 'wp-admin-disconnected';
-		} elseif ( $this->is_block_editor() || $is_next_admin || $is_ciab_garden ) {
+		} elseif ( $this->is_block_editor() || $is_next_admin ) {
 			$variant = 'gutenberg' . ( $this->is_jetpack_disconnected() ? '-disconnected' : '' );
 		} else {
 			$variant = 'wp-admin' . ( $this->is_jetpack_disconnected() ? '-disconnected' : '' );


### PR DESCRIPTION
## Proposed changes

This PR adds a new `isCIABGarden` field to the Help Center data, similar to the existing `isNextAdmin` field, but using the `ciab_garden_init` action instead of `next_admin_init`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

1. Apply this on a simple site.
2. Go to wp-admin of that site.
3. Open the console and log `helpCenterData`.
4. It should say `isCIABGarden: false`.

Fixes DOTCOM-14968