### PR TITLE
Forms: Fix only show the sidebar if you have one response selected

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-only-show-one
+++ b/projects/packages/forms/changelog/fix-forms-only-show-one
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Only show the sidebar if only one item is selected

--- a/projects/packages/forms/src/dashboard/components/response-view/single.tsx
+++ b/projects/packages/forms/src/dashboard/components/response-view/single.tsx
@@ -3,7 +3,7 @@ import {
 	__experimentalHStack as HStack,
 	Modal,
 } from '@wordpress/components';
-import { useCallback, useState } from '@wordpress/element';
+import { useCallback, useState, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import useResponseNavigation from '../../hooks/use-response-navigation';
 import ResponseActions from '../response-actions';
@@ -20,6 +20,7 @@ import { ResponseViewBody } from './index';
  * @param {boolean}      props.isMobile          - Whether the view is mobile.
  * @param {Function}     props.onChangeSelection - The function to change the selection.
  * @param {string[]}     props.selection         - The selection.
+ * @param {string}       props.viewResponseId    - The response ID from the 'v' query parameter.
  * @return {import('react').JSX.Element} The single response component.
  */
 const SingleResponseView = ( {
@@ -29,9 +30,18 @@ const SingleResponseView = ( {
 	isMobile,
 	onChangeSelection,
 	selection,
+	viewResponseId,
 } ) => {
 	const [ isChildModalOpen, setIsChildModalOpen ] = useState( false );
 	const [ isModalOpen, setIsModalOpen ] = useState( true );
+
+	// Sync modal state with viewResponseId changes
+	// This ensures the modal opens when the 'v' URL parameter is set
+	useEffect( () => {
+		if ( isMobile && viewResponseId ) {
+			setIsModalOpen( true );
+		}
+	}, [ viewResponseId, isMobile ] );
 
 	const onRequestClose = useCallback( () => {
 		if ( ! isChildModalOpen ) {

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
@@ -23,7 +23,7 @@ import { useSearchParams } from 'react-router';
  */
 import Gravatar from '../../components/gravatar';
 import InboxStatusToggle from '../../components/inbox-status-toggle';
-import { SingleResponseView } from '../../components/response-view';
+import { SingleResponseView, ResponseMobileView } from '../../components/response-view';
 import useInboxData from '../../hooks/use-inbox-data';
 import EmptyResponses from '../empty-responses';
 import { getPath, getItemId, getCountryFlagEmoji } from '../utils.js';
@@ -455,6 +455,13 @@ export default function InboxView() {
 				} );
 
 				const [ item ] = items;
+				const selectedId = item.id.toString();
+				// Set the 'v' query param to show this item in modal on mobile
+				setSearchParams( previousSearchParams => {
+					const _searchParams = new URLSearchParams( previousSearchParams );
+					_searchParams.set( 'v', selectedId );
+					return _searchParams;
+				} );
 
 				return <ResponseMobileView response={ item } closeModal={ closeModal } />;
 			},
@@ -474,6 +481,13 @@ export default function InboxView() {
 				const selectionWithoutSelectedId = selection.filter( id => id !== selectedId );
 
 				onChangeSelection( [ ...selectionWithoutSelectedId, selectedId ] );
+
+				// Set the 'v' query param to show this item in the sidebar
+				setSearchParams( previousSearchParams => {
+					const _searchParams = new URLSearchParams( previousSearchParams );
+					_searchParams.set( 'v', selectedId );
+					return _searchParams;
+				} );
 			},
 		};
 
@@ -496,7 +510,7 @@ export default function InboxView() {
 					...secondaryActions,
 				];
 		}
-	}, [ isMobile, onChangeSelection, selection, statusFilter ] );
+	}, [ isMobile, onChangeSelection, selection, statusFilter, setSearchParams ] );
 
 	const resetPage = useCallback( () => {
 		view.page = 1;

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
@@ -23,7 +23,7 @@ import { useSearchParams } from 'react-router';
  */
 import Gravatar from '../../components/gravatar';
 import InboxStatusToggle from '../../components/inbox-status-toggle';
-import { ResponseMobileView, SingleResponseView } from '../../components/response-view';
+import { SingleResponseView } from '../../components/response-view';
 import useInboxData from '../../hooks/use-inbox-data';
 import EmptyResponses from '../empty-responses';
 import { getPath, getItemId, getCountryFlagEmoji } from '../utils.js';
@@ -116,6 +116,8 @@ export default function InboxView() {
 		}
 	}, [ isMobileViewport, closeResponseModal ] );
 
+	const viewResponseId = searchParams.get( 'v' );
+
 	useEffect( () => {
 		return setupSidebarWidthObserver();
 	}, [] );
@@ -176,6 +178,8 @@ export default function InboxView() {
 		setSelectedResponses( validSelectedIds );
 	}, [ records, selection, setSelectedResponses ] );
 
+	const [ sidePanelItem, setSidePanelItem ] = useState();
+
 	const onChangeSelection = useCallback(
 		items => {
 			// Set the side panel item only when we are not on mobile and exactly one item is selected.
@@ -194,19 +198,74 @@ export default function InboxView() {
 				} else {
 					_searchParams.delete( 'r' );
 				}
+				// Clear the 'v' param when selection changes
+				_searchParams.delete( 'v' );
 				return _searchParams;
 			} );
 		},
 		[ records, setSearchParams, isMobile ]
 	);
 
-	const [ sidePanelItem, setSidePanelItem ] = useState();
+	// Create a navigation callback that updates the 'v' param when navigating in view mode
+	const onNavigateResponse = useCallback(
+		items => {
+			if ( viewResponseId && items?.length === 1 ) {
+				// If we're in view mode (v param exists), update the v param instead of selection
+				setSearchParams( previousSearchParams => {
+					const _searchParams = new URLSearchParams( previousSearchParams );
+					_searchParams.set( 'v', items[ 0 ] );
+					return _searchParams;
+				} );
+			} else if ( items?.length === 0 ) {
+				// Closing sidebar - clear v param and only clear selection if single item selected
+				setSearchParams( previousSearchParams => {
+					const _searchParams = new URLSearchParams( previousSearchParams );
+					_searchParams.delete( 'v' );
+					// Only clear 'r' param if there's exactly one selection
+					if ( selection?.length === 1 ) {
+						_searchParams.delete( 'r' );
+					}
+					return _searchParams;
+				} );
+			} else {
+				// Otherwise use normal selection logic
+				onChangeSelection( items );
+			}
+		},
+		[ viewResponseId, setSearchParams, onChangeSelection, selection ]
+	);
 	// Because selection is in sync with the URL and data takes some time to load,
 	// We need to carefully (avoid infinite loops by always updating the state)
 	// set the sidePanelItem when we have data and selection.
-	// We don't need to do this in `mobile`,  because we don't render the side panel.
-	if ( ! isMobile && !! records && selection.length === 1 ) {
-		// Only show sidebar when exactly one item is selected
+
+	// Priority 1: If 'v' query param exists, show that item in sidebar/modal (view action was clicked)
+	// This works for both mobile (modal) and desktop (sidebar)
+	if ( !! records && viewResponseId ) {
+		const recordToShow = records?.find( record => getItemId( record ) === viewResponseId );
+		if ( ! sidePanelItem && recordToShow ) {
+			setSidePanelItem( recordToShow );
+		} else if ( !! sidePanelItem && ! recordToShow ) {
+			// This case handles the case where we were having a side panel item
+			// visible but the data have changed and the item is not there anymore.
+			setSidePanelItem();
+		} else if (
+			!! sidePanelItem &&
+			!! recordToShow &&
+			getItemId( sidePanelItem ) === getItemId( recordToShow ) &&
+			sidePanelItem !== recordToShow
+		) {
+			// Update side panel item if the data has been refreshed for the SAME item (e.g., after an action)
+			// This ensures the side panel shows the latest version of the same entity
+			setSidePanelItem( recordToShow );
+		} else if (
+			!! recordToShow &&
+			( ! sidePanelItem || getItemId( sidePanelItem ) !== getItemId( recordToShow ) )
+		) {
+			// Set side panel item when selecting a different item
+			setSidePanelItem( recordToShow );
+		}
+	} else if ( ! isMobile && !! records && selection.length === 1 ) {
+		// Priority 2: Only show sidebar when exactly one item is selected (no 'v' param)
 		const singleSelectedId = selection[ 0 ];
 		const recordToShow = records?.find( record => getItemId( record ) === singleSelectedId );
 		if ( ! sidePanelItem && recordToShow ) {
@@ -231,8 +290,13 @@ export default function InboxView() {
 			// Set side panel item when selecting a different item
 			setSidePanelItem( recordToShow );
 		}
-	} else if ( ! isMobile && !! records && selection.length > 1 ) {
-		// Multiple selections - hide sidebar
+	} else if ( ! isMobile && !! records && selection.length > 1 && ! viewResponseId ) {
+		// Multiple selections without 'v' param - hide sidebar
+		if ( sidePanelItem ) {
+			setSidePanelItem( undefined );
+		}
+	} else if ( ! isMobile && ! viewResponseId && selection.length === 0 ) {
+		// No selections and no 'v' param - hide sidebar
 		if ( sidePanelItem ) {
 			setSidePanelItem( undefined );
 		}
@@ -500,12 +564,13 @@ export default function InboxView() {
 				) }
 			</div>
 			<SingleResponseView
-				sidePanelItem={ selection.length && sidePanelItem }
+				sidePanelItem={ selection.length || viewResponseId ? sidePanelItem : null }
 				setSidePanelItem={ setSidePanelItem }
 				isLoadingData={ isLoadingData }
 				isMobile={ isMobile }
-				onChangeSelection={ onChangeSelection }
+				onChangeSelection={ onNavigateResponse }
 				selection={ selection }
+				viewResponseId={ viewResponseId }
 			/>
 		</HStack>
 	);

--- a/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/dataviews/index.js
@@ -178,12 +178,14 @@ export default function InboxView() {
 
 	const onChangeSelection = useCallback(
 		items => {
-			// Set the side panel item only when we are not on mobile.
+			// Set the side panel item only when we are not on mobile and exactly one item is selected.
 			if ( ! isMobile ) {
-				setSidePanelItem(
-					!! items?.length &&
-						records?.find( record => getItemId( record ) === items[ items.length - 1 ] )
-				);
+				if ( items?.length === 1 ) {
+					setSidePanelItem( records?.find( record => getItemId( record ) === items[ 0 ] ) );
+				} else {
+					// Multiple or zero selections - clear sidebar
+					setSidePanelItem( undefined );
+				}
 			}
 			setSearchParams( previousSearchParams => {
 				const _searchParams = new URLSearchParams( previousSearchParams );
@@ -203,13 +205,10 @@ export default function InboxView() {
 	// We need to carefully (avoid infinite loops by always updating the state)
 	// set the sidePanelItem when we have data and selection.
 	// We don't need to do this in `mobile`,  because we don't render the side panel.
-	if ( ! isMobile && !! records && !! selection.length ) {
-		// Find the last (most recently selected) valid selection instead of the first
-		const lastValidSelection = selection
-			.slice()
-			.reverse()
-			.find( id => records.some( record => getItemId( record ) === id ) );
-		const recordToShow = records?.find( record => getItemId( record ) === lastValidSelection );
+	if ( ! isMobile && !! records && selection.length === 1 ) {
+		// Only show sidebar when exactly one item is selected
+		const singleSelectedId = selection[ 0 ];
+		const recordToShow = records?.find( record => getItemId( record ) === singleSelectedId );
 		if ( ! sidePanelItem && recordToShow ) {
 			setSidePanelItem( recordToShow );
 		} else if ( !! sidePanelItem && ! recordToShow ) {
@@ -231,6 +230,11 @@ export default function InboxView() {
 		) {
 			// Set side panel item when selecting a different item
 			setSidePanelItem( recordToShow );
+		}
+	} else if ( ! isMobile && !! records && selection.length > 1 ) {
+		// Multiple selections - hide sidebar
+		if ( sidePanelItem ) {
+			setSidePanelItem( undefined );
 		}
 	}
 	const paginationInfo = useMemo(

--- a/projects/plugins/jetpack/changelog/fix-forms-only-show-one
+++ b/projects/plugins/jetpack/changelog/fix-forms-only-show-one
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: Only show the sidebar if only one response is selected


### PR DESCRIPTION
Currently we show the latest response that is selected. 

<img width="1496" height="297" alt="Screenshot 2025-10-21 at 5 45 00 PM" src="https://github.com/user-attachments/assets/23eef588-cad5-4a8c-9f6d-cac7ebcea46b" />

Fixes FORMS-363

This PR fixes this by making it so that only one selected response is shown. 
If you have multiple responses selected, you will still be able to view responses. (Without loosing the selection). 

I think this PR makes things more like you would expect. 

## Proposed changes:
* It introduced a new `v` query parameter that make it possible to pass the value via the URL and open the response in the open modal. 
* The `r` query parameter still controls if something is selected or not. (as before) 

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
Make the selecetion and viewing more intuitive in the dashboard. 

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Go to the dashboard. 
Select one response. Select all, view just one responses. (it should open in the sidebar) deselect all, selected only one. 

On the mobile side of things try to do the same. 

Also play around with pagination, different filters and tabs ( inbox, spam, trash ) 

Does it work you would expect? 

