### PR TITLE
Help Center: Limit the persisted Help Center history size

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/help-center-limit-history-size
+++ b/projects/packages/jetpack-mu-wpcom/changelog/help-center-limit-history-size
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Limit persisted Help Center history stack to 50 entries

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
@@ -52,8 +52,41 @@ class Help_Center {
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_wp_admin_scripts' ), 100 );
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_wp_admin_scripts' ), 100 );
 		add_filter( 'in_admin_header', array( $this, 'jetpack_remove_core_help_tab' ) );
+		add_filter( 'calypso_preferences_update', array( $this, 'calypso_preferences_update' ) );
 
 		$this->is_support_site = defined( 'WPCOM_SUPPORT_BLOG_IDS' ) && in_array( get_current_blog_id(), (array) WPCOM_SUPPORT_BLOG_IDS, true );
+	}
+
+	/**
+	 * Update the calypso preferences.
+	 *
+	 * @param array $preferences The preferences.
+	 * @return array The preferences.
+	 */
+	public function calypso_preferences_update( $preferences ) {
+		$router_history = $preferences['help_center_router_history'];
+		$entries        = $router_history['entries'];
+
+		// Limit entries to 50 to prevent memory issues.
+		if ( count( $entries ) > 50 ) {
+			// Keep only the last 49 entries and add the root entry at the beginning.
+			$entries = array_slice( $entries, -49 );
+			// Keep the start at root so the back button always works.
+			array_unshift(
+				$entries,
+				array(
+					'pathname' => '/',
+					'search'   => '',
+					'hash'     => '',
+					'key'      => 'default',
+					'state'    => null,
+				)
+			);
+			// Update the entries and index in the router history.
+			$preferences['help_center_router_history']['entries'] = $entries;
+			$preferences['help_center_router_history']['index']   = 49;
+		}
+		return $preferences;
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
@@ -64,27 +64,27 @@ class Help_Center {
 	 * @return array The preferences.
 	 */
 	public function calypso_preferences_update( $preferences ) {
-		$router_history = $preferences['help_center_router_history'];
-		$entries        = $router_history['entries'];
+		if ( isset( $preferences->help_center_router_history ) ) {
+			$router_history = &$preferences->help_center_router_history;
+			$entries        = &$router_history['entries'];
 
-		// Limit entries to 50 to prevent memory issues.
-		if ( count( $entries ) > 50 ) {
-			// Keep only the last 49 entries and add the root entry at the beginning.
-			$entries = array_slice( $entries, -49 );
-			// Keep the start at root so the back button always works.
-			array_unshift(
-				$entries,
-				array(
-					'pathname' => '/',
-					'search'   => '',
-					'hash'     => '',
-					'key'      => 'default',
-					'state'    => null,
-				)
-			);
-			// Update the entries and index in the router history.
-			$preferences['help_center_router_history']['entries'] = $entries;
-			$preferences['help_center_router_history']['index']   = 49;
+			// Limit entries to 50 to prevent spamming entries in the router history.
+			if ( count( $entries ) > 5 ) {
+				// Keep only the last 49 entries and add the root entry at the beginning.
+				$entries = array_slice( $entries, -4 );
+				// Keep the start at root so the back button always works.
+				array_unshift(
+					$entries,
+					array(
+						'pathname' => '/',
+						'search'   => '',
+						'hash'     => '',
+						'key'      => 'default',
+						'state'    => null,
+					)
+				);
+				$router_history['index'] = 4;
+			}
 		}
 		return $preferences;
 	}

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
@@ -64,32 +64,43 @@ class Help_Center {
 	 * @return \stdClass The preferences.
 	 */
 	public function calypso_preferences_update( $preferences ) {
-		if ( isset( $preferences->help_center_router_history ) &&
-			is_array( $preferences->help_center_router_history ) &&
-			isset( $preferences->help_center_router_history['entries'] ) &&
-			is_array( $preferences->help_center_router_history['entries'] ) ) {
-
-			$history = &$preferences->help_center_router_history;
-			$entries = &$history['entries'];
-
-			// Limit entries to 50 to prevent spamming entries in the router history.
-			if ( count( $entries ) > 50 ) {
-				// Keep only the last 49 entries and add the root entry at the beginning.
-				$entries = array_slice( $entries, -49 );
-				// Keep the start at root so the back button always works.
-				array_unshift(
-					$entries,
-					array(
-						'pathname' => '/',
-						'search'   => '',
-						'hash'     => '',
-						'key'      => 'default',
-						'state'    => null,
-					)
-				);
-				$history['index'] = 49;
-			}
+		// Check if help_center_router_history exists and is a valid array structure
+		if ( ! isset( $preferences->help_center_router_history ) ||
+			! is_array( $preferences->help_center_router_history ) ) {
+			return $preferences;
 		}
+
+		$router_history = $preferences->help_center_router_history;
+
+		// Check if entries exist and is an array
+		if ( ! isset( $router_history['entries'] ) ||
+			! is_array( $router_history['entries'] ) ) {
+			return $preferences;
+		}
+
+		$entries = $router_history['entries'];
+
+		// Limit entries to 50 to prevent spamming entries in the router history.
+		if ( count( $entries ) > 50 ) {
+			// Keep only the last 49 entries and add the root entry at the beginning.
+			$entries = array_slice( $entries, -49 );
+			// Keep the start at root so the back button always works.
+			array_unshift(
+				$entries,
+				array(
+					'pathname' => '/',
+					'search'   => '',
+					'hash'     => '',
+					'key'      => 'default',
+					'state'    => null,
+				)
+			);
+
+			// Update the preferences object directly
+			$preferences->help_center_router_history['entries'] = $entries;
+			$preferences->help_center_router_history['index']   = 49;
+		}
+
 		return $preferences;
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
@@ -60,8 +60,8 @@ class Help_Center {
 	/**
 	 * Update the calypso preferences.
 	 *
-	 * @param array $preferences The preferences.
-	 * @return array The preferences.
+	 * @param stdClass $preferences The preferences.
+	 * @return stdClass The preferences.
 	 */
 	public function calypso_preferences_update( $preferences ) {
 		if ( isset( $preferences->help_center_router_history ) ) {
@@ -69,7 +69,7 @@ class Help_Center {
 			$entries        = &$router_history['entries'];
 
 			// Limit entries to 50 to prevent spamming entries in the router history.
-			if ( count( $entries ) > 5 ) {
+			if ( count( $entries ) > 50 ) {
 				// Keep only the last 49 entries and add the root entry at the beginning.
 				$entries = array_slice( $entries, -4 );
 				// Keep the start at root so the back button always works.
@@ -83,7 +83,7 @@ class Help_Center {
 						'state'    => null,
 					)
 				);
-				$router_history['index'] = 4;
+				$router_history['index'] = 49;
 			}
 		}
 		return $preferences;

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
@@ -60,8 +60,8 @@ class Help_Center {
 	/**
 	 * Update the calypso preferences.
 	 *
-	 * @param stdClass $preferences The preferences.
-	 * @return stdClass The preferences.
+	 * @param \stdClass $preferences The preferences.
+	 * @return \stdClass The preferences.
 	 */
 	public function calypso_preferences_update( $preferences ) {
 		if ( isset( $preferences->help_center_router_history ) ) {

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
@@ -64,7 +64,7 @@ class Help_Center {
 	 * @return \stdClass The preferences.
 	 */
 	public function calypso_preferences_update( $preferences ) {
-		if ( isset( $preferences->help_center_router_history ) ) {
+		if ( isset( $preferences->help_center_router_history ) && ! empty( $preferences->help_center_router_history['entries'] ) ) {
 			$router_history = &$preferences->help_center_router_history;
 			$entries        = &$router_history['entries'];
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
@@ -64,7 +64,7 @@ class Help_Center {
 	 * @return \stdClass The preferences.
 	 */
 	public function calypso_preferences_update( $preferences ) {
-		if ( isset( $preferences->help_center_router_history ) && ! empty( $preferences->help_center_router_history['entries'] ) ) {
+		if ( isset( $preferences->help_center_router_history ) && is_array( $preferences->help_center_router_history['entries'] ) ) {
 			$router_history = &$preferences->help_center_router_history;
 			$entries        = &$router_history['entries'];
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
@@ -64,27 +64,24 @@ class Help_Center {
 	 * @return \stdClass The preferences.
 	 */
 	public function calypso_preferences_update( $preferences ) {
-		if ( isset( $preferences->help_center_router_history ) && is_array( $preferences->help_center_router_history['entries'] ) ) {
-			$router_history = &$preferences->help_center_router_history;
-			$entries        = &$router_history['entries'];
-
-			// Limit entries to 50 to prevent spamming entries in the router history.
-			if ( count( $entries ) > 50 ) {
-				// Keep only the last 49 entries and add the root entry at the beginning.
-				$entries = array_slice( $entries, -49 );
-				// Keep the start at root so the back button always works.
-				array_unshift(
-					$entries,
-					array(
-						'pathname' => '/',
-						'search'   => '',
-						'hash'     => '',
-						'key'      => 'default',
-						'state'    => null,
-					)
-				);
-				$router_history['index'] = 49;
-			}
+		$entries = &$preferences->help_center_router_history['entries'] ?? null;
+		$index   = &$preferences->help_center_router_history['index'] ?? null;
+		// Limit entries to 50 to prevent spamming entries in the router history.
+		if ( $entries && count( $entries ) > 50 ) {
+			// Keep only the last 49 entries and add the root entry at the beginning.
+			$entries = array_slice( $entries, -49 );
+			// Keep the start at root so the back button always works.
+			array_unshift(
+				$entries,
+				array(
+					'pathname' => '/',
+					'search'   => '',
+					'hash'     => '',
+					'key'      => 'default',
+					'state'    => null,
+				)
+			);
+			$index = 49;
 		}
 		return $preferences;
 	}

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
@@ -71,7 +71,7 @@ class Help_Center {
 			// Limit entries to 50 to prevent spamming entries in the router history.
 			if ( count( $entries ) > 50 ) {
 				// Keep only the last 49 entries and add the root entry at the beginning.
-				$entries = array_slice( $entries, -4 );
+				$entries = array_slice( $entries, -49 );
 				// Keep the start at root so the back button always works.
 				array_unshift(
 					$entries,

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
@@ -64,24 +64,31 @@ class Help_Center {
 	 * @return \stdClass The preferences.
 	 */
 	public function calypso_preferences_update( $preferences ) {
-		$entries = &$preferences->help_center_router_history['entries'] ?? null;
-		$index   = &$preferences->help_center_router_history['index'] ?? null;
-		// Limit entries to 50 to prevent spamming entries in the router history.
-		if ( $entries && count( $entries ) > 50 ) {
-			// Keep only the last 49 entries and add the root entry at the beginning.
-			$entries = array_slice( $entries, -49 );
-			// Keep the start at root so the back button always works.
-			array_unshift(
-				$entries,
-				array(
-					'pathname' => '/',
-					'search'   => '',
-					'hash'     => '',
-					'key'      => 'default',
-					'state'    => null,
-				)
-			);
-			$index = 49;
+		if ( isset( $preferences->help_center_router_history ) &&
+			is_array( $preferences->help_center_router_history ) &&
+			isset( $preferences->help_center_router_history['entries'] ) &&
+			is_array( $preferences->help_center_router_history['entries'] ) ) {
+
+			$history = &$preferences->help_center_router_history;
+			$entries = &$history['entries'];
+
+			// Limit entries to 50 to prevent spamming entries in the router history.
+			if ( count( $entries ) > 50 ) {
+				// Keep only the last 49 entries and add the root entry at the beginning.
+				$entries = array_slice( $entries, -49 );
+				// Keep the start at root so the back button always works.
+				array_unshift(
+					$entries,
+					array(
+						'pathname' => '/',
+						'search'   => '',
+						'hash'     => '',
+						'key'      => 'default',
+						'state'    => null,
+					)
+				);
+				$history['index'] = 49;
+			}
 		}
 		return $preferences;
 	}


### PR DESCRIPTION
Fixes DOTSUP-319

## Proposed changes:
A backend replica of https://github.com/Automattic/wp-calypso/pull/106447

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

This is a bit tricky to test. 

It's difficult to create 50 records, so for testing purposes, please change the 50 to 5, and the 49 to 4 [here](https://github.com/Automattic/jetpack/blob/help-center/limit-history-size/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php#L72-L86).

1. Apply this to sun/moon.
2. Sandbox Public API.
3. Open the Help Center.
4. Open an article.
5. Click on another article link inside the first one. You can tell it's an article by hovering and verifying the link has `support` in it.
6. Repeat at least 5 more times (6 in total).
7. Check the response of `/me/preferences`. The entries in `help_center_router_history` should not exceed 5, and the index should not cross 4.
8. Refresh the page. The Help Center should reopen at the same page.
9. Click back 5 times, you should end up at the Help Center home.
