### PR TITLE
External Media: Use previous enqueue process to prevent performance issues

### DIFF
--- a/projects/packages/external-media/changelog/fix-external-media-script-performance-issues
+++ b/projects/packages/external-media/changelog/fix-external-media-script-performance-issues
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+External media: Prevent site editor performance issues by bringing back previous script enqueue approach.

--- a/projects/packages/external-media/src/class-external-media.php
+++ b/projects/packages/external-media/src/class-external-media.php
@@ -33,13 +33,9 @@ class External_Media {
 			require_once __DIR__ . '/features/admin/external-media-import.php';
 		}
 
-		if ( is_admin() ) {
-			// This loads assets in the editor iframe (block content) context
-			add_action( 'enqueue_block_assets', array( __CLASS__, 'enqueue_block_editor_assets' ) );
-		} else {
-			// This loads assets specific to the editing interface like the block toolbar, as well as a front-end fallback.
-			add_action( 'enqueue_block_editor_assets', array( __CLASS__, 'enqueue_block_editor_assets' ) );
-		}
+		// @todo this current approach results in a console warning in the editor related to adding the css to the iframe incorrectly.
+		// It has been temporarily added back to prevent performance issues in the site editor. See pdWQjU-1rA-p2 for more details.
+		add_action( 'enqueue_block_editor_assets', array( __CLASS__, 'enqueue_block_editor_assets' ) );
 
 		External_Connections::add_settings_for_service(
 			'media',

--- a/projects/plugins/jetpack/changelog/fix-external-media-script-performance-issues
+++ b/projects/plugins/jetpack/changelog/fix-external-media-script-performance-issues
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+External media: Prevent site editor performance issues by bringing back previous script enqueue approach.


### PR DESCRIPTION
Fixes JETPACK-915

## Proposed changes:

* This PR changes the approach to enqueuing external media scripts and styles back to how it was prior to this PR: https://github.com/Automattic/jetpack/pull/42985
* While this will re-introduce the console warnings that that PR fixed, it will prevent performance issues related to duplicate JS loading in the site editor
* A project exists in order to review Jetpack's block and script / style registration processes more generally, so this is just a short-term solution.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

More information at: pdWQjU-1rA-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:

On a local development site or Jurassic Ninja site running Jetpack trunk, as well as on a WoA test site using the Jetpack beta tester plugin, or a sandboxed Simple site using the commands in the generated comment below:
* Open up a new post. You shouldn't need script debug enabled (nor does it matter if you have a block based theme or legacy theme), and should not see warnings in the console related to CSS scripts being added to the iframe incorrectly, related to external-media.
* Observe the network tab when opening up the site editor templates page, and you should see the size of the data being transferred (see this post for details - pdWQjU-1rA-p2 ).

With this PR applied:
* The console warnings related to `jetpack-external-media-editor-css` should be visible.
* On the site editor, the size of the data being transferred should be significantly reduced.