### PR TITLE
WooCommerce Analytic: Set anonymous id when initializing the tracker

### DIFF
--- a/projects/packages/woocommerce-analytics/changelog/update-ensure-anonymous-id-set
+++ b/projects/packages/woocommerce-analytics/changelog/update-ensure-anonymous-id-set
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Ensure anonymous ID is set

--- a/projects/packages/woocommerce-analytics/src/class-wc-analytics-tracking.php
+++ b/projects/packages/woocommerce-analytics/src/class-wc-analytics-tracking.php
@@ -297,8 +297,20 @@ class WC_Analytics_Tracking extends WC_Tracks {
 			return self::$cached_visitor_id;
 		}
 
-		self::$cached_visitor_id = null;
-		return null;
+		// Generate anonymous ID
+		self::$cached_visitor_id = wp_generate_password( 24 );
+		setcookie(
+			'tk_ai',
+			self::$cached_visitor_id,
+			array(
+				'expires'  => time() + ( 365 * 24 * 60 * 60 ), // 1 year
+				'path'     => '/',
+				'domain'   => COOKIE_DOMAIN,
+				'secure'   => is_ssl(),
+				'httponly' => true,
+				'samesite' => 'Strict',
+			)
+		);
 	}
 
 	/**

--- a/projects/packages/woocommerce-analytics/src/class-wc-analytics-tracking.php
+++ b/projects/packages/woocommerce-analytics/src/class-wc-analytics-tracking.php
@@ -297,8 +297,14 @@ class WC_Analytics_Tracking extends WC_Tracks {
 			return self::$cached_visitor_id;
 		}
 
-		// Generate anonymous ID
-		self::$cached_visitor_id = wp_generate_password( 24 );
+		// Generate a new anonId and try to save it in the browser's cookies.
+		// Note that base64-encoding an 18 character string generates a 24-character anon id.
+		for ( $i = 0; $i < 18; ++$i ) {
+			$binary .= chr( wp_rand( 0, 255 ) );
+		}
+
+		self::$cached_visitor_id = base64_encode( $binary ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
+
 
 		if ( ! headers_sent()
 			&& ! ( defined( 'REST_REQUEST' ) && REST_REQUEST )

--- a/projects/packages/woocommerce-analytics/src/class-wc-analytics-tracking.php
+++ b/projects/packages/woocommerce-analytics/src/class-wc-analytics-tracking.php
@@ -299,6 +299,7 @@ class WC_Analytics_Tracking extends WC_Tracks {
 
 		// Generate a new anonId and try to save it in the browser's cookies.
 		// Note that base64-encoding an 18 character string generates a 24-character anon id.
+		$binary = '';
 		for ( $i = 0; $i < 18; ++$i ) {
 			$binary .= chr( wp_rand( 0, 255 ) );
 		}

--- a/projects/packages/woocommerce-analytics/src/class-wc-analytics-tracking.php
+++ b/projects/packages/woocommerce-analytics/src/class-wc-analytics-tracking.php
@@ -299,18 +299,24 @@ class WC_Analytics_Tracking extends WC_Tracks {
 
 		// Generate anonymous ID
 		self::$cached_visitor_id = wp_generate_password( 24 );
-		setcookie(
-			'tk_ai',
-			self::$cached_visitor_id,
-			array(
-				'expires'  => time() + ( 365 * 24 * 60 * 60 ), // 1 year
-				'path'     => '/',
-				'domain'   => COOKIE_DOMAIN,
-				'secure'   => is_ssl(),
-				'httponly' => true,
-				'samesite' => 'Strict',
-			)
-		);
+
+		if ( ! headers_sent()
+			&& ! ( defined( 'REST_REQUEST' ) && REST_REQUEST )
+			&& ! ( defined( 'XMLRPC_REQUEST' ) && XMLRPC_REQUEST )
+		) {
+			setcookie(
+				'tk_ai',
+				self::$cached_visitor_id,
+				array(
+					'expires'  => time() + ( 365 * 24 * 60 * 60 ), // 1 year
+					'path'     => '/',
+					'domain'   => COOKIE_DOMAIN,
+					'secure'   => is_ssl(),
+					'httponly' => true,
+					'samesite' => 'Strict',
+				)
+			);
+		}
 		return self::$cached_visitor_id;
 	}
 

--- a/projects/packages/woocommerce-analytics/src/class-wc-analytics-tracking.php
+++ b/projects/packages/woocommerce-analytics/src/class-wc-analytics-tracking.php
@@ -311,6 +311,7 @@ class WC_Analytics_Tracking extends WC_Tracks {
 				'samesite' => 'Strict',
 			)
 		);
+		return self::$cached_visitor_id;
 	}
 
 	/**

--- a/projects/packages/woocommerce-analytics/src/client/analytics.ts
+++ b/projects/packages/woocommerce-analytics/src/client/analytics.ts
@@ -261,7 +261,7 @@ export class Analytics {
 
 		if ( ! anonId ) {
 			// Set a first-party cookie (same domain only, 1 year)
-			const randomToken = generateRandomToken( 18 );
+			const randomToken = generateRandomToken( 18 ); // 18 * 4/3 = 24 (base64 encoded chars)
 			const expires = new Date( Date.now() + 1 * 365 * 24 * 60 * 60 * 1000 ).toUTCString();
 			document.cookie = `tk_ai=${ randomToken }; path=/; secure; samesite=strict; expires=${ expires }`;
 		}

--- a/projects/packages/woocommerce-analytics/src/client/analytics.ts
+++ b/projects/packages/woocommerce-analytics/src/client/analytics.ts
@@ -9,6 +9,7 @@ import { ApiClient } from './api-client';
 import { consentManager } from './consent';
 import { EVENT_NAME_REGEX, EVENT_PREFIX, CLICK_HOUSE_EVENTS } from './constants';
 import SessionManager from './session-manager';
+import { getCookie, generateRandomToken } from './utils';
 import type { AnalyticsConfig } from './types/shared';
 
 const debug = debugFactory( 'wc-analytics:analytics' );
@@ -82,6 +83,7 @@ export class Analytics {
 			this.recordEvent( 'page_view' );
 		}
 
+		this.maybeSetAnonId();
 		this.processEventQueue();
 		this.initListeners();
 
@@ -250,4 +252,18 @@ export class Analytics {
 			this.sessionManager.init();
 		}
 	};
+
+	/**
+	 * Set anonymous ID if not already set
+	 */
+	private maybeSetAnonId() {
+		const anonId = getCookie( 'tk_ai' );
+
+		if ( ! anonId ) {
+			// Set a first-party cookie (same domain only, 1 year)
+			const randomToken = generateRandomToken( 18 );
+			const expires = new Date( Date.now() + 1 * 365 * 24 * 60 * 60 * 1000 ).toUTCString();
+			document.cookie = `tk_ai=${ randomToken }; path=/; secure; samesite=strict; expires=${ expires }`;
+		}
+	}
 }

--- a/projects/packages/woocommerce-analytics/src/client/session-manager.ts
+++ b/projects/packages/woocommerce-analytics/src/client/session-manager.ts
@@ -24,9 +24,24 @@ export default class SessionManager {
 			return;
 		}
 
+		this.maybeSetAnonId();
 		this.loadOrCreateSession();
 		this.isInitialized = true;
 	};
+
+	/**
+	 * Set anonymous ID if not already set
+	 */
+	maybeSetAnonId() {
+		const anonId = this.getCookie( 'tk_ai' );
+
+		if ( ! anonId ) {
+			// Set a first-party cookie (same domain only, 1 year)
+			const randomToken = this.generateRandomToken( 18 );
+			const expires = new Date( Date.now() + 1 * 365 * 24 * 60 * 60 * 1000 ).toUTCString();
+			document.cookie = `tk_ai=${ randomToken }; path=/; secure; samesite=strict; expires=${ expires }`;
+		}
+	}
 
 	/**
 	 * Load existing session or create new one
@@ -129,6 +144,27 @@ export default class SessionManager {
 
 		const expirationTime = Math.min( thirtyMinutesFromNow, midnightUTC.getTime() );
 		return new Date( expirationTime ).toUTCString();
+	}
+
+	/**
+	 * Generate a random token
+	 *
+	 * @param randomBytesLength - Length of the random bytes
+	 * @return string
+	 */
+	generateRandomToken( randomBytesLength: number ): string {
+		let randomBytes: Uint8Array | number[];
+
+		if ( window.crypto && window.crypto.getRandomValues ) {
+			randomBytes = new Uint8Array( randomBytesLength );
+			window.crypto.getRandomValues( randomBytes );
+		} else {
+			for ( let i = 0; i < randomBytesLength; ++i ) {
+				randomBytes[ i ] = Math.floor( Math.random() * 256 );
+			}
+		}
+
+		return btoa( String.fromCharCode( ...randomBytes ) );
 	}
 
 	/**

--- a/projects/packages/woocommerce-analytics/src/client/session-manager.ts
+++ b/projects/packages/woocommerce-analytics/src/client/session-manager.ts
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import { COOKIE_NAME } from './constants';
+import { getCookie } from './utils';
 import type { SessionCookieData } from './types/shared';
 
 /**
@@ -24,24 +25,9 @@ export default class SessionManager {
 			return;
 		}
 
-		this.maybeSetAnonId();
 		this.loadOrCreateSession();
 		this.isInitialized = true;
 	};
-
-	/**
-	 * Set anonymous ID if not already set
-	 */
-	maybeSetAnonId() {
-		const anonId = this.getCookie( 'tk_ai' );
-
-		if ( ! anonId ) {
-			// Set a first-party cookie (same domain only, 1 year)
-			const randomToken = this.generateRandomToken( 18 );
-			const expires = new Date( Date.now() + 1 * 365 * 24 * 60 * 60 * 1000 ).toUTCString();
-			document.cookie = `tk_ai=${ randomToken }; path=/; secure; samesite=strict; expires=${ expires }`;
-		}
-	}
 
 	/**
 	 * Load existing session or create new one
@@ -86,7 +72,7 @@ export default class SessionManager {
 	 * @return SessionCookieData | null
 	 */
 	getSessionCookie(): SessionCookieData | null {
-		const rawCookie = this.getCookie( COOKIE_NAME );
+		const rawCookie = getCookie( COOKIE_NAME );
 		if ( ! rawCookie ) {
 			return null;
 		}
@@ -97,21 +83,6 @@ export default class SessionManager {
 			console.error( 'Error parsing session cookie', _error );
 			return null;
 		}
-	}
-
-	/**
-	 * Get cookie value by name
-	 *
-	 * @param name - Cookie name
-	 * @return string | null
-	 */
-	getCookie( name: string ): string | null {
-		const value = `; ${ document.cookie }`;
-		const parts = value.split( `; ${ name }=` );
-		if ( parts.length === 2 ) {
-			return parts.pop()?.split( ';' ).shift() || null;
-		}
-		return null;
 	}
 
 	/**
@@ -126,7 +97,7 @@ export default class SessionManager {
 
 		document.cookie = `${ COOKIE_NAME }=${ encoded }; expires=${ expires }; path=/; secure; samesite=strict`;
 
-		const isCookieSet = this.getCookie( COOKIE_NAME ) === encoded;
+		const isCookieSet = getCookie( COOKIE_NAME ) === encoded;
 		return isCookieSet;
 	}
 
@@ -144,27 +115,6 @@ export default class SessionManager {
 
 		const expirationTime = Math.min( thirtyMinutesFromNow, midnightUTC.getTime() );
 		return new Date( expirationTime ).toUTCString();
-	}
-
-	/**
-	 * Generate a random token
-	 *
-	 * @param randomBytesLength - Length of the random bytes
-	 * @return string
-	 */
-	generateRandomToken( randomBytesLength: number ): string {
-		let randomBytes: Uint8Array | number[];
-
-		if ( window.crypto && window.crypto.getRandomValues ) {
-			randomBytes = new Uint8Array( randomBytesLength );
-			window.crypto.getRandomValues( randomBytes );
-		} else {
-			for ( let i = 0; i < randomBytesLength; ++i ) {
-				randomBytes[ i ] = Math.floor( Math.random() * 256 );
-			}
-		}
-
-		return btoa( String.fromCharCode( ...randomBytes ) );
 	}
 
 	/**

--- a/projects/packages/woocommerce-analytics/src/client/utils.ts
+++ b/projects/packages/woocommerce-analytics/src/client/utils.ts
@@ -1,0 +1,35 @@
+/**
+ * Get cookie value by name
+ *
+ * @param name - Cookie name
+ * @return string | null
+ */
+export function getCookie( name: string ): string | null {
+	const value = `; ${ document.cookie }`;
+	const parts = value.split( `; ${ name }=` );
+	if ( parts.length === 2 ) {
+		return parts.pop()?.split( ';' ).shift() || null;
+	}
+	return null;
+}
+
+/**
+ * Generate a random token
+ *
+ * @param randomBytesLength - Length of the random bytes
+ * @return string
+ */
+export function generateRandomToken( randomBytesLength: number ): string {
+	let randomBytes: Uint8Array | number[];
+
+	if ( window.crypto && window.crypto.getRandomValues ) {
+		randomBytes = new Uint8Array( randomBytesLength );
+		window.crypto.getRandomValues( randomBytes );
+	} else {
+		for ( let i = 0; i < randomBytesLength; ++i ) {
+			randomBytes[ i ] = Math.floor( Math.random() * 256 );
+		}
+	}
+
+	return btoa( String.fromCharCode( ...randomBytes ) );
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes [WOOA7S-568](https://linear.app/a8c/issue/WOOA7S-568/woocommerceanalytics-product-purchase-tracks-event-is-getting-rejected)

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

- Ensure the anonymous ID (`tk_ai`) is created during both server-side and client-side if it doesn't already exist, so that `tk_ai` is available before users interact with the site. Set it on both sides to ensure consistency.


**Why**

Following the move to server-side event recording, some events have been rejected because a user ID was missing. This may occur if:

1. Server-side events may be initiated before frontend events have been captured by `s.js`, or if `s.js` is unavailable due to being blocked.
2. API calls made directly to the store's API endpoints.


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### Client-side Testing

1. **Preparation**
    - Ensure that WP Consent API and WooCommerce Analytics plugins are **disabled** to avoid interference with analytics event tracking.

2. **Verify `tk_ai` Cookie Creation**
    - Open a new incognito/private browser window to ensure a clean testing environment.
    - Navigate to your site's Home page.
    - Open your browser's developer tools > Application/Storage > Cookies tab.
    - **Expected Result:** Confirm that a `tk_ai` cookie is created for your site. This should be visible in the cookie storage area for your domain.

---

### Server-side Testing

1. **Enable Event Logging**
    - Add the following PHP code snippet to your site's `functions.php` file or use a plugin like Code Snippets to insert it. This will log all incoming WooCommerce analytics pixel events:
    ```php
    function log_remote_pixels( $preempt, $parsed_args, $url ) {
        if (
            strpos( $url, WC_Tracks_Client::PIXEL ) === 0 ||
            strpos( $url, 'https://pixel.wp.com/w.gif' ) === 0
        ) {
            $parsed_url = wp_parse_url( $url );
            parse_str( $parsed_url['query'], $params );
            error_log( $url );
            error_log( $params['_en'] . ' -- ' . print_r( $params, true ));
        }
        return $preempt;
    }
    add_action( 'pre_http_request', 'log_remote_pixels', 10, 3 );
    ```
    - This logs events to `wp-content/debug.log`. Ensure that [`WP_DEBUG`](https://developer.wordpress.org/apis/wp-config-php/#wp_debug) and [`WP_DEBUG_LOG`](https://developer.wordpress.org/apis/wp-config-php/#wp_debug_log) are enabled in your `wp-config.php` file.

2. **Trigger an Analytics Event**
    - Go to your site's Shop page.
    - Open your browser's Developer Tools and go to the Network tab.
    - Add a product to the cart.

3. **Simulate Direct API Call Without Cookie**
    - In the Network tab, find the "Add to cart" API request. Copy the fetch/cURL command for that request.
    - In your browser or a tool like Postman, **delete the `tk_ai` cookie** (in Application/Storage > Cookies, remove `tk_ai` for your domain).
    - Re-run the "Add to cart" API request directly, without the `tk_ai` cookie being present.

4. **Review the Results**
    - Check `wp-content/debug.log` for the event logs generated by your request.
    - **Expected Result:** The log entry for the corresponding event should have a non-null value for the `_ui` (user/visitor ID) parameter, confirming that the server-side logic correctly issues a new `tk_ai` identifier even if the cookie is missing.

