### PR TITLE
Forms: remove Jetpack logo in dashboard header

### DIFF
--- a/projects/packages/forms/changelog/change-forms-dashboard-header-1
+++ b/projects/packages/forms/changelog/change-forms-dashboard-header-1
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Forms: remove logo from dashboard, align header styles with ciab"

--- a/projects/packages/forms/src/dashboard/components/layout/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/layout/index.tsx
@@ -108,7 +108,8 @@ const Layout = () => {
 		<div className="jp-forms__layout">
 			<div className="jp-forms__layout-header">
 				<Heading level={ 1 } size="15px" lineHeight="32px">
-					{ __( 'Forms', 'jetpack-forms' ) }
+					Forms
+					{ /** "Forms" is a product name, do not translate. */ }
 				</Heading>
 				{ isSm ? (
 					<>

--- a/projects/packages/forms/src/dashboard/components/layout/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/layout/index.tsx
@@ -3,7 +3,11 @@
  */
 import jetpackAnalytics from '@automattic/jetpack-analytics';
 import { useBreakpointMatch } from '@automattic/jetpack-components';
-import { TabPanel } from '@wordpress/components';
+import {
+	TabPanel,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalHeading as Heading,
+} from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { useCallback, useEffect, useMemo } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
@@ -18,7 +22,6 @@ import ExportResponsesButton from '../../inbox/export-responses';
 import { store as dashboardStore } from '../../store';
 import ActionsDropdownMenu from '../actions-dropdown-menu';
 import CreateFormButton from '../create-form-button';
-import JetpackFormsLogo from '../logo';
 
 import './style.scss';
 
@@ -104,9 +107,9 @@ const Layout = () => {
 	return (
 		<div className="jp-forms__layout">
 			<div className="jp-forms__layout-header">
-				<div className="jp-forms__logo-wrapper">
-					<JetpackFormsLogo />
-				</div>
+				<Heading level={ 1 } size="15px" lineHeight="32px">
+					{ __( 'Forms', 'jetpack-forms' ) }
+				</Heading>
 				{ isSm ? (
 					<>
 						{ isResponsesTab && isResponsesTrashView && <EmptyTrashButton /> }

--- a/projects/packages/forms/src/dashboard/components/layout/style.scss
+++ b/projects/packages/forms/src/dashboard/components/layout/style.scss
@@ -51,12 +51,13 @@ body.jetpack_page_jetpack-forms-admin {
 }
 
 #jp-forms-dashboard .jp-forms__layout {
+	background: var(--wpds-color-bg-surface-neutral-strong, #f9f9f6);
 
 	.jp-forms__layout-header {
 		display: flex;
 		align-items: center;
 		justify-content: space-between;
-		padding: 30px 30px 0 0;
+		padding: 30px 30px 0 30px;
 
 		@media (max-width: 782px) {
 			padding-top: 8px;
@@ -70,7 +71,7 @@ body.jetpack_page_jetpack-forms-admin {
 
 		> .components-tab-panel__tabs {
 			margin: 0;
-			padding: 0 48px;
+			padding-inline: 20px;
 			border-bottom: 1px solid var(--jp-gray-5);
 
 			.components-tab-panel__tabs-item {

--- a/projects/packages/forms/src/dashboard/components/layout/style.scss
+++ b/projects/packages/forms/src/dashboard/components/layout/style.scss
@@ -59,7 +59,7 @@ body.jetpack_page_jetpack-forms-admin {
 		padding: 30px 30px 0 0;
 
 		@media (max-width: 782px) {
-			padding: 40px 20px 0 0;
+			padding-top: 8px;
 		}
 	}
 


### PR DESCRIPTION
Related to FORMS-348

## Proposed changes:
Remove the JP logo from header and adjust styles for desktop and mobile

<img width="1330" height="330" alt="image" src="https://github.com/user-attachments/assets/8cc69d86-d4cd-4e89-b70c-9db85403811b" />

## Jetpack product discussion
p1760695290228499-slack-C052XEUUBL4

## Does this pull request change what data or activity we track or use?
No

## Testing instructions
Load the dashboard and verify styles on desktop and mobile. Logo should not be present anymore.