### PR TITLE
Forms: Fix useSelect errors and reduce re-rendering

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-useState-errors
+++ b/projects/packages/forms/changelog/fix-forms-useState-errors
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Forms: reduce rerenders in the dashboard 
+Forms: reduce re-renders in the dashboard 

--- a/projects/packages/forms/changelog/fix-forms-useState-errors
+++ b/projects/packages/forms/changelog/fix-forms-useState-errors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: reduce rerenders in the dashboard 

--- a/projects/packages/forms/src/dashboard/hooks/use-inbox-data.ts
+++ b/projects/packages/forms/src/dashboard/hooks/use-inbox-data.ts
@@ -131,7 +131,7 @@ export default function useInboxData(): UseInboxDataReturn {
 		totalPages,
 	} = useEntityRecords( 'postType', 'feedback', queryWithInvalidIds );
 
-	const records = useSelect(
+	const editedRecords = useSelect(
 		select => {
 			return ( rawRecords || [] ).map( record => {
 				// Get the edited version of this record if it exists
@@ -140,26 +140,32 @@ export default function useInboxData(): UseInboxDataReturn {
 					'feedback',
 					( record as FormResponse ).id
 				);
-				return {
-					...( ( editedRecord || record ) as FormResponse ),
-					fields: Object.entries( ( record as FormResponse ).fields || {} ).reduce(
-						( accumulator, [ key, value ] ) => {
-							let _key = formatFieldName( key );
-							let counter = 2;
-							while ( accumulator[ _key ] ) {
-								_key = `${ formatFieldName( key ) } (${ counter })`;
-								counter++;
-							}
-							accumulator[ _key ] = formatFieldValue( decodeEntities( value as string ) );
-							return accumulator;
-						},
-						{}
-					),
-				};
-			} ) as FormResponse[];
+				return editedRecord || record;
+			} );
 		},
 		[ rawRecords ]
 	);
+
+	const records = useMemo( () => {
+		return editedRecords.map( record => {
+			return {
+				...( record as FormResponse ),
+				fields: Object.entries( ( record as FormResponse ).fields || {} ).reduce(
+					( accumulator, [ key, value ] ) => {
+						let _key = formatFieldName( key );
+						let counter = 2;
+						while ( accumulator[ _key ] ) {
+							_key = `${ formatFieldName( key ) } (${ counter })`;
+							counter++;
+						}
+						accumulator[ _key ] = formatFieldValue( decodeEntities( value as string ) );
+						return accumulator;
+					},
+					{}
+				),
+			};
+		} ) as FormResponse[];
+	}, [ editedRecords ] );
 
 	// Prepare query params for counts resolver
 	const countsQueryParams = useMemo( () => {

--- a/projects/packages/forms/src/dashboard/hooks/use-inbox-data.ts
+++ b/projects/packages/forms/src/dashboard/hooks/use-inbox-data.ts
@@ -148,9 +148,10 @@ export default function useInboxData(): UseInboxDataReturn {
 
 	const records = useMemo( () => {
 		return editedRecords.map( record => {
+			const formResponse = record as FormResponse;
 			return {
-				...( record as FormResponse ),
-				fields: Object.entries( ( record as FormResponse ).fields || {} ).reduce(
+				...formResponse,
+				fields: Object.entries( formResponse.fields || {} ).reduce(
 					( accumulator, [ key, value ] ) => {
 						let _key = formatFieldName( key );
 						let counter = 2;

--- a/projects/packages/forms/src/dashboard/integrations/index.tsx
+++ b/projects/packages/forms/src/dashboard/integrations/index.tsx
@@ -22,11 +22,13 @@ import './style.scss';
 import type { SelectIntegrations, IntegrationsDispatch } from '../../store/integrations';
 import type { Integration } from '../../types';
 
+const EMPTY_ARRAY: Integration[] = [];
+
 const Integrations = () => {
 	const { integrations } = useSelect( ( select: SelectIntegrations ) => {
 		const store = select( INTEGRATIONS_STORE );
 		return {
-			integrations: store.getIntegrations() || [],
+			integrations: store.getIntegrations() ?? EMPTY_ARRAY,
 		};
 	}, [] ) as { integrations: Integration[] };
 	const { refreshIntegrations } = useDispatch( INTEGRATIONS_STORE ) as IntegrationsDispatch;


### PR DESCRIPTION
Fixes [FORMS-333](https://linear.app/a8c/issue/FORMS-333/address-browser-errors-in-forms-use-state)

This PR fixes the browser errors that I saw

<img width="898" height="542" alt="Screenshot 2025-10-21 at 6 09 50 AM" src="https://github.com/user-attachments/assets/dc23ad2c-bb4b-4c3d-91b2-0e31c7b5aad1" />



## Proposed changes:
* update code to useMemo instead of just useSelect. 
* update code to return the same empty array constant. 

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
No

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Visit the responses dashboard. 
Use different filters. 
Bump between the different tabs. ( Inbox, Spam, Trash ) 
Jump between the different pages. 
Does things work as expected. 

Do you see any browser errors in the console? 
