### PR TITLE
Backport jetpack 15.2-a.5 Changes

### DIFF
--- a/projects/js-packages/charts/CHANGELOG.md
+++ b/projects/js-packages/charts/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.44.0] - 2025-10-21
+### Changed
+- Improve legends toggling. [#45545]
+
 ## [0.43.0] - 2025-10-20
 ### Added
 - Add legend interactivity. [#45506]
@@ -519,6 +523,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed lints following ESLint rule changes for TS [#40584]
 - Fixing a bug in Chart storybook data. [#40640]
 
+[0.44.0]: https://github.com/Automattic/charts/compare/v0.43.0...v0.44.0
 [0.43.0]: https://github.com/Automattic/charts/compare/v0.42.0...v0.43.0
 [0.42.0]: https://github.com/Automattic/charts/compare/v0.41.1...v0.42.0
 [0.41.1]: https://github.com/Automattic/charts/compare/v0.41.0...v0.41.1

--- a/projects/js-packages/charts/changelog/update-charts-54-legends-toggling-improvements
+++ b/projects/js-packages/charts/changelog/update-charts-54-legends-toggling-improvements
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Charts: improve legends toggling

--- a/projects/js-packages/charts/package.json
+++ b/projects/js-packages/charts/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/charts",
-	"version": "0.43.0",
+	"version": "0.44.0",
 	"description": "Display charts within Automattic products.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/charts/#readme",
 	"bugs": {

--- a/projects/packages/forms/CHANGELOG.md
+++ b/projects/packages/forms/CHANGELOG.md
@@ -5,11 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.12.0] - 2025-10-21
+### Added
+- Show gravatar on dataviews list. [#45555]
+
+### Changed
+- Merge email and push notification settings panels. [#45548]
+- Stop preloading the integrations endpoint. [#45558]
+
+### Deprecated
+- Remove unused `useFormsConfig` hook. [#45554]
+
+### Fixed
+- Fix bug where the responsive modal is not able to be closed. [#45541] [#45557]
+- Fix renderable status of image select field. [#45542]
+- Make integrations background white. [#45562]
+- Reset the selection on tab switch. [#45543]
+
 ## [6.11.0] - 2025-10-20
 ### Added
-- Forms: Add Hostinger Reach integration. [#45271]
-- Forms: Add programmatic initialization support via `window.jetpackFormsInit()`. [#45531]
-- Forms: Add unread/read filter to the dashboard. [#45514]
+- Add Hostinger Reach integration. [#45271]
+- Add programmatic initialization support via `window.jetpackFormsInit()`. [#45531]
+- Add unread/read filter to the dashboard. [#45514]
 
 ### Changed
 - Add new useConfigValue hook and start using it on the dashboard. [#45472]
@@ -1713,6 +1730,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a new jetpack/forms package [#28409]
 - Added a public load_contact_form method for initializing the contact form module. [#28416]
 
+[6.12.0]: https://github.com/automattic/jetpack-forms/compare/v6.11.0...v6.12.0
 [6.11.0]: https://github.com/automattic/jetpack-forms/compare/v6.10.0...v6.11.0
 [6.10.0]: https://github.com/automattic/jetpack-forms/compare/v6.9.0...v6.10.0
 [6.9.0]: https://github.com/automattic/jetpack-forms/compare/v6.8.0...v6.9.0

--- a/projects/packages/forms/changelog/add-forms-dashboard-dataviews-gravatar
+++ b/projects/packages/forms/changelog/add-forms-dashboard-dataviews-gravatar
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Forms: show gravatar on dataviews list

--- a/projects/packages/forms/changelog/fix-close-modal-forms
+++ b/projects/packages/forms/changelog/fix-close-modal-forms
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Forms: fix bug where the responsvie modal is not able to be closed. 

--- a/projects/packages/forms/changelog/fix-double-close-pr
+++ b/projects/packages/forms/changelog/fix-double-close-pr
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Forms: fix a bug that you makes you click the close button twice. 

--- a/projects/packages/forms/changelog/fix-forms-clear-selection-when-switching-tabs
+++ b/projects/packages/forms/changelog/fix-forms-clear-selection-when-switching-tabs
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Forms: reset the selection on tab switch

--- a/projects/packages/forms/changelog/fix-forms-integrations-background
+++ b/projects/packages/forms/changelog/fix-forms-integrations-background
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Forms: make integrations background white.

--- a/projects/packages/forms/changelog/fix-remove-preloading-form-integrations
+++ b/projects/packages/forms/changelog/fix-remove-preloading-form-integrations
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Forms: stop preloading the integrations endpoint 

--- a/projects/packages/forms/changelog/update-form-notifications-ui
+++ b/projects/packages/forms/changelog/update-form-notifications-ui
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Forms: merged email and push notification settings panels.

--- a/projects/packages/forms/changelog/update-forms-image-select-no-options
+++ b/projects/packages/forms/changelog/update-forms-image-select-no-options
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Forms: Fix renderable status of image select field

--- a/projects/packages/forms/changelog/update-forms-remove-useformsconfig
+++ b/projects/packages/forms/changelog/update-forms-remove-useformsconfig
@@ -1,4 +1,0 @@
-Significance: minor
-Type: deprecated
-
-Forms: remove unused useFormsConfig hook.

--- a/projects/packages/forms/composer.json
+++ b/projects/packages/forms/composer.json
@@ -71,7 +71,7 @@
 			"link-template": "https://github.com/automattic/jetpack-forms/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "6.11.x-dev"
+			"dev-trunk": "6.12.x-dev"
 		},
 		"textdomain": "jetpack-forms",
 		"version-constants": {

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-forms",
-	"version": "6.11.0",
+	"version": "6.12.0",
 	"private": true,
 	"description": "Jetpack Forms",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/forms/#readme",

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -14,7 +14,7 @@ use Automattic\Jetpack\Forms\Dashboard\Dashboard;
  */
 class Jetpack_Forms {
 
-	const PACKAGE_VERSION = '6.11.0';
+	const PACKAGE_VERSION = '6.12.0';
 
 	/**
 	 * Load the contact form module.

--- a/projects/packages/my-jetpack/CHANGELOG.md
+++ b/projects/packages/my-jetpack/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.27.8] - 2025-10-21
+### Changed
+- Update dependencies. [#45493]
+
 ## [5.27.7] - 2025-10-20
 ### Fixed
 - Prevent PHP errors when notification data is malformed. [#45385]
@@ -2384,6 +2388,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created package
 
+[5.27.8]: https://github.com/Automattic/jetpack-my-jetpack/compare/5.27.7...5.27.8
 [5.27.7]: https://github.com/Automattic/jetpack-my-jetpack/compare/5.27.6...5.27.7
 [5.27.6]: https://github.com/Automattic/jetpack-my-jetpack/compare/5.27.5...5.27.6
 [5.27.5]: https://github.com/Automattic/jetpack-my-jetpack/compare/5.27.4...5.27.5

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "5.27.7",
+	"version": "5.27.8",
 	"private": true,
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -39,7 +39,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '5.27.7';
+	const PACKAGE_VERSION = '5.27.8';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.

--- a/projects/packages/search/CHANGELOG.md
+++ b/projects/packages/search/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.52.24] - 2025-10-21
+### Fixed
+- Instant Search: Handle browser privacy settings stripping out the search query value. [#45533]
+
 ## [0.52.23] - 2025-10-20
 ### Changed
 - Update dependencies. [#45488]
@@ -1352,6 +1356,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Update PHPUnit configs to include just what needs coverage rather than include everything then try to exclude stuff that doesn't.
 
+[0.52.24]: https://github.com/Automattic/jetpack-search/compare/v0.52.23...v0.52.24
 [0.52.23]: https://github.com/Automattic/jetpack-search/compare/v0.52.22...v0.52.23
 [0.52.22]: https://github.com/Automattic/jetpack-search/compare/v0.52.21...v0.52.22
 [0.52.21]: https://github.com/Automattic/jetpack-search/compare/v0.52.20...v0.52.21

--- a/projects/packages/search/changelog/fix-privacy-settings-breaking-jetpack-search
+++ b/projects/packages/search/changelog/fix-privacy-settings-breaking-jetpack-search
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Instant Search: address browser privacy settings from stripping out the search query value.

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -15,7 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Search package general information
  */
 class Package {
-	const VERSION = '0.52.23';
+	const VERSION = '0.52.24';
 	const SLUG    = 'search';
 
 	/**

--- a/projects/plugins/jetpack/CHANGELOG.md
+++ b/projects/plugins/jetpack/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ### This is a list detailing changes for all Jetpack releases.
 
+## 15.2-a.5 - 2025-10-21
+### Enhancements
+- Forms: merged email and push notification settings panels. [#45548]
+
+### Bug fixes
+- Forms: Fix a bug where ther responsive modal is not able to be closed. [#45541] [#45557]
+- Forms: Reset the selection on tab switch in dashboard. [#45543]
+- Forms: Stop preloading the integrations endpoint. [#45558]
+- Instant Search: Handle browser privacy settings stripping out the search query value. [#45533]
+
+### Other changes <!-- Non-user-facing changes go here. This section will not be copied to readme.txt. -->
+- Forms: Remove unused `useFormsConfig` hook. [#45554]
+
 ## 15.2-a.3 - 2025-10-20
 ### Enhancements
 - Forms: Update "Action after submit" sidebar section. [#45502]

--- a/projects/plugins/jetpack/changelog/fix-close-modal-forms
+++ b/projects/plugins/jetpack/changelog/fix-close-modal-forms
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Forms: fix a bug where ther responsive modal is not able to be closed.

--- a/projects/plugins/jetpack/changelog/fix-forms-clear-selection-when-switching-tabs
+++ b/projects/plugins/jetpack/changelog/fix-forms-clear-selection-when-switching-tabs
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Forms: reset the selection on tab switch in dashboard

--- a/projects/plugins/jetpack/changelog/fix-privacy-settings-breaking-jetpack-search
+++ b/projects/plugins/jetpack/changelog/fix-privacy-settings-breaking-jetpack-search
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Instant Search: address browser privacy settings from stripping out the search query value.

--- a/projects/plugins/jetpack/changelog/fix-remove-preloading-form-integrations
+++ b/projects/plugins/jetpack/changelog/fix-remove-preloading-form-integrations
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Forms stop preloading the integrations endpoint

--- a/projects/plugins/jetpack/changelog/update-form-notifications-ui
+++ b/projects/plugins/jetpack/changelog/update-form-notifications-ui
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Forms: merged email and push notification settings panels.

--- a/projects/plugins/jetpack/changelog/update-forms-remove-useformsconfig
+++ b/projects/plugins/jetpack/changelog/update-forms-remove-useformsconfig
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Forms: remove unused useFormsConfig hook.

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -111,7 +111,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ15_2_a_3",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ15_2_a_5",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -1490,7 +1490,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/forms",
-                "reference": "ea1f9bb89ab93313fb1f56986c159517dd5b163a"
+                "reference": "e7cb1f32b7ba9bf64e566c669597f8fed4fc013b"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1523,7 +1523,7 @@
                     "link-template": "https://github.com/automattic/jetpack-forms/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "6.11.x-dev"
+                    "dev-trunk": "6.12.x-dev"
                 },
                 "textdomain": "jetpack-forms",
                 "version-constants": {

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 15.2-a.3
+ * Version: 15.2-a.5
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -38,7 +38,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 if ( ! defined( 'JETPACK__VERSION' ) ) {
 	// This breaks the project version checks when a one-liner.
-	define( 'JETPACK__VERSION', '15.2-a.3' );
+	define( 'JETPACK__VERSION', '15.2-a.5' );
 }
 defined( 'JETPACK__MINIMUM_WP_VERSION' ) || define( 'JETPACK__MINIMUM_WP_VERSION', '6.7' );
 defined( 'JETPACK__MINIMUM_PHP_VERSION' ) || define( 'JETPACK__MINIMUM_PHP_VERSION', '7.2' );

--- a/projects/plugins/jetpack/readme.txt
+++ b/projects/plugins/jetpack/readme.txt
@@ -326,26 +326,15 @@ Jetpack Backup can do a full website migration to a new host, migrate theme file
 
 
 == Changelog ==
-### 15.2-a.3 - 2025-10-20
+### 15.2-a.5 - 2025-10-21
 #### Enhancements
-- Forms: Update "Action after submit" sidebar section.
-- Sharing Buttons block: Update Reddit logo to match updated design.
-- Sitemaps: Use XMLWriter by default for more performant sitemap generation.
-
-#### Improved compatibility
-- Custom post types: Ensure features remain available when theme support is added.
-- Forms: Remove Creative Mail promotion.
+- Forms: merged email and push notification settings panels.
 
 #### Bug fixes
-- Forms: Send emails to the author of the form only if they are able to edit it.
-- Forms: Prevent the required text from being removed from required fields when creating a form from a pattern.
-- Forms: Store the feedback source info with more context.
-- Maps Block: Fix compatibility with MapKit JS version 5.80.0+.
-- My Jetpack page: Fix visual compatibility issue with Hello Dolly plugin.
-- Podcast feed: Prevent fatals when content is empty.
-- Related Posts: Prevent PHP errors when settings are malformed.
-- Slideshow block: Ensure image size selection is correctly reflected in editor at all times.
-- Stats: Prevent fatal when chart response is invalid.
+- Forms: Fix a bug where ther responsive modal is not able to be closed.
+- Forms: Reset the selection on tab switch in dashboard.
+- Forms: Stop preloading the integrations endpoint.
+- Instant Search: Handle browser privacy settings stripping out the search query value.
 
 --------
 


### PR DESCRIPTION
Closes MONOREP-158

 <!--- This template is used for backporting changes made during a plugin release back to trunk. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Backports changes for jetpack 15.2-a.5

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/a
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Proofread changes.