### PR TITLE
Forms: remove hovercards on inbox

### DIFF
--- a/projects/packages/forms/changelog/remove-forms-inbox-hovercards
+++ b/projects/packages/forms/changelog/remove-forms-inbox-hovercards
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Forms: remove hovercards from inbox list

--- a/projects/packages/forms/src/dashboard/components/gravatar/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/gravatar/index.tsx
@@ -12,6 +12,7 @@ type GravatarProps = {
 	displayName?: string;
 	email: string;
 	size?: number;
+	useHovercard?: boolean;
 };
 
 /**
@@ -27,12 +28,13 @@ export default function Gravatar( {
 	displayName,
 	email,
 	size = 48,
+	useHovercard = true,
 }: GravatarProps ): JSX.Element | null {
 	const profileImageRef = useRef( null );
 	const hovercardRef = useRef( null );
 
 	useEffect( () => {
-		if ( profileImageRef.current ) {
+		if ( useHovercard && profileImageRef.current ) {
 			hovercardRef.current = new Hovercards( {
 				// Documented at https://github.com/Automattic/gravatar/tree/trunk/web/packages/hovercards#translations
 				i18n: {
@@ -59,7 +61,7 @@ export default function Gravatar( {
 			} );
 			hovercardRef.current.attach( profileImageRef.current );
 		}
-	}, [] );
+	}, [ useHovercard ] );
 
 	if ( ! email ) {
 		return null;

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
@@ -250,6 +250,7 @@ export default function InboxView() {
 									displayName={ authorInfo }
 									key={ decodeEntities( item.author_email ) }
 									size={ 32 }
+									useHovercard={ false }
 								/>
 							) }
 							{ wrapperUnread( item.is_unread, authorInfo ) }


### PR DESCRIPTION
Part of FORMS-396

Follow-up to https://github.com/Automattic/jetpack/pull/45555

## Proposed changes:
This PR removes the hovercard feature from the inbox list.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1761065204768069-slack-C052XEUUBL4

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Visit the Forms dashboard inbox, see the avatars on the list don't hold a hovercard (hover any of them). Select a response, see the hovercard for the gravatar on the response view sidebar still works.