### PR TITLE
Help Center: Rename commerce garden constant

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/help-center-ciab-garden-field
+++ b/projects/packages/jetpack-mu-wpcom/changelog/help-center-ciab-garden-field
@@ -1,5 +1,5 @@
 Significance: patch
 Type: added
-Comment: Add isCIABGarden field to Help Center data for CIAB Garden integration
+Comment: Add isCommerceGarden field to Help Center data for CIAB Garden integration
 
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
@@ -212,7 +212,7 @@ class Help_Center {
 			$display_name       = $user_data->display_name;
 			$avatar_url         = function_exists( 'wpcom_get_avatar_url' ) ? wpcom_get_avatar_url( $user_email, 64, '', true )[0] : get_avatar_url( $user_id );
 			$is_next_admin      = (bool) did_action( 'next_admin_init' );
-			$is_commerce_garden = (bool) is_defined( 'IS_COMMERCE_GARDEN' );
+			$is_commerce_garden = (bool) defined( 'IS_COMMERCE_GARDEN' );
 
 			wp_add_inline_script(
 				'help-center',

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
@@ -205,34 +205,34 @@ class Help_Center {
 				'before'
 			);
 
-			$user_id        = get_current_user_id();
-			$user_data      = get_userdata( $user_id );
-			$username       = $user_data->user_login;
-			$user_email     = $user_data->user_email;
-			$display_name   = $user_data->display_name;
-			$avatar_url     = function_exists( 'wpcom_get_avatar_url' ) ? wpcom_get_avatar_url( $user_email, 64, '', true )[0] : get_avatar_url( $user_id );
-			$is_next_admin  = (bool) did_action( 'next_admin_init' );
-			$is_ciab_garden = (bool) did_action( 'ciab_garden_init' );
+			$user_id            = get_current_user_id();
+			$user_data          = get_userdata( $user_id );
+			$username           = $user_data->user_login;
+			$user_email         = $user_data->user_email;
+			$display_name       = $user_data->display_name;
+			$avatar_url         = function_exists( 'wpcom_get_avatar_url' ) ? wpcom_get_avatar_url( $user_email, 64, '', true )[0] : get_avatar_url( $user_id );
+			$is_next_admin      = (bool) did_action( 'next_admin_init' );
+			$is_commerce_garden = (bool) is_defined( 'IS_COMMERCE_GARDEN' );
 
 			wp_add_inline_script(
 				'help-center',
 				'const helpCenterData = ' . wp_json_encode(
 					array(
-						'isProxied'    => boolval( self::is_proxied() ),
-						'isSU'         => defined( 'WPCOM_SUPPORT_SESSION' ) && WPCOM_SUPPORT_SESSION,
-						'isSSP'        => isset( $_COOKIE['ssp'] ),
-						'sectionName'  => $this->is_support_site ? 'wp.com/support' : $variant,
-						'isNextAdmin'  => $is_next_admin,
-						'isCIABGarden' => $is_ciab_garden,
-						'currentUser'  => array(
+						'isProxied'        => boolval( self::is_proxied() ),
+						'isSU'             => defined( 'WPCOM_SUPPORT_SESSION' ) && WPCOM_SUPPORT_SESSION,
+						'isSSP'            => isset( $_COOKIE['ssp'] ),
+						'sectionName'      => $this->is_support_site ? 'wp.com/support' : $variant,
+						'isNextAdmin'      => $is_next_admin,
+						'isCommerceGarden' => $is_commerce_garden,
+						'currentUser'      => array(
 							'ID'           => $user_id,
 							'username'     => $username,
 							'display_name' => $display_name,
 							'avatar_URL'   => $avatar_url,
 							'email'        => $user_email,
 						),
-						'site'         => $this->get_current_site(),
-						'locale'       => self::determine_iso_639_locale(),
+						'site'             => $this->get_current_site(),
+						'locale'           => self::determine_iso_639_locale(),
 					)
 				),
 				'before'

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
@@ -211,8 +211,8 @@ class Help_Center {
 			$user_email         = $user_data->user_email;
 			$display_name       = $user_data->display_name;
 			$avatar_url         = function_exists( 'wpcom_get_avatar_url' ) ? wpcom_get_avatar_url( $user_email, 64, '', true )[0] : get_avatar_url( $user_id );
+			$is_commerce_garden = defined( 'IS_COMMERCE_GARDEN' );
 			$is_next_admin      = (bool) did_action( 'next_admin_init' );
-			$is_commerce_garden = (bool) defined( 'IS_COMMERCE_GARDEN' );
 
 			wp_add_inline_script(
 				'help-center',


### PR DESCRIPTION
## Proposed changes:
Renames the commerce garden detect logic to use a constant instead.


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:

1. Apply this on a simple site.
2. Go to wp-admin of that site.
3. Open the console and log `helpCenterData`.
4. It should say `isCommerceGarden: false`.
