### PR TITLE
Forms: fix close modal in responsive mode

### DIFF
--- a/projects/packages/forms/changelog/fix-close-modal-forms
+++ b/projects/packages/forms/changelog/fix-close-modal-forms
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: fix bug where the responsvie modal is not able to be closed. 

--- a/projects/packages/forms/src/dashboard/components/response-view/single.tsx
+++ b/projects/packages/forms/src/dashboard/components/response-view/single.tsx
@@ -31,12 +31,17 @@ const SingleResponseView = ( {
 	selection,
 } ) => {
 	const [ isChildModalOpen, setIsChildModalOpen ] = useState( false );
+	const [ isModalOpen, setIsModalOpen ] = useState( true );
 
 	const onRequestClose = useCallback( () => {
 		if ( ! isChildModalOpen ) {
 			onChangeSelection?.( [] );
 		}
-	}, [ onChangeSelection, isChildModalOpen ] );
+
+		if ( isMobile ) {
+			setIsModalOpen( false );
+		}
+	}, [ onChangeSelection, isChildModalOpen, setIsModalOpen, isMobile ] );
 
 	const handleModalStateChange = useCallback(
 		isOpen => {
@@ -102,6 +107,10 @@ const SingleResponseView = ( {
 				{ contents }
 			</div>
 		);
+	}
+
+	if ( ! isModalOpen ) {
+		return null;
 	}
 
 	return (

--- a/projects/plugins/jetpack/changelog/fix-close-modal-forms
+++ b/projects/plugins/jetpack/changelog/fix-close-modal-forms
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: fix a bug where ther responsive modal is not able to be closed.


### PR DESCRIPTION
Currently when you have are on the dashboard and you have a response open for viewing. 
And you resize the window from desktop to mobile the modal that shows up is not able to be closed.

This PR makes it so that the modal is able to be closed when we end up in this situation. 

See 

https://github.com/user-attachments/assets/d9245488-7636-452f-bfd4-85c50cbee5c1



## Proposed changes:
* Have a new state that is only used for this modal. 

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion


## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Visit the forms dashboard. 
Open a response. 
Resize the window till you see the Modal. 
Click the X or press `esc` and notice that the Modal closes as expected.

