### PR TITLE
Forms: remove preloading form integrations endpoint

### DIFF
--- a/projects/packages/forms/changelog/fix-remove-preloading-form-integrations
+++ b/projects/packages/forms/changelog/fix-remove-preloading-form-integrations
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Forms: stop preloading the intergrations endpoint 
+Forms: stop preloading the integrations endpoint 

--- a/projects/packages/forms/changelog/fix-remove-preloading-form-integrations
+++ b/projects/packages/forms/changelog/fix-remove-preloading-form-integrations
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Forms: stop preloading the intergrations endpoint 

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -811,8 +811,6 @@ class Contact_Form_Block {
 	public static function preload_endpoints( $paths ) {
 		$paths[] = array( '/wp/v2/feedback/config', 'GET' );
 		$paths[] = array( '/wp/v2/feedback/config?_locale=user', 'GET' );
-		$paths[] = array( '/wp/v2/feedback/integrations?version=2', 'GET' );
-		$paths[] = array( '/wp/v2/feedback/integrations?version=2&_locale=user', 'GET' );
 		return $paths;
 	}
 

--- a/projects/plugins/jetpack/changelog/fix-remove-preloading-form-integrations
+++ b/projects/plugins/jetpack/changelog/fix-remove-preloading-form-integrations
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms stop preloading the intergrations endpoint

--- a/projects/plugins/jetpack/changelog/fix-remove-preloading-form-integrations
+++ b/projects/plugins/jetpack/changelog/fix-remove-preloading-form-integrations
@@ -1,4 +1,4 @@
 Significance: patch
 Type: bugfix
 
-Forms stop preloading the intergrations endpoint
+Forms stop preloading the integrations endpoint


### PR DESCRIPTION
Load the editor faster by skipping the preloading of the /me/connections endpoint. 

This is done so that the initial loading of the editor is fast. 

Before: 
<img width="758" height="58" alt="Screenshot 2025-10-20 at 12 17 04 PM" src="https://github.com/user-attachments/assets/125dd0b0-305f-47d3-ac12-d709bc5eafba" />

After:
<img width="778" height="47" alt="Screenshot 2025-10-20 at 12 17 26 PM" src="https://github.com/user-attachments/assets/f3cd2c48-f445-4139-bea9-804f0e64b543" />

This is done to make sure that the editor fast. 


## Proposed changes:
* Remove the preloading of the /intergraruins endpoint which in some cases can call the 

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
See p1760985078540009-slack-C02FMH4G8

## Does this pull request change what data or activity we track or use?
No


## Testing instructions:
Load the editor. Notice that it loads a bit faster now. In some cases a lot faster.
Add the forms block.
Notice that you can add an integrations though the integrations modal as before. 
