### PR TITLE
Prevent PHP fatals when directly accessing files, round 9

### DIFF
--- a/projects/packages/boost-core/changelog/fix-jetpack-direct_access_fatals_part_9
+++ b/projects/packages/boost-core/changelog/fix-jetpack-direct_access_fatals_part_9
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Prevent PHP errors by limiting direct access to files.
+
+

--- a/projects/packages/boost-core/src/lib/class-wpcom-boost-api-client.php
+++ b/projects/packages/boost-core/src/lib/class-wpcom-boost-api-client.php
@@ -9,6 +9,10 @@ namespace Automattic\Jetpack\Boost_Core\Lib;
 
 use Automattic\Jetpack\Boost_Core\Contracts\Boost_API_Client;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * A class that handles the Boost API client.
  *

--- a/projects/packages/boost-speed-score/changelog/fix-jetpack-direct_access_fatals_part_9
+++ b/projects/packages/boost-speed-score/changelog/fix-jetpack-direct_access_fatals_part_9
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Prevent PHP errors by limiting direct access to files.
+
+

--- a/projects/packages/boost-speed-score/src/class-speed-score-request.php
+++ b/projects/packages/boost-speed-score/src/class-speed-score-request.php
@@ -11,6 +11,10 @@ use Automattic\Jetpack\Boost_Core\Lib\Boost_API;
 use Automattic\Jetpack\Boost_Core\Lib\Cacheable;
 use Automattic\Jetpack\Boost_Core\Lib\Url;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * Class Speed_Score_Request
  */

--- a/projects/packages/classic-theme-helper/changelog/fix-jetpack-direct_access_fatals_part_9
+++ b/projects/packages/classic-theme-helper/changelog/fix-jetpack-direct_access_fatals_part_9
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Prevent PHP errors by limiting direct access to files.
+
+

--- a/projects/packages/classic-theme-helper/src/class-main.php
+++ b/projects/packages/classic-theme-helper/src/class-main.php
@@ -9,6 +9,10 @@ namespace Automattic\Jetpack\Classic_Theme_Helper;
 
 use WP_Error;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * Classic Theme Helper Loader.
  */

--- a/projects/packages/classic-theme-helper/src/content-options.php
+++ b/projects/packages/classic-theme-helper/src/content-options.php
@@ -6,6 +6,10 @@
  * @package automattic/jetpack-classic-theme-helper
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * Content Options.
  *

--- a/projects/packages/classic-theme-helper/src/custom-content-types.php
+++ b/projects/packages/classic-theme-helper/src/custom-content-types.php
@@ -18,6 +18,10 @@ use Automattic\Jetpack\Classic_Theme_Helper\Jetpack_Testimonial;
 use Automattic\Jetpack\Redirect;
 use Automattic\Jetpack\Status\Host;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 if ( ! function_exists( 'jetpack_load_custom_post_types' ) ) {
 	/**
 	 * Load Portfolio, Testimonial, and Nova CPT.

--- a/projects/packages/classic-theme-helper/src/custom-post-types/class-jetpack-testimonial-textarea-control.php
+++ b/projects/packages/classic-theme-helper/src/custom-post-types/class-jetpack-testimonial-textarea-control.php
@@ -7,6 +7,10 @@
 
 namespace Automattic\Jetpack\Classic_Theme_Helper;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 if ( ! class_exists( __NAMESPACE__ . '\Jetpack_Testimonial_Textarea_Control' ) ) {
 	/**
 	 * Extends the WP_Customize_Control class to clean the textarea content.

--- a/projects/packages/classic-theme-helper/src/custom-post-types/class-jetpack-testimonial-title-control.php
+++ b/projects/packages/classic-theme-helper/src/custom-post-types/class-jetpack-testimonial-title-control.php
@@ -7,6 +7,10 @@
 
 namespace Automattic\Jetpack\Classic_Theme_Helper;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 if ( ! class_exists( __NAMESPACE__ . '\Jetpack_Testimonial_Title_Control' ) ) {
 	/**
 	 * Extends the WP_Customize_Control class to clean the title parameter.

--- a/projects/packages/classic-theme-helper/src/site-breadcrumbs.php
+++ b/projects/packages/classic-theme-helper/src/site-breadcrumbs.php
@@ -7,6 +7,10 @@
  * @package automattic/jetpack-classic-theme-helper
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 $host = new Automattic\Jetpack\Status\Host();
 if ( ! function_exists( 'jetpack_breadcrumbs' ) && ! $host->is_wpcom_simple() ) {
 	/**

--- a/projects/packages/classic-theme-helper/src/social-menu.php
+++ b/projects/packages/classic-theme-helper/src/social-menu.php
@@ -11,6 +11,10 @@
  * @package automattic/jetpack-classic-theme-helper
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 if ( ! function_exists( 'jetpack_social_menu_init' ) ) {
 	/**
 	 * Activate the Social Menu plugin.

--- a/projects/packages/external-media/changelog/fix-jetpack-direct_access_fatals_part_9
+++ b/projects/packages/external-media/changelog/fix-jetpack-direct_access_fatals_part_9
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Prevent PHP errors by limiting direct access to files.
+
+

--- a/projects/packages/external-media/src/features/admin/external-media-import.php
+++ b/projects/packages/external-media/src/features/admin/external-media-import.php
@@ -12,6 +12,10 @@ namespace Automattic\Jetpack\External_Media;
 use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * Whether the current user is connected to WordPress.com.
  */

--- a/projects/packages/image-cdn/changelog/fix-jetpack-direct_access_fatals_part_9
+++ b/projects/packages/image-cdn/changelog/fix-jetpack-direct_access_fatals_part_9
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Prevent PHP errors by limiting direct access to files.
+
+

--- a/projects/packages/image-cdn/src/compatibility/activitypub.php
+++ b/projects/packages/image-cdn/src/compatibility/activitypub.php
@@ -11,6 +11,10 @@ namespace Automattic\Jetpack\Image_CDN\Compatibility;
 
 use Automattic\Jetpack\Image_CDN\Image_CDN;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * Hook the compatibility functions into ActivityPub filters if necessary.
  *

--- a/projects/packages/masterbar/changelog/fix-jetpack-direct_access_fatals_part_9
+++ b/projects/packages/masterbar/changelog/fix-jetpack-direct_access_fatals_part_9
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Prevent PHP errors by limiting direct access to files.
+
+

--- a/projects/packages/masterbar/src/admin-menu/class-domain-only-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-domain-only-admin-menu.php
@@ -7,6 +7,10 @@
 
 namespace Automattic\Jetpack\Masterbar;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * Class Domain_Only_Admin_Menu.
  */

--- a/projects/packages/masterbar/src/admin-menu/load.php
+++ b/projects/packages/masterbar/src/admin-menu/load.php
@@ -11,6 +11,10 @@ use Automattic\Jetpack\Modules;
 use Automattic\Jetpack\Status\Host;
 use Automattic\Jetpack\Tracking;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * Checks whether the navigation customizations should be performed for the given class.
  *

--- a/projects/packages/masterbar/src/nudges/additional-css/class-css-nudge-customize-control.php
+++ b/projects/packages/masterbar/src/nudges/additional-css/class-css-nudge-customize-control.php
@@ -8,6 +8,10 @@
 
 namespace Automattic\Jetpack\Masterbar;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * Class CSS_Nudge_Customize_Control
  */

--- a/projects/packages/masterbar/src/profile-edit/bootstrap.php
+++ b/projects/packages/masterbar/src/profile-edit/bootstrap.php
@@ -9,6 +9,10 @@ namespace Automattic\Jetpack\Masterbar;
 
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 require_once __DIR__ . '/class-wpcom-user-profile-fields-revert.php';
 
 /**

--- a/projects/packages/masterbar/src/profile-edit/profile-edit.php
+++ b/projects/packages/masterbar/src/profile-edit/profile-edit.php
@@ -10,6 +10,10 @@ namespace Automattic\Jetpack\Masterbar;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use WP_User;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * Hides profile fields for WordPress.com connected users.
  *

--- a/projects/packages/masterbar/src/wp-posts-list/bootstrap.php
+++ b/projects/packages/masterbar/src/wp-posts-list/bootstrap.php
@@ -7,6 +7,10 @@
 
 namespace Automattic\Jetpack\Masterbar;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * Load the Posts_List_Notification.
  */

--- a/projects/packages/protect-status/changelog/fix-jetpack-direct_access_fatals_part_9
+++ b/projects/packages/protect-status/changelog/fix-jetpack-direct_access_fatals_part_9
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Prevent PHP errors by limiting direct access to files.
+
+

--- a/projects/packages/protect-status/src/class-protect-status.php
+++ b/projects/packages/protect-status/src/class-protect-status.php
@@ -20,6 +20,10 @@ use Automattic\Jetpack\Sync\Functions as Sync_Functions;
 use Jetpack_Options;
 use WP_Error;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * Class that handles fetching and caching the Status of vulnerabilities check from the WPCOM servers
  */

--- a/projects/packages/protect-status/src/class-scan-status.php
+++ b/projects/packages/protect-status/src/class-scan-status.php
@@ -19,6 +19,10 @@ use Automattic\Jetpack\Sync\Functions as Sync_Functions;
 use Jetpack_Options;
 use WP_Error;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * Class that handles fetching of threats from the Scan API
  */

--- a/projects/packages/videopress/changelog/fix-jetpack-direct_access_fatals_part_9
+++ b/projects/packages/videopress/changelog/fix-jetpack-direct_access_fatals_part_9
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Prevent PHP errors by limiting direct access to files.
+
+

--- a/projects/packages/videopress/src/utility-functions.php
+++ b/projects/packages/videopress/src/utility-functions.php
@@ -2,6 +2,10 @@
 
 use Automattic\Jetpack\Connection\Client;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 defined( 'VIDEOPRESS_MIN_WIDTH' ) || define( 'VIDEOPRESS_MIN_WIDTH', 60 );
 defined( 'VIDEOPRESS_DEFAULT_WIDTH' ) || define( 'VIDEOPRESS_DEFAULT_WIDTH', 640 );
 

--- a/projects/packages/waf/changelog/fix-jetpack-direct_access_fatals_part_9
+++ b/projects/packages/waf/changelog/fix-jetpack-direct_access_fatals_part_9
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Prevent PHP errors by limiting direct access to files.
+
+

--- a/projects/packages/waf/src/brute-force-protection/class-brute-force-protection-blocked-login-page.php
+++ b/projects/packages/waf/src/brute-force-protection/class-brute-force-protection-blocked-login-page.php
@@ -10,6 +10,10 @@ namespace Automattic\Jetpack\Waf\Brute_Force_Protection;
 use Automattic\Jetpack\Redirect;
 use Automattic\Jetpack\Waf\Blocked_Login_Page;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * Brute Force Protection Blocked Login Page class.
  */

--- a/projects/plugins/jetpack/changelog/fix-jetpack-direct_access_fatals_part_9
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-direct_access_fatals_part_9
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Prevent PHP errors by limiting direct access to files.
+
+

--- a/projects/plugins/jetpack/extensions/blocks/sharing-buttons/sharing-buttons.php
+++ b/projects/plugins/jetpack/extensions/blocks/sharing-buttons/sharing-buttons.php
@@ -12,6 +12,10 @@ namespace Automattic\Jetpack\Extensions\Sharing_Buttons;
 use Automattic\Jetpack\Blocks;
 use Automattic\Jetpack\Status\Request;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 /**
  * Registers the block for use in Gutenberg
  * This is done via an action so that we can disable

--- a/projects/plugins/jetpack/extensions/blocks/top-posts/top-posts.php
+++ b/projects/plugins/jetpack/extensions/blocks/top-posts/top-posts.php
@@ -18,6 +18,10 @@ use Automattic\Jetpack\Status\Request;
 use Jetpack_Gutenberg;
 use Jetpack_Top_Posts_Helper;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 if ( ! class_exists( 'Jetpack_Top_Posts_Helper' ) ) {
 	require_once JETPACK__PLUGIN_DIR . '/_inc/lib/class-jetpack-top-posts-helper.php';
 }

--- a/projects/plugins/jetpack/extensions/extended-blocks/videopress-video/videopress-video.php
+++ b/projects/plugins/jetpack/extensions/extended-blocks/videopress-video/videopress-video.php
@@ -9,6 +9,10 @@ namespace Automattic\Jetpack\Extensions\VideoPress_Video;
 
 use Automattic\Jetpack\VideoPress\Initializer as VideoPress_Pkg_Initializer;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 // Set the videopress/video block availability, depending on the site plan.
 add_action(
 	'jetpack_register_gutenberg_extensions',

--- a/projects/plugins/jetpack/extensions/plugins/ai-content-lens/ai-content-lens.php
+++ b/projects/plugins/jetpack/extensions/plugins/ai-content-lens/ai-content-lens.php
@@ -11,6 +11,10 @@ use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Status\Host;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
 // Feature name.
 const FEATURE_NAME = 'ai-content-lens';
 


### PR DESCRIPTION
Closes MONOREP-155

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

As a follow-up to #44574, this gates against direct access to some more files as found in the logs.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

