### PR TITLE
WooCommerce Analytics: Prevent server-side track event rejections due to array event properties

### DIFF
--- a/projects/packages/woocommerce-analytics/changelog/fix-wa-event-prop-invalid
+++ b/projects/packages/woocommerce-analytics/changelog/fix-wa-event-prop-invalid
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix improved data handling due to invalid prop name

--- a/projects/packages/woocommerce-analytics/src/class-wc-analytics-tracking.php
+++ b/projects/packages/woocommerce-analytics/src/class-wc-analytics-tracking.php
@@ -228,7 +228,31 @@ class WC_Analytics_Tracking extends WC_Tracks {
 			)
 			: array();
 
-		return array_merge( $properties, $required_properties );
+		$all_properties = array_merge( $properties, $required_properties );
+
+		// Convert array values to a comma-separated string and URL-encode them to ensure compatibility with JavaScript's encodeURIComponent() for pixel URL transmission.
+		foreach ( $all_properties as $key => $value ) {
+			if ( ! is_array( $value ) ) {
+				continue;
+			}
+
+			if ( empty( $value ) ) {
+				$all_properties[ $key ] = '';
+				continue;
+			}
+
+			$is_indexed_array = array_keys( $value ) === range( 0, count( $value ) - 1 );
+			if ( $is_indexed_array ) {
+				$value_string           = implode( ',', $value );
+				$all_properties[ $key ] = rawurlencode( $value_string );
+				continue;
+			}
+
+			// Serialize non-indexed arrays to JSON strings.
+			$all_properties[ $key ] = wp_json_encode( $value );
+		}
+
+		return $all_properties;
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Partially fixes [WOOA7S-568](https://linear.app/a8c/issue/WOOA7S-568/woocommerceanalytics-product-purchase-tracks-event-is-getting-rejected)

## Proposed changes:

This PR addresses a bug where server-side events, such as `product_purchase`, are being rejected due to invalid event prop names when there are additional blocks present on the cart or checkout page.

While the ideal solution would be to address these issues directly in WooCommerce core, the core release schedule means we have to implement this fix here first and subsequently submit a PR to WooCommerce core.

**Root cause:**  

Event prop names are required to match the pattern `^[a-z_][a-z0-9_]*$`. However, when arrays are passed as event properties (for example, an array like `additional_blocks_on_checkout_page`), the serialization performed by [`http_build_query`](https://github.com/woocommerce/woocommerce/blob/6d0562432af0da79714869435ef6020552d91067/plugins/woocommerce/includes/tracks/class-wc-tracks-event.php#L131) turns them into query parameters with keys such as `additional_blocks_on_checkout_page[0]`, `additional_blocks_on_checkout_page[1]`, etc. These prop names contain brackets (`[0]`), which violates the required event prop naming convention and results in events getting rejected.

Example:

```php
$query_string = http_build_query(array(
	"additional_blocks_on_checkout_page" => array( 1, 2, 3),
	'tmp' => ''
));
echo $query_string;
// Output: additional_blocks_on_checkout_page%5B0%5D=1&additional_blocks_on_checkout_page%5B1%5D=2&additional_blocks_on_checkout_page%5B2%5D=3&tmp=
// `additional_blocks_on_checkout_page%5B0%5D` name is invalid
```

Here is the method used by `s.js` to construct the query string:

```js
var serialize = function( obj ) {
	var str = [];
	for ( var p in obj ) {
		if ( obj.hasOwnProperty( p ) ) {
			str.push(
				encodeURIComponent( p ) + '=' + encodeURIComponent( obj[ p ] )
			);
		}
	}
	return str.join( '&' );
};
```

**How this PR fixes it:**  

This update encodes event property values when they are arrays, preventing the creation of invalid property names.



### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

no, this doesn't add/change any data or activity we track or use but just fixes a bug where server-side events are rejected due to invalid event prop names when there are additional blocks present on the cart or checkout page.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### Prerequisites:

* Generate some products
* Call `set_transient( 'jetpack_woocommerce_analytics_additional_blocks_on_checkout_page', array( 'core/group', 'core/heading' ), DAY_IN_SECONDS );` in any file that gets loaded before the cart or checkout page is loaded.
* Use the following code snippet to log the events:

```php
 function log_remote_pixels( $preempt, $parsed_args, $url ) {
	if ( strpos( $url, WC_Tracks_Client::PIXEL ) === 0 ||  strpos( $url, 'https://pixel.wp.com/w.gif' ) === 0  ) {
		$parsed_url = wp_parse_url( $url );
		parse_str( $parsed_url['query'], $params );
		error_log( $url );
		error_log( $params['_en'] . ' -- ' . print_r( $params, true ));
	}

	return $preempt;
}

add_action( 'pre_http_request', 'log_remote_pixels', 10, 3 );
```

1. Go to the cart page and add a product to the cart.
2. Confirm that `woocommerceanalytics_add_to_cart` event is logged in `wp-content/debug.log` and `additional_blocks_on_checkout_page` prop value is encoded as a single string with the values separated by commas. Confirm that the `additional_blocks_on_cart_page` prop value is empty string (`additional_blocks_on_cart_page=&additional_blocks_on_checkout_page=core%252Fgroup%252Ccore%252Fheading&`).
3. Complete the checkout process and confirm that `woocommerceanalytics_product_purchase` event is logged in `wp-content/debug.log` and `additional_blocks_on_checkout_page` prop value is encoded as a single string with the values separated by commas. Confirm that the `additional_blocks_on_cart_page` prop value is empty string (`additional_blocks_on_cart_page=&additional_blocks_on_checkout_page=core%252Fgroup%252Ccore%252Fheading&`).

<img width="1140" height="357" alt="Screenshot 2025-10-18 at 06 24 41" src="https://github.com/user-attachments/assets/1d949ddd-99e3-41bf-8e43-4fed2e956da1" />


You can also search the events via the Tracks Live View to confirm that the events are logged correctly.
