### PR TITLE
Instant Search: address browser privacy settings stripping the $query= value.

### DIFF
--- a/projects/packages/search/changelog/fix-privacy-settings-breaking-jetpack-search
+++ b/projects/packages/search/changelog/fix-privacy-settings-breaking-jetpack-search
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Instant Search: address browser privacy settings from stripping out the search query value.

--- a/projects/packages/search/src/instant-search/components/dom-event-handler.jsx
+++ b/projects/packages/search/src/instant-search/components/dom-event-handler.jsx
@@ -122,9 +122,13 @@ export default class DomEventHandler extends Component {
 	};
 
 	handleInput = debounce( event => {
+		// Safari's Advanced Tracking and Fingerprinting Protection blocks reading event.target.value,
+		// so we read directly from the input element itself.
+		const inputValue = event.currentTarget.value;
+
 		// Reference: https://rawgit.com/w3c/input-events/v1/index.html#interface-InputEvent-Attributes
 		// NOTE: inputType is not compatible with IE11, so we use optional chaining here. https://caniuse.com/mdn-api_inputevent_inputtype
-		if ( event.inputType?.includes( 'format' ) || event.target.value === '' ) {
+		if ( event.inputType?.includes( 'format' ) || inputValue === '' ) {
 			return;
 		}
 
@@ -140,7 +144,7 @@ export default class DomEventHandler extends Component {
 			return;
 		}
 
-		this.props.setSearchQuery( event.target.value );
+		this.props.setSearchQuery( inputValue );
 
 		if ( [ 'immediate', 'results' ].includes( this.props.overlayOptions.overlayTrigger ) ) {
 			this.props.showResults();
@@ -150,7 +154,9 @@ export default class DomEventHandler extends Component {
 	handleKeyup = event => {
 		// If user presses enter, propagate the query value and immediately show the results.
 		if ( event.key === 'Enter' ) {
-			this.props.setSearchQuery( event.target.value );
+			// Safari's Advanced Tracking and Fingerprinting Protection blocks reading event.target.value,
+			// so we read directly from the input element itself.
+			this.props.setSearchQuery( event.currentTarget.value );
 			this.props.showResults();
 		}
 	};

--- a/projects/packages/search/src/instant-search/components/search-box.jsx
+++ b/projects/packages/search/src/instant-search/components/search-box.jsx
@@ -41,7 +41,11 @@ const SearchBox = props => {
 						inputMode="search"
 						// IE11 will immediately fire an onChange event when the placeholder contains a unicode character.
 						// Ensure that the search application is visible before invoking the onChange callback to guard against this.
-						onChange={ props.isVisible ? props.onChange : null }
+						// Safari's Advanced Tracking and Fingerprinting Protection blocks reading event.currentTarget.value,
+						// so we read directly from the ref instead.
+						onChange={
+							props.isVisible ? () => props.onChange( inputRef.current?.value ?? '' ) : null
+						}
 						ref={ inputRef }
 						placeholder={ __( 'Search…', 'jetpack-search-pkg' ) }
 						type="search"

--- a/projects/packages/search/src/instant-search/components/search-form.jsx
+++ b/projects/packages/search/src/instant-search/components/search-form.jsx
@@ -6,7 +6,7 @@ const noop = event => event.preventDefault();
 
 class SearchForm extends Component {
 	onClear = () => this.props.onChangeSearch( '' );
-	onChangeSearch = event => this.props.onChangeSearch( event.currentTarget.value );
+	onChangeSearch = value => this.props.onChangeSearch( value );
 
 	render() {
 		return (

--- a/projects/plugins/jetpack/changelog/fix-privacy-settings-breaking-jetpack-search
+++ b/projects/plugins/jetpack/changelog/fix-privacy-settings-breaking-jetpack-search
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Instant Search: address browser privacy settings from stripping out the search query value.

--- a/projects/plugins/search/changelog/fix-privacy-settings-breaking-jetpack-search
+++ b/projects/plugins/search/changelog/fix-privacy-settings-breaking-jetpack-search
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Instant Search: address browser privacy settings from stripping out the search query value.


### PR DESCRIPTION
Fixes # [SEARCH-104](https://linear.app/a8c/issue/SEARCH-104/jetpack-search-broken-for-safari-on-wpcom-jetpack-tumblr-and-pocket#comment-1ad2539a)

## Proposed changes:

This PR refactors the input value handling to use a privacy-friendly pattern that works within Safari's protection constraints. Instead of reading the input value from the event object (which Safari identifies as a tracking pattern), we now read it directly from either the React ref or `event.currentTarget`:

- `search-box.jsx`: Modified `onChange` handler to read value from `inputRef.current.value`
  instead of `event.currentTarget.value`
- `search-form.jsx`: Updated `onChangeSearch` to receive the value directly as a parameter
  instead of extracting it from the event
- `dom-event-handler.jsx`: Updated `handleInput` and `handleKeyup` handlers to read from
  `event.currentTarget.value` instead of `event.target.value`


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

No

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

- Checkout this branch on your WPcom sandbox with `bin/jetpack-downloader test jetpack fix/privacy-settings-breaking-jetpack-search`
- Point both WPcom and the API to your sandbox
- Open wordpress.com/support in Safari
- Enable the **Settings** --> **Advanced** --> "Use advanced tracking and fingerpriting protection" setting for all browsing sessions
- Follow these steps on sandboxing with Safari PCYsg-e-p2
- Ensure that search works as expected, and continues to work in other browsers