### PR TITLE
Forms: add gravatars on dashboard rows

### DIFF
--- a/projects/packages/forms/changelog/add-forms-dashboard-dataviews-gravatar
+++ b/projects/packages/forms/changelog/add-forms-dashboard-dataviews-gravatar
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Forms: show gravatar on dataviews list

--- a/projects/packages/forms/src/dashboard/components/gravatar/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/gravatar/index.tsx
@@ -11,6 +11,7 @@ import './style.scss';
 type GravatarProps = {
 	displayName?: string;
 	email: string;
+	size?: number;
 };
 
 /**
@@ -22,7 +23,11 @@ type GravatarProps = {
  * @param {GravatarProps} props - The component props.
  * @return {JSX.Element} The Gravatar component
  */
-export default function Gravatar( { displayName, email }: GravatarProps ): JSX.Element | null {
+export default function Gravatar( {
+	displayName,
+	email,
+	size = 48,
+}: GravatarProps ): JSX.Element | null {
 	const profileImageRef = useRef( null );
 	const hovercardRef = useRef( null );
 
@@ -68,6 +73,8 @@ export default function Gravatar( { displayName, email }: GravatarProps ): JSX.E
 			className="jp-forms__gravatar"
 			ref={ profileImageRef }
 			src={ `https://0.gravatar.com/avatar/${ hashedEmail }?d=initials&name=${ displayName }` }
+			width={ size }
+			height={ size }
 		/>
 	);
 }

--- a/projects/packages/forms/src/dashboard/components/gravatar/style.scss
+++ b/projects/packages/forms/src/dashboard/components/gravatar/style.scss
@@ -2,7 +2,5 @@
 	background-color: var(--jp-gray-5);
 	border-radius: 50%;
 	flex-shrink: 0; // Prevent shrinking when Gravatar is inside flex containers
-	height: 48px;
 	overflow: hidden;
-	width: 48px;
 }

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
@@ -17,6 +17,7 @@ import { useSearchParams } from 'react-router';
 /**
  * Internal dependencies
  */
+import Gravatar from '../../components/gravatar';
 import InboxStatusToggle from '../../components/inbox-status-toggle';
 import { ResponseMobileView, SingleResponseView } from '../../components/response-view';
 import useInboxData from '../../hooks/use-inbox-data';
@@ -230,6 +231,14 @@ export default function InboxView() {
 								>
 									●
 								</span>
+							) }
+							{ item.author_email && (
+								<Gravatar
+									email={ item.author_email }
+									displayName={ authorInfo }
+									key={ decodeEntities( item.author_email ) }
+									size={ 32 }
+								/>
 							) }
 							{ wrapperUnread( item.is_unread, authorInfo ) }
 						</>

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -377,6 +377,10 @@
 			width: calc(100% - var(--forms-admin-sidebar-width, variables.$admin-sidebar-width));
 		}
 	}
+
+	.dataviews-view-table__cell-content-wrapper {
+		gap: 16px;
+	}
 }
 
 /*
@@ -560,4 +564,5 @@ body.jetpack_page_jetpack-forms-admin {
 	margin-right: 4.5px;
 	margin-left: -12px;
 	vertical-align: middle;
+	position: absolute;
 }


### PR DESCRIPTION
Part of FORMS-334
Resolves FORMS-396

## Proposed changes:
This PR adds gravatars on dataviews rows as depicted on latest designs.

<img width="745" height="279" alt="image" src="https://github.com/user-attachments/assets/08ab8ef9-0d1d-4dfa-a3e6-a65e7197d27b" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1760695290228499-slack-C052XEUUBL4

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Visit the dashboard. See the rows now show a gravatar at the beginning.