### PR TITLE
Forms: Reduce image size in dashboard

### DIFF
--- a/projects/packages/forms/changelog/update-forms-image-select-dashboard-image-size
+++ b/projects/packages/forms/changelog/update-forms-image-select-dashboard-image-size
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Just a small and specific CSS change
+
+

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -282,8 +282,8 @@
 
 	.image-select-field-image {
 		margin: 0;
-		width: 200px;
-		height: 200px;
+		width: 60px;
+		height: 60px;
 
 		&.is-empty {
 			position: relative;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Reduces the image size on responses on dashboard. See screenshots.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Submit a form with an image select field
* Check that the image selected image(s) on the dashboard are smaller

| Before | After |
| - | - |
| <img width="678" height="460" alt="Screenshot from 2025-10-21 18-06-06" src="https://github.com/user-attachments/assets/ff24ba0b-90dd-47a3-8074-1620fba29aa2" /> | <img width="409" height="334" alt="Screenshot from 2025-10-21 18-06-23" src="https://github.com/user-attachments/assets/cadfc63b-75ec-4c91-b0b6-daef45b15010" /> |
