### PR TITLE
Forms: add new ConsentToggle component

### DIFF
--- a/projects/packages/forms/changelog/update-forms-consent-component
+++ b/projects/packages/forms/changelog/update-forms-consent-component
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: add shared ConsentToggle component.

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/consent-toggle.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/consent-toggle.tsx
@@ -1,0 +1,52 @@
+import { store as blockEditorStore } from '@wordpress/block-editor';
+import { createBlock } from '@wordpress/blocks';
+import { ToggleControl } from '@wordpress/components';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+
+type ConsentToggleProps = {
+	className?: string;
+};
+
+const ConsentToggle = ( { className }: ConsentToggleProps ) => {
+	const selectedBlock = useSelect( select => select( blockEditorStore ).getSelectedBlock(), [] );
+	const { insertBlock, removeBlock } = useDispatch( blockEditorStore );
+	const hasEmailBlock = selectedBlock?.innerBlocks?.some(
+		( { name }: { name: string } ) => name === 'jetpack/field-email'
+	);
+	const consentBlock = selectedBlock?.innerBlocks?.find(
+		( { name }: { name: string } ) => name === 'jetpack/field-consent'
+	);
+
+	const toggleConsent = async () => {
+		if ( ! selectedBlock ) {
+			return;
+		}
+		if ( consentBlock ) {
+			await removeBlock( consentBlock.clientId, false );
+			return;
+		}
+		const buttonBlockIndex = selectedBlock.innerBlocks.findIndex(
+			( { name }: { name: string } ) => name === 'jetpack/button'
+		);
+		const newConsentBlock = await createBlock( 'jetpack/field-consent' );
+		await insertBlock( newConsentBlock, buttonBlockIndex, selectedBlock.clientId, false );
+	};
+
+	if ( ! hasEmailBlock ) {
+		return null;
+	}
+
+	return (
+		<div className={ className ?? 'integration-card__section' }>
+			<ToggleControl
+				label={ __( 'Add email permission request before submit button', 'jetpack-forms' ) }
+				checked={ !! consentBlock }
+				onChange={ toggleConsent }
+				__nextHasNoMarginBottom
+			/>
+		</div>
+	);
+};
+
+export default ConsentToggle;

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/consent-toggle.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/consent-toggle.tsx
@@ -26,11 +26,14 @@ const ConsentToggle = ( { className }: ConsentToggleProps ) => {
 			await removeBlock( consentBlock.clientId, false );
 			return;
 		}
-		const buttonBlockIndex = selectedBlock.innerBlocks.findIndex(
-			( { name }: { name: string } ) => name === 'jetpack/button'
+		// Insert after the email field, or at the end if not found
+		const emailBlockIndex = selectedBlock.innerBlocks.findIndex(
+			( { name }: { name: string } ) => name === 'jetpack/field-email'
 		);
-		const newConsentBlock = await createBlock( 'jetpack/field-consent' );
-		await insertBlock( newConsentBlock, buttonBlockIndex, selectedBlock.clientId, false );
+		const insertIndex =
+			emailBlockIndex === -1 ? selectedBlock.innerBlocks.length : emailBlockIndex + 1;
+		const newConsentBlock = createBlock( 'jetpack/field-consent', { consentType: 'explicit' } );
+		await insertBlock( newConsentBlock, insertIndex, selectedBlock.clientId, false );
 	};
 
 	if ( ! hasEmailBlock ) {
@@ -40,7 +43,7 @@ const ConsentToggle = ( { className }: ConsentToggleProps ) => {
 	return (
 		<div className={ className ?? 'integration-card__section' }>
 			<ToggleControl
-				label={ __( 'Add email permission request before submit button', 'jetpack-forms' ) }
+				label={ __( 'Add email permission request after the email field', 'jetpack-forms' ) }
 				checked={ !! consentBlock }
 				onChange={ toggleConsent }
 				__nextHasNoMarginBottom

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/hostinger-reach-card.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/hostinger-reach-card.tsx
@@ -1,16 +1,13 @@
-import { store as blockEditorStore } from '@wordpress/block-editor';
-import { createBlock } from '@wordpress/blocks';
 import {
 	Button,
 	ExternalLink,
 	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
-	ToggleControl,
 	TextControl,
 } from '@wordpress/components';
-import { useDispatch, useSelect } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import HostingerReachIcon from '../../../../icons/hostinger-reach';
+import ConsentToggle from './consent-toggle';
 import IntegrationCard from './integration-card';
 import type { SingleIntegrationCardProps, IntegrationCardData } from '../../../../types';
 
@@ -30,27 +27,6 @@ const HostingerReachCard = ( {
 	refreshStatus,
 }: HostingerReachCardProps ) => {
 	const { isConnected = false, settingsUrl = '' } = data || {};
-
-	const selectedBlock = useSelect( select => select( blockEditorStore ).getSelectedBlock(), [] );
-	const { insertBlock, removeBlock } = useDispatch( blockEditorStore );
-	const hasEmailBlock = selectedBlock?.innerBlocks?.some(
-		( { name }: { name: string } ) => name === 'jetpack/field-email'
-	);
-	const consentBlock = selectedBlock?.innerBlocks?.find(
-		( { name }: { name: string } ) => name === 'jetpack/field-consent'
-	);
-
-	const toggleConsent = async () => {
-		if ( consentBlock ) {
-			await removeBlock( consentBlock.clientId, false );
-		} else {
-			const buttonBlockIndex = selectedBlock.innerBlocks.findIndex(
-				( { name }: { name: string } ) => name === 'jetpack/button'
-			);
-			const newConsentBlock = await createBlock( 'jetpack/field-consent' );
-			await insertBlock( newConsentBlock, buttonBlockIndex, selectedBlock.clientId, false );
-		}
-	};
 
 	const cardData: IntegrationCardData = {
 		...data,
@@ -133,16 +109,7 @@ const HostingerReachCard = ( {
 							__nextHasNoMarginBottom
 						/>
 					</div>
-					{ hasEmailBlock && (
-						<div className="integration-card__section">
-							<ToggleControl
-								label={ __( 'Add email permission request before submit button', 'jetpack-forms' ) }
-								checked={ !! consentBlock }
-								onChange={ toggleConsent }
-								__nextHasNoMarginBottom
-							/>
-						</div>
-					) }
+					<ConsentToggle />
 					<p className="integration-card__description">
 						<ExternalLink href={ settingsUrl }>
 							{ __( 'View Hostinger Reach dashboard', 'jetpack-forms' ) }

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/mailpoet-card.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integrations-modal/mailpoet-card.tsx
@@ -1,16 +1,13 @@
-import { store as blockEditorStore } from '@wordpress/block-editor';
-import { createBlock } from '@wordpress/blocks';
 import {
 	Button,
 	ExternalLink,
 	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	SelectControl,
-	ToggleControl,
 } from '@wordpress/components';
-import { useDispatch, useSelect } from '@wordpress/data';
 import { createInterpolateElement, useEffect, useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import MailPoetIcon from '../../../../icons/mailpoet';
+import ConsentToggle from './consent-toggle';
 import IntegrationCard from './integration-card';
 import type { SingleIntegrationCardProps, IntegrationCardData } from '../../../../types';
 
@@ -45,26 +42,6 @@ const MailPoetCard = ( {
 		() => ( Array.isArray( data?.details?.lists ) ? ( data.details.lists as MailPoetList[] ) : [] ),
 		[ data?.details?.lists ]
 	);
-
-	const selectedBlock = useSelect( select => select( blockEditorStore ).getSelectedBlock(), [] );
-	const { insertBlock, removeBlock } = useDispatch( blockEditorStore );
-	const hasEmailBlock = selectedBlock?.innerBlocks?.some(
-		( { name }: { name: string } ) => name === 'jetpack/field-email'
-	);
-	const consentBlock = selectedBlock?.innerBlocks?.find(
-		( { name }: { name: string } ) => name === 'jetpack/field-consent'
-	);
-	const toggleConsent = async () => {
-		if ( consentBlock ) {
-			await removeBlock( consentBlock.clientId, false );
-		} else {
-			const buttonBlockIndex = selectedBlock.innerBlocks.findIndex(
-				( { name }: { name: string } ) => name === 'jetpack/button'
-			);
-			const newConsentBlock = await createBlock( 'jetpack/field-consent' );
-			await insertBlock( newConsentBlock, buttonBlockIndex, selectedBlock.clientId, false );
-		}
-	};
 
 	useEffect( () => {
 		if ( ! mailpoet.enabledForForm ) {
@@ -189,16 +166,7 @@ const MailPoetCard = ( {
 							) }
 						</p>
 					) }
-					{ hasEmailBlock && (
-						<div className="integration-card__section">
-							<ToggleControl
-								label={ __( 'Add email permission request before submit button', 'jetpack-forms' ) }
-								checked={ !! consentBlock }
-								onChange={ toggleConsent }
-								__nextHasNoMarginBottom
-							/>
-						</div>
-					) }
+					<ConsentToggle />
 					<p className="integration-card__description">
 						<ExternalLink href={ settingsUrl }>
 							{ __( 'View MailPoet dashboard', 'jetpack-forms' ) }

--- a/projects/packages/forms/src/blocks/field-consent/edit.js
+++ b/projects/packages/forms/src/blocks/field-consent/edit.js
@@ -13,6 +13,15 @@ import { __, sprintf } from '@wordpress/i18n';
 import JetpackFieldWidth from '../shared/components/jetpack-field-width';
 import useFormWrapper from '../shared/hooks/use-form-wrapper';
 
+// Returns a translated placeholder based on the consent type.
+function getConsentPlaceholder( consentType ) {
+	return sprintf(
+		/* translators: %s a type of consent: implicit or explicit */
+		__( 'Add %s consent message…', 'jetpack-forms' ),
+		consentType
+	);
+}
+
 export default function ConsentFieldEdit( props ) {
 	const { attributes, clientId, setAttributes } = props;
 	const { consentType, width, implicitConsentMessage, explicitConsentMessage, className } =
@@ -42,11 +51,7 @@ export default function ConsentFieldEdit( props ) {
 				'jetpack/option',
 				{
 					label: implicitConsentMessage,
-					placeholder: sprintf(
-						/* translators: %s a type of consent: implicit or explicit */
-						__( 'Add %s consent message…', 'jetpack-forms' ),
-						'implicit'
-					),
+					placeholder: getConsentPlaceholder( 'implicit' ),
 					isStandalone: true,
 					hideInput: true,
 				},
@@ -73,26 +78,33 @@ export default function ConsentFieldEdit( props ) {
 	const prevConsentType = usePrevious( consentType );
 	const prevLabel = usePrevious( optionBlock?.attributes?.label );
 
-	// Update the inner option block when the consentType changes.
+	// Update the inner option block when the consentType changes,
+	// or when hideInput is out of sync with the consentType (e.g., programmatic insert).
 	useEffect( () => {
-		if ( optionBlockId && consentType !== prevConsentType ) {
-			const label = consentType === 'explicit' ? explicitConsentMessage : implicitConsentMessage;
+		if ( ! optionBlockId ) {
+			return;
+		}
 
+		const shouldHideInput = consentType !== 'explicit';
+		const label = shouldHideInput ? implicitConsentMessage : explicitConsentMessage;
+		const placeholder = getConsentPlaceholder( consentType );
+
+		const shouldUpdate =
+			optionBlock?.attributes?.hideInput !== shouldHideInput || consentType !== prevConsentType;
+
+		if ( shouldUpdate ) {
 			// As this is an automated update, ensure it doesn't end up in the undo stack
 			// by calling `__unstableMarkNextChangeAsNotPersistent`.
 			__unstableMarkNextChangeAsNotPersistent();
 			updateBlockAttributes( optionBlockId, {
 				label,
-				placeholder: sprintf(
-					/* translators: %s a type of consent: implicit or explicit */
-					__( 'Add %s consent message…', 'jetpack-forms' ),
-					consentType
-				),
-				hideInput: consentType !== 'explicit',
+				placeholder,
+				hideInput: shouldHideInput,
 			} );
 		}
 	}, [
 		optionBlockId,
+		optionBlock?.attributes?.hideInput,
 		consentType,
 		prevConsentType,
 		explicitConsentMessage,

--- a/projects/plugins/jetpack/changelog/update-forms-consent-component
+++ b/projects/plugins/jetpack/changelog/update-forms-consent-component
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: add shared ConsentToggle component.


### PR DESCRIPTION
Fixes [FORMS-292](https://linear.app/a8c/issue/FORMS-292/forms-mailpoet-integration-consent-checkbox)

## Proposed changes:

MailPoet and Hostinger integrations show a toggle to add a consent field. This PR does three things: 
* creates a shared component and removes duplicate code from MailPoet/Hostinger
* updates the toggle so the consent file is inserted after the email (vs at end of form), and the consent type is explicit with checkbox (vs implicit). 
* adds some logic to the consent field to ensure the checkbox and correct message show when programatically inserted.

This PR replaces this [older one](https://github.com/Automattic/jetpack/pull/45253). 

<img width="839" height="588" alt="mailpoet-consent-toggle" src="https://github.com/user-attachments/assets/027dc4b3-b418-4564-b6df-54ee59e2e12a" />

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
See linear issue.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add a form to a page (must have an email field)
* Open the integrations modal and click to add the consent toggle in either the MailPoet or Hostinger cards. 
* Confirm the toggle is added after the email field (vs end of form like before)
* Confirm the checkbox shows (explicit consent type) 
* As an extra check, publish and submit the form on the frontend to confirm everything submits as intended

