### PR TITLE
Forms: fixes for non-white dashboard background

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-integrations-background
+++ b/projects/packages/forms/changelog/fix-forms-integrations-background
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: make integrations background white.

--- a/projects/packages/forms/src/dashboard/components/layout/style.scss
+++ b/projects/packages/forms/src/dashboard/components/layout/style.scss
@@ -108,6 +108,7 @@ body.jetpack_page_jetpack-forms-admin {
 		.components-tab-panel__tab-content {
 			display: flex;
 			flex: 1;
+			background: #fff;
 		}
 	}
 }

--- a/projects/packages/forms/src/dashboard/components/layout/style.scss
+++ b/projects/packages/forms/src/dashboard/components/layout/style.scss
@@ -108,7 +108,7 @@ body.jetpack_page_jetpack-forms-admin {
 		.components-tab-panel__tab-content {
 			display: flex;
 			flex: 1;
-			background: #fff;
+			background: var(--jp-white);
 		}
 	}
 }

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -416,6 +416,7 @@
 }
 
 .jp-forms__inbox__dataviews-response {
+	background: var(--jp-white);
 	min-width: 300px !important;
 	overflow: auto;
 	flex: 1 1 40%;

--- a/projects/packages/forms/src/dashboard/integrations/style.scss
+++ b/projects/packages/forms/src/dashboard/integrations/style.scss
@@ -30,7 +30,7 @@
 		border: 1px solid colors.$gray-200;
 		border-radius: 8px;
 		padding: 12px 24px;
-		background: #fff;
+		background: colors.$white;
 
 		> div:last-of-type {
 			border-bottom: none;

--- a/projects/packages/forms/src/dashboard/integrations/style.scss
+++ b/projects/packages/forms/src/dashboard/integrations/style.scss
@@ -30,6 +30,7 @@
 		border: 1px solid colors.$gray-200;
 		border-radius: 8px;
 		padding: 12px 24px;
+		background: #fff;
 
 		> div:last-of-type {
 			border-bottom: none;


### PR DESCRIPTION
## Proposed changes:

In most WP instances, admin page backgrounds are white. In CIAB, they are gray. We are seeing the non-white background seep through on the responses and integrations screens. This PR forces white background on dataviews container and integrations container. 

**Before**
<img width="1350" height="727" alt="responses-background" src="https://github.com/user-attachments/assets/cde55659-efed-4e39-9667-0a9bd9ffed8a" />

<img width="1636" height="1146" alt="Screenshot 2025-10-20 at 3 22 01 PM" src="https://github.com/user-attachments/assets/8a546ef9-1136-4820-84e6-23f7ae79187a" />

**After**
<img width="1346" height="727" alt="responses-background-after" src="https://github.com/user-attachments/assets/20fe224f-8970-448d-98ab-d7d9c1376064" />

<img width="748" height="630" alt="integrations-background-after" src="https://github.com/user-attachments/assets/22e98375-a41d-4e66-97fa-3c745bb2f022" />



### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None. 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No. 

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Go to Jetpack > Forms > Integrations in a CIAB environment and confirm integrations background is all white. 

