### PR TITLE
Forms: fix dashboard inbox alignments

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-dashboard-inbox-alignments
+++ b/projects/packages/forms/changelog/fix-forms-dashboard-inbox-alignments
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Forms: align layout grid/components with DataViews table grid

--- a/projects/packages/forms/src/dashboard/components/layout/style.scss
+++ b/projects/packages/forms/src/dashboard/components/layout/style.scss
@@ -75,7 +75,7 @@ body.jetpack_page_jetpack-forms-admin {
 
 		> .components-tab-panel__tabs {
 			margin: 0;
-			padding-inline: 20px;
+			padding-inline: 32px;
 			border-bottom: 1px solid var(--jp-gray-5);
 
 			.components-tab-panel__tabs-item {

--- a/projects/packages/forms/src/dashboard/components/layout/style.scss
+++ b/projects/packages/forms/src/dashboard/components/layout/style.scss
@@ -57,7 +57,11 @@ body.jetpack_page_jetpack-forms-admin {
 		display: flex;
 		align-items: center;
 		justify-content: space-between;
-		padding: 30px 30px 0 30px;
+
+		box-sizing: border-box;
+		margin: 0;
+		padding: 16px 48px 0;
+		width: 100%;
 
 		@media (max-width: 782px) {
 			padding-top: 8px;
@@ -112,18 +116,3 @@ body.jetpack_page_jetpack-forms-admin {
 	}
 }
 
-.jp-forms__layout-header {
-	box-sizing: border-box;
-	margin: 0;
-	padding: 16px 48px 0;
-	width: 100%;
-}
-
-.jp-forms__layout-title {
-	display: inline-flex;
-	font-size: 36px;
-	font-weight: 700;
-	height: 40px;
-	line-height: 40px;
-	margin: 0;
-}

--- a/projects/packages/forms/src/dashboard/components/layout/style.scss
+++ b/projects/packages/forms/src/dashboard/components/layout/style.scss
@@ -64,7 +64,7 @@ body.jetpack_page_jetpack-forms-admin {
 		width: 100%;
 
 		@media (max-width: 782px) {
-			padding-top: 8px;
+			padding: 8px 24px 0;
 		}
 	}
 
@@ -100,7 +100,7 @@ body.jetpack_page_jetpack-forms-admin {
 			}
 
 			@media (max-width: 660px) {
-				padding: 0 24px;
+				padding: 0 8px;
 			}
 		}
 

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
@@ -235,7 +235,7 @@ export default function InboxView() {
 						item.author_name || item.author_email || item.author_url || item.ip
 					);
 					return (
-						<>
+						<div className="jp-forms__inbox__author-field">
 							{ item.is_unread && (
 								<span
 									className="jp-forms__inbox__unread-indicator"
@@ -253,7 +253,7 @@ export default function InboxView() {
 								/>
 							) }
 							{ wrapperUnread( item.is_unread, authorInfo ) }
-						</>
+						</div>
 					);
 				},
 				getValue: ( { item } ) => {

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -378,8 +378,19 @@
 		}
 	}
 
-	.dataviews-view-table__cell-content-wrapper {
-		gap: 16px;
+	.jp-forms__inbox__author-field {
+		position: relative;
+		display: flex;
+		align-items: center;
+		gap: 12px;
+	}
+
+	.jp-forms__inbox__unread-indicator {
+		color: #d63638;
+		font-size: 8px;
+		position: absolute;
+		left: -12px;
+		cursor: pointer;
 	}
 }
 
@@ -558,11 +569,3 @@ body.jetpack_page_jetpack-forms-admin {
 	font-weight: 600;
 }
 
-.jp-forms__inbox__unread-indicator {
-	color: #d63638;
-	font-size: 8px;
-	margin-right: 4.5px;
-	margin-left: -12px;
-	vertical-align: middle;
-	position: absolute;
-}

--- a/projects/packages/forms/src/dashboard/integrations/style.scss
+++ b/projects/packages/forms/src/dashboard/integrations/style.scss
@@ -28,6 +28,7 @@
 
 	.jp-forms__integrations-body {
 		border: 1px solid colors.$gray-200;
+		background-color: colors.$white;
 		border-radius: 8px;
 		padding: 12px 24px;
 


### PR DESCRIPTION
## Proposed changes:
This PR addresses some alignment issues between layout components and DataViews table grids.

It also cleans up some styles (remove unused, merge spread style declarations, move styles within hierarchy/scope)

Page title, tab headers and rows:

| Before                          | After                          |
| ------------------------------- | ------------------------------ |
| <img width="466" height="503" alt="image" src="https://github.com/user-attachments/assets/4860e519-cb42-4f0c-a1e3-df838015c522" /> | <img width="473" height="487" alt="image" src="https://github.com/user-attachments/assets/2f728358-2254-4c6c-8701-2cefb8e9941b" /> |

Also on mobile views:

| Before                          | After                          |
| ------------------------------- | ------------------------------ |
| <img width="463" height="647" alt="image" src="https://github.com/user-attachments/assets/5bb496ab-20af-47d8-b360-bba46b1c67e6" /> | <img width="464" height="557" alt="image" src="https://github.com/user-attachments/assets/e6a99bca-1256-4698-90e4-97886af58fda" /> |

| Before                          | After                          |
| ------------------------------- | ------------------------------ |
| <img width="942" height="640" alt="Screenshot 2025-10-20 at 3 22 20 PM" src="https://github.com/user-attachments/assets/39dd3382-e889-42e9-9260-0cd50f8dbdfa" /> | <img width="828" height="688" alt="Screenshot 2025-10-20 at 3 30 58 PM" src="https://github.com/user-attachments/assets/4092d7dc-ddb8-41e2-9510-ebf7731b106e" /> |




Author field now uses its own container to control spacing between avatar and name, so we don't go overwriting DataViews default styles:

| Before                          | After                          |
| ------------------------------- | ------------------------------ |
| <img width="370" height="225" alt="image" src="https://github.com/user-attachments/assets/5630715a-e6df-4934-bd76-29deba39ef77" /> | <img width="327" height="228" alt="image" src="https://github.com/user-attachments/assets/b8474459-beb5-4d7e-877b-9bdcf28a702a" /> |



### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1760979557146909-slack-C08LJ97DJ6A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Open the forms dashboard. See the styles match the screenshots, verify there are no regressions.