### PR TITLE
Tests: Fix Jetpack_Sync_Functions_Test::test_get_post_types_method() test

### DIFF
--- a/projects/plugins/jetpack/changelog/disable-tests-sync_issues_with_wp_trunk
+++ b/projects/plugins/jetpack/changelog/disable-tests-sync_issues_with_wp_trunk
@@ -1,5 +1,5 @@
 Significance: patch
 Type: other
-Comment: Temporarily disable test that broke on WP 6.9 beta.
+Comment: Fix Sync test that broke on WP 6.9 beta.
 
 

--- a/projects/plugins/jetpack/changelog/disable-tests-sync_issues_with_wp_trunk
+++ b/projects/plugins/jetpack/changelog/disable-tests-sync_issues_with_wp_trunk
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Temporarily disable test that broke on WP 6.9 beta.
+
+

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Functions_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Functions_Test.php
@@ -794,8 +794,14 @@ class Jetpack_Sync_Functions_Test extends Jetpack_Sync_TestBase {
 			if ( isset( $post_type_object->revisions_rest_controller_class ) ) {
 				$post_type_object->revisions_rest_controller_class = false;
 			}
+			if ( isset( $post_type_object->revisions_rest_controller ) ) {
+				$post_type_object->revisions_rest_controller = null;
+			}
 			if ( isset( $post_type_object->autosave_rest_controller_class ) ) {
 				$post_type_object->autosave_rest_controller_class = false;
+			}
+			if ( isset( $post_type_object->autosave_rest_controller ) ) {
+				$post_type_object->autosave_rest_controller = null;
 			}
 			if ( isset( $post_type_object->late_route_registration ) ) {
 				$post_type_object->late_route_registration = false;

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Functions_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Functions_Test.php
@@ -782,10 +782,6 @@ class Jetpack_Sync_Functions_Test extends Jetpack_Sync_TestBase {
 	}
 
 	public function test_get_post_types_method() {
-		// WP 6.9 beta broke this test, so disabling temporarily until a proper fix is in place.
-		// The commit that broke things is this:
-		// https://github.com/WordPress/WordPress/commit/82c917225c
-		$this->markTestSkipped( 'is temporarily skipped' );
 		if ( defined( 'IS_ATOMIC' ) && IS_ATOMIC ) {
 			$this->markTestSkipped( 'is temporarily skipped' );
 		}

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Functions_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Functions_Test.php
@@ -782,6 +782,10 @@ class Jetpack_Sync_Functions_Test extends Jetpack_Sync_TestBase {
 	}
 
 	public function test_get_post_types_method() {
+		// WP 6.9 beta broke this test, so disabling temporarily until a proper fix is in place.
+		// The commit that broke things is this:
+		// https://github.com/WordPress/WordPress/commit/82c917225c
+		$this->markTestSkipped( 'is temporarily skipped' );
 		if ( defined( 'IS_ATOMIC' ) && IS_ATOMIC ) {
 			$this->markTestSkipped( 'is temporarily skipped' );
 		}


### PR DESCRIPTION
Closes MONOREP-159

 <!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This WP core commit broke a Sync test:
https://github.com/WordPress/WordPress/commit/82c917225c

This initializes the properties in question to be `null` by default.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

After installing WP 6.9 beta, this will fail in `trunk` and pass on `disable/tests/sync_issues_with_wp_trunk`:
```
jetpack docker phpunit jetpack -- --filter=Jetpack_Sync_Functions_Test
```