### PR TITLE
Forms: merge email and push notifications settings panel

### DIFF
--- a/projects/packages/forms/changelog/update-form-notifications-ui
+++ b/projects/packages/forms/changelog/update-form-notifications-ui
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: merged email and push notification settings panels.

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-email-connection-settings.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-email-connection-settings.js
@@ -2,7 +2,6 @@ import { TextControl, ToggleControl } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { validate as emailValidatorValidate } from 'email-validator';
-import InspectorHint from '../../shared/components/inspector-hint';
 import HelpMessage from '../components/help-message';
 
 const JetpackEmailConnectionSettings = ( {
@@ -91,14 +90,12 @@ const JetpackEmailConnectionSettings = ( {
 			<ToggleControl
 				label={ __( 'Send responses to email', 'jetpack-forms' ) }
 				checked={ emailNotifications }
+				help={ __( 'Get incoming form responses sent to your email inbox.', 'jetpack-forms' ) }
 				onChange={ value => setAttributes( { emailNotifications: value } ) }
 				__nextHasNoMarginBottom={ true }
 			/>
 			{ emailNotifications && (
 				<>
-					<InspectorHint>
-						{ __( 'Get incoming form responses sent to your email inbox:', 'jetpack-forms' ) }
-					</InspectorHint>
 					<TextControl
 						aria-describedby={ `contact-form-${ instanceId }-email-${
 							hasEmailErrors() ? 'error' : 'help'

--- a/projects/packages/forms/src/blocks/contact-form/components/notifications-settings.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/notifications-settings.js
@@ -1,11 +1,20 @@
-import { FormTokenField, ToggleControl } from '@wordpress/components';
+import { FormTokenField, ToggleControl, ExternalLink } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
-import { useState } from '@wordpress/element';
+import { useState, createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import JetpackEmailConnectionSettings from './jetpack-email-connection-settings';
 
-const NotificationsSettings = ( { setAttributes, notificationRecipients } ) => {
+const NotificationsSettings = ( {
+	setAttributes,
+	notificationRecipients,
+	emailAddress,
+	emailSubject,
+	emailNotifications,
+	instanceId,
+	postAuthorEmail,
+} ) => {
 	const [ localNotificationRecipients, setLocalNotificationRecipients ] =
 		useState( notificationRecipients );
 	const [ localFormNotifications, setLocalFormNotifications ] = useState(
@@ -48,9 +57,27 @@ const NotificationsSettings = ( { setAttributes, notificationRecipients } ) => {
 
 	return (
 		<>
+			<JetpackEmailConnectionSettings
+				emailAddress={ emailAddress }
+				emailSubject={ emailSubject }
+				emailNotifications={ emailNotifications }
+				instanceId={ instanceId }
+				postAuthorEmail={ postAuthorEmail }
+				setAttributes={ setAttributes }
+			/>
 			<ToggleControl
 				label={ __( 'Enable notifications for responses', 'jetpack-forms' ) }
-				help={ __( 'Receive notifications when someone fills out your form.', 'jetpack-forms' ) }
+				help={ createInterpolateElement(
+					__(
+						'Receive push notifications when someone fills out your form. <pushNotificationsLink>Learn more.</pushNotificationsLink>',
+						'jetpack-forms'
+					),
+					{
+						pushNotificationsLink: (
+							<ExternalLink href="https://jetpack.com/support/notifications/" />
+						),
+					}
+				) }
 				checked={ localFormNotifications }
 				onChange={ value => {
 					if ( value ) {

--- a/projects/packages/forms/src/blocks/contact-form/components/notifications-settings.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/notifications-settings.js
@@ -4,7 +4,6 @@ import { useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import InspectorHint from '../../shared/components/inspector-hint';
 
 const NotificationsSettings = ( { setAttributes, notificationRecipients } ) => {
 	const [ localNotificationRecipients, setLocalNotificationRecipients ] =
@@ -50,7 +49,8 @@ const NotificationsSettings = ( { setAttributes, notificationRecipients } ) => {
 	return (
 		<>
 			<ToggleControl
-				label={ __( 'Enable form response notifications', 'jetpack-forms' ) }
+				label={ __( 'Enable notifications for responses', 'jetpack-forms' ) }
+				help={ __( 'Receive notifications when someone fills out your form.', 'jetpack-forms' ) }
 				checked={ localFormNotifications }
 				onChange={ value => {
 					if ( value ) {
@@ -77,9 +77,6 @@ const NotificationsSettings = ( { setAttributes, notificationRecipients } ) => {
 			/>
 			{ localFormNotifications && (
 				<>
-					<InspectorHint>
-						{ __( 'Select users who can receive form response notifications:', 'jetpack-forms' ) }
-					</InspectorHint>
 					<FormTokenField
 						label={ __( 'Send notifications to', 'jetpack-forms' ) }
 						value={ selectedUserNames }

--- a/projects/packages/forms/src/blocks/contact-form/components/notifications-settings.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/notifications-settings.js
@@ -1,3 +1,4 @@
+import { hasFeatureFlag } from '@automattic/jetpack-shared-extension-utils';
 import { FormTokenField, ToggleControl, ExternalLink } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
@@ -65,63 +66,67 @@ const NotificationsSettings = ( {
 				postAuthorEmail={ postAuthorEmail }
 				setAttributes={ setAttributes }
 			/>
-			<ToggleControl
-				label={ __( 'Enable notifications for responses', 'jetpack-forms' ) }
-				help={ createInterpolateElement(
-					__(
-						'Receive push notifications when someone fills out your form. <pushNotificationsLink>Learn more.</pushNotificationsLink>',
-						'jetpack-forms'
-					),
-					{
-						pushNotificationsLink: (
-							<ExternalLink href="https://jetpack.com/support/notifications/" />
-						),
-					}
-				) }
-				checked={ localFormNotifications }
-				onChange={ value => {
-					if ( value ) {
-						// Auto-select post author when enabling notifications
-						const authorIdStr = postAuthorId?.toString();
-						let recipientsToSet = localNotificationRecipients;
-
-						if (
-							recipientsToSet.length === 0 &&
-							authorIdStr &&
-							eligibleUsers.some( user => user.id === postAuthorId )
-						) {
-							recipientsToSet = [ authorIdStr ];
-						}
-
-						setLocalNotificationRecipients( recipientsToSet );
-						setAttributes( { notificationRecipients: recipientsToSet } );
-					} else {
-						setAttributes( { notificationRecipients: [] } );
-					}
-					setLocalFormNotifications( value );
-				} }
-				__nextHasNoMarginBottom={ true }
-			/>
-			{ localFormNotifications && (
+			{ hasFeatureFlag( 'form-notifications' ) && (
 				<>
-					<FormTokenField
-						label={ __( 'Send notifications to', 'jetpack-forms' ) }
-						value={ selectedUserNames }
-						suggestions={ allUserNames }
-						onChange={ selectedNames => {
-							// Convert user names back to IDs
-							const newRecipients = selectedNames
-								.map( name => {
-									const user = eligibleUsers.find( u => ( u.name || u.slug ) === name );
-									return user ? user.id.toString() : null;
-								} )
-								.filter( Boolean );
-							setLocalNotificationRecipients( newRecipients );
-							setAttributes( { notificationRecipients: newRecipients } );
+					<ToggleControl
+						label={ __( 'Enable notifications for responses', 'jetpack-forms' ) }
+						help={ createInterpolateElement(
+							__(
+								'Receive push notifications when someone fills out your form. <pushNotificationsLink>Learn more.</pushNotificationsLink>',
+								'jetpack-forms'
+							),
+							{
+								pushNotificationsLink: (
+									<ExternalLink href="https://jetpack.com/support/notifications/" />
+								),
+							}
+						) }
+						checked={ localFormNotifications }
+						onChange={ value => {
+							if ( value ) {
+								// Auto-select post author when enabling notifications
+								const authorIdStr = postAuthorId?.toString();
+								let recipientsToSet = localNotificationRecipients;
+
+								if (
+									recipientsToSet.length === 0 &&
+									authorIdStr &&
+									eligibleUsers.some( user => user.id === postAuthorId )
+								) {
+									recipientsToSet = [ authorIdStr ];
+								}
+
+								setLocalNotificationRecipients( recipientsToSet );
+								setAttributes( { notificationRecipients: recipientsToSet } );
+							} else {
+								setAttributes( { notificationRecipients: [] } );
+							}
+							setLocalFormNotifications( value );
 						} }
 						__nextHasNoMarginBottom={ true }
-						__next40pxDefaultSize={ true }
 					/>
+					{ localFormNotifications && (
+						<>
+							<FormTokenField
+								label={ __( 'Send notifications to', 'jetpack-forms' ) }
+								value={ selectedUserNames }
+								suggestions={ allUserNames }
+								onChange={ selectedNames => {
+									// Convert user names back to IDs
+									const newRecipients = selectedNames
+										.map( name => {
+											const user = eligibleUsers.find( u => ( u.name || u.slug ) === name );
+											return user ? user.id.toString() : null;
+										} )
+										.filter( Boolean );
+									setLocalNotificationRecipients( newRecipients );
+									setAttributes( { notificationRecipients: newRecipients } );
+								} }
+								__nextHasNoMarginBottom={ true }
+								__next40pxDefaultSize={ true }
+							/>
+						</>
+					) }
 				</>
 			) }
 		</>

--- a/projects/packages/forms/src/blocks/contact-form/components/notifications-settings.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/notifications-settings.js
@@ -1,3 +1,4 @@
+import { isWpcomPlatformSite } from '@automattic/jetpack-script-data';
 import { hasFeatureFlag } from '@automattic/jetpack-shared-extension-utils';
 import { FormTokenField, ToggleControl, ExternalLink } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
@@ -56,6 +57,10 @@ const NotificationsSettings = ( {
 	// All available user names for suggestions
 	const allUserNames = eligibleUsers.map( user => user.name || user.slug );
 
+	const supportNotificationsLink = isWpcomPlatformSite()
+		? 'https://jetpack.com/support/notifications/'
+		: 'https://wordpress.com/support/notifications/';
+
 	return (
 		<>
 			<JetpackEmailConnectionSettings
@@ -76,9 +81,7 @@ const NotificationsSettings = ( {
 								'jetpack-forms'
 							),
 							{
-								pushNotificationsLink: (
-									<ExternalLink href="https://jetpack.com/support/notifications/" />
-								),
+								pushNotificationsLink: <ExternalLink href={ supportNotificationsLink } />,
 							}
 						) }
 						checked={ localFormNotifications }

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -49,7 +49,6 @@ import { CORE_BLOCKS } from '../shared/util/constants';
 import { childBlocks } from './child-blocks';
 import { ContactFormPlaceholder } from './components/jetpack-contact-form-placeholder';
 import ContactFormSkeletonLoader from './components/jetpack-contact-form-skeleton-loader';
-import JetpackEmailConnectionSettings from './components/jetpack-email-connection-settings';
 import NotificationsSettings from './components/notifications-settings';
 import useFormBlockDefaults from './shared/hooks/use-form-block-defaults';
 import VariationPicker from './variation-picker';
@@ -889,20 +888,6 @@ function JetpackContactFormEdit( {
 							</div>
 						) }
 					</PanelBody>
-					<PanelBody
-						title={ __( 'Email responses', 'jetpack-forms' ) }
-						initialOpen={ false }
-						className="jetpack-contact-form__panel"
-					>
-						<JetpackEmailConnectionSettings
-							emailAddress={ to }
-							emailSubject={ subject }
-							emailNotifications={ emailNotifications }
-							instanceId={ instanceId }
-							postAuthorEmail={ postAuthorEmail }
-							setAttributes={ setAttributes }
-						/>
-					</PanelBody>
 					{ hasFeatureFlag( 'form-notifications' ) && (
 						<PanelBody
 							title={ __( 'Form notifications', 'jetpack-forms' ) }
@@ -911,6 +896,11 @@ function JetpackContactFormEdit( {
 						>
 							<NotificationsSettings
 								notificationRecipients={ notificationRecipients }
+								emailAddress={ to }
+								emailSubject={ subject }
+								emailNotifications={ emailNotifications }
+								instanceId={ instanceId }
+								postAuthorEmail={ postAuthorEmail }
 								setAttributes={ setAttributes }
 							/>
 						</PanelBody>

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { ThemeProvider } from '@automattic/jetpack-components';
-import { hasFeatureFlag, useModuleStatus } from '@automattic/jetpack-shared-extension-utils';
+import { useModuleStatus } from '@automattic/jetpack-shared-extension-utils';
 import {
 	URLInput,
 	InspectorAdvancedControls,
@@ -888,23 +888,21 @@ function JetpackContactFormEdit( {
 							</div>
 						) }
 					</PanelBody>
-					{ hasFeatureFlag( 'form-notifications' ) && (
-						<PanelBody
-							title={ __( 'Form notifications', 'jetpack-forms' ) }
-							initialOpen={ false }
-							className="jetpack-contact-form__panel"
-						>
-							<NotificationsSettings
-								notificationRecipients={ notificationRecipients }
-								emailAddress={ to }
-								emailSubject={ subject }
-								emailNotifications={ emailNotifications }
-								instanceId={ instanceId }
-								postAuthorEmail={ postAuthorEmail }
-								setAttributes={ setAttributes }
-							/>
-						</PanelBody>
-					) }
+					<PanelBody
+						title={ __( 'Form notifications', 'jetpack-forms' ) }
+						initialOpen={ false }
+						className="jetpack-contact-form__panel"
+					>
+						<NotificationsSettings
+							notificationRecipients={ notificationRecipients }
+							emailAddress={ to }
+							emailSubject={ subject }
+							emailNotifications={ emailNotifications }
+							instanceId={ instanceId }
+							postAuthorEmail={ postAuthorEmail }
+							setAttributes={ setAttributes }
+						/>
+					</PanelBody>
 					{ showFormIntegrations && (
 						<Suspense fallback={ <div /> }>
 							<IntegrationControls attributes={ attributes } setAttributes={ setAttributes } />

--- a/projects/packages/forms/tests/js/contact-form/components/notifications-settings.test.js
+++ b/projects/packages/forms/tests/js/contact-form/components/notifications-settings.test.js
@@ -74,15 +74,41 @@ jest.mock( '@wordpress/components', () => {
 		);
 	}
 
+	/**
+	 * Mock ExternalLink component.
+	 *
+	 * @param {object} root0          - Component props
+	 * @param {string} root0.href     - Link URL
+	 * @param {*}      root0.children - Child elements
+	 * @return {object} React element
+	 */
+	function ExternalLinkComponent( { href, children } ) {
+		return (
+			<a href={ href } target="_blank" rel="noopener noreferrer">
+				{ children }
+			</a>
+		);
+	}
+
 	return {
 		ToggleControl: ToggleControlComponent,
 		FormTokenField: FormTokenFieldComponent,
+		ExternalLink: ExternalLinkComponent,
 	};
 } );
 
 // Mock WordPress i18n
 jest.mock( '@wordpress/i18n', () => ( {
 	__: jest.fn( text => text ),
+} ) );
+
+// Mock WordPress element
+jest.mock( '@wordpress/element', () => ( {
+	...jest.requireActual( '@wordpress/element' ),
+	createInterpolateElement: jest.fn( text => {
+		// Simple mock that returns the text with link component
+		return <span>{ text }</span>;
+	} ),
 } ) );
 
 // Mock WordPress data
@@ -129,8 +155,35 @@ jest.mock( '../../../../src/blocks/shared/components/inspector-hint', () => ( { 
 	<div data-testid="inspector-hint">{ children }</div>
 ) );
 
+// Mock JetpackEmailConnectionSettings component
+jest.mock(
+	'../../../../src/blocks/contact-form/components/jetpack-email-connection-settings',
+	() =>
+		( { emailNotifications } ) =>
+			emailNotifications ? <div data-testid="email-settings">Email Settings</div> : null
+);
+
+// Mock Jetpack shared extension utils
+jest.mock( '@automattic/jetpack-shared-extension-utils', () => ( {
+	hasFeatureFlag: jest.fn( () => true ),
+} ) );
+
+// Mock Jetpack script data
+jest.mock( '@automattic/jetpack-script-data', () => ( {
+	isWpcomPlatformSite: jest.fn( () => false ),
+} ) );
+
 describe( 'NotificationsSettings', () => {
 	let setAttributesMock;
+
+	// Default props for the component
+	const defaultProps = {
+		emailAddress: '',
+		emailSubject: '',
+		emailNotifications: true,
+		instanceId: 1,
+		postAuthorEmail: 'admin@example.com',
+	};
 
 	beforeEach( () => {
 		setAttributesMock = jest.fn();
@@ -139,15 +192,23 @@ describe( 'NotificationsSettings', () => {
 
 	it( 'renders the toggle control', () => {
 		render(
-			<NotificationsSettings setAttributes={ setAttributesMock } notificationRecipients={ [] } />
+			<NotificationsSettings
+				setAttributes={ setAttributesMock }
+				notificationRecipients={ [] }
+				{ ...defaultProps }
+			/>
 		);
 
-		expect( screen.getByText( 'Enable form response notifications' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Enable notifications for responses' ) ).toBeInTheDocument();
 	} );
 
 	it( 'does not show user selector when toggle is disabled', () => {
 		render(
-			<NotificationsSettings setAttributes={ setAttributesMock } notificationRecipients={ [] } />
+			<NotificationsSettings
+				setAttributes={ setAttributesMock }
+				notificationRecipients={ [] }
+				{ ...defaultProps }
+			/>
 		);
 
 		expect( screen.queryByTestId( 'form-token-field' ) ).not.toBeInTheDocument();
@@ -155,7 +216,11 @@ describe( 'NotificationsSettings', () => {
 
 	it( 'shows user selector when toggle is enabled', async () => {
 		render(
-			<NotificationsSettings setAttributes={ setAttributesMock } notificationRecipients={ [] } />
+			<NotificationsSettings
+				setAttributes={ setAttributesMock }
+				notificationRecipients={ [] }
+				{ ...defaultProps }
+			/>
 		);
 
 		const toggle = screen.getByRole( 'checkbox' );
@@ -167,7 +232,11 @@ describe( 'NotificationsSettings', () => {
 
 	it( 'auto-selects post author when toggle is enabled with no recipients', async () => {
 		render(
-			<NotificationsSettings setAttributes={ setAttributesMock } notificationRecipients={ [] } />
+			<NotificationsSettings
+				setAttributes={ setAttributesMock }
+				notificationRecipients={ [] }
+				{ ...defaultProps }
+			/>
 		);
 
 		const toggle = screen.getByRole( 'checkbox' );
@@ -184,6 +253,7 @@ describe( 'NotificationsSettings', () => {
 			<NotificationsSettings
 				setAttributes={ setAttributesMock }
 				notificationRecipients={ [ '2' ] }
+				{ ...defaultProps }
 			/>
 		);
 
@@ -200,6 +270,7 @@ describe( 'NotificationsSettings', () => {
 			<NotificationsSettings
 				setAttributes={ setAttributesMock }
 				notificationRecipients={ [ '1', '2' ] }
+				{ ...defaultProps }
 			/>
 		);
 
@@ -217,6 +288,7 @@ describe( 'NotificationsSettings', () => {
 			<NotificationsSettings
 				setAttributes={ setAttributesMock }
 				notificationRecipients={ [ '1' ] }
+				{ ...defaultProps }
 			/>
 		);
 
@@ -236,6 +308,7 @@ describe( 'NotificationsSettings', () => {
 			<NotificationsSettings
 				setAttributes={ setAttributesMock }
 				notificationRecipients={ [ '1', '2' ] }
+				{ ...defaultProps }
 			/>
 		);
 
@@ -244,18 +317,5 @@ describe( 'NotificationsSettings', () => {
 		// Should display user names, not IDs
 		expect( input.value ).toContain( 'Admin User' );
 		expect( input.value ).toContain( 'Editor User' );
-	} );
-
-	it( 'shows inspector hint when toggle is enabled', async () => {
-		render(
-			<NotificationsSettings setAttributes={ setAttributesMock } notificationRecipients={ [] } />
-		);
-
-		const toggle = screen.getByRole( 'checkbox' );
-		await userEvent.click( toggle );
-
-		const hint = screen.getByTestId( 'inspector-hint' );
-		expect( hint ).toBeInTheDocument();
-		expect( hint ).toHaveTextContent( 'Select users who can receive form response notifications:' );
 	} );
 } );

--- a/projects/plugins/jetpack/changelog/update-form-notifications-ui
+++ b/projects/plugins/jetpack/changelog/update-form-notifications-ui
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: merged email and push notification settings panels.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes [FORMS-327](https://linear.app/a8c/issue/FORMS-327/merge-email-and-push-notifications-settings-panel)

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Merged email notifications and push notifications settings panel
* Changed the copies
* Added a link to the push notifications documentation
* Adjusted some margins

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<table>
<tr>
<th> Before </th>
<th> After </th>
</tr>
<tr>
<td>
<img width="288" height="776" alt="Screenshot 2025-10-20 at 13 26 13" src="https://github.com/user-attachments/assets/7e0f816d-11ab-4009-95e5-c054a39f7f71" />

</td>
<td>
<img width="285" height="980" alt="Screenshot 2025-10-20 at 13 27 38" src="https://github.com/user-attachments/assets/b91d6f58-3e44-4941-8e0e-4329aa707e19" />

</td>
</tr>
</table>

<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add a form to a post or page.
* Select the form block and go to the block settings sidebar.
* Without the form notification's feature flag, test that email notifications continue to work as expected.
* Enable the form notification's feature flag `jetpack_forms_enable_notifications`.
* Test that the push notifications work on form submissions.
* Test that the `Learn more` link takes you to the right support documentation page (for a self-hosted site it should be https://jetpack.com/support/notifications/, for a WP.com site it should be https://wordpress.com/support/notifications/)

