### PR TITLE
Forms: clear selection when switching tabs

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-clear-selection-when-switching-tabs
+++ b/projects/packages/forms/changelog/fix-forms-clear-selection-when-switching-tabs
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Forms: reset the selection of the on tab switch
+Forms: reset the selection on tab switch

--- a/projects/packages/forms/changelog/fix-forms-clear-selection-when-switching-tabs
+++ b/projects/packages/forms/changelog/fix-forms-clear-selection-when-switching-tabs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: reset the selection of the on tab switch

--- a/projects/packages/forms/src/dashboard/components/inbox-status-toggle/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/inbox-status-toggle/index.tsx
@@ -66,7 +66,7 @@ export default function InboxStatusToggle( { onChange }: InboxStatusToggleProps 
 			setSearchParams( prev => {
 				const params = new URLSearchParams( prev );
 				params.set( 'status', newStatus );
-				params.delete( 'r' ); // Reset to first page on status change.
+				params.delete( 'r' ); // Clear selected responses when changing tabs.
 				return params;
 			} );
 			setSelectedResponses( [] );

--- a/projects/packages/forms/src/dashboard/components/inbox-status-toggle/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/inbox-status-toggle/index.tsx
@@ -44,7 +44,7 @@ export default function InboxStatusToggle( { onChange }: InboxStatusToggleProps 
 	const status = searchParams.get( 'status' ) || 'inbox';
 	const [ isSm ] = useBreakpointMatch( 'sm' );
 
-	const { totalItemsInbox, totalItemsSpam, totalItemsTrash } = useInboxData();
+	const { totalItemsInbox, totalItemsSpam, totalItemsTrash, setSelectedResponses } = useInboxData();
 
 	const statusTabs = [
 		{ label: getTabLabel( __( 'Inbox', 'jetpack-forms' ), totalItemsInbox ), value: 'inbox' },
@@ -66,13 +66,13 @@ export default function InboxStatusToggle( { onChange }: InboxStatusToggleProps 
 			setSearchParams( prev => {
 				const params = new URLSearchParams( prev );
 				params.set( 'status', newStatus );
-
+				params.delete( 'r' ); // Reset to first page on status change.
 				return params;
 			} );
-
+			setSelectedResponses( [] );
 			onChange( newStatus );
 		},
-		[ isSm, status, setSearchParams, onChange ]
+		[ isSm, status, setSearchParams, onChange, setSelectedResponses ]
 	);
 
 	return (

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
@@ -134,7 +134,8 @@ export default function InboxView() {
 		setCurrentQuery( _queryArgs );
 	}, [ view, statusFilter, setCurrentQuery ] );
 
-	const [ selection, setSelection ] = useState( selectedResponses?.split( ',' ) || EMPTY_ARRAY );
+	const selection = selectedResponses?.split( ',' ) || EMPTY_ARRAY;
+
 	// We need to keep the valid selection item in state to be used in `export`.
 	// We do this because a user can have in their selection either ids that
 	// do not exist at all or ids that are not in the current data set.
@@ -142,12 +143,13 @@ export default function InboxView() {
 		const validSelectedIds = ( selection || [] ).filter( id =>
 			records?.some( record => getItemId( record ) === id )
 		);
+
 		setSelectedResponses( validSelectedIds );
 	}, [ records, selection, setSelectedResponses ] );
+
 	const [ sidePanelItem, setSidePanelItem ] = useState();
 	const onChangeSelection = useCallback(
 		items => {
-			setSelection( items );
 			// Set the side panel item only when we are not on mobile.
 			if ( ! isMobile ) {
 				setSidePanelItem(
@@ -157,8 +159,17 @@ export default function InboxView() {
 			}
 			setSearchParams( previousSearchParams => {
 				const _searchParams = new URLSearchParams( previousSearchParams );
-				if ( items.length ) {
-					_searchParams.set( 'r', items.join( ',' ) );
+				const currentURLSelection = _searchParams.get( 'r' )?.split( ',' ) || [];
+
+				// remove all the currentURLSelection items ID that are duplicates and are also in the records list
+				const currentSelection = currentURLSelection.filter(
+					id => ! ( items.includes( id ) || records?.some( record => getItemId( record ) === id ) )
+				);
+
+				// merge items with the current url
+				const mergedItems = [ ...new Set( [ ...currentSelection, ...items ] ) ];
+				if ( mergedItems.length ) {
+					_searchParams.set( 'r', mergedItems.join( ',' ) );
 				} else {
 					_searchParams.delete( 'r' );
 				}

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
@@ -166,7 +166,7 @@ export default function InboxView() {
 					id => ! ( items.includes( id ) || records?.some( record => getItemId( record ) === id ) )
 				);
 
-				// merge items with the current url
+				// merge items with the current URL
 				const mergedItems = [ ...new Set( [ ...currentSelection, ...items ] ) ];
 				if ( mergedItems.length ) {
 					_searchParams.set( 'r', mergedItems.join( ',' ) );

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
@@ -161,7 +161,8 @@ export default function InboxView() {
 				const _searchParams = new URLSearchParams( previousSearchParams );
 				const currentURLSelection = _searchParams.get( 'r' )?.split( ',' ) || [];
 
-				// remove all the currentURLSelection items ID that are duplicates and are also in the records list
+				// Filter out IDs from the current URL selection that are either already selected in the current view
+				// or already present in the current records, to avoid duplication when merging selections across pages.
 				const currentSelection = currentURLSelection.filter(
 					id => ! ( items.includes( id ) || records?.some( record => getItemId( record ) === id ) )
 				);

--- a/projects/plugins/jetpack/changelog/fix-forms-clear-selection-when-switching-tabs
+++ b/projects/plugins/jetpack/changelog/fix-forms-clear-selection-when-switching-tabs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: reset the selection on tab switch in dashboard


### PR DESCRIPTION
This PR fixed the issue where when a user has selected responses and then switches tabs ( Inbox, Spam, Trash ). 
and then navigates back to the previous tab that the selection is still active. 

This is unexpected since the selection should be cleared.  

https://github.com/user-attachments/assets/05fee23b-14f1-4152-b35a-6843d1a3db65


## Proposed changes:
* This PR clears the selection and move the state of what is selected to the URL. 
* The selection persists across pages. 

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion


## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Go to the dashboard. 
Select responses. Notice that the selection is updated in the URL. 
Change tabs. ( Inbox, Spam, Trash ). Notice that the selection  is cleared in the URL. 
Notice that non of the checkboxes are selected. 

