### PR TITLE
Forms: UX and accessibility fixes for image select field

### DIFF
--- a/projects/packages/forms/changelog/update-forms-image-select-further-feedback
+++ b/projects/packages/forms/changelog/update-forms-image-select-further-feedback
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: UX and accessibility fixes for image select field

--- a/projects/packages/forms/src/blocks/field-image-select/style.scss
+++ b/projects/packages/forms/src/blocks/field-image-select/style.scss
@@ -57,6 +57,7 @@ figure.wp-block-image {
 	}
 
 	.jetpack-input-image-option {
+		--outline-color: var(--jetpack-input-image-option--outline-color, var(--wp--preset--color--primary, var(--jetpack--contact-form--button-outline--background-color)));
 		box-sizing: border-box;
 		display: flex;
 		flex-direction: column;
@@ -67,10 +68,11 @@ figure.wp-block-image {
 		&.is-checked {
 			backdrop-filter: contrast(0.9) saturate(1.2);
 			cursor: pointer;
+			outline: 1px solid var(--outline-color);
 		}
 
 		&:not(.wp-block):focus-within {
-			outline: 2px solid var(--wp--preset--color--primary, var(--jetpack--contact-form--button-outline--background-color));
+			outline: 2px solid var(--outline-color);
 		}
 
 		.jetpack-input-image-option__wrapper {

--- a/projects/packages/forms/src/blocks/field-image-select/style.scss
+++ b/projects/packages/forms/src/blocks/field-image-select/style.scss
@@ -154,7 +154,6 @@ figure.wp-block-image {
 }
 
 div:where(.jetpack-input-image-option__outer) {
-	border-radius: 5px;
 	background-color: var(--jetpack--contact-form--background-color);
 }
 

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -2112,6 +2112,23 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 					} else {
 							$border_styles = "border-radius:{$radius_value};";
 					}
+				} else {
+					// Handle individual border radius properties when border-radius is not present
+					preg_match( '/border-top-left-radius:([^;]+)/', $option['style'], $top_left_match );
+					preg_match( '/border-top-right-radius:([^;]+)/', $option['style'], $top_right_match );
+					preg_match( '/border-bottom-right-radius:([^;]+)/', $option['style'], $bottom_right_match );
+					preg_match( '/border-bottom-left-radius:([^;]+)/', $option['style'], $bottom_left_match );
+
+					if ( ! empty( $top_left_match[1] ) || ! empty( $top_right_match[1] ) || ! empty( $bottom_right_match[1] ) || ! empty( $bottom_left_match[1] ) ) {
+						$width_value = ! empty( $width_match[1] ) ? trim( $width_match[1] ) : '1px';
+
+						$top_left     = ! empty( $top_left_match[1] ) ? trim( $top_left_match[1] ) : '4px';
+						$top_right    = ! empty( $top_right_match[1] ) ? trim( $top_right_match[1] ) : '4px';
+						$bottom_right = ! empty( $bottom_right_match[1] ) ? trim( $bottom_right_match[1] ) : '4px';
+						$bottom_left  = ! empty( $bottom_left_match[1] ) ? trim( $bottom_left_match[1] ) : '4px';
+
+						$border_styles = "border-radius:calc({$top_left} + {$width_value}) calc({$top_right} + {$width_value}) calc({$bottom_right} + {$width_value}) calc({$bottom_left} + {$width_value});";
+					}
 				}
 			}
 

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -2083,6 +2083,13 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 			$option_id                   = $id . '-' . $option_letter;
 			$used_html_ids[ $option_id ] = true;
 
+			$figcaption_id = esc_attr( $option_id . '-figcaption' );
+
+			// Add id attribute to figcaption for accessibility
+			if ( ! empty( $rendered_image_block ) && strpos( $rendered_image_block, '<figcaption' ) !== false ) {
+				$rendered_image_block = preg_replace( '/(<figcaption[^>]*)(>)/', '$1 id="' . $figcaption_id . '"$2', $rendered_image_block );
+			}
+
 			// To be able to apply the backdrop-filter for the hover effect, we need to separate the background into an outer div.
 			// This outer div needs the color styles separately, and also the border radius to match the inner div without sticking out.
 			$option_outer_classes = 'jetpack-input-image-option__outer ' . ( isset( $option['classcolor'] ) ? $option['classcolor'] : '' );
@@ -2121,6 +2128,25 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 			$field .= "<div {$option_classes} {$option_styles} data-wp-on--click='actions.onImageOptionClick' data-wp-init='callbacks.setImageOptionOutlineColor'>";
 
 			$input_id = esc_attr( $option_id );
+			$label_id = esc_attr( $option_id . '-label' );
+
+			/* translators: %s is the letter associated with the option, e.g. "Option A" */
+			$aria_label_parts = array( sprintf( __( 'Option %s', 'jetpack-forms' ), $perceived_letters[ $option_index ] ) );
+
+			if ( ! empty( $option_label ) ) {
+				$aria_label_parts[] = $option_label;
+			}
+
+			$aria_label = implode( ': ', $aria_label_parts );
+
+			// Build aria-describedby to reference label and figcaption
+			$aria_describedby_parts = array( $label_id );
+
+			if ( ! empty( $rendered_image_block ) && strpos( $rendered_image_block, '<figcaption' ) !== false ) {
+				$aria_describedby_parts[] = $figcaption_id;
+			}
+
+			$aria_describedby = implode( ' ', $aria_describedby_parts );
 
 			$field .= "<div class='jetpack-input-image-option__wrapper'>";
 			$field .= "<input
@@ -2129,6 +2155,8 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 			type='" . esc_attr( $input_type ) . "'
 			name='" . esc_attr( $input_name ) . "'
 			value='" . esc_attr( $option_value ) . "'
+			aria-label='" . esc_attr( $aria_label ) . "'
+			aria-describedby='" . esc_attr( $aria_describedby ) . "'
 			data-wp-init='callbacks.setImageOptionCheckColor'
 			data-wp-on--keydown='actions.onKeyDownImageOption'
 			data-wp-on--change='" . ( $is_multiple ? 'actions.onMultipleFieldChange' : 'actions.onFieldChange' ) . "' "
@@ -2145,7 +2173,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 
 			$label_classes  = 'jetpack-input-image-option__label';
 			$label_classes .= $show_labels ? '' : ' visually-hidden';
-			$field         .= "<span class='{$label_classes}'>" . esc_html( $option_label ) . '</span>';
+			$field         .= "<span id='{$label_id}' class='{$label_classes}'>" . esc_html( $option_label ) . '</span>';
 			$field         .= '</div></div></div>';
 		}
 

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -2196,6 +2196,8 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 
 		$field .= '</div></div>';
 
+		$field .= $this->get_error_div( $id, 'image-select' );
+
 		$field .= '</fieldset>';
 
 		$field .= '</div>';

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -2115,14 +2115,9 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 			$option_styles   = empty( $option['style'] ) ? '' : "style='" . esc_attr( $option['style'] ) . "'";
 			$option_classes  = "class='" . ( empty( $option['class'] ) ? $default_classes : $default_classes . ' ' . $option['class'] ) . "'";
 
-			$field .= "<div {$option_classes} {$option_styles} data-wp-on--click='actions.onImageOptionClick'>";
+			$field .= "<div {$option_classes} {$option_styles} data-wp-on--click='actions.onImageOptionClick' data-wp-init='callbacks.setImageOptionOutlineColor'>";
 
 			$input_id = esc_attr( $option_id );
-
-			$context             = array(
-				'inputId' => $input_id,
-			);
-			$interactivity_attrs = ' data-wp-interactive="jetpack/form" ' . wp_interactivity_data_wp_context( $context ) . ' ';
 
 			$field .= "<div class='jetpack-input-image-option__wrapper'>";
 			$field .= "<input
@@ -2131,7 +2126,6 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 			type='" . esc_attr( $input_type ) . "'
 			name='" . esc_attr( $input_name ) . "'
 			value='" . esc_attr( $option_value ) . "'
-			" . $interactivity_attrs . "
 			data-wp-init='callbacks.setImageOptionCheckColor'
 			data-wp-on--keydown='actions.onKeyDownImageOption'
 			data-wp-on--change='" . ( $is_multiple ? 'actions.onMultipleFieldChange' : 'actions.onFieldChange' ) . "' "

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -2049,9 +2049,12 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 			$option_letter = Contact_Form_Plugin::strip_tags( $option['letter'] );
 			$image_block   = $option['image'];
 
-			// Extract image src from rendered block
 			$rendered_image_block = render_block( $image_block );
-			$image_src            = '';
+			// Remove any links from the rendered block
+			$rendered_image_block = preg_replace( '/<a[^>]*>(.*?)<\/a>/s', '$1', $rendered_image_block );
+
+			// Extract image src from rendered block
+			$image_src = '';
 
 			if ( ! empty( $rendered_image_block ) ) {
 				if ( preg_match( '/<img[^>]+src=["\']([^"\']+)["\'][^>]*>/i', $rendered_image_block, $matches ) ) {

--- a/projects/packages/forms/src/modules/form/view.js
+++ b/projects/packages/forms/src/modules/form/view.js
@@ -5,6 +5,7 @@ import {
 	getContext,
 	store,
 	getConfig,
+	getElement,
 	withSyncEvent as originalWithSyncEvent,
 } from '@wordpress/interactivity';
 /*
@@ -581,19 +582,36 @@ const { state, actions } = store( NAMESPACE, {
 		},
 
 		setImageOptionCheckColor() {
-			const context = getContext();
+			const { ref } = getElement();
 
-			const { inputId } = context;
-			const input = document.getElementById( inputId );
-
-			if ( ! input ) {
+			if ( ! ref ) {
 				return;
 			}
 
-			const color = window.getComputedStyle( input ).color;
+			const color = window.getComputedStyle( ref ).color;
 			const inverseColor = window.jetpackForms.getInverseReadableColor( color );
+			const style = ref.getAttribute( 'style' ) ?? '';
 
-			input.setAttribute( 'style', `--jetpack-input-image-option--check-color: ${ inverseColor }` );
+			ref.setAttribute(
+				'style',
+				style + `--jetpack-input-image-option--check-color: ${ inverseColor }`
+			);
+		},
+
+		setImageOptionOutlineColor() {
+			const { ref } = getElement();
+
+			if ( ! ref ) {
+				return;
+			}
+
+			const { borderColor } = window.getComputedStyle( ref );
+			const style = ref.getAttribute( 'style' ) ?? '';
+
+			ref.setAttribute(
+				'style',
+				style + `--jetpack-input-image-option--outline-color: ${ borderColor }`
+			);
 		},
 	},
 } );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of FORMS-60

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Addresses remaining feedback on call for testing:
* Removes links from figcaptions to prevent them from interfering with keyboard navigation
* Improves accessibility by setting the aria labels
* Fixes the leaking background issue
* Adds the error message to the fieldset if the field is required and was not filled
* Matches the border and outline colors and makes selected elements have an outline to make them easier to see

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add a required image select field
* Change its border radius and set a background color
* Select one image from pixabay or any service with links in the default caption
* Publish the form
* Check that the background color does not leak behind the border radius
* Try to submit it without selecting any image
* Check that the error message is visible
* Use the keyboard to navigate between options
* Check that the caption of the image is not selected at any moment
* Check that the aria labels are correct and point to the image label and figcaption (if present)

<img width="662" height="980" alt="Screenshot from 2025-10-20 21-14-43" src="https://github.com/user-attachments/assets/c274def8-36ba-441b-b315-0f888ed14c1e" />
