### PR TITLE
Forms: Fixes the double close

### DIFF
--- a/projects/packages/forms/changelog/fix-double-close-pr
+++ b/projects/packages/forms/changelog/fix-double-close-pr
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: fix a bug that you makes you click the close button twice. 

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
@@ -395,7 +395,7 @@ export default function InboxView() {
 				/>
 			</div>
 			<SingleResponseView
-				sidePanelItem={ sidePanelItem }
+				sidePanelItem={ selection.length && sidePanelItem }
 				setSidePanelItem={ setSidePanelItem }
 				isLoadingData={ isLoadingData }
 				isMobile={ isMobile }


### PR DESCRIPTION
This PR fixes the need to click the X button twice to close the sidebar. 

This regression was introduces when https://github.com/Automattic/jetpack/pull/45543 and https://github.com/Automattic/jetpack/pull/45541 landed in trunk. 


## Proposed changes:
* Makes it so if there is no selection that we close the sidebar right away. 

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* Navigate to the dashboard. 
* Click to expand a response. Notice that clicking X works as expected. 
* Notice that when you are in responsive mode that it still works as expected. 
* Notice when you open up the view on Mobile that it also works as expected. 


