### PR TITLE
Related Posts: Prevent PHP warnings when settings are malformed

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-related-posts-warnings
+++ b/projects/plugins/jetpack/changelog/fix-related-posts-warnings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Related Posts: Prevent PHP errors when settings are malformed.

--- a/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
+++ b/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
@@ -1309,7 +1309,7 @@ EOT;
 			'show_date'       => (bool) ( $options['show_date'] ?? true ),
 			'show_context'    => (bool) ( $options['show_context'] ?? true ),
 			'layout'          => (string) ( $options['layout'] ?? 'grid' ),
-			'headline'        => (string) $options['headline'] ?? '',
+			'headline'        => (string) ( $options['headline'] ?? '' ),
 			'items'           => array(),
 		);
 

--- a/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
+++ b/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
@@ -931,7 +931,7 @@ EOT;
 		}
 
 		if (
-			! $options['enabled']
+			empty( $options['enabled'] )
 			|| 0 === (int) $post_id
 			|| empty( $options['size'] )
 		) {
@@ -1305,15 +1305,15 @@ EOT;
 
 		$response = array(
 			'version'         => self::VERSION,
-			'show_thumbnails' => (bool) $options['show_thumbnails'],
-			'show_date'       => (bool) $options['show_date'],
-			'show_context'    => (bool) $options['show_context'],
-			'layout'          => (string) $options['layout'],
-			'headline'        => (string) $options['headline'],
+			'show_thumbnails' => (bool) ( $options['show_thumbnails'] ?? false ),
+			'show_date'       => (bool) ( $options['show_date'] ?? true ),
+			'show_context'    => (bool) ( $options['show_context'] ?? true ),
+			'layout'          => (string) ( $options['layout'] ?? 'grid' ),
+			'headline'        => (string) $options['headline'] ?? '',
 			'items'           => array(),
 		);
 
-		if ( count( $related_posts ) === $options['size'] ) {
+		if ( ! empty( $options['size'] ) && count( $related_posts ) === $options['size'] ) {
 			$response['items'] = $related_posts;
 		}
 

--- a/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
+++ b/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
@@ -198,7 +198,7 @@ class Jetpack_RelatedPosts {
 	public function get_headline() {
 		$options = $this->get_options();
 
-		if ( $options['show_headline'] ) {
+		if ( ! empty( $options['show_headline'] ) ) {
 			$headline = sprintf(
 				/** This filter is already documented in modules/sharedaddy/sharing-service.php */
 				apply_filters( 'jetpack_sharing_headline_html', '<h3 class="jp-relatedposts-headline"><em>%s</em></h3>', esc_html( $options['headline'] ), 'related-posts' ),


### PR DESCRIPTION
Closes MONOREP-156

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This addresses the following warnings:
```
PHP Warning: Trying to access array offset on false in /wordpress/plugins/jetpack/15.2-a.1/modules/related-posts/jetpack-related-posts.php on line 201
PHP Warning: Trying to access array offset on false in /wordpress/plugins/jetpack/15.2-a.1/modules/related-posts/jetpack-related-posts.php on line 934
PHP Warning: Trying to access array offset on false in /wordpress/plugins/jetpack/15.2-a.1/modules/related-posts/jetpack-related-posts.php on line 1308
PHP Warning: Trying to access array offset on false in /wordpress/plugins/jetpack/15.2-a.1/modules/related-posts/jetpack-related-posts.php on line 1309
PHP Warning: Trying to access array offset on false in /wordpress/plugins/jetpack/15.2-a.1/modules/related-posts/jetpack-related-posts.php on line 1310
PHP Warning: Trying to access array offset on false in /wordpress/plugins/jetpack/15.2-a.1/modules/related-posts/jetpack-related-posts.php on line 1311
PHP Warning: Trying to access array offset on false in /wordpress/plugins/jetpack/15.2-a.1/modules/related-posts/jetpack-related-posts.php on line 1312
PHP Warning: Trying to access array offset on false in /wordpress/plugins/jetpack/15.2-a.1/modules/related-posts/jetpack-related-posts.php on line 1316
```

These are due to settings being malformed. I've largely set things to use the defaults as the fallback with null coalescence. At some point the module should have more robust validation, but that's out of scope here.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

I'm not sure the best way to reproduce. Verify that the code changes will address the immediate concern.