### PR TITLE
Forms: Fix dashboard initialization

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-spa-init
+++ b/projects/packages/forms/changelog/fix-forms-spa-init
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Forms: Make dashboard initialization idempotent for SPA environments by using data attribute to track state

--- a/projects/packages/forms/src/dashboard/index.tsx
+++ b/projects/packages/forms/src/dashboard/index.tsx
@@ -21,23 +21,17 @@ declare global {
 	}
 }
 
-let isInitialized = false;
-
 /**
  * Initialize the Forms dashboard
  */
 function initFormsDashboard() {
-	if ( isInitialized ) {
-		return;
-	}
-
 	const container = document.getElementById( 'jp-forms-dashboard' );
 
-	if ( ! container ) {
+	if ( ! container || container.dataset.formsInitialized ) {
 		return;
 	}
 
-	isInitialized = true;
+	container.dataset.formsInitialized = 'true';
 
 	const router = createHashRouter( [
 		{


### PR DESCRIPTION

  Fixes #

  ## Proposed changes:
  <!--- Explain what functional changes your PR includes -->
  * Makes the Forms dashboard initialization idempotent to work correctly in SPA environments where components unmount and remount during navigation
  * Uses `container.dataset.formsInitialized` data attribute to track initialization state instead of checking `children.length`
  * Ensures the dashboard can be called multiple times but only initializes once per container

  ### Other information:

  - [ ] Have you written new tests for your changes, if applicable?
  - [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
  - [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

  ## Jetpack product discussion
  <!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
  <!-- Make sure any changes to existing products have been discussed and agreed upon -->

  ## Does this pull request change what data or activity we track or use?
  No

  ## Testing instructions:
  <!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
  <!-- Please include detailed testing steps, explaining how to test your change. -->
  <!-- Bear in mind that context you working on is not obvious for everyone.  -->
  <!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
  <!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

  * In an SPA environment that uses Forms programmatically (via `window.jetpackFormsInit()`)
  * Navigate to the Forms dashboard route/page
  * Verify the Forms dashboard loads and displays correctly
  * Navigate away to another page/route in the SPA
  * Navigate back to the Forms dashboard
  * Verify the Forms dashboard loads correctly again (not blank)
  * Check browser console - should see no warnings about duplicate React roots or store registration

