### PR TITLE
Forms: Add programmatic initialization support

### DIFF
--- a/projects/packages/forms/changelog/add-forms-programmatic-init
+++ b/projects/packages/forms/changelog/add-forms-programmatic-init
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: Add programmatic initialization support via window.jetpackFormsInit()

--- a/projects/packages/forms/src/dashboard/index.tsx
+++ b/projects/packages/forms/src/dashboard/index.tsx
@@ -15,6 +15,12 @@ import Integrations from './integrations';
 import DashboardNotices from './notices-list';
 import './style.scss';
 
+declare global {
+	interface Window {
+		jetpackFormsInit?: () => void;
+	}
+}
+
 let isInitialized = false;
 
 /**

--- a/projects/packages/forms/src/dashboard/index.tsx
+++ b/projects/packages/forms/src/dashboard/index.tsx
@@ -15,8 +15,23 @@ import Integrations from './integrations';
 import DashboardNotices from './notices-list';
 import './style.scss';
 
-window.addEventListener( 'load', () => {
+let isInitialized = false;
+
+/**
+ * Initialize the Forms dashboard
+ */
+function initFormsDashboard() {
+	if ( isInitialized ) {
+		return;
+	}
+
 	const container = document.getElementById( 'jp-forms-dashboard' );
+
+	if ( ! container ) {
+		return;
+	}
+
+	isInitialized = true;
 
 	const router = createHashRouter( [
 		{
@@ -51,4 +66,7 @@ window.addEventListener( 'load', () => {
 			<DashboardNotices />
 		</ThemeProvider>
 	);
-} );
+}
+
+window.jetpackFormsInit = initFormsDashboard;
+window.addEventListener( 'load', initFormsDashboard );


### PR DESCRIPTION
## Proposed changes:
* Add `window.jetpackFormsInit()` function to allow programmatic initialization of the Jetpack Forms dashboard
* Add initialization guard to prevent duplicate initialization when called multiple times
* Export initialization function alongside existing `load` event listener for backward compatibility

This change enables the Forms dashboard to be initialized programmatically without relying solely on the window `load` event, which is useful for dynamic loading scenarios like React
applications or admin interfaces that load Forms on demand.

### Other information:

- [x] Have you written new tests for your changes, if applicable? - No tests needed, behavioral change only
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them? - Will verify
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

### Current behavior (still works):
1. Go to Jetpack > Forms in wp-admin
2. Forms dashboard loads automatically on page load
3. Verify Forms dashboard displays correctly

### New programmatic initialization:
1. Open browser console on any page with Forms JS loaded
2. Add a container element: `document.body.innerHTML = '<div id="jp-forms-dashboard"></div>'`
3. Call `window.jetpackFormsInit()`
4. Verify Forms dashboard initializes in the container

### Duplicate initialization protection:
1. Follow steps above to initialize Forms
2. Call `window.jetpackFormsInit()` again
3. Verify no console errors and Forms continues working normally